### PR TITLE
Update GHC2Core.hs

### DIFF
--- a/src-ghc/CLaSH/GHC/GHC2Core.hs
+++ b/src-ghc/CLaSH/GHC/GHC2Core.hs
@@ -177,6 +177,7 @@ makeTyCon tc = tycon
           PtrRep  -> C.VoidRep
           WordRep -> C.VoidRep
           DoubleRep -> C.VoidRep
+          Word64Rep -> C.VoidRep
           _ -> error $ $(curLoc) ++ "Can't convert PrimRep: " ++ showPpr p ++ " in tycon: " ++ showPpr tc
 
 makeAlgTyConRhs :: AlgTyConRhs


### PR DESCRIPTION
It's quick fix for error:
**\* Exception: CLaSH.GHC.GHC2Core(180): Can't convert PrimRep: Word64Rep in tycon: GHC.Prim.Word64#
