### PR TITLE
Change the primitives for quot# and rem# to match the types in prelude

### DIFF
--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
@@ -122,14 +122,14 @@
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.quot#"
-    , "type"      : "quot# :: KnownNat n => Signed n -> Signed n -> Signed n"
-    , "templateE" : "~ARG[1] / ~ARG[2]"
+    , "type"      : "quot# :: Signed n -> Signed n -> Signed n"
+    , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rem#"
-    , "type"      : "rem# :: KnownNat n => Signed n -> Signed n -> Signed n"
-    , "templateE" : "~ARG[1] % ~ARG[2]"
+    , "type"      : "rem# :: Signed n -> Signed n -> Signed n"
+    , "templateE" : "~ARG[0] % ~ARG[1]"
     }
   }
 , { "BlackBox" :

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.Signed.json
@@ -122,14 +122,14 @@
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.quot#"
-    , "type"      : "quot# :: KnownNat n => Signed n -> Signed n -> Signed n"
-    , "templateE" : "~ARG[1] / ~ARG[2]"
+    , "type"      : "quot# :: Signed n -> Signed n -> Signed n"
+    , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rem#"
-    , "type"      : "rem# :: KnownNat n => Signed n -> Signed n -> Signed n"
-    , "templateE" : "~ARG[1] % ~ARG[2]"
+    , "type"      : "rem# :: Signed n -> Signed n -> Signed n"
+    , "templateE" : "~ARG[0] % ~ARG[1]"
     }
   }
 , { "BlackBox" :

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.Signed.json
@@ -124,14 +124,14 @@
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.quot#"
-    , "type"      : "quot# :: KnownNat n => Signed n -> Signed n -> Signed n"
-    , "templateE" : "~ARG[1] / ~ARG[2]"
+    , "type"      : "quot# :: Signed n -> Signed n -> Signed n"
+    , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rem#"
-    , "type"      : "rem# :: KnownNat n => Signed n -> Signed n -> Signed n"
-    , "templateE" : "~ARG[1] rem ~ARG[2]"
+    , "type"      : "rem# :: Signed n -> Signed n -> Signed n"
+    , "templateE" : "~ARG[0] rem ~ARG[1]"
     }
   }
 , { "BlackBox" :


### PR DESCRIPTION
Fixes https://github.com/clash-lang/clash-compiler/issues/73