### PR TITLE
Fix Index maxBound

### DIFF
--- a/clash-systemverilog/primitives/CLaSH.Prelude.Testbench.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.Testbench.json
@@ -12,7 +12,7 @@
 "// assert begin
 // pragma translate_off
 always @(posedge ~CLK[2] or posedge ~RST[2]) begin
-  if (~ARG[4] != ~ARG[5]) begin
+  if (~ARG[4] !== ~ARG[5]) begin
     $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[3], ~TYPM[5]_to_lv(~ARG[5]), ~TYPM[4]_to_lv(~ARG[4]));
     $stop;
   end

--- a/clash-verilog/primitives/CLaSH.Prelude.Testbench.json
+++ b/clash-verilog/primitives/CLaSH.Prelude.Testbench.json
@@ -12,7 +12,7 @@
 "// assert begin
 // pragma translate_off
 always @(posedge ~CLK[2] or posedge ~RST[2]) begin
-  if (~ARG[4] != ~ARG[5]) begin
+  if (~ARG[4] !== ~ARG[5]) begin
     $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[3], ~ARG[5], ~ARG[4]);
     $finish;
   end

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.Index.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.Index.json
@@ -37,7 +37,7 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => Index n"
-    , "templateE" : "to_unsigned(max(0,~LIT[0]-1),~RESULT'length);"
+    , "templateE" : "to_unsigned(max(0,~LIT[0]-1),~SIZE[~TYPO])"
     }
   }
 , { "BlackBox" :

--- a/tests/shouldwork/Numbers/Bounds.hs
+++ b/tests/shouldwork/Numbers/Bounds.hs
@@ -1,18 +1,22 @@
 module Bounds where
 import CLaSH.Prelude
 
-(expected,actual) = unzip $
-        (   0, toInteger (minBound :: Index 43))
-     :> (  42, toInteger (maxBound :: Index 43))
-     :> (-256, toInteger (minBound :: Signed 9))
-     :> ( 255, toInteger (maxBound :: Signed 9))
-     :> (   0, toInteger (minBound :: Unsigned 9))
-     :> ( 511, toInteger (maxBound :: Unsigned 9))
-     :> ( -64, toInteger $ unFixed (minBound :: SFixed 4 3))
-     :> (  63, toInteger $ unFixed (maxBound :: SFixed 4 3))
-     :> (   0, toInteger $ unFixed (minBound :: UFixed 3 4))
-     :> ( 127, toInteger $ unFixed (maxBound :: UFixed 3 4))
-     :> Nil
+
+expected
+    =     0 :>  42
+    :> -256 :> 255
+    :>    0 :> 511
+    :>  -64 :>  63
+    :>    0 :> 127
+    :> (Nil::Vec 0 Integer)
+
+actual
+    =  toInteger (minBound :: Index 43)             :> toInteger (maxBound :: Index 43)
+    :> toInteger (minBound :: Signed 9)             :> toInteger (maxBound :: Signed 9)
+    :> toInteger (minBound :: Unsigned 9)           :> toInteger (maxBound :: Unsigned 9)
+    :> toInteger (unFixed (minBound :: SFixed 4 3)) :> toInteger (unFixed (maxBound :: SFixed 4 3))
+    :> toInteger (unFixed (minBound :: UFixed 3 4)) :> toInteger (unFixed (maxBound :: UFixed 3 4))
+    :> Nil
 
 topEntity :: Signal () -> Signal Integer
 topEntity = mealy loop actual
@@ -25,7 +29,6 @@ loop xs _ = (xs <<+ last xs, head xs)
 expectedOutput :: Signal Integer -> Signal Bool
 expectedOutput = outputVerifier expected
 
--- create the right number of inputs
-stimuli = map (const ()) actual
 
-testInput = stimuliGenerator stimuli
+testInput :: Signal ()
+testInput  = signal ()

--- a/tests/shouldwork/Numbers/Bounds.hs
+++ b/tests/shouldwork/Numbers/Bounds.hs
@@ -1,0 +1,31 @@
+module Bounds where
+import CLaSH.Prelude
+
+(expected,actual) = unzip $
+        (   0, toInteger (minBound :: Index 43))
+     :> (  42, toInteger (maxBound :: Index 43))
+     :> (-256, toInteger (minBound :: Signed 9))
+     :> ( 255, toInteger (maxBound :: Signed 9))
+     :> (   0, toInteger (minBound :: Unsigned 9))
+     :> ( 511, toInteger (maxBound :: Unsigned 9))
+     :> ( -64, toInteger $ unFixed (minBound :: SFixed 4 3))
+     :> (  63, toInteger $ unFixed (maxBound :: SFixed 4 3))
+     :> (   0, toInteger $ unFixed (minBound :: UFixed 3 4))
+     :> ( 127, toInteger $ unFixed (maxBound :: UFixed 3 4))
+     :> Nil
+
+topEntity :: Signal () -> Signal Integer
+topEntity = mealy loop actual
+
+loop :: Vec (n+2) a -> () -> (Vec (n+2) a, a)
+--loop (x:>xs) _ = (xs <: last xs, x)
+loop xs _ = (xs <<+ last xs, head xs)
+
+
+expectedOutput :: Signal Integer -> Signal Bool
+expectedOutput = outputVerifier expected
+
+-- create the right number of inputs
+stimuli = map (const ()) actual
+
+testInput = stimuliGenerator stimuli

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -71,7 +71,8 @@ main =
             , runTest ("tests" </> "shouldwork" </> "HOPrim") Both [] "VecFun" (Just ("testbench",True))
             ]
         , testGroup "Numbers"
-            [ runTest ("tests" </> "shouldwork" </> "Numbers") Both [] "Resize" (Just ("testbench",True))
+            [ runTest ("tests" </> "shouldwork" </> "Numbers") Both [] "Bounds"  (Just ("testbench",True))
+            , runTest ("tests" </> "shouldwork" </> "Numbers") Both [] "Resize"  (Just ("testbench",True))
             , runTest ("tests" </> "shouldwork" </> "Numbers") Both [] "Resize2" (Just ("testbench",True))
             , runTest ("tests" </> "shouldwork" </> "Numbers") Both [] "SatMult" (Just ("topEntity",False))
             ]


### PR DESCRIPTION
This started out as one simple thing, and then became many things.
If you like I can open separate issues.



First the vhdl primitive for maxBound on Index was broken.
Here is a fix for that.

I also included a test which checks the bounds of Index and some other types.

But this test currently fails, because it turns out that when min/maxBound of type Unsigned are converted to Integer, then something breaks.

When translating clash seems think:
```haskell
toInteger (minBound :: Unsigned 9) == 9
toInteger (maxBound :: Unsigned 9) == 2^9 -- should be 2^9-1
```


Furthermore the testbench for Bounds should currently fail for both VHDL and Verilog.
And it does fail in both Modelsim and ISim.
But I couldn't get iverilog/vvp to fail it on my machine.
If the vvp test for this succeeds on the Travis CI system in the current state, then is a bug.
