### PR TITLE
Add a stack.yaml to install easily

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,13 @@
+resolver: lts-3.11
+
+packages:
+- 'clash-lib'
+- 'clash-verilog'
+- 'clash-systemverilog'
+- 'clash-vhdl'
+- 'clash-ghc'
+
+extra-deps:
+- clash-prelude-0.10.3
+- ghc-typelits-extra-0.1
+


### PR DESCRIPTION
Hi,

Add a stack.yaml for compiling this project with stack.
(Cabal  sometimes happens build-dependency-problems.)

