### PR TITLE
necessary infrastructure for differential clock inputs

### DIFF
--- a/clash-lib/src/CLaSH/Driver/TopWrapper.hs
+++ b/clash-lib/src/CLaSH/Driver/TopWrapper.hs
@@ -240,13 +240,13 @@ mkClockDecl s = NetDecl (pack s) (Clock (pack name) (read rate))
 
 
 -- | Create a single clock path
-clockPorts :: Maybe (String,String) -> [(String,String)]
+clockPorts :: [(String,String)] -> [(String,String)]
            -> ([(Identifier,Expr)],[String])
-clockPorts inp outp = (inp' ++ outp',clks)
+clockPorts inp outp = (ports,clks)
   where
-    inp'  = maybe [] ((:[]) . (pack *** stringToVar)) inp
-    outp' = map (pack *** stringToVar) outp
+    ports = map (pack *** stringToVar) (inp ++ outp)
     clks  = map snd outp
+
 
 -- | Generate resets
 mkResets :: PrimMap

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -491,6 +491,9 @@ expr_ _ (Identifier id_ (Just (Indexed (ty@(Product _ _),_,fI)))) = text id_ <> 
 expr_ _ (Identifier id_ (Just (Indexed ((Vector _ _),1,1)))) = text id_ <> parens (int 0)
 expr_ _ (Identifier id_ (Just (Indexed ((Vector n _),1,2)))) = text id_ <> parens (int 1 <+> "to" <+> int (n-1))
 
+expr_ _ (Identifier id_ (Just (Indexed ((BitVector _),1,lane)))) = text id_ <> parens (int lane)
+
+
 -- This is a HACK for CLaSH.Driver.TopWrapper.mkOutput
 -- Vector's don't have a 10'th constructor, this is just so that we can
 -- recognize the particular case


### PR DESCRIPTION
By using a list of clock inputs we
can model 0, 1=single-ended, 2=differential
variants.

Needs clash-prelude changes to compile.