### PR TITLE
Clean up preprocessor directives

### DIFF
--- a/clash-ghc/src-bin/GhciMonad.hs
+++ b/clash-ghc/src-bin/GhciMonad.hs
@@ -56,10 +56,6 @@ import qualified System.Console.Haskeline as Haskeline
 import Control.Monad.Trans.Class
 import Control.Monad.IO.Class
 
-#if __GLASGOW_HASKELL__ < 709
-import Control.Applicative (Applicative(..))
-#endif
-
 -----------------------------------------------------------------------------
 -- GHCi monad
 

--- a/clash-ghc/src-bin/InteractiveUI.hs
+++ b/clash-ghc/src-bin/InteractiveUI.hs
@@ -81,11 +81,7 @@ import Data.Maybe
 import Exception hiding (catch)
 
 import Foreign.C
-#if __GLASGOW_HASKELL__ >= 709
 import Foreign
-#else
-import Foreign.Safe
-#endif
 
 import System.Directory
 import System.Environment

--- a/clash-ghc/src-bin/hschooks.c
+++ b/clash-ghc/src-bin/hschooks.c
@@ -30,14 +30,10 @@ initGCStatistics(void)
 void
 defaultsHook (void)
 {
-#if __GLASGOW_HASKELL__ >= 707
     // This helps particularly with large compiles, but didn't work
     // very well with earlier GHCs because it caused large amounts of
     // fragmentation.  See rts/sm/BlockAlloc.c:allocLargeChunk().
     RtsFlags.GcFlags.heapSizeSuggestionAuto = rtsTrue;
-#else
-    RtsFlags.GcFlags.heapSizeSuggestion = 6*1024*1024 / BLOCK_SIZE;
-#endif
 
     RtsFlags.GcFlags.maxStkSize         = 512*1024*1024 / sizeof(W_);
 


### PR DESCRIPTION
GHC 7.10.x is mandatory, so these #ifdefs
are not needed any more.