### PR TITLE
Add black box for `trace`. See issue #117

### DIFF
--- a/clash-systemverilog/clash-systemverilog.cabal
+++ b/clash-systemverilog/clash-systemverilog.cabal
@@ -63,6 +63,7 @@ Data-files:           primitives/CLaSH.Driver.TestbenchGen.json
                       primitives/CLaSH.Sized.Vector.json
                       primitives/CLaSH.Transformations.json
                       primitives/Control.Exception.Base.json
+                      primitives/Debug.Trace.json
                       primitives/GHC.Base.json
                       primitives/GHC.Classes.json
                       primitives/GHC.CString.json

--- a/clash-systemverilog/primitives/Debug.Trace.json
+++ b/clash-systemverilog/primitives/Debug.Trace.json
@@ -1,0 +1,7 @@
+[ { "BlackBox" :
+    { "name"      : "Debug.Trace.trace"
+    , "type"      : "trace :: String -> a -> a"
+    , "templateE" : "~ARG[1]"
+    }
+  }
+]

--- a/clash-verilog/clash-verilog.cabal
+++ b/clash-verilog/clash-verilog.cabal
@@ -63,6 +63,7 @@ Data-files:           primitives/CLaSH.Driver.TestbenchGen.json
                       primitives/CLaSH.Sized.Vector.json
                       primitives/CLaSH.Transformations.json
                       primitives/Control.Exception.Base.json
+                      primitives/Debug.Trace.json
                       primitives/GHC.Base.json
                       primitives/GHC.Classes.json
                       primitives/GHC.CString.json

--- a/clash-verilog/primitives/Debug.Trace.json
+++ b/clash-verilog/primitives/Debug.Trace.json
@@ -1,0 +1,7 @@
+[ { "BlackBox" :
+    { "name"      : "Debug.Trace.trace"
+    , "type"      : "trace :: String -> a -> a"
+    , "templateE" : "~ARG[1]"
+    }
+  }
+]

--- a/clash-vhdl/clash-vhdl.cabal
+++ b/clash-vhdl/clash-vhdl.cabal
@@ -63,6 +63,7 @@ Data-files:           primitives/CLaSH.Driver.TestbenchGen.json
                       primitives/CLaSH.Sized.Vector.json
                       primitives/CLaSH.Transformations.json
                       primitives/Control.Exception.Base.json
+                      primitives/Debug.Trace.json
                       primitives/GHC.Base.json
                       primitives/GHC.Classes.json
                       primitives/GHC.CString.json

--- a/clash-vhdl/primitives/Debug.Trace.json
+++ b/clash-vhdl/primitives/Debug.Trace.json
@@ -1,0 +1,7 @@
+[ { "BlackBox" :
+    { "name"      : "Debug.Trace.trace"
+    , "type"      : "trace :: String -> a -> a"
+    , "templateE" : "~ARG[1]"
+    }
+  }
+]

--- a/tests/shouldwork/Basic/BlackBox.hs
+++ b/tests/shouldwork/Basic/BlackBox.hs
@@ -4,4 +4,4 @@ import CLaSH.Prelude
 import Debug.Trace
 
 topEntity :: Unsigned 32 -> Unsigned 32
-topEntity y = trace "some trace" y
+topEntity y = trace "some trace" y + traceShowId y

--- a/tests/shouldwork/Basic/BlackBox.hs
+++ b/tests/shouldwork/Basic/BlackBox.hs
@@ -1,0 +1,7 @@
+module BlackBox where
+
+import CLaSH.Prelude
+import Debug.Trace
+
+topEntity :: Unsigned 32 -> Unsigned 32
+topEntity y = trace "some trace" y

--- a/tests/shouldwork/Basic/Trace.hs
+++ b/tests/shouldwork/Basic/Trace.hs
@@ -1,4 +1,4 @@
-module BlackBox where
+module Trace where
 
 import CLaSH.Prelude
 import Debug.Trace

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -35,7 +35,8 @@ main =
       ]
     , testGroup "unit-tests"
         [ testGroup "Basic"
-            [ runTest ("tests" </> "shouldwork" </> "Basic") Both [] "ByteSwap32" (Just ("testbench",True))
+            [ runTest ("tests" </> "shouldwork" </> "Basic") Both [] "BlackBox" (Just ("topEntity",False))
+            , runTest ("tests" </> "shouldwork" </> "Basic") Both [] "ByteSwap32" (Just ("testbench",True))
             , runTest ("tests" </> "shouldwork" </> "Basic") Both [] "CharTest" (Just ("testbench",True))
             , runTest ("tests" </> "shouldwork" </> "Basic") Both [] "ClassOps" (Just ("topEntity",False))
             , runTest ("tests" </> "shouldwork" </> "Basic") Both [] "CountTrailingZeros" (Just ("testbench",True))

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -35,7 +35,7 @@ main =
       ]
     , testGroup "unit-tests"
         [ testGroup "Basic"
-            [ runTest ("tests" </> "shouldwork" </> "Basic") Both [] "BlackBox" (Just ("topEntity",False))
+            [ runTest ("tests" </> "shouldwork" </> "Basic") Both [] "Trace" (Just ("topEntity",False))
             , runTest ("tests" </> "shouldwork" </> "Basic") Both [] "ByteSwap32" (Just ("testbench",True))
             , runTest ("tests" </> "shouldwork" </> "Basic") Both [] "CharTest" (Just ("testbench",True))
             , runTest ("tests" </> "shouldwork" </> "Basic") Both [] "ClassOps" (Just ("topEntity",False))


### PR DESCRIPTION
Try this with https://github.com/ggreif/clash-ground/commit/32f4902466e6090b272528e1bed5d87bdd622aaf#diff-838276822f7df3fd184ac927bd842b4eR47

You get:
```
*Add> :vhdl
[1 of 1] Compiling Add              ( Add.hs, Add.o )

Add.hs:52:1: Warning:
    Pattern match(es) are overlapped
    In an equation for  adder :
        adder (DONEXT rom :> stk, (trivial -> i)) Nothing = ...

Add.hs:52:1: Warning:
    Pattern match(es) are overlapped
    In an equation for  adder :
        adder (DONEXT rom :> stk, (trivial -> i)) Nothing = ...
Loading dependencies took 0.436388s
CLaSH.Normalize(118): Expr belonging to bndr: Add.adder_go11054 (:: GHC.Types.[] GHC.Types.Char
-> GHC.Types.[] GHC.Types.Char -> GHC.Types.[] GHC.Types.Char) remains recursive after normalization:
 (s :: GHC.Types.[] GHC.Types.Char) ->
 (ds4 :: GHC.Types.[] GHC.Types.Char) ->
letrec
  repANF :: GHC.Types.[] GHC.Types.Char
  = Add.adder_go11054
      s
      ys
  altLet :: GHC.Types.[] GHC.Types.Char
  = GHC.Types.:
    @GHC.Types.Char
      y
      repANF
  y :: GHC.Types.Char
  = case ds4 of
      GHC.Types.:
        (sel :: GHC.Types.Char)
        (wild :: GHC.Types.[] GHC.Types.Char) ->
        sel
  ys :: GHC.Types.[] GHC.Types.Char
  = case ds4 of
      GHC.Types.:
        (wild :: GHC.Types.Char)
        (sel :: GHC.Types.[] GHC.Types.Char) ->
        sel
  topLet :: GHC.Types.[] GHC.Types.Char
  = case ds4 of
      GHC.Types.[] -> s
      GHC.Types.:
        (y1 :: GHC.Types.Char)
        (ys1 :: GHC.Types.[] GHC.Types.Char) ->
        altLet
in topLet
CLaSH.Normalize(118): Expr belonging to bndr: Add.adder_go11055 (:: GHC.Types.[] GHC.Types.Char
-> GHC.Types.[] GHC.Types.Char -> GHC.Types.[] GHC.Types.Char) remains recursive after normalization:
 (s :: GHC.Types.[] GHC.Types.Char) ->
 (ds4 :: GHC.Types.[] GHC.Types.Char) ->
letrec
  repANF :: GHC.Types.[] GHC.Types.Char
  = Add.adder_go11055
      s
      ys
  altLet :: GHC.Types.[] GHC.Types.Char
  = GHC.Types.:
    @GHC.Types.Char
      y
      repANF
  y :: GHC.Types.Char
  = case ds4 of
      GHC.Types.:
        (sel :: GHC.Types.Char)
        (wild :: GHC.Types.[] GHC.Types.Char) ->
        sel
  ys :: GHC.Types.[] GHC.Types.Char
  = case ds4 of
      GHC.Types.:
        (wild :: GHC.Types.Char)
        (sel :: GHC.Types.[] GHC.Types.Char) ->
        sel
  topLet :: GHC.Types.[] GHC.Types.Char
  = case ds4 of
      GHC.Types.[] -> s
      GHC.Types.:
        (y1 :: GHC.Types.Char)
        (ys1 :: GHC.Types.[] GHC.Types.Char) ->
        altLet
in topLet
CLaSH.Normalize(118): Expr belonging to bndr: Add.adder_go11056 (:: GHC.Types.[] GHC.Types.Char
-> GHC.Types.[] GHC.Types.Char -> GHC.Types.[] GHC.Types.Char) remains recursive after normalization:
 (s :: GHC.Types.[] GHC.Types.Char) ->
 (ds4 :: GHC.Types.[] GHC.Types.Char) ->
letrec
  repANF :: GHC.Types.[] GHC.Types.Char
  = Add.adder_go11056
      s
      ys
  altLet :: GHC.Types.[] GHC.Types.Char
  = GHC.Types.:
    @GHC.Types.Char
      y
      repANF
  y :: GHC.Types.Char
  = case ds4 of
      GHC.Types.:
        (sel :: GHC.Types.Char)
        (wild :: GHC.Types.[] GHC.Types.Char) ->
        sel
  ys :: GHC.Types.[] GHC.Types.Char
  = case ds4 of
      GHC.Types.:
        (wild :: GHC.Types.Char)
        (sel :: GHC.Types.[] GHC.Types.Char) ->
        sel
  topLet :: GHC.Types.[] GHC.Types.Char
  = case ds4 of
      GHC.Types.[] -> s
      GHC.Types.:
        (y1 :: GHC.Types.Char)
        (ys1 :: GHC.Types.[] GHC.Types.Char) ->
        altLet
in topLet
*** Exception: CLaSH.Normalize(165): Callgraph after normalisation contains following recursive cycles: [[Add.adder_go11056],[Add.adder_go11055],[Add.adder_go11054]]
```