### PR TITLE
Ensure that all names in black boxes are unique

### DIFF
--- a/CLaSH.hs
+++ b/CLaSH.hs
@@ -36,7 +36,7 @@ doHDL b src = do
   pd      <- primDir b
   primMap <- generatePrimMap [pd,"."]
   (bindingsMap,tcm,tupTcm,topEnt,testInpM,expOutM) <- generateBindings primMap src Nothing
-  generateHDL bindingsMap (Just b) primMap tcm tupTcm (ghcTypeToHWType WORD_SIZE_IN_BITS) reduceConstant topEnt testInpM expOutM (CLaSHOpts 20 20 15 DebugFinal True WORD_SIZE_IN_BITS Nothing HDLSYN)
+  generateHDL bindingsMap (Just b) primMap tcm tupTcm (ghcTypeToHWType WORD_SIZE_IN_BITS) reduceConstant topEnt testInpM expOutM (CLaSHOpts 20 20 15 DebugNone True WORD_SIZE_IN_BITS Nothing HDLSYN)
 
 main :: IO ()
 main = genVHDL "./examples/FIR.hs"

--- a/CLaSH.hs
+++ b/CLaSH.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 #include "MachDeps.h"
-#define HDLSYN Vivado
+#define HDLSYN Other
 
 import CLaSH.Driver
 import CLaSH.Driver.Types

--- a/clash-lib/src/CLaSH/Backend.hs
+++ b/clash-lib/src/CLaSH/Backend.hs
@@ -14,6 +14,8 @@ import Text.PrettyPrint.Leijen.Text.Monadic (Doc)
 import CLaSH.Netlist.Types
 import CLaSH.Netlist.BlackBox.Types
 
+type ModName = String
+
 class Backend state where
   -- | Initial state for state monad
   initBackend :: Int -> HdlSyn -> state
@@ -59,3 +61,5 @@ class Backend state where
   hdlSyn           :: State state HdlSyn
   -- | mkBasicId
   mkBasicId        :: State state (Identifier -> Identifier)
+  -- | setModName
+  setModName       :: ModName -> state -> state

--- a/clash-lib/src/CLaSH/Backend.hs
+++ b/clash-lib/src/CLaSH/Backend.hs
@@ -58,4 +58,4 @@ class Backend state where
   -- | Synthesis tool we're generating HDL for
   hdlSyn           :: State state HdlSyn
   -- | mkBasicId
-  mkBasicId        :: State state (String -> String)
+  mkBasicId        :: State state (Identifier -> Identifier)

--- a/clash-lib/src/CLaSH/Driver.hs
+++ b/clash-lib/src/CLaSH/Driver.hs
@@ -87,7 +87,8 @@ generateHDL bindingsMap hdlState primMap tcm tupTcm typeTrans eval (topEntity,an
   let modName   = takeWhile (/= '.') (name2String topEntity)
       iw        = opt_intWidth opts
       hdlsyn    = opt_hdlSyn opts
-      hdlState' = fromMaybe (initBackend iw hdlsyn :: backend) hdlState
+      hdlState' = setModName modName
+                $ fromMaybe (initBackend iw hdlsyn :: backend) hdlState
       mkId      = evalState mkBasicId hdlState'
       topNm     = maybe (mkId (Text.pack $ modName ++ "_topEntity"))
                         (Text.pack . t_name)

--- a/clash-lib/src/CLaSH/Driver/TopWrapper.hs
+++ b/clash-lib/src/CLaSH/Driver/TopWrapper.hs
@@ -34,14 +34,15 @@ import CLaSH.Util
 
 -- | Create a wrapper around a component, potentially initiating clock sources
 mkTopWrapper :: PrimMap BlackBoxTemplate
+             -> (Identifier -> Identifier)
              -> Maybe TopEntity -- ^ TopEntity specifications
              -> String          -- ^ Name of the module containing the @topEntity@
              -> Int             -- ^ Int/Word/Integer bit-width
              -> Component       -- ^ Entity to wrap
              -> Component
-mkTopWrapper primMap teM modName iw topComponent
+mkTopWrapper primMap mkId teM modName iw topComponent
   = Component
-  { componentName = maybe (pack modName `append` "_topEntity") (pack . t_name) teM
+  { componentName = maybe (mkId (pack modName `append` "_topEntity")) (pack . t_name) teM
   , inputs        = inputs'' ++ extraIn teM
   , outputs       = outputs'' ++ extraOut teM
   , hiddenPorts   = case maybe [] t_clocks teM of
@@ -301,5 +302,5 @@ unsafeRunNetlist :: Int
 unsafeRunNetlist iw
   = unsafePerformIO
   . fmap fst
-  . runNetlistMonad Nothing HashMap.empty HashMap.empty
-      HashMap.empty (\_ _ -> Nothing) "" [] iw id
+  . runNetlistMonad HashMap.empty HashMap.empty
+      HashMap.empty (\_ _ -> Nothing) "" [] iw id []

--- a/clash-lib/src/CLaSH/Netlist.hs
+++ b/clash-lib/src/CLaSH/Netlist.hs
@@ -103,7 +103,7 @@ runNetlistMonad s p tcm typeTrans modName dfiles iw mkId seen
   . (fmap fst . runWriterT)
   . runNetlist
   where
-    s' = NetlistState s HashMap.empty 0 HashMap.empty p typeTrans tcm modName Text.empty dfiles iw mkId [] seen' names
+    s' = NetlistState s HashMap.empty 0 HashMap.empty p typeTrans tcm Text.empty dfiles iw mkId [] seen' names
     (seen',names) = genNames mkId modName seen HashMap.empty (HashMap.keys s)
 
 genNames :: (Identifier -> Identifier)

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
@@ -98,6 +98,7 @@ pTagE =  O                 <$  pToken "~RESULT"
      <|> IsVar             <$> (pToken "~ISVAR" *> pBrackets pNatural)
      <|> GenSym            <$> (pToken "~GENSYM" *> pBrackets pSigD) <*> pBrackets pNatural
      <|> And               <$> (pToken "~AND" *> listParser pTagE)
+     <|> Vars              <$> (pToken "~VARS" *> pBrackets pNatural)
 
 
 -- | Parse a bracketed text

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
@@ -11,6 +11,7 @@ module CLaSH.Netlist.BlackBox.Parser
 where
 
 import           Data.Text.Lazy                           (Text, pack)
+import qualified Data.Text.Lazy                           as Text
 import           Text.ParserCombinators.UU
 import           Text.ParserCombinators.UU.BasicInstances hiding (Parser)
 import qualified Text.ParserCombinators.UU.Core           as PCC (parse)
@@ -71,7 +72,7 @@ pTagE =  O                 <$  pToken "~RESULT"
      <|> Clk Nothing       <$  pToken "~CLKO"
      <|> (Rst . Just)      <$> (pToken "~RST" *> pBrackets pNatural)
      <|> Rst Nothing       <$  pToken "~RSTO"
-     <|> Sym               <$> (pToken "~SYM" *> pBrackets pNatural)
+     <|> (Sym Text.empty)  <$> (pToken "~SYM" *> pBrackets pNatural)
      <|> Typ Nothing       <$  pToken "~TYPO"
      <|> (Typ . Just)      <$> (pToken "~TYP" *> pBrackets pNatural)
      <|> TypM Nothing      <$  pToken "~TYPMO"
@@ -95,6 +96,8 @@ pTagE =  O                 <$  pToken "~RESULT"
      <|> (BV False)        <$> (pToken "~FROMBV" *> pBrackets pSigD) <*> pBrackets pTagE
      <|> IsLit             <$> (pToken "~ISLIT" *> pBrackets pNatural)
      <|> IsVar             <$> (pToken "~ISVAR" *> pBrackets pNatural)
+     <|> GenSym            <$> (pToken "~GENSYM" *> pBrackets pSigD) <*> pBrackets pNatural
+     <|> And               <$> (pToken "~AND" *> listParser pTagE)
 
 
 -- | Parse a bracketed text

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
@@ -45,6 +45,7 @@ data Element = C   !Text         -- ^ Constant
              | BV !Bool [Element] !Element -- ^ Convert to (True)/from(False) a bit-vector
              | IsLit !Int
              | IsVar !Int
+             | Vars !Int
              | GenSym [Element] !Int
              | SigD [Element] !(Maybe Int)
   deriving Show

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
@@ -19,7 +19,7 @@ data Element = C   !Text         -- ^ Constant
              | O                 -- ^ Output hole
              | I   !Int          -- ^ Input hole
              | L   !Int          -- ^ Literal hole
-             | Sym !Int          -- ^ Symbol hole
+             | Sym !Text !Int    -- ^ Symbol hole
              | Clk !(Maybe Int)  -- ^ Clock hole (Maybe clk corresponding to
                                  -- input, clk corresponding to output if Nothing)
              | Rst !(Maybe Int)  -- ^ Reset hole
@@ -37,6 +37,7 @@ data Element = C   !Text         -- ^ Constant
              | Gen !Bool         -- ^ Hole marking beginning (True) or end (False)
                                  -- of a generative construct
              | IF !Element [Element] [Element]
+             | And [Element]
              | IW64              -- ^ Hole indicating whether Int/Word/Integer
                                  -- are 64-Bit
              | HdlSyn HdlSyn     -- ^ Hole indicating which synthesis tool we're
@@ -44,6 +45,7 @@ data Element = C   !Text         -- ^ Constant
              | BV !Bool [Element] !Element -- ^ Convert to (True)/from(False) a bit-vector
              | IsLit !Int
              | IsVar !Int
+             | GenSym [Element] !Int
              | SigD [Element] !(Maybe Int)
   deriving Show
 

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
@@ -102,7 +102,7 @@ setSym l = evalStateT (mapM setSym' l) IntMap.empty
             t' <- lift (mkUniqueIdentifier (concatT t))
             modify (IntMap.insert i t')
             return (GenSym [C t'] i)
-          Just _ -> error ("Symbol #" ++ show i ++ " is already defined")
+          Just _ -> error ("Symbol #" ++ show (t,i) ++ " is already defined")
       D (Decl n l') -> D <$> (Decl n <$> mapM (combineM (mapM setSym') (mapM setSym')) l')
       IF c t f      -> IF <$> pure c <*> mapM setSym' t <*> mapM setSym' f
       SigD e' m     -> SigD <$> (mapM setSym' e') <*> pure m

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -53,7 +53,6 @@ data NetlistState
   , _primitives     :: PrimMap BlackBoxTemplate -- ^ Primitive Definitions
   , _typeTranslator :: HashMap TyConName TyCon -> Type -> Maybe (Either String HWType) -- ^ Hardcoded Type -> HWType translator
   , _tcCache        :: HashMap TyConName TyCon -- ^ TyCon cache
-  , _modNm          :: !String -- ^ Name of the module containing the @topEntity@
   , _curCompNm      :: !Identifier
   , _dataFiles      :: [(String,FilePath)]
   , _intWidth       :: Int

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -49,7 +49,6 @@ data NetlistState
   { _bindings       :: HashMap TmName (Type,Term) -- ^ Global binders
   , _varEnv         :: Gamma -- ^ Type environment/context
   , _varCount       :: !Int -- ^ Number of signal declarations
-  , _cmpCount       :: !Int -- ^ Number of create components
   , _components     :: HashMap TmName Component -- ^ Cached components
   , _primitives     :: PrimMap BlackBoxTemplate -- ^ Primitive Definitions
   , _typeTranslator :: HashMap TyConName TyCon -> Type -> Maybe (Either String HWType) -- ^ Hardcoded Type -> HWType translator
@@ -58,8 +57,9 @@ data NetlistState
   , _curCompNm      :: !Identifier
   , _dataFiles      :: [(String,FilePath)]
   , _intWidth       :: Int
-  , _mkBasicIdFn    :: String -> String
+  , _mkBasicIdFn    :: Identifier -> Identifier
   , _seenIds        :: [Identifier]
+  , _seenComps      :: [Identifier]
   }
 
 -- | Signal reference

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -60,6 +60,7 @@ data NetlistState
   , _mkBasicIdFn    :: Identifier -> Identifier
   , _seenIds        :: [Identifier]
   , _seenComps      :: [Identifier]
+  , _componentNames :: HashMap TmName Identifier
   }
 
 -- | Signal reference

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -291,15 +291,6 @@ mkUnique = go []
       let iN_unpacked = unpack iN
           i'          = modifyVarName (repName iN_unpacked) i
       go (i':processed) ((i,i'):subst) is
-      --iN <- mkBasicId . pack . name2String $ varName i
-      --if any ((== iN).pack.name2String.varName) seen
-      --   then do
-      --     varCnt <- varCount <<%= (+1)
-      --     let i' = modifyVarName (repName ((unpack iN) ++ '_':show varCnt)) i
-      --     go (i':processed) (i':seen) ((i,i'):subst) is
-      --   else do
-      --     let i' = modifyVarName (repName (unpack iN)) i
-      --     go (i':processed) (i':seen) ((i,i'):subst) is
 
     repName s n = makeName s (name2Integer n)
 

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -20,6 +20,7 @@ import           Data.HashMap.Strict     (HashMap)
 import qualified Data.HashMap.Strict     as HashMap
 import           Data.Maybe              (catMaybes,fromMaybe)
 import           Data.Text.Lazy          (append,pack,unpack)
+import qualified Data.Text.Lazy          as Text
 import           Unbound.Generics.LocallyNameless (Embed, Fresh, bind, embed, makeName,
                                           name2Integer, name2String, unbind,
                                           unembed, unrec)
@@ -38,9 +39,12 @@ import           CLaSH.Netlist.Types     as HW
 import           CLaSH.Util
 
 mkBasicId :: Identifier -> NetlistMonad Identifier
-mkBasicId s = do
-  f <- Lens.use mkBasicIdFn
-  return (f s)
+mkBasicId n = do
+  f  <- Lens.use mkBasicIdFn
+  let n' = f n
+  if Text.null n'
+     then return (pack "x")
+     else return n'
 
 -- | Split a normalized term into: a list of arguments, a list of let-bindings,
 -- and a variable reference that is the body of the let-binding. Returns a

--- a/clash-systemverilog/primitives/CLaSH.Driver.TopWrapper.json
+++ b/clash-systemverilog/primitives/CLaSH.Driver.TopWrapper.json
@@ -2,8 +2,8 @@
     { "name"      : "CLaSH.TopWrapper.syncReset"
     , "templateD" :
 "// reset ~RESULT is asynchronously asserted, but synchronously de-asserted
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
+~SIGD[~GENSYM[r1][0]][0];
+~SIGD[~GENSYM[r2][1]][0];
 
 always_ff @(posedge ~CLKO or negedge ~ARG[0])
 if (~ ~ARG[0]) begin

--- a/clash-systemverilog/primitives/CLaSH.Prelude.BlockRam.File.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.BlockRam.File.json
@@ -12,21 +12,21 @@
                -> Signal' clk (BitVector m)"
     , "templateD" :
 "// blockRamFile begin
-~SIGDO[RAM_~SYM[0]] [0:~LIT[2]-1];
-~SIGD[dout_~SYM[1]][7];
+~SIGDO[~GENSYM[RAM][0]] [0:~LIT[2]-1];
+~SIGD[~GENSYM[dout][1]][7];
 
 initial begin
-  $readmemb(~FILE[~LIT[3]],RAM_~SYM[0]);
+  $readmemb(~FILE[~LIT[3]],~SYM[0]);
 end
 
-always @(posedge ~CLK[1]) begin : blockRamFile_~COMPNAME_~SYM[2]
+always @(posedge ~CLK[1]) begin : ~GENSYM[~COMPNAME_blockRamFile][2]
   if (~ARG[7]) begin
-    RAM_~SYM[0][~ARG[4]] <= ~ARG[7];
+    ~SYM[0][~ARG[4]] <= ~ARG[7];
   end
-  dout_~SYM[1] <= RAM_~SYM[0][~ARG[6]];
+  ~SYM[1] <= ~SYM[0][~ARG[6]];
 end
 
-assign ~RESULT = dout_~SYM[1];
+assign ~RESULT = ~SYM[1];
 // blockRamFile end"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Prelude.BlockRam.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.BlockRam.json
@@ -11,30 +11,30 @@
            -> Signal' clk a"
     , "templateD" :
 "// blockRam begin
-typedef logic [~SIZE[~TYPO]-1:0] RAM_array_~SYM[4] [0:~LENGTH[~TYP[2]]-1];
-RAM_array_~SYM[4] RAM_~SYM[0];
-logic [~SIZE[~TYPO]-1:0] dout_~SYM[1];
+typedef logic [~SIZE[~TYPO]-1:0] ~GENSYM[RAM_array][4] [0:~LENGTH[~TYP[2]]-1];
+~SYM[4] ~GENSYM[RAM][0];
+logic [~SIZE[~TYPO]-1:0] ~GENSYM[dout][1];
 
-function RAM_array_~SYM[4] init_to_bv_~SYM[2];
+function ~SYM[4] ~GENSYM[init_to_bv][2];
   input ~SIGD[value][2];
   begin
-    for (int i_~SYM[3]=0; i_~SYM[3]<~LENGTH[~TYP[2]]; i_~SYM[3]=i_~SYM[3]+1)
-      init_to_bv_~SYM[2][i_~SYM[3]] = ~TOBV[value[ i_~SYM[3] ]][6];
+    for (int ~GENSYM[i][5]=0; ~SYM[5]<~LENGTH[~TYP[2]]; ~SYM[5]=~SYM[5]+1)
+      ~SYM[2][i] = ~TOBV[value[ ~SYM[5] ]][~TYP[6]];
   end
 endfunction
 
 initial begin
-  RAM_~SYM[0] = init_to_bv_~SYM[2](~LIT[2]);
+  ~SYM[0] = ~SYM[2](~LIT[2]);
 end
 
-always @(posedge ~CLK[1]) begin : blockRam_~COMPNAME_~SYM[3]
+always @(posedge ~CLK[1]) begin : ~GENSYM[~COMPNAME_blockRam][3]
   if (~ARG[5]) begin
-    RAM_~SYM[0][~ARG[3]] <= ~TOBV[~ARG[6]][6];
+    ~SYM[0][~ARG[3]] <= ~TOBV[~ARG[6]][~TYP[6]];
   end
-  dout_~SYM[1] <= RAM_~SYM[0][~ARG[4]];
+  ~SYM[1] <= ~SYM[0][~ARG[4]];
 end
 
-assign ~RESULT = ~FROMBV[dout_~SYM[1]][6];
+assign ~RESULT = ~FROMBV[~SYM[1]][~TYP[6]];
 // blockRam end"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Prelude.RAM.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.RAM.json
@@ -11,15 +11,15 @@
            -> Signal' rclk a"
     , "templateD" :
 "// asyncRam begin
-~SIGD[RAM_~SYM[0]][6] [0:~LIT[2]-1];
+~SIGD[~GENSYM[RAM][0]][6] [0:~LIT[2]-1];
 
-always @(posedge ~CLK[0]) begin : Ram_~COMPNAME_~SYM[4]
+always @(posedge ~CLK[0]) begin : ~GENSYM[~COMPNAME_Ram][4]
   if (~ARG[5]) begin
-    RAM_~SYM[0][~ARG[3]] <= ~ARG[6];
+    ~SYM[0][~ARG[3]] <= ~ARG[6];
   end
 end
 
-assign ~RESULT = RAM_~SYM[0][~ARG[4]];
+assign ~RESULT = ~SYM[0][~ARG[4]];
 // asyncRam end"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Prelude.ROM.File.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.ROM.File.json
@@ -8,13 +8,13 @@
               -> BitVector m"
     , "templateD" :
 "// asyncRomFile begin
-~SIGDO[ROM_~SYM[0]] [0:~LIT[1]-1];
+~SIGDO[~GENSYM[ROM][0]] [0:~LIT[1]-1];
 
 initial begin
-  $readmemb(~FILE[~LIT[2]],ROM_~SYM[0]);
+  $readmemb(~FILE[~LIT[2]],~SYM[0]);
 end
 
-assign ~RESULT = ROM_~SYM[0][~ARG[3]];
+assign ~RESULT = ~SYM[0][~ARG[3]];
 // asyncRomFile end"
     }
   }
@@ -29,18 +29,18 @@ assign ~RESULT = ROM_~SYM[0][~ARG[3]];
           -> Signal' clk (BitVector m)"
     , "templateD" :
 "// romFile begin
-~SIGDO[ROM_~SYM[0]] [0:~LIT[2]-1];
+~SIGDO[~GENSYM[ROM][0]] [0:~LIT[2]-1];
 
 initial begin
-  $readmemb(~FILE[~LIT[3]],ROM_~SYM[0]);
+  $readmemb(~FILE[~LIT[3]],~SYM[0]);
 end
 
-~SIGDO[dout_~SYM[1]];
-always @(posedge ~CLK[1]) begin : romFile_~COMPNAME_~SYM[2]
-  dout_~SYM[1] <= ROM_~SYM[0][~ARG[4]];
+~SIGDO[~GENSYM[dout][1]];
+always @(posedge ~CLK[1]) begin : ~GENSYM[~COMPNAME_romFile][2]
+  ~SYM[1] <= ~SYM[0][~ARG[4]];
 end
 
-assign ~RESULT = dout_~SYM[1];
+assign ~RESULT = ~SYM[1];
 // romFile end"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Prelude.ROM.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.ROM.json
@@ -7,10 +7,10 @@
            -> a"
     , "templateD" :
 "// asyncRom begin
-~SIGD[ROM_~SYM[0]][1];
-assign ROM_SYM[0] = ~ARG[1];
+~SIGD[~GENSYM[ROM][0]][1];
+assign ~SYM[0] = ~ARG[1];
 
-assign ~RESULT = ROM_~SYM[0][~ARG[2]];
+assign ~RESULT = ~SYM[0][~ARG[2]];
 // asyncRom end"
     }
   }
@@ -24,15 +24,15 @@ assign ~RESULT = ROM_~SYM[0][~ARG[2]];
       -> Signal' clk a"
     , "templateD" :
 "// rom begin
-~SIGD[ROM_~SYM[0]][2];
-assign ROM_~SYM[0] = ~ARG[2];
+~SIGD[~GENSYM[ROM][0]][2];
+assign ~SYM[0] = ~ARG[2];
 
-~SIGDO[dout_~SYM[1]];
-always @(posedge ~CLK[1]) begin : rom_~COMPNAME_~SYM[2]
-  dout_~SYM[1] <= ROM_~SYM[0][~ARG[3]];
+~SIGDO[~GENSYM[dout][1]];
+always @(posedge ~CLK[1]) begin : ~GENSYM[~COMPNAME_rom][2]
+  ~SYM[1] <= ~SYM[0][~ARG[3]];
 end
 
-assign ~RESULT = dout_~SYM[1];
+assign ~RESULT = ~SYM[1];
 // rom end"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Prelude.Testbench.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.Testbench.json
@@ -13,7 +13,7 @@
 // pragma translate_off
 always @(posedge ~CLK[2] or posedge ~RST[2]) begin
   if (~ARG[4] !== ~ARG[5]) begin
-    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[3], ~TYPM[5]_to_lv(~ARG[5]), ~TYPM[4]_to_lv(~ARG[4]));
+    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[3], ~TOBV[~ARG[5]][~TYP[5]], ~TOBV[~ARG[4]][~TYP[4]]);
     $stop;
   end
 end

--- a/clash-systemverilog/primitives/CLaSH.Signal.Internal.json
+++ b/clash-systemverilog/primitives/CLaSH.Signal.Internal.json
@@ -7,9 +7,9 @@
            -> Signal' clk a"
     , "templateD" :
 "// register begin
-~SIGD[~SYM[0]][2];
+~SIGD[~GENSYM[dout][0]][2];
 
-always_ff @(posedge ~CLK[0] or negedge ~RST[0]) begin : register_~COMPNAME_~SYM[1]
+always_ff @(posedge ~CLK[0] or negedge ~RST[0]) begin : ~GENSYM[~COMPNAME_register][1]
   if (~ ~RST[0]) begin
     ~SYM[0] <= ~ARG[1];
   end else begin
@@ -31,9 +31,9 @@ assign ~RESULT = ~SYM[0];
         -> Signal' clk a"
     , "templateD" :
 "// regEn begin
-~SIGD[~SYM[0]][3];
+~SIGD[~GENSYM[dout][0]][3];
 
-always_ff @(posedge ~CLK[0] or negedge ~RST[0]) begin : regEn_~COMPNAME_~SYM[1]
+always_ff @(posedge ~CLK[0] or negedge ~RST[0]) begin : ~GENSYM[~COMPNAME_regEn][1]
   if (~ ~RST[0]) begin
     ~SYM[0] <= ~ARG[1];
   end else begin

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -55,10 +55,10 @@
         -> Bit"
     , "templateD" :
 "// indexBit begin
-~SIGD[vec_~SYM[0]][1];
-assign vec_~SYM[0] = ~ARG[1];
+~SIGD[~GENSYM[bv][0]][1];
+assign ~SYM[0] = ~ARG[1];
 
-assign ~RESULT = vec_~SYM[0][~ARG[2]];
+assign ~RESULT = ~SYM[0][~ARG[2]];
 // indexBit end"
     }
   }
@@ -72,16 +72,14 @@ assign ~RESULT = vec_~SYM[0][~ARG[2]];
              -> BitVector n"
     , "templateD" :
 "// replaceBit start
-~SIGD[vec_~SYM[0]][1];
-~SIGD[din_~SYM[1]][3];
-assign din_~SYM[1] = ~ARG[3];
+~SIGD[~GENSYM[bv][0]][1];
 
 always_comb begin
-  vec_~SYM[0] = ~ARG[1];
-  vec_~SYM[0][~ARG[2]] = din_~SYM[1];
+  ~SYM[0] = ~ARG[1];
+  ~SYM[0][~ARG[2]] = ~ARG[3];
 end
 
-assign ~RESULT = vec_~SYM[0];
+assign ~RESULT = ~SYM[0];
 // replaceBit end"
     }
   }
@@ -95,7 +93,7 @@ assign ~RESULT = vec_~SYM[0];
            -> BitVector (m + 1 + i)"
     , "templateD" :
 "// setSlice begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[bv][0]][0];
 
 always_comb begin
   ~SYM[0] = ~ARG[0];
@@ -115,7 +113,7 @@ assign ~RESULT = ~SYM[0];
         -> BitVector (m + 1 - n)"
     , "templateD" :
 "// slice begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[bv][0]][0];
 assign ~SYM[0] = ~ARG[0];
 assign ~RESULT = ~SYM[0][~LIT[1] : ~LIT[2]];
 // slice end"
@@ -129,7 +127,7 @@ assign ~RESULT = ~SYM[0][~LIT[1] : ~LIT[2]];
         -> (BitVector m, BitVector n)"
     , "templateD" :
 "// split begin
-~SIGD[~SYM[0]][1];
+~SIGD[~GENSYM[bv][0]][1];
 assign ~SYM[0] = ~ARG[1];
 assign ~RESULT = '{ ~SYM[0][$high(~SYM[0]) : ~LIT[0]]
                   , ~SYM[0][(~LIT[0]-1) : 0]
@@ -145,7 +143,7 @@ assign ~RESULT = '{ ~SYM[0][$high(~SYM[0]) : ~LIT[0]]
       -> Bit"
     , "templateD" :
 "// msb begin~IF ~LIT[0] ~THEN
-~SIGD[~SYM[0]][1];
+~SIGD[~GENSYM[bv][0]][1];
 assign ~SYM[0] = ~ARG[1];
 assign ~RESULT = ~SYM[0][~LIT[0]-1];
 ~ELSE
@@ -160,7 +158,7 @@ assign ~RESULT = 1'b0;
       -> Bit"
     , "templateD" :
 "// lsb begin~IF ~SIZE[~TYP[0]] ~THEN
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[bv][0]][0];
 assign ~SYM[0] = ~ARG[0];
 assign ~RESULT = ~SYM[0][0];
 ~ELSE
@@ -323,7 +321,7 @@ assign ~RESULT = 1'b0;
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
 "// rotateL begin
-logic [2*~LIT[0]-1:0] ~SYM[0];
+logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
 assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
 // rotateL end"
@@ -334,7 +332,7 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
 "// rotateR begin
-logic [2*~LIT[0]-1:0] ~SYM[0];
+logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
 assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
 // rotateR end"

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
@@ -137,9 +137,9 @@
     , "type"      : "div# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// divSigned begin
-~SIGD[~SYM[0]][1];
-~SIGD[~SYM[1]][1];
-~SIGD[~SYM[2]][2];
+~SIGD[~GENSYM[quot_res][0]][1];
+~SIGD[~GENSYM[dividend][1]][1];
+~SIGD[~GENSYM[divider][2]][2];
 
 // divide (rounds towards zero)
 assign ~SYM[0] = ~ARG[1] / ~ARG[2];
@@ -156,9 +156,9 @@ assign ~RESULT = (~SYM[1][~LIT[0]-1] == ~SYM[2][~LIT[0]-1]) ? ~SYM[0] : ~SYM[0] 
     , "type"      : "mod# :: Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// modSigned begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
-~SIGD[~SYM[2]][1];
+~SIGD[~GENSYM[rem_res][0]][0];
+~SIGD[~GENSYM[dividend][1]][0];
+~SIGD[~GENSYM[divider][2]][1];
 
 // remainder
 assign ~SYM[0] = ~ARG[0] % ~ARG[1];
@@ -219,7 +219,7 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateD" :
 "// rotateL begin
-logic [2*~LIT[0]-1:0] ~SYM[0];
+logic [2*~LIT[0]-1:0] ~GENSYM[s][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
 assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);
 // rotateL end"
@@ -230,7 +230,7 @@ assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateD" :
 "// rotateR begin
-logic [2*~LIT[0]-1:0] ~SYM[0];
+logic [2*~LIT[0]-1:0] ~GENSYM[s][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
 assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);
 // rotateR end"
@@ -245,7 +245,7 @@ assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);
 ~GENERATE
   if (~LIT[1] < ~LIT[0]) begin
     // truncate, sign preserving
-    ~SIGD[~SYM[0]][2];
+    ~SIGD[~GENSYM[s][0]][2];
     assign ~SYM[0] = ~ARG[2];
     assign ~RESULT = $signed({~SYM[0][~LIT[0]-1],~SYM[0][(~LIT[1]-2):0]});
   end else begin

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Unsigned.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Unsigned.json
@@ -171,7 +171,7 @@
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateD" :
 "// rotateL begin
-logic [2*~LIT[0]-1:0] ~SYM[0];
+logic [2*~LIT[0]-1:0] ~GENSYM[u][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
 assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];
 // rotateL end"
@@ -182,7 +182,7 @@ assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateD" :
 "// rotateR begin
-logic [2*~LIT[0]-1:0] ~SYM[0];
+logic [2*~LIT[0]-1:0] ~GENSYM[u][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
 assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];
 // rotateR end"

--- a/clash-systemverilog/primitives/CLaSH.Sized.Vector.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Vector.json
@@ -3,7 +3,7 @@
     , "type"      : "head :: Vec (n + 1) a -> a"
     , "templateD" :
 "// head begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = ~SYM[0][0];
@@ -15,7 +15,7 @@ assign ~RESULT = ~SYM[0][0];
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
     , "templateD" :
 "// tail begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = ~SYM[0][1 : $high(~SYM[0])];
@@ -27,7 +27,7 @@ assign ~RESULT = ~SYM[0][1 : $high(~SYM[0])];
     , "type"      : "Vec (n + 1) a -> a"
     , "templateD" :
 "// last begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = ~SYM[0][$high(~SYM[0])];
@@ -39,7 +39,7 @@ assign ~RESULT = ~SYM[0][$high(~SYM[0])];
     , "type"      : "Vec (n + 1) a -> Vec n a"
     , "templateD" :
 "// init begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = ~SYM[0][0 : $high(~SYM[0]) - 1];
@@ -57,12 +57,12 @@ assign ~RESULT = ~SYM[0][0 : $high(~SYM[0]) - 1];
         -> Vec n a"
     , "templateD" :
 "// select begin
-~SIGD[~SYM[0]][4];
+~SIGD[~GENSYM[vec][0]][4];
 assign ~SYM[0] = ~ARG[4];
 
-genvar ~SYM[1];
+genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1]=0; ~SYM[1] < ~LIT[3]; ~SYM[1] = ~SYM[1] + 1) begin : select_~SYM[2]
+  for (~SYM[1]=0; ~SYM[1] < ~LIT[3]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[select][2]
     assign ~RESULT[~SYM[1]] = ~SYM[0][~LIT[1] + (~LIT[2] * ~SYM[1])];
   end
 ~ENDGENERATE
@@ -74,15 +74,15 @@ genvar ~SYM[1];
     , "type"      : "(++) :: Vec n a -> Vec m a -> Vec (n + m) a"
     , "templateD" :
 "// (++) begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][1];
+~SIGD[~GENSYM[vec1][0]][0];
+~SIGD[~GENSYM[vec2][1]][1];
 
 assign ~SYM[0] = ~ARG[0];
 assign ~SYM[1] = ~ARG[1];
 
-genvar ~SYM[2];
+genvar ~GENSYM[n][2];
 ~GENERATE
-  for (~SYM[2]=0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : append_~SYM[3]
+  for (~SYM[2]=0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[append][3]
     if (~SYM[2] < $size(~SYM[0])) begin
       assign ~RESULT[~SYM[2]] = ~SYM[0][~SYM[2]];
     end else begin
@@ -98,12 +98,12 @@ genvar ~SYM[2];
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "templateD" :
 "// concat begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
-genvar ~SYM[1];
+genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1]=0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : concat_~SYM[2]
+  for (~SYM[1]=0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[concat][2]
     assign ~RESULT[(~SYM[1] * $size(~SYM[0][0])) : ((~SYM[1] * $size(~SYM[0][0])) + $high(~SYM[0][0]))] = ~SYM[0][~SYM[1]];
   end
 ~ENDGENERATE
@@ -115,7 +115,7 @@ genvar ~SYM[1];
     , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
     , "templateD" :
 "// splitAt begin
-~SIGD[~SYM[0]][1];
+~SIGD[~GENSYM[vec][0]][1];
 assign ~SYM[0] = ~ARG[1];
 
 assign ~RESULT = '{~SYM[0][$left(~RESULT.~TYPMO_sel0) : $right(~RESULT.~TYPMO_sel0)]
@@ -133,12 +133,12 @@ assign ~RESULT = '{~SYM[0][$left(~RESULT.~TYPMO_sel0) : $right(~RESULT.~TYPMO_se
            -> Vec n (Vec m a)"
     , "templateD" :
 "// unconcat begin
-~SIGD[~SYM[0]][2];
+~SIGD[~GENSYM[vec][0]][2];
 assign ~SYM[0] = ~ARG[2];
 
-genvar ~SYM[1];
+genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : unconcat_~SYM[2]
+  for (~SYM[1] = 0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[unconcat][2]
     assign ~RESULT[~SYM[1]] = ~SYM[0][(~SYM[1] * ~LIT[1]) : ((~SYM[1] * ~LIT[1]) + ~LIT[1] - 1)];
   end
 ~ENDGENERATE
@@ -150,12 +150,12 @@ genvar ~SYM[1];
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// map begin
-~SIGD[~SYM[0]][1];
+~SIGD[~GENSYM[vec][0]][1];
 assign ~SYM[0] = ~ARG[1];
 
-genvar ~SYM[1];
+genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : map_~SYM[2]
+  for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]
     ~INST 0
       ~OUTPUT <= ~RESULT[~SYM[1]]~ ~TYPEL[~TYPO]~
       ~INPUT  <= ~SYM[0][~SYM[1]]~ ~TYPEL[~TYP[1]]~
@@ -170,13 +170,13 @@ genvar ~SYM[1];
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// imap begin
-~SIGD[~SYM[0]][2];
+~SIGD[~GENSYM[vec][0]][2];
 assign ~SYM[0] = ~ARG[2];
 
-genvar ~SYM[1];
+genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : map_~SYM[2]
-    logic [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~SYM[3];
+  for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
+    logic [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~GENSYM[i][3];
     assign ~SYM[3] = ~SYM[1];
     ~INST 1
       ~OUTPUT <= ~RESULT[~SYM[1]]~ ~TYPEL[~TYPO]~
@@ -193,14 +193,14 @@ genvar ~SYM[1];
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "templateD" :
 "// zipWith begin
-~SIGD[~SYM[0]][1];
-~SIGD[~SYM[1]][2];
+~SIGD[~GENSYM[vec1][0]][1];
+~SIGD[~GENSYM[vec2][1]][2];
 assign ~SYM[0] = ~ARG[1];
 assign ~SYM[1] = ~ARG[2];
 
-genvar ~SYM[2];
+genvar ~GENSYM[n][2];
 ~GENERATE
-  for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : zipWith_~SYM[2]
+  for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][3]
     ~INST 0
       ~OUTPUT <= ~RESULT[~SYM[2]]~ ~TYPEL[~TYPO]~
       ~INPUT  <= ~SYM[0][~SYM[2]]~ ~TYPEL[~TYP[1]]~
@@ -216,24 +216,24 @@ genvar ~SYM[2];
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "templateD" :
 "// foldr start~IF ~LENGTH[~TYP[2]] ~THEN
-~SIGDO[intermediate_~SYM[0]] [0:~LENGTH[~TYP[2]]];
-assign intermediate_~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];
+~SIGDO[~GENSYM[intermediate][0]] [0:~LENGTH[~TYP[2]]];
+assign ~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];
 
-~SIGD[xs_~SYM[2]][2];
-assign xs_~SYM[2] = ~ARG[2];
+~SIGD[~GENSYM[xs][2]][2];
+assign ~SYM[2] = ~ARG[2];
 
-genvar i_~SYM[3];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i_~SYM[3]=0; i_~SYM[3] < ~LENGTH[~TYP[2]]; i_~SYM[3]=i_~SYM[3]+1) begin : foldr_loop
+for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr_loop][4]
   ~INST 0
-    ~OUTPUT <= intermediate_~SYM[0][i_~SYM[3]]~ ~TYP[1]~
-    ~INPUT <= xs_~SYM[2][i_~SYM[3]]~ ~TYPEL[~TYP[2]]~
-    ~INPUT <= intermediate_~SYM[0][i_~SYM[3]+1]~ ~TYP[1]~
+    ~OUTPUT <= ~SYM[0][~SYM[3]]~ ~TYP[1]~
+    ~INPUT <= ~SYM[2][~SYM[3]]~ ~TYPEL[~TYP[2]]~
+    ~INPUT <= ~SYM[0][~SYM[3]+1]~ ~TYP[1]~
   ~INST
 end
 ~ENDGENERATE
 
-assign ~RESULT = intermediate_~SYM[0][0];
+assign ~RESULT = ~SYM[0][0];
 ~ELSE
 assign ~RESULT = ~ARG[1];
 ~FI// foldr end"
@@ -246,32 +246,32 @@ assign ~RESULT = ~ARG[1];
     , "templateD" :
 "// fold begin
 // put flat input array into the first half of the intermediate array
-~SIGDO[intermediate_~SYM[0]][0:(2*~LENGTH[~TYP[1]])-2];
-assign intermediate_~SYM[0][0:~LENGTH[~TYP[1]]-1] = ~ARG[1];
+~SIGDO[~GENSYM[intermediate][0]][0:(2*~LENGTH[~TYP[1]])-2];
+assign ~SYM[0][0:~LENGTH[~TYP[1]]-1] = ~ARG[1];
 
 // calculate the depth of the tree
-localparam levels_~SYM[4] = $clog2(~LENGTH[~TYP[1]]);
+localparam ~GENSYM[levels][4] = $clog2(~LENGTH[~TYP[1]]);
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[8];
+function integer ~GENSYM[depth2Index][8];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[8] = (2 ** levels) - (2 ** depth);
+  ~SYM[8] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[5];
-genvar i_~SYM[6];
+genvar ~GENSYM[d][5];
+genvar ~GENSYM[i][6];
 ~GENERATE
-if (levels_~SYM[4] != 0) begin : make_tree_~SYM[7]
-  for (d_~SYM[5] = (levels_~SYM[4] - 1); d_~SYM[5] >= 0; d_~SYM[5]=d_~SYM[5]-1) begin : tree_depth
-    for (i_~SYM[6] = 0; i_~SYM[6] < (2**d_~SYM[5]); i_~SYM[6] = i_~SYM[6]+1) begin : tree_depth_loop
+if (~SYM[4] != 0) begin : ~GENSYM[make_tree][7]
+  for (~SYM[5] = (~SYM[4] - 1); ~SYM[5] >= 0; ~SYM[5]=~SYM[5]-1) begin : tree_depth
+    for (~SYM[6] = 0; ~SYM[6] < (2**~SYM[5]); ~SYM[6] = ~SYM[6]+1) begin : tree_depth_loop
         ~INST 0
-          ~OUTPUT <= intermediate_~SYM[0][depth2Index_~SYM[8](levels_~SYM[4]+1,d_~SYM[5]+1)+i_~SYM[6]]~ ~TYPO~
-          ~INPUT  <= intermediate_~SYM[0][depth2Index_~SYM[8](levels_~SYM[4]+1,d_~SYM[5]+2)+(2*i_~SYM[6])]~ ~TYPO~
-          ~INPUT  <= intermediate_~SYM[0][depth2Index_~SYM[8](levels_~SYM[4]+1,d_~SYM[5]+2)+(2*i_~SYM[6])+1]~ ~TYPO~
+          ~OUTPUT <= ~SYM[0][~SYM[8](~SYM[4]+1,~SYM[5]+1)+~SYM[6]]~ ~TYPO~
+          ~INPUT  <= ~SYM[0][~SYM[8](~SYM[4]+1,~SYM[5]+2)+(2*~SYM[6])]~ ~TYPO~
+          ~INPUT  <= ~SYM[0][~SYM[8](~SYM[4]+1,~SYM[5]+2)+(2*~SYM[6])+1]~ ~TYPO~
         ~INST
     end
   end
@@ -279,7 +279,7 @@ end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = intermediate_~SYM[0][(2*~LENGTH[~TYP[1]])-2];
+assign ~RESULT = ~SYM[0][(2*~LENGTH[~TYP[1]])-2];
 // fold end"
     }
   }
@@ -288,10 +288,10 @@ assign ~RESULT = intermediate_~SYM[0][(2*~LENGTH[~TYP[1]])-2];
     , "type"      : "index_integer :: KnownNat n => Vec n a -> Int -> a"
     , "templateD" :
 "// indexVec begin
-~SIGD[vec_~SYM[0]][1];
-assign vec_~SYM[0] = ~ARG[1];
+~SIGD[~GENSYM[vec][0]][1];
+assign ~SYM[0] = ~ARG[1];
 
-assign ~RESULT = vec_~SYM[0][~ARG[2]];
+assign ~RESULT = ~SYM[0][~ARG[2]];
 // indexVec end"
     }
   }
@@ -300,16 +300,14 @@ assign ~RESULT = vec_~SYM[0][~ARG[2]];
     , "type"      : "replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a"
     , "templateD" :
 "// replaceVec start
-~SIGD[vec_~SYM[0]][1];
-~SIGD[din_~SYM[1]][3];
-assign din_~SYM[1] = ~ARG[3];
+~SIGD[~GENSYM[vec][0]][1];
 
 always_comb begin
-  vec_~SYM[0] = ~ARG[1];
-  vec_~SYM[0][~ARG[2]] = din_~SYM[1];
+  ~SYM[0] = ~ARG[1];
+  ~SYM[0][~ARG[2]] = ~ARG[3];
 end
 
-assign ~RESULT = vec_~SYM[0];
+assign ~RESULT = ~SYM[0];
 // replaceVec end"
     }
   }
@@ -336,14 +334,14 @@ assign ~RESULT = vec_~SYM[0];
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "templateD" :
 "// transpose begin
-~SIGD[~SYM[0]][1];
+~SIGD[~GENSYM[matrix][0]][1];
 assign ~SYM[0] = ~ARG[1];
 
-genvar ~SYM[1];
-genvar ~SYM[2];
+genvar ~GENSYM[row_index][1];
+genvar ~GENSYM[col_index][2];
 ~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : transpose_outer_~SYM[3]
-    for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : transpose_inner_~SYM[4]
+  for (~SYM[1] = 0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]
+    for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[transpose_inner][4]
       assign ~RESULT[~SYM[2]][~SYM[1]] = ~SYM[0][~SYM[1]][~SYM[2]];
     end
   end
@@ -356,12 +354,12 @@ genvar ~SYM[2];
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "templateD" :
 "// reverse begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
-genvar ~SYM[1];
+genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : reverse_~SYM[2]
+  for (~SYM[1] = 0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]
     assign ~RESULT[$high(~SYM[0]) - ~SYM[1]] = ~SYM[0][~SYM[1]];
   end
 ~ENDGENERATE
@@ -382,12 +380,12 @@ genvar ~SYM[1];
                   -> BitVector (n * m)"
     , "templateD" :
 "// concatBitVector begin
-~SIGD[~SYM[0]][1];
+~SIGD[~GENSYM[vec][0]][1];
 assign ~SYM[0] = ~ARG[1];
 
-genvar ~SYM[1];
+genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : concatBitVector_~SYM[2]
+  for (~SYM[1] = 0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[concatBitVector][2]
     assign ~RESULT[((~SYM[1] * ~LIT[0]) + ~LIT[0] - 1) : (~SYM[1] * ~LIT[0])] = ~SYM[0][$high(~SYM[0]) - ~SYM[1]];
   end
 ~ENDGENERATE
@@ -402,12 +400,12 @@ genvar ~SYM[1];
                     -> Vec n (BitVector m)"
     , "templateD" :
 "// unconcatBitVector begin
-~SIGD[~SYM[0]][2];
+~SIGD[~GENSYM[bv][0]][2];
 assign ~SYM[0] = ~ARG[2];
 
-genvar ~SYM[1];
+genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : unconcatBitVector_~SYM[2]
+  for (~SYM[1] = 0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[unconcatBitVector][2]
     assign ~RESULT[$high(~RESULT) - ~SYM[1]] = ~SYM[0][((~SYM[1] * ~LIT[1]) + ~LIT[1] - 1) : (~SYM[1] * ~LIT[1])];
   end
 ~ENDGENERATE
@@ -419,17 +417,17 @@ genvar ~SYM[1];
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "// rotateLeftS begin
-~SIGD[~SYM[1]][1];
-localparam shift_amount_~SYM[2] = ~LIT[2] % ~LIT[0];
+~SIGD[~GENSYM[vec][1]][1];
+localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
 
 assign ~SYM[1] = ~ARG[1];
 
 ~GENERATE
-if (shift_amount_~SYM[2] == 0) begin : no_shift_~SYM[3]
+if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
   assign ~RESULT = ~SYM[1];
-end else begin : do_shift_~SYM[4]
-  assign ~RESULT[0:~LIT[0]-shift_amount_~SYM[2]-1] = ~SYM[1][shift_amount_~SYM[2]:~LIT[0]-1];
-  assign ~RESULT[shift_amount_~SYM[2]:~LIT[0]-1] = ~SYM[1][0 to shift_amount_~SYM[2]-1];
+end else begin : ~GENSYM[do_shift][4]
+  assign ~RESULT[0:~LIT[0]-~SYM[2]-1] = ~SYM[1][~SYM[2]:~LIT[0]-1];
+  assign ~RESULT[~SYM[2]:~LIT[0]-1] = ~SYM[1][0 to ~SYM[2]-1];
 end
 ~ENDGENERATE
 // rotateLeftS end"
@@ -440,17 +438,17 @@ end
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "// rotateRightS begin
-~SIGD[~SYM[1]][1];
-localparam shift_amount_~SYM[2] = ~LIT[2] % ~LIT[0];
+~SIGD[~GENSYM[vec][1]][1];
+localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
 
 assign ~SYM[1] = ~ARG[1];
 
 ~GENERATE
-if (shift_amount_~SYM[2] == 0) begin : no_shift_~SYM[3]
+if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
   assign ~RESULT = ~SYM[1];
-end else begin : do_shift_~SYM[4]
-  assign ~RESULT[0:shift_amount_~SYM[2]-1] = ~SYM[1][~LIT[0]-shift_amount_~SYM[2]:~LIT[0]-1];
-  assign ~RESULT[shift_amount_~SYM[2]:~LIT[0]-1] = ~SYM[1][0:~LIT[0]-shift_amount_~SYM[2]-1];
+end else begin : ~GENSYM[do_shift][4]
+  assign ~RESULT[0:~SYM[2]-1] = ~SYM[1][~LIT[0]-~SYM[2]:~LIT[0]-1];
+  assign ~RESULT[~SYM[2]:~LIT[0]-1] = ~SYM[1][0:~LIT[0]-~SYM[2]-1];
 end
 ~ENDGENERATE
 // rotateRightS end"

--- a/clash-systemverilog/primitives/GHC.Base.json
+++ b/clash-systemverilog/primitives/GHC.Base.json
@@ -20,9 +20,9 @@
     , "type"      : "divInt :: Int -> Int -> Int"
     , "templateD" :
 "// divInt begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
-~SIGD[~SYM[2]][1];
+~SIGD[~GENSYM[quot_res][0]][0];
+~SIGD[~GENSYM[dividend][1]][0];
+~SIGD[~GENSYM[divider][2]][1];
 
 // divide (rounds towards zero)
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
@@ -39,9 +39,9 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInt :: Int -> Int -> Int"
     , "templateD" :
 "// modInt begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
-~SIGD[~SYM[2]][1];
+~SIGD[~GENSYM[rem_res][0]][0];
+~SIGD[~GENSYM[dividend][1]][0];
+~SIGD[~GENSYM[divider][2]][1];
 
 // remainder
 assign ~SYM[0] = ~ARG[0] % ~ARG[1];

--- a/clash-systemverilog/primitives/GHC.Classes.json
+++ b/clash-systemverilog/primitives/GHC.Classes.json
@@ -57,9 +57,9 @@
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "templateD" :
 "// divInt begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
-~SIGD[~SYM[2]][1];
+~SIGD[~GENSYM[quot_res][0]][0];
+~SIGD[~GENSYM[dividend][1]][0];
+~SIGD[~GENSYM[divider][2]][1];
 
 // divide (rounds towards zero)
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
@@ -76,9 +76,9 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInt# :: Int# -> Int# -> Int#"
     , "templateD" :
 "// modInt begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
-~SIGD[~SYM[2]][1];
+~SIGD[~GENSYM[rem_res][0]][0];
+~SIGD[~GENSYM[dividend][1]][0];
+~SIGD[~GENSYM[divider][2]][1];
 
 // remainder
 assign ~SYM[0] = ~ARG[0] % ~ARG[1];

--- a/clash-systemverilog/primitives/GHC.Integer.Type.json
+++ b/clash-systemverilog/primitives/GHC.Integer.Type.json
@@ -45,9 +45,9 @@
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// divInteger begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
-~SIGD[~SYM[2]][1];
+~SIGD[~GENSYM[quot_res][0]][0];
+~SIGD[~GENSYM[dividend][1]][0];
+~SIGD[~GENSYM[divider][2]][1];
 
 // divide (rounds towards zero)
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
@@ -64,9 +64,9 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// modInteger begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
-~SIGD[~SYM[2]][1];
+~SIGD[~GENSYM[rem_res][0]][0];
+~SIGD[~GENSYM[dividend][1]][0];
+~SIGD[~GENSYM[divider][2]][1];
 
 // remainder
 assign ~SYM[0] = ~ARG[0] % ~ARG[1];

--- a/clash-systemverilog/primitives/GHC.Prim.json
+++ b/clash-systemverilog/primitives/GHC.Prim.json
@@ -75,8 +75,8 @@
     , "type"      : "quotRemInt# :: Int# -> Int# -> (#Int#, Int##)"
     , "templateD" :
 "// quotRemInt begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
+~SIGD[~GENSYM[quot_res][0]][0];
+~SIGD[~GENSYM[rem_res][1]][0];
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
 assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
@@ -215,8 +215,8 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
     , "type"      : "quotRemWord# :: Word# -> Word# -> (#Word#, Word##)"
     , "templateD" :
 "// quotRemWord begin
-~SIGD[~SYM[0]][0];
-~SIGD[~SYM[1]][0];
+~SIGD[~GENSYM[quot_res][0]][0];
+~SIGD[~GENSYM[rem_res][1]][0];
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
 assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
@@ -307,57 +307,47 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
     , "type"      : "popCnt8# :: Word# -> Word#"
     , "templateD" :
 "// popCnt8 begin
-localparam width_~SYM[0] = 8;
-
-// ceiling of log2
-function integer log2_~SYM[1];
-  input integer value;
-  begin
-    value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
-      value = value>>1;
-  end
-endfunction
+localparam ~GENSYM[width][0] = 8;
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
 
-wire [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt8 end"
     }
   }
@@ -366,57 +356,47 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "popCnt16# :: Word# -> Word#"
     , "templateD" :
 "// popCnt16 begin
-localparam width_~SYM[0] = 16;
-
-// ceiling of log2
-function integer log2_~SYM[1];
-  input integer value;
-  begin
-    value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
-      value = value>>1;
-  end
-endfunction
+localparam ~GENSYM[width][0] = 16;
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
 
-logic [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt16 end"
     }
   }
@@ -425,57 +405,47 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "popCnt32# :: Word# -> Word#"
     , "templateD" :
 "// popCnt32 begin
-localparam width_~SYM[0] = 32;
-
-// ceiling of log2
-function integer log2_~SYM[1];
-  input integer value;
-  begin
-    value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
-      value = value>>1;
-  end
-endfunction
+localparam ~GENSYM[width][0] = 32;
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
 
-logic [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt32 end"
     }
   }
@@ -484,57 +454,47 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "popCnt64# :: Word# -> Word#"
     , "templateD" :
 "// popCnt64 begin
-localparam width_~SYM[0] = 64;
-
-// ceiling of log2
-function integer log2_~SYM[1];
-  input integer value;
-  begin
-    value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
-      value = value>>1;
-  end
-endfunction
+localparam ~GENSYM[width][0] = 64;
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
 
-logic [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt64 end"
     }
   }
@@ -543,57 +503,47 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "popCnt8# :: Word# -> Word#"
     , "templateD" :
 "// popCnt begin
-localparam width_~SYM[0] = ~SIZE[~TYPO];
-
-// ceiling of log2
-function integer log2_~SYM[1];
-  input integer value;
-  begin
-    value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
-      value = value>>1;
-  end
-endfunction
+localparam ~GENSYM[width][0] = ~SIZE[~TYPO];
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
 
-logic [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt end"
     }
   }
@@ -602,63 +552,59 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "clz8 :: Word# -> Word#"
     , "templateD" :
 "// clz8 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-logic [0:7] v;
-assign v = ~ARG[0][7:0];
+logic [0:7] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][7:0];
 
-logic [0:7] e;
-genvar i;
+logic [0:7] ~GENSYM[e][2];
+genvar ~GENSYM[n][3];
 ~GENERATE
-for (i=0;i<4;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-logic [0:5] a;
-genvar i1;
+logic [0:5] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<2;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage1][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-logic [0:3] res;
+logic [0:3] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 3;
 logic [5:0] i;
-assign i = a[0:5];
-always @(*) begin
+assign i = ~SYM[4][0:5];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz8 end"
     }
   }
@@ -667,79 +613,75 @@ end
     , "type"      : "clz16 :: Word# -> Word#"
     , "templateD" :
 "// clz16 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-logic [0:15] v;
-assign v = ~ARG[0][15:0];
+logic [0:15] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][15:0];
 
-logic [0:15] e;
-genvar i;
+logic [0:15] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<8;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:11] a;
-genvar i1;
+logic [0:11] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<4;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:7] b;
-genvar i2;
+logic [0:7] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<2;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:4] res;
+logic [0:4] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 4;
 logic [7:0] i;
-assign i = b[0:7];
-always @(*) begin
+assign i = ~SYM[9][0:7];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz16 end"
     }
   }
@@ -748,95 +690,91 @@ end
     , "type"      : "clz32 :: Word# -> Word#"
     , "templateD" :
 "// clz32 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-logic [0:31] v;
-assign v = ~ARG[0][31:0];
+logic [0:31] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][31:0];
 
-logic [0:31] e;
-genvar i;
+logic [0:31] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<16;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:23] a;
-genvar i1;
+logic [0:23] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<8;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:15] b;
-genvar i2;
+logic [0:15] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<4;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:9] c;
-genvar i3;
+logic [0:9] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<2;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   logic [7:0] i;
-  assign i = b[i3*8:i3*8+7];
-  always @(*) begin
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:5] res;
+logic [0:5] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 5;
 logic [9:0] i;
-assign i = c[0:9];
-always @(*) begin
+assign i = ~SYM[12][0:9];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz32 end"
     }
   }
@@ -845,111 +783,107 @@ end
     , "type"      : "clz64 :: Word# -> Word#"
     , "templateD" :
 "// clz64 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-logic [0:63] v;
-assign v = ~ARG[0][63:0];
+logic [0:63] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][63:0];
 
-logic [0:63] e;
-genvar i;
+logic [0:63] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<32;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:47] a;
-genvar i1;
+logic [0:47] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<16;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:31] b;
-genvar i2;
+logic [0:31] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<8;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:19] c;
-genvar i3;
+logic [0:19] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<4;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   logic [7:0] i;
-  assign i = b[i3*8:i3*8+7];
-  always @(*) begin
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:11] d;
-genvar i4;
+logic [0:11] ~GENSYM[d][15];
+genvar ~GENSYM[i4][16];
 ~GENERATE
-for (i4=0;i4<2;i4=i4+1) begin : mux_stage4
+for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
   localparam n = 5;
   logic [9:0] i;
-  assign i = c[i4*10:i4*10+9];
-  always @(*) begin
+  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:6] res;
+logic [0:6] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 6;
 logic [11:0] i;
-assign i = d[0:11];
-always @(*) begin
+assign i = ~SYM[15][0:11];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz64 end"
     }
   }
@@ -958,185 +892,181 @@ end
     , "type"      : "clz :: Word# -> Word#"
     , "templateD" :
 "// clz begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 ~IF ~IW64 ~THEN
-logic [0:63] v;
-assign v = ~ARG[0][63:0];
+logic [0:63] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][63:0];
 
-logic [0:63] e;
-genvar i;
+logic [0:63] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<32;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:47] a;
-genvar i1;
+logic [0:47] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<16;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:31] b;
-genvar i2;
+logic [0:31] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<8;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:19] c;
-genvar i3;
+logic [0:19] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<4;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   logic [7:0] i;
-  assign i = b[i3*8:i3*8+7];
-  always @(*) begin
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:11] d;
-genvar i4;
+logic [0:11] ~GENSYM[d][15];
+genvar ~GENSYM[i4][16];
 ~GENERATE
-for (i4=0;i4<2;i4=i4+1) begin : mux_stage4
+for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
   localparam n = 5;
   logic [9:0] i;
-  assign i = c[i4*10:i4*10+9];
-  always @(*) begin
+  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:6] res;
+logic [0:6] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 6;
 logic [11:0] i;
-assign i = d[0:11];
-always @(*) begin
+assign i = ~SYM[15][0:11];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 ~ELSE
-logic [0:31] v;
-assign v = ~ARG[0][31:0];
+logic [0:31] ~SYM[1];
+assign ~SYM[1] = ~ARG[0][31:0];
 
-logic [0:31] e;
-genvar i;
+logic [0:31] ~SYM[2];
+genvar ~SYM[3];
 ~GENERATE
-for (i=0;i<16;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:23] a;
-genvar i1;
+logic [0:23] ~SYM[4];
+genvar ~SYM[5];
 ~GENERATE
-for (i1=0;i1<8;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:15] b;
-genvar i2;
+logic [0:15] ~SYM[9];
+genvar ~SYM[10];
 ~GENERATE
-for (i2=0;i2<4;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:9] c;
-genvar i3;
+logic [0:9] ~SYM[12];
+genvar ~SYM[13];
 ~GENERATE
-for (i3=0;i3<2;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]
   localparam n = 4;
   logic [7:0] i;
-  assign i = b[i3*8:i3*8+7];
-  always @(*) begin
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:5] res;
+logic [0:5] ~SYM[7];
 ~GENERATE
 if (1) begin
 localparam n = 5;
 logic [9:0] i;
-assign i = c[0:9];
-always @(*) begin
+assign i = ~SYM[12][0:9];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 ~FI
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz end"
     }
   }
@@ -1145,68 +1075,64 @@ end
     , "type"      : "ctz8 :: Word# -> Word#"
     , "templateD" :
 "// ctz8 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-logic [0:7] v;
-genvar k;
+logic [0:7] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<8;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<8;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-logic [0:7] e;
-genvar i;
+logic [0:7] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<4;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:5] a;
-genvar i1;
+logic [0:5] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<2;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:3] res;
+logic [0:3] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 3;
 logic [5:0] i;
-assign i = a[0:5];
-always @(*) begin
+assign i = ~SYM[4][0:5];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz8 end"
     }
   }
@@ -1215,84 +1141,80 @@ end
     , "type"      : "ctz16 :: Word# -> Word#"
     , "templateD" :
 "// ctz16 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-logic [0:15] v;
-genvar k;
+logic [0:15] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<16;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<16;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-logic [0:15] e;
-genvar i;
+logic [0:15] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<8;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:11] a;
-genvar i1;
+logic [0:11] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<4;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:7] b;
-genvar i2;
+logic [0:7] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<2;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:4] res;
+logic [0:4] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 4;
 logic [7:0] i;
-assign i = b[0:7];
-always @(*) begin
+assign i = ~SYM[9][0:7];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz16 end"
     }
   }
@@ -1301,100 +1223,96 @@ end
     , "type"      : "ctz32 :: Word# -> Word#"
     , "templateD" :
 "// ctz32 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-logic [0:31] v;
-genvar k;
+logic [0:31] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<32;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-logic [0:31] e;
-genvar i;
+logic [0:31] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<16;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:23] a;
-genvar i1;
+logic [0:23] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<8;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:15] b;
-genvar i2;
+logic [0:15] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<4;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:9] c;
-genvar i3;
+logic [0:9] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<2;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   logic [7:0] i;
-  assign i = b[i3*8:i3*8+7];
-  always @(*) begin
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:5] res;
+logic [0:5] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 5;
 logic [9:0] i;
-assign i = c[0:9];
-always @(*) begin
+assign i = ~SYM[12][0:9];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz32 end"
     }
   }
@@ -1403,116 +1321,112 @@ end
     , "type"      : "ctz64 :: Word# -> Word#"
     , "templateD" :
 "// ctz64 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-logic [0:63] v;
-genvar k;
+logic [0:63] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<64;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-logic [0:63] e;
-genvar i;
+logic [0:63] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<32;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:47] a;
-genvar i1;
+logic [0:47] a;
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<16;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:31] b;
-genvar i2;
+logic [0:31] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<8;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:19] c;
-genvar i3;
+logic [0:19] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<4;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   logic [7:0] i;
-  assign i = b[i3*8:i3*8+7];
-  always @(*) begin
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:11] d;
-genvar i4;
+logic [0:11] ~GENSYM[d][15];
+genvar ~GENSYM[i4][16];
 ~GENERATE
-for (i4=0;i4<2;i4=i4+1) begin : mux_stage4
+for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
   localparam n = 5;
   logic [9:0] i;
-  assign i = c[i4*10:i4*10+9];
-  always @(*) begin
+  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:6] res;
+logic [0:6] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 6;
 logic [11:0] i;
-assign i = d[0:11];
-always @(*) begin
+assign i = ~SYM[15][0:11];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz64 end"
     }
   }
@@ -1521,195 +1435,191 @@ end
     , "type"      : "ctz :: Word# -> Word#"
     , "templateD" :
 "// ctz begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 ~IF ~IW64 ~THEN
-logic [0:63] v;
-genvar k;
+logic [0:63] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<64;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-logic [0:63] e;
-genvar i;
+logic [0:63] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<32;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:47] a;
-genvar i1;
+logic [0:47] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<16;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:31] b;
-genvar i2;
+logic [0:31] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<8;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:19] c;
-genvar i3;
+logic [0:19] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<4;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   logic [7:0] i;
-  assign i = b[i3*8:i3*8+7];
-  always @(*) begin
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:11] d;
-genvar i4;
+logic [0:11] ~GENSYM[d][15];
+genvar ~GENSYM[i4][16];
 ~GENERATE
-for (i4=0;i4<2;i4=i4+1) begin : mux_stage4
+for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
   localparam n = 5;
   logic [9:0] i;
-  assign i = c[i4*10:i4*10+9];
-  always @(*) begin
+  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:6] res;
+logic [0:6] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 6;
 logic [11:0] i;
-assign i = d[0:11];
-always @(*) begin
+assign i = ~SYM[15][0:11];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 ~ELSE
-logic [0:31] v;
-genvar k;
+logic [0:31] ~SYM[1];
+genvar ~SYM[18];
 ~GENERATE
-for (k=0;k<32;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~SYM[19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-logic [0:31] e;
-genvar i;
+logic [0:31] ~SYM[2];
+genvar ~SYM[3];
 ~GENERATE
-for (i=0;i<16;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:23] a;
-genvar i1;
+logic [0:23] ~SYM[4];
+genvar ~SYM[5];
 ~GENERATE
-for (i1=0;i1<8;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]
   localparam n = 2;
   logic [3:0] i;
-  assign i = e[i1*4:i1*4+3];
-  always @(*) begin
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:15] b;
-genvar i2;
+logic [0:15] ~SYM[9];
+genvar ~SYM[10];
 ~GENERATE
-for (i2=0;i2<4;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]
   localparam n = 3;
   logic [5:0] i;
-  assign i = a[i2*6:i2*6+5];
-  always @(*) begin
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:9] c;
-genvar i3;
+logic [0:9] ~SYM[12];
+genvar ~SYM[13];
 ~GENERATE
-for (i3=0;i3<2;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]
   localparam n = 4;
   logic [7:0] i;
-  assign i = b[i3*8:i3*8+7];
-  always @(*) begin
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
+  always_comb begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:5] res;
+logic [0:5] ~SYM[7];
 ~GENERATE
 if (1) begin
 localparam n = 5;
 logic [9:0] i;
-assign i = c[0:9];
-always @(*) begin
+assign i = ~SYM[12][0:9];
+always_comb begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 ~FI
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz end"
     }
   }
@@ -1718,13 +1628,10 @@ end
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap16 begin
-~SIGDO[~SYM[0]];
-assign ~SYM[0] = ~ARG[0];
-~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[0][63:16],~SYM[0][7:0],~SYM[0][15:8]};
-~ELSE
-assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};
-~FI
+~SIGDO[~GENSYM[w][0]];
+assign ~SYM[0] = ~ARG[0];~IF ~IW64 ~THEN
+assign ~RESULT = {~SYM[0][63:16],~SYM[0][7:0],~SYM[0][15:8]};~ELSE
+assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};~FI
 // byteSwap16 end"
     }
   }
@@ -1733,13 +1640,10 @@ assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap32 begin
-~SIGDO[~SYM[0]];
-assign ~SYM[0] = ~ARG[0];
-~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[0][63:32],~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};
-~ELSE
-assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};
-~FI
+~SIGDO[~GENSYM[w][0]];
+assign ~SYM[0] = ~ARG[0];~IF ~IW64 ~THEN
+assign ~RESULT = {~SYM[0][63:32],~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~ELSE
+assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~FI
 // byteSwap32 end"
     }
   }
@@ -1748,7 +1652,7 @@ assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap64 begin
-~SIGDO[~SYM[1]];
+~SIGDO[~GENSYM[w][1]];
 assign ~SYM[1] = ~ARG[0];
 assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
                  ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};
@@ -1760,14 +1664,11 @@ assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap begin
-~SIGDO[~SYM[1]];
-assign ~SYM[1] = ~ARG[0];
-~IF ~IW64 ~THEN
+~SIGDO[~GENSYM[w][1]];
+assign ~SYM[1] = ~ARG[0];~IF ~IW64 ~THEN
 assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
-                 ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};
-~ELSE
-assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};
-~FI
+                 ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};~ELSE
+assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};~FI
 // byteSwap end"
     }
   }
@@ -1776,7 +1677,7 @@ assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};
     , "type"      : "narrow8Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow8Int begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[s][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $signed(~SYM[0][7:0]);
@@ -1788,7 +1689,7 @@ assign ~RESULT = $signed(~SYM[0][7:0]);
     , "type"      : "narrow16Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow16Int begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[s][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $signed(~SYM[0][15:0]);
@@ -1800,7 +1701,7 @@ assign ~RESULT = $signed(~SYM[0][15:0]);
     , "type"      : "narrow32Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow32Int begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[s][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $signed(~SYM[0][31:0]);
@@ -1812,7 +1713,7 @@ assign ~RESULT = $signed(~SYM[0][31:0]);
     , "type"      : "narrow8Int# :: Word# -> Word#"
     , "templateD" :
 "// narrow8Word begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[w][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $unsigned(~SYM[0][7:0]);
@@ -1824,7 +1725,7 @@ assign ~RESULT = $unsigned(~SYM[0][7:0]);
     , "type"      : "narrow16Word# :: Word# -> Word#"
     , "templateD" :
 "// narrow16Word begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[w][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $unsigned(~SYM[0][15:0]);
@@ -1836,7 +1737,7 @@ assign ~RESULT = $unsigned(~SYM[0][15:0]);
     , "type"      : "narrow32Int# :: Word# -> Word#"
     , "templateD" :
 "// narrow32Word begin
-~SIGD[~SYM[0]][0];
+~SIGD[~GENSYM[w][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $unsigned(~SYM[0][31:0]);

--- a/clash-systemverilog/primitives/GHC.Prim.json
+++ b/clash-systemverilog/primitives/GHC.Prim.json
@@ -80,7 +80,7 @@
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
 assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
-assign ~RESULT = {~SYM[0],~SYM[1]};
+assign ~RESULT = '{~SYM[0],~SYM[1]};
 // quotRemInt end"
     }
   }
@@ -220,7 +220,7 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
 assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
-assign ~RESULT = {~SYM[0],~SYM[1]};
+assign ~RESULT = '{~SYM[0],~SYM[1]};
 // quotRemWord end"
     }
   }

--- a/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
+++ b/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
@@ -19,7 +19,6 @@ import qualified Control.Applicative                  as A
 import           Control.Lens                         hiding (Indexed)
 import           Control.Monad                        (join,liftM,zipWithM)
 import           Control.Monad.State                  (State)
-import           Data.Char                            (toUpper)
 import           Data.Graph.Inductive                 (Gr, mkGraph, topsort')
 import           Data.HashMap.Lazy                    (HashMap)
 import qualified Data.HashMap.Lazy                    as HashMap
@@ -28,6 +27,7 @@ import qualified Data.HashSet                         as HashSet
 import           Data.List                            (mapAccumL,nubBy)
 import           Data.Maybe                           (catMaybes,mapMaybe)
 import           Data.Text.Lazy                       (pack,unpack)
+import qualified Data.Text.Lazy                       as Text
 import           Prelude                              hiding ((<$>))
 import           Text.PrettyPrint.Leijen.Text.Monadic
 
@@ -96,7 +96,7 @@ instance Backend SystemVerilogState where
 type SystemVerilogM a = State SystemVerilogState a
 
 -- List of reserved SystemVerilog-2012 keywords
-reservedWords :: [String]
+reservedWords :: [Identifier]
 reservedWords = ["accept_on","alias","always","always_comb","always_ff"
   ,"always_latch","and","assert","assign","assume","automatic","before","begin"
   ,"bind","bins","binsof","bit","break","buf","bufif0","bufif1","byte","case"
@@ -131,9 +131,9 @@ reservedWords = ["accept_on","alias","always","always_comb","always_ff"
   ,"var","vectored","virtual","void","wait","wait_order","wand","weak","weak0"
   ,"weak1","while","wildcard","wire","with","within","wor","xnor","xor"]
 
-filterReserved :: String -> String
+filterReserved :: Identifier -> Identifier
 filterReserved s = if s `elem` reservedWords
-  then init s ++ [toUpper (last s)]
+  then Text.init s `Text.append` (Text.toUpper . Text.singleton . Text.last) s
   else s
 
 -- | Generate VHDL for a Netlist component

--- a/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
+++ b/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
@@ -137,7 +137,7 @@ reservedWords = ["accept_on","alias","always","always_comb","always_ff"
 
 filterReserved :: Identifier -> Identifier
 filterReserved s = if s `elem` reservedWords
-  then Text.init s `Text.append` (Text.toUpper . Text.singleton . Text.last) s
+  then s `Text.append` "_r"
   else s
 
 -- | Generate VHDL for a Netlist component

--- a/clash-verilog/primitives/CLaSH.Driver.TestbenchGen.json
+++ b/clash-verilog/primitives/CLaSH.Driver.TestbenchGen.json
@@ -2,7 +2,7 @@
     { "name"      : "CLaSH.Driver.TestbenchGen.clockGen"
     , "templateD" :
 "// pragma translate_off
-reg ~TYPO ~SYM[0];
+reg ~TYPO ~GENSYM[clk][0];
 always begin
   ~SYM[0] = 0;
   #~LIT[0] forever begin
@@ -20,7 +20,7 @@ assign ~RESULT = ~SYM[0];
     { "name"      : "CLaSH.Driver.TestbenchGen.resetGen"
     , "templateD" :
 "// pragma translate_off
-reg ~TYPO ~SYM[0];
+reg ~TYPO ~GENSYM[rst_n][0];
 initial begin
   #1 ~SYM[0] = 0;
   #~LIT[0] ~SYM[0] = 1;
@@ -47,7 +47,7 @@ end
 , { "BlackBox" :
     { "name"      : "CLaSH.Driver.TestbenchGen.finishedGen"
     , "templateD" :
-"reg ~TYPO ~SYM[0];
+"reg ~TYPO ~GENSYM[done][0];
 always begin
 // pragma translate_off
   ~SYM[0] <= 1'b0;

--- a/clash-verilog/primitives/CLaSH.Driver.TopWrapper.json
+++ b/clash-verilog/primitives/CLaSH.Driver.TopWrapper.json
@@ -2,8 +2,8 @@
     { "name"      : "CLaSH.TopWrapper.syncReset"
     , "templateD" :
 "// reset ~RESULT is asynchronously asserted, but synchronously de-asserted
-reg ~SIGD[~SYM[0]][0];
-reg ~SIGD[~SYM[1]][0];
+reg ~SIGD[~GENSYM[r1][0]][0];
+reg ~SIGD[~GENSYM[r2][1]][0];
 
 always @(posedge ~CLKO or negedge ~ARG[0])
 if (~ ~ARG[0]) begin

--- a/clash-verilog/primitives/CLaSH.Prelude.BlockRam.File.json
+++ b/clash-verilog/primitives/CLaSH.Prelude.BlockRam.File.json
@@ -12,21 +12,21 @@
                -> Signal' clk (BitVector m)"
     , "templateD" :
 "// blockRamFile begin
-reg ~TYPO RAM_~SYM[0] [0:~LIT[2]-1];
-reg ~TYPO dout_~SYM[1];
+reg ~TYPO ~GENSYM[RAM][0] [0:~LIT[2]-1];
+reg ~TYPO ~GENSYM[dout][1];
 
 initial begin
-  $readmemb(~FILE[~LIT[3]],RAM_~SYM[0]);
+  $readmemb(~FILE[~LIT[3]],~SYM[0]);
 end
 
-always @(posedge ~CLK[1]) begin : blockRamFile_~COMPNAME_~SYM[2]
+always @(posedge ~CLK[1]) begin : ~GENSYM[~COMPNAME_blockRamFile][2]
   if (~ARG[6]) begin
-    RAM_~SYM[0][~ARG[4]] <= ~ARG[7];
+    ~SYM[0][~ARG[4]] <= ~ARG[7];
   end
-  dout_~SYM[1] <= RAM_~SYM[0][~ARG[5]];
+  ~SYM[1] <= ~SYM[0][~ARG[5]];
 end
 
-assign ~RESULT = dout_~SYM[1];
+assign ~RESULT = ~SYM[1];
 // blockRamFile end"
     }
   }

--- a/clash-verilog/primitives/CLaSH.Prelude.BlockRam.json
+++ b/clash-verilog/primitives/CLaSH.Prelude.BlockRam.json
@@ -11,26 +11,26 @@
            -> Signal' clk a"
     , "templateD" :
 "// blockRam begin
-reg ~TYPO RAM_~SYM[0] [0:~LIT[0]-1];
-reg ~TYPO dout_~SYM[1];
+reg ~TYPO ~GENSYM[RAM][0] [0:~LIT[0]-1];
+reg ~TYPO ~GENSYM[dout][1];
 
-reg ~TYP[2] ram_init_~SYM[2];
-integer ~SYM[3];
+reg ~TYP[2] ~GENSYM[ram_init][2];
+integer ~GENSYM[i][3];
 initial begin
-  ram_init_~SYM[2] = ~ARG[2];
+  ~SYM[2] = ~ARG[2];
   for (~SYM[3]=0; ~SYM[3] < ~LIT[0]; ~SYM[3] = ~SYM[3] + 1) begin
-    RAM_~SYM[0][~LIT[0]-1-~SYM[3]] = ram_init_~SYM[2][~SYM[3]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+    ~SYM[0][~LIT[0]-1-~SYM[3]] = ~SYM[2][~SYM[3]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
   end
 end
 
-always @(posedge ~CLK[1]) begin : blockRam_~COMPNAME_~SYM[4]
+always @(posedge ~CLK[1]) begin : ~GENSYM[~COMPNAME_blockRam][4]
   if (~ARG[5]) begin
-    RAM_~SYM[0][~ARG[3]] <= ~ARG[6];
+    ~SYM[0][~ARG[3]] <= ~ARG[6];
   end
-  dout_~SYM[1] <= RAM_~SYM[0][~ARG[4]];
+  ~SYM[1] <= ~SYM[0][~ARG[4]];
 end
 
-assign ~RESULT = dout_~SYM[1];
+assign ~RESULT = ~SYM[1];
 // blockRam end"
     }
   }

--- a/clash-verilog/primitives/CLaSH.Prelude.RAM.json
+++ b/clash-verilog/primitives/CLaSH.Prelude.RAM.json
@@ -11,15 +11,15 @@
            -> Signal' rclk a"
     , "templateD" :
 "// asyncRam begin
-reg ~TYPO RAM_~SYM[0] [0:~LIT[2]-1];
+reg ~TYPO ~GENSYM[RAM][0] [0:~LIT[2]-1];
 
-always @(posedge ~CLK[0]) begin : Ram_~COMPNAME_~SYM[4]
+always @(posedge ~CLK[0]) begin : ~GENSYM[~COMPNAME_Ram][1]
   if (~ARG[5]) begin
-    RAM_~SYM[0][~ARG[3]] <= ~ARG[6];
+    ~SYM[0][~ARG[3]] <= ~ARG[6];
   end
 end
 
-assign ~RESULT = RAM_~SYM[0][~ARG[4]];
+assign ~RESULT = ~SYM[0][~ARG[4]];
 // asyncRam end"
     }
   }

--- a/clash-verilog/primitives/CLaSH.Prelude.ROM.File.json
+++ b/clash-verilog/primitives/CLaSH.Prelude.ROM.File.json
@@ -8,13 +8,13 @@
               -> BitVector m"
     , "templateD" :
 "// asyncRomFile begin
-reg ~TYPO ROM_~SYM[0] [0:~LIT[1]-1];
+reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[1]-1];
 
 initial begin
-  $readmemb(~FILE[~LIT[2]],ROM_~SYM[0]);
+  $readmemb(~FILE[~LIT[2]],~SYM[0]);
 end
 
-assign ~RESULT = ROM_~SYM[0][~ARG[3]];
+assign ~RESULT = ~SYM[0][~ARG[3]];
 // asyncRomFile end"
     }
   }
@@ -29,18 +29,18 @@ assign ~RESULT = ROM_~SYM[0][~ARG[3]];
           -> Signal' clk (BitVector m)"
     , "templateD" :
 "// romFile begin
-reg ~TYPO ROM_~SYM[0] [0:~LIT[2]-1];
+reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[2]-1];
 
 initial begin
-  $readmemb(~FILE[~LIT[3]],ROM_~SYM[0]);
+  $readmemb(~FILE[~LIT[3]],~SYM[0]);
 end
 
-reg ~TYPO dout_~SYM[1];
-always @(posedge ~CLK[1]) begin : romFile_~COMPNAME_~SYM[2]
-  dout_~SYM[1] <= ROM_~SYM[0][~ARG[4]];
+reg ~TYPO ~GENSYM[dout][1];
+always @(posedge ~CLK[1]) begin : ~GENSYM[~COMPNAME_romFile][2]
+  ~SYM[1] <= ~SYM[0][~ARG[4]];
 end
 
-assign ~RESULT = dout_~SYM[1];
+assign ~RESULT = ~SYM[1];
 // romFile end"
     }
   }

--- a/clash-verilog/primitives/CLaSH.Prelude.ROM.json
+++ b/clash-verilog/primitives/CLaSH.Prelude.ROM.json
@@ -7,18 +7,18 @@
            -> a"
     , "templateD" :
 "// asyncRom begin
-wire ~TYPO ROM_~SYM[0] [0:~LIT[0]-1];
+wire ~TYPO ~GENSYM[ROM][0] [0:~LIT[0]-1];
 
-wire ~TYP[1] romflat_~SYM[1];
-assign romflat_~SYM[1] = ~ARG[1];
-genvar ~SYM[2];
+wire ~TYP[1] ~GENSYM[romflat][1];
+assign ~SYM[1] = ~ARG[1];
+genvar ~GENSYM[i][2];
 ~GENERATE
-for (~SYM[2]=0; ~SYM[2] < ~LIT[0]; ~SYM[2]=~SYM[2]+1) begin : array_~SYM[3]
-  assign ROM_~SYM[0][(~LIT[0]-1)-~SYM[2]] = romflat_~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+for (~SYM[2]=0; ~SYM[2] < ~LIT[0]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
+  assign ~SYM[0][(~LIT[0]-1)-~SYM[2]] = ~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
 end
 ~ENDGENERATE
 
-assign ~RESULT = ROM_~SYM[0][~ARG[2]];
+assign ~RESULT = ~SYM[0][~ARG[2]];
 // asyncRom end"
     }
   }
@@ -32,23 +32,23 @@ assign ~RESULT = ROM_~SYM[0][~ARG[2]];
       -> Signal' clk a"
     , "templateD" :
 "// rom begin
-reg ~TYPO ROM_~SYM[0] [0:~LIT[0]-1];
-reg ~TYPO dout_~SYM[1];
+reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[0]-1];
+reg ~TYPO ~GENSYM[dout][1];
 
-reg ~TYP[2] rom_init_~SYM[2];
-integer ~SYM[3];
+reg ~TYP[2] ~GENSYM[rom_init][2];
+integer ~GENSYM[i][3];
 initial begin
-  rom_init_~SYM[2] = ~ARG[2];
+  ~SYM[2] = ~ARG[2];
   for (~SYM[3]=0; ~SYM[3] < ~LIT[0]; ~SYM[3] = ~SYM[3] + 1) begin
-    ROM_~SYM[0][~LIT[0]-1-~SYM[3]] = rom_init_~SYM[2][~SYM[3]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+    ~SYM[0][~LIT[0]-1-~SYM[3]] = ~SYM[2][~SYM[3]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
   end
 end
 
-always @(posedge ~CLK[1]) begin : blockRam_~COMPNAME_~SYM[4]
-  dout_~SYM[1] <= ROM_~SYM[0][~ARG[3]];
+always @(posedge ~CLK[1]) begin : ~GENSYM[~COMPNAME_rom][4]
+  ~SYM[1] <= ~SYM[0][~ARG[3]];
 end
 
-assign ~RESULT = dout_~SYM[1];
+assign ~RESULT = ~SYM[1];
 // rom end"
     }
   }

--- a/clash-verilog/primitives/CLaSH.Signal.Internal.json
+++ b/clash-verilog/primitives/CLaSH.Signal.Internal.json
@@ -7,9 +7,9 @@
            -> Signal' clk a"
     , "templateD" :
 "// register begin
-reg ~SIGD[~SYM[0]][2];
+reg ~SIGD[~GENSYM[dout][0]][2];
 
-always @(posedge ~CLK[0] or negedge ~RST[0]) begin : register_~COMPNAME_~SYM[1]
+always @(posedge ~CLK[0] or negedge ~RST[0]) begin : ~GENSYM[~COMPNAME_register][1]
   if (~ ~RST[0]) begin
     ~SYM[0] <= ~ARG[1];
   end else begin
@@ -31,9 +31,9 @@ assign ~RESULT = ~SYM[0];
         -> Signal' clk a"
     , "templateD" :
 "// regEn begin
-reg ~SIGD[~SYM[0]][3];
+reg ~SIGD[~GENSYM[dout][0]][3];
 
-always @(posedge ~CLK[0] or negedge ~RST[0]) begin : regEn_~COMPNAME_~SYM[1]
+always @(posedge ~CLK[0] or negedge ~RST[0]) begin : ~GENSYM[~COMPNAME_regEn][1]
   if (~ ~RST[0]) begin
     ~SYM[0] <= ~ARG[1];
   end else begin

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -55,10 +55,10 @@
         -> Bit"
     , "templateD" :
 "// indexBit begin
-wire ~TYP[1] vec_~SYM[0];
-assign vec_~SYM[0] = ~ARG[1];
+wire ~TYP[1] ~GENSYM[bv][0];
+assign ~SYM[0] = ~ARG[1];
 
-assign ~RESULT = vec_~SYM[0][~ARG[2]];
+assign ~RESULT = ~SYM[0][~ARG[2]];
 // indexBit end"
     }
   }
@@ -72,16 +72,16 @@ assign ~RESULT = vec_~SYM[0][~ARG[2]];
              -> BitVector n"
     , "templateD" :
 "// replaceBit start
-reg ~TYPO vec_~SYM[0];
-wire ~TYP[3] din_~SYM[1];
-assign din_~SYM[1] = ~ARG[3];
+reg ~TYPO ~GENSYM[bv][0];
+wire ~TYP[3] ~GENSYM[din][1];
+assign ~SYM[1] = ~ARG[3];
 
 always @(*) begin
-  vec_~SYM[0] = ~ARG[1];
-  vec_~SYM[0][~ARG[2]] = din_~SYM[1];
+  ~SYM[0] = ~ARG[1];
+  ~SYM[0][~ARG[2]] = ~SYM[1];
 end
 
-assign ~RESULT = vec_~SYM[0];
+assign ~RESULT = ~SYM[0];
 // replaceBit end"
     }
   }
@@ -95,13 +95,13 @@ assign ~RESULT = vec_~SYM[0];
            -> BitVector (m + 1 + i)"
     , "templateD" :
 "// setSlice begin
-reg ~SIGD[~SYM[0]][0];
-wire ~TYP[3] din_~SYM[1];
-assign din_~SYM[1] = ~ARG[3]
+reg ~SIGD[~GENSYM[bv][0]][0];
+wire ~TYP[3] ~GENSYM[din][1];
+assign ~SYM[1] = ~ARG[3]
 
 always @(*) begin
   ~SYM[0] = ~ARG[0];
-  ~SYM[0][~LIT[1] : ~LIT[2]] = din_~SYM[1];
+  ~SYM[0][~LIT[1] : ~LIT[2]] = ~SYM[1];
 end
 
 assign ~RESULT = ~SYM[0];
@@ -117,7 +117,7 @@ assign ~RESULT = ~SYM[0];
         -> BitVector (m + 1 - n)"
     , "templateD" :
 "// slice begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[bv][0]][0];
 assign ~SYM[0] = ~ARG[0];
 assign ~RESULT = ~SYM[0][~LIT[1] : ~LIT[2]];
 // slice end"
@@ -140,7 +140,7 @@ assign ~RESULT = ~SYM[0][~LIT[1] : ~LIT[2]];
       -> Bit"
     , "templateD" :
 "// msb begin~IF ~LIT[0] ~THEN
-wire ~SIGD[~SYM[0]][1];
+wire ~SIGD[~GENSYM[bv][0]][1];
 assign ~SYM[0] = ~ARG[1];
 assign ~RESULT = ~SYM[0][~LIT[0]-1];
 ~ELSE
@@ -155,7 +155,7 @@ assign ~RESULT = 1'b0;
       -> Bit"
     , "templateD" :
 "// lsb begin~IF ~SIZE[~TYP[0]] ~THEN
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[bv][0]][0];
 assign ~SYM[0] = ~ARG[0];
 assign ~RESULT = ~SYM[0][0];
 ~ELSE
@@ -329,7 +329,7 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
 "// rotateR begin
-wire [2*~LIT[0]-1:0] ~SYM[0];
+wire [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
 assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
 // rotateR end"

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.Signed.json
@@ -137,9 +137,9 @@
     , "type"      : "div# :: Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// divInt begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
-wire ~SIGD[~SYM[2]][1];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+wire ~SIGD[~GENSYM[dividend][1]][0];
+wire ~SIGD[~GENSYM[divider][2]][1];
 
 // divide (rounds towards zero)
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
@@ -156,9 +156,9 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "mod# :: Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// modSigned begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
-wire ~SIGD[~SYM[2]][1];
+wire ~SIGD[~GENSYM[rem_res][0]][0];
+wire ~SIGD[~GENSYM[dividend][1]][0];
+wire ~SIGD[~GENSYM[divider][2]][1];
 
 // remainder
 assign ~SYM[0] = ~ARG[0] % ~ARG[1];
@@ -230,7 +230,7 @@ assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateD" :
 "// rotateR begin
-wire [2*~LIT[0]-1:0] ~SYM[0];
+wire [2*~LIT[0]-1:0] ~GENSYM[s][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
 assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);
 // rotateR end"
@@ -245,7 +245,7 @@ assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);
 ~GENERATE
 if (~LIT[1] < ~LIT[0]) begin
   // truncate, sign preserving
-  wire ~SIGD[~SYM[0]][2];
+  wire ~SIGD[~GENSYM[s][0]][2];
   assign ~SYM[0] = ~ARG[2];
   assign ~RESULT = $signed({~SYM[0][~LIT[0]-1],~SYM[0][(~LIT[1]-2):0]});
 end else begin

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.Unsigned.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.Unsigned.json
@@ -171,7 +171,7 @@
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateD" :
 "// rotateL begin
-wire [2*~LIT[0]-1:0] ~SYM[0];
+wire [2*~LIT[0]-1:0] ~GENSYM[u][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
 assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];
 // rotateL end"
@@ -182,7 +182,7 @@ assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateD" :
 "// rotateR begin
-wire [2*~LIT[0]-1:0] ~SYM[0];
+wire [2*~LIT[0]-1:0] ~GENSYM[u][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
 assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];
 // rotateR end"

--- a/clash-verilog/primitives/CLaSH.Sized.Vector.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Vector.json
@@ -3,7 +3,7 @@
     , "type"      : "head :: Vec (n + 1) a -> a"
     , "templateD" :
 "// head begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = ~SYM[0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]];
@@ -15,7 +15,7 @@ assign ~RESULT = ~SYM[0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]];
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
     , "templateD" :
 "// tail begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
@@ -27,7 +27,7 @@ assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
     , "type"      : "Vec (n + 1) a -> a"
     , "templateD" :
 "// last begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1:0];
@@ -39,7 +39,7 @@ assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1:0];
     , "type"      : "Vec (n + 1) a -> Vec n a"
     , "templateD" :
 "// init begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = ~SYM[0][~SIZE[~TYP[0]]-1 : ~SIZE[~TYPEL[~TYP[0]]]];
@@ -57,20 +57,20 @@ assign ~RESULT = ~SYM[0][~SIZE[~TYP[0]]-1 : ~SIZE[~TYPEL[~TYP[0]]]];
         -> Vec n a"
     , "templateD" :
 "// select begin
-wire ~SIGD[~SYM[0]][4];
+wire ~SIGD[~GENSYM[vec][0]][4];
 assign ~SYM[0] = ~ARG[4];
 
 wire ~TYPEL[~TYPO] ~SYM[1] [0:~LENGTH[~TYP[4]]-1];
-genvar ~SYM[2];
+genvar ~GENSYM[i][2];
 ~GENERATE
-for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[4]]; ~SYM[2]=~SYM[2]+1) begin : array_~SYM[3]
+for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[4]]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
   assign ~SYM[1][(~LENGTH[~TYP[4]]-1)-~SYM[2]] = ~SYM[0][~SYM[2]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];
 end
 ~ENDGENERATE
 
-genvar ~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (~SYM[4]=0; ~SYM[4] < ~LIT[3]; ~SYM[4] = ~SYM[4] + 1) begin : select_~SYM[5]
+for (~SYM[4]=0; ~SYM[4] < ~LIT[3]; ~SYM[4] = ~SYM[4] + 1) begin : ~GENSYM[select][5]
   assign ~RESULT[(~LIT[3]-1-~SYM[4])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[1][~LIT[1] + (~LIT[2] * ~SYM[4])];
 end
 ~ENDGENERATE
@@ -110,14 +110,14 @@ end
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// map begin
-wire ~SIGD[~SYM[0]][1];
+wire ~SIGD[~GENSYM[vec][0]][1];
 assign ~SYM[0] = ~ARG[1];
 
-genvar ~SYM[1];
+genvar ~GENSYM[i][1];
 ~GENERATE
-for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : map_~SYM[2]
-  wire ~TYPEL[~TYP[1]] ~SYM[3];
-  wire ~TYPEL[~TYPO] ~SYM[4];
+for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]
+  wire ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];
+  wire ~TYPEL[~TYPO] ~GENSYM[map_out][4];
 
   assign ~SYM[3] = ~SYM[0][~SYM[1]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];
   ~INST 0
@@ -135,15 +135,15 @@ end
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// imap begin
-wire ~SIGD[~SYM[0]][2];
+wire ~SIGD[~GENSYM[vec][0]][2];
 assign ~SYM[0] = ~ARG[2];
 
-genvar ~SYM[1];
+genvar ~GENSYM[i][1];
 ~GENERATE
-for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : map_~SYM[2]
-  wire [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~SYM[3];
-  wire ~TYPEL[~TYP[2]] ~SYM[4];
-  wire ~TYPEL[~TYPO] ~SYM[5];
+for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
+  wire [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~GENSYM[map_index][3];
+  wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];
+  wire ~TYPEL[~TYPO] ~GENSYM[map_out][5];
 
   assign ~SYM[3] = ~SYM[1];
   assign ~SYM[4] = ~SYM[0][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
@@ -163,16 +163,16 @@ end
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "templateD" :
 "// zipWith start
-wire ~SIGD[~SYM[0]][1];
-wire ~SIGD[~SYM[1]][2];
+wire ~SIGD[~GENSYM[vec1][0]][1];
+wire ~SIGD[~GENSYM[vec2][1]][2];
 assign ~SYM[0] = ~ARG[1];
 assign ~SYM[1] = ~ARG[2];
 
-genvar ~SYM[2];
+genvar ~GENSYM[i][2];
 ~GENERATE
-for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : zipWith_~SYM[2]
-  wire ~TYPEL[~TYP[1]] ~SYM[3];
-  wire ~TYPEL[~TYP[2]] ~SYM[4];
+for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][6]
+  wire ~TYPEL[~TYP[1]] ~GENSYM[zipWith_in1][3];
+  wire ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][4];
   wire ~TYPEL[~TYPO] ~SYM[5];
 
   assign ~SYM[3] = ~SYM[0][~SYM[2]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];
@@ -193,31 +193,31 @@ end
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "templateD" :
 "// foldr start~IF ~LENGTH[~TYP[2]] ~THEN
-wire ~TYPO intermediate_~SYM[0] [0:~LENGTH[~TYP[2]]];
-assign intermediate_~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];
+wire ~TYPO ~GENSYM[intermediate][0] [0:~LENGTH[~TYP[2]]];
+assign ~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];
 
-wire ~TYP[2] xs_~SYM[2];
-assign xs_~SYM[2] = ~ARG[2];
+wire ~TYP[2] ~GENSYM[xs][2];
+assign ~SYM[2] = ~ARG[2];
 
-genvar i_~SYM[3];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i_~SYM[3]=0; i_~SYM[3] < ~LENGTH[~TYP[2]]; i_~SYM[3]=i_~SYM[3]+1) begin : foldr_~SYM[4]
-  wire ~TYPEL[~TYP[2]] ~SYM[5];
-  wire ~TYPO ~SYM[6];
-  wire ~TYPO ~SYM[7];
+for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr][4]
+  wire ~TYPEL[~TYP[2]] ~GENSYM[foldr_in1][5];
+  wire ~TYPO ~GENSYM[foldr_in2][6];
+  wire ~TYPO ~GENSYM[foldr_out][7];
 
-  assign ~SYM[5] = xs_~SYM[2][(~LENGTH[~TYP[2]]-1-i_~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
-  assign ~SYM[6] = intermediate_~SYM[0][i_~SYM[3]+1];
+  assign ~SYM[5] = ~SYM[2][(~LENGTH[~TYP[2]]-1-~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
+  assign ~SYM[6] = ~SYM[0][~SYM[3]+1];
   ~INST 0
     ~OUTPUT <= ~SYM[7]~ ~TYP[1]~
     ~INPUT  <= ~SYM[5]~ ~TYPEL[~TYP[2]]~
     ~INPUT  <= ~SYM[6]~ ~TYP[1]~
   ~INST
-  assign intermediate_~SYM[0][i_~SYM[3]] = ~SYM[7];
+  assign ~SYM[0][~SYM[3]] = ~SYM[7];
 end
 ~ENDGENERATE
 
-assign ~RESULT = intermediate_~SYM[0][0];
+assign ~RESULT = ~SYM[0][0];
 ~ELSE
 assign ~RESULT = ~ARG[1];
 ~FI// foldr end"
@@ -230,63 +230,63 @@ assign ~RESULT = ~ARG[1];
     , "templateD" :
 "// fold begin
 // put flat input array into the first half of the intermediate array
-wire ~TYPO intermediate_~SYM[0] [0:(2*~LENGTH[~TYP[1]])-2];
-wire ~TYP[1] vecflat_~SYM[1];
-assign vecflat_~SYM[1] = ~ARG[1];
-genvar ~SYM[2];
+wire ~TYPO ~GENSYM[intermediate][0] [0:(2*~LENGTH[~TYP[1]])-2];
+wire ~TYP[1] ~GENSYM[vecflat][1];
+assign ~SYM[1] = ~ARG[1];
+genvar ~GENSYM[i][2];
 ~GENERATE
-for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[1]]; ~SYM[2]=~SYM[2]+1) begin : array_~SYM[3]
-  assign intermediate_~SYM[0][(~LENGTH[~TYP[1]]-1)-~SYM[2]] = vecflat_~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[1]]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
+  assign ~SYM[0][(~LENGTH[~TYP[1]]-1)-~SYM[2]] = ~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
 end
 ~ENDGENERATE
 
 // calculate the depth of the tree
-function integer log2_~SYM[9];
+function integer ~GENSYM[log2][14];
   input integer value;
   begin
     value = value-1;
-    for (log2_~SYM[9]=0; value>0; log2_~SYM[9]=log2_~SYM[9]+1)
+    for (~SYM[14]=0; value>0; ~SYM[14]=~SYM[14]+1)
       value = value>>1;
   end
 endfunction
 
-localparam levels_~SYM[4] = log2_~SYM[9](~LENGTH[~TYP[1]]);
+localparam ~GENSYM[levels][4] = ~SYM[14](~LENGTH[~TYP[1]]);
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[8];
+function integer ~GENSYM[depth2Index][13];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[8] = (2 ** levels) - (2 ** depth);
+  ~SYM[13] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[5];
-genvar i_~SYM[6];
+genvar ~GENSYM[d][5];
+genvar ~GENSYM[i][6];
 ~GENERATE
-if (levels_~SYM[4] != 0) begin : make_tree_~SYM[7]
-  for (d_~SYM[5] = (levels_~SYM[4] - 1); d_~SYM[5] >= 0; d_~SYM[5]=d_~SYM[5]-1) begin : tree_depth
-    for (i_~SYM[6] = 0; i_~SYM[6] < (2**d_~SYM[5]); i_~SYM[6] = i_~SYM[6]+1) begin : tree_depth_loop
-      wire ~TYPO ~SYM[8];
-      wire ~TYPO ~SYM[9];
-      wire ~TYPO ~SYM[10];
+if (~SYM[4] != 0) begin : ~GENSYM[make_tree][7]
+  for (~SYM[5] = (~SYM[4] - 1); ~SYM[5] >= 0; ~SYM[5]=~SYM[5]-1) begin : ~GENSYM[tree_depth][11]
+    for (~SYM[6] = 0; ~SYM[6] < (2**~SYM[5]); ~SYM[6] = ~SYM[6]+1) begin : ~GENSYM[tree_depth_loop][12]
+      wire ~TYPO ~GENSYM[fold_in1][8];
+      wire ~TYPO ~GENSYM[fold_in2][9];
+      wire ~TYPO ~GENSYM[fold_out][10];
 
-      assign ~SYM[8] = intermediate_~SYM[0][depth2Index_~SYM[8](levels_~SYM[4]+1,d_~SYM[5]+2)+(2*i_~SYM[6])];
-      assign ~SYM[9] = intermediate_~SYM[0][depth2Index_~SYM[8](levels_~SYM[4]+1,d_~SYM[5]+2)+(2*i_~SYM[6])+1];
+      assign ~SYM[8] = ~SYM[0][~SYM[13](~SYM[4]+1,~SYM[5]+2)+(2*~SYM[6])];
+      assign ~SYM[9] = ~SYM[0][~SYM[13](~SYM[4]+1,~SYM[5]+2)+(2*~SYM[6])+1];
       ~INST 0
         ~OUTPUT <= ~SYM[10]~ ~TYPO~
         ~INPUT  <= ~SYM[8]~ ~TYPO~
         ~INPUT  <= ~SYM[9]~ ~TYPO~
       ~INST
-      assign intermediate_~SYM[0][depth2Index_~SYM[8](levels_~SYM[4]+1,d_~SYM[5]+1)+i_~SYM[6]] = ~SYM[10];
+      assign ~SYM[0][~SYM[13](~SYM[4]+1,~SYM[5]+1)+~SYM[6]] = ~SYM[10];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = intermediate_~SYM[0][(2*~LENGTH[~TYP[1]])-2];
+assign ~RESULT = ~SYM[0][(2*~LENGTH[~TYP[1]])-2];
 // fold end"
     }
   }
@@ -295,18 +295,18 @@ assign ~RESULT = intermediate_~SYM[0][(2*~LENGTH[~TYP[1]])-2];
     , "type"      : "index_integer :: KnownNat n => Vec n a -> Int -> a"
     , "templateD" :
 "// indexVec begin
-wire ~TYPO vec_~SYM[0] [0:~LIT[0]-1];
+wire ~TYPO ~GENSYM[vec][0] [0:~LIT[0]-1];
 
-wire ~TYP[1] vecflat_~SYM[1];
-assign vecflat_~SYM[1] = ~ARG[1];
-genvar ~SYM[2];
+wire ~TYP[1] ~GENSYM[vecflat][1];
+assign ~SYM[1] = ~ARG[1];
+genvar ~GENSYM[i][2];
 ~GENERATE
-for (~SYM[2]=0; ~SYM[2] < ~LIT[0]; ~SYM[2]=~SYM[2]+1) begin : array_~SYM[3]
-  assign vec_~SYM[0][(~LIT[0]-1)-~SYM[2]] = vecflat_~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+for (~SYM[2]=0; ~SYM[2] < ~LIT[0]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
+  assign ~SYM[0][(~LIT[0]-1)-~SYM[2]] = ~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
 end
 ~ENDGENERATE
 
-assign ~RESULT = vec_~SYM[0][~ARG[2]];
+assign ~RESULT = ~SYM[0][~ARG[2]];
 // indexVec end"
     }
   }
@@ -315,22 +315,22 @@ assign ~RESULT = vec_~SYM[0][~ARG[2]];
     , "type"      : "replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a"
     , "templateD" :
 "// replaceVec start
-wire ~TYP[1] vecflat_~SYM[0];
-assign vecflat_~SYM[0] = ~ARG[1];
+wire ~TYP[1] ~GENSYM[vecflat][0];
+assign ~SYM[0] = ~ARG[1];
 
-reg ~TYP[3] vec_~SYM[1] [0:~LIT[0]-1];
-integer ~SYM[2];
+reg ~TYP[3] ~GENSYM[vec][1] [0:~LIT[0]-1];
+integer ~GENSYM[i][2];
 always @(*) begin
   for (~SYM[2]=0;~SYM[2]<~LIT[0];~SYM[2]=~SYM[2]+1) begin
-    vec_~SYM[1][~LIT[0]-1-~SYM[2]] = vecflat_~SYM[0][~SYM[2]*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]];
+    ~SYM[1][~LIT[0]-1-~SYM[2]] = ~SYM[0][~SYM[2]*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]];
   end
-  vec_~SYM[1][~ARG[2]] = ~ARG[3];
+  ~SYM[1][~ARG[2]] = ~ARG[3];
 end
 
-genvar ~SYM[3];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (~SYM[3]=0;~SYM[3]<~LIT[0];~SYM[3]=~SYM[3]+1) begin : vec_~SYM[4]
-  assign ~RESULT[~SYM[3]*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]] = vec_~SYM[1][(~LIT[0]-1)-~SYM[3]];
+for (~SYM[3]=0;~SYM[3]<~LIT[0];~SYM[3]=~SYM[3]+1) begin : ~GENSYM[mk_vec][4]
+  assign ~RESULT[~SYM[3]*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]] = ~SYM[1][(~LIT[0]-1)-~SYM[3]];
 end
 ~ENDGENERATE
 // replaceVec end"
@@ -359,14 +359,14 @@ end
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "templateD" :
 "// transpose begin
-wire ~SIGD[~SYM[0]][1];
+wire ~SIGD[~GENSYM[matrix][0]][1];
 assign ~SYM[0] = ~ARG[1];
 
-genvar ~SYM[1];
-genvar ~SYM[2];
+genvar ~GENSYM[row_index][1];
+genvar ~GENSYM[col_index][2];
 ~GENERATE
-for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYP[1]]; ~SYM[1] = ~SYM[1] + 1) begin : transpose_outer_~SYM[3]
-  for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : transpose_inner_~SYM[4]
+for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYP[1]]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]
+  for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[transpose_inner][4]
     assign ~RESULT[((~SYM[2]*~SIZE[~TYPEL[~TYPO]])+(~SYM[1]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~SYM[0][((~SYM[1]*~SIZE[~TYPEL[~TYP[1]]])+(~SYM[2]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]];
   end
 end
@@ -379,12 +379,12 @@ end
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "templateD" :
 "// reverse begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[vec][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
-genvar ~SYM[1];
+genvar ~GENSYM[i][1];
 ~GENERATE
-for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : reverse_~SYM[2]
+for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]
   assign ~RESULT[(~LENGTH[~TYPO] - 1 - ~SYM[1])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[0][~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];
 end
 ~ENDGENERATE
@@ -420,17 +420,17 @@ end
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "// rotateLeftS begin
-wire ~TYP[1] ~SYM[1];
-localparam shift_amount_~SYM[2] = ~LIT[2] % ~LIT[0];
+wire ~TYP[1] ~GENSYM[vec][1];
+localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
 
 assign ~SYM[1] = ~ARG[1];
 
 ~GENERATE
-if (shift_amount_~SYM[2] == 0) begin : no_shift_~SYM[3]
+if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
   assign ~RESULT = ~SYM[1];
-end else begin : do_shift_~SYM[4]
-  assign ~RESULT = {~SYM[1][((~LIT[0]-shift_amount_~SYM[2])*~SIZE[~TYPEL[~TYPO]])-1 : 0]
-                   ,~SYM[1][~SIZE[~TYPO]-1 : (~LIT[0]-shift_amount_~SYM[2])*~SIZE[~TYPEL[~TYPO]]]
+end else begin : ~GENSYM[do_shift][4]
+  assign ~RESULT = {~SYM[1][((~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]])-1 : 0]
+                   ,~SYM[1][~SIZE[~TYPO]-1 : (~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]]]
                    };
 end
 ~ENDGENERATE
@@ -442,17 +442,17 @@ end
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "// rotateRightS begin
-wire ~TYP[1] ~SYM[1];
-localparam shift_amount_~SYM[2] = ~LIT[2] % ~LIT[0];
+wire ~TYP[1] ~GENSYM[vec][1];
+localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
 
 assign ~SYM[1] = ~ARG[1];
 
 ~GENERATE
-if (shift_amount_~SYM[2] == 0) begin : no_shift_~SYM[3]
+if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
   assign ~RESULT = ~SYM[1];
-end else begin : do_shift_~SYM[4]
-  assign ~RESULT = {~SYM[1][(shift_amount_~SYM[2]*~SIZE[~TYPEL[~TYPO]])-1 : 0]
-                   ,~SYM[1][~SIZE[~TYPO]-1 : shift_amount_~SYM[2]*~SIZE[~TYPEL[~TYPO]]]
+end else begin : ~GENSYM[do_shift][4]
+  assign ~RESULT = {~SYM[1][(~SYM[2]*~SIZE[~TYPEL[~TYPO]])-1 : 0]
+                   ,~SYM[1][~SIZE[~TYPO]-1 : ~SYM[2]*~SIZE[~TYPEL[~TYPO]]]
                    };
 end
 ~ENDGENERATE

--- a/clash-verilog/primitives/GHC.Base.json
+++ b/clash-verilog/primitives/GHC.Base.json
@@ -20,9 +20,9 @@
     , "type"      : "divInt :: Int -> Int -> Int"
     , "templateD" :
 "// divInt begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
-wire ~SIGD[~SYM[2]][1];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+wire ~SIGD[~GENSYM[dividend][1]][0];
+wire ~SIGD[~GENSYM[divider][2]][1];
 
 // divide (rounds towards zero)
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
@@ -39,9 +39,9 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInt :: Int -> Int -> Int"
     , "templateD" :
 "// modInt begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
-wire ~SIGD[~SYM[2]][1];
+wire ~SIGD[~GENSYM[rem_res][0]][0];
+wire ~SIGD[~GENSYM[dividend][1]][0];
+wire ~SIGD[~GENSYM[divider][2]][1];
 
 // remainder
 assign ~SYM[0] = ~ARG[0] % ~ARG[1];

--- a/clash-verilog/primitives/GHC.Classes.json
+++ b/clash-verilog/primitives/GHC.Classes.json
@@ -57,9 +57,9 @@
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "templateD" :
 "// divInt begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
-wire ~SIGD[~SYM[2]][1];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+wire ~SIGD[~GENSYM[dividend][1]][0];
+wire ~SIGD[~GENSYM[divider][2]][1];
 
 // divide (rounds towards zero)
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
@@ -76,9 +76,9 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInt# :: Int# -> Int# -> Int#"
     , "templateD" :
 "// modInt begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
-wire ~SIGD[~SYM[2]][1];
+wire ~SIGD[~GENSYM[rem_res][0]][0];
+wire ~SIGD[~GENSYM[dividend][1]][0];
+wire ~SIGD[~GENSYM[divider][2]][1];
 
 // remainder
 assign ~SYM[0] = ~ARG[0] % ~ARG[1];

--- a/clash-verilog/primitives/GHC.Integer.Type.json
+++ b/clash-verilog/primitives/GHC.Integer.Type.json
@@ -45,9 +45,9 @@
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// divInteger begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
-wire ~SIGD[~SYM[2]][1];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+wire ~SIGD[~GENSYM[dividend][1]][0];
+wire ~SIGD[~GENSYM[divider][2]][1];
 
 // divide (rounds towards zero)
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
@@ -64,9 +64,9 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// modInteger begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
-wire ~SIGD[~SYM[2]][1];
+wire ~SIGD[~GENSYM[rem_res][0]][0];
+wire ~SIGD[~GENSYM[dividend][1]][0];
+wire ~SIGD[~GENSYM[divider][2]][1];
 
 // remainder
 assign ~SYM[0] = ~ARG[0] % ~ARG[1];

--- a/clash-verilog/primitives/GHC.Prim.json
+++ b/clash-verilog/primitives/GHC.Prim.json
@@ -75,8 +75,8 @@
     , "type"      : "quotRemInt# :: Int# -> Int# -> (#Int#, Int##)"
     , "templateD" :
 "// quotRemInt begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+wire ~SIGD[~GENSYM[rem_res][1]][0];
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
 assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
@@ -215,8 +215,8 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
     , "type"      : "quotRemWord# :: Word# -> Word# -> (#Word#, Word##)"
     , "templateD" :
 "// quotRemWord begin
-wire ~SIGD[~SYM[0]][0];
-wire ~SIGD[~SYM[1]][0];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+wire ~SIGD[~GENSYM[rem_res][1]][0];
 assign ~SYM[0] = ~ARG[0] / ~ARG[1];
 assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
@@ -307,57 +307,57 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
     , "type"      : "popCnt8# :: Word# -> Word#"
     , "templateD" :
 "// popCnt8 begin
-localparam width_~SYM[0] = 8;
+localparam ~GENSYM[width][0] = 8;
 
 // ceiling of log2
-function integer log2_~SYM[1];
+function integer ~GENSYM[log2][1];
   input integer value;
   begin
     value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
+    for (~SYM[1]=0; value>0; ~SYM[1]=~SYM[1]+1)
       value = value>>1;
   end
 endfunction
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = ~SYM[1](~SYM[0]);
 
-wire [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt8 end"
     }
   }
@@ -366,57 +366,57 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "popCnt16# :: Word# -> Word#"
     , "templateD" :
 "// popCnt16 begin
-localparam width_~SYM[0] = 16;
+localparam ~GENSYM[width][0] = 16;
 
 // ceiling of log2
-function integer log2_~SYM[1];
+function integer ~GENSYM[log2][1];
   input integer value;
   begin
     value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
+    for (~SYM[1]=0; value>0; ~SYM[1]=~SYM[1]+1)
       value = value>>1;
   end
 endfunction
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = ~SYM[1](~SYM[0]);
 
-wire [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt16 end"
     }
   }
@@ -425,57 +425,57 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "popCnt32# :: Word# -> Word#"
     , "templateD" :
 "// popCnt32 begin
-localparam width_~SYM[0] = 32;
+localparam ~GENSYM[width][0] = 32;
 
 // ceiling of log2
-function integer log2_~SYM[1];
+function integer ~GENSYM[log2][1];
   input integer value;
   begin
     value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
+    for (~SYM[1]=0; value>0; ~SYM[1]=~SYM[1]+1)
       value = value>>1;
   end
 endfunction
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = ~SYM[1](~SYM[0]);
 
-wire [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt32 end"
     }
   }
@@ -484,57 +484,57 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "popCnt64# :: Word# -> Word#"
     , "templateD" :
 "// popCnt64 begin
-localparam width_~SYM[0] = 64;
+localparam ~GENSYM[width][0] = 64;
 
 // ceiling of log2
-function integer log2_~SYM[1];
+function integer ~GENSYM[log2][1];
   input integer value;
   begin
     value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
+    for (~SYM[1]=0; value>0; ~SYM[1]=~SYM[1]+1)
       value = value>>1;
   end
 endfunction
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = ~SYM[1](~SYM[0]);
 
-wire [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt64 end"
     }
   }
@@ -543,57 +543,57 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "popCnt8# :: Word# -> Word#"
     , "templateD" :
 "// popCnt begin
-localparam width_~SYM[0] = ~SIZE[~TYPO];
+localparam ~GENSYM[width][0] = ~SIZE[~TYPO];
 
 // ceiling of log2
-function integer log2_~SYM[1];
+function integer ~GENSYM[log2][1];
   input integer value;
   begin
     value = value-1;
-    for (log2_~SYM[1]=0; value>0; log2_~SYM[1]=log2_~SYM[1]+1)
+    for (~SYM[1]=0; value>0; ~SYM[1]=~SYM[1]+1)
       value = value>>1;
   end
 endfunction
 
 // depth of the tree
-localparam levels_~SYM[2] = log2_~SYM[1](width_~SYM[0]);
+localparam ~GENSYM[levels][2] = ~SYM[1](~SYM[0]);
 
-wire [levels_~SYM[2]:0] intermediate_~SYM[3] [0:(2*width_~SYM[0])-2];
+wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 
 // put input into the first half of the intermediate array
-genvar i_~SYM[4];
+genvar ~GENSYM[i][4];
 ~GENERATE
-for (i_~SYM[4] = 0; i_~SYM[4] < width_~SYM[0]; i_~SYM[4]=i_~SYM[4]+1) begin : array_~SYM[5]
-  assign intermediate_~SYM[3][i_~SYM[4]] = $unsigned(~ARG[0][i_~SYM[4]]);
+for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
+  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
 end
 ~ENDGENERATE
 
 // given a level and a depth, calculate the corresponding index into the
 // intermediate array
-function integer depth2Index_~SYM[5];
+function integer ~GENSYM[depth2Index][5];
   input integer levels;
   input integer depth;
 
-  depth2Index_~SYM[5] = (2 ** levels) - (2 ** depth);
+  ~SYM[5] = (2 ** levels) - (2 ** depth);
 endfunction
 
 // Create the tree of instantiated components
-genvar d_~SYM[6];
-genvar i_~SYM[7];
+genvar ~GENSYM[d][6];
+genvar ~GENSYM[i][7];
 ~GENERATE
-if (levels_~SYM[2] != 0) begin : make_tree_~SYM[8]
-  for (d_~SYM[6] = (levels_~SYM[2] - 1); d_~SYM[6] >= 0; d_~SYM[6]=d_~SYM[6]-1) begin : tree_depth
-    for (i_~SYM[7] = 0; i_~SYM[7] < (2**d_~SYM[6]); i_~SYM[7] = i_~SYM[7]+1) begin : tree_depth_loop
-      assign intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+1)+i_~SYM[7]] =
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])] +
-             intermediate_~SYM[3][depth2Index_~SYM[5](levels_~SYM[2]+1,d_~SYM[6]+2)+(2*i_~SYM[7])+1];
+if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
+  for (~SYM[6] = (~SYM[2] - 1); ~SYM[6] >= 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
+    for (~SYM[7] = 0; ~SYM[7] < (2**~SYM[6]); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
+      assign ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+1)+~SYM[7]] =
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])] +
+             ~SYM[3][~SYM[5](~SYM[2]+1,~SYM[6]+2)+(2*~SYM[7])+1];
     end
   end
 end
 ~ENDGENERATE
 
 // The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
+assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 // popCnt end"
     }
   }
@@ -602,63 +602,59 @@ assign ~RESULT = $unsigned(intermediate_~SYM[3][(2*width_~SYM[0])-2]);
     , "type"      : "clz8 :: Word# -> Word#"
     , "templateD" :
 "// clz8 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-wire [0:7] v;
-assign v = ~ARG[0][7:0];
+wire [0:7] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][7:0];
 
-wire [0:7] e;
-genvar i;
+wire [0:7] ~GENSYM[e][2];
+genvar ~GENSYM[n][3];
 ~GENERATE
-for (i=0;i<4;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:5] a;
-genvar i1;
+reg [0:5] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<2;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage1][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:3] res;
+reg [0:3] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 3;
 wire [5:0] i;
-assign i = a[0:5];
+assign i = ~SYM[4][0:5];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz8 end"
     }
   }
@@ -667,79 +663,75 @@ end
     , "type"      : "clz16 :: Word# -> Word#"
     , "templateD" :
 "// clz16 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-wire [0:15] v;
-assign v = ~ARG[0][15:0];
+wire [0:15] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][15:0];
 
-wire [0:15] e;
-genvar i;
+wire [0:15] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<8;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:11] a;
-genvar i1;
+reg [0:11] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<4;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:7] b;
-genvar i2;
+reg [0:7] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<2;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:4] res;
+reg [0:4] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 4;
 wire [7:0] i;
-assign i = b[0:7];
+assign i = ~SYM[9][0:7];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz16 end"
     }
   }
@@ -748,95 +740,91 @@ end
     , "type"      : "clz32 :: Word# -> Word#"
     , "templateD" :
 "// clz32 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-wire [0:31] v;
-assign v = ~ARG[0][31:0];
+wire [0:31] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][31:0];
 
-wire [0:31] e;
-genvar i;
+wire [0:31] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<16;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:23] a;
-genvar i1;
+reg [0:23] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<8;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:15] b;
-genvar i2;
+reg [0:15] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<4;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:9] c;
-genvar i3;
+reg [0:9] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<2;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   wire [7:0] i;
-  assign i = b[i3*8:i3*8+7];
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:5] res;
+reg [0:5] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 5;
 wire [9:0] i;
-assign i = c[0:9];
+assign i = ~SYM[12][0:9];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz32 end"
     }
   }
@@ -845,111 +833,107 @@ end
     , "type"      : "clz64 :: Word# -> Word#"
     , "templateD" :
 "// clz64 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-wire [0:63] v;
-assign v = ~ARG[0][63:0];
+wire [0:63] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][63:0];
 
-wire [0:63] e;
-genvar i;
+wire [0:63] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<32;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:47] a;
-genvar i1;
+reg [0:47] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<16;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:31] b;
-genvar i2;
+reg [0:31] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<8;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:19] c;
-genvar i3;
+reg [0:19] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<4;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   wire [7:0] i;
-  assign i = b[i3*8:i3*8+7];
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:11] d;
-genvar i4;
+reg [0:11] ~GENSYM[d][15];
+genvar ~GENSYM[i4][16];
 ~GENERATE
-for (i4=0;i4<2;i4=i4+1) begin : mux_stage4
+for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
   localparam n = 5;
   wire [9:0] i;
-  assign i = c[i4*10:i4*10+9];
+  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:6] res;
+reg [0:6] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 6;
 wire [11:0] i;
-assign i = d[0:11];
+assign i = ~SYM[15][0:11];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz64 end"
     }
   }
@@ -958,185 +942,181 @@ end
     , "type"      : "clz :: Word# -> Word#"
     , "templateD" :
 "// clz begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 ~IF ~IW64 ~THEN
-wire [0:63] v;
-assign v = ~ARG[0][63:0];
+wire [0:63] ~GENSYM[v][1];
+assign ~SYM[1] = ~ARG[0][63:0];
 
-wire [0:63] e;
-genvar i;
+wire [0:63] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<32;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:47] a;
-genvar i1;
+reg [0:47] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<16;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:31] b;
-genvar i2;
+reg [0:31] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<8;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:19] c;
-genvar i3;
+reg [0:19] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<4;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   wire [7:0] i;
-  assign i = b[i3*8:i3*8+7];
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:11] d;
-genvar i4;
+reg [0:11] ~GENSYM[d][15];
+genvar ~GENSYM[i4][16];
 ~GENERATE
-for (i4=0;i4<2;i4=i4+1) begin : mux_stage4
+for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
   localparam n = 5;
   wire [9:0] i;
-  assign i = c[i4*10:i4*10+9];
+  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:6] res;
+reg [0:6] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 6;
 wire [11:0] i;
-assign i = d[0:11];
+assign i = ~SYM[15][0:11];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 ~ELSE
-wire [0:31] v;
-assign v = ~ARG[0][31:0];
+wire [0:31] ~SYM[1];
+assign ~SYM[1] = ~ARG[0][31:0];
 
-wire [0:31] e;
-genvar i;
+wire [0:31] ~SYM[2];
+genvar ~SYM[3];
 ~GENERATE
-for (i=0;i<16;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:23] a;
-genvar i1;
+reg [0:23] ~SYM[4];
+genvar ~SYM[5];
 ~GENERATE
-for (i1=0;i1<8;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:15] b;
-genvar i2;
+reg [0:15] ~SYM[9];
+genvar ~SYM[10];
 ~GENERATE
-for (i2=0;i2<4;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:9] c;
-genvar i3;
+reg [0:9] ~SYM[12];
+genvar ~SYM[13];
 ~GENERATE
-for (i3=0;i3<2;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]
   localparam n = 4;
   wire [7:0] i;
-  assign i = b[i3*8:i3*8+7];
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:5] res;
+reg [0:5] ~SYM[7];
 ~GENERATE
 if (1) begin
 localparam n = 5;
 wire [9:0] i;
-assign i = c[0:9];
+assign i = ~SYM[12][0:9];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 ~FI
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // clz end"
     }
   }
@@ -1145,68 +1125,64 @@ end
     , "type"      : "ctz8 :: Word# -> Word#"
     , "templateD" :
 "// ctz8 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-wire [0:7] v;
-genvar k;
+wire [0:7] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<8;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<8;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-wire [0:7] e;
-genvar i;
+wire [0:7] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<4;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:5] a;
-genvar i1;
+reg [0:5] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<2;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:3] res;
+reg [0:3] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 3;
 wire [5:0] i;
-assign i = a[0:5];
+assign i = ~SYM[4][0:5];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz8 end"
     }
   }
@@ -1215,84 +1191,80 @@ end
     , "type"      : "ctz16 :: Word# -> Word#"
     , "templateD" :
 "// ctz16 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-wire [0:15] v;
-genvar k;
+wire [0:15] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<16;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<16;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-wire [0:15] e;
-genvar i;
+wire [0:15] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<8;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:11] a;
-genvar i1;
+reg [0:11] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<4;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:7] b;
-genvar i2;
+reg [0:7] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<2;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:4] res;
+reg [0:4] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 4;
 wire [7:0] i;
-assign i = b[0:7];
+assign i = ~SYM[9][0:7];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz16 end"
     }
   }
@@ -1301,100 +1273,96 @@ end
     , "type"      : "ctz32 :: Word# -> Word#"
     , "templateD" :
 "// ctz32 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-wire [0:31] v;
-genvar k;
+wire [0:31] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<32;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-wire [0:31] e;
-genvar i;
+wire [0:31] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<16;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:23] a;
-genvar i1;
+reg [0:23] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<8;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:15] b;
-genvar i2;
+reg [0:15] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<4;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:9] c;
-genvar i3;
+reg [0:9] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<2;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   wire [7:0] i;
-  assign i = b[i3*8:i3*8+7];
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:5] res;
+reg [0:5] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 5;
 wire [9:0] i;
-assign i = c[0:9];
+assign i = ~SYM[12][0:9];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz32 end"
     }
   }
@@ -1403,116 +1371,112 @@ end
     , "type"      : "ctz64 :: Word# -> Word#"
     , "templateD" :
 "// ctz64 begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 
-wire [0:63] v;
-genvar k;
+wire [0:63] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<64;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-wire [0:63] e;
-genvar i;
+wire [0:63] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<32;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
 reg [0:47] a;
-genvar i1;
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<16;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:31] b;
-genvar i2;
+reg [0:31] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<8;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:19] c;
-genvar i3;
+reg [0:19] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<4;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   wire [7:0] i;
-  assign i = b[i3*8:i3*8+7];
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:11] d;
-genvar i4;
+reg [0:11] ~GENSYM[d][15];
+genvar ~GENSYM[i4][16];
 ~GENERATE
-for (i4=0;i4<2;i4=i4+1) begin : mux_stage4
+for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
   localparam n = 5;
   wire [9:0] i;
-  assign i = c[i4*10:i4*10+9];
+  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:6] res;
+reg [0:6] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 6;
 wire [11:0] i;
-assign i = d[0:11];
+assign i = ~SYM[15][0:11];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz64 end"
     }
   }
@@ -1521,195 +1485,191 @@ end
     , "type"      : "ctz :: Word# -> Word#"
     , "templateD" :
 "// ctz begin
-~GENERATE
-if (1) begin
-function [1:0] enc;
+function [1:0] ~GENSYM[enc][0];
   input [1:0] a;
   case (a)
-    2'b00:   enc = 2'b10;
-    2'b01:   enc = 2'b01;
-    2'b10:   enc = 2'b00;
-    default: enc = 2'b00;
+    2'b00:   ~SYM[0] = 2'b10;
+    2'b01:   ~SYM[0] = 2'b01;
+    2'b10:   ~SYM[0] = 2'b00;
+    default: ~SYM[0] = 2'b00;
   endcase
 endfunction
 ~IF ~IW64 ~THEN
-wire [0:63] v;
-genvar k;
+wire [0:63] ~GENSYM[v][1];
+genvar ~GENSYM[k][18];
 ~GENERATE
-for (k=0;k<64;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-wire [0:63] e;
-genvar i;
+wire [0:63] ~GENSYM[e][2];
+genvar ~GENSYM[i][3];
 ~GENERATE
-for (i=0;i<32;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:47] a;
-genvar i1;
+reg [0:47] ~GENSYM[a][4];
+genvar ~GENSYM[i1][5];
 ~GENERATE
-for (i1=0;i1<16;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:31] b;
-genvar i2;
+reg [0:31] ~GENSYM[b][9];
+genvar ~GENSYM[i2][10];
 ~GENERATE
-for (i2=0;i2<8;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:19] c;
-genvar i3;
+reg [0:19] ~GENSYM[c][12];
+genvar ~GENSYM[i3][13];
 ~GENERATE
-for (i3=0;i3<4;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
   localparam n = 4;
   wire [7:0] i;
-  assign i = b[i3*8:i3*8+7];
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:11] d;
-genvar i4;
+reg [0:11] ~GENSYM[d][15];
+genvar ~GENSYM[i4][16];
 ~GENERATE
-for (i4=0;i4<2;i4=i4+1) begin : mux_stage4
+for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
   localparam n = 5;
   wire [9:0] i;
-  assign i = c[i4*10:i4*10+9];
+  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : d[i4*6:i4*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:6] res;
+reg [0:6] ~GENSYM[res][7];
 ~GENERATE
 if (1) begin
 localparam n = 6;
 wire [11:0] i;
-assign i = d[0:11];
+assign i = ~SYM[15][0:11];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 ~ELSE
-wire [0:31] v;
-genvar k;
+wire [0:31] ~SYM[1];
+genvar ~SYM[18];
 ~GENERATE
-for (k=0;k<32;k=k+1) begin : reverse
-  assign v[k] = ~ARG[0][k];
+for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~SYM[19]
+  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
 end
 ~ENDGENERATE
 
-wire [0:31] e;
-genvar i;
+wire [0:31] ~SYM[2];
+genvar ~SYM[3];
 ~GENERATE
-for (i=0;i<16;i=i+1) begin : enc_stage
-  assign e[i*2:i*2+1] = enc(v[i*2:i*2+1]);
+for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]
+  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~SYM[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
 end
 ~ENDGENERATE
 
-reg [0:23] a;
-genvar i1;
+reg [0:23] ~SYM[4];
+genvar ~SYM[5];
 ~GENERATE
-for (i1=0;i1<8;i1=i1+1) begin : mux_stage1
+for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]
   localparam n = 2;
   wire [3:0] i;
-  assign i = e[i1*4:i1*4+3];
+  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : a[i1*3:i1*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:15] b;
-genvar i2;
+reg [0:15] ~SYM[9];
+genvar ~SYM[10];
 ~GENERATE
-for (i2=0;i2<4;i2=i2+1) begin : mux_stage2
+for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]
   localparam n = 3;
   wire [5:0] i;
-  assign i = a[i2*6:i2*6+5];
+  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : b[i2*4:i2*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:9] c;
-genvar i3;
+reg [0:9] ~SYM[12];
+genvar ~SYM[13];
 ~GENERATE
-for (i3=0;i3<2;i3=i3+1) begin : mux_stage3
+for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]
   localparam n = 4;
   wire [7:0] i;
-  assign i = b[i3*8:i3*8+7];
+  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
   always @(*) begin
     case (i[n-1+n])
-      1'b0    : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : c[i3*5:i3*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
     endcase
   end
 end
 ~ENDGENERATE
 
-reg [0:5] res;
+reg [0:5] ~SYM[7];
 ~GENERATE
 if (1) begin
 localparam n = 5;
 wire [9:0] i;
-assign i = c[0:9];
+assign i = ~SYM[12][0:9];
 always @(*) begin
   case (i[n-1+n])
-    1'b0    : res = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : res = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
+    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
+    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
   endcase
 end
 end
 ~ENDGENERATE
 ~FI
-assign ~RESULT = $unsigned(res);
-end
-~ENDGENERATE
+assign ~RESULT = $unsigned(~SYM[7]);
 // ctz end"
     }
   }
@@ -1718,13 +1678,10 @@ end
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap16 begin
-wire ~TYP[0] ~SYM[0];
-assign ~SYM[0] = ~ARG[0];
-~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[0][63:16],~SYM[0][7:0],~SYM[0][15:8]};
-~ELSE
-assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};
-~FI
+wire ~TYP[0] ~GENSYM[w][0];
+assign ~SYM[0] = ~ARG[0];~IF ~IW64 ~THEN
+assign ~RESULT = {~SYM[0][63:16],~SYM[0][7:0],~SYM[0][15:8]};~ELSE
+assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};~FI
 // byteSwap16 end"
     }
   }
@@ -1733,13 +1690,10 @@ assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap32 begin
-wire ~TYPO ~SYM[0];
-assign ~SYM[0] = ~ARG[0];
-~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[0][63:32],~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};
-~ELSE
-assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};
-~FI
+wire ~TYPO ~GENSYM[w][0];
+assign ~SYM[0] = ~ARG[0];~IF ~IW64 ~THEN
+assign ~RESULT = {~SYM[0][63:32],~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~ELSE
+assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~FI
 // byteSwap32 end"
     }
   }
@@ -1748,7 +1702,7 @@ assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap64 begin
-wire ~TYP[0] ~SYM[1];
+wire ~TYP[0] ~GENSYM[w][1];
 assign ~SYM[1] = ~ARG[0];
 assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
                  ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};
@@ -1760,14 +1714,11 @@ assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap begin
-wire ~TYP[0] ~SYM[1];
-assign ~SYM[1] = ~ARG[0];
-~IF ~IW64 ~THEN
+wire ~TYP[0] ~GENSYM[w][1];
+assign ~SYM[1] = ~ARG[0];~IF ~IW64 ~THEN
 assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
-                 ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};
-~ELSE
-assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};
-~FI
+                 ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};~ELSE
+assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};~FI
 // byteSwap end"
     }
   }
@@ -1776,7 +1727,7 @@ assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};
     , "type"      : "narrow8Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow8Int begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[s][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $signed(~SYM[0][7:0]);
@@ -1788,7 +1739,7 @@ assign ~RESULT = $signed(~SYM[0][7:0]);
     , "type"      : "narrow16Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow16Int begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[s][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $signed(~SYM[0][15:0]);
@@ -1800,7 +1751,7 @@ assign ~RESULT = $signed(~SYM[0][15:0]);
     , "type"      : "narrow32Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow32Int begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[s][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $signed(~SYM[0][31:0]);
@@ -1812,7 +1763,7 @@ assign ~RESULT = $signed(~SYM[0][31:0]);
     , "type"      : "narrow8Int# :: Word# -> Word#"
     , "templateD" :
 "// narrow8Word begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[w][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $unsigned(~SYM[0][7:0]);
@@ -1824,7 +1775,7 @@ assign ~RESULT = $unsigned(~SYM[0][7:0]);
     , "type"      : "narrow16Word# :: Word# -> Word#"
     , "templateD" :
 "// narrow16Word begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[w][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $unsigned(~SYM[0][15:0]);
@@ -1836,7 +1787,7 @@ assign ~RESULT = $unsigned(~SYM[0][15:0]);
     , "type"      : "narrow32Int# :: Word# -> Word#"
     , "templateD" :
 "// narrow32Word begin
-wire ~SIGD[~SYM[0]][0];
+wire ~SIGD[~GENSYM[w][0]][0];
 assign ~SYM[0] = ~ARG[0];
 
 assign ~RESULT = $unsigned(~SYM[0][31:0]);

--- a/clash-verilog/src/CLaSH/Backend/Verilog.hs
+++ b/clash-verilog/src/CLaSH/Backend/Verilog.hs
@@ -83,6 +83,7 @@ instance Backend VerilogState where
   fromBV _        = text
   hdlSyn          = use hdlsyn
   mkBasicId       = return (filterReserved . mkBasicId' True)
+  setModName _    = id
 
 type VerilogM a = State VerilogState a
 

--- a/clash-verilog/src/CLaSH/Backend/Verilog.hs
+++ b/clash-verilog/src/CLaSH/Backend/Verilog.hs
@@ -18,10 +18,10 @@ module CLaSH.Backend.Verilog (VerilogState) where
 import qualified Control.Applicative                  as A
 import           Control.Lens                         ((+=),(-=), makeLenses, use)
 import           Control.Monad.State                  (State)
-import           Data.Char                            (toUpper)
 import qualified Data.HashSet                         as HashSet
 import           Data.Maybe                           (catMaybes)
 import           Data.Text.Lazy                       (pack, unpack)
+import qualified Data.Text.Lazy                       as Text
 import           Prelude                              hiding ((<$>))
 import           Text.PrettyPrint.Leijen.Text.Monadic
 
@@ -87,7 +87,7 @@ instance Backend VerilogState where
 type VerilogM a = State VerilogState a
 
 -- List of reserved Verilog-2005 keywords
-reservedWords :: [String]
+reservedWords :: [Identifier]
 reservedWords = ["always","and","assign","automatic","begin","buf","bufif0"
   ,"bufif1","case","casex","casez","cell","cmos","config","deassign","default"
   ,"defparam","design","disable","edge","else","end","endcase","endconfig"
@@ -105,9 +105,9 @@ reservedWords = ["always","and","assign","automatic","begin","buf","bufif0"
   ,"tri0","tri1","triand","trior","trireg","unsigned","use","uwire","vectored"
   ,"wait","wand","weak0","weak1","while","wire","wor","xnor","xor"]
 
-filterReserved :: String -> String
+filterReserved :: Identifier -> Identifier
 filterReserved s = if s `elem` reservedWords
-  then init s ++ [toUpper (last s)]
+  then Text.init s `Text.append` (Text.toUpper . Text.singleton . Text.last) s
   else s
 
 -- | Generate VHDL for a Netlist component

--- a/clash-verilog/src/CLaSH/Backend/Verilog.hs
+++ b/clash-verilog/src/CLaSH/Backend/Verilog.hs
@@ -108,7 +108,7 @@ reservedWords = ["always","and","assign","automatic","begin","buf","bufif0"
 
 filterReserved :: Identifier -> Identifier
 filterReserved s = if s `elem` reservedWords
-  then Text.init s `Text.append` (Text.toUpper . Text.singleton . Text.last) s
+  then s `Text.append` "_r"
   else s
 
 -- | Generate VHDL for a Netlist component

--- a/clash-vhdl/primitives/CLaSH.Driver.TopWrapper.json
+++ b/clash-vhdl/primitives/CLaSH.Driver.TopWrapper.json
@@ -2,9 +2,9 @@
     { "name"      : "CLaSH.TopWrapper.syncReset"
     , "templateD" :
 "-- reset ~RESULT is asynchronously asserted, but synchronously de-asserted
-resetSync_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
-  signal ~SYM[2] : ~TYP[0];
+~GENSYM[resetSync][0] : block
+  signal ~GENSYM[r1][1] : ~TYP[0];
+  signal ~GENSYM[r2][2] : ~TYP[0];
 begin
   process(~CLKO,~ARG[0])
   begin

--- a/clash-vhdl/primitives/CLaSH.Prelude.BlockRam.File.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.BlockRam.File.json
@@ -12,10 +12,10 @@
                -> Signal' clk (BitVector m)"
     , "templateD" :
 "-- blockRamFile begin
-blockRamFile_~COMPNAME_~SYM[0] : block
+~GENSYM[~COMPNAME_blockRamFile][0] : block
   type RamType is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
 
-  impure function InitRamFromFile (RamFileName : in string) return RamType is
+  impure function ~GENSYM[InitRamFromFile][1] (RamFileName : in string) return RamType is
     FILE RamFile : text open read_mode is RamFileName;
     variable RamFileLine : line;
     variable RAM : RamType(0 to ~LIT[2]-1);
@@ -27,18 +27,18 @@ blockRamFile_~COMPNAME_~SYM[0] : block
     return RAM;
   end function;
 
-  signal RAM_~SYM[1]  : RamType(0 to ~LIT[2]-1) := InitRamFromFile(~FILE[~LIT[3]]);
-  signal dout_~SYM[2] : ~TYP[7];
-  signal wr_~SYM[3]   : integer range 0 to ~LIT[2]-1;
-  signal rd_~SYM[4]   : integer range 0 to ~LIT[2]-1;
+  signal ~GENSYM[RAM][2] : RamType(0 to ~LIT[2]-1) := ~SYM[1](~FILE[~LIT[3]]);
+  signal ~GENSYM[dout][3] : ~TYP[7];
+  signal ~GENSYM[wr][4] : integer range 0 to ~LIT[2]-1;
+  signal ~GENSYM[rd][5] : integer range 0 to ~LIT[2]-1;
 begin
-  wr_~SYM[3] <= to_integer(~ARG[4])
+  ~SYM[4] <= to_integer(~ARG[4])
   -- pragma translate_off
                 mod ~LIT[2]
   -- pragma translate_on
                 ;
 
-  rd_~SYM[4] <= to_integer(~ARG[5])
+  ~SYM[5] <= to_integer(~ARG[5])
   -- pragma translate_off
                 mod ~LIT[2]
   -- pragma translate_on
@@ -48,14 +48,13 @@ begin
   begin
     if (rising_edge(~CLK[1])) then
       if ~ARG[6] then
-        RAM_~SYM[1](wr_~SYM[3]) <= to_bitvector(~ARG[7]);
+        ~SYM[2](~SYM[4]) <= to_bitvector(~ARG[7]);
       end if;
-
-      dout_~SYM[2] <= to_stdlogicvector(RAM_~SYM[1](rd_~SYM[4]));
+      ~SYM[3] <= to_stdlogicvector(~SYM[2](~SYM[5]));
     end if;
   end process;
 
-  ~RESULT <= dout_~SYM[2];
+  ~RESULT <= ~SYM[3];
 end block;
 -- blockRamFile end"
     }

--- a/clash-vhdl/primitives/CLaSH.Prelude.BlockRam.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.BlockRam.json
@@ -11,23 +11,20 @@
            -> Signal' clk a"
     , "templateD" :
 "-- blockRam begin
-blockRam_~COMPNAME_~SYM[0] : block
-  signal RAM_~SYM[1]  : ~TYP[2] := ~LIT[2];
-~IF ~VIVADO ~THEN
-  signal dout_~SYM[2] : std_logic_vector(~SIZE[~TYP[6]]-1 downto 0);
-~ELSE
-  signal dout_~SYM[2] : ~TYP[6];
-~FI
-  signal wr_~SYM[3]   : integer range 0 to ~LIT[0] - 1;
-  signal rd_~SYM[4]   : integer range 0 to ~LIT[0] - 1;
+~GENSYM[~COMPNAME_blockRam][0] : block
+  signal ~GENSYM[RAM][1] : ~TYP[2] := ~LIT[2];~IF ~VIVADO ~THEN
+  signal ~GENSYM[dout][2] : std_logic_vector(~SIZE[~TYP[6]]-1 downto 0);~ELSE
+  signal ~SYM[2] : ~TYP[6];~FI
+  signal ~GENSYM[wr][3] : integer range 0 to ~LIT[0] - 1;
+  signal ~GENSYM[rd][4] : integer range 0 to ~LIT[0] - 1;
 begin
-  wr_~SYM[3] <= to_integer(~ARG[3])
+  ~SYM[3] <= to_integer(~ARG[3])
   -- pragma translate_off
                 mod ~LIT[0]
   -- pragma translate_on
                 ;
 
-  rd_~SYM[4] <= to_integer(~ARG[4])
+  ~SYM[4] <= to_integer(~ARG[4])
   -- pragma translate_off
                 mod ~LIT[0]
   -- pragma translate_on
@@ -36,21 +33,15 @@ begin
   blockRam_sync : process(~CLK[1])
   begin
     if rising_edge(~CLK[1]) then
-      if ~ARG[5] then
-~IF ~VIVADO ~THEN
-        RAM_~SYM[1](wr_~SYM[3]) <= ~TOBV[~ARG[6]][~TYP[6]];
-~ELSE
-        RAM_~SYM[1](wr_~SYM[3]) <= ~ARG[6];
-~FI
+      if ~ARG[5] then~IF ~VIVADO ~THEN
+        ~SYM[1](~SYM[3]) <= ~TOBV[~ARG[6]][~TYP[6]];~ELSE
+        ~SYM[1](~SYM[3]) <= ~ARG[6];~FI
       end if;
-      dout_~SYM[2] <= RAM_~SYM[1](rd_~SYM[4]);
+      ~SYM[2] <= ~SYM[1](~SYM[4]);
     end if;
-  end process;
-~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[dout_~SYM[2]][~TYPO];
-~ELSE
-  ~RESULT <= dout_~SYM[2];
-~FI
+  end process;~IF ~VIVADO ~THEN
+  ~RESULT <= ~FROMBV[~SYM[2]][~TYPO];~ELSE
+  ~RESULT <= ~SYM[2];~FI
 end block;
 -- blockRam end"
     }

--- a/clash-vhdl/primitives/CLaSH.Prelude.RAM.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.RAM.json
@@ -11,19 +11,19 @@
            -> Signal' rclk a"
     , "templateD" :
 "-- asyncRam begin
-asyncRam_~COMPNAME_~SYM[0] : block
+~GENSYM[~COMPNAME_asyncRam][0] : block
   type RamType is array(natural range <>) of ~TYP[6];
-  signal RAM_~SYM[1] : RamType(0 to ~LIT[2]-1);
-  signal wr_~SYM[2]  : integer range 0 to ~LIT[2] - 1;
-  signal rd_~SYM[3]  : integer range 0 to ~LIT[2] - 1;
+  signal ~GENSYM[RAM][1] : RamType(0 to ~LIT[2]-1);
+  signal ~GENSYM[wr][2] : integer range 0 to ~LIT[2] - 1;
+  signal ~GENSYM[rd][3] : integer range 0 to ~LIT[2] - 1;
 begin
-  wr_~SYM[2] <= to_integer(~ARG[3])
+  ~SYM[2] <= to_integer(~ARG[3])
   -- pragma translate_off
                 mod ~LIT[2]
   -- pragma translate_on
                 ;
 
-  rd_~SYM[3] <= to_integer(~ARG[4])
+  ~SYM[3] <= to_integer(~ARG[4])
   -- pragma translate_off
                 mod ~LIT[2]
   -- pragma translate_on
@@ -33,12 +33,12 @@ begin
   begin
     if rising_edge(~CLK[0]) then
       if ~ARG[5] then
-        RAM_~SYM[1](wr_~SYM[2]) <= ~ARG[6];
+        ~SYM[1](~SYM[2]) <= ~ARG[6];
       end if;
     end if;
   end process;
 
-  ~RESULT <= RAM_~SYM[1](rd_~SYM[3]);
+  ~RESULT <= ~SYM[1](~SYM[3]);
 end block;
 -- asyncRam end"
     }

--- a/clash-vhdl/primitives/CLaSH.Prelude.ROM.File.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.ROM.File.json
@@ -8,10 +8,10 @@
                -> BitVector m"
     , "templateD" :
 "-- asyncRomFile begin
-asyncROMFile_~SYM[0] : block
+~GENSYM[asyncROMFile][0] : block
   type RomType is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
 
-  impure function InitRomFromFile (RomFileName : in string) return RomType is
+  impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return RomType is
     FILE RomFile : text open read_mode is RomFileName;
     variable RomFileLine : line;
     variable ROM : RomType(0 to ~LIT[1]-1);
@@ -23,16 +23,16 @@ asyncROMFile_~SYM[0] : block
     return ROM;
   end function;
 
-  signal ROM_~SYM[1] : RomType(0 to ~LIT[1]-1) := InitRomFromFile(~FILE[~LIT[2]]);
-  signal rd_~SYM[2]  : integer range 0 to ~LIT[1]-1;
+  signal ~GENSYM[ROM][2] : RomType(0 to ~LIT[1]-1) := ~SYM[1](~FILE[~LIT[2]]);
+  signal ~GENSYM[rd][3] : integer range 0 to ~LIT[1]-1;
 begin
-  rd_~SYM[2] <= to_integer(~ARG[3])
+  ~SYM[3] <= to_integer(~ARG[3])
   -- pragma translate_off
                 mod ~LIT[1]
   -- pragma translate_on
                 ;
 
-  ~RESULT <= to_stdlogicvector(ROM_~SYM[1](rd_~SYM[2]));
+  ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
 end block;
 -- asyncRomFile end"
     }
@@ -48,10 +48,10 @@ end block;
           -> Signal' clk (BitVector m)"
     , "templateD" :
 "-- romFile begin
-romFile_~COMPNAME_~SYM[0] : block
+~GENSYM[~COMPNAME_romFile][0] : block
   type RomType is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
 
-  impure function InitRomFromFile (RomFileName : in string) return RomType is
+  impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return RomType is
     FILE RomFile : text open read_mode is RomFileName;
     variable RomFileLine : line;
     variable ROM : RomType(0 to ~LIT[2]-1);
@@ -63,11 +63,10 @@ romFile_~COMPNAME_~SYM[0] : block
     return ROM;
   end function;
 
-  signal ROM_~SYM[1]  : RomType(0 to ~LIT[2]-1) := InitRomFromFile(~FILE[~LIT[3]]);
-  signal rd_~SYM[2]   : integer range 0 to ~LIT[2]-1;
-  signal dout_~SYM[3] : ~TYPO;
+  signal ~GENSYM[ROM][2] : RomType(0 to ~LIT[2]-1) := ~SYM[1](~FILE[~LIT[3]]);
+  signal ~GENSYM[rd][3] : integer range 0 to ~LIT[2]-1;
 begin
-  rd_~SYM[2] <= to_integer(~ARG[4])
+  ~SYM[3] <= to_integer(~ARG[4])
   -- pragma translate_off
                 mod ~LIT[2]
   -- pragma translate_on
@@ -76,11 +75,9 @@ begin
   romFileSync : process (~CLK[1])
   begin
     if (rising_edge(~CLK[1])) then
-      dout_~SYM[3] <= to_stdlogicvector(ROM_~SYM[1](rd_~SYM[2]));
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
     end if;
   end process;
-
-  ~RESULT <= dout_~SYM[3];
 end block;
 -- romFile end"
     }

--- a/clash-vhdl/primitives/CLaSH.Prelude.ROM.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.ROM.json
@@ -7,19 +7,19 @@
            -> a"
     , "templateD" :
 "-- asyncRom begin
-asyncRom_~SYM[0] : block
-  signal ROM_~SYM[1]       : ~TYP[1];
-  signal rom_index_~SYM[2] : integer range 0 to ~LIT[0]-1;
+~GENSYM[asyncRom][0] : block
+  signal ~GENSYM[ROM][1] : ~TYP[1];
+  signal ~GENSYM[rd][2] : integer range 0 to ~LIT[0]-1;
 begin
-  ROM_~SYM[1] <= ~ARG[1];
+  ~SYM[1] <= ~ARG[1];
 
-  rom_index~SYM[2] <= to_integer(~ARG[2])
+  ~SYM[2] <= to_integer(~ARG[2])
   -- pragma translate_off
                       mod ~LIT[0]
   -- pragma translate_on
                       ;
 
-  ~RESULT <= ROM_~SYM[1](rom_index_~SYM[2]);
+  ~RESULT <= ~SYM[1](~SYM[2]);
 end block;
 -- asyncRom end"
     }
@@ -34,14 +34,13 @@ end block;
       -> Signal' clk a"
     , "templateD" :
 "-- rom begin
-rom_~COMPNAME_~SYM[0] : block
-  signal ROM_~SYM[1]  : ~TYP[2];
-  signal rd_~SYM[2]   : integer range 0 to ~LIT[0]-1;
-  signal dout_~SYM[3] : ~TYPO;
+~GENSYM[~COMPNAME_rom][0] : block
+  signal ~GENSYM[ROM][1] : ~TYP[2];
+  signal ~GENSYM[rd][2] : integer range 0 to ~LIT[0]-1;
 begin
-  ROM_~SYM[1] <= ~ARG[2];
+  ~SYM[1] <= ~ARG[2];
 
-  rd_~SYM[2] <= to_integer(~ARG[3])
+  ~SYM[2] <= to_integer(~ARG[3])
   -- pragma translate_off
                 mod ~LIT[0]
   -- pragma translate_on
@@ -50,11 +49,9 @@ begin
   romSync : process (~CLK[1])
   begin
     if (rising_edge(~CLK[1])) then
-      dout_~SYM[3] <= ROM_~SYM[1](rd_~SYM[2]);
+      ~RESULT <= ~SYM[1](~SYM[2]);
     end if;
   end process;
-
-  ~RESULT <= dout_~SYM[3];
 end block;
 -- rom end"
     }

--- a/clash-vhdl/primitives/CLaSH.Prelude.Testbench.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.Testbench.json
@@ -10,9 +10,9 @@
          -> Signal' t b"
     , "templateD" :
 "-- assert begin
-assert_~SYM[0] : block
+~GENSYM[assert][0] : block
   -- pragma translate_off
-  function slv2string (slv : std_logic_vector) return STRING is
+  function ~GENSYM[slv2string][1] (slv : std_logic_vector) return STRING is
      variable result : string (1 to slv'length);
      variable res_l : string (1 to 3);
      variable r : integer;
@@ -25,17 +25,17 @@ assert_~SYM[0] : block
      end loop;
      return result;
   end;
-  signal actual_~SYM[1]   : ~TYP[4];
-  signal expected_~SYM[2] : ~TYP[5];
+  signal ~GENSYM[actual][2] : ~TYP[4];
+  signal ~GENSYM[expected][3] : ~TYP[5];
   -- pragma translate_on
 begin
   -- pragma translate_off
-  actual_~SYM[1]   <= ~ARG[4];
-  expected_~SYM[2] <= ~ARG[5];
+  ~SYM[2] <= ~ARG[4];
+  ~SYM[3] <= ~ARG[5];
   process(~CLK[2],~RST[2]) is
   begin
     if (rising_edge(~CLK[2]) or rising_edge(~RST[2])) then
-      assert (actual_~SYM[1] = expected_~SYM[2]) report (~LIT[3] & \", expected: \" & slv2string(toSLV(expected_~SYM[2])) & \", actual: \" & slv2string(toSLV(actual_~SYM[1]))) severity error;
+      assert (~SYM[2] = ~SYM[3]) report (~LIT[3] & \", expected: \" & ~SYM[1](toSLV(~SYM[3])) & \", actual: \" & ~SYM[1](toSLV(~SYM[2]))) severity error;
     end if;
   end process;
   -- pragma translate_on

--- a/clash-vhdl/primitives/CLaSH.Signal.Internal.json
+++ b/clash-vhdl/primitives/CLaSH.Signal.Internal.json
@@ -6,29 +6,15 @@
            -> Signal' clk a  -- ARG[2]
            -> Signal' clk a"
     , "templateD" :
-"-- register begin~IF ~ISLIT[1] ~THEN
-~GENSYM[~COMPNAME_register][0] : process(~CLK[0],~RST[0])
+"-- register begin
+~GENSYM[~COMPNAME_register][0] : process(~CLK[0],~RST[0]~VARS[1])
 begin
   if ~RST[0] = '0' then
     ~RESULT <= ~ARG[1];
   elsif rising_edge(~CLK[0]) then
     ~RESULT <= ~ARG[2];
   end if;
-end process;~ELSE
-~SYM[0] : block
-  signal ~GENSYM[reset_val][1] : ~TYP[1];
-begin
-  ~SYM[1] <= ~ARG[1];
-
-  process(~CLK[0],~RST[0],~SYM[1])
-  begin
-    if ~RST[0] = '0' then
-      ~RESULT <= ~SYM[1];
-    elsif rising_edge(~CLK[0]) then
-      ~RESULT <= ~ARG[2];
-    end if;
-  end process;
-end block;~FI
+end process;
 -- register end"
     }
   }
@@ -41,8 +27,8 @@ end block;~FI
         -> Signal' clk a    -- ARG[3]
         -> Signal' clk a"
     , "templateD" :
-"-- regEn begin~IF ~AND[~ISLIT[1],~ISVAR[2]] ~THEN
-~GENSYM[~COMPNAME_regEn][0] : process(~CLK[0],~RST[0],~ARG[2])
+"-- regEn begin
+~GENSYM[~COMPNAME_regEn][0] : process(~CLK[0],~RST[0]~VARS[1]~VARS[2])
 begin
   if ~RST[0] = '0' then
     ~RESULT <= ~ARG[1];
@@ -51,27 +37,7 @@ begin
       ~RESULT <= ~ARG[3];
     end if;
   end if;
-end process;~ELSE
-~SYM[0] : block
-  signal ~GENSYM[reset_val][1] : ~TYP[1];
-  signal ~GENSYM[en][2] : ~TYP[2];
-begin
-  ~SYM[1] <= ~ARG[1];
-  ~SYM[2] <= ~ARG[2];
-
-  process(~CLK[0],~RST[0],~SYM[1],~SYM[2])
-  begin
-    if ~RST[0] = '0' then
-      ~RESULT <= ~SYM[1];
-    elsif rising_edge(~CLK[0]) then
-      if ~SYM[2] then
-        ~RESULT <= ~ARG[3];
-      end if;
-    end if;
-  end process;
-
-  ~RESULT <= ~SYM[3];
-end block;~FI
+end process;
 -- regEn end"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Signal.Internal.json
+++ b/clash-vhdl/primitives/CLaSH.Signal.Internal.json
@@ -6,24 +6,29 @@
            -> Signal' clk a  -- ARG[2]
            -> Signal' clk a"
     , "templateD" :
-"-- register begin
-register_~COMPNAME_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
-  signal ~SYM[2] : ~TYP[2];
+"-- register begin~IF ~ISLIT[1] ~THEN
+~GENSYM[~COMPNAME_register][0] : process(~CLK[0],~RST[0])
+begin
+  if ~RST[0] = '0' then
+    ~RESULT <= ~ARG[1];
+  elsif rising_edge(~CLK[0]) then
+    ~RESULT <= ~ARG[2];
+  end if;
+end process;~ELSE
+~SYM[0] : block
+  signal ~GENSYM[reset_val][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[1];
 
   process(~CLK[0],~RST[0],~SYM[1])
   begin
     if ~RST[0] = '0' then
-      ~SYM[2] <= ~SYM[1];
+      ~RESULT <= ~SYM[1];
     elsif rising_edge(~CLK[0]) then
-      ~SYM[2] <= ~ARG[2];
+      ~RESULT <= ~ARG[2];
     end if;
   end process;
-
-  ~RESULT <= ~SYM[2];
-end block;
+end block;~FI
 -- register end"
     }
   }
@@ -36,11 +41,20 @@ end block;
         -> Signal' clk a    -- ARG[3]
         -> Signal' clk a"
     , "templateD" :
-"-- regEn begin
-regEn_~COMPNAME_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
-  signal ~SYM[2] : ~TYP[2];
-  signal ~SYM[3] : ~TYP[3];
+"-- regEn begin~IF ~AND[~ISLIT[1],~ISVAR[2]] ~THEN
+~GENSYM[~COMPNAME_regEn][0] : process(~CLK[0],~RST[0],~ARG[2])
+begin
+  if ~RST[0] = '0' then
+    ~RESULT <= ~ARG[1];
+  elsif rising_edge(~CLK[0]) then
+    if ~ARG[2] then
+      ~RESULT <= ~ARG[3];
+    end if;
+  end if;
+end process;~ELSE
+~SYM[0] : block
+  signal ~GENSYM[reset_val][1] : ~TYP[1];
+  signal ~GENSYM[en][2] : ~TYP[2];
 begin
   ~SYM[1] <= ~ARG[1];
   ~SYM[2] <= ~ARG[2];
@@ -48,16 +62,16 @@ begin
   process(~CLK[0],~RST[0],~SYM[1],~SYM[2])
   begin
     if ~RST[0] = '0' then
-      ~SYM[3] <= ~SYM[1];
+      ~RESULT <= ~SYM[1];
     elsif rising_edge(~CLK[0]) then
       if ~SYM[2] then
-        ~SYM[3] <= ~ARG[3];
+        ~RESULT <= ~ARG[3];
       end if;
     end if;
   end process;
 
   ~RESULT <= ~SYM[3];
-end block;
+end block;~FI
 -- regEn end"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -33,7 +33,7 @@
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
     , "templateD" :
 "-- reduceAnd begin
-reduceAnd_~SYM[0] : block
+~GENSYM[reduceAnd][0] : block
   function and_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
     variable half         : integer;
@@ -66,7 +66,7 @@ end block;
     , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
     , "templateD" :
 "-- reduceOr begin
-reduceOr_~SYM[0] : block
+~GENSYM[reduceOr][0] : block
   function or_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
     variable half         : integer;
@@ -99,7 +99,7 @@ end block;
     , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
     , "templateD" :
 "-- reduceXor begin
-reduceXor_~SYM[0] : block
+~GENSYM[reduceXor][0] : block
   function xor_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
     variable half         : integer;
@@ -135,21 +135,31 @@ end block;
         -> Int         -- ARG[2]
         -> Bit"
     , "templateD" :
-"-- indexBitVector begin
-indexBitVector_~SYM[0] : block
-  signal vec       : ~TYP[1];
-  signal vec_index : integer range 0 to ~LIT[0]-1;
+"-- indexBitVector begin~IF ~ISVAR[1] ~THEN
+~GENSYM[indexBitVector][0] : block
+  signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
-  vec <= ~ARG[1];
-
-  vec_index <= to_integer(~ARG[2])
+  ~SYM[1] <= to_integer(~ARG[2])
   -- pragma translate_off
                mod ~LIT[0]
   -- pragma translate_on
                ;
 
-  ~RESULT <= vec(vec_index downto vec_index);
-end block;
+  ~RESULT <= ~ARG[1](~SYM[1] downto ~SYM[1]);
+end block;~ELSE
+~SYM[0] : block
+  signal ~GENSYM[bv][2] : ~TYP[1];
+  signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
+begin
+  ~SYM[2] <= ~ARG[1];
+  ~SYM[1] <= to_integer(~ARG[2])
+  -- pragma translate_off
+               mod ~LIT[0]
+  -- pragma translate_on
+               ;
+
+  ~RESULT <= ~SYM[2](~SYM[1] downto ~SYM[1]);
+end block;~FI
 -- indexBitVector end"
     }
   }
@@ -162,28 +172,45 @@ end block;
              -> Bit         -- ARG[3]
              -> BitVector n"
     , "templateD" :
-"-- replaceBit begin
-replaceBit_~SYM[0] : block
-  signal vec       : ~TYP[1];
-  signal vec_index : integer range 0 to ~LIT[0]-1;
-  signal din       : ~TYP[3];
+"-- replaceBit begin~IF ~AND[~ISVAR[1],~ISVAR[2],~ISVAR[3]] ~THEN
+~GENSYM[replaceBit][0] : block
+  signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
-  vec <= ~ARG[1];
-  vec_index <= to_integer(~ARG[2])
+  ~SYM[1] <= to_integer(~ARG[2])
   -- pragma translate_off
                mod ~LIT[0]
   -- pragma translate_on
                ;
-  din <= ~ARG[3];
 
-  process(vec,vec_index,din)
-    variable ivec : ~TYP[1];
+  process(~ARG[1],~SYM[1],~ARG[3])
+    variable ~GENSYM[ivec][2] : ~TYP[1];
   begin
-    ivec := vec;
-    ivec(vec_index downto vec_index) := din;
-    ~RESULT <= ivec;
+    ~SYM[2] := ~ARG[1];
+    ~SYM[2](~SYM[1] downto ~SYM[1]) := ~ARG[3];
+    ~RESULT <= ~SYM[2];
   end process;
-end block;
+end block;~ELSE
+~SYM[0] : block
+  signal ~GENSYM[bv][3] : ~TYP[1];
+  signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
+  signal ~GENSYM[din][4] : ~TYP[3];
+begin
+  ~SYM[3] <= ~ARG[1];
+  ~SYM[1] <= to_integer(~ARG[2])
+  -- pragma translate_off
+               mod ~LIT[0]
+  -- pragma translate_on
+               ;
+  ~SYM[4] <= ~ARG[3];
+
+  process(~SYM[3],~SYM[1],~SYM[4])
+    variable ~SYM[2] : ~TYP[1];
+  begin
+    ~SYM[2] := ~SYM[3];
+    ~SYM[2](~SYM[1] downto ~SYM[1]) := ~SYM[4];
+    ~RESULT <= ~SYM[2];
+  end process;
+end block;~FI
 -- replaceBit end"
     }
   }
@@ -196,21 +223,28 @@ end block;
            -> BitVector (m + 1 - n) -- ARG[3]
            -> BitVector (m + 1 + i)"
     , "templateD" :
-"-- setSlice begin
-setSlice_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
-  signal ~SYM[2] : ~TYP[3];
+"-- setSlice begin~IF ~AND[~ISVAR[0],~ISVAR[3]] ~THEN
+~GENSYM[setSlice][0] : process(~ARG[0],~ARG[3])
+  variable ~GENSYM[ivec][1] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-  ~SYM[2] <= ~ARG[3];
-  process(~SYM[1],~SYM[2])
-    variable ~SYM[3] : ~TYP[0];
+  ~SYM[1] := ~ARG[0];
+  ~SYM[1](~LIT[1] downto ~LIT[2]) := ~ARG[3];
+  ~RESULT <= ~SYM[1];
+end process;~ELSE
+~SYM[0] : block
+  signal ~GENSYM[bv][2] : ~TYP[0];
+  signal ~GENSYM[din][3] : ~TYP[3];
+begin
+  ~SYM[2] <= ~ARG[0];
+  ~SYM[3] <= ~ARG[3];
+  process(~SYM[2],~SYM[3])
+    variable ~SYM[1] : ~TYP[0];
   begin
-    ~SYM[3] := ~SYM[1];
-    ~SYM[3](~LIT[1] downto ~LIT[2]) := ~SYM[2];
-    ~RESULT <= ~SYM[3];
+    ~SYM[1] := ~SYM[2];
+    ~SYM[1](~LIT[1] downto ~LIT[2]) := ~SYM[3];
+    ~RESULT <= ~SYM[1];
   end process;
-end block;
+end block;~FI
 -- setSlice end"
     }
   }
@@ -222,13 +256,14 @@ end block;
         -> SNat n                -- ARG[2]
         -> BitVector (m + 1 - n)"
     , "templateD" :
-"-- slice begin
-slice_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+"-- slice begin~IF ~ISVAR[0] ~THEN
+~RESULT <= ~ARG[0](~LIT[1] downto ~LIT[2]);~ELSE
+~GENSYM[slice][0] : block
+  signal ~GENSYM[bv][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= ~SYM[1](~LIT[1] downto ~LIT[2]);
-end block;
+end block;~FI
 -- slice end"
     }
   }
@@ -239,16 +274,20 @@ end block;
         => BitVector (m + n) -- ARG[1]
         -> (BitVector m, BitVector n)"
     , "templateD" :
-"-- split begin
-split_~SYM[0]: block
-  signal ~SYM[1] : ~TYP[1];
+"-- split begin~IF ~ISVAR[1] ~THEN
+~RESULT <= (~ARG[1](~RESULT.~TYPMO_sel0'left + ~RESULT.~TYPMO_sel1'length downto
+            ~RESULT.~TYPMO_sel0'right + ~RESULT.~TYPMO_sel1'length)
+           ,~ARG[1](~RESULT.~TYPMO_sel1'left downto ~RESULT.~TYPMO_sel1'right)
+           );~ELSE
+~GENSYM[split][0]: block
+  signal ~GENSYM[bv][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[1];
-  ~RESULT <= ( ~SYM[1](~RESULT.~TYPMO_sel0'left + ~RESULT.~TYPMO_sel1'length downto
-               ~RESULT.~TYPMO_sel0'right + ~RESULT.~TYPMO_sel1'length)
-             , ~SYM[1](~RESULT.~TYPMO_sel1'left downto ~RESULT.~TYPMO_sel1'right)
+  ~RESULT <= (~SYM[1](~RESULT.~TYPMO_sel0'left + ~RESULT.~TYPMO_sel1'length downto
+              ~RESULT.~TYPMO_sel0'right + ~RESULT.~TYPMO_sel1'length)
+             ,~SYM[1](~RESULT.~TYPMO_sel1'left downto ~RESULT.~TYPMO_sel1'right)
              );
-end block;
+end block;~FI
 -- split end"
     }
   }
@@ -259,16 +298,16 @@ end block;
       => BitVector n -- ARG[1]
       -> Bit"
     , "templateD" :
-"-- msb begin~IF ~LIT[0] ~THEN
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
+"-- msb begin~IF ~LIT[0] ~THEN ~IF ~ISVAR[1] ~THEN
+~RESULT <= ~ARG[1](~ARG[1]'high downto ~ARG[1]'high);~ELSE
+~GENSYM[msb][0] : block
+  signal ~GENSYM[bv][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[1];
   ~RESULT <= ~SYM[1](~SYM[1]'high downto ~SYM[1]'high);
-end block;
-~ELSE
-~RESULT <= \"0\";
-~FI-- msb end"
+end block;~FI~ELSE
+~RESULT <= \"0\";~FI
+-- msb end"
     }
   }
 , { "BlackBox" :
@@ -277,16 +316,16 @@ end block;
 "lsb# :: BitVector n -- ARG[0]
       -> Bit"
     , "templateD" :
-"-- lsb begin~IF ~SIZE[~TYP[0]] ~THEN
-lsb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+"-- lsb begin~IF ~SIZE[~TYP[0]] ~THEN ~IF ~ISVAR[0] ~THEN
+~RESULT <= ~ARG[0](0 downto 0);~ELSE
+~GENSYM[lsb][0] : block
+  signal ~GENSYM[bv][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= ~SYM[1](0 downto 0);
-end block;
-~ELSE
-~RESULT <= \"0\";
-~FI-- lsb end"
+end block;~FI~ELSE
+~RESULT <= \"0\";~FI
+-- lsb end"
     }
   }
 , { "BlackBox" :

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -172,7 +172,7 @@ end block;~FI
              -> Bit         -- ARG[3]
              -> BitVector n"
     , "templateD" :
-"-- replaceBit begin~IF ~AND[~ISVAR[1],~ISVAR[2],~ISVAR[3]] ~THEN
+"-- replaceBit begin
 ~GENSYM[replaceBit][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
@@ -182,35 +182,14 @@ begin
   -- pragma translate_on
                ;
 
-  process(~ARG[1],~SYM[1],~ARG[3])
+  process(~SYM[1]~VARS[1]~VARS[3])
     variable ~GENSYM[ivec][2] : ~TYP[1];
   begin
     ~SYM[2] := ~ARG[1];
     ~SYM[2](~SYM[1] downto ~SYM[1]) := ~ARG[3];
     ~RESULT <= ~SYM[2];
   end process;
-end block;~ELSE
-~SYM[0] : block
-  signal ~GENSYM[bv][3] : ~TYP[1];
-  signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
-  signal ~GENSYM[din][4] : ~TYP[3];
-begin
-  ~SYM[3] <= ~ARG[1];
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~LIT[0]
-  -- pragma translate_on
-               ;
-  ~SYM[4] <= ~ARG[3];
-
-  process(~SYM[3],~SYM[1],~SYM[4])
-    variable ~SYM[2] : ~TYP[1];
-  begin
-    ~SYM[2] := ~SYM[3];
-    ~SYM[2](~SYM[1] downto ~SYM[1]) := ~SYM[4];
-    ~RESULT <= ~SYM[2];
-  end process;
-end block;~FI
+end block;
 -- replaceBit end"
     }
   }
@@ -223,8 +202,8 @@ end block;~FI
            -> BitVector (m + 1 - n) -- ARG[3]
            -> BitVector (m + 1 + i)"
     , "templateD" :
-"-- setSlice begin~IF ~AND[~ISVAR[0],~ISVAR[3]] ~THEN
-~GENSYM[setSlice][0] : process(~ARG[0],~ARG[3])
+"-- setSlice begin~IF ~ISVAR[0] ~THEN
+~GENSYM[setSlice][0] : process(~ARG[0]~VARS[3])
   variable ~GENSYM[ivec][1] : ~TYP[0];
 begin
   ~SYM[1] := ~ARG[0];
@@ -233,15 +212,13 @@ begin
 end process;~ELSE
 ~SYM[0] : block
   signal ~GENSYM[bv][2] : ~TYP[0];
-  signal ~GENSYM[din][3] : ~TYP[3];
 begin
   ~SYM[2] <= ~ARG[0];
-  ~SYM[3] <= ~ARG[3];
-  process(~SYM[2],~SYM[3])
+  process(~SYM[2]~VARS[3])
     variable ~SYM[1] : ~TYP[0];
   begin
     ~SYM[1] := ~SYM[2];
-    ~SYM[1](~LIT[1] downto ~LIT[2]) := ~SYM[3];
+    ~SYM[1](~LIT[1] downto ~LIT[2]) := ARG[3];
     ~RESULT <= ~SYM[1];
   end process;
 end block;~FI

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.Signed.json
@@ -138,10 +138,17 @@
     { "name"      : "CLaSH.Sized.Internal.Signed.div#"
     , "type"      : "div# :: Signed n -> Signed n -> Signed n"
     , "templateD" :
-"-- divSigned begin
-divSigned_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
-  signal ~SYM[2] : ~TYP[1];
+"-- divSigned begin~IF ~AND[~ISVAR[0],~ISVAR[1]] ~THEN
+~GENSYM[divSigned][0] : block
+  signal ~GENSYM[quot_res][3] : ~TYP[0];
+begin
+  ~SYM[3] <= ~ARG[0] / ~ARG[1];
+  ~RESULT <= ~SYM[3] - to_signed(1,~SIZE[~TYPO]) when ~ARG[0](~ARG[0]'high) = not (~ARG[1](~ARG[1]'high)) else
+             ~SYM[3];
+end block;~ELSE
+~SYM[0] : block
+  signal ~GENSYM[dividend][1] : ~TYP[0];
+  signal ~GENSYM[divider][2] : ~TYP[1];
   signal ~SYM[3] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
@@ -149,7 +156,7 @@ begin
   ~SYM[3] <= ~SYM[1] / ~SYM[2];
   ~RESULT <= ~SYM[3] - to_signed(1,~SIZE[~TYPO]) when ~SYM[1](~SYM[1]'high) = not (~SYM[2](~SYM[2]'high)) else
              ~SYM[3];
-end block;
+end block;~FI
 -- divSigned end"
     }
   }
@@ -223,13 +230,14 @@ end block;
     { "name"      : "CLaSH.Sized.Internal.Signed.truncateB#"
     , "type"      : "truncateB# :: KnownNat m => Signed (n + m) -> Signed m"
     , "templateD" :
-"-- truncateB begin
-truncateB_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
+"-- truncateB begin~IF ~ISVAR[1] ~THEN
+~RESULT <= ~ARG[1](~LIT[0]-1 downto 0);~ELSE
+~GENSYM[truncateB][0] : block
+  signal ~GENSYM[s][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[1];
   ~RESULT <= ~SYM[1](~LIT[0]-1 downto 0);
-end block;
+end block;~FI
 -- truncateB end"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Sized.Vector.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Vector.json
@@ -2,18 +2,16 @@
     { "name"      : "CLaSH.Sized.Vector.head"
     , "type"      : "head :: Vec (n + 1) a -> a"
     , "templateD" :
-"-- head begin
-head_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+"-- head begin~IF ~ISVAR[0] ~THEN ~IF ~VIVADO ~THEN
+~RESULT <= ~FROMBV[~ARG[0](0)][~TYPO];~ELSE
+~RESULT <= ~ARG[0](0);~FI~ELSE
+~GENSYM[head][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-
-~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[1](0)][~TYPO];
-~ELSE
-  ~RESULT <= ~SYM[1](0);
-~FI
-end block;
+  ~SYM[1] <= ~ARG[0];~IF ~VIVADO ~THEN
+  ~RESULT <= ~FROMBV[~SYM[1](0)][~TYPO];~ELSE
+  ~RESULT <= ~SYM[1](0);~FI
+end block;~FI
 -- head end"
     }
   }
@@ -21,13 +19,14 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.tail"
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
     , "templateD" :
-"-- tail begin
-tail_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+"-- tail begin~IF ~ISVAR[0] ~THEN
+~RESULT <= ~ARG[0](1 to ~ARG[0]'high);~ELSE
+~GENSYM[tail][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= ~SYM[1](1 to ~SYM[1]'high);
-end block;
+end block;~FI
 -- tail end"
     }
   }
@@ -35,17 +34,16 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.last"
     , "type"      : "Vec (n + 1) a -> a"
     , "templateD" :
-"-- last begin
-last_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+"-- last begin~IF ~ISVAR[0] ~THEN ~IF ~VIVADO ~THEN
+~RESULT <= ~FROMBV[~ARG[0](~ARG[0]'high)][~TYPO];~ELSE
+~RESULT <= ~ARG[0](~ARG[0]'high);~FI~ELSE
+~GENSYM[last][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[1](~SYM[1]'high)][~TYPO];
-~ELSE
-  ~RESULT <= ~SYM[1](~SYM[1]'high);
-~FI
-end block;
+  ~SYM[1] <= ~ARG[0];~IF ~VIVADO ~THEN
+  ~RESULT <= ~FROMBV[~SYM[1](~SYM[1]'high)][~TYPO];~ELSE
+  ~RESULT <= ~SYM[1](~SYM[1]'high);~FI
+end block;~FI
 -- last end"
     }
   }
@@ -53,13 +51,14 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.init"
     , "type"      : "Vec (n + 1) a -> Vec n a"
     , "templateD" :
-"-- init begin
-init_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+"-- init begin~IF ~ISVAR[0] ~THEN
+~RESULT <= ~ARG[0](0 to ~ARG[0]'high - 1);~ELSE
+~GENSYM[init][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= ~SYM[1](0 to ~SYM[1]'high - 1);
-end block;
+end block;~FI
 -- init end"
     }
   }
@@ -73,17 +72,19 @@ end block;
         -> Vec i a                       -- ARG[4]
         -> Vec n a"
     , "templateD" :
-"-- select begin
-select_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[4];
+"-- select begin~IF ~ISVAR[4] ~THEN
+~GENSYM[select][0] : for ~GENSYM[i][1] in ~RESULT'range generate
+  ~RESULT(~SYM[1]) <= ~ARG[4](~LIT[1]+(~LIT[2]*~SYM[1]));
+end generate;~ELSE
+~GENSYM[select][2] : block
+  signal ~GENSYM[vec][3] : ~TYP[4];
 begin
-  ~SYM[1] <= ~ARG[4];
-
-  select_loop : for ~SYM[2] in ~RESULT'range generate
+  ~SYM[3] <= ~ARG[4];
+  ~SYM[0] : for ~SYM[1] in ~RESULT'range generate
   begin
-      ~RESULT(~SYM[2]) <= ~SYM[1](~LIT[1]+(~LIT[2]*~SYM[2]));
+    ~RESULT(~SYM[1]) <= ~SYM[3](~LIT[1]+(~LIT[2]*~SYM[1]));
   end generate;
-end block;
+end block;~FI
 -- select end"
     }
   }
@@ -97,21 +98,22 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.concat"
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "templateD" :
-"-- concat begin
-concat_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+"-- concat begin~IF ~ISVAR[0] ~THEN
+~GENSYM[concat][0] : for ~GENSYM[i][1] in ~ARG[0]'range generate
+begin~IF ~VIVADO ~THEN
+~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~FROMBV[~ARG[0](~SYM[1])][~TYPEL[~TYP[0]]];~ELSE
+~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~ARG[0](~SYM[1]);~FI
+end generate;~ELSE
+~SYM[0] : block
+  signal ~GENSYM[vec][2] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-
-  concat_loop : for ~SYM[2] in ~SYM[1]'range generate
-  begin
-~IF ~VIVADO ~THEN
-    ~RESULT(~SYM[2] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[2]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~FROMBV[~SYM[1](~SYM[2])][~TYPEL[~TYP[0]]];
-~ELSE
-    ~RESULT(~SYM[2] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[2]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~SYM[1](~SYM[2]);
-~FI
+  ~SYM[2] <= ~ARG[0];
+  ~SYM[3] : for ~SYM[1] in ~SYM[2]'range generate
+  begin~IF ~VIVADO ~THEN
+    ~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~FROMBV[~SYM[2](~SYM[1])][~TYPEL[~TYP[0]]];~ELSE
+    ~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~SYM[2](~SYM[1]);~FI
   end generate;
-end block;
+end block;~FI
 -- concat end"
     }
   }
@@ -119,14 +121,16 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.splitAt"
     , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
     , "templateD" :
-"-- splitAt begin
-splitAt_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
+"-- splitAt begin~IF ~ISVAR[1] ~THEN
+  ~RESULT <= (~ARG[1](~RESULT.~TYPMO_sel0'left to ~RESULT.~TYPMO_sel0'right)
+             ,~ARG[1](~RESULT.~TYPMO_sel1'left + ~RESULT.~TYPMO_sel0'length to ~RESULT.~TYPMO_sel1'right + ~RESULT.~TYPMO_sel0'length));~ELSE
+~GENSYM[splitAt][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[1];
   ~RESULT <= (~SYM[1](~RESULT.~TYPMO_sel0'left to ~RESULT.~TYPMO_sel0'right)
              ,~SYM[1](~RESULT.~TYPMO_sel1'left + ~RESULT.~TYPMO_sel0'length to ~RESULT.~TYPMO_sel1'right + ~RESULT.~TYPMO_sel0'length));
-end block;
+end block;~FI
 -- splitAt end"
     }
   }
@@ -138,21 +142,22 @@ end block;
           -> Vec (n * m) a  -- ARG[2]
           -> Vec n (Vec m a)"
     , "templateD" :
-"-- unconcat begin
-unconcat_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[2];
+"-- unconcat begin~IF ~ISVAR[2] ~THEN
+~GENSYM[unconcat][0] : for ~GENSYM[i][2] in ~RESULT'range generate
+begin~IF ~VIVADO ~THEN
+  ~RESULT(~SYM[2]) <= ~TOBV[~ARG[2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];~ELSE
+  ~RESULT(~SYM[2]) <= ~ARG[2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1));~FI
+end generate;~ELSE
+~SYM[0] : block
+  signal ~GENSYM[vec][1] : ~TYP[2];
 begin
   ~SYM[1] <= ~ARG[2];
-
-  unconcat_loop : for ~SYM[2] in ~RESULT'range generate
-  begin
-~IF ~VIVADO ~THEN
-    ~RESULT(~SYM[2]) <= ~TOBV[~SYM[1]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];
-~ELSE
-    ~RESULT(~SYM[2]) <= ~SYM[1]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1));
-~FI
+  ~GENSYM[unconcat][3] : for ~SYM[2] in ~RESULT'range generate
+  begin~IF ~VIVADO ~THEN
+    ~RESULT(~SYM[2]) <= ~TOBV[~SYM[1]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];~ELSE
+    ~RESULT(~SYM[2]) <= ~SYM[1]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1));~FI
   end generate;
-end block;
+end block;~FI
 -- unconcat end"
     }
   }
@@ -160,32 +165,46 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.map"
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
-"-- map begin
-map_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
-~IF ~VIVADO ~THEN
-  type restype_~SYM[4] is array(natural range <>) of ~TYPEL[~TYPO];
-  signal ~SYM[3] : restype_~SYM[4](0 to ~LENGTH[~TYPO]);
-~ELSE ~FI
+"-- map begin~IF ~ISVAR[1] ~THEN
+~GENSYM[map][0] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN
+  signal ~GENSYM[map_in][2] : ~TYPEL[~TYP[1]];
+  signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];
 begin
-  ~SYM[1] <= ~ARG[1];
-
-  map_loop : for ~SYM[2] in ~RESULT'range generate~IF ~VIVADO ~THEN
-    signal ~SYM[5] : ~TYPEL[~TYP[1]];
+  ~SYM[2] <= ~FROMBV[~ARG[1](~SYM[1])][~TYPEL[~TYP[1]]];
+  ~INST 0
+    ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
+    ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
+  ~INST
+  ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
+end generate;~ELSE
+begin
+  ~INST 0
+    ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
+    ~INPUT  <= ~ARG[1](~SYM[1])~ ~TYPEL[~TYP[1]]~
+  ~INST
+end generate;~FI~ELSE
+~SYM[0] : block
+  signal ~GENSYM[vec][4] : ~TYP[1];
+begin
+  ~SYM[4] <= ~ARG[1];
+  ~GENSYM[map][5] : for ~SYM[1] in ~RESULT'range generate~IF ~VIVADO ~THEN
+    signal ~SYM[2] : ~TYPEL[~TYP[1]];
+    signal ~SYM[3] : ~TYPEL[~TYPO];
   begin
-    ~SYM[5] <= ~FROMBV[~SYM[1](~SYM[2])][~TYPEL[~TYP[1]]];
+    ~SYM[2] <= ~FROMBV[~SYM[4](~SYM[1])][~TYPEL[~TYP[1]]];
     ~INST 0
-      ~OUTPUT <= ~SYM[3](~SYM[2])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= ~SYM[5]~ ~TYPEL[~TYP[1]]~
+      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
+      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
     ~INST
-    ~RESULT(~SYM[2]) <= ~TOBV[~SYM[3](~SYM[2])][~TYPEL[~TYPO]];~ELSE
+    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
+  end generate;~ELSE
   begin
     ~INST 0
-      ~OUTPUT <= ~RESULT(~SYM[2])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= ~SYM[1](~SYM[2])~ ~TYPEL[~TYP[1]]~
-    ~INST~FI
-  end generate;
-end block;
+      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
+      ~INPUT  <= ~SYM[4](~SYM[1])~ ~TYPEL[~TYP[1]]~
+    ~INST
+  end generate;~FI
+end block;~FI
 -- map end"
     }
   }
@@ -193,40 +212,65 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.imap"
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
-"-- imap begin
-imap_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[2];
-~IF ~VIVADO ~THEN
-  type restype_~SYM[4] is array(natural range <>) of ~TYPEL[~TYPO];
-  signal ~SYM[3] : restype_~SYM[4](0 to ~LENGTH[~TYPO]);
-~ELSE ~FI
-  function max (l,r : in natural) return natural is
+"-- imap begin~IF ~ISVAR[2] ~THEN
+~GENSYM[imap][0] : block
+  function ~GENSYM[max][6] (l,r : in natural) return natural is
   begin
     if l > r then return l;
     else return r;
     end if;
   end function;
 begin
-  ~SYM[1] <= ~ARG[2];
-
-  imap_loop : for ~SYM[2] in ~RESULT'range generate~IF ~VIVADO ~THEN
-    signal ~SYM[5] : ~TYPEL[~TYP[2]];
+  ~GENSYM[imap][5] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN
+    signal ~GENSYM[map_in][2] : ~TYPEL[~TYP[2]];
+    signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];
   begin
-    ~SYM[5] <= ~FROMBV[~SYM[1](~SYM[2])][~TYPEL[~TYP[2]]];
+    ~SYM[2] <= ~FROMBV[~ARG[2](~SYM[1])][~TYPEL[~TYP[2]]];
     ~INST 1
-      ~OUTPUT <= ~SYM[3](~SYM[2])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= to_unsigned(~SYM[2],max(1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
-      ~INPUT  <= ~SYM[5]~ ~TYPEL[~TYP[2]]~
+      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
+      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
+      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
     ~INST
-    ~RESULT(~SYM[2]) <= ~TOBV[~SYM[3](~SYM[2])][~TYPEL[~TYPO]];~ELSE
+    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
+  end generate;~ELSE
   begin
     ~INST 1
-      ~OUTPUT <= ~RESULT(~SYM[2])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= to_unsigned(~SYM[2],max(1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
-      ~INPUT  <= ~SYM[1](~SYM[2])~ ~TYPEL[~TYP[2]]~
-    ~INST~FI
-  end generate;
-end block;
+      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
+      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
+      ~INPUT  <= ~ARG[2](~SYM[1])~ ~TYPEL[~TYP[1]]~
+    ~INST
+  end generate;~FI
+end block;~ELSE
+~SYM[0] : block
+  function ~SYM[6] (l,r : in natural) return natural is
+  begin
+    if l > r then return l;
+    else return r;
+    end if;
+  end function;
+  signal ~GENSYM[vec][4] : ~TYP[2];
+begin
+  ~SYM[4] <= ~ARG[2];
+  ~SYM[5] : for ~SYM[1] in ~RESULT'range generate~IF ~VIVADO ~THEN
+    signal ~SYM[2] : ~TYPEL[~TYP[1]];
+    signal ~SYM[3] : ~TYPEL[~TYPO];
+  begin
+    ~SYM[2] <= ~FROMBV[~SYM[4](~SYM[1])][~TYPEL[~TYP[1]]];
+    ~INST 1
+      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
+      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
+      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
+    ~INST
+    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
+  end generate;~ELSE
+  begin
+    ~INST 1
+      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
+      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
+      ~INPUT  <= ~SYM[4](~SYM[1])~ ~TYPEL[~TYP[1]]~
+    ~INST
+  end generate;~FI
+end block;~FI
 -- imap end"
     }
   }
@@ -234,36 +278,56 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.zipWith"
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "templateD" :
-"-- zipWith begin
-zipWith_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
-  signal ~SYM[2] : ~TYP[2];~IF ~VIVADO ~THEN
-  type restype_~SYM[4] is array(natural range <>) of ~TYPEL[~TYPO];
-  signal ~SYM[5] : restype_~SYM[4](0 to ~LENGTH[~TYPO]);~ELSE ~FI
+"-- zipWith begin~IF ~AND[~ISVAR[1],~ISVAR[2]] ~THEN
+~GENSYM[zipWith][0] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN
+  signal ~GENSYM[zipWith_in1][2] : ~TYPEL[~TYP[1]];
+  signal ~GENSYM[zipWith_in2][6] : ~TYPEL[~TYP[2]];
+  signal ~GENSYM[zipWith_out][3] : ~TYPEL[~TYPO];
 begin
-  ~SYM[1] <= ~ARG[1];
-  ~SYM[2] <= ~ARG[2];
-
-  zipWith_loop : for ~SYM[3] in ~RESULT'range generate ~IF ~VIVADO ~THEN
-    signal ~SYM[6] : ~TYPEL[~TYP[1]];
-    signal ~SYM[7] : ~TYPEL[~TYP[2]];
+  ~SYM[2] <= ~FROMBV[~ARG[1](~SYM[1])][~TYPEL[~TYP[1]]];
+  ~SYM[6] <= ~FROMBV[~ARG[2](~SYM[1])][~TYPEL[~TYP[2]]];
+  ~INST 0
+    ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
+    ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
+    ~INPUT  <= ~SYM[6]~ ~TYPEL[~TYP[2]]~
+  ~INST
+  ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
+end generate;~ELSE
+begin
+  ~INST 0
+    ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
+    ~INPUT  <= ~ARG[1](~SYM[1])~ ~TYPEL[~TYP[1]]~
+    ~INPUT  <= ~ARG[2](~SYM[1])~ ~TYPEL[~TYP[2]]~
+  ~INST
+end generate;~FI~ELSE
+~SYM[0] : block
+  signal ~GENSYM[vec1][4] : ~TYP[1];
+  signal ~GENSYM[vec2][7] : ~TYP[2];
+begin
+  ~SYM[4] <= ~ARG[1];
+  ~SYM[7] <= ~ARG[2];
+  ~GENSYM[zipWith][5] : for ~SYM[1] in ~RESULT'range generate~IF ~VIVADO ~THEN
+    signal ~SYM[2] : ~TYPEL[~TYP[1]];
+    signal ~SYM[6] : ~TYPEL[~TYP[2]];
+    signal ~SYM[3] : ~TYPEL[~TYPO];
   begin
-    ~SYM[6] <= ~FROMBV[~SYM[1](~SYM[3])][~TYPEL[~TYP[1]]];
-    ~SYM[7] <= ~FROMBV[~SYM[2](~SYM[3])][~TYPEL[~TYP[2]]];
+    ~SYM[2] <= ~FROMBV[~SYM[4](~SYM[1])][~TYPEL[~TYP[1]]];
+    ~SYM[6] <= ~FROMBV[~SYM[7](~SYM[1])][~TYPEL[~TYP[2]]];
     ~INST 0
-      ~OUTPUT <= ~SYM[5](~SYM[3])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= ~SYM[6]~ ~TYPEL[~TYP[1]]~
-      ~INPUT  <= ~SYM[7]~ ~TYPEL[~TYP[2]]~
+      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
+      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
+      ~INPUT  <= ~SYM[6]~ ~TYPEL[~TYP[2]]~
     ~INST
-    ~RESULT(~SYM[3]) <= ~TOBV[~SYM[5](~SYM[3])][~TYPEL[~TYPO]];~ELSE
+    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
+  end generate;~ELSE
   begin
     ~INST 0
-      ~OUTPUT <= ~RESULT(~SYM[3])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= ~SYM[1](~SYM[3])~ ~TYPEL[~TYP[1]]~
-      ~INPUT  <= ~SYM[2](~SYM[3])~ ~TYPEL[~TYP[2]]~
-    ~INST~FI
-  end generate;
-end block;
+      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
+      ~INPUT  <= ~SYM[4](~SYM[1])~ ~TYPEL[~TYP[1]]~
+      ~INPUT  <= ~SYM[7](~SYM[1])~ ~TYPEL[~TYP[2]]~
+    ~INST
+  end generate;~FI
+end block;~FI
 -- zipWith end"
     }
   }
@@ -271,37 +335,63 @@ end block;
     { "name"      : "CLaSH.Sized.Vector.foldr"
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "templateD" :
-"-- foldr begin~IF ~LENGTH[~TYP[2]] ~THEN
-foldr_~SYM[0] : block
-  type foldr_res_vec is array (natural range <>) of ~TYP[1];
-  signal intermediate_~SYM[2] : foldr_res_vec (0 to ~LENGTH[~TYP[2]]);
-  signal xs_~SYM[3] : ~TYP[2];
+"-- foldr begin~IF ~LENGTH[~TYP[2]] ~THEN ~IF ~ISVAR[2] ~THEN
+~GENSYM[foldr][0] : block
+  type ~GENSYM[foldr_res_type][1] is array (natural range <>) of ~TYP[1];
+  signal ~GENSYM[intermediate][2] : ~SYM[1] (0 to ~LENGTH[~TYP[2]]);
 begin
-  intermediate_~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];
-  xs_~SYM[3] <= ~ARG[2];
+  ~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];
 
-  foldr_loop : for i_~SYM[4] in xs_~SYM[3]'range generate~IF ~VIVADO ~THEN
-    signal ~SYM[5] : ~TYPEL[~TYP[2]];
+  foldr_loop : for ~GENSYM[i][3] in ~ARG[2]'range generate~IF ~VIVADO ~THEN
+    signal ~GENSYM[foldr_in][4] : ~TYPEL[~TYP[2]];
   begin
-    ~SYM[5] <= ~FROMBV[xs_~SYM[3](i_~SYM[4])][~TYPEL[~TYP[2]]];
+    ~SYM[4] <= ~FROMBV[~ARG[2](~SYM[3])][~TYPEL[~TYP[2]]];
     ~INST 0
-      ~OUTPUT <= intermediate_~SYM[2](i_~SYM[4])~ ~TYP[1]~
-      ~INPUT  <= ~SYM[5]~ ~TYPEL[~TYP[2]]~
-      ~INPUT  <= intermediate_~SYM[2](i_~SYM[4]+1)~ ~TYP[1]~
-    ~INST~ELSE
+      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
+      ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
+      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
+    ~INST
+  end generate;~ELSE
   begin
     ~INST 0
-      ~OUTPUT <= intermediate_~SYM[2](i_~SYM[4])~ ~TYP[1]~
-      ~INPUT  <= xs_~SYM[3](i_~SYM[4])~ ~TYPEL[~TYP[2]]~
-      ~INPUT  <= intermediate_~SYM[2](i_~SYM[4]+1)~ ~TYP[1]~
-    ~INST ~FI
-  end generate;
+      ~OUTPUT <= ~SYM[2](i_~SYM[3])~ ~TYP[1]~
+      ~INPUT  <= ~ARG[2](i_~SYM[3])~ ~TYPEL[~TYP[2]]~
+      ~INPUT  <= ~SYM[2](i_~SYM[3]+1)~ ~TYP[1]~
+    ~INST
+  end generate;~FI
 
-  ~RESULT <= intermediate_~SYM[2](0);
-end block;
-~ELSE
-~RESULT <= ~ARG[1];
-~FI-- foldr end"
+  ~RESULT <= ~SYM[2](0);
+end block;~ELSE
+~SYM[0] : block
+  type ~SYM[1] is array (natural range <>) of ~TYP[1];
+  signal ~SYM[2] : ~SYM[1] (0 to ~LENGTH[~TYP[2]]);
+  signal ~GENSYM[vec][5] : ~TYP[2];
+begin
+  ~SYM[5] <= ~ARG[2];
+  ~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];
+
+  foldr_loop : for ~SYM[3] in ~SYM[5]'range generate~IF ~VIVADO ~THEN
+    signal ~SYM[4] : ~TYPEL[~TYP[2]];
+  begin
+    ~SYM[4] <= ~FROMBV[~SYM[5](~SYM[3])][~TYPEL[~TYP[2]]];
+    ~INST 0
+      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
+      ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
+      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
+    ~INST
+  end generate;~ELSE
+  begin
+    ~INST 0
+      ~OUTPUT <= ~SYM[2](i_~SYM[3])~ ~TYP[1]~
+      ~INPUT  <= ~SYM[5](i_~SYM[3])~ ~TYPEL[~TYP[2]]~
+      ~INPUT  <= ~SYM[2](i_~SYM[3]+1)~ ~TYP[1]~
+    ~INST
+  end generate;~FI
+
+  ~RESULT <= ~SYM[2](0);
+end block;~FI~ELSE
+~RESULT <= ~ARG[1];~FI
+-- foldr end"
     }
   }
 , { "BlackBox" :
@@ -310,48 +400,45 @@ end block;
     , "comment"   : "THIS ONLY WORKS FOR POWER OF TWO LENGTH VECTORS"
     , "templateD" :
 "-- fold begin
-fold_~SYM[0] : block
+~GENSYM[fold][0] : block
   -- given a level and a depth, calculate the corresponding index into the
   -- intermediate array
-  function depth2Index (levels,depth : in natural) return natural is
+  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
   begin
     return (2 ** levels - 2 ** depth);
   end function;
-
 ~IF ~VIVADO ~THEN
-  type restype_~SYM[2] is array(natural range <>) of ~TYPO;
-  signal intermediate_~SYM[1] : restype_~SYM[2](0 to (2*~LENGTH[~TYP[1]])-2);
-  signal ~SYM[3] : ~TYP[1];
-~ELSE
-  signal intermediate_~SYM[1] : ~TYPM[1](0 to (2*~LENGTH[~TYP[1]])-2);
-~FI
-  constant levels : natural := natural (ceil (log2 (real (~LENGTH[~TYP[1]]))));
+  type ~GENSYM[fold_res_type][2] is array(natural range <>) of ~TYPO;
+  signal ~GENSYM[intermediate][3] : ~SYM[2](0 to (2*~LENGTH[~TYP[1]])-2);~IF ~ISLIT[1] ~THEN
+  signal ~GENSYM[vec][4] : ~TYP[1];~ELSE ~FI ~ELSE
+  signal ~SYM[3] : ~TYPM[1](0 to (2*~LENGTH[~TYP[1]])-2);~FI
+  constant ~GENSYM[levels][5] : natural := natural (ceil (log2 (real (~LENGTH[~TYP[1]]))));
 begin
-  -- put input array into the first half of the intermediate array
-~IF ~VIVADO ~THEN
-  ~SYM[3] <= ~ARG[1];
-  fill_tree : for d in ~SYM[3]'range generate
-    intermediate_~SYM[1](d) <= ~FROMBV[~SYM[3](d)][~TYPO];
-  end generate;
-~ELSE
-  intermediate_~SYM[1](0 to ~LENGTH[~TYP[1]]-1) <= ~ARG[1];
-~FI
+  -- put input array into the first half of the intermediate array~IF ~VIVADO ~THEN~IF ~ISLIT[1] ~THEN
+  ~SYM[4] <= ~ARG[1];
+  ~GENSYM[fill_tree][6] : for ~GENSYM[d][7] in ~SYM[4]'range generate
+    ~SYM[3](~SYM[7]) <= ~FROMBV[~SYM[3](~SYM[7])][~TYPO];
+  end generate;~ELSE
+  ~SYM[6] : for ~SYM[7] in ~ARG[1]'range generate
+    ~SYM[3](~SYM[7]) <= ~FROMBV[~ARG[1](~SYM[7])][~TYPO];
+  end generate;~FI~ELSE
+  ~SYM[3](0 to ~LENGTH[~TYP[1]]-1) <= ~ARG[1];~FI
 
   -- Create the tree of instantiated components
-  make_tree : if levels /= 0 generate
-    tree_depth : for d in levels-1 downto 0 generate
-      tree_depth_loop: for i in 0 to (natural(2**d) - 1) generate
+  ~GENSYM[make_tree][8] : if ~SYM[5] /= 0 generate
+    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[5]-1 downto 0 generate
+      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
         ~INST 0
-          ~OUTPUT <= intermediate_~SYM[1](depth2Index(levels+1,d+1)+i)~ ~TYPO~
-          ~INPUT  <= intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i))~ ~TYPO~
-          ~INPUT  <= intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)+1)~ ~TYPO~
+          ~OUTPUT <= ~SYM[3](~SYM[1](~SYM[5]+1,~SYM[10]+1)+~SYM[12])~ ~TYPO~
+          ~INPUT  <= ~SYM[3](~SYM[1](~SYM[5]+1,~SYM[10]+2)+(2*~SYM[12]))~ ~TYPO~
+          ~INPUT  <= ~SYM[3](~SYM[1](~SYM[5]+1,~SYM[10]+2)+(2*~SYM[12])+1)~ ~TYPO~
         ~INST
       end generate;
     end generate;
   end generate;
 
   -- The last element of the intermediate array holds the result
-  ~RESULT <= intermediate_~SYM[1]((2*~LENGTH[~TYP[1]])-2);
+  ~RESULT <= ~SYM[3]((2*~LENGTH[~TYP[1]])-2);
 end block;
 -- fold end"
     }
@@ -361,24 +448,29 @@ end block;
     , "type"      : "index_int :: KnownNat n => Vec n a -> Int -> a"
     , "templateD" :
 "-- index begin
-indexVec_~SYM[0] : block
-  signal vec       : ~TYP[1];
-  signal vec_index : integer range 0 to ~LIT[0]-1;
+~GENSYM[indexVec][0] : block ~IF ~ISVAR[1] ~THEN
+  signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
-  vec <= ~ARG[1];
-
-  vec_index <= to_integer(~ARG[2])
+  ~SYM[1] <= to_integer(~ARG[2])
   -- pragma translate_off
                mod ~LIT[0]
   -- pragma translate_on
-               ;
-
-~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[vec(vec_index)][~TYPO];
-~ELSE
-  ~RESULT <= vec(vec_index);
-~FI
-end block;
+               ;~IF ~VIVADO ~THEN
+  ~RESULT <= ~FROMBV[~ARG[1](~SYM[1])][~TYPO];~ELSE
+  ~RESULT <= ~ARG[1](~SYM[1]);~FI
+end block;~ELSE
+signal ~GENSYM[vec][2] : ~TYP[1];
+signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
+begin
+  ~SYM[2] <= ~ARG[1];
+  ~SYM[1] <= to_integer(~ARG[2])
+  -- pragma translate_off
+               mod ~LIT[0]
+  -- pragma translate_on
+               ;~IF ~VIVADO ~THEN
+  ~RESULT <= ~FROMBV[~SYM[2](~SYM[1])][~TYPO];~ELSE
+  ~RESULT <= ~SYM[2](~SYM[1]);~FI
+end block;~FI
 -- index end"
     }
   }
@@ -387,29 +479,26 @@ end block;
     , "type"      : "replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a"
     , "templateD" :
 "-- replace begin
-replaceVec_~SYM[0] : block
-  signal vec       : ~TYP[1];
-  signal vec_index : integer range 0 to ~LIT[0]-1;
-  signal din       : ~TYP[3];
+~GENSYM[replaceVec][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[1];
+  signal ~GENSYM[vec_index][2] : integer range 0 to ~LIT[0]-1;
+  signal ~GENSYM[din][3] : ~TYP[3];
 begin
-  vec <= ~ARG[1];
-  vec_index <= to_integer(~ARG[2])
+  ~SYM[1] <= ~ARG[1];
+  ~SYM[2] <= to_integer(~ARG[2])
   -- pragma translate_off
                mod ~LIT[0]
   -- pragma translate_on
                ;
-  din <= ~ARG[3];
+  ~SYM[3] <= ~ARG[3];
 
-  process(vec,vec_index,din)
-    variable ivec : ~TYP[1];
+  process(~SYM[1],~SYM[1],~SYM[3])
+    variable ~GENSYM[ivec][4] : ~TYP[1];
   begin
-    ivec := vec;
-~IF ~VIVADO ~THEN
-    ivec(vec_index) := ~TOBV[din][~TYP[3]];
-~ELSE
-    ivec(vec_index) := din;
-~FI
-    ~RESULT <= ivec;
+    ~SYM[4] := ~SYM[1];~IF ~VIVADO ~THEN
+    ~SYM[4](~SYM[2]) := ~TOBV[~SYM[3]][~TYP[3]];~ELSE
+    ~SYM[4](~SYM[2]) := ~SYM[3];~FI
+    ~RESULT <= ~SYM[4];
   end process;
 end block;
 -- replace end"
@@ -438,15 +527,15 @@ end block;
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "templateD" :
 "-- transpose begin
-transpose_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
+~GENSYM[transpose][0] : block
+  signal ~GENSYM[matrix][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[1];
 
-  transpose_outer : for row_index in ~SYM[1]'range generate
-    transpose_inner : for col_index in ~RESULT'range generate~IF ~VIVADO ~THEN
-      ~RESULT(col_index)((~SYM[1]'length-row_index)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~SYM[1]'length-row_index-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]) <= ~SYM[1](row_index)((~RESULT'length-col_index)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~RESULT'length-col_index-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]);~ELSE
-      ~RESULT(col_index)(row_index) <= ~SYM[1](row_index)(col_index);~FI
+  ~GENSYM[transpose_outer][2] : for ~GENSYM[row_index][3] in ~SYM[1]'range generate
+    ~GENSYM[transpose_inner][4] : for ~GENSYM[col_index][5] in ~RESULT'range generate~IF ~VIVADO ~THEN
+      ~RESULT(~SYM[5])((~SYM[1]'length-~SYM[3])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~SYM[1]'length-~SYM[3]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]) <= ~SYM[1](~SYM[3])((~RESULT'length-~SYM[5])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~RESULT'length-~SYM[5]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]);~ELSE
+      ~RESULT(~SYM[5])(~SYM[3]) <= ~SYM[1](~SYM[3])(~SYM[5]);~FI
     end generate;
   end generate;
 end block;
@@ -458,13 +547,12 @@ end block;
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "templateD" :
 "-- reverse begin
-reverse_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[reverse][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
-
-  reverse_loop : for ~SYM[2] in ~SYM[1]'range generate
-    ~RESULT(~SYM[1]'high - ~SYM[2]) <= ~SYM[1](~SYM[2]);
+  ~GENSYM[reverse_loop][2] : for ~GENSYM[i][3] in ~SYM[1]'range generate
+    ~RESULT(~SYM[1]'high - ~SYM[3]) <= ~SYM[1](~SYM[3]);
   end generate;
 end block;
 -- reverse end"
@@ -484,13 +572,12 @@ end block;
                   -> BitVector (n * m)"
     , "templateD" :
 "-- concatBitVector begin
-concatBitVector_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
+~GENSYM[concatBitVector][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[1];
-
-  concatBitVectorIter_loop : for ~SYM[2] in ~SYM[1]'range generate
-    ~RESULT(((~SYM[2] * ~LIT[0]) + ~LIT[0] - 1) downto (~SYM[2] * ~LIT[0])) <= ~TYPMO(~SYM[1](~SYM[1]'high - ~SYM[2]));
+  ~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~SYM[1]'range generate
+    ~RESULT(((~SYM[3] * ~LIT[0]) + ~LIT[0] - 1) downto (~SYM[3] * ~LIT[0])) <= ~TYPMO'(~SYM[1](~SYM[1]'high - ~SYM[3]));
   end generate;
 end block;
 -- concatBitVector end"
@@ -504,13 +591,12 @@ end block;
                     -> Vec n (BitVector m)"
     , "templateD" :
 "-- unconcatBitVector begin
-unconcatBitVector_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[2];
+~GENSYM[unconcatBitVector][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[2];
 begin
   ~SYM[1] <= ~ARG[2];
-
-  unconcatBitVectorIter_loop : for ~SYM[2] in ~RESULT'range generate
-    ~RESULT(~RESULT'high - ~SYM[2]) <= ~SYM[1](((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[2] * ~LIT[1]));
+  ~GENSYM[unconcatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~RESULT'range generate
+    ~RESULT(~RESULT'high - ~SYM[3]) <= ~SYM[1](((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1]));
   end generate;
 end block;
 -- unconcatBitVector end"
@@ -521,19 +607,19 @@ end block;
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "-- rotateLeftS begin
-rotateLeftS_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
-  constant shift_amount_~SYM[2] : natural := ~LIT[2] mod ~LIT[0];
+~GENSYM[rotateLeftS][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[1];
+  constant ~GENSYM[shift_amount][2] : natural := ~LIT[2] mod ~LIT[0];
 begin
   ~SYM[1] <= ~ARG[1];
 
-  no_shift : if shift_amount_~SYM[2] = 0 generate
+  ~GENSYM[no_shift][3] : if ~SYM[2] = 0 generate
     ~RESULT <= ~SYM[1];
   end generate;
 
-  do_shift : if shift_amount_~SYM[2] /= 0 generate
-    ~RESULT <= ~SYM[1](shift_amount_~SYM[2] to ~LIT[0]-1) &
-               ~SYM[1](0 to shift_amount_~SYM[2]-1);
+  ~GENSYM[do_shift][4] : if ~SYM[2] /= 0 generate
+    ~RESULT <= ~SYM[1](~SYM[2] to ~LIT[0]-1) &
+               ~SYM[1](0 to ~SYM[2]-1);
   end generate;
 end block;
 -- rotateLeftS end"
@@ -544,19 +630,19 @@ end block;
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "-- rotateRightS begin
-rotateLeftS_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
-  constant shift_amount_~SYM[2] : natural := ~LIT[2] mod ~LIT[0];
+~GENSYM[rotateLeftS][0] : block
+  signal ~GENSYM[vec][1] : ~TYP[1];
+  constant ~GENSYM[shift_amount][2] : natural := ~LIT[2] mod ~LIT[0];
 begin
   ~SYM[1] <= ~ARG[1];
 
-  no_shift : if shift_amount_~SYM[2] = 0 generate
+  ~GENSYM[no_shift][3] : if ~SYM[2] = 0 generate
     ~RESULT <= ~SYM[1];
   end generate;
 
-  do_shift : if shift_amount_~SYM[2] /= 0 generate
-    ~RESULT <= ~SYM[1](~LIT[0]-shift_amount_~SYM[2] to ~LIT[0]-1) &
-               ~SYM[1](0 to ~LIT[0]-shift_amount_~SYM[2]-1);
+  ~GENSYM[do_shift][4] : if ~SYM[2] /= 0 generate
+    ~RESULT <= ~SYM[1](~LIT[0]-~SYM[2] to ~LIT[0]-1) &
+               ~SYM[1](0 to ~LIT[0]-~SYM[2]-1);
   end generate;
 end block;
 -- rotateRightS end"

--- a/clash-vhdl/primitives/CLaSH.Sized.Vector.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Vector.json
@@ -480,25 +480,21 @@ end block;~FI
     , "templateD" :
 "-- replace begin
 ~GENSYM[replaceVec][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[1];
-  signal ~GENSYM[vec_index][2] : integer range 0 to ~LIT[0]-1;
-  signal ~GENSYM[din][3] : ~TYP[3];
+  signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
-  ~SYM[1] <= ~ARG[1];
-  ~SYM[2] <= to_integer(~ARG[2])
+  ~SYM[1] <= to_integer(~ARG[2])
   -- pragma translate_off
                mod ~LIT[0]
   -- pragma translate_on
                ;
-  ~SYM[3] <= ~ARG[3];
 
-  process(~SYM[1],~SYM[1],~SYM[3])
-    variable ~GENSYM[ivec][4] : ~TYP[1];
+  process(~SYM[1]~VARS[1]~VARS[3])
+    variable ~GENSYM[ivec][2] : ~TYP[1];
   begin
-    ~SYM[4] := ~SYM[1];~IF ~VIVADO ~THEN
-    ~SYM[4](~SYM[2]) := ~TOBV[~SYM[3]][~TYP[3]];~ELSE
-    ~SYM[4](~SYM[2]) := ~SYM[3];~FI
-    ~RESULT <= ~SYM[4];
+    ~SYM[2] := ~ARG[1];~IF ~VIVADO ~THEN
+    ~SYM[2](~SYM[1]) := ~TOBV[~ARG[3]][~TYP[3]];~ELSE
+    ~SYM[2](~SYM[1]) := ~ARG[3];~FI
+    ~RESULT <= ~SYM[2];
   end process;
 end block;
 -- replace end"

--- a/clash-vhdl/primitives/CLaSH.Sized.Vector.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Vector.json
@@ -354,9 +354,9 @@ begin
   end generate;~ELSE
   begin
     ~INST 0
-      ~OUTPUT <= ~SYM[2](i_~SYM[3])~ ~TYP[1]~
-      ~INPUT  <= ~ARG[2](i_~SYM[3])~ ~TYPEL[~TYP[2]]~
-      ~INPUT  <= ~SYM[2](i_~SYM[3]+1)~ ~TYP[1]~
+      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
+      ~INPUT  <= ~ARG[2](~SYM[3])~ ~TYPEL[~TYP[2]]~
+      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
     ~INST
   end generate;~FI
 
@@ -382,9 +382,9 @@ begin
   end generate;~ELSE
   begin
     ~INST 0
-      ~OUTPUT <= ~SYM[2](i_~SYM[3])~ ~TYP[1]~
-      ~INPUT  <= ~SYM[5](i_~SYM[3])~ ~TYPEL[~TYP[2]]~
-      ~INPUT  <= ~SYM[2](i_~SYM[3]+1)~ ~TYP[1]~
+      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
+      ~INPUT  <= ~SYM[5](~SYM[3])~ ~TYPEL[~TYP[2]]~
+      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
     ~INST
   end generate;~FI
 

--- a/clash-vhdl/primitives/GHC.Base.json
+++ b/clash-vhdl/primitives/GHC.Base.json
@@ -20,8 +20,8 @@
     , "type"      : "divInt :: Int -> Int -> Int"
     , "templateD" :
 "-- divInt begin
-divInt_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
+~GENSYM[divInt][0] : block
+  signal ~GENSYM[quot_res][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[0] / ~ARG[1];
   ~RESULT <= ~SYM[1] - 1 when ((~ARG[0] = abs ~ARG[0]) /= (~ARG[1] = abs ~ARG[1])) else

--- a/clash-vhdl/primitives/GHC.Classes.json
+++ b/clash-vhdl/primitives/GHC.Classes.json
@@ -57,8 +57,8 @@
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "templateD" :
 "-- divInt begin
-divInt_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
+~GENSYM[divInt][0] : block
+  signal ~GENSYM[quot_res][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[0] / ~ARG[1];
   ~RESULT <= ~SYM[1] - 1 when ((~ARG[0] = abs ~ARG[0]) /= (~ARG[1] = abs ~ARG[1])) else

--- a/clash-vhdl/primitives/GHC.Integer.Type.json
+++ b/clash-vhdl/primitives/GHC.Integer.Type.json
@@ -45,8 +45,8 @@
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "-- divInteger begin
-divInteger_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[1];
+~GENSYM[divInteger][0] : block
+  signal ~GENSYM[quot_res][1] : ~TYP[1];
 begin
   ~SYM[1] <= ~ARG[0] / ~ARG[1];
   ~RESULT <= ~SYM[1] - 1 when ((~ARG[0] = abs ~ARG[0]) /= (~ARG[1] = abs ~ARG[1])) else

--- a/clash-vhdl/primitives/GHC.Prim.json
+++ b/clash-vhdl/primitives/GHC.Prim.json
@@ -291,37 +291,37 @@
     , "type"      : "popCnt8 :: Word# -> Word#"
     , "templateD" :
 "-- popCnt8 begin
-popCnt8_~SYM[0] : block
+~GENSYM[popCnt8][0] : block
   -- given a level and a depth, calculate the corresponding index into the
   -- intermediate array
-  function depth2Index (levels,depth : in natural) return natural is
+  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
   begin
     return (2 ** levels - 2 ** depth);
   end function;
 
-  constant width : natural := 8;
-  constant levels : natural := natural (ceil (log2 (real (width))));
-  type popCnt_res_vec is array (natural range <>) of unsigned(levels downto 0);
-  signal intermediate_~SYM[1] : popCnt_res_vec(0 to (2*width)-2);
+  constant ~GENSYM[width][2] : natural := 8;
+  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
+  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
+  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
 begin
   -- put input into the first half of the intermediate array
-  make_array: for i in 0 to (width - 1) generate
-    intermediate_~SYM[1](i) <= resize(~ARG[0](i downto i),levels+1);
+  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
+    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
-  make_tree : if levels /= 0 generate
-    tree_depth : for d in levels-1 downto 0 generate
-      tree_depth_loop: for i in 0 to (natural(2**d) - 1) generate
-        intermediate_~SYM[1](depth2Index(levels+1,d+1)+i) <=
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)) +
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)+1);
+  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
+    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
+      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
+        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
       end generate;
     end generate;
   end generate;
 
   -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(intermediate_~SYM[1]((2*width)-2),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
 end block;
 -- popCnt8 end"
     }
@@ -331,37 +331,37 @@ end block;
     , "type"      : "popCnt16 :: Word# -> Word#"
     , "templateD" :
 "-- popCnt16 begin
-popCnt16_~SYM[0] : block
+~GENSYM[popCnt16][0] : block
   -- given a level and a depth, calculate the corresponding index into the
   -- intermediate array
-  function depth2Index (levels,depth : in natural) return natural is
+  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
   begin
     return (2 ** levels - 2 ** depth);
   end function;
 
-  constant width : natural := 16;
-  constant levels : natural := natural (ceil (log2 (real (width))));
-  type popCnt_res_vec is array (natural range <>) of unsigned(levels downto 0);
-  signal intermediate_~SYM[1] : popCnt_res_vec(0 to (2*width)-2);
+  constant ~GENSYM[width][2] : natural := 16;
+  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
+  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
+  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
 begin
   -- put input into the first half of the intermediate array
-  make_array: for i in 0 to (width - 1) generate
-    intermediate_~SYM[1](i) <= resize(~ARG[0](i downto i),levels+1);
+  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
+    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
-  make_tree : if levels /= 0 generate
-    tree_depth : for d in levels-1 downto 0 generate
-      tree_depth_loop: for i in 0 to (natural(2**d) - 1) generate
-        intermediate_~SYM[1](depth2Index(levels+1,d+1)+i) <=
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)) +
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)+1);
+  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
+    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
+      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
+        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
       end generate;
     end generate;
   end generate;
 
   -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(intermediate_~SYM[1]((2*width)-2),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
 end block;
 -- popCnt16 end"
     }
@@ -371,37 +371,37 @@ end block;
     , "type"      : "popCnt16 :: Word# -> Word#"
     , "templateD" :
 "-- popCnt32 begin
-popCnt32_~SYM[0] : block
+~GENSYM[popCnt32][0] : block
   -- given a level and a depth, calculate the corresponding index into the
   -- intermediate array
-  function depth2Index (levels,depth : in natural) return natural is
+  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
   begin
     return (2 ** levels - 2 ** depth);
   end function;
 
-  constant width : natural := 32;
-  constant levels : natural := natural (ceil (log2 (real (width))));
-  type popCnt_res_vec is array (natural range <>) of unsigned(levels downto 0);
-  signal intermediate_~SYM[1] : popCnt_res_vec(0 to (2*width)-2);
+  constant ~GENSYM[width][2] : natural := 32;
+  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
+  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
+  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
 begin
   -- put input into the first half of the intermediate array
-  make_array: for i in 0 to (width - 1) generate
-    intermediate_~SYM[1](i) <= resize(~ARG[0](i downto i),levels+1);
+  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
+    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
-  make_tree : if levels /= 0 generate
-    tree_depth : for d in levels-1 downto 0 generate
-      tree_depth_loop: for i in 0 to (natural(2**d) - 1) generate
-        intermediate_~SYM[1](depth2Index(levels+1,d+1)+i) <=
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)) +
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)+1);
+  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
+    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
+      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
+        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
       end generate;
     end generate;
   end generate;
 
   -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(intermediate_~SYM[1]((2*width)-2),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
 end block;
 -- popCnt32 end"
     }
@@ -411,37 +411,37 @@ end block;
     , "type"      : "popCnt16 :: Word# -> Word#"
     , "templateD" :
 "-- popCnt64 begin
-popCnt64_~SYM[0] : block
+~GENSYM[popCnt64][0] : block
   -- given a level and a depth, calculate the corresponding index into the
   -- intermediate array
-  function depth2Index (levels,depth : in natural) return natural is
+  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
   begin
     return (2 ** levels - 2 ** depth);
   end function;
 
-  constant width : natural := 64;
-  constant levels : natural := natural (ceil (log2 (real (width))));
-  type popCnt_res_vec is array (natural range <>) of unsigned(levels downto 0);
-  signal intermediate_~SYM[1] : popCnt_res_vec(0 to (2*width)-2);
+  constant ~GENSYM[width][2] : natural := 64;
+  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
+  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
+  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
 begin
   -- put input into the first half of the intermediate array
-  make_array: for i in 0 to (width - 1) generate
-    intermediate_~SYM[1](i) <= resize(~ARG[0](i downto i),levels+1);
+  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
+    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
-  make_tree : if levels /= 0 generate
-    tree_depth : for d in levels-1 downto 0 generate
-      tree_depth_loop: for i in 0 to (natural(2**d) - 1) generate
-        intermediate_~SYM[1](depth2Index(levels+1,d+1)+i) <=
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)) +
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)+1);
+  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
+    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
+      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
+        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
       end generate;
     end generate;
   end generate;
 
   -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(intermediate_~SYM[1]((2*width)-2),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
 end block;
 -- popCnt64 end"
     }
@@ -451,37 +451,37 @@ end block;
     , "type"      : "popCnt :: Word# -> Word#"
     , "templateD" :
 "-- popCnt begin
-popCnt_~SYM[0] : block
+~GENSYM[popCnt][0] : block
   -- given a level and a depth, calculate the corresponding index into the
   -- intermediate array
-  function depth2Index (levels,depth : in natural) return natural is
+  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
   begin
     return (2 ** levels - 2 ** depth);
   end function;
 
-  constant width : natural := ~SIZE[~TYPO];
-  constant levels : natural := natural (ceil (log2 (real (width))));
-  type popCnt_res_vec is array (natural range <>) of unsigned(levels downto 0);
-  signal intermediate_~SYM[1] : popCnt_res_vec(0 to (2*width)-2);
+  constant ~GENSYM[width][2] : natural := ~SIZE[~TYPO];
+  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
+  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
+  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
 begin
   -- put input into the first half of the intermediate array
-  make_array: for i in 0 to (width - 1) generate
-    intermediate_~SYM[1](i) <= resize(~ARG[0](i downto i),levels+1);
+  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
+    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
-  make_tree : if levels /= 0 generate
-    tree_depth : for d in levels-1 downto 0 generate
-      tree_depth_loop: for i in 0 to (natural(2**d) - 1) generate
-        intermediate_~SYM[1](depth2Index(levels+1,d+1)+i) <=
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)) +
-          intermediate_~SYM[1](depth2Index(levels+1,d+2)+(2*i)+1);
+  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
+    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
+      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
+        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
+          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
       end generate;
     end generate;
   end generate;
 
   -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(intermediate_~SYM[1]((2*width)-2),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
 end block;
 -- popCnt end"
     }
@@ -491,8 +491,8 @@ end block;
     , "type"      : "clz8 :: Word# -> Word#"
     , "templateD" :
 "-- clz8 begin
-clz8~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+~GENSYM[clz8][0] : block
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -502,7 +502,7 @@ clz8~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -514,16 +514,16 @@ clz8~SYM[0] : block
     end if;
   end function;
 
-  function clz8 (constant v : unsigned(0 to 7)) return unsigned is
+  function ~GENSYM[clz8][3] (constant v : unsigned(0 to 7)) return unsigned is
     variable e : unsigned(0 to 7);     -- 8
     variable a : unsigned(0 to 2*3-1); -- 6
   begin
-    for i in 0 to 3 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
-    for i in 0 to 1 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
-    return clzi(3,a(0 to 5));
+    for i in 0 to 3 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
+    for i in 0 to 1 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
+    return ~SYM[2](3,a(0 to 5));
   end function;
 begin
-  ~RESULT <= resize(clz8(~ARG[0](7 downto 0)),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~ARG[0](7 downto 0)),~SIZE[~TYPO]);
 end block;
 -- clz8 end"
     }
@@ -534,7 +534,7 @@ end block;
     , "templateD" :
 "-- clz16 begin
 clz16~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -544,7 +544,7 @@ clz16~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -556,18 +556,18 @@ clz16~SYM[0] : block
     end if;
   end function;
 
-  function clz16 (constant v : unsigned(0 to 15)) return unsigned is
+  function ~GENSYM[clz16][3] (constant v : unsigned(0 to 15)) return unsigned is
     variable e : unsigned(0 to 15);    -- 16
     variable a : unsigned(0 to 4*3-1); -- 12
     variable b : unsigned(0 to 2*4-1); -- 8
   begin
-    for i in 0 to 7 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
-    for i in 0 to 3 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 1 loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
-    return clzi(4,b(0 to 7));
+    for i in 0 to 7 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
+    for i in 0 to 3 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
+    for i in 0 to 1 loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
+    return ~SYM[2](4,b(0 to 7));
   end function;
 begin
-  ~RESULT <= resize(clz16(~ARG[0](15 downto 0)),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~ARG[0](15 downto 0)),~SIZE[~TYPO]);
 end block;
 -- clz16 end"
     }
@@ -578,7 +578,7 @@ end block;
     , "templateD" :
 "-- clz32 begin
 clz32~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -588,7 +588,7 @@ clz32~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -600,20 +600,20 @@ clz32~SYM[0] : block
     end if;
   end function;
 
-  function clz32 (constant v : unsigned(0 to 31)) return unsigned is
+  function ~GENSYM[clz32][3] (constant v : unsigned(0 to 31)) return unsigned is
     variable e : unsigned(0 to 31);    -- 32
     variable a : unsigned(0 to 8*3-1); -- 24
     variable b : unsigned(0 to 4*4-1); -- 16
     variable c : unsigned(0 to 2*5-1); -- 10
   begin
-    for i in 0 to 15 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
-    for i in 0 to 7  loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 3  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
-    for i in 0 to 1  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7)); end loop;
-    return clzi(5,c(0 to 9));
+    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
+    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
+    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
+    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
+    return ~SYM[2](5,c(0 to 9));
   end function;
 begin
-  ~RESULT <= resize(clz32(~ARG[0](31 downto 0)),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~ARG[0](31 downto 0)),~SIZE[~TYPO]);
 end block;
 -- clz32 end"
     }
@@ -624,7 +624,7 @@ end block;
     , "templateD" :
 "-- clz64 begin
 clz64~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -634,7 +634,7 @@ clz64~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -646,22 +646,22 @@ clz64~SYM[0] : block
     end if;
   end function;
 
-  function clz64 (constant v : unsigned(0 to 63)) return unsigned is
+  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
     variable e : unsigned(0 to 63);     -- 64
     variable a : unsigned(0 to 16*3-1); -- 48
     variable b : unsigned(0 to 8*4-1);  -- 32
     variable c : unsigned(0 to 4*5-1);  -- 20
     variable d : unsigned(0 to 2*6-1);  -- 12
   begin
-    for i in 0 to 31 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));      end loop;
-    for i in 0 to 15 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3));   end loop;
-    for i in 0 to 7  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5));   end loop;
-    for i in 0 to 3  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7));   end loop;
-    for i in 0 to 1  loop d(i*6 to i*6+5):=clzi(5,c(i*10 to i*10+9)); end loop;
-    return clzi(6,d(0 to 11));
+    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
+    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
+    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
+    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
+    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
+    return ~SYM[2](6,d(0 to 11));
   end function;
 begin
-  ~RESULT <= resize(clz64(~ARG[0]),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~ARG[0]),~SIZE[~TYPO]);
 end block;
 -- clz64 end"
     }
@@ -672,7 +672,7 @@ end block;
     , "templateD" :
 "-- clz begin
 clz~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -682,7 +682,7 @@ clz~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -694,39 +694,39 @@ clz~SYM[0] : block
     end if;
   end function;
 ~IF ~IW64 ~THEN
-  function clz64 (constant v : unsigned(0 to 63)) return unsigned is
+  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
     variable e : unsigned(0 to 63);     -- 64
     variable a : unsigned(0 to 16*3-1); -- 48
     variable b : unsigned(0 to 8*4-1);  -- 32
     variable c : unsigned(0 to 4*5-1);  -- 20
     variable d : unsigned(0 to 2*6-1);  -- 12
   begin
-    for i in 0 to 31 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));      end loop;
-    for i in 0 to 15 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3));   end loop;
-    for i in 0 to 7  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5));   end loop;
-    for i in 0 to 3  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7));   end loop;
-    for i in 0 to 1  loop d(i*6 to i*6+5):=clzi(5,c(i*10 to i*10+9)); end loop;
-    return clzi(6,d(0 to 11));
+    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
+    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
+    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
+    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
+    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
+    return ~SYM[2](6,d(0 to 11));
   end function;
 ~ELSE
-  function clz32 (constant v : unsigned(0 to 31)) return unsigned is
+  function ~GENSYM[clz32][4] (constant v : unsigned(0 to 31)) return unsigned is
     variable e : unsigned(0 to 31);    -- 32
     variable a : unsigned(0 to 8*3-1); -- 24
     variable b : unsigned(0 to 4*4-1); -- 16
     variable c : unsigned(0 to 2*5-1); -- 10
   begin
-    for i in 0 to 15 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
-    for i in 0 to 7  loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 3  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
-    for i in 0 to 1  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7)); end loop;
-    return clzi(5,c(0 to 9));
+    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
+    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
+    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
+    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
+    return ~SYM[2](5,c(0 to 9));
   end function;
 ~FI
 begin
 ~IF ~IW64 ~THEN
-  ~RESULT <= resize(clz64(~ARG[0]),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~ARG[0]),~SIZE[~TYPO]);
 ~ELSE
-  ~RESULT <= resize(clz32(~ARG[0]),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[4](~ARG[0]),~SIZE[~TYPO]);
 ~FI
 end block;
 -- clz end"
@@ -737,8 +737,8 @@ end block;
     , "type"      : "ctz8 :: Word# -> Word#"
     , "templateD" :
 "-- ctz8 begin
-ctz8~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+~GENSYM[ctz8][0] : block
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -748,7 +748,7 @@ ctz8~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -760,26 +760,26 @@ ctz8~SYM[0] : block
     end if;
   end function;
 
-  function clz8 (constant v : unsigned(0 to 7)) return unsigned is
+  function ~GENSYM[clz8][3] (constant v : unsigned(0 to 7)) return unsigned is
     variable e : unsigned(0 to 7);     -- 8
     variable a : unsigned(0 to 2*3-1); -- 6
   begin
-    for i in 0 to 3 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
-    for i in 0 to 1 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
-    return clzi(3,a(0 to 5));
+    for i in 0 to 3 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
+    for i in 0 to 1 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
+    return ~SYM[2](3,a(0 to 5));
   end function;
 
-  signal ~SYM[1] : ~TYP[0];
-  signal ~SYM[2] : ~TYP[0];
+  signal ~GENSYM[s][4] : ~TYP[0];
+  signal ~GENSYM[s_reversed][5] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-  reverse_loop : for ~SYM[3] in ~SYM[1]'range generate
-    ~SYM[2](~SYM[1]'high - ~SYM[3]) <= ~SYM[1](~SYM[3]);
+  ~SYM[4] <= ~ARG[0];
+  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~SYM[4]'range generate
+    ~SYM[5](~SYM[4]'high - ~SYM[7]) <= ~SYM[4](~SYM[7]);
   end generate;
 ~IF ~IW64 ~THEN
-  ~RESULT <= resize(clz8(~SYM[2](63 downto 56)),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 56)),~SIZE[~TYPO]);
 ~ELSE
-  ~RESULT <= resize(clz8(~SYM[2](31 downto 24)),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~SYM[5](31 downto 24)),~SIZE[~TYPO]);
 ~FI
 end block;
 -- ctz8 end"
@@ -790,8 +790,8 @@ end block;
     , "type"      : "ctz16 :: Word# -> Word#"
     , "templateD" :
 "-- ctz16 begin
-ctz16~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+~GENSYM[ctz16][0] : block
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -801,7 +801,7 @@ ctz16~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -813,28 +813,28 @@ ctz16~SYM[0] : block
     end if;
   end function;
 
-  function clz16 (constant v : unsigned(0 to 15)) return unsigned is
+  function ~GENSYM[clz16][3] (constant v : unsigned(0 to 15)) return unsigned is
     variable e : unsigned(0 to 15);    -- 16
     variable a : unsigned(0 to 4*3-1); -- 12
     variable b : unsigned(0 to 2*4-1); -- 8
   begin
-    for i in 0 to 7 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
-    for i in 0 to 3 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 1 loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
-    return clzi(4,b(0 to 7));
+    for i in 0 to 7 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
+    for i in 0 to 3 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
+    for i in 0 to 1 loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
+    return ~SYM[2](4,b(0 to 7));
   end function;
 
-  signal ~SYM[1] : ~TYP[0];
-  signal ~SYM[2] : ~TYP[0];
+  signal ~GENSYM[s][4] : ~TYP[0];
+  signal ~GENSYM[s_reversed][5] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-  reverse_loop : for ~SYM[3] in ~SYM[1]'range generate
-    ~SYM[2](~SYM[1]'high - ~SYM[3]) <= ~SYM[1](~SYM[3]);
+  ~SYM[4] <= ~ARG[0];
+  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~SYM[4]'range generate
+    ~SYM[5](~SYM[4]'high - ~SYM[7]) <= ~SYM[4](~SYM[7]);
   end generate;
 ~IF ~IW64 ~THEN
-  ~RESULT <= resize(clz16(~SYM[2](63 downto 48)),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 48)),~SIZE[~TYPO]);
 ~ELSE
-  ~RESULT <= resize(clz16(~SYM[2](31 downto 16)),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~SYM[5](31 downto 16)),~SIZE[~TYPO]);
 ~FI
 end block;
 -- ctz16 end"
@@ -845,8 +845,8 @@ end block;
     , "type"      : "ctz32 :: Word# -> Word#"
     , "templateD" :
 "-- ctz32 begin
-ctz32~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+~GENSYM[ctz32][0] : block
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -856,7 +856,7 @@ ctz32~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -868,30 +868,30 @@ ctz32~SYM[0] : block
     end if;
   end function;
 
-  function clz32 (constant v : unsigned(0 to 31)) return unsigned is
+  function ~GENSYM[clz32][3] (constant v : unsigned(0 to 31)) return unsigned is
     variable e : unsigned(0 to 31);    -- 32
     variable a : unsigned(0 to 8*3-1); -- 24
     variable b : unsigned(0 to 4*4-1); -- 16
     variable c : unsigned(0 to 2*5-1); -- 10
   begin
-    for i in 0 to 15 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
-    for i in 0 to 7  loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 3  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
-    for i in 0 to 1  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7)); end loop;
-    return clzi(5,c(0 to 9));
+    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
+    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
+    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
+    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
+    return ~SYM[2](5,c(0 to 9));
   end function;
 
-  signal ~SYM[1] : ~TYP[0];
-  signal ~SYM[2] : ~TYP[0];
+  signal ~GENSYM[s][4] : ~TYP[0];
+  signal ~GENSYM[s_reversed][5] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-  reverse_loop : for ~SYM[3] in ~SYM[1]'range generate
-    ~SYM[2](~SYM[1]'high - ~SYM[3]) <= ~SYM[1](~SYM[3]);
+  ~SYM[4] <= ~ARG[0];
+  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~SYM[4]'range generate
+    ~SYM[5](~SYM[4]'high - ~SYM[7]) <= ~SYM[4](~SYM[3]);
   end generate;
 ~IF ~IW64 ~THEN
-  ~RESULT <= resize(clz32(~SYM[2](63 downto 32)),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 32)),~SIZE[~TYPO]);
 ~ELSE
-  ~RESULT <= resize(clz32(~SYM[2]),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);
 ~FI
 end block;
 -- ctz32 end"
@@ -902,8 +902,8 @@ end block;
     , "type"      : "ctz64 :: Word# -> Word#"
     , "templateD" :
 "-- ctz64 begin
-ctz64~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+~GENSYM[ctz64][0] : block
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -913,7 +913,7 @@ ctz64~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -925,30 +925,30 @@ ctz64~SYM[0] : block
     end if;
   end function;
 
-  function clz64 (constant v : unsigned(0 to 63)) return unsigned is
+  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
     variable e : unsigned(0 to 63);     -- 64
     variable a : unsigned(0 to 16*3-1); -- 48
     variable b : unsigned(0 to 8*4-1);  -- 32
     variable c : unsigned(0 to 4*5-1);  -- 20
     variable d : unsigned(0 to 2*6-1);  -- 12
   begin
-    for i in 0 to 31 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));      end loop;
-    for i in 0 to 15 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3));   end loop;
-    for i in 0 to 7  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5));   end loop;
-    for i in 0 to 3  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7));   end loop;
-    for i in 0 to 1  loop d(i*6 to i*6+5):=clzi(5,c(i*10 to i*10+9)); end loop;
-    return clzi(6,d(0 to 11));
+    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
+    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
+    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
+    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
+    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
+    return ~SYM[2](6,d(0 to 11));
   end function;
 
-  signal ~SYM[1] : ~TYP[0];
-  signal ~SYM[2] : ~TYP[0];
+  signal ~GENSYM[s][4] : ~TYP[0];
+  signal ~GENSYM[s_reversed][5] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-  reverse_loop : for ~SYM[3] in ~SYM[1]'range generate
-    ~SYM[2](~SYM[1]'high - ~SYM[3]) <= ~SYM[1](~SYM[3]);
+  ~SYM[4] <= ~ARG[0];
+  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~SYM[4]'range generate
+    ~SYM[5](~SYM[4]'high - ~SYM[7]) <= ~SYM[4](~SYM[7]);
   end generate;
 
-  ~RESULT <= resize(clz64(~SYM[2]),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);
 end block;
 -- ctz64 end"
     }
@@ -958,8 +958,8 @@ end block;
     , "type"      : "ctz :: Word# -> Word#"
     , "templateD" :
 "-- ctz begin
-ctz~SYM[0] : block
-  function enc(constant a : unsigned(1 downto 0)) return unsigned is
+~GENSYM[ctz][0] : block
+  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
   begin
     case a is
       when \"00\" => return \"10\";
@@ -969,7 +969,7 @@ ctz~SYM[0] : block
     end case;
   end function;
 
-  function clzi(
+  function ~GENSYM[clzi][2] (
     constant n : in natural;
     constant i : in unsigned) return unsigned is
     variable v : unsigned(i'length-1 downto 0):=i;
@@ -982,46 +982,46 @@ ctz~SYM[0] : block
   end function;
 
 ~IF ~IW64 ~THEN
-  function clz64 (constant v : unsigned(0 to 63)) return unsigned is
+  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
     variable e : unsigned(0 to 63);     -- 64
     variable a : unsigned(0 to 16*3-1); -- 48
     variable b : unsigned(0 to 8*4-1);  -- 32
     variable c : unsigned(0 to 4*5-1);  -- 20
     variable d : unsigned(0 to 2*6-1);  -- 12
   begin
-    for i in 0 to 31 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));      end loop;
-    for i in 0 to 15 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3));   end loop;
-    for i in 0 to 7  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5));   end loop;
-    for i in 0 to 3  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7));   end loop;
-    for i in 0 to 1  loop d(i*6 to i*6+5):=clzi(5,c(i*10 to i*10+9)); end loop;
-    return clzi(6,d(0 to 11));
+    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
+    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
+    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
+    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
+    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
+    return ~SYM[2](6,d(0 to 11));
   end function;
 ~ELSE
-  function clz32 (constant v : unsigned(0 to 31)) return unsigned is
+  function ~GENSYM[clz32][4] (constant v : unsigned(0 to 31)) return unsigned is
     variable e : unsigned(0 to 31);    -- 32
     variable a : unsigned(0 to 8*3-1); -- 24
     variable b : unsigned(0 to 4*4-1); -- 16
     variable c : unsigned(0 to 2*5-1); -- 10
   begin
-    for i in 0 to 15 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
-    for i in 0 to 7  loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 3  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
-    for i in 0 to 1  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7)); end loop;
-    return clzi(5,c(0 to 9));
+    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
+    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
+    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
+    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
+    return ~SYM[2](5,c(0 to 9));
   end function;
 ~FI
 
-  signal ~SYM[1] : ~TYP[0];
-  signal ~SYM[2] : ~TYP[0];
+  signal ~GENSYM[s][5] : ~TYP[0];
+  signal ~GENSYM[s_reversed][6] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-  reverse_loop : for ~SYM[3] in ~SYM[1]'range generate
-    ~SYM[2](~SYM[1]'high - ~SYM[3]) <= ~SYM[1](~SYM[3]);
+  ~SYM[5] <= ~ARG[0];
+  ~GENSYM[reverse_loop][7] : for ~GENSYM[n][8] in ~SYM[5]'range generate
+    ~SYM[6](~SYM[5]'high - ~SYM[8]) <= ~SYM[5](~SYM[8]);
   end generate;
 ~IF ~IW64 ~THEN
-  ~RESULT <= resize(clz64(~SYM[2]),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[3](~SYM[6]),~SIZE[~TYPO]);
 ~ELSE
-  ~RESULT <= resize(clz32(~SYM[2]),~SIZE[~TYPO]);
+  ~RESULT <= resize(~SYM[4](~SYM[6]),~SIZE[~TYPO]);
 ~FI
 end block;
 -- ctz end"
@@ -1032,15 +1032,12 @@ end block;
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "templateD" :
 "-- byteSwap16 begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[byteSwap16][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-~IF ~IW64 ~THEN
-  ~RESULT <= ~SYM[1](63 downto 16) & ~SYM[1](7 downto 0) & ~SYM[1](15 downto 8);
-~ELSE
-  ~RESULT <= ~SYM[1](31 downto 16) & ~SYM[1](7 downto 0) & ~SYM[1](15 downto 8);
-~FI
+  ~SYM[1] <= ~ARG[0];~IF ~IW64 ~THEN
+  ~RESULT <= ~SYM[1](63 downto 16) & ~SYM[1](7 downto 0) & ~SYM[1](15 downto 8);~ELSE
+  ~RESULT <= ~SYM[1](31 downto 16) & ~SYM[1](7 downto 0) & ~SYM[1](15 downto 8);~FI
 end block;
 -- byteSwap16 end"
     }
@@ -1050,17 +1047,14 @@ end block;
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "templateD" :
 "-- byteSwap32 begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[byteSwap32][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-~IF ~IW64 ~THEN
+  ~SYM[1] <= ~ARG[0];~IF ~IW64 ~THEN
   ~RESULT <= ~SYM[1](63 downto 32) & ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
-                                   & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);
-~ELSE
+                                   & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);~ELSE
   ~RESULT <= ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
-           & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);
-~FI
+           & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);~FI
 end block;
 -- byteSwap32 end"
     }
@@ -1070,8 +1064,8 @@ end block;
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "templateD" :
 "-- byteSwap64 begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[byteSwap64][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
@@ -1087,19 +1081,16 @@ end block;
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "templateD" :
 "-- byteSwap begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[byteSwap][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
-  ~SYM[1] <= ~ARG[0];
-~IF ~IW64 ~THEN
+  ~SYM[1] <= ~ARG[0];~IF ~IW64 ~THEN
   ~RESULT <= ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
            & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24)
            & ~SYM[1](39 downto 32) & ~SYM[1](47 downto 40)
-           & ~SYM[1](55 downto 48) & ~SYM[1](63 downto 56);
-~ELSE
+           & ~SYM[1](55 downto 48) & ~SYM[1](63 downto 56);~ELSE
   ~RESULT <= ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
-           & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);
-~FI
+           & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);~FI
 end block;
 -- byteSwap end"
     }
@@ -1109,8 +1100,8 @@ end block;
     , "type"      : "narrow8Int# :: Int# -> Int#"
     , "templateD" :
 "-- narrow8Int begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[narrow8Int][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= resize(~SYM[1](7 downto 0),~SIZE[~TYPO]);
@@ -1123,8 +1114,8 @@ end block;
     , "type"      : "narrow16Int# :: Int# -> Int#"
     , "templateD" :
 "-- narrow16Int begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[narrow16Int][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= resize(~SYM[1](15 downto 0),~SIZE[~TYPO]);
@@ -1137,8 +1128,8 @@ end block;
     , "type"      : "narrow32Int# :: Int# -> Int#"
     , "templateD" :
 "-- narrow32Int begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[narrow32Int][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= resize(~SYM[1](31 downto 0),~SIZE[~TYPO]);
@@ -1151,8 +1142,8 @@ end block;
     , "type"      : "narrow8Word# :: Word# -> Word#"
     , "templateD" :
 "-- narrow8Word begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[narrow8Word][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= resize(~SYM[1](7 downto 0),~SIZE[~TYPO]);
@@ -1165,8 +1156,8 @@ end block;
     , "type"      : "narrow16Word# :: Word# -> Word#"
     , "templateD" :
 "-- narrow16Word begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[narrow16Word][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= resize(~SYM[1](15 downto 0),~SIZE[~TYPO]);
@@ -1179,8 +1170,8 @@ end block;
     , "type"      : "narrow32Word# :: Word# -> Word#"
     , "templateD" :
 "-- narrow32Word begin
-msb_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
+~GENSYM[narrow32Word][0] : block
+  signal ~GENSYM[s][1] : ~TYP[0];
 begin
   ~SYM[1] <= ~ARG[0];
   ~RESULT <= resize(~SYM[1](31 downto 0),~SIZE[~TYPO]);

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -87,6 +87,9 @@ instance Backend VHDLState where
 type VHDLM a = State VHDLState a
 
 -- List of reserved VHDL-2008 keywords
+-- + used internal names: toslv, fromslv, tagtoenum, datatotag
+-- + used IEEE library names: integer, boolean, std_logic, std_logic_vector,
+--   signed, unsigned, to_integer, to_signed, to_unsigned, string
 reservedWords :: [Identifier]
 reservedWords = ["abs","access","after","alias","all","and","architecture"
   ,"array","assert","assume","assume_guarantee","attribute","begin","block"
@@ -101,7 +104,9 @@ reservedWords = ["abs","access","after","alias","all","and","architecture"
   ,"return","rol","ror","select","sequence","severity","signal","shared","sla"
   ,"sll","sra","srl","strong","subtype","then","to","transport","type"
   ,"unaffected","units","until","use","variable","vmode","vprop","vunit","wait"
-  ,"when","while","with","xnor","xor","toslv","fromslv","tagtoenum","datatotag"]
+  ,"when","while","with","xnor","xor","toslv","fromslv","tagtoenum","datatotag"
+  ,"integer", "boolean", "std_logic", "std_logic_vector", "signed", "unsigned"
+  ,"to_integer", "to_signed", "to_unsigned", "string"]
 
 filterReserved :: Identifier -> Identifier
 filterReserved s = if s `elem` reservedWords

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -82,6 +82,7 @@ instance Backend VHDLState where
   fromBV hty id_  = fromSLV hty id_ (typeSize hty - 1) 0
   hdlSyn          = use hdlsyn
   mkBasicId       = return (filterReserved . T.toLower . mkBasicId' True)
+  setModName _    = id
 
 type VHDLM a = State VHDLState a
 

--- a/tests/shouldwork/Signal/MAC.hs
+++ b/tests/shouldwork/Signal/MAC.hs
@@ -2,9 +2,10 @@ module MAC where
 
 import CLaSH.Prelude
 
-topEntity :: (Signal Integer, Signal Integer)
+topEntity :: Integer
+          -> (Signal Integer, Signal Integer)
           -> Signal Integer
-topEntity = macT <^> 0
+topEntity i = macT <^> i
 
 macT s (x,y) = (s',o)
   where

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -140,7 +140,6 @@ clashHDL t env extraArgs modName =
                        ,case t of { VHDL -> "--vhdl"
                                   ; Verilog -> "--verilog"
                                   }
-                       ,"-clash-hdlsyn", "Vivado"
                        ]
                       ,extraArgs
                       ,[modName <.> "hs"]

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -18,8 +18,8 @@ main =
   defaultMain $ testGroup "tests"
     [ testGroup "examples"
       [runTest "examples"             Both [] "ALU"          (Just ("topEntity",False))
-      ,runTest "examples"             VHDL [] "Blinker"      (Just ("topEntity_0",False))
-      ,runTest "examples"             Verilog [] "Blinker_v" (Just ("blinker_0",False))
+      ,runTest "examples"             VHDL [] "Blinker"      (Just ("topEntity",False))
+      ,runTest "examples"             Verilog [] "Blinker_v" (Just ("blinker",False))
       ,runTest "examples"             Both [] "BlockRamTest" (Just ("topEntity",False))
       ,runTest "examples"             Both [] "Calculator"   (Just ("testbench",True ))
       ,runTest "examples"             Both [] "CochleaPlus"  (Just ("topEntity",False))


### PR DESCRIPTION
By trying to preserve Haskell names in the HDL output (See #128), we could no longer user a simple counter to ensure that all names are unique. This meant we had to update all black boxes to ensure that all the generated symbols are unique.