### PR TITLE
Prepend 'work.' to use declaration of _types file

### DIFF
--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -363,7 +363,7 @@ tyImports nm = do
     , "use IEEE.MATH_REAL.ALL"
     , "use std.textio.all"
     , "use work.all"
-    , "use" <+> text (mkId (T.pack nm `T.append` "_types")) <> ".all"
+    , "use work." <+> text (mkId (T.pack nm `T.append` "_types")) <> ".all"
     ]
 
 


### PR DESCRIPTION
This seems to have been removed in 35689c4. Without qualifying using the
package name, xst is unable to find the imported module.