### PR TITLE
ghdl -r needs workdir

### DIFF
--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -162,7 +162,7 @@ ghdlMake :: FilePath -> String -> String -> TestTree
 ghdlMake env modName entity = testProgram "GHDL (make)" "ghdl" ["-m","--workdir=work","--std=93",modName ++ "_" ++ entity] (Just env) False False
 
 ghdlSim :: FilePath -> String -> TestTree
-ghdlSim env modName = testProgram "GHDL (sim)" "ghdl" ["-r","--std=93",modName ++ "_testbench","--assert-level=error"] (Just env) False False
+ghdlSim env modName = testProgram "GHDL (sim)" "ghdl" ["-r","--workdir=work","--std=93",modName ++ "_testbench","--assert-level=error"] (Just env) False False
 
 iverilog :: FilePath -> String -> String -> TestTree
 iverilog dir modName entity = withResource (return dir) (const (return ()))


### PR DESCRIPTION
Using your description I tried to indicate the workdir for '-r' and it worked.
Some more tests failing, but this might be another cause.

> 12 out of 504 tests failed (548.23s)
