### PR TITLE
Allow clash-lib to compile under ghc 8.0.2

### DIFF
--- a/clash-ghc/src-ghc/CLaSH/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/LoadInterfaceFiles.hs
@@ -4,6 +4,7 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
@@ -50,7 +51,11 @@ runIfl modName action = do
   hscEnv <- GHC.getSession
   let localEnv = TcRnTypes.IfLclEnv modName (text "runIfl")
                    UniqFM.emptyUFM UniqFM.emptyUFM
+#if MIN_VERSION_GLASGOW_HASKELL(8,0,1,20161117)
   let globalEnv = TcRnTypes.IfGblEnv empty Nothing
+#else
+  let globalEnv = TcRnTypes.IfGblEnv Nothing
+#endif
   MonadUtils.liftIO $ TcRnMonad.initTcRnIf 'r' hscEnv globalEnv
                         localEnv action
 

--- a/clash-ghc/src-ghc/CLaSH/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/LoadInterfaceFiles.hs
@@ -34,7 +34,7 @@ import qualified Maybes
 import qualified MkCore
 import qualified MonadUtils
 import qualified Name
-import           Outputable  (showPpr, showSDoc, text)
+import           Outputable  (showPpr, showSDoc, text, empty)
 import qualified TcIface
 import qualified TcRnMonad
 import qualified TcRnTypes
@@ -50,7 +50,7 @@ runIfl modName action = do
   hscEnv <- GHC.getSession
   let localEnv = TcRnTypes.IfLclEnv modName (text "runIfl")
                    UniqFM.emptyUFM UniqFM.emptyUFM
-  let globalEnv = TcRnTypes.IfGblEnv Nothing
+  let globalEnv = TcRnTypes.IfGblEnv empty Nothing
   MonadUtils.liftIO $ TcRnMonad.initTcRnIf 'r' hscEnv globalEnv
                         localEnv action
 

--- a/clash-lib/src/GHC/Extra.hs
+++ b/clash-lib/src/GHC/Extra.hs
@@ -4,12 +4,15 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module GHC.Extra where
 
+#if !(MIN_VERSION_GLASGOW_HASKELL(8,0,2,0))
 import Control.DeepSeq
 import SrcLoc (SrcSpan)
 
 instance NFData SrcSpan where
   rnf x = x `seq` ()
+#endif

--- a/clash-lib/src/GHC/Extra.hs
+++ b/clash-lib/src/GHC/Extra.hs
@@ -9,7 +9,7 @@
 
 module GHC.Extra where
 
-#if !(MIN_VERSION_GLASGOW_HASKELL(8,0,2,0))
+#if !(MIN_VERSION_GLASGOW_HASKELL(8,0,1,20161117))
 import Control.DeepSeq
 import SrcLoc (SrcSpan)
 


### PR DESCRIPTION
Conditionally compile the instance for NFData for SrcSpan.
