### PR TITLE
gitignore: update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-dist
+dist*
+.stack-work
 cabal-dev
 *.o
 *.o-boot


### PR DESCRIPTION
Cabal new-build uses `dist-newstyle`, so generalize the `dist*` rule. Also add `.stack-work`, too.