### PR TITLE
Sum-of-product types: unused bits now "don't-care"

### DIFF
--- a/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
+++ b/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
@@ -724,7 +724,7 @@ expr_ _ (DataCon ty@(SP _ args) (DC (_,i)) es) = assignExpr
     argExprs   = zipWith toSLV argTys es
     extraArg   = case typeSize ty - dcSize of
                    0 -> []
-                   n -> [exprLit (Just (ty,n)) (NumLit 0)]
+                   n -> [int n <> "'b" <> bits (replicate n U)]
     assignExpr = braces (hcat $ punctuate comma $ sequence (dcExpr:argExprs ++ extraArg))
 
 expr_ _ (DataCon ty@(Sum _ _) (DC (_,i)) []) = int (typeSize ty) <> "'d" <> int i

--- a/clash-verilog/src/CLaSH/Backend/Verilog.hs
+++ b/clash-verilog/src/CLaSH/Backend/Verilog.hs
@@ -383,7 +383,7 @@ expr_ _ (DataCon ty@(SP _ args) (DC (_,i)) es) = assignExpr
     argExprs   = map (expr_ False) es
     extraArg   = case typeSize ty - dcSize of
                    0 -> []
-                   n -> [exprLit (Just (ty,n)) (NumLit 0)]
+                   n -> [int n <> "'b" <> bits (replicate n U)]
     assignExpr = braces (hcat $ punctuate comma $ sequence (dcExpr:argExprs ++ extraArg))
 
 expr_ _ (DataCon ty@(Sum _ _) (DC (_,i)) []) = int (typeSize ty) <> "'d" <> int i

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -737,7 +737,7 @@ expr_ _ (DataCon ty@(SP _ args) (DC (_,i)) es) = assignExpr
     argExprs   = zipWith toSLV argTys es
     extraArg   = case typeSize ty - dcSize of
                    0 -> []
-                   n -> [exprLit (Just (ty,n)) (NumLit 0)]
+                   n -> [bits (replicate n U)]
     assignExpr = "std_logic_vector'" <> parens (hcat $ punctuate " & " $ sequence (dcExpr:argExprs ++ extraArg))
 
 expr_ _ (DataCon ty@(Sum _ _) (DC (_,i)) []) = "to_unsigned" <> tupled (sequence [int i,int (typeSize ty)])


### PR DESCRIPTION
Sum-of-product types include common types like Maybe and Either.  The
representations of values of such types often have bit positions that
are unused in some cases.

For example, the type 'Maybe (Unsigned 8)' is represented as a 9-bit
type, with a 1-bit "discriminator" that is set for Just and clear for
Nothing, and an 8-bit 'Unsigned 8' payload.  In the 'Nothing' case, the
8 bits of payload are unused.

Previously, these unused bits were explicitly initialized to zero.  This
isn't wrong, but it is overly conservative, and effectively instructs
the synthesis tool to put work into ensuring the value of bits that will
never be used.

This commit switches the representation of bits to use each backend
language's "don't-care" or "unknown" representation, giving the
synthesis tool more freedom and (in my tests) producing better results.

Fixes #212