### PR TITLE
Verilog primitive fixes

### DIFF
--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -265,7 +265,7 @@ assign ~RESULT = 1'b0;
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.quot#"
     , "type"      : "quot# :: BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "~ARG[0]) / ~ARG[1]"
+    , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -241,7 +241,7 @@ assign ~RESULT = 1'b0;
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
-    , "templateE" : "$unsigned(~ARG[1])"
+    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Index.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Index.json
@@ -73,7 +73,7 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Index n"
-    , "templateE" : "$unsigned(~ARG[1])"
+    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
@@ -99,7 +99,7 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Signed (n :: Nat)"
-    , "templateE" : "$signed(~ARG[1])"
+    , "templateE" : "$signed(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Unsigned.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Unsigned.json
@@ -91,7 +91,7 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Unsigned n"
-    , "templateE" : "$unsigned(~ARG[1])"
+    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -262,7 +262,7 @@ assign ~RESULT = 1'b0;
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.quot#"
     , "type"      : "quot# :: BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "~ARG[0]) / ~ARG[1]"
+    , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -238,7 +238,7 @@ assign ~RESULT = 1'b0;
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
-    , "templateE" : "$unsigned(~ARG[1])"
+    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.Index.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.Index.json
@@ -73,7 +73,7 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Index n"
-    , "templateE" : "$unsigned(~ARG[1])"
+    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.Signed.json
@@ -99,7 +99,7 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Signed (n :: Nat)"
-    , "templateE" : "$signed(~ARG[1])"
+    , "templateE" : "$signed(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :

--- a/clash-verilog/primitives/CLaSH.Sized.Internal.Unsigned.json
+++ b/clash-verilog/primitives/CLaSH.Sized.Internal.Unsigned.json
@@ -91,7 +91,7 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Unsigned n"
-    , "templateE" : "$unsigned(~ARG[1])"
+    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :


### PR DESCRIPTION
This mostly addresses #219 and fixes it in my use case, though I am uncomfortable declaring the fix "complete" because there are other appearances of `Int` and `Integer` remaining in primitive templates.

I also fixed a syntax error while I was in there (second commit).