### PR TITLE
Name generation

### DIFF
--- a/clash-ghc/src-ghc/CLaSH/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/Evaluator.hs
@@ -155,6 +155,9 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
       ] <- reduceTerms tcm isSubj args
     -> Literal (WordLiteral (w `shiftL` fromInteger i))
 
+  "GHC.Classes.geInt" | Just (i,j) <- intCLiterals tcm isSubj args
+    -> boolToBoolLiteral tcm ty (i >= j)
+
   "GHC.Integer.Logarithms.integerLogBase#"
     | Just (a,b) <- integerLiterals tcm isSubj args
     , Just c <- flogBase a b
@@ -492,6 +495,13 @@ integerLiterals tcm isSubj args = case reduceTerms tcm isSubj args of
 intLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 intLiterals tcm isSubj args = case reduceTerms tcm isSubj args of
   [Literal (IntLiteral i), Literal (IntLiteral j)] -> Just (i,j)
+  _ -> Nothing
+
+intCLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+intCLiterals tcm isSubj args = case reduceTerms tcm isSubj args of
+  ([collectArgs -> (Data _,[Left (Literal (IntLiteral i))])
+   ,collectArgs -> (Data _,[Left (Literal (IntLiteral j))])])
+    -> Just (i,j)
   _ -> Nothing
 
 wordLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)

--- a/clash-ghc/src-ghc/CLaSH/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/Evaluator.hs
@@ -26,24 +26,24 @@ import           GHC.Int
 import           GHC.Prim
 import           GHC.Real            (Ratio (..))
 import           GHC.Word
-import           Unbound.Generics.LocallyNameless (runFreshM, bind, embed,
-                                                   string2Name)
+import           Unbound.Generics.LocallyNameless (runFreshM, bind, embed)
 
 import           CLaSH.Core.DataCon  (DataCon (..))
 import           CLaSH.Core.Literal  (Literal (..))
+import           CLaSH.Core.Name     (Name (..), string2SystemName)
 import           CLaSH.Core.Pretty   (showDoc)
 import           CLaSH.Core.Term     (Term (..))
 import           CLaSH.Core.Type     (Type (..), ConstTy (..), LitTy (..),
                                       TypeView (..), tyView, mkFunTy,
                                       mkTyConApp, splitFunForallTy)
-import           CLaSH.Core.TyCon    (TyCon, TyConName, tyConDataCons)
+import           CLaSH.Core.TyCon    (TyCon, TyConOccName, tyConDataCons)
 import           CLaSH.Core.TysPrim
 import           CLaSH.Core.Util     (collectArgs,mkApps,mkRTree,mkVec,termType,
                                       tyNatSize)
 import           CLaSH.Core.Var      (Var (..))
 import           CLaSH.Util          (clogBase, flogBase, curLoc)
 
-reduceConstant :: HashMap.HashMap TyConName TyCon -> Bool -> Term -> Term
+reduceConstant :: HashMap.HashMap TyConOccName TyCon -> Bool -> Term -> Term
 reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
   "GHC.Prim.eqChar#" | Just (i,j) <- charLiterals tcm isSubj args
     -> boolToIntLiteral (i == j)
@@ -68,7 +68,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
 
   "GHC.Prim.quotRemInt#" | Just (i,j) <- intLiterals tcm isSubj args
     -> let (_,tyView -> TyConApp tupTcNm tyArgs) = splitFunForallTy ty
-           (Just tupTc) = HashMap.lookup tupTcNm tcm
+           (Just tupTc) = HashMap.lookup (nameOcc tupTcNm) tcm
            [tupDc] = tyConDataCons tupTc
            (q,r)   = quotRem i j
            ret     = mkApps (Data tupDc) (map Right tyArgs ++
@@ -106,7 +106,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
   "GHC.Prim.tagToEnum#"
     | [Right (ConstTy (TyCon tcN)), Left (Literal (IntLiteral i))] <-
       map (Bifunctor.bimap (reduceConstant tcm isSubj) id) args
-    -> let dc = do { tc <- HashMap.lookup tcN tcm
+    -> let dc = do { tc <- HashMap.lookup (nameOcc tcN) tcm
                    ; let dcs = tyConDataCons tc
                    ; List.find ((== (i+1)) . toInteger . dcTag) dcs
                    }
@@ -118,7 +118,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
 
   "GHC.Prim.plusWord2#" | Just (i,j) <- wordLiterals tcm isSubj args
     -> let (_,tyView -> TyConApp tupTcNm tyArgs) = splitFunForallTy ty
-           (Just tupTc) = HashMap.lookup tupTcNm tcm
+           (Just tupTc) = HashMap.lookup (nameOcc tupTcNm) tcm
            [tupDc] = tyConDataCons tupTc
            !(W# a)  = fromInteger i
            !(W# b)  = fromInteger j
@@ -129,7 +129,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
 
   "GHC.Prim.timesWord2#" | Just (i,j) <- wordLiterals tcm isSubj args
     -> let (_,tyView -> TyConApp tupTcNm tyArgs) = splitFunForallTy ty
-           (Just tupTc) = HashMap.lookup tupTcNm tcm
+           (Just tupTc) = HashMap.lookup (nameOcc tupTcNm) tcm
            [tupDc] = tyConDataCons tupTc
            !(W# a)  = fromInteger i
            !(W# b)  = fromInteger j
@@ -140,7 +140,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
 
   "GHC.Prim.subWordC#" | Just (i,j) <- wordLiterals tcm isSubj args
     -> let (_,tyView -> TyConApp tupTcNm tyArgs) = splitFunForallTy ty
-           (Just tupTc) = HashMap.lookup tupTcNm tcm
+           (Just tupTc) = HashMap.lookup (nameOcc tupTcNm) tcm
            [tupDc] = tyConDataCons tupTc
            !(W# a)  = fromInteger i
            !(W# b)  = fromInteger j
@@ -195,7 +195,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
 
   "GHC.Integer.Type.divModInteger" | Just (i,j) <- integerLiterals tcm isSubj args
     -> let (_,tyView -> TyConApp ubTupTcNm [liftedKi,_,intTy,_]) = splitFunForallTy ty
-           (Just ubTupTc) = HashMap.lookup ubTupTcNm tcm
+           (Just ubTupTc) = HashMap.lookup (nameOcc ubTupTcNm) tcm
            [ubTupDc] = tyConDataCons ubTupTc
            (d,m) = divMod i j
        in  mkApps (Data ubTupDc) [ Right liftedKi, Right liftedKi
@@ -275,7 +275,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
     | isSubj
     , [Literal (IntLiteral i)] <- reduceTerms tcm isSubj args
     ->  let (_,tyView -> TyConApp intTcNm []) = splitFunForallTy ty
-            (Just intTc) = HashMap.lookup intTcNm tcm
+            (Just intTc) = HashMap.lookup (nameOcc intTcNm) tcm
             [intDc] = tyConDataCons intTc
         in  mkApps (Data intDc) [Left (Literal (IntLiteral i))]
 
@@ -330,7 +330,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
                  2 -> 1 `shiftL` (fromInteger b)
                  _ -> a ^ b
            (_,tyView -> TyConApp snatTcNm _) = splitFunForallTy ty
-           (Just snatTc) = HashMap.lookup snatTcNm tcm
+           (Just snatTc) = HashMap.lookup (nameOcc snatTcNm) tcm
            [snatDc] = tyConDataCons snatTc
        in  mkApps (Data snatDc) [ Right (LitTy (NumTy c))
 #if MIN_VERSION_ghc(8,2,0)
@@ -344,7 +344,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
     , Just c <- flogBase a b
     , let c' = toInteger c
     -> let (_,tyView -> TyConApp snatTcNm _) = splitFunForallTy ty
-           (Just snatTc) = HashMap.lookup snatTcNm tcm
+           (Just snatTc) = HashMap.lookup (nameOcc snatTcNm) tcm
            [snatDc] = tyConDataCons snatTc
        in  mkApps (Data snatDc) [ Right (LitTy (NumTy c'))
 #if MIN_VERSION_ghc(8,2,0)
@@ -358,7 +358,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
     , Just c <- clogBase a b
     , let c' = toInteger c
     -> let (_,tyView -> TyConApp snatTcNm _) = splitFunForallTy ty
-           (Just snatTc) = HashMap.lookup snatTcNm tcm
+           (Just snatTc) = HashMap.lookup (nameOcc snatTcNm) tcm
            [snatDc] = tyConDataCons snatTc
        in  mkApps (Data snatDc) [ Right (LitTy (NumTy c'))
 #if MIN_VERSION_ghc(8,2,0)
@@ -372,7 +372,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
     , Just c <- flogBase a b
     , let c' = toInteger c
     -> let (_,tyView -> TyConApp snatTcNm _) = splitFunForallTy ty
-           (Just snatTc) = HashMap.lookup snatTcNm tcm
+           (Just snatTc) = HashMap.lookup (nameOcc snatTcNm) tcm
            [snatDc] = tyConDataCons snatTc
        in  mkApps (Data snatDc) [ Right (LitTy (NumTy c'))
 #if MIN_VERSION_ghc(8,2,0)
@@ -445,7 +445,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
     | isSubj
     , (TyConApp treeTcNm [lenTy,argTy]) <- tyView (runFreshM (termType tcm e))
     , Right len <- runExcept (tyNatSize tcm lenTy)
-    -> let (Just treeTc) = HashMap.lookup treeTcNm tcm
+    -> let (Just treeTc) = HashMap.lookup (nameOcc treeTcNm) tcm
            [lrCon,brCon] = tyConDataCons treeTc
        in  mkRTree lrCon brCon argTy len (replicate (2^len) (last $ Either.lefts args))
 
@@ -453,7 +453,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
     | isSubj
     , (TyConApp vecTcNm [lenTy,argTy]) <- tyView (runFreshM (termType tcm e))
     , Right len <- runExcept (tyNatSize tcm lenTy)
-    -> let (Just vecTc) = HashMap.lookup vecTcNm tcm
+    -> let (Just vecTc) = HashMap.lookup (nameOcc vecTcNm) tcm
            [nilCon,consCon] = tyConDataCons vecTc
        in  mkVec nilCon consCon argTy len (replicate (fromInteger len) (last $ Either.lefts args))
 
@@ -463,7 +463,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
     , Right n <- runExcept (tyNatSize tcm nTy)
     -> let ty' = runFreshM (termType tcm e)
            (TyConApp intTcNm _) = tyView ty'
-           (Just intTc) = HashMap.lookup intTcNm tcm
+           (Just intTc) = HashMap.lookup (nameOcc intTcNm) tcm
            [intCon] = tyConDataCons intTc
        in  mkApps (Data intCon) [Left (Literal (IntLiteral (toInteger (n - 1))))]
 
@@ -473,7 +473,7 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
     , Right n <-runExcept (tyNatSize tcm nTy)
     -> let ty' = runFreshM (termType tcm e)
            (TyConApp intTcNm _) = tyView ty'
-           (Just intTc) = HashMap.lookup intTcNm tcm
+           (Just intTc) = HashMap.lookup (nameOcc intTcNm) tcm
            [intCon] = tyConDataCons intTc
        in  mkApps (Data intCon) [Left (Literal (IntLiteral (toInteger n)))]
 
@@ -481,30 +481,30 @@ reduceConstant tcm isSubj e@(collectArgs -> (Prim nm ty, args)) = case nm of
 
 reduceConstant _ _ e = e
 
-reduceTerms :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> [Term]
+reduceTerms :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> [Term]
 reduceTerms tcm isSubj = map (reduceConstant tcm isSubj) . Either.lefts
 
-integerLiterals :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+integerLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 integerLiterals tcm isSubj args = case reduceTerms tcm isSubj args of
   [Literal (IntegerLiteral i), Literal (IntegerLiteral j)] -> Just (i,j)
   _ -> Nothing
 
-intLiterals :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+intLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 intLiterals tcm isSubj args = case reduceTerms tcm isSubj args of
   [Literal (IntLiteral i), Literal (IntLiteral j)] -> Just (i,j)
   _ -> Nothing
 
-wordLiterals :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+wordLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 wordLiterals tcm isSubj args = case (map (reduceConstant tcm isSubj) . Either.lefts) args of
   [Literal (WordLiteral i), Literal (WordLiteral j)] -> Just (i,j)
   _ -> Nothing
 
-charLiterals :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Char,Char)
+charLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Char,Char)
 charLiterals tcm isSubj args = case (map (reduceConstant tcm isSubj) . Either.lefts) args of
   [Literal (CharLiteral i), Literal (CharLiteral j)] -> Just (i,j)
   _ -> Nothing
 
-sizedLiterals :: Text -> HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+sizedLiterals :: Text -> HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 sizedLiterals szCon tcm isSubj args
   = case reduceTerms tcm isSubj args of
       ([ collectArgs -> (Prim nm  _,[Right _, Left _, Left (Literal (IntegerLiteral i))])
@@ -513,25 +513,25 @@ sizedLiterals szCon tcm isSubj args
         , nm' == szCon -> Just (i,j)
       _ -> Nothing
 
-bitVectorLiterals :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+bitVectorLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 bitVectorLiterals = sizedLiterals "CLaSH.Sized.Internal.BitVector.fromInteger#"
 
-indexLiterals :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+indexLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 indexLiterals = sizedLiterals "CLaSH.Sized.Internal.Index.fromInteger#"
 
-signedLiterals :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+signedLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 signedLiterals = sizedLiterals "CLaSH.Sized.Internal.Signed.fromInteger#"
 
-unsignedLiterals :: HashMap.HashMap TyConName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
+unsignedLiterals :: HashMap.HashMap TyConOccName TyCon -> Bool -> [Either Term Type] -> Maybe (Integer,Integer)
 unsignedLiterals = sizedLiterals "CLaSH.Sized.Internal.Unsigned.fromInteger#"
 
 boolToIntLiteral :: Bool -> Term
 boolToIntLiteral b = if b then Literal (IntLiteral 1) else Literal (IntLiteral 0)
 
-boolToBoolLiteral :: HashMap.HashMap TyConName TyCon -> Type -> Bool -> Term
+boolToBoolLiteral :: HashMap.HashMap TyConOccName TyCon -> Type -> Bool -> Term
 boolToBoolLiteral tcm ty b =
  let (_,tyView -> TyConApp boolTcNm []) = splitFunForallTy ty
-     (Just boolTc) = HashMap.lookup boolTcNm tcm
+     (Just boolTc) = HashMap.lookup (nameOcc boolTcNm) tcm
      [falseDc,trueDc] = tyConDataCons boolTc
      retDc = if b then trueDc else falseDc
  in  Data retDc
@@ -553,8 +553,8 @@ signedConPrim = Prim "CLaSH.Sized.Internal.Signed.fromInteger#" (ForAllTy (bind 
 #else
     funTy        = foldr1 mkFunTy [integerPrimTy,integerPrimTy,mkTyConApp signedTcNm [nVar]]
 #endif
-    signedTcNm = string2Name "CLaSH.Sized.Internal.Signed.Signed"
-    nName      = string2Name "n"
+    signedTcNm = string2SystemName "CLaSH.Sized.Internal.Signed.Signed"
+    nName      = string2SystemName "n"
     nVar       = VarTy typeNatKind nName
     nTV        = TyVar nName (embed typeNatKind)
 
@@ -566,7 +566,7 @@ unsignedConPrim = Prim "CLaSH.Sized.Internal.Unsigned.fromInteger#" (ForAllTy (b
 #else
     funTy        = foldr1 mkFunTy [integerPrimTy,integerPrimTy,mkTyConApp unsignedTcNm [nVar]]
 #endif
-    unsignedTcNm = string2Name "CLaSH.Sized.Internal.Unsigned.Unsigned"
-    nName        = string2Name "n"
+    unsignedTcNm = string2SystemName "CLaSH.Sized.Internal.Unsigned.Unsigned"
+    nName        = string2SystemName "n"
     nVar         = VarTy typeNatKind nName
     nTV          = TyVar nName (embed typeNatKind)

--- a/clash-ghc/src-ghc/CLaSH/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/GHC2Core.hs
@@ -543,9 +543,9 @@ coreToName :: (b -> Name)
            -> State GHC2CoreState (C.Name a)
 coreToName toName toUnique toString v = do
   ns <- toString (toName v)
-  let nm = Unbound.makeName ns (toInteger . getKey . toUnique $ v)
-  return (C.Name C.User nm (getSrcSpan (toName v)))
-  -- return (Unbound.makeName ns (toInteger . getKey . toUnique $ v))
+  let nm  = Unbound.makeName ns (toInteger . getKey . toUnique $ v)
+      loc = getSrcSpan (toName v)
+  return (C.Name C.User nm loc)
 
 qualfiedNameString :: Name
                    -> State GHC2CoreState String

--- a/clash-ghc/src-ghc/CLaSH/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/GHC2Core.hs
@@ -42,9 +42,8 @@ import qualified Data.HashMap.Strict         as HSM
 import           Data.Maybe                  (catMaybes,fromMaybe,listToMaybe)
 import           Data.Text                   (isInfixOf,pack)
 import qualified Data.Traversable            as T
-import           Unbound.Generics.LocallyNameless     (bind, embed, rebind, rec,
-                                              runFreshM, string2Name, unbind,
-                                              unembed)
+import           Unbound.Generics.LocallyNameless
+  (bind, embed, rebind, rec, runFreshM, unbind, unembed)
 import qualified Unbound.Generics.LocallyNameless     as Unbound
 
 -- GHC API
@@ -102,6 +101,7 @@ import VarSet     (isEmptyVarSet)
 -- Local imports
 import qualified CLaSH.Core.DataCon          as C
 import qualified CLaSH.Core.Literal          as C
+import qualified CLaSH.Core.Name             as C
 import qualified CLaSH.Core.Term             as C
 import qualified CLaSH.Core.TyCon            as C
 import qualified CLaSH.Core.Type             as C
@@ -115,7 +115,7 @@ instance Hashable Name where
 
 data GHC2CoreState
   = GHC2CoreState
-  { _tyConMap :: HashMap C.TyConName TyCon
+  { _tyConMap :: HashMap C.TyConOccName TyCon
   , _nameMap  :: HashMap Name String
   }
 
@@ -124,9 +124,10 @@ makeLenses ''GHC2CoreState
 emptyGHC2CoreState :: GHC2CoreState
 emptyGHC2CoreState = GHC2CoreState HSM.empty HSM.empty
 
-makeAllTyCons :: GHC2CoreState
-              -> FamInstEnvs
-              -> HashMap C.TyConName C.TyCon
+makeAllTyCons
+  :: GHC2CoreState
+  -> FamInstEnvs
+  -> HashMap C.TyConOccName C.TyCon
 makeAllTyCons hm fiEnvs = go hm hm
   where
     go old new
@@ -347,7 +348,7 @@ coreToTerm errorInvalidCoercions primMap unlocs srcsp coreExpr = Reader.runReade
     var srcsp' x = do
         xVar   <- coreToVar x
         xPrim  <- coreToPrimVar x
-        let xNameS = pack $ Unbound.name2String xPrim
+        let xNameS = pack $ C.name2String xPrim
         xType  <- coreToType (varType x)
         case isDataConId_maybe x of
           Just dc -> case HashMap.lookup xNameS primMap of
@@ -498,7 +499,7 @@ coreToType' (TyConApp tc args)
                         foldl C.AppTy <$> coreToType synTy' <*> mapM coreToType remArgs
                       _ -> do
                         tcName <- coreToName tyConName tyConUnique qualfiedNameString tc
-                        tyConMap %= (HSM.insert tcName tc)
+                        tyConMap %= (HSM.insert (C.nameOcc tcName) tc)
                         C.mkTyConApp <$> (pure tcName) <*> mapM coreToType args
 #if MIN_VERSION_ghc(8,2,0)
 coreToType' (ForAllTy (TvBndr tv _) ty) = C.ForAllTy <$> (bind <$> coreToTyVar tv <*> coreToType ty)
@@ -528,21 +529,23 @@ coreToId i =
   C.Id <$> (coreToVar i) <*> (embed <$> coreToType (varType i))
 
 coreToVar :: Var
-          -> State GHC2CoreState (Unbound.Name a)
+          -> State GHC2CoreState (C.Name a)
 coreToVar = coreToName varName varUnique qualfiedNameStringM
 
 coreToPrimVar :: Var
-              -> State GHC2CoreState (Unbound.Name C.Term)
+              -> State GHC2CoreState (C.Name C.Term)
 coreToPrimVar = coreToName varName varUnique qualfiedNameString
 
 coreToName :: (b -> Name)
            -> (b -> Unique)
            -> (Name -> State GHC2CoreState String)
            -> b
-           -> State GHC2CoreState (Unbound.Name a)
+           -> State GHC2CoreState (C.Name a)
 coreToName toName toUnique toString v = do
   ns <- toString (toName v)
-  return (Unbound.makeName ns (toInteger . getKey . toUnique $ v))
+  let nm = Unbound.makeName ns (toInteger . getKey . toUnique $ v)
+  return (C.Name C.User nm (getSrcSpan (toName v)))
+  -- return (Unbound.makeName ns (toInteger . getKey . toUnique $ v))
 
 qualfiedNameString :: Name
                    -> State GHC2CoreState String
@@ -593,8 +596,8 @@ mapSignalTerm (C.ForAllTy tvATy) =
       }
     (C.FunTy _ funTy'') = C.tyView funTy
     (C.FunTy aTy bTy)   = C.tyView funTy''
-    fName = string2Name "f"
-    xName = string2Name "x"
+    fName = C.string2SystemName "f"
+    xName = C.string2SystemName "x"
     fTy   = C.mkFunTy aTy bTy
     fId   = C.Id fName (embed fTy)
     xId   = C.Id xName (embed aTy)
@@ -622,7 +625,7 @@ signalTerm (C.ForAllTy tvATy) =
       ; return (aTV',clkTV',funTy')
       }
     (C.FunTy _ aTy) = C.tyView funTy
-    xName = string2Name "x"
+    xName = C.string2SystemName "x"
     xId   = C.Id xName (embed aTy)
 
 signalTerm ty = error $ $(curLoc) ++ show ty
@@ -658,8 +661,8 @@ appSignalTerm (C.ForAllTy tvClkTy) =
       }
     (C.FunTy _ funTy'') = C.tyView funTy
     (C.FunTy aTy bTy)   = C.tyView funTy''
-    fName = string2Name "f"
-    xName = string2Name "x"
+    fName = C.string2SystemName "f"
+    xName = C.string2SystemName "x"
     fTy   = C.mkFunTy aTy bTy
     fId   = C.Id fName (embed fTy)
     xId   = C.Id xName (embed aTy)
@@ -694,7 +697,7 @@ vecUnwrapTerm (C.ForAllTy tvTTy) =
       ; return (tTV',nTV',aTV',funTy')
       }
     (C.FunTy _ vsTy) = C.tyView funTy
-    vsName           = string2Name "vs"
+    vsName           = C.string2SystemName "vs"
     vsId             = C.Id vsName   (embed vsTy)
 
 vecUnwrapTerm ty = error $ $(curLoc) ++ show ty
@@ -734,9 +737,9 @@ traverseTerm (C.ForAllTy tvFTy) =
     (C.FunTy dictTy funTy1) = C.tyView funTy
     (C.FunTy gTy    funTy2) = C.tyView funTy1
     (C.FunTy xTy    _)      = C.tyView funTy2
-    dictName = string2Name "dict"
-    gName    = string2Name "g"
-    xName    = string2Name "x"
+    dictName = C.string2SystemName "dict"
+    gName    = C.string2SystemName "g"
+    xName    = C.string2SystemName "x"
     dictId   = C.Id dictName (embed dictTy)
     gId      = C.Id gName (embed gTy)
     xId      = C.Id xName (embed xTy)
@@ -774,8 +777,8 @@ dollarTerm (C.ForAllTy tvRTy) =
       }
     (C.FunTy fTy funTy'') = C.tyView funTy
     (C.FunTy aTy _)       = C.tyView funTy''
-    fName = string2Name "f"
-    xName = string2Name "x"
+    fName = C.string2SystemName "f"
+    xName = C.string2SystemName "x"
     fId   = C.Id fName (embed fTy)
     xId   = C.Id xName (embed aTy)
 
@@ -811,8 +814,8 @@ withFrozenCallStackTerm (C.ForAllTy tvATy) =
   where
     (aTV,funTy) = runFreshM (unbind tvATy)
     (C.FunTy callStackTy fTy) = C.tyView funTy
-    callStackName = string2Name "callStack"
-    fName         = string2Name "f"
+    callStackName = C.string2SystemName "callStack"
+    fName         = C.string2SystemName "f"
     callStackId   = C.Id callStackName (embed callStackTy)
     fId           = C.Id fName (embed fTy)
 

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -130,6 +130,7 @@ Library
                       CLaSH.Core.DataCon
                       CLaSH.Core.FreeVars
                       CLaSH.Core.Literal
+                      CLaSH.Core.Name
                       CLaSH.Core.Pretty
                       CLaSH.Core.Subst
                       CLaSH.Core.Term
@@ -171,5 +172,6 @@ Library
 
   Other-Modules:      CLaSH.Annotations.TopEntity.Extra
                       Data.Aeson.Extra
+                      GHC.SrcLoc.Extra
                       Paths_clash_lib
                       Unbound.Generics.LocallyNameless.Extra

--- a/clash-lib/prims/systemverilog/CLaSH_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/systemverilog/CLaSH_Sized_Internal_BitVector.json
@@ -53,13 +53,7 @@
         => BitVector n -- ARG[1]
         -> Int         -- ARG[2]
         -> Bit"
-    , "templateD" :
-"// indexBit begin
-~SIGD[~GENSYM[bv][0]][1];
-assign ~SYM[0] = ~ARG[1];
-
-assign ~RESULT = ~SYM[0][~ARG[2]];
-// indexBit end"
+    , "templateE" : "~VAR[bv][1][~ARG[2]]"
     }
   }
 , { "BlackBox" :
@@ -72,14 +66,10 @@ assign ~RESULT = ~SYM[0][~ARG[2]];
              -> BitVector n"
     , "templateD" :
 "// replaceBit start
-~SIGD[~GENSYM[bv][0]][1];
-
 always_comb begin
-  ~SYM[0] = ~ARG[1];
-  ~SYM[0][~ARG[2]] = ~ARG[3];
+  ~RESULT = ~ARG[1];
+  ~RESULT[~ARG[2]] = ~ARG[3];
 end
-
-assign ~RESULT = ~SYM[0];
 // replaceBit end"
     }
   }
@@ -93,14 +83,10 @@ assign ~RESULT = ~SYM[0];
            -> BitVector (m + 1 + i)"
     , "templateD" :
 "// setSlice begin
-~SIGD[~GENSYM[bv][0]][0];
-
 always_comb begin
-  ~SYM[0] = ~ARG[0];
-  ~SYM[0][~LIT[1] : ~LIT[2]] = ~ARG[3];
+  ~RESULT = ~ARG[0];
+  ~RESULT[~LIT[1] : ~LIT[2]] = ~ARG[3];
 end
-
-assign ~RESULT = ~SYM[0];
 // setSlice end"
     }
   }
@@ -111,12 +97,7 @@ assign ~RESULT = ~SYM[0];
         -> SNat m                -- ARG[1]
         -> SNat n                -- ARG[2]
         -> BitVector (m + 1 - n)"
-    , "templateD" :
-"// slice begin
-~SIGD[~GENSYM[bv][0]][0];
-assign ~SYM[0] = ~ARG[0];
-assign ~RESULT = ~SYM[0][~LIT[1] : ~LIT[2]];
-// slice end"
+    , "templateE" : "~VAR[bv][0][~LIT[1] : ~LIT[2]]"
     }
   }
 , { "BlackBox" :
@@ -127,10 +108,8 @@ assign ~RESULT = ~SYM[0][~LIT[1] : ~LIT[2]];
         -> (BitVector m, BitVector n)"
     , "templateD" :
 "// split begin
-~SIGD[~GENSYM[bv][0]][1];
-assign ~SYM[0] = ~ARG[1];
-assign ~RESULT = { ~SYM[0][$high(~SYM[0]) : ~LIT[0]]
-                 , ~SYM[0][(~LIT[0]-1) : 0]
+assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
+                 , ~VAR[bv][1][(~LIT[0]-1) : 0]
                  };
 // split end"
     }
@@ -141,14 +120,7 @@ assign ~RESULT = { ~SYM[0][$high(~SYM[0]) : ~LIT[0]]
 "msb# :: KnownNat n  -- ARG[0]
       => BitVector n -- ARG[1]
       -> Bit"
-    , "templateD" :
-"// msb begin~IF ~LIT[0] ~THEN
-~SIGD[~GENSYM[bv][0]][1];
-assign ~SYM[0] = ~ARG[1];
-assign ~RESULT = ~SYM[0][~LIT[0]-1];
-~ELSE
-assign ~RESULT = 1'b0;
-~FI// msb end"
+    , "templateE" : "~IF ~LIT[0] ~THEN ~VAR[bv][1][~LIT[0]-1] ~ELSE 1'b0 ~FI"
     }
   }
 , { "BlackBox" :
@@ -156,14 +128,7 @@ assign ~RESULT = 1'b0;
     , "type" :
 "lsb# :: BitVector n -- ARG[0]
       -> Bit"
-    , "templateD" :
-"// lsb begin~IF ~SIZE[~TYP[0]] ~THEN
-~SIGD[~GENSYM[bv][0]][0];
-assign ~SYM[0] = ~ARG[0];
-assign ~RESULT = ~SYM[0][0];
-~ELSE
-assign ~RESULT = 1'b0;
-~FI// lsb end"
+    , "templateE" :"~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0][0] ~ELSE 1'b0 ~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/systemverilog/CLaSH_Sized_Internal_Signed.json
+++ b/clash-lib/prims/systemverilog/CLaSH_Sized_Internal_Signed.json
@@ -137,17 +137,12 @@
     , "type"      : "div# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// divSigned begin
-~SIGD[~GENSYM[quot_res][0]][1];
-~SIGD[~GENSYM[dividend][1]][1];
-~SIGD[~GENSYM[divider][2]][2];
-
 // divide (rounds towards zero)
-assign ~SYM[0] = ~ARG[1] / ~ARG[2];
+~SIGD[~GENSYM[quot_res][0]][1];
+assign ~SYM[0] = ~VAR[dividend][1] / ~VAR[divider][2];
 
 // round toward minus infinity
-assign ~SYM[1] = ~ARG[1];
-assign ~SYM[2] = ~ARG[2];
-assign ~RESULT = (~SYM[1][~LIT[0]-1] == ~SYM[2][~LIT[0]-1]) ? ~SYM[0] : ~SYM[0] - ~LIT[0]'sd1;
+assign ~RESULT = (~VAR[dividend][1][~LIT[0]-1] == ~VAR[divider][2][~LIT[0]-1]) ? ~SYM[0] : ~SYM[0] - ~LIT[0]'sd1;
 // divSigned end"
     }
   }
@@ -156,19 +151,14 @@ assign ~RESULT = (~SYM[1][~LIT[0]-1] == ~SYM[2][~LIT[0]-1]) ? ~SYM[0] : ~SYM[0] 
     , "type"      : "mod# :: Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// modSigned begin
-~SIGD[~GENSYM[rem_res][0]][0];
-~SIGD[~GENSYM[dividend][1]][0];
-~SIGD[~GENSYM[divider][2]][1];
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-
 // remainder
-assign ~SYM[0] = ~SYM[1] % ~SYM[2];
+~SIGD[~GENSYM[rem_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 (~SYM[1] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~SYM[2]);
+                 (~VAR[dividend][0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modSigned end"
     }
   }
@@ -245,12 +235,10 @@ assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
 ~GENERATE
   if (~LIT[1] < ~LIT[0]) begin
     // truncate, sign preserving
-    ~SIGD[~GENSYM[s][0]][2];
-    assign ~SYM[0] = ~ARG[2];
-    assign ~RESULT = $signed({~SYM[0][~LIT[0]-1],~SYM[0][(~LIT[1]-2):0]});
+    assign ~RESULT = $signed({~VAR[s][2][~LIT[0]-1],~VAR[s][2][(~LIT[1]-2):0]});
   end else begin
     // sign-extend
-    assign ~RESULT = $signed(~ARG[2]);
+    assign ~RESULT = $signed(~VAR[s][2]);
   end
 ~ENDGENERATE
 // resize end"

--- a/clash-lib/prims/systemverilog/CLaSH_Sized_RTree.json
+++ b/clash-lib/prims/systemverilog/CLaSH_Sized_RTree.json
@@ -7,25 +7,13 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.RTree.textract"
     , "type"      : "textract :: RTree 0 a -> a"
-    , "templateD" :
-"// textract begin
-~SIGD[~GENSYM[tree][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~FROMBV[~SYM[0][\\0\\]][~TYPO];
-// textract end"
+    , "templateE" : "~FROMBV[~VAR[tree][0][\\0\\]][~TYPO]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.RTree.tsplit"
     , "type"      : "tsplit:: RTree (d+1) a -> (RTree d a,RTree d a)"
-    , "templateD" :
-"// tsplit begin
-~SIGD[~GENSYM[tree][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~TOBV[~SYM[0]][~TYP[0]];
-// tsplit end"
+    , "templateE" : "~TOBV[~VAR[tree][0]][~TYP[0]]"
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/CLaSH_Sized_Vector.json
+++ b/clash-lib/prims/systemverilog/CLaSH_Sized_Vector.json
@@ -1,49 +1,25 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.head"
     , "type"      : "head :: Vec (n + 1) a -> a"
-    , "templateD" :
-"// head begin
-~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~FROMBV[~SYM[0][\\0\\]][~TYPO];
-// head end"
+    , "templateE" : "~FROMBV[~VAR[vec][0][\\0\\]][~TYPO]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.tail"
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
-    , "templateD" :
-"// tail begin
-~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~SYM[0][1 : $high(~SYM[0])];
-// tail end"
+    , "templateE" : "~VAR[vec][0][1 : $high(~VAR[vec][0])]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.last"
     , "type"      : "Vec (n + 1) a -> a"
-    , "templateD" :
-"// last begin
-~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~FROMBV[~SYM[0][\\$high(~SYM[0])\\]][~TYPO];
-// last end"
+    , "templateE" : "~FROMBV[~VAR[vec][0][\\$high(~VAR[vec][0])\\]][~TYPO]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.init"
     , "type"      : "Vec (n + 1) a -> Vec n a"
-    , "templateD" :
-"// init begin
-~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~SYM[0][0 : $high(~SYM[0]) - 1];
-// init end"
+    , "templateE" : "~VAR[vec][0][0 : $high(~VAR[vec][0]) - 1]"
     }
   }
 , { "BlackBox" :
@@ -57,13 +33,10 @@ assign ~RESULT = ~SYM[0][0 : $high(~SYM[0]) - 1];
         -> Vec n a"
     , "templateD" :
 "// select begin
-~SIGD[~GENSYM[vec][0]][4];
-assign ~SYM[0] = ~ARG[4];
-
 genvar ~GENSYM[n][1];
 ~GENERATE
   for (~SYM[1]=0; ~SYM[1] < ~LIT[3]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[select][2]
-    assign ~RESULT[~SYM[1]] = ~SYM[0][~LIT[1] + (~LIT[2] * ~SYM[1])];
+    assign ~RESULT[~SYM[1]] = ~VAR[vec][4][~LIT[1] + (~LIT[2] * ~SYM[1])];
   end
 ~ENDGENERATE
 // select end"
@@ -80,13 +53,10 @@ genvar ~GENSYM[n][1];
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "templateD" :
 "// concat begin
-~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
 genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1]=0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[concat][2]
-    assign ~RESULT[~SYM[1]*~LENGTH[~TYPEL[~TYP[0]]] : ~SYM[1]*~LENGTH[~TYPEL[~TYP[0]]]+(~LENGTH[~TYPEL[~TYP[0]]]-1)] = ~FROMBV[~SYM[0][\\~SYM[1]\\]][~TYPEL[~TYP[0]]];
+  for (~SYM[1]=0; ~SYM[1] < $size(~VAR[vec][0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[concat][2]
+    assign ~RESULT[~SYM[1]*~LENGTH[~TYPEL[~TYP[0]]] : ~SYM[1]*~LENGTH[~TYPEL[~TYP[0]]]+(~LENGTH[~TYPEL[~TYP[0]]]-1)] = ~FROMBV[~VAR[vec][0][\\~SYM[1]\\]][~TYPEL[~TYP[0]]];
   end
 ~ENDGENERATE
 // concat end"
@@ -120,13 +90,10 @@ assign ~SYM[0] = ~TOBV[~ARG[1]][~TYP[1]];
            -> Vec n (Vec m a)"
     , "templateD" :
 "// unconcat begin
-~SIGD[~GENSYM[vec][0]][2];
-assign ~SYM[0] = ~ARG[2];
-
 genvar ~GENSYM[n][1];
 ~GENERATE
   for (~SYM[1] = 0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[unconcat][2]
-    assign ~RESULT[~SYM[1]] = ~TOBV[~SYM[0][\\(~SYM[1] * ~LIT[1]) : ((~SYM[1] * ~LIT[1]) + ~LIT[1] - 1)\\]][~TYPEL[~TYPO]];
+    assign ~RESULT[~SYM[1]] = ~TOBV[~VAR[vec][2][\\(~SYM[1] * ~LIT[1]) : ((~SYM[1] * ~LIT[1]) + ~LIT[1] - 1)\\]][~TYPEL[~TYPO]];
   end
 ~ENDGENERATE
 // unconcat end"
@@ -137,15 +104,12 @@ genvar ~GENSYM[n][1];
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// map begin
-~SIGD[~GENSYM[vec][0]][1];
-assign ~SYM[0] = ~ARG[1];
-
 genvar ~GENSYM[n][1];
 ~GENERATE
   for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]
     ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];
     ~TYPEL[~TYPO] ~GENSYM[map_out][4];
-    assign ~SYM[3] = ~FROMBV[~SYM[0][\\~SYM[1]\\]][~TYPEL[~TYP[1]]];
+    assign ~SYM[3] = ~FROMBV[~VAR[vec][1][\\~SYM[1]\\]][~TYPEL[~TYP[1]]];
     ~INST 0
       ~OUTPUT <= ~SYM[4]~ ~TYPEL[~TYPO]~
       ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
@@ -161,9 +125,6 @@ genvar ~GENSYM[n][1];
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// imap begin
-~SIGD[~GENSYM[vec][0]][2];
-assign ~SYM[0] = ~ARG[2];
-
 genvar ~GENSYM[n][1];
 ~GENERATE
   for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
@@ -171,7 +132,7 @@ genvar ~GENSYM[n][1];
     assign ~SYM[3] = ~LENGTH[~TYPO] - 1 - ~SYM[1];
     ~TYPEL[~TYP[2]] ~GENSYM[imap_in][4];
     ~TYPEL[~TYPO] ~GENSYM[imap_out][5];
-    assign ~SYM[4] = ~FROMBV[~SYM[0][\\~SYM[1]\\]][~TYPEL[~TYP[2]]];
+    assign ~SYM[4] = ~FROMBV[~VAR[vec][2][\\~SYM[1]\\]][~TYPEL[~TYP[2]]];
     ~INST 1
       ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
       ~INPUT  <= ~SYM[3]~ ~INDEXTYPE[~LIT[0]]~
@@ -188,19 +149,14 @@ genvar ~GENSYM[n][1];
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "templateD" :
 "// zipWith begin
-~SIGD[~GENSYM[vec1][0]][1];
-~SIGD[~GENSYM[vec2][1]][2];
-assign ~SYM[0] = ~ARG[1];
-assign ~SYM[1] = ~ARG[2];
-
 genvar ~GENSYM[n][2];
 ~GENERATE
   for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][3]
     ~TYPEL[~TYP[1]] ~GENSYM[zipWith_in1][4];
     ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][5];
     ~TYPEL[~TYPO] ~GENSYM[zipWith_out][6];
-    assign ~SYM[4] = ~FROMBV[~SYM[0][\\~SYM[2]\\]][~TYPEL[~TYP[1]]];
-    assign ~SYM[5] = ~FROMBV[~SYM[1][\\~SYM[2]\\]][~TYPEL[~TYP[2]]];
+    assign ~SYM[4] = ~FROMBV[~VAR[vec1][1][\\~SYM[2]\\]][~TYPEL[~TYP[1]]];
+    assign ~SYM[5] = ~FROMBV[~VAR[vec2][2][\\~SYM[2]\\]][~TYPEL[~TYP[2]]];
     ~INST 0
       ~OUTPUT <= ~SYM[6]~ ~TYPEL[~TYPO]~
       ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[1]]~
@@ -220,14 +176,11 @@ genvar ~GENSYM[n][2];
 ~SIGDO[~GENSYM[intermediate][0]] [0:~LENGTH[~TYP[2]]];
 assign ~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];
 
-~SIGD[~GENSYM[xs][2]][2];
-assign ~SYM[2] = ~ARG[2];
-
 genvar ~GENSYM[i][3];
 ~GENERATE
 for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr_loop][4]
   ~TYPEL[~TYP[2]] ~GENSYM[foldr_in][5];
-  assign ~SYM[5] = ~FROMBV[~SYM[2][\\~SYM[3]\\]][~TYPEL[~TYP[2]]];
+  assign ~SYM[5] = ~FROMBV[~VAR[xs][2][\\~SYM[3]\\]][~TYPEL[~TYP[2]]];
   ~INST 0
     ~OUTPUT <= ~SYM[0][~SYM[3]]~ ~TYP[1]~
     ~INPUT <= ~SYM[5]~ ~TYPEL[~TYP[2]]~
@@ -289,13 +242,7 @@ assign ~RESULT = ~SYM[0][(2*~LENGTH[~TYP[1]])-2];
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.index_int"
     , "type"      : "index_integer :: KnownNat n => Vec n a -> Int -> a"
-    , "templateD" :
-"// indexVec begin
-~SIGD[~GENSYM[vec][0]][1];
-assign ~SYM[0] = ~ARG[1];
-
-assign ~RESULT = ~FROMBV[~SYM[0][\\~ARG[2]\\]][~TYPO];
-// indexVec end"
+    , "templateE" : "~FROMBV[~VAR[vec][1][\\~ARG[2]\\]][~TYPO]"
     }
   }
 , { "BlackBox" :
@@ -303,14 +250,10 @@ assign ~RESULT = ~FROMBV[~SYM[0][\\~ARG[2]\\]][~TYPO];
     , "type"      : "replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a"
     , "templateD" :
 "// replaceVec start
-~SIGD[~GENSYM[vec][0]][1];
-
 always_comb begin
-  ~SYM[0] = ~ARG[1];
-  ~SYM[0][~ARG[2]] = ~TOBV[~ARG[3]][~TYP[3]];
+  ~RESULT = ~ARG[1];
+  ~RESULT[~ARG[2]] = ~TOBV[~ARG[3]][~TYP[3]];
 end
-
-assign ~RESULT = ~SYM[0];
 // replaceVec end"
     }
   }
@@ -337,16 +280,13 @@ assign ~RESULT = ~SYM[0];
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "templateD" :
 "// transpose begin
-~SIGD[~GENSYM[matrix][0]][1];
-assign ~SYM[0] = ~ARG[1];
-
 genvar ~GENSYM[row_index][1];
 genvar ~GENSYM[col_index][2];
 ~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]
+  for (~SYM[1] = 0; ~SYM[1] < $size(~VAR[matrix][1]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]
     for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[transpose_inner][4]~IF ~VIVADO ~THEN
-      assign ~RESULT[~SYM[2]][($size(~SYM[0])-~SYM[1])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 : ($size(~SYM[0])-~SYM[1]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~SYM[0][~SYM[1]][($size(~RESULT)-~SYM[2])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 : ($size(~RESULT)-~SYM[2]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]];~ELSE
-      assign ~RESULT[~SYM[2]][~SYM[1]] = ~SYM[0][~SYM[1]][~SYM[2]];~FI
+      assign ~RESULT[~SYM[2]][($size(~VAR[matrix][1])-~SYM[1])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 : ($size(~VAR[matrix][1])-~SYM[1]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~VAR[matrix][1][~SYM[1]][($size(~RESULT)-~SYM[2])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 : ($size(~RESULT)-~SYM[2]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]];~ELSE
+      assign ~RESULT[~SYM[2]][~SYM[1]] = ~VAR[matrix][1][~SYM[1]][~SYM[2]];~FI
     end
   end
 ~ENDGENERATE
@@ -358,13 +298,10 @@ genvar ~GENSYM[col_index][2];
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "templateD" :
 "// reverse begin
-~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
 genvar ~GENSYM[n][1];
 ~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~SYM[0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]
-    assign ~RESULT[$high(~SYM[0]) - ~SYM[1]] = ~SYM[0][~SYM[1]];
+  for (~SYM[1] = 0; ~SYM[1] < $size(~VAR[vec][0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]
+    assign ~RESULT[$high(~VAR[vec][0]) - ~SYM[1]] = ~VAR[vec][0][~SYM[1]];
   end
 ~ENDGENERATE
 // reverse end"
@@ -399,17 +336,14 @@ genvar ~GENSYM[n][1];
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "// rotateLeftS begin
-~SIGD[~GENSYM[vec][1]][1];
 localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
-
-assign ~SYM[1] = ~ARG[1];
 
 ~GENERATE
 if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
-  assign ~RESULT = ~SYM[1];
+  assign ~RESULT = ~VAR[vec][1];
 end else begin : ~GENSYM[do_shift][4]
-  assign ~RESULT[0:~LIT[0]-~SYM[2]-1] = ~SYM[1][~SYM[2]:~LIT[0]-1];
-  assign ~RESULT[~LIT[0]-~SYM[2]:~LIT[0]-1] = ~SYM[1][0:~SYM[2]-1];
+  assign ~RESULT[0:~LIT[0]-~SYM[2]-1] = ~VAR[vec][1][~SYM[2]:~LIT[0]-1];
+  assign ~RESULT[~LIT[0]-~SYM[2]:~LIT[0]-1] = ~VAR[vec][1][0:~SYM[2]-1];
 end
 ~ENDGENERATE
 // rotateLeftS end"
@@ -420,17 +354,14 @@ end
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "// rotateRightS begin
-~SIGD[~GENSYM[vec][1]][1];
 localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
-
-assign ~SYM[1] = ~ARG[1];
 
 ~GENERATE
 if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
-  assign ~RESULT = ~SYM[1];
+  assign ~RESULT = ~VAR[vec][1];
 end else begin : ~GENSYM[do_shift][4]
-  assign ~RESULT[0:~SYM[2]-1] = ~SYM[1][~LIT[0]-~SYM[2]:~LIT[0]-1];
-  assign ~RESULT[~SYM[2]:~LIT[0]-1] = ~SYM[1][0:~LIT[0]-~SYM[2]-1];
+  assign ~RESULT[0:~SYM[2]-1] = ~VAR[vec][1][~LIT[0]-~SYM[2]:~LIT[0]-1];
+  assign ~RESULT[~SYM[2]:~LIT[0]-1] = ~VAR[vec][1][0:~LIT[0]-~SYM[2]-1];
 end
 ~ENDGENERATE
 // rotateRightS end"

--- a/clash-lib/prims/systemverilog/GHC_Base.json
+++ b/clash-lib/prims/systemverilog/GHC_Base.json
@@ -20,17 +20,12 @@
     , "type"      : "divInt :: Int -> Int -> Int"
     , "templateD" :
 "// divInt begin
-~SIGD[~GENSYM[quot_res][0]][0];
-~SIGD[~GENSYM[dividend][1]][0];
-~SIGD[~GENSYM[divider][2]][1];
-
 // divide (rounds towards zero)
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+~SIGD[~GENSYM[quot_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
 
 // round toward minus infinity
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
 // divInt end"
     }
   }
@@ -39,19 +34,14 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInt :: Int -> Int -> Int"
     , "templateD" :
 "// modInt begin
-~SIGD[~GENSYM[rem_res][0]][0];
-~SIGD[~GENSYM[dividend][1]][0];
-~SIGD[~GENSYM[divider][2]][1];
-
 // remainder
-assign ~SYM[0] = ~ARG[0] % ~ARG[1];
+~SIGD[~GENSYM[rem_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 ((~ARG[1] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~ARG[1]);
+                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInt end"
     }
   }

--- a/clash-lib/prims/systemverilog/GHC_Classes.json
+++ b/clash-lib/prims/systemverilog/GHC_Classes.json
@@ -56,40 +56,30 @@
     { "name"      : "GHC.Classes.divInt#"
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "templateD" :
-"// divInt begin
-~SIGD[~GENSYM[quot_res][0]][0];
-~SIGD[~GENSYM[dividend][1]][0];
-~SIGD[~GENSYM[divider][2]][1];
-
+"// divInt# begin
 // divide (rounds towards zero)
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+~SIGD[~GENSYM[quot_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
 
 // round toward minus infinity
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
-// divInt end"
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+// divInt# end"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.modInt#"
     , "type"      : "modInt# :: Int# -> Int# -> Int#"
     , "templateD" :
-"// modInt begin
-~SIGD[~GENSYM[rem_res][0]][0];
-~SIGD[~GENSYM[dividend][1]][0];
-~SIGD[~GENSYM[divider][2]][1];
-
+"// modInt# begin
 // remainder
-assign ~SYM[0] = ~ARG[0] % ~ARG[1];
+~SIGD[~GENSYM[rem_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 ((~ARG[1] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~ARG[1]);
-// modInt end"
+                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
+// modInt# end"
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/systemverilog/GHC_Integer_Type.json
@@ -45,17 +45,12 @@
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// divInteger begin
-~SIGD[~GENSYM[quot_res][0]][0];
-~SIGD[~GENSYM[dividend][1]][0];
-~SIGD[~GENSYM[divider][2]][1];
-
 // divide (rounds towards zero)
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+~SIGD[~GENSYM[quot_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
 
 // round toward minus infinity
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
 // divInteger end"
     }
   }
@@ -64,19 +59,14 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// modInteger begin
-~SIGD[~GENSYM[rem_res][0]][0];
-~SIGD[~GENSYM[dividend][1]][0];
-~SIGD[~GENSYM[divider][2]][1];
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-
 // remainder
-assign ~SYM[0] = ~SYM[1] % ~SYM[2];
+~SIGD[~GENSYM[rem_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 (~SYM[1] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~SYM[2]);
+                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInteger end"
     }
   }

--- a/clash-lib/prims/systemverilog/GHC_Prim.json
+++ b/clash-lib/prims/systemverilog/GHC_Prim.json
@@ -1627,11 +1627,9 @@ assign ~RESULT = $unsigned(~SYM[7]);
     { "name"      : "GHC.Prim.byteSwap16#"
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "templateD" :
-"// byteSwap16 begin
-~SIGDO[~GENSYM[w][0]];
-assign ~SYM[0] = ~ARG[0];~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[0][63:16],~SYM[0][7:0],~SYM[0][15:8]};~ELSE
-assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};~FI
+"// byteSwap16 begin~IF ~IW64 ~THEN
+assign ~RESULT = {~VAR[w][0][63:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~ELSE
+assign ~RESULT = {~VAR[w][0][31:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~FI
 // byteSwap16 end"
     }
   }
@@ -1639,11 +1637,9 @@ assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};~FI
     { "name"      : "GHC.Prim.byteSwap32#"
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "templateD" :
-"// byteSwap32 begin
-~SIGDO[~GENSYM[w][0]];
-assign ~SYM[0] = ~ARG[0];~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[0][63:32],~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~ELSE
-assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~FI
+"// byteSwap32 begin~IF ~IW64 ~THEN
+assign ~RESULT = {~VAR[w][0][63:32],~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~ELSE
+assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~FI
 // byteSwap32 end"
     }
   }
@@ -1652,10 +1648,8 @@ assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~FI
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap64 begin
-~SIGDO[~GENSYM[w][1]];
-assign ~SYM[1] = ~ARG[0];
-assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
-                 ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};
+assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]
+                 ,~VAR[w][0][39:32],~VAR[w][0][47:40],~VAR[w][0][55:48],~VAR[w][0][63:56]};
 // byteSwap64 end"
     }
   }
@@ -1663,12 +1657,10 @@ assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
     { "name"      : "GHC.Prim.byteSwap#"
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "templateD" :
-"// byteSwap begin
-~SIGDO[~GENSYM[w][1]];
-assign ~SYM[1] = ~ARG[0];~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
-                 ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};~ELSE
-assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};~FI
+"// byteSwap begin~IF ~IW64 ~THEN
+assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]
+                 ,~VAR[w][0][39:32],~VAR[w][0][47:40],~VAR[w][0][55:48],~VAR[w][0][63:56]};~ELSE
+assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~FI
 // byteSwap end"
     }
   }
@@ -1677,10 +1669,7 @@ assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};~FI
     , "type"      : "narrow8Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow8Int begin
-~SIGD[~GENSYM[s][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $signed(~SYM[0][7:0]);
+assign ~RESULT = $signed(~VAR[i][0][7:0]);
 // narrow8Int end"
     }
   }
@@ -1689,10 +1678,7 @@ assign ~RESULT = $signed(~SYM[0][7:0]);
     , "type"      : "narrow16Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow16Int begin
-~SIGD[~GENSYM[s][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $signed(~SYM[0][15:0]);
+assign ~RESULT = $signed(~VAR[i][0][15:0]);
 // narrow16Int end"
     }
   }
@@ -1701,10 +1687,7 @@ assign ~RESULT = $signed(~SYM[0][15:0]);
     , "type"      : "narrow32Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow32Int begin
-~SIGD[~GENSYM[s][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $signed(~SYM[0][31:0]);
+assign ~RESULT = $signed(~VAR[i][0][31:0]);
 // narrow32Int end"
     }
   }
@@ -1713,10 +1696,7 @@ assign ~RESULT = $signed(~SYM[0][31:0]);
     , "type"      : "narrow8Int# :: Word# -> Word#"
     , "templateD" :
 "// narrow8Word begin
-~SIGD[~GENSYM[w][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $unsigned(~SYM[0][7:0]);
+assign ~RESULT = $unsigned(~VAR[w][0][7:0]);
 // narrow8Word end"
     }
   }
@@ -1725,10 +1705,7 @@ assign ~RESULT = $unsigned(~SYM[0][7:0]);
     , "type"      : "narrow16Word# :: Word# -> Word#"
     , "templateD" :
 "// narrow16Word begin
-~SIGD[~GENSYM[w][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $unsigned(~SYM[0][15:0]);
+assign ~RESULT = $unsigned(~VAR[w][0][15:0]);
 // narrow16Word end"
     }
   }
@@ -1737,10 +1714,7 @@ assign ~RESULT = $unsigned(~SYM[0][15:0]);
     , "type"      : "narrow32Int# :: Word# -> Word#"
     , "templateD" :
 "// narrow32Word begin
-~SIGD[~GENSYM[w][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $unsigned(~SYM[0][31:0]);
+assign ~RESULT = $unsigned(~VAR[w][0][31:0]);
 // narrow32Word end"
     }
   }

--- a/clash-lib/prims/verilog/CLaSH_Explicit_BlockRam.json
+++ b/clash-lib/prims/verilog/CLaSH_Explicit_BlockRam.json
@@ -10,10 +10,10 @@
   -> Signal dom Int  -- wr,   ARG[5]
   -> Signal dom a    -- din,  ARG[6]
   -> Signal dom a"
+    , "outputReg" : true
     , "templateD" :
 "// blockRam begin
 reg ~TYPO ~GENSYM[RAM][0] [0:~LENGTH[~TYP[2]]-1];
-reg ~TYPO ~GENSYM[~RESULT_q][1];
 
 reg ~TYP[2] ~GENSYM[ram_init][2];
 integer ~GENSYM[i][3];
@@ -29,23 +29,21 @@ always @(posedge ~ARG[1][1]) begin : ~GENSYM[~COMPNAME_blockRam][4]~IF ~VIVADO ~
     if (~ARG[4]) begin
       ~SYM[0][~ARG[5]] <= ~ARG[6];
     end
-    ~SYM[1] <= ~SYM[0][~ARG[3]];
+    ~RESULT <= ~SYM[0][~ARG[3]];
   end~ELSE
   if (~ARG[4] & ~ARG[1][0]) begin
     ~SYM[0][~ARG[5]] <= ~ARG[6];
   end
   if (~ARG[1][0]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[3]];
+    ~RESULT <= ~SYM[0][~ARG[3]];
   end~FI
 end~ELSE
 always @(posedge ~ARG[1]) begin : ~SYM[4]
   if (~ARG[4]) begin
     ~SYM[0][~ARG[5]] <= ~ARG[6];
   end
-  ~SYM[1] <= ~SYM[0][~ARG[3]];
+  ~RESULT <= ~SYM[0][~ARG[3]];
 end~FI
-
-assign ~RESULT = ~SYM[1];
 // blockRam end"
     }
   }

--- a/clash-lib/prims/verilog/CLaSH_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/verilog/CLaSH_Explicit_BlockRam_File.json
@@ -11,10 +11,10 @@
   -> Signal dom Int            -- wr,   ARG[7]
   -> Signal dom (BitVector m)  -- din,  ARG[8]
   -> Signal dom (BitVector m)"
+    , "outputReg" : true
     , "templateD" :
 "// blockRamFile begin
 reg ~TYPO ~GENSYM[RAM][0] [0:~LIT[3]-1];
-reg ~TYPO ~GENSYM[~RESULT_q][1];
 
 initial begin
   $readmemb(~FILE[~LIT[4]],~SYM[0]);
@@ -25,23 +25,21 @@ always @(posedge ~ARG[2][1]) begin : ~GENSYM[~COMPNAME_blockRamFile][2]~IF ~VIVA
     if (~ARG[6]) begin
       ~SYM[0][~ARG[7]] <= ~ARG[8];
     end
-    ~SYM[1] <= ~SYM[0][~ARG[5]];
+    ~RESULT <= ~SYM[0][~ARG[5]];
   end~ELSE
   if (~ARG[6] & ~ARG[2][0]) begin
     ~SYM[0][~ARG[7]] <= ~ARG[8];
   end
   if (~ARG[2][0]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[5]];
+    ~RESULT <= ~SYM[0][~ARG[5]];
   end~FI
 end~ELSE
 always @(posedge ~ARG[2]) begin : ~SYM[2]
   if (~ARG[6]) begin
     ~SYM[0][~ARG[7]] <= ~ARG[8];
   end
-  ~SYM[1] <= ~SYM[0][~ARG[5]];
+  ~RESULT <= ~SYM[0][~ARG[5]];
 end~FI
-
-assign ~RESULT = ~SYM[1];
 // blockRamFile end"
     }
   }

--- a/clash-lib/prims/verilog/CLaSH_Explicit_ROM.json
+++ b/clash-lib/prims/verilog/CLaSH_Explicit_ROM.json
@@ -6,10 +6,10 @@
       -> Vec n a         -- init, ARG[2]
       -> Signal dom Int  -- rd,   ARG[3]
       -> Signal dom a"
+    , "outputReg" : true
     , "templateD" :
 "// rom begin
 reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[0]-1];
-reg ~TYPO ~GENSYM[~RESULT_q][1];
 
 reg ~TYP[2] ~GENSYM[rom_init][2];
 integer ~GENSYM[i][3];
@@ -22,14 +22,12 @@ end
 ~IF ~ISGATED[1] ~THEN
 always @(posedge ~ARG[1][1]) begin : ~GENSYM[~COMPNAME_rom][4]
   if (~ARG[1][0]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[3]];
+    ~RESULT <= ~SYM[0][~ARG[3]];
   end
 end~ELSE
 always @(posedge ~ARG[1]) begin : ~SYM[4]
-  ~SYM[1] <= ~SYM[0][~ARG[3]];
+  ~RESULT <= ~SYM[0][~ARG[3]];
 end~FI
-
-assign ~RESULT = ~SYM[1];
 // rom end"
     }
   }

--- a/clash-lib/prims/verilog/CLaSH_Explicit_ROM_File.json
+++ b/clash-lib/prims/verilog/CLaSH_Explicit_ROM_File.json
@@ -7,6 +7,7 @@
           -> FilePath        -- file, ARG[3]
           -> Signal dom Int  -- rd,   ARG[4]
           -> Signal dom (BitVector m)"
+    , "outputReg" : true
     , "templateD" :
 "// romFile begin
 reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[2]-1];
@@ -14,18 +15,15 @@ reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[2]-1];
 initial begin
   $readmemb(~FILE[~LIT[3]],~SYM[0]);
 end
-
-reg ~TYPO ~GENSYM[~RESULT_q][1];~IF ~ISGATED[1] ~THEN
+~IF ~ISGATED[1] ~THEN
 always @(posedge ~ARG[1][1]) begin : ~GENSYM[~COMPNAME_romFile][2]
   if (~ARG[1][0]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[4]];
+    ~RESULT <= ~SYM[0][~ARG[4]];
   end
 end~ELSE
 always @(posedge ~ARG[1]) begin : ~SYM[2]
-  ~SYM[1] <= ~SYM[0][~ARG[4]];
+  ~RESULT <= ~SYM[0][~ARG[4]];
 end~FI
-
-assign ~RESULT = ~SYM[1];
 // romFile end"
     }
   }

--- a/clash-lib/prims/verilog/CLaSH_Signal_Internal.json
+++ b/clash-lib/prims/verilog/CLaSH_Signal_Internal.json
@@ -6,20 +6,18 @@
   => Clock domain gated       -- ARG[1]
   -> Signal clk a             -- ARG[2]
   -> Signal clk a"
+    , "outputReg" : true
     , "templateD" :
-"// register begin
-reg ~SIGD[~GENSYM[~RESULT_q][0]][2];~IF ~ISGATED[1] ~THEN
+"// delay begin~IF ~ISGATED[1] ~THEN
 always @(posedge ~ARG[1][1]) begin : ~GENSYM[~COMPNAME_delay][1]
   if (~ARG[1][0]) begin
-    ~SYM[0] <= ~ARG[2];
+    ~RESULT <= ~ARG[2];
   end
 end~ELSE
 always @(posedge ~ARG[1]) begin : ~SYM[1]
-  ~SYM[0] <= ~ARG[2];
+  ~RESULT <= ~ARG[2];
 end~FI
-
-assign ~RESULT = ~SYM[0];
-// register end"
+// delay end"
     }
   }
 , { "BlackBox" :
@@ -32,25 +30,23 @@ assign ~RESULT = ~SYM[0];
   -> a                        -- ARG[3]
   -> Signal clk a             -- ARG[4]
   -> Signal clk a"
+    , "outputReg" : true
     , "templateD" :
-"// register begin
-reg ~SIGD[~GENSYM[~RESULT_q][0]][3];~IF ~ISGATED[1] ~THEN
+"// register begin~IF ~ISGATED[1] ~THEN
 always @(posedge ~ARG[1][1]~IF ~ISSYNC[2] ~THEN ~ELSE or posedge ~ARG[2]~FI) begin : ~GENSYM[~COMPNAME_register][1]
   if (~ARG[2]) begin
-    ~SYM[0] <= ~ARG[3];
+    ~RESULT <= ~ARG[3];
   end else if (~ARG[1][0]) begin
-    ~SYM[0] <= ~ARG[4];
+    ~RESULT <= ~ARG[4];
   end
 end~ELSE
 always @(posedge ~ARG[1]~IF ~ISSYNC[2] ~THEN ~ELSE or posedge ~ARG[2]~FI) begin : ~SYM[1]
   if (~ARG[2]) begin
-    ~SYM[0] <= ~ARG[3];
+    ~RESULT <= ~ARG[3];
   end else begin
-    ~SYM[0] <= ~ARG[4];
+    ~RESULT <= ~ARG[4];
   end
 end~FI
-
-assign ~RESULT = ~SYM[0];
 // register end"
     }
   }

--- a/clash-lib/prims/verilog/CLaSH_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/verilog/CLaSH_Sized_Internal_BitVector.json
@@ -53,13 +53,7 @@
         => BitVector n -- ARG[1]
         -> Int         -- ARG[2]
         -> Bit"
-    , "templateD" :
-"// indexBit begin
-wire ~TYP[1] ~GENSYM[bv][0];
-assign ~SYM[0] = ~ARG[1];
-
-assign ~RESULT = ~SYM[0][~ARG[2]];
-// indexBit end"
+    , "templateE" : "~VAR[bv][1][~ARG[2]]"
     }
   }
 , { "BlackBox" :
@@ -73,12 +67,9 @@ assign ~RESULT = ~SYM[0][~ARG[2]];
     , "outputReg" : true
     , "templateD" :
 "// replaceBit start
-wire ~TYP[3] ~GENSYM[din][1];
-assign ~SYM[1] = ~ARG[3];
-
 always @(*) begin
   ~RESULT = ~ARG[1];
-  ~RESULT[~ARG[2]] = ~SYM[1];
+  ~RESULT[~ARG[2]] = ~VAR[din][3];
 end
 // replaceBit end"
     }
@@ -94,12 +85,9 @@ end
     , "outputReg" : true
     , "templateD" :
 "// setSlice begin
-wire ~TYP[3] ~GENSYM[din][1];
-assign ~SYM[1] = ~ARG[3]
-
 always @(*) begin
   ~RESULT = ~ARG[0];
-  ~RESULT[~LIT[1] : ~LIT[2]] = ~SYM[1];
+  ~RESULT[~LIT[1] : ~LIT[2]] = ~VAR[din][3];
 end
 // setSlice end"
     }
@@ -111,12 +99,7 @@ end
         -> SNat m                -- ARG[1]
         -> SNat n                -- ARG[2]
         -> BitVector (m + 1 - n)"
-    , "templateD" :
-"// slice begin
-wire ~SIGD[~GENSYM[bv][0]][0];
-assign ~SYM[0] = ~ARG[0];
-assign ~RESULT = ~SYM[0][~LIT[1] : ~LIT[2]];
-// slice end"
+    , "templateE" : "~VAR[bv][0][~LIT[1] : ~LIT[2]]"
     }
   }
 , { "BlackBox" :
@@ -134,14 +117,7 @@ assign ~RESULT = ~SYM[0][~LIT[1] : ~LIT[2]];
 "msb# :: KnownNat n  -- ARG[0]
       => BitVector n -- ARG[1]
       -> Bit"
-    , "templateD" :
-"// msb begin~IF ~LIT[0] ~THEN
-wire ~SIGD[~GENSYM[bv][0]][1];
-assign ~SYM[0] = ~ARG[1];
-assign ~RESULT = ~SYM[0][~LIT[0]-1];
-~ELSE
-assign ~RESULT = 1'b0;
-~FI// msb end"
+    , "templateE" : "~IF ~LIT[0] ~THEN ~VAR[bv][1][~LIT[0]-1] ~ELSE 1'b0 ~FI"
     }
   }
 , { "BlackBox" :
@@ -149,14 +125,7 @@ assign ~RESULT = 1'b0;
     , "type" :
 "lsb# :: BitVector n -- ARG[0]
       -> Bit"
-    , "templateD" :
-"// lsb begin~IF ~SIZE[~TYP[0]] ~THEN
-wire ~SIGD[~GENSYM[bv][0]][0];
-assign ~SYM[0] = ~ARG[0];
-assign ~RESULT = ~SYM[0][0];
-~ELSE
-assign ~RESULT = 1'b0;
-~FI// lsb end"
+    , "templateE" : "~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0][0] ~ELSE 1'b0 ~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/verilog/CLaSH_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/verilog/CLaSH_Sized_Internal_BitVector.json
@@ -70,18 +70,16 @@ assign ~RESULT = ~SYM[0][~ARG[2]];
              -> Int         -- ARG[2]
              -> Bit         -- ARG[3]
              -> BitVector n"
+    , "outputReg" : true
     , "templateD" :
 "// replaceBit start
-reg ~TYPO ~GENSYM[bv][0];
 wire ~TYP[3] ~GENSYM[din][1];
 assign ~SYM[1] = ~ARG[3];
 
 always @(*) begin
-  ~SYM[0] = ~ARG[1];
-  ~SYM[0][~ARG[2]] = ~SYM[1];
+  ~RESULT = ~ARG[1];
+  ~RESULT[~ARG[2]] = ~SYM[1];
 end
-
-assign ~RESULT = ~SYM[0];
 // replaceBit end"
     }
   }
@@ -93,18 +91,16 @@ assign ~RESULT = ~SYM[0];
            -> SNat n                -- ARG[2]
            -> BitVector (m + 1 - n) -- ARG[3]
            -> BitVector (m + 1 + i)"
+    , "outputReg" : true
     , "templateD" :
 "// setSlice begin
-reg ~SIGD[~GENSYM[bv][0]][0];
 wire ~TYP[3] ~GENSYM[din][1];
 assign ~SYM[1] = ~ARG[3]
 
 always @(*) begin
-  ~SYM[0] = ~ARG[0];
-  ~SYM[0][~LIT[1] : ~LIT[2]] = ~SYM[1];
+  ~RESULT = ~ARG[0];
+  ~RESULT[~LIT[1] : ~LIT[2]] = ~SYM[1];
 end
-
-assign ~RESULT = ~SYM[0];
 // setSlice end"
     }
   }

--- a/clash-lib/prims/verilog/CLaSH_Sized_Internal_Signed.json
+++ b/clash-lib/prims/verilog/CLaSH_Sized_Internal_Signed.json
@@ -136,19 +136,14 @@
     { "name"      : "CLaSH.Sized.Internal.Signed.div#"
     , "type"      : "div# :: Signed n -> Signed n -> Signed n"
     , "templateD" :
-"// divInt begin
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-wire ~SIGD[~GENSYM[dividend][1]][0];
-wire ~SIGD[~GENSYM[divider][2]][1];
-
+"// divSigned begin
 // divide (rounds towards zero)
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+wire ~SIGD[~GENSYM[quot_res][0]][1];
+assign ~SYM[0] = ~VAR[dividend][1] / ~VAR[divider][2];
 
 // round toward minus infinity
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
-// divInt end"
+assign ~RESULT = (~VAR[dividend][1][~LIT[0]-1] == ~VAR[divider][2][~LIT[0]-1]) ? ~SYM[0] : ~SYM[0] - ~LIT[0]'sd1;
+// divSigned end"
     }
   }
 , { "BlackBox" :
@@ -156,19 +151,14 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "mod# :: Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// modSigned begin
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-wire ~SIGD[~GENSYM[dividend][1]][0];
-wire ~SIGD[~GENSYM[divider][2]][1];
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-
 // remainder
-assign ~SYM[0] = ~SYM[1] % ~SYM[2];
+~SIGD[~GENSYM[rem_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 (~SYM[1] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~SYM[2]);
+                 (~VAR[dividend][0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modSigned end"
     }
   }
@@ -243,15 +233,13 @@ assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
     , "templateD" :
 "// resize begin
 ~GENERATE
-if (~LIT[1] < ~LIT[0]) begin
-  // truncate, sign preserving
-  wire ~SIGD[~GENSYM[s][0]][2];
-  assign ~SYM[0] = ~ARG[2];
-  assign ~RESULT = $signed({~SYM[0][~LIT[0]-1],~SYM[0][(~LIT[1]-2):0]});
-end else begin
-  // sign-extend
-  assign ~RESULT = $signed(~ARG[2]);
-end
+  if (~LIT[1] < ~LIT[0]) begin
+    // truncate, sign preserving
+    assign ~RESULT = $signed({~VAR[s][2][~LIT[0]-1],~VAR[s][2][(~LIT[1]-2):0]});
+  end else begin
+    // sign-extend
+    assign ~RESULT = $signed(~VAR[s][2]);
+  end
 ~ENDGENERATE
 // resize end"
     }

--- a/clash-lib/prims/verilog/CLaSH_Sized_RTree.json
+++ b/clash-lib/prims/verilog/CLaSH_Sized_RTree.json
@@ -7,13 +7,7 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.RTree.textract"
     , "type"      : "textract :: RTree 0 a -> a"
-    , "templateD" :
-"// textract begin
-wire ~SIGD[~GENSYM[tree][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~SYM[0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]];
-// textract end"
+    , "templateE" : "~VAR[tree][0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]]"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/verilog/CLaSH_Sized_Vector.json
+++ b/clash-lib/prims/verilog/CLaSH_Sized_Vector.json
@@ -1,49 +1,25 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.head"
     , "type"      : "head :: Vec (n + 1) a -> a"
-    , "templateD" :
-"// head begin
-wire ~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~SYM[0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]];
-// head end"
+    , "templateE" : "~VAR[vec][0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.tail"
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
-    , "templateD" :
-"// tail begin
-wire ~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
-// tail end"
+    , "templateE" : "~VAR[vec][0][~SIZE[~TYPO]-1 : 0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.last"
     , "type"      : "Vec (n + 1) a -> a"
-    , "templateD" :
-"// last begin
-wire ~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1:0];
-// last end"
+    , "templateE" : "~VAR[vec][0][~SIZE[~TYPO]-1:0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.init"
     , "type"      : "Vec (n + 1) a -> Vec n a"
-    , "templateD" :
-"// init begin
-wire ~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = ~SYM[0][~SIZE[~TYP[0]]-1 : ~SIZE[~TYPEL[~TYP[0]]]];
-// init end"
+    , "templateE" : "~VAR[vec][0][~SIZE[~TYP[0]]-1 : ~SIZE[~TYPEL[~TYP[0]]]]"
     }
   }
 , { "BlackBox" :
@@ -57,14 +33,11 @@ assign ~RESULT = ~SYM[0][~SIZE[~TYP[0]]-1 : ~SIZE[~TYPEL[~TYP[0]]]];
         -> Vec n a"
     , "templateD" :
 "// select begin
-wire ~SIGD[~GENSYM[vec][0]][4];
-assign ~SYM[0] = ~ARG[4];
-
 wire ~TYPEL[~TYPO] ~SYM[1] [0:~LENGTH[~TYP[4]]-1];
 genvar ~GENSYM[i][2];
 ~GENERATE
 for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[4]]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
-  assign ~SYM[1][(~LENGTH[~TYP[4]]-1)-~SYM[2]] = ~SYM[0][~SYM[2]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];
+  assign ~SYM[1][(~LENGTH[~TYP[4]]-1)-~SYM[2]] = ~VAR[vec][4][~SYM[2]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];
 end
 ~ENDGENERATE
 
@@ -110,16 +83,13 @@ end
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// map begin
-wire ~SIGD[~GENSYM[vec][0]][1];
-assign ~SYM[0] = ~ARG[1];
-
 genvar ~GENSYM[i][1];
 ~GENERATE
 for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]
   wire ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];
   ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~GENSYM[map_out][4];
 
-  assign ~SYM[3] = ~SYM[0][~SYM[1]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];
+  assign ~SYM[3] = ~VAR[vec][1][~SYM[1]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];
   ~INST 0
     ~OUTPUT <= ~SYM[4]~ ~TYPEL[~TYPO]~
     ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
@@ -135,9 +105,6 @@ end
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// imap begin
-wire ~SIGD[~GENSYM[vec][0]][2];
-assign ~SYM[0] = ~ARG[2];
-
 genvar ~GENSYM[i][1];
 ~GENERATE
 for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
@@ -146,7 +113,7 @@ for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM
   ~OUTPUTWIREREG[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
 
   assign ~SYM[3] = ~LENGTH[~TYPO] - 1 - ~SYM[1];
-  assign ~SYM[4] = ~SYM[0][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
+  assign ~SYM[4] = ~VAR[vec][2][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
   ~INST 1
     ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
     ~INPUT  <= ~SYM[3]~ ~INDEXTYPE[~LIT[0]]~
@@ -163,11 +130,6 @@ end
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "templateD" :
 "// zipWith start
-wire ~SIGD[~GENSYM[vec1][0]][1];
-wire ~SIGD[~GENSYM[vec2][1]][2];
-assign ~SYM[0] = ~ARG[1];
-assign ~SYM[1] = ~ARG[2];
-
 genvar ~GENSYM[i][2];
 ~GENERATE
 for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][6]
@@ -175,8 +137,8 @@ for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENS
   wire ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][4];
   ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~SYM[5];
 
-  assign ~SYM[3] = ~SYM[0][~SYM[2]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];
-  assign ~SYM[4] = ~SYM[1][~SYM[2]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
+  assign ~SYM[3] = ~VAR[vec1][1][~SYM[2]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];
+  assign ~SYM[4] = ~VAR[vec2][2][~SYM[2]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
   ~INST 0
     ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
     ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
@@ -196,9 +158,6 @@ end
 wire ~TYPO ~GENSYM[intermediate][0] [0:~LENGTH[~TYP[2]]];
 assign ~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];
 
-wire ~TYP[2] ~GENSYM[xs][2];
-assign ~SYM[2] = ~ARG[2];
-
 genvar ~GENSYM[i][3];
 ~GENERATE
 for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr][4]
@@ -206,7 +165,7 @@ for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[f
   wire ~TYPO ~GENSYM[foldr_in2][6];
   ~OUTPUTWIREREG[0] ~TYPO ~GENSYM[foldr_out][7];
 
-  assign ~SYM[5] = ~SYM[2][(~LENGTH[~TYP[2]]-1-~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
+  assign ~SYM[5] = ~VAR[xs][2][(~LENGTH[~TYP[2]]-1-~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
   assign ~SYM[6] = ~SYM[0][~SYM[3]+1];
   ~INST 0
     ~OUTPUT <= ~SYM[7]~ ~TYP[1]~
@@ -231,12 +190,11 @@ assign ~RESULT = ~ARG[1];
 "// fold begin
 // put flat input array into the first half of the intermediate array
 wire ~TYPO ~GENSYM[intermediate][0] [0:(2*~LENGTH[~TYP[1]])-2];
-wire ~TYP[1] ~GENSYM[vecflat][1];
-assign ~SYM[1] = ~ARG[1];
+
 genvar ~GENSYM[i][2];
 ~GENERATE
 for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[1]]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
-  assign ~SYM[0][(~LENGTH[~TYP[1]]-1)-~SYM[2]] = ~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+  assign ~SYM[0][(~LENGTH[~TYP[1]]-1)-~SYM[2]] = ~VAR[vecflat][1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
 end
 ~ENDGENERATE
 
@@ -297,12 +255,10 @@ assign ~RESULT = ~SYM[0][(2*~LENGTH[~TYP[1]])-2];
 "// indexVec begin
 wire ~TYPO ~GENSYM[vec][0] [0:~LIT[0]-1];
 
-wire ~TYP[1] ~GENSYM[vecflat][1];
-assign ~SYM[1] = ~ARG[1];
 genvar ~GENSYM[i][2];
 ~GENERATE
 for (~SYM[2]=0; ~SYM[2] < ~LIT[0]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
-  assign ~SYM[0][(~LIT[0]-1)-~SYM[2]] = ~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+  assign ~SYM[0][(~LIT[0]-1)-~SYM[2]] = ~VAR[vecflat][1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
 end
 ~ENDGENERATE
 
@@ -315,14 +271,11 @@ assign ~RESULT = ~SYM[0][~ARG[2]];
     , "type"      : "replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a"
     , "templateD" :
 "// replaceVec start
-wire ~TYP[1] ~GENSYM[vecflat][0];
-assign ~SYM[0] = ~ARG[1];
-
 reg ~TYP[3] ~GENSYM[vec][1] [0:~LIT[0]-1];
 integer ~GENSYM[i][2];
 always @(*) begin
   for (~SYM[2]=0;~SYM[2]<~LIT[0];~SYM[2]=~SYM[2]+1) begin
-    ~SYM[1][~LIT[0]-1-~SYM[2]] = ~SYM[0][~SYM[2]*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]];
+    ~SYM[1][~LIT[0]-1-~SYM[2]] = ~VAR[vecflat][1][~SYM[2]*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]];
   end
   ~SYM[1][~ARG[2]] = ~ARG[3];
 end
@@ -359,15 +312,12 @@ end
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "templateD" :
 "// transpose begin
-wire ~SIGD[~GENSYM[matrix][0]][1];
-assign ~SYM[0] = ~ARG[1];
-
 genvar ~GENSYM[row_index][1];
 genvar ~GENSYM[col_index][2];
 ~GENERATE
 for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYP[1]]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]
   for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[transpose_inner][4]
-    assign ~RESULT[((~SYM[2]*~SIZE[~TYPEL[~TYPO]])+(~SYM[1]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~SYM[0][((~SYM[1]*~SIZE[~TYPEL[~TYP[1]]])+(~SYM[2]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]];
+    assign ~RESULT[((~SYM[2]*~SIZE[~TYPEL[~TYPO]])+(~SYM[1]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~VAR[matrix][1][((~SYM[1]*~SIZE[~TYPEL[~TYP[1]]])+(~SYM[2]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]];
   end
 end
 ~ENDGENERATE
@@ -379,13 +329,10 @@ end
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "templateD" :
 "// reverse begin
-wire ~SIGD[~GENSYM[vec][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
 genvar ~GENSYM[i][1];
 ~GENERATE
 for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]
-  assign ~RESULT[(~LENGTH[~TYPO] - 1 - ~SYM[1])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[0][~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];
+  assign ~RESULT[(~LENGTH[~TYPO] - 1 - ~SYM[1])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~VAR[vec][0][~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];
 end
 ~ENDGENERATE
 // reverse end"
@@ -420,17 +367,14 @@ end
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "// rotateLeftS begin
-wire ~TYP[1] ~GENSYM[vec][1];
 localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
-
-assign ~SYM[1] = ~ARG[1];
 
 ~GENERATE
 if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
-  assign ~RESULT = ~SYM[1];
+  assign ~RESULT = ~VAR[vec][1];
 end else begin : ~GENSYM[do_shift][4]
-  assign ~RESULT = {~SYM[1][((~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]])-1 : 0]
-                   ,~SYM[1][~SIZE[~TYPO]-1 : (~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]]]
+  assign ~RESULT = {~VAR[vec][1][((~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]])-1 : 0]
+                   ,~VAR[vec][1][~SIZE[~TYPO]-1 : (~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]]]
                    };
 end
 ~ENDGENERATE
@@ -442,17 +386,14 @@ end
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "templateD" :
 "// rotateRightS begin
-wire ~TYP[1] ~GENSYM[vec][1];
 localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
-
-assign ~SYM[1] = ~ARG[1];
 
 ~GENERATE
 if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
-  assign ~RESULT = ~SYM[1];
+  assign ~RESULT = ~VAR[vec][1];
 end else begin : ~GENSYM[do_shift][4]
-  assign ~RESULT = {~SYM[1][(~SYM[2]*~SIZE[~TYPEL[~TYPO]])-1 : 0]
-                   ,~SYM[1][~SIZE[~TYPO]-1 : ~SYM[2]*~SIZE[~TYPEL[~TYPO]]]
+  assign ~RESULT = {~VAR[vec][1][(~SYM[2]*~SIZE[~TYPEL[~TYPO]])-1 : 0]
+                   ,~VAR[vec][1][~SIZE[~TYPO]-1 : ~SYM[2]*~SIZE[~TYPEL[~TYPO]]]
                    };
 end
 ~ENDGENERATE

--- a/clash-lib/prims/verilog/CLaSH_Sized_Vector.json
+++ b/clash-lib/prims/verilog/CLaSH_Sized_Vector.json
@@ -117,7 +117,7 @@ genvar ~GENSYM[i][1];
 ~GENERATE
 for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]
   wire ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];
-  wire ~TYPEL[~TYPO] ~GENSYM[map_out][4];
+  ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~GENSYM[map_out][4];
 
   assign ~SYM[3] = ~SYM[0][~SYM[1]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];
   ~INST 0
@@ -143,7 +143,7 @@ genvar ~GENSYM[i][1];
 for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
   wire [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~GENSYM[map_index][3];
   wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];
-  wire ~TYPEL[~TYPO] ~GENSYM[map_out][5];
+  ~OUTPUTWIREREG[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
 
   assign ~SYM[3] = ~LENGTH[~TYPO] - 1 - ~SYM[1];
   assign ~SYM[4] = ~SYM[0][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
@@ -173,7 +173,7 @@ genvar ~GENSYM[i][2];
 for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][6]
   wire ~TYPEL[~TYP[1]] ~GENSYM[zipWith_in1][3];
   wire ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][4];
-  wire ~TYPEL[~TYPO] ~SYM[5];
+  ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~SYM[5];
 
   assign ~SYM[3] = ~SYM[0][~SYM[2]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];
   assign ~SYM[4] = ~SYM[1][~SYM[2]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
@@ -204,7 +204,7 @@ genvar ~GENSYM[i][3];
 for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr][4]
   wire ~TYPEL[~TYP[2]] ~GENSYM[foldr_in1][5];
   wire ~TYPO ~GENSYM[foldr_in2][6];
-  wire ~TYPO ~GENSYM[foldr_out][7];
+  ~OUTPUTWIREREG[0] ~TYPO ~GENSYM[foldr_out][7];
 
   assign ~SYM[5] = ~SYM[2][(~LENGTH[~TYP[2]]-1-~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];
   assign ~SYM[6] = ~SYM[0][~SYM[3]+1];
@@ -270,7 +270,7 @@ if (~SYM[4] != 0) begin : ~GENSYM[make_tree][7]
     for (~SYM[6] = 0; ~SYM[6] < (2**~SYM[5]); ~SYM[6] = ~SYM[6]+1) begin : ~GENSYM[tree_depth_loop][12]
       wire ~TYPO ~GENSYM[fold_in1][8];
       wire ~TYPO ~GENSYM[fold_in2][9];
-      wire ~TYPO ~GENSYM[fold_out][10];
+      ~OUTPUTWIREREG[0] ~TYPO ~GENSYM[fold_out][10];
 
       assign ~SYM[8] = ~SYM[0][~SYM[13](~SYM[4]+1,~SYM[5]+2)+(2*~SYM[6])];
       assign ~SYM[9] = ~SYM[0][~SYM[13](~SYM[4]+1,~SYM[5]+2)+(2*~SYM[6])+1];

--- a/clash-lib/prims/verilog/GHC_Base.json
+++ b/clash-lib/prims/verilog/GHC_Base.json
@@ -20,17 +20,12 @@
     , "type"      : "divInt :: Int -> Int -> Int"
     , "templateD" :
 "// divInt begin
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-wire ~SIGD[~GENSYM[dividend][1]][0];
-wire ~SIGD[~GENSYM[divider][2]][1];
-
 // divide (rounds towards zero)
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
 
 // round toward minus infinity
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
 // divInt end"
     }
   }
@@ -39,19 +34,14 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInt :: Int -> Int -> Int"
     , "templateD" :
 "// modInt begin
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-wire ~SIGD[~GENSYM[dividend][1]][0];
-wire ~SIGD[~GENSYM[divider][2]][1];
-
 // remainder
-assign ~SYM[0] = ~ARG[0] % ~ARG[1];
+wire ~SIGD[~GENSYM[rem_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 ((~ARG[1] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~ARG[1]);
+                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInt end"
     }
   }

--- a/clash-lib/prims/verilog/GHC_Classes.json
+++ b/clash-lib/prims/verilog/GHC_Classes.json
@@ -56,40 +56,30 @@
     { "name"      : "GHC.Classes.divInt#"
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "templateD" :
-"// divInt begin
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-wire ~SIGD[~GENSYM[dividend][1]][0];
-wire ~SIGD[~GENSYM[divider][2]][1];
-
+"// divInt# begin
 // divide (rounds towards zero)
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
 
 // round toward minus infinity
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
-// divInt end"
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+// divInt# end"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.modInt#"
     , "type"      : "modInt# :: Int# -> Int# -> Int#"
     , "templateD" :
-"// modInt begin
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-wire ~SIGD[~GENSYM[dividend][1]][0];
-wire ~SIGD[~GENSYM[divider][2]][1];
-
+"// modInt# begin
 // remainder
-assign ~SYM[0] = ~ARG[0] % ~ARG[1];
+wire ~SIGD[~GENSYM[rem_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 ((~ARG[1] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~ARG[1]);
-// modInt end"
+                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
+// modInt# end"
     }
   }
 ]

--- a/clash-lib/prims/verilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/verilog/GHC_Integer_Type.json
@@ -45,17 +45,12 @@
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// divInteger begin
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-wire ~SIGD[~GENSYM[dividend][1]][0];
-wire ~SIGD[~GENSYM[divider][2]][1];
-
 // divide (rounds towards zero)
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
 
 // round toward minus infinity
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
 // divInteger end"
     }
   }
@@ -64,19 +59,14 @@ assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ? ~SYM[0] 
     , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// modInteger begin
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-wire ~SIGD[~GENSYM[dividend][1]][0];
-wire ~SIGD[~GENSYM[divider][2]][1];
-assign ~SYM[1] = ~ARG[0];
-assign ~SYM[2] = ~ARG[1];
-
 // remainder
-assign ~SYM[0] = ~SYM[1] % ~SYM[2];
+wire ~SIGD[~GENSYM[rem_res][0]][0];
+assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
-assign ~RESULT = (~SYM[1][~SIZE[~TYPO]-1] == ~SYM[2][~SIZE[~TYPO]-1]) ?
+assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 (~SYM[1] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~SYM[2]);
+                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInteger end"
     }
   }

--- a/clash-lib/prims/verilog/GHC_Prim.json
+++ b/clash-lib/prims/verilog/GHC_Prim.json
@@ -1677,11 +1677,9 @@ assign ~RESULT = $unsigned(~SYM[7]);
     { "name"      : "GHC.Prim.byteSwap16#"
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "templateD" :
-"// byteSwap16 begin
-wire ~TYP[0] ~GENSYM[w][0];
-assign ~SYM[0] = ~ARG[0];~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[0][63:16],~SYM[0][7:0],~SYM[0][15:8]};~ELSE
-assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};~FI
+"// byteSwap16 begin~IF ~IW64 ~THEN
+assign ~RESULT = {~VAR[w][0][63:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~ELSE
+assign ~RESULT = {~VAR[w][0][31:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~FI
 // byteSwap16 end"
     }
   }
@@ -1689,11 +1687,9 @@ assign ~RESULT = {~SYM[0][31:16],~SYM[0][7:0],~SYM[0][15:8]};~FI
     { "name"      : "GHC.Prim.byteSwap32#"
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "templateD" :
-"// byteSwap32 begin
-wire ~TYPO ~GENSYM[w][0];
-assign ~SYM[0] = ~ARG[0];~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[0][63:32],~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~ELSE
-assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~FI
+"// byteSwap32 begin~IF ~IW64 ~THEN
+assign ~RESULT = {~VAR[w][0][63:32],~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~ELSE
+assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~FI
 // byteSwap32 end"
     }
   }
@@ -1702,10 +1698,8 @@ assign ~RESULT = {~SYM[0][7:0],~SYM[0][15:8],~SYM[0][23:16],~SYM[0][31:24]};~FI
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "templateD" :
 "// byteSwap64 begin
-wire ~TYP[0] ~GENSYM[w][1];
-assign ~SYM[1] = ~ARG[0];
-assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
-                 ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};
+assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]
+                 ,~VAR[w][0][39:32],~VAR[w][0][47:40],~VAR[w][0][55:48],~VAR[w][0][63:56]};
 // byteSwap64 end"
     }
   }
@@ -1713,12 +1707,10 @@ assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
     { "name"      : "GHC.Prim.byteSwap#"
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "templateD" :
-"// byteSwap begin
-wire ~TYP[0] ~GENSYM[w][1];
-assign ~SYM[1] = ~ARG[0];~IF ~IW64 ~THEN
-assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]
-                 ,~SYM[1][39:32],~SYM[1][47:40],~SYM[1][55:48],~SYM[1][63:56]};~ELSE
-assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};~FI
+"// byteSwap begin~IF ~IW64 ~THEN
+assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]
+                 ,~VAR[w][0][39:32],~VAR[w][0][47:40],~VAR[w][0][55:48],~VAR[w][0][63:56]};~ELSE
+assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~FI
 // byteSwap end"
     }
   }
@@ -1727,10 +1719,7 @@ assign ~RESULT = {~SYM[1][7:0],~SYM[1][15:8],~SYM[1][23:16],~SYM[1][31:24]};~FI
     , "type"      : "narrow8Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow8Int begin
-wire ~SIGD[~GENSYM[s][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $signed(~SYM[0][7:0]);
+assign ~RESULT = $signed(~VAR[i][0][7:0]);
 // narrow8Int end"
     }
   }
@@ -1739,10 +1728,7 @@ assign ~RESULT = $signed(~SYM[0][7:0]);
     , "type"      : "narrow16Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow16Int begin
-wire ~SIGD[~GENSYM[s][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $signed(~SYM[0][15:0]);
+assign ~RESULT = $signed(~VAR[i][0][15:0]);
 // narrow16Int end"
     }
   }
@@ -1751,10 +1737,7 @@ assign ~RESULT = $signed(~SYM[0][15:0]);
     , "type"      : "narrow32Int# :: Int# -> Int#"
     , "templateD" :
 "// narrow32Int begin
-wire ~SIGD[~GENSYM[s][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $signed(~SYM[0][31:0]);
+assign ~RESULT = $signed(~VAR[i][0][31:0]);
 // narrow32Int end"
     }
   }
@@ -1763,10 +1746,7 @@ assign ~RESULT = $signed(~SYM[0][31:0]);
     , "type"      : "narrow8Int# :: Word# -> Word#"
     , "templateD" :
 "// narrow8Word begin
-wire ~SIGD[~GENSYM[w][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $unsigned(~SYM[0][7:0]);
+assign ~RESULT = $unsigned(~VAR[w][0][7:0]);
 // narrow8Word end"
     }
   }
@@ -1775,10 +1755,7 @@ assign ~RESULT = $unsigned(~SYM[0][7:0]);
     , "type"      : "narrow16Word# :: Word# -> Word#"
     , "templateD" :
 "// narrow16Word begin
-wire ~SIGD[~GENSYM[w][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $unsigned(~SYM[0][15:0]);
+assign ~RESULT = $unsigned(~VAR[w][0][15:0]);
 // narrow16Word end"
     }
   }
@@ -1787,10 +1764,7 @@ assign ~RESULT = $unsigned(~SYM[0][15:0]);
     , "type"      : "narrow32Int# :: Word# -> Word#"
     , "templateD" :
 "// narrow32Word begin
-wire ~SIGD[~GENSYM[w][0]][0];
-assign ~SYM[0] = ~ARG[0];
-
-assign ~RESULT = $unsigned(~SYM[0][31:0]);
+assign ~RESULT = $unsigned(~VAR[w][0][31:0]);
 // narrow32Word end"
     }
   }

--- a/clash-lib/prims/vhdl/CLaSH_Explicit_BlockRam.json
+++ b/clash-lib/prims/vhdl/CLaSH_Explicit_BlockRam.json
@@ -39,7 +39,11 @@ begin
         if ~ARG[4] then
           ~SYM[1](~SYM[4]) <= ~TOBV[~ARG[6]][~TYP[6]];
         end if;
-        ~RESULT <= fromSLV(~SYM[1](~SYM[3]));
+        ~RESULT <= fromSLV(~SYM[1](~SYM[3]))
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       end if;
     end if;
   end process;~ELSE
@@ -49,7 +53,11 @@ begin
       if ~ARG[4] then
         ~SYM[1](~SYM[4]) <= ~TOBV[~ARG[6]][~TYP[6]];
       end if;
-      ~RESULT <= fromSLV(~SYM[1](~SYM[3]));
+      ~RESULT <= fromSLV(~SYM[1](~SYM[3]))
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
     end if;
   end process;~FI ~ELSE ~IF ~ISGATED[1] ~THEN
   (~SYM[5],~SYM[6]) <= ~ARG[1];
@@ -60,7 +68,11 @@ begin
         ~SYM[1](~SYM[4]) <= ~ARG[6];
       end if;
       if ~SYM[6] then
-        ~RESULT <= ~SYM[1](~SYM[3]);
+        ~RESULT <= ~SYM[1](~SYM[3])
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       end if;
     end if;
   end process;~ELSE
@@ -70,7 +82,11 @@ begin
       if ~ARG[4] then
         ~SYM[1](~SYM[4]) <= ~ARG[6];
       end if;
-      ~RESULT <= ~SYM[1](~SYM[3]);
+      ~RESULT <= ~SYM[1](~SYM[3])
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
     end if;
   end process;~FI ~FI
 end block;

--- a/clash-lib/prims/vhdl/CLaSH_Explicit_BlockRam.json
+++ b/clash-lib/prims/vhdl/CLaSH_Explicit_BlockRam.json
@@ -13,13 +13,11 @@
     , "templateD" :
 "-- blockRam begin
 ~GENSYM[~COMPNAME_blockRam][0] : block
-  signal ~GENSYM[RAM][1] : ~TYP[2] := ~LIT[2];~IF ~VIVADO ~THEN
-  signal ~GENSYM[~RESULT_q][2] : std_logic_vector(~SIZE[~TYP[6]]-1 downto 0);~ELSE
-  signal ~SYM[2] : ~TYP[6];~FI
-  signal ~GENSYM[rd][3] : integer range 0 to ~LENGTH[~TYP[2]] - 1;
-  signal ~GENSYM[wr][4] : integer range 0 to ~LENGTH[~TYP[2]] - 1;~IF ~ISGATED[1] ~THEN
+  signal ~GENSYM[RAM][1] : ~TYP[2] := ~LIT[2];
+  signal ~GENSYM[rd][3]  : integer range 0 to ~LENGTH[~TYP[2]] - 1;
+  signal ~GENSYM[wr][4]  : integer range 0 to ~LENGTH[~TYP[2]] - 1;~IF ~ISGATED[1] ~THEN
   signal ~GENSYM[clk][5] : std_logic;
-  signal ~GENSYM[ce][6] : std_logic;~ELSE ~FI
+  signal ~GENSYM[ce][6]  : boolean;~ELSE ~FI
 begin
   ~SYM[3] <= to_integer(~ARG[3])
   -- pragma translate_off
@@ -32,39 +30,51 @@ begin
                 mod ~LENGTH[~TYP[2]]
   -- pragma translate_on
                 ;
-  ~IF ~ISGATED[1] ~THEN
+~IF ~VIVADO ~THEN ~IF ~ISGATED[1] ~THEN
   (~SYM[5],~SYM[6]) <= ~ARG[1];
   ~GENSYM[blockRam_sync][7] : process(~SYM[5])
   begin
-    if rising_edge(~SYM[5]) then~IF ~VIVADO ~THEN
+    if rising_edge(~SYM[5]) then
       if ~SYM[6] then
         if ~ARG[4] then
           ~SYM[1](~SYM[4]) <= ~TOBV[~ARG[6]][~TYP[6]];
         end if;
-        ~SYM[2] <= ~SYM[1](~SYM[3]);
-      end if;~ELSE
-      if ~ARG[4] and ~SYM[6] then
-        ~SYM[1](~SYM[4]) <= ~ARG[6];
+        ~RESULT <= fromSLV(~SYM[1](~SYM[3]));
       end if;
-      if ~SYM[6] then
-        ~SYM[2] <= ~SYM[1](~SYM[3]);
-      end if;~FI
     end if;
   end process;~ELSE
   ~SYM[7] : process(~ARG[1])
   begin
     if rising_edge(~ARG[1]) then
-      if ~ARG[4] then~IF ~VIVADO ~THEN
-        ~SYM[1](~SYM[4]) <= ~TOBV[~ARG[6]][~TYP[6]];~ELSE
-        ~SYM[1](~SYM[4]) <= ~ARG[6];~FI
+      if ~ARG[4] then
+        ~SYM[1](~SYM[4]) <= ~TOBV[~ARG[6]][~TYP[6]];
       end if;
-      ~SYM[2] <= ~SYM[1](~SYM[3]);
+      ~RESULT <= fromSLV(~SYM[1](~SYM[3]));
     end if;
-  end process;~FI~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[2]][~TYPO];~ELSE
-  ~RESULT <= ~SYM[2];~FI
+  end process;~FI ~ELSE ~IF ~ISGATED[1] ~THEN
+  (~SYM[5],~SYM[6]) <= ~ARG[1];
+  ~SYM[7] : process(~SYM[5])
+  begin
+    if rising_edge(~SYM[5]) then
+      if ~ARG[4] and ~SYM[6] then
+        ~SYM[1](~SYM[4]) <= ~ARG[6];
+      end if;
+      if ~SYM[6] then
+        ~RESULT <= ~SYM[1](~SYM[3]);
+      end if;
+    end if;
+  end process;~ELSE
+  ~SYM[7] : process(~ARG[1])
+  begin
+    if rising_edge(~ARG[1]) then
+      if ~ARG[4] then
+        ~SYM[1](~SYM[4]) <= ~ARG[6];
+      end if;
+      ~RESULT <= ~SYM[1](~SYM[3]);
+    end if;
+  end process;~FI ~FI
 end block;
--- blockRam end"
+--end blockRam"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/CLaSH_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/vhdl/CLaSH_Explicit_BlockRam_File.json
@@ -54,7 +54,11 @@ begin
         if ~ARG[6] then
           ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
         end if;
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]));
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       end if;
     end if;
   end process;~ELSE
@@ -64,7 +68,11 @@ begin
       if ~ARG[6] then
         ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
       end if;
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]));
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
     end if;
   end process;~FI ~ELSE ~IF ~ISGATED[2] ~THEN
   (~SYM[7],~SYM[8]) <= ~ARG[2];
@@ -75,7 +83,11 @@ begin
         ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
       end if;
       if ~SYM[8] then
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]));
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       end if;
     end if;
   end process;~ELSE
@@ -85,7 +97,11 @@ begin
       if ~ARG[6] then
         ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
       end if;
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]));
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
     end if;
   end process;~FI ~FI
 end block;

--- a/clash-lib/prims/vhdl/CLaSH_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/vhdl/CLaSH_Explicit_BlockRam_File.json
@@ -29,11 +29,10 @@
   end function;
 
   signal ~GENSYM[RAM][2] : ~SYM[6](0 to ~LIT[3]-1) := ~SYM[1](~FILE[~LIT[4]]);
-  signal ~GENSYM[~RESULT_q][3] : ~TYP[8];
-  signal ~GENSYM[rd][4] : integer range 0 to ~LIT[3]-1;
-  signal ~GENSYM[wr][5] : integer range 0 to ~LIT[3]-1;~IF ~ISGATED[2] ~THEN
+  signal ~GENSYM[rd][4]  : integer range 0 to ~LIT[3]-1;
+  signal ~GENSYM[wr][5]  : integer range 0 to ~LIT[3]-1;~IF ~ISGATED[2] ~THEN
   signal ~GENSYM[clk][7] : std_logic;
-  signal ~GENSYM[ce][8] : boolean;~ELSE ~FI
+  signal ~GENSYM[ce][8]  : boolean;~ELSE ~FI
 begin
   ~SYM[4] <= to_integer(~ARG[5])
   -- pragma translate_off
@@ -46,36 +45,49 @@ begin
                 mod ~LIT[3]
   -- pragma translate_on
                 ;
-  ~IF ~ISGATED[2] ~THEN
+  ~IF ~VIVADO ~THEN ~IF ~ISGATED[2] ~THEN
   (~SYM[7],~SYM[8]) <= ~ARG[2];
   ~GENSYM[blockRamFile_sync][9] : process(~SYM[7])
   begin
-    if (rising_edge(~SYM[7])) then~IF ~VIVADO ~THEN
+    if rising_edge(~SYM[7]) then
       if ~SYM[8] then
         if ~ARG[6] then
           ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
         end if;
-        ~SYM[3] <= to_stdlogicvector(~SYM[2](~SYM[4]));
-      end if;~ELSE
-      if ~ARG[6] and ~SYM[8] then
-        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]));
       end if;
-      if ~SYM[8] then
-        ~SYM[3] <= to_stdlogicvector(~SYM[2](~SYM[4]));
-      end if;~FI
     end if;
   end process;~ELSE
   ~SYM[9] : process(~ARG[2])
   begin
-    if (rising_edge(~ARG[2])) then
+    if rising_edge(~ARG[2]) then
       if ~ARG[6] then
         ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
       end if;
-      ~SYM[3] <= to_stdlogicvector(~SYM[2](~SYM[4]));
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]));
     end if;
-  end process;~FI
-
-  ~RESULT <= ~SYM[3];
+  end process;~FI ~ELSE ~IF ~ISGATED[2] ~THEN
+  (~SYM[7],~SYM[8]) <= ~ARG[2];
+  ~SYM[9] : process(~SYM[7])
+  begin
+    if rising_edge(~SYM[7]) then
+      if ~ARG[6] and ~SYM[8] then
+        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
+      end if;
+      if ~SYM[8] then
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]));
+      end if;
+    end if;
+  end process;~ELSE
+  ~SYM[9] : process(~ARG[2])
+  begin
+    if rising_edge(~ARG[2]) then
+      if ~ARG[6] then
+        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
+      end if;
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]));
+    end if;
+  end process;~FI ~FI
 end block;
 -- blockRamFile end"
     }

--- a/clash-lib/prims/vhdl/CLaSH_Explicit_ROM.json
+++ b/clash-lib/prims/vhdl/CLaSH_Explicit_ROM.json
@@ -27,16 +27,32 @@ begin
   begin
     if (rising_edge(~SYM[3])) then
       if ~SYM[4] then~IF ~VIVADO ~THEN
-        ~RESULT <= ~FROMBV[~SYM[1](~SYM[2])][~TYPO];~ELSE
-        ~RESULT <= ~SYM[1](~SYM[2]);~FI
+        ~RESULT <= ~FROMBV[~SYM[1](~SYM[2])][~TYPO]
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;~ELSE
+        ~RESULT <= ~SYM[1](~SYM[2])
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;~FI
       end if;
     end if;
   end process;~ELSE
   ~SYM[5] : process (~ARG[1])
   begin
     if (rising_edge(~ARG[1])) then~IF ~VIVADO ~THEN
-      ~RESULT <= ~FROMBV[~SYM[1](~SYM[2])][~TYPO];~ELSE
-      ~RESULT <= ~SYM[1](~SYM[2]);~FI
+      ~RESULT <= ~FROMBV[~SYM[1](~SYM[2])][~TYPO]
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;~ELSE
+      ~RESULT <= ~SYM[1](~SYM[2])
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;~FI
     end if;
   end process;~FI
 end block;

--- a/clash-lib/prims/vhdl/CLaSH_Explicit_ROM_File.json
+++ b/clash-lib/prims/vhdl/CLaSH_Explicit_ROM_File.json
@@ -40,14 +40,22 @@ begin
   begin
     if (rising_edge(~SYM[5])) then
       if ~SYM[6] then
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       end if;
     end if;
   end process;~ELSE
   ~SYM[7] : process (~ARG[1])
   begin
     if (rising_edge(~ARG[1])) then
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
     end if;
   end process;~FI
 end block;

--- a/clash-lib/prims/vhdl/CLaSH_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/CLaSH_Signal_Internal.json
@@ -17,7 +17,11 @@ begin
   begin
     if rising_edge(~SYM[1]) then
       if ~SYM[2] then
-        ~RESULT <= ~ARG[2];
+        ~RESULT <= ~ARG[2]
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       end if;
     end if;
   end process;
@@ -25,7 +29,11 @@ end block;~ELSE
 ~SYM[0] : process(~ARG[1])
 begin
   if rising_edge(~ARG[1]) then
-    ~RESULT <= ~ARG[2];
+    ~RESULT <= ~ARG[2]
+    -- pragma translate_off
+    after 1 ps
+    -- pragma translate_on
+    ;
   end if;
 end process;~FI
 -- register end"
@@ -52,9 +60,17 @@ begin
   begin
     if rising_edge(~SYM[1]) then
       if ~ARG[2] = '1' then
-        ~RESULT <= ~ARG[3];
+        ~RESULT <= ~ARG[3]
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       elsif ~SYM[2] then
-        ~RESULT <= ~ARG[4];
+        ~RESULT <= ~ARG[4]
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       end if;
     end if;
   end process;~ELSE
@@ -64,7 +80,11 @@ begin
       ~RESULT <= ~ARG[3];
     elsif rising_edge(~SYM[1]) then
       if ~SYM[2] then
-        ~RESULT <= ~ARG[4];
+        ~RESULT <= ~ARG[4]
+        -- pragma translate_off
+        after 1 ps
+        -- pragma translate_on
+        ;
       end if;
     end if;
   end process;~FI
@@ -73,18 +93,34 @@ end block;~ELSE ~IF ~ISSYNC[2] ~THEN
 begin
   if rising_edge(~ARG[1]) then
     if ~ARG[2] = '1' then
-      ~RESULT <= ~ARG[3];
+      ~RESULT <= ~ARG[3]
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
     else
-      ~RESULT <= ~ARG[4];
+      ~RESULT <= ~ARG[4]
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
     end if;
   end if;
 end process;~ELSE
 ~SYM[0] : process(~ARG[1],~ARG[2]~VARS[3])
 begin
   if ~ARG[2] = '1' then
-    ~RESULT <= ~ARG[3];
+    ~RESULT <= ~ARG[3]
+    -- pragma translate_off
+    after 1 ps
+    -- pragma translate_on
+    ;
   elsif rising_edge(~ARG[1]) then
-    ~RESULT <= ~ARG[4];
+    ~RESULT <= ~ARG[4]
+    -- pragma translate_off
+    after 1 ps
+    -- pragma translate_on
+    ;
   end if;
 end process;~FI~FI
 -- register end"

--- a/clash-lib/prims/vhdl/CLaSH_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/vhdl/CLaSH_Sized_Internal_BitVector.json
@@ -148,17 +148,15 @@ begin
   ~RESULT(0) <= ~ARG[1](~SYM[1]);
 end block;~ELSE
 ~SYM[0] : block
-  signal ~GENSYM[bv][2] : ~TYP[1];
   signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
 begin
-  ~SYM[2] <= ~ARG[1];
   ~SYM[1] <= to_integer(~ARG[2])
   -- pragma translate_off
                mod ~LIT[0]
   -- pragma translate_on
                ;
 
-  ~RESULT(0) <= ~SYM[2](~SYM[1]);
+  ~RESULT(0) <= ~VAR[bv][1](~SYM[1]);
 end block;~FI
 -- indexBitVector end"
     }
@@ -172,7 +170,7 @@ end block;~FI
              -> Bit         -- ARG[3]
              -> BitVector n"
     , "templateD" :
-"-- replaceBit begin~IF ~ISVAR[3] ~THEN
+"-- replaceBit begin
 ~GENSYM[replaceBit][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
@@ -182,33 +180,14 @@ begin
   -- pragma translate_on
                ;
 
-  process(~SYM[1]~VARS[1]~VARS[3])
+  process(~SYM[1],~VAR[b][3]~VARS[1])
     variable ~GENSYM[ivec][2] : ~TYP[1];
   begin
     ~SYM[2] := ~ARG[1];
-    ~SYM[2](~SYM[1]) := ~ARG[3](0);
+    ~SYM[2](~SYM[1]) := ~VAR[b][3](0);
     ~RESULT <= ~SYM[2];
   end process;
-end block;~ELSE
-~SYM[0] : block
-  signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
-  signal ~GENSYM[b][3] : ~TYP[3];
-begin
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~LIT[0]
-  -- pragma translate_on
-               ;
-  ~SYM[3] <= ~ARG[3];
-
-  process(~SYM[1],~SYM[3]~VARS[1])
-    variable ~SYM[2] : ~TYP[1];
-  begin
-    ~SYM[2] := ~ARG[1];
-    ~SYM[2](~SYM[1]) := ~SYM[3](0);
-    ~RESULT <= ~SYM[2];
-  end process;
-end block;~FI
+end block;
 -- replaceBit end"
     }
   }
@@ -221,26 +200,14 @@ end block;~FI
            -> BitVector (m + 1 - n) -- ARG[3]
            -> BitVector (m + 1 + i)"
     , "templateD" :
-"-- setSlice begin~IF ~ISVAR[0] ~THEN
-~GENSYM[setSlice][0] : process(~ARG[0]~VARS[3])
+"-- setSlice begin
+~GENSYM[setSlice][0] : process(~VAR[bv][0]~VARS[3])
   variable ~GENSYM[ivec][1] : ~TYP[0];
 begin
   ~SYM[1] := ~ARG[0];
-  ~SYM[1](~LIT[1] downto ~LIT[2]) := ~ARG[3];
+  ~SYM[1](~LIT[1] downto ~LIT[2]) := ~VAR[bv][3];
   ~RESULT <= ~SYM[1];
-end process;~ELSE
-~SYM[0] : block
-  signal ~GENSYM[bv][2] : ~TYP[0];
-begin
-  ~SYM[2] <= ~ARG[0];
-  process(~SYM[2]~VARS[3])
-    variable ~SYM[1] : ~TYP[0];
-  begin
-    ~SYM[1] := ~SYM[2];
-    ~SYM[1](~LIT[1] downto ~LIT[2]) := ARG[3];
-    ~RESULT <= ~SYM[1];
-  end process;
-end block;~FI
+end process;
 -- setSlice end"
     }
   }
@@ -251,16 +218,7 @@ end block;~FI
         -> SNat m                -- ARG[1]
         -> SNat n                -- ARG[2]
         -> BitVector (m + 1 - n)"
-    , "templateD" :
-"-- slice begin~IF ~ISVAR[0] ~THEN
-~RESULT <= ~ARG[0](~LIT[1] downto ~LIT[2]);~ELSE
-~GENSYM[slice][0] : block
-  signal ~GENSYM[bv][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= ~SYM[1](~LIT[1] downto ~LIT[2]);
-end block;~FI
--- slice end"
+    , "templateE" : "~VAR[bv][0](~LIT[1] downto ~LIT[2])"
     }
   }
 , { "BlackBox" :
@@ -269,20 +227,7 @@ end block;~FI
 "split# :: KnownNat n        -- ARG[0]
         => BitVector (m + n) -- ARG[1]
         -> (BitVector m, BitVector n)"
-    , "templateD" :
-"-- split begin~IF ~ISVAR[1] ~THEN
-~RESULT <= (~ARG[1](~ARG[1]'high downto ~LIT[0])
-           ,~ARG[1](~LIT[0]-1 downto 0)
-           );~ELSE
-~GENSYM[split][0]: block
-  signal ~GENSYM[bv][1] : ~TYP[1];
-begin
-  ~SYM[1] <= ~ARG[1];
-  ~RESULT <= (~SYM[1](~SYM[1]'high downto ~LIT[0])
-             ,~SYM[1](~LIT[0]-1 downto 0)
-             );
-end block;~FI
--- split end"
+    , "templateE" : "(~VAR[bv][1](~VAR[bv][1]'high downto ~LIT[0]),~VAR[bv][1](~LIT[0]-1 downto 0))"
     }
   }
 , { "BlackBox" :
@@ -291,17 +236,7 @@ end block;~FI
 "msb# :: KnownNat n  -- ARG[0]
       => BitVector n -- ARG[1]
       -> Bit"
-    , "templateD" :
-"-- msb begin~IF ~LIT[0] ~THEN ~IF ~ISVAR[1] ~THEN
-~RESULT <= ~ARG[1](~ARG[1]'high downto ~ARG[1]'high);~ELSE
-~GENSYM[msb][0] : block
-  signal ~GENSYM[bv][1] : ~TYP[1];
-begin
-  ~SYM[1] <= ~ARG[1];
-  ~RESULT <= ~SYM[1](~SYM[1]'high downto ~SYM[1]'high);
-end block;~FI~ELSE
-~RESULT <= \"0\";~FI
--- msb end"
+    , "templateE" : "~IF ~LIT[0] ~THEN ~VAR[bv][1](~VAR[bv][1]'high downto ~VAR[bv][1]'high) ~ELSE \"0\" ~FI"
     }
   }
 , { "BlackBox" :
@@ -309,17 +244,7 @@ end block;~FI~ELSE
     , "type" :
 "lsb# :: BitVector n -- ARG[0]
       -> Bit"
-    , "templateD" :
-"-- lsb begin~IF ~SIZE[~TYP[0]] ~THEN ~IF ~ISVAR[0] ~THEN
-~RESULT <= ~ARG[0](0 downto 0);~ELSE
-~GENSYM[lsb][0] : block
-  signal ~GENSYM[bv][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= ~SYM[1](0 downto 0);
-end block;~FI~ELSE
-~RESULT <= \"0\";~FI
--- lsb end"
+    , "templateE" : "~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0](0 downto 0) ~ELSE \"0\" ~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/CLaSH_Sized_Internal_Signed.json
+++ b/clash-lib/prims/vhdl/CLaSH_Sized_Internal_Signed.json
@@ -138,25 +138,14 @@
     { "name"      : "CLaSH.Sized.Internal.Signed.div#"
     , "type"      : "div# :: Signed n -> Signed n -> Signed n"
     , "templateD" :
-"-- divSigned begin~IF ~AND[~ISVAR[0],~ISVAR[1]] ~THEN
+"-- divSigned begin
 ~GENSYM[divSigned][0] : block
   signal ~GENSYM[quot_res][3] : ~TYP[0];
 begin
   ~SYM[3] <= ~ARG[0] / ~ARG[1];
-  ~RESULT <= ~SYM[3] - to_signed(1,~SIZE[~TYPO]) when ~ARG[0](~ARG[0]'high) = not (~ARG[1](~ARG[1]'high)) else
+  ~RESULT <= ~SYM[3] - to_signed(1,~SIZE[~TYPO]) when ~VAR[dividend][0](~VAR[dividend][0]'high) = not (~VAR[divider][1](~VAR[divider][1]'high)) else
              ~SYM[3];
-end block;~ELSE
-~SYM[0] : block
-  signal ~GENSYM[dividend][1] : ~TYP[0];
-  signal ~GENSYM[divider][2] : ~TYP[1];
-  signal ~SYM[3] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~SYM[2] <= ~ARG[1];
-  ~SYM[3] <= ~SYM[1] / ~SYM[2];
-  ~RESULT <= ~SYM[3] - to_signed(1,~SIZE[~TYPO]) when ~SYM[1](~SYM[1]'high) = not (~SYM[2](~SYM[2]'high)) else
-             ~SYM[3];
-end block;~FI
+end block;
 -- divSigned end"
     }
   }
@@ -229,16 +218,7 @@ end block;~FI
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.truncateB#"
     , "type"      : "truncateB# :: KnownNat m => Signed (n + m) -> Signed m"
-    , "templateD" :
-"-- truncateB begin~IF ~ISVAR[1] ~THEN
-~RESULT <= ~ARG[1](~LIT[0]-1 downto 0);~ELSE
-~GENSYM[truncateB][0] : block
-  signal ~GENSYM[s][1] : ~TYP[1];
-begin
-  ~SYM[1] <= ~ARG[1];
-  ~RESULT <= ~SYM[1](~LIT[0]-1 downto 0);
-end block;~FI
--- truncateB end"
+    , "templateE" : "~VAR[s][1](~LIT[0]-1 downto 0)"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/CLaSH_Sized_RTree.json
+++ b/clash-lib/prims/vhdl/CLaSH_Sized_RTree.json
@@ -7,31 +7,13 @@
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.RTree.textract"
     , "type"      : "textract :: RTree 0 a -> a"
-    , "templateD" :
-"-- textract begin
-textract_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[1](0)][~TYPO];~ELSE
-  ~RESULT <= ~SYM[1](0);~FI
-end block;
--- textract end"
+    , "templateE" : "~IF ~VIVADO ~THEN ~FROMBV[~VAR[t][0]][~TYPO] ~ELSE ~VAR[t][0](0) ~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.RTree.tsplit"
     , "type"      : "tsplit:: RTree (d+1) a -> (RTree d a,RTree d a)"
-    , "templateD" :
-"-- tsplit begin
-textract_~SYM[0] : block
-  signal ~SYM[1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= (~SYM[1](0 to (2**(~DEPTH[~TYP[0]]-1))-1)
-             ,~SYM[1](2**(~DEPTH[~TYP[0]]-1) to (2**~DEPTH[~TYP[0]])-1));
-end block;
--- tsplit end"
+    , "templateE" : "(~VAR[t][0](0 to (2**(~DEPTH[~TYP[0]]-1))-1) ,~VAR[t][0](2**(~DEPTH[~TYP[0]]-1) to (2**~DEPTH[~TYP[0]])-1))"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/CLaSH_Sized_Vector.json
+++ b/clash-lib/prims/vhdl/CLaSH_Sized_Vector.json
@@ -1,65 +1,25 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.head"
     , "type"      : "head :: Vec (n + 1) a -> a"
-    , "templateD" :
-"-- head begin~IF ~ISVAR[0] ~THEN ~IF ~VIVADO ~THEN
-~RESULT <= ~FROMBV[~ARG[0](0)][~TYPO];~ELSE
-~RESULT <= ~ARG[0](0);~FI~ELSE
-~GENSYM[head][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[1](0)][~TYPO];~ELSE
-  ~RESULT <= ~SYM[1](0);~FI
-end block;~FI
--- head end"
+    , "templateE" : "~IF ~VIVADO ~THEN fromSLV(~VAR[vec][0](0)) ~ELSE ~VAR[vec][0](0) ~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.tail"
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
-    , "templateD" :
-"-- tail begin~IF ~ISVAR[0] ~THEN
-~RESULT <= ~ARG[0](1 to ~ARG[0]'high);~ELSE
-~GENSYM[tail][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= ~SYM[1](1 to ~SYM[1]'high);
-end block;~FI
--- tail end"
+    , "templateE" : "~VAR[vec][0](1 to ~VAR[vec][0]'high)"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.last"
     , "type"      : "Vec (n + 1) a -> a"
-    , "templateD" :
-"-- last begin~IF ~ISVAR[0] ~THEN ~IF ~VIVADO ~THEN
-~RESULT <= ~FROMBV[~ARG[0](~ARG[0]'high)][~TYPO];~ELSE
-~RESULT <= ~ARG[0](~ARG[0]'high);~FI~ELSE
-~GENSYM[last][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[1](~SYM[1]'high)][~TYPO];~ELSE
-  ~RESULT <= ~SYM[1](~SYM[1]'high);~FI
-end block;~FI
--- last end"
+    , "templateE" : "~IF ~VIVADO ~THEN fromSLV(~VAR[vec][0](~VAR[vec][0]'high)) ~ELSE ~VAR[vec][0](~VAR[vec][0]'high) ~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.init"
     , "type"      : "Vec (n + 1) a -> Vec n a"
-    , "templateD" :
-"-- init begin~IF ~ISVAR[0] ~THEN
-~RESULT <= ~ARG[0](0 to ~ARG[0]'high - 1);~ELSE
-~GENSYM[init][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= ~SYM[1](0 to ~SYM[1]'high - 1);
-end block;~FI
--- init end"
+    , "templateE" : "~VAR[vec][0](0 to ~VAR[vec][0]'high - 1)"
     }
   }
 , { "BlackBox" :
@@ -72,19 +32,10 @@ end block;~FI
         -> Vec i a                       -- ARG[4]
         -> Vec n a"
     , "templateD" :
-"-- select begin~IF ~ISVAR[4] ~THEN
+"-- select begin
 ~GENSYM[select][0] : for ~GENSYM[i][1] in ~RESULT'range generate
-  ~RESULT(~SYM[1]) <= ~ARG[4](~LIT[1]+(~LIT[2]*~SYM[1]));
-end generate;~ELSE
-~GENSYM[select][2] : block
-  signal ~GENSYM[vec][3] : ~TYP[4];
-begin
-  ~SYM[3] <= ~ARG[4];
-  ~SYM[0] : for ~SYM[1] in ~RESULT'range generate
-  begin
-    ~RESULT(~SYM[1]) <= ~SYM[3](~LIT[1]+(~LIT[2]*~SYM[1]));
-  end generate;
-end block;~FI
+  ~RESULT(~SYM[1]) <= ~VAR[vec][4](~LIT[1]+(~LIT[2]*~SYM[1]));
+end generate;
 -- select end"
     }
   }
@@ -98,40 +49,19 @@ end block;~FI
     { "name"      : "CLaSH.Sized.Vector.concat"
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "templateD" :
-"-- concat begin~IF ~ISVAR[0] ~THEN
-~GENSYM[concat][0] : for ~GENSYM[i][1] in ~ARG[0]'range generate
+"-- concat begin
+~GENSYM[concat][0] : for ~GENSYM[i][1] in ~VAR[vec][0]'range generate
 begin~IF ~VIVADO ~THEN
-~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~FROMBV[~ARG[0](~SYM[1])][~TYPEL[~TYP[0]]];~ELSE
-~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~ARG[0](~SYM[1]);~FI
-end generate;~ELSE
-~SYM[0] : block
-  signal ~GENSYM[vec][2] : ~TYP[0];
-begin
-  ~SYM[2] <= ~ARG[0];
-  ~SYM[3] : for ~SYM[1] in ~SYM[2]'range generate
-  begin~IF ~VIVADO ~THEN
-    ~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~FROMBV[~SYM[2](~SYM[1])][~TYPEL[~TYP[0]]];~ELSE
-    ~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~SYM[2](~SYM[1]);~FI
-  end generate;
-end block;~FI
+~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= fromSLV(~VAR[vec][0](~SYM[1]));~ELSE
+~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~VAR[vec][0](~SYM[1]);~FI
+end generate;
 -- concat end"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.splitAt"
     , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
-    , "templateD" :
-"-- splitAt begin~IF ~ISVAR[1] ~THEN
-~RESULT <= (~ARG[1](0 to ~LIT[0]-1)
-           ,~ARG[1](~LIT[0] to ~ARG[1]'high));~ELSE
-~GENSYM[splitAt][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[1];
-begin
-  ~SYM[1] <= ~ARG[1];
-  ~RESULT <= (~SYM[1](0 to ~LIT[0]-1)
-             ,~SYM[1](~LIT[0] to ~SYM[1]'high));
-end block;~FI
--- splitAt end"
+    , "templateE" : "(~VAR[vec][1](0 to ~LIT[0]-1),~VAR[vec][1](~LIT[0] to ~VAR[vec][1]'high))"
     }
   }
 , { "BlackBox" :
@@ -142,22 +72,12 @@ end block;~FI
           -> Vec (n * m) a  -- ARG[2]
           -> Vec n (Vec m a)"
     , "templateD" :
-"-- unconcat begin~IF ~ISVAR[2] ~THEN
+"-- unconcat begin
 ~GENSYM[unconcat][0] : for ~GENSYM[i][2] in ~RESULT'range generate
 begin~IF ~VIVADO ~THEN
-  ~RESULT(~SYM[2]) <= ~TOBV[~ARG[2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];~ELSE
-  ~RESULT(~SYM[2]) <= ~ARG[2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1));~FI
-end generate;~ELSE
-~SYM[0] : block
-  signal ~GENSYM[vec][1] : ~TYP[2];
-begin
-  ~SYM[1] <= ~ARG[2];
-  ~GENSYM[unconcat][3] : for ~SYM[2] in ~RESULT'range generate
-  begin~IF ~VIVADO ~THEN
-    ~RESULT(~SYM[2]) <= ~TOBV[~SYM[1]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];~ELSE
-    ~RESULT(~SYM[2]) <= ~SYM[1]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1));~FI
-  end generate;
-end block;~FI
+  ~RESULT(~SYM[2]) <= ~TOBV[~VAR[vec][2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];~ELSE
+  ~RESULT(~SYM[2]) <= ~VAR[vec][2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1));~FI
+end generate;
 -- unconcat end"
     }
   }
@@ -165,12 +85,12 @@ end block;~FI
     { "name"      : "CLaSH.Sized.Vector.map"
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
-"-- map begin~IF ~ISVAR[1] ~THEN
+"-- map begin
 ~GENSYM[map][0] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN
-  signal ~GENSYM[map_in][2] : ~TYPEL[~TYP[1]];
+  signal ~GENSYM[map_in][2]  : ~TYPEL[~TYP[1]];
   signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];
 begin
-  ~SYM[2] <= ~FROMBV[~ARG[1](~SYM[1])][~TYPEL[~TYP[1]]];
+  ~SYM[2] <= fromSLV(~VAR[vec][1](~SYM[1]));
   ~INST 0
     ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
     ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
@@ -180,31 +100,9 @@ end generate;~ELSE
 begin
   ~INST 0
     ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~ARG[1](~SYM[1])~ ~TYPEL[~TYP[1]]~
+    ~INPUT  <= ~VAR[vec][1](~SYM[1])~ ~TYPEL[~TYP[1]]~
   ~INST
-end generate;~FI~ELSE
-~SYM[0] : block
-  signal ~GENSYM[vec][4] : ~TYP[1];
-begin
-  ~SYM[4] <= ~ARG[1];
-  ~GENSYM[map][5] : for ~SYM[1] in ~RESULT'range generate~IF ~VIVADO ~THEN
-    signal ~SYM[2] : ~TYPEL[~TYP[1]];
-    signal ~SYM[3] : ~TYPEL[~TYPO];
-  begin
-    ~SYM[2] <= ~FROMBV[~SYM[4](~SYM[1])][~TYPEL[~TYP[1]]];
-    ~INST 0
-      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
-      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
-    ~INST
-    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
-  end generate;~ELSE
-  begin
-    ~INST 0
-      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= ~SYM[4](~SYM[1])~ ~TYPEL[~TYP[1]]~
-    ~INST
-  end generate;~FI
-end block;~FI
+end generate;~FI
 -- map end"
     }
   }
@@ -212,7 +110,7 @@ end block;~FI
     { "name"      : "CLaSH.Sized.Vector.imap"
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
-"-- imap begin~IF ~ISVAR[2] ~THEN
+"-- imap begin
 ~GENSYM[imap][0] : block
   function ~GENSYM[max][6] (l,r : in natural) return natural is
   begin
@@ -222,10 +120,10 @@ end block;~FI
   end function;
 begin
   ~GENSYM[imap][5] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN
-    signal ~GENSYM[map_in][2] : ~TYPEL[~TYP[2]];
+    signal ~GENSYM[map_in][2]  : ~TYPEL[~TYP[2]];
     signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];
   begin
-    ~SYM[2] <= ~FROMBV[~ARG[2](~SYM[1])][~TYPEL[~TYP[2]]];
+    ~SYM[2] <= fromSLV(~VAR[vec][2](~SYM[1]));
     ~INST 1
       ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
       ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
@@ -237,40 +135,10 @@ begin
     ~INST 1
       ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
       ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
-      ~INPUT  <= ~ARG[2](~SYM[1])~ ~TYPEL[~TYP[1]]~
+      ~INPUT  <= ~VAR[vec][2](~SYM[1])~ ~TYPEL[~TYP[1]]~
     ~INST
   end generate;~FI
-end block;~ELSE
-~SYM[0] : block
-  function ~SYM[6] (l,r : in natural) return natural is
-  begin
-    if l > r then return l;
-    else return r;
-    end if;
-  end function;
-  signal ~GENSYM[vec][4] : ~TYP[2];
-begin
-  ~SYM[4] <= ~ARG[2];
-  ~SYM[5] : for ~SYM[1] in ~RESULT'range generate~IF ~VIVADO ~THEN
-    signal ~SYM[2] : ~TYPEL[~TYP[1]];
-    signal ~SYM[3] : ~TYPEL[~TYPO];
-  begin
-    ~SYM[2] <= ~FROMBV[~SYM[4](~SYM[1])][~TYPEL[~TYP[1]]];
-    ~INST 1
-      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
-      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
-      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
-    ~INST
-    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
-  end generate;~ELSE
-  begin
-    ~INST 1
-      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
-      ~INPUT  <= ~SYM[4](~SYM[1])~ ~TYPEL[~TYP[1]]~
-    ~INST
-  end generate;~FI
-end block;~FI
+end block;
 -- imap end"
     }
   }
@@ -278,14 +146,14 @@ end block;~FI
     { "name"      : "CLaSH.Sized.Vector.zipWith"
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "templateD" :
-"-- zipWith begin~IF ~AND[~ISVAR[1],~ISVAR[2]] ~THEN
+"-- zipWith begin
 ~GENSYM[zipWith][0] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN
   signal ~GENSYM[zipWith_in1][2] : ~TYPEL[~TYP[1]];
   signal ~GENSYM[zipWith_in2][6] : ~TYPEL[~TYP[2]];
   signal ~GENSYM[zipWith_out][3] : ~TYPEL[~TYPO];
 begin
-  ~SYM[2] <= ~FROMBV[~ARG[1](~SYM[1])][~TYPEL[~TYP[1]]];
-  ~SYM[6] <= ~FROMBV[~ARG[2](~SYM[1])][~TYPEL[~TYP[2]]];
+  ~SYM[2] <= fromSLV(~VAR[vec1][1](~SYM[1]));
+  ~SYM[6] <= fromSLV(~VAR[vec2][2](~SYM[1]));
   ~INST 0
     ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
     ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
@@ -296,38 +164,10 @@ end generate;~ELSE
 begin
   ~INST 0
     ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~ARG[1](~SYM[1])~ ~TYPEL[~TYP[1]]~
-    ~INPUT  <= ~ARG[2](~SYM[1])~ ~TYPEL[~TYP[2]]~
+    ~INPUT  <= ~VAR[vec1][1](~SYM[1])~ ~TYPEL[~TYP[1]]~
+    ~INPUT  <= ~VAR[vec2][2](~SYM[1])~ ~TYPEL[~TYP[2]]~
   ~INST
-end generate;~FI~ELSE
-~SYM[0] : block
-  signal ~GENSYM[vec1][4] : ~TYP[1];
-  signal ~GENSYM[vec2][7] : ~TYP[2];
-begin
-  ~SYM[4] <= ~ARG[1];
-  ~SYM[7] <= ~ARG[2];
-  ~GENSYM[zipWith][5] : for ~SYM[1] in ~RESULT'range generate~IF ~VIVADO ~THEN
-    signal ~SYM[2] : ~TYPEL[~TYP[1]];
-    signal ~SYM[6] : ~TYPEL[~TYP[2]];
-    signal ~SYM[3] : ~TYPEL[~TYPO];
-  begin
-    ~SYM[2] <= ~FROMBV[~SYM[4](~SYM[1])][~TYPEL[~TYP[1]]];
-    ~SYM[6] <= ~FROMBV[~SYM[7](~SYM[1])][~TYPEL[~TYP[2]]];
-    ~INST 0
-      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
-      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
-      ~INPUT  <= ~SYM[6]~ ~TYPEL[~TYP[2]]~
-    ~INST
-    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
-  end generate;~ELSE
-  begin
-    ~INST 0
-      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= ~SYM[4](~SYM[1])~ ~TYPEL[~TYP[1]]~
-      ~INPUT  <= ~SYM[7](~SYM[1])~ ~TYPEL[~TYP[2]]~
-    ~INST
-  end generate;~FI
-end block;~FI
+end generate;~FI
 -- zipWith end"
     }
   }
@@ -335,17 +175,17 @@ end block;~FI
     { "name"      : "CLaSH.Sized.Vector.foldr"
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "templateD" :
-"-- foldr begin~IF ~LENGTH[~TYP[2]] ~THEN ~IF ~ISVAR[2] ~THEN
+"-- foldr begin~IF ~LENGTH[~TYP[2]] ~THEN
 ~GENSYM[foldr][0] : block
   type ~GENSYM[foldr_res_type][1] is array (natural range <>) of ~TYP[1];
   signal ~GENSYM[intermediate][2] : ~SYM[1] (0 to ~LENGTH[~TYP[2]]);
 begin
   ~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];
 
-  foldr_loop : for ~GENSYM[i][3] in ~ARG[2]'range generate~IF ~VIVADO ~THEN
+  foldr_loop : for ~GENSYM[i][3] in ~VAR[vec][2]'range generate~IF ~VIVADO ~THEN
     signal ~GENSYM[foldr_in][4] : ~TYPEL[~TYP[2]];
   begin
-    ~SYM[4] <= ~FROMBV[~ARG[2](~SYM[3])][~TYPEL[~TYP[2]]];
+    ~SYM[4] <= fromSLV(~VAR[vec][2](~SYM[3]));
     ~INST 0
       ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
       ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
@@ -355,41 +195,13 @@ begin
   begin
     ~INST 0
       ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
-      ~INPUT  <= ~ARG[2](~SYM[3])~ ~TYPEL[~TYP[2]]~
+      ~INPUT  <= ~VAR[vec][2](~SYM[3])~ ~TYPEL[~TYP[2]]~
       ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
     ~INST
   end generate;~FI
 
   ~RESULT <= ~SYM[2](0);
 end block;~ELSE
-~SYM[0] : block
-  type ~SYM[1] is array (natural range <>) of ~TYP[1];
-  signal ~SYM[2] : ~SYM[1] (0 to ~LENGTH[~TYP[2]]);
-  signal ~GENSYM[vec][5] : ~TYP[2];
-begin
-  ~SYM[5] <= ~ARG[2];
-  ~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];
-
-  foldr_loop : for ~SYM[3] in ~SYM[5]'range generate~IF ~VIVADO ~THEN
-    signal ~SYM[4] : ~TYPEL[~TYP[2]];
-  begin
-    ~SYM[4] <= ~FROMBV[~SYM[5](~SYM[3])][~TYPEL[~TYP[2]]];
-    ~INST 0
-      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
-      ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
-      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
-    ~INST
-  end generate;~ELSE
-  begin
-    ~INST 0
-      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
-      ~INPUT  <= ~SYM[5](~SYM[3])~ ~TYPEL[~TYP[2]]~
-      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
-    ~INST
-  end generate;~FI
-
-  ~RESULT <= ~SYM[2](0);
-end block;~FI~ELSE
 ~RESULT <= ~ARG[1];~FI
 -- foldr end"
     }
@@ -409,20 +221,15 @@ end block;~FI~ELSE
   end function;
 ~IF ~VIVADO ~THEN
   type ~GENSYM[fold_res_type][2] is array(natural range <>) of ~TYPO;
-  signal ~GENSYM[intermediate][3] : ~SYM[2](0 to (2*~LENGTH[~TYP[1]])-2);~IF ~ISLIT[1] ~THEN
-  signal ~GENSYM[vec][4] : ~TYP[1];~ELSE ~FI ~ELSE
+  signal ~GENSYM[intermediate][3] : ~SYM[2](0 to (2*~LENGTH[~TYP[1]])-2);~ELSE
   signal ~SYM[3] : ~TYPM[1](0 to (2*~LENGTH[~TYP[1]])-2);~FI
   constant ~GENSYM[levels][5] : natural := natural (ceil (log2 (real (~LENGTH[~TYP[1]]))));
 begin
-  -- put input array into the first half of the intermediate array~IF ~VIVADO ~THEN~IF ~ISLIT[1] ~THEN
-  ~SYM[4] <= ~ARG[1];
-  ~GENSYM[fill_tree][6] : for ~GENSYM[d][7] in ~SYM[4]'range generate
-    ~SYM[3](~SYM[7]) <= ~FROMBV[~SYM[3](~SYM[7])][~TYPO];
+  -- put input array into the first half of the intermediate array~IF ~VIVADO ~THEN
+  ~SYM[6] : for ~SYM[7] in ~VAR[vec][1]'range generate
+    ~SYM[3](~SYM[7]) <= fromSLV(~VAR[vec][1](~SYM[7]));
   end generate;~ELSE
-  ~SYM[6] : for ~SYM[7] in ~ARG[1]'range generate
-    ~SYM[3](~SYM[7]) <= ~FROMBV[~ARG[1](~SYM[7])][~TYPO];
-  end generate;~FI~ELSE
-  ~SYM[3](0 to ~LENGTH[~TYP[1]]-1) <= ~ARG[1];~FI
+  ~SYM[3](0 to ~LENGTH[~TYP[1]]-1) <= ~VAR[vec][1];~FI
 
   -- Create the tree of instantiated components
   ~GENSYM[make_tree][8] : if ~SYM[5] /= 0 generate
@@ -448,7 +255,7 @@ end block;
     , "type"      : "index_int :: KnownNat n => Vec n a -> Int -> a"
     , "templateD" :
 "-- index begin
-~GENSYM[indexVec][0] : block ~IF ~ISVAR[1] ~THEN
+~GENSYM[indexVec][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
   ~SYM[1] <= to_integer(~ARG[2])
@@ -456,21 +263,9 @@ begin
                mod ~LIT[0]
   -- pragma translate_on
                ;~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~ARG[1](~SYM[1])][~TYPO];~ELSE
-  ~RESULT <= ~ARG[1](~SYM[1]);~FI
-end block;~ELSE
-signal ~GENSYM[vec][2] : ~TYP[1];
-signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
-begin
-  ~SYM[2] <= ~ARG[1];
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~LIT[0]
-  -- pragma translate_on
-               ;~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[2](~SYM[1])][~TYPO];~ELSE
-  ~RESULT <= ~SYM[2](~SYM[1]);~FI
-end block;~FI
+  ~RESULT <= fromSLV(~VAR[vec][1](~SYM[1]));~ELSE
+  ~RESULT <= ~VAR[vec][1](~SYM[1]);~FI
+end block;
 -- index end"
     }
   }
@@ -523,18 +318,12 @@ end block;
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "templateD" :
 "-- transpose begin
-~GENSYM[transpose][0] : block
-  signal ~GENSYM[matrix][1] : ~TYP[1];
-begin
-  ~SYM[1] <= ~ARG[1];
-
-  ~GENSYM[transpose_outer][2] : for ~GENSYM[row_index][3] in ~SYM[1]'range generate
-    ~GENSYM[transpose_inner][4] : for ~GENSYM[col_index][5] in ~RESULT'range generate~IF ~VIVADO ~THEN
-      ~RESULT(~SYM[5])((~SYM[1]'length-~SYM[3])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~SYM[1]'length-~SYM[3]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]) <= ~SYM[1](~SYM[3])((~RESULT'length-~SYM[5])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~RESULT'length-~SYM[5]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]);~ELSE
-      ~RESULT(~SYM[5])(~SYM[3]) <= ~SYM[1](~SYM[3])(~SYM[5]);~FI
-    end generate;
+~GENSYM[transpose_outer][2] : for ~GENSYM[row_index][3] in ~VAR[matrix][1]'range generate
+  ~GENSYM[transpose_inner][4] : for ~GENSYM[col_index][5] in ~RESULT'range generate~IF ~VIVADO ~THEN
+    ~RESULT(~SYM[5])((~VAR[matrix][1]'length-~SYM[3])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~VAR[matrix][1]'length-~SYM[3]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]) <= ~VAR[vec][1](~SYM[3])((~RESULT'length-~SYM[5])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~RESULT'length-~SYM[5]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]);~ELSE
+    ~RESULT(~SYM[5])(~SYM[3]) <= ~VAR[matrix][1](~SYM[3])(~SYM[5]);~FI
   end generate;
-end block;
+end generate;
 -- transpose end"
     }
   }
@@ -543,14 +332,9 @@ end block;
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "templateD" :
 "-- reverse begin
-~GENSYM[reverse][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~GENSYM[reverse_loop][2] : for ~GENSYM[i][3] in ~SYM[1]'range generate
-    ~RESULT(~SYM[1]'high - ~SYM[3]) <= ~SYM[1](~SYM[3]);
-  end generate;
-end block;
+~GENSYM[reverse_loop][2] : for ~GENSYM[i][3] in ~VAR[vec][0]'range generate
+  ~RESULT(~VAR[vec][0]'high - ~SYM[3]) <= ~VAR[vec][0](~SYM[3]);
+end generate;
 -- reverse end"
     }
   }
@@ -568,14 +352,9 @@ end block;
                   -> BitVector (n * m)"
     , "templateD" :
 "-- concatBitVector begin
-~GENSYM[concatBitVector][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[1];
-begin
-  ~SYM[1] <= ~ARG[1];
-  ~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~SYM[1]'range generate
-    ~RESULT(((~SYM[3] * ~LIT[0]) + ~LIT[0] - 1) downto (~SYM[3] * ~LIT[0])) <= ~TYPMO'(~SYM[1](~SYM[1]'high - ~SYM[3]));
-  end generate;
-end block;
+~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~VAR[vec][1]'range generate
+  ~RESULT(((~SYM[3] * ~LIT[0]) + ~LIT[0] - 1) downto (~SYM[3] * ~LIT[0])) <= ~TYPMO'(~VAR[vec][1](~VAR[vec][1]'high - ~SYM[3]));
+end generate;
 -- concatBitVector end"
     }
   }
@@ -587,14 +366,9 @@ end block;
                     -> Vec n (BitVector m)"
     , "templateD" :
 "-- unconcatBitVector begin
-~GENSYM[unconcatBitVector][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[2];
-begin
-  ~SYM[1] <= ~ARG[2];
-  ~GENSYM[unconcatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~RESULT'range generate
-    ~RESULT(~RESULT'high - ~SYM[3]) <= ~SYM[1](((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1]));
-  end generate;
-end block;
+~GENSYM[unconcatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~RESULT'range generate
+  ~RESULT(~RESULT'high - ~SYM[3]) <= ~VAR[vec][2](((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1]));
+end generate;
 -- unconcatBitVector end"
     }
   }
@@ -604,18 +378,15 @@ end block;
     , "templateD" :
 "-- rotateLeftS begin
 ~GENSYM[rotateLeftS][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[1];
   constant ~GENSYM[shift_amount][2] : natural := ~LIT[2] mod ~LIT[0];
 begin
-  ~SYM[1] <= ~ARG[1];
-
   ~GENSYM[no_shift][3] : if ~SYM[2] = 0 generate
-    ~RESULT <= ~SYM[1];
+    ~RESULT <= ~VAR[vec][1];
   end generate;
 
   ~GENSYM[do_shift][4] : if ~SYM[2] /= 0 generate
-    ~RESULT <= ~SYM[1](~SYM[2] to ~LIT[0]-1) &
-               ~SYM[1](0 to ~SYM[2]-1);
+    ~RESULT <= ~VAR[vec][1](~SYM[2] to ~LIT[0]-1) &
+               ~VAR[vec][1](0 to ~SYM[2]-1);
   end generate;
 end block;
 -- rotateLeftS end"
@@ -627,18 +398,15 @@ end block;
     , "templateD" :
 "-- rotateRightS begin
 ~GENSYM[rotateLeftS][0] : block
-  signal ~GENSYM[vec][1] : ~TYP[1];
   constant ~GENSYM[shift_amount][2] : natural := ~LIT[2] mod ~LIT[0];
 begin
-  ~SYM[1] <= ~ARG[1];
-
   ~GENSYM[no_shift][3] : if ~SYM[2] = 0 generate
-    ~RESULT <= ~SYM[1];
+    ~RESULT <= ~VAR[vec][1];
   end generate;
 
   ~GENSYM[do_shift][4] : if ~SYM[2] /= 0 generate
-    ~RESULT <= ~SYM[1](~LIT[0]-~SYM[2] to ~LIT[0]-1) &
-               ~SYM[1](0 to ~LIT[0]-~SYM[2]-1);
+    ~RESULT <= ~VAR[vec][1](~LIT[0]-~SYM[2] to ~LIT[0]-1) &
+               ~VAR[vec][1](0 to ~LIT[0]-~SYM[2]-1);
   end generate;
 end block;
 -- rotateRightS end"

--- a/clash-lib/prims/vhdl/GHC_Prim.json
+++ b/clash-lib/prims/vhdl/GHC_Prim.json
@@ -769,12 +769,10 @@ end block;
     return ~SYM[2](3,a(0 to 5));
   end function;
 
-  signal ~GENSYM[s][4] : ~TYP[0];
-  signal ~GENSYM[s_reversed][5] : ~TYP[0];
+  signal ~GENSYM[w_reversed][5] : ~TYP[0];
 begin
-  ~SYM[4] <= ~ARG[0];
-  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~SYM[4]'range generate
-    ~SYM[5](~SYM[4]'high - ~SYM[7]) <= ~SYM[4](~SYM[7]);
+  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
+    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
   end generate;
 ~IF ~IW64 ~THEN
   ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 56)),~SIZE[~TYPO]);
@@ -824,12 +822,10 @@ end block;
     return ~SYM[2](4,b(0 to 7));
   end function;
 
-  signal ~GENSYM[s][4] : ~TYP[0];
-  signal ~GENSYM[s_reversed][5] : ~TYP[0];
+  signal ~GENSYM[w_reversed][5] : ~TYP[0];
 begin
-  ~SYM[4] <= ~ARG[0];
-  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~SYM[4]'range generate
-    ~SYM[5](~SYM[4]'high - ~SYM[7]) <= ~SYM[4](~SYM[7]);
+  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
+    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
   end generate;
 ~IF ~IW64 ~THEN
   ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 48)),~SIZE[~TYPO]);
@@ -881,12 +877,10 @@ end block;
     return ~SYM[2](5,c(0 to 9));
   end function;
 
-  signal ~GENSYM[s][4] : ~TYP[0];
-  signal ~GENSYM[s_reversed][5] : ~TYP[0];
+  signal ~GENSYM[w_reversed][5] : ~TYP[0];
 begin
-  ~SYM[4] <= ~ARG[0];
-  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~SYM[4]'range generate
-    ~SYM[5](~SYM[4]'high - ~SYM[7]) <= ~SYM[4](~SYM[3]);
+  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
+    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[3]);
   end generate;
 ~IF ~IW64 ~THEN
   ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 32)),~SIZE[~TYPO]);
@@ -940,12 +934,10 @@ end block;
     return ~SYM[2](6,d(0 to 11));
   end function;
 
-  signal ~GENSYM[s][4] : ~TYP[0];
-  signal ~GENSYM[s_reversed][5] : ~TYP[0];
+  signal ~GENSYM[w_reversed][5] : ~TYP[0];
 begin
-  ~SYM[4] <= ~ARG[0];
-  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~SYM[4]'range generate
-    ~SYM[5](~SYM[4]'high - ~SYM[7]) <= ~SYM[4](~SYM[7]);
+  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
+    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
   end generate;
 
   ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);
@@ -1011,12 +1003,10 @@ end block;
   end function;
 ~FI
 
-  signal ~GENSYM[s][5] : ~TYP[0];
-  signal ~GENSYM[s_reversed][6] : ~TYP[0];
+  signal ~GENSYM[w_reversed][6] : ~TYP[0];
 begin
-  ~SYM[5] <= ~ARG[0];
-  ~GENSYM[reverse_loop][7] : for ~GENSYM[n][8] in ~SYM[5]'range generate
-    ~SYM[6](~SYM[5]'high - ~SYM[8]) <= ~SYM[5](~SYM[8]);
+  ~GENSYM[reverse_loop][7] : for ~GENSYM[n][8] in ~VAR[w][0]'range generate
+    ~SYM[6](~VAR[w][0]'high - ~SYM[8]) <= ~VAR[w][0](~SYM[8]);
   end generate;
 ~IF ~IW64 ~THEN
   ~RESULT <= resize(~SYM[3](~SYM[6]),~SIZE[~TYPO]);
@@ -1031,14 +1021,9 @@ end block;
     { "name"      : "GHC.Prim.byteSwap16#"
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "templateD" :
-"-- byteSwap16 begin
-~GENSYM[byteSwap16][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];~IF ~IW64 ~THEN
-  ~RESULT <= ~SYM[1](63 downto 16) & ~SYM[1](7 downto 0) & ~SYM[1](15 downto 8);~ELSE
-  ~RESULT <= ~SYM[1](31 downto 16) & ~SYM[1](7 downto 0) & ~SYM[1](15 downto 8);~FI
-end block;
+"-- byteSwap16 begin~IF ~IW64 ~THEN
+~RESULT <= ~VAR[w][0](63 downto 16) & ~VAR[w][0](7 downto 0) & ~VAR[w][0](15 downto 8);~ELSE
+~RESULT <= ~VAR[w][0](31 downto 16) & ~VAR[w][0](7 downto 0) & ~VAR[w][0](15 downto 8);~FI
 -- byteSwap16 end"
     }
   }
@@ -1046,16 +1031,11 @@ end block;
     { "name"      : "GHC.Prim.byteSwap32#"
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "templateD" :
-"-- byteSwap32 begin
-~GENSYM[byteSwap32][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];~IF ~IW64 ~THEN
-  ~RESULT <= ~SYM[1](63 downto 32) & ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
-                                   & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);~ELSE
-  ~RESULT <= ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
-           & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);~FI
-end block;
+"-- byteSwap32 begin~IF ~IW64 ~THEN
+~RESULT <= ~VAR[w][0](63 downto 32) & ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
+                                    & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~ELSE
+~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
+         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~FI
 -- byteSwap32 end"
     }
   }
@@ -1064,15 +1044,10 @@ end block;
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "templateD" :
 "-- byteSwap64 begin
-~GENSYM[byteSwap64][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
-           & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24)
-           & ~SYM[1](39 downto 32) & ~SYM[1](47 downto 40)
-           & ~SYM[1](55 downto 48) & ~SYM[1](63 downto 56);
-end block;
+~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
+         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24)
+         & ~VAR[w][0](39 downto 32) & ~VAR[w][0](47 downto 40)
+         & ~VAR[w][0](55 downto 48) & ~VAR[w][0](63 downto 56);
 -- byteSwap64 end"
     }
   }
@@ -1080,103 +1055,50 @@ end block;
     { "name"      : "GHC.Prim.byteSwap#"
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "templateD" :
-"-- byteSwap begin
-~GENSYM[byteSwap][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];~IF ~IW64 ~THEN
-  ~RESULT <= ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
-           & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24)
-           & ~SYM[1](39 downto 32) & ~SYM[1](47 downto 40)
-           & ~SYM[1](55 downto 48) & ~SYM[1](63 downto 56);~ELSE
-  ~RESULT <= ~SYM[1](7  downto 0 ) & ~SYM[1](15 downto 8)
-           & ~SYM[1](23 downto 16) & ~SYM[1](31 downto 24);~FI
-end block;
+"-- byteSwap begin ~IF ~IW64 ~THEN
+~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
+         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24)
+         & ~VAR[w][0](39 downto 32) & ~VAR[w][0](47 downto 40)
+         & ~VAR[w][0](55 downto 48) & ~VAR[w][0](63 downto 56);~ELSE
+~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
+         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~FI
 -- byteSwap end"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow8Int#"
     , "type"      : "narrow8Int# :: Int# -> Int#"
-    , "templateD" :
-"-- narrow8Int begin
-~GENSYM[narrow8Int][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= resize(~SYM[1](7 downto 0),~SIZE[~TYPO]);
-end block;
--- narrow8Int end"
+    , "templateE" : "resize(~VAR[i][0](7 downto 0),~SIZE[~TYPO])"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow16Int#"
     , "type"      : "narrow16Int# :: Int# -> Int#"
-    , "templateD" :
-"-- narrow16Int begin
-~GENSYM[narrow16Int][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= resize(~SYM[1](15 downto 0),~SIZE[~TYPO]);
-end block;
--- narrow16Int end"
+    , "templateE" : "resize(~VAR[i][0](15 downto 0),~SIZE[~TYPO])"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow32Int#"
     , "type"      : "narrow32Int# :: Int# -> Int#"
-    , "templateD" :
-"-- narrow32Int begin
-~GENSYM[narrow32Int][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= resize(~SYM[1](31 downto 0),~SIZE[~TYPO]);
-end block;
--- narrow32Int end"
+    , "templateE" : "resize(~VAR[i][0](31 downto 0),~SIZE[~TYPO])"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow8Word#"
     , "type"      : "narrow8Word# :: Word# -> Word#"
-    , "templateD" :
-"-- narrow8Word begin
-~GENSYM[narrow8Word][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= resize(~SYM[1](7 downto 0),~SIZE[~TYPO]);
-end block;
--- narrow8Word end"
+    , "templateE" : "resize(~VAR[w][0](7 downto 0),~SIZE[~TYPO])"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow16Word#"
     , "type"      : "narrow16Word# :: Word# -> Word#"
-    , "templateD" :
-"-- narrow16Word begin
-~GENSYM[narrow16Word][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= resize(~SYM[1](15 downto 0),~SIZE[~TYPO]);
-end block;
--- narrow16Word end"
+    , "templateE" : "resize(~VAR[w][0](15 downto 0),~SIZE[~TYPO])"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow32Word#"
     , "type"      : "narrow32Word# :: Word# -> Word#"
-    , "templateD" :
-"-- narrow32Word begin
-~GENSYM[narrow32Word][0] : block
-  signal ~GENSYM[s][1] : ~TYP[0];
-begin
-  ~SYM[1] <= ~ARG[0];
-  ~RESULT <= resize(~SYM[1](31 downto 0),~SIZE[~TYPO]);
-end block;
--- narrow32Word end"
+    , "templateE" : "resize(~VAR[w][0](31 downto 0),~SIZE[~TYPO])"
     }
   }
 , { "Primitive" :

--- a/clash-lib/src/CLaSH/Backend.hs
+++ b/clash-lib/src/CLaSH/Backend.hs
@@ -13,6 +13,7 @@ import Text.PrettyPrint.Leijen.Text.Monadic (Doc)
 
 import SrcLoc (SrcSpan)
 
+import CLaSH.Netlist.Id
 import CLaSH.Netlist.Types
 import CLaSH.Netlist.BlackBox.Types
 
@@ -66,8 +67,10 @@ class Backend state where
   fromBV           :: HWType -> Text -> State state Doc
   -- | Synthesis tool we're generating HDL for
   hdlSyn           :: State state HdlSyn
-  -- | mkBasicId
-  mkBasicId        :: State state (Identifier -> Identifier)
+  -- | mkIdentifier
+  mkIdentifier     :: State state (IdType -> Identifier -> Identifier)
+  -- | mkIdentifier
+  extendIdentifier :: State state (IdType -> Identifier -> Identifier -> Identifier)
   -- | setModName
   setModName       :: ModName -> state -> state
   -- | setSrcSpan

--- a/clash-lib/src/CLaSH/Backend/SystemVerilog.hs
+++ b/clash-lib/src/CLaSH/Backend/SystemVerilog.hs
@@ -115,7 +115,9 @@ instance Backend SystemVerilogState where
       go Extended (rmSlash -> nm) ext =
         let nmExt = nm `Text.append` ext
         in  case go Basic nm ext of
-              nm' | nm' /= nmExt -> Text.concat ["\\",nmExt," "]
+              nm' | nm' /= nmExt -> case Text.head nmExt of
+                      '#' -> Text.concat ["\\",nmExt," "]
+                      _   -> Text.concat ["\\#",nmExt," "]
                   | otherwise    -> nm'
 
   setModName nm s = s {_modNm = nm}

--- a/clash-lib/src/CLaSH/Backend/SystemVerilog.hs
+++ b/clash-lib/src/CLaSH/Backend/SystemVerilog.hs
@@ -729,6 +729,16 @@ expr_ _ (Identifier id_ (Just (DC (ty@(SP _ _),_)))) = text id_ <> brackets (int
     start = typeSize ty - 1
     end   = typeSize ty - conSize ty
 
+expr_ b (Identifier id_ (Just (Nested m1 m2))) = case (m1,m2) of
+  (Indexed (Vector n elTy,1,2),Indexed (Vector _ _,1,1)) ->
+    expr_ b (Identifier id_ (Just (Indexed (Vector n elTy,10,1))))
+  (Indexed ((RTree d elTy),1,n),Indexed ((RTree _ _),0,1)) -> do
+    let n' = case n of {1 -> 0; _ -> 1}
+    expr_ b (Identifier id_ (Just (Indexed (RTree d elTy,10,n'))))
+  _ -> do
+    k <- expr_ b (Identifier id_ (Just m1))
+    expr_ b (Identifier (displayT (renderOneLine k)) (Just m2))
+
 expr_ _ (Identifier id_ (Just _))                      = text id_
 
 expr_ b (DataCon _ (DC (Void, -1)) [e]) =  expr_ b e

--- a/clash-lib/src/CLaSH/Backend/VHDL.hs
+++ b/clash-lib/src/CLaSH/Backend/VHDL.hs
@@ -818,6 +818,16 @@ expr_ _ (Identifier id_ (Just (Indexed ((Unsigned _),_,_)))) = do
   iw <- use intWidth
   "resize" <> parens (text id_ <> "," <> int iw)
 
+expr_ b (Identifier id_ (Just (Nested m1 m2))) = case (m1,m2) of
+  (Indexed (Vector n elTy,1,2),Indexed (Vector _ _,1,1)) ->
+    expr_ b (Identifier id_ (Just (Indexed (Vector n elTy,10,1))))
+  (Indexed ((RTree d elTy),1,n),Indexed ((RTree _ _),0,1)) -> do
+    let n' = case n of {1 -> 0; _ -> 1}
+    expr_ b (Identifier id_ (Just (Indexed (RTree d elTy,10,n'))))
+  _ -> do
+    k <- expr_ b (Identifier id_ (Just m1))
+    expr_ b (Identifier (displayT (renderOneLine k)) (Just m2))
+
 expr_ _ (Identifier id_ (Just _)) = text id_
 
 expr_ b (DataCon _ (DC (Void, -1)) [e]) =  expr_ b e

--- a/clash-lib/src/CLaSH/Backend/VHDL.hs
+++ b/clash-lib/src/CLaSH/Backend/VHDL.hs
@@ -529,7 +529,7 @@ entity c = do
             $ [ (,fromIntegral $ T.length i) A.<$> (encodingNote ty <$> fill l (text i) <+> colon <+> "in" <+> vhdlType ty)
               | (i,ty) <- inputs c ] ++
               [ (,fromIntegral $ T.length i) A.<$> (encodingNote ty <$> fill l (text i) <+> colon <+> "out" <+> vhdlType ty)
-              | (i,ty) <- outputs c ]
+              | (_,(i,ty)) <- outputs c ]
 
 architecture :: Component -> VHDLM Doc
 architecture c =
@@ -671,7 +671,7 @@ decls ds = do
       _  -> punctuate' semi (A.pure dsDoc)
 
 decl :: Int ->  Declaration -> VHDLM (Maybe (Doc,Int))
-decl l (NetDecl' noteM id_ ty) = Just A.<$> (,fromIntegral (T.length id_)) A.<$>
+decl l (NetDecl' noteM _ id_ ty) = Just A.<$> (,fromIntegral (T.length id_)) A.<$>
   maybe id addNote noteM ("signal" <+> fill l (text id_) <+> colon <+> either text vhdlType ty)
   where
     addNote n = ("--" <+> text n <$>)

--- a/clash-lib/src/CLaSH/Backend/VHDL.hs
+++ b/clash-lib/src/CLaSH/Backend/VHDL.hs
@@ -671,8 +671,10 @@ decls ds = do
       _  -> punctuate' semi (A.pure dsDoc)
 
 decl :: Int ->  Declaration -> VHDLM (Maybe (Doc,Int))
-decl l (NetDecl' id_ ty) = Just A.<$> (,fromIntegral (T.length id_)) A.<$>
-  "signal" <+> fill l (text id_) <+> colon <+> either text vhdlType ty
+decl l (NetDecl' noteM id_ ty) = Just A.<$> (,fromIntegral (T.length id_)) A.<$>
+  maybe id addNote noteM ("signal" <+> fill l (text id_) <+> colon <+> either text vhdlType ty)
+  where
+    addNote n = ("--" <+> text n <$>)
 
 decl _ _ = return Nothing
 

--- a/clash-lib/src/CLaSH/Backend/VHDL.hs
+++ b/clash-lib/src/CLaSH/Backend/VHDL.hs
@@ -106,7 +106,9 @@ instance Backend VHDLState where
       go Extended (rmSlash -> nm) ext =
         let nmExt = nm `T.append` ext
         in  case go Basic nm ext of
-              nm' | nm' /= nmExt -> T.concat ["\\",nmExt,"\\"]
+              nm' | nm' /= nmExt -> case T.head nmExt of
+                      '#' -> T.concat ["\\",nmExt,"\\"]
+                      _   -> T.concat ["\\#",nmExt,"\\"]
                   | otherwise    -> nm'
 
   setModName nm s = s {_modNm = nm}

--- a/clash-lib/src/CLaSH/Backend/Verilog.hs
+++ b/clash-lib/src/CLaSH/Backend/Verilog.hs
@@ -104,7 +104,9 @@ instance Backend VerilogState where
       go Extended (rmSlash -> nm) ext =
         let nmExt = nm `Text.append` ext
         in  case go Basic nm ext of
-              nm' | nm' /= nmExt -> Text.concat ["\\",nmExt," "]
+              nm' | nm' /= nmExt -> case Text.head nmExt of
+                      '#' -> Text.concat ["\\",nmExt," "]
+                      _   -> Text.concat ["\\#",nmExt," "]
                   | otherwise    -> nm'
 
   setModName _    = id

--- a/clash-lib/src/CLaSH/Backend/Verilog.hs
+++ b/clash-lib/src/CLaSH/Backend/Verilog.hs
@@ -180,7 +180,7 @@ addSeen :: Component -> VerilogM ()
 addSeen c = do
   let iport = map fst $ inputs c
       oport = map fst $ outputs c
-      nets  = mapMaybe (\case {NetDecl' i _ -> Just i; _ -> Nothing}) $ declarations c
+      nets  = mapMaybe (\case {NetDecl' _ i _ -> Just i; _ -> Nothing}) $ declarations c
   idSeen .= concat [iport,oport,nets]
 
 mkUniqueId :: Identifier -> VerilogM Identifier
@@ -235,8 +235,12 @@ decls ds = do
       _  -> punctuate' semi (A.pure dsDoc)
 
 decl :: Declaration -> VerilogM (Maybe Doc)
-decl (NetDecl' id_ (Right ty)) = Just A.<$> "wire" <+> sigDecl (text id_) ty
-decl (NetDecl' id_ (Left ty))  = Just A.<$> "wire" <+> text ty <+> text id_
+decl (NetDecl' noteM id_ tyE) =
+  Just A.<$> maybe id addNote noteM ("wire" <+> tyDec tyE)
+  where
+    tyDec (Left  ty) = text ty <+> text id_
+    tyDec (Right ty) = sigDecl (text id_) ty
+    addNote n = ("//" <+> text n <$>)
 
 decl _ = return Nothing
 
@@ -302,7 +306,7 @@ inst_ (BlackBoxD _ _ _ (Just (nm,inc)) bs bbCtx) = do
   includes %= ((unpack nm', inc''):)
   fmap Just (string t)
 
-inst_ (NetDecl' _ _) = return Nothing
+inst_ (NetDecl' _ _ _) = return Nothing
 
 -- | Turn a Netlist expression into a SystemVerilog expression
 expr_ :: Bool -- ^ Enclose in parenthesis?

--- a/clash-lib/src/CLaSH/Backend/Verilog.hs
+++ b/clash-lib/src/CLaSH/Backend/Verilog.hs
@@ -361,7 +361,11 @@ modifier offset (DC (ty@(SP _ _),_)) = Just (start+offset,end+offset)
 modifier offset (Nested m1 m2) = do
   case modifier offset m1 of
     Nothing    -> modifier offset m2
-    Just (_,e) -> modifier e m2
+    Just (s,e) -> case modifier e m2 of
+      -- In case the second modifier is `Nothing` that means we want the entire
+      -- thing calculated by the first modifier
+      Nothing -> Just (s,e)
+      m       -> m
 
 modifier _ _ = Nothing
 

--- a/clash-lib/src/CLaSH/Core/DataCon.hs
+++ b/clash-lib/src/CLaSH/Core/DataCon.hs
@@ -29,7 +29,7 @@ where
 import Control.DeepSeq                        (NFData(..))
 import Data.Hashable                          (Hashable)
 import GHC.Generics                           (Generic)
-import Unbound.Generics.LocallyNameless       (Alpha(..),Name,Subst(..))
+import Unbound.Generics.LocallyNameless       (Alpha(..),Subst(..))
 import Unbound.Generics.LocallyNameless.Extra ()
 #if MIN_VERSION_unbound_generics(0,3,0)
 import Data.Monoid                            (All (..))
@@ -37,6 +37,7 @@ import Unbound.Generics.LocallyNameless       (NthPatFind (..),
                                                NamePatFind (..))
 #endif
 
+import CLaSH.Core.Name                        (Name (..))
 import {-# SOURCE #-} CLaSH.Core.Type         (TyName, Type)
 import CLaSH.Util
 
@@ -117,4 +118,4 @@ dataConInstArgTys (MkData { dcArgTys     = arg_tys
   = Nothing
 
   where
-    tyvars = univ_tvs ++ ex_tvs
+    tyvars = map nameOcc (univ_tvs ++ ex_tvs)

--- a/clash-lib/src/CLaSH/Core/FreeVars.hs
+++ b/clash-lib/src/CLaSH/Core/FreeVars.hs
@@ -11,17 +11,17 @@ module CLaSH.Core.FreeVars where
 import Control.Lens.Fold                (Fold)
 import Unbound.Generics.LocallyNameless (fv)
 
-import CLaSH.Core.Term                  (Term, TmName)
-import CLaSH.Core.Type                  (TyName, Type)
+import CLaSH.Core.Term                  (Term, TmOccName)
+import CLaSH.Core.Type                  (TyOccName, Type)
 
 -- | Gives the free type-variables in a Type
-typeFreeVars :: Fold Type TyName
+typeFreeVars :: Fold Type TyOccName
 typeFreeVars = fv
 
 -- | Gives the free term-variables of a Term
-termFreeIds :: Fold Term TmName
+termFreeIds :: Fold Term TmOccName
 termFreeIds = fv
 
 -- | Gives the free type-variables of a Term
-termFreeTyVars :: Fold Term TyName
+termFreeTyVars :: Fold Term TyOccName
 termFreeTyVars = fv

--- a/clash-lib/src/CLaSH/Core/Name.hs
+++ b/clash-lib/src/CLaSH/Core/Name.hs
@@ -51,7 +51,7 @@ type OccName a = Unbound.Name a
 data NameSort
   = User
   | System
-  | Derived
+  | Internal
   deriving (Eq,Ord,Show,Generic,NFData,Hashable)
 
 instance Typeable a => Alpha (Name a) where
@@ -76,6 +76,9 @@ string2OccName = Unbound.string2Name
 string2SystemName :: String -> Name a
 string2SystemName nm = Name System (string2OccName nm) noSrcSpan
 
+string2InternalName :: String -> Name a
+string2InternalName nm = Name Internal (string2OccName ('#':nm)) noSrcSpan
+
 makeOccName :: String -> Integer -> OccName a
 makeOccName = Unbound.makeName
 
@@ -89,6 +92,8 @@ coerceName nm = nm {nameOcc = go (nameOcc nm)}
     go _                = error "Trying to coerce bound name"
 
 appendToName :: Name a -> String -> Name a
-appendToName (Name _ n loc) s = Name Derived n' loc
+appendToName (Name sort nm loc) s = Name Internal nm' loc
   where
-    n' = Unbound.makeName (Unbound.name2String n ++ s) (Unbound.name2Integer n)
+    n   = Unbound.name2String nm
+    n'  = case sort of {Internal -> n; _ -> '#':n}
+    nm' = Unbound.makeName (n' ++ s) (Unbound.name2Integer nm)

--- a/clash-lib/src/CLaSH/Core/Name.hs
+++ b/clash-lib/src/CLaSH/Core/Name.hs
@@ -1,0 +1,94 @@
+{-|
+  Copyright   :  (C) 2017, Google Inc.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+
+  Names
+-}
+
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell       #-}
+
+module CLaSH.Core.Name
+  ( module CLaSH.Core.Name
+  , noSrcSpan
+  )
+where
+
+import           Control.DeepSeq                        (NFData)
+import           Data.Function                          (on)
+import           Data.Hashable                          (Hashable)
+import           Data.Typeable                          (Typeable)
+import           GHC.Generics                           (Generic)
+import           GHC.SrcLoc.Extra                       ()
+import           Unbound.Generics.LocallyNameless       hiding
+  (Name, name2String, string2Name)
+import qualified Unbound.Generics.LocallyNameless       as Unbound
+import qualified Unbound.Generics.LocallyNameless.Name  as Unbound
+import           Unbound.Generics.LocallyNameless.TH
+import           Unbound.Generics.LocallyNameless.Extra ()
+import           SrcLoc                                 (SrcSpan, noSrcSpan)
+
+data Name a
+  = Name
+  { nameSort :: NameSort
+  , nameOcc  :: OccName a
+  , nameLoc  :: !SrcSpan
+  }
+  deriving (Show,Generic,NFData,Hashable)
+
+instance Eq (Name a) where
+  (==) = (==) `on` nameOcc
+
+instance Ord (Name a) where
+  compare = compare `on` nameOcc
+
+type OccName a = Unbound.Name a
+
+data NameSort
+  = User
+  | System
+  | Derived
+  deriving (Eq,Ord,Show,Generic,NFData,Hashable)
+
+instance Typeable a => Alpha (Name a) where
+  aeq'      ctx (Name _ nm1 _) (Name _ nm2 _) = aeq'      ctx nm1 nm2
+  acompare' ctx (Name _ nm1 _) (Name _ nm2 _) = acompare' ctx nm1 nm2
+
+makeClosedAlpha ''NameSort
+
+instance Subst b (Name a) where subst _ _ = id; substs _ = id
+
+name2String :: Name a -> String
+name2String = Unbound.name2String . nameOcc
+{-# INLINE name2String #-}
+
+name2Integer :: Name a -> Integer
+name2Integer = Unbound.name2Integer . nameOcc
+
+string2OccName :: String -> OccName a
+string2OccName = Unbound.string2Name
+{-# INLINE string2OccName #-}
+
+string2SystemName :: String -> Name a
+string2SystemName nm = Name System (string2OccName nm) noSrcSpan
+
+makeOccName :: String -> Integer -> OccName a
+makeOccName = Unbound.makeName
+
+makeSystemName :: String -> Integer -> Name a
+makeSystemName s i = Name System (makeOccName s i) noSrcSpan
+
+coerceName :: Name a -> Name b
+coerceName nm = nm {nameOcc = go (nameOcc nm)}
+  where
+    go (Unbound.Fn s i) = Unbound.Fn s i
+    go _                = error "Trying to coerce bound name"
+
+appendToName :: Name a -> String -> Name a
+appendToName (Name _ n loc) s = Name Derived n' loc
+  where
+    n' = Unbound.makeName (Unbound.name2String n ++ s) (Unbound.name2Integer n)

--- a/clash-lib/src/CLaSH/Core/Pretty.hs
+++ b/clash-lib/src/CLaSH/Core/Pretty.hs
@@ -24,12 +24,12 @@ import Text.PrettyPrint                 (Doc, char, comma, empty, equals, hang,
                                          hsep, integer, parens, punctuate,
                                          render, sep, text, vcat, ($$), ($+$),
                                          (<+>), (<>), nest, float, double)
-import Unbound.Generics.LocallyNameless (Embed (..), LFresh, Name, lunbind,
-                                         name2String, runLFreshM, unembed,
-                                         unrebind, unrec)
+import Unbound.Generics.LocallyNameless
+  (Embed (..), LFresh, lunbind, runLFreshM, unembed, unrebind, unrec)
 
 import CLaSH.Core.DataCon               (DataCon (..))
 import CLaSH.Core.Literal               (Literal (..))
+import CLaSH.Core.Name                  (Name (..), OccName, name2String)
 import CLaSH.Core.Term                  (Pat (..), Term (..))
 import CLaSH.Core.TyCon                 (TyCon (..), TyConName, isTupleTyConLike)
 import CLaSH.Core.Type                  (ConstTy (..), Kind, LitTy (..),
@@ -58,8 +58,11 @@ prettyParen :: Bool -> Doc -> Doc
 prettyParen False = id
 prettyParen True  = parens
 
-instance Pretty (Name a) where
+instance Pretty (OccName a) where
   pprPrec _ = return . text . show
+
+instance Pretty (Name a) where
+  pprPrec p = pprPrec p . nameOcc
 
 instance Pretty a => Pretty [a] where
   pprPrec prec xs = do

--- a/clash-lib/src/CLaSH/Core/Subst.hs
+++ b/clash-lib/src/CLaSH/Core/Subst.hs
@@ -1,5 +1,6 @@
 {-|
-  Copyright   :  (C) 2012-2016, University of Twente
+  Copyright   :  (C) 2012-2016, University of Twente,
+                          2017, Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
@@ -10,50 +11,50 @@ module CLaSH.Core.Subst where
 
 import Unbound.Generics.LocallyNameless (subst, substs)
 
-import CLaSH.Core.Term                  (Term, TmName)
-import {-# SOURCE #-} CLaSH.Core.Type   (KiName, Kind, TyName, Type)
+import CLaSH.Core.Term                  (Term, TmOccName)
+import {-# SOURCE #-} CLaSH.Core.Type   (KiOccName, Kind, TyOccName, Type)
 
 -- | Substitutes types in a type
-substTys :: [(TyName,Type)]
+substTys :: [(TyOccName,Type)]
          -> Type
          -> Type
 substTys = substs
 
 -- | Substitutes a type in a type
-substTy :: TyName
+substTy :: TyOccName
         -> Type
         -> Type
         -> Type
 substTy = subst
 
 -- | Substitutes kinds in a kind
-substKindWith :: [(KiName,Kind)]
+substKindWith :: [(KiOccName,Kind)]
               -> Kind
               -> Kind
 substKindWith = substs
 
 -- | Substitutes a type in a term
-substTyInTm :: TyName
+substTyInTm :: TyOccName
             -> Type
             -> Term
             -> Term
 substTyInTm = subst
 
 -- | Substitutes types in a term
-substTysinTm :: [(TyName,Type)]
+substTysinTm :: [(TyOccName,Type)]
              -> Term
              -> Term
 substTysinTm = substs
 
 -- | Substitutes a term in a term
-substTm :: TmName
+substTm :: TmOccName
         -> Term
         -> Term
         -> Term
 substTm = subst
 
 -- | Substitutes terms in a term
-substTms :: [(TmName,Term)]
+substTms :: [(TmOccName,Term)]
          -> Term
          -> Term
 substTms = substs

--- a/clash-lib/src/CLaSH/Core/Subst.hs
+++ b/clash-lib/src/CLaSH/Core/Subst.hs
@@ -7,11 +7,13 @@
   Capture-free substitution function for CoreHW
 -}
 
+{-# LANGUAGE ViewPatterns #-}
+
 module CLaSH.Core.Subst where
 
-import Unbound.Generics.LocallyNameless (subst, substs)
+import Unbound.Generics.LocallyNameless (embed, subst, substs, unembed)
 
-import CLaSH.Core.Term                  (Term, TmOccName)
+import CLaSH.Core.Term                  (LetBinding, Term, TmOccName)
 import {-# SOURCE #-} CLaSH.Core.Type   (KiOccName, Kind, TyOccName, Type)
 
 -- | Substitutes types in a type
@@ -58,3 +60,7 @@ substTms :: [(TmOccName,Term)]
          -> Term
          -> Term
 substTms = substs
+
+-- | Substitutes a term in a let-binding
+substBndr :: TmOccName -> Term -> LetBinding -> LetBinding
+substBndr nm tm (id_,unembed -> tm') = (id_,embed (substTm nm tm tm'))

--- a/clash-lib/src/CLaSH/Core/Term.hs
+++ b/clash-lib/src/CLaSH/Core/Term.hs
@@ -16,6 +16,7 @@
 module CLaSH.Core.Term
   ( Term (..)
   , TmName
+  , TmOccName
   , LetBinding
   , Pat (..)
   )
@@ -26,12 +27,13 @@ import Control.DeepSeq
 import Data.Hashable                           (Hashable)
 import Data.Text                               (Text)
 import GHC.Generics
-import Unbound.Generics.LocallyNameless
+import Unbound.Generics.LocallyNameless        hiding (Name)
 import Unbound.Generics.LocallyNameless.Extra  ()
 
 -- Internal Modules
 import CLaSH.Core.DataCon                      (DataCon)
 import CLaSH.Core.Literal                      (Literal)
+import CLaSH.Core.Name                         (Name (..), OccName)
 import {-# SOURCE #-} CLaSH.Core.Type          (Type)
 import CLaSH.Core.Var                          (Id, TyVar)
 
@@ -52,6 +54,7 @@ data Term
 
 -- | Term reference
 type TmName     = Name Term
+type TmOccName  = OccName Term
 -- | Binding in a LetRec construct
 type LetBinding = (Id, Embed Term)
 
@@ -85,7 +88,7 @@ instance Subst Type Pat
 instance Subst Term Pat
 
 instance Subst Term Term where
-  isvar (Var _ x) = Just (SubstName x)
+  isvar (Var _ x) = Just (SubstName (nameOcc x))
   isvar _         = Nothing
 
 instance Subst Type Term

--- a/clash-lib/src/CLaSH/Core/Term.hs
+++ b/clash-lib/src/CLaSH/Core/Term.hs
@@ -19,6 +19,7 @@ module CLaSH.Core.Term
   , TmOccName
   , LetBinding
   , Pat (..)
+  , Alt
   )
 where
 
@@ -48,7 +49,7 @@ data Term
   | App     !Term !Term                     -- ^ Application
   | TyApp   !Term !Type                     -- ^ Type-application
   | Letrec  !(Bind (Rec [LetBinding]) Term) -- ^ Recursive let-binding
-  | Case    !Term !Type [Bind Pat Term]     -- ^ Case-expression: subject, type of
+  | Case    !Term !Type [Alt]               -- ^ Case-expression: subject, type of
                                             -- alternatives, list of alternatives
   deriving (Show,Generic,NFData,Hashable)
 
@@ -68,6 +69,8 @@ data Pat
   | DefaultPat
   -- ^ Default pattern
   deriving (Eq,Show,Generic,NFData,Alpha,Hashable)
+
+type Alt = Bind Pat Term
 
 instance Eq Term where
   (==) = aeq

--- a/clash-lib/src/CLaSH/Core/Term.hs-boot
+++ b/clash-lib/src/CLaSH/Core/Term.hs-boot
@@ -8,8 +8,8 @@
 
 module CLaSH.Core.Term where
 
-import GHC.Generics                     (Generic)
-import Unbound.Generics.LocallyNameless (Name)
+import GHC.Generics    (Generic)
+import CLaSH.Core.Name (Name)
 
 data Term
 type TmName = Name Term

--- a/clash-lib/src/CLaSH/Core/TyCon.hs
+++ b/clash-lib/src/CLaSH/Core/TyCon.hs
@@ -15,6 +15,7 @@
 module CLaSH.Core.TyCon
   ( TyCon (..)
   , TyConName
+  , TyConOccName
   , AlgTyConRhs (..)
   , mkKindTyCon
   , isTupleTyConLike
@@ -31,7 +32,6 @@ import Control.DeepSeq
 import GHC.Generics
 import Unbound.Generics.LocallyNameless       (Alpha(..))
 import Unbound.Generics.LocallyNameless.Extra ()
-import Unbound.Generics.LocallyNameless.Name  (Name,name2String)
 #if MIN_VERSION_unbound_generics(0,3,0)
 import Data.Monoid                            (All (..))
 import Unbound.Generics.LocallyNameless       (NthPatFind (..),
@@ -40,6 +40,7 @@ import Unbound.Generics.LocallyNameless       (NthPatFind (..),
 
 -- Internal Imports
 import CLaSH.Core.DataCon                     (DataCon)
+import CLaSH.Core.Name
 import {-# SOURCE #-} CLaSH.Core.Type         (Kind, TyName, Type)
 import CLaSH.Util
 
@@ -85,6 +86,7 @@ instance Ord TyCon where
 
 -- | TyCon reference
 type TyConName = Name TyCon
+type TyConOccName = OccName TyCon
 
 -- | The RHS of an Algebraic Datatype
 data AlgTyConRhs

--- a/clash-lib/src/CLaSH/Core/TyCon.hs-boot
+++ b/clash-lib/src/CLaSH/Core/TyCon.hs-boot
@@ -6,7 +6,8 @@
 
 module CLaSH.Core.TyCon where
 
-import Unbound.Generics.LocallyNameless (Name)
+import CLaSH.Core.Name (Name, OccName)
 
 data TyCon
 type TyConName = Name TyCon
+type TyConOccName = OccName TyCon

--- a/clash-lib/src/CLaSH/Core/Type.hs-boot
+++ b/clash-lib/src/CLaSH/Core/Type.hs-boot
@@ -14,8 +14,9 @@ module CLaSH.Core.Type where
 import Control.DeepSeq                  (NFData)
 import Data.Hashable                    (Hashable)
 import GHC.Generics                     (Generic)
-import Unbound.Generics.LocallyNameless (Alpha,Name,Subst)
+import Unbound.Generics.LocallyNameless (Alpha,Subst)
 
+import                CLaSH.Core.Name
 import {-# SOURCE #-} CLaSH.Core.Term
 import {-# SOURCE #-} CLaSH.Core.TyCon
 
@@ -23,7 +24,9 @@ data Type
 
 type Kind   = Type
 type TyName = Name Type
+type TyOccName = OccName Type
 type KiName = Name Kind
+type KiOccName = OccName Kind
 
 instance Eq       Type
 instance Generic  Type

--- a/clash-lib/src/CLaSH/Core/TysPrim.hs
+++ b/clash-lib/src/CLaSH/Core/TysPrim.hs
@@ -27,22 +27,23 @@ module CLaSH.Core.TysPrim
   )
 where
 
+import           Control.Arrow                    (first)
 import           Data.HashMap.Strict              (HashMap)
 import qualified Data.HashMap.Strict              as HashMap
-import           Unbound.Generics.LocallyNameless (makeName, string2Name)
 
 import           PrelNames
 import           Unique                           (Unique, getKey)
 
+import           CLaSH.Core.Name
 import           CLaSH.Core.TyCon
 import {-# SOURCE #-} CLaSH.Core.Type
 
 -- | Builtin Name
 tySuperKindTyConName, liftedTypeKindTyConName, typeNatKindTyConName, typeSymbolKindTyConName :: TyConName
-tySuperKindTyConName      = string2Name "BOX"
-liftedTypeKindTyConName   = string2Name "*"
-typeNatKindTyConName      = string2Name "Nat"
-typeSymbolKindTyConName   = string2Name "Symbol"
+tySuperKindTyConName      = string2SystemName "BOX"
+liftedTypeKindTyConName   = string2SystemName "*"
+typeNatKindTyConName      = string2SystemName "Nat"
+typeSymbolKindTyConName   = string2SystemName "Symbol"
 
 -- | Builtin Kind
 liftedTypeKindtc, tySuperKindtc, typeNatKindtc, typeSymbolKindtc :: TyCon
@@ -64,29 +65,29 @@ intPrimTyConName, integerPrimTyConName, charPrimTyConName, stringPrimTyConName,
   voidPrimTyConName, wordPrimTyConName, int64PrimTyConName,
   word64PrimTyConName, floatPrimTyConName, doublePrimTyConName,
   naturalPrimTyConName :: TyConName
-intPrimTyConName     = makeName "GHC.Prim.Int#"
+intPrimTyConName     = makeSystemName "GHC.Prim.Int#"
                                 (uniqueToInteger intPrimTyConKey)
-integerPrimTyConName = makeName "GHC.Integer.Type.Integer"
+integerPrimTyConName = makeSystemName "GHC.Integer.Type.Integer"
                                 (uniqueToInteger integerTyConKey)
-stringPrimTyConName  = string2Name "String"
-charPrimTyConName    = makeName "GHC.Prim.Char#"
+stringPrimTyConName  = string2SystemName "String"
+charPrimTyConName    = makeSystemName "GHC.Prim.Char#"
                                 (uniqueToInteger charPrimTyConKey)
-voidPrimTyConName    = string2Name "VOID"
-wordPrimTyConName    = makeName "GHC.Prim.Word#"
+voidPrimTyConName    = string2SystemName "VOID"
+wordPrimTyConName    = makeSystemName "GHC.Prim.Word#"
                                 (uniqueToInteger wordPrimTyConKey)
-int64PrimTyConName   = makeName "GHC.Prim.Int64#"
+int64PrimTyConName   = makeSystemName "GHC.Prim.Int64#"
                                 (uniqueToInteger int64PrimTyConKey)
-word64PrimTyConName  = makeName "GHC.Prim.Word64#"
+word64PrimTyConName  = makeSystemName "GHC.Prim.Word64#"
                                 (uniqueToInteger word64PrimTyConKey)
-floatPrimTyConName   = makeName "GHC.Prim.Float#"
+floatPrimTyConName   = makeSystemName "GHC.Prim.Float#"
                                 (uniqueToInteger floatPrimTyConKey)
-doublePrimTyConName  = makeName "GHC.Prim.Double#"
+doublePrimTyConName  = makeSystemName "GHC.Prim.Double#"
                                 (uniqueToInteger doublePrimTyConKey)
 #if MIN_VERSION_ghc(8,2,0)
-naturalPrimTyConName = makeName "GHC.Natural.Natural"
+naturalPrimTyConName = makeSystemName "GHC.Natural.Natural"
                                 (uniqueToInteger naturalTyConKey)
 #else
-naturalPrimTyConName = string2Name "GHC.Natural.Natural"
+naturalPrimTyConName = string2SystemName "GHC.Natural.Natural"
 #endif
 
 liftedPrimTC :: TyConName
@@ -122,8 +123,8 @@ floatPrimTy   = mkTyConTy floatPrimTyConName
 doublePrimTy  = mkTyConTy doublePrimTyConName
 naturalPrimTy = mkTyConTy naturalPrimTyConName
 
-tysPrimMap :: HashMap TyConName TyCon
-tysPrimMap = HashMap.fromList
+tysPrimMap :: HashMap TyConOccName TyCon
+tysPrimMap = HashMap.fromList $ map (first nameOcc)
   [ (tySuperKindTyConName,tySuperKindtc)
   , (liftedTypeKindTyConName,liftedTypeKindtc)
   , (typeNatKindTyConName,typeNatKindtc)

--- a/clash-lib/src/CLaSH/Core/Var.hs
+++ b/clash-lib/src/CLaSH/Core/Var.hs
@@ -23,9 +23,9 @@ import Control.DeepSeq                  (NFData (..))
 import Data.Hashable                    (Hashable)
 import Data.Typeable                    (Typeable)
 import GHC.Generics                     (Generic)
-import Unbound.Generics.LocallyNameless (Alpha,Embed,Name,Subst(..))
-import Unbound.Generics.LocallyNameless.Extra ()
+import Unbound.Generics.LocallyNameless (Alpha,Embed,Subst(..))
 
+import CLaSH.Core.Name                  (Name)
 import {-# SOURCE #-} CLaSH.Core.Term   (Term)
 import {-# SOURCE #-} CLaSH.Core.Type   (Kind, Type)
 

--- a/clash-lib/src/CLaSH/Driver.hs
+++ b/clash-lib/src/CLaSH/Driver.hs
@@ -263,7 +263,7 @@ createHDL backend modName components (topName,manifestE) = flip evalState backen
       topFiles = hdl ++ qincs
   manifest <- either return (\m -> do
       topInTypes  <- mapM (fmap (displayT . renderOneLine) . hdlType . snd) (inputs top)
-      topOutTypes <- mapM (fmap (displayT . renderOneLine) . hdlType . snd) (outputs top)
+      topOutTypes <- mapM (fmap (displayT . renderOneLine) . hdlType . snd . snd) (outputs top)
       return (m {portInTypes = topInTypes, portOutTypes = topOutTypes})
     ) manifestE
   let manDoc = ( topName <.> "manifest"

--- a/clash-lib/src/CLaSH/Driver.hs
+++ b/clash-lib/src/CLaSH/Driver.hs
@@ -50,6 +50,7 @@ import           CLaSH.Driver.Types
 import           CLaSH.Netlist                    (genComponentName, genNetlist)
 import           CLaSH.Netlist.BlackBox.Parser    (runParse)
 import           CLaSH.Netlist.BlackBox.Types     (BlackBoxTemplate)
+import           CLaSH.Netlist.Id                 (IdType (..))
 import           CLaSH.Netlist.Types              (Component (..), HWType)
 import           CLaSH.Normalize                  (checkNonRecursive, cleanupGraph,
                                                    normalize, runNormalization)
@@ -107,8 +108,9 @@ generateHDL bindingsMap hdlState primMap tcm tupTcm typeTrans eval topEntities
       hdlDir    = fromMaybe "." (opt_hdlDir opts) </>
                         CLaSH.Backend.name hdlState' </>
                         takeWhile (/= '.') (name2String topEntity)
-      mkId      = evalState mkBasicId hdlState'
-      topNm     = maybe (mkId (Text.pack $ modName ++ "_topEntity"))
+      mkId      = evalState mkIdentifier hdlState'
+      extId     = evalState extendIdentifier hdlState'
+      topNm     = maybe (mkId Basic (Text.pack $ modName ++ "_topEntity"))
                         (Text.pack . t_name)
                         annM
 
@@ -154,7 +156,7 @@ generateHDL bindingsMap hdlState primMap tcm tupTcm typeTrans eval topEntities
 
       -- 2. Generate netlist for topEntity
       (netlist,dfiles,_) <- genNetlist transformedBindings topEntities primMap'
-                              tcm typeTrans modName [] iw mkId (HM.empty,[topNm])
+                              tcm typeTrans modName [] iw mkId extId (HM.empty,[topNm])
                               hdlDir (nameOcc topEntity)
 
       netlistTime <- netlist `deepseq` Clock.getCurrentTime
@@ -195,7 +197,7 @@ generateHDL bindingsMap hdlState primMap tcm tupTcm typeTrans eval topEntities
 
       -- 2. Generate netlist for topEntity
       (netlist,dfiles,_) <- genNetlist transformedBindings topEntities primMap'
-                              tcm typeTrans modName' [] iw mkId (HM.empty,[topNm])
+                              tcm typeTrans modName' [] iw mkId extId (HM.empty,[topNm])
                               hdlDir (nameOcc tb)
 
       netlistTime <- netlist `deepseq` Clock.getCurrentTime

--- a/clash-lib/src/CLaSH/Driver.hs
+++ b/clash-lib/src/CLaSH/Driver.hs
@@ -226,13 +226,13 @@ generateHDL bindingsMap hdlState primMap tcm tupTcm typeTrans eval topEntities
   go benchTime topEntities'
 
 parsePrimitive :: Primitive Text -> Primitive BlackBoxTemplate
-parsePrimitive (BlackBox pNm libM imps inc templT) =
+parsePrimitive (BlackBox pNm oReg libM imps inc templT) =
   let (templ,err) = either (first Left . runParse) (first Right . runParse) templT
       inc'        = case fmap (second runParse) inc of
                       Just (x,(t,[])) -> Just (x,t)
                       _ -> Nothing
   in  case err of
-        [] -> BlackBox pNm libM imps inc' templ
+        [] -> BlackBox pNm oReg libM imps inc' templ
         _  -> error $ "Errors in template for: " ++ show pNm ++ ":\n" ++ show err
 parsePrimitive (Primitive pNm typ) = Primitive pNm typ
 

--- a/clash-lib/src/CLaSH/Driver/TopWrapper.hs
+++ b/clash-lib/src/CLaSH/Driver/TopWrapper.hs
@@ -18,20 +18,21 @@ module CLaSH.Driver.TopWrapper where
 import Data.Text.Lazy              (append, pack)
 
 import CLaSH.Annotations.TopEntity (TopEntity (..), PortName (..))
+import CLaSH.Netlist.Id            (IdType (..))
 import CLaSH.Netlist.Types
   (Component (..), Declaration (..), Expr (..), Identifier, HWType (..),
    Modifier (..), PortDirection(..))
 import CLaSH.Util
 
 -- | Create a wrapper around a component, potentially initiating clock sources
-mkTopWrapper :: (Identifier -> Identifier)
+mkTopWrapper :: (IdType -> Identifier -> Identifier)
              -> Maybe TopEntity -- ^ TopEntity specifications
              -> String          -- ^ Name of the module containing the @topEntity@
              -> Component       -- ^ Entity to wrap
              -> Component
 mkTopWrapper mkId teM modName topComponent
   = Component
-  { componentName = maybe (mkId (pack modName `append` "_topEntity")) (pack . t_name) teM
+  { componentName = maybe (mkId Basic (pack modName `append` "_topEntity")) (pack . t_name) teM
   , inputs        = inputs3
   , outputs       = outputs3
   , declarations  = concat [wrappers,topCompDecl:unwrappers]

--- a/clash-lib/src/CLaSH/Driver/TopWrapper.hs
+++ b/clash-lib/src/CLaSH/Driver/TopWrapper.hs
@@ -107,7 +107,7 @@ mkInput pM = case pM of
           inputs1  = map (appendNumber (i,hwty')) [0..(sz-1)]
           inputs2  = map (mkInput Nothing) inputs1
           (ports,decls,ids) = concatPortDecls inputs2
-          netdecl  = NetDecl i hwty
+          netdecl  = NetDecl Nothing i hwty
           ids'     = map (`Identifier` Nothing) ids
           netassgn = Assignment i (mkVectorChain sz hwty' ids')
 
@@ -117,7 +117,7 @@ mkInput pM = case pM of
           inputs2  = map (mkInput Nothing) inputs1
           (ports,decls,ids) = concatPortDecls inputs2
           ids'     = map (`Identifier` Nothing) ids
-          netdecl  = NetDecl i hwty
+          netdecl  = NetDecl Nothing i hwty
           netassgn = Assignment i (mkRTreeChain d hwty' ids')
 
       Product _ hwtys -> (ports,netdecl:netassgn:decls,i)
@@ -126,7 +126,7 @@ mkInput pM = case pM of
           inputs2  = map (mkInput Nothing) inputs1
           (ports,decls,ids) = concatPortDecls inputs2
           ids'     = map (`Identifier` Nothing) ids
-          netdecl  = NetDecl i hwty
+          netdecl  = NetDecl Nothing i hwty
           netassgn = Assignment i (DataCon hwty (DC (hwty,0)) ids')
 
       _ -> ([(i,hwty)],[],i)
@@ -138,7 +138,7 @@ mkInput pM = case pM of
           inputs1  = map (appendNumber (pN,hwty')) [0..(sz-1)]
           inputs2  = zipWith mkInput (extendPorts ps) inputs1
           (ports,decls,ids) = concatPortDecls inputs2
-          netdecl  = NetDecl pN hwty
+          netdecl  = NetDecl Nothing pN hwty
           ids'     = map (`Identifier` Nothing) ids
           netassgn = Assignment pN (mkVectorChain sz hwty' ids')
 
@@ -147,7 +147,7 @@ mkInput pM = case pM of
           inputs1  = map (appendNumber (pN,hwty')) [0..((2^d)-1)]
           inputs2  = zipWith mkInput (extendPorts ps) inputs1
           (ports,decls,ids) = concatPortDecls inputs2
-          netdecl  = NetDecl pN hwty
+          netdecl  = NetDecl Nothing pN hwty
           ids'     = map (`Identifier` Nothing) ids
           netassgn = Assignment pN (mkRTreeChain d hwty' ids')
 
@@ -157,7 +157,7 @@ mkInput pM = case pM of
           inputs2  = zipWith mkInput (extendPorts ps) inputs1
           (ports,decls,ids) = concatPortDecls inputs2
           ids'     = map (`Identifier` Nothing) ids
-          netdecl  = NetDecl pN hwty
+          netdecl  = NetDecl Nothing pN hwty
           netassgn = Assignment pN (DataCon hwty (DC (hwty,0)) ids')
 
       _ -> ([(pN,hwty)],[],pN)
@@ -205,7 +205,7 @@ mkOutput pM = case pM of
           outputs1 = map (appendNumber (o,hwty')) [0..(sz-1)]
           outputs2 = map (mkOutput Nothing) outputs1
           (ports,decls,ids) = concatPortDecls outputs2
-          netdecl  = NetDecl o hwty
+          netdecl  = NetDecl Nothing o hwty
           assigns  = zipWith (assingId o hwty 10) ids [0..]
 
       RTree d hwty' -> (ports,netdecl:assigns ++ decls,o)
@@ -213,7 +213,7 @@ mkOutput pM = case pM of
           outputs1 = map (appendNumber (o,hwty')) [0..((2^d)-1)]
           outputs2 = map (mkOutput Nothing) outputs1
           (ports,decls,ids) = concatPortDecls outputs2
-          netdecl  = NetDecl o hwty
+          netdecl  = NetDecl Nothing o hwty
           assigns  = zipWith (assingId o hwty 10) ids [0..]
 
       Product _ hwtys -> (ports,netdecl:assigns ++ decls,o)
@@ -221,7 +221,7 @@ mkOutput pM = case pM of
           outputs1 = zipWith appendNumber (map (o,) hwtys) [0..]
           outputs2 = map (mkOutput Nothing) outputs1
           (ports,decls,ids) = concatPortDecls outputs2
-          netdecl  = NetDecl o hwty
+          netdecl  = NetDecl Nothing o hwty
           assigns  = zipWith (assingId o hwty 0) ids [0..]
 
       _ -> ([(o,hwty)],[],o)
@@ -233,7 +233,7 @@ mkOutput pM = case pM of
           outputs1 = map (appendNumber (pN,hwty')) [0..(sz-1)]
           outputs2 = zipWith mkOutput (extendPorts ps) outputs1
           (ports,decls,ids) = concatPortDecls outputs2
-          netdecl  = NetDecl pN hwty
+          netdecl  = NetDecl Nothing pN hwty
           assigns  = zipWith (assingId pN hwty 10) ids [0..]
 
       RTree d hwty' -> (ports,netdecl:assigns ++ decls,pN)
@@ -241,7 +241,7 @@ mkOutput pM = case pM of
           outputs1 = map (appendNumber (pN,hwty')) [0..((2^d)-1)]
           outputs2 = zipWith mkOutput (extendPorts ps) outputs1
           (ports,decls,ids) = concatPortDecls outputs2
-          netdecl  = NetDecl pN hwty
+          netdecl  = NetDecl Nothing pN hwty
           assigns  = zipWith (assingId pN hwty 10) ids [0..]
 
       Product _ hwtys -> (ports,netdecl:assigns ++ decls,pN)
@@ -249,7 +249,7 @@ mkOutput pM = case pM of
           outputs1 = zipWith appendNumber (map (pN,) hwtys) [0..]
           outputs2 = zipWith mkOutput (extendPorts ps) outputs1
           (ports,decls,ids) = concatPortDecls outputs2
-          netdecl  = NetDecl pN hwty
+          netdecl  = NetDecl Nothing pN hwty
           assigns  = zipWith (assingId pN hwty 0) ids [0..]
 
       _ -> ([(pN,hwty)],[],pN)

--- a/clash-lib/src/CLaSH/Driver/Types.hs
+++ b/clash-lib/src/CLaSH/Driver/Types.hs
@@ -19,14 +19,14 @@ import Data.Text.Lazy    (Text)
 
 import SrcLoc            (SrcSpan, noSrcSpan)
 
-import CLaSH.Core.Term   (Term,TmName)
+import CLaSH.Core.Term   (Term,TmName,TmOccName)
 import CLaSH.Core.Type   (Type)
 
 import CLaSH.Rewrite.Types (DebugLevel)
 import CLaSH.Netlist.BlackBox.Types (HdlSyn)
 
 -- | Global function binders
-type BindingMap = HashMap TmName (Type,SrcSpan,Term)
+type BindingMap = HashMap TmOccName (TmName,Type,SrcSpan,Term)
 
 data CLaSHOpts = CLaSHOpts { opt_inlineLimit :: Int
                            , opt_specLimit   :: Int

--- a/clash-lib/src/CLaSH/Driver/Types.hs
+++ b/clash-lib/src/CLaSH/Driver/Types.hs
@@ -24,6 +24,7 @@ import CLaSH.Core.Type   (Type)
 
 import CLaSH.Rewrite.Types (DebugLevel)
 import CLaSH.Netlist.BlackBox.Types (HdlSyn)
+import CLaSH.Netlist.Types (Identifier)
 
 -- | Global function binders
 type BindingMap = HashMap TmOccName (TmName,Type,SrcSpan,Term)
@@ -66,5 +67,9 @@ data Manifest
     --
     -- Used when dealing with multiple @TopEntity@s who have different names
     -- for types which are structurally equal
+  , componentNames :: [Identifier]
+    -- ^ Names of all the generated components for the @TopEntity@ (does not
+    -- include the names of the components of the @TestBench@ accompanying
+    -- the @TopEntity@).
   }
   deriving (Show,Read)

--- a/clash-lib/src/CLaSH/Netlist.hs-boot
+++ b/clash-lib/src/CLaSH/Netlist.hs-boot
@@ -4,10 +4,10 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-module CLaSH.Netlist (genComponent,mkExpr,mkDcApplication) where
+module CLaSH.Netlist (genComponent,mkExpr,mkDcApplication,mkProjection) where
 
 import CLaSH.Core.DataCon   (DataCon)
-import CLaSH.Core.Term      (Term,TmOccName)
+import CLaSH.Core.Term      (Alt,Term,TmOccName)
 import CLaSH.Core.Type      (Type)
 import CLaSH.Core.Var       (Id)
 import CLaSH.Driver.Types   (SrcSpan)
@@ -28,3 +28,10 @@ mkDcApplication :: HWType
                 -> DataCon
                 -> [Term]
                 -> NetlistMonad (Expr,[Declaration])
+
+mkProjection
+  :: Either Identifier Id
+  -> Term
+  -> Type
+  -> Alt
+  -> NetlistMonad (Expr, [Declaration])

--- a/clash-lib/src/CLaSH/Netlist.hs-boot
+++ b/clash-lib/src/CLaSH/Netlist.hs-boot
@@ -7,14 +7,14 @@
 module CLaSH.Netlist (genComponent,mkExpr,mkDcApplication) where
 
 import CLaSH.Core.DataCon   (DataCon)
-import CLaSH.Core.Term      (Term,TmName)
+import CLaSH.Core.Term      (Term,TmOccName)
 import CLaSH.Core.Type      (Type)
 import CLaSH.Core.Var       (Id)
 import CLaSH.Driver.Types   (SrcSpan)
 import CLaSH.Netlist.Types  (Expr, HWType, Identifier, NetlistMonad, Component,
                              Declaration)
 
-genComponent :: TmName
+genComponent :: TmOccName
              -> NetlistMonad (SrcSpan,Component)
 
 mkExpr :: Bool

--- a/clash-lib/src/CLaSH/Netlist/BlackBox.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox.hs
@@ -272,7 +272,7 @@ mkFunInput resId e = do
               normalized <- Lens.use bindings
               case HashMap.lookup fun normalized of
                 Just _ -> do
-                  (_,Component compName compInps [compOutp] _) <- preserveVarEnv $ genComponent fun
+                  (_,Component compName compInps [snd -> compOutp] _) <- preserveVarEnv $ genComponent fun
                   let inpAssigns    = zipWith (\(i,t) e' -> (Identifier i Nothing,In,t,e')) compInps [ Identifier (pack ("~ARG[" ++ show x ++ "]")) Nothing | x <- [(0::Int)..] ]
                       outpAssign    = (Identifier (fst compOutp) Nothing,Out,snd compOutp,Identifier (pack "~RESULT") Nothing)
                   i <- varCount <<%= (+1)

--- a/clash-lib/src/CLaSH/Netlist/BlackBox.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox.hs
@@ -184,7 +184,7 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
                 _ -> do
                   scrutHTy <- unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
                   tmpRhs <- mkUniqueIdentifier Extended (pack "#tte_rhs")
-                  let netDeclRhs   = NetDecl tmpRhs scrutHTy
+                  let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                       netAssignRhs = Assignment tmpRhs scrutExpr
                   return (DataTag hwTy (Left tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
             _ -> error $ $(curLoc) ++ "tagToEnum: " ++ show (map (either showDoc showDoc) args)
@@ -201,7 +201,7 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
               Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
               _ -> do
                 tmpRhs  <- mkUniqueIdentifier Extended "#dtt_rhs"
-                let netDeclRhs   = NetDecl tmpRhs scrutHTy
+                let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                     netAssignRhs = Assignment tmpRhs scrutExpr
                 return (DataTag scrutHTy (Right tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
           _ -> error $ $(curLoc) ++ "dataToTag: " ++ show (map (either showDoc showDoc) args)
@@ -223,7 +223,7 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
           let nm3 = (string2SystemName (Text.unpack nm'')) { nameSort = Internal }
           hwTy <- N.unsafeCoreTypeToHWTypeM $(curLoc) ty
           let id_ = Id nm3 (embed ty)
-              idDecl = NetDecl nm'' hwTy
+              idDecl = NetDecl Nothing nm'' hwTy
           return (id_,nm'',[idDecl])
       Right dstR -> return (dstR,Text.pack . name2String . varName $ dstR,[])
 

--- a/clash-lib/src/CLaSH/Netlist/BlackBox.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox.hs
@@ -178,12 +178,12 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
             [Right _, Left scrut] -> do
               tcm     <- Lens.use tcCache
               scrutTy <- termType tcm scrut
-              (scrutExpr,scrutDecls) <- mkExpr False (Left "tte_rhs") scrutTy scrut
+              (scrutExpr,scrutDecls) <- mkExpr False (Left "#tte_rhs") scrutTy scrut
               case scrutExpr of
                 Identifier id_ Nothing -> return (DataTag hwTy (Left id_),scrutDecls)
                 _ -> do
                   scrutHTy <- unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
-                  tmpRhs <- mkUniqueIdentifier Extended (pack "tte_rhs")
+                  tmpRhs <- mkUniqueIdentifier Extended (pack "#tte_rhs")
                   let netDeclRhs   = NetDecl tmpRhs scrutHTy
                       netAssignRhs = Assignment tmpRhs scrutExpr
                   return (DataTag hwTy (Left tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
@@ -196,11 +196,11 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
             tcm      <- Lens.use tcCache
             scrutTy  <- termType tcm scrut
             scrutHTy <- unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
-            (scrutExpr,scrutDecls) <- mkExpr False (Left "dtt_rhs") scrutTy scrut
+            (scrutExpr,scrutDecls) <- mkExpr False (Left "#dtt_rhs") scrutTy scrut
             case scrutExpr of
               Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
               _ -> do
-                tmpRhs  <- mkUniqueIdentifier Extended "dtt_rhs"
+                tmpRhs  <- mkUniqueIdentifier Extended "#dtt_rhs"
                 let netDeclRhs   = NetDecl tmpRhs scrutHTy
                     netAssignRhs = Assignment tmpRhs scrutExpr
                 return (DataTag scrutHTy (Right tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
@@ -220,7 +220,7 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
         True -> do
           nm'  <- extendIdentifier Extended dstL "_app_arg"
           nm'' <- mkUniqueIdentifier Extended nm'
-          let nm3 = (string2SystemName (Text.unpack nm'')) { nameSort = Derived }
+          let nm3 = (string2SystemName (Text.unpack nm'')) { nameSort = Internal }
           hwTy <- N.unsafeCoreTypeToHWTypeM $(curLoc) ty
           let id_ = Id nm3 (embed ty)
               idDecl = NetDecl nm'' hwTy

--- a/clash-lib/src/CLaSH/Netlist/BlackBox.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox.hs
@@ -41,8 +41,8 @@ import           CLaSH.Core.TyCon              as C (tyConDataCons)
 import           CLaSH.Core.Util               (collectArgs, isFun, termType)
 import           CLaSH.Core.Var                as V (Id, Var (..))
 import           CLaSH.Driver.Types            (CLaSHException (..))
-import {-# SOURCE #-} CLaSH.Netlist            (genComponent, mkDcApplication,
-                                                mkExpr)
+import {-# SOURCE #-} CLaSH.Netlist
+  (genComponent, mkDcApplication, mkExpr, mkProjection)
 import           CLaSH.Netlist.BlackBox.Types  as B
 import           CLaSH.Netlist.BlackBox.Util   as B
 import           CLaSH.Netlist.Id              (IdType (..))
@@ -132,6 +132,9 @@ mkArgument bndr e = do
         (Data dc, args) -> do
           (exprN,dcDecls) <- mkDcApplication hwTy (Left bndr) dc (lefts args)
           return ((exprN,hwTy,isConstant e),dcDecls)
+        (Case scrut ty' [alt],[]) -> do
+          (projection,decls) <- mkProjection (Left bndr) scrut ty' alt
+          return ((projection,hwTy,False),decls)
         _ ->
           return ((Identifier (error ($(curLoc) ++ "Forced to evaluate unexpected function argument: " ++ eTyMsg)) Nothing
                   ,hwTy,False),[])

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
@@ -69,6 +69,7 @@ pTagE =  O                 <$  pToken "~RESULT"
      <|> I                 <$> (pToken "~ARG" *> pBrackets pNatural)
      <|> L                 <$> (pToken "~LIT" *> pBrackets pNatural)
      <|> N                 <$> (pToken "~NAME" *> pBrackets pNatural)
+     <|> Var               <$> (pToken "~VAR" *> pBrackets pSigD) <*> pBrackets pNatural
      <|> (Sym Text.empty)  <$> (pToken "~SYM" *> pBrackets pNatural)
      <|> Typ Nothing       <$  pToken "~TYPO"
      <|> (Typ . Just)      <$> (pToken "~TYP" *> pBrackets pNatural)

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
@@ -97,6 +97,7 @@ pTagE =  O                 <$  pToken "~RESULT"
      <|> IsVar             <$> (pToken "~ISVAR" *> pBrackets pNatural)
      <|> IsGated           <$> (pToken "~ISGATED" *> pBrackets pNatural)
      <|> IsSync            <$> (pToken "~ISSYNC" *> pBrackets pNatural)
+     <|> OutputWireReg     <$> (pToken "~OUTPUTWIREREG" *> pBrackets pNatural)
      <|> GenSym            <$> (pToken "~GENSYM" *> pBrackets pSigD) <*> pBrackets pNatural
      <|> And               <$> (pToken "~AND" *> listParser pTagE)
      <|> Vars              <$> (pToken "~VARS" *> pBrackets pNatural)

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
@@ -20,6 +20,7 @@ data Element = C   !Text         -- ^ Constant
              | I   !Int          -- ^ Input hole
              | N   !Int          -- ^ Name hole
              | L   !Int          -- ^ Literal hole
+             | Var [Element] !Int    --
              | Sym !Text !Int    -- ^ Symbol hole
              | Typ !(Maybe Int)  -- ^ Type declaration hole
              | TypM !(Maybe Int) -- ^ Type root hole

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
@@ -47,6 +47,7 @@ data Element = C   !Text         -- ^ Constant
              | IsVar !Int
              | IsGated !Int
              | IsSync !Int
+             | OutputWireReg !Int
              | Vars !Int
              | GenSym [Element] !Int
              | SigD [Element] !(Maybe Int)

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
@@ -39,6 +39,7 @@ import           CLaSH.Backend                        (Backend (..))
 import           CLaSH.Driver.Types                   (CLaSHException (..))
 import           CLaSH.Netlist.BlackBox.Parser
 import           CLaSH.Netlist.BlackBox.Types
+import           CLaSH.Netlist.Id                     (IdType (..))
 import           CLaSH.Netlist.Types
   (HWType (..), Identifier, BlackBoxContext (..), Expr (..), Literal (..),
    NetlistMonad, Modifier (..))
@@ -92,7 +93,7 @@ setSym bbCtx l = evalStateT (mapM setSym' l) IntMap.empty
         symM <- IntMap.lookup i <$> get
         case symM of
           Nothing -> do
-            t <- lift (mkUniqueIdentifier (Text.pack "n"))
+            t <- lift (mkUniqueIdentifier Basic (Text.pack "n"))
             modify (IntMap.insert i t)
             return (Sym t i)
           Just t -> return (Sym t i)
@@ -100,7 +101,7 @@ setSym bbCtx l = evalStateT (mapM setSym' l) IntMap.empty
         symM <- IntMap.lookup i <$> get
         case symM of
           Nothing -> do
-            t' <- lift (mkUniqueIdentifier (concatT t))
+            t' <- lift (mkUniqueIdentifier Basic (concatT t))
             modify (IntMap.insert i t')
             return (GenSym [C t'] i)
           Just _ -> error ("Symbol #" ++ show (t,i) ++ " is already defined")

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
@@ -15,11 +15,9 @@
 
 module CLaSH.Netlist.BlackBox.Util where
 
---import           Control.Lens                         (at, use, (%=), (+=), _1,
---                                                       _2)
 import           Control.Exception                    (throw)
-import           Control.Monad.State                  (State, StateT, evalStateT,
-                                                       lift, modify, get)
+import           Control.Lens                         (_1,_2,(%=),use)
+import           Control.Monad.State                  (State, StateT (..), lift)
 import           Data.Bool                            (bool)
 import           Data.Foldable                        (foldrM)
 import qualified Data.IntMap                          as IntMap
@@ -81,28 +79,44 @@ extractLiterals = map (\case (e,_,_) -> e)
 setSym
   :: BlackBoxContext
   -> BlackBoxTemplate
-  -> NetlistMonad BlackBoxTemplate
-setSym bbCtx l = evalStateT (mapM setSym' l) IntMap.empty
+  -> NetlistMonad (BlackBoxTemplate,[N.Declaration])
+setSym bbCtx l = do
+    (a,(_,decls)) <- runStateT (mapM setSym' l) (IntMap.empty,IntMap.empty)
+    return (a,concatMap snd (IntMap.elems decls))
   where
     setSym' :: Element
-            -> StateT (IntMap.IntMap Identifier)
+            -> StateT ( IntMap.IntMap Identifier
+                      , IntMap.IntMap (Identifier,[N.Declaration]))
                       NetlistMonad
                       Element
     setSym' e = case e of
+      Var nm i | i < length (bbInputs bbCtx) -> case bbInputs bbCtx !! i of
+        (Identifier nm' Nothing,_,_) -> return (Var [C nm'] i)
+        (e',hwTy,_) -> do
+          varM <- IntMap.lookup i <$> use _2
+          case varM of
+            Nothing -> do
+              nm' <- lift (mkUniqueIdentifier Extended (concatT (C "#":nm)))
+              let decls = [N.NetDecl Nothing nm' hwTy
+                          ,N.Assignment nm' e'
+                          ]
+              _2 %= (IntMap.insert i (nm',decls))
+              return (Var [C nm'] i)
+            Just (nm',_) -> return (Var [C nm'] i)
       Sym _ i -> do
-        symM <- IntMap.lookup i <$> get
+        symM <- IntMap.lookup i <$> use _1
         case symM of
           Nothing -> do
-            t <- lift (mkUniqueIdentifier Basic (Text.pack "n"))
-            modify (IntMap.insert i t)
+            t <- lift (mkUniqueIdentifier Extended (Text.pack "#n"))
+            _1 %= (IntMap.insert i t)
             return (Sym t i)
           Just t -> return (Sym t i)
       GenSym t i -> do
-        symM <- IntMap.lookup i <$> get
+        symM <- IntMap.lookup i <$> use _1
         case symM of
           Nothing -> do
             t' <- lift (mkUniqueIdentifier Basic (concatT t))
-            modify (IntMap.insert i t')
+            _1 %= (IntMap.insert i t')
             return (GenSym [C t'] i)
           Just _ -> error ("Symbol #" ++ show (t,i) ++ " is already defined")
       D (Decl n l') -> D <$> (Decl n <$> mapM (combineM (mapM setSym') (mapM setSym')) l')
@@ -163,25 +177,52 @@ renderBlackBox l bbCtx
   = fmap Text.concat
   $ mapM (renderElem bbCtx) l
 
+-- | Assign @Var@ holes in the context of a primitive HDL template that is
+-- passed as an argument of a higher-order HDL template. For the general case,
+-- use 'setSym'
+--
+-- This functions errors when the @Var@ hole cannot be filled with a variable,
+-- as it is (currently) impossible to create unique names this late in the
+-- pipeline.
+setSimpleVar
+  :: BlackBoxContext
+  -> BlackBoxTemplate
+  -> BlackBoxTemplate
+setSimpleVar bbCtx = map go
+  where
+    go e = case e of
+      Var _ i
+        | i < length (bbInputs bbCtx)
+        , (Identifier nm' Nothing,_,_) <- bbInputs bbCtx !! i
+        -> Var [C nm'] i
+        | otherwise
+        -> error $ $(curLoc) ++ "You can only pass variables to function arguments in a higher-order primitive"
+      D (Decl n l') -> D (Decl n (map (map go *** map go) l'))
+      IF c t f      -> IF c (map go t) (map go f)
+      SigD e' m     -> SigD (map go e') m
+      BV t e' m     -> BV t (map go e') m
+      _             -> e
+
 -- | Render a single template element
 renderElem :: Backend backend
            => BlackBoxContext
            -> Element
            -> State backend Text
 renderElem b (D (Decl n (l:ls))) = do
-    (o,oTy,_) <- idToExpr <$> combineM (lineToIdentifier b) (return . lineToType b) l
-    is <- mapM (fmap idToExpr . combineM (lineToIdentifier b) (return . lineToType b)) ls
-    let Just (templ,_,pCtx)  = IntMap.lookup n (bbFunctions b)
-        b' = pCtx { bbResult = (o,oTy), bbInputs = bbInputs pCtx ++ is }
-    templ' <- case templ of
-                Left t  -> return t
-                Right d -> do Just inst' <- inst d
-                              return . parseFail . displayT $ renderCompact inst'
-    if verifyBlackBoxContext b' templ'
-      then Text.concat <$> mapM (renderElem b') templ'
-      else do
-        sp <- getSrcSpan
-        throw (CLaSHException sp ($(curLoc) ++ "\nCan't match context:\n" ++ show b' ++ "\nwith template:\n" ++ show templ) Nothing)
+  (o,oTy,_) <- idToExpr <$> combineM (lineToIdentifier b) (return . lineToType b) l
+  is <- mapM (fmap idToExpr . combineM (lineToIdentifier b) (return . lineToType b)) ls
+  let Just (templ,_,pCtx)  = IntMap.lookup n (bbFunctions b)
+      b' = pCtx { bbResult = (o,oTy), bbInputs = bbInputs pCtx ++ is }
+  templ' <- case templ of
+              Left t  -> return t
+              Right d -> do Just inst' <- inst d
+                            return . parseFail . displayT $ renderCompact inst'
+  let t2 = setSimpleVar b' templ'
+  if verifyBlackBoxContext b' t2
+    then Text.concat <$> mapM (renderElem b') t2
+    else do
+      sp <- getSrcSpan
+      throw (CLaSHException sp ($(curLoc) ++ "\nCan't match context:\n" ++ show b' ++ "\nwith template:\n" ++ show templ) Nothing)
 
 renderElem b (SigD e m) = do
   e' <- Text.concat <$> mapM (renderElem b) e
@@ -316,6 +357,7 @@ renderTag b (L n)           = let (e,_,_) = bbInputs b !! n
     mkLit (DataCon _ (DC (Void, _)) [Literal (Just (Unsigned _,_)) i]) = Literal Nothing i
     mkLit i                               = i
 
+renderTag _ (Var [C t] _) = return t
 renderTag _ (Sym t _) = return t
 
 renderTag b (BV True es e) = do
@@ -407,6 +449,9 @@ prettyElem O = return "~RESULT"
 prettyElem (I i) = (displayT . renderOneLine) <$> (text "~ARG" <> brackets (int i))
 prettyElem (L i) = (displayT . renderOneLine) <$> (text "~LIT" <> brackets (int i))
 prettyElem (N i) = (displayT . renderOneLine) <$> (text "~NAME" <> brackets (int i))
+prettyElem (Var es i) = do
+  es' <- prettyBlackBox es
+  (displayT .renderOneLine) <$> (text "~VAR" <> brackets (text es') <> brackets (int i))
 prettyElem (Sym _ i) = (displayT . renderOneLine) <$> (text "~SYM" <> brackets (int i))
 prettyElem (Typ Nothing) = return "~TYPO"
 prettyElem (Typ (Just i)) = (displayT . renderOneLine) <$> (text "~TYP" <> brackets (int i))
@@ -484,6 +529,7 @@ usedArguments = nub . concatMap go
       I i -> [i]
       L i -> [i]
       N i -> [i]
+      Var _ i -> [i]
       IndexType e -> go e
       FilePath e -> go e
       IF b esT esF -> go b ++ usedArguments esT ++ usedArguments esF

--- a/clash-lib/src/CLaSH/Netlist/Id.hs
+++ b/clash-lib/src/CLaSH/Netlist/Id.hs
@@ -11,7 +11,8 @@
 {-# LANGUAGE ViewPatterns      #-}
 
 module CLaSH.Netlist.Id
-  ( mkBasicId'
+  ( IdType (..)
+  , mkBasicId'
   , stripDollarPrefixes
   )
 where
@@ -22,6 +23,8 @@ where
 
 import Data.Char      (isAsciiLower,isAsciiUpper,isDigit)
 import Data.Text.Lazy as Text
+
+data IdType = Basic | Extended
 
 mkBasicId' :: Bool
            -> Text

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -162,6 +162,7 @@ data Modifier
   | DC (HWType,Int) -- ^ See expression in a DataCon context: (Type of the expression, DataCon tag)
   | VecAppend -- ^ See the expression in the context of a Vector append operation
   | RTreeAppend -- ^ See the expression in the context of a Tree append operation
+  | Nested Modifier Modifier
   deriving Show
 
 -- | Expression used in RHS of a declaration

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -78,7 +78,7 @@ data Component
   = Component
   { componentName :: !Identifier -- ^ Name of the component
   , inputs        :: [(Identifier,HWType)] -- ^ Input ports
-  , outputs       :: [(Identifier,HWType)] -- ^ Output ports
+  , outputs       :: [(WireOrReg,(Identifier,HWType))] -- ^ Output ports
   , declarations  :: [Declaration] -- ^ Internal declarations
   }
   deriving Show
@@ -137,13 +137,18 @@ data Declaration
   -- * List of: (Maybe expression scrutinized expression is compared with,RHS of alternative)
   | InstDecl !Identifier !Identifier [(Expr,PortDirection,HWType,Expr)] -- ^ Instantiation of another component
   | BlackBoxD !S.Text [S.Text] [S.Text] (Maybe (S.Text,BlackBoxTemplate)) !BlackBoxTemplate BlackBoxContext -- ^ Instantiation of blackbox declaration
-  | NetDecl' (Maybe Identifier) !Identifier (Either Identifier HWType) -- ^ Signal declaration
+  | NetDecl' (Maybe Identifier) WireOrReg !Identifier (Either Identifier HWType) -- ^ Signal declaration
   deriving Show
 
+data WireOrReg = Wire | Reg
+  deriving (Show,Generic)
+
+instance NFData WireOrReg
+
 pattern NetDecl :: Maybe Identifier -> Identifier -> HWType -> Declaration
-pattern NetDecl note d ty <- NetDecl' note d (Right ty)
+pattern NetDecl note d ty <- NetDecl' note Wire d (Right ty)
   where
-    NetDecl note d ty = NetDecl' note d (Right ty)
+    NetDecl note d ty = NetDecl' note Wire d (Right ty)
 
 data PortDirection = In | Out
   deriving Show

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -31,9 +31,9 @@ import Unbound.Generics.LocallyNameless              (Fresh, FreshMT)
 import SrcLoc                               (SrcSpan)
 
 import CLaSH.Annotations.TopEntity          (TopEntity)
-import CLaSH.Core.Term                      (Term, TmName)
+import CLaSH.Core.Term                      (Term, TmName, TmOccName)
 import CLaSH.Core.Type                      (Type)
-import CLaSH.Core.TyCon                     (TyCon, TyConName)
+import CLaSH.Core.TyCon                     (TyCon, TyConOccName)
 import CLaSH.Core.Util                      (Gamma)
 import CLaSH.Netlist.BlackBox.Types
 import CLaSH.Primitives.Types               (PrimMap)
@@ -49,21 +49,22 @@ newtype NetlistMonad a =
 -- | State of the NetlistMonad
 data NetlistState
   = NetlistState
-  { _bindings       :: HashMap TmName (Type,SrcSpan,Term) -- ^ Global binders
+  { _bindings       :: HashMap TmOccName (TmName,Type,SrcSpan,Term) -- ^ Global binders
   , _varEnv         :: Gamma -- ^ Type environment/context
   , _varCount       :: !Int -- ^ Number of signal declarations
-  , _components     :: HashMap TmName (SrcSpan,Component) -- ^ Cached components
+  , _components     :: HashMap TmOccName (SrcSpan,Component) -- ^ Cached components
   , _primitives     :: PrimMap BlackBoxTemplate -- ^ Primitive Definitions
-  , _typeTranslator :: HashMap TyConName TyCon -> Type -> Maybe (Either String HWType) -- ^ Hardcoded Type -> HWType translator
-  , _tcCache        :: HashMap TyConName TyCon -- ^ TyCon cache
+  , _typeTranslator :: HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType)
+  -- ^ Hardcoded Type -> HWType translator
+  , _tcCache        :: HashMap TyConOccName TyCon -- ^ TyCon cache
   , _curCompNm      :: !(Identifier,SrcSpan)
   , _dataFiles      :: [(String,FilePath)]
   , _intWidth       :: Int
   , _mkBasicIdFn    :: Identifier -> Identifier
   , _seenIds        :: [Identifier]
   , _seenComps      :: [Identifier]
-  , _componentNames :: HashMap TmName Identifier
-  , _topEntityAnns  :: HashMap TmName (Type, Maybe TopEntity)
+  , _componentNames :: HashMap TmOccName Identifier
+  , _topEntityAnns  :: HashMap TmOccName (Type, Maybe TopEntity)
   , _hdlDir         :: FilePath
   }
 

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -196,10 +196,13 @@ data BlackBoxContext
   = Context
   { bbResult    :: (Expr,HWType) -- ^ Result name and type
   , bbInputs    :: [(Expr,HWType,Bool)] -- ^ Argument names, types, and whether it is a literal
-  , bbFunctions :: IntMap (Either BlackBoxTemplate Declaration,BlackBoxContext)
+  , bbFunctions :: IntMap (Either BlackBoxTemplate Declaration,WireOrReg,BlackBoxContext)
   -- ^ Function arguments (subset of inputs):
   --
-  -- * (Blackbox Template,Partial Blackbox Concext)
+  -- * ( Blackbox Template
+  --   , Whether the result should be /reg/ or a /wire/ (Verilog only)
+  --   , Partial Blackbox Context
+  --   )
   , bbQsysIncName :: Maybe Identifier
   }
   deriving Show

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -137,13 +137,13 @@ data Declaration
   -- * List of: (Maybe expression scrutinized expression is compared with,RHS of alternative)
   | InstDecl !Identifier !Identifier [(Expr,PortDirection,HWType,Expr)] -- ^ Instantiation of another component
   | BlackBoxD !S.Text [S.Text] [S.Text] (Maybe (S.Text,BlackBoxTemplate)) !BlackBoxTemplate BlackBoxContext -- ^ Instantiation of blackbox declaration
-  | NetDecl' !Identifier (Either Identifier HWType) -- ^ Signal declaration
+  | NetDecl' (Maybe Identifier) !Identifier (Either Identifier HWType) -- ^ Signal declaration
   deriving Show
 
-pattern NetDecl :: Identifier -> HWType -> Declaration
-pattern NetDecl d ty <- NetDecl' d (Right ty)
+pattern NetDecl :: Maybe Identifier -> Identifier -> HWType -> Declaration
+pattern NetDecl note d ty <- NetDecl' note d (Right ty)
   where
-    NetDecl d ty = NetDecl' d (Right ty)
+    NetDecl note d ty = NetDecl' note d (Right ty)
 
 data PortDirection = In | Out
   deriving Show

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -36,6 +36,7 @@ import CLaSH.Core.Type                      (Type)
 import CLaSH.Core.TyCon                     (TyCon, TyConOccName)
 import CLaSH.Core.Util                      (Gamma)
 import CLaSH.Netlist.BlackBox.Types
+import CLaSH.Netlist.Id                     (IdType)
 import CLaSH.Primitives.Types               (PrimMap)
 import CLaSH.Signal.Internal                (ClockKind, ResetKind)
 import CLaSH.Util
@@ -60,7 +61,8 @@ data NetlistState
   , _curCompNm      :: !(Identifier,SrcSpan)
   , _dataFiles      :: [(String,FilePath)]
   , _intWidth       :: Int
-  , _mkBasicIdFn    :: Identifier -> Identifier
+  , _mkIdentifierFn :: IdType -> Identifier -> Identifier
+  , _extendIdentifierFn :: IdType -> Identifier -> Identifier -> Identifier
   , _seenIds        :: [Identifier]
   , _seenComps      :: [Identifier]
   , _componentNames :: HashMap TmOccName Identifier

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -17,7 +17,6 @@ module CLaSH.Netlist.Util where
 import           Control.Error           (hush)
 import           Control.Lens            ((.=),(%=))
 import qualified Control.Lens            as Lens
-import qualified Control.Monad           as Monad
 import           Control.Monad.Trans.Except (runExcept)
 import           Data.Either             (partitionEithers)
 import           Data.HashMap.Strict     (HashMap)
@@ -25,9 +24,9 @@ import qualified Data.HashMap.Strict     as HashMap
 import           Data.Maybe              (catMaybes,fromMaybe)
 import           Data.Text.Lazy          (Text,append,pack,unpack)
 import qualified Data.Text.Lazy          as Text
-import           Unbound.Generics.LocallyNameless (Embed, Fresh, bind, embed, makeName,
-                                          name2Integer, name2String, unbind,
-                                          unembed, unrec)
+import           Unbound.Generics.LocallyNameless
+  (Embed, Fresh, embed, unbind, unembed, unrec)
+import qualified Unbound.Generics.LocallyNameless as Unbound
 
 import           CLaSH.Annotations.TopEntity (PortName (..), TopEntity (..))
 import           CLaSH.Driver.TopWrapper
@@ -35,10 +34,12 @@ import           CLaSH.Driver.TopWrapper
 import           CLaSH.Driver.Types      (Manifest (..))
 import           CLaSH.Core.DataCon      (DataCon (..))
 import           CLaSH.Core.FreeVars     (termFreeIds, typeFreeVars)
+import           CLaSH.Core.Name         (Name (..), appendToName, name2String)
 import           CLaSH.Core.Pretty       (showDoc)
-import           CLaSH.Core.Subst        (substTys)
-import           CLaSH.Core.Term         (LetBinding, Term (..), TmName)
-import           CLaSH.Core.TyCon        (TyCon (..), TyConName, tyConDataCons)
+import           CLaSH.Core.Subst        (substTms, substTys)
+import           CLaSH.Core.Term         (LetBinding, Term (..), TmName, TmOccName)
+import           CLaSH.Core.TyCon
+  (TyCon (..), TyConName, TyConOccName, tyConDataCons)
 import           CLaSH.Core.Type         (Type (..), TypeView (..), LitTy (..),
                                           coreView, splitTyConAppM, tyView)
 import           CLaSH.Core.Util         (collectBndrs, termType, tyNatSize)
@@ -58,7 +59,7 @@ mkBasicId n = do
 -- and a variable reference that is the body of the let-binding. Returns a
 -- String containing the error is the term was not in a normalized form.
 splitNormalized :: Fresh m
-                => HashMap TyConName TyCon
+                => HashMap TyConOccName TyCon
                 -> Term
                 -> m (Either String ([Id],[LetBinding],Id))
 splitNormalized tcm expr = do
@@ -78,8 +79,8 @@ splitNormalized tcm expr = do
 -- | Converts a Core type to a HWType given a function that translates certain
 -- builtin types. Errors if the Core type is not translatable.
 unsafeCoreTypeToHWType :: String
-                       -> (HashMap TyConName TyCon -> Type -> Maybe (Either String HWType))
-                       -> HashMap TyConName TyCon
+                       -> (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
+                       -> HashMap TyConOccName TyCon
                        -> Type
                        -> HWType
 unsafeCoreTypeToHWType loc builtInTranslation m = either (error . (loc ++)) id . coreTypeToHWType builtInTranslation m
@@ -96,7 +97,7 @@ coreTypeToHWTypeM :: Type
 coreTypeToHWTypeM ty = hush <$> (coreTypeToHWType <$> Lens.use typeTranslator <*> Lens.use tcCache <*> pure ty)
 
 -- | Returns the name and period of the clock corresponding to a type
-synchronizedClk :: HashMap TyConName TyCon -- ^ TyCon cache
+synchronizedClk :: HashMap TyConOccName TyCon -- ^ TyCon cache
                 -> Type
                 -> Maybe (Identifier,Integer)
 synchronizedClk tcm ty
@@ -112,9 +113,9 @@ synchronizedClk tcm ty
         Just (_,[LitTy (SymTy s),litTy])
           | Right i <- runExcept (tyNatSize tcm litTy) -> Just (pack s,i)
         _ -> error $ $(curLoc) ++ "Clock period not a simple literal: " ++ showDoc ty
-      _                               -> case tyConDataCons (tcm HashMap.! tyCon) of
+      _                               -> case tyConDataCons (tcm HashMap.! nameOcc tyCon) of
                                            [dc] -> let argTys   = dcArgTys dc
-                                                       argTVs   = dcUnivTyVars dc
+                                                       argTVs   = map nameOcc (dcUnivTyVars dc)
                                                        argSubts = zip argTVs args
                                                        args'    = map (substTys argSubts) argTys
                                                    in case args' of
@@ -127,8 +128,8 @@ synchronizedClk tcm ty
 -- | Converts a Core type to a HWType given a function that translates certain
 -- builtin types. Returns a string containing the error message when the Core
 -- type is not translatable.
-coreTypeToHWType :: (HashMap TyConName TyCon -> Type -> Maybe (Either String HWType))
-                 -> HashMap TyConName TyCon
+coreTypeToHWType :: (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
+                 -> HashMap TyConOccName TyCon
                  -> Type
                  -> Either String HWType
 coreTypeToHWType builtInTranslation m (builtInTranslation m -> Just hty) = hty
@@ -137,8 +138,8 @@ coreTypeToHWType builtInTranslation m ty@(tyView -> TyConApp tc args) = mkADT bu
 coreTypeToHWType _ _ ty = Left $ "Can't translate non-tycon type: " ++ showDoc ty
 
 -- | Converts an algebraic Core type (split into a TyCon and its argument) to a HWType.
-mkADT :: (HashMap TyConName TyCon -> Type -> Maybe (Either String HWType)) -- ^ Hardcoded Type -> HWType translator
-      -> HashMap TyConName TyCon -- ^ TyCon cache
+mkADT :: (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType)) -- ^ Hardcoded Type -> HWType translator
+      -> HashMap TyConOccName TyCon -- ^ TyCon cache
       -> String -- ^ String representation of the Core type for error messages
       -> TyConName -- ^ The TyCon
       -> [Type] -- ^ Its applied arguments
@@ -147,13 +148,13 @@ mkADT _ m tyString tc _
   | isRecursiveTy m tc
   = Left $ $(curLoc) ++ "Can't translate recursive type: " ++ tyString
 
-mkADT builtInTranslation m tyString tc args = case tyConDataCons (m HashMap.! tc) of
+mkADT builtInTranslation m tyString tc args = case tyConDataCons (m HashMap.! nameOcc tc) of
   []  -> Left $ $(curLoc) ++ "Can't translate empty type: " ++ tyString
   dcs -> do
     let tcName       = pack $ name2String tc
         argTyss      = map dcArgTys dcs
         argTVss      = map dcUnivTyVars dcs
-        argSubts     = map (`zip` args) argTVss
+        argSubts     = map ((`zip` args) . map nameOcc) argTVss
         substArgTyss = zipWith (\s tys -> map (substTys s) tys) argSubts argTyss
     argHTyss         <- mapM (mapM (coreTypeToHWType builtInTranslation m)) substArgTyss
     case (dcs,argHTyss) of
@@ -168,8 +169,8 @@ mkADT builtInTranslation m tyString tc args = case tyConDataCons (m HashMap.! tc
                                                 ) dcs elemHTys
 
 -- | Simple check if a TyCon is recursively defined.
-isRecursiveTy :: HashMap TyConName TyCon -> TyConName -> Bool
-isRecursiveTy m tc = case tyConDataCons (m HashMap.! tc) of
+isRecursiveTy :: HashMap TyConOccName TyCon -> TyConName -> Bool
+isRecursiveTy m tc = case tyConDataCons (m HashMap.! nameOcc tc) of
     []  -> False
     dcs -> let argTyss      = map dcArgTys dcs
                argTycons    = (map fst . catMaybes) $ (concatMap . map) splitTyConAppM argTyss
@@ -177,9 +178,9 @@ isRecursiveTy m tc = case tyConDataCons (m HashMap.! tc) of
 
 -- | Determines if a Core type is translatable to a HWType given a function that
 -- translates certain builtin types.
-representableType :: (HashMap TyConName TyCon -> Type -> Maybe (Either String HWType))
+representableType :: (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
                   -> Bool -- ^ Allow zero-bit things
-                  -> HashMap TyConName TyCon
+                  -> HashMap TyConOccName TyCon
                   -> Type
                   -> Bool
 representableType builtInTranslation allowZero m = either (const False) isRepresentable . coreTypeToHWType builtInTranslation m
@@ -264,15 +265,19 @@ mkUniqueNormalized (args,binds,res) = do
   ([res1],subst') <- mkUnique subst [res]
   let bndrs = map fst binds
       exprs = map (unembed . snd) binds
-      usesOutput = concatMap (filter (== varName res) . Lens.toListOf termFreeIds) exprs
+      usesOutput = concatMap (filter ( == (nameOcc . varName) res)
+                                     . Lens.toListOf termFreeIds
+                                     ) exprs
   -- If the let-binder carrying the result is used in a feedback loop
   -- rename the let-binder to "<X>_rec", and assign the "<X>_rec" to
   -- "<X>". We do this because output ports in most HDLs cannot be read.
   (res2,subst'',extraBndr) <- case usesOutput of
-    [] -> return (varName res1,(res,res1):subst',[] :: [(Id, Embed Term)])
+    [] -> return (varName res1
+                 ,(nameOcc $ varName res, Var (unembed $ varType res1) (varName res1)):subst'
+                 ,[] :: [(Id, Embed Term)])
     _  -> do
       ([res3],_) <- mkUnique [] [modifyVarName (`appendToName` "_rec") res1]
-      return (varName res3,(res,res3):subst'
+      return (varName res3,(nameOcc $ varName res,Var (unembed $ varType res3) (varName res3)):subst'
              ,[(res1,embed $ Var (unembed $ varType res) (varName res3))])
   -- Replace occurences of "<X>" by "<X>_rec"
   let resN    = varName res
@@ -281,45 +286,30 @@ mkUniqueNormalized (args,binds,res) = do
   -- Make let-binders unique
   (bndrsL',substL) <- mkUnique subst'' bndrsL
   (bndrsR',substR) <- mkUnique substL  bndrsR
-  -- Replace old IDs by update unique IDs in the RHSs of the let-binders
-  exprs' <- fmap (map embed) $ Monad.foldM subsBndrs exprs substR
+  -- Replace old IDs by updated unique IDs in the RHSs of the let-binders
+  let exprs' = map (embed . substTms substR) exprs
   -- Return the uniquely named arguments, let-binders, and result
   return (args',zip (bndrsL' ++ r:bndrsR') exprs' ++ extraBndr,varName res1)
-  where
-    subsBndrs :: [Term] -> (Id,Id) -> NetlistMonad [Term]
-    subsBndrs es (f,r) = mapM (subsBndr f r) es
-
-    subsBndr :: Id -> Id -> Term -> NetlistMonad Term
-    subsBndr f r e = case e of
-      Var t v | v == varName f -> return . Var t $ varName r
-      App e1 e2                -> App <$> subsBndr f r e1
-                                      <*> subsBndr f r e2
-      Case scrut ty alts       -> Case <$> subsBndr f r scrut
-                                       <*> pure ty
-                                       <*> mapM ( return
-                                                . uncurry bind
-                                                <=< secondM (subsBndr f r)
-                                                <=< unbind
-                                                ) alts
-      _ -> return e
 
 -- | Make a set of IDs unique; also returns a substitution from old ID to new
 -- updated unique ID.
-mkUnique :: [(Id,Id)] -- ^ Existing substitution
+mkUnique :: [(TmOccName,Term)] -- ^ Existing substitution
          -> [Id]      -- ^ IDs to make unique
-         -> NetlistMonad ([Id],[(Id,Id)])
+         -> NetlistMonad ([Id],[(TmOccName,Term)])
          -- ^ (Unique IDs, update substitution)
 mkUnique = go []
   where
-    go :: [Id] -> [(Id,Id)] -> [Id] -> NetlistMonad ([Id],[(Id,Id)])
+    go :: [Id] -> [(TmOccName,Term)] -> [Id] -> NetlistMonad ([Id],[(TmOccName,Term)])
     go processed subst []     = return (reverse processed,subst)
     go processed subst (i:is) = do
       iN <- mkUniqueIdentifier . pack . name2String $ varName i
       let iN_unpacked = unpack iN
           i'          = modifyVarName (repName iN_unpacked) i
-      go (i':processed) ((i,i'):subst) is
+      go (i':processed)
+         ((nameOcc . varName $ i,Var (unembed $ varType i') (varName i')):subst)
+         is
 
-    repName s n = makeName s (name2Integer n)
+    repName s (Name sort _ loc) = Name sort (Unbound.string2Name s) loc
 
 mkUniqueIdentifier :: Identifier
                    -> NetlistMonad Identifier
@@ -342,12 +332,6 @@ mkUniqueIdentifier nm = do
          else do
           seenIds %= (i':)
           return i'
-
--- | Append a string to a name
-appendToName :: TmName
-             -> String
-             -> TmName
-appendToName n s = makeName (name2String n ++ s) (name2Integer n)
 
 -- | Preserve the Netlist '_varEnv' and '_varCount' when executing a monadic action
 preserveVarEnv :: NetlistMonad a

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -495,7 +495,7 @@ mkTopInput topM itys pM = case pM of
     -- No @PortName@
     go itys' (i,hwty) = do
       i' <- mkUniqueIdentifier Basic i
-      let iDecl = NetDecl i' hwty
+      let iDecl = NetDecl Nothing i' hwty
       case hwty of
         Vector sz hwty' -> do
           let inputs1 = map (appendNumber (i,hwty')) [0..sz-1]
@@ -530,14 +530,14 @@ mkTopInput topM itys pM = case pM of
     go' (PortName p) (ity:itys') (i,hwty) = do
       let pN = portName p i
       pN' <- mkUniqueIdentifier Basic pN
-      return (itys',([(pN,pN',hwty)],[NetDecl' pN' (Left ity)],Right (pN',hwty)))
+      return (itys',([(pN,pN',hwty)],[NetDecl' Nothing pN' (Left ity)],Right (pN',hwty)))
 
     go' (PortName _) [] _ = error "This shouldnt happen"
 
     go' (PortField p ps) itys' (i,hwty) = do
       let pN = portName p i
       pN' <- mkUniqueIdentifier Basic pN
-      let pDecl = NetDecl pN' hwty
+      let pDecl = NetDecl Nothing pN' hwty
       case hwty of
         Vector sz hwty' -> do
           let inputs1 = map (appendNumber (pN,hwty')) [0..sz-1]
@@ -595,7 +595,7 @@ mkTopOutput topM otys pM = case pM of
     -- No @PortName@
     go otys' (o,hwty) = do
       o' <- mkUniqueIdentifier Basic o
-      let oDecl = NetDecl o' hwty
+      let oDecl = NetDecl Nothing o' hwty
       case hwty of
         Vector sz hwty' -> do
           let outputs1 = map (appendNumber (o,hwty')) [0..sz-1]
@@ -627,14 +627,14 @@ mkTopOutput topM otys pM = case pM of
     go' (PortName p) (oty:otys') (o,hwty) = do
       let pN = portName p o
       pN' <- mkUniqueIdentifier Basic pN
-      return (otys',([(pN,pN',hwty)],[NetDecl' pN' (Left oty)],Right (pN',hwty)))
+      return (otys',([(pN,pN',hwty)],[NetDecl' Nothing pN' (Left oty)],Right (pN',hwty)))
 
     go' (PortName _) [] _ = error "This shouldnt happen"
 
     go' (PortField p ps) otys' (o,hwty) = do
       let pN = portName p o
       pN' <- mkUniqueIdentifier Basic pN
-      let pDecl = NetDecl pN' hwty
+      let pDecl = NetDecl Nothing pN' hwty
       case hwty of
         Vector sz hwty' -> do
           let outputs1 = map (appendNumber (pN,hwty')) [0..sz-1]

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -530,7 +530,7 @@ mkTopInput topM itys pM = case pM of
     go' (PortName p) (ity:itys') (i,hwty) = do
       let pN = portName p i
       pN' <- mkUniqueIdentifier Basic pN
-      return (itys',([(pN,pN',hwty)],[NetDecl' Nothing pN' (Left ity)],Right (pN',hwty)))
+      return (itys',([(pN,pN',hwty)],[NetDecl' Nothing Wire pN' (Left ity)],Right (pN',hwty)))
 
     go' (PortName _) [] _ = error "This shouldnt happen"
 
@@ -627,7 +627,7 @@ mkTopOutput topM otys pM = case pM of
     go' (PortName p) (oty:otys') (o,hwty) = do
       let pN = portName p o
       pN' <- mkUniqueIdentifier Basic pN
-      return (otys',([(pN,pN',hwty)],[NetDecl' Nothing pN' (Left oty)],Right (pN',hwty)))
+      return (otys',([(pN,pN',hwty)],[NetDecl' Nothing Wire pN' (Left oty)],Right (pN',hwty)))
 
     go' (PortName _) [] _ = error "This shouldnt happen"
 

--- a/clash-lib/src/CLaSH/Normalize/DEC.hs
+++ b/clash-lib/src/CLaSH/Normalize/DEC.hs
@@ -62,7 +62,7 @@ import qualified Unbound.Generics.LocallyNameless as Unbound
 -- internal
 import CLaSH.Core.DataCon    (DataCon, dcTag)
 import CLaSH.Core.FreeVars   (termFreeIds, typeFreeVars)
-import CLaSH.Core.Name       (Name (..), string2SystemName)
+import CLaSH.Core.Name       (Name (..), string2InternalName)
 import CLaSH.Core.Literal    (Literal (..))
 import CLaSH.Core.Term       (LetBinding, Pat (..), Term (..), TmOccName)
 import CLaSH.Core.TyCon      (tyConDataCons)
@@ -316,7 +316,7 @@ disJointSelProj argTys cs = do
             tupTy        = mkTyConApp tupTcNm tys'
             cs'          = fmap (\es -> map (es !!) tyIxs) cs
             djCase       = genCase tupTy (Just tupDc) tys' cs'
-        (scrutId,scrutVar) <- mkInternalVar (string2SystemName "tupIn") tupTy
+        (scrutId,scrutVar) <- mkInternalVar (string2InternalName "tupIn") tupTy
         projections <- mapM (mkSelectorCase ($(curLoc) ++ "disJointSelProj")
                                             tcm scrutVar (dcTag tupDc)) [0..m-1]
         return (Just (scrutId,embed djCase),projections)

--- a/clash-lib/src/CLaSH/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/CLaSH/Normalize/PrimitiveReductions.hs
@@ -38,11 +38,11 @@ module CLaSH.Normalize.PrimitiveReductions where
 import qualified Control.Lens                     as Lens
 import qualified Data.HashMap.Lazy                as HashMap
 import qualified Data.Maybe                       as Maybe
-import           Unbound.Generics.LocallyNameless (bind, embed, rec, rebind,
-                                                   string2Name)
+import           Unbound.Generics.LocallyNameless (bind, embed, rec, rebind)
 
 import           CLaSH.Core.DataCon               (DataCon, dataConInstArgTys)
 import           CLaSH.Core.Literal               (Literal (..))
+import           CLaSH.Core.Name
 import           CLaSH.Core.Pretty                (showDoc)
 import           CLaSH.Core.Term                  (Term (..), Pat (..))
 import           CLaSH.Core.Type                  (LitTy (..), Type (..),
@@ -81,7 +81,7 @@ reduceZipWith n lhsElTy rhsElTy resElTy fun lhsArg rhsArg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
       = let (varsL,elemsL)   = second concat . unzip
                              $ extractElems consCon lhsElTy 'L' n lhsArg
@@ -109,7 +109,7 @@ reduceMap n argElTy resElTy fun arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc)     <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc)     <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
       = let (vars,elems)     = second concat . unzip
                              $ extractElems consCon argElTy 'A' n arg
@@ -135,14 +135,14 @@ reduceImap n argElTy resElTy fun arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc)     <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc)     <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
       = do
         let (vars,elems)     = second concat . unzip
                              $ extractElems consCon argElTy 'I' n arg
         (Right idxTy:_,_) <- splitFunForallTy <$> termType tcm fun
         let (TyConApp idxTcNm _) = tyView idxTy
-            nTv              = string2Name "n"
+            nTv              = string2SystemName "n"
             -- fromInteger# :: KnownNat n => Integer -> Index n
             idxFromIntegerTy = ForAllTy (bind (TyVar nTv (embed typeNatKind))
                                          (foldr mkFunTy
@@ -180,12 +180,12 @@ reduceTraverse n aTy fTy bTy dict fun arg = do
   where
     go tcm apDictTcNm (coreView tcm -> Just ty') = go tcm apDictTcNm ty'
     go tcm apDictTcNm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
-      = let (Just apDictTc)    = HashMap.lookup apDictTcNm tcm
+      = let (Just apDictTc)    = HashMap.lookup (nameOcc apDictTcNm) tcm
             [apDictCon]        = tyConDataCons apDictTc
             (Just apDictIdTys) = dataConInstArgTys apDictCon [fTy]
-            apDictIds          = zipWith Id (map string2Name ["functorDict"
+            apDictIds          = zipWith Id (map string2SystemName ["functorDict"
                                                              ,"pure"
                                                              ,"ap"
                                                              ,"apConstL"
@@ -193,10 +193,10 @@ reduceTraverse n aTy fTy bTy dict fun arg = do
                                             (map embed apDictIdTys)
 
             (TyConApp funcDictTcNm _) = tyView (head apDictIdTys)
-            (Just funcDictTc) = HashMap.lookup funcDictTcNm tcm
+            (Just funcDictTc) = HashMap.lookup (nameOcc funcDictTcNm) tcm
             [funcDictCon] = tyConDataCons funcDictTc
             (Just funcDictIdTys) = dataConInstArgTys funcDictCon [fTy]
-            funcDicIds    = zipWith Id (map string2Name ["fmap","fmapConst"])
+            funcDicIds    = zipWith Id (map string2SystemName ["fmap","fmapConst"])
                                        (map embed funcDictIdTys)
 
             apPat    = DataPat (embed apDictCon) (rebind [] apDictIds)
@@ -204,21 +204,21 @@ reduceTraverse n aTy fTy bTy dict fun arg = do
 
             -- Extract the 'pure' function from the Applicative dictionary
             pureTy = apDictIdTys!!1
-            pureTm = Case dict pureTy [bind apPat (Var pureTy (string2Name "pure"))]
+            pureTm = Case dict pureTy [bind apPat (Var pureTy (string2SystemName "pure"))]
 
             -- Extract the '<*>' function from the Applicative dictionary
             apTy   = apDictIdTys!!2
-            apTm   = Case dict apTy [bind apPat (Var apTy (string2Name "ap"))]
+            apTm   = Case dict apTy [bind apPat (Var apTy (string2SystemName "ap"))]
 
             -- Extract the Functor dictionary from the Applicative dictionary
             funcTy = (head apDictIdTys)
             funcTm = Case dict funcTy
-                               [bind apPat (Var funcTy (string2Name "functorDict"))]
+                               [bind apPat (Var funcTy (string2SystemName "functorDict"))]
 
             -- Extract the 'fmap' function from the Functor dictionary
             fmapTy = (head funcDictIdTys)
-            fmapTm = Case (Var funcTy (string2Name "functorDict")) fmapTy
-                          [bind fnPat (Var fmapTy (string2Name "fmap"))]
+            fmapTm = Case (Var funcTy (string2SystemName "functorDict")) fmapTy
+                          [bind fnPat (Var fmapTy (string2SystemName "fmap"))]
 
             (vars,elems) = second concat . unzip
                          $ extractElems consCon aTy 'T' n arg
@@ -301,7 +301,7 @@ reduceFoldr n aTy fun start arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [_,consCon] <- tyConDataCons vecTc
       = let (vars,elems)     = second concat . unzip
                              $ extractElems consCon aTy 'G' n arg
@@ -325,7 +325,7 @@ reduceFold n aTy fun arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [_,consCon]  <- tyConDataCons vecTc
       = let (vars,elems)     = second concat . unzip
                              $ extractElems consCon aTy 'F' n arg
@@ -356,14 +356,14 @@ reduceDFold n aTy fun start arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [_,consCon]  <- tyConDataCons vecTc
       = do
         let  (vars,elems)     = second concat . unzip
                          $ extractElems consCon aTy 'D' n arg
         (_ltv:Right snTy:_,_) <- splitFunForallTy <$> termType tcm fun
         let (TyConApp snatTcNm _) = tyView snTy
-            (Just snatTc)         = HashMap.lookup snatTcNm tcm
+            (Just snatTc)         = HashMap.lookup (nameOcc snatTcNm) tcm
             [snatDc]              = tyConDataCons snatTc
             lbody = doFold (buildSNat snatDc) (n-1) vars
             lb    = Letrec (bind (rec (init elems)) lbody)
@@ -392,7 +392,7 @@ reduceHead n aTy vArg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [_,consCon]  <- tyConDataCons vecTc
       = let (vars,elems)  = second concat . unzip
                           $ extractElems consCon aTy 'H' n vArg
@@ -414,7 +414,7 @@ reduceTail n aTy vArg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [_,consCon]  <- tyConDataCons vecTc
       = let (_,elems)    = second concat . unzip
                          $ extractElems consCon aTy 'L' n vArg
@@ -437,7 +437,7 @@ reduceLast n aTy vArg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [_,consCon]  <- tyConDataCons vecTc
       = let (_,elems)    = unzip
                          $ extractElems consCon aTy 'L' n vArg
@@ -461,7 +461,7 @@ reduceInit n aTy vArg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [nilCon,consCon]  <- tyConDataCons vecTc
       = let (_,elems)    = unzip
                          $ extractElems consCon aTy 'L' n vArg
@@ -491,7 +491,7 @@ reduceAppend n m aTy lArg rArg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [_,consCon]  <- tyConDataCons vecTc
       = let (vars,elems) = second concat . unzip
                          $ extractElems consCon aTy 'C' n lArg
@@ -515,7 +515,7 @@ reduceUnconcat n 0 aTy arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc)     <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc)     <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
       = let nilVec           = mkVec nilCon consCon aTy 0 []
             innerVecTy       = mkTyConApp vecTcNm [LitTy (NumTy 0), aTy]
@@ -540,7 +540,7 @@ reduceTranspose n 0 aTy arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc)     <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc)     <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
       = let nilVec           = mkVec nilCon consCon aTy 0 []
             innerVecTy       = mkTyConApp vecTcNm [LitTy (NumTy 0), aTy]
@@ -561,7 +561,7 @@ reduceReplicate n aTy eTy arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc)     <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc)     <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
       = let retVec = mkVec nilCon consCon aTy n (replicate (fromInteger n) arg)
         in  changed retVec
@@ -583,13 +583,13 @@ reduceDTFold n aTy lrFun brFun arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
-      | (Just vecTc) <- HashMap.lookup vecTcNm tcm
+      | (Just vecTc) <- HashMap.lookup (nameOcc vecTcNm) tcm
       , [_,consCon]  <- tyConDataCons vecTc
       = do let (vars,elems) = second concat . unzip
                             $ extractElems consCon aTy 'T' (2^n) arg
            (_ltv:Right snTy:_,_) <- splitFunForallTy <$> termType tcm brFun
            let (TyConApp snatTcNm _) = tyView snTy
-               (Just snatTc)         = HashMap.lookup snatTcNm tcm
+               (Just snatTc)         = HashMap.lookup (nameOcc snatTcNm) tcm
                [snatDc]              = tyConDataCons snatTc
                lbody = doFold (buildSNat snatDc) (n-1) vars
                lb    = Letrec (bind (rec (init elems)) lbody)
@@ -625,12 +625,12 @@ reduceTFold n aTy lrFun brFun arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp treeTcNm _)
-      | (Just treeTc) <- HashMap.lookup treeTcNm tcm
+      | (Just treeTc) <- HashMap.lookup (nameOcc treeTcNm) tcm
       , [lrCon,brCon] <- tyConDataCons treeTc
       = do let (vars,elems)     = extractTElems lrCon brCon aTy 'T' n arg
            (_ltv:Right snTy:_,_) <- splitFunForallTy <$> termType tcm brFun
            let (TyConApp snatTcNm _) = tyView snTy
-               (Just snatTc)         = HashMap.lookup snatTcNm tcm
+               (Just snatTc)         = HashMap.lookup (nameOcc snatTcNm) tcm
                [snatDc]              = tyConDataCons snatTc
                lbody = doFold (buildSNat snatDc) (n-1) vars
                lb    = Letrec (bind (rec elems) lbody)
@@ -660,7 +660,7 @@ reduceTReplicate n aTy eTy arg = do
   where
     go tcm (coreView tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp treeTcNm _)
-      | (Just treeTc) <- HashMap.lookup treeTcNm tcm
+      | (Just treeTc) <- HashMap.lookup (nameOcc treeTcNm) tcm
       , [lrCon,brCon] <- tyConDataCons treeTc
       = let retVec = mkRTree lrCon brCon aTy n (replicate (2^n) arg)
         in  changed retVec

--- a/clash-lib/src/CLaSH/Normalize/Strategy.hs
+++ b/clash-lib/src/CLaSH/Normalize/Strategy.hs
@@ -17,7 +17,7 @@ import CLaSH.Rewrite.Util
 -- | Normalisation transformation
 normalization :: NormRewrite
 normalization = rmDeadcode >-> constantPropgation >-> etaTL >-> rmUnusedExpr >-!-> anf >-!-> rmDeadcode >->
-                bindConst >-> letTL >-> evalConst >-!-> cse >-!-> recLetRec
+                bindConst >-> letTL >-> evalConst >-!-> cse >-!-> recLetRec >-> cleanup
   where
     etaTL      = apply "etaTL" etaExpansionTL !-> innerMost (apply "applicationPropagation" appProp)
     anf        = topdownR (apply "nonRepANF" nonRepANF) >-> apply "ANF" makeANF
@@ -28,6 +28,7 @@ normalization = rmDeadcode >-> constantPropgation >-> etaTL >-> rmUnusedExpr >-!
     bindConst  = topdownR (apply "bindConstantVar" bindConstantVar)
     evalConst  = topdownR (apply "evalConst" reduceConst)
     cse        = topdownR (apply "CSE" simpleCSE)
+    cleanup    = topdownSucR (apply "inlineCleanup" inlineCleanup)
 
 
 constantPropgation :: NormRewrite

--- a/clash-lib/src/CLaSH/Normalize/Transformations.hs
+++ b/clash-lib/src/CLaSH/Normalize/Transformations.hs
@@ -453,7 +453,7 @@ removeUnusedExpr :: NormRewrite
 removeUnusedExpr _ e@(collectArgs -> (p@(Prim nm _),args)) = do
   bbM <- HashMap.lookup nm <$> Lens.use (extra.primitives)
   case bbM of
-    Just (BlackBox pNm _ _ inc templ) -> do
+    Just (BlackBox pNm _ _ _ inc templ) -> do
       let usedArgs = if pNm `elem` ["CLaSH.Sized.Internal.Signed.fromInteger#"
                                    ,"CLaSH.Sized.Internal.Unsigned.fromInteger#"
                                    ,"CLaSH.Sized.Internal.BitVector.fromInteger#"

--- a/clash-lib/src/CLaSH/Normalize/Transformations.hs
+++ b/clash-lib/src/CLaSH/Normalize/Transformations.hs
@@ -59,7 +59,7 @@ import           Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
 import           CLaSH.Core.DataCon          (DataCon (..))
 import           CLaSH.Core.Name
-  (Name (..), name2String, string2SystemName)
+  (Name (..), name2String, string2InternalName, string2SystemName)
 import           CLaSH.Core.FreeVars         (termFreeIds, termFreeTyVars,
                                               typeFreeVars)
 import           CLaSH.Core.Literal          (Literal (..))
@@ -912,7 +912,7 @@ etaExpansionTL ctx e
                  . splitFunTy tcm
                  <=< termType tcm
                  ) e
-        (newIdB,newIdV) <- mkInternalVar (string2SystemName "arg") argTy
+        (newIdB,newIdV) <- mkInternalVar (string2InternalName "arg") argTy
         e' <- etaExpansionTL (LamBody newIdB:ctx) (App e newIdV)
         changed . Lam $ bind newIdB e'
       else return e
@@ -1314,7 +1314,7 @@ disjointExpressionConsolidation ctx e@(Case _scrut _ty _alts@(_:_:_)) = do
                    (Prim nm' _,_) -> unpack nm'
                    _             -> "complex_expression_"
           nm'' = (reverse . List.takeWhile (/='.') . reverse) nm ++ "Out"
-      mkInternalVar (string2SystemName nm'') ty
+      mkInternalVar (string2InternalName nm'') ty
 
     l2m = go []
       where

--- a/clash-lib/src/CLaSH/Normalize/Types.hs
+++ b/clash-lib/src/CLaSH/Normalize/Types.hs
@@ -17,7 +17,7 @@ import Data.Map            (Map)
 
 import SrcLoc (SrcSpan)
 
-import CLaSH.Core.Term        (Term, TmName)
+import CLaSH.Core.Term        (Term, TmName, TmOccName)
 import CLaSH.Core.Type        (Type)
 import CLaSH.Netlist.BlackBox.Types (BlackBoxTemplate)
 import CLaSH.Primitives.Types (PrimMap)
@@ -27,19 +27,19 @@ import CLaSH.Util
 -- | State of the 'NormalizeMonad'
 data NormalizeState
   = NormalizeState
-  { _normalized          :: HashMap TmName (Type,SrcSpan,Term)
+  { _normalized          :: HashMap TmOccName (TmName,Type,SrcSpan,Term)
   -- ^ Global binders
-  , _specialisationCache :: Map (TmName,Int,Either Term Type) (TmName,Type)
+  , _specialisationCache :: Map (TmOccName,Int,Either Term Type) (TmName,Type)
   -- ^ Cache of previously specialised functions:
   --
   -- * Key: (name of the original function, argument position, specialised term/type)
   --
   -- * Elem: (name of specialised function,type of specialised function)
-  , _specialisationHistory :: HashMap TmName Int
+  , _specialisationHistory :: HashMap TmOccName Int
   -- ^ Cache of how many times a function was specialized
   , _specialisationLimit :: !Int
   -- ^ Number of time a function 'f' can be specialized
-  , _inlineHistory   :: HashMap TmName (HashMap TmName Int)
+  , _inlineHistory   :: HashMap TmOccName (HashMap TmOccName Int)
   -- ^ Cache of function where inlining took place:
   --
   -- * Key: function where inlining took place
@@ -51,7 +51,7 @@ data NormalizeState
   -- ^ Size of a function below which it is always inlined if it is not
   -- recursive
   , _primitives :: PrimMap BlackBoxTemplate -- ^ Primitive Definitions
-  , _recursiveComponents :: HashMap TmName Bool
+  , _recursiveComponents :: HashMap TmOccName Bool
   -- ^ Map telling whether a components is part of a recursive group
   }
 

--- a/clash-lib/src/CLaSH/Rewrite/Types.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Types.hs
@@ -30,9 +30,9 @@ import Unbound.Generics.LocallyNameless.Name (Name (..))
 
 import SrcLoc (SrcSpan)
 
-import CLaSH.Core.Term           (Term, TmName)
+import CLaSH.Core.Term           (Term, TmName, TmOccName)
 import CLaSH.Core.Type           (Type)
-import CLaSH.Core.TyCon          (TyCon, TyConName)
+import CLaSH.Core.TyCon          (TyCon, TyConName, TyConOccName)
 import CLaSH.Core.Var            (Id, TyVar)
 import CLaSH.Netlist.Types       (HWType)
 import CLaSH.Util
@@ -57,7 +57,7 @@ data RewriteState extra
   = RewriteState
   { _transformCounter :: {-# UNPACK #-} !Int
   -- ^ Number of applied transformations
-  , _bindings         :: !(HashMap TmName (Type,SrcSpan,Term))
+  , _bindings         :: !(HashMap TmOccName (TmName,Type,SrcSpan,Term))
   -- ^ Global binders
   , _uniqSupply       :: !Supply
   -- ^ Supply of unique numbers
@@ -85,18 +85,18 @@ data RewriteEnv
   = RewriteEnv
   { _dbgLevel       :: DebugLevel
   -- ^ Lvl at which we print debugging messages
-  , _typeTranslator :: HashMap TyConName TyCon -> Type
+  , _typeTranslator :: HashMap TyConOccName TyCon -> Type
                     -> Maybe (Either String HWType)
   -- ^ Hardcode Type -> HWType translator
-  , _tcCache        :: HashMap TyConName TyCon
+  , _tcCache        :: HashMap TyConOccName TyCon
   -- ^ TyCon cache
   , _tupleTcCache   :: IntMap TyConName
   -- ^ Tuple TyCon cache
-  , _evaluator      :: HashMap TyConName TyCon -> Bool -> Term -> Term
+  , _evaluator      :: HashMap TyConOccName TyCon -> Bool -> Term -> Term
   -- ^ Hardcoded evaluator (delta-reduction)}
   , _allowZero      :: Bool
   -- ^ Zero bit wide things are representable
-  , _topEntities    :: HashSet TmName
+  , _topEntities    :: HashSet TmOccName
   -- ^ Functions that are considered TopEntities
   }
 

--- a/clash-lib/src/CLaSH/Rewrite/Util.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Util.hs
@@ -99,7 +99,7 @@ apply name rewrite ctx expr = do
                            , "\nto: ", show (afterFTV,afterFV)
                            ]
                   )
-    traceIf ( beforeTy /= afterTy)
+    traceIf (lvl >= DebugAll && beforeTy /= afterTy)
             ( concat [ $(curLoc)
                      , "Error when applying rewrite ", name
                      , " to:\n" , before
@@ -535,7 +535,7 @@ mkSelectorCase caller tcm scrut dcI fieldI = do
             else do
               wildBndrs <- mapM mkWildValBinder fieldTys
               let ty = indexNote ($(curLoc) ++ "No DC field#: " ++ show fieldI) fieldTys fieldI
-              selBndr <- mkInternalVar (string2SystemName "sel") ty
+              selBndr <- mkInternalVar (string2InternalName "sel") ty
               let bndrs  = take fieldI wildBndrs ++ [fst selBndr] ++ drop (fieldI+1) wildBndrs
                   pat    = DataPat (embed dc) (rebind [] bndrs)
                   retVal = Case scrut ty [ bind pat (snd selBndr) ]

--- a/clash-lib/src/GHC/SrcLoc/Extra.hs
+++ b/clash-lib/src/GHC/SrcLoc/Extra.hs
@@ -1,0 +1,37 @@
+{-|
+  Copyright   :  (C) 2017, Google Inc.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module GHC.SrcLoc.Extra where
+
+import Data.Hashable                        (Hashable (..))
+import GHC.Generics
+import SrcLoc
+  (SrcSpan (..), RealSrcSpan, srcSpanFile, srcSpanStartLine, srcSpanEndLine,
+   srcSpanStartCol, srcSpanEndCol)
+import FastString                           (FastString (..))
+import Unbound.Generics.LocallyNameless     (Alpha (..))
+import Unbound.Generics.LocallyNameless.TH
+
+deriving instance Generic SrcSpan
+instance Hashable SrcSpan
+
+makeClosedAlpha ''SrcSpan
+
+instance Hashable RealSrcSpan where
+  hashWithSalt salt rss =
+    hashWithSalt salt (srcSpanFile rss,srcSpanStartLine rss, srcSpanEndLine rss
+                      ,srcSpanStartCol rss, srcSpanEndCol rss)
+
+instance Hashable FastString where
+  hashWithSalt salt fs = hashWithSalt salt (uniq fs)
+

--- a/tests/shouldwork/Signal/BlockRamFile.hs
+++ b/tests/shouldwork/Signal/BlockRamFile.hs
@@ -21,7 +21,6 @@ testBench :: Signal System Bool
 testBench = done'
   where
     testInput      = register 0 (testInput + 1)
-    {-# NOINLINE testInput #-}
     expectedOutput = outputVerifier $(listToVecTH [0::Unsigned 8,0,1,2,3,4,5,6,7,8])
     done           = expectedOutput (topEntity testInput)
     done'          = withClockReset (tbSystemClock (not <$> done')) systemReset done

--- a/tests/shouldwork/Signal/Rom.hs
+++ b/tests/shouldwork/Signal/Rom.hs
@@ -24,7 +24,6 @@ testBench :: Signal System Bool
 testBench = done'
   where
     testInput      = register 0 (testInput + 1)
-    {-# NOINLINE testInput #-}
     expectedOutput = outputVerifier $(listToVecTH $ L.map (\x -> (x,x)) [0::Unsigned 8,0,1,2,3,4,5,6,7,8])
     done           = expectedOutput (topEntity testInput)
     done'          = withClockReset (tbSystemClock (not <$> done')) systemReset done

--- a/tests/shouldwork/Signal/RomFile.hs
+++ b/tests/shouldwork/Signal/RomFile.hs
@@ -23,7 +23,6 @@ testBench :: Signal System Bool
 testBench = done'
   where
     testInput      = register 0 (testInput + 1)
-    {-# NOINLINE testInput #-}
     expectedOutput = outputVerifier $(listToVecTH [0::Unsigned 8,0,1,2,3,4,5,6,7,8])
     done           = expectedOutput (topEntity testInput)
     done'          = withClockReset (tbSystemClock (not <$> done')) systemReset done

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -28,36 +28,36 @@ main =
       [runTest "examples"             defBuild [] "ALU"          ([""],"ALU_topEntity",False)
       ,runTest "examples"             VHDL     [] "Blinker"      (["blinker"],"blinker",False)
       ,runTest "examples"             defBuild [] "BlockRamTest" ([""],"BlockRamTest_topEntity",False)
-      ,runTest "examples"             defBuild [] "Calculator"   (["","Calculator_testBench"],"Calculator_testBench_testBench",True )
+      ,runTest "examples"             defBuild [] "Calculator"   (["","Calculator_testBench"],"Calculator_testBench",True )
       ,runTest "examples"             defBuild [] "CochleaPlus"  ([""],"CochleaPlus_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
-      ,runTest "examples"             defBuild [] "FIR"          (["","FIR_testBench"],"FIR_testBench_testBench",True ) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
+      ,runTest "examples"             defBuild [] "FIR"          (["","FIR_testBench"],"FIR_testBench",True ) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
       ,runTest "examples"             defBuild [] "Fifo"         ([""],"Fifo_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
-      ,runTest "examples"             defBuild [] "MAC"          (["","MAC_testBench"],"MAC_testBench_testBench",True)
-      ,runTest "examples"             defBuild [] "MatrixVect"   (["","MatrixVect_testBench"],"MatrixVect_testBench_testBench",True)
+      ,runTest "examples"             defBuild [] "MAC"          (["","MAC_testBench"],"MAC_testBench",True)
+      ,runTest "examples"             defBuild [] "MatrixVect"   (["","MatrixVect_testBench"],"MatrixVect_testBench",True)
       ,runTest "examples"             defBuild [] "Queens"       ([""],"Queens_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
       ,runTest "examples"             defBuild [] "Reducer"      ([""],"Reducer_topEntity",False)
       ,runTest "examples"             defBuild [] "Sprockell"    ([""],"Sprockell_topEntity",False)
       ,runTest "examples"             defBuild [] "Windows"      ([""],"Windows_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
-      ,runTest ("examples" </> "crc32") defBuild [] "CRC32"      (["","CRC32_testBench"],"CRC32_testBench_testBench",True)  -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
+      ,runTest ("examples" </> "crc32") defBuild [] "CRC32"      (["","CRC32_testBench"],"CRC32_testBench",True)  -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
       ,runTest ("examples" </> "i2c") defBuild ["-O2"] "I2C"     (["i2c","bitmaster","bytemaster"],"i2c",False)
       ]
     , testGroup "unit-tests"
         [ testGroup "Basic"
             [ runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "BangData"            ([""],"BangData_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "Trace"               ([""],"Trace_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "ByteSwap32"          (["","ByteSwap32_testBench"],"ByteSwap32_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CharTest"            (["","CharTest_testBench"],"CharTest_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "ClassOps"            (["","ClassOps_testBench"],"ClassOps_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CountTrailingZeros"  (["","CountTrailingZeros_testBench"],"CountTrailingZeros_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "ByteSwap32"          (["","ByteSwap32_testBench"],"ByteSwap32_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CharTest"            (["","CharTest_testBench"],"CharTest_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "ClassOps"            (["","ClassOps_testBench"],"ClassOps_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CountTrailingZeros"  (["","CountTrailingZeros_testBench"],"CountTrailingZeros_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "DivMod"              ([""],"DivMod_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "IrrefError"          ([""],"IrrefError_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LambdaDrop"          ([""],"LambdaDrop_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LotOfStates"         (["","LotOfStates_testBench"],"LotOfStates_testBench_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
+            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LotOfStates"         (["","LotOfStates_testBench"],"LotOfStates_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NestedPrimitives"    ([""],"NestedPrimitives_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NestedPrimitives2"   ([""],"NestedPrimitives2_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NORX"                (["","NORX_testBench"],"NORX_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NORX"                (["","NORX_testBench"],"NORX_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "PatError"            ([""],"PatError_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "PopCount"            (["","PopCount_testBench"],"PopCount_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "PopCount"            (["","PopCount_testBench"],"PopCount_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "RecordSumOfProducts" ([""],"RecordSumOfProducts_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "Shift"               ([""],"Shift_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "SimpleConstructor"   ([""],"SimpleConstructor_topEntity",False)
@@ -66,8 +66,8 @@ main =
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TwoFunctions"        ([""],"TwoFunctions_topEntity",False)
             ]
         , testGroup "BitVector"
-            [ runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "Box"     (["","Box_testBench"],"Box_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "BoxGrow" (["","BoxGrow_testBench"],"BoxGrow_testBench_testBench",True)
+            [ runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "Box"     (["","Box_testBench"],"Box_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "BoxGrow" (["","BoxGrow_testBench"],"BoxGrow_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "RePack"  ([""],"RePack_topEntity",False)
             ]
         , testGroup "BoxedFunctions"
@@ -78,27 +78,27 @@ main =
             , runTest ("tests" </> "shouldwork" </> "CSignal") defBuild [] "MAC"           ([""],"MAC_topEntity",False)
             ]
         , testGroup "Feedback" -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
-            [ runTest ("tests" </> "shouldwork" </> "Feedback") defBuild [] "Fib" (["","Fib_testBench"],"Fib_testBench_testBench",True)
+            [ runTest ("tests" </> "shouldwork" </> "Feedback") defBuild [] "Fib" (["","Fib_testBench"],"Fib_testBench",True)
             ]
         , testGroup "Fixed"
-            [ runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "Mixer"      (["","Mixer_testBench"],"Mixer_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "SFixedTest" (["","SFixedTest_testBench"],"SFixedTest_testBench_testBench",True)
+            [ runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "Mixer"      (["","Mixer_testBench"],"Mixer_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "SFixedTest" (["","SFixedTest_testBench"],"SFixedTest_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "SatWrap"    ([""],"SatWrap_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "ZeroInt"    (["","ZeroInt_testBench"],"ZeroInt_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "ZeroInt"    (["","ZeroInt_testBench"],"ZeroInt_testBench",True)
             ]
         , testGroup "Floating"
             [ runTest ("tests" </> "shouldwork" </> "Floating") defBuild ["-clash-float-support"] "FloatPack" ([""],"FloatPack_topEntity",False)
             ]
         , testGroup "HOPrim"
-            [ runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "HOImap"    (["","HOImap_testBench"],"HOImap_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "TestMap"   (["","TestMap_testBench"],"TestMap_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Transpose" (["","Transpose_testBench"],"Transpose_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "VecFun"    (["","VecFun_testBench"],"VecFun_testBench_testBench",True)
+            [ runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "HOImap"    (["","HOImap_testBench"],"HOImap_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "TestMap"   (["","TestMap_testBench"],"TestMap_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Transpose" (["","Transpose_testBench"],"Transpose_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "VecFun"    (["","VecFun_testBench"],"VecFun_testBench",True)
             ]
         , testGroup "Numbers"
-            [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"  (["","Bounds_testBench"],"Bounds_testBench_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
-            , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize"  (["","Resize_testBench"],"Resize_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize2" (["","Resize2_testBench"],"Resize2_testBench_testBench",True)
+            [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"  (["","Bounds_testBench"],"Bounds_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
+            , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize"  (["","Resize_testBench"],"Resize_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize2" (["","Resize2_testBench"],"Resize2_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SatMult" ([""],"SatMult_topEntity",False)
             ]
         , testGroup "Polymorphism"
@@ -111,48 +111,48 @@ main =
             ]
         , testGroup "Signal"
             [ runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "AlwaysHigh"   ([""],"AlwaysHigh_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
-            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamFile" (["","BlockRamFile_testBench"],"BlockRamFile_testBench_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
+            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamFile" (["","BlockRamFile_testBench"],"BlockRamFile_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamTest" ([""],"BlockRamTest_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "MAC"          ([""],"MAC_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "NoCPR"        (["example"],"example",False)
-            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Ram"          (["","Ram_testBench"],"Ram_testBench_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
-            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Rom"          (["","Rom_testBench"],"Rom_testBench_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
-            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "RomFile"      (["","RomFile_testBench"],"RomFile_testBench_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
+            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Ram"          (["","Ram_testBench"],"Ram_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
+            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Rom"          (["","Rom_testBench"],"Rom_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
+            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "RomFile"      (["","RomFile_testBench"],"RomFile_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "SigP"         ([""],"SigP_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525
             ]
         , testGroup "Testbench" -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/1152
-            [ runTest ("tests" </> "shouldwork" </> "Testbench") defBuild ["-clash-inline-limit=0"] "TB" (["","TB_testBench"],"TB_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Testbench") defBuild [] "SyncTB"                    (["","SyncTB_testBench"],"SyncTB_testBench_testBench",True)
+            [ runTest ("tests" </> "shouldwork" </> "Testbench") defBuild ["-clash-inline-limit=0"] "TB" (["","TB_testBench"],"TB_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Testbench") defBuild [] "SyncTB"                    (["","SyncTB_testBench"],"SyncTB_testBench",True)
             ]
         , testGroup "Vector"
-            [ runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Concat"    (["","Concat_testBench"],"Concat_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DFold"     (["","DFold_testBench"],"DFold_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DFold2"    (["","DFold2_testBench"],"DFold2_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DTFold"    (["","DTFold_testBench"],"DTFold_testBench_testBench",True)
+            [ runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Concat"    (["","Concat_testBench"],"Concat_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DFold"     (["","DFold_testBench"],"DFold_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DFold2"    (["","DFold2_testBench"],"DFold2_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DTFold"    (["","DTFold_testBench"],"DTFold_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "EnumTypes" ([""],"EnumTypes_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FindIndex" (["","FindIndex_testBench"],"FindIndex_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Fold"      (["","Fold_testBench"],"Fold_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Foldr"     (["","Foldr_testBench"],"Foldr_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FindIndex" (["","FindIndex_testBench"],"FindIndex_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Fold"      (["","Fold_testBench"],"Fold_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Foldr"     (["","Foldr_testBench"],"Foldr_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "HOClock"   ([""],"HOClock_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/115
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "HOCon"     ([""],"HOCon_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "HOPrim"    ([""],"HOPrim_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Minimum"   (["","Minimum_testBench"],"Minimum_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Minimum"   (["","Minimum_testBench"],"Minimum_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "MovingAvg" ([""],"MovingAvg_topEntity", False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/115
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "PatHOCon"  ([""],"PatHOCon_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Scatter"   (["","Scatter_testBench"],"Scatter_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Scatter"   (["","Scatter_testBench"],"Scatter_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Split"     ([""],"Split_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "ToList"    (["","ToList_testBench"],"ToList_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Unconcat"  (["","Unconcat_testBench"],"Unconcat_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "ToList"    (["","ToList_testBench"],"ToList_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Unconcat"  (["","Unconcat_testBench"],"Unconcat_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VACC"      ([""],"VACC_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VIndex"    ([""],"VIndex_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VFold"     (["","VFold_testBench"],"VFold_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VFold"     (["","VFold_testBench"],"VFold_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VMapAccum" ([""],"VMapAccum_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VMerge"    (["","VMerge_testBench"],"VMerge_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VReplace"  (["","VReplace_testBench"],"VReplace_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VReverse"  (["","VReverse_testBench"],"VReverse_testBench_testBench",True)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VRotate"   (["","VRotate_testBench"],"VRotate_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VMerge"    (["","VMerge_testBench"],"VMerge_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VReplace"  (["","VReplace_testBench"],"VReplace_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VReverse"  (["","VReverse_testBench"],"VReverse_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VRotate"   (["","VRotate_testBench"],"VRotate_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VScan"     ([""],"VScan_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VSelect"   (["","VSelect_testBench"],"VSelect_testBench_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VSelect"   (["","VSelect_testBench"],"VSelect_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VZip"      ([""],"VZip_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VecConst"  ([""],"VecConst_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VecOfSum"  ([""],"VecOfSum_topEntity",False)


### PR DESCRIPTION
This PR contains the following changes:

* Modules (or entities in VHDL) have a hierarchical name similar to the fully qualified name in Haskell (dots are replaced by underscores)
* Registers and other memory elements are assigning their results to a `reg` with the same name as the let/where-binding in the Haskell source code. i.e. variable names of memory elements are preserved.
* Names generated by the clash compiler a prefixed with a `#` (requires the use of /escaped/ identifiers) [1]
* let-bindings with a clash-generated name, and are used only once, are inlined.
* `wire` and `reg` declarations are annotated with their Haskell source locations when available in the GHC Core code [2].

1: Right now, clash cannot differentiate between names generated by GHC, or those created by the user. And so some GHC-generated names are not prefixed with a `#`.
2: While the entire machinery to add source locations is present, the GHC optimizer has removed most source locations before Clash gets a hold of them. However, the machinery that is in place can be witnessed when taking the output directly from the GHC desugarer. We plan to take a look at GHC and see if there are possibilities to have the GHC optimizer preserve source locations.