### PR TITLE
clash-lib: change type of t_output from [PortName] to PortName

### DIFF
--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -349,7 +349,7 @@ mkUniqueResult (Just teM) res = do
       o'   = pack (name2String o)
       ty   = unembed (varType res)
       hwty = unsafeCoreTypeToHWType $(curLoc) typeTrans tcm ty
-      oPortSupply = maybe Nothing (listToMaybe . t_outputs) teM
+      oPortSupply = fmap t_output teM
   (ports,decls,pN) <- mkOutput oPortSupply (o',hwty)
   let pO = repName (unpack pN) o
   return (ports,decls,Id pO (embed ty),(nameOcc o,Var ty pO))
@@ -675,7 +675,7 @@ mkTopUnWrapper topEntity annM man dstId args = do
 
   -- output
   let oPortSupply = maybe (repeat Nothing)
-                        (extendPorts . t_outputs)
+                        (extendPorts . (:[]) . t_output)
                         annM
 
       result = ("result",snd dstId)

--- a/examples/Blinker.hs
+++ b/examples/Blinker.hs
@@ -8,11 +8,12 @@ type Dom50 = Dom "System" 20000
 
 {-# ANN topEntity
   (defTop
-    { t_name     = "blinker"
-    , t_inputs   = [PortName "CLOCK_50"
-                   ,PortName "KEY0"
-                   ,PortName "KEY1"]
-    , t_outputs  = [PortName "LED"]
+    { t_name   = "blinker"
+    , t_inputs = [ PortName "CLOCK_50"
+                 , PortName "KEY0"
+                 , PortName "KEY1"
+                 ]
+    , t_output = PortName "LED"
     }) #-}
 topEntity :: Clock Dom50 Source -> Reset Dom50 Asynchronous -> Signal Dom50 Bit -> Signal Dom50 (BitVector 8)
 topEntity clk rst key1 =

--- a/examples/i2c/I2C.hs
+++ b/examples/i2c/I2C.hs
@@ -21,7 +21,7 @@ import I2C.Types
                    , PortName "ackIn"
                    , PortName "din"
                    , PortName "i2cI"]
-    , t_outputs  = [ PortField ""
+    , t_output   = PortField ""
                      [ PortName "dout"
                      , PortName "hostAck"
                      , PortName "busy"
@@ -29,7 +29,6 @@ import I2C.Types
                      , PortName "ackOut"
                      , PortField "" [PortName "i2cO_clk"]
                      ]
-                   ]
     }) #-}
 i2c rst ena clkCnt start stop read write ackIn din i2cI = (dout,hostAck,busy,al,ackOut,i2cO)
   where

--- a/examples/i2c/I2C/BitMaster.hs
+++ b/examples/i2c/I2C/BitMaster.hs
@@ -44,7 +44,7 @@ type BitMasterO = (BitRespSig,Bool,I2COut)
                           , PortName "din" ]
                       , PortName "i2cI" ]
                    ]
-    , t_outputs  = [ PortField ""
+    , t_output   = PortField ""
                      [ PortField ""
                         [ PortName "cmdAck"
                         , PortName "al"
@@ -52,7 +52,6 @@ type BitMasterO = (BitRespSig,Bool,I2COut)
                      , PortName "busy"
                      , PortName "i2cO"
                      ]
-                   ]
     }) #-}
 bitMaster
   :: SystemClockReset

--- a/examples/i2c/I2C/ByteMaster.hs
+++ b/examples/i2c/I2C/ByteMaster.hs
@@ -48,13 +48,12 @@ type ByteMasterO = (Bool,Bool,BitVector 8,BitCtrlSig)
                       , PortName "din"
                       , PortName "bitResp" ]
                    ]
-    , t_outputs  = [ PortField ""
+    , t_output   = PortField ""
                      [ PortName "hostAck"
                      , PortName "ackOut"
                      , PortName "dout"
                      , PortName "bitCtrl"
                      ]
-                   ]
     }) #-}
 byteMaster
   :: SystemClockReset

--- a/tests/shouldwork/Signal/NoCPR.hs
+++ b/tests/shouldwork/Signal/NoCPR.hs
@@ -8,11 +8,10 @@ import           CLaSH.Prelude
   (defTop { t_name = "example"
           , t_inputs = [ PortName "a"
                        ]
-          , t_outputs = [ PortField ""
-                            [ PortName "b"
-                            , PortName "c"
-                            ]
-                        ]
+          , t_output = PortField ""
+                         [ PortName "b"
+                         , PortName "c"
+                         ]
           }
   )#-}
 


### PR DESCRIPTION
This is the compiler change for clash-lang/clash-prelude#121