### PR TITLE
Handle 'read' failures on manifest files

### DIFF
--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -38,6 +38,7 @@ import qualified System.IO                        as IO
 import           System.IO.Error                  (isDoesNotExistError)
 import           Text.PrettyPrint.Leijen.Text     (Doc, renderPretty, text)
 import           Text.PrettyPrint.Leijen.Text.Monadic (displayT, renderOneLine)
+import           Text.Read                        (readMaybe)
 
 import           GHC.BasicTypes.Extra             ()
 
@@ -126,9 +127,8 @@ generateHDL bindingsMap hdlState primMap tcm tupTcm typeTrans eval topEntities
         manFile = maybe (hdlDir </> Text.unpack topNm <.> "manifest")
                         (\ann -> hdlDir </> t_name ann </> t_name ann <.> "manifest")
                         annM
-    manM <- fmap read . either (const Nothing) Just <$>
+    manM <- (>>= readMaybe) . either (const Nothing) Just <$>
             tryJust (guard . isDoesNotExistError) (readFile manFile)
-    -- manM <- fmap (Just . read) (readFile manFile)
     return (maybe (False,False,manifestI)
                   (\man -> (fst (manifestHash man) == topHash
                            ,snd (manifestHash man) == benchHashM

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -27,6 +27,7 @@ import qualified Data.HashMap.Lazy                as HashMap
 import           Data.List                        (elemIndex, intersperse)
 import qualified Data.Text.Lazy                   as Text
 import           System.FilePath                  ((</>), (<.>))
+import           Text.Read                        (readMaybe)
 import           Unbound.Generics.LocallyNameless
   (Embed (..), runFreshMT, unbind, unembed, unrebind)
 
@@ -352,7 +353,7 @@ mkFunApp dst fun args = do
             topName <- extendIdentifier Basic (Text.pack modName)
                          (Text.pack "_topEntity")
             return (env </> (Text.unpack topName) <.> "manifest")
-        man <- read <$> liftIO (readFile manFile)
+        Just man <- readMaybe <$> liftIO (readFile manFile)
         instDecls <- mkTopUnWrapper fun annM man (dstId,dstHWty)
                        (zip argExprs argHWTys)
         return (argDecls ++ instDecls)


### PR DESCRIPTION
When I updated my compiler and the manifest type/fileformat changed the compiler crashed with the very unhelpful message "Prelude.read: no parse"

Not sure if it can also fail in Clash.Netlist.mkFunApp, and if it does how to handle it gracefully.
But this way at least we get an pattern match error with a location.

Or we could put in something like `error "Something is wrong with your .manifest file, try deleting it."`