### PR TITLE
Add a -fclash-nocache flag

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -41,7 +41,7 @@ doHDL b src = do
   let prepStartDiff = Clock.diffUTCTime prepTime startTime
   putStrLn $ "Loading dependencies took " ++ show prepStartDiff
   generateHDL bindingsMap (Just b) primMap tcm tupTcm (ghcTypeToHWType WORD_SIZE_IN_BITS True) reduceConstant topEntities
-    (ClashOpts 20 20 15 0 DebugFinal True WORD_SIZE_IN_BITS Nothing HDLSYN True True False ["."] True) (startTime,prepTime)
+    (ClashOpts 20 20 15 0 DebugFinal False True WORD_SIZE_IN_BITS Nothing HDLSYN True True False ["."] True) (startTime,prepTime)
 
 main :: IO ()
 main = genVHDL "./examples/FIR.hs"

--- a/clash-ghc/src-bin/Clash/Main.hs
+++ b/clash-ghc/src-bin/Clash/Main.hs
@@ -139,6 +139,7 @@ defaultMain = flip withArgs $ do
                              , opt_specLimit   = 20
                              , opt_inlineFunctionLimit = 15
                              , opt_inlineConstantLimit = 0
+                             , opt_cachehdl    = True
                              , opt_cleanhdl    = True
                              , opt_intWidth    = WORD_SIZE_IN_BITS
                              , opt_hdlDir      = Nothing

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -40,6 +40,7 @@ flagsClash r = [
     defFlag "fclash-debug"                   $ SepArg (setDebugLevel r)
   , defFlag "fclash-hdldir"                  $ SepArg (setHdlDir r)
   , defFlag "fclash-hdlsyn"                  $ SepArg (setHdlSyn r)
+  , defFlag "fclash-nocache"                 $ NoArg (liftEwM (setNoCache r))
   , defFlag "fclash-noclean"                 $ NoArg (liftEwM (setNoClean r))
   , defFlag "fclash-spec-limit"              $ IntSuffix (liftEwM . setSpecLimit r)
   , defFlag "fclash-inline-limit"            $ IntSuffix (liftEwM . setInlineLimit r)
@@ -80,6 +81,9 @@ setDebugLevel :: IORef ClashOpts
 setDebugLevel r s = case readMaybe s of
   Just dbgLvl -> liftEwM $ modifyIORef r (\c -> c {opt_dbgLevel = dbgLvl})
   Nothing     -> addWarn (s ++ " is an invalid debug level")
+
+setNoCache :: IORef ClashOpts -> IO ()
+setNoCache r = modifyIORef r (\c -> c {opt_cachehdl = False})
 
 setNoClean :: IORef ClashOpts -> IO ()
 setNoClean r = modifyIORef r (\c -> c {opt_cleanhdl = False})

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -44,6 +44,7 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            , opt_inlineFunctionLimit :: Word
                            , opt_inlineConstantLimit :: Word
                            , opt_dbgLevel    :: DebugLevel
+                           , opt_cachehdl    :: Bool
                            , opt_cleanhdl    :: Bool
                            , opt_intWidth    :: Int
                            , opt_hdlDir      :: Maybe String


### PR DESCRIPTION
When this flag is enabled the .manifest file and cached compilation results are ignored.
And the module is always recompiled.

This flag is also enabled when running the clash-dev script.
Mostly useful when making changes to compiler, because that's when you really don't want to get cached results.