### PR TITLE
Fix haddock errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
 - stack --no-terminal --skip-ghc-check build $STACKOPTS
 # - stack --no-terminal --skip-ghc-check sdist
 - stack exec clash-testsuite
+- stack haddock
 matrix:
   fast_finish: true
   include:

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -753,7 +753,7 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     -> reduce (Literal (NaturalLiteral w))
 
   -- GHC.Real.^  -- XXX: Very fragile
-  -- ^_f, $wf, $wf1 are specialisations of the internal function f in the implementation of (^) in GHC.Real
+  --   ^_f, $wf, $wf1 are specialisations of the internal function f in the implementation of (^) in GHC.Real
   "GHC.Real.^_f"  -- :: Integer -> Integer -> Integer
     | [Lit (IntegerLiteral i), Lit (IntegerLiteral j)] <- args
     -> reduce (integerToIntegerLiteral $ i ^ j)
@@ -3093,10 +3093,10 @@ liftBitVector2 :: KnownNat n
 liftBitVector2 = liftSized2 bitVectorLiterals' mkBitVectorLit
 
 liftSized2 :: (KnownNat n, Integral (sized n))
-           => -- | literal argument extraction function
-              ([Value] -> [Integer])
-           -> -- | literal contruction function
-              (Type -> Type -> Integer -> Integer -> Term)
+           => ([Value] -> [Integer])
+              -- ^ literal argument extraction function
+           -> (Type -> Type -> Integer -> Integer -> Term)
+              -- ^ literal contruction function
            -> (sized n -> sized n -> sized n)
            -> Type
            -> TyConMap


### PR DESCRIPTION
I was getting the following error when building haddock:

```
src-ghc/Clash/GHC/Evaluator.hs:756:3: error:
    parse error on input ‘-- ^_f, $wf, $wf1 are specialisations of the internal function f in the implementation of (^) in GHC.Real’
    |
756 |   -- ^_f, $wf, $wf1 are specialisations of the internal function f in the implementation of (^) in GHC.Real
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The PR fixes all the haddock issues.