### PR TITLE
Extend alteraPll to include all 9 pllout ports

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -151,7 +151,13 @@ domain m (tyView -> TyConApp tcNm [LitTy (SymTy nm),rateTy])
   | name2String tcNm == "Clash.Signal.Internal.Dom"
   = do rate <- mapExceptT (Just . coerce) (tyNatSize m rateTy)
        return (nm,rate)
-domain _ ty = fail $ "Can't translate domain: " ++ showDoc ty
+
+-- Polymorphic clocks are clocks which domains are left polymorphic. This usually
+-- is a result of 'ignoring' a number of PLL outputs. Ideally, we would like to
+-- display an error whenever a program *uses* an polymorphic clock, but Clash has
+-- to deeply evaluate the result we will yield in this function, thus always
+-- triggering an error even for valid use cases.
+domain _ _ = return ("__polymorphic clock / undefined domain__", -1)
 
 clockKind
   :: HashMap TyConOccName TyCon

--- a/clash-lib/prims/systemverilog/Clash_Intel_ClockGen.json
+++ b/clash-lib/prims/systemverilog/Clash_Intel_ClockGen.json
@@ -23,13 +23,31 @@
   :: SSymbol name               -- ARG[0]
   -> Clock  pllIn 'Source       -- ARG[1]
   -> Reset  pllIn 'Asynchronous -- ARG[2]
-  -> (Clock pllOut 'Source, Signal pllOut Bool)"
+  -> ( Clock pllOut0 'Source
+     , Clock pllOut1 'Source
+     , Clock pllOut2 'Source
+     , Clock pllOut3 'Source
+     , Clock pllOut4 'Source
+     , Clock pllOut5 'Source
+     , Clock pllOut6 'Source
+     , Clock pllOut7 'Source
+     , Clock pllOut8 'Source
+     , Signal pllOut0 Bool
+     )"
     , "templateD" :
 "// alteraPll begin
 ~NAME[0] ~GENSYM[alteraPll_inst][2]
 (.refclk   (~ARG[1])
 ,.rst      (~ARG[2])
-,.outclk_0 (~RESULT[1])
+,.outclk_0 (~RESULT[9])
+,.outclk_1 (~RESULT[8])
+,.outclk_2 (~RESULT[7])
+,.outclk_3 (~RESULT[6])
+,.outclk_4 (~RESULT[5])
+,.outclk_5 (~RESULT[4])
+,.outclk_6 (~RESULT[3])
+,.outclk_7 (~RESULT[2])
+,.outclk_8 (~RESULT[1])
 ,.locked   (~RESULT[0]));
 // alteraPll end"
     }

--- a/clash-lib/prims/verilog/Clash_Intel_ClockGen.json
+++ b/clash-lib/prims/verilog/Clash_Intel_ClockGen.json
@@ -23,13 +23,31 @@
   :: SSymbol name               -- ARG[0]
   -> Clock  pllIn 'Source       -- ARG[1]
   -> Reset  pllIn 'Asynchronous -- ARG[2]
-  -> (Clock pllOut 'Source, Signal pllOut Bool)"
+  -> ( Clock pllOut0 'Source
+     , Clock pllOut1 'Source
+     , Clock pllOut2 'Source
+     , Clock pllOut3 'Source
+     , Clock pllOut4 'Source
+     , Clock pllOut5 'Source
+     , Clock pllOut6 'Source
+     , Clock pllOut7 'Source
+     , Clock pllOut8 'Source
+     , Signal pllOut0 Bool
+     )"
     , "templateD" :
 "// alteraPll begin
 ~NAME[0] ~GENSYM[alteraPll_inst][2]
 (.refclk   (~ARG[1])
 ,.rst      (~ARG[2])
-,.outclk_0 (~RESULT[1])
+,.outclk_0 (~RESULT[9])
+,.outclk_1 (~RESULT[8])
+,.outclk_2 (~RESULT[7])
+,.outclk_3 (~RESULT[6])
+,.outclk_4 (~RESULT[5])
+,.outclk_5 (~RESULT[4])
+,.outclk_6 (~RESULT[3])
+,.outclk_7 (~RESULT[2])
+,.outclk_8 (~RESULT[1])
 ,.locked   (~RESULT[0]));
 // alteraPll end"
     }

--- a/clash-lib/prims/vhdl/Clash_Intel_ClockGen.json
+++ b/clash-lib/prims/vhdl/Clash_Intel_ClockGen.json
@@ -34,24 +34,62 @@ end block;
   :: SSymbol name               -- ARG[0]
   -> Clock  pllIn 'Source       -- ARG[1]
   -> Reset  pllIn 'Asynchronous -- ARG[2]
-  -> (Clock pllOut 'Source, Signal pllOut Bool)"
+  -> ( Clock pllOut0 'Source
+     , Clock pllOut1 'Source
+     , Clock pllOut2 'Source
+     , Clock pllOut3 'Source
+     , Clock pllOut4 'Source
+     , Clock pllOut5 'Source
+     , Clock pllOut6 'Source
+     , Clock pllOut7 'Source
+     , Clock pllOut8 'Source
+     , Signal pllOut0 Bool
+     )"
     , "templateD" :
 "-- alteraPll begin
 ~GENSYM[alteraPll][0] : block
-  signal ~GENSYM[pllOut][1]  : std_logic;
-  signal ~GENSYM[locked][2]  : std_logic;
-  signal ~GENSYM[pllLock][3] : boolean;
+  signal ~GENSYM[pllOut0][1]  : std_logic;
+  signal ~GENSYM[pllOut1][2]  : std_logic;
+  signal ~GENSYM[pllOut2][3]  : std_logic;
+  signal ~GENSYM[pllOut3][4]  : std_logic;
+  signal ~GENSYM[pllOut4][5]  : std_logic;
+  signal ~GENSYM[pllOut5][6]  : std_logic;
+  signal ~GENSYM[pllOut6][7]  : std_logic;
+  signal ~GENSYM[pllOut7][8]  : std_logic;
+  signal ~GENSYM[pllOut8][9]  : std_logic;
+  signal ~GENSYM[locked][10]  : std_logic;
+  signal ~GENSYM[pllLock][11] : boolean;
 
   component ~NAME[0]
     port (refclk   : in std_logic;
           rst      : in std_logic;
           outclk_0 : out std_logic;
+          outclk_1 : out std_logic;
+          outclk_2 : out std_logic;
+          outclk_3 : out std_logic;
+          outclk_4 : out std_logic;
+          outclk_5 : out std_logic;
+          outclk_6 : out std_logic;
+          outclk_7 : out std_logic;
+          outclk_8 : out std_logic;
           locked   : out std_logic);
   end component;
 begin
-  ~GENSYM[alteraPll_inst][4] : component ~NAME[0] port map (~ARG[1],~ARG[2],~SYM[1],~SYM[2]);
-  ~SYM[3] <= true when ~SYM[2] = '1' else false;
-  ~RESULT <= (~SYM[1],~SYM[3]);
+  ~GENSYM[alteraPll_inst][12] : component ~NAME[0] port map ( ~ARG[1]
+                                                           , ~ARG[2]
+                                                           , ~SYM[1]
+                                                           , ~SYM[2]
+                                                           , ~SYM[3]
+                                                           , ~SYM[4]
+                                                           , ~SYM[5]
+                                                           , ~SYM[6]
+                                                           , ~SYM[7]
+                                                           , ~SYM[8]
+                                                           , ~SYM[9]
+                                                           , ~SYM[10]
+                                                           );
+  ~SYM[11] <= true when ~SYM[10] = '1' else false;
+  ~RESULT <= (~SYM[1],~SYM[2],~SYM[3],~SYM[4],~SYM[5],~SYM[6],~SYM[7],~SYM[8],~SYM[9],~SYM[11]);
 end block;
 -- alteraPll end"
     }


### PR DESCRIPTION
This commits extends alteraPll to include of all of the available 9 output ports. This includes a commit fixing a bug where clash would consider `Clock` a user-generated type if one (or more) clock outputs where ignored and thus polymorphic. 

Should be merged in tandem with: https://github.com/clash-lang/clash-prelude/pull/130