### PR TITLE
Implemented InOut ports

### DIFF
--- a/clash-ghc/src-bin/Clash/Main.hs
+++ b/clash-ghc/src-bin/Clash/Main.hs
@@ -438,6 +438,7 @@ checkOptions mode dflags srcs objs = do
          && isInterpretiveMode mode) $
         hPutStrLn stderr ("Warning: -debug, -threaded and -ticky are ignored by GHCi")
 
+
         -- -prof and --interactive are not a good combination
    when ((filter (not . wayRTSOnly) (ways dflags) /= interpWays)
          && isInterpretiveMode mode

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -94,6 +94,9 @@ ghcTypeToHWType iw floatSupport = go
 
         "GHC.Prim.Any" -> return (BitVector 1)
 
+        "Clash.Signal.Internal.InOut" ->
+          ExceptT $ return $ coreTypeToHWType go m (args !! 1)
+
         "Clash.Signal.Internal.Signal" ->
           ExceptT $ return $ coreTypeToHWType go m (args !! 1)
 

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -453,21 +453,21 @@ module_ c = do
     }
   where
     ports = sequence
-          $ [ encodingNote hwty <$> text i | (i,hwty) <- inputs c ] ++
-            [ encodingNote hwty <$> text i | (_,(i,hwty)) <- outputs c]
+          $ [ encodingNote hwty <$> text id_ | (_,id_,hwty) <- inputs c ] ++
+            [ encodingNote hwty <$> text id_ | (_,(_,id_,hwty)) <- outputs c]
 
     inputPorts = case inputs c of
                    [] -> empty
-                   p  -> vcat (punctuate semi (sequence [ "input" <+> sigDecl (text i) ty | (i,ty) <- p ])) <> semi
+                   p  -> vcat (punctuate semi (sequence [ getDirection "input" portType <+> sigDecl (text i) ty | (portType,i,ty) <- p ])) <> semi
 
     outputPorts = case outputs c of
                    [] -> empty
-                   p  -> vcat (punctuate semi (sequence [ "output" <+> sigDecl (text i) ty | (_,(i,ty)) <- p ])) <> semi
+                   p  -> vcat (punctuate semi (sequence [ getDirection "output" portType <+> sigDecl (text i) ty | (_,(portType,i,ty)) <- p ])) <> semi
 
 addSeen :: Component -> SystemVerilogM ()
 addSeen c = do
-  let iport = map fst $ inputs c
-      oport = map (fst.snd) $ outputs c
+  let iport = [id_ | (_, id_, _) <- inputs c]
+      oport = [id_ | (_, (_, id_, _)) <- outputs c]
       nets  = mapMaybe (\case {NetDecl' _ _ i _ -> Just i; _ -> Nothing}) $ declarations c
   idSeen .= concat [iport,oport,nets]
   oports .= oport

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -542,10 +542,10 @@ entity c = do
       "end" <> semi
   where
     ports l = sequence
-            $ [ (,fromIntegral $ T.length i) A.<$> (encodingNote ty <$> fill l (text i) <+> colon <+> "in" <+> vhdlType ty)
-              | (i,ty) <- inputs c ] ++
-              [ (,fromIntegral $ T.length i) A.<$> (encodingNote ty <$> fill l (text i) <+> colon <+> "out" <+> vhdlType ty)
-              | (_,(i,ty)) <- outputs c ]
+            $ [ (,fromIntegral $ T.length i) A.<$> (encodingNote ty <$> fill l (text i) <+> colon <+> getDirection "in" portType <+> vhdlType ty)
+              | (portType, i,ty) <- inputs c ] ++
+              [ (,fromIntegral $ T.length i) A.<$> (encodingNote ty <$> fill l (text i) <+> colon <+> getDirection "out" portType <+> vhdlType ty)
+              | (_,(portType, i,ty)) <- outputs c ]
 
 architecture :: Component -> VHDLM Doc
 architecture c =

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -191,7 +191,11 @@ module_ c = addSeen c *> modVerilog <* (idSeen .= [])
         port = case sPort of
                   Nothing     -> getDirection "input" portType
                   (Just Wire) -> (getDirection "output" portType) <+> "wire"
-                  (Just Reg)  -> (getDirection "output" portType) <+> "reg"
+                  (Just Reg)  -> case portType of
+                                    Bidirectional  -> error $ printf
+                                                       "`inout` cannot be of type `reg`, context: {sPort=%s, nm=%s, hwTy=%s}"
+                                                       (show sPort) (show nm) (show hwTy)
+                                    Unidirectional -> "output" <+> "reg"
 
     -- slightly more readable than 'tupled', makes the output Haskell-y-er
     commafy v = (comma <> space) <> pure v

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -271,10 +271,10 @@ createHDL backend modName components top (topName,manifestE) = flip evalState ba
       qincs = map (first (<.> "qsys")) (concat incs)
       topFiles = hdl ++ qincs
   manifest <- either return (\m -> do
-      let topInNames  = map fst (inputs top)
-      topInTypes  <- mapM (fmap (displayT . renderOneLine) . hdlType . snd) (inputs top)
-      let topOutNames = map (fst . snd) (outputs top)
-      topOutTypes <- mapM (fmap (displayT . renderOneLine) . hdlType . snd . snd) (outputs top)
+      let topInNames  = [iName | (_,iName,_) <- inputs top]
+      topInTypes  <- mapM (fmap (displayT . renderOneLine) . hdlType) [hwType | (_, _, hwType) <- inputs top]
+      let topOutNames = [oName | (_, (_,oName,_)) <- outputs top]
+      topOutTypes <- mapM (fmap (displayT . renderOneLine) . hdlType) [hwType | (_, (_, _, hwType)) <- outputs top]
       let compNames = map (componentName.snd) components
       return (m { portInNames    = topInNames
                 , portInTypes    = topInTypes

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE TemplateHaskell          #-}
 {-# LANGUAGE TupleSections            #-}
 
+
 module Clash.Driver where
 
 import qualified Control.Concurrent.Supply        as Supply
@@ -75,7 +76,7 @@ generateHDL
   -- ^ TyCon cache
   -> IntMap TyConName
   -- ^ Tuple TyCon cache
-  -> (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
+  -> (Bool -> HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
   -> PrimEvaluator
   -- ^ Hardcoded evaluator (delta-reduction)
@@ -363,7 +364,7 @@ normalizeEntity
   -- ^ TyCon cache
   -> IntMap TyConName
   -- ^ Tuple TyCon cache
-  -> (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
+  -> (Bool -> HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
   -> PrimEvaluator
   -- ^ Hardcoded evaluator (delta-reduction)

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -57,6 +57,9 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            , opt_errorInvalidCoercions :: Bool
                            }
 
+-- | Represents an exception in Clash, caused by an approximate line of code (@SrcSpan@). Clash will
+--   display the first string given to this constructor. The second argument can hold extra
+--   information the user can request by providing an extra flag, but which is not displayed by default.
 data ClashException = ClashException SrcSpan String (Maybe String)
 
 instance Show ClashException where

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -69,7 +69,7 @@ genNetlist :: BindingMap
            -- ^ Primitive definitions
            -> HashMap TyConOccName TyCon
            -- ^ TyCon cache
-           -> (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
+           -> (Bool -> HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
            -- ^ Hardcoded Type -> HWType translator
            -> [(String,FilePath)]
            -- ^ Set of collected data-files
@@ -105,7 +105,7 @@ runNetlistMonad :: BindingMap
                 -- ^ Primitive Definitions
                 -> HashMap TyConOccName TyCon
                 -- ^ TyCon cache
-                -> (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
+                -> (Bool -> HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
                 -- ^ Hardcode Type -> HWType translator
                 -> [(String,FilePath)]
                 -- ^ Set of collected data-files

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -282,9 +282,9 @@ mkFunInput resId e = do
               normalized <- Lens.use bindings
               case HashMap.lookup fun normalized of
                 Just _ -> do
-                  (_,Component compName compInps [snd -> compOutp] _) <- preserveVarEnv $ genComponent fun
-                  let inpAssigns    = zipWith (\(i,t) e' -> (Identifier i Nothing,In,t,e')) compInps [ Identifier (pack ("~ARG[" ++ show x ++ "]")) Nothing | x <- [(0::Int)..] ]
-                      outpAssign    = (Identifier (fst compOutp) Nothing,Out,snd compOutp,Identifier (pack "~RESULT") Nothing)
+                  (_,Component compName compInps [snd -> (_, id_, hwType)] _) <- preserveVarEnv $ genComponent fun
+                  let inpAssigns    = zipWith (\(_,i_,t) e' -> (Identifier i_ Nothing,In,t,e')) compInps [ Identifier (pack ("~ARG[" ++ show x ++ "]")) Nothing | x <- [(0::Int)..] ]
+                      outpAssign    = (Identifier id_ Nothing,Out,hwType,Identifier (pack "~RESULT") Nothing)
                   i <- varCount <<%= (+1)
                   let instLabel     = Text.concat [compName,pack ("_" ++ show i)]
                       instDecl      = InstDecl compName instLabel (outpAssign:inpAssigns)

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -76,15 +76,15 @@ type Identifier = Text
 data Component
   = Component
   { componentName :: !Identifier -- ^ Name of the component
-  , inputs        :: [(Identifier,HWType)] -- ^ Input ports
-  , outputs       :: [(WireOrReg,(Identifier,HWType))] -- ^ Output ports
+  , inputs        :: [(PortType,Identifier,HWType)] -- ^ Input ports
+  , outputs       :: [(WireOrReg,(PortType,Identifier,HWType))] -- ^ Output ports
   , declarations  :: [Declaration] -- ^ Internal declarations
   }
   deriving Show
 
 instance NFData Component where
   rnf c = case c of
-    Component nm inps outps decls -> rnf nm    `seq` rnf inps `seq`
+    Component nm inps outps decls -> rnf nm `seq` rnf inps `seq`
                                      rnf outps `seq` rnf decls
 
 -- | Size indication of a type (e.g. bit-size or number of elements)
@@ -148,6 +148,12 @@ pattern NetDecl :: Maybe Identifier -> Identifier -> HWType -> Declaration
 pattern NetDecl note d ty <- NetDecl' note Wire d (Right ty)
   where
     NetDecl note d ty = NetDecl' note Wire d (Right ty)
+
+-- Unidirectional implies either an `in` or `out` port, while bidirectional implies `inout`
+data PortType = Unidirectional | Bidirectional
+  deriving (Show,Generic)
+
+instance NFData PortType
 
 data PortDirection = In | Out
   deriving Show

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -54,7 +54,7 @@ data NetlistState
   , _varCount       :: !Int -- ^ Number of signal declarations
   , _components     :: HashMap TmOccName (SrcSpan,Component) -- ^ Cached components
   , _primitives     :: PrimMap BlackBoxTemplate -- ^ Primitive Definitions
-  , _typeTranslator :: HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType)
+  , _typeTranslator :: Bool -> HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType)
   -- ^ Hardcoded Type -> HWType translator
   , _tcCache        :: HashMap TyConOccName TyCon -- ^ TyCon cache
   , _curCompNm      :: !(Identifier,SrcSpan)

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -73,7 +73,7 @@ runNormalization
   -- ^ UniqueSupply
   -> BindingMap
   -- ^ Global Binders
-  -> (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
+  -> (Bool -> HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
   -- ^ Hardcoded Type -> HWType translator
   -> HashMap TyConOccName TyCon
   -- ^ TyCon cache
@@ -358,7 +358,7 @@ callTreeToList visited (CBranch (nm,bndr) used)
 -- * There are 2 or more reset arguments in scope that have the same reset
 --   domain annotation, and at least one of them is an asynchronous reset.
 clockResetErrors
-  :: (HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
+  :: (Bool -> HashMap TyConOccName TyCon -> Type -> Maybe (Either String HWType))
   -> HashMap TyConOccName TyCon
   -> Type
   -> [String]

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -81,7 +81,7 @@ data RewriteEnv
   = RewriteEnv
   { _dbgLevel       :: DebugLevel
   -- ^ Lvl at which we print debugging messages
-  , _typeTranslator :: HashMap TyConOccName TyCon -> Type
+  , _typeTranslator :: Bool -> HashMap TyConOccName TyCon -> Type
                     -> Maybe (Either String HWType)
   -- ^ Hardcode Type -> HWType translator
   , _tcCache        :: HashMap TyConOccName TyCon

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -6,6 +6,7 @@
   Assortment of utility function used in the Clash library
 -}
 
+
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE MagicHash            #-}

--- a/tests/shouldfail/InOutAsResult.hs
+++ b/tests/shouldfail/InOutAsResult.hs
@@ -1,0 +1,8 @@
+module InOutAsResult where
+
+import Clash.Prelude (Int,undefined)
+import Clash.Signal (InOut,System,Signal)
+
+
+topEntity :: Signal System Int -> InOut System Int
+topEntity _ = undefined

--- a/tests/shouldfail/InOutAsSubtype.hs
+++ b/tests/shouldfail/InOutAsSubtype.hs
@@ -1,0 +1,8 @@
+module InOut where
+
+import Clash.Prelude (Int,undefined)
+import Clash.Signal (InOut,System,Signal)
+
+
+topEntity :: Signal System Int -> Signal System (InOut System Int) -> Signal System Int
+topEntity _ = undefined

--- a/tests/shouldfail/InOutInCompositeTypeInArg.hs
+++ b/tests/shouldfail/InOutInCompositeTypeInArg.hs
@@ -1,0 +1,9 @@
+module InOutInCompositeTypeInArg where
+
+import Clash.Prelude (Int,undefined)
+import Clash.Signal (InOut,System,Signal)
+
+
+topEntity :: (Signal System Int, InOut System Int) -> Signal System Int
+topEntity _ = undefined
+

--- a/tests/shouldfail/InOutInCompositeTypeInResult.hs
+++ b/tests/shouldfail/InOutInCompositeTypeInResult.hs
@@ -1,0 +1,8 @@
+module InOutInCompositeTypeInResult where
+
+import Clash.Prelude (Int,undefined)
+import Clash.Signal (InOut,System,Signal)
+
+
+topEntity :: Signal System Int -> (Signal System Int, InOut System Int)
+topEntity _ = undefined

--- a/tests/shouldwork/Signal/InOut.hs
+++ b/tests/shouldwork/Signal/InOut.hs
@@ -1,0 +1,8 @@
+module InOut where
+
+import Clash.Prelude (Int,undefined)
+import Clash.Signal (InOut,System,Signal)
+
+
+topEntity :: Signal System Int -> InOut System Int -> Signal System Int
+topEntity _ = undefined


### PR DESCRIPTION
This patch adds support for `inout` ports according to [this](https://github.com/clash-lang/clash-compiler/wiki/Plan-for-%60inout%60-signals) plan and [this](https://github.com/clash-lang/clash-compiler/issues/231#issuecomment-335721415) comment. This has been tested by implementing a simple program for a DRAM controller (PR coming soon-ish).

Should be merged in tandem with: https://github.com/clash-lang/clash-prelude/pull/131