### PR TITLE
Fix pack#/unpack# of Signed in Verilog.

### DIFF
--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
@@ -7,13 +7,13 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.pack#"
     , "type"      : "pack# :: KnownNat n => Signed n -> BitVector n"
-    , "templateE" : "~ARG[1]"
+    , "templateE" : "$unsigned(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.unpack#"
     , "type"      : "unpack# :: KnownNat n => BitVector n -> Signed n"
-    , "templateE" : "~ARG[1]"
+    , "templateE" : "$signed(~ARG[1])"
     }
   }
 , { "BlackBox" :
@@ -56,14 +56,14 @@
     { "name"      : "Clash.Sized.Internal.Signed.minBound#"
     , "type"      : "minBound# :: KnownNat n => Signed n"
     , "comment"   : "Generates incorrect SV for n=0"
-    , "templateE" : "{1'b1, {(~LIT[0]-1) {1'b0}}}"
+    , "templateE" : "$signed({1'b1, {(~LIT[0]-1) {1'b0}}})"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => Signed n"
     , "comment"   : "Generates incorrect SV for n=0"
-    , "templateE" : "{1'b0, {(~LIT[0]-1) {1'b1}}}"
+    , "templateE" : "$signed({1'b0, {(~LIT[0]-1) {1'b1}}})"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
@@ -7,13 +7,13 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.pack#"
     , "type"      : "pack# :: KnownNat n => Signed n -> BitVector n"
-    , "templateE" : "~ARG[1]"
+    , "templateE" : "$unsigned(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.unpack#"
     , "type"      : "unpack# :: KnownNat n => BitVector n -> Signed n"
-    , "templateE" : "~ARG[1]"
+    , "templateE" : "$signed(~ARG[1])"
     }
   }
 , { "BlackBox" :
@@ -56,14 +56,14 @@
     { "name"      : "Clash.Sized.Internal.Signed.minBound#"
     , "type"      : "minBound# :: KnownNat n => Signed n"
     , "comment"   : "Generates incorrect SV for n=0"
-    , "templateE" : "{1'b1, {(~LIT[0]-1) {1'b0}}}"
+    , "templateE" : "$signed({1'b1, {(~LIT[0]-1) {1'b0}}})"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => Signed n"
     , "comment"   : "Generates incorrect SV for n=0"
-    , "templateE" : "{1'b0, {(~LIT[0]-1) {1'b1}}}"
+    , "templateE" : "$signed({1'b0, {(~LIT[0]-1) {1'b1}}})"
     }
   }
 , { "BlackBox" :


### PR DESCRIPTION
This explicitly alters the signedness of values when moving between
BitVector and Signed, to ensure that BitVectors are interpreted as
unsigned and Signed as, well, signed.

This cropped up in the compilation of code like the following:

    signedLessThan :: BitVector 8 -> BitVector 8 -> Bool
    signedLessThan a b = signed a < signed b
      where signed :: BitVector 8 -> Signed 8
            signed = unpack

which wound up using an unsigned comparison in the Verilog output.

While in the prim definitions, I fixed two cases where an unsigned bit
literal was masquerading as a signed value, which would have produced
the same issue if a signed value were compared to maxBound/minBound.