### PR TITLE
Display an error when failing to parse primitive json

### DIFF
--- a/clash-lib/src/Data/Aeson/Extra.hs
+++ b/clash-lib/src/Data/Aeson/Extra.hs
@@ -6,19 +6,56 @@
 
 module Data.Aeson.Extra where
 
-import Data.Aeson           (FromJSON, Result (..), fromJSON, json)
-import Data.Attoparsec.Lazy (Result (..), parse)
-import Data.ByteString.Lazy (ByteString)
-import Clash.Util           (traceIf)
+import qualified Data.Ix              as Ix
+import qualified Data.Text            as T
+import           Data.Text            (Text,pack,unpack)
+import           Data.List            (intercalate)
+import           Data.Aeson           (FromJSON, Result (..), fromJSON, json)
+import           Data.Attoparsec.Lazy (Result (..), parse)
+import           Data.ByteString.Lazy (ByteString)
+import           System.FilePath      ()
+
+-- Quick and dirty way of replacing fake escapes in naively converted bytestring
+replaceCommonEscapes :: Text -> Text
+replaceCommonEscapes = ( T.replace (pack "\\n") (pack "\n") ) .
+                       ( T.replace (pack "\\\\") (pack "\\") ) .
+                       ( T.replace (pack "\\\"") (pack "\"") )
+
+genLineErr' :: [Text] -> (Int, Int) -> Int -> Text
+genLineErr' allLines range errorLineN = T.unlines [ T.concat [ if i == errorLineN then pack ">> " else  pack "   "
+                                                             , pack $ show i
+                                                             , pack ". "
+                                                             , allLines !! i
+                                                             ] | i <- Ix.range range]
+
+-- | Pretty print part of json file related to error
+genLineErr :: ByteString -> ByteString -> Text
+genLineErr full part = genLineErr' allLines interval errorLineN
+  where
+    -- Determine interval, and pass to helper function
+    nLastLines = 1 + (length $ T.lines $ replaceCommonEscapes $ pack $ show part)
+    errorLineN = length allLines - nLastLines + 1
+    allLines   = T.lines $ replaceCommonEscapes $ pack $ show full
+    interval   = (max 0 (errorLineN - 5), min (max 0 $ length allLines - 1) (errorLineN + 5))
 
 -- | Parse a ByteString according to the given JSON template. Prints failures
 -- on @stdout@, and returns 'Nothing' if parsing fails.
-decodeAndReport :: (FromJSON a)
-                => ByteString -- ^ Bytestring to parse
+decodeOrErr :: (FromJSON a)
+                => FilePath
+                -> ByteString -- ^ Bytestring to parse
                 -> Maybe a
-decodeAndReport s =
-  case parse json s of
+decodeOrErr path contents =
+  case parse json contents of
     Done _ v -> case fromJSON v of
                     Success a -> Just a
-                    Error msg -> traceIf True msg Nothing
-    Fail _ _ msg -> traceIf True msg Nothing
+                    Error msg -> error ("Could not deduce valid scheme for '" ++ show path ++ "'. Error was: \n\n" ++ msg)
+
+    -- JSON parse error:
+    Fail bytes cntxs msg -> error ( "Could not read or parse " ++ show path ++ ". "
+                                 ++ (if null cntxs then "" else "Context was:\n  " ++ intercalate "\n  " cntxs)
+                                 ++ "\n\nError reported by Attoparsec was:\n  "
+                                 ++ msg
+                                 ++ "\n\nApproximate location of error:\n\n"
+                                 -- HACK: Replace with proper parser/fail logic in future. Or don't. It's not important.
+                                 ++ (unpack $ genLineErr contents bytes)
+                                 )


### PR DESCRIPTION
If clash encounters an invalid primitive json file it will display an (easy to miss and cryptic) warning. This pull request changes this warning to an error halting any compilation process. It includes some (quick and dirty) formatting code which will display the approximate location of the encountered error. 

Example output:

```
<no location info>: error:
    Clash error call:
    Could not read or parse "/home/martijn/code/clash-compiler/.stack-work/install/x86_64-linux/nightly-2017-08-15/8.2.1/share/x86_64-linux-ghc-8.2.1/clash-lib-0.99/prims/vhdl/Clash_Signal_BiSignal.json". 

Error reported by Attoparsec was:
  Failed reading: satisfy

Approximate location of error:

   46.       ",
   47.       "templateD":"
   48. 
   49.         -- writeToBiSignal#
   50.         with (~ARG[2]) select
>> 51.           result <= ~ARG[3] when "true\",
   52.           'Z'               when others;
   53. 
   54.       "
   55.     }
   56.   },


```

