### PR TITLE
Add test of fromJust

### DIFF
--- a/tests/shouldwork/Basic/FromJust.hs
+++ b/tests/shouldwork/Basic/FromJust.hs
@@ -1,0 +1,10 @@
+module FromJust where
+
+import Data.Maybe
+import Clash.Prelude
+
+{-# ANN dut (defTop { t_name = "FromJust_topEntity" }) #-}
+
+dut :: Signal System (Maybe Int)
+    -> Signal System Int
+dut a = fmap fromJust a

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -50,6 +50,7 @@ main =
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "ClassOps"            (["","ClassOps_testBench"],"ClassOps_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CountTrailingZeros"  (["","CountTrailingZeros_testBench"],"CountTrailingZeros_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "DivMod"              ([""],"DivMod_topEntity",False)
+            , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "FromJust"            ([""],"FromJust_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "IrrefError"          ([""],"IrrefError_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LambdaDrop"          ([""],"LambdaDrop_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LotOfStates"         (["","LotOfStates_testBench"],"LotOfStates_testBench",True) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/11525


### PR DESCRIPTION
I have found that fromJust fails to synthesize on GHC 8.2.1 due to missing
unfolding. Namely, the Data.Maybe interface file contains,
```
4cb6dd3ae4cd37241b07963360b4332c
  fromJust :: Maybe a -> a
  {- Arity: 1, Strictness: <S,1*U>,
     Unfolding: InlineRule (1, True, False)
                (\ @ a (ds :: Maybe a) ->
                 case ds of wild { Nothing -> fromJust1 @ a Just x -> x }) -}
53c35d567be116685e810e0ba1a76ff0
  fromJust1 :: a
  {- Strictness: x -}
```