### PR TITLE
Fix heap shortcutting

### DIFF
--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -18,7 +18,7 @@ module Clash.Core.Pretty
 where
 
 import Data.Char                        (isSymbol, isUpper, ord)
-import Data.Text                        (unpack)
+import Data.Text                        (Text, unpack)
 import GHC.Show                         (showMultiLineString)
 import Numeric                          (fromRat)
 import Text.PrettyPrint                 (Doc, char, comma, empty, equals, hang,
@@ -88,6 +88,9 @@ period = char '.'
 
 rarrow :: Doc
 rarrow = text "->"
+
+instance Pretty Text where
+  pprPrec _ = pure . text . unpack
 
 instance Pretty Type where
   pprPrec _ = pprType

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -213,7 +213,8 @@ generateHDL bindingsMap hdlState primMap tcm tupTcm typeTrans eval topEntities
       putStrLn $ "Testbench netlist generation took " ++ show normNetDiff
 
       -- 3. Write HDL
-      let (hdlDocs,_) = createHDL hdlState2 modName' netlist undefined
+      let (hdlDocs,_) = createHDL hdlState2 modName' netlist
+                           (error "Driver: dummy top component")
                            (Text.unpack topNm, Left manifest')
           dir = hdlDir </> maybe "" t_name annM </> modName'
       prepareDir (opt_cleanhdl opts) (extension hdlState2) dir

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -377,7 +377,8 @@ inlineOrLiftBinders condition inlineOrLift ctx expr@(Letrec b) = do
       -- that we intend to lift, the other binders, and the body
       let (others',res')     = substituteBinders doInline (doLift ++ others) res
           (doLift',others'') = splitAt (length doLift) others'
-      (gamma,delta) <- mkEnv (LetBinding undefined (map fst xes) : ctx)
+      (gamma,delta) <- mkEnv (LetBinding (error "inlineOrLiftBinders: dummy binder")
+                                         (map fst xes) : ctx)
       doLift'' <- mapM (liftBinding gamma delta) doLift'
       -- We then substitute the lifted binders in the other binders and the body
       let (others3,res'') = substituteBinders doLift'' others'' res'


### PR DESCRIPTION
This branch fixes a bug in the compile-time evalutor's heap management. The bulk of the change is described in e86d71b. I would like to stress that I'm not yet completely confident that I understand the precise trigger of the bug. That being said, I am much more confident in the implementation after this change than before.

I have also included a variety of patches improving error messages, which I found quite useful in the course of debugging.