### PR TITLE
CI: Haddock testing speedups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,9 @@ install:
   $HOME/.stack-work-cache/installplan.txt; fi;
 script:
 - if [ "$PEDANTIC" = "YES" ]; then export STACKOPTS=--pedantic; fi
-- stack --no-terminal --skip-ghc-check build $STACKOPTS
+- stack --no-terminal --skip-ghc-check build --haddock --no-haddock-deps $STACKOPTS
 # - stack --no-terminal --skip-ghc-check sdist
 - stack exec clash-testsuite
-- stack haddock
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Lately a lot of our test runs on Travis have been timing out.

This patch combines the haddock generation pass with the build pass, thereby avoiding stack building everything twice.
Also disables haddock generation of all our dependencies.

This should speedup testing on Travis quite a lot.