### PR TITLE
Fixed right logical shift primitives for Verilog and SystemVerilog (#266)

### DIFF
--- a/clash-lib/prims/systemverilog/GHC_Prim.json
+++ b/clash-lib/prims/systemverilog/GHC_Prim.json
@@ -255,7 +255,7 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
     }
   }
 , { "BlackBox" :
-    { "name"      : "GHC.Prim.uncheckedIShiftL#"
+    { "name"      : "GHC.Prim.uncheckedShiftRL#"
     , "type"      : "uncheckedShiftRL# :: Word# -> Int# -> Word#"
     , "templateE" : "~ARG[0] >> ~ARG[1]"
     }

--- a/clash-lib/prims/verilog/GHC_Prim.json
+++ b/clash-lib/prims/verilog/GHC_Prim.json
@@ -255,7 +255,7 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
     }
   }
 , { "BlackBox" :
-    { "name"      : "GHC.Prim.uncheckedIShiftL#"
+    { "name"      : "GHC.Prim.uncheckedShiftRL#"
     , "type"      : "uncheckedShiftRL# :: Word# -> Int# -> Word#"
     , "templateE" : "~ARG[0] >> ~ARG[1]"
     }


### PR DESCRIPTION
Hey, I'm still getting familiar with Clash's codebase but this seemed like something easy to fix, so here you go. I hope I'm not missing anything.

This (hopefully) fixes issue #266.

Thanks.