### PR TITLE
Support Unsigned LIT in IF statements

### DIFF
--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -258,6 +258,8 @@ renderElem b (IF c t f) = do
               _ -> error $ $(curLoc) ++ "IF: LIT must be a numeric lit"
           | DataCon (Signed _) _ [Literal _ (NumLit i)] <- l
             -> fromInteger i
+          | DataCon (Unsigned _) _ [Literal _ (NumLit i)] <- l
+            -> fromInteger i
         k -> error $ $(curLoc) ++ ("IF: LIT must be a numeric lit:" ++ show k)
       (Depth e)  -> case lineToType b [e] of
                       (RTree n _) -> n


### PR DESCRIPTION
This is to prevent the following error:

```
<no location info>: error:                                                                     
    Clash error call:                                                                          
    Clash.Netlist.BlackBox.Util(261): IF: LIT must be a numeric lit:(DataCon (Unsigned 64) (DC 
(Void,-1)) [Literal (Just (Unsigned 64,64)) (NumLit 3)],Unsigned 64,True)
```