### PR TITLE
Add primitive warnings

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -41,7 +41,7 @@ doHDL b src = do
   let prepStartDiff = Clock.diffUTCTime prepTime startTime
   putStrLn $ "Loading dependencies took " ++ show prepStartDiff
   generateHDL bindingsMap (Just b) primMap tcm tupTcm (ghcTypeToHWType WORD_SIZE_IN_BITS True) reduceConstant topEntities
-    (ClashOpts 20 20 15 0 DebugFinal False True WORD_SIZE_IN_BITS Nothing HDLSYN True True False ["."]) (startTime,prepTime)
+    (ClashOpts 20 20 15 0 DebugFinal False True True WORD_SIZE_IN_BITS Nothing HDLSYN True True False ["."]) (startTime,prepTime)
 
 main :: IO ()
 main = genVHDL "./examples/FIR.hs"

--- a/clash-ghc/src-bin/Clash/Main.hs
+++ b/clash-ghc/src-bin/Clash/Main.hs
@@ -141,6 +141,7 @@ defaultMain = flip withArgs $ do
                              , opt_inlineConstantLimit = 0
                              , opt_cachehdl    = True
                              , opt_cleanhdl    = True
+                             , opt_primWarn    = True
                              , opt_intWidth    = WORD_SIZE_IN_BITS
                              , opt_hdlDir      = Nothing
                              , opt_hdlSyn      = Other

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -43,6 +43,7 @@ flagsClash r = [
   , defFlag "fclash-hdlsyn"                  $ SepArg (setHdlSyn r)
   , defFlag "fclash-nocache"                 $ NoArg (liftEwM (setNoCache r))
   , defFlag "fclash-noclean"                 $ NoArg (liftEwM (setNoClean r))
+  , defFlag "fclash-no-prim-warn"            $ NoArg (liftEwM (setNoPrimWarn r))
   , defFlag "fclash-spec-limit"              $ IntSuffix (liftEwM . setSpecLimit r)
   , defFlag "fclash-inline-limit"            $ IntSuffix (liftEwM . setInlineLimit r)
   , defFlag "fclash-inline-function-limit"   $ IntSuffix (liftEwM . setInlineFunctionLimit r)
@@ -87,6 +88,9 @@ setNoCache r = modifyIORef r (\c -> c {opt_cachehdl = False})
 
 setNoClean :: IORef ClashOpts -> IO ()
 setNoClean r = modifyIORef r (\c -> c {opt_cleanhdl = False})
+
+setNoPrimWarn :: IORef ClashOpts -> IO ()
+setNoPrimWarn r = modifyIORef r (\c -> c {opt_primWarn = False})
 
 setIntWidth :: IORef ClashOpts
             -> Int

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
@@ -64,6 +64,7 @@ assign ~RESULT = {~ARG[0],~ARG[1]};~FI
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.clockGen"
+    , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
 "clockGen
   :: (domain ~ Dom nm period -- ARG[0]
@@ -88,6 +89,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.tbClockGen"
+    , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
 "tbClockGen
   :: (domain ~ Dom nm period -- ARG[0]

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.json
@@ -66,6 +66,7 @@ assign ~RESULT = {~ARG[0],~ARG[1]};~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.clockGen"
+    , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
 "clockGen
   :: (domain ~ Dom nm period -- ARG[0]
@@ -92,6 +93,7 @@ assign ~RESULT = ~SYM[0];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.tbClockGen"
+    , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
 "tbClockGen
   :: (domain ~ Dom nm period -- ARG[0]

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.json
@@ -142,6 +142,7 @@ end process;~FI~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.clockGen"
+    , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
 "clockGen
   :: (domain ~ Dom nm period -- ARG[0]
@@ -168,6 +169,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.tbClockGen"
+    , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
 "tbClockGen
   :: (domain ~ Dom nm period -- ARG[0]

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -47,6 +47,7 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            , opt_dbgLevel    :: DebugLevel
                            , opt_cachehdl    :: Bool
                            , opt_cleanhdl    :: Bool
+                           , opt_primWarn    :: Bool
                            , opt_intWidth    :: Int
                            , opt_hdlDir      :: Maybe String
                            , opt_hdlSyn      :: HdlSyn

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -19,6 +19,7 @@ module Clash.Netlist.BlackBox where
 import           Control.Exception             (throw)
 import           Control.Lens                  ((.=),(<<%=))
 import qualified Control.Lens                  as Lens
+import           Control.Monad.IO.Class        (liftIO)
 import           Data.Char                     (ord)
 import           Data.Either                   (lefts)
 import qualified Data.HashMap.Lazy             as HashMap
@@ -151,7 +152,9 @@ mkPrimitive :: Bool -- ^ Put BlackBox expression in parenthesis
 mkPrimitive bbEParen bbEasD dst nm args ty = do
   bbM <- HashMap.lookup nm <$> Lens.use primitives
   case bbM of
-    Just p@(P.BlackBox {outputReg = wr}) -> do
+    Just p@(P.BlackBox { warning = wn, outputReg = wr}) -> do
+      -- Print blackbox warning
+      maybe (pure ()) (liftIO . putStrLn . ("Warning: " ++) . unpack) wn
       case template p of
         (Left tempD) -> do
           let pNm = name p

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -476,7 +476,7 @@ removeUnusedExpr :: NormRewrite
 removeUnusedExpr _ e@(collectArgs -> (p@(Prim nm _),args)) = do
   bbM <- HashMap.lookup nm <$> Lens.use (extra.primitives)
   case bbM of
-    Just (BlackBox pNm _ _ _ inc templ) -> do
+    Just (BlackBox pNm _ _ _ _ inc templ) -> do
       let usedArgs = if pNm `elem` ["Clash.Sized.Internal.Signed.fromInteger#"
                                    ,"Clash.Sized.Internal.Unsigned.fromInteger#"
                                    ,"Clash.Sized.Internal.BitVector.fromInteger#"

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -29,6 +29,10 @@ data Primitive a
   = BlackBox
   { name     :: !S.Text
     -- ^ Name of the primitive
+  , warning  :: Maybe S.Text
+    -- ^ A warning to be outputted when the primitive is instantiated.
+    -- This is intended to be used as a warning for primitives that are not
+    -- synthesizable, but may also be used for other purposes.
   , outputReg :: Bool
     -- ^ Verilog only: whether the result should be a /reg/(@True@) or /wire/
     -- (@False@); when not specified in the /.json/ file, the value will default
@@ -53,6 +57,7 @@ instance FromJSON (Primitive Text) where
   parseJSON (Object v) = case H.toList v of
     [(conKey,Object conVal)] -> case conKey of
       "BlackBox"  -> BlackBox <$> conVal .: "name"
+                              <*> conVal .:? "warning"
                               <*> conVal .:? "outputReg" .!= False
                               <*> conVal .:? "libraries" .!= []
                               <*> conVal .:? "imports" .!= []


### PR DESCRIPTION
This PR adds the possibility to specify warnings in the Clash primitive blackbox declarations. These will be shown to the user when generating a NetList using such primitives.

A Clash flag `-fclash-no-prim-warn` will remove the warning (which are enabled by default). Maybe these warnings shouldn't be shown by default?

The main use-case for these warnings is to warn the user that the primitive they are directly or indirectly using is not synthesizable. It is obviously fine to use such primitives in a `testbench` (and maybe the warnings should actually be disabled in testbenches).

The only blackboxes that currently have the warnings enabled are:

- `clockGen`
- `tbClockGen`

I will add warnings to more primitives as I think about them. I welcome any suggestions to improve this PR.

My own suggestions for improvements (I will make further commits to address them if they are of interest to other Clash contributors):

- Print warning to `stderr` instead of `stdout`
- Coloured warnings (orange?)
- Disable warnings for the `testbench` netlist generation
- Remove duplicate warnings (for the same primitive)