### PR TITLE
Added `runFailingTest` function to testsuite

### DIFF
--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -80,7 +80,7 @@ splitNormalized tcm expr = do
       | otherwise -> return $! Left ($(curLoc) ++ "Not in normal form: tyArgs")
     _ -> do
       ty <- termType tcm expr
-      return $! Left ($(curLoc) ++ "Not in normal from: no Letrec:\n\n" ++ showDoc expr ++ "\n\nWhich has type:\n\n"  ++ showDoc ty)
+      return $! Left ($(curLoc) ++ "Not in normal form: no Letrec:\n\n" ++ showDoc expr ++ "\n\nWhich has type:\n\n"  ++ showDoc ty)
 
 -- | Converts a Core type to a HWType given a function that translates certain
 -- builtin types. Errors if the Core type is not translatable.

--- a/tests/shouldfail/RecursiveBoxed.hs
+++ b/tests/shouldfail/RecursiveBoxed.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE ExplicitForAll, ScopedTypeVariables #-}
 module RecursiveBoxed where
 
+import Clash.Prelude
+
 data B a = B a
 
 topEntity :: B (Int -> Int)

--- a/tests/shouldfail/RecursiveDatatype.hs
+++ b/tests/shouldfail/RecursiveDatatype.hs
@@ -1,4 +1,6 @@
 module RecursiveDatatype where
 
+import Clash.Prelude
+
 topEntity :: [Bool]
 topEntity = [True]

--- a/tests/shouldfail/RecursivePoly.hs
+++ b/tests/shouldfail/RecursivePoly.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module RecursivePoly where
 
+import Clash.Prelude
+
 topEntity :: Integer
 topEntity = f 0
 

--- a/testsuite/Test/Tasty/Program.hs
+++ b/testsuite/Test/Tasty/Program.hs
@@ -34,7 +34,9 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-matches #-}
 
 -- | This module provides a function that tests whether a program can
 -- be run successfully. For example if you have 'foo.hs' source file:
@@ -62,37 +64,119 @@
 
 module Test.Tasty.Program (
    testProgram
+ , testFailingProgram
+ , PrintOutput(..)
  ) where
 
 import Control.DeepSeq      ( deepseq                                  )
 import Data.Typeable        ( Typeable                                 )
-import Data.Proxy           ( Proxy (..)                               )
 import System.Directory     ( findExecutable                           )
 import System.Exit          ( ExitCode(..)                             )
 import System.Process       ( runInteractiveProcess, waitForProcess    )
-import System.IO            ( hGetContents                             )
 import Test.Tasty.Providers ( IsTest (..), Result, TestName, TestTree,
                               singleTest, testPassed, testFailed       )
-import Test.Tasty.Options   ( IsOption (..), OptionDescription(..),
-                              safeRead, lookupOption, flagCLParser     )
+import NeatInterpolation    ( text )
 
-data TestProgram = TestProgram String [String] (Maybe FilePath) Bool Bool
+import Text.Regex.PCRE ((=~))
+import Text.Regex.PCRE.Text ()
+
+import qualified Data.Text    as T
+import qualified Data.Text.IO as T
+
+
+data PrintOutput
+  = PrintBoth
+  | PrintStdErr
+  | PrintStdOut
+  | PrintNeither
+
+data TestProgram =
+  TestProgram String [String] (Maybe FilePath) PrintOutput Bool
      deriving (Typeable)
+
+data TestFailingProgram =
+  TestFailingProgram
+    String
+    -- ^ Executable
+    [String]
+    -- ^ Executable args
+    (Maybe FilePath)
+    -- ^ Working directory
+    PrintOutput
+    -- ^ What output to print on test success
+    Bool
+    -- ^ Whether an empty stderr means test failure
+    (Maybe Int)
+    -- ^ Expected return code
+    (Maybe String)
+    -- ^ Expected string in stderr (regular expression)
+     deriving (Typeable)
+
+testOutput
+  :: PrintOutput
+  -- ^ What output to return
+  -> T.Text
+  -- ^ Stderr
+  -> T.Text
+  -- ^ Stdout
+  -> T.Text
+testOutput PrintNeither _stderr _stdout = T.empty
+testOutput PrintStdErr   stderr _stdout = stderr
+testOutput PrintStdOut  _stderr  stdout = stdout
+testOutput PrintBoth     stderr  stdout = [text|
+  Stderr was:
+  $stderr
+
+  Stdout was:
+  $stdout
+  |]
+
 
 -- | Create test that runs a program with given options. Test succeeds
 -- if program terminates successfully.
-testProgram :: TestName        -- ^ Test name
-            -> String          -- ^ Program name
-            -> [String]        -- ^ Program options
-            -> Maybe FilePath  -- ^ Optional working directory
-            -> Bool            -- ^ Whether to print stdout or stderr on success
-            -> Bool            -- ^ Whether a non-empty stdout means failure
-            -> TestTree
+testProgram
+  :: TestName
+  -- ^ Test name
+  -> String
+  -- ^ Program name
+  -> [String]
+  -- ^ Program options
+  -> Maybe FilePath
+  -- ^ Optional working directory
+  -> PrintOutput
+  -- ^ Whether to print stdout or stderr on success
+  -> Bool
+  -- ^ Whether a non-empty stdout means failure
+  -> TestTree
 testProgram testName program opts workingDir stdO stdF =
-    singleTest testName (TestProgram program opts workingDir stdO stdF)
+  singleTest testName (TestProgram program opts workingDir stdO stdF)
+
+-- | Create test that runs a program with given options. Test succeeds
+-- if program terminates with error
+testFailingProgram
+  :: TestName
+  -- ^ Test name
+  -> String
+  -- ^ Program name
+  -> [String]
+  -- ^ Program options
+  -> Maybe FilePath
+  -- ^ Optional working directory
+  -> PrintOutput
+  -- ^ Whether to print stdout or stderr on success
+  -> Bool
+  -- ^ Whether an empty stderr means failure
+  -> Maybe Int
+  -- ^ Expected error code. Test will *only* succeed if program fails and the
+  -- returned error code is equal to the given one.
+  -> (Maybe String)
+  -- ^ Expected string in stderr (regular expression)
+  -> TestTree
+testFailingProgram testName program opts workingDir stdO stdF errCode expectedOutput=
+  singleTest testName (TestFailingProgram program opts workingDir stdO stdF errCode expectedOutput)
 
 instance IsTest TestProgram where
-  run opts (TestProgram program args workingDir stdO stdF) _ = do
+  run _opts (TestProgram program args workingDir stdO stdF) _ = do
     execFound <- findExecutable program
 
     case execFound of
@@ -101,26 +185,92 @@ instance IsTest TestProgram where
 
   testOptions = return []
 
+instance IsTest TestFailingProgram where
+  run _opts (TestFailingProgram program args workingDir stdO stdF errCode expectedOutput) _ = do
+    execFound <- findExecutable program
+
+    case execFound of
+      Nothing       -> return $ execNotFoundFailure program
+      Just progPath -> runFailingProgram progPath args workingDir stdO stdF errCode expectedOutput
+
+  testOptions = return []
+
 -- | Run a program with given options and optional working directory.
 -- Return success if program exits with success code.
-runProgram :: String          -- ^ Program name
-           -> [String]        -- ^ Program options
-           -> Maybe FilePath  -- ^ Optional working directory
-           -> Bool            -- ^ Whether to print stdout or stderr on success
-           -> Bool            -- ^ Whether a non-empty stdout means failure
-           -> IO Result
+runProgram
+  :: String
+  -- ^ Program name
+  -> [String]
+  -- ^ Program options
+  -> Maybe FilePath
+  -- ^ Optional working directory
+  -> PrintOutput
+  -- ^ Whether to print stdout or stderr on success
+  -> Bool
+  -- ^ Whether a non-empty stdout means failure
+  -> IO Result
 runProgram program args workingDir stdO stdF = do
   (_, stdoutH, stderrH, pid) <- runInteractiveProcess program args workingDir Nothing
 
-  stderr <- hGetContents stderrH
-  stdout <- hGetContents stdoutH
+  stderr <- T.hGetContents stderrH
+  stdout <- T.hGetContents stdoutH
   ecode  <- stdout `deepseq` stderr `deepseq` waitForProcess pid
 
   case ecode of
-    ExitSuccess      -> if stdF && not (null stdout)
-                           then return (exitFailure program 1 stderr stdout)
-                           else return (testPassed (if stdO then stdout else stderr))
-    ExitFailure code -> return $ exitFailure program code stderr stdout
+    ExitSuccess ->
+      if stdF && not (T.null stdout)
+        then return (exitFailure program 1 stderr stdout)
+        else return (testPassed $ T.unpack $ testOutput stdO stderr stdout)
+    ExitFailure code ->
+      return $ exitFailure program code stderr stdout
+
+-- | Run a program with given options and optional working directory.
+-- Return success if program exists with error code. Fails if program does
+-- not return (an expected) error code or if the program fails to execute at
+-- all.
+runFailingProgram
+  :: String
+  -- ^ Program name
+  -> [String]
+  -- ^ Program options
+  -> Maybe FilePath
+  -- ^ Optional working directory
+  -> PrintOutput
+  -- ^ Whether to print stdout or stderr on test success
+  -> Bool
+  -- ^ Whether an empty stderr means test failure
+  -> Maybe Int
+  -- ^ Expected error code. Test will *only* succeed if program fails and the
+  -- returned error code is equal to the given one.
+  -> (Maybe String)
+  -- ^ Expected string in stderr (regular expression)
+  -> IO Result
+runFailingProgram program args workingDir stdO errOnEmptyStderr expectedCode expectedStderr = do
+  (_, stdoutH, stderrH, pid) <- runInteractiveProcess program args workingDir Nothing
+
+  stderr <- T.hGetContents stderrH
+  stdout <- T.hGetContents stdoutH
+  ecode  <- stdout `deepseq` stderr `deepseq` waitForProcess pid
+
+  let passed = testPassed (T.unpack $ testOutput stdO stderr stdout)
+
+  return $ case ecode of
+    ExitSuccess ->
+      unexpectedSuccess program stderr stdout
+    ExitFailure code ->
+      if errOnEmptyStderr && T.null stderr
+        then
+          unexpectedEmptyStderr program code stdout
+        else
+          case expectedStderr of
+            Just r | not ((stderr =~ T.pack r) :: Bool) ->
+              unexpectedStderr program code stderr stdout r
+            _ ->
+              case expectedCode of
+                Nothing -> passed
+                Just n | n == code -> passed
+                       | otherwise -> unexpectedCode program code n stderr stdout
+
 
 -- | Indicates that program does not exist in the path
 execNotFoundFailure :: String -> Result
@@ -128,8 +278,101 @@ execNotFoundFailure file =
   testFailed $ "Cannot locate program " ++ file ++ " in the PATH"
 
 -- | Indicates that program failed with an error code
-exitFailure :: String -> Int -> String -> String -> Result
-exitFailure file code stderr stdout =
-  testFailed $ "Program " ++ file ++ " failed with code " ++ show code
-               ++ "\n Stderr was: \n" ++ stderr
-               ++ "\n Stdout was: \n" ++ stdout
+exitFailure :: String -> Int -> T.Text -> T.Text -> Result
+exitFailure (T.pack -> file) (showT -> code) stderr stdout =
+  testFailed $ T.unpack $ [text|
+    Program $file failed with error-code $code.
+
+    Stderr was:
+    $stderr
+
+    Stdout was:
+    $stdout
+  |]
+
+unexpectedStderr
+  :: String
+  -- ^ Program name
+  -> Int
+  -- ^ Code returned by program
+  -> T.Text
+  -- ^ stderr
+  -> T.Text
+  -- ^ stdout
+  -> String
+  -- ^ Expected stderr (regular expression)
+  -> Result
+unexpectedStderr (T.pack -> file) (showT -> code) stderr stdout (T.pack -> expectedStderr) =
+  testFailed $ T.unpack $ [text|
+    Program $file did not print expected output to stderr. We expected:
+
+       $expectedStderr
+
+    Stderr was:
+    $stderr
+
+    Stdout was:
+    $stdout
+  |]
+
+unexpectedEmptyStderr
+  :: String
+  -- ^ Program name
+  -> Int
+  -- ^ Code returned by program
+  -> T.Text
+  -- ^ stdout
+  -> Result
+unexpectedEmptyStderr (T.pack -> file) (showT -> code) stdout =
+  testFailed $ T.unpack $ [text|
+    Program $file (return code: $code) did not print anything
+    to stderr unexpectedly.
+
+    Stdout was:
+    $stdout
+  |]
+
+unexpectedCode
+  :: String
+  -- ^ Program name
+  -> Int
+  -- ^ Error code returned by program
+  -> Int
+  -- ^ Expected code
+  -> T.Text
+  -- ^ stderr
+  -> T.Text
+  -- ^ stdout
+  -> Result
+unexpectedCode (T.pack -> file) (showT -> code) (showT -> expectedCode) stderr stdout =
+  testFailed $ T.unpack $ [text|
+    Program $file exited with code $code, but we expected $expectedCode.
+
+    Stderr was:
+    $stderr
+
+    Stdout was:
+    $stdout
+  |]
+
+unexpectedSuccess
+  :: String
+  -- ^ Program name
+  -> T.Text
+  -- stderr
+  -> T.Text
+  -- stdout
+  -> Result
+unexpectedSuccess (T.pack -> file) stderr stdout =
+  testFailed $ T.unpack $ [text|
+    Program exited $file succesfully, but we expected an error.
+
+    Stderr was:
+    $stderr
+
+    Stdout was:
+    $stdout
+  |]
+
+showT :: Show a => a -> T.Text
+showT = T.pack . show

--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -26,13 +26,19 @@ executable clash-testsuite
   main-is:             Main.hs
   ghc-options:         -Wall
   other-modules:       Test.Tasty.Program
-  other-extensions:    DeriveDataTypeable
-  build-depends:       base          >=4.8      && <5,
-                       deepseq       >=1.4      && <1.5,
-                       directory     >=1.2      && <1.4,
-                       filepath      >=1.4      && <1.5,
-                       process       >=1.2      && <1.7,
-                       tasty         >=0.10.1.2 && <0.12
+  default-extensions:  DeriveDataTypeable
+                       OverloadedStrings
+                       ViewPatterns
+  build-depends:       base               >=4.8      && <5,
+                       deepseq            >=1.4      && <1.5,
+                       directory          >=1.2      && <1.4,
+                       filepath           >=1.4      && <1.5,
+                       process            >=1.2      && <1.7,
+                       tasty              >=0.10.1.2 && <0.12,
+                       neat-interpolation >=0.3      && <0.4,
+                       regex-pcre-builtin >=0.9      && <1,
+                       regex-pcre-text    >=0.9      && <1,
+                       text
 
   -- hs-source-dirs:
   default-language:    Haskell2010


### PR DESCRIPTION
This PR adds tests which are meant to fail to the testsuite. This is needed to test for negative results (i.e., clash halting compilation due to some user error).

It adds `neat-interpolation` as a dependency, to generate multiline strings nicely. This package could use some work (i.e., `string` option, formatting with Markdown like paragraphs for nice error messages), for ideal use. If this is believed to be a valuable addition to the Clash project, I could spend half a day implementing the "ideal" (for our purposes) interpolation package.