### PR TITLE
Ensure we have parens around fields in SOP Con

### DIFF
--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -902,7 +902,7 @@ expr_ _ (DataCon ty@(SP _ args) (DC (_,i)) es) = assignExpr
     argTys     = snd $ args !! i
     dcSize     = conSize ty + sum (map typeSize argTys)
     dcExpr     = expr_ False (dcToExpr ty i)
-    argExprs   = zipWith toSLV argTys es
+    argExprs   = map parens (zipWith toSLV argTys es)
     extraArg   = case typeSize ty - dcSize of
                    0 -> []
                    n -> [bits (replicate n U)]


### PR DESCRIPTION
Since we allow simple expressions to be/remain inlined, the
operator precedence of `&` in VHDL was messing with expressions
in the field position of a SOP Con