### PR TITLE
Feature multithreaded tests. Fixes #270.

### DIFF
--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -38,6 +38,8 @@ executable clash-testsuite
                        neat-interpolation >=0.3      && <0.4,
                        regex-pcre-builtin >=0.9      && <1,
                        regex-pcre-text    >=0.9      && <1,
+                       concurrent-extra   >=0.7      && <0.8,
+                       temporary,
                        text
 
   -- hs-source-dirs:


### PR DESCRIPTION
This PR implements multithreaded tests (see: https://github.com/clash-lang/clash-compiler/issues/270 ). It has been pre-merged with https://github.com/clash-lang/clash-compiler/pull/292. Because Tasty does not actually support sequential tests, tests simply wait for their predecessors to finish using locks. Our average number of sequentially executing tests lies somewhere in between 3 and 4, so the optimal number of threads to use is ~`3.5 * number of cores`. Test with:

```bash
cabal new-run -- testsuite -j16
```

where `16` would be the number of threads spawned.