### PR TITLE
Map `Bit` to a HDL scalar type

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -109,8 +109,11 @@ ghcTypeToHWType iw floatSupport = go
                 synchronous <- resetKind m rstKind
                 return (Reset (pack nm) rate synchronous)
 
-        "Clash.Sized.Internal.BitVector.BitVector" ->
-          (BitVector . fromInteger) <$> mapExceptT (Just . coerce) (tyNatSize m (head args))
+        "Clash.Sized.Internal.BitVector.BitVector" -> do
+          n <- mapExceptT (Just . coerce) (tyNatSize m (head args))
+          case n of
+            1 -> return Bit
+            _ -> return (BitVector (fromInteger n))
 
         "Clash.Sized.Internal.Index.Index" ->
           Index <$> mapExceptT (Just . coerce) (tyNatSize m (head args))

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
@@ -31,19 +31,19 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
-    , "templateE" : "& (~ARG[1])"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE& (~ARG[1])~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
     , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
-    , "templateE" : "| (~ARG[0])"
+    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE| (~ARG[0])~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
     , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
-    , "templateE" : "^ (~ARG[0])"
+    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE^ (~ARG[0])~FI"
     }
   }
 , { "BlackBox" :
@@ -53,7 +53,7 @@
         => BitVector n -- ARG[1]
         -> Int         -- ARG[2]
         -> Bit"
-    , "templateE" : "~VAR[bv][1][~ARG[2]]"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~VAR[bv][1][~ARG[2]]~FI"
     }
   }
 , { "BlackBox" :
@@ -65,11 +65,12 @@
              -> Bit         -- ARG[3]
              -> BitVector n"
     , "templateD" :
-"// replaceBit start
+"// replaceBit start~IF~ISBIT[1]~THEN
+assign ~RESULT = ~ARG[3];~ELSE
 always_comb begin
   ~RESULT = ~ARG[1];
   ~RESULT[~ARG[2]] = ~ARG[3];
-end
+end~FI
 // replaceBit end"
     }
   }
@@ -82,11 +83,13 @@ end
            -> BitVector (m + 1 - n) -- ARG[3]
            -> BitVector (m + 1 + i)"
     , "templateD" :
-"// setSlice begin
+"// setSlice begin~IF~ISBIT[0]~THEN
+assign ~RESULT = ~ARG[3];~ELSE
 always_comb begin
-  ~RESULT = ~ARG[0];
-  ~RESULT[~LIT[1] : ~LIT[2]] = ~ARG[3];
-end
+  ~RESULT = ~ARG[0];~IF~ISBIT[3]~THEN
+  ~RESULT[~LIT[1]] = ~ARG[3];~ELSE
+  ~RESULT[~LIT[1] : ~LIT[2]] = ~ARG[3];~FI
+end~FI
 // setSlice end"
     }
   }
@@ -97,21 +100,25 @@ end
         -> SNat m                -- ARG[1]
         -> SNat n                -- ARG[2]
         -> BitVector (m + 1 - n)"
-    , "templateE" : "~VAR[bv][0][~LIT[1] : ~LIT[2]]"
+    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE~IF~ISBITO~THEN~VAR[bv][0][~LIT[1]]~ELSE~VAR[bv][0][~LIT[1] : ~LIT[2]]~FI~FI"
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.split#"
+    { "name" : "Clash.Sized.Internal.BitVector.splitL#"
     , "type" :
-"split# :: KnownNat n        -- ARG[0]
-        => BitVector (m + n) -- ARG[1]
-        -> (BitVector m, BitVector n)"
-    , "templateD" :
-"// split begin
-assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
-                 , ~VAR[bv][1][(~LIT[0]-1) : 0]
-                 };
-// split end"
+"splitL# :: KnownNat n        -- ARG[0]
+         => BitVector (m + n) -- ARG[1]
+         -> BitVector m"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][LIT[0]]~ELSE~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]~FI~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name" : "Clash.Sized.Internal.BitVector.splitR#"
+    , "type" :
+"splitR# :: KnownNat n        -- ARG[0]
+         => BitVector (m + n) -- ARG[1]
+         -> BitVector n"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][0]~ELSE~VAR[bv][1][(~LIT[0]-1) : 0]~FI~FI"
     }
   }
 , { "BlackBox" :
@@ -176,7 +183,7 @@ assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => BitVector n"
-    , "templateE" : "{~LIT[0] {1'b1}}"
+    , "templateE" : "~IF~ISBITO~THEN1'b1~ELSE{~LIT[0] {1'b1}}~FI"
     }
   }
 , { "BlackBox" :
@@ -206,7 +213,10 @@ assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
-    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
+    , "templateD" :
+"~IF ~ISBITO ~THEN
+assign ~RESULT = ~VAR[bv][1][0];~ELSE
+assign ~RESULT = $unsigned(~VAR[bv][1][(~LIT[0]-1):0]);~FI"
     }
   }
 , { "BlackBox" :
@@ -285,10 +295,11 @@ assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
     { "name"      : "Clash.Sized.Internal.BitVector.rotateL#"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
-"// rotateL begin
+"// rotateL begin~IF ~ISBITO ~THEN
+assign ~RESULT = ~ARG[1];~ELSE
 logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
-assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
+assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];~FI
 // rotateL end"
     }
   }
@@ -296,10 +307,11 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     { "name"      : "Clash.Sized.Internal.BitVector.rotateR#"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
-"// rotateR begin
+"// rotateR begin~IF ~ISBITO ~THEN
+assign ~RESULT = ~ARG[1];~ELSE
 logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
+assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];~FI
 // rotateR end"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.json
@@ -16,8 +16,24 @@
 ~SIGD[~GENSYM[dataout_h][2]][6];
 ~SIGD[~GENSYM[d][3]][6];
 assign ~SYM[3] = ~ARG[6];
-
-genvar ~GENSYM[i][8];
+~IF~ISBIT[6]~THEN
+IDDR #(
+  .DDR_CLK_EDGE(\"SAME_EDGE\"),
+  .INIT_Q1(1'b0),
+  .INIT_Q2(1'b0),
+  .SRTYPE(~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
+) ~GENSYM[~COMPNAME_IDDR][9] (
+  .Q1(~SYM[1]),
+  .Q2(~SYM[2]),~IF ~ISGATED[6] ~THEN
+  .C(~ARG[4][1]),
+  .CE(~ARG[4][0]),~ELSE
+  .C(~ARG[4]),
+  .CE(1'b1),~FI
+  .D(~SYM[3]),
+  .R(~ARG[5]),
+  .S(1'b0)
+);
+~ELSEgenvar ~GENSYM[i][8];
 ~GENERATE
 for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
   IDDR #(
@@ -25,7 +41,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .INIT_Q1(1'b0),
     .INIT_Q2(1'b0),
     .SRTYPE(~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~GENSYM[~COMPNAME_IDDR][9] (
+  ) ~SYM[9] (
     .Q1(~SYM[1][~SYM[8]]),
     .Q2(~SYM[2][~SYM[8]]),~IF ~ISGATED[6] ~THEN
     .C(~ARG[4][1]),
@@ -37,7 +53,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .S(1'b0)
   );
 end
-~ENDGENERATE
+~ENDGENERATE~FI
 
 assign ~RESULT = {~SYM[2],~SYM[1]};
 // iddr end"
@@ -63,15 +79,30 @@ assign ~RESULT = {~SYM[2],~SYM[1]};
 
 assign ~SYM[1] = ~ARG[5];
 assign ~SYM[2] = ~ARG[6];
-
-genvar ~GENSYM[i][8];
+~IF~ISBIT[5]~THEN
+ODDR #(
+  .DDR_CLK_EDGE(\"SAME_EDGE\"),
+  .INIT(1'b0),
+  .SRTYPE(~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
+) ~GENSYM[~COMPNAME_ODDR][9] (
+  .Q(~SYM[3]),~IF ~ISGATED[3] ~THEN
+  .C(~ARG[3][1]),
+  .CE(~ARG[3][0]),~ELSE
+  .C(~ARG[3]),
+  .CE(1'b1),~FI
+  .D1(~SYM[1]),
+  .D2(~SYM[2]),
+  .R(~ARG[4]),
+  .S(1'b0)
+);
+~ELSEgenvar ~GENSYM[i][8];
 ~GENERATE
 for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
   ODDR #(
     .DDR_CLK_EDGE(\"SAME_EDGE\"),
     .INIT(1'b0),
     .SRTYPE(~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~GENSYM[~COMPNAME_ODDR][9] (
+  ) ~SYM[9] (
     .Q(~SYM[3][~SYM[8]]),~IF ~ISGATED[3] ~THEN
     .C(~ARG[3][1]),
     .CE(~ARG[3][0]),~ELSE
@@ -83,7 +114,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .S(1'b0)
   );
 end
-~ENDGENERATE
+~ENDGENERATE~FI
 
 assign ~RESULT = ~SYM[3];
 // oddr end"

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
@@ -31,19 +31,19 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
-    , "templateE" : "& (~ARG[1])"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE& (~ARG[1])~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
     , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
-    , "templateE" : "| (~ARG[0])"
+    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE| (~ARG[0])~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
     , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
-    , "templateE" : "^ (~ARG[0])"
+    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE^ (~ARG[0])~FI"
     }
   }
 , { "BlackBox" :
@@ -53,7 +53,7 @@
         => BitVector n -- ARG[1]
         -> Int         -- ARG[2]
         -> Bit"
-    , "templateE" : "~VAR[bv][1][~ARG[2]]"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~VAR[bv][1][~ARG[2]]~FI"
     }
   }
 , { "BlackBox" :
@@ -67,9 +67,10 @@
     , "outputReg" : true
     , "templateD" :
 "// replaceBit start
-always @(*) begin
+always @(*) begin~IF~ISBIT[1]~THEN
+  ~RESULT = ~VAR[din][3]~ELSE
   ~RESULT = ~ARG[1];
-  ~RESULT[~ARG[2]] = ~VAR[din][3];
+  ~RESULT[~ARG[2]] = ~VAR[din][3]~FI;
 end
 // replaceBit end"
     }
@@ -85,9 +86,10 @@ end
     , "outputReg" : true
     , "templateD" :
 "// setSlice begin
-always @(*) begin
+always @(*) begin~IF~ISBIT[0]~THEN
+  ~RESULT = ~VAR[din][3]~ELSE
   ~RESULT = ~ARG[0];
-  ~RESULT[~LIT[1] : ~LIT[2]] = ~VAR[din][3];
+  ~RESULT[~LIT[1] : ~LIT[2]] = ~VAR[din][3];~FI
 end
 // setSlice end"
     }
@@ -99,16 +101,25 @@ end
         -> SNat m                -- ARG[1]
         -> SNat n                -- ARG[2]
         -> BitVector (m + 1 - n)"
-    , "templateE" : "~VAR[bv][0][~LIT[1] : ~LIT[2]]"
+    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE~IF~ISBITO~THEN~VAR[bv][0][~LIT[1]~ELSE~VAR[bv][0][~LIT[1] : ~LIT[2]]~FI~FI"
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.split#"
+    { "name" : "Clash.Sized.Internal.BitVector.splitL#"
     , "type" :
-"split# :: KnownNat n        -- ARG[0]
-        => BitVector (m + n) -- ARG[1]
-        -> (BitVector m, BitVector n)"
-    , "templateE" : "~ARG[1]"
+"splitL# :: KnownNat n        -- ARG[0]
+         => BitVector (m + n) -- ARG[1]
+         -> BitVector m"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][LIT[0]]~ELSE~VAR[bv][1][(~SIZE[~TYP[1]]-1) : ~LIT[0]]~FI~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name" : "Clash.Sized.Internal.BitVector.splitR#"
+    , "type" :
+"splitR# :: KnownNat n        -- ARG[0]
+         => BitVector (m + n) -- ARG[1]
+         -> BitVector n"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][0]~ELSE~VAR[bv][1][(~LIT[0]-1) : 0]~FI~FI"
     }
   }
 , { "BlackBox" :
@@ -173,7 +184,7 @@ end
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => BitVector n"
-    , "templateE" : "{~LIT[0] {1'b1}}"
+    , "templateE" : "~IF~ISBITO~THEN1'b1~ELSE{~LIT[0] {1'b1}}~FI"
     }
   }
 , { "BlackBox" :
@@ -203,7 +214,7 @@ end
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
-    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
+    , "templateE" : "~IF~ISBITO~THEN~VAR[bv][1][0]~ELSE$unsigned(~VAR[bv][1][(~LIT[0]-1):0])~FI"
     }
   }
 , { "BlackBox" :
@@ -269,23 +280,24 @@ end
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.shiftL#"
     , "type"      : "shiftL# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "~ARG[1] << ~ARG[2]"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSE~ARG[1] << ~ARG[2]~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.shiftR#"
     , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "~ARG[1] >> ~ARG[2]"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSE~ARG[1] >> ~ARG[2]~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rotateL#"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
-"// rotateL begin
+"// rotateL begin~IF~ISBITO~THEN
+assign ~RESULT = ~ARG[1];~ELSE
 wire [2*~LIT[0]-1:0] ~SYM[0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
-assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
+assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];~FI
 // rotateL end"
     }
   }
@@ -293,10 +305,11 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     { "name"      : "Clash.Sized.Internal.BitVector.rotateR#"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
-"// rotateR begin
+"// rotateR begin~IF~ISBITO~THEN
+assign ~RESULT = ~ARG[1];~ELSE
 wire [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
+assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];~FI
 // rotateR end"
     }
   }

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.json
@@ -16,8 +16,24 @@ wire ~SIGD[~GENSYM[dataout_l][1]][6];
 wire ~SIGD[~GENSYM[dataout_h][2]][6];
 wire ~SIGD[~GENSYM[d][3]][6];
 assign ~SYM[3] = ~ARG[6];
-
-genvar ~GENSYM[i][8];
+~IF~ISBIT[6]~THEN
+IDDR #(
+  .DDR_CLK_EDGE(\"SAME_EDGE\"),
+  .INIT_Q1(1'b0),
+  .INIT_Q2(1'b0),
+  .SRTYPE(~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
+) ~GENSYM[~COMPNAME_IDDR][9] (
+  .Q1(~SYM[1]),
+  .Q2(~SYM[2]),~IF ~ISGATED[6] ~THEN
+  .C(~ARG[4][1]),
+  .CE(~ARG[4][0]),~ELSE
+  .C(~ARG[4]),
+  .CE(1'b1),~FI
+  .D(~SYM[3]),
+  .R(~ARG[5]),
+  .S(1'b0)
+);
+~ELSEgenvar ~GENSYM[i][8];
 ~GENERATE
 for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
   IDDR #(
@@ -25,7 +41,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .INIT_Q1(1'b0),
     .INIT_Q2(1'b0),
     .SRTYPE(~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~GENSYM[~COMPNAME_IDDR][9] (
+  ) ~SYM[9] (
     .Q1(~SYM[1][~SYM[8]]),
     .Q2(~SYM[2][~SYM[8]]),~IF ~ISGATED[6] ~THEN
     .C(~ARG[4][1]),
@@ -37,7 +53,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .S(1'b0)
   );
 end
-~ENDGENERATE
+~ENDGENERATE~FI
 
 assign ~RESULT = {~SYM[2],~SYM[1]};
 // iddr end"
@@ -63,7 +79,23 @@ wire ~SIGD[~GENSYM[q][3]][6];
 
 assign ~SYM[1] = ~ARG[5];
 assign ~SYM[2] = ~ARG[6];
-
+~IF~ISBIT[6]~THEN
+ODDR #(
+  .DDR_CLK_EDGE(\"SAME_EDGE\"),
+  .INIT(1'b0),
+  .SRTYPE(~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
+) ~GENSYM[~COMPNAME_ODDR][9] (
+  .Q(~SYM[3]),~IF ~ISGATED[3] ~THEN
+  .C(~ARG[3][1]),
+  .CE(~ARG[3][0]),~ELSE
+  .C(~ARG[3]),
+  .CE(1'b1),~FI
+  .D1(~SYM[1]),
+  .D2(~SYM[2]),
+  .R(~ARG[4]),
+  .S(1'b0)
+);
+~ELSE
 genvar ~GENSYM[i][8];
 ~GENERATE
 for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
@@ -71,7 +103,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .DDR_CLK_EDGE(\"SAME_EDGE\"),
     .INIT(1'b0),
     .SRTYPE(~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~GENSYM[~COMPNAME_ODDR][9] (
+  ) ~SYM[9] (
     .Q(~SYM[3][~SYM[8]]),~IF ~ISGATED[3] ~THEN
     .C(~ARG[3][1]),
     .CE(~ARG[3][0]),~ELSE
@@ -83,7 +115,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .S(1'b0)
   );
 end
-~ENDGENERATE
+~ENDGENERATE~FI
 
 assign ~RESULT = ~SYM[3];
 // oddr end"

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
@@ -51,10 +51,12 @@ begin
   begin
     if rising_edge(~SYM[7]) then
       if ~SYM[8] then
-        if ~ARG[6] then
-          ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
-        end if;
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
+        if ~ARG[6] then~IF~ISBITO~THEN
+          ~SYM[2](~SYM[5]) <= to_bitvector(0 => ~ARG[8]);~ELSE
+          ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);~FI
+        end if;~IF~ISBITO~THEN
+        ~RESULT <= to_stdulogic(~SYM[2](~SYM[4])(0))~ELSE
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))~FI
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -65,10 +67,12 @@ begin
   ~SYM[9] : process(~ARG[2])
   begin
     if rising_edge(~ARG[2]) then
-      if ~ARG[6] then
-        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
-      end if;
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
+      if ~ARG[6] then~IF~ISBITO~THEN
+        ~SYM[2](~SYM[5]) <= to_bitvector(0 => ~ARG[8]);~ELSE
+        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);~FI
+      end if;~IF~ISBITO~THEN
+      ~RESULT <= to_stdulogic(~SYM[2](~SYM[4])(0))~ELSE
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))~FI
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on
@@ -79,11 +83,13 @@ begin
   ~SYM[9] : process(~SYM[7])
   begin
     if rising_edge(~SYM[7]) then
-      if ~ARG[6] and ~SYM[8] then
-        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
+      if ~ARG[6] and ~SYM[8] then~IF~ISBITO~THEN
+        ~SYM[2](~SYM[5]) <= to_bitvector(0 => ~ARG[8]);~ELSE
+        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);~FI
       end if;
-      if ~SYM[8] then
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
+      if ~SYM[8] then~IF~ISBITO~THEN
+        ~RESULT <= to_stdulogic(~SYM[2](~SYM[4]))~ELSE
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))~FI
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -94,10 +100,12 @@ begin
   ~SYM[9] : process(~ARG[2])
   begin
     if rising_edge(~ARG[2]) then
-      if ~ARG[6] then
-        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
-      end if;
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
+      if ~ARG[6] then~IF~ISBITO~THEN
+        ~SYM[2](~SYM[5]) <= to_bitvector(0 => ~ARG[8]);~ELSE
+        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);~FI
+      end if;~IF~ISBITO~THEN
+      ~RESULT <= to_stdulogic(~SYM[2](~SYM[4])(0))~ELSE
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))~FI
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
@@ -39,8 +39,9 @@ begin
   ~GENSYM[romFileSync][7] : process (~SYM[5])
   begin
     if (rising_edge(~SYM[5])) then
-      if ~SYM[6] then
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))
+      if ~SYM[6] then~IF~ISBITO~THEN
+        ~RESULT <= to_stdulogic(~SYM[2](~SYM[3])(0))~ELSE
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))~FI
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -50,8 +51,9 @@ begin
   end process;~ELSE
   ~SYM[7] : process (~ARG[1])
   begin
-    if (rising_edge(~ARG[1])) then
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))
+    if (rising_edge(~ARG[1])) then~IF~ISBITO~THEN
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3])(0))~ELSE
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))~FI
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.json
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.json
@@ -31,8 +31,9 @@ begin
                 mod ~LIT[1]
   -- pragma translate_on
                 ;
-
-  ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
+  ~IF~ISBITO~THEN
+  ~RESULT <= to_stdulogic(~SYM[2](~SYM[3])(0));~ELSE
+  ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));~FI
 end block;
 -- asyncRomFile end"
     }

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
@@ -13,26 +13,33 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.high"
     , "type"      : "high :: Bit"
-    , "templateE" : "std_logic_vector'(\"1\")"
+    , "templateE" : "'1'"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.low"
     , "type"      : "low :: Bit"
-    , "templateE" : "std_logic_vector'(\"0\")"
+    , "templateE" : "'0'"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.++#"
     , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
-    , "templateE" : "std_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic_vector'(~ARG[2]))"
+    , "templateE" :
+"~IF~ISBIT[1]~THEN~IF~ISBIT[2]
+~THENstd_logic_vector'(std_logic'(~ARG[1]) & std_logic'(~ARG[2]))
+~ELSEstd_logic_vector'(std_logic'(~ARG[1]) & std_logic_vector'(~ARG[2]))~FI
+~ELSE~IF~ISBIT[2]
+~THENstd_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic'(~ARG[2]))
+~ELSEstd_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic_vector'(~ARG[2]))~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
     , "templateD" :
-"-- reduceAnd begin
+"-- reduceAnd begin~IF ~ISBIT[1] ~THEN
+~RESULT <= ~ARG[1];~ELSE
 ~GENSYM[reduceAnd][0] : block
   function and_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -56,8 +63,8 @@
     return result;
   end;
 begin
-  ~RESULT <= (0 => and_reduce(~ARG[1]));
-end block;
+  ~RESULT <= and_reduce(~ARG[1]);
+end block;~FI
 -- reduceAnd end"
     }
   }
@@ -65,7 +72,8 @@ end block;
     { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
     , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
     , "templateD" :
-"-- reduceOr begin
+"-- reduceOr begin~IF ~ISBIT[0] ~THEN
+~RESULT <= ~ARG[0];~ELSE
 ~GENSYM[reduceOr][0] : block
   function or_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -89,8 +97,8 @@ end block;
     return result;
   end;
 begin
-  ~RESULT <= (0 => or_reduce(~ARG[0]));
-end block;
+  ~RESULT <= or_reduce(~ARG[0]);
+end block;~FI
 -- reduceOr end"
     }
   }
@@ -98,7 +106,8 @@ end block;
     { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
     , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
     , "templateD" :
-"-- reduceXor begin
+"-- reduceXor begin~IF ~ISBIT[0] ~THEN
+~RESULT <= ~ARG[0];~ELSE
 ~GENSYM[reduceXor][0] : block
   function xor_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -122,8 +131,8 @@ end block;
     return result;
   end;
 begin
-  ~RESULT <= (0 => xor_reduce(~ARG[0]));
-end block;
+  ~RESULT <= xor_reduce(~ARG[0]);
+end block;~FI
 -- reduceXor end"
     }
   }
@@ -135,7 +144,8 @@ end block;
         -> Int         -- ARG[2]
         -> Bit"
     , "templateD" :
-"-- indexBitVector begin~IF ~ISVAR[1] ~THEN
+"-- indexBitVector begin~IF ~ISBIT[1] ~THEN
+~RESULT <= ~ARG[1];~ELSE
 ~GENSYM[indexBitVector][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
@@ -145,18 +155,7 @@ begin
   -- pragma translate_on
                ;
 
-  ~RESULT(0) <= ~ARG[1](~SYM[1]);
-end block;~ELSE
-~SYM[0] : block
-  signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
-begin
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~LIT[0]
-  -- pragma translate_on
-               ;
-
-  ~RESULT(0) <= ~VAR[bv][1](~SYM[1]);
+  ~RESULT <= ~VAR[bv][1](~SYM[1]);
 end block;~FI
 -- indexBitVector end"
     }
@@ -170,7 +169,8 @@ end block;~FI
              -> Bit         -- ARG[3]
              -> BitVector n"
     , "templateD" :
-"-- replaceBit begin
+"-- replaceBit begin~IF ~ISBIT[1] ~THEN
+~RESULT <= ~ARG[3];~ELSE
 ~GENSYM[replaceBit][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
@@ -187,7 +187,7 @@ begin
     ~SYM[2](~SYM[1]) := ~VAR[b][3](0);
     ~RESULT <= ~SYM[2];
   end process;
-end block;
+end block;~FI
 -- replaceBit end"
     }
   }
@@ -200,14 +200,15 @@ end block;
            -> BitVector (m + 1 - n) -- ARG[3]
            -> BitVector (m + 1 + i)"
     , "templateD" :
-"-- setSlice begin
+"-- setSlice begin~IF ~ISBIT[0] ~THEN
+~RESULT <= ~ARG[3];~ELSE
 ~GENSYM[setSlice][0] : process(~VAR[bv][0]~VARS[3])
   variable ~GENSYM[ivec][1] : ~TYP[0];
 begin
   ~SYM[1] := ~ARG[0];
   ~SYM[1](~LIT[1] downto ~LIT[2]) := ~VAR[bv][3];
   ~RESULT <= ~SYM[1];
-end process;
+end process;~FI
 -- setSlice end"
     }
   }
@@ -222,12 +223,23 @@ end process;
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.split#"
+    { "name" : "Clash.Sized.Internal.BitVector.splitL#"
     , "type" :
-"split# :: KnownNat n        -- ARG[0]
-        => BitVector (m + n) -- ARG[1]
-        -> (BitVector m, BitVector n)"
-    , "templateE" : "(~VAR[bv][1](~VAR[bv][1]'high downto ~LIT[0]),~VAR[bv][1](~LIT[0]-1 downto 0))"
+"splitL#
+  :: KnownNat n        -- ARG[0]
+  => BitVector (m + n) -- ARG[1]
+  -> BitVector m"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][~LIT[0]]~ELSE~VAR[bv][1](~VAR[bv][1]'high downto ~LIT[0])~FI~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name" : "Clash.Sized.Internal.BitVector.splitR#"
+    , "type" :
+"splitR#
+  :: KnownNat n        -- ARG[0]
+  => BitVector (m + n) -- ARG[1]
+  -> BitVector n"
+    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][0]~ELSE~VAR[bv][1](~LIT[0]-1 downto 0)~FI~FI"
     }
   }
 , { "BlackBox" :
@@ -236,7 +248,7 @@ end process;
 "msb# :: KnownNat n  -- ARG[0]
       => BitVector n -- ARG[1]
       -> Bit"
-    , "templateE" : "~IF ~LIT[0] ~THEN ~VAR[bv][1](~VAR[bv][1]'high downto ~VAR[bv][1]'high) ~ELSE \"0\" ~FI"
+    , "templateE" : "~IF~LIT[0]~THEN~VAR[bv][1](~VAR[bv][1]'high)~ELSE'0'~FI"
     }
   }
 , { "BlackBox" :
@@ -244,7 +256,7 @@ end process;
     , "type" :
 "lsb# :: BitVector n -- ARG[0]
       -> Bit"
-    , "templateE" : "~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0](0 downto 0) ~ELSE \"0\" ~FI"
+    , "templateE" : "~IF~SIZE[~TYP[0]]~THEN~VAR[bv][0](0)~ELSE'0'~FI"
     }
   }
 , { "BlackBox" :
@@ -287,80 +299,98 @@ end process;
     { "name"      : "Clash.Sized.Internal.BitVector.minBound#"
     , "type"      : "minBound# :: BitVector n"
     , "comment"   : "Generates incorrect VDHL for n=0"
-    , "templateE" : "std_logic_vector'(~SIZE[~TYPO]-1 downto 0 => '0')"
+    , "templateE" : "~IF~ISBITO~THEN'0'~ELSEstd_logic_vector'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => BitVector n"
     , "comment"   : "Generates incorrect VDHL for n=0"
-    , "templateE" : "std_logic_vector'(~LIT[0]-1 downto 0 => '1')"
+    , "templateE" : "~IF~ISBITO~THEN'1'~ELSEstd_logic_vector'(~LIT[0]-1 downto 0 => '1')~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.+#"
     , "type"      : "(+#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "std_logic_vector(unsigned(~ARG[1]) + unsigned(~ARG[2]))"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1] xor ~ARG[2]~ELSEstd_logic_vector(unsigned(~ARG[1]) + unsigned(~ARG[2]))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.-#"
     , "type"      : "(-#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "std_logic_vector(unsigned(~ARG[1]) - unsigned(~ARG[2]))"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1] xor ~ARG[2]~ELSEstd_logic_vector(unsigned(~ARG[1]) - unsigned(~ARG[2]))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.*#"
     , "type"      : "(*#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "std_logic_vector(resize(unsigned(~ARG[1]) * unsigned(~ARG[2]), ~LIT[0]))"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1] and ~ARG[2]~ELSEstd_logic_vector(resize(unsigned(~ARG[1]) * unsigned(~ARG[2]), ~LIT[0]))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.negate#"
     , "type"      : "negate# :: KnownNat n => BitVector n -> BitVector n"
-    , "templateE" : "std_logic_vector(-(signed(~ARG[1])))"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSEstd_logic_vector(-(signed(~ARG[1])))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
-    , "templateE" : "std_logic_vector(resize(unsigned(std_logic_vector(~ARG[1])),~LIT[0]))"
+    , "templateE" : "~IF~ISBITO~THEN~VAR[bv][1](0)~ELSEstd_logic_vector(resize(unsigned(std_logic_vector(~ARG[1])),~LIT[0]))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.plus#"
     , "type"      : "plus# :: BitVector m -> BitVector n -> BitVector (Max m n + 1)"
-    , "templateE" : "std_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO]) + resize(unsigned(~ARG[1]),~SIZE[~TYPO]))"
+    , "templateE" :
+"~IF~ISBIT[0]~THEN~IF~ISBIT[1]
+~THENstd_logic_vector(resize(unsigned'(0 => ~ARG[0]),~SIZE[~TYPO]) + resize(unsigned'(0 => ~ARG[1]),~SIZE[~TYPO]))
+~ELSEstd_logic_vector(resize(unsigned'(0 => ~ARG[0]),~SIZE[~TYPO]) - resize(unsigned(~ARG[1]),~SIZE[~TYPO])~FI
+~ELSE~IF~ISBIT[1]
+~THENstd_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO]) - resize(unsigned'(0 => ~ARG[1]),~SIZE[~TYPO])
+~ELSEstd_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO]) - resize(unsigned(~ARG[1]),~SIZE[~TYPO])~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.minus#"
     , "type"      : "minus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
-    , "templateE" : "std_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) - resize(unsigned(~ARG[3]),~SIZE[~TYPO]))"
+    , "templateE" :
+"~IF~ISBIT[2]~THEN~IF~ISBIT[3]
+~THENstd_logic_vector(resize(unsigned'(0 => ~ARG[2]),~SIZE[~TYPO]) - resize(unsigned'(0 => ~ARG[3]),~SIZE[~TYPO]))
+~ELSEstd_logic_vector(resize(unsigned'(0 => ~ARG[2]),~SIZE[~TYPO]) - resize(unsigned(~ARG[3]),~SIZE[~TYPO]))~FI
+~ELSE~IF~ISBIT[3]
+~THENstd_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) - resize(unsigned'(0 => ~ARG[3]),~SIZE[~TYPO]))
+~ELSEstd_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) - resize(unsigned(~ARG[3]),~SIZE[~TYPO]))~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.times#"
     , "type"      : "times# :: BitVector m -> BitVector n -> BitVector (m + n)"
-    , "templateE" : "std_logic_vector(unsigned(~ARG[0]) * unsigned(~ARG[1]))"
+    , "templateE" :
+"~IF~ISBIT[0]~THEN~IF~ISBIT[1]
+~THENstd_logic_vector(unsigned'(0 => ~ARG[0]) * unsigned'(0 => ~ARG[1]))
+~ELSEstd_logic_vector(unsigned'(0 => ~ARG[0]) * unsigned(~ARG[1]))~FI
+~ELSE~IF~ISBIT[1]
+~THENstd_logic_vector(unsigned(~ARG[0]) * unsigned'(0 => ~ARG[1]))
+~ELSEstd_logic_vector(unsigned(~ARG[0]) * unsigned(~ARG[1]))~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.quot#"
     , "type"      : "quot# :: BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "std_logic_vector(unsigned(~ARG[0]) / unsigned(~ARG[1]))"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[0]~ELSEstd_logic_vector(unsigned(~ARG[0]) / unsigned(~ARG[1]))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rem#"
     , "type"      : "rem# :: BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "std_logic_vector(unsigned(~ARG[0]) rem unsigned(~ARG[1]))"
+    , "templateE" : "~IF~ISBITO~THEN'0'~ELSEstd_logic_vector(unsigned(~ARG[0]) rem unsigned(~ARG[1]))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.toInteger#"
     , "type"      : "toInteger# :: BitVector n -> Integer"
-    , "templateE" : "signed(std_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO])))"
+    , "templateE" : "~IF~ISBIT[0]~THENsigned(std_logic_vector(resize(unsigned'(0 => ~ARG[0]),~SIZE[~TYPO])))~ELSEsigned(std_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO])))~FI"
     }
   }
 , { "BlackBox" :
@@ -396,25 +426,31 @@ end process;
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.shiftR#"
     , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "std_logic_vector(shift_right(unsigned(~ARG[1]),to_integer(~ARG[2])))"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSEstd_logic_vector(shift_right(unsigned(~ARG[1]),to_integer(~ARG[2])))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rotateL#"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2])))"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSEstd_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2])))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rotateR#"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2])))"
+    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSEstd_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2])))~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.resize#"
     , "type"      : "resize# :: KnownNat m => BitVector n -> BitVector m"
-    , "templateE" : "std_logic_vector(resize(unsigned(~ARG[1]),~LIT[0]))"
+    , "templateE" :
+"~IF~ISBITO~THEN~IF~ISBIT[1]
+~THEN~ARG[1]
+~ELSE~VAR[bv][1](0)~FI
+~ELSE~IF~ISBIT[1]
+~THENstd_logic_vector(resize(unsigned'(0 => ~ARG[1]),~LIT[0]))
+~ELSEstd_logic_vector(resize(unsigned(~ARG[1]),~LIT[0]))~FI~FI"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.json
@@ -1,13 +1,13 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.pack#"
     , "type"      : "pack# :: Index n -> BitVector (CLog 2 n)"
-    , "templateE" : "std_logic_vector(~ARG[0])"
+    , "templateE" : "~IF~ISBITO~THEN~VAR[i][0](0)~ELSEstd_logic_vector(~ARG[0])~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.unpack#"
     , "type"      : "unpack# :: KnownNat n => BitVector (CLog 2 n) -> Index n"
-    , "templateE" : "unsigned(~ARG[1])"
+    , "templateE" : "~IF~ISBIT[1]~THENunsigned'(0 => ~ARG[1])~ELSEunsigned(~ARG[1])~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
@@ -7,13 +7,13 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.pack#"
     , "type"      : "pack# :: KnownNat n => Signed n -> BitVector n"
-    , "templateE" : "std_logic_vector(~ARG[1])"
+    , "templateE" : "~IF~ISBITO~THEN~VAR[s][1](0)~ELSEstd_logic_vector(~ARG[1])~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.unpack#"
     , "type"      : "unpack# :: KnownNat n => BitVector n -> Signed n"
-    , "templateE" : "signed(~ARG[1])"
+    , "templateE" : "~IF~ISBIT[1]~THENsigned'(0 => ~ARG[1])~ELSEsigned(~ARG[1])~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.json
@@ -7,13 +7,13 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.pack#"
     , "type"      : "pack# :: Unsigned n -> BitVector n"
-    , "templateE" : "std_logic_vector(~ARG[0])"
+    , "templateE" : "~IF~ISBITO~THEN~VAR[u][0](0)~ELSEstd_logic_vector(~ARG[0])~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.unpack#"
     , "type"      : "unpack# :: BitVector n -> Unsigned n"
-    , "templateE" : "unsigned(~ARG[0])"
+    , "templateE" : "~IF~ISBIT[0]~THENunsigned'(0 => ~ARG[0])~ELSEunsigned(~ARG[0])~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.json
@@ -381,12 +381,7 @@ end generate;
 "concatBitVector# :: (KnownNat n,KnownNat m) -- (ARG[0],ARG[1])
                   => Vec n (BitVector m)     -- ARG[2]
                   -> BitVector (n * m)"
-    , "templateD" :
-"-- concatBitVector begin
-~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~VAR[vec][2]'range generate
-  ~RESULT(((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1])) <= ~TYPMO'(~VAR[vec][2](~VAR[vec][2]'high - ~SYM[3]));
-end generate;
--- concatBitVector end"
+    , "templateE" : "~IF~ISBITO~THEN~VAR[v][2](0)~ELSE~TOBV[~ARG[2]][~TYP[2]]~FI"
     }
   }
 , { "BlackBox" :
@@ -395,12 +390,7 @@ end generate;
 "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
                     => BitVector (n * m)        -- ARG[2]
                     -> Vec n (BitVector m)"
-    , "templateD" :
-"-- unconcatBitVector begin
-~GENSYM[unconcatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~RESULT'range generate
-  ~RESULT(~RESULT'high - ~SYM[3]) <= ~VAR[vec][2](((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1]));
-end generate;
--- unconcatBitVector end"
+    , "templateE" : "~IF~ISBIT[2]~THEN~TYPMO'(0 => ~ARG[2])~ELSE~FROMBV[~ARG[2]][~TYPO]~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.json
@@ -25,10 +25,27 @@ begin~IF ~ISGATED[4] ~THEN
   (~SYM[4],~SYM[5]) <= ~ARG[4];
   ~SYM[6] <= '1' when (~SYM[5]) else '0';~ELSE ~FI
   ~SYM[3] <= ~ARG[6];
-
+~IF~ISBIT[6]~THEN
+  ~GENSYM[~COMPNAME_IDDR_inst][9] : IDDR
+  generic map (
+    DDR_CLK_EDGE => \"SAME_EDGE\",
+    INIT_Q1      => '0',
+    INIT_Q2      => '0',
+    SRTYPE       => ~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
+  port map (
+    Q1 => ~SYM[1],   -- 1-bit output for positive edge of clock
+    Q2 => ~SYM[2],   -- 1-bit output for negative edge of clock~IF ~ISGATED[4] ~THEN
+    C  => ~SYM[4],   -- 1-bit clock input
+    CE => ~SYM[6],   -- 1-bit clock enable input~ELSE
+    C  => ~ARG[4],   -- 1-bit clock input
+    CE => '1',       -- 1-bit clock enable input~FI
+    D  => ~SYM[3],   -- 1-bit DDR data input
+    R  => ~ARG[5],   -- 1-bit reset
+    S  => '0'        -- 1-bit set
+  );~ELSE
   ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
   begin
-    ~GENSYM[~COMPNAME_IDDR_inst][9] : IDDR
+    ~SYM[9] : IDDR
     generic map (
       DDR_CLK_EDGE => \"SAME_EDGE\",
       INIT_Q1      => '0',
@@ -45,7 +62,7 @@ begin~IF ~ISGATED[4] ~THEN
       R  => ~ARG[5],   -- 1-bit reset
       S  => '0'        -- 1-bit set
     );
-  end generate;
+  end generate;~FI
 
   ~RESULT <= (~SYM[2], ~SYM[1]);
 end block;
@@ -80,10 +97,25 @@ begin~IF ~ISGATED[3] ~THEN
   ~SYM[6] <= '1' when (~SYM[5]) else '0';~ELSE ~FI
   ~SYM[1] <= ~ARG[5];
   ~SYM[2] <= ~ARG[6];
-
+  ~IF~ISBIT[6]~THEN
+  generic map(
+    DDR_CLK_EDGE => \"SAME_EDGE\",
+    INIT => '0',
+    SRTYPE => ~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
+  port map (
+    Q  => ~SYM[3],   -- 1-bit DDR output~IF ~ISGATED[3] ~THEN
+    C  => ~SYM[4],   -- 1-bit clock input
+    CE => ~SYM[6],   -- 1-bit clock enable input~ELSE
+    C  => ~ARG[3],   -- 1-bit clock input
+    CE => '1',       -- 1-bit clock enable input~FI
+    D1 => ~SYM[1],   -- 1-bit data input (positive edge)
+    D2 => ~SYM[2],   -- 1-bit data input (negative edge)
+    R  => ~ARG[4],   -- 1-bit reset input
+    S  => '0'        -- 1-bit set input
+  );~ELSE
   ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
   begin
-    ~GENSYM[~COMPNAME_ODDR_inst][9] : ODDR
+    ~SYM[9] : ODDR
     generic map(
       DDR_CLK_EDGE => \"SAME_EDGE\",
       INIT => '0',
@@ -99,7 +131,7 @@ begin~IF ~ISGATED[3] ~THEN
       R  => ~ARG[4],    -- 1-bit reset input
       S  => '0'         -- 1-bit set input
     );
-  end generate;
+  end generate;~FI
 
   ~RESULT <= ~SYM[3];
 end block;

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -225,6 +225,7 @@ mkTyPackage_ modName hwtys =
 
     isUnsigned :: HWType -> Bool
     isUnsigned Bool          = True
+    isUnsigned Bit           = True
     isUnsigned (Unsigned _)  = True
     isUnsigned (BitVector _) = True
     isUnsigned (Index _)     = True
@@ -238,7 +239,7 @@ mkUsedTys v@(Vector _ elTy)   = v : mkUsedTys elTy
 mkUsedTys t@(RTree _ elTy)    = t : mkUsedTys elTy
 mkUsedTys p@(Product _ elTys) = p : concatMap mkUsedTys elTys
 mkUsedTys sp@(SP _ elTys)     = sp : concatMap mkUsedTys (concatMap snd elTys)
-mkUsedTys c@(Clock n r Gated) = [c,Clock n r Source,Bool]
+mkUsedTys c@(Clock _ _ Gated) = [c,Bit,Bool]
 mkUsedTys t                   = [t]
 
 topSortHWTys :: [HWType]
@@ -313,7 +314,7 @@ tyDec ty@(Product _ tys) | typeSize ty > 0 = Just A.<$> prodDec
 tyDec _ = pure Nothing
 
 gatedClockType :: HWType -> HWType
-gatedClockType (Clock nm rt Gated) = Product ("GatedClock" `Text.append` (pack (show (nm,rt)))) [Clock nm rt Source,Bool]
+gatedClockType (Clock nm rt Gated) = Product ("GatedClock" `Text.append` (pack (show (nm,rt)))) [Bit,Bool]
 gatedClockType ty = ty
 {-# INLINE gatedClockType #-}
 
@@ -325,6 +326,7 @@ splitVecTy = fmap splitElemTy . go
       Vector _ _  -> error $ $(curLoc) ++ "impossible"
       Clock {}    -> (ns, verilogType t)
       Reset {}    -> (ns, "logic")
+      Bit         -> (ns, "logic")
       String      -> (ns, "string")
       Signed n    -> (ns ++ [Left n],"logic signed")
       _           -> (ns ++ [Left (typeSize t)], "logic")
@@ -514,6 +516,7 @@ verilogType t = do
     Clock _ _ Gated -> verilogType (gatedClockType t)
     Clock {}      -> "logic"
     Reset {}      -> "logic"
+    Bit           -> "logic"
     String        -> "string"
     _ -> "logic" <+> brackets (int (typeSize t -1) <> colon <> int 0)
 
@@ -533,7 +536,8 @@ verilogTypeMark t = do
     _ -> empty
 
 tyName :: HWType -> SystemVerilogM Doc
-tyName Bool              = "logic_vector_1"
+tyName Bool              = "logic"
+tyName Bit               = "logic"
 tyName (Vector n elTy)   = "array_of_" <> int n <> "_" <> tyName elTy
 tyName (RTree n elTy)    = "tree_of_" <> int n <> "_" <> tyName elTy
 tyName (BitVector n)     = "logic_vector_" <> int n
@@ -703,8 +707,8 @@ expr_ _ (Identifier id_ (Just (Indexed (ty@(Product _ tys),_,fI)))) = do
   id'<- fmap (displayT . renderOneLine) (text id_ <> dot <> tyName ty <> "_sel" <> int fI)
   simpleFromSLV (tys !! fI) id'
 
-expr_ _ (Identifier id_ (Just (Indexed (ty@(Clock nm rt Gated),_,fI)))) = do
-  let tys = [Clock nm rt Source, Bool]
+expr_ _ (Identifier id_ (Just (Indexed (ty@(Clock _ _ Gated),_,fI)))) = do
+  let tys = [Bit, Bool]
       ty' = gatedClockType ty
   id'<- fmap (displayT . renderOneLine) (text id_ <> dot <> tyName ty' <> "_sel" <> int fI)
   simpleFromSLV (tys !! fI) id'
@@ -790,8 +794,8 @@ expr_ _ (DataCon ty@(SP _ args) (DC (_,i)) es) = assignExpr
 
 expr_ _ (DataCon ty@(Sum _ _) (DC (_,i)) []) = int (typeSize ty) <> "'d" <> int i
 expr_ _ (DataCon (Product _ tys) _ es) = listBraces (zipWithM toSLV tys es)
-expr_ _ (DataCon (Clock nm rt Gated) _ es) =
-  listBraces (zipWithM toSLV [Clock nm rt Source,Bool] es)
+expr_ _ (DataCon (Clock _ _ Gated) _ es) =
+  listBraces (zipWithM toSLV [Bit,Bool] es)
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Signed.fromInteger#"

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -249,17 +249,18 @@ verilogType' isDecl t =
       getVerilogTy _          = (empty,    typeSize t)
 
   in case t of
-       -- special case: clocks and resets
+       -- special case: Bit, clocks and resets
        Clock _ _ Gated -> verilogType' isDecl (gatedClockType t)
        Clock {} -> empty
        Reset {} -> empty
+       Bit      -> empty
 
        -- otherwise, print the type and prefix
        ty | (prefix, sz) <- getVerilogTy ty
          -> prefix <+> renderVerilogTySize (sz-1)
 
 gatedClockType :: HWType -> HWType
-gatedClockType (Clock nm rt Gated) = Product "GatedClock" [Clock nm rt Source,Bool]
+gatedClockType (Clock _ _ Gated) = Product "GatedClock" [Bit,Bool]
 gatedClockType ty = ty
 {-# INLINE gatedClockType #-}
 
@@ -372,9 +373,9 @@ modifier offset (Indexed (ty@(Product _ argTys),_,fI)) = Just (start+offset,end+
     start   = typeSize ty - 1 - otherSz
     end     = start - argSize + 1
 
-modifier offset (Indexed (ty@(Clock nm rt Gated),_,fI)) = Just (start+offset,end+offset)
+modifier offset (Indexed (ty@(Clock _ _ Gated),_,fI)) = Just (start+offset,end+offset)
   where
-    argTys  = [Clock nm rt Source, Bool]
+    argTys  = [Bit, Bool]
     argTy   = argTys !! fI
     argSize = typeSize argTy
     otherSz = otherSize argTys (fI - 1)

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -110,7 +110,7 @@ mkArgument bndr e = do
     ty    <- termType tcm e
     iw    <- Lens.use intWidth
     hwTyM <- N.termHWTypeM e
-    let eTyMsg = "(" ++ showDoc e ++ " :: " ++ showDoc ty ++ ")"
+    let eTyMsg = "(" ++ showDoc e ++ " :: " ++ show ty ++ ")"
     ((e',t,l),d) <- case hwTyM of
       Nothing   ->
         return ((Identifier (error ($(curLoc) ++ "Forced to evaluate untranslatable type: " ++ eTyMsg)) Nothing

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -101,6 +101,8 @@ pTagE =  O True            <$  pToken "~ERESULT"
      <|> IsVar             <$> (pToken "~ISVAR" *> pBrackets pNatural)
      <|> IsGated           <$> (pToken "~ISGATED" *> pBrackets pNatural)
      <|> IsSync            <$> (pToken "~ISSYNC" *> pBrackets pNatural)
+     <|> IsBit Nothing     <$  (pToken "~ISBITO")
+     <|> (IsBit . Just)    <$> (pToken "~ISBIT" *> pBrackets pNatural)
      <|> StrCmp            <$> (pToken "~STRCMP" *> pBrackets pSigD) <*> pBrackets pNatural
      <|> OutputWireReg     <$> (pToken "~OUTPUTWIREREG" *> pBrackets pNatural)
      <|> GenSym            <$> (pToken "~GENSYM" *> pBrackets pSigD) <*> pBrackets pNatural

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -51,6 +51,7 @@ data Element = C   !Text         -- ^ Constant
              | IsVar !Int
              | IsGated !Int
              | IsSync !Int
+             | IsBit !(Maybe Int)
              | StrCmp [Element] !Int
              | OutputWireReg !Int
              | Vars !Int

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -284,6 +284,13 @@ renderElem b (IF c t f) = do
                     in case ty of
                        Reset _ _ Synchronous -> 1
                        _ -> 0
+      (IsBit nM)  -> let ty = case nM of
+                                Just n | (_,ty',_) <- bbInputs b !! n -> ty'
+                                _ -> snd (bbResult b)
+                     in case ty of
+                        BitVector 1 -> 1
+                        Bit -> 1
+                        _ -> 0
       (StrCmp [C t1] n) ->
         let (e,_,_) = bbInputs b !! n
         in  case exprToText e of
@@ -527,6 +534,8 @@ prettyElem (IsLit i) = (displayT . renderOneLine) <$> (text "~ISLIT" <> brackets
 prettyElem (IsVar i) = (displayT . renderOneLine) <$> (text "~ISVAR" <> brackets (int i))
 prettyElem (IsGated i) = (displayT . renderOneLine) <$> (text "~ISGATED" <> brackets (int i))
 prettyElem (IsSync i) = (displayT . renderOneLine) <$> (text "~ISSYNC" <> brackets (int i))
+prettyElem (IsBit Nothing) = return "~ISBITO"
+prettyElem (IsBit (Just i)) = (displayT . renderOneLine) <$> (text "~ISBIT" <> brackets (int i))
 prettyElem (StrCmp es i) = do
   es' <- prettyBlackBox es
   (displayT . renderOneLine) <$> (text "~STRCMP" <> brackets (text es') <> brackets (int i))

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -95,6 +95,7 @@ data HWType
   = Void -- ^ Empty type
   | String -- ^ String type
   | Bool -- ^ Boolean type
+  | Bit -- ^ Bit type
   | BitVector !Size -- ^ BitVector of a specified size
   | Index    !Integer -- ^ Unsigned integer with specified (exclusive) upper bounder
   | Signed   !Size -- ^ Signed integer of a specified size

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -199,6 +199,7 @@ representableType builtInTranslation allowZero stringRepresentable m =
     isRepresentable hty = case hty of
       String          -> stringRepresentable
       Bool            -> True
+      Bit             -> True
       BitVector n     -> (n > 0) || allowZero
       Index n         -> (n > 0) || allowZero
       Signed n        -> (n > 0) || allowZero
@@ -219,6 +220,7 @@ typeSize :: HWType
 typeSize Void = 0
 typeSize String = 1
 typeSize Bool = 1
+typeSize Bit = 1
 typeSize (Clock {}) = 1
 typeSize (Reset {}) = 1
 typeSize (BitVector i) = i

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1186,7 +1186,7 @@ reduceBinders processed body ((id_,expr):binders) = case List.find ((== expr) . 
     Nothing -> reduceBinders ((id_,expr):processed) body binders
 
 reduceConst :: NormRewrite
-reduceConst _ e@(App _ _)
+reduceConst _ e
   | isConstant e
   , (conPrim, _) <- collectArgs e
   , isPrim conPrim


### PR DESCRIPTION
So instead of mapping `Bit` to

VHDL: `std_logic_vector(0 downto 0)`
Verilog: `wire [0:0]`

We map `Bit` to:

VHDL: `std_logic`
Verilog: `wire`

We now map Enums to `std_logic_vector` in VHDL instead of
`unsigned` so that people can still get a:

`std_logic_vector(0 downto 0)`

By creating a 2-value Enum.