### PR TITLE
Generate QSysIncludeName hash non-recursively

### DIFF
--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -675,13 +675,16 @@ inst_ (BlackBoxD _ _ _ Nothing bs bbCtx) = do
   fmap Just (string t)
 
 inst_ (BlackBoxD _ _ _ (Just (nm,inc)) bs bbCtx) = do
-  inc' <- renderBlackBox inc bbCtx
   iw <- use intWidth
-  let incHash = hash inc'
+  incForHash <- renderBlackBox inc (bbCtx {bbQsysIncName = Just "~QSYSINCLUDENAME"})
+  let incHash = hash incForHash
       nm'     = Text.concat [ Text.fromStrict nm
                             , Text.pack (printf ("%0" ++ show iw ++ "X") incHash)
                             ]
-  t <- renderBlackBox bs (bbCtx {bbQsysIncName = Just nm'})
+      bbNamedCtx = bbCtx {bbQsysIncName = Just nm'}
+
+  inc' <- renderBlackBox inc bbNamedCtx
+  t <- renderBlackBox bs bbNamedCtx
   inc'' <- text inc'
   includes %= ((unpack nm', inc''):)
   fmap Just (string t)

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -770,13 +770,16 @@ inst_ (BlackBoxD _ libs packs Nothing bs bbCtx) = do
 inst_ (BlackBoxD _ libs packs (Just (nm,inc)) bs bbCtx) = do
   libraries %= ((map T.fromStrict libs) ++)
   packages  %= ((map T.fromStrict packs) ++)
-  inc' <- renderBlackBox inc bbCtx
+  incForHash <- renderBlackBox inc (bbCtx {bbQsysIncName = Just "~QSYSINCLUDENAME"})
   iw <- use intWidth
-  let incHash = hash inc'
+  let incHash = hash incForHash
       nm'     = T.concat [ T.fromStrict nm
                          , T.pack (printf ("%0" ++ show (iw `div` 4) ++ "X") incHash)
                          ]
-  t <- renderBlackBox bs (bbCtx {bbQsysIncName = Just nm'})
+      bbNamedCtx = bbCtx {bbQsysIncName = Just nm'}
+
+  inc' <- renderBlackBox inc bbNamedCtx
+  t <- renderBlackBox bs bbNamedCtx
   inc'' <- text inc'
   includes %= ((unpack nm', inc''):)
   fmap Just (string t)

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -336,13 +336,16 @@ inst_ (BlackBoxD _ _ _ Nothing bs bbCtx) = do
   fmap Just (string t)
 
 inst_ (BlackBoxD _ _ _ (Just (nm,inc)) bs bbCtx) = do
-  inc' <- renderBlackBox inc bbCtx
   iw <- use intWidth
-  let incHash = hash inc'
+  incForHash <- renderBlackBox inc (bbCtx {bbQsysIncName = Just "~QSYSINCLUDENAME"})
+  let incHash = hash incForHash
       nm'     = Text.concat [ Text.fromStrict nm
                             , Text.pack (printf ("%0" ++ show (iw `div` 4) ++ "X") incHash)
                             ]
-  t <- renderBlackBox bs (bbCtx {bbQsysIncName = Just nm'})
+      bbNamedCtx = bbCtx {bbQsysIncName = Just nm'}
+
+  inc' <- renderBlackBox inc bbNamedCtx
+  t <- renderBlackBox bs bbNamedCtx
   inc'' <- text inc'
   includes %= ((unpack nm', inc''):)
   fmap Just (string t)


### PR DESCRIPTION
This changes `BlackBox` generation so `~QSYSINCLUDENAME` an be used in the `qsysInclude` json entry. As `~QSYSINCLUDENAME` contains a hash of `qsysInclude` we have to take the hash of `qsysInclude` keeping the string "~QSYSINCLUDENAME" in place (but replace literals and other bits) and then regenerate the `.qsys` replacing "~QSYSINCLUDENAME".