### PR TITLE
 Map `Bit` to a HDL scalar type

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -975,12 +975,51 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
        in  reduce (mkApps (Data intCon) [Left (Literal (IntLiteral (kn-1)))])
 
 -- Construction
-  "Clash.Sized.Internal.BitVector.high"
+  "Clash.Sized.Internal.BitVector.high" -- :: Bit
+    -> reduce (mkBitLit ty 1)
+  "Clash.Sized.Internal.BitVector.low" -- :: Bit
+    -> reduce (mkBitLit ty 0)
+
+-- Eq
+  "Clash.Sized.Internal.BitVector.eq##" | [i,j] <- bitLiterals args
+    -> reduce (boolToBoolLiteral tcm ty (i == j))
+  "Clash.Sized.Internal.BitVector.neq##" | [i,j] <- bitLiterals args
+    -> reduce (boolToBoolLiteral tcm ty (i /= j))
+
+-- Ord
+  "Clash.Sized.Internal.BitVector.lt##" | [i,j] <- bitLiterals args
+    -> reduce (boolToBoolLiteral tcm ty (i <  j))
+  "Clash.Sized.Internal.BitVector.ge##" | [i,j] <- bitLiterals args
+    -> reduce (boolToBoolLiteral tcm ty (i >= j))
+  "Clash.Sized.Internal.BitVector.gt##" | [i,j] <- bitLiterals args
+    -> reduce (boolToBoolLiteral tcm ty (i >  j))
+  "Clash.Sized.Internal.BitVector.le##" | [i,j] <- bitLiterals args
+    -> reduce (boolToBoolLiteral tcm ty (i <= j))
+
+-- Bits
+  "Clash.Sized.Internal.BitVector.and##"
+    | [i,j] <- bitLiterals args
+    -> reduce (mkBitLit ty (i .&. j))
+  "Clash.Sized.Internal.BitVector.or##"
+    | [i,j] <- bitLiterals args
+    -> reduce (mkBitLit ty (i .|. j))
+  "Clash.Sized.Internal.BitVector.xor##"
+    | [i,j] <- bitLiterals args
+    -> reduce (mkBitLit ty (i `xor` j))
+
+  "Clash.Sized.Internal.BitVector.complement##"
+    | [i] <- bitLiterals args
+    -> reduce (mkBitLit ty (complement i))
+
+-- Pack
+  "Clash.Sized.Internal.BitVector.pack#"
+    | [i] <- bitLiterals args
     -> let resTyInfo = extractTySizeInfo tcm ty tys
-    in reduce (mkBitVectorLit' resTyInfo 1)
-  "Clash.Sized.Internal.BitVector.low"
-    -> let resTyInfo = extractTySizeInfo tcm ty tys
-    in reduce (mkBitVectorLit' resTyInfo 0)
+       in  reduce (mkBitVectorLit' resTyInfo i)
+
+  "Clash.Sized.Internal.BitVector.unpack#"
+    | [i] <- bitVectorLiterals' args
+    -> reduce (mkBitLit ty i)
 
 -- Concatenation
   "Clash.Sized.Internal.BitVector.++#" -- :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)
@@ -991,30 +1030,30 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     in reduce (mkBitVectorLit' resTyInfo val)
 
 -- Reduction
-  "Clash.Sized.Internal.BitVector.reduceAnd#" -- :: KnownNat n => BitVector n -> BitVector 1
+  "Clash.Sized.Internal.BitVector.reduceAnd#" -- :: KnownNat n => BitVector n -> Bit
     | [i] <- bitVectorLiterals' args
     , Just (_, kn) <- extractKnownNat tcm tys
-    -> let resTyInfo = extractTySizeInfo tcm ty tys
+    -> let resTy = getResultTy tcm ty tys
            val = reifyNat kn (op (fromInteger i))
-    in reduce (mkBitVectorLit' resTyInfo val)
+    in reduce (mkBitLit resTy val)
     where
       op :: KnownNat n => BitVector n -> Proxy n -> Integer
       op u _ = toInteger (BitVector.reduceAnd# u)
-  "Clash.Sized.Internal.BitVector.reduceOr#" -- :: KnownNat n => BitVector n -> BitVector 1
+  "Clash.Sized.Internal.BitVector.reduceOr#" -- :: KnownNat n => BitVector n -> Bit
     | [i] <- bitVectorLiterals' args
     , Just (_, kn) <- extractKnownNat tcm tys
-    -> let resTyInfo = extractTySizeInfo tcm ty tys
+    -> let resTy = getResultTy tcm ty tys
            val = reifyNat kn (op (fromInteger i))
-    in reduce (mkBitVectorLit' resTyInfo val)
+    in reduce (mkBitLit resTy val)
     where
       op :: KnownNat n => BitVector n -> Proxy n -> Integer
       op u _ = toInteger (BitVector.reduceOr# u)
-  "Clash.Sized.Internal.BitVector.reduceXor#" -- :: KnownNat n => BitVector n -> BitVector 1
+  "Clash.Sized.Internal.BitVector.reduceXor#" -- :: KnownNat n => BitVector n -> Bit
     | [i] <- bitVectorLiterals' args
     , Just (_, kn) <- extractKnownNat tcm tys
-    -> let resTyInfo = extractTySizeInfo tcm ty tys
+    -> let resTy = getResultTy tcm ty tys
            val = reifyNat kn (op (fromInteger i))
-    in reduce (mkBitVectorLit' resTyInfo val)
+    in reduce (mkBitLit resTy val)
     where
       op :: KnownNat n => BitVector n -> Proxy n -> Integer
       op u _ = toInteger (BitVector.reduceXor# u)
@@ -1023,9 +1062,9 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
 -- Indexing
   "Clash.Sized.Internal.BitVector.index#" -- :: KnownNat n => BitVector n -> Int -> Bit
     | Just (_,kn,i,j) <- bitVectorLitIntLit tcm tys args
-      -> let resTyInfo = extractTySizeInfo tcm ty tys
+      -> let resTy = getResultTy tcm ty tys
              val = reifyNat kn (op (fromInteger i) (fromInteger j))
-      in reduce (mkBitVectorLit' resTyInfo val)
+         in  reduce (mkBitLit resTy val)
       where
         op :: KnownNat n => BitVector n -> Int -> Proxy n -> Integer
         op u i _ = toInteger (BitVector.index# u i)
@@ -1034,10 +1073,10 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     , [ _
       , PrimVal bvNm _ _ [_, Lit (IntegerLiteral bv)]
       , valArgs -> Just [Literal (IntLiteral i)]
-      , PrimVal bNm  _ _ [_, Lit (IntegerLiteral b)]
+      , PrimVal bNm  _ _ [Lit (IntegerLiteral b)]
       ] <- args
     , bvNm == "Clash.Sized.Internal.BitVector.fromInteger#"
-    , bNm  == "Clash.Sized.Internal.BitVector.fromInteger#"
+    , bNm  == "Clash.Sized.Internal.BitVector.fromInteger##"
       -> let resTyInfo = extractTySizeInfo tcm ty tys
              val = reifyNat n (op (fromInteger bv) (fromInteger i) (fromInteger b))
       in reduce (mkBitVectorLit' resTyInfo val)
@@ -1086,18 +1125,18 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
   "Clash.Sized.Internal.BitVector.msb#" -- :: forall n. KnownNat n => BitVector n -> Bit
     | [i] <- bitVectorLiterals' args
     , Just (_, kn) <- extractKnownNat tcm tys
-    -> let resTyInfo = extractTySizeInfo tcm ty tys
+    -> let resTy = getResultTy tcm ty tys
            val = reifyNat kn (op (fromInteger i))
-    in reduce (mkBitVectorLit' resTyInfo val)
+       in reduce (mkBitLit resTy val)
     where
       op :: KnownNat n => BitVector n -> Proxy n -> Integer
       op u _ = toInteger (BitVector.msb# u)
   "Clash.Sized.Internal.BitVector.lsb#" -- BitVector n -> Bit
     | [i] <- bitVectorLiterals' args
     , Just (_, kn) <- extractKnownNat tcm tys
-    -> let resTyInfo = extractTySizeInfo tcm ty tys
+    -> let resTy = getResultTy tcm ty tys
            val = reifyNat kn (op (fromInteger i))
-    in reduce (mkBitVectorLit' resTyInfo val)
+    in reduce (mkBitLit resTy val)
     where
       op :: KnownNat n => BitVector n -> Proxy n -> Integer
       op u _ = toInteger (BitVector.lsb# u)
@@ -2833,6 +2872,16 @@ sizedLiteral szCon val = case val of
   PrimVal nm  _ _ [_, Lit (IntegerLiteral i)] | nm == szCon -> Just i
   _ -> Nothing
 
+bitLiterals
+  :: [Value]
+  -> [Integer]
+bitLiterals = typedLiterals' go
+ where
+  go val = case val of
+    PrimVal nm _ _ [_, Lit (IntegerLiteral i)]
+      | nm == "Clash.Sized.Internal.BitVector.fromInteger##"
+      -> Just i
+    _ -> Nothing
 
 bitVectorLiterals, indexLiterals, signedLiterals, unsignedLiterals
   :: [Value] -> Maybe (Integer,Integer)
@@ -2902,6 +2951,17 @@ mkSizedLit conPrim ty nTy kn val
   = mkApps (conPrim sTy) [Right nTy,Left (Literal (NaturalLiteral kn)),Left (Literal (IntegerLiteral ( val)))]
   where
     (_,sTy) = splitFunForallTy ty
+
+mkBitLit
+  :: Type
+  -- ^ Result type
+  -> Integer
+  -- ^ Value
+  -> Term
+mkBitLit ty val =
+  mkApps (bConPrim sTy) [Left (Literal (IntegerLiteral val))]
+ where
+  (_,sTy) = splitFunForallTy ty
 
 mkBitVectorLit, mkSignedLit, mkUnsignedLit
   :: Type    -- result type
@@ -3022,6 +3082,13 @@ integerToWordLiteral = Literal . WordLiteral . toInteger . (fromInteger :: Integ
 integerToIntegerLiteral :: Integer -> Term
 integerToIntegerLiteral = Literal . IntegerLiteral
 
+bConPrim :: Type -> Term
+bConPrim (tyView -> TyConApp bTcNm _)
+  = Prim "Clash.Sized.Internal.BitVector.fromInteger##" funTy
+  where
+    funTy      = foldr1 mkFunTy [integerPrimTy,mkTyConApp bTcNm []]
+bConPrim _ = error $ $(curLoc) ++ "called with incorrect type"
+
 bvConPrim :: Type -> Term
 bvConPrim (tyView -> TyConApp bvTcNm _)
   = Prim "Clash.Sized.Internal.BitVector.fromInteger#" (ForAllTy (bind nTV funTy))
@@ -3130,6 +3197,16 @@ extractTySizeInfo tcm ty tys = (resTy,resSizeTy,resSize)
     (_,resTy) = splitFunForallTy ty'
     TyConApp _ [resSizeTy] = tyView resTy
     Right resSize = runExcept (tyNatSize tcm resSizeTy)
+
+getResultTy
+  :: TyConMap
+  -> Type
+  -> [Type]
+  -> Type
+getResultTy tcm ty tys = resTy
+ where
+  ty' = List.foldl' ((runFreshM .) . applyTy tcm) ty tys
+  (_,resTy) = splitFunForallTy ty'
 
 liftDDI :: (Double# -> Double# -> Int#) -> [Value] -> Maybe Term
 liftDDI f args = case doubleLiterals' args of

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -1065,26 +1065,24 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
                $ BitVector.slice# (BV i) (unsafeSNat m) (unsafeSNat n)
            resTyInfo = extractTySizeInfo tcm ty tys
        in  reduce (mkBitVectorLit' resTyInfo val)
-  "Clash.Sized.Internal.BitVector.splitL#"
-  -- :: forall n m. KnownNat n => BitVector (m + n) -> BitVector m
-   | nTy : mTy : _ <- tys
-   , Right n <-  runExcept (tyNatSize tcm nTy)
-   , Right m <-  runExcept (tyNatSize tcm mTy)
-   , [i] <- bitVectorLiterals' args
-   -> let ty' = List.foldl' ((runFreshM .) . applyTy tcm) ty tys
-          (_,bvTy) = splitFunForallTy ty'
-          valM = i `shiftR` fromInteger n
-      in reduce (mkBitVectorLit bvTy mTy m valM)
-  "Clash.Sized.Internal.BitVector.splitR#"
-  -- :: forall n m. KnownNat n => BitVector (m + n) -> BitVector n
-   | nTy : _ : _ <- tys
-   , Right n <-  runExcept (tyNatSize tcm nTy)
-   , [i] <- bitVectorLiterals' args
-   -> let ty' = List.foldl' ((runFreshM .) . applyTy tcm) ty tys
-          (_,bvTy) = splitFunForallTy ty'
-          valN = i .&. mask
-          mask = bit (fromInteger n) - 1
-      in reduce (mkBitVectorLit bvTy nTy n valN)
+  "Clash.Sized.Internal.BitVector.split#" -- :: forall n m. KnownNat n => BitVector (m + n) -> (BitVector m, BitVector n)
+    | nTy : mTy : _ <- tys
+    , Right n <-  runExcept (tyNatSize tcm nTy)
+    , Right m <-  runExcept (tyNatSize tcm mTy)
+    , [i] <- bitVectorLiterals' args
+    -> let ty' = List.foldl' ((runFreshM .) . applyTy tcm) ty tys
+           (_,tyView -> TyConApp tupTcNm tyArgs) = splitFunForallTy ty'
+           (Just tupTc) = HashMap.lookup (nameOcc tupTcNm) tcm
+           [tupDc] = tyConDataCons tupTc
+           bvTy : _ = tyArgs
+           valM = i `shiftR` fromInteger n
+           valN = i .&. mask
+           mask = bit (fromInteger n) - 1
+    in reduce $
+       mkApps (Data tupDc) (map Right tyArgs ++
+                [ Left (mkBitVectorLit bvTy mTy m valM)
+                , Left (mkBitVectorLit bvTy nTy n valN)])
+
   "Clash.Sized.Internal.BitVector.msb#" -- :: forall n. KnownNat n => BitVector n -> Bit
     | [i] <- bitVectorLiterals' args
     , Just (_, kn) <- extractKnownNat tcm tys

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -423,7 +423,8 @@ hasPrimCo co@(AxiomInstCo _ _ coers) = do
   where
     isPrimTc (TyConApp tc _) = do
       tcNm <- qualfiedNameString (tyConName tc)
-      return (tcNm `elem` ["Clash.Sized.Internal.BitVector.BitVector"
+      return (tcNm `elem` ["Clash.Sized.Internal.BitVector.Bit"
+                          ,"Clash.Sized.Internal.BitVector.BitVector"
                           ,"Clash.Sized.Internal.Index.Index"
                           ,"Clash.Sized.Internal.Signed.Signed"
                           ,"Clash.Sized.Internal.Unsigned.Unsigned"

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -109,6 +109,8 @@ ghcTypeToHWType iw floatSupport = go
                 synchronous <- resetKind m rstKind
                 return (Reset (pack nm) rate synchronous)
 
+        "Clash.Sized.Internal.BitVector.Bit" -> return Bit
+
         "Clash.Sized.Internal.BitVector.BitVector" ->
           (BitVector . fromInteger) <$> mapExceptT (Just . coerce) (tyNatSize m (head args))
 

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -109,11 +109,8 @@ ghcTypeToHWType iw floatSupport = go
                 synchronous <- resetKind m rstKind
                 return (Reset (pack nm) rate synchronous)
 
-        "Clash.Sized.Internal.BitVector.BitVector" -> do
-          n <- mapExceptT (Just . coerce) (tyNatSize m (head args))
-          case n of
-            1 -> return Bit
-            _ -> return (BitVector (fromInteger n))
+        "Clash.Sized.Internal.BitVector.BitVector" ->
+          (BitVector . fromInteger) <$> mapExceptT (Just . coerce) (tyNatSize m (head args))
 
         "Clash.Sized.Internal.Index.Index" ->
           Index <$> mapExceptT (Just . coerce) (tyNatSize m (head args))

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -60,6 +60,7 @@ Extra-source-files:
 
 Data-files:
   prims/common/*.json,
+  prims/commonverilog/*.json,
   prims/verilog/*.json,
   prims/systemverilog/*.json,
   prims/vhdl/*.json

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.json
@@ -1,0 +1,109 @@
+[ { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.high"
+    , "type"      : "high :: Bit"
+    , "templateE" : "1'b1"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.low"
+    , "type"      : "low :: Bit"
+    , "templateE" : "1'b0"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.pack#"
+    , "type"      : "pack# :: Bit -> BitVector 1"
+    , "templateE" : "~ARG[0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.unpack#"
+    , "type"      : "unpack# :: BitVector 1 -> Bit"
+    , "templateE" : "~ARG[0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
+    , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> Bit"
+    , "templateE" : "& (~ARG[1])"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
+    , "type"      : "reduceOr# :: BitVector n -> Bit"
+    , "templateE" : "| (~ARG[0])"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
+    , "type"      : "reduceXor# :: BitVector n -> Bit"
+    , "templateE" : "^ (~ARG[0])"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.eq##"
+    , "type"      : "eq## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] == ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.neq##"
+    , "type"      : "neq## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] != ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.lt##"
+    , "type"      : "lt## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] < ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.ge##"
+    , "type"      : "ge## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] >= ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.gt##"
+    , "type"      : "gt## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] > ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.le##"
+    , "type"      : "le## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] <= ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.fromInteger##"
+    , "type"      : "fromInteger# :: Integer -> Bit"
+    , "templateE" : "~VAR[i][0][0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.and##"
+    , "type"      : "and## :: Bit -> Bit -> Bit"
+    , "templateE" : "~ARG[0] & ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.or##"
+    , "type"      : "or## :: Bit -> Bit -> Bit"
+    , "templateE" : "~ARG[0] | ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.xor##"
+    , "type"      : "xor## :: Bit -> Bit -> Bit"
+    , "templateE" : "~ARG[0] ^ ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.complement##"
+    , "type"      : "complement## :: Bit -> Bit"
+    , "templateE" : "~ ~ARG[0]"
+    }
+  }
+]

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
@@ -31,19 +31,19 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE& (~ARG[1])~FI"
+    , "templateE" : "& (~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
     , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
-    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE| (~ARG[0])~FI"
+    , "templateE" : "| (~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
     , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
-    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE^ (~ARG[0])~FI"
+    , "templateE" : "^ (~ARG[0])"
     }
   }
 , { "BlackBox" :
@@ -53,7 +53,7 @@
         => BitVector n -- ARG[1]
         -> Int         -- ARG[2]
         -> Bit"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~VAR[bv][1][~ARG[2]]~FI"
+    , "templateE" : "~VAR[bv][1][~ARG[2]]"
     }
   }
 , { "BlackBox" :
@@ -65,12 +65,11 @@
              -> Bit         -- ARG[3]
              -> BitVector n"
     , "templateD" :
-"// replaceBit start~IF~ISBIT[1]~THEN
-assign ~RESULT = ~ARG[3];~ELSE
+"// replaceBit start
 always_comb begin
   ~RESULT = ~ARG[1];
   ~RESULT[~ARG[2]] = ~ARG[3];
-end~FI
+end
 // replaceBit end"
     }
   }
@@ -83,13 +82,11 @@ end~FI
            -> BitVector (m + 1 - n) -- ARG[3]
            -> BitVector (m + 1 + i)"
     , "templateD" :
-"// setSlice begin~IF~ISBIT[0]~THEN
-assign ~RESULT = ~ARG[3];~ELSE
+"// setSlice begin
 always_comb begin
-  ~RESULT = ~ARG[0];~IF~ISBIT[3]~THEN
-  ~RESULT[~LIT[1]] = ~ARG[3];~ELSE
-  ~RESULT[~LIT[1] : ~LIT[2]] = ~ARG[3];~FI
-end~FI
+  ~RESULT = ~ARG[0];
+  ~RESULT[~LIT[1] : ~LIT[2]] = ~ARG[3];
+end
 // setSlice end"
     }
   }
@@ -100,25 +97,21 @@ end~FI
         -> SNat m                -- ARG[1]
         -> SNat n                -- ARG[2]
         -> BitVector (m + 1 - n)"
-    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE~IF~ISBITO~THEN~VAR[bv][0][~LIT[1]]~ELSE~VAR[bv][0][~LIT[1] : ~LIT[2]]~FI~FI"
+    , "templateE" : "~VAR[bv][0][~LIT[1] : ~LIT[2]]"
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.splitL#"
+    { "name" : "Clash.Sized.Internal.BitVector.split#"
     , "type" :
-"splitL# :: KnownNat n        -- ARG[0]
-         => BitVector (m + n) -- ARG[1]
-         -> BitVector m"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][LIT[0]]~ELSE~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]~FI~FI"
-    }
-  }
-, { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.splitR#"
-    , "type" :
-"splitR# :: KnownNat n        -- ARG[0]
-         => BitVector (m + n) -- ARG[1]
-         -> BitVector n"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][0]~ELSE~VAR[bv][1][(~LIT[0]-1) : 0]~FI~FI"
+"split# :: KnownNat n        -- ARG[0]
+        => BitVector (m + n) -- ARG[1]
+        -> (BitVector m, BitVector n)"
+    , "templateD" :
+"// split begin
+assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
+                 , ~VAR[bv][1][(~LIT[0]-1) : 0]
+                 };
+// split end"
     }
   }
 , { "BlackBox" :
@@ -183,7 +176,7 @@ end~FI
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN1'b1~ELSE{~LIT[0] {1'b1}}~FI"
+    , "templateE" : "{~LIT[0] {1'b1}}"
     }
   }
 , { "BlackBox" :
@@ -213,10 +206,7 @@ end~FI
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
-    , "templateD" :
-"~IF ~ISBITO ~THEN
-assign ~RESULT = ~VAR[bv][1][0];~ELSE
-assign ~RESULT = $unsigned(~VAR[bv][1][(~LIT[0]-1):0]);~FI"
+    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :
@@ -295,11 +285,10 @@ assign ~RESULT = $unsigned(~VAR[bv][1][(~LIT[0]-1):0]);~FI"
     { "name"      : "Clash.Sized.Internal.BitVector.rotateL#"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
-"// rotateL begin~IF ~ISBITO ~THEN
-assign ~RESULT = ~ARG[1];~ELSE
+"// rotateL begin
 logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
-assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];~FI
+assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
 // rotateL end"
     }
   }
@@ -307,11 +296,10 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];~FI
     { "name"      : "Clash.Sized.Internal.BitVector.rotateR#"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
-"// rotateR begin~IF ~ISBITO ~THEN
-assign ~RESULT = ~ARG[1];~ELSE
+"// rotateR begin
 logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];~FI
+assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
 // rotateR end"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
@@ -11,39 +11,9 @@
     }
   }
 , { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.BitVector.high"
-    , "type"      : "high :: Bit"
-    , "templateE" : "1'b1"
-    }
-  }
-, { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.BitVector.low"
-    , "type"      : "low :: Bit"
-    , "templateE" : "1'b0"
-    }
-  }
-, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.++#"
     , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
     , "templateE" : "{~ARG[1],~ARG[2]}"
-    }
-  }
-, { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
-    , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
-    , "templateE" : "& (~ARG[1])"
-    }
-  }
-, { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
-    , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
-    , "templateE" : "| (~ARG[0])"
-    }
-  }
-, { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
-    , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
-    , "templateE" : "^ (~ARG[0])"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.json
@@ -16,24 +16,8 @@
 ~SIGD[~GENSYM[dataout_h][2]][6];
 ~SIGD[~GENSYM[d][3]][6];
 assign ~SYM[3] = ~ARG[6];
-~IF~ISBIT[6]~THEN
-IDDR #(
-  .DDR_CLK_EDGE(\"SAME_EDGE\"),
-  .INIT_Q1(1'b0),
-  .INIT_Q2(1'b0),
-  .SRTYPE(~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-) ~GENSYM[~COMPNAME_IDDR][9] (
-  .Q1(~SYM[1]),
-  .Q2(~SYM[2]),~IF ~ISGATED[6] ~THEN
-  .C(~ARG[4][1]),
-  .CE(~ARG[4][0]),~ELSE
-  .C(~ARG[4]),
-  .CE(1'b1),~FI
-  .D(~SYM[3]),
-  .R(~ARG[5]),
-  .S(1'b0)
-);
-~ELSEgenvar ~GENSYM[i][8];
+
+genvar ~GENSYM[i][8];
 ~GENERATE
 for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
   IDDR #(
@@ -41,7 +25,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .INIT_Q1(1'b0),
     .INIT_Q2(1'b0),
     .SRTYPE(~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~SYM[9] (
+  ) ~GENSYM[~COMPNAME_IDDR][9] (
     .Q1(~SYM[1][~SYM[8]]),
     .Q2(~SYM[2][~SYM[8]]),~IF ~ISGATED[6] ~THEN
     .C(~ARG[4][1]),
@@ -53,7 +37,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .S(1'b0)
   );
 end
-~ENDGENERATE~FI
+~ENDGENERATE
 
 assign ~RESULT = {~SYM[2],~SYM[1]};
 // iddr end"
@@ -79,30 +63,15 @@ assign ~RESULT = {~SYM[2],~SYM[1]};
 
 assign ~SYM[1] = ~ARG[5];
 assign ~SYM[2] = ~ARG[6];
-~IF~ISBIT[5]~THEN
-ODDR #(
-  .DDR_CLK_EDGE(\"SAME_EDGE\"),
-  .INIT(1'b0),
-  .SRTYPE(~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-) ~GENSYM[~COMPNAME_ODDR][9] (
-  .Q(~SYM[3]),~IF ~ISGATED[3] ~THEN
-  .C(~ARG[3][1]),
-  .CE(~ARG[3][0]),~ELSE
-  .C(~ARG[3]),
-  .CE(1'b1),~FI
-  .D1(~SYM[1]),
-  .D2(~SYM[2]),
-  .R(~ARG[4]),
-  .S(1'b0)
-);
-~ELSEgenvar ~GENSYM[i][8];
+
+genvar ~GENSYM[i][8];
 ~GENERATE
 for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
   ODDR #(
     .DDR_CLK_EDGE(\"SAME_EDGE\"),
     .INIT(1'b0),
     .SRTYPE(~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~SYM[9] (
+  ) ~GENSYM[~COMPNAME_ODDR][9] (
     .Q(~SYM[3][~SYM[8]]),~IF ~ISGATED[3] ~THEN
     .C(~ARG[3][1]),
     .CE(~ARG[3][0]),~ELSE
@@ -114,7 +83,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .S(1'b0)
   );
 end
-~ENDGENERATE~FI
+~ENDGENERATE
 
 assign ~RESULT = ~SYM[3];
 // oddr end"

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
@@ -31,19 +31,19 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE& (~ARG[1])~FI"
+    , "templateE" : "& (~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
     , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
-    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE| (~ARG[0])~FI"
+    , "templateE" : "| (~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
     , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
-    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE^ (~ARG[0])~FI"
+    , "templateE" : "^ (~ARG[0])"
     }
   }
 , { "BlackBox" :
@@ -53,7 +53,7 @@
         => BitVector n -- ARG[1]
         -> Int         -- ARG[2]
         -> Bit"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~VAR[bv][1][~ARG[2]]~FI"
+    , "templateE" : "~VAR[bv][1][~ARG[2]]"
     }
   }
 , { "BlackBox" :
@@ -67,10 +67,9 @@
     , "outputReg" : true
     , "templateD" :
 "// replaceBit start
-always @(*) begin~IF~ISBIT[1]~THEN
-  ~RESULT = ~VAR[din][3]~ELSE
+always @(*) begin
   ~RESULT = ~ARG[1];
-  ~RESULT[~ARG[2]] = ~VAR[din][3]~FI;
+  ~RESULT[~ARG[2]] = ~VAR[din][3];
 end
 // replaceBit end"
     }
@@ -86,10 +85,9 @@ end
     , "outputReg" : true
     , "templateD" :
 "// setSlice begin
-always @(*) begin~IF~ISBIT[0]~THEN
-  ~RESULT = ~VAR[din][3]~ELSE
+always @(*) begin
   ~RESULT = ~ARG[0];
-  ~RESULT[~LIT[1] : ~LIT[2]] = ~VAR[din][3];~FI
+  ~RESULT[~LIT[1] : ~LIT[2]] = ~VAR[din][3];
 end
 // setSlice end"
     }
@@ -101,25 +99,16 @@ end
         -> SNat m                -- ARG[1]
         -> SNat n                -- ARG[2]
         -> BitVector (m + 1 - n)"
-    , "templateE" : "~IF~ISBIT[0]~THEN~ARG[0]~ELSE~IF~ISBITO~THEN~VAR[bv][0][~LIT[1]~ELSE~VAR[bv][0][~LIT[1] : ~LIT[2]]~FI~FI"
+    , "templateE" : "~VAR[bv][0][~LIT[1] : ~LIT[2]]"
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.splitL#"
+    { "name" : "Clash.Sized.Internal.BitVector.split#"
     , "type" :
-"splitL# :: KnownNat n        -- ARG[0]
-         => BitVector (m + n) -- ARG[1]
-         -> BitVector m"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][LIT[0]]~ELSE~VAR[bv][1][(~SIZE[~TYP[1]]-1) : ~LIT[0]]~FI~FI"
-    }
-  }
-, { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.splitR#"
-    , "type" :
-"splitR# :: KnownNat n        -- ARG[0]
-         => BitVector (m + n) -- ARG[1]
-         -> BitVector n"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][0]~ELSE~VAR[bv][1][(~LIT[0]-1) : 0]~FI~FI"
+"split# :: KnownNat n        -- ARG[0]
+        => BitVector (m + n) -- ARG[1]
+        -> (BitVector m, BitVector n)"
+    , "templateE" : "~ARG[1]"
     }
   }
 , { "BlackBox" :
@@ -184,7 +173,7 @@ end
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN1'b1~ELSE{~LIT[0] {1'b1}}~FI"
+    , "templateE" : "{~LIT[0] {1'b1}}"
     }
   }
 , { "BlackBox" :
@@ -214,7 +203,7 @@ end
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~VAR[bv][1][0]~ELSE$unsigned(~VAR[bv][1][(~LIT[0]-1):0])~FI"
+    , "templateE" : "$unsigned(~ARG[1][(~LIT[0]-1):0])"
     }
   }
 , { "BlackBox" :
@@ -280,24 +269,23 @@ end
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.shiftL#"
     , "type"      : "shiftL# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSE~ARG[1] << ~ARG[2]~FI"
+    , "templateE" : "~ARG[1] << ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.shiftR#"
     , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSE~ARG[1] >> ~ARG[2]~FI"
+    , "templateE" : "~ARG[1] >> ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rotateL#"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
-"// rotateL begin~IF~ISBITO~THEN
-assign ~RESULT = ~ARG[1];~ELSE
+"// rotateL begin
 wire [2*~LIT[0]-1:0] ~SYM[0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
-assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];~FI
+assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
 // rotateL end"
     }
   }
@@ -305,11 +293,10 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];~FI
     { "name"      : "Clash.Sized.Internal.BitVector.rotateR#"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
-"// rotateR begin~IF~ISBITO~THEN
-assign ~RESULT = ~ARG[1];~ELSE
+"// rotateR begin
 wire [2*~LIT[0]-1:0] ~GENSYM[bv][0];
 assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];~FI
+assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
 // rotateR end"
     }
   }

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.json
@@ -16,24 +16,8 @@ wire ~SIGD[~GENSYM[dataout_l][1]][6];
 wire ~SIGD[~GENSYM[dataout_h][2]][6];
 wire ~SIGD[~GENSYM[d][3]][6];
 assign ~SYM[3] = ~ARG[6];
-~IF~ISBIT[6]~THEN
-IDDR #(
-  .DDR_CLK_EDGE(\"SAME_EDGE\"),
-  .INIT_Q1(1'b0),
-  .INIT_Q2(1'b0),
-  .SRTYPE(~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-) ~GENSYM[~COMPNAME_IDDR][9] (
-  .Q1(~SYM[1]),
-  .Q2(~SYM[2]),~IF ~ISGATED[6] ~THEN
-  .C(~ARG[4][1]),
-  .CE(~ARG[4][0]),~ELSE
-  .C(~ARG[4]),
-  .CE(1'b1),~FI
-  .D(~SYM[3]),
-  .R(~ARG[5]),
-  .S(1'b0)
-);
-~ELSEgenvar ~GENSYM[i][8];
+
+genvar ~GENSYM[i][8];
 ~GENERATE
 for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
   IDDR #(
@@ -41,7 +25,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .INIT_Q1(1'b0),
     .INIT_Q2(1'b0),
     .SRTYPE(~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~SYM[9] (
+  ) ~GENSYM[~COMPNAME_IDDR][9] (
     .Q1(~SYM[1][~SYM[8]]),
     .Q2(~SYM[2][~SYM[8]]),~IF ~ISGATED[6] ~THEN
     .C(~ARG[4][1]),
@@ -53,7 +37,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .S(1'b0)
   );
 end
-~ENDGENERATE~FI
+~ENDGENERATE
 
 assign ~RESULT = {~SYM[2],~SYM[1]};
 // iddr end"
@@ -79,23 +63,7 @@ wire ~SIGD[~GENSYM[q][3]][6];
 
 assign ~SYM[1] = ~ARG[5];
 assign ~SYM[2] = ~ARG[6];
-~IF~ISBIT[6]~THEN
-ODDR #(
-  .DDR_CLK_EDGE(\"SAME_EDGE\"),
-  .INIT(1'b0),
-  .SRTYPE(~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-) ~GENSYM[~COMPNAME_ODDR][9] (
-  .Q(~SYM[3]),~IF ~ISGATED[3] ~THEN
-  .C(~ARG[3][1]),
-  .CE(~ARG[3][0]),~ELSE
-  .C(~ARG[3]),
-  .CE(1'b1),~FI
-  .D1(~SYM[1]),
-  .D2(~SYM[2]),
-  .R(~ARG[4]),
-  .S(1'b0)
-);
-~ELSE
+
 genvar ~GENSYM[i][8];
 ~GENERATE
 for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
@@ -103,7 +71,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .DDR_CLK_EDGE(\"SAME_EDGE\"),
     .INIT(1'b0),
     .SRTYPE(~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~SYM[9] (
+  ) ~GENSYM[~COMPNAME_ODDR][9] (
     .Q(~SYM[3][~SYM[8]]),~IF ~ISGATED[3] ~THEN
     .C(~ARG[3][1]),
     .CE(~ARG[3][0]),~ELSE
@@ -115,7 +83,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[6]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .S(1'b0)
   );
 end
-~ENDGENERATE~FI
+~ENDGENERATE
 
 assign ~RESULT = ~SYM[3];
 // oddr end"

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
@@ -51,12 +51,10 @@ begin
   begin
     if rising_edge(~SYM[7]) then
       if ~SYM[8] then
-        if ~ARG[6] then~IF~ISBITO~THEN
-          ~SYM[2](~SYM[5]) <= to_bitvector(0 => ~ARG[8]);~ELSE
-          ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);~FI
-        end if;~IF~ISBITO~THEN
-        ~RESULT <= to_stdulogic(~SYM[2](~SYM[4])(0))~ELSE
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))~FI
+        if ~ARG[6] then
+          ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
+        end if;
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -67,12 +65,10 @@ begin
   ~SYM[9] : process(~ARG[2])
   begin
     if rising_edge(~ARG[2]) then
-      if ~ARG[6] then~IF~ISBITO~THEN
-        ~SYM[2](~SYM[5]) <= to_bitvector(0 => ~ARG[8]);~ELSE
-        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);~FI
-      end if;~IF~ISBITO~THEN
-      ~RESULT <= to_stdulogic(~SYM[2](~SYM[4])(0))~ELSE
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))~FI
+      if ~ARG[6] then
+        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
+      end if;
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on
@@ -83,13 +79,11 @@ begin
   ~SYM[9] : process(~SYM[7])
   begin
     if rising_edge(~SYM[7]) then
-      if ~ARG[6] and ~SYM[8] then~IF~ISBITO~THEN
-        ~SYM[2](~SYM[5]) <= to_bitvector(0 => ~ARG[8]);~ELSE
-        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);~FI
+      if ~ARG[6] and ~SYM[8] then
+        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
       end if;
-      if ~SYM[8] then~IF~ISBITO~THEN
-        ~RESULT <= to_stdulogic(~SYM[2](~SYM[4]))~ELSE
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))~FI
+      if ~SYM[8] then
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -100,12 +94,10 @@ begin
   ~SYM[9] : process(~ARG[2])
   begin
     if rising_edge(~ARG[2]) then
-      if ~ARG[6] then~IF~ISBITO~THEN
-        ~SYM[2](~SYM[5]) <= to_bitvector(0 => ~ARG[8]);~ELSE
-        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);~FI
-      end if;~IF~ISBITO~THEN
-      ~RESULT <= to_stdulogic(~SYM[2](~SYM[4])(0))~ELSE
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))~FI
+      if ~ARG[6] then
+        ~SYM[2](~SYM[5]) <= to_bitvector(~ARG[8]);
+      end if;
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[4]))
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
@@ -39,9 +39,8 @@ begin
   ~GENSYM[romFileSync][7] : process (~SYM[5])
   begin
     if (rising_edge(~SYM[5])) then
-      if ~SYM[6] then~IF~ISBITO~THEN
-        ~RESULT <= to_stdulogic(~SYM[2](~SYM[3])(0))~ELSE
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))~FI
+      if ~SYM[6] then
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -51,9 +50,8 @@ begin
   end process;~ELSE
   ~SYM[7] : process (~ARG[1])
   begin
-    if (rising_edge(~ARG[1])) then~IF~ISBITO~THEN
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3])(0))~ELSE
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))~FI
+    if (rising_edge(~ARG[1])) then
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.json
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.json
@@ -31,9 +31,8 @@ begin
                 mod ~LIT[1]
   -- pragma translate_on
                 ;
-  ~IF~ISBITO~THEN
-  ~RESULT <= to_stdulogic(~SYM[2](~SYM[3])(0));~ELSE
-  ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));~FI
+
+  ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
 end block;
 -- asyncRomFile end"
     }

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
@@ -13,33 +13,26 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.high"
     , "type"      : "high :: Bit"
-    , "templateE" : "'1'"
+    , "templateE" : "std_logic_vector'(\"1\")"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.low"
     , "type"      : "low :: Bit"
-    , "templateE" : "'0'"
+    , "templateE" : "std_logic_vector'(\"0\")"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.++#"
     , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
-    , "templateE" :
-"~IF~ISBIT[1]~THEN~IF~ISBIT[2]
-~THENstd_logic_vector'(std_logic'(~ARG[1]) & std_logic'(~ARG[2]))
-~ELSEstd_logic_vector'(std_logic'(~ARG[1]) & std_logic_vector'(~ARG[2]))~FI
-~ELSE~IF~ISBIT[2]
-~THENstd_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic'(~ARG[2]))
-~ELSEstd_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic_vector'(~ARG[2]))~FI~FI"
+    , "templateE" : "std_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic_vector'(~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
     , "templateD" :
-"-- reduceAnd begin~IF ~ISBIT[1] ~THEN
-~RESULT <= ~ARG[1];~ELSE
+"-- reduceAnd begin
 ~GENSYM[reduceAnd][0] : block
   function and_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -63,8 +56,8 @@
     return result;
   end;
 begin
-  ~RESULT <= and_reduce(~ARG[1]);
-end block;~FI
+  ~RESULT <= (0 => and_reduce(~ARG[1]));
+end block;
 -- reduceAnd end"
     }
   }
@@ -72,8 +65,7 @@ end block;~FI
     { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
     , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
     , "templateD" :
-"-- reduceOr begin~IF ~ISBIT[0] ~THEN
-~RESULT <= ~ARG[0];~ELSE
+"-- reduceOr begin
 ~GENSYM[reduceOr][0] : block
   function or_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -97,8 +89,8 @@ end block;~FI
     return result;
   end;
 begin
-  ~RESULT <= or_reduce(~ARG[0]);
-end block;~FI
+  ~RESULT <= (0 => or_reduce(~ARG[0]));
+end block;
 -- reduceOr end"
     }
   }
@@ -106,8 +98,7 @@ end block;~FI
     { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
     , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
     , "templateD" :
-"-- reduceXor begin~IF ~ISBIT[0] ~THEN
-~RESULT <= ~ARG[0];~ELSE
+"-- reduceXor begin
 ~GENSYM[reduceXor][0] : block
   function xor_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -131,8 +122,8 @@ end block;~FI
     return result;
   end;
 begin
-  ~RESULT <= xor_reduce(~ARG[0]);
-end block;~FI
+  ~RESULT <= (0 => xor_reduce(~ARG[0]));
+end block;
 -- reduceXor end"
     }
   }
@@ -144,8 +135,7 @@ end block;~FI
         -> Int         -- ARG[2]
         -> Bit"
     , "templateD" :
-"-- indexBitVector begin~IF ~ISBIT[1] ~THEN
-~RESULT <= ~ARG[1];~ELSE
+"-- indexBitVector begin~IF ~ISVAR[1] ~THEN
 ~GENSYM[indexBitVector][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
@@ -155,7 +145,18 @@ begin
   -- pragma translate_on
                ;
 
-  ~RESULT <= ~VAR[bv][1](~SYM[1]);
+  ~RESULT(0) <= ~ARG[1](~SYM[1]);
+end block;~ELSE
+~SYM[0] : block
+  signal ~SYM[1] : integer range 0 to ~LIT[0]-1;
+begin
+  ~SYM[1] <= to_integer(~ARG[2])
+  -- pragma translate_off
+               mod ~LIT[0]
+  -- pragma translate_on
+               ;
+
+  ~RESULT(0) <= ~VAR[bv][1](~SYM[1]);
 end block;~FI
 -- indexBitVector end"
     }
@@ -169,8 +170,7 @@ end block;~FI
              -> Bit         -- ARG[3]
              -> BitVector n"
     , "templateD" :
-"-- replaceBit begin~IF ~ISBIT[1] ~THEN
-~RESULT <= ~ARG[3];~ELSE
+"-- replaceBit begin
 ~GENSYM[replaceBit][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
@@ -187,7 +187,7 @@ begin
     ~SYM[2](~SYM[1]) := ~VAR[b][3](0);
     ~RESULT <= ~SYM[2];
   end process;
-end block;~FI
+end block;
 -- replaceBit end"
     }
   }
@@ -200,15 +200,14 @@ end block;~FI
            -> BitVector (m + 1 - n) -- ARG[3]
            -> BitVector (m + 1 + i)"
     , "templateD" :
-"-- setSlice begin~IF ~ISBIT[0] ~THEN
-~RESULT <= ~ARG[3];~ELSE
+"-- setSlice begin
 ~GENSYM[setSlice][0] : process(~VAR[bv][0]~VARS[3])
   variable ~GENSYM[ivec][1] : ~TYP[0];
 begin
   ~SYM[1] := ~ARG[0];
   ~SYM[1](~LIT[1] downto ~LIT[2]) := ~VAR[bv][3];
   ~RESULT <= ~SYM[1];
-end process;~FI
+end process;
 -- setSlice end"
     }
   }
@@ -223,23 +222,12 @@ end process;~FI
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.splitL#"
+    { "name" : "Clash.Sized.Internal.BitVector.split#"
     , "type" :
-"splitL#
-  :: KnownNat n        -- ARG[0]
-  => BitVector (m + n) -- ARG[1]
-  -> BitVector m"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][~LIT[0]]~ELSE~VAR[bv][1](~VAR[bv][1]'high downto ~LIT[0])~FI~FI"
-    }
-  }
-, { "BlackBox" :
-    { "name" : "Clash.Sized.Internal.BitVector.splitR#"
-    , "type" :
-"splitR#
-  :: KnownNat n        -- ARG[0]
-  => BitVector (m + n) -- ARG[1]
-  -> BitVector n"
-    , "templateE" : "~IF~ISBIT[1]~THEN~ARG[1]~ELSE~IF~ISBITO~THEN~VAR[bv][1][0]~ELSE~VAR[bv][1](~LIT[0]-1 downto 0)~FI~FI"
+"split# :: KnownNat n        -- ARG[0]
+        => BitVector (m + n) -- ARG[1]
+        -> (BitVector m, BitVector n)"
+    , "templateE" : "(~VAR[bv][1](~VAR[bv][1]'high downto ~LIT[0]),~VAR[bv][1](~LIT[0]-1 downto 0))"
     }
   }
 , { "BlackBox" :
@@ -248,7 +236,7 @@ end process;~FI
 "msb# :: KnownNat n  -- ARG[0]
       => BitVector n -- ARG[1]
       -> Bit"
-    , "templateE" : "~IF~LIT[0]~THEN~VAR[bv][1](~VAR[bv][1]'high)~ELSE'0'~FI"
+    , "templateE" : "~IF ~LIT[0] ~THEN ~VAR[bv][1](~VAR[bv][1]'high downto ~VAR[bv][1]'high) ~ELSE \"0\" ~FI"
     }
   }
 , { "BlackBox" :
@@ -256,7 +244,7 @@ end process;~FI
     , "type" :
 "lsb# :: BitVector n -- ARG[0]
       -> Bit"
-    , "templateE" : "~IF~SIZE[~TYP[0]]~THEN~VAR[bv][0](0)~ELSE'0'~FI"
+    , "templateE" : "~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0](0 downto 0) ~ELSE \"0\" ~FI"
     }
   }
 , { "BlackBox" :
@@ -299,98 +287,80 @@ end process;~FI
     { "name"      : "Clash.Sized.Internal.BitVector.minBound#"
     , "type"      : "minBound# :: BitVector n"
     , "comment"   : "Generates incorrect VDHL for n=0"
-    , "templateE" : "~IF~ISBITO~THEN'0'~ELSEstd_logic_vector'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
+    , "templateE" : "std_logic_vector'(~SIZE[~TYPO]-1 downto 0 => '0')"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxBound#"
     , "type"      : "maxBound# :: KnownNat n => BitVector n"
     , "comment"   : "Generates incorrect VDHL for n=0"
-    , "templateE" : "~IF~ISBITO~THEN'1'~ELSEstd_logic_vector'(~LIT[0]-1 downto 0 => '1')~FI"
+    , "templateE" : "std_logic_vector'(~LIT[0]-1 downto 0 => '1')"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.+#"
     , "type"      : "(+#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1] xor ~ARG[2]~ELSEstd_logic_vector(unsigned(~ARG[1]) + unsigned(~ARG[2]))~FI"
+    , "templateE" : "std_logic_vector(unsigned(~ARG[1]) + unsigned(~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.-#"
     , "type"      : "(-#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1] xor ~ARG[2]~ELSEstd_logic_vector(unsigned(~ARG[1]) - unsigned(~ARG[2]))~FI"
+    , "templateE" : "std_logic_vector(unsigned(~ARG[1]) - unsigned(~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.*#"
     , "type"      : "(*#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1] and ~ARG[2]~ELSEstd_logic_vector(resize(unsigned(~ARG[1]) * unsigned(~ARG[2]), ~LIT[0]))~FI"
+    , "templateE" : "std_logic_vector(resize(unsigned(~ARG[1]) * unsigned(~ARG[2]), ~LIT[0]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.negate#"
     , "type"      : "negate# :: KnownNat n => BitVector n -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSEstd_logic_vector(-(signed(~ARG[1])))~FI"
+    , "templateE" : "std_logic_vector(-(signed(~ARG[1])))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger#"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~VAR[bv][1](0)~ELSEstd_logic_vector(resize(unsigned(std_logic_vector(~ARG[1])),~LIT[0]))~FI"
+    , "templateE" : "std_logic_vector(resize(unsigned(std_logic_vector(~ARG[1])),~LIT[0]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.plus#"
     , "type"      : "plus# :: BitVector m -> BitVector n -> BitVector (Max m n + 1)"
-    , "templateE" :
-"~IF~ISBIT[0]~THEN~IF~ISBIT[1]
-~THENstd_logic_vector(resize(unsigned'(0 => ~ARG[0]),~SIZE[~TYPO]) + resize(unsigned'(0 => ~ARG[1]),~SIZE[~TYPO]))
-~ELSEstd_logic_vector(resize(unsigned'(0 => ~ARG[0]),~SIZE[~TYPO]) - resize(unsigned(~ARG[1]),~SIZE[~TYPO])~FI
-~ELSE~IF~ISBIT[1]
-~THENstd_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO]) - resize(unsigned'(0 => ~ARG[1]),~SIZE[~TYPO])
-~ELSEstd_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO]) - resize(unsigned(~ARG[1]),~SIZE[~TYPO])~FI~FI"
+    , "templateE" : "std_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO]) + resize(unsigned(~ARG[1]),~SIZE[~TYPO]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.minus#"
     , "type"      : "minus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
-    , "templateE" :
-"~IF~ISBIT[2]~THEN~IF~ISBIT[3]
-~THENstd_logic_vector(resize(unsigned'(0 => ~ARG[2]),~SIZE[~TYPO]) - resize(unsigned'(0 => ~ARG[3]),~SIZE[~TYPO]))
-~ELSEstd_logic_vector(resize(unsigned'(0 => ~ARG[2]),~SIZE[~TYPO]) - resize(unsigned(~ARG[3]),~SIZE[~TYPO]))~FI
-~ELSE~IF~ISBIT[3]
-~THENstd_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) - resize(unsigned'(0 => ~ARG[3]),~SIZE[~TYPO]))
-~ELSEstd_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) - resize(unsigned(~ARG[3]),~SIZE[~TYPO]))~FI~FI"
+    , "templateE" : "std_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) - resize(unsigned(~ARG[3]),~SIZE[~TYPO]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.times#"
     , "type"      : "times# :: BitVector m -> BitVector n -> BitVector (m + n)"
-    , "templateE" :
-"~IF~ISBIT[0]~THEN~IF~ISBIT[1]
-~THENstd_logic_vector(unsigned'(0 => ~ARG[0]) * unsigned'(0 => ~ARG[1]))
-~ELSEstd_logic_vector(unsigned'(0 => ~ARG[0]) * unsigned(~ARG[1]))~FI
-~ELSE~IF~ISBIT[1]
-~THENstd_logic_vector(unsigned(~ARG[0]) * unsigned'(0 => ~ARG[1]))
-~ELSEstd_logic_vector(unsigned(~ARG[0]) * unsigned(~ARG[1]))~FI~FI"
+    , "templateE" : "std_logic_vector(unsigned(~ARG[0]) * unsigned(~ARG[1]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.quot#"
     , "type"      : "quot# :: BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[0]~ELSEstd_logic_vector(unsigned(~ARG[0]) / unsigned(~ARG[1]))~FI"
+    , "templateE" : "std_logic_vector(unsigned(~ARG[0]) / unsigned(~ARG[1]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rem#"
     , "type"      : "rem# :: BitVector n -> BitVector n -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN'0'~ELSEstd_logic_vector(unsigned(~ARG[0]) rem unsigned(~ARG[1]))~FI"
+    , "templateE" : "std_logic_vector(unsigned(~ARG[0]) rem unsigned(~ARG[1]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.toInteger#"
     , "type"      : "toInteger# :: BitVector n -> Integer"
-    , "templateE" : "~IF~ISBIT[0]~THENsigned(std_logic_vector(resize(unsigned'(0 => ~ARG[0]),~SIZE[~TYPO])))~ELSEsigned(std_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO])))~FI"
+    , "templateE" : "signed(std_logic_vector(resize(unsigned(~ARG[0]),~SIZE[~TYPO])))"
     }
   }
 , { "BlackBox" :
@@ -426,31 +396,25 @@ end process;~FI
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.shiftR#"
     , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSEstd_logic_vector(shift_right(unsigned(~ARG[1]),to_integer(~ARG[2])))~FI"
+    , "templateE" : "std_logic_vector(shift_right(unsigned(~ARG[1]),to_integer(~ARG[2])))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rotateL#"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSEstd_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2])))~FI"
+    , "templateE" : "std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2])))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rotateR#"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~ARG[1]~ELSEstd_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2])))~FI"
+    , "templateE" : "std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2])))"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.resize#"
     , "type"      : "resize# :: KnownNat m => BitVector n -> BitVector m"
-    , "templateE" :
-"~IF~ISBITO~THEN~IF~ISBIT[1]
-~THEN~ARG[1]
-~ELSE~VAR[bv][1](0)~FI
-~ELSE~IF~ISBIT[1]
-~THENstd_logic_vector(resize(unsigned'(0 => ~ARG[1]),~LIT[0]))
-~ELSEstd_logic_vector(resize(unsigned(~ARG[1]),~LIT[0]))~FI~FI"
+    , "templateE" : "std_logic_vector(resize(unsigned(~ARG[1]),~LIT[0]))"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
@@ -13,13 +13,91 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.high"
     , "type"      : "high :: Bit"
-    , "templateE" : "std_logic_vector'(\"1\")"
+    , "templateE" : "'1'"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.low"
     , "type"      : "low :: Bit"
-    , "templateE" : "std_logic_vector'(\"0\")"
+    , "templateE" : "'0'"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.pack#"
+    , "type"      : "pack# :: Bit -> BitVector 1"
+    , "templateE" : "std_logic_vector'(0 => ~ARG[0])"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.unpack#"
+    , "type"      : "unpack# :: BitVector 1 -> Bit"
+    , "templateE" : "~VAR[bv][0](0)"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.eq##"
+    , "type"      : "eq## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] = ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.neq##"
+    , "type"      : "neq## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] /= ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.lt##"
+    , "type"      : "lt## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] < ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.ge##"
+    , "type"      : "ge## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] >= ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.gt##"
+    , "type"      : "gt## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] > ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.le##"
+    , "type"      : "le## :: Bit -> Bit -> Bool"
+    , "templateE" : "~ARG[0] <= ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.fromInteger##"
+    , "type"      : "fromInteger# :: Integer -> Bit"
+    , "templateE" : "~VAR[i][0](0)"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.and##"
+    , "type"      : "and## :: Bit -> Bit -> Bit"
+    , "templateE" : "~ARG[0] and ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.or##"
+    , "type"      : "or## :: Bit -> Bit -> Bit"
+    , "templateE" : "~ARG[0] or ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.xor##"
+    , "type"      : "xor## :: Bit -> Bit -> Bit"
+    , "templateE" : "~ARG[0] xor ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.complement##"
+    , "type"      : "complement## :: Bit -> Bit"
+    , "templateE" : "not ~ARG[0]"
     }
   }
 , { "BlackBox" :
@@ -30,7 +108,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
-    , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
+    , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> Bit"
     , "templateD" :
 "-- reduceAnd begin
 ~GENSYM[reduceAnd][0] : block
@@ -56,14 +134,14 @@
     return result;
   end;
 begin
-  ~RESULT <= (0 => and_reduce(~ARG[1]));
+  ~RESULT <= and_reduce(~ARG[1]);
 end block;
 -- reduceAnd end"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
-    , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
+    , "type"      : "reduceOr# :: BitVector n -> Bit"
     , "templateD" :
 "-- reduceOr begin
 ~GENSYM[reduceOr][0] : block
@@ -89,14 +167,14 @@ end block;
     return result;
   end;
 begin
-  ~RESULT <= (0 => or_reduce(~ARG[0]));
+  ~RESULT <= or_reduce(~ARG[0]);
 end block;
 -- reduceOr end"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
-    , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
+    , "type"      : "reduceXor# :: BitVector n -> Bit"
     , "templateD" :
 "-- reduceXor begin
 ~GENSYM[reduceXor][0] : block
@@ -122,7 +200,7 @@ end block;
     return result;
   end;
 begin
-  ~RESULT <= (0 => xor_reduce(~ARG[0]));
+  ~RESULT <= xor_reduce(~ARG[0]);
 end block;
 -- reduceXor end"
     }
@@ -156,7 +234,7 @@ begin
   -- pragma translate_on
                ;
 
-  ~RESULT(0) <= ~VAR[bv][1](~SYM[1]);
+  ~RESULT <= ~VAR[bv][1](~SYM[1]);
 end block;~FI
 -- indexBitVector end"
     }
@@ -184,7 +262,7 @@ begin
     variable ~GENSYM[ivec][2] : ~TYP[1];
   begin
     ~SYM[2] := ~ARG[1];
-    ~SYM[2](~SYM[1]) := ~VAR[b][3](0);
+    ~SYM[2](~SYM[1]) := ~ARG[3];
     ~RESULT <= ~SYM[2];
   end process;
 end block;
@@ -236,7 +314,7 @@ end process;
 "msb# :: KnownNat n  -- ARG[0]
       => BitVector n -- ARG[1]
       -> Bit"
-    , "templateE" : "~IF ~LIT[0] ~THEN ~VAR[bv][1](~VAR[bv][1]'high downto ~VAR[bv][1]'high) ~ELSE \"0\" ~FI"
+    , "templateE" : "~IF ~LIT[0] ~THEN ~VAR[bv][1](~VAR[bv][1]'high) ~ELSE \"0\" ~FI"
     }
   }
 , { "BlackBox" :
@@ -244,7 +322,7 @@ end process;
     , "type" :
 "lsb# :: BitVector n -- ARG[0]
       -> Bit"
-    , "templateE" : "~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0](0 downto 0) ~ELSE \"0\" ~FI"
+    , "templateE" : "~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0](0) ~ELSE \"0\" ~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.json
@@ -1,13 +1,13 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.pack#"
     , "type"      : "pack# :: Index n -> BitVector (CLog 2 n)"
-    , "templateE" : "~IF~ISBITO~THEN~VAR[i][0](0)~ELSEstd_logic_vector(~ARG[0])~FI"
+    , "templateE" : "std_logic_vector(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.unpack#"
     , "type"      : "unpack# :: KnownNat n => BitVector (CLog 2 n) -> Index n"
-    , "templateE" : "~IF~ISBIT[1]~THENunsigned'(0 => ~ARG[1])~ELSEunsigned(~ARG[1])~FI"
+    , "templateE" : "unsigned(~ARG[1])"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
@@ -7,13 +7,13 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.pack#"
     , "type"      : "pack# :: KnownNat n => Signed n -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~VAR[s][1](0)~ELSEstd_logic_vector(~ARG[1])~FI"
+    , "templateE" : "std_logic_vector(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.unpack#"
     , "type"      : "unpack# :: KnownNat n => BitVector n -> Signed n"
-    , "templateE" : "~IF~ISBIT[1]~THENsigned'(0 => ~ARG[1])~ELSEsigned(~ARG[1])~FI"
+    , "templateE" : "signed(~ARG[1])"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.json
@@ -7,13 +7,13 @@
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.pack#"
     , "type"      : "pack# :: Unsigned n -> BitVector n"
-    , "templateE" : "~IF~ISBITO~THEN~VAR[u][0](0)~ELSEstd_logic_vector(~ARG[0])~FI"
+    , "templateE" : "std_logic_vector(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.unpack#"
     , "type"      : "unpack# :: BitVector n -> Unsigned n"
-    , "templateE" : "~IF~ISBIT[0]~THENunsigned'(0 => ~ARG[0])~ELSEunsigned(~ARG[0])~FI"
+    , "templateE" : "unsigned(~ARG[0])"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.json
@@ -381,7 +381,12 @@ end generate;
 "concatBitVector# :: (KnownNat n,KnownNat m) -- (ARG[0],ARG[1])
                   => Vec n (BitVector m)     -- ARG[2]
                   -> BitVector (n * m)"
-    , "templateE" : "~IF~ISBITO~THEN~VAR[v][2](0)~ELSE~TOBV[~ARG[2]][~TYP[2]]~FI"
+    , "templateD" :
+"-- concatBitVector begin
+~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~VAR[vec][2]'range generate
+  ~RESULT(((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1])) <= ~TYPMO'(~VAR[vec][2](~VAR[vec][2]'high - ~SYM[3]));
+end generate;
+-- concatBitVector end"
     }
   }
 , { "BlackBox" :
@@ -390,7 +395,12 @@ end generate;
 "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
                     => BitVector (n * m)        -- ARG[2]
                     -> Vec n (BitVector m)"
-    , "templateE" : "~IF~ISBIT[2]~THEN~TYPMO'(0 => ~ARG[2])~ELSE~FROMBV[~ARG[2]][~TYPO]~FI"
+    , "templateD" :
+"-- unconcatBitVector begin
+~GENSYM[unconcatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~RESULT'range generate
+  ~RESULT(~RESULT'high - ~SYM[3]) <= ~VAR[vec][2](((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1]));
+end generate;
+-- unconcatBitVector end"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.json
@@ -25,27 +25,10 @@ begin~IF ~ISGATED[4] ~THEN
   (~SYM[4],~SYM[5]) <= ~ARG[4];
   ~SYM[6] <= '1' when (~SYM[5]) else '0';~ELSE ~FI
   ~SYM[3] <= ~ARG[6];
-~IF~ISBIT[6]~THEN
-  ~GENSYM[~COMPNAME_IDDR_inst][9] : IDDR
-  generic map (
-    DDR_CLK_EDGE => \"SAME_EDGE\",
-    INIT_Q1      => '0',
-    INIT_Q2      => '0',
-    SRTYPE       => ~IF ~ISSYNC[5] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  port map (
-    Q1 => ~SYM[1],   -- 1-bit output for positive edge of clock
-    Q2 => ~SYM[2],   -- 1-bit output for negative edge of clock~IF ~ISGATED[4] ~THEN
-    C  => ~SYM[4],   -- 1-bit clock input
-    CE => ~SYM[6],   -- 1-bit clock enable input~ELSE
-    C  => ~ARG[4],   -- 1-bit clock input
-    CE => '1',       -- 1-bit clock enable input~FI
-    D  => ~SYM[3],   -- 1-bit DDR data input
-    R  => ~ARG[5],   -- 1-bit reset
-    S  => '0'        -- 1-bit set
-  );~ELSE
+
   ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
   begin
-    ~SYM[9] : IDDR
+    ~GENSYM[~COMPNAME_IDDR_inst][9] : IDDR
     generic map (
       DDR_CLK_EDGE => \"SAME_EDGE\",
       INIT_Q1      => '0',
@@ -62,7 +45,7 @@ begin~IF ~ISGATED[4] ~THEN
       R  => ~ARG[5],   -- 1-bit reset
       S  => '0'        -- 1-bit set
     );
-  end generate;~FI
+  end generate;
 
   ~RESULT <= (~SYM[2], ~SYM[1]);
 end block;
@@ -97,25 +80,10 @@ begin~IF ~ISGATED[3] ~THEN
   ~SYM[6] <= '1' when (~SYM[5]) else '0';~ELSE ~FI
   ~SYM[1] <= ~ARG[5];
   ~SYM[2] <= ~ARG[6];
-  ~IF~ISBIT[6]~THEN
-  generic map(
-    DDR_CLK_EDGE => \"SAME_EDGE\",
-    INIT => '0',
-    SRTYPE => ~IF ~ISSYNC[4] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  port map (
-    Q  => ~SYM[3],   -- 1-bit DDR output~IF ~ISGATED[3] ~THEN
-    C  => ~SYM[4],   -- 1-bit clock input
-    CE => ~SYM[6],   -- 1-bit clock enable input~ELSE
-    C  => ~ARG[3],   -- 1-bit clock input
-    CE => '1',       -- 1-bit clock enable input~FI
-    D1 => ~SYM[1],   -- 1-bit data input (positive edge)
-    D2 => ~SYM[2],   -- 1-bit data input (negative edge)
-    R  => ~ARG[4],   -- 1-bit reset input
-    S  => '0'        -- 1-bit set input
-  );~ELSE
+
   ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
   begin
-    ~SYM[9] : ODDR
+    ~GENSYM[~COMPNAME_ODDR_inst][9] : ODDR
     generic map(
       DDR_CLK_EDGE => \"SAME_EDGE\",
       INIT => '0',
@@ -131,7 +99,7 @@ begin~IF ~ISGATED[3] ~THEN
       R  => ~ARG[4],    -- 1-bit reset input
       S  => '0'         -- 1-bit set input
     );
-  end generate;~FI
+  end generate;
 
   ~RESULT <= ~SYM[3];
 end block;

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -81,6 +81,7 @@ instance Backend SystemVerilogState where
   hdlKind         = const SystemVerilog
   primDirs        = const $ do root <- primsRoot
                                return [ root System.FilePath.</> "common"
+                                      , root System.FilePath.</> "commonverilog"
                                       , root System.FilePath.</> "systemverilog"
                                       ]
   extractTypes    = _tyCache
@@ -219,12 +220,13 @@ mkTyPackage_ modName hwtys =
     eqReprTy (RTree n ty1) (RTree m ty2)
       | m == n    = eqReprTy ty1 ty2
       | otherwise = False
+    eqReprTy Bit  ty2 = ty2 `elem` [Bit,Bool]
+    eqReprTy Bool ty2 = ty2 `elem` [Bit,Bool]
     eqReprTy ty1 ty2
       | isUnsigned ty1 && isUnsigned ty2 = typeSize ty1 == typeSize ty2
       | otherwise                        = ty1 == ty2
 
     isUnsigned :: HWType -> Bool
-    isUnsigned Bool          = True
     isUnsigned (Unsigned _)  = True
     isUnsigned (BitVector _) = True
     isUnsigned (Index _)     = True
@@ -238,7 +240,7 @@ mkUsedTys v@(Vector _ elTy)   = v : mkUsedTys elTy
 mkUsedTys t@(RTree _ elTy)    = t : mkUsedTys elTy
 mkUsedTys p@(Product _ elTys) = p : concatMap mkUsedTys elTys
 mkUsedTys sp@(SP _ elTys)     = sp : concatMap mkUsedTys (concatMap snd elTys)
-mkUsedTys c@(Clock n r Gated) = [c,Clock n r Source,Bool]
+mkUsedTys c@(Clock _ _ Gated) = [c,Bit,Bool]
 mkUsedTys t                   = [t]
 
 topSortHWTys :: [HWType]
@@ -313,7 +315,7 @@ tyDec ty@(Product _ tys) | typeSize ty > 0 = Just A.<$> prodDec
 tyDec _ = pure Nothing
 
 gatedClockType :: HWType -> HWType
-gatedClockType (Clock nm rt Gated) = Product ("GatedClock" `Text.append` (pack (show (nm,rt)))) [Clock nm rt Source,Bool]
+gatedClockType (Clock nm rt Gated) = Product ("GatedClock" `Text.append` (pack (show (nm,rt)))) [Bit,Bool]
 gatedClockType ty = ty
 {-# INLINE gatedClockType #-}
 
@@ -325,6 +327,8 @@ splitVecTy = fmap splitElemTy . go
       Vector _ _  -> error $ $(curLoc) ++ "impossible"
       Clock {}    -> (ns, verilogType t)
       Reset {}    -> (ns, "logic")
+      Bool        -> (ns, "logic")
+      Bit         -> (ns, "logic")
       String      -> (ns, "string")
       Signed n    -> (ns ++ [Left n],"logic signed")
       _           -> (ns ++ [Left (typeSize t)], "logic")
@@ -514,6 +518,8 @@ verilogType t = do
     Clock _ _ Gated -> verilogType (gatedClockType t)
     Clock {}      -> "logic"
     Reset {}      -> "logic"
+    Bit           -> "logic"
+    Bool          -> "logic"
     String        -> "string"
     _ -> "logic" <+> brackets (int (typeSize t -1) <> colon <> int 0)
 
@@ -533,7 +539,8 @@ verilogTypeMark t = do
     _ -> empty
 
 tyName :: HWType -> SystemVerilogM Doc
-tyName Bool              = "logic_vector_1"
+tyName Bool              = "logic"
+tyName Bit               = "logic"
 tyName (Vector n elTy)   = "array_of_" <> int n <> "_" <> tyName elTy
 tyName (RTree n elTy)    = "tree_of_" <> int n <> "_" <> tyName elTy
 tyName (BitVector n)     = "logic_vector_" <> int n
@@ -706,8 +713,8 @@ expr_ _ (Identifier id_ (Just (Indexed (ty@(Product _ tys),_,fI)))) = do
   id'<- fmap (displayT . renderOneLine) (text id_ <> dot <> tyName ty <> "_sel" <> int fI)
   simpleFromSLV (tys !! fI) id'
 
-expr_ _ (Identifier id_ (Just (Indexed (ty@(Clock nm rt Gated),_,fI)))) = do
-  let tys = [Clock nm rt Source, Bool]
+expr_ _ (Identifier id_ (Just (Indexed (ty@(Clock _ _ Gated),_,fI)))) = do
+  let tys = [Bit, Bool]
       ty' = gatedClockType ty
   id'<- fmap (displayT . renderOneLine) (text id_ <> dot <> tyName ty' <> "_sel" <> int fI)
   simpleFromSLV (tys !! fI) id'
@@ -810,6 +817,11 @@ expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.BitVector.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
   = exprLit (Just (BitVector (fromInteger n),fromInteger n)) i
+
+expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
+  | pNm == "Clash.Sized.Internal.BitVector.fromInteger##"
+  , [Literal _ i] <- extractLiterals bbCtx
+  = exprLit (Just (Bit,1)) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Index.fromInteger#"

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -104,9 +104,7 @@ instance Backend VHDLState where
   toBV _ id_      = do
     nm <- use modNm
     text (T.toLower $ T.pack nm) <> "_types.toSLV" <> parens (text id_)
-  fromBV _ id_    = do
-    nm <- use modNm
-    text (T.toLower $ T.pack nm) <> "_types.fromSLV" <> parens (text id_)
+  fromBV hty id_  = fromSLV hty id_ (typeSize hty - 1) 0
   hdlSyn          = use hdlsyn
   mkIdentifier    = return go
     where
@@ -234,6 +232,7 @@ mkTyPackage_ modName hwtys = do
     eqTypM (Signed _) (Signed _)         = True
     eqTypM (Unsigned _) (Unsigned _)     = True
     eqTypM (BitVector _) (BitVector _)   = True
+    eqTypM (Clock _ _ g) (Clock _ _ g')  = g == g'
     eqTypM ty1 ty2 = ty1 == ty2
 
 mkUsedTys :: HWType
@@ -270,11 +269,9 @@ normaliseType ty@(SP _ elTys)      = do
   mapM_ ((tyCache %=) . HashSet.insert) (concatMap snd elTys)
   return (BitVector (typeSize ty))
 normaliseType ty@(Index _)     = return (Unsigned (typeSize ty))
-normaliseType ty@(Sum _ _)     = return (BitVector (typeSize ty))
-normaliseType (Clock _ _ Gated) =
-  return (Product "GatedClock" [Bit,Bool])
-normaliseType (Clock {}) = return Bit
-normaliseType (Reset {}) = return Bit
+normaliseType ty@(Sum _ _)     = return (Unsigned (typeSize ty))
+normaliseType (Clock nm rt Gated) =
+  return (Product "GatedClock" [Clock nm rt Source,Bool])
 normaliseType ty = return ty
 
 mkVecZ :: HWType -> HWType
@@ -352,22 +349,6 @@ funDec _ Bool = Just
                                 ,  indent 2 ("return" <+> "to_signed" <> parens (int 0 <> comma <> (use intWidth >>= int)) <> semi)
                                 ,"end" <+> "if" <> semi
                                 ]) <$>
-    "end" <> semi
-  )
-
-funDec _ Bit = Just
-  ( "function" <+> "toSLV" <+> parens ("sl" <+> colon <+> "in" <+> "std_logic") <+> "return" <+> "std_logic_vector" <> semi <$>
-    "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "std_logic" <> semi
-  , "function" <+> "toSLV" <+> parens ("sl" <+> colon <+> "in" <+> "std_logic") <+> "return" <+> "std_logic_vector" <+> "is" <$>
-    "begin" <$>
-      indent 2 ("return" <+> "std_logic_vector'" <> parens (int 0 <+> rarrow <+> "sl") <> semi) <$>
-    "end" <> semi <$>
-    "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "std_logic" <+> "is" <$>
-      indent 2
-        ( "alias islv : std_logic_vector (0 to slv'length - 1) is slv;"
-        ) <$>
-    "begin" <$>
-      indent 2 ("return" <+> "islv" <> parens (int 0) <> semi) <$>
     "end" <> semi
   )
 
@@ -483,6 +464,20 @@ funDec _ (BitVector _) = Just
     "end" <> semi
   )
 
+funDec _ (Clock {}) = Just
+  ( "function" <+> "toSLV" <+> parens ("sl" <+> colon <+> "in" <+> "std_logic") <+> "return" <+> "std_logic_vector" <> semi <$>
+    "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "std_logic" <> semi
+  , "function" <+> "toSLV" <+> parens ("sl" <+> colon <+> "in" <+> "std_logic") <+> "return" <+> "std_logic_vector" <+> "is" <$>
+    "begin" <$>
+      indent 2 ("return" <+> "(0 => sl)" <> semi) <$>
+    "end" <> semi <$>
+    "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "std_logic" <+> "is" <$>
+      indent 2 "alias islv : std_logic_vector(0 to slv'length - 1) is slv;" <$>
+    "begin" <$>
+      indent 2 ("return" <+> "islv(0)" <> semi) <$>
+    "end" <> semi
+  )
+
 funDec syn t@(RTree _ elTy) = Just
   ( "function" <+> "toSLV" <+> parens ("value : " <+> vhdlTypeMark t) <+> "return std_logic_vector" <> semi <$>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> vhdlTypeMark t <> semi
@@ -584,7 +579,6 @@ vhdlType hwty = do
   where
     go :: HWType -> VHDLM Doc
     go Bool            = "boolean"
-    go Bit             = "std_logic"
     go (Clock {})      = "std_logic"
     go (Reset {})      = "std_logic"
     go (BitVector n)   = case n of
@@ -620,7 +614,6 @@ vhdlTypeMark hwty = do
   go hwty'
   where
     go Bool            = "boolean"
-    go Bit             = "std_logic"
     go (Clock {})      = "std_logic"
     go (Reset {})      = "std_logic"
     go (BitVector _)   = "std_logic_vector"
@@ -639,7 +632,6 @@ vhdlTypeMark hwty = do
 
 tyName :: HWType -> VHDLM Doc
 tyName Bool              = "boolean"
-tyName Bit               = "std_logic"
 tyName (Clock {})        = "std_logic"
 tyName (Reset {})        = "std_logic"
 tyName (Vector n elTy)   = "array_of_" <> int n <> "_" <> tyName elTy
@@ -648,7 +640,7 @@ tyName (BitVector n)     = "std_logic_vector_" <> int n
 tyName t@(Index _)       = "unsigned_" <> int (typeSize t)
 tyName (Signed n)        = "signed_" <> int n
 tyName (Unsigned n)      = "unsigned_" <> int n
-tyName t@(Sum _ _)       = "std_logic_vector_" <> int (typeSize t)
+tyName t@(Sum _ _)       = "unsigned_" <> int (typeSize t)
 tyName t@(Product nm _)  = do
     tN <- normaliseType t
     makeCached tN nameCache prodName
@@ -678,7 +670,6 @@ tyName _ = empty
 -- | Convert a Netlist HWType to an error VHDL value for that type
 vhdlTypeErrValue :: HWType -> VHDLM Doc
 vhdlTypeErrValue Bool                = "true"
-vhdlTypeErrValue Bit                 = "'-'"
 vhdlTypeErrValue t@(Vector n elTy)   = do
   syn <-hdlSyn
   case syn of
@@ -920,10 +911,7 @@ expr_ _ (DataCon ty@(SP _ args) (DC (_,i)) es) = assignExpr
                    n -> [bits (replicate n U)]
     assignExpr = "std_logic_vector'" <> parens (hcat $ punctuate " & " $ sequence (dcExpr:argExprs ++ extraArg))
 
-expr_ _ (DataCon ty@(Sum _ _) (DC (_,i)) []) =
-  let n = typeSize ty
-  in  exprLit (Just (BitVector n, n)) (NumLit (toInteger i))
-
+expr_ _ (DataCon ty@(Sum _ _) (DC (_,i)) []) = "to_unsigned" <> tupled (sequence [int i,int (typeSize ty)])
 expr_ _ (DataCon ty@(Product _ _) _ es) =
     tupled $ zipWithM (\i e' -> tyName ty <> "_sel" <> int i <+> rarrow <+> expr_ False e') [0..] es
 
@@ -943,10 +931,8 @@ expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.BitVector.fromInteger#"
-  , [Literal _ (NumLit n), Literal _ i@(NumLit b)] <- extractLiterals bbCtx
-  = case n of
-      1 -> exprLit Nothing (if b == 0 then BitLit L else BitLit H)
-      _ -> exprLit (Just (BitVector (fromInteger n),fromInteger n)) i
+  , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
+  = exprLit (Just (BitVector (fromInteger n),fromInteger n)) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Index.fromInteger#"
@@ -999,10 +985,10 @@ expr_ _ (DataTag Bool (Left id_)) = "tagToEnum" <> parens (text id_)
 expr_ _ (DataTag Bool (Right id_)) = "dataToTag" <> parens (text id_)
 
 expr_ _ (DataTag hty@(Sum _ _) (Left id_)) =
-  "std_logic_vector" <> parens ("resize" <> parens ("unsigned" <> parens ("std_logic_vector" <> parens (text id_)) <> "," <> int (typeSize hty)))
+  "resize" <> parens ("unsigned" <> parens ("std_logic_vector" <> parens (text id_)) <> "," <> int (typeSize hty))
 expr_ _ (DataTag (Sum _ _) (Right id_)) = do
   iw <- use intWidth
-  "signed" <> parens ("std_logic_vector" <> parens ("resize" <> parens ("unsigned" <> parens (text id_) <> "," <> int iw)))
+  "signed" <> parens ("std_logic_vector" <> parens ("resize" <> parens (text id_ <> "," <> int iw)))
 
 expr_ _ (DataTag (Product _ _) (Right _))  = do
   iw <- use intWidth
@@ -1090,7 +1076,6 @@ exprLit _             (StringLit s) = text . T.pack $ show s
 exprLit _             l             = error $ $(curLoc) ++ "exprLit: " ++ show l
 
 patLit :: HWType -> Literal -> VHDLM Doc
-patLit Bit (NumLit i) = if i == 0 then "'0'" else "'1'"
 patLit hwTy (NumLit i) =
   let sz = conSize hwTy
   in  case sz `mod` 4 of
@@ -1130,9 +1115,6 @@ toSLV :: HWType -> Expr -> VHDLM Doc
 toSLV Bool         e = do
   nm <- use modNm
   text (T.toLower $ T.pack nm) <> "_types.toSLV" <> parens (expr_ False e)
-toSLV Bit e = do
-  nm <- use modNm
-  text (T.toLower $ T.pack nm) <> "_types.toSLV" <> parens (expr_ False e)
 toSLV (Clock {})    e = do
   nm <- use modNm
   text (T.toLower $ T.pack nm) <> "_types.toSLV" <> parens (expr_ False e)
@@ -1143,7 +1125,7 @@ toSLV (BitVector _) e = expr_ False e
 toSLV (Signed _)   e = "std_logic_vector" <> parens (expr_ False e)
 toSLV (Unsigned _) e = "std_logic_vector" <> parens (expr_ False e)
 toSLV (Index _)    e = "std_logic_vector" <> parens (expr_ False e)
-toSLV (Sum _ _)    e = expr_ False e
+toSLV (Sum _ _)    e = "std_logic_vector" <> parens (expr_ False e)
 toSLV t@(Product _ tys) (Identifier id_ Nothing) = do
     selIds' <- sequence selIds
     encloseSep lparen rparen " & " (zipWithM toSLV tys selIds')
@@ -1177,12 +1159,11 @@ fromSLV :: HWType -> Identifier -> Int -> Int -> VHDLM Doc
 fromSLV Bool              id_ start _   = do
   nm <- use modNm
   text (T.toLower $ T.pack nm) <> "_types.fromSLV" <> parens (text id_ <> parens (int start <+> "downto" <+> int start))
-fromSLV Bit               id_ start _   = text id_ <> parens (int start)
 fromSLV (BitVector _)     id_ start end = text id_ <> parens (int start <+> "downto" <+> int end)
 fromSLV (Index _)         id_ start end = "unsigned" <> parens (text id_ <> parens (int start <+> "downto" <+> int end))
 fromSLV (Signed _)        id_ start end = "signed" <> parens (text id_ <> parens (int start <+> "downto" <+> int end))
 fromSLV (Unsigned _)      id_ start end = "unsigned" <> parens (text id_ <> parens (int start <+> "downto" <+> int end))
-fromSLV (Sum _ _)         id_ start end = text id_ <> parens (int start <+> "downto" <+> int end)
+fromSLV (Sum _ _)         id_ start end = "unsigned" <> parens (text id_ <> parens (int start <+> "downto" <+> int end))
 fromSLV t@(Product _ tys) id_ start _ = do
     tupled $ zipWithM (\s e -> s <+> rarrow <+> e) selNames args
   where

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -249,18 +249,17 @@ verilogType' isDecl t =
       getVerilogTy _          = (empty,    typeSize t)
 
   in case t of
-       -- special case: Bit, clocks and resets
+       -- special case: clocks and resets
        Clock _ _ Gated -> verilogType' isDecl (gatedClockType t)
        Clock {} -> empty
        Reset {} -> empty
-       Bit      -> empty
 
        -- otherwise, print the type and prefix
        ty | (prefix, sz) <- getVerilogTy ty
          -> prefix <+> renderVerilogTySize (sz-1)
 
 gatedClockType :: HWType -> HWType
-gatedClockType (Clock _ _ Gated) = Product "GatedClock" [Bit,Bool]
+gatedClockType (Clock nm rt Gated) = Product "GatedClock" [Clock nm rt Source,Bool]
 gatedClockType ty = ty
 {-# INLINE gatedClockType #-}
 
@@ -376,9 +375,9 @@ modifier offset (Indexed (ty@(Product _ argTys),_,fI)) = Just (start+offset,end+
     start   = typeSize ty - 1 - otherSz
     end     = start - argSize + 1
 
-modifier offset (Indexed (ty@(Clock _ _ Gated),_,fI)) = Just (start+offset,end+offset)
+modifier offset (Indexed (ty@(Clock nm rt Gated),_,fI)) = Just (start+offset,end+offset)
   where
-    argTys  = [Bit, Bool]
+    argTys  = [Clock nm rt Source, Bool]
     argTy   = argTys !! fI
     argSize = typeSize argTy
     otherSz = otherSize argTys (fI - 1)

--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -410,6 +410,7 @@ primop
   -> Maybe State
 primop eval gbl tcm h k nm ty tys vs v []
   | nm `elem` ["Clash.Sized.Internal.BitVector.fromInteger#"
+              ,"Clash.Sized.Internal.BitVector.fromInteger##"
               ,"Clash.Sized.Internal.Index.fromInteger#"
               ,"Clash.Sized.Internal.Signed.fromInteger#"
               ,"Clash.Sized.Internal.Unsigned.fromInteger#"

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -535,7 +535,8 @@ normalizeType tcMap = go
       -> go elTy
       -- These Clash types are implemented with newtypes.
       -- We need to keep these newtypes because they define the width of the numbers.
-      | name2String tcNm == "Clash.Sized.Internal.BitVector.BitVector" ||
+      | name2String tcNm == "Clash.Sized.Internal.BitVector.Bit" ||
+        name2String tcNm == "Clash.Sized.Internal.BitVector.BitVector" ||
         name2String tcNm == "Clash.Sized.Internal.Index.Index"         ||
         name2String tcNm == "Clash.Sized.Internal.Signed.Signed"       ||
         name2String tcNm == "Clash.Sized.Internal.Unsigned.Unsigned"

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -110,7 +110,7 @@ mkArgument bndr e = do
     ty    <- termType tcm e
     iw    <- Lens.use intWidth
     hwTyM <- N.termHWTypeM e
-    let eTyMsg = "(" ++ showDoc e ++ " :: " ++ show ty ++ ")"
+    let eTyMsg = "(" ++ showDoc e ++ " :: " ++ showDoc ty ++ ")"
     ((e',t,l),d) <- case hwTyM of
       Nothing   ->
         return ((Identifier (error ($(curLoc) ++ "Forced to evaluate untranslatable type: " ++ eTyMsg)) Nothing

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -101,8 +101,6 @@ pTagE =  O True            <$  pToken "~ERESULT"
      <|> IsVar             <$> (pToken "~ISVAR" *> pBrackets pNatural)
      <|> IsGated           <$> (pToken "~ISGATED" *> pBrackets pNatural)
      <|> IsSync            <$> (pToken "~ISSYNC" *> pBrackets pNatural)
-     <|> IsBit Nothing     <$  (pToken "~ISBITO")
-     <|> (IsBit . Just)    <$> (pToken "~ISBIT" *> pBrackets pNatural)
      <|> StrCmp            <$> (pToken "~STRCMP" *> pBrackets pSigD) <*> pBrackets pNatural
      <|> OutputWireReg     <$> (pToken "~OUTPUTWIREREG" *> pBrackets pNatural)
      <|> GenSym            <$> (pToken "~GENSYM" *> pBrackets pSigD) <*> pBrackets pNatural

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -51,7 +51,6 @@ data Element = C   !Text         -- ^ Constant
              | IsVar !Int
              | IsGated !Int
              | IsSync !Int
-             | IsBit !(Maybe Int)
              | StrCmp [Element] !Int
              | OutputWireReg !Int
              | Vars !Int

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -284,13 +284,6 @@ renderElem b (IF c t f) = do
                     in case ty of
                        Reset _ _ Synchronous -> 1
                        _ -> 0
-      (IsBit nM)  -> let ty = case nM of
-                                Just n | (_,ty',_) <- bbInputs b !! n -> ty'
-                                _ -> snd (bbResult b)
-                     in case ty of
-                        BitVector 1 -> 1
-                        Bit -> 1
-                        _ -> 0
       (StrCmp [C t1] n) ->
         let (e,_,_) = bbInputs b !! n
         in  case exprToText e of
@@ -534,8 +527,6 @@ prettyElem (IsLit i) = (displayT . renderOneLine) <$> (text "~ISLIT" <> brackets
 prettyElem (IsVar i) = (displayT . renderOneLine) <$> (text "~ISVAR" <> brackets (int i))
 prettyElem (IsGated i) = (displayT . renderOneLine) <$> (text "~ISGATED" <> brackets (int i))
 prettyElem (IsSync i) = (displayT . renderOneLine) <$> (text "~ISSYNC" <> brackets (int i))
-prettyElem (IsBit Nothing) = return "~ISBITO"
-prettyElem (IsBit (Just i)) = (displayT . renderOneLine) <$> (text "~ISBIT" <> brackets (int i))
 prettyElem (StrCmp es i) = do
   es' <- prettyBlackBox es
   (displayT . renderOneLine) <$> (text "~STRCMP" <> brackets (text es') <> brackets (int i))

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -95,7 +95,6 @@ data HWType
   = Void -- ^ Empty type
   | String -- ^ String type
   | Bool -- ^ Boolean type
-  | Bit -- ^ Bit type
   | BitVector !Size -- ^ BitVector of a specified size
   | Index    !Integer -- ^ Unsigned integer with specified (exclusive) upper bounder
   | Signed   !Size -- ^ Signed integer of a specified size

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -95,6 +95,7 @@ data HWType
   = Void -- ^ Empty type
   | String -- ^ String type
   | Bool -- ^ Boolean type
+  | Bit -- ^ Bit type
   | BitVector !Size -- ^ BitVector of a specified size
   | Index    !Integer -- ^ Unsigned integer with specified (exclusive) upper bounder
   | Signed   !Size -- ^ Signed integer of a specified size

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -199,6 +199,7 @@ representableType builtInTranslation allowZero stringRepresentable m =
     isRepresentable hty = case hty of
       String          -> stringRepresentable
       Bool            -> True
+      Bit             -> True
       BitVector n     -> (n > 0) || allowZero
       Index n         -> (n > 0) || allowZero
       Signed n        -> (n > 0) || allowZero
@@ -219,6 +220,7 @@ typeSize :: HWType
 typeSize Void = 0
 typeSize String = 1
 typeSize Bool = 1
+typeSize Bit = 1
 typeSize (Clock {}) = 1
 typeSize (Reset {}) = 1
 typeSize (BitVector i) = i

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -199,7 +199,6 @@ representableType builtInTranslation allowZero stringRepresentable m =
     isRepresentable hty = case hty of
       String          -> stringRepresentable
       Bool            -> True
-      Bit             -> True
       BitVector n     -> (n > 0) || allowZero
       Index n         -> (n > 0) || allowZero
       Signed n        -> (n > 0) || allowZero
@@ -220,7 +219,6 @@ typeSize :: HWType
 typeSize Void = 0
 typeSize String = 1
 typeSize Bool = 1
-typeSize Bit = 1
 typeSize (Clock {}) = 1
 typeSize (Reset {}) = 1
 typeSize (BitVector i) = i

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -473,7 +473,8 @@ interestingToLift inScope eval e@(Prim nm pty) args =
 
     isPow2 x = x /= 0 && (x .&. (complement x + 1)) == x
 
-    isFromInteger x = x `elem` ["Clash.Sized.Internal.BitVector.fromInteger#"
+    isFromInteger x = x `elem` ["Clash.Sized.Internal.BitVector.fromInteger##"
+                               ,"Clash.Sized.Internal.BitVector.fromInteger#"
                                ,"Clash.Sized.Integer.Index.fromInteger"
                                ,"Clash.Sized.Internal.Signed.fromInteger#"
                                ,"Clash.Sized.Internal.Unsigned.fromInteger#"

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -500,11 +500,7 @@ removeUnusedExpr _ e@(collectArgs -> (p@(Prim nm _),args)) = do
   bbM <- HashMap.lookup nm <$> Lens.use (extra.primitives)
   case bbM of
     Just (BlackBox pNm _ _ _ inc templ) -> do
-      let usedArgs = if pNm `elem` ["Clash.Sized.Internal.Signed.fromInteger#"
-                                   ,"Clash.Sized.Internal.Unsigned.fromInteger#"
-                                   ,"Clash.Sized.Internal.BitVector.fromInteger#"
-                                   ,"Clash.Sized.Internal.Index.fromInteger#"
-                                   ]
+      let usedArgs = if isFromInt pNm
                         then [0,1]
                         else either usedArguments usedArguments templ ++
                              maybe [] (usedArguments . snd) inc
@@ -926,7 +922,8 @@ isEq nm = nm == "Clash.Sized.Internal.BitVector.eq#" ||
           nm == "Clash.Sized.Internal.Unsigned.eq#"
 
 isFromInt :: Text -> Bool
-isFromInt nm = nm == "Clash.Sized.Internal.BitVector.fromInteger#" ||
+isFromInt nm = nm == "Clash.Sized.Internal.BitVector.fromInteger##" ||
+               nm == "Clash.Sized.Internal.BitVector.fromInteger#" ||
                nm == "Clash.Sized.Internal.Index.fromInteger#" ||
                nm == "Clash.Sized.Internal.Signed.fromInteger#" ||
                nm == "Clash.Sized.Internal.Unsigned.fromInteger#"

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1186,7 +1186,7 @@ reduceBinders processed body ((id_,expr):binders) = case List.find ((== expr) . 
     Nothing -> reduceBinders ((id_,expr):processed) body binders
 
 reduceConst :: NormRewrite
-reduceConst _ e
+reduceConst _ e@(App _ _)
   | isConstant e
   , (conPrim, _) <- collectArgs e
   , isPrim conPrim

--- a/examples/i2c/I2C/ByteMaster.hs
+++ b/examples/i2c/I2C/ByteMaster.hs
@@ -130,14 +130,14 @@ byteMasterT s@(ByteS {_srState = ShiftRegister {..}, ..})
         shiftsr    .= True
     Read -> when coreAck $ do
       shiftsr .= True
-      coreTxd .= pack ackIn
+      coreTxd .= bitCoerce ackIn
       if cntDone then do
         byteStateM .= Ack
         coreCmd    .= I2Cwrite
       else do
         coreCmd    .= I2Cread
     Ack -> if coreAck then do
-        ackOut  .= unpack coreRxd
+        ackOut  .= bitCoerce coreRxd
         coreTxd .= high
         -- check for stop; Should a STOP command be generated?
         if stop then do
@@ -149,7 +149,7 @@ byteMasterT s@(ByteS {_srState = ShiftRegister {..}, ..})
           -- generate command acknowledge signal
           hostAck    .= True
       else
-        coreTxd .= pack ackIn
+        coreTxd .= bitCoerce ackIn
     Stop -> when coreAck $ do
       byteStateM .= Idle
       coreCmd    .= I2Cnop

--- a/tests/shouldwork/Basic/LambdaDrop.hs
+++ b/tests/shouldwork/Basic/LambdaDrop.hs
@@ -3,7 +3,7 @@ module LambdaDrop where
 import Clash.Prelude
 
 topEntity :: Signal System (BitVector 2)
-topEntity = (++#) <$> outport1 <*> outport2
+topEntity = (++#) <$> (pack <$> outport1) <*> (pack <$> outport2)
   where
     (outport1, outResp1) = gpio (decodeReq 1 req)
     (outport2, outResp2) = gpio (decodeReq 2 req)


### PR DESCRIPTION
So instead of mapping `Bit` to

VHDL: `std_logic_vector(0 downto 0)`
Verilog: `wire [0:0]`

We map `Bit` to:

VHDL: `std_logic`
Verilog: `wire`

Unlike #297, `BitVector 1` is still mapped to `std_logic_vector(0 downto 0)`