### PR TITLE
Use a `reflection`-like API for implicit clocks and resets

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -96,12 +96,6 @@ ghcTypeToHWType iw floatSupport = go
 
         "GHC.Prim.Any" -> return (Void Nothing)
 
-        "Clash.Signal.SomeClock" ->
-          throwE $ $(curLoc) ++ "Unbound hidden clock, use `exposeClock`: " ++ showDoc ty
-
-        "Clash.Signal.SomeReset" ->
-          throwE $ $(curLoc) ++ "Unbound hidden reset, use `exposeReset`: " ++ showDoc ty
-
         "Clash.Signal.Internal.Signal" ->
           ExceptT $ return $ coreTypeToHWType go m keepVoid (args !! 1)
 

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -96,6 +96,12 @@ ghcTypeToHWType iw floatSupport = go
 
         "GHC.Prim.Any" -> return (Void Nothing)
 
+        "Clash.Signal.SomeClock" ->
+          throwE $ $(curLoc) ++ "Unbound hidden clock, use `exposeClock`: " ++ showDoc ty
+
+        "Clash.Signal.SomeReset" ->
+          throwE $ $(curLoc) ++ "Unbound hidden reset, use `exposeReset`: " ++ showDoc ty
+
         "Clash.Signal.Internal.Signal" ->
           ExceptT $ return $ coreTypeToHWType go m keepVoid (args !! 1)
 

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -160,7 +160,7 @@ normalize' nm = do
                             , showDoc (tmNorm ^. _5) ])
                     (return ())
             tyTrans <- Lens.view typeTranslator
-            case clockResetErrors tyTrans tcm ty of
+            case clockResetErrors sp tyTrans tcm ty of
               msgs@(_:_) -> traceIf True (concat (nmS:" (:: ":showDoc (tmNorm ^. _2)
                               :")\nhas potentially dangerous meta-stability issues:\n\n"
                               :msgs))
@@ -365,16 +365,17 @@ callTreeToList visited (CBranch (nm,bndr) used)
 -- * There are 2 or more reset arguments in scope that have the same reset
 --   domain annotation, and at least one of them is an asynchronous reset.
 clockResetErrors
-  :: (HashMap TyConOccName TyCon -> Bool -> Type -> Maybe (Either String HWType))
+  :: SrcSpan
+  -> (HashMap TyConOccName TyCon -> Bool -> Type -> Maybe (Either String HWType))
   -> HashMap TyConOccName TyCon
   -> Type
   -> [String]
-clockResetErrors tyTran tcm ty =
+clockResetErrors sp tyTran tcm ty =
    (Maybe.mapMaybe reportClock clks ++ Maybe.mapMaybe reportResets rsts)
   where
     (args,_)  = splitCoreFunForallTy tcm ty
     (_,args') = partitionEithers args
-    hwArgs    = zip (map (unsafeCoreTypeToHWType $(curLoc) tyTran tcm False) args') args'
+    hwArgs    = zip (map (unsafeCoreTypeToHWType sp $(curLoc) tyTran tcm False) args') args'
     clks      = groupBy ((==) `on` fst) . sortBy (compare `on` fst)
               $ [ ((nm,i),ty') | (Clock nm i _,ty') <- hwArgs]
     rsts      = groupBy ((==) `on` (fst.fst)) . sortBy (compare `on` (fst.fst))

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -17,7 +17,7 @@ import Clash.Rewrite.Util
 -- | Normalisation transformation
 normalization :: NormRewrite
 normalization = rmDeadcode >-> constantPropgation >-> etaTL >-> rmUnusedExpr >-!-> anf >-!-> rmDeadcode >->
-                bindConst >-> letTL >-> evalConst >-!-> cse >-!-> recLetRec >-> cleanup
+                bindConst >-> letTL >-> evalConst >-!-> cse >-!-> cleanup >-> recLetRec
   where
     etaTL      = apply "etaTL" etaExpansionTL !-> innerMost (apply "applicationPropagation" appProp)
     anf        = topdownR (apply "nonRepANF" nonRepANF) >-> apply "ANF" makeANF

--- a/examples/BlockRamTest.hs
+++ b/examples/BlockRamTest.hs
@@ -3,8 +3,8 @@ module BlockRamTest where
 import Clash.Prelude
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Unsigned 7)
+  :: Clock  System Source
+  -> Signal System (Unsigned 7)
   -> Signal System (Maybe (Unsigned 7,Unsigned 4))
   -> Signal System (Unsigned 4)
-topEntity = blockRamPow2 (repeat 0)
+topEntity = exposeClock (blockRamPow2 (repeat 0))

--- a/examples/CochleaPlus.hs
+++ b/examples/CochleaPlus.hs
@@ -53,10 +53,11 @@ c_frm (ws,ts,hist) vs = ((ws',ts',hist'),y)
     y   = hist'
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Vec 6 Integer)
+  :: Clock  System Source
+  -> Reset  System Asynchronous
+  -> Signal System (Vec 6 Integer)
   -> Signal System (Vec 12 Integer)
-topEntity = c_frm `mealy` (c_ws0,c_ts0,c_hist0)
+topEntity = exposeClockReset (c_frm `mealy` (c_ws0,c_ts0,c_hist0))
 
 -- Haskell
 sim f s [] = []
@@ -64,7 +65,7 @@ sim f s (x:xs) = y : sim f s' xs
   where
     (s',y) = f s x
 -- Clash
-c_sim f i = L.take (L.length i) $ simulate f c_vss
+c_sim f i = L.take (L.length i) $ simulate (f clockGen systemResetGen) c_vss
 
 c_outp = c_sim topEntity c_vss
 

--- a/examples/FIR.hs
+++ b/examples/FIR.hs
@@ -10,7 +10,7 @@ dotp :: SaturatingNum a
 dotp as bs = fold boundedPlus (zipWith boundedMult as bs)
 
 fir
-  :: (Default a, KnownNat n, SaturatingNum a, HiddenClockReset domain)
+  :: (Default a, KnownNat n, SaturatingNum a, HiddenClockReset domain gated synchronous)
   => Vec (n + 1) a -> Signal domain a -> Signal domain a
 fir coeffs x_t = y_t
   where

--- a/examples/Fifo.hs
+++ b/examples/Fifo.hs
@@ -40,7 +40,12 @@ fifoL
   -> Signal System (Bool,Bool,Elm)
 fifoL = fifo `mealy` (0,0,replicate d4 0)
 
-topEntity = fifoL
+topEntity
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System (Elm,Bool,Bool)
+  -> Signal System (Bool,Bool,Elm)
+topEntity = exposeClockReset fifoL
 
 testdatas :: [[(Elm,Bool,Bool)]]
 testdatas = [

--- a/examples/MAC.hs
+++ b/examples/MAC.hs
@@ -10,7 +10,10 @@ macT acc (x,y) = (acc',o)
     acc' = ma acc (x,y)
     o    = acc
 
-mac :: HiddenClockReset System => Signal System (Signed 9, Signed 9) -> Signal System (Signed 9)
+mac
+  :: HiddenClockReset System Source Asynchronous
+  => Signal System (Signed 9, Signed 9)
+  -> Signal System (Signed 9)
 mac = macT `mealy` 0
 
 topEntity

--- a/examples/MatrixVect.hs
+++ b/examples/MatrixVect.hs
@@ -1,6 +1,7 @@
 module MatrixVect where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 import qualified Data.List as L
 
 row1 = 1 :> 2 :> 3 :> Nil
@@ -18,9 +19,10 @@ topEntity = matrixVector matrix
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator ((2 :> 3 :> 4 :> Nil) :> Nil)
-    expectedOutput = outputVerifier   ((20 :> 47 :> 74 :> Nil) :> Nil)
+    testInput      = stimuliGenerator clk rst ((2 :> 3 :> 4 :> Nil) :> Nil)
+    expectedOutput = outputVerifier clk rst ((20 :> 47 :> 74 :> Nil) :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/examples/Queens.hs
+++ b/examples/Queens.hs
@@ -29,5 +29,5 @@ mbfilter (dout,ind) din = ((dout',ind'), low)
 
                   (dout',ind') = foldl f (dout0,ind0) din
 
-topEntity :: SystemClockReset => Signal System Din -> Signal System Bit
-topEntity = mbfilter `mealy` (dout0, ind0)
+topEntity :: Clock System Source -> Reset System Asynchronous -> Signal System Din -> Signal System Bit
+topEntity = exposeClockReset (mbfilter `mealy` (dout0, ind0))

--- a/examples/Reducer.hs
+++ b/examples/Reducer.hs
@@ -165,7 +165,12 @@ reducer (dataIn,index) = redOut
     (fromResMem,redOut)        = mealyB resBuffer     initResState (newDiscr,newDiscrVal,index,pipe,toResMem)
     (arg1,arg2,shift,toResMem) = fmapB controller (inp1, inp2, pipe, fromResMem)
 
-topEntity = reducer
+topEntity
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> (Signal System DataInt, Signal System ArrayIndex)
+  -> Signal System OutputSignal
+topEntity = exposeClockReset reducer
 
 fmapB f = unbundle . fmap f . bundle
 

--- a/examples/Windows.hs
+++ b/examples/Windows.hs
@@ -61,10 +61,11 @@ hfk1d xs = x2 + multwc (x1 - 2 * x2 + x3)
     x3 = xs !! 2
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Vec 2 Temp)
+  :: Clock  System Source
+  -> Reset  System Asynchronous
   -> Signal System (Vec 2 Temp)
-topEntity = (swarch1d hfk1d) `mealy` (repeat 0)
+  -> Signal System (Vec 2 Temp)
+topEntity = exposeClockReset ((swarch1d hfk1d) `mealy` (repeat 0))
 
 res :: [Vec 2 Temp]
-res = simulate topEntity $ L.repeat (repeat 45)
+res = simulate (topEntity clockGen systemResetGen) $ L.repeat (repeat 45)

--- a/examples/crc32/CRC32.hs
+++ b/examples/crc32/CRC32.hs
@@ -15,7 +15,7 @@ crc32Step prevCRC byte = entry `xor` (prevCRC `shiftR` 8)
     entry = asyncRom $(lift crc32Table) (truncateB prevCRC `xor` byte)
 
 crc32
-  :: HiddenClockReset domain
+  :: HiddenClockReset domain gated synchronous
   => Signal domain (BitVector 8) -> Signal domain (BitVector 32)
 crc32 = moore crc32Step complement 0xFFFFFFFF . register 0
 

--- a/examples/i2c/I2C.hs
+++ b/examples/i2c/I2C.hs
@@ -30,8 +30,8 @@ import I2C.Types
                      , PortField "" [PortName "i2cO_clk"]
                      ]
     }) #-}
-i2c rst ena clkCnt start stop read write ackIn din i2cI = (dout,hostAck,busy,al,ackOut,i2cO)
+i2c clk arst rst ena clkCnt start stop read write ackIn din i2cI = (dout,hostAck,busy,al,ackOut,i2cO)
   where
-    (hostAck,ackOut,dout,bitCtrl) = byteMaster (rst,start,stop,read,write,ackIn,din,bitResp)
-    (bitResp,busy,i2cO)           = bitMaster  (rst,ena,clkCnt,bitCtrl,i2cI)
+    (hostAck,ackOut,dout,bitCtrl) = byteMaster clk arst (rst,start,stop,read,write,ackIn,din,bitResp)
+    (bitResp,busy,i2cO)           = bitMaster  clk arst (rst,ena,clkCnt,bitCtrl,i2cI)
     (cmdAck,al,dbout)             = unbundle bitResp

--- a/examples/i2c/I2C/BitMaster.hs
+++ b/examples/i2c/I2C/BitMaster.hs
@@ -31,10 +31,8 @@ type BitMasterO = (BitRespSig,Bool,I2COut)
 {-# ANN bitMaster
   (defTop
     { t_name     = "bitmaster"
-    , t_inputs   = [ PortField ""
-                      [ PortName "clk"
-                      , PortName "arst"
-                      ]
+    , t_inputs   = [ PortName "clk"
+                   , PortName "arst"
                    , PortField ""
                       [ PortName "rst"
                       , PortName "ena"
@@ -54,10 +52,11 @@ type BitMasterO = (BitRespSig,Bool,I2COut)
                      ]
     }) #-}
 bitMaster
-  :: SystemClockReset
-  => Unbundled System BitMasterI
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Unbundled System BitMasterI
   -> Unbundled System BitMasterO
-bitMaster = mealyB bitMasterT bitMasterInit
+bitMaster = exposeClockReset (mealyB bitMasterT bitMasterInit)
 {-# NOINLINE bitMaster #-}
 
 bitMasterInit = BitS { _stateMachine   = stateMachineStart

--- a/examples/i2c/I2C/ByteMaster.hs
+++ b/examples/i2c/I2C/ByteMaster.hs
@@ -34,10 +34,8 @@ type ByteMasterO = (Bool,Bool,BitVector 8,BitCtrlSig)
 {-# ANN byteMaster
   (defTop
     { t_name     = "bytemaster"
-    , t_inputs   = [ PortField ""
-                      [ PortName "clk"
-                      , PortName "arst"
-                      ]
+    , t_inputs   = [ PortName "clk"
+                   , PortName "arst"
                    , PortField ""
                       [ PortName "rst"
                       , PortName "start"
@@ -56,10 +54,11 @@ type ByteMasterO = (Bool,Bool,BitVector 8,BitCtrlSig)
                      ]
     }) #-}
 byteMaster
-  :: SystemClockReset
-  => Unbundled System ByteMasterI
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Unbundled System ByteMasterI
   -> Unbundled System ByteMasterO
-byteMaster = mealyB byteMasterT byteMasterInit
+byteMaster = exposeClockReset (mealyB byteMasterT byteMasterInit)
 {-# NOINLINE byteMaster #-}
 
 {-# INLINE byteMasterInit #-}

--- a/tests/shouldwork/Basic/ByteSwap32.hs
+++ b/tests/shouldwork/Basic/ByteSwap32.hs
@@ -2,6 +2,7 @@
 module ByteSwap32 where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 import GHC.Word
 import Data.Bits
 
@@ -10,9 +11,10 @@ topEntity = byteSwap32
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH [1::Word32,3,8,50,0])
-    expectedOutput = outputVerifier $(listToVecTH ([16777216,50331648,134217728,838860800,0]::[Word32]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH [1::Word32,3,8,50,0])
+    expectedOutput = outputVerifier clk rst $(listToVecTH ([16777216,50331648,134217728,838860800,0]::[Word32]))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Basic/CharTest.hs
+++ b/tests/shouldwork/Basic/CharTest.hs
@@ -1,6 +1,7 @@
 module CharTest where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 import Data.Char
 
 topEntity :: (Int,Char) -> (Int,Char,Char)
@@ -8,9 +9,10 @@ topEntity (i,c) = (ord c,chr i,'λ')
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH [(0::Int,'a'),(3,' '),(8,'\t'),(50,'8'),(600,'λ')])
-    expectedOutput = outputVerifier $(listToVecTH ([(97,'\NUL','\955'),(32,'\ETX','\955'),(9,'\b','\955'),(56,'2','\955'),(955,'\600','\955')]::[(Int,Char,Char)]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH [(0::Int,'a'),(3,' '),(8,'\t'),(50,'8'),(600,'λ')])
+    expectedOutput = outputVerifier clk rst $(listToVecTH ([(97,'\NUL','\955'),(32,'\ETX','\955'),(9,'\b','\955'),(56,'2','\955'),(955,'\600','\955')]::[(Int,Char,Char)]))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Basic/ClassOps.hs
+++ b/tests/shouldwork/Basic/ClassOps.hs
@@ -1,15 +1,17 @@
 module ClassOps where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: (Integer,Integer) -> Integer
 topEntity = uncurry mod
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH [(19,4)::(Integer,Integer),(7,3),(55,-10),(9,-2),(0,-10),(11,10)])
-    expectedOutput = outputVerifier $(listToVecTH ([3::Integer,1,-5,-1,0,1]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH [(19,4)::(Integer,Integer),(7,3),(55,-10),(9,-2),(0,-10),(11,10)])
+    expectedOutput = outputVerifier clk rst $(listToVecTH ([3::Integer,1,-5,-1,0,1]))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Basic/CountTrailingZeros.hs
+++ b/tests/shouldwork/Basic/CountTrailingZeros.hs
@@ -4,6 +4,7 @@ module CountTrailingZeros where
 #include "MachDeps.h"
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 import GHC.Word
 import Data.Bits
 
@@ -12,15 +13,16 @@ topEntity = countTrailingZeros
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH [1::Word,3,8,50,0])
+    testInput      = stimuliGenerator clk rst $(listToVecTH [1::Word,3,8,50,0])
 #if WORD_SIZE_IN_BITS == 64
-    expectedOutput = outputVerifier $(listToVecTH ([0,0,3,1,64]::[Int]))
+    expectedOutput = outputVerifier clk rst $(listToVecTH ([0,0,3,1,64]::[Int]))
 #elif WORD_SIZE_IN_BITS == 32
-    expectedOutput = outputVerifier $(listToVecTH ([0,0,3,1,32]::[Int]))
+    expectedOutput = outputVerifier clk rst $(listToVecTH ([0,0,3,1,32]::[Int]))
 #else
 #error Unsupported word size
 #endif
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Basic/NORX.hs
+++ b/tests/shouldwork/Basic/NORX.hs
@@ -1,6 +1,7 @@
 module NORX where
 import Data.Bits
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 type W = Unsigned 32
 
@@ -48,10 +49,11 @@ topEntity = norx
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator ((0:>1:>2:>3:>4:>5:>6:>7:>8:>9:>10:>11:>12:>13:>14:>15:>Nil):>Nil)
-    expectedOutput = outputVerifier   ((   0x99a0283a
+    testInput      = stimuliGenerator clk rst ((0:>1:>2:>3:>4:>5:>6:>7:>8:>9:>10:>11:>12:>13:>14:>15:>Nil):>Nil)
+    expectedOutput = outputVerifier   clk rst
+                                      ((   0x99a0283a
                                         :> 0x16c4b42e
                                         :> 0x6e7fa00b
                                         :> 0x7d075c66
@@ -69,4 +71,5 @@ testBench = done'
                                         :> 0x9ce6be37
                                         :> Nil) :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Basic/PopCount.hs
+++ b/tests/shouldwork/Basic/PopCount.hs
@@ -2,6 +2,7 @@
 module PopCount where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 import GHC.Word
 import Data.Bits
 
@@ -10,9 +11,10 @@ topEntity = popCount
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH [1::Word,3,8,50,0])
-    expectedOutput = outputVerifier   $(listToVecTH ([1,2,1,3,0]::[Int]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH [1::Word,3,8,50,0])
+    expectedOutput = outputVerifier   clk rst $(listToVecTH ([1,2,1,3,0]::[Int]))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Basic/RecordSumOfProducts.hs
+++ b/tests/shouldwork/Basic/RecordSumOfProducts.hs
@@ -13,8 +13,11 @@ data DbState = DbInitDisp (Unsigned 4) | DbWriteRam (Signed 14) (Signed 14)
 data DbS = DbS { dbS :: DbState }
 
 
-topEntity :: SystemClockReset => Signal System Bit -> Signal System Bit
-topEntity = walkState <^> DbS (DbInitDisp 0)
+topEntity
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System Bit -> Signal System Bit
+topEntity = exposeClockReset (walkState <^> DbS (DbInitDisp 0))
 
 walkState :: DbS
           -> Bit

--- a/tests/shouldwork/BitVector/Box.hs
+++ b/tests/shouldwork/BitVector/Box.hs
@@ -1,6 +1,7 @@
 module Box where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: BitVector 16 -> (BitVector 16,BitVector 8,Vec 8 Bit)
 topEntity vec = (pack  tup
@@ -13,9 +14,10 @@ topEntity vec = (pack  tup
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (0x00FF)
-    expectedOutput = outputVerifier ((0x00FF,0x0F,1:>1:>1:>1:>0:>0:>0:>0:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((0x00FF,0x0F,1:>1:>1:>1:>0:>0:>0:>0:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/BitVector/BoxGrow.hs
+++ b/tests/shouldwork/BitVector/BoxGrow.hs
@@ -1,6 +1,7 @@
 module BoxGrow where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 ys >:> xss = zipWith (:>) ys xss
 xss <:< ys = zipWith (:<) xss ys
@@ -15,10 +16,10 @@ topEntity = box0
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (repeat (repeat 1))
-    expectedOutput = outputVerifier ( ((0 :> 0 :> 0 :> 0 :> 0 :> 0 :> 0 :> 0 :> Nil) :>
+    expectedOutput = outputVerifier clk rst ( ((0 :> 0 :> 0 :> 0 :> 0 :> 0 :> 0 :> 0 :> Nil) :>
                                       (0 :> 1 :> 1 :> 1 :> 1 :> 1 :> 1 :> 0 :> Nil) :>
                                       (0 :> 1 :> 1 :> 1 :> 1 :> 1 :> 1 :> 0 :> Nil) :>
                                       (0 :> 1 :> 1 :> 1 :> 1 :> 1 :> 1 :> 0 :> Nil) :>
@@ -26,4 +27,5 @@ testBench = done'
                                       (0 :> 1 :> 1 :> 1 :> 1 :> 1 :> 1 :> 0 :> Nil) :>
                                       (0 :> 0 :> 0 :> 0 :> 0 :> 0 :> 0 :> 0 :> Nil) :> Nil) :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Feedback/Fib.hs
+++ b/tests/shouldwork/Feedback/Fib.hs
@@ -3,7 +3,7 @@ module Fib where
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
-fib :: HiddenClockReset dom => Signal dom (Unsigned 64)
+fib :: HiddenClockReset dom gated synchronous => Signal dom (Unsigned 64)
 fib = register 1 fib + register 0 (register 0 fib)
 
 topEntity

--- a/tests/shouldwork/Feedback/Fib.hs
+++ b/tests/shouldwork/Feedback/Fib.hs
@@ -1,20 +1,22 @@
 module Fib where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
--- TODO: revert this back to (HasClockReset dom gated synchronous)
-fib :: (HasClock dom gated, HasReset dom synchronous) => Signal dom (Unsigned 64)
+fib :: HiddenClockReset dom => Signal dom (Unsigned 64)
 fib = register 1 fib + register 0 (register 0 fib)
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Unsigned 64)
-topEntity = fib
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System (Unsigned 64)
+topEntity = exposeClockReset fib
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    expectedOutput = outputVerifier $(listToVecTH [1 :: Unsigned 64,1,2,3,5])
-    done           = expectedOutput topEntity
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    expectedOutput = outputVerifier clk rst $(listToVecTH [1 :: Unsigned 64,1,2,3,5])
+    done           = expectedOutput (topEntity clk rst)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Fixed/Mixer.hs
+++ b/tests/shouldwork/Fixed/Mixer.hs
@@ -1,6 +1,7 @@
 module Mixer where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 k               = 0.6
 piFHalf         = 1.5707963267948966 :: SFixed 3 8
@@ -18,9 +19,10 @@ topEntity = cordic
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator (0.7853981633974483 :> Nil)
-    expectedOutput = outputVerifier   (0.59765625 :> Nil)
+    testInput      = stimuliGenerator clk rst (0.7853981633974483 :> Nil)
+    expectedOutput = outputVerifier   clk rst (0.59765625 :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Fixed/SFixedTest.hs
+++ b/tests/shouldwork/Fixed/SFixedTest.hs
@@ -1,6 +1,7 @@
 module SFixedTest where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 type SF = SFixed 4 18
 
@@ -9,9 +10,10 @@ topEntity x = x * 2.56
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH ([1.2, 1.8, 3.5] :: [SFixed 4 18] ))
-    expectedOutput = outputVerifier   $(listToVecTH ([3.07199, 4.607991, 8.96] :: [SFixed 4 18]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH ([1.2, 1.8, 3.5] :: [SFixed 4 18] ))
+    expectedOutput = outputVerifier   clk rst $(listToVecTH ([3.07199, 4.607991, 8.96] :: [SFixed 4 18]))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Fixed/ZeroInt.hs
+++ b/tests/shouldwork/Fixed/ZeroInt.hs
@@ -1,15 +1,17 @@
 module ZeroInt where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: (UFixed 0 8,UFixed 0 8) -> UFixed 0 8
 topEntity = uncurry (*)
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (0.2,0.35)
-    expectedOutput = outputVerifier $(listToVecTH [0.06640625 :: UFixed 0 8])
+    expectedOutput = outputVerifier clk rst $(listToVecTH [0.06640625 :: UFixed 0 8])
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Floating/FloatConstFolding.hs
+++ b/tests/shouldwork/Floating/FloatConstFolding.hs
@@ -1,6 +1,7 @@
 module FloatConstFolding where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Signal System (Float,Double,Signed 8,Signed 9)
 topEntity = pure ( resFloat
@@ -69,8 +70,9 @@ f = e + pi_noinline
 expectedOutput = (unpack 0x3F45628A, unpack 0x3FED4161686C9EEE, 1, 1) :> Nil
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    expectOutput = outputVerifier expectedOutput
+    expectOutput = outputVerifier clk rst expectedOutput
     done         = expectOutput topEntity
-    done'        = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk          = tbSystemClockGen (not <$> done)
+    rst          = systemResetGen

--- a/tests/shouldwork/HOPrim/Transpose.hs
+++ b/tests/shouldwork/HOPrim/Transpose.hs
@@ -1,6 +1,7 @@
 module Transpose where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity = transposeV
 {-# NOINLINE topEntity #-}
@@ -9,9 +10,10 @@ transposeV :: Vec 3 (Vec 4 Int) -> Vec 4 (Vec 3 Int)
 transposeV = sequenceA
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure ((1:>2:>3:>4:>Nil):>(5:>6:>7:>8:>Nil):>(9:>10:>11:>12:>Nil):>Nil)
-    expectedOutput = outputVerifier ((transpose ((1:>2:>3:>4:>Nil):>(5:>6:>7:>8:>Nil):>(9:>10:>11:>12:>Nil):>Nil)):>Nil)
+    expectedOutput = outputVerifier clk rst ((transpose ((1:>2:>3:>4:>Nil):>(5:>6:>7:>8:>Nil):>(9:>10:>11:>12:>Nil):>Nil)):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/HOPrim/VecFun.hs
+++ b/tests/shouldwork/HOPrim/VecFun.hs
@@ -1,6 +1,7 @@
 module VecFun where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity = work
 {-# NOINLINE topEntity #-}
@@ -12,9 +13,10 @@ work xs = zipWith sel xs funs where
     sel x f = f x
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (1:>2:>3:>Nil)
-    expectedOutput = outputVerifier ((2:>3:>4:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((2:>3:>4:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Numbers/Resize.hs
+++ b/tests/shouldwork/Numbers/Resize.hs
@@ -1,15 +1,17 @@
 module Resize where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Signed 4 -> Signed 3
 topEntity = resize
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH ([minBound .. maxBound]::[Signed 4]))
-    expectedOutput = outputVerifier $(listToVecTH ([-4,-3,-2,-1,-4,-3,-2,-1,0,1,2,3,0,1,2,3]::[Signed 3]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH ([minBound .. maxBound]::[Signed 4]))
+    expectedOutput = outputVerifier clk rst $(listToVecTH ([-4,-3,-2,-1,-4,-3,-2,-1,0,1,2,3,0,1,2,3]::[Signed 3]))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Numbers/Resize2.hs
+++ b/tests/shouldwork/Numbers/Resize2.hs
@@ -1,15 +1,17 @@
 module Resize2 where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Signed 4 -> Signed 5
 topEntity = resize
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH ([minBound .. maxBound]::[Signed 4]))
-    expectedOutput = outputVerifier $(listToVecTH ([-8,-7,-6,-5,-4,-3,-2,-1,0,1,2,3,4,5,6,7]::[Signed 5]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH ([minBound .. maxBound]::[Signed 4]))
+    expectedOutput = outputVerifier clk rst $(listToVecTH ([-8,-7,-6,-5,-4,-3,-2,-1,0,1,2,3,4,5,6,7]::[Signed 5]))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Numbers/Strict.hs
+++ b/tests/shouldwork/Numbers/Strict.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 module Strict where
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 {-
 Test the strict evaluation of Unsigned values
@@ -37,10 +38,11 @@ g x !y = x `seq` x + y :> Nil
 
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput    = stimuliGenerator ((big1,big2) :> Nil)
+    testInput    = stimuliGenerator clk rst ((big1,big2) :> Nil)
     testEntity   = fmap $ map (`shiftR` 64) . uncurry topEntity
-    expectOutput = outputVerifier (repeat 0xc :> Nil)
+    expectOutput = outputVerifier clk rst (repeat 0xc :> Nil)
     done         = expectOutput (testEntity testInput)
-    done'        = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk          = tbSystemClockGen (not <$> done)
+    rst          = systemResetGen

--- a/tests/shouldwork/Signal/AlwaysHigh.hs
+++ b/tests/shouldwork/Signal/AlwaysHigh.hs
@@ -3,6 +3,7 @@ module AlwaysHigh where
 import Clash.Prelude
 
 topEntity
-  :: SystemClockReset
-  => Signal System Bit
-topEntity = register high (pure high)
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System Bit
+topEntity = exposeClockReset (register high (pure high))

--- a/tests/shouldwork/Signal/BlockRamFile.hs
+++ b/tests/shouldwork/Signal/BlockRamFile.hs
@@ -1,26 +1,30 @@
 module BlockRamFile where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
+import qualified Clash.Explicit.Prelude as Explicit
 
 zeroAt0
-  :: HasClockReset domain gated synchronous
+  :: HiddenClockReset domain
   => Signal domain (Unsigned 8) -> Signal domain (Unsigned 8)
 zeroAt0 a = mux en a 0
   where
     en = register False (pure True)
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Unsigned 8) -> Signal System (Unsigned 8)
-topEntity rd = zeroAt0 (unpack <$> dout)
-  where
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System (Unsigned 8) -> Signal System (Unsigned 8)
+topEntity = exposeClockReset go where
+  go rd = zeroAt0 (unpack <$> dout) where
     dout = blockRamFilePow2 "memory.list" rd (pure Nothing)
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = register 0 (testInput + 1)
-    expectedOutput = outputVerifier $(listToVecTH [0::Unsigned 8,0,1,2,3,4,5,6,7,8])
-    done           = expectedOutput (topEntity testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    testInput      = Explicit.register clk rst 0 (testInput + 1)
+    expectedOutput = outputVerifier clk rst $(listToVecTH [0::Unsigned 8,0,1,2,3,4,5,6,7,8])
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Signal/BlockRamFile.hs
+++ b/tests/shouldwork/Signal/BlockRamFile.hs
@@ -5,7 +5,7 @@ import Clash.Explicit.Testbench
 import qualified Clash.Explicit.Prelude as Explicit
 
 zeroAt0
-  :: HiddenClockReset domain
+  :: HiddenClockReset domain gated synchronous
   => Signal domain (Unsigned 8) -> Signal domain (Unsigned 8)
 zeroAt0 a = mux en a 0
   where

--- a/tests/shouldwork/Signal/BlockRamTest.hs
+++ b/tests/shouldwork/Signal/BlockRamTest.hs
@@ -4,8 +4,8 @@ module BlockRamTest where
 import Clash.Prelude
 
 topEntity
-  :: HasClock System Source
-  => Signal System (Unsigned 7)
+  :: Clock System Source
+  -> Signal System (Unsigned 7)
   -> Signal System (Maybe (Unsigned 7, Vec 4 Bit))
   -> Signal System (Vec 4 Bit)
-topEntity = blockRam (replicate d128 (repeat high))
+topEntity = exposeClock (blockRam (replicate d128 (repeat high)))

--- a/tests/shouldwork/Signal/MAC.hs
+++ b/tests/shouldwork/Signal/MAC.hs
@@ -3,11 +3,12 @@ module MAC where
 import Clash.Prelude
 
 topEntity
-  :: SystemClockReset
-  => Integer
+  :: Integer
+  -> Clock System Source
+  -> Reset System Asynchronous
   -> (Signal System Integer, Signal System Integer)
   -> Signal System Integer
-topEntity i = macT <^> i
+topEntity i = exposeClockReset (macT <^> i)
 
 macT s (x,y) = (s',o)
   where

--- a/tests/shouldwork/Signal/Ram.hs
+++ b/tests/shouldwork/Signal/Ram.hs
@@ -1,10 +1,12 @@
 module Ram where
 
 import Clash.Prelude
+import qualified Clash.Explicit.Prelude as Explicit
+import Clash.Explicit.Testbench
 import qualified Data.List as L
 
 zeroAt0
-  :: HasClockReset domain gated synchronous
+  :: HiddenClockReset domain
   => Signal domain (Unsigned 8,Unsigned 8)
   -> Signal domain (Unsigned 8,Unsigned 8)
 zeroAt0 a = mux en a (bundle (0,0))
@@ -12,19 +14,21 @@ zeroAt0 a = mux en a (bundle (0,0))
     en = register False (pure True)
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Unsigned 8)
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System (Unsigned 8)
   -> Signal System (Unsigned 8,Unsigned 8)
-topEntity rd = zeroAt0 dout
-  where
+topEntity = exposeClockReset go where
+  go rd = zeroAt0 dout where
     dout = asyncRamPow2 rd (Just <$> bundle (wr, bundle (wr,wr)))
     wr   = register 1 (wr + 1)
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = register 0 (testInput + 1)
-    expectedOutput = outputVerifier $(listToVecTH $ L.map (\x -> (x,x)) [0::Unsigned 8,1,2,3,4,5,6,7,8])
-    done           = expectedOutput (topEntity testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    testInput      = Explicit.register clk rst 0 (testInput + 1)
+    expectedOutput = outputVerifier clk rst $(listToVecTH $ L.map (\x -> (x,x)) [0::Unsigned 8,1,2,3,4,5,6,7,8])
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Signal/Ram.hs
+++ b/tests/shouldwork/Signal/Ram.hs
@@ -6,7 +6,7 @@ import Clash.Explicit.Testbench
 import qualified Data.List as L
 
 zeroAt0
-  :: HiddenClockReset domain
+  :: HiddenClockReset domain gated synchronous
   => Signal domain (Unsigned 8,Unsigned 8)
   -> Signal domain (Unsigned 8,Unsigned 8)
 zeroAt0 a = mux en a (bundle (0,0))

--- a/tests/shouldwork/Signal/Rom.hs
+++ b/tests/shouldwork/Signal/Rom.hs
@@ -1,10 +1,12 @@
 module Rom where
 
 import Clash.Prelude
+import qualified Clash.Explicit.Prelude as Explicit
+import Clash.Explicit.Testbench
 import qualified Data.List as L
 
 zeroAt0
-  :: HasClockReset domain gated synchronous
+  :: HiddenClockReset domain
   => Signal domain (Unsigned 8,Unsigned 8)
   -> Signal domain (Unsigned 8,Unsigned 8)
 zeroAt0 a = mux en a (bundle (0,0))
@@ -12,18 +14,20 @@ zeroAt0 a = mux en a (bundle (0,0))
     en = register False (pure True)
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Unsigned 8)
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System (Unsigned 8)
   -> Signal System (Unsigned 8,Unsigned 8)
-topEntity rd = zeroAt0 dout
-  where
+topEntity = exposeClockReset go where
+  go rd = zeroAt0 dout where
     dout = rom $(listToVecTH $ L.map (\x -> (x,x))  [0::Unsigned 8,1,2,3,4,5,6,7,8])  rd
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = register 0 (testInput + 1)
-    expectedOutput = outputVerifier $(listToVecTH $ L.map (\x -> (x,x)) [0::Unsigned 8,0,1,2,3,4,5,6,7,8])
-    done           = expectedOutput (topEntity testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    testInput      = Explicit.register clk rst 0 (testInput + 1)
+    expectedOutput = outputVerifier clk rst $(listToVecTH $ L.map (\x -> (x,x)) [0::Unsigned 8,0,1,2,3,4,5,6,7,8])
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Signal/Rom.hs
+++ b/tests/shouldwork/Signal/Rom.hs
@@ -6,7 +6,7 @@ import Clash.Explicit.Testbench
 import qualified Data.List as L
 
 zeroAt0
-  :: HiddenClockReset domain
+  :: HiddenClockReset domain gated synchronous
   => Signal domain (Unsigned 8,Unsigned 8)
   -> Signal domain (Unsigned 8,Unsigned 8)
 zeroAt0 a = mux en a (bundle (0,0))

--- a/tests/shouldwork/Signal/RomFile.hs
+++ b/tests/shouldwork/Signal/RomFile.hs
@@ -5,7 +5,7 @@ import qualified Clash.Explicit.Prelude as Explicit
 import Clash.Explicit.Testbench
 
 zeroAt0
-  :: HiddenClockReset domain
+  :: HiddenClockReset domain gated synchronous
   => Signal domain (Unsigned 8)
   -> Signal domain (Unsigned 8)
 zeroAt0 a = mux en a 0

--- a/tests/shouldwork/Signal/SigP.hs
+++ b/tests/shouldwork/Signal/SigP.hs
@@ -3,7 +3,8 @@ module SigP where
 import Clash.Prelude
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Bool, Bool)
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System (Bool, Bool)
   -> (Signal System Bool, Signal System Bool)
-topEntity = unbundle . register (False,False)
+topEntity = exposeClockReset (unbundle . register (False,False))

--- a/tests/shouldwork/Vector/Concat.hs
+++ b/tests/shouldwork/Vector/Concat.hs
@@ -1,15 +1,17 @@
 module Concat where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 2 (Vec 3 (Unsigned 8)) -> Vec 6 (Unsigned 8)
 topEntity = concat
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure ((1 :> 2 :> 3 :> Nil) :> (4 :> 5 :> 6 :> Nil) :> Nil)
-    expectedOutput = outputVerifier ((1:>2:>3:>4:>5:>6:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((1:>2:>3:>4:>5:>6:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/DFold.hs
+++ b/tests/shouldwork/Vector/DFold.hs
@@ -2,6 +2,7 @@
 module DFold where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 #if MIN_VERSION_singletons(2,4,0)
 import Data.Singletons.Prelude hiding (type (+))
 #else
@@ -19,9 +20,10 @@ topEntity = uncurry append'
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (7:>8:>9:>Nil,0:>1:>2:>3:>4:>5:>6:>Nil)
-    expectedOutput = outputVerifier ((7:>8:>9:>0:>1:>2:>3:>4:>5:>6:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((7:>8:>9:>0:>1:>2:>3:>4:>5:>6:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/DFold2.hs
+++ b/tests/shouldwork/Vector/DFold2.hs
@@ -2,6 +2,7 @@
 module DFold2 where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 import Data.Proxy
 
 topEntity :: Vec 4 (Vec 4 (Unsigned 8)) -> Vec 4 (Vec 4 (Unsigned 8))
@@ -9,12 +10,13 @@ topEntity = smap (flip rotateRightS)
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (replicate d4 (0 :> 1 :> 2 :> 3 :> Nil))
-    expectedOutput = outputVerifier (((0:>1:>2:>3:>Nil):>
+    expectedOutput = outputVerifier clk rst (((0:>1:>2:>3:>Nil):>
                                       (3:>0:>1:>2:>Nil):>
                                       (2:>3:>0:>1:>Nil):>
                                       (1:>2:>3:>0:>Nil):>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/DTFold.hs
+++ b/tests/shouldwork/Vector/DTFold.hs
@@ -2,6 +2,7 @@
 module DTFold where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 #if MIN_VERSION_singletons(2,4,0)
 import Data.Singletons.Prelude hiding (type (+))
 #else
@@ -24,9 +25,10 @@ topEntity = populationCount
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator $(listToVecTH ([0..20]::[BitVector 16]))
-    expectedOutput = outputVerifier   $(listToVecTH ([0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2]::[Index 17]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH ([0..20]::[BitVector 16]))
+    expectedOutput = outputVerifier   clk rst $(listToVecTH ([0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2]::[Index 17]))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/FindIndex.hs
+++ b/tests/shouldwork/Vector/FindIndex.hs
@@ -1,15 +1,17 @@
 module FindIndex where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 7 (Unsigned 8) -> Maybe (Index 7)
 topEntity = findIndex (> 3)
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (1:>3:>2:>4:>3:>5:>6:>Nil)
-    expectedOutput = outputVerifier ((Just 3) :> Nil)
+    expectedOutput = outputVerifier clk rst ((Just 3) :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/Fold.hs
+++ b/tests/shouldwork/Vector/Fold.hs
@@ -1,15 +1,17 @@
 module Fold where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 8 Int -> Int
 topEntity = fold (+)
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (1:>2:>3:>4:>5:>6:>7:>8:>Nil)
-    expectedOutput = outputVerifier (36 :> Nil)
+    expectedOutput = outputVerifier clk rst (36 :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/Foldr.hs
+++ b/tests/shouldwork/Vector/Foldr.hs
@@ -1,15 +1,17 @@
 module Foldr where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 4 (Unsigned 8) -> (Unsigned 8)
 topEntity = foldr div 1
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (24 :> 7 :> 4 :> 2 :> Nil)
-    expectedOutput = outputVerifier (8 :> Nil)
+    expectedOutput = outputVerifier clk rst (8 :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/HOClock.hs
+++ b/tests/shouldwork/Vector/HOClock.hs
@@ -3,6 +3,7 @@ module HOClock where
 import Clash.Prelude
 
 topEntity
-  :: SystemClockReset
-  => Vec 8 (Signal System (Int,Int)) -> Vec 8 (Signal System (Int,Int))
-topEntity = map (register (0,0))
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Vec 8 (Signal System (Int,Int)) -> Vec 8 (Signal System (Int,Int))
+topEntity = exposeClockReset (map (register (0,0)))

--- a/tests/shouldwork/Vector/Minimum.hs
+++ b/tests/shouldwork/Vector/Minimum.hs
@@ -1,15 +1,17 @@
 module Minimum where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 3 Int -> Int
 topEntity = minimum
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (4 :> 8 :> (-2) :> Nil)
-    expectedOutput = outputVerifier (singleton (-2))
+    expectedOutput = outputVerifier clk rst (singleton (-2))
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/MovingAvg.hs
+++ b/tests/shouldwork/Vector/MovingAvg.hs
@@ -3,7 +3,7 @@ module MovingAvg where
 import Clash.Prelude
 
 windowN
-  :: (Default a,KnownNat n, HasClockReset domain gated synchronous)
+  :: (Default a,KnownNat n, HiddenClockReset domain)
   => SNat (n+1)
   -> Signal domain a
   -> Vec (n + 1) (Signal domain a)
@@ -12,7 +12,8 @@ windowN size = window
 movingAvarageNaive size signal =  fold (+) <$> bundle (windowN size signal)
 
 topEntity
-  :: SystemClockReset
-  => Signal System (Signed 9)
+  :: Clock System Source
+  -> Reset System Asynchronous
   -> Signal System (Signed 9)
-topEntity = movingAvarageNaive d5
+  -> Signal System (Signed 9)
+topEntity = exposeClockReset (movingAvarageNaive d5)

--- a/tests/shouldwork/Vector/MovingAvg.hs
+++ b/tests/shouldwork/Vector/MovingAvg.hs
@@ -3,7 +3,7 @@ module MovingAvg where
 import Clash.Prelude
 
 windowN
-  :: (Default a,KnownNat n, HiddenClockReset domain)
+  :: (Default a,KnownNat n, HiddenClockReset domain gated synchronous)
   => SNat (n+1)
   -> Signal domain a
   -> Vec (n + 1) (Signal domain a)

--- a/tests/shouldwork/Vector/Scatter.hs
+++ b/tests/shouldwork/Vector/Scatter.hs
@@ -1,6 +1,7 @@
 module Scatter where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 5 (Unsigned 10) -> Vec 5 (Unsigned 10)
 topEntity = scatter defvec to
@@ -10,9 +11,10 @@ topEntity = scatter defvec to
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator ((1 :> 2 :> 3 :> 4 :> 5 :> Nil) :> Nil)
-    expectedOutput = outputVerifier   ((1 :> 5 :> 3 :> 4 :> 2 :> Nil) :> Nil)
+    testInput      = stimuliGenerator clk rst ((1 :> 2 :> 3 :> 4 :> 5 :> Nil) :> Nil)
+    expectedOutput = outputVerifier   clk rst ((1 :> 5 :> 3 :> 4 :> 2 :> Nil) :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/ToList.hs
+++ b/tests/shouldwork/Vector/ToList.hs
@@ -1,6 +1,7 @@
 module ToList where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 import qualified Data.List as L
 
 topEntity :: Vec 3 Int -> Int
@@ -8,9 +9,10 @@ topEntity xs = L.foldr (+) 0 (toList xs)
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (1 :> 2 :> 3 :> Nil)
-    expectedOutput = outputVerifier (6 :> Nil)
+    expectedOutput = outputVerifier clk rst (6 :> Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/Unconcat.hs
+++ b/tests/shouldwork/Vector/Unconcat.hs
@@ -1,15 +1,17 @@
 module Unconcat where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 6 (Unsigned 8) -> Vec 2 (Vec 3 (Unsigned 8))
 topEntity = unconcatI
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (1 :> 2 :> 3 :> 4 :> 5 :> 6 :> Nil)
-    expectedOutput = outputVerifier (((1 :> 2 :> 3 :> Nil) :> (4 :> 5 :> 6 :> Nil) :> Nil):>Nil)
+    expectedOutput = outputVerifier clk rst (((1 :> 2 :> 3 :> Nil) :> (4 :> 5 :> 6 :> Nil) :> Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/VFold.hs
+++ b/tests/shouldwork/Vector/VFold.hs
@@ -1,6 +1,7 @@
 module VFold where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 csSort = vfold (const csRow)
   where
@@ -12,9 +13,10 @@ topEntity = csSort
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (7 :> 3 :> 9 :> 1 :> Nil)
-    expectedOutput = outputVerifier ((1:>3:>7:>9:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((1:>3:>7:>9:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/VMerge.hs
+++ b/tests/shouldwork/Vector/VMerge.hs
@@ -1,15 +1,17 @@
 module VMerge where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: (Vec 2 Int,Vec 2 Int) -> Vec 4 Int
 topEntity (x,y) = merge x y
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (iterateI (+1) 1,iterateI (+1) 3)
-    expectedOutput = outputVerifier ((1:>3:>2:>4:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((1:>3:>2:>4:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/VReplace.hs
+++ b/tests/shouldwork/Vector/VReplace.hs
@@ -1,17 +1,19 @@
 module VReplace where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: (Integer,Unsigned 4,Vec 8 (Unsigned 4)) -> Vec 8 (Vec 8 (Unsigned 4))
 topEntity (i,j,as) = zipWith (\i u -> replace i u as) (iterateI (+1) i) ((iterateI (subtract 1) j))
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput      = stimuliGenerator
+    testInput      = stimuliGenerator clk rst
                       $(listToVecTH ([(0,8,replicate d8 0)]::[(Integer,Unsigned 4,Vec 8 (Unsigned 4))]))
-    expectedOutput = outputVerifier (((8:>0:>0:>0:>0:>0:>0:>0:>Nil):>
+    expectedOutput = outputVerifier clk rst
+                                    (((8:>0:>0:>0:>0:>0:>0:>0:>Nil):>
                                       (0:>7:>0:>0:>0:>0:>0:>0:>Nil):>
                                       (0:>0:>6:>0:>0:>0:>0:>0:>Nil):>
                                       (0:>0:>0:>5:>0:>0:>0:>0:>Nil):>
@@ -20,4 +22,5 @@ testBench = done'
                                       (0:>0:>0:>0:>0:>0:>2:>0:>Nil):>
                                       (0:>0:>0:>0:>0:>0:>0:>1:>Nil):>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/VReverse.hs
+++ b/tests/shouldwork/Vector/VReverse.hs
@@ -1,15 +1,17 @@
 module VReverse where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 4 Int -> Vec 4 Int
 topEntity = reverse
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (iterateI (+1) 1)
-    expectedOutput = outputVerifier ((4:>3:>2:>1:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((4:>3:>2:>1:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/VRotate.hs
+++ b/tests/shouldwork/Vector/VRotate.hs
@@ -1,15 +1,17 @@
 module VRotate where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 5 Int -> (Vec 5 Int,Vec 5 Int)
 topEntity v = (rotateLeftS v d2,rotateRightS v d2)
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (1:>2:>3:>4:>5:>Nil)
-    expectedOutput = outputVerifier ((3:>4:>5:>1:>2:>Nil,4:>5:>1:>2:>3:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((3:>4:>5:>1:>2:>Nil,4:>5:>1:>2:>3:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/VSelect.hs
+++ b/tests/shouldwork/Vector/VSelect.hs
@@ -1,15 +1,17 @@
 module VSelect where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Vec 8 Int -> Vec 4 Int
 topEntity x = select d1 d2 d4 x
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
     testInput      = pure (iterateI (+1) 1)
-    expectedOutput = outputVerifier ((2:>4:>6:>8:>Nil):>Nil)
+    expectedOutput = outputVerifier clk rst ((2:>4:>6:>8:>Nil):>Nil)
     done           = expectedOutput (topEntity <$> testInput)
-    done'          = withClockReset (tbSystemClockGen (not <$> done')) systemResetGen done
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen


### PR DESCRIPTION
It still uses `ImplicitParameters` under the hood, but that's because we need their magic inference rules.