### PR TITLE
Add InlinePrimitive annotations

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -16,10 +16,14 @@ module Clash.GHC.LoadInterfaceFiles
 where
 
 -- External Modules
-import           Data.Either (partitionEithers)
-import           Data.List   (elemIndex, foldl', partition)
-import           Data.Maybe  (isJust, isNothing, mapMaybe)
-import           Data.Word   (Word8)
+import           Control.Monad.IO.Class      (MonadIO (..))
+import           Data.Char                   (toLower)
+import           Data.Either                 (partitionEithers)
+import           Data.List                   (elemIndex, foldl', partition)
+import           Data.Maybe                  (isJust, isNothing, mapMaybe)
+import           Data.Word                   (Word8)
+import           System.Directory            (createDirectoryIfMissing)
+import           System.FilePath.Posix       ((<.>), (</>))
 
 import           Clash.Annotations.Primitive
 
@@ -30,7 +34,7 @@ import qualified Class
 import qualified CoreFVs
 import qualified CoreSyn
 import qualified Demand
-import           DynFlags    (unsafeGlobalDynFlags)
+import           DynFlags                    (unsafeGlobalDynFlags)
 import qualified GHC
 import qualified Id
 import qualified IdInfo
@@ -43,7 +47,7 @@ import qualified Module
 #endif
 import qualified MonadUtils
 import qualified Name
-import           Outputable  (showPpr, showSDoc, text)
+import           Outputable                  (showPpr, showSDoc, text)
 #if MIN_VERSION_ghc(8,4,1)
 import qualified GhcPlugins
 #else
@@ -60,7 +64,7 @@ import qualified VarSet
 #endif
 
 -- Internal Modules
-import           Clash.Util  ((***), curLoc, traceIf)
+import           Clash.Util                  (curLoc, traceIf, (***))
 
 runIfl :: GHC.GhcMonad m => GHC.Module -> TcRnTypes.IfL a -> m a
 runIfl modName action = do
@@ -183,7 +187,7 @@ loadExprFromIface hdl bndr = do
           let declM = filter ((== nameFun) . IfaceSyn.ifName) decls
 #endif
           anns <- TcIface.tcIfaceAnnotations (GHC.mi_anns iface)
-          let primFPs = loadPrimitiveAnnotations hdl anns
+          primFPs <- loadPrimitiveAnnotations hdl anns
           case declM of
             [namedDecl] -> do
               tyThing <- loadDecl namedDecl
@@ -191,22 +195,36 @@ loadExprFromIface hdl bndr = do
             _ -> return (Right bndr,primFPs)
     Nothing -> return (Right bndr,[])
 
-loadPrimitiveAnnotations
-  :: HDL
+loadPrimitiveAnnotations ::
+  MonadIO m
+  => HDL
   -> [Annotations.Annotation]
-  -> [FilePath]
-loadPrimitiveAnnotations hdl anns = mapMaybe toFP (concat prims)
+  -> m [FilePath]
+loadPrimitiveAnnotations hdl anns = sequence $ mapMaybe toFP prims
   where
-    annEnv       = Annotations.mkAnnEnv anns
-    prims        = UniqFM.eltsUFM (Annotations.deserializeAnns deserializer annEnv)
+    prims = mapMaybe filterPrim anns
+    filterPrim (Annotations.Annotation target value) =
+      let qualifiedName =
+            case target of
+              Annotations.NamedTarget name -> Name.nameStableString name
+              Annotations.ModuleTarget mod -> Module.moduleStableString mod
+      in (qualifiedName,) <$> Serialized.fromSerialized deserializer value
 #if MIN_VERSION_ghc(8,4,1)
     deserializer = GhcPlugins.deserializeWithData :: ([Word8] -> Primitive)
 #else
     deserializer = Serialized.deserializeWithData :: ([Word8] -> Primitive)
 #endif
-    toFP (Primitive hdl' fp)
+    toFP (_, Primitive hdl' fp)
       | hdl == hdl'
-      = Just fp
+      = Just $ pure fp
+    toFP (name, InlinePrimitive hdl' content)
+      | hdl == hdl'
+      = Just . liftIO $ do
+          let inlinePrimsDir = "inline_primitives" </> map toLower (show hdl)
+              primFile = inlinePrimsDir </> name <.> "json"
+          createDirectoryIfMissing True inlinePrimsDir
+          writeFile primFile content
+          return inlinePrimsDir
     toFP _ = Nothing
 
 loadExprFromTyThing :: CoreSyn.CoreBndr


### PR DESCRIPTION
This PR adds support for InlinePrimitive annotations such as the following example:

```
{-# LANGUAGE DataKinds   #-}
{-# LANGUAGE QuasiQuotes #-}

module InlinePrimitive where

import           Clash.Annotations.Primitive
import           Clash.Prelude
import           Data.String.Interpolate      (i)
import           Data.String.Interpolate.Util (unindent)

{-# ANN example (InlinePrimitive VHDL $ unindent [i|
 [ { "BlackBox" :
     { "name" : "InlinePrimitive.example"
     , "templateD" :
 "-- begin InlinePrimitive example test:
 ~GENSYM[example][0] : block
 ~RESULT <= 1 + ~ARG[0];
 end block;
 -- end InlinePrimitive example test"
     }
   }
 ]
 |]) #-}
{-# NOINLINE example #-}
example :: Signal System (BitVector 2) -> Signal System (BitVector 2)
example = fmap succ
```

The main use case for inline primitives is to easily generate primitives in Template Haskell in such a way that:

- It uses no IO in Template Haskell (I used to write a `JSON` file to disk with TH)
- The generated primitives can be used in a dependency package. The `JSON` file used to be passed via cabal `data-files`, it should now automatically be passed via the `ANN` pragmas.

These annotations can be attached to a single function or to the module as a whole if preferred.

The primitives are serialised as `JSON` in `<stubdir>/inline-primitive` and use a unique and deterministic name so that they can be overwritten by consecutive builds while not overlapping with other inline primitives.