### PR TITLE
Support HDL record selector generation

### DIFF
--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -65,6 +65,8 @@ class Backend state where
   hdlTypeErrValue  :: HWType       -> Mon (State state) Doc
   -- | Convert a Netlist HWType to the root of a target HDL type
   hdlTypeMark      :: HWType       -> Mon (State state) Doc
+  -- | Create a record selector
+  hdlRecSel        :: HWType -> Int -> Mon (State state) Doc
   -- | Create a signal declaration from an identifier (Text) and Netlist HWType
   hdlSig           :: Text -> HWType -> Mon (State state) Doc
   -- | Create a generative block statement marker

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -99,6 +99,7 @@ instance Backend SystemVerilogState where
   hdlType _       = verilogType
   hdlTypeErrValue = verilogTypeErrValue
   hdlTypeMark     = verilogTypeMark
+  hdlRecSel       = verilogRecSel
   hdlSig t ty     = sigDecl (string t) ty
   genStmt True    = do cnt <- use genDepth
                        genDepth += 1
@@ -630,6 +631,12 @@ verilogTypeErrValue (RTree n elTy) = do
     _ -> char '\'' <> braces (int (2^n) <+> braces (verilogTypeErrValue elTy))
 verilogTypeErrValue String = "\"ERROR\""
 verilogTypeErrValue ty  = braces (int (typeSize ty) <+> braces "1'bx")
+
+verilogRecSel
+  :: HWType
+  -> Int
+  -> SystemVerilogM Doc
+verilogRecSel ty i = tyName ty <> "_sel" <> int i
 
 decls :: [Declaration] -> SystemVerilogM Doc
 decls [] = emptyDoc

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -97,6 +97,7 @@ instance Backend VHDLState where
     _           -> vhdlType ty
   hdlTypeErrValue = vhdlTypeErrValue
   hdlTypeMark     = vhdlTypeMark
+  hdlRecSel       = vhdlRecSel
   hdlSig t ty     = sigDecl (pretty t) ty
   genStmt         = const emptyDoc
   inst            = inst_
@@ -705,6 +706,12 @@ vhdlTypeErrValue (Clock _ _ Gated)   = "('-',false)"
 vhdlTypeErrValue (Void {})           = "std_logic_vector'(0 downto 1 => '-')"
 vhdlTypeErrValue String              = "\"ERROR\""
 vhdlTypeErrValue t                   = vhdlTypeMark t <> "'" <> parens (int 0 <+> "to" <+> int (typeSize t - 1) <+> rarrow <+> "'-'")
+
+vhdlRecSel
+  :: HWType
+  -> Int
+  -> VHDLM Doc
+vhdlRecSel ty i = tyName ty <> "_sel" <> int i
 
 decls :: [Declaration] -> VHDLM Doc
 decls [] = emptyDoc

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -90,6 +90,7 @@ instance Backend VerilogState where
   hdlType _       = verilogType
   hdlTypeErrValue = verilogTypeErrValue
   hdlTypeMark     = verilogTypeMark
+  hdlRecSel       = verilogRecSel
   hdlSig t ty     = sigDecl (string t) ty
   genStmt True    = do cnt <- use genDepth
                        genDepth += 1
@@ -295,6 +296,14 @@ verilogTypeMark = const emptyDoc
 -- | Convert a Netlist HWType to an error VHDL value for that type
 verilogTypeErrValue :: HWType -> VerilogM Doc
 verilogTypeErrValue ty = braces (int (typeSize ty) <+> braces "1'bx")
+
+verilogRecSel
+  :: HWType
+  -> Int
+  -> VerilogM Doc
+verilogRecSel ty i = case modifier 0 (Indexed (ty,0,i)) of
+  Just (start,end) -> brackets (int start <> colon <> int end)
+  _ -> error "Can't make a record selector"
 
 decls :: [Declaration] -> VerilogM Doc
 decls [] = emptyDoc

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -98,6 +98,7 @@ pTagE =  O True            <$  string "~ERESULT"
      <|> (HdlSyn Other)    <$  string "~OTHERSYN"
      <|> (BV True)         <$> (string "~TOBV" *> brackets' pSigD) <*> brackets' pTagE
      <|> (BV False)        <$> (string "~FROMBV" *> brackets' pSigD) <*> brackets' pTagE
+     <|> Sel               <$> (string "~SEL" *> brackets' pTagE) <*> brackets' natural'
      <|> IsLit             <$> (string "~ISLIT" *> brackets' natural')
      <|> IsVar             <$> (string "~ISVAR" *> brackets' natural')
      <|> IsGated           <$> (string "~ISGATED" *> brackets' natural')

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -47,6 +47,7 @@ data Element = C   !Text         -- ^ Constant
              | HdlSyn HdlSyn     -- ^ Hole indicating which synthesis tool we're
                                  -- generating HDL for
              | BV !Bool [Element] !Element -- ^ Convert to (True)/from(False) a bit-vector
+             | Sel !Element !Int -- ^ Record selector of a type
              | IsLit !Int
              | IsVar !Int
              | IsGated !Int

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -427,6 +427,10 @@ renderTag b (BV False es e) = do
   let ty = lineToType b [e]
   renderOneLine <$> getMon (fromBV ty e')
 
+renderTag b (Sel e n) =
+  let ty = lineToType b [e]
+  in  renderOneLine <$> getMon (hdlRecSel ty n)
+
 renderTag b (Typ Nothing)   = fmap renderOneLine . getMon . hdlType Internal . snd $ bbResult b
 renderTag b (Typ (Just n))  = let (_,ty,_) = bbInputs b !! n
                               in  renderOneLine <$> getMon (hdlType Internal ty)
@@ -574,6 +578,9 @@ prettyElem (BV b es e) = do
     if b
        then string "~TOBV" <> brackets (string es') <> brackets (string e')
        else string "~FROMBV" <> brackets (string es') <> brackets (string e')
+prettyElem (Sel e i) = do
+  e' <- prettyElem e
+  renderOneLine <$> (string "~SEL" <> brackets (string e') <> brackets (int i))
 prettyElem (IsLit i) = renderOneLine <$> (string "~ISLIT" <> brackets (int i))
 prettyElem (IsVar i) = renderOneLine <$> (string "~ISVAR" <> brackets (int i))
 prettyElem (IsGated i) = renderOneLine <$> (string "~ISGATED" <> brackets (int i))


### PR DESCRIPTION
e.g. `~SEL[~TYPO][0]` generates a selector for the first field of the type of the output of the primitive.