### PR TITLE
Simplify GHC API imports

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -51,11 +51,7 @@ import qualified Module
 import qualified MonadUtils
 import qualified Name
 import           Outputable                  (showPpr, showSDoc, text)
-#if MIN_VERSION_ghc(8,4,1)
-import qualified GhcPlugins
-#else
-import qualified Serialized
-#endif
+import qualified GhcPlugins                  (deserializeWithData, fromSerialized)
 import qualified TcIface
 import qualified TcRnMonad
 import qualified TcRnTypes
@@ -214,15 +210,9 @@ loadPrimitiveAnnotations hdl outDir anns =
     prims = mapMaybe filterPrim anns
     filterPrim (Annotations.Annotation target value) =
       (target,) <$> deserialize value
-#if MIN_VERSION_ghc(8,4,1)
     deserialize =
       GhcPlugins.fromSerialized
         (GhcPlugins.deserializeWithData :: [Word8] -> Primitive)
-#else
-    deserialize =
-      Serialized.fromSerialized
-        (Serialized.deserializeWithData :: [Word8] -> Primitive)
-#endif
 
 primitiveFilePath ::
   MonadIO m

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -50,11 +50,7 @@ import qualified HscMain
 import qualified HscTypes
 import qualified MonadUtils
 import qualified Panic
-#if MIN_VERSION_ghc(8,4,1)
-import qualified GhcPlugins
-#else
-import qualified Serialized
-#endif
+import qualified GhcPlugins                      (deserializeWithData)
 import qualified TcRnMonad
 import qualified TcRnTypes
 import qualified TidyPgm
@@ -312,11 +308,7 @@ findSynthesizeAnnotations
   => [CoreSyn.CoreBndr]
   -> m [(CoreSyn.CoreBndr,Maybe TopEntity)]
 findSynthesizeAnnotations bndrs = do
-#if MIN_VERSION_ghc(8,4,1)
   let deserializer = GhcPlugins.deserializeWithData :: ([Word8] -> TopEntity)
-#else
-  let deserializer = Serialized.deserializeWithData :: ([Word8] -> TopEntity)
-#endif
       targets      = map (Annotations.NamedTarget . Var.varName) bndrs
 
   anns <- mapM (GHC.findGlobalAnns deserializer) targets
@@ -335,11 +327,7 @@ findTestBenchAnnotations
   => [CoreSyn.CoreBndr]
   -> m [(CoreSyn.CoreBndr,CoreSyn.CoreBndr)]
 findTestBenchAnnotations bndrs = do
-#if MIN_VERSION_ghc(8,4,1)
   let deserializer = GhcPlugins.deserializeWithData :: ([Word8] -> TopEntity)
-#else
-  let deserializer = Serialized.deserializeWithData :: ([Word8] -> TopEntity)
-#endif
       targets      = map (Annotations.NamedTarget . Var.varName) bndrs
 
   anns <- mapM (GHC.findGlobalAnns deserializer) targets
@@ -377,11 +365,7 @@ findPrimitiveAnnotations hdl bndrs = do
 
   let -- Using the stub directory as the output directory for inline primitives
       outDir = fromMaybe "." $ GHC.stubDir dflags
-#if MIN_VERSION_ghc(8,4,1)
       deserializer = GhcPlugins.deserializeWithData :: ([Word8] -> Primitive)
-#else
-      deserializer = Serialized.deserializeWithData :: ([Word8] -> Primitive)
-#endif
       targets =
         concatMap
           ( (\v -> catMaybes


### PR DESCRIPTION
Serialized is hidden since GHC-8.4, but deserializeWithData was already being
exported from GhcPlugins since at least GHC-8.0.