### PR TITLE
Use new `source-repository-package` clauses for cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,11 +24,25 @@ index-state: 2018-07-03T07:02:43Z
 package clash-ghc
   executable-dynamic: True
 
-optional-packages:
-  ghc-typelits-extra/ghc-typelits-extra.cabal
-  ghc-typelits-knownnat/ghc-typelits-knownnat.cabal
-  ghc-typelits-natnormalise/ghc-typelits-natnormalise.cabal
-  ghc-tcplugins-extra/ghc-tcplugins-extra.cabal
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/ghc-typelits-extra
+  tag: b9333c256151132eb97f72b262ddb23bd6a62446
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/ghc-typelits-knownnat
+  tag: 9731ed3ae9c87a8930dd40eedced7c0128cb5e82
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/ghc-typelits-natnormalise
+  tag: b4951d4d9b7307154eac0984530bf2d70bca3358
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/ghc-tcplugins-extra
+  tag: 4f2defb334da089100a16c8e75ba462b06c9d465
 
 -- Build documentation for all dependencies so we can upload docs to hackage
 -- with proper links

--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,10 @@
 -- preferred by the solver over other versions.
 packages: ./*/*.cabal
 
-allow-newer: *:base, *:template-haskell, *:ghc-typelits-natnormalise, *:ghc-typelits-knownnat, *:ghc-typelits-extra, *:ghc-tcplugins-extra
+allow-newer:
+  *:base, *:template-haskell,
+  *:ghc-typelits-natnormalise, *:ghc-typelits-knownnat, *:ghc-typelits-extra,
+  *:ghc-tcplugins-extra
 
 repository head.hackage
   url: http://head.hackage.haskell.org/
@@ -21,10 +24,11 @@ index-state: 2018-07-03T07:02:43Z
 package clash-ghc
   executable-dynamic: True
 
-optional-packages: ghc-typelits-extra/ghc-typelits-extra.cabal
-                   ghc-typelits-knownnat/ghc-typelits-knownnat.cabal
-                   ghc-typelits-natnormalise/ghc-typelits-natnormalise.cabal
-                   ghc-tcplugins-extra/ghc-tcplugins-extra.cabal
+optional-packages:
+  ghc-typelits-extra/ghc-typelits-extra.cabal
+  ghc-typelits-knownnat/ghc-typelits-knownnat.cabal
+  ghc-typelits-natnormalise/ghc-typelits-natnormalise.cabal
+  ghc-tcplugins-extra/ghc-tcplugins-extra.cabal
 
 -- Build documentation for all dependencies so we can upload docs to hackage
 -- with proper links


### PR DESCRIPTION
The upcoming version of cabal 2.4 will finally feature this (as well as a slew of other new amazing features), so we can jump right in.