### PR TITLE
Fix compilation of unnamed modules

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -178,7 +178,7 @@ loadModules hdl modName dflagsM = do
     let dflags1 = dflags
                     { DynFlags.optLevel = 2
                     , DynFlags.ghcMode  = GHC.CompManager
-                    , DynFlags.ghcLink  = GHC.NoLink
+                    , DynFlags.ghcLink  = GHC.LinkInMemory
 #if MIN_VERSION_ghc(8,2,0)
                     , DynFlags.hscTarget
                         = if DynFlags.rtsIsProfiled


### PR DESCRIPTION
Our minimal clash file used to be only 2 lines:
```haskell
import Clash.Prelude
topEntity = not
```

In commit c9cf5fadd285ea9c we broke the ability to compile unnamed modules.
And we're required to name the module:
```haskell
module MyModuleName where
import Clash.Prelude
topEntity = not
```

This commit restores the previous behaviour.