### PR TITLE
VHDL: BV convert: add parenthesis around expressions

### DIFF
--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1329,7 +1329,7 @@ toSLV (Clock {})    e = do
 toSLV (Reset {})    e = do
   nm <- Mon $ use modNm
   pretty (T.toLower $ T.pack nm) <> "_types.toSLV" <> parens (expr_ False e)
-toSLV (BitVector _) e = expr_ False e
+toSLV (BitVector _) e = expr_ True e
 toSLV (Signed _)   e = "std_logic_vector" <> parens (expr_ False e)
 toSLV (Unsigned _) e = "std_logic_vector" <> parens (expr_ False e)
 toSLV (Index _)    e = "std_logic_vector" <> parens (expr_ False e)


### PR DESCRIPTION
Otherwise we sometimes end up with precedence conflict, e.g.
before for:
```haskell
topEntity :: BitVector 8 -> Maybe (BitVector 8, BitVector 8)
topEntity x = Just (x,x .&. 2)
```
```
"1" & (x & x and std_logic_vector'(x"02"))
```
where the `&` and `and` conflict, now we generate:
```
"1" & (x & (x and std_logic_vector'(x"02)))
```