### PR TITLE
HDL annotations

### DIFF
--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -99,7 +99,7 @@ library
 
   Build-Depends:      array                     >= 0.4      && < 0.6,
                       base                      >= 4.3.1.0  && < 5,
-                      bifunctors                >= 4.1.1    && < 5.6,
+                      bifunctors                >= 4.1.1    && < 6.0,
                       bytestring                >= 0.9      && < 0.11,
                       containers                >= 0.5.4.0  && < 0.7,
                       directory                 >= 1.2      && < 1.4,

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -124,9 +124,12 @@ setHdlSyn :: IORef ClashOpts
           -> EwM IO ()
 setHdlSyn r s = case readMaybe s of
   Just hdlSyn -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = hdlSyn})
-  Nothing     -> if s == "Xilinx"
-                    then liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Vivado})
-                    else addWarn (s ++ " is an unknown hdl synthesis tool")
+  Nothing -> case s of
+    "Xilinx"  -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Vivado})
+    "ISE"     -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Vivado})
+    "Altera"  -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Quartus})
+    "Intel"   -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Quartus})
+    _         -> addWarn (s ++ " is an unknown hdl synthesis tool")
 
 setErrorExtra :: IORef ClashOpts -> IO ()
 setErrorExtra r = modifyIORef r (\c -> c {opt_errorExtra = True})

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -45,6 +45,10 @@ ghcTypeToHWType
   -> Maybe (Either String HWType)
 ghcTypeToHWType iw floatSupport = go
   where
+    go reprs m keepVoid (AnnType attrs typ) = runExceptT $ do
+      typ' <- ExceptT $ return $ coreTypeToHWType go reprs m keepVoid typ
+      return $ Annotated attrs typ'
+
     go reprs m keepVoid ty@(tyView -> TyConApp tc args) = runExceptT $
       case name2String tc of
         "GHC.Int.Int8"                  -> return (Signed 8)

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1,19 +1,21 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
-                          2017, Google Inc.
+                     2017-2018, Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
   Generate VHDL for assorted Netlist datatypes
 -}
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE MultiWayIf        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecursiveDo       #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecursiveDo         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 module Clash.Backend.VHDL (VHDLState) where
 
@@ -23,11 +25,12 @@ import           Control.Monad                        (forM,join,liftM,zipWithM)
 import           Control.Monad.State                  (State)
 import           Data.Bits                            (testBit, Bits)
 import           Data.Graph.Inductive                 (Gr, mkGraph, topsort')
+import           Data.Hashable                        (Hashable)
 import           Data.HashMap.Lazy                    (HashMap)
 import qualified Data.HashMap.Lazy                    as HashMap
 import           Data.HashSet                         (HashSet)
 import qualified Data.HashSet                         as HashSet
-import           Data.List                            (mapAccumL,nub,nubBy)
+import           Data.List                            (mapAccumL,nub,nubBy,intersperse)
 import           Data.Maybe                           (catMaybes,fromMaybe,mapMaybe)
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Monoid                          hiding (Sum, Product)
@@ -48,6 +51,7 @@ import           Clash.Annotations.BitRepresentation.ClashLib
 import           Clash.Annotations.BitRepresentation.Util
   (BitOrigin(Lit, Field), bitOrigins, bitRanges)
 import           Clash.Backend
+import           Clash.Core.Var                       (Attr'(..),attrName)
 import           Clash.Driver.Types                   (SrcSpan, noSrcSpan)
 import           Clash.Netlist.BlackBox.Types         (HdlSyn (..))
 import           Clash.Netlist.BlackBox.Util
@@ -299,6 +303,7 @@ topSortHWTys hwtys = sorted
     edge _                 = []
 
 normaliseType :: HWType -> VHDLM HWType
+normaliseType (Annotated _ ty) = normaliseType ty
 normaliseType (Vector n ty)    = Vector n <$> (normaliseType ty)
 normaliseType (RTree d ty)     = RTree d <$> (normaliseType ty)
 normaliseType (Product nm tys) = Product nm <$> (mapM normaliseType tys)
@@ -620,12 +625,118 @@ entity c = do
 architecture :: Component -> VHDLM Doc
 architecture c =
   nest 2
-    ("architecture structural of" <+> pretty (componentName c) <+> "is" <> line <>
+    (("architecture structural of" <+> pretty (componentName c) <+> "is" <> line <>
      decls (declarations c)) <> line <>
+     line <>
+     renderAttrs attrs) <> line <>
   nest 2
     ("begin" <> line <>
      insts (declarations c)) <> line <>
     "end" <> semi
+ where
+   attrs       = inputAttrs ++ outputAttrs ++ declAttrs
+   netdecls    = filter isNetDecl (declarations c)
+   declAttrs   = [(id_, attr) | NetDecl' _ _ id_ (Right hwtype) <- netdecls, attr <- hwTypeAttrs hwtype]
+   inputAttrs  = [(id_, attr) | (id_, hwtype) <- inputs c, attr <- hwTypeAttrs hwtype]
+   outputAttrs = [(id_, attr) | (_wireOrReg, (id_, hwtype)) <- outputs c, attr <- hwTypeAttrs hwtype]
+
+   isNetDecl :: Declaration -> Bool
+   isNetDecl (NetDecl' _ _ _ (Right _)) = True
+   isNetDecl _                          = False
+
+
+attrType
+  :: t ~ HashMap T.Text T.Text
+  => t
+  -> Attr'
+  -> t
+attrType types attr =
+  case HashMap.lookup name' types of
+    Nothing    -> HashMap.insert name' type' types
+    Just type'' | type'' == type' -> types
+                | otherwise -> error $
+                      $(curLoc) ++ unwords [ T.unpack name', "already assigned"
+                                           , T.unpack type'', "while we tried to"
+                                           , "add", T.unpack type' ]
+ where
+  name' = T.pack $ attrName attr
+  type' = T.pack $ case attr of
+            BoolAttr' _ _    -> "boolean"
+            IntegerAttr' _ _ -> "integer"
+            StringAttr' _ _  -> "string"
+            Attr' _          -> "bool"
+
+-- | Create 'attrname -> type' mapping for given attributes. Will err if multiple
+-- types are assigned to the same name.
+attrTypes :: [Attr'] -> HashMap T.Text T.Text
+attrTypes = foldl attrType HashMap.empty
+
+-- | Create a 'attrname -> (type, [(signalname, value)]). Will err if multiple
+-- types are assigned to the same name.
+attrMap
+  :: forall t
+   . t ~ HashMap T.Text (T.Text, [(T.Text, T.Text)])
+  => [(T.Text, Attr')]
+  -> t
+attrMap attrs = foldl go empty' attrs
+ where
+  empty' = HashMap.fromList
+           [(k, (types HashMap.! k, [])) | k <- HashMap.keys types]
+  types = attrTypes (map snd attrs)
+
+  go :: t -> (T.Text, Attr') -> t
+  go map' attr = HashMap.adjust
+                   (go' attr)
+                   (T.pack $ attrName $ snd attr)
+                   map'
+
+  go'
+    :: (T.Text, Attr')
+    -> (T.Text, [(T.Text, T.Text)])
+    -> (T.Text, [(T.Text, T.Text)])
+  go' (signalName, attr) (typ, elems) =
+    (typ, (signalName, renderAttr attr) : elems)
+
+renderAttrs
+  :: [(T.Text, Attr')]
+  -> VHDLM Doc
+renderAttrs (attrMap -> attrs) =
+  vcat $ sequence $ intersperse " " $ map renderAttrGroup (assocs attrs)
+ where
+  renderAttrGroup
+    :: (T.Text, (T.Text, [(T.Text, T.Text)]))
+    -> VHDLM Doc
+  renderAttrGroup (attrname, (typ, elems)) =
+    ("attribute" <+> string attrname <+> colon <+> string typ <> semi)
+    <> line <>
+    (hcat $ sequence $ map (renderAttrDecl attrname) elems)
+
+  renderAttrDecl
+    :: T.Text
+    -> (T.Text, T.Text)
+    -> VHDLM Doc
+  renderAttrDecl attrname (signalName, value) = "attribute"
+                                             <+> string attrname
+                                             <+> "of"
+                                             <+> string signalName
+                                             <+> colon
+                                             <+> "signal is"
+                                             <+> string value
+                                             <+> semi
+
+-- | Return all key/value pairs in the map in arbitrary key order.
+assocs :: Eq a => Hashable a => HashMap a b -> [(a,b)]
+assocs m = zip keys (map (m HashMap.!) keys)
+ where
+  keys = (HashMap.keys m)
+
+-- | Convert single attribute to VHDL syntax
+renderAttr :: Attr' -> T.Text
+renderAttr (StringAttr'  _key value) = T.pack $ show value
+renderAttr (IntegerAttr' _key value) = T.pack $ show value
+renderAttr (BoolAttr'    _key True ) = T.pack $ "true"
+renderAttr (BoolAttr'    _key False) = T.pack $ "false"
+renderAttr (Attr'        _key      ) = T.pack $ "true"
 
 -- | Convert a Netlist HWType to a VHDL type
 vhdlType :: HWType -> VHDLM Doc

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -632,7 +632,8 @@ entity c = do
          [] -> emptyDoc
          _  -> case syn of
           -- See: [Note] Hack entity attributes in architecture
-          Other -> indent 2 (rports p <> line <> line <> attrs) <> line <> "end" <> semi
+          Other -> indent 2 (rports p <> if null attrs then emptyDoc else
+                              line <> line <> rattrs) <> line <> "end" <> semi
           _     -> indent 2 (rports p) <> "end" <> semi
       )
   where
@@ -641,7 +642,8 @@ entity c = do
 
     rports p = "port" <> (parens (align (vcat (punctuate semi (pure p))))) <> semi
 
-    attrs       = renderAttrs $ inputAttrs ++ outputAttrs
+    rattrs      = renderAttrs attrs
+    attrs       = inputAttrs ++ outputAttrs
     inputAttrs  = [(id_, attr) | (id_, hwtype) <- inputs c, attr <- hwTypeAttrs hwtype]
     outputAttrs = [(id_, attr) | (_wireOrReg, (id_, hwtype)) <- outputs c, attr <- hwTypeAttrs hwtype]
 
@@ -736,7 +738,7 @@ renderAttrs (attrMap -> attrs) =
   renderAttrGroup (attrname, (typ, elems)) =
     ("attribute" <+> string attrname <+> colon <+> string typ <> semi)
     <> line <>
-    (hcat $ sequence $ map (renderAttrDecl attrname) elems)
+    (vcat $ sequence $ map (renderAttrDecl attrname) elems)
 
   renderAttrDecl
     :: T.Text
@@ -749,7 +751,7 @@ renderAttrs (attrMap -> attrs) =
                                              <+> colon
                                              <+> "signal is"
                                              <+> string value
-                                             <+> semi
+                                             <> semi
 
 -- | Return all key/value pairs in the map in arbitrary key order.
 assocs :: Eq a => Hashable a => HashMap a b -> [(a,b)]

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -255,6 +255,7 @@ ppr_type _ (VarTy _ tv)                 = ppr tv
 ppr_type _ (LitTy tyLit)                = ppr tyLit
 ppr_type p ty@(ForAllTy _)              = pprForAllType p ty
 ppr_type p (ConstTy (TyCon tc))         = pprTcApp p ppr_type tc []
+ppr_type p (AnnType _ann typ)           = ppr_type p typ
 ppr_type p (tyView -> TyConApp tc args) = pprTcApp p ppr_type tc args
 ppr_type p (tyView -> FunTy ty1 ty2)    = pprArrowChain p <$> ppr_type FunPrec ty1 <:> pprFunTail ty2
   where

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -1,6 +1,6 @@
 {-|
   Copyright   :  (C) 2012-2016, University of Twente,
-                          2017, Google Inc.
+                     2017-2018, Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
@@ -12,22 +12,45 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Clash.Core.Var
-  ( Var (..)
+  ( Attr' (..)
+  , Var (..)
   , Id
   , TyVar
   , modifyVarName
+  , attrName
   )
 where
+
 
 import Control.DeepSeq                  (NFData (..))
 import Data.Hashable                    (Hashable)
 import Data.Typeable                    (Typeable)
 import GHC.Generics                     (Generic)
 import Unbound.Generics.LocallyNameless (Alpha,Embed,Subst(..))
-
 import Clash.Core.Name                  (Name)
 import {-# SOURCE #-} Clash.Core.Term   (Term)
 import {-# SOURCE #-} Clash.Core.Type   (Kind, Type)
+
+
+-- | Interal version of Clash.Annotation.SynthesisAttributes.Attr.
+--
+-- Needed because Clash.Annotation.SynthesisAttributes.Attr uses the Symbol
+-- kind for names, which do not have a term-level representation
+data Attr'
+  = BoolAttr' String Bool
+  | IntegerAttr' String Integer
+  | StringAttr' String String
+  | Attr' String
+  deriving (Eq, Show, NFData, Generic, Hashable, Typeable, Alpha, Ord)
+
+instance Subst Type Attr'
+instance Subst Term Attr'
+
+attrName :: Attr' -> String
+attrName (BoolAttr' n _)    = n
+attrName (IntegerAttr' n _) = n
+attrName (StringAttr' n _)  = n
+attrName (Attr' n)          = n
 
 -- | Variables in CoreHW
 data Var a

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -15,7 +15,7 @@ module Clash.Netlist.BlackBox.Types
  , TemplateKind (..)
  , Element(..)
  , Decl(..)
- , HdlSyn(Vivado, Other)
+ , HdlSyn(..)
  ) where
 
 import                Data.Text.Lazy             (Text)
@@ -126,5 +126,5 @@ data Element = C   !Text         -- ^ Constant
 data Decl = Decl !Int [(BlackBoxTemplate,BlackBoxTemplate)]
   deriving Show
 
-data HdlSyn = Vivado | Other
+data HdlSyn = Vivado | Quartus | Other
   deriving (Eq,Show,Read)

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -1,6 +1,7 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
-                    2017     , Google Inc., Myrtle Software Ltd
+                    2017     , Myrtle Software Ltd
+                    2017-2018, Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
@@ -20,7 +21,7 @@ import           Control.Error           (hush)
 import           Control.Exception       (throw)
 import           Control.Lens            ((.=),(%=))
 import qualified Control.Lens            as Lens
-import           Control.Monad           (when, zipWithM)
+import           Control.Monad           (unless, when, zipWithM)
 import           Control.Monad.Trans.Except (runExcept)
 import           Data.Either             (partitionEithers)
 import           Data.HashMap.Strict     (HashMap)
@@ -32,6 +33,7 @@ import qualified Data.Text.Lazy          as Text
 import           Unbound.Generics.LocallyNameless
   (Embed, Fresh, embed, unbind, unembed, unrec)
 import qualified Unbound.Generics.LocallyNameless as Unbound
+import           Text.Printf             (printf)
 
 import           Clash.Annotations.BitRepresentation.ClashLib
   (coreToType')
@@ -51,7 +53,7 @@ import           Clash.Core.TyCon
 import           Clash.Core.Type         (Type (..), TypeView (..), LitTy (..),
                                           coreView, splitTyConAppM, tyView)
 import           Clash.Core.Util         (collectBndrs, termType, tyNatSize)
-import           Clash.Core.Var          (Id, Var (..), modifyVarName)
+import           Clash.Core.Var          (Id, Var (..),modifyVarName)
 import           Clash.Netlist.Id        (IdType (..), stripDollarPrefixes)
 import           Clash.Netlist.Types     as HW
 import           Clash.Signal.Internal   (ClockKind (..))
@@ -351,6 +353,7 @@ representableType builtInTranslation reprs stringRepresentable m =
       Product _ elTys -> all isRepresentable elTys
       SP _ elTyss     -> all (all isRepresentable . snd) elTyss
       BiDirectional _ t -> isRepresentable t
+      Annotated _ ty  -> isRepresentable ty
       _               -> True
 
 -- | Determines the bitsize of a type
@@ -378,6 +381,7 @@ typeSize (BiDirectional In h) = typeSize h
 typeSize (BiDirectional Out _) = 0
 typeSize (CustomSP _ _ size _) = fromIntegral size
 typeSize (CustomSum _ _ size _) = fromIntegral size
+typeSize (Annotated _ ty) = typeSize ty
 
 -- | Determines the bitsize of the constructor of a type
 conSize :: HWType
@@ -708,6 +712,7 @@ mkInput pM = case pM of
   where
     go (i,hwty) = do
       i' <- mkUniqueIdentifier Extended i
+      let attrs = hwTypeAttrs hwty
       case hwty of
         Vector sz hwty' -> do
           arguments <- mapM (appendIdentifier (i',hwty')) [0..sz-1]
@@ -716,7 +721,10 @@ mkInput pM = case pM of
               netdecl  = NetDecl Nothing i' (Vector sz hwty2)
               vecExpr  = mkVectorChain sz hwty2 exprs
               netassgn = Assignment i' vecExpr
-          return (concat ports,[netdecl,netassgn],vecExpr,i')
+          if null attrs then
+            return (concat ports,[netdecl,netassgn],vecExpr,i')
+          else
+            throwAnnotatedSplitError $(curLoc) "Vector"
 
         RTree d hwty' -> do
           arguments <- mapM (appendIdentifier (i',hwty')) [0..2^d-1]
@@ -725,7 +733,10 @@ mkInput pM = case pM of
               netdecl  = NetDecl Nothing i' (RTree d hwty2)
               trExpr   = mkRTreeChain d hwty2 exprs
               netassgn = Assignment i' trExpr
-          return (concat ports,[netdecl,netassgn],trExpr,i')
+          if null attrs then
+            return (concat ports,[netdecl,netassgn],trExpr,i')
+          else
+            throwAnnotatedSplitError $(curLoc) "RTree"
 
         Product _ hwtys -> do
           arguments <- zipWithM appendIdentifier (map (i',) hwtys) [0..]
@@ -745,7 +756,10 @@ mkInput pM = case pM of
                   netdecl  = NetDecl Nothing i' hwty'
                   dcExpr   = DataCon hwty' (DC (hwty',0)) exprs
                   netassgn = Assignment i' dcExpr
-              in  return (concat ports,[netdecl,netassgn],dcExpr,i')
+              in  if null attrs then
+                    return (concat ports,[netdecl,netassgn],dcExpr,i')
+                  else
+                    throwAnnotatedSplitError $(curLoc) "Product"
 
         Clock nm rt Gated -> do
           let hwtys = [Clock nm rt Source,Bool]
@@ -765,6 +779,7 @@ mkInput pM = case pM of
 
     go' (PortProduct p ps) (i,hwty) = do
       pN <- uniquePortName p i
+      let attrs = hwTypeAttrs hwty
       case hwty of
         Vector sz hwty' -> do
           arguments <- mapM (appendIdentifier (pN,hwty')) [0..sz-1]
@@ -773,7 +788,10 @@ mkInput pM = case pM of
               netdecl  = NetDecl Nothing pN (Vector sz hwty2)
               vecExpr  = mkVectorChain sz hwty2 exprs
               netassgn = Assignment pN vecExpr
-          return (concat ports,[netdecl,netassgn],vecExpr,pN)
+          if null attrs then
+            return (concat ports,[netdecl,netassgn],vecExpr,pN)
+          else
+            throwAnnotatedSplitError $(curLoc) "Vector"
 
         RTree d hwty' -> do
           arguments <- mapM (appendIdentifier (pN,hwty')) [0..2^d-1]
@@ -782,7 +800,10 @@ mkInput pM = case pM of
               netdecl  = NetDecl Nothing pN (RTree d hwty2)
               trExpr   = mkRTreeChain d hwty2 exprs
               netassgn = Assignment pN trExpr
-          return (concat ports,[netdecl,netassgn],trExpr,pN)
+          if null attrs then
+            return (concat ports,[netdecl,netassgn],trExpr,pN)
+          else
+            throwAnnotatedSplitError $(curLoc) "RTree"
 
         Product _ hwtys -> do
           arguments <- zipWithM appendIdentifier (map (pN,) hwtys) [0..]
@@ -801,7 +822,10 @@ mkInput pM = case pM of
                      netdecl  = NetDecl Nothing pN hwty'
                      dcExpr   = DataCon hwty' (DC (hwty',0)) exprs
                      netassgn = Assignment pN dcExpr
-                 in  return (concat ports,[netdecl,netassgn],dcExpr,pN)
+                 in  if null attrs then
+                       return (concat ports,[netdecl,netassgn],dcExpr,pN)
+                     else
+                       throwAnnotatedSplitError $(curLoc) "Product"
 
         Clock nm rt Gated -> do
           let hwtys = [Clock nm rt Source, Bool]
@@ -908,8 +932,11 @@ mkOutput' pM = case pM of
   where
     go (o,hwty) = do
       o' <- mkUniqueIdentifier Extended o
+      let attrs = hwTypeAttrs hwty
       case hwty of
         Vector sz hwty' -> do
+          unless (null attrs)
+            (throwAnnotatedSplitError $(curLoc) "Vector")
           results <- mapM (appendIdentifier (o',hwty')) [0..sz-1]
           (ports,decls,ids) <- unzip3 <$> mapM (mkOutput' Nothing) results
           let hwty2   = Vector sz (filterVoid hwty')
@@ -918,6 +945,8 @@ mkOutput' pM = case pM of
           return (concat ports,netdecl:assigns ++ concat decls,o')
 
         RTree d hwty' -> do
+          unless (null attrs)
+            (throwAnnotatedSplitError $(curLoc) "RTree")
           results <- mapM (appendIdentifier (o',hwty')) [0..2^d-1]
           (ports,decls,ids) <- unzip3 <$> mapM (mkOutput' Nothing) results
           let hwty2   = RTree d (filterVoid hwty')
@@ -941,7 +970,10 @@ mkOutput' pM = case pM of
               let hwty'   = filterVoid hwty
                   netdecl = NetDecl Nothing o' hwty'
                   assigns = zipWith (assignId o' hwty' 0) ids [0..]
-              in  return (concat ports,netdecl:assigns ++ concat decls,o')
+              in  if null attrs then
+                     return (concat ports,netdecl:assigns ++ concat decls,o')
+                  else
+                    throwAnnotatedSplitError $(curLoc) "Product"
 
         _ -> return ([(o',hwty)],[],o')
 
@@ -951,8 +983,11 @@ mkOutput' pM = case pM of
 
     go' (PortProduct p ps) (o,hwty) = do
       pN <- uniquePortName p o
+      let attrs = hwTypeAttrs hwty
       case hwty of
         Vector sz hwty' -> do
+          unless (null attrs)
+            (throwAnnotatedSplitError $(curLoc) "Vector")
           results <- mapM (appendIdentifier (pN,hwty')) [0..sz-1]
           (ports,decls,ids) <- unzip3 <$> zipWithM mkOutput' (extendPorts ps) results
           let hwty2   = Vector sz (filterVoid hwty')
@@ -961,6 +996,8 @@ mkOutput' pM = case pM of
           return (concat ports,netdecl:assigns ++ concat decls,pN)
 
         RTree d hwty' -> do
+          unless (null attrs)
+            (throwAnnotatedSplitError $(curLoc) "RTree")
           results <- mapM (appendIdentifier (pN,hwty')) [0..2^d-1]
           (ports,decls,ids) <- unzip3 <$> zipWithM mkOutput' (extendPorts ps) results
           let hwty2   = RTree d (filterVoid hwty')
@@ -982,7 +1019,10 @@ mkOutput' pM = case pM of
             _   -> let hwty'   = filterVoid hwty
                        netdecl = NetDecl Nothing pN hwty'
                        assigns = zipWith (assignId pN hwty' 0) ids [0..]
-                   in  return (concat ports,netdecl:assigns ++ concat decls,pN)
+                   in  if null attrs then
+                         return (concat ports,netdecl:assigns ++ concat decls,pN)
+                       else
+                         throwAnnotatedSplitError $(curLoc) "Product"
 
         _ -> return ([(pN,hwty)],[],pN)
 
@@ -1018,7 +1058,7 @@ mkTopUnWrapper topEntity annM man dstId args = do
   let iPortSupply = maybe (repeat Nothing)
                         (extendPorts . t_inputs)
                         annM
-  arguments <- zipWithM appendIdentifier (map (first (const "input")) args) [0..]
+  arguments <- zipWithM appendIdentifier (map (\a -> ("input",snd a)) args) [0..]
   (_,arguments1) <- mapAccumLM (\acc (p,i) -> mkTopInput topM acc p i)
                       (zip inNames inTys)
                       (zip iPortSupply arguments)
@@ -1150,6 +1190,7 @@ mkTopInput topM inps pM = case pM of
     go inps'@((iN,_):rest) (i,hwty) = do
       i' <- mkUniqueIdentifier Basic i
       let iDecl = NetDecl Nothing i' hwty
+      let attrs = hwTypeAttrs hwty
       case hwty of
         Vector sz hwty' -> do
           arguments <- mapM (appendIdentifier (i',hwty')) [0..sz-1]
@@ -1158,7 +1199,10 @@ mkTopInput topM inps pM = case pM of
               assigns = zipWith (argBV topM) ids
                           [ Identifier i' (Just (Indexed (hwty,10,n)))
                           | n <- [0..]]
-          return (inps'',(concat ports,iDecl:assigns++concat decls,Left i'))
+          if null attrs then
+            return (inps'',(concat ports,iDecl:assigns++concat decls,Left i'))
+          else
+            throwAnnotatedSplitError $(curLoc) "Vector"
 
         RTree d hwty' -> do
           arguments <- mapM (appendIdentifier (i',hwty')) [0..2^d-1]
@@ -1167,7 +1211,10 @@ mkTopInput topM inps pM = case pM of
               assigns = zipWith (argBV topM) ids
                           [ Identifier i' (Just (Indexed (hwty,10,n)))
                           | n <- [0..]]
-          return (inps'',(concat ports,iDecl:assigns++concat decls,Left i'))
+          if null attrs then
+            return (inps'',(concat ports,iDecl:assigns++concat decls,Left i'))
+          else
+            throwAnnotatedSplitError $(curLoc) "RTree"
 
         Product _ hwtys -> do
           arguments <- zipWithM appendIdentifier (map (i,) hwtys) [0..]
@@ -1176,7 +1223,10 @@ mkTopInput topM inps pM = case pM of
               assigns = zipWith (argBV topM) ids
                           [ Identifier i' (Just (Indexed (hwty,0,n)))
                           | n <- [0..]]
-          return (inps'',(concat ports,iDecl:assigns++concat decls,Left i'))
+          if null attrs then
+            return (inps'',(concat ports,iDecl:assigns++concat decls,Left i'))
+          else
+            throwAnnotatedSplitError $(curLoc) "Product"
 
         Clock nm rt Gated -> do
           let hwtys = [Clock nm rt Source,Bool]
@@ -1205,6 +1255,7 @@ mkTopInput topM inps pM = case pM of
       let pN = portName p i
       pN' <- mkUniqueIdentifier Extended pN
       let pDecl = NetDecl Nothing pN' hwty
+      let attrs = hwTypeAttrs hwty
       case hwty of
         Vector sz hwty' -> do
           arguments <- mapM (appendIdentifier (pN',hwty')) [0..sz-1]
@@ -1215,7 +1266,10 @@ mkTopInput topM inps pM = case pM of
               assigns = zipWith (argBV topM) ids
                           [ Identifier pN' (Just (Indexed (hwty,10,n)))
                           | n <- [0..]]
-          return (inps'',(concat ports,pDecl:assigns ++ concat decls,Left pN'))
+          if null attrs then
+            return (inps'',(concat ports,pDecl:assigns ++ concat decls,Left pN'))
+          else
+            throwAnnotatedSplitError $(curLoc) "Vector"
 
         RTree d hwty' -> do
           arguments <- mapM (appendIdentifier (pN',hwty')) [0..2^d-1]
@@ -1226,7 +1280,10 @@ mkTopInput topM inps pM = case pM of
               assigns = zipWith (argBV topM) ids
                           [ Identifier pN' (Just (Indexed (hwty,10,n)))
                           | n <- [0..]]
-          return (inps'',(concat ports,pDecl:assigns ++ concat decls,Left pN'))
+          if null attrs then
+            return (inps'',(concat ports,pDecl:assigns ++ concat decls,Left pN'))
+          else
+            throwAnnotatedSplitError $(curLoc) "RTree"
 
         Product _ hwtys -> do
           arguments <- zipWithM appendIdentifier (map (pN',) hwtys) [0..]
@@ -1237,7 +1294,10 @@ mkTopInput topM inps pM = case pM of
               assigns = zipWith (argBV topM) ids
                           [ Identifier pN' (Just (Indexed (hwty,0,n)))
                           | n <- [0..]]
-          return (inps'',(concat ports,pDecl:assigns ++ concat decls,Left pN'))
+          if null attrs then
+            return (inps'',(concat ports,pDecl:assigns ++ concat decls,Left pN'))
+          else
+            throwAnnotatedSplitError $(curLoc) "Product"
 
         Clock nm rt Gated -> do
           let hwtys = [Clock nm rt Source,Bool]
@@ -1252,6 +1312,31 @@ mkTopInput topM inps pM = case pM of
           return (inps'',(concat ports,pDecl:assigns ++ concat decls,Left pN'))
 
         _ -> return (tail inps',([(pN,pN',hwty)],[pDecl],Left pN'))
+
+
+-- | Consider the following type signature:
+--
+-- @
+--   f :: Signal dom (Vec 6 A) `Annotate` ConstAttr "keep"
+--     -> Signal dom (Vec 6 B)
+-- @
+--
+-- What does the annotation mean, considering that Clash will split these
+-- vectors into multiple in- and output ports? Should we apply the annotation
+-- to all individual ports? How would we handle pin mappings? For now, we simply
+-- throw an error. This is a helper function to do so.
+throwAnnotatedSplitError
+  :: String
+  -> String
+  -> NetlistMonad a
+throwAnnotatedSplitError loc typ = do
+  (_,sp) <- Lens.use curCompNm
+  throw $ ClashException sp (loc ++ printf msg typ typ) Nothing
+ where
+  msg = unwords $ [ "Attempted to split %s into a number of HDL ports. This"
+                  , "is not allowed in combination with attribute annotations."
+                  , "You can annotate %s's components by splitting it up"
+                  , "manually." ]
 
 -- | Generate output port mappings for the TopEntity. Yields /Nothing/ if
 -- the output is Void
@@ -1297,6 +1382,7 @@ mkTopOutput' topM outps pM = case pM of
     go outps'@((oN,_):rest) (o,hwty) = do
       o' <- mkUniqueIdentifier Extended o
       let oDecl = NetDecl Nothing o' hwty
+      let attrs = hwTypeAttrs hwty
       case hwty of
         Vector sz hwty' -> do
           results <- mapM (appendIdentifier (o',hwty')) [0..sz-1]
@@ -1304,7 +1390,10 @@ mkTopOutput' topM outps pM = case pM of
           let (ports,decls,ids) = unzip3 results1
               ids' = map (resBV topM) ids
               netassgn = Assignment o' (mkVectorChain sz hwty' ids')
-          return (outps'',(concat ports,oDecl:netassgn:concat decls,Left o'))
+          if null attrs then
+            return (outps'',(concat ports,oDecl:netassgn:concat decls,Left o'))
+          else
+            throwAnnotatedSplitError $(curLoc) "Vector"
 
         RTree d hwty' -> do
           results <- mapM (appendIdentifier (o',hwty')) [0..2^d-1]
@@ -1312,7 +1401,10 @@ mkTopOutput' topM outps pM = case pM of
           let (ports,decls,ids) = unzip3 results1
               ids' = map (resBV topM) ids
               netassgn = Assignment o' (mkRTreeChain d hwty' ids')
-          return (outps'',(concat ports,oDecl:netassgn:concat decls,Left o'))
+          if null attrs then
+            return (outps'',(concat ports,oDecl:netassgn:concat decls,Left o'))
+          else
+            throwAnnotatedSplitError $(curLoc) "RTree"
 
         Product _ hwtys -> do
           results <- zipWithM appendIdentifier (map (o',) hwtys) [0..]
@@ -1320,7 +1412,10 @@ mkTopOutput' topM outps pM = case pM of
           let (ports,decls,ids) = unzip3 results1
               ids' = map (resBV topM) ids
               netassgn = Assignment o' (DataCon hwty (DC (hwty,0)) ids')
-          return (outps'',(concat ports,oDecl:netassgn:concat decls,Left o'))
+          if null attrs then
+            return (outps'', (concat ports,oDecl:netassgn:concat decls,Left o'))
+          else
+            throwAnnotatedSplitError $(curLoc) "Product"
 
         _ -> return (rest,([(oN,o',hwty)],[oDecl],Left o'))
 
@@ -1339,6 +1434,7 @@ mkTopOutput' topM outps pM = case pM of
       let pN = portName p o
       pN' <- mkUniqueIdentifier Extended pN
       let pDecl = NetDecl Nothing pN' hwty
+      let attrs = hwTypeAttrs hwty
       case hwty of
         Vector sz hwty' -> do
           results <- mapM (appendIdentifier (pN',hwty')) [0..sz-1]
@@ -1348,7 +1444,10 @@ mkTopOutput' topM outps pM = case pM of
           let (ports,decls,ids) = unzip3 results1
               ids' = map (resBV topM) ids
               netassgn = Assignment pN' (mkVectorChain sz hwty' ids')
-          return (outps'',(concat ports,pDecl:netassgn:concat decls,Left pN'))
+          if null attrs then
+            return (outps'',(concat ports,pDecl:netassgn:concat decls,Left pN'))
+          else
+            throwAnnotatedSplitError $(curLoc) "Vector"
 
         RTree d hwty' -> do
           results <- mapM (appendIdentifier (pN',hwty')) [0..2^d-1]
@@ -1358,7 +1457,10 @@ mkTopOutput' topM outps pM = case pM of
           let (ports,decls,ids) = unzip3 results1
               ids' = map (resBV topM) ids
               netassgn = Assignment pN' (mkRTreeChain d hwty' ids')
-          return (outps'',(concat ports,pDecl:netassgn:concat decls,Left pN'))
+          if null attrs then
+            return (outps'',(concat ports,pDecl:netassgn:concat decls,Left pN'))
+          else
+            throwAnnotatedSplitError $(curLoc) "RTree"
 
         Product _ hwtys -> do
           results <- zipWithM appendIdentifier (map (pN',) hwtys) [0..]
@@ -1368,7 +1470,10 @@ mkTopOutput' topM outps pM = case pM of
           let (ports,decls,ids) = unzip3 results1
               ids' = map (resBV topM) ids
               netassgn = Assignment pN' (DataCon hwty (DC (hwty,0)) ids')
-          return (outps'',(concat ports,pDecl:netassgn:concat decls,Left pN'))
+          if null attrs then
+            return (outps'',(concat ports,pDecl:netassgn:concat decls,Left pN'))
+          else
+            throwAnnotatedSplitError $(curLoc) "Product"
 
         _ -> return (tail outps',([(pN,pN',hwty)],[pDecl],Left pN'))
 

--- a/examples/FIR.hs
+++ b/examples/FIR.hs
@@ -7,7 +7,7 @@ dotp :: SaturatingNum a
      => Vec (n + 1) a
      -> Vec (n + 1) a
      -> a
-dotp as bs = fold boundedPlus (zipWith boundedMult as bs)
+dotp as bs = fold boundedAdd (zipWith boundedMul as bs)
 
 fir
   :: (Default a, KnownNat n, SaturatingNum a, Undefined a, HiddenClockReset domain gated synchronous)

--- a/tests/shouldfail/SynthesisAttributes/ProductInArgs.hs
+++ b/tests/shouldfail/SynthesisAttributes/ProductInArgs.hs
@@ -1,0 +1,18 @@
+-- Test annotations on product types, but not their individual components.
+module ProductInArgs where
+
+import Clash.Prelude hiding (assert, (++))
+import Clash.Annotations.SynthesisAttributes
+
+mac xy = mealy macT 0 xy
+  where
+    macT acc (x,y) = (acc',o)
+      where
+        acc' = acc + x * y
+        o    = acc
+
+topEntity
+  :: SystemClockReset
+  => Signal System (Signed 9, Signed 9) `Annotate` 'StringAttr "args" "product"
+  -> Signal System (Signed 9)
+topEntity xy = mac xy

--- a/tests/shouldfail/SynthesisAttributes/ProductInResult.hs
+++ b/tests/shouldfail/SynthesisAttributes/ProductInResult.hs
@@ -1,0 +1,20 @@
+-- Test annotations on product types, but not their individual components.
+module ProductInResult where
+
+import Clash.Prelude hiding (assert, (++))
+import Clash.Annotations.SynthesisAttributes
+
+mac xy = mealy macT 0 xy
+  where
+    macT acc (x,y) = (acc',o)
+      where
+        acc' = acc + x * y
+        o    = acc
+
+topEntity
+  :: SystemClockReset
+  => Signal System (Signed 9, Signed 9)
+  -> Signal System (Signed 9, Signed 9) `Annotate` 'StringAttr "result" "product"
+topEntity xy = bundle (s, s)
+  where
+    s = mac xy

--- a/tests/shouldwork/Fixed/SatWrap.hs
+++ b/tests/shouldwork/Fixed/SatWrap.hs
@@ -3,4 +3,4 @@ module SatWrap where
 import Clash.Prelude
 
 topEntity:: (SFixed 2 6) -> (SFixed 2 6) -> (SFixed 2 6)
-topEntity = satPlus SatWrap
+topEntity = satAdd SatWrap

--- a/tests/shouldwork/Numbers/SatMult.hs
+++ b/tests/shouldwork/Numbers/SatMult.hs
@@ -3,4 +3,4 @@ module SatMult where
 import Clash.Prelude
 
 topEntity :: Signed 3 -> Signed 3 -> Signed 3
-topEntity = satMult SatSymmetric
+topEntity = satMul SatSymmetric

--- a/tests/shouldwork/RTree/TFold.hs
+++ b/tests/shouldwork/RTree/TFold.hs
@@ -14,7 +14,7 @@ import Data.Singletons.Prelude
 data IIndex (f :: TyFun Nat *) :: *
 type instance Apply IIndex l = Index ((2^l)+1)
 
-popCountT = tdfold (Proxy :: Proxy IIndex) fromIntegral (const plus)
+popCountT = tdfold (Proxy :: Proxy IIndex) fromIntegral (const add)
 
 popCount = popCountT . v2t . bv2v
 

--- a/tests/shouldwork/SynthesisAttributes/MultipleAnnotations.hs
+++ b/tests/shouldwork/SynthesisAttributes/MultipleAnnotations.hs
@@ -1,0 +1,61 @@
+module Product where
+
+import qualified Prelude as P
+import Prelude ((++))
+
+import Clash.Prelude hiding (assert, (++))
+import Clash.Annotations.SynthesisAttributes
+
+import Data.String (IsString)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+import Text.Regex.PCRE ((=~))
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+--------------- Logic -------------------
+mac xy = mealy macT 0 xy
+  where
+    macT acc (x,y) = (acc',o)
+      where
+        acc' = acc + x * y
+        o    = acc
+
+topEntity
+  :: SystemClockReset
+  => (Signal System (Signed 9) `Annotate` 'StringAttr "top" "input1") `Annotate` 'StringAttr "top" "input2"
+  -> Signal System (Signed 9)
+  -> Signal System (Signed 9)
+topEntity x y = mac $ bundle (x, y)
+
+
+--------------- Actual tests for generated HDL -------------------
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | haystack =~ needle = return ()
+  | otherwise = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                   , "\n\nIn:\n\n", haystack ]
+
+-- VHDL test
+mainVHDL :: IO ()
+mainVHDL = do
+  [modDir, topFile] <- getArgs
+  content <- readFile (modDir </> topFile)
+
+  assertIn "attribute top : string;" content
+  assertIn "attribute top of .+ : signal is \"input1\"" content
+  assertIn "attribute top of .+ : signal is \"input2\"" content
+
+-- Verilog test
+mainVerilog :: IO ()
+mainVerilog = do
+  [modDir, topFile] <- getArgs
+  content <- readFile (modDir </> topFile)
+
+  assertIn "\\(\\* top = \"input1\" \\*\\) input" content
+  assertIn "\\(\\* top = \"input2\" \\*\\) input" content
+
+-- Verilog and SystemVerilog should share annotation syntax
+mainSystemVerilog = mainVerilog
+

--- a/tests/shouldwork/SynthesisAttributes/Product.hs
+++ b/tests/shouldwork/SynthesisAttributes/Product.hs
@@ -1,0 +1,68 @@
+module Product where
+
+import qualified Prelude as P
+import Prelude ((++))
+
+import Clash.Prelude hiding (assert, (++))
+import Clash.Prelude.Testbench
+import Clash.Annotations.SynthesisAttributes
+
+import Data.String (IsString)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+import Text.Regex.PCRE ((=~))
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+--------------- Logic -------------------
+mac xy = mealy macT 0 xy
+  where
+    macT acc (x,y) = (acc',o)
+      where
+        acc' = acc + x * y
+        o    = acc
+
+topEntity
+  :: SystemClockReset
+  => Signal System (Signed 9) `Annotate` 'StringAttr "top" "input1"
+  -> Signal System (Signed 9) `Annotate` 'StringAttr "top" "input2"
+  -> Signal System ( Signed 9 `Annotate` 'StringAttr "top" "output1"
+                   , Signed 9 `Annotate` 'StringAttr "top" "output2" )
+topEntity x y = bundle (s, s)
+  where
+    s = mac $ bundle (x, y)
+
+
+--------------- Actual tests for generated HDL -------------------
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | haystack =~ needle = return ()
+  | otherwise = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                   , "\n\nIn:\n\n", haystack ]
+
+-- VHDL test
+mainVHDL :: IO ()
+mainVHDL = do
+  [modDir, topFile] <- getArgs
+  content <- readFile (modDir </> topFile)
+
+  assertIn "attribute top : string;" content
+  assertIn "attribute top of .+ : signal is \"input1\"" content
+  assertIn "attribute top of .+ : signal is \"input2\"" content
+  assertIn "attribute top of .+ : signal is \"output1\"" content
+  assertIn "attribute top of .+ : signal is \"output2\"" content
+
+-- Verilog test
+mainVerilog :: IO ()
+mainVerilog = do
+  [modDir, topFile] <- getArgs
+  content <- readFile (modDir </> topFile)
+
+  assertIn "\\(\\* top = \"input1\" \\*\\) input" content
+  assertIn "\\(\\* top = \"input2\" \\*\\) input" content
+  assertIn "\\(\\* top = \"output1\" \\*\\) output" content
+  assertIn "\\(\\* top = \"output2\" \\*\\) output" content
+
+-- Verilog and SystemVerilog should share annotation syntax
+mainSystemVerilog = mainVerilog

--- a/tests/shouldwork/SynthesisAttributes/Simple.hs
+++ b/tests/shouldwork/SynthesisAttributes/Simple.hs
@@ -1,0 +1,63 @@
+module Simple where
+
+import qualified Prelude as P
+import Prelude ((++))
+
+import Clash.Prelude hiding (assert, (++))
+import Clash.Annotations.SynthesisAttributes
+
+import Data.String (IsString)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+import Text.Regex.PCRE ((=~))
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+--------------- Logic -------------------
+mac xy = mealy macT 0 xy
+  where
+    macT acc (x,y) = (acc',o)
+      where
+        acc' = acc + x * y
+        o    = acc
+
+topEntity
+  :: SystemClockReset
+  => Signal System (Signed 9) `Annotate` 'StringAttr "top" "input1"
+  -> Signal System (Signed 9) `Annotate` 'StringAttr "top" "input2"
+  -> Signal System (Signed 9) `Annotate` 'StringAttr "top" "outp"
+topEntity x y = mac $ bundle (x, y)
+
+
+--------------- Actual tests for generated HDL -------------------
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | haystack =~ needle = return ()
+  | otherwise = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                   , "\n\nIn:\n\n", haystack ]
+
+-- VHDL test
+mainVHDL :: IO ()
+mainVHDL = do
+  [modDir, topFile] <- getArgs
+  content <- readFile (modDir </> topFile)
+
+  assertIn "attribute top : string;" content
+  assertIn "attribute top of .+ : signal is \"input1\"" content
+  assertIn "attribute top of .+ : signal is \"input2\"" content
+  assertIn "attribute top of .+ : signal is \"outp\"" content
+
+-- Verilog test
+mainVerilog :: IO ()
+mainVerilog = do
+  [modDir, topFile] <- getArgs
+  content <- readFile (modDir </> topFile)
+
+  assertIn "\\(\\* top = \"input1\" \\*\\) input" content
+  assertIn "\\(\\* top = \"input2\" \\*\\) input" content
+  assertIn "\\(\\* top = \"outp\" \\*\\) output" content
+
+-- Verilog and SystemVerilog should share annotation syntax
+mainSystemVerilog = mainVerilog
+

--- a/tests/shouldwork/Vector/DTFold.hs
+++ b/tests/shouldwork/Vector/DTFold.hs
@@ -17,7 +17,7 @@ populationCount :: (KnownNat k, KnownNat (2^k))
                 => BitVector (2^k) -> Index ((2^k)+1)
 populationCount bv = dtfold (Proxy :: Proxy IIndex)
                             fromIntegral
-                            (\_ x y -> plus x y)
+                            (\_ x y -> add x y)
                             (bv2v bv)
 
 topEntity :: BitVector 16 -> Index 17

--- a/tests/shouldwork/Vector/Indices.hs
+++ b/tests/shouldwork/Vector/Indices.hs
@@ -5,7 +5,7 @@ import Clash.Explicit.Prelude
 topEntity
   :: Vec 2 (Index 2)
   -> Vec 2 (Index 3)
-topEntity input = liftA2 plus (indices SNat) input
+topEntity input = liftA2 add (indices SNat) input
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -170,7 +170,8 @@ main = do
             , runTest ("tests" </> "shouldwork" </> "Signal" </> "BiSignal") defBuild [] "CounterHalfTupleRev" (["","CounterHalfTupleRev_testBench"],"CounterHalfTupleRev_testBench",True)
             ]
         , testGroup "SynthesisAttributes"
-            [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Simple"              ([""],"Simple_topEntity",False) "main"
+            [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Simple"  ([""],"Simple_topEntity",False) "main"
+            , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Product" ([""],"Product_topEntity",False) "main"
             ]
         , testGroup "Testbench" -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/1152
             [ runTest ("tests" </> "shouldwork" </> "Testbench") defBuild ["-fclash-inline-limit=0"] "TB" (["","TB_testBench"],"TB_testBench",True)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -172,6 +172,10 @@ main = do
         , testGroup "SynthesisAttributes"
             [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Simple"  ([""],"Simple_topEntity",False) "main"
             , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Product" ([""],"Product_topEntity",False) "main"
+            , testGroup "Failing" [
+                runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInArgs" (Just "Attempted to split Product into a number of HDL ports.")
+              , runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInResult" (Just "Attempted to split Product into a number of HDL ports.")
+              ]
             ]
         , testGroup "Testbench" -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/1152
             [ runTest ("tests" </> "shouldwork" </> "Testbench") defBuild ["-fclash-inline-limit=0"] "TB" (["","TB_testBench"],"TB_testBench",True)
@@ -524,7 +528,7 @@ runFailingTest' _ All  _ _ _ = error "Unexpected test target: All"
 runFailingTest' _ Both _ _ _ = error "Unexpected test target: Both"
 runFailingTest' env target extraArgs modName expectedStderr =
   let cwDir       = Unsafe.unsafePerformIO $ Directory.getCurrentDirectory in
-  let (cmd, args) = clashCmd target (cwDir </> env) extraArgs modName in
+  let (cmd, args) = clashCmd target (cwDir </> env) ("-fclash-nocache" : extraArgs) modName in
   let testName    = "clash (" ++ show target ++ ")" in
   testFailingProgram
     testName

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -172,8 +172,9 @@ main = do
         , testGroup "SynthesisAttributes"
             [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Simple"  ([""],"Simple_topEntity",False) "main"
             , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Product" ([""],"Product_topEntity",False) "main"
+            , runTest    ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Product" (["", "Product_testBench"],"Product_testBench",True)
             , testGroup "Failing" [
-                runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInArgs" (Just "Attempted to split Product into a number of HDL ports.")
+                runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInArgs"   (Just "Attempted to split Product into a number of HDL ports.")
               , runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInResult" (Just "Attempted to split Product into a number of HDL ports.")
               ]
             ]
@@ -577,9 +578,26 @@ outputTest' funcName env target _hdlDir modDir modName entityName =
       args = [ "new-exec"
              , "--"
              , "runghc"
+             , "-XBinaryLiterals"
+             , "-XConstraintKinds"
              , "-XDataKinds"
+             , "-XDeriveLift"
+             , "-XExplicitForAll"
+             , "-XExplicitNamespaces"
+             , "-XFlexibleContexts"
+             , "-XKindSignatures"
+             , "-XMagicHash"
+             , "-XMonoLocalBinds"
+             , "-XScopedTypeVariables"
+             , "-XTemplateHaskell"
+             , "-XTemplateHaskellQuotes"
+             ,  "-XTypeApplications"
+             , "-XTypeFamilies"
              , "-XTypeOperators"
              , "-XNoImplicitPrelude"
+             , "-XNoMonomorphismRestriction"
+             , "-XNoStrict"
+             , "-XNoStrictData"
              , "-main-is"
              , "--ghc-arg=" ++ modName ++ "." ++ funcName ++ show target
              , env </> modName <.> "hs"


### PR DESCRIPTION
Synthesis attributes are directives passed to sythesis tools, such as Quartus. An example of such an attribute in VHDL:

```vhdl
attribute chip_pin : string;
attribute chip_pin of sel : signal is "C4";
attribute chip_pin of data : signal is "D1, D2, D3, D4";
```

This would instruct the synthesis tool to map the wire `sel` to pin `C4`, and wire `data` to pins `D1`, `D2`, `D3`, and `D4`. To achieve this in Clash, we add `Attr`s. An example of the same annotation in Clash:

```haskell
import Clash.Annotations.SynthesisAttributes (Attr (..), Annotate )

myFunc
    :: (Signal System Bool `Annotate` StringAttr "chip_pin" "C4")
    -> (Signal System Int4 `Annotate` StringAttr "chip_pin" "D1, D2, D3, D4")
    -> ...
myFunc sel data = ...
{-# NOINLINE myFunc #-}
```

To ensure this function will be rendered as its own module, do not forget a NOINLINE pragma.

Multiple attributes for the _same_ argument can be specified by using a list. For example:

```haskell
:: Signal System Bool `Annotate`
    [ StringAttr "chip_pin" "C4"
    , BoolAttr "direct_enable" True
    , IntegerAttr "max_depth" 512
    , Attr "keep"
    ]
```