### PR TITLE
Add benchmarks for normalization process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ cabal.config
 *.prof
 *.aux
 *.hp
+*.bin
 
 *~
 *.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ script:
   - (cd "./clash-ghc" && cabal sdist && cd "..")
   - mv "."/clash-ghc/dist/clash-ghc-*.tar.gz ${DISTDIR}/
   - find ${DISTDIR} -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' -C ${DISTDIR} \;
-  - "printf 'packages: %b/clash-lib-*/*.cabal %b/clash-ghc-*/*.cabal clash-prelude/*.cabal clash-cosim/*.cabal testsuite/*.cabal\\npackage clash-testsuite\\n  flags: travisci cosim\\n\\npackage clash-ghc\\n  executable-dynamic: True\\n' ${DISTDIR} ${DISTDIR} > cabal.project"
+  - "printf 'packages: %b/clash-lib-*/*.cabal %b/clash-ghc-*/*.cabal clash-prelude/*.cabal clash-cosim/*.cabal testsuite/*.cabal benchmark/*.cabal benchmark/profiling/*/*.cabal\\npackage clash-testsuite\\n  flags: travisci cosim\\n\\npackage clash-ghc\\n  executable-dynamic: True\\n' ${DISTDIR} ${DISTDIR} > cabal.project"
   - cat cabal.project
   # this builds all libraries and executables (without tests/benchmarks)
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all

--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+
+{-# OPTIONS_GHC -Wno-orphans                 #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
+import           Clash.Annotations.TopEntity
+import           Clash.Core.Name
+import           Clash.Core.Term
+import           Clash.Core.TyCon
+import           Clash.Core.Type
+import           Clash.Driver
+import           Clash.Driver.Types
+import           Clash.GHC.Evaluator          (reduceConstant)
+import           Clash.Primitives.Types
+
+import           Criterion.Main
+
+import qualified Control.Concurrent.Supply    as Supply
+import           Control.DeepSeq              (NFData(rnf),rwhnf)
+import           Data.HashMap.Strict          (HashMap)
+import           Data.IntMap.Strict           (IntMap)
+import           Data.List                    (break, isPrefixOf)
+import           System.Environment           (getArgs, withArgs)
+import           System.FilePath              (FilePath)
+
+import BenchmarkCommon
+
+-- | Run benchmark the normalization process
+--
+-- You can provide you own test cases as commandline arguments.
+--
+-- All arguments from the first one starting with a '-' are given to criterion.
+-- All argument before that are interpreted as test cases.
+main :: IO ()
+main = do
+  args <- getArgs
+  let (fileArgs,optionArgs) = break (isPrefixOf "-") args
+      tests | null fileArgs = defaultTests
+            | otherwise     = fileArgs
+  withArgs optionArgs (defaultMain $ fmap benchFile tests)
+
+benchFile :: FilePath -> Benchmark
+benchFile src =
+  env (setupEnv src) $
+    \ ~((bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity),supplyN) -> do
+      bench ("normalization of " ++ src)
+            (nf (normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans
+                                 reduceConstant topEntityNames
+                                 opts supplyN :: _ -> BindingMap) topEntity)
+
+setupEnv
+  :: FilePath
+  -> IO ((BindingMap, HashMap TyConOccName TyCon, IntMap TyConName
+         ,[(TmName, Type, Maybe TopEntity, Maybe TmName)]
+         ,CompiledPrimMap, CustomReprs, [OccName Term], TmOccName
+         )
+        ,Supply.Supply
+        )
+setupEnv src = do
+  inp <- runInputStage src
+  supplyN <- Supply.newSupply
+  return (inp,supplyN)
+
+instance NFData Supply.Supply where
+  rnf = rwhnf

--- a/benchmark/clash-benchmark.cabal
+++ b/benchmark/clash-benchmark.cabal
@@ -1,0 +1,40 @@
+name:                clash-benchmark
+version:             0.1.0
+synopsis:            Criterion based Clash benchmark
+-- description:
+homepage:            http://www.clash-lang.org/
+license:             BSD2
+author:              Leon Schoorl
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  HS-Source-Dirs:      common
+  default-language:    Haskell2010
+  ghc-options:         -O2 -Wall
+  Exposed-Modules:     BenchmarkCommon
+  build-depends:       base                 >= 4.8      && < 5,
+                       containers           >= 0.5.4.0  && < 0.6,
+                       unordered-containers >= 0.2.3.3  && < 0.3,
+
+                       clash-ghc,
+                       clash-lib,
+                       clash-prelude
+
+executable clash-benchmark-normalization
+  main-is:             benchmark-normalization.hs
+  default-language:    Haskell2010
+  ghc-options:         -O2 -Wall
+  build-depends:       base                 >= 4.8      && < 5,
+                       concurrent-supply    >= 0.1.7    && < 0.2,
+                       containers           >= 0.5.4.0  && < 0.6,
+                       criterion            >= 1.1.1.0  && < 1.5,
+                       deepseq              >= 1.4      && < 1.5,
+                       filepath             >= 1.4      && < 1.5,
+                       unordered-containers >= 0.2.3.3  && < 0.3,
+
+                       clash-benchmark,
+                       clash-ghc,
+                       clash-lib,
+                       clash-prelude

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE CPP #-}
+
+#include "MachDeps.h"
+#define HDLSYN Other
+
+module BenchmarkCommon where
+
+import Clash.Annotations.BitRepresentation.Internal (CustomReprs, buildCustomReprs)
+import Clash.Annotations.TopEntity
+import Clash.Backend
+import Clash.Backend.VHDL
+import Clash.Core.Name
+import Clash.Core.Term
+import Clash.Core.TyCon
+import Clash.Core.Type
+import Clash.Driver
+import Clash.Driver.Types
+import Clash.GHC.GenerateBindings
+import Clash.GHC.LoadModules (ghcLibDir)
+import Clash.GHC.NetlistTypes
+import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
+import Clash.Netlist.Types          (HWType)
+import Clash.Primitives.Types
+
+import Data.HashMap.Strict          (HashMap)
+import Data.IntMap.Strict           (IntMap)
+
+defaultTests :: [FilePath]
+defaultTests =
+  [ "examples/FIR.hs"
+  , "examples/Queens.hs"
+  , "benchmark/tests/BundleMapRepeat.hs"
+  , "benchmark/tests/PipelinesViaFolds.hs"
+  ]
+
+typeTrans :: (CustomReprs -> HashMap TyConOccName TyCon -> Bool -> Type -> Maybe (Either String HWType))
+typeTrans = ghcTypeToHWType WORD_SIZE_IN_BITS True
+
+opts :: ClashOpts
+opts = ClashOpts 20 20 15 0 DebugNone False True WORD_SIZE_IN_BITS Nothing HDLSYN True True ["."] Nothing
+
+backend :: VHDLState
+backend = initBackend WORD_SIZE_IN_BITS HDLSYN
+
+runInputStage
+  :: FilePath
+  -> IO (BindingMap
+        ,HashMap TyConOccName TyCon
+        ,IntMap TyConName
+        ,[(TmName, Type,Maybe TopEntity, Maybe TmName)]
+        ,CompiledPrimMap
+        ,CustomReprs
+        ,[OccName Term]
+        ,TmOccName
+        )
+runInputStage src = do
+  pds <- primDirs backend
+  (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <- generateBindings pds ["."] (hdlKind backend) src Nothing
+  let topEntityNames = map (\(x,_,_,_) -> nameOcc x) topEntities
+      [(topEntity,_,_,_)] = topEntities
+      tm = nameOcc topEntity
+  topDir   <- ghcLibDir
+  primMap2 <- sequence $ fmap (compilePrimitive [] topDir) primMap
+  return (bindingsMap,tcm,tupTcm,topEntities, primMap2, buildCustomReprs reprs, topEntityNames,tm)

--- a/benchmark/profiling/README.profiling.md
+++ b/benchmark/profiling/README.profiling.md
@@ -1,0 +1,15 @@
+You can use this to profile just the normalization process.
+
+Add the following lines to your cabal.project.local:
+```
+packages: ./benchmark/profiling/*/*.cabal
+
+package clash-profiling
+  profiling: True
+```
+
+And run using:
+```
+$ cabal new-run clash-profile-normalization-prepare -- [INPUT_FILES]
+$ cabal new-run clash-profile-normalization-run -- [INPUT_FILES] +RTS -p
+```

--- a/benchmark/profiling/prepare/clash-profiling-prepare.cabal
+++ b/benchmark/profiling/prepare/clash-profiling-prepare.cabal
@@ -1,0 +1,37 @@
+name:                clash-profiling-prepare
+version:             0.1.0
+synopsis:            Runs ghc frontend and prepares input for clash-profile-normalization-run
+-- description:
+homepage:            http://www.clash-lang.org/
+license:             BSD2
+author:              Leon Schoorl
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  HS-Source-Dirs:      instances
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  Exposed-Modules:     SerialiseInstances
+  build-depends:       base                  >= 4.8      && < 5,
+                       binary                >= 0.8.5    && < 0.11,
+                       hashable              >= 1.1.2.3  && < 1.3,
+                       template-haskell      >= 2.12.0.0 && < 2.15,
+                       unordered-containers  >= 0.2.3.3  && < 0.3,
+
+                       clash-lib,
+                       clash-prelude
+
+executable clash-profile-normalization-prepare
+  main-is:             profile-normalization-prepare.hs
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  build-depends:       base                  >= 4.8      && < 5,
+                       binary                >= 0.8.5    && < 0.11,
+                       bytestring            >= 0.10.0.2 && < 0.11,
+                       filepath              >= 1.4      && < 1.5,
+                       ghc                   >= 8.2.0    && < 8.6,
+
+                       clash-benchmark,
+                       clash-profiling-prepare

--- a/benchmark/profiling/prepare/instances/SerialiseInstances.hs
+++ b/benchmark/profiling/prepare/instances/SerialiseInstances.hs
@@ -1,0 +1,40 @@
+{-# OPTIONS_GHC -Wno-orphans    #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE StandaloneDeriving #-}
+module SerialiseInstances where
+
+import Data.Binary
+
+import Data.Hashable (Hashable)
+
+import qualified Clash.Annotations.BitRepresentation.Internal as CP
+
+import qualified Clash.Primitives.Types                       as CL
+import qualified Clash.Netlist.Types                          as CL (BlackBox)
+import qualified Clash.Netlist.BlackBox.Types                 as CL
+
+import qualified Data.HashMap.Strict                          as HM
+
+
+-- | Like C.CompiledPrimitive but without the functions BlackBoxFunction so we can serialise it
+type CompiledPrimitive' = CL.Primitive CL.BlackBoxTemplate CL.BlackBox ()
+type CompiledPrimMap' = CL.PrimMap CompiledPrimitive'
+
+deriving instance Functor (CL.Primitive a b)
+
+-- Remove BlackBoxFunctions
+removeBBfunc :: CL.CompiledPrimitive -> CompiledPrimitive'
+removeBBfunc = fmap $ const ()
+
+-- Put errors in places where BlackBoxFunctions used to be
+unremoveBBfunc :: CompiledPrimitive' -> CL.CompiledPrimitive
+unremoveBBfunc = fmap $ const (error "BlackBoxFunction can't be preserved by serialisation")
+
+-- BitRepresentation internal
+instance Binary CP.Type'
+instance Binary CP.DataRepr'
+instance Binary CP.ConstrRepr'
+
+instance (Binary k, Binary v, Eq k, Hashable k) => Binary (HM.HashMap k v) where
+  put = put . HM.toList
+  get = HM.fromList <$> get

--- a/benchmark/profiling/prepare/profile-normalization-prepare.hs
+++ b/benchmark/profiling/prepare/profile-normalization-prepare.hs
@@ -1,0 +1,28 @@
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+import           System.Environment           (getArgs)
+import           System.FilePath              (FilePath)
+
+import           Data.Binary (encode)
+import qualified Data.ByteString.Lazy as B
+
+import           SerialiseInstances
+import           BenchmarkCommon
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let tests | null args = defaultTests
+            | otherwise = args
+  mapM_ prepareFile tests
+
+prepareFile :: FilePath -> IO ()
+prepareFile fIn = do
+  putStrLn $ "Preparing: " ++ fIn
+  let fOut = fIn ++ ".bin"
+  inp <- runInputStage fIn
+  let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity) = inp
+      inp' = (bindingsMap,tcm,tupTcm,_topEntities, fmap removeBBfunc primMap, reprs,topEntityNames,topEntity)
+  putStrLn $ "Serialising to : " ++ fOut
+  B.writeFile fOut $ encode inp'
+  putStrLn "Done"

--- a/benchmark/profiling/run/clash-profiling.cabal
+++ b/benchmark/profiling/run/clash-profiling.cabal
@@ -1,0 +1,31 @@
+name:                clash-profiling
+version:             0.1.0
+synopsis:            A profilable run of the Clash normalization process
+-- description:
+homepage:            http://www.clash-lang.org/
+license:             BSD2
+author:              Leon Schoorl
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable clash-profile-normalization-run
+  main-is:             profile-normalization-run.hs
+  default-language:    Haskell2010
+  ghc-options:         -O2 -Wall
+  build-depends:       base                 >= 4.8      && < 5,
+                       binary               >= 0.8.5    && < 0.11,
+                       bytestring           >= 0.10.0.2 && < 0.11,
+                       concurrent-supply    >= 0.1.7    && < 0.2,
+                       containers           >= 0.5.4.0  && < 0.6,
+                       deepseq              >= 1.4      && < 1.5,
+                       filepath             >= 1.4      && < 1.5,
+                       unordered-containers >= 0.2.3.3  && < 0.3,
+
+                       clash-benchmark,
+                       clash-ghc,
+                       clash-lib,
+                       clash-prelude,
+                       clash-profiling-prepare
+  -- automatically build ...-prepare tool
+  build-tool-depends:  clash-profiling-prepare:clash-profile-normalization-prepare

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -1,0 +1,50 @@
+import           Clash.Annotations.TopEntity
+import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
+import           Clash.Core.Name
+import           Clash.Core.Term
+import           Clash.Core.TyCon
+import           Clash.Core.Type
+import           Clash.Driver
+import           Clash.Driver.Types
+import           Clash.GHC.Evaluator          (reduceConstant)
+
+import qualified Control.Concurrent.Supply    as Supply
+import           Control.DeepSeq              (deepseq)
+import           Data.Binary                  (decode)
+import           Data.HashMap.Strict          (HashMap)
+import           Data.IntMap.Strict           (IntMap)
+import           System.Environment           (getArgs)
+import           System.FilePath              (FilePath)
+
+import qualified Data.ByteString.Lazy as B
+
+import           SerialiseInstances
+import           BenchmarkCommon
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let tests | null args = defaultTests
+            | otherwise = args
+  res <- mapM benchFile tests
+  deepseq res $ return ()
+
+benchFile :: FilePath -> IO ()
+benchFile src = do
+  supplyN <- Supply.newSupply
+  env <- setupEnv src
+  putStrLn $ "Doing normalization of " ++ src
+  let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity) = env
+      primMap' = fmap unremoveBBfunc primMap
+      res :: BindingMap
+      res = normalizeEntity reprs bindingsMap primMap' tcm tupTcm typeTrans reduceConstant
+                   topEntityNames opts supplyN topEntity
+  res `deepseq` putStrLn ".. done\n"
+
+setupEnv :: FilePath -> IO (BindingMap,HashMap TyConOccName TyCon,IntMap TyConName
+                           ,[(TmName, Type, Maybe TopEntity, Maybe TmName)],CompiledPrimMap'
+                           ,CustomReprs,[OccName Term],TmOccName)
+setupEnv src = do
+  let bin = src ++ ".bin"
+  putStrLn $ "Reading from: " ++ bin
+  decode <$> B.readFile bin

--- a/benchmark/tests/BundleMapRepeat.hs
+++ b/benchmark/tests/BundleMapRepeat.hs
@@ -1,0 +1,8 @@
+-- source: https://github.com/clash-lang/clash-compiler/issues/236
+
+module BundleMapRepeat where
+
+import Clash.Prelude
+
+topEntity :: Signal System (Unsigned 16) -> Signal System (Vec 17 (Unsigned 16))
+topEntity x = bundle . map ($ x) $ repeat id

--- a/benchmark/tests/PipelinesViaFolds.hs
+++ b/benchmark/tests/PipelinesViaFolds.hs
@@ -1,0 +1,35 @@
+-- source: https://github.com/clash-lang/clash-compiler/issues/251
+
+module PipelinesViaFolds where
+
+import Clash.Prelude
+import Data.Word
+
+topEntity :: SystemClockReset => Signal System Word32 -> Signal System Word32
+topEntity = pipeline
+  where
+    pipeline :: Signal System Word32 -> Signal System Word32
+    -- slow normalisation, 32s
+    pipeline = foldr (\x acc -> stage x . acc) id $ iterate d32 (+1) 1
+
+    -- slow normalisation, killed after 60s
+    -- pipeline = foldr (.) id $ map stage $ iterate d32 (+1) 1
+
+    -- fast normalisation, 1s
+    -- pipeline =
+    --     stage 1 .  stage 2 .  stage 3 .  stage 4 .  stage 5 .  stage 6 .
+    --     stage 7 .  stage 8 .  stage 9 .  stage 10 .  stage 11 .  stage 12 .
+    --     stage 13 .  stage 14 .  stage 15 .  stage 16 .  stage 17 .  stage 18 .
+    --     stage 19 .  stage 20 .  stage 21 .  stage 22 .  stage 23 .  stage 24 .
+    --     stage 25 .  stage 26 .  stage 27 .  stage 28 .  stage 29 .  stage 30 .
+    --     stage 31 .  stage 32
+
+    -- Christiaan's workaround
+    -- pipeline i = last stages
+    --   where
+    --     stages = zipWith stage (iterate d32 (subtract 1) 32) (i :> init stages)
+
+    -- Simple example where `stage` is configured by its order in the pipeline
+    stage :: Word32 -> Signal System Word32 -> Signal System Word32
+    stage i s = let delay = register i $ xor <$> delay <*> s
+                in delay

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,12 @@
 -- there are no top level packages. any package can be checked out under the
 -- root directory (i.e. patched copies, or forks) and will automatically be
 -- preferred by the solver over other versions.
-packages: ./clash-ghc/*.cabal, ./clash-lib/*.cabal, ./clash-prelude/*.cabal, ./testsuite/*.cabal
+packages:
+  ./clash-ghc/*.cabal,
+  ./clash-lib/*.cabal,
+  ./clash-prelude/*.cabal,
+  ./testsuite/*.cabal,
+  ./benchmark/*.cabal
 
 allow-newer: *:Cabal, *:array, *:base, *:binary, *:^bytestring, *:containers,
   *:deepseq, *:directory, *:filepath, *:ghc, *:ghc-boot, *:ghc-boot-th,

--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,7 @@
 -- preferred by the solver over other versions.
 packages: ./clash-ghc/*.cabal, ./clash-lib/*.cabal, ./clash-prelude/*.cabal, ./testsuite/*.cabal
 
-allow-newer: *:Cabal, *:array, *:base, *:binary, *:bytestring, *:containers,
+allow-newer: *:Cabal, *:array, *:base, *:binary, *:^bytestring, *:containers,
   *:deepseq, *:directory, *:filepath, *:ghc, *:ghc-boot, *:ghc-boot-th,
   *:ghc-compact, *:ghc-heap, *:ghc-prim, *:ghci, *:haskeline, *:hpc,
   *:integer-gmp, *:libiserv, *:mtl, *:parsec, *:pretty, *:process, *:stm,

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -142,18 +142,21 @@ library
   C-Sources:          cbits/hschooks.c
 
   Exposed-Modules:    Clash.Main
+
+                      -- exposed for use by the benchmarks
+                      Clash.GHC.Evaluator
+                      Clash.GHC.GenerateBindings
+                      Clash.GHC.NetlistTypes
+
   Other-Modules:      Clash.GHCi.UI
                       Clash.GHCi.UI.Info
                       Clash.GHCi.UI.Monad
                       Clash.GHCi.UI.Tags
 
                       Clash.GHC.ClashFlags
-                      Clash.GHC.Evaluator
-                      Clash.GHC.GenerateBindings
                       Clash.GHC.GHC2Core
                       Clash.GHC.LoadInterfaceFiles
                       Clash.GHC.LoadModules
-                      Clash.GHC.NetlistTypes
                       Paths_clash_ghc
   if impl(ghc >= 8.6.0)
     Other-Modules:    Clash.GHCi.Leak

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -146,6 +146,7 @@ library
                       -- exposed for use by the benchmarks
                       Clash.GHC.Evaluator
                       Clash.GHC.GenerateBindings
+                      Clash.GHC.LoadModules
                       Clash.GHC.NetlistTypes
 
   Other-Modules:      Clash.GHCi.UI
@@ -156,7 +157,6 @@ library
                       Clash.GHC.ClashFlags
                       Clash.GHC.GHC2Core
                       Clash.GHC.LoadInterfaceFiles
-                      Clash.GHC.LoadModules
                       Paths_clash_ghc
   if impl(ghc >= 8.6.0)
     Other-Modules:    Clash.GHCi.Leak

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -100,6 +100,7 @@ Library
                       ansi-wl-pprint          >= 0.6.8.2  && < 1.0,
                       attoparsec              >= 0.10.4.0 && < 0.14,
                       base                    >= 4.8      && < 5,
+                      binary                  >= 0.8.5    && < 0.11,
                       bytestring              >= 0.10.0.2 && < 0.11,
                       clash-prelude           >= 0.11.1   && < 1.0,
                       concurrent-supply       >= 0.1.7    && < 0.2,
@@ -128,6 +129,7 @@ Library
                       transformers            >= 0.3.0.0  && < 0.6,
                       trifecta                >= 1.7.1.1  && < 2.0,
                       vector                  >= 0.11     && < 1.0,
+                      vector-binary-instances >= 0.2.3.5  && < 0.3,
                       unbound-generics        >= 0.1      && < 0.4,
                       unordered-containers    >= 0.2.3.3  && < 0.3
 

--- a/clash-lib/src/Clash/Annotations/TopEntity/Extra.hs
+++ b/clash-lib/src/Clash/Annotations/TopEntity/Extra.hs
@@ -12,6 +12,7 @@ import Clash.Annotations.TopEntity (TopEntity, PortName)
 import Language.Haskell.TH.Syntax
   (ModName, Name, NameFlavour, NameSpace, PkgName, OccName)
 import Data.Hashable               (Hashable)
+import Control.DeepSeq             (NFData)
 
 instance Hashable TopEntity
 instance Hashable PortName
@@ -22,3 +23,13 @@ instance Hashable NameFlavour
 instance Hashable NameSpace
 instance Hashable PkgName
 instance Hashable OccName
+
+instance NFData TopEntity
+instance NFData PortName
+
+instance NFData ModName
+instance NFData Name
+instance NFData NameFlavour
+instance NFData NameSpace
+instance NFData PkgName
+instance NFData OccName

--- a/clash-lib/src/Clash/Annotations/TopEntity/Extra.hs
+++ b/clash-lib/src/Clash/Annotations/TopEntity/Extra.hs
@@ -11,8 +11,19 @@ module Clash.Annotations.TopEntity.Extra where
 import Clash.Annotations.TopEntity (TopEntity, PortName)
 import Language.Haskell.TH.Syntax
   (ModName, Name, NameFlavour, NameSpace, PkgName, OccName)
+import Data.Binary                 (Binary)
 import Data.Hashable               (Hashable)
 import Control.DeepSeq             (NFData)
+
+instance Binary TopEntity
+instance Binary PortName
+
+instance Binary Name
+instance Binary OccName
+instance Binary NameFlavour
+instance Binary ModName
+instance Binary NameSpace
+instance Binary PkgName
 
 instance Hashable TopEntity
 instance Hashable PortName

--- a/clash-lib/src/Clash/Core/DataCon.hs
+++ b/clash-lib/src/Clash/Core/DataCon.hs
@@ -27,6 +27,7 @@ where
 #endif
 
 import Control.DeepSeq                        (NFData(..))
+import Data.Binary                            (Binary)
 import Data.Hashable                          (Hashable)
 import GHC.Generics                           (Generic)
 import Unbound.Generics.LocallyNameless       (Alpha(..),Subst(..))
@@ -54,7 +55,7 @@ data DataCon
                              -- these type variables are not part of the result
                              -- of the DataCon, but only of the arguments.
   , dcArgTys     :: [Type]   -- ^ Argument types
-  } deriving (Generic,NFData,Hashable)
+  } deriving (Generic,NFData,Hashable,Binary)
 
 instance Show DataCon where
   show = show . dcName

--- a/clash-lib/src/Clash/Core/Literal.hs
+++ b/clash-lib/src/Clash/Core/Literal.hs
@@ -20,6 +20,8 @@ module Clash.Core.Literal
 where
 
 import Control.DeepSeq                        (NFData (..))
+import Data.Binary                            (Binary)
+import Data.Vector.Binary                     ()
 import Data.Hashable                          (Hashable)
 import Data.Vector.Primitive.Extra            (Vector)
 import Data.Word                              (Word8)
@@ -48,7 +50,7 @@ data Literal
   | CharLiteral     !Char
   | NaturalLiteral  !Integer
   | ByteArrayLiteral !(Vector Word8)
-  deriving (Eq,Ord,Show,Generic,NFData,Hashable)
+  deriving (Eq,Ord,Show,Generic,NFData,Hashable,Binary)
 
 instance Alpha Literal where
   fvAny' _ _ l = pure l

--- a/clash-lib/src/Clash/Core/Name.hs
+++ b/clash-lib/src/Clash/Core/Name.hs
@@ -19,9 +19,11 @@ module Clash.Core.Name
 where
 
 import           Control.DeepSeq                        (NFData)
+import           Data.Binary                            (Binary)
 import           Data.Function                          (on)
 import           Data.Hashable                          (Hashable)
 import           Data.Typeable                          (Typeable)
+import           GHC.BasicTypes.Extra                   ()
 import           GHC.Generics                           (Generic)
 import           GHC.SrcLoc.Extra                       ()
 import           Unbound.Generics.LocallyNameless       hiding
@@ -38,7 +40,7 @@ data Name a
   , nameOcc  :: OccName a
   , nameLoc  :: !SrcSpan
   }
-  deriving (Show,Generic,NFData,Hashable)
+  deriving (Show,Generic,NFData,Hashable,Binary)
 
 instance Eq (Name a) where
   (==) = (==) `on` nameOcc
@@ -52,7 +54,7 @@ data NameSort
   = User
   | System
   | Internal
-  deriving (Eq,Ord,Show,Generic,NFData,Hashable)
+  deriving (Eq,Ord,Show,Generic,NFData,Hashable,Binary)
 
 instance Typeable a => Alpha (Name a) where
   aeq'      ctx (Name _ nm1 _) (Name _ nm2 _) = aeq'      ctx nm1 nm2

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -25,6 +25,7 @@ where
 
 -- External Modules
 import Control.DeepSeq
+import Data.Binary                             (Binary)
 import Data.Hashable                           (Hashable)
 import Data.Text                               (Text)
 import GHC.Generics
@@ -52,7 +53,7 @@ data Term
   | Case    !Term !Type [Alt]               -- ^ Case-expression: subject, type of
                                             -- alternatives, list of alternatives
   | Cast    !Term !Type !Type               -- ^ Cast a term from one type to another
-  deriving (Show,Generic,NFData,Hashable)
+  deriving (Show,Generic,NFData,Hashable,Binary)
 
 -- | Term reference
 type TmName     = Name Term
@@ -69,7 +70,7 @@ data Pat
   -- ^ Literal pattern
   | DefaultPat
   -- ^ Default pattern
-  deriving (Eq,Show,Generic,NFData,Alpha,Hashable)
+  deriving (Eq,Show,Generic,NFData,Alpha,Hashable,Binary)
 
 type Alt = Bind Pat Term
 

--- a/clash-lib/src/Clash/Core/TyCon.hs
+++ b/clash-lib/src/Clash/Core/TyCon.hs
@@ -30,6 +30,7 @@ where
 
 -- External Import
 import Control.DeepSeq
+import Data.Binary                            (Binary)
 import Data.HashMap.Lazy                      (HashMap)
 import GHC.Generics
 import Unbound.Generics.LocallyNameless       (Alpha(..))
@@ -72,7 +73,7 @@ data TyCon
   | SuperKindTyCon
   { tyConName :: !TyConName     -- ^ Name of the TyCon
   }
-  deriving (Generic,NFData)
+  deriving (Generic,NFData,Binary)
 
 instance Show TyCon where
   show (AlgTyCon       {tyConName = n}) = "AlgTyCon: " ++ show n
@@ -104,7 +105,7 @@ data AlgTyConRhs
                                  -- The TyName's are the type-variables from
                                  -- the corresponding TyCon.
   }
-  deriving (Show,Generic,NFData,Alpha)
+  deriving (Show,Generic,NFData,Alpha,Binary)
 
 instance Alpha TyCon where
   aeq' c tc1 tc2      = aeq' c (tyConName tc1) (tyConName tc2)

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -59,6 +59,7 @@ where
 
 -- External import
 import           Control.DeepSeq                         as DS
+import           Data.Binary                             (Binary)
 import           Data.Hashable                           (Hashable)
 import           Data.HashMap.Strict                     (HashMap)
 import qualified Data.HashMap.Strict                     as HashMap
@@ -104,7 +105,7 @@ data Type
   | AppTy    !Type !Type        -- ^ Type Application
   | LitTy    !LitTy             -- ^ Type literal
   | AnnType  [Attr'] !Type      -- ^ Annotated type, see Clash.Annotations.SynthesisAttributes
-  deriving (Show,Generic,NFData,Hashable)
+  deriving (Show,Generic,NFData,Hashable,Binary)
 
 -- | An easier view on types
 data TypeView
@@ -117,13 +118,13 @@ data TypeView
 data ConstTy
   = TyCon !TyConName -- ^ TyCon type
   | Arrow            -- ^ Function type
-  deriving (Show,Generic,NFData,Alpha,Hashable)
+  deriving (Show,Generic,NFData,Alpha,Hashable,Binary)
 
 -- | Literal Types
 data LitTy
   = NumTy !Integer
   | SymTy !String
-  deriving (Show,Generic,NFData,Alpha,Hashable)
+  deriving (Show,Generic,NFData,Alpha,Hashable,Binary)
 
 -- | The level above types
 type Kind       = Type

--- a/clash-lib/src/Clash/Core/Type.hs-boot
+++ b/clash-lib/src/Clash/Core/Type.hs-boot
@@ -12,6 +12,7 @@
 module Clash.Core.Type where
 
 import Control.DeepSeq                  (NFData)
+import Data.Binary                      (Binary)
 import Data.Hashable                    (Hashable)
 import GHC.Generics                     (Generic)
 import Unbound.Generics.LocallyNameless (Alpha,Subst)
@@ -36,5 +37,6 @@ instance Subst    Type Type
 instance Subst    Term Type
 instance NFData   Type
 instance Hashable Type
+instance Binary   Type
 
 mkTyConTy :: TyConName -> Type

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -23,6 +23,7 @@ where
 
 
 import Control.DeepSeq                  (NFData (..))
+import Data.Binary                      (Binary)
 import Data.Hashable                    (Hashable)
 import Data.Typeable                    (Typeable)
 import GHC.Generics                     (Generic)
@@ -41,7 +42,7 @@ data Attr'
   | IntegerAttr' String Integer
   | StringAttr' String String
   | Attr' String
-  deriving (Eq, Show, NFData, Generic, Hashable, Typeable, Alpha, Ord)
+  deriving (Eq, Show, NFData, Generic, Hashable, Typeable, Alpha, Ord, Binary)
 
 instance Subst Type Attr'
 instance Subst Term Attr'
@@ -64,7 +65,7 @@ data Var a
   { varName :: Name a
   , varType :: Embed Type
   }
-  deriving (Eq,Show,Generic,NFData,Hashable)
+  deriving (Eq,Show,Generic,NFData,Hashable,Binary)
 
 -- | Term variable
 type Id    = Var Term

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -7,6 +7,9 @@
   Types used in BlackBox modules
 -}
 
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+
 module Clash.Netlist.BlackBox.Types
  ( BlackBoxMeta(..)
  , emptyBlackBoxMeta
@@ -18,8 +21,10 @@ module Clash.Netlist.BlackBox.Types
  , HdlSyn(..)
  ) where
 
+import                Control.DeepSeq            (NFData)
 import                Data.Text.Lazy             (Text)
 import qualified      Data.Text                  as S
+import                GHC.Generics               (Generic)
 
 import                Clash.Core.Term            (Term)
 import                Clash.Core.Type            (Type)
@@ -29,7 +34,7 @@ import {-# SOURCE #-} Clash.Netlist.Types        (BlackBox, Identifier)
 data TemplateKind
   = TDecl
   | TExpr
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic, NFData)
 
 -- | See @Clash.Primitives.Types.BlackBox@ for documentation on this record's
 -- fields. (They are intentionally renamed to prevent name clashes.)
@@ -114,7 +119,7 @@ data Element = C   !Text         -- ^ Constant
              | Repeat [Element] [Element] -- ^ Repeat <hole> n times
              | DevNull [Element]          -- ^ Evaluate <hole> but swallow output
              | SigD [Element] !(Maybe Int)
-  deriving Show
+  deriving (Show, Generic, NFData)
 
 -- | Component instantiation hole. First argument indicates which function argument
 -- to instantiate. Second argument corresponds to output and input assignments,
@@ -124,7 +129,7 @@ data Element = C   !Text         -- ^ Constant
 -- The LHS of the tuple is the name of the signal, while the RHS of the tuple
 -- is the type of the signal
 data Decl = Decl !Int [(BlackBoxTemplate,BlackBoxTemplate)]
-  deriving Show
+  deriving (Show, Generic, NFData)
 
 data HdlSyn = Vivado | Quartus | Other
-  deriving (Eq,Show,Read)
+  deriving (Eq, Show, Read, Generic, NFData)

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -22,6 +22,7 @@ module Clash.Netlist.BlackBox.Types
  ) where
 
 import                Control.DeepSeq            (NFData)
+import                Data.Binary                (Binary)
 import                Data.Text.Lazy             (Text)
 import qualified      Data.Text                  as S
 import                GHC.Generics               (Generic)
@@ -34,7 +35,7 @@ import {-# SOURCE #-} Clash.Netlist.Types        (BlackBox, Identifier)
 data TemplateKind
   = TDecl
   | TExpr
-  deriving (Show, Eq, Generic, NFData)
+  deriving (Show, Eq, Generic, NFData, Binary)
 
 -- | See @Clash.Primitives.Types.BlackBox@ for documentation on this record's
 -- fields. (They are intentionally renamed to prevent name clashes.)
@@ -119,7 +120,7 @@ data Element = C   !Text         -- ^ Constant
              | Repeat [Element] [Element] -- ^ Repeat <hole> n times
              | DevNull [Element]          -- ^ Evaluate <hole> but swallow output
              | SigD [Element] !(Maybe Int)
-  deriving (Show, Generic, NFData)
+  deriving (Show, Generic, NFData, Binary)
 
 -- | Component instantiation hole. First argument indicates which function argument
 -- to instantiate. Second argument corresponds to output and input assignments,
@@ -129,7 +130,7 @@ data Element = C   !Text         -- ^ Constant
 -- The LHS of the tuple is the name of the signal, while the RHS of the tuple
 -- is the type of the signal
 data Decl = Decl !Int [(BlackBoxTemplate,BlackBoxTemplate)]
-  deriving (Show, Generic, NFData)
+  deriving (Show, Generic, NFData, Binary)
 
 data HdlSyn = Vivado | Quartus | Other
-  deriving (Eq, Show, Read, Generic, NFData)
+  deriving (Eq, Show, Read, Generic, NFData, Binary)

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -331,6 +331,7 @@ data BlackBoxContext
 data BlackBox
   = BBTemplate BlackBoxTemplate
   | BBFunction TemplateFunction
+  deriving (Generic,NFData)
 
 data TemplateFunction where
   TemplateFunction
@@ -342,6 +343,9 @@ data TemplateFunction where
 instance Show BlackBox where
   show (BBTemplate t)  = show t
   show (BBFunction {}) = "TemplateFunction"
+
+instance NFData TemplateFunction where
+  rnf (TemplateFunction is f _) = rnf is `seq` f `seq` ()
 
 emptyBBContext :: BlackBoxContext
 emptyBBContext

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -31,6 +31,7 @@ import Control.DeepSeq
 import Control.Monad.State                  (State)
 import Control.Monad.State.Strict           (MonadIO, MonadState, StateT)
 import Data.Bits                            (testBit)
+import Data.Binary                          (Binary(..))
 import Data.Hashable
 import Data.HashMap.Lazy                    (HashMap)
 import Data.IntMap.Lazy                     (IntMap, empty)
@@ -331,7 +332,7 @@ data BlackBoxContext
 data BlackBox
   = BBTemplate BlackBoxTemplate
   | BBFunction TemplateFunction
-  deriving (Generic,NFData)
+  deriving (Generic, NFData, Binary)
 
 data TemplateFunction where
   TemplateFunction
@@ -346,6 +347,12 @@ instance Show BlackBox where
 
 instance NFData TemplateFunction where
   rnf (TemplateFunction is f _) = rnf is `seq` f `seq` ()
+
+-- | __NB__: serialisation doesn't preserve the embedded function
+instance Binary TemplateFunction where
+  put (TemplateFunction is _ _ ) = put is
+  get = (\is -> TemplateFunction is err err) <$> get
+    where err = const $ error "TemplateFunction functions can't be preserved by serialisation"
 
 emptyBBContext :: BlackBoxContext
 emptyBBContext

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -39,6 +39,7 @@ import           Control.Applicative          ((<|>))
 import           Control.DeepSeq              (NFData)
 import           Data.Aeson
   (FromJSON (..), Value (..), (.:), (.:?), (.!=))
+import           Data.Binary                  (Binary)
 import           Data.Char                    (isUpper, isLower, isAlphaNum)
 import           Data.Either                  (lefts)
 import           Data.HashMap.Lazy            (HashMap)
@@ -69,7 +70,7 @@ type PrimMap a = HashMap S.Text a
 -- guaranteed to have at least one module name which is not /Main/.
 data BlackBoxFunctionName =
   BlackBoxFunctionName [String] String
-    deriving (Eq, Generic, NFData)
+    deriving (Eq, Generic, NFData, Binary)
 
 instance Show BlackBoxFunctionName where
   show (BlackBoxFunctionName mods funcName) =
@@ -164,7 +165,7 @@ data Primitive a b c
   , primType :: !Text
     -- ^ Additional information
   }
-  deriving (Show, Generic, NFData)
+  deriving (Show, Generic, NFData, Binary)
 
 instance FromJSON UnresolvedPrimitive where
   parseJSON (Object v) =

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -8,8 +8,10 @@
   Type and instance definitions for Primitive
 -}
 
+{-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveFoldable    #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase        #-}
@@ -34,6 +36,7 @@ import {-# SOURCE #-} Clash.Netlist.Types
 import           Clash.Netlist.BlackBox.Types
   (BlackBoxTemplate, BlackBoxFunction, TemplateKind (..))
 import           Control.Applicative          ((<|>))
+import           Control.DeepSeq              (NFData)
 import           Data.Aeson
   (FromJSON (..), Value (..), (.:), (.:?), (.!=))
 import           Data.Char                    (isUpper, isLower, isAlphaNum)
@@ -43,6 +46,7 @@ import qualified Data.HashMap.Strict          as H
 import           Data.List                    (intercalate)
 import qualified Data.Text                    as S
 import           Data.Text.Lazy               (Text)
+import           GHC.Generics                 (Generic)
 import           GHC.Stack                    (HasCallStack)
 
 -- | An unresolved primitive still contains pointers to files.
@@ -65,7 +69,7 @@ type PrimMap a = HashMap S.Text a
 -- guaranteed to have at least one module name which is not /Main/.
 data BlackBoxFunctionName =
   BlackBoxFunctionName [String] String
-    deriving (Eq)
+    deriving (Eq, Generic, NFData)
 
 instance Show BlackBoxFunctionName where
   show (BlackBoxFunctionName mods funcName) =
@@ -160,7 +164,7 @@ data Primitive a b c
   , primType :: !Text
     -- ^ Additional information
   }
-  deriving Show
+  deriving (Show, Generic, NFData)
 
 instance FromJSON UnresolvedPrimitive where
   parseJSON (Object v) =

--- a/clash-lib/src/GHC/BasicTypes/Extra.hs
+++ b/clash-lib/src/GHC/BasicTypes/Extra.hs
@@ -13,7 +13,9 @@ module GHC.BasicTypes.Extra where
 
 import BasicTypes
 import Control.DeepSeq
+import Data.Binary
 import GHC.Generics
 
 deriving instance Generic InlineSpec
 instance NFData InlineSpec
+instance Binary InlineSpec

--- a/clash-lib/src/Unbound/Generics/LocallyNameless/Extra.hs
+++ b/clash-lib/src/Unbound/Generics/LocallyNameless/Extra.hs
@@ -20,6 +20,7 @@ module Unbound.Generics.LocallyNameless.Extra where
 #if !MIN_VERSION_unbound_generics(0,2,0)
 import Control.DeepSeq
 #endif
+import Data.Binary
 import Data.Vector.Primitive
 import Data.Hashable                           (Hashable(..),hash)
 #if MIN_VERSION_unbound_generics(0,3,0)
@@ -113,3 +114,9 @@ instance Alpha Text where
 instance Subst b Text where
   subst  _ _ = id
   substs _   = id
+
+instance (Binary a, Binary b) => Binary (Bind a b)
+instance Binary a => Binary (Embed a)
+instance Binary (Name a)
+instance (Binary a, Binary b) => Binary (Rebind a b)
+instance Binary a => Binary (Rec a)


### PR DESCRIPTION
`clash-benchmark-normalization`: a criterion based benchmark of the normalization process
`clash-profile-normalization-run`: runs just the normalization process, so it's easier to profile
`clash-profile-normalization-prepare`: prepares input files for clash-profile-normalization-run