### PR TITLE
Faster capture-free substitution

### DIFF
--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -5,10 +5,8 @@
 
 import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
 import           Clash.Annotations.TopEntity
-import           Clash.Core.Name
-import           Clash.Core.Term
 import           Clash.Core.TyCon
-import           Clash.Core.Type
+import           Clash.Core.Var
 import           Clash.Driver
 import           Clash.Driver.Types
 import           Clash.GHC.Evaluator          (reduceConstant)
@@ -18,7 +16,6 @@ import           Criterion.Main
 
 import qualified Control.Concurrent.Supply    as Supply
 import           Control.DeepSeq              (NFData(rnf),rwhnf)
-import           Data.HashMap.Strict          (HashMap)
 import           Data.IntMap.Strict           (IntMap)
 import           Data.List                    (break, isPrefixOf)
 import           System.Environment           (getArgs, withArgs)
@@ -45,15 +42,15 @@ benchFile src =
   env (setupEnv src) $
     \ ~((bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity),supplyN) -> do
       bench ("normalization of " ++ src)
-            (nf (normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans
+            (nf (fst . normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans
                                  reduceConstant topEntityNames
                                  opts supplyN :: _ -> BindingMap) topEntity)
 
 setupEnv
   :: FilePath
-  -> IO ((BindingMap, HashMap TyConOccName TyCon, IntMap TyConName
-         ,[(TmName, Type, Maybe TopEntity, Maybe TmName)]
-         ,CompiledPrimMap, CustomReprs, [OccName Term], TmOccName
+  -> IO ((BindingMap, TyConMap, IntMap TyConName
+         ,[(Id, Maybe TopEntity, Maybe Id)]
+         ,CompiledPrimMap, CustomReprs, [Id], Id
          )
         ,Supply.Supply
         )

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -9,10 +9,9 @@ import Clash.Annotations.BitRepresentation.Internal (CustomReprs, buildCustomRep
 import Clash.Annotations.TopEntity
 import Clash.Backend
 import Clash.Backend.VHDL
-import Clash.Core.Name
-import Clash.Core.Term
 import Clash.Core.TyCon
 import Clash.Core.Type
+import Clash.Core.Var
 import Clash.Driver
 import Clash.Driver.Types
 import Clash.GHC.GenerateBindings
@@ -22,7 +21,6 @@ import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
 import Clash.Netlist.Types          (HWType)
 import Clash.Primitives.Types
 
-import Data.HashMap.Strict          (HashMap)
 import Data.IntMap.Strict           (IntMap)
 
 defaultTests :: [FilePath]
@@ -33,7 +31,7 @@ defaultTests =
   , "benchmark/tests/PipelinesViaFolds.hs"
   ]
 
-typeTrans :: (CustomReprs -> HashMap TyConOccName TyCon -> Bool -> Type -> Maybe (Either String HWType))
+typeTrans :: (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
 typeTrans = ghcTypeToHWType WORD_SIZE_IN_BITS True
 
 opts :: ClashOpts
@@ -45,20 +43,20 @@ backend = initBackend WORD_SIZE_IN_BITS HDLSYN
 runInputStage
   :: FilePath
   -> IO (BindingMap
-        ,HashMap TyConOccName TyCon
+        ,TyConMap
         ,IntMap TyConName
-        ,[(TmName, Type,Maybe TopEntity, Maybe TmName)]
+        ,[(Id, Maybe TopEntity, Maybe Id)]
         ,CompiledPrimMap
         ,CustomReprs
-        ,[OccName Term]
-        ,TmOccName
+        ,[Id]
+        ,Id
         )
 runInputStage src = do
   pds <- primDirs backend
   (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <- generateBindings pds ["."] (hdlKind backend) src Nothing
-  let topEntityNames = map (\(x,_,_,_) -> nameOcc x) topEntities
-      [(topEntity,_,_,_)] = topEntities
-      tm = nameOcc topEntity
+  let topEntityNames = map (\(x,_,_) -> x) topEntities
+      [(topEntity,_,_)] = topEntities
+      tm = topEntity
   topDir   <- ghcLibDir
   primMap2 <- sequence $ fmap (compilePrimitive [] topDir) primMap
   return (bindingsMap,tcm,tupTcm,topEntities, primMap2, buildCustomReprs reprs, topEntityNames,tm)

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -1,9 +1,7 @@
 import           Clash.Annotations.TopEntity
 import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
-import           Clash.Core.Name
-import           Clash.Core.Term
 import           Clash.Core.TyCon
-import           Clash.Core.Type
+import           Clash.Core.Var
 import           Clash.Driver
 import           Clash.Driver.Types
 import           Clash.GHC.Evaluator          (reduceConstant)
@@ -11,7 +9,6 @@ import           Clash.GHC.Evaluator          (reduceConstant)
 import qualified Control.Concurrent.Supply    as Supply
 import           Control.DeepSeq              (deepseq)
 import           Data.Binary                  (decode)
-import           Data.HashMap.Strict          (HashMap)
 import           Data.IntMap.Strict           (IntMap)
 import           System.Environment           (getArgs)
 import           System.FilePath              (FilePath)
@@ -37,13 +34,13 @@ benchFile src = do
   let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity) = env
       primMap' = fmap unremoveBBfunc primMap
       res :: BindingMap
-      res = normalizeEntity reprs bindingsMap primMap' tcm tupTcm typeTrans reduceConstant
+      res = fst $ normalizeEntity reprs bindingsMap primMap' tcm tupTcm typeTrans reduceConstant
                    topEntityNames opts supplyN topEntity
   res `deepseq` putStrLn ".. done\n"
 
-setupEnv :: FilePath -> IO (BindingMap,HashMap TyConOccName TyCon,IntMap TyConName
-                           ,[(TmName, Type, Maybe TopEntity, Maybe TmName)],CompiledPrimMap'
-                           ,CustomReprs,[OccName Term],TmOccName)
+setupEnv :: FilePath -> IO (BindingMap,TyConMap,IntMap TyConName
+                           ,[(Id, Maybe TopEntity, Maybe Id)],CompiledPrimMap'
+                           ,CustomReprs,[Id],Id)
 setupEnv src = do
   let bin = src ++ ".bin"
   putStrLn $ "Reading from: " ++ bin

--- a/cabal.project
+++ b/cabal.project
@@ -35,6 +35,9 @@ package clash-ghc
 package clash-testsuite
   flags: cosim
 
+package clash-lib
+  flags: debug
+
 optional-packages: singletons/th-desugar/th-desugar.cabal
                    singletons/singletons.cabal
                    clash-cosim/clash-cosim.cabal

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -112,7 +112,6 @@ library
                       mtl                       >= 2.1.1    && < 2.3,
                       text                      >= 0.11.3.1 && < 1.3,
                       transformers              >= 0.4.2    && < 0.6,
-                      unbound-generics          >= 0.1      && < 0.4,
                       unordered-containers      >= 0.2.1.0  && < 0.3,
 
                       clash-lib                 >= 0.7.1    && < 1.0,

--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -93,10 +93,10 @@ import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import           Clash.Driver.Types
-  (ClashOpts (..), ClashException (..), defClashOpts)
+  (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
-import           Clash.Util (clashLibVersion)
+import           Clash.Util (ClashException (..), clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir)
 
 -----------------------------------------------------------------------------

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -94,10 +94,10 @@ import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import           Clash.Driver.Types
-  (ClashOpts (..), ClashException (..), defClashOpts)
+  (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
-import           Clash.Util (clashLibVersion)
+import           Clash.Util (ClashException (..), clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir)
 
 -----------------------------------------------------------------------------

--- a/clash-ghc/src-bin/Clash/Main.hs
+++ b/clash-ghc/src-bin/Clash/Main.hs
@@ -93,10 +93,10 @@ import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import           Clash.Driver.Types
-  (ClashOpts (..), ClashException (..), defClashOpts)
+  (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
-import           Clash.Util (clashLibVersion)
+import           Clash.Util (ClashException (..), clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir)
 
 -----------------------------------------------------------------------------

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -5,23 +5,22 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE LambdaCase      #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE ViewPatterns    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.GHC.GenerateBindings
   (generateBindings)
 where
 
-import           Control.Lens            ((%~),(&))
+import           Control.Lens            ((%~),(&),view,_1)
 import           Control.Monad.State     (State)
 import qualified Control.Monad.State     as State
+import           Data.Coerce             (coerce)
 import           Data.Either             (lefts, rights)
-import           Data.HashMap.Strict     (HashMap)
-import qualified Data.HashMap.Strict     as HashMap
 import           Data.IntMap.Strict      (IntMap)
-import qualified Data.IntMap.Strict      as IM
-import           Unbound.Generics.LocallyNameless (bind,embed,rec,runFreshM,unembed)
+import qualified Data.IntMap.Strict      as IMS
 
 import qualified BasicTypes              as GHC
 import qualified CoreSyn                 as GHC
@@ -37,13 +36,14 @@ import           Clash.Annotations.BitRepresentation.Internal (DataRepr')
 import           Clash.Annotations.TopEntity (TopEntity)
 import           Clash.Annotations.Primitive (HDL)
 
-import           Clash.Core.Name         (Name (..), string2SystemName)
-import           Clash.Core.Term         (Term (..), TmName, TmOccName)
+import           Clash.Core.Term         (Term (..))
 import           Clash.Core.Type         (Type (..), TypeView (..), mkFunTy, splitFunForallTy, tyView)
-import           Clash.Core.TyCon        (TyCon, TyConName, TyConOccName)
+import           Clash.Core.TyCon        (TyConMap, TyConName)
 import           Clash.Core.TysPrim      (tysPrimMap)
 import           Clash.Core.Util         (mkLams, mkTyLams)
-import           Clash.Core.Var          (Var (..))
+import           Clash.Core.Var          (Var (..), Id)
+import           Clash.Core.VarEnv
+  (InScopeSet, VarEnv, extendInScopeSet, mkInScopeSet, mkVarEnv, unionVarEnv)
 import           Clash.Driver.Types      (BindingMap)
 import           Clash.GHC.GHC2Core      (GHC2CoreState, tyConMap, coreToId, coreToName, coreToTerm,
                                           makeAllTyCons, qualfiedNameString, emptyGHC2CoreState)
@@ -51,6 +51,8 @@ import           Clash.GHC.LoadModules   (loadModules)
 import           Clash.Primitives.Types  (PrimMap, ResolvedPrimMap, Primitive)
 import           Clash.Primitives.Util   (generatePrimMap)
 import           Clash.Rewrite.Util      (mkInternalVar, mkSelectorCase)
+import           Clash.Unique
+  (listToUniqMap, lookupUniqMap, mapUniqMap, unionUniqMap, uniqMapToUniqSet)
 import           Clash.Util              ((***),first)
 
 generateBindings
@@ -63,12 +65,11 @@ generateBindings
   -> String
   -> Maybe  (GHC.DynFlags)
   -> IO ( BindingMap
-        , HashMap TyConOccName TyCon
+        , TyConMap
         , IntMap TyConName
-        , [( TmName          -- topEntity bndr
-           , Type            -- type of the topEntity bndr
+        , [( Id
            , Maybe TopEntity -- (maybe) TopEntity annotation
-           , Maybe TmName    -- (maybe) associated testbench
+           , Maybe Id        -- (maybe) associated testbench
            )]
         , ResolvedPrimMap  -- The primitives found in '.' and 'primDir'
         , [DataRepr']
@@ -79,17 +80,20 @@ generateBindings primDirs importDirs hdl modName dflagsM = do
   let ((bindingsMap,clsVMap),tcMap) = State.runState (mkBindings primMap bindings clsOps unlocatable) emptyGHC2CoreState
       (tcMap',tupTcCache)           = mkTupTyCons tcMap
       tcCache                       = makeAllTyCons tcMap' fiEnvs
-      allTcCache                    = tysPrimMap `HashMap.union` tcCache
-      clsMap                        = HashMap.map (\(nm,ty,i) -> (nm,ty,GHC.noSrcSpan,GHC.Inline,mkClassSelector allTcCache ty i)) clsVMap
-      allBindings                   = bindingsMap `HashMap.union` clsMap
+      allTcCache                    = tysPrimMap `unionUniqMap` tcCache
+      inScope0 = mkInScopeSet (uniqMapToUniqSet
+                      ((mapUniqMap (coerce . view _1) bindingsMap) `unionUniqMap`
+                       (mapUniqMap (coerce . view _1) clsMap)))
+      clsMap                        = mapUniqMap (\(v,i) -> (v,GHC.noSrcSpan,GHC.Inline,mkClassSelector inScope0 allTcCache (varType v) i)) clsVMap
+      allBindings                   = bindingsMap `unionVarEnv` clsMap
       topEntities'                  =
         flip State.evalState tcMap' $ mapM (\(topEnt,annM,benchM) -> do
           topEnt' <- coreToName GHC.varName GHC.varUnique qualfiedNameString topEnt
-          benchM' <- traverse (coreToName GHC.varName GHC.varUnique qualfiedNameString) benchM
+          benchM' <- traverse coreToId benchM
           return (topEnt',annM,benchM')) topEntities
-      topEntities''                 = map (\(topEnt,annM,benchM) -> case HashMap.lookup (nameOcc topEnt) allBindings of
-                                              Just (_,ty,_,_,_) -> (topEnt,ty,annM,benchM)
-                                              Nothing       -> error "This shouldn't happen"
+      topEntities''                 = map (\(topEnt,annM,benchM) -> case lookupUniqMap topEnt allBindings of
+                                              Just (v,_,_,_) -> (v,annM,benchM)
+                                              Nothing        -> error "This shouldn't happen"
                                           ) topEntities'
 
   return (allBindings, allTcCache, tupTcCache, topEntities'', primMap, reprs)
@@ -104,7 +108,7 @@ mkBindings
   -- Unlocatable Expressions
   -> State GHC2CoreState
            ( BindingMap
-           , HashMap TmOccName (TmName,Type,Int)
+           , VarEnv (Id,Int)
            )
 mkBindings primMap bindings clsOps unlocatable = do
   bindingsList <- mapM (\case
@@ -113,7 +117,7 @@ mkBindings primMap bindings clsOps unlocatable = do
                                 inl = GHC.inlinePragmaSpec . GHC.inlinePragInfo $ GHC.idInfo v
                             tm <- coreToTerm primMap unlocatable sp e
                             v' <- coreToId v
-                            return [(nameOcc (varName v'), (varName v',unembed (varType v'), sp, inl, tm))]
+                            return [(v', (v', sp, inl, tm))]
                           GHC.Rec bs -> do
                             tms <- mapM (\(v,e) -> do
                                           let sp = GHC.getSrcSpan v
@@ -122,47 +126,46 @@ mkBindings primMap bindings clsOps unlocatable = do
                                           return (v',sp,tm)
                                         ) bs
                             case tms of
-                              [(v,sp,tm)] -> return [(nameOcc (varName v), (varName v,unembed (varType v), sp, GHC.NoInline, tm))]
-                              _ ->
-                                return $ map (\(v,sp,e) -> (nameOcc (varName v),(varName v,unembed (varType v),sp,GHC.NoInline
-                                                  ,Letrec (bind (rec (map (\(x,_,y) -> (x,embed y)) tms)) e)))) tms
+                              [(v,sp,tm)] -> return [(v, (v, sp, GHC.NoInline, tm))]
+                              _ -> return $ map (\(v,sp,e) -> (v,(v,sp,GHC.NoInline, Letrec (map (\(x,_,y) -> (x,y)) tms) e))) tms
                        ) bindings
   clsOpList    <- mapM (\(v,i) -> do
                           v' <- coreToId v
-                          let ty = unembed $ varType v'
-                          return (nameOcc (varName v'), (varName v',ty,i))
+                          return (v', (v',i))
                        ) clsOps
 
-  return (HashMap.fromList (concat bindingsList), HashMap.fromList clsOpList)
+  return (mkVarEnv (concat bindingsList), mkVarEnv clsOpList)
 
 mkClassSelector
-  :: HashMap TyConOccName TyCon
+  :: InScopeSet
+  -> TyConMap
   -> Type
   -> Int
   -> Term
-mkClassSelector tcm ty sel = newExpr
+mkClassSelector inScope0 tcm ty sel = newExpr
   where
     ((tvs,dictTy:_),_) = first (lefts *** rights)
                        $ first (span (\l -> case l of Left _ -> True
                                                       _      -> False))
                        $ splitFunForallTy ty
     newExpr = case tyView dictTy of
-      (TyConApp _ _) -> runFreshM $ flip State.evalStateT (0 :: Int) $ do
-                          (dcId,dcVar) <- mkInternalVar (string2SystemName "dict") dictTy
-                          selE         <- mkSelectorCase "mkClassSelector" tcm dcVar 1 sel
+      (TyConApp _ _) -> flip State.evalState (0 :: Int) $ do
+                          dcId <- mkInternalVar inScope0 "dict" dictTy
+                          let inScope1 = extendInScopeSet inScope0 dcId
+                          selE <- mkSelectorCase "mkClassSelector" inScope1 tcm (Var dcId) 1 sel
                           return (mkTyLams (mkLams selE [dcId]) tvs)
-      (FunTy arg res) -> runFreshM $ flip State.evalStateT (0 :: Int) $ do
-                           (dcId,dcVar) <- mkInternalVar (string2SystemName "dict") (mkFunTy arg res)
-                           return (mkTyLams (mkLams dcVar [dcId]) tvs)
-      (OtherType oTy) -> runFreshM $ flip State.evalStateT (0 :: Int) $ do
-                           (dcId,dcVar) <- mkInternalVar (string2SystemName "dict") oTy
-                           return (mkTyLams (mkLams dcVar [dcId]) tvs)
+      (FunTy arg res) -> flip State.evalState (0 :: Int) $ do
+                           dcId <- mkInternalVar inScope0 "dict" (mkFunTy arg res)
+                           return (mkTyLams (mkLams (Var dcId) [dcId]) tvs)
+      (OtherType oTy) -> flip State.evalState (0 :: Int) $ do
+                           dcId <- mkInternalVar inScope0 "dict" oTy
+                           return (mkTyLams (mkLams (Var dcId) [dcId]) tvs)
 
 mkTupTyCons :: GHC2CoreState -> (GHC2CoreState,IntMap TyConName)
 mkTupTyCons tcMap = (tcMap'',tupTcCache)
   where
     tupTyCons        = map (GHC.tupleTyCon GHC.Boxed) [2..62]
     (tcNames,tcMap') = State.runState (mapM (\tc -> coreToName GHC.tyConName GHC.tyConUnique qualfiedNameString tc) tupTyCons) tcMap
-    tupTcCache       = IM.fromList (zip [2..62] tcNames)
-    tupHM            = HashMap.fromList (zip (map nameOcc tcNames) tupTyCons)
-    tcMap''          = tcMap' & tyConMap %~ (`HashMap.union` tupHM)
+    tupTcCache       = IMS.fromList (zip [2..62] tcNames)
+    tupHM            = listToUniqMap (zip tcNames tupTyCons)
+    tcMap''          = tcMap' & tyConMap %~ (`unionUniqMap` tupHM)

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -35,6 +35,7 @@ import           Data.Generics.Uniplate.DataOnly (transform)
 import           Data.List                       (foldl', lookup, nub)
 import           Data.Maybe                      (catMaybes, fromMaybe,
                                                   listToMaybe, mapMaybe)
+import qualified Data.Text                       as Text
 import           Data.Word                       (Word8)
 import           System.Exit                     (ExitCode (..))
 import           System.IO                       (hGetLine)
@@ -406,11 +407,11 @@ findTestBenchAnnotations bndrs = do
         "TestBench named: " ++ show tb ++ " not found"
     findTB _ = Panic.pgmError "Unexpected Synthesize"
 
-    eqNm thNm bndr = show thNm == qualNm
+    eqNm thNm bndr = Text.pack (show thNm) == qualNm
       where
         bndrNm  = Var.varName bndr
-        qualNm  = maybe occName (\modName -> modName ++ ('.':occName)) (modNameM bndrNm)
-        occName = OccName.occNameString (Name.nameOccName bndrNm)
+        qualNm  = maybe occName (\modName -> modName `Text.append` ('.' `Text.cons` occName)) (modNameM bndrNm)
+        occName = Text.pack (OccName.occNameString (Name.nameOccName bndrNm))
 
 findPrimitiveAnnotations
   :: GHC.GhcMonad m

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -57,6 +57,7 @@ Build-type:           Simple
 Extra-source-files:
   README.md,
   CHANGELOG.md
+  src/ClashDebug.h
 
 Data-files:
   prims/common/*.json,
@@ -70,6 +71,12 @@ Cabal-version:        >=1.10
 source-repository head
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
+
+flag debug
+   description:
+     Build a debug compiler
+   default: False
+   manual: True
 
 Library
   HS-Source-Dirs:     src
@@ -130,7 +137,6 @@ Library
                       trifecta                >= 1.7.1.1  && < 2.0,
                       vector                  >= 0.11     && < 1.0,
                       vector-binary-instances >= 0.2.3.5  && < 0.3,
-                      unbound-generics        >= 0.1      && < 0.4,
                       unordered-containers    >= 0.2.3.3  && < 0.3
 
   Exposed-modules:    Clash.Annotations.BitRepresentation.ClashLib
@@ -153,6 +159,7 @@ Library
                       Clash.Core.TysPrim
                       Clash.Core.Util
                       Clash.Core.Var
+                      Clash.Core.VarEnv
 
                       Clash.Driver
                       Clash.Driver.Types
@@ -183,6 +190,7 @@ Library
                       Clash.Rewrite.Types
                       Clash.Rewrite.Util
 
+                      Clash.Unique
                       Clash.Util
 
                       Data.Text.Prettyprint.Doc.Extra
@@ -194,4 +202,6 @@ Library
                       GHC.BasicTypes.Extra
                       GHC.SrcLoc.Extra
                       Paths_clash_lib
-                      Unbound.Generics.LocallyNameless.Extra
+
+  if flag(debug)
+    cpp-options:      -DDEBUG

--- a/clash-lib/src/Clash/Annotations/BitRepresentation/ClashLib.hs
+++ b/clash-lib/src/Clash/Annotations/BitRepresentation/ClashLib.hs
@@ -18,11 +18,9 @@ import           Clash.Annotations.BitRepresentation.Internal
   (Type'(AppTy',ConstTy',LitTy'))
 import qualified Clash.Annotations.BitRepresentation.Util as BitRepresentation
 import qualified Clash.Core.Type                          as C
-import           Clash.Core.Name                          (name2String)
+import           Clash.Core.Name                          (nameOcc)
 import qualified Clash.Netlist.Types                      as Netlist
 import           Clash.Util                               (curLoc)
-import qualified Data.Text.Lazy                           as Text
-
 
 -- Convert Core type to BitRepresentation type
 coreToType'
@@ -36,7 +34,7 @@ coreToType'
 coreToType' (C.AppTy t1 t2) =
   AppTy' <$> coreToType' t1 <*> coreToType' t2
 coreToType' (C.ConstTy (C.TyCon name)) =
-   return $ ConstTy' (Text.pack $ name2String name)
+   return $ ConstTy' (nameOcc name)
 coreToType' (C.LitTy (C.NumTy n)) =
    return $ LitTy' n
 coreToType' e =

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -14,8 +14,9 @@ import qualified  Control.Lens              as Lens
 import Data.HashSet                         (HashSet)
 import Data.Maybe                           (fromMaybe)
 import Data.Semigroup.Monad                 (Mon (..))
-import qualified Data.Text.Lazy             as T
-import Data.Text.Lazy                       (Text)
+import qualified Data.Text                  as T
+import Data.Text                            (Text)
+import qualified Data.Text.Lazy             as LT
 import Control.Monad.State                  (State)
 import Data.Text.Prettyprint.Doc.Extra      (Doc)
 
@@ -27,7 +28,7 @@ import Clash.Netlist.BlackBox.Types
 
 import Clash.Annotations.Primitive          (HDL)
 
-type ModName = String
+type ModName = Identifier
 
 -- | Is a type used for internal or external use
 data Usage
@@ -57,9 +58,9 @@ class Backend state where
   extractTypes     :: state -> HashSet HWType
 
   -- | Generate HDL for a Netlist component
-  genHDL           :: String -> SrcSpan -> [Identifier] -> Component -> Mon (State state) ((String, Doc),[(String,Doc)])
+  genHDL           :: Identifier -> SrcSpan -> [Identifier] -> Component -> Mon (State state) ((String, Doc),[(String,Doc)])
   -- | Generate a HDL package containing type definitions for the given HWTypes
-  mkTyPackage      :: String -> [HWType] -> Mon (State state) [(String, Doc)]
+  mkTyPackage      :: Identifier -> [HWType] -> Mon (State state) [(String, Doc)]
   -- | Convert a Netlist HWType to a target HDL type
   hdlType          :: Usage -> HWType -> Mon (State state) Doc
   -- | Convert a Netlist HWType to an HDL error value for that type
@@ -69,7 +70,7 @@ class Backend state where
   -- | Create a record selector
   hdlRecSel        :: HWType -> Int -> Mon (State state) Doc
   -- | Create a signal declaration from an identifier (Text) and Netlist HWType
-  hdlSig           :: Text -> HWType -> Mon (State state) Doc
+  hdlSig           :: LT.Text -> HWType -> Mon (State state) Doc
   -- | Create a generative block statement marker
   genStmt          :: Bool -> State state Doc
   -- | Turn a Netlist Declaration to a HDL concurrent block
@@ -79,9 +80,9 @@ class Backend state where
   -- | Bit-width of Int/Word/Integer
   iwWidth          :: State state Int
   -- | Convert to a bit-vector
-  toBV             :: HWType -> Text -> Mon (State state) Doc
+  toBV             :: HWType -> LT.Text -> Mon (State state) Doc
   -- | Convert from a bit-vector
-  fromBV           :: HWType -> Text -> Mon (State state) Doc
+  fromBV           :: HWType -> LT.Text -> Mon (State state) Doc
   -- | Synthesis tool we're generating HDL for
   hdlSyn           :: State state HdlSyn
   -- | mkIdentifier
@@ -99,8 +100,8 @@ class Backend state where
   -- | unextend/unescape identifier
   unextend         :: State state (Identifier -> Identifier)
   addIncludes      :: [(String, Doc)] -> State state ()
-  addLibraries     :: [Text] -> State state ()
-  addImports       :: [Text] -> State state ()
+  addLibraries     :: [LT.Text] -> State state ()
+  addImports       :: [LT.Text] -> State state ()
   addAndSetData    :: FilePath -> State state String
   getDataFiles     :: State state [(String,FilePath)]
   addMemoryDataFile  :: (String,String) -> State state ()

--- a/clash-lib/src/Clash/Core/FreeVars.hs
+++ b/clash-lib/src/Clash/Core/FreeVars.hs
@@ -6,22 +6,223 @@
   Free variable calculations
 -}
 
-module Clash.Core.FreeVars where
+{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE RankNTypes   #-}
+{-# LANGUAGE ViewPatterns #-}
 
+module Clash.Core.FreeVars
+  (-- * Free variable calculation
+    typeFreeVars
+  , termFreeVars
+  , termFreeIds
+  , termFreeTyVars
+  , tyFVsOfTypes
+  , fVsOfTerms
+  -- * Fast
+  , noFreeVarsOfType
+  -- * occurrence check
+  , idOccursIn
+  , idDoesNotOccurIn
+  , idsDoNotOccurIn
+  , varsDoNotOccurIn
+  -- * Internal
+  , typeFreeVars'
+  , termFreeVars'
+  )
+where
+
+import qualified Control.Lens           as Lens
 import Control.Lens.Fold                (Fold)
-import Unbound.Generics.LocallyNameless (fv)
+import Control.Lens.Getter              (Contravariant)
+import Data.Coerce
+import qualified Data.IntSet            as IntSet
+import Data.Monoid                      (All (..), Any (..))
 
-import Clash.Core.Term                  (Term, TmOccName)
-import Clash.Core.Type                  (TyOccName, Type)
+import Clash.Core.Term                  (Pat (..), Term (..))
+import Clash.Core.Type                  (Type (..))
+import Clash.Core.Var                   (Id,TyVar,Var (..))
+import Clash.Core.VarEnv                (VarSet, unitVarSet)
 
--- | Gives the free type-variables in a Type
-typeFreeVars :: Fold Type TyOccName
-typeFreeVars = fv
+-- | Gives the free type-variables in a Type, implemented as a 'Fold'
+--
+-- The 'Fold' is closed over the types of its variables, so:
+--
+-- @
+-- foldMapOf typeFreeVars unitVarSet ((a:* -> k) Int) = {a, k}
+-- @
+typeFreeVars :: Fold Type TyVar
+typeFreeVars = typeFreeVars' (const True) IntSet.empty
 
--- | Gives the free term-variables of a Term
-termFreeIds :: Fold Term TmOccName
-termFreeIds = fv
+-- | Gives the "interesting" free variables in a Type, implemented as a 'Fold'
+--
+-- The 'Fold' is closed over the types of variables, so:
+--
+-- @
+-- foldMapOf (typeFreeVars' (const True) IntSet.empty) unitVarSet ((a:* -> k) Int) = {a, k}
+-- @
+typeFreeVars'
+  :: (Contravariant f, Applicative f)
+  => (forall b . Var b -> Bool)
+  -- ^ Predicate telling whether a variable is interesting
+  -> IntSet.IntSet
+  -- ^ Uniques of the variables in scope, used by 'termFreeVars''
+  -> (Var a -> f (Var a))
+  -> Type
+  -> f Type
+typeFreeVars' interesting is f = go is where
+  go inScope = \case
+    VarTy tv
+      | interesting tv
+      , varUniq tv `IntSet.notMember` inScope
+      -> VarTy . coerce <$> f (coerce tv) <*
+         go inScope (varType tv)
+      | otherwise
+      -> pure (VarTy tv)
+    ForAllTy tv ty -> ForAllTy <$> goBndr inScope tv
+                               <*> go (IntSet.insert (varUniq tv) inScope) ty
+    AppTy l r -> AppTy <$> go inScope l <*> go inScope r
+    ty -> pure ty
 
--- | Gives the free type-variables of a Term
-termFreeTyVars :: Fold Term TyOccName
-termFreeTyVars = fv
+  goBndr inScope tv = (\t -> tv {varType = t}) <$> go inScope (varType tv)
+
+-- | Check whether an identifier does not occur free in a term
+idDoesNotOccurIn
+  :: Id
+  -> Term
+  -> Bool
+idDoesNotOccurIn v e = getAll (Lens.foldMapOf termFreeIds (All . (/= v)) e)
+
+-- | Check whether a set of identifiers does not occur free in a term
+idsDoNotOccurIn
+  :: [Id]
+  -> Term
+  -> Bool
+idsDoNotOccurIn vs e =
+  getAll (Lens.foldMapOf termFreeIds (All . (`notElem` vs)) e)
+
+-- | Check whether a set of variables does not occur free in a term
+varsDoNotOccurIn
+  :: [Var a]
+  -> Term
+  -> Bool
+varsDoNotOccurIn vs e =
+  getAll (Lens.foldMapOf termFreeVars (All . (`notElem` vs)) e)
+
+-- | Check whether an identifier occurs free in a term
+idOccursIn
+  :: Id
+  -> Term
+  -> Bool
+idOccursIn v e = getAny (Lens.foldMapOf termFreeIds (Any . (== v)) e)
+
+-- | Gives the free identifiers of a Term, implemented as a 'Fold'
+termFreeIds :: Fold Term Id
+termFreeIds = termFreeVars' isId where
+  isId (Id {}) = True
+  isId _       = False
+
+-- | Gives the free type-variables of a Term, implemented as a 'Fold'
+--
+-- The 'Fold' is closed over the types of variables, so:
+--
+-- @
+-- foldMapOf termFreeTyVars unitVarSet (case (x : (a:* -> k) Int)) of {}) = {a, k}
+-- @
+termFreeTyVars :: Fold Term TyVar
+termFreeTyVars = termFreeVars' isTV where
+  isTV (TyVar {}) = True
+  isTV _          = False
+
+-- | Gives the free variables of a Term, implemented as a 'Fold'
+--
+-- The 'Fold' is closed over the types of variables, so:
+--
+-- @
+-- foldMapOf termFreeVars unitVarSet (case (x : (a:* -> k) Int)) of {}) = {x, a, k}
+-- @
+termFreeVars :: Fold Term (Var a)
+termFreeVars = termFreeVars' (const True)
+
+-- | Gives the "interesting" free variables in a Term, implemented as a 'Fold'
+--
+-- The 'Fold' is closed over the types of variables, so:
+--
+-- @
+-- foldMapOf (termFreeVars' (const True)) unitVarSet (case (x : (a:* -> k) Int)) of {}) = {x, a, k}
+-- @
+termFreeVars'
+  :: (Contravariant f, Applicative f)
+  => (forall b . Var b -> Bool)
+  -- ^ Predicate telling whether a variable is interesting
+  -> (Var a -> f (Var a))
+  -> Term
+  -> f Term
+termFreeVars' interesting f = go IntSet.empty where
+  go inScope = \case
+    Var v
+      | interesting v
+      , varUniq v `IntSet.notMember` inScope
+      -> Var . coerce <$> (f (coerce v)) <*
+         typeFreeVars' interesting inScope f (varType v)
+      | otherwise
+      -> pure (Var v)
+    Lam id_ tm -> Lam <$> goBndr inScope id_
+                      <*> go (IntSet.insert (varUniq id_) inScope) tm
+    TyLam tv tm -> TyLam <$> goBndr inScope tv
+                         <*> go (IntSet.insert (varUniq tv) inScope) tm
+    App l r -> App <$> go inScope l <*> go inScope r
+    TyApp l r -> TyApp <$> go inScope l
+                       <*> typeFreeVars' interesting inScope f r
+    Letrec bs e -> Letrec <$> traverse (goBind inScope') bs <*> go inScope' e
+      where inScope' = foldr IntSet.insert inScope (map (varUniq.fst) bs)
+    Case subj ty alts -> Case <$> go inScope subj
+                              <*> typeFreeVars' interesting inScope f ty
+                              <*> traverse (goAlt inScope) alts
+    Cast tm t1 t2 -> Cast <$> go inScope tm
+                          <*> typeFreeVars' interesting inScope f t1
+                          <*> typeFreeVars' interesting inScope f t2
+    tm -> pure tm
+
+  goBndr inScope v =
+    (\t -> v  {varType = t}) <$> typeFreeVars' interesting inScope f (varType v)
+
+  goBind inScope (l,r) = (,) <$> goBndr inScope l <*> go inScope r
+
+  goAlt inScope (pat,alt) = case pat of
+    DataPat dc tvs ids -> (,) <$> (DataPat <$> pure dc
+                                           <*> traverse (goBndr inScope') tvs
+                                           <*> traverse (goBndr inScope') ids)
+                              <*> go inScope' alt
+      where
+        inScope' = foldr IntSet.insert
+                         (foldr IntSet.insert inScope (map varUniq tvs))
+                         (map varUniq ids)
+    _ -> (,) <$> pure pat <*> go inScope alt
+
+-- | Determine whether a type has no free type variables.
+noFreeVarsOfType
+  :: Type
+  -> Bool
+noFreeVarsOfType ty = case ty of
+  VarTy {}    -> False
+  ForAllTy {} -> getAll (Lens.foldMapOf typeFreeVars (const (All False)) ty)
+  AppTy l r   -> noFreeVarsOfType l && noFreeVarsOfType r
+  _           -> True
+
+-- | Collect the free variables of a collection of type into a set
+tyFVsOfTypes
+  :: Foldable f
+  => f Type
+  -> VarSet
+tyFVsOfTypes = foldMap go
+ where
+  go = Lens.foldMapOf typeFreeVars unitVarSet
+
+-- | Collect the free variables of a collection of terms into a set
+fVsOfTerms
+  :: Foldable f
+  => f Term
+  -> VarSet
+fVsOfTerms = foldMap go
+ where
+  go = Lens.foldMapOf termFreeVars unitVarSet

--- a/clash-lib/src/Clash/Core/Literal.hs
+++ b/clash-lib/src/Clash/Core/Literal.hs
@@ -26,8 +26,6 @@ import Data.Hashable                          (Hashable)
 import Data.Vector.Primitive.Extra            (Vector)
 import Data.Word                              (Word8)
 import GHC.Generics                           (Generic)
-import Unbound.Generics.LocallyNameless.Extra ()
-import Unbound.Generics.LocallyNameless       (Alpha (..), Subst (..))
 
 import {-# SOURCE #-} Clash.Core.Type         (Type)
 import Clash.Core.TysPrim                     (intPrimTy, integerPrimTy,
@@ -51,13 +49,6 @@ data Literal
   | NaturalLiteral  !Integer
   | ByteArrayLiteral !(Vector Word8)
   deriving (Eq,Ord,Show,Generic,NFData,Hashable,Binary)
-
-instance Alpha Literal where
-  fvAny' _ _ l = pure l
-
-instance Subst a Literal where
-  subst _ _ l = l
-  substs _ l  = l
 
 -- | Determines the Type of a Literal
 literalType :: Literal

--- a/clash-lib/src/Clash/Core/Name.hs
+++ b/clash-lib/src/Clash/Core/Name.hs
@@ -21,34 +21,38 @@ where
 import           Control.DeepSeq                        (NFData)
 import           Data.Binary                            (Binary)
 import           Data.Function                          (on)
-import           Data.Hashable                          (Hashable)
-import           Data.Typeable                          (Typeable)
+import           Data.Hashable                          (Hashable (..))
+import           Data.Text                              (Text, append, cons)
 import           GHC.BasicTypes.Extra                   ()
 import           GHC.Generics                           (Generic)
 import           GHC.SrcLoc.Extra                       ()
-import           Unbound.Generics.LocallyNameless       hiding
-  (Name, name2String, string2Name)
-import qualified Unbound.Generics.LocallyNameless       as Unbound
-import qualified Unbound.Generics.LocallyNameless.Name  as Unbound
-import           Unbound.Generics.LocallyNameless.TH
-import           Unbound.Generics.LocallyNameless.Extra ()
 import           SrcLoc                                 (SrcSpan, noSrcSpan)
+
+import           Clash.Unique
 
 data Name a
   = Name
   { nameSort :: NameSort
-  , nameOcc  :: OccName a
+  , nameOcc  :: !OccName
+  , nameUniq :: {-# UNPACK #-} !Unique
   , nameLoc  :: !SrcSpan
   }
-  deriving (Show,Generic,NFData,Hashable,Binary)
+  deriving (Show,Generic,NFData,Binary)
 
 instance Eq (Name a) where
-  (==) = (==) `on` nameOcc
+  (==) = (==) `on` nameUniq
+  (/=) = (/=) `on` nameUniq
 
 instance Ord (Name a) where
-  compare = compare `on` nameOcc
+  compare = compare `on` nameUniq
 
-type OccName a = Unbound.Name a
+instance Hashable (Name a) where
+  hashWithSalt salt nm = hashWithSalt salt (nameUniq nm)
+
+instance Uniquable (Name a) where
+  getUnique = nameUniq
+
+type OccName = Text
 
 data NameSort
   = User
@@ -56,46 +60,20 @@ data NameSort
   | Internal
   deriving (Eq,Ord,Show,Generic,NFData,Hashable,Binary)
 
-instance Typeable a => Alpha (Name a) where
-  aeq'      ctx (Name _ nm1 _) (Name _ nm2 _) = aeq'      ctx nm1 nm2
-  acompare' ctx (Name _ nm1 _) (Name _ nm2 _) = acompare' ctx nm1 nm2
+mkUnsafeSystemName
+  :: Text
+  -> Unique
+  -> Name a
+mkUnsafeSystemName s i = Name System s i noSrcSpan
 
-makeClosedAlpha ''NameSort
+mkUnsafeInternalName
+  :: Text
+  -> Unique
+  -> Name a
+mkUnsafeInternalName s i = Name Internal ('#' `cons` s) i noSrcSpan
 
-instance Subst b (Name a) where subst _ _ = id; substs _ = id
-
-name2String :: Name a -> String
-name2String = Unbound.name2String . nameOcc
-{-# INLINE name2String #-}
-
-name2Integer :: Name a -> Integer
-name2Integer = Unbound.name2Integer . nameOcc
-
-string2OccName :: String -> OccName a
-string2OccName = Unbound.string2Name
-{-# INLINE string2OccName #-}
-
-string2SystemName :: String -> Name a
-string2SystemName nm = Name System (string2OccName nm) noSrcSpan
-
-string2InternalName :: String -> Name a
-string2InternalName nm = Name Internal (string2OccName ('#':nm)) noSrcSpan
-
-makeOccName :: String -> Integer -> OccName a
-makeOccName = Unbound.makeName
-
-makeSystemName :: String -> Integer -> Name a
-makeSystemName s i = Name System (makeOccName s i) noSrcSpan
-
-coerceName :: Name a -> Name b
-coerceName nm = nm {nameOcc = go (nameOcc nm)}
+appendToName :: Name a -> Text -> Name a
+appendToName (Name sort nm uniq loc) s = Name Internal nm2 uniq loc
   where
-    go (Unbound.Fn s i) = Unbound.Fn s i
-    go _                = error "Trying to coerce bound name"
-
-appendToName :: Name a -> String -> Name a
-appendToName (Name sort nm loc) s = Name Internal nm' loc
-  where
-    n   = Unbound.name2String nm
-    n'  = case sort of {Internal -> n; _ -> '#':n}
-    nm' = Unbound.makeName (n' ++ s) (Unbound.name2Integer nm)
+    nm1 = case sort of {Internal -> nm; _ -> '#' `cons` nm}
+    nm2 = nm1 `append` s

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -7,60 +7,739 @@
   Capture-free substitution function for CoreHW
 -}
 
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns      #-}
 
-module Clash.Core.Subst where
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
-import Unbound.Generics.LocallyNameless (embed, subst, substs, unembed)
+#include "../../ClashDebug.h"
 
-import Clash.Core.Term                  (LetBinding, Term, TmOccName)
-import {-# SOURCE #-} Clash.Core.Type   (KiOccName, Kind, TyOccName, Type)
+module Clash.Core.Subst
+  ( -- * Substitution into types
+    -- ** Substitution environments
+    TvSubst (..)
+  , TvSubstEnv
+  -- , mkTvSubst
+  , extendTvSubst
+  , extendTvSubstList
+    -- ** Applying substitutions
+  , substTy
+  , substTyWith
+    -- * Substitution into terms
+    -- ** Substitution environments
+  , Subst (..)
+  , mkSubst
+  , mkTvSubst
+  , extendInScopeId
+  , extendInScopeIdList
+  , extendIdSubst
+  , extendIdSubstList
+    -- ** Applying substitutions
+  , substTm
+    -- * Variable renaming
+  , deShadowTerm
+  , freshenTm
+    -- * Alpha equivalence
+  , aeqType
+  , aeqTerm
+  )
+where
 
--- | Substitutes types in a type
-substTys :: [(TyOccName,Type)]
-         -> Type
-         -> Type
-substTys = substs
+import           Data.Coerce               (coerce)
+import           Data.Text.Prettyprint.Doc
+import qualified Data.List                 as List
 
--- | Substitutes a type in a type
-substTy :: TyOccName
-        -> Type
-        -> Type
-        -> Type
-substTy = subst
+import           Clash.Core.FreeVars
+  (noFreeVarsOfType, fVsOfTerms, tyFVsOfTypes)
+import           Clash.Core.Pretty         (ppr)
+import           Clash.Core.Term           (LetBinding, Pat (..), Term (..))
+import           Clash.Core.Type           (Type (..))
+import           Clash.Core.VarEnv
+import           Clash.Core.Var            (Id, Var (..), TyVar)
+import           Clash.Unique
+import           Clash.Util
 
--- | Substitutes kinds in a kind
-substKindWith :: [(KiOccName,Kind)]
-              -> Kind
-              -> Kind
-substKindWith = substs
+-- * Subst
 
--- | Substitutes a type in a term
-substTyInTm :: TyOccName
-            -> Type
-            -> Term
-            -> Term
-substTyInTm = subst
+-- | A substitution of 'Type's for 'TyVar's
+--
+-- Note [Extending the TvSubstEnv]
+-- See 'TvSubst' for the invariants that must hold
+--
+-- This invariant allows a short-cut when the subst env is empty: if the
+-- TvSubstEnv is empty, i.e. @nullVarEnv TvSubstEnv@ holds, then
+-- (substTy subst ty) does nothing.
+--
+-- For example, consider:
+--
+--    (/\a -> /\b(a ~ Int) -> ... b ...) Int
+--
+-- We substitute Int for 'a'. The Unique of 'b' does not change, but
+-- nevertheless we add 'b' to the 'TvSubstEnv' because b's kind does change
+--
+-- This invariant has several consequences:
+--
+--   * In 'substTyVarBndr', we extend TvSubstEnv if the unique has changed, or
+--     if the kind has changed
+--
+--   * In 'substTyVar', we do not need to consult the 'InScopeSet'; the
+--     TvSubstEnv is enough
+--
+--   * In 'substTy', we can short-circuit when TvSubstEnv is empty
+type TvSubstEnv = VarEnv Type
 
--- | Substitutes types in a term
-substTysinTm :: [(TyOccName,Type)]
-             -> Term
-             -> Term
-substTysinTm = substs
+-- | Type substitution
+--
+-- The following invariants must hold:
+--
+--   1. The 'InScopeSet' is needed only to guide the generation of fresh uniques
+--
+--   2. In particular, the kind of the type variables in the 'InScopeSet' is not
+--      relevant.
+--
+--   3. The substitution is only applied once
+--
+-- Note [Apply Once]
+--
+-- We might instantiate @forall a b. ty@ with the types @[a, b]@ or @[b, a]@.
+-- So the substitution might go like @[a -> b, b -> a]@. A similar situation
+-- arises in terms when we find a redex like @(/\a -> /\b -> e) b a@. Then we
+-- also end up with a substitution that permutes variables. Other variations
+-- happen to; for example @[a -> (a,b)]@.
+--
+-- SO A TvSubst MUST BE APPLIED PRECISELY ONCE, OR THINGS MIGHT LOOP
+--
+-- Note [The substitution invariant]
+--
+-- When calling (substTy subst ty) it should be the case that the 'InScopeSet'
+-- is a superset of both:
+--
+--   * The free variables of the range of the substitution
+--
+--   * The free variables of /ty/ minus the domain of the substitution
+data TvSubst
+  = TvSubst InScopeSet -- Variable in scope /after/ substitution
+            TvSubstEnv -- Substitution for types
 
--- | Substitutes a term in a term
-substTm :: TmOccName
-        -> Term
-        -> Term
-        -> Term
-substTm = subst
+instance Pretty TvSubst where
+  pretty (TvSubst ins tenv) =
+    brackets $ sep [ "TvSubst"
+                   , nest 2 ("In scope:" <+> pretty ins)
+                   , nest 2 ("Type env:" <+> pretty tenv)]
 
--- | Substitutes terms in a term
-substTms :: [(TmOccName,Term)]
-         -> Term
-         -> Term
-substTms = substs
+-- | A substitution  of 'Term's for 'Id's
+--
+-- Note [Extending the Subst]
+--
+-- For a term 'Subst', which binds 'Id's as well, we make a different choice for
+-- Ids than we do for TyVars.
+--
+-- For TyVars see 'TvSubstEnv's Note [Extending the TvSubstEnv]
+--
+-- For Ids, we have a different invariant:
+--
+--   The IdSubstEnv is extended only when the Unique on an Id changes.
+--   Otherwise, we just extend the InScopeSet
+--
+-- In consequence:
+--
+--   * If all subst envs are empty, substsTm would be a no-op
+--
+--     However, substTm still goes ahead and substitutes. Reason: we may want
+--     to replace existing Ids with new ones from the in-scope set, to avoid
+--     space leaks.
+--
+--   * In substIdBndr, we extend the 'IdSubstEnv' only when the unique changes
+--
+--   * If TvSubstEnv and IdSubstEnv are all empty, substExpr does nothing
+--     (Note that the above rule for 'substIdBndr' maintains this property.)
+--
+--   * In 'lookupIdSubst', we must look up the Id in the in-scope set, because
+--     it may contain non-trivial changes. Exmaple:
+--
+--     (/\a -> \x:a. ... x ...) Int
+--
+--     We extend the 'TvSubstEnv' with a @[a |-> Int]@; but x's unique does not
+--     change so we only extend the in-scope set. Then we must look up in the
+--     in-scope set when we find the occurrence of x.
+--
+--   * The requirement to look  up the Id in the in-scope set means that we
+--     must not take no-op short cut when the 'IdSubstEnv' is empty. We must
+--     still look up ever Id in the in-scope set.
+--
+--   * (However, we don't need to do so for the expression found in the
+--     IdSubstEnv, whose range is assumed to be correct wrt the in-scope set)
+type IdSubstEnv = VarEnv Term
 
--- | Substitutes a term in a let-binding
-substBndr :: TmOccName -> Term -> LetBinding -> LetBinding
-substBndr nm tm (id_,unembed -> tm') = (id_,embed (substTm nm tm tm'))
+-- | A substitution environment containing containing both 'Id' and 'TyVar'
+-- substitutions.
+--
+-- Some invariants apply to how you use the substitution:
+--
+--   1. The 'InScopeSet' contains at least those 'Id's and 'TyVar's that will
+--      be in scope /after/ applying the substitution  to a term. Precisely,
+--      the in-scope set must be a superset of the free variables of the
+--      substitution range that might possibly clash with locally-bound
+--      variables in the thing being substituted in.
+--
+--   2. You may only apply the substitution once. See 'TvSubst'
+--
+-- There are various ways of setting up the in-scope set such that the first of
+-- of these invariants holds:
+--
+--   * Arrange that the in-scope set really is all the things in scope
+--
+--   * Arrange that it's the  free vars of the range of the substitution
+--
+--   * Make it empty, if you know that all the free variables of the
+--     substitution are fresh, and hence can´t possibly clash
+data Subst
+  = Subst
+  { substInScope :: InScopeSet -- Variables in scope /after/ substitution
+  , substTmEnv   :: IdSubstEnv -- Substitution for terms
+  , substTyEnv   :: TvSubstEnv -- Substitution for types
+  }
+
+emptySubst
+  :: Subst
+emptySubst = Subst emptyInScopeSet emptyVarEnv emptyVarEnv
+
+-- | An empty substitution, starting the variables currently in scope
+mkSubst
+  :: InScopeSet
+  -> Subst
+mkSubst is = Subst is emptyVarEnv emptyVarEnv
+
+-- | Create a type substitution
+mkTvSubst
+  :: InScopeSet
+  -> VarEnv Type
+  -> Subst
+mkTvSubst is env = Subst is emptyVarEnv env
+
+-- | Generates the in-scope set for the 'Subst' from the types in the incoming
+-- environment.
+--
+-- Should only be used the type we're substituting into has no free variables
+-- outside of the domain of substitution
+zipTvSubst
+  :: [TyVar]
+  -> [Type]
+  -> Subst
+zipTvSubst tvs tys
+  | debugIsOn
+  , neLength tvs tys
+  = pprTrace "zipTvSubst" (ppr tvs <> line <> ppr tys) emptySubst
+  | otherwise
+  = Subst (mkInScopeSet (tyFVsOfTypes tys)) emptyVarEnv tenv
+ where
+  tenv = zipTyEnv tvs tys
+
+zipTyEnv
+  :: [TyVar]
+  -> [Type]
+  -> VarEnv Type
+zipTyEnv tvs tys = mkVarEnv (zipEqual tvs tys)
+
+-- | Extend the substitution environment with a new 'Id' substitution
+extendIdSubst
+  :: Subst
+  -> Id
+  -> Term
+  -> Subst
+extendIdSubst (Subst is env tenv) i e = Subst is (extendVarEnv i e env) tenv
+
+-- | Extend the substitution environment with a list of 'Id' substitutions
+extendIdSubstList
+  :: Subst
+  -> [(Id,Term)]
+  -> Subst
+extendIdSubstList (Subst is env tenv) es = Subst is (extendVarEnvList env es) tenv
+
+-- | Extend the substitution environment with a new 'TyVar' substitution
+extendTvSubst
+  :: Subst
+  -> TyVar
+  -> Type
+  -> Subst
+extendTvSubst (Subst is env tenv) tv t = Subst is env (extendVarEnv tv t tenv)
+
+-- | Extend the substitution environment with a list of 'TyVar' substitutions
+extendTvSubstList
+  :: Subst
+  -> [(TyVar, Type)]
+  -> Subst
+extendTvSubstList (Subst is env tenv) ts = Subst is env (extendVarEnvList tenv ts)
+
+-- | Add an 'Id' to the in-scope set: as a side effect, remove any existing
+-- substitutions for it.
+extendInScopeId
+  :: Subst
+  -> Id
+  -> Subst
+extendInScopeId (Subst inScope env tenv) ids =
+  Subst inScope' env' tenv
+ where
+  inScope' = extendInScopeSet inScope ids
+  env'     = delVarEnv env ids
+
+-- | Add 'Id's to the in-scope set. See also 'extendInScopeId'
+extendInScopeIdList
+  :: Subst
+  -> [Id]
+  -> Subst
+extendInScopeIdList (Subst inScope env tenv) ids =
+  Subst inScope' env' tenv
+ where
+  inScope' = extendInScopeSetList inScope ids
+  env'     = delVarEnvList env ids
+
+-- | Substitute within a 'Type'
+--
+-- The substitution has to satisfy the invariant described in
+-- 'TvSubst's Note [The substitution environment]
+substTy
+  :: Subst
+  -> Type
+  -> Type
+substTy (Subst inScope _ tvS) ty
+  | nullVarEnv tvS
+  = ty
+  | otherwise
+  = checkValidSubst s' [ty] (substTy' s' ty)
+ where
+  s' = TvSubst inScope tvS
+
+-- | Like 'substTy', but skips the checks for the invariants described in
+-- 'TvSubts' Note [The substitution environment]. Should be used inside this
+-- module only.
+substTyUnchecked
+  :: TvSubst
+  -> Type
+  -> Type
+substTyUnchecked subst@(TvSubst _ tvS) ty
+  | nullVarEnv tvS
+  = ty
+  | otherwise
+  = substTy' subst ty
+
+-- | This checks if the substitution satisfies the invariant from 'TvSbust's
+-- Note [The substitution invariant].
+checkValidSubst
+  :: TvSubst
+  -> [Type]
+  -> a
+  -> a
+checkValidSubst subst@(TvSubst inScope tenv) tys a =
+  WARN( not (isValidSubst subst),
+        "inScope" <+> pretty inScope <> line <>
+        "tenv" <+> pretty tenv <> line <>
+        "tenvFVs" <+> pretty (tyFVsOfTypes tenv) <> line <>
+        "tys" <+> ppr tys)
+  WARN( not tysFVsInSope,
+       "inScope" <+> pretty inScope <> line <>
+       "tenv" <+> pretty tenv <> line <>
+       "tys" <+> ppr tys <> line <>
+       "needsInScope" <+> pretty needsInScope)
+  a
+ where
+  needsInScope = foldrWithUnique (\k _ s -> delVarSetByKey k s)
+                   (tyFVsOfTypes tys)
+                   tenv
+  tysFVsInSope = needsInScope `varSetInScope` inScope
+
+-- | When calling 'substTy' it should be the case that the in-scope set in the
+-- substitution is a superset of the free variables of the range of the
+-- substitution.
+--
+-- See also 'TvSubst's Note [The substitution invariant].
+isValidSubst
+  :: TvSubst
+  -> Bool
+isValidSubst (TvSubst inScope tenv) = tenvFVs `varSetInScope` inScope
+ where
+  tenvFVs = tyFVsOfTypes tenv
+
+-- | The work-horse of 'substTy'
+substTy'
+  :: TvSubst
+  -> Type
+  -> Type
+substTy' subst = go where
+  go = \case
+    VarTy tv -> substTyVar subst tv
+    ForAllTy tv ty -> case substTyVarBndr subst tv of
+      (subst', tv') -> ForAllTy tv' (substTy' subst' ty)
+    AppTy fun arg -> AppTy (go fun) (go arg)
+    ty -> ty
+
+-- | Substitute a variable with a type if it's within the substitution's domain.
+--
+-- Does not substitute within the kind of free variables.
+substTyVar
+  :: TvSubst
+  -> TyVar
+  -> Type
+substTyVar (TvSubst _ tenv) tv = case lookupVarEnv tv tenv of
+  Just ty -> ty
+  _       -> VarTy tv
+
+-- | Substitute a type variable in a binding position, returning an extended
+-- substitution environment and a new type variable.
+--
+-- Substitutes within the kind of the type variable
+substTyVarBndr
+  :: TvSubst
+  -> TyVar
+  -> (TvSubst, TyVar)
+substTyVarBndr subst@(TvSubst inScope tenv) oldVar =
+  ASSERT2( no_capture, ppr oldVar <> line <> ppr newVar <> line <> pretty subst)
+  (TvSubst (inScope `extendInScopeSet` newVar) newEnv, newVar)
+ where
+  newEnv | noChange  = delVarEnv tenv oldVar
+         | otherwise = extendVarEnv oldVar (VarTy newVar) tenv
+
+  -- Assertion that we're not capturing something in the substitution
+  no_capture = not (newVar `elemVarSet` tyFVsOfTypes tenv)
+
+  oldKi        = varType oldVar
+  -- verify that the kind is closed
+  noKindChange = noFreeVarsOfType oldKi
+  -- noChange means that the new type variable is identical in all respects to
+  -- the old type variable (same unique, same kind)
+  -- See 'TvSubstEnv's Note [Extending the TvSubstEnv]
+  --
+  -- In that case we don't need to extend the substitution to map old to new.
+  -- But instead we must zap any current substitution for the variable. For
+  -- example
+  --
+  --   (\x.e) with subst = [x | -> e']
+  --
+  -- Here we must simply zap the substitution for x
+  noChange     = noKindChange && (newVar == oldVar)
+
+  -- uniqAway ensures that the new variable is not already in scope
+  newVar | noKindChange = uniqAway inScope oldVar
+         | otherwise    = uniqAway inScope
+                            (oldVar {varType = substTyUnchecked subst oldKi})
+
+-- | Substitute within a 'Type'
+substTm
+  :: Doc ()
+  -> Subst
+  -> Term
+  -> Term
+substTm doc subst = go where
+  go = \case
+    Var v -> lookupIdSubst (doc <> line <> "subsTm") subst v
+    Lam v e -> case substIdBndr subst v of
+      (subst',v') -> Lam v' (substTm doc subst' e)
+    TyLam v e -> case substTyVarBndr' subst v of
+      (subst',v') -> TyLam v' (substTm doc subst' e)
+    App l r -> App (go l) (go r)
+    TyApp l r -> TyApp (go l) (substTy subst r)
+    Letrec bs e -> case substBind doc subst bs of
+      (subst',bs') -> Letrec bs' (substTm doc subst' e)
+    Case subj ty alts -> Case (go subj) (substTy subst ty) (map goAlt alts)
+    Cast e t1 t2 -> Cast (go e) (substTy subst t1) (substTy subst t2)
+    tm -> tm
+
+  goAlt (pat,alt) = case pat of
+    DataPat dc tvs ids -> case List.mapAccumL substTyVarBndr' subst tvs of
+      (subst1,tvs') -> case List.mapAccumL substIdBndr subst1 ids of
+        (subst2,ids') -> (DataPat dc tvs' ids',substTm doc subst2 alt)
+    _ -> (pat,go alt)
+
+-- | Find the substitution for an 'Id' in the 'Subst'
+lookupIdSubst
+  :: Doc ann
+  -> Subst
+  -> Id
+  -> Term
+lookupIdSubst doc (Subst inScope tmS _) v
+  | Just e <- lookupVarEnv v tmS = e
+  -- Vital! See 'IdSubstEnv' Note [Extending the Subst]
+  | Just v' <- lookupInScope inScope v = Var (coerce v')
+  | otherwise = WARN (True, "Subst.lookupIdSubst" <+> doc <+> ppr v)
+                Var v
+
+-- | Substitute an 'Id' for another one according to the 'Subst' given,
+-- returning the result and an update 'Subst' that should be used in subsequent
+-- substitutions.
+substIdBndr
+  :: Subst
+  -> Id
+  -> (Subst,Id)
+substIdBndr subst@(Subst inScope env tenv) oldId =
+  (Subst (inScope `extendInScopeSet` newId) newEnv tenv, newId)
+ where
+  id1 = uniqAway inScope oldId
+  newId | noTypeChange = id1
+        | otherwise    = id1 {varType = substTy subst (varType id1)}
+
+  oldTy = varType oldId
+  noTypeChange = nullVarEnv tenv || noFreeVarsOfType oldTy
+
+  -- Extend the substitution if the unique has changed.
+  --
+  -- In case it hasn't changed we don't need to extend the substitution to map
+  -- old to new. But instead we must zap any current substitution for the
+  -- variable. For example
+  --
+  --   (\x.e) with subst = [x | -> e']
+  --
+  -- Here we must simply zap the substitution for x
+  newEnv | noChange  = delVarEnv env oldId
+         | otherwise = extendVarEnv oldId (Var newId) env
+
+  -- See Note [Extending the Subst] why it's not necessary to check noTypeChange
+  noChange = id1 == oldId
+
+-- | Like 'substTyVarBndr' but takes a 'Subst' instead of a 'TvSubst'
+substTyVarBndr'
+  :: Subst
+  -> TyVar
+  -> (Subst,TyVar)
+substTyVarBndr' (Subst inScope tmS tyS) tv =
+  case substTyVarBndr (TvSubst inScope tyS) tv of
+    (TvSubst inScope' tyS',tv') -> (Subst inScope' tmS tyS', tv')
+
+-- | Apply a substitution to an entire set of let-bindings, additionally
+-- returning an updated 'Subst' that should be used by subsequent substitutions.
+substBind
+  :: Doc ()
+  -> Subst
+  -> [LetBinding]
+  -> (Subst,[LetBinding])
+substBind doc subst xs =
+  (subst',zip bndrs' rhss')
+ where
+  (bndrs,rhss)    = unzip xs
+  (subst',bndrs') = List.mapAccumL substIdBndr subst bndrs
+  rhss'           = map (substTm ("substBind" <+> doc) subst') rhss
+
+-- | Type substitution, see 'zipTvSubst'
+--
+-- Works only if the domain of the substitution is superset of the type being
+-- substituted into
+substTyWith
+  :: [TyVar]
+  -> [Type]
+  -> Type
+  -> Type
+substTyWith tvs tys =
+  ASSERT ( tvs `equalLength` tys )
+  substTy (zipTvSubst tvs tys)
+
+-- | Ensure that non of the binders in an expression shadow each-other, nor
+-- conflict with he in-scope set
+deShadowTerm
+  :: InScopeSet
+  -> Term
+  -> Term
+deShadowTerm is e = substTm "deShadowTerm" (mkSubst is) e
+
+-- | A much stronger variant of `deShadowTerm` that ensures that all bound
+-- variables are unique
+freshenTm
+  :: InScopeSet
+  -> Term
+  -> Term
+freshenTm is0 = snd . go (mkSubst is0) where
+  go subst0 = \case
+    Var v -> (substInScope subst0, lookupIdSubst "freshenTm" subst0 v)
+    Lam v e -> case substIdBndr subst0 v of
+      (subst1,v') -> case go subst1 e of
+        (is2,e') -> (is2, Lam v' e')
+    TyLam v e -> case substTyVarBndr' subst0 v of
+      (subst1,v') -> case go subst1 e of
+        (is2,e') -> (is2,TyLam v' e')
+    App l r -> case go subst0 l of
+      (is1,l') -> case go subst0 {substInScope = is1} r of
+        (is2,r') -> (is2, App l' r')
+    TyApp l r -> case go subst0 l of
+      (is1,l') -> (is1, TyApp l' (substTy subst0 r))
+    Letrec bs e -> case goBind subst0 bs of
+      (subst1,bs') -> case go subst1 e of
+        (is2,e') -> (is2,Letrec bs' e')
+    Case subj ty alts -> case go subst0 subj of
+      (is1,subj') -> case List.mapAccumL (\isN -> goAlt subst0 {substInScope = isN}) is1 alts of
+        (is2,alts') -> (is2, Case subj' (substTy subst0 ty) alts')
+    Cast e t1 t2 -> case go subst0 e of
+      (is1, e') -> (is1, Cast e' (substTy subst0 t1) (substTy subst0 t2))
+    tm -> (substInScope subst0, tm)
+
+  goBind subst0 xs =
+    let (bndrs,rhss)    = unzip xs
+        (subst1,bndrs') = List.mapAccumL substIdBndr subst0 bndrs
+        (is2,rhss')     = List.mapAccumL (\isN -> go subst1 {substInScope = isN})
+                                         (substInScope subst1)
+                                         rhss
+    in  (subst1 {substInScope = is2},zip bndrs' rhss')
+
+  goAlt subst0 (pat,alt) = case pat of
+    DataPat dc tvs ids -> case List.mapAccumL substTyVarBndr' subst0 tvs of
+      (subst1,tvs') -> case List.mapAccumL substIdBndr subst1 ids of
+        (subst2,ids') -> case go subst2 alt of
+          (is3,alt') -> (is3,(DataPat dc tvs' ids',alt'))
+    _ -> case go subst0 alt of
+      (is1,alt') -> (is1,(pat,alt'))
+
+-- * AEQ
+
+-- | Alpha equality for types
+aeqType
+  :: Type
+  -> Type
+  -> Bool
+aeqType t1 t2 = acmpType' rnEnv t1 t2 == EQ
+ where
+  rnEnv = mkRnEnv (mkInScopeSet (tyFVsOfTypes [t1,t2]))
+
+-- | Alpha comparison for types
+acmpType
+  :: Type
+  -> Type
+  -> Ordering
+acmpType t1 t2 = acmpType' (mkRnEnv inScope) t1 t2
+ where
+  inScope = mkInScopeSet (tyFVsOfTypes [t1,t2])
+
+-- | Alpha comparison for types. Faster than 'acmpType' as it doesn't need to
+-- calculate the free variables to create the 'InScopeSet'
+acmpType'
+  :: RnEnv
+  -> Type
+  -> Type
+  -> Ordering
+acmpType' = go
+ where
+  go env (VarTy tv1) (VarTy tv2) = compare (rnOccLTy env tv1) (rnOccRTy env tv2)
+  go _   (ConstTy c1) (ConstTy c2) = compare c1 c2
+  go env (ForAllTy tv1 t1) (ForAllTy tv2 t2) =
+    go env (varType tv1) (varType tv2) `thenCompare` go (rnTyBndr env tv1 tv2) t1 t2
+  go env (AppTy s1 t1) (AppTy s2 t2) =
+    go env s1 s2 `thenCompare` go env t1 t2
+  go _ (LitTy l1) (LitTy l2) = compare l1 l2
+  go _ t1 t2 = compare (getRank t1) (getRank t2)
+
+  getRank :: Type -> Word
+  getRank (VarTy {})    = 0
+  getRank (LitTy {})    = 1
+  getRank (ConstTy {})  = 2
+  getRank (AnnType {})  = 3
+  getRank (AppTy {})    = 4
+  getRank (ForAllTy {}) = 5
+
+-- | Alpha equality for terms
+aeqTerm
+  :: Term
+  -> Term
+  -> Bool
+aeqTerm t1 t2 = aeqTerm' inScope t1 t2
+ where
+  inScope = mkInScopeSet (fVsOfTerms [t1,t2])
+
+-- | Alpha equality for terms. Faster than 'aeqTerm' as it doesn't need to
+-- calculate the free variables to create the 'InScopeSet'
+aeqTerm'
+  :: InScopeSet
+  -- ^ Superset of variables in scope of the left and right term
+  -> Term
+  -> Term
+  -> Bool
+aeqTerm' inScope t1 t2 = acmpTerm' inScope t1 t2 == EQ
+
+-- | Alpha comparison for types
+acmpTerm
+  :: Term
+  -> Term
+  -> Ordering
+acmpTerm t1 t2 = acmpTerm' inScope t1 t2
+ where
+  inScope = mkInScopeSet (fVsOfTerms [t1,t2])
+
+-- | Alpha comparison for types. Faster than 'acmpTerm' as it doesn't need to
+-- calculate the free variables to create the 'InScopeSet'
+acmpTerm'
+  :: InScopeSet
+  -- ^ Superset of variables in scope of the left and right term
+  -> Term
+  -> Term
+  -> Ordering
+acmpTerm' inScope = go (mkRnEnv inScope)
+ where
+  thenCmpTm EQ  rel = rel
+  thenCmpTm rel _   = rel
+
+  go env (Var id1) (Var id2)   = compare (rnOccLId env id1) (rnOccRId env id2)
+  go _   (Data dc1) (Data dc2) = compare dc1 dc2
+  go _   (Literal l1) (Literal l2) = compare l1 l2
+  go _   (Prim p1 _) (Prim p2 _) = compare p1 p2
+  go env (Lam b1 e1) (Lam b2 e2) =
+    acmpType' env (varType b1) (varType b2) `thenCompare`
+    go (rnTmBndr env b1 b2) e1 e2
+  go env (TyLam b1 e1) (TyLam b2 e2) =
+    acmpType' env (varType b1) (varType b2) `thenCompare`
+    go (rnTyBndr env b1 b2) e1 e2
+  go env (App l1 r1) (App l2 r2) =
+    go env l1 l2 `thenCompare` go env r1 r2
+  go env (TyApp l1 r1) (TyApp l2 r2) =
+    go env l1 l2 `thenCompare` acmpType' env r1 r2
+  go env (Letrec bs1 e1) (Letrec bs2 e2) =
+    compare (length bs1) (length bs2) `thenCompare`
+    foldr thenCmpTm EQ (zipWith (go env') rhs1 rhs2) `thenCompare`
+    go env' e1 e2
+   where
+    (ids1,rhs1) = unzip bs1
+    (ids2,rhs2) = unzip bs2
+    env' = rnTmBndrs env ids1 ids2
+  go env (Case e1 _ a1) (Case e2 _ a2) =
+    compare (length a1) (length a2) `thenCompare`
+    go env e1 e2 `thenCompare`
+    foldr thenCmpTm EQ (zipWith (goAlt env) a1 a2)
+  go env (Cast e1 l1 r1) (Cast e2 l2 r2) =
+    go env e1 e2 `thenCompare`
+    acmpType' env l1 l2 `thenCompare`
+    acmpType' env r1 r2
+
+  go _ e1 e2 = compare (getRank e1) (getRank e2)
+
+  goAlt env (DataPat c1 tvs1 ids1,e1) (DataPat c2 tvs2 ids2,e2) =
+    compare c1 c2 `thenCompare` go env' e1 e2
+   where
+    env' = rnTmBndrs (rnTyBndrs env tvs1 tvs2) ids1 ids2
+  goAlt env (c1,e1) (c2,e2) =
+    compare c1 c2 `thenCompare` go env e1 e2
+
+  getRank :: Term -> Word
+  getRank = \case
+    Var {}     -> 0
+    Data {}    -> 1
+    Literal {} -> 2
+    Prim {}    -> 3
+    Cast {}    -> 4
+    App {}     -> 5
+    TyApp {}   -> 6
+    Lam {}     -> 7
+    TyLam {}   -> 8
+    Letrec {}  -> 9
+    Case {}    -> 10
+
+thenCompare :: Ordering -> Ordering -> Ordering
+thenCompare EQ rel = rel
+thenCompare rel _  = rel
+
+instance Eq Type where
+  (==) = aeqType
+
+instance Ord Type where
+  compare = acmpType
+
+instance Eq Term where
+  (==) = aeqTerm
+
+instance Ord Term where
+  compare = acmpTerm

--- a/clash-lib/src/Clash/Core/Subst.hs-boot
+++ b/clash-lib/src/Clash/Core/Subst.hs-boot
@@ -1,0 +1,15 @@
+module Clash.Core.Subst where
+
+import {-# SOURCE #-} Clash.Core.Type (Type)
+import Clash.Core.Var (TyVar)
+
+substTyWith
+  :: [TyVar]
+  -> [Type]
+  -> Type
+  -> Type
+
+aeqType
+  :: Type
+  -> Type
+  -> Bool

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -16,7 +16,6 @@
 module Clash.Core.Term
   ( Term (..)
   , TmName
-  , TmOccName
   , LetBinding
   , Pat (..)
   , Alt
@@ -29,27 +28,25 @@ import Data.Binary                             (Binary)
 import Data.Hashable                           (Hashable)
 import Data.Text                               (Text)
 import GHC.Generics
-import Unbound.Generics.LocallyNameless        hiding (Name)
-import Unbound.Generics.LocallyNameless.Extra  ()
 
 -- Internal Modules
 import Clash.Core.DataCon                      (DataCon)
 import Clash.Core.Literal                      (Literal)
-import Clash.Core.Name                         (Name (..), OccName)
+import Clash.Core.Name                         (Name (..))
 import {-# SOURCE #-} Clash.Core.Type          (Type)
 import Clash.Core.Var                          (Id, TyVar)
 
 -- | Term representation in the CoreHW language: System F + LetRec + Case
 data Term
-  = Var     !Type !TmName                   -- ^ Variable reference
+  = Var     !Id                             -- ^ Variable reference
   | Data    !DataCon                        -- ^ Datatype constructor
   | Literal !Literal                        -- ^ Literal
   | Prim    !Text !Type                     -- ^ Primitive
-  | Lam     !(Bind Id Term)                 -- ^ Term-abstraction
-  | TyLam   !(Bind TyVar Term)              -- ^ Type-abstraction
+  | Lam     !Id Term                        -- ^ Term-abstraction
+  | TyLam   !TyVar Term                     -- ^ Type-abstraction
   | App     !Term !Term                     -- ^ Application
   | TyApp   !Term !Type                     -- ^ Type-application
-  | Letrec  !(Bind (Rec [LetBinding]) Term) -- ^ Recursive let-binding
+  | Letrec  [LetBinding] Term               -- ^ Recursive let-binding
   | Case    !Term !Type [Alt]               -- ^ Case-expression: subject, type of
                                             -- alternatives, list of alternatives
   | Cast    !Term !Type !Type               -- ^ Cast a term from one type to another
@@ -57,43 +54,19 @@ data Term
 
 -- | Term reference
 type TmName     = Name Term
-type TmOccName  = OccName Term
 -- | Binding in a LetRec construct
-type LetBinding = (Id, Embed Term)
+type LetBinding = (Id, Term)
 
 -- | Patterns in the LHS of a case-decomposition
 data Pat
-  = DataPat !(Embed DataCon) !(Rebind [TyVar] [Id])
+  = DataPat !DataCon [TyVar] [Id]
   -- ^ Datatype pattern, '[TyVar]' bind existentially-quantified
   -- type-variables of a DataCon
-  | LitPat  !(Embed Literal)
+  | LitPat  !Literal
   -- ^ Literal pattern
   | DefaultPat
   -- ^ Default pattern
-  deriving (Eq,Show,Generic,NFData,Alpha,Hashable,Binary)
+  deriving (Eq,Ord,Show,Generic,NFData,Hashable,Binary)
 
-type Alt = Bind Pat Term
+type Alt = (Pat,Term)
 
-instance Eq Term where
-  (==) = aeq
-
-instance Ord Term where
-  compare = acompare
-
-instance Alpha Term where
-  aeq' c (Var _ n)   (Var _ m)   = aeq' c n m
-  aeq' _ (Prim t1 _) (Prim t2 _) = t1 == t2
-  aeq' c t1          t2          = gaeq c (from t1) (from t2)
-
-  acompare' c (Var _ n)   (Var _ m)   = acompare' c n m
-  acompare' _ (Prim t1 _) (Prim t2 _) = compare t1 t2
-  acompare' c t1          t2          = gacompare c (from t1) (from t2)
-
-instance Subst Type Pat
-instance Subst Term Pat
-
-instance Subst Term Term where
-  isvar (Var _ x) = Just (SubstName (nameOcc x))
-  isvar _         = Nothing
-
-instance Subst Type Term

--- a/clash-lib/src/Clash/Core/Term.hs-boot
+++ b/clash-lib/src/Clash/Core/Term.hs-boot
@@ -12,6 +12,7 @@ import GHC.Generics    (Generic)
 import Clash.Core.Name (Name)
 
 data Term
+
 type TmName = Name Term
 
 instance Generic Term

--- a/clash-lib/src/Clash/Core/TyCon.hs
+++ b/clash-lib/src/Clash/Core/TyCon.hs
@@ -15,7 +15,6 @@
 module Clash.Core.TyCon
   ( TyCon (..)
   , TyConName
-  , TyConOccName
   , TyConMap
   , AlgTyConRhs (..)
   , mkKindTyCon
@@ -31,47 +30,46 @@ where
 -- External Import
 import Control.DeepSeq
 import Data.Binary                            (Binary)
-import Data.HashMap.Lazy                      (HashMap)
+import qualified Data.Text as T
 import GHC.Generics
-import Unbound.Generics.LocallyNameless       (Alpha(..))
-import Unbound.Generics.LocallyNameless.Extra ()
-#if MIN_VERSION_unbound_generics(0,3,0)
-import Data.Monoid                            (All (..))
-import Unbound.Generics.LocallyNameless       (NthPatFind (..),
-                                               NamePatFind (..))
-#endif
 
 -- Internal Imports
 import Clash.Core.DataCon                     (DataCon)
 import Clash.Core.Name
-import {-# SOURCE #-} Clash.Core.Type         (Kind, TyName, Type)
+import {-# SOURCE #-} Clash.Core.Type         (Kind, Type)
+import Clash.Core.Var                         (TyVar)
+import Clash.Unique
 import Clash.Util
 
 -- | Type Constructor
 data TyCon
   -- | Algorithmic DataCons
   = AlgTyCon
-  { tyConName   :: !TyConName   -- ^ Name of the TyCon
+  { tyConUniq   :: {-# UNPACK #-} !Unique
+  , tyConName   :: !TyConName   -- ^ Name of the TyCon
   , tyConKind   :: !Kind        -- ^ Kind of the TyCon
   , tyConArity  :: !Int         -- ^ Number of type arguments
   , algTcRhs    :: !AlgTyConRhs -- ^ DataCon definitions
   }
   -- | Function TyCons (e.g. type families)
   | FunTyCon
-  { tyConName   :: !TyConName      -- ^ Name of the TyCon
+  { tyConUniq   :: {-# UNPACK #-} !Unique
+  , tyConName   :: !TyConName      -- ^ Name of the TyCon
   , tyConKind   :: !Kind           -- ^ Kind of the TyCon
   , tyConArity  :: !Int            -- ^ Number of type arguments
   , tyConSubst  :: [([Type],Type)] -- ^ List of: ([LHS match types], RHS type)
   }
   -- | Primitive TyCons
   | PrimTyCon
-  { tyConName    :: !TyConName  -- ^ Name of the TyCon
+  { tyConUniq    :: {-# UNPACK #-} !Unique
+  , tyConName    :: !TyConName  -- ^ Name of the TyCon
   , tyConKind    :: !Kind       -- ^ Kind of the TyCon
   , tyConArity   :: !Int        -- ^ Number of type arguments
   }
   -- | To close the loop on the type hierarchy
   | SuperKindTyCon
-  { tyConName :: !TyConName     -- ^ Name of the TyCon
+  { tyConUniq    :: {-# UNPACK #-} !Unique
+  , tyConName    :: !TyConName  -- ^ Name of the TyCon
   }
   deriving (Generic,NFData,Binary)
 
@@ -82,15 +80,15 @@ instance Show TyCon where
   show (SuperKindTyCon {tyConName = n}) = "SuperKindTyCon: " ++ show n
 
 instance Eq TyCon where
-  (==) = (==) `on` tyConName
+  (==) = (==) `on` tyConUniq
+  (/=) = (/=) `on` tyConUniq
 
-instance Ord TyCon where
-  compare = compare `on` tyConName
+instance Uniquable TyCon where
+  getUnique = tyConUniq
 
 -- | TyCon reference
 type TyConName = Name TyCon
-type TyConOccName = OccName TyCon
-type TyConMap = HashMap TyConOccName TyCon
+type TyConMap  = UniqMap TyCon
 
 -- | The RHS of an Algebraic Datatype
 data AlgTyConRhs
@@ -99,55 +97,29 @@ data AlgTyConRhs
   }
   | NewTyCon
   { dataCon   :: !DataCon        -- ^ The newtype DataCon
-  , ntEtadRhs :: ([TyName],Type) -- ^ The argument type of the newtype
+  , ntEtadRhs :: ([TyVar],Type)  -- ^ The argument type of the newtype
                                  -- DataCon in eta-reduced form, which is
                                  -- just the representation of the TyCon.
                                  -- The TyName's are the type-variables from
                                  -- the corresponding TyCon.
   }
-  deriving (Show,Generic,NFData,Alpha,Binary)
-
-instance Alpha TyCon where
-  aeq' c tc1 tc2      = aeq' c (tyConName tc1) (tyConName tc2)
-
-  fvAny' _ _ tc       = pure tc
-
-  close _ _ tc        = tc
-  open _ _ tc         = tc
-
-  isPat _             = mempty
-
-#if MIN_VERSION_unbound_generics(0,3,0)
-  isTerm _            = All True
-  nthPatFind _        = NthPatFind Left
-  namePatFind _       = NamePatFind (const (Left 0))
-#else
-  isTerm _            = True
-  nthPatFind _        = Left
-  namePatFind _ _     = Left 0
-#endif
-
-  swaps' _ _ tc       = tc
-  lfreshen' _ tc cont = cont tc mempty
-  freshen' _ tc       = return (tc,mempty)
-
-  acompare' c tc1 tc2 = acompare' c (tyConName tc1) (tyConName tc2)
+  deriving (Show,Generic,NFData,Binary)
 
 -- | Create a Kind out of a TyConName
 mkKindTyCon :: TyConName
             -> Kind
             -> TyCon
 mkKindTyCon name kind
-  = PrimTyCon name kind 0
+  = PrimTyCon (nameUniq name) name kind 0
 
 -- | Does the TyCon look like a tuple TyCon
 isTupleTyConLike :: TyConName -> Bool
-isTupleTyConLike nm = tupleName (name2String nm)
+isTupleTyConLike nm = tupleName (nameOcc nm)
   where
     tupleName nm'
-      | '(' <- head nm'
-      , ')' <- last nm'
-      = all (== ',') (init $ tail nm')
+      | '(' <- T.head nm'
+      , ')' <- T.last nm'
+      = T.all (== ',') (T.init $ T.tail nm')
     tupleName _ = False
 
 -- | Get the DataCons belonging to a TyCon

--- a/clash-lib/src/Clash/Core/TyCon.hs-boot
+++ b/clash-lib/src/Clash/Core/TyCon.hs-boot
@@ -6,8 +6,7 @@
 
 module Clash.Core.TyCon where
 
-import Clash.Core.Name (Name, OccName)
+import Clash.Core.Name (Name)
 
 data TyCon
 type TyConName = Name TyCon
-type TyConOccName = OccName TyCon

--- a/clash-lib/src/Clash/Core/Type.hs-boot
+++ b/clash-lib/src/Clash/Core/Type.hs-boot
@@ -15,26 +15,18 @@ import Control.DeepSeq                  (NFData)
 import Data.Binary                      (Binary)
 import Data.Hashable                    (Hashable)
 import GHC.Generics                     (Generic)
-import Unbound.Generics.LocallyNameless (Alpha,Subst)
 
 import                Clash.Core.Name
-import {-# SOURCE #-} Clash.Core.Term
 import {-# SOURCE #-} Clash.Core.TyCon
 
 data Type
 
 type Kind   = Type
 type TyName = Name Type
-type TyOccName = OccName Type
 type KiName = Name Kind
-type KiOccName = OccName Kind
 
-instance Eq       Type
 instance Generic  Type
 instance Show     Type
-instance Alpha    Type
-instance Subst    Type Type
-instance Subst    Term Type
 instance NFData   Type
 instance Hashable Type
 instance Binary   Type

--- a/clash-lib/src/Clash/Core/TysPrim.hs
+++ b/clash-lib/src/Clash/Core/TysPrim.hs
@@ -7,7 +7,8 @@
   Builtin Type and Kind definitions
 -}
 
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Core.TysPrim
   ( liftedTypeKind
@@ -29,30 +30,29 @@ module Clash.Core.TysPrim
   )
 where
 
-import           Control.Arrow                    (first)
-import           Data.HashMap.Strict              (HashMap)
-import qualified Data.HashMap.Strict              as HashMap
+import qualified Data.List            as List
 
 import           PrelNames
-import           Unique                           (Unique, getKey)
+import           Unique               (getKey)
 
 import           Clash.Core.Name
 import           Clash.Core.TyCon
 import {-# SOURCE #-} Clash.Core.Type
+import           Clash.Unique
 
 -- | Builtin Name
 tySuperKindTyConName, liftedTypeKindTyConName, typeNatKindTyConName, typeSymbolKindTyConName :: TyConName
-tySuperKindTyConName      = string2SystemName "BOX"
-liftedTypeKindTyConName   = string2SystemName "*"
-typeNatKindTyConName      = string2SystemName "Nat"
-typeSymbolKindTyConName   = string2SystemName "Symbol"
+tySuperKindTyConName      = mkUnsafeSystemName "tYPE" (getKey tYPETyConKey)
+liftedTypeKindTyConName   = mkUnsafeSystemName "*" (getKey liftedTypeKindTyConKey)
+typeNatKindTyConName      = mkUnsafeSystemName "Nat" (getKey typeNatKindConNameKey)
+typeSymbolKindTyConName   = mkUnsafeSystemName "Symbol" (getKey typeSymbolKindConNameKey)
 
 -- | Builtin Kind
-liftedTypeKindtc, tySuperKindtc, typeNatKindtc, typeSymbolKindtc :: TyCon
-tySuperKindtc    = SuperKindTyCon tySuperKindTyConName
-liftedTypeKindtc = mkKindTyCon liftedTypeKindTyConName tySuperKind
-typeNatKindtc    = mkKindTyCon typeNatKindTyConName tySuperKind
-typeSymbolKindtc = mkKindTyCon typeSymbolKindTyConName tySuperKind
+liftedTypeKindTc, tySuperKindTc, typeNatKindTc, typeSymbolKindTc :: TyCon
+tySuperKindTc    = SuperKindTyCon (nameUniq tySuperKindTyConName) tySuperKindTyConName
+liftedTypeKindTc = mkKindTyCon liftedTypeKindTyConName tySuperKind
+typeNatKindTc    = mkKindTyCon typeNatKindTyConName tySuperKind
+typeSymbolKindTc = mkKindTyCon typeSymbolKindTyConName tySuperKind
 
 liftedTypeKind, tySuperKind, typeNatKind, typeSymbolKind :: Type
 tySuperKind    = mkTyConTy tySuperKindTyConName
@@ -60,43 +60,40 @@ liftedTypeKind = mkTyConTy liftedTypeKindTyConName
 typeNatKind    = mkTyConTy typeNatKindTyConName
 typeSymbolKind = mkTyConTy typeSymbolKindTyConName
 
-uniqueToInteger :: Unique -> Integer
-uniqueToInteger = toInteger . getKey
-
 intPrimTyConName, integerPrimTyConName, charPrimTyConName, stringPrimTyConName,
   voidPrimTyConName, wordPrimTyConName, int64PrimTyConName,
   word64PrimTyConName, floatPrimTyConName, doublePrimTyConName,
   naturalPrimTyConName, byteArrayPrimTyConName :: TyConName
-intPrimTyConName     = makeSystemName "GHC.Prim.Int#"
-                                (uniqueToInteger intPrimTyConKey)
-integerPrimTyConName = makeSystemName "GHC.Integer.Type.Integer"
-                                (uniqueToInteger integerTyConKey)
-stringPrimTyConName  = string2SystemName "String"
-charPrimTyConName    = makeSystemName "GHC.Prim.Char#"
-                                (uniqueToInteger charPrimTyConKey)
-voidPrimTyConName    = string2SystemName "VOID"
-wordPrimTyConName    = makeSystemName "GHC.Prim.Word#"
-                                (uniqueToInteger wordPrimTyConKey)
-int64PrimTyConName   = makeSystemName "GHC.Prim.Int64#"
-                                (uniqueToInteger int64PrimTyConKey)
-word64PrimTyConName  = makeSystemName "GHC.Prim.Word64#"
-                                (uniqueToInteger word64PrimTyConKey)
-floatPrimTyConName   = makeSystemName "GHC.Prim.Float#"
-                                (uniqueToInteger floatPrimTyConKey)
-doublePrimTyConName  = makeSystemName "GHC.Prim.Double#"
-                                (uniqueToInteger doublePrimTyConKey)
+intPrimTyConName     = mkUnsafeSystemName "GHC.Prim.Int#"
+                                (getKey intPrimTyConKey)
+integerPrimTyConName = mkUnsafeSystemName "GHC.Integer.Type.Integer"
+                                (getKey integerTyConKey)
+stringPrimTyConName  = mkUnsafeSystemName "GHC.Prim.Addr#" (getKey addrPrimTyConKey)
+charPrimTyConName    = mkUnsafeSystemName "GHC.Prim.Char#"
+                                (getKey charPrimTyConKey)
+voidPrimTyConName    = mkUnsafeSystemName "Void#" (getKey voidPrimTyConKey)
+wordPrimTyConName    = mkUnsafeSystemName "GHC.Prim.Word#"
+                                (getKey wordPrimTyConKey)
+int64PrimTyConName   = mkUnsafeSystemName "GHC.Prim.Int64#"
+                                (getKey int64PrimTyConKey)
+word64PrimTyConName  = mkUnsafeSystemName "GHC.Prim.Word64#"
+                                (getKey word64PrimTyConKey)
+floatPrimTyConName   = mkUnsafeSystemName "GHC.Prim.Float#"
+                                (getKey floatPrimTyConKey)
+doublePrimTyConName  = mkUnsafeSystemName "GHC.Prim.Double#"
+                                (getKey doublePrimTyConKey)
 #if MIN_VERSION_ghc(8,2,0)
-naturalPrimTyConName = makeSystemName "GHC.Natural.Natural"
-                                (uniqueToInteger naturalTyConKey)
+naturalPrimTyConName = mkUnsafeSystemName "GHC.Natural.Natural"
+                                (getKey naturalTyConKey)
 #else
 naturalPrimTyConName = string2SystemName "GHC.Natural.Natural"
 #endif
-byteArrayPrimTyConName = makeSystemName "GHC.Prim.ByteArray#"
-                          (uniqueToInteger byteArrayPrimTyConKey)
+byteArrayPrimTyConName = mkUnsafeSystemName "GHC.Prim.ByteArray#"
+                          (getKey byteArrayPrimTyConKey)
 
 liftedPrimTC :: TyConName
              -> TyCon
-liftedPrimTC name = PrimTyCon name liftedTypeKind 0
+liftedPrimTC name = PrimTyCon (nameUniq name) name liftedTypeKind 0
 
 -- | Builtin Type
 intPrimTc, integerPrimTc, charPrimTc, stringPrimTc, voidPrimTc, wordPrimTc,
@@ -131,22 +128,22 @@ doublePrimTy  = mkTyConTy doublePrimTyConName
 naturalPrimTy = mkTyConTy naturalPrimTyConName
 byteArrayPrimTy = mkTyConTy byteArrayPrimTyConName
 
-tysPrimMap :: HashMap TyConOccName TyCon
-tysPrimMap = HashMap.fromList $ map (first nameOcc)
-  [ (tySuperKindTyConName,tySuperKindtc)
-  , (liftedTypeKindTyConName,liftedTypeKindtc)
-  , (typeNatKindTyConName,typeNatKindtc)
-  , (typeSymbolKindTyConName,typeSymbolKindtc)
-  , (intPrimTyConName,intPrimTc)
-  , (integerPrimTyConName,integerPrimTc)
-  , (charPrimTyConName,charPrimTc)
-  , (stringPrimTyConName,stringPrimTc)
-  , (voidPrimTyConName,voidPrimTc)
-  , (wordPrimTyConName,wordPrimTc)
-  , (int64PrimTyConName,int64PrimTc)
-  , (word64PrimTyConName,word64PrimTc)
-  , (floatPrimTyConName,floatPrimTc)
-  , (doublePrimTyConName,doublePrimTc)
-  , (naturalPrimTyConName,naturalPrimTc)
-  , (byteArrayPrimTyConName,byteArrayPrimTc)
+tysPrimMap :: TyConMap
+tysPrimMap = List.foldl' (\s (k,x) -> extendUniqMap k x s) emptyUniqMap
+  [  (tySuperKindTyConName , tySuperKindTc)
+  ,  (liftedTypeKindTyConName , liftedTypeKindTc)
+  ,  (typeNatKindTyConName , typeNatKindTc)
+  ,  (typeSymbolKindTyConName , typeSymbolKindTc)
+  ,  (intPrimTyConName , intPrimTc)
+  ,  (integerPrimTyConName , integerPrimTc)
+  ,  (charPrimTyConName , charPrimTc)
+  ,  (stringPrimTyConName , stringPrimTc)
+  ,  (voidPrimTyConName , voidPrimTc)
+  ,  (wordPrimTyConName , wordPrimTc)
+  ,  (int64PrimTyConName , int64PrimTc)
+  ,  (word64PrimTyConName , word64PrimTc)
+  ,  (floatPrimTyConName , floatPrimTc)
+  ,  (doublePrimTyConName , doublePrimTc)
+  ,  (naturalPrimTyConName , naturalPrimTc)
+  ,  (byteArrayPrimTyConName , byteArrayPrimTc)
   ]

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -6,65 +6,76 @@
   Smart constructor and destructor functions for CoreHW
 -}
 
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Core.Util where
 
+import           Control.Concurrent.Supply     (Supply, freshId)
+import qualified Control.Lens                  as Lens
 import Control.Monad.Trans.Except              (Except, throwE)
-import qualified Data.HashMap.Strict           as HMS
-import qualified Data.HashMap.Lazy             as HashMap
-import Data.HashMap.Lazy                       (HashMap)
+import           Data.Coerce                   (coerce)
+import qualified Data.IntSet                   as IntSet
 import qualified Data.HashSet                  as HashSet
+import Data.List                               (foldl', mapAccumR)
 import Data.Maybe                              (fromJust, mapMaybe)
-import Unbound.Generics.LocallyNameless
-  (Fresh, bind, embed, rebind, unbind, unembed, unrebind, unrec)
-import Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
+import qualified Data.Text                     as T
+import           Data.Text.Prettyprint.Doc     (line)
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup
+#endif
 
-import Clash.Core.DataCon                      (DataCon, dcType, dataConInstArgTys)
+import Clash.Core.DataCon
+  (DataCon, dcType, dataConInstArgTys)
+import Clash.Core.FreeVars                     (termFreeVars, tyFVsOfTypes)
 import Clash.Core.Literal                      (literalType)
 import Clash.Core.Name
-  (Name (..), name2String, string2SystemName)
-import Clash.Core.Pretty                       (showDoc)
+  (Name (..), OccName, mkUnsafeInternalName, mkUnsafeSystemName)
+import Clash.Core.Pretty                       (ppr, showDoc)
+import Clash.Core.Subst
+  (extendTvSubst, mkSubst, mkTvSubst, substTy)
 import Clash.Core.Term
-  (LetBinding, Pat (..), Term (..), TmName, TmOccName)
+  (LetBinding, Pat (..), Term (..))
 import Clash.Core.Type
-  (Kind, LitTy (..), TyName, TyOccName, Type (..), TypeView (..), applyTy,
+  (Kind, LitTy (..), Type (..), TypeView (..),
    coreView, isFunTy, isPolyFunCoreTy, mkFunTy, splitFunTy, tyView)
 import Clash.Core.TyCon
-  (TyCon (..), TyConOccName, tyConDataCons)
+  (TyConMap, tyConDataCons)
 import Clash.Core.TysPrim                      (typeNatKind)
-import Clash.Core.Var                          (Id, TyVar, Var (..), varType)
+import Clash.Core.Var
+  (Id, TyVar, Var (..), mkId, mkTyVar)
+import Clash.Core.VarEnv
+  (InScopeSet, VarEnv, emptyVarEnv, extendInScopeSet, extendVarEnv,
+   lookupVarEnv, mkInScopeSet, uniqAway)
+import Clash.Unique
 import Clash.Util
 
 -- | Type environment/context
-type Gamma = HashMap TmOccName Type
+type Gamma = VarEnv Type
 -- | Kind environment/context
-type Delta = HashMap TyOccName Kind
+type Delta = VarEnv Kind
 
 -- | Determine the type of a term
-termType :: Fresh m
-         => HashMap TyConOccName TyCon
-         -> Term
-         -> m Type
+termType
+  :: TyConMap
+  -> Term
+  -> Type
 termType m e = case e of
-  Var t _        -> return t
-  Data dc        -> return $ dcType dc
-  Literal l      -> return $ literalType l
-  Prim _ t       -> return t
-  Lam b          -> do (v,e') <- unbind b
-                       mkFunTy (unembed $ varType v) <$> termType m e'
-  TyLam b        -> do (tv,e') <- unbind b
-                       ForAllTy <$> bind tv <$> termType m e'
+  Var t          -> varType t
+  Data dc        -> dcType dc
+  Literal l      -> literalType l
+  Prim _ t       -> t
+  Lam v e'       -> mkFunTy (varType v) (termType m e')
+  TyLam tv e'    -> ForAllTy tv (termType m e')
   App _ _        -> case collectArgs e of
-                      (fun, args) -> termType m fun >>=
-                                     (flip (applyTypeToArgs m) args)
-  TyApp e' ty    -> termType m e' >>= (\f -> applyTy m f ty)
-  Letrec b       -> do (_,e') <- unbind b
-                       termType m e'
-  Case _ ty _    -> return ty
-  Cast _ _ ty2   -> return ty2
+                      (fun, args) -> applyTypeToArgs e m (termType m fun) args
+  TyApp _ _      -> case collectArgs e of
+                      (fun, args) -> applyTypeToArgs e m (termType m fun) args
+  Letrec _ e'    -> termType m e'
+  Case _ ty _    -> ty
+  Cast _ _ ty2   -> ty2
 
 -- | Split a (Type)Application in the applied term and it arguments
 collectArgs :: Term
@@ -76,63 +87,140 @@ collectArgs = go []
     go args e           = (e, args)
 
 -- | Split a (Type)Abstraction in the bound variables and the abstracted term
-collectBndrs :: Fresh m
-             => Term
-             -> m ([Either Id TyVar], Term)
+collectBndrs :: Term
+             -> ([Either Id TyVar], Term)
 collectBndrs = go []
   where
-    go bs (Lam b) = do
-      (v,e') <- unbind b
-      go (Left v:bs) e'
-    go bs (TyLam b) = do
-      (tv,e') <- unbind b
-      go (Right tv:bs) e'
-    go bs e' = return (reverse bs,e')
+    go bs (Lam v e')    = go (Left v:bs) e'
+    go bs (TyLam tv e') = go (Right tv:bs) e'
+    go bs e'            = (reverse bs,e')
 
 -- | Get the result type of a polymorphic function given a list of arguments
-applyTypeToArgs :: Fresh m
-                => HashMap TyConOccName TyCon
-                -> Type
-                -> [Either Term Type]
-                -> m Type
-applyTypeToArgs _ opTy []              = return opTy
-applyTypeToArgs m opTy (Right ty:args) = applyTy m opTy ty >>=
-                                          (flip (applyTypeToArgs m) args)
-applyTypeToArgs m opTy (Left e:args)   = case splitFunTy m opTy of
-  Just (_,resTy) -> applyTypeToArgs m resTy args
-  Nothing        -> error $
-                    concat [ $(curLoc)
-                           , "applyTypeToArgs splitFunTy: not a funTy:\n"
-                           , "opTy: "
-                           , showDoc opTy
-                           , "\nTerm: "
-                           , showDoc e
-                           , "\nOtherArgs: "
-                           , unlines (map (either showDoc showDoc) args)
-                           ]
+applyTypeToArgs
+  :: Term
+  -> TyConMap
+  -> Type
+  -> [Either Term Type]
+  -> Type
+applyTypeToArgs e m opTy args = go opTy args
+ where
+  go opTy' []               = opTy'
+  go opTy' (Right ty:args') = goTyArgs opTy' [ty] args'
+  go opTy' (Left _:args')   = case splitFunTy m opTy' of
+    Just (_,resTy) -> go resTy args'
+    _ -> error $ unlines ["applyTypeToArgs:"
+                         ,"Expression: " ++ showDoc (ppr e)
+                         ,"Type: " ++ showDoc (ppr opTy)
+                         ,"Args: " ++ unlines (map (either (showDoc.ppr) (showDoc.ppr)) args)
+                         ]
+
+  goTyArgs opTy' revTys (Right ty:args') = goTyArgs opTy' (ty:revTys) args'
+  goTyArgs opTy' revTys args'            = go (piResultTys m opTy' (reverse revTys)) args'
+
+-- | Like 'piResultTyMaybe', but errors out when a type application is not
+-- valid.
+--
+-- Do not iterate 'piResultTy', because it's inefficient to substitute one
+-- variable at a time; instead use 'piResultTys'
+piResultTy
+  :: TyConMap
+  -> Type
+  -> Type
+  -> Type
+piResultTy m ty arg = case piResultTyMaybe m ty arg of
+  Just res -> res
+  Nothing  -> pprPanic "piResultTy" (ppr ty <> line <> ppr arg)
+
+-- | Like 'piResultTys' but for a single argument.
+--
+-- Do not iterate 'piResultTyMaybe', because it's inefficient to substitute one
+-- variable at a time; instead use 'piResultTys'
+piResultTyMaybe
+  :: TyConMap
+  -> Type
+  -> Type
+  -> Maybe Type
+piResultTyMaybe m ty arg
+  | Just ty' <- coreView m ty
+  = piResultTyMaybe m ty' arg
+  | FunTy _ res <- tyView ty
+  = Just res
+  | ForAllTy tv res <- ty
+  = let emptySubst = mkSubst (mkInScopeSet (tyFVsOfTypes [arg,res]))
+    in  Just (substTy (extendTvSubst emptySubst tv arg) res)
+  | otherwise
+  = Nothing
+
+-- | @(piResultTys f_ty [ty1, ..., tyn])@ give sthe type of @(f ty1 .. tyn)@
+-- where @f :: f_ty@
+--
+-- 'piResultTys' is interesting because:
+--
+--    1. 'f_ty' may have more foralls than there are args
+--    2. Less obviously, it may have fewer foralls
+--
+-- Fore case 2. think of:
+--
+--   piResultTys (forall a . a) [forall b.b, Int]
+--
+-- This really can happen, such as situations involving 'undefined's type:
+--
+--   undefined :: forall a. a
+--
+--   undefined (forall b. b -> b) Int
+--
+-- This term should have the type @(Int -> Int)@, but notice that there are
+-- more type args than foralls in 'undefined's type.
+--
+-- For efficiency reasons, when there are no foralls, we simply drop arrows from
+-- a function type/kind.
+piResultTys
+  :: TyConMap
+  -> Type
+  -> [Type]
+  -> Type
+piResultTys _ ty [] = ty
+piResultTys m ty origArgs@(arg:args)
+  | Just ty' <- coreView m ty
+  = piResultTys m ty' origArgs
+  | FunTy _ res <- tyView ty
+  = piResultTys m res args
+  | ForAllTy tv res <- ty
+  = go (extendVarEnv tv arg emptyVarEnv) res args
+  | otherwise
+  = pprPanic "piResultTys1" (ppr ty <> line <> ppr origArgs)
+ where
+  inScope = mkInScopeSet (tyFVsOfTypes (ty:origArgs))
+
+  go env ty' [] = substTy (mkTvSubst inScope env) ty'
+  go env ty' allArgs@(arg':args')
+    | Just ty'' <- coreView m ty'
+    = go env ty'' allArgs
+    | FunTy _ res <- tyView ty'
+    = go env res args'
+    | ForAllTy tv res <- ty'
+    = go (extendVarEnv tv arg' env) res args'
+    | VarTy tv <- ty'
+    , Just ty'' <- lookupVarEnv tv env
+      -- Deals with (piResultTys  (forall a.a) [forall b.b, Int])
+    = piResultTys m ty'' allArgs
+    | otherwise
+    = pprPanic "piResultTys2" (ppr ty' <> line <> ppr origArgs <> line <> ppr allArgs)
 
 -- | Get the list of term-binders out of a DataType pattern
 patIds :: Pat -> ([TyVar],[Id])
-patIds (DataPat _ ids) = unrebind ids
-patIds _               = ([],[])
+patIds (DataPat _  tvs ids) = (tvs,ids)
+patIds _                    = ([],[])
 
--- | Make a type variable
-mkTyVar :: Kind
-        -> TyName
-        -> TyVar
-mkTyVar tyKind tyName = TyVar tyName (embed tyKind)
-
--- | Make a term variable
-mkId :: Type
-     -> TmName
-     -> Id
-mkId tmType tmName = Id tmName (embed tmType)
+patVars :: Pat -> [Var a]
+patVars (DataPat _ tvs ids) = coerce tvs ++ coerce ids
+patVars _ = []
 
 -- | Abstract a term over a list of term and type variables
 mkAbstraction :: Term
               -> [Either Id TyVar]
               -> Term
-mkAbstraction = foldr (either (Lam `dot` bind) (TyLam `dot` bind))
+mkAbstraction = foldr (either Lam TyLam)
 
 -- | Abstract a term over a list of term variables
 mkTyLams :: Term
@@ -150,96 +238,93 @@ mkLams tm = mkAbstraction tm . map Left
 mkApps :: Term
        -> [Either Term Type]
        -> Term
-mkApps = foldl (\e a -> either (App e) (TyApp e) a)
+mkApps = foldl' (\e a -> either (App e) (TyApp e) a)
 
 -- | Apply a list of terms to a term
 mkTmApps :: Term
          -> [Term]
          -> Term
-mkTmApps = foldl App
+mkTmApps = foldl' App
 
 -- | Apply a list of types to a term
 mkTyApps :: Term
          -> [Type]
          -> Term
-mkTyApps = foldl TyApp
+mkTyApps = foldl' TyApp
 
 -- | Does a term have a function type?
-isFun :: Fresh m
-      => HashMap TyConOccName TyCon
+isFun :: TyConMap
       -> Term
-      -> m Bool
-isFun m t = fmap (isFunTy m) $ (termType m) t
+      -> Bool
+isFun m t = isFunTy m (termType m t)
 
 -- | Does a term have a function or polymorphic type?
-isPolyFun :: Fresh m
-          => HashMap TyConOccName TyCon
+isPolyFun :: TyConMap
           -> Term
-          -> m Bool
-isPolyFun m t = isPolyFunCoreTy m <$> termType m t
+          -> Bool
+isPolyFun m t = isPolyFunCoreTy m (termType m t)
 
 -- | Is a term a term-abstraction?
 isLam :: Term
       -> Bool
-isLam (Lam _) = True
-isLam _       = False
+isLam (Lam {}) = True
+isLam _        = False
 
 -- | Is a term a recursive let-binding?
 isLet :: Term
       -> Bool
-isLet (Letrec _) = True
-isLet _          = False
+isLet (Letrec {}) = True
+isLet _           = False
 
 -- | Is a term a variable reference?
 isVar :: Term
       -> Bool
-isVar (Var _ _) = True
-isVar _         = False
+isVar (Var {}) = True
+isVar _        = False
 
 -- | Is a term a datatype constructor?
 isCon :: Term
       -> Bool
-isCon (Data _) = True
-isCon _        = False
+isCon (Data {}) = True
+isCon _         = False
 
 -- | Is a term a primitive?
 isPrim :: Term
        -> Bool
-isPrim (Prim _ _) = True
-isPrim _          = False
+isPrim (Prim {}) = True
+isPrim _         = False
 
 -- | Make variable reference out of term variable
 idToVar :: Id
         -> Term
-idToVar (Id nm tyE) = Var (unembed tyE) nm
-idToVar tv          = error $ $(curLoc) ++ "idToVar: tyVar: " ++ showDoc tv
+idToVar i@(Id {}) = Var i
+idToVar tv        = error $ $(curLoc) ++ "idToVar: tyVar: " ++ showDoc (ppr tv)
 
 -- | Make a term variable out of a variable reference
 varToId :: Term
         -> Id
-varToId (Var ty nm) = Id nm (embed ty)
-varToId e           = error $ $(curLoc) ++ "varToId: not a var: " ++ showDoc e
+varToId (Var i) = i
+varToId e       = error $ $(curLoc) ++ "varToId: not a var: " ++ showDoc (ppr e)
 
 termSize :: Term
          -> Word
-termSize (Var _ _)   = 1
-termSize (Data _)    = 1
-termSize (Literal _) = 1
-termSize (Prim _ _)  = 1
-termSize (Lam b)     = let (_,e) = unsafeUnbind b
-                       in  termSize e + 1
-termSize (TyLam b)   = let (_,e) = unsafeUnbind b
-                       in  termSize e
-termSize (App e1 e2) = termSize e1 + termSize e2
-termSize (TyApp e _) = termSize e
-termSize (Cast e _ _)= termSize e
-termSize (Letrec b)  = let (bndrsR,body) = unsafeUnbind b
-                           bndrSzs       = map (termSize . unembed . snd) (unrec bndrsR)
-                           bodySz        = termSize body
-                       in sum (bodySz:bndrSzs)
-termSize (Case subj _ alts) = let subjSz = termSize subj
-                                  altSzs = map (termSize . snd . unsafeUnbind) alts
-                              in  sum (subjSz:altSzs)
+termSize (Var {})     = 1
+termSize (Data {})    = 1
+termSize (Literal {}) = 1
+termSize (Prim {})    = 1
+termSize (Lam _ e)    = termSize e + 1
+termSize (TyLam _ e)  = termSize e
+termSize (App e1 e2)  = termSize e1 + termSize e2
+termSize (TyApp e _)  = termSize e
+termSize (Cast e _ _) = termSize e
+termSize (Letrec bndrs e) = sum (bodySz:bndrSzs)
+ where
+  bndrSzs = map (termSize . snd) bndrs
+  bodySz  = termSize e
+termSize (Case subj _ alts) = sum (subjSz:altSzs)
+ where
+  subjSz = termSize subj
+  altSzs = map (termSize . snd) alts
 
 -- | Create a vector of supplied elements
 mkVec :: DataCon -- ^ The Nil constructor
@@ -291,97 +376,141 @@ appendToVec consCon resTy vec = go
                                                    ,resTy
                                                    ,(LitTy (NumTy (n-1)))])
 
+
+availableUniques
+  :: Term
+  -> [Unique]
+availableUniques t = [ n | n <- [0..] , n `IntSet.notMember` avoid ]
+ where
+  avoid = Lens.foldMapOf termFreeVars (\a i -> IntSet.insert (varUniq a) i) t
+            IntSet.empty
+
 -- | Create let-bindings with case-statements that select elements out of a
 -- vector. Returns both the variables to which element-selections are bound
 -- and the let-bindings
-extractElems :: DataCon -- ^ The Cons (:>) constructor
-             -> Type    -- ^ The element type
-             -> Char    -- ^ Char to append to the bound variable names
-             -> Integer -- ^ Length of the vector
-             -> Term    -- ^ The vector
-             -> [(Term,[LetBinding])]
-extractElems consCon resTy s maxN = go maxN
-  where
-    go :: Integer -> Term -> [(Term,[LetBinding])]
-    go 0 _ = []
-    go n e = (elVar
-             ,[(Id elBNm (embed resTy) ,embed lhs)
-              ,(Id restBNm (embed restTy),embed rhs)
-              ]
-             ) :
-             go (n-1) (Var restTy restBNm)
+extractElems
+  :: Supply
+  -- ^ Unique supply
+  -> InScopeSet
+  -- ^ (Superset of) in scope variables
+  -> DataCon
+  -- ^ The Cons (:>) constructor
+  -> Type
+  -- ^ The element type
+  -> Char
+  -- ^ Char to append to the bound variable names
+  -> Integer
+  -- ^ Length of the vector
+  -> Term
+  -- ^ The vector
+  -> (Supply, [(Term,[LetBinding])])
+extractElems supply inScope consCon resTy s maxN vec =
+  first fst (go maxN (supply,inScope) vec)
+ where
+  go :: Integer -> (Supply,InScopeSet) -> Term
+     -> ((Supply,InScopeSet),[(Term,[LetBinding])])
+  go 0 uniqs _ = (uniqs,[])
+  go n uniqs0 e =
+    (uniqs3,(elNVar,[(elNId, lhs),(restNId, rhs)]):restVs)
+   where
+    tys = [(LitTy (NumTy n)),resTy,(LitTy (NumTy (n-1)))]
+    (Just idTys) = dataConInstArgTys consCon tys
+    restTy       = last idTys
 
-      where
-        elBNm     = string2SystemName ("el" ++ s:show (maxN-n))
-        restBNm   = string2SystemName ("rest" ++ s:show (maxN-n))
-        elVar     = Var resTy elBNm
-        pat       = DataPat (embed consCon) (rebind [mTV] [co,el,rest])
-        elPatNm   = string2SystemName "el"
-        restPatNm = string2SystemName "rest"
-        lhs       = Case e resTy  [bind pat (Var resTy  elPatNm)]
-        rhs       = Case e restTy [bind pat (Var restTy restPatNm)]
+    (uniqs1,mTV) = mkUniqSystemTyVar uniqs0 ("m",typeNatKind)
+    (uniqs2,[elNId,restNId,co,el,rest]) =
+      mapAccumR mkUniqSystemId uniqs1 $ zip
+        ["el" `T.append` (s `T.cons` T.pack (show (maxN-n)))
+        ,"rest" `T.append` (s `T.cons` T.pack (show (maxN-n)))
+        ,"_co_"
+        ,"el"
+        ,"rest"
+        ]
+        (resTy:restTy:idTys)
 
-        mName = string2SystemName "m"
-        mTV   = TyVar mName (embed typeNatKind)
-        tys   = [(LitTy (NumTy n)),resTy,(LitTy (NumTy (n-1)))]
-        (Just idTys) = dataConInstArgTys consCon tys
-        [co,el,rest] = zipWith Id [string2SystemName "_co_",elPatNm, restPatNm]
-                                  (map embed idTys)
-        restTy = last (fromJust (dataConInstArgTys consCon tys))
+    elNVar    = Var elNId
+    pat       = DataPat consCon [mTV] [co,el,rest]
+    lhs       = Case e resTy  [(pat,Var el)]
+    rhs       = Case e restTy [(pat,Var rest)]
 
+    (uniqs3,restVs) = go (n-1) uniqs2 (Var restNId)
 
 -- | Create let-bindings with case-statements that select elements out of a
 -- tree. Returns both the variables to which element-selections are bound
 -- and the let-bindings
-extractTElems :: DataCon -- ^ The 'LR' constructor
-              -> DataCon -- ^ The 'BR' constructor
-              -> Type    -- ^ The element type
-              -> Char    -- ^ Char to append to the bound variable names
-              -> Integer -- ^ Depth of the tree
-              -> Term    -- ^ The tree
-              -> ([Term],[LetBinding])
-extractTElems lrCon brCon resTy s maxN = go maxN [0..(2^(maxN+1))-2] [0..(2^maxN - 1)]
-  where
-    go :: Integer -> [Int] -> [Int] -> Term -> ([Term],[LetBinding])
-    go 0 _ ks e = ([elVar],[(Id elBNm (embed resTy), embed lhs)])
-      where
-        elBNm   = string2SystemName ("el" ++ s:show (head ks))
-        elVar   = Var resTy elBNm
-        pat     = DataPat (embed lrCon) (rebind [] [co,el])
-        elPatNm = string2SystemName "el"
-        lhs     = Case e resTy [bind pat (Var resTy elPatNm)]
+extractTElems
+  :: Supply
+  -- ^ Unique supply
+  -> InScopeSet
+  -- ^ (Superset of) in scope variables
+  -> DataCon
+  -- ^ The 'LR' constructor
+  -> DataCon
+  -- ^ The 'BR' constructor
+  -> Type
+  -- ^ The element type
+  -> Char
+  -- ^ Char to append to the bound variable names
+  -> Integer
+  -- ^ Depth of the tree
+  -> Term
+  -- ^ The tree
+  -> (Supply,([Term],[LetBinding]))
+extractTElems supply inScope lrCon brCon resTy s maxN tree =
+  first fst (go maxN [0..(2^(maxN+1))-2] [0..(2^maxN - 1)] (supply,inScope) tree)
+ where
+  go :: Integer
+     -> [Int]
+     -> [Int]
+     -> (Supply,InScopeSet)
+     -> Term
+     -> ((Supply,InScopeSet),([Term],[LetBinding]))
+  go 0 _ ks uniqs0 e = (uniqs1,([elNVar],[(elNId, rhs)]))
+   where
+    tys          = [LitTy (NumTy 0),resTy]
+    (Just idTys) = dataConInstArgTys lrCon tys
 
-        tys          = [LitTy (NumTy 0),resTy]
-        (Just idTys) = dataConInstArgTys lrCon tys
-        [co,el]      = zipWith Id [string2SystemName "_co_",elPatNm]
-                                  (map embed idTys)
+    (uniqs1,[elNId,co,el]) =
+      mapAccumR mkUniqSystemId uniqs0 $ zip
+        [ "el" `T.append` (s `T.cons` T.pack (show (head ks)))
+        , "_co_"
+        , "el"
+        ]
+        (resTy:idTys)
+    elNVar = Var elNId
+    pat    = DataPat lrCon [] [co,el]
+    rhs    = Case e resTy [(pat,Var el)]
 
-    go n bs ks e = (lVars ++ rVars,(Id ltBNm (embed brTy),embed ltLhs):
-                                   (Id rtBNm (embed brTy),embed rtLhs):
-                                   (lBinds ++ rBinds))
-      where
-        ltBNm = string2SystemName ("lt" ++ s:show b0)
-        rtBNm = string2SystemName ("rt" ++ s:show b1)
-        ltVar = Var brTy ltBNm
-        rtVar = Var brTy rtBNm
-        pat   = DataPat (embed brCon) (rebind [mTV] [co,lt,rt])
-        ltPatNm = string2SystemName "lt"
-        rtPatNm = string2SystemName "rt"
-        ltLhs   = Case e brTy [bind pat (Var brTy ltPatNm)]
-        rtLhs   = Case e brTy [bind pat (Var brTy rtPatNm)]
+  go n bs ks uniqs0 e =
+    (uniqs4
+    ,(lVars ++ rVars,(ltNId, ltRhs):
+                     (rtNId, rtRhs):
+                     (lBinds ++ rBinds)))
+   where
+    tys = [LitTy (NumTy n),resTy,LitTy (NumTy (n-1))]
+    (Just idTys) = dataConInstArgTys brCon tys
 
-        mName = string2SystemName "m"
-        mTV = TyVar mName (embed typeNatKind)
-        tys = [LitTy (NumTy n),resTy,LitTy (NumTy (n-1))]
-        (Just idTys) = dataConInstArgTys brCon tys
-        [co,lt,rt] = zipWith Id [string2SystemName "_co_",ltPatNm,rtPatNm]
-                                (map embed idTys)
-        brTy = last idTys
-        (kL,kR) = splitAt (length ks `div` 2) ks
-        (b0:bL,b1:bR) = splitAt (length bs `div` 2) bs
+    (uniqs1,mTV) = mkUniqSystemTyVar uniqs0 ("m",typeNatKind)
+    (b0:bL,b1:bR) = splitAt (length bs `div` 2) bs
+    brTy = last idTys
+    (uniqs2,[ltNId,rtNId,co,lt,rt]) =
+      mapAccumR mkUniqSystemId uniqs1 $ zip
+        ["lt" `T.append` (s `T.cons` T.pack (show b0))
+        ,"rt" `T.append` (s `T.cons` T.pack (show b1))
+        ,"_co_"
+        ,"lt"
+        ,"rt"
+        ]
+        (brTy:brTy:idTys)
+    ltVar = Var ltNId
+    rtVar = Var rtNId
+    pat   = DataPat brCon [mTV] [co,lt,rt]
+    ltRhs = Case e brTy [(pat,Var lt)]
+    rtRhs = Case e brTy [(pat,Var rt)]
 
-        (lVars,lBinds) = go (n-1) bL kL ltVar
-        (rVars,rBinds) = go (n-1) bR kR rtVar
+    (kL,kR) = splitAt (length ks `div` 2) ks
+    (uniqs3,(lVars,lBinds)) = go (n-1) bL kL uniqs2 ltVar
+    (uniqs4,(rVars,rBinds)) = go (n-1) bR kR uniqs3 rtVar
 
 -- | Create a vector of supplied elements
 mkRTree :: DataCon -- ^ The LR constructor
@@ -429,15 +558,15 @@ mkRTree lrCon brCon resTy = go
 --   * BiSignalIn High System Int
 --   * etc.
 --
-isSignalType :: HashMap TyConOccName TyCon -> Type -> Bool
+isSignalType :: TyConMap -> Type -> Bool
 isSignalType tcm ty = go HashSet.empty ty
   where
-    go tcSeen (tyView -> TyConApp tcNm args) = case name2String tcNm of
+    go tcSeen (tyView -> TyConApp tcNm args) = case nameOcc tcNm of
       "Clash.Signal.Internal.Signal"      -> True
       "Clash.Signal.BiSignal.BiSignalIn"  -> True
       "Clash.Signal.Internal.BiSignalOut" -> True
       _ | tcNm `HashSet.member` tcSeen    -> False -- Do not follow rec types
-        | otherwise -> case HashMap.lookup (nameOcc tcNm) tcm of
+        | otherwise -> case lookupUniqMap tcNm tcm of
             Just tc -> let dcs         = tyConDataCons tc
                            dcInsArgTys = concat
                                        $ mapMaybe (`dataConInstArgTys` args) dcs
@@ -449,19 +578,53 @@ isSignalType tcm ty = go HashSet.empty ty
     go _ _ = False
 
 isClockOrReset
-  :: HashMap TyConOccName TyCon
+  :: TyConMap
   -> Type
   -> Bool
 isClockOrReset m (coreView m -> Just ty) = isClockOrReset m ty
-isClockOrReset _ (tyView -> TyConApp tcNm _) = case name2String tcNm of
+isClockOrReset _ (tyView -> TyConApp tcNm _) = case nameOcc tcNm of
   "Clash.Signal.Internal.Clock" -> True
   "Clash.Signal.Internal.Reset" -> True
   _ -> False
 isClockOrReset _ _ = False
 
-tyNatSize :: HMS.HashMap TyConOccName TyCon
+tyNatSize :: TyConMap
           -> Type
           -> Except String Integer
 tyNatSize m (coreView m -> Just ty) = tyNatSize m ty
 tyNatSize _ (LitTy (NumTy i))       = return i
-tyNatSize _ ty = throwE $ $(curLoc) ++ "Cannot reduce to an integer:\n" ++ showDoc ty
+tyNatSize _ ty = throwE $ $(curLoc) ++ "Cannot reduce to an integer:\n" ++ showDoc (ppr ty)
+
+
+mkUniqSystemTyVar
+  :: (Supply, InScopeSet)
+  -> (OccName, Kind)
+  -> ((Supply, InScopeSet), TyVar)
+mkUniqSystemTyVar (supply,inScope) (nm, ki) =
+  ((supply',extendInScopeSet inScope v'), v')
+ where
+  (u,supply') = freshId supply
+  v           = mkTyVar ki (mkUnsafeSystemName nm u)
+  v'          = uniqAway inScope v
+
+mkUniqSystemId
+  :: (Supply, InScopeSet)
+  -> (OccName, Type)
+  -> ((Supply,InScopeSet), Id)
+mkUniqSystemId (supply,inScope) (nm, ty) =
+  ((supply',extendInScopeSet inScope v'), v')
+ where
+  (u,supply') = freshId supply
+  v           = mkId ty (mkUnsafeSystemName nm u)
+  v'          = uniqAway inScope v
+
+mkUniqInternalId
+  :: (Supply, InScopeSet)
+  -> (OccName, Type)
+  -> ((Supply,InScopeSet), Id)
+mkUniqInternalId (supply,inScope) (nm, ty) =
+  ((supply',extendInScopeSet inScope v'), v')
+ where
+  (u,supply') = freshId supply
+  v           = mkId ty (mkUnsafeInternalName nm u)
+  v'          = uniqAway inScope v

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -1,0 +1,550 @@
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
+
+module Clash.Core.VarEnv
+  ( -- * Environment with variables as keys
+    VarEnv
+    -- ** Accessors
+    -- *** Size information
+  , nullVarEnv
+    -- ** Indexing
+  , lookupVarEnv
+  , lookupVarEnv'
+    -- ** Construction
+  , emptyVarEnv
+  , unitVarEnv
+  , mkVarEnv
+    -- ** Modification
+  , extendVarEnv
+  , extendVarEnvList
+  , extendVarEnvWith
+  , delVarEnv
+  , delVarEnvList
+  , unionVarEnv
+  , unionVarEnvWith
+    -- ** Element-wise operations
+    -- *** Mapping
+  , mapVarEnv
+  , mapMaybeVarEnv
+    -- ** Working with predicates
+    -- *** Searching
+  , elemVarEnv
+  , notElemVarEnv
+    -- ** Conversions
+    -- *** Lists
+  , eltsVarEnv
+    -- * Sets of variables
+  , VarSet
+    -- ** Construction
+  , emptyVarSet
+  , unitVarSet
+    -- ** Modification
+  , delVarSetByKey
+  , unionVarSet
+    -- ** Working with predicates
+    -- *** Searching
+  , elemVarSet
+  , notElemVarSet
+    -- ** Conversions
+    -- *** Lists
+  , mkVarSet
+    -- * In-scope sets
+  , InScopeSet
+    -- ** Accessors
+    -- *** Size information
+  , emptyInScopeSet
+    -- *** Indexing
+  , lookupInScope
+    -- ** Construction
+  , mkInScopeSet
+    -- ** Modification
+  , extendInScopeSet
+  , extendInScopeSetList
+  , unionInScope
+    -- ** Working with predicates
+    -- *** Searching
+  , elemInScopeSet
+  , notElemInScopeSet
+  , varSetInScope
+    -- ** Unique generation
+  , uniqAway
+    -- * Dual renaming
+  , RnEnv
+    -- ** Construction
+  , mkRnEnv
+    -- ** Renaming
+  , rnTmBndr
+  , rnTyBndr
+  , rnTmBndrs
+  , rnTyBndrs
+  , rnOccLId
+  , rnOccRId
+  , rnOccLTy
+  , rnOccRTy
+  )
+where
+
+import           Data.Coerce               (coerce)
+import qualified Data.List                 as List
+import           Data.Maybe                (fromMaybe)
+import           Data.Text.Prettyprint.Doc
+import           GHC.Exts                  (Any)
+
+import           Clash.Core.Pretty
+import           Clash.Core.Var
+import           Clash.Unique
+import           Clash.Util
+
+-- * VarEnv
+
+-- | Map indexed by variables
+type VarEnv a = UniqMap a
+
+-- | Empty map
+emptyVarEnv
+  :: VarEnv a
+emptyVarEnv = emptyUniqMap
+
+-- | Environment containing a single variable-value pair
+unitVarEnv
+  :: Var b
+  -> a
+  -> VarEnv a
+unitVarEnv = unitUniqMap
+
+-- | Look up a value based on the variable
+lookupVarEnv
+  :: Var b
+  -> VarEnv a
+  -> Maybe a
+lookupVarEnv = lookupUniqMap
+
+-- | Lookup a value based on the variable
+--
+-- Errors out when the variable is not present
+lookupVarEnv'
+  :: VarEnv a
+  -> Var b
+  -> a
+lookupVarEnv' = lookupUniqMap'
+
+-- | Remove a variable-value pair from the environment
+delVarEnv
+  :: VarEnv a
+  -> Var b
+  -> VarEnv a
+delVarEnv = delUniqMap
+
+-- | Remove a list of variable-value pairs from the environment
+delVarEnvList
+  :: VarEnv a
+  -> [Var b]
+  -> VarEnv a
+delVarEnvList = delListUniqMap
+
+-- | Add a variable-value pair to the environment; overwrites the value if the
+-- variable already exists
+extendVarEnv
+  :: Var b
+  -> a
+  -> VarEnv a
+  -> VarEnv a
+extendVarEnv = extendUniqMap
+
+-- | Add a variable-value pair to the environment; if the variable already
+-- exists, the two values are merged with the given function
+extendVarEnvWith
+  :: Var b
+  -> a
+  -> (a -> a -> a)
+  -> VarEnv a
+  -> VarEnv a
+extendVarEnvWith = extendUniqMapWith
+
+-- | Add a list of variable-value pairs; the values of existing keys will be
+-- overwritten
+extendVarEnvList
+  :: VarEnv a
+  -> [(Var b, a)]
+  -> VarEnv a
+extendVarEnvList = extendListUniqMap
+
+-- | Is the environment empty
+nullVarEnv
+  :: VarEnv a
+  -> Bool
+nullVarEnv = nullUniqMap
+
+-- | Get the (left-biased) union of two environments
+unionVarEnv
+  :: VarEnv a
+  -> VarEnv a
+  -> VarEnv a
+unionVarEnv = unionUniqMap
+
+-- | Get the union of two environments, mapped values existing in both
+-- environments will be merged with the given function.
+unionVarEnvWith
+  :: (a -> a -> a)
+  -> VarEnv a
+  -> VarEnv a
+  -> VarEnv a
+unionVarEnvWith = unionUniqMapWith
+
+-- | Create an environment given a list of var-value pairs
+mkVarEnv
+  :: [(Var a,b)]
+  -> VarEnv b
+mkVarEnv = listToUniqMap
+
+-- | Apply a function to every element in the environment
+mapVarEnv
+  :: (a -> b)
+  -> VarEnv a
+  -> VarEnv b
+mapVarEnv = mapUniqMap
+
+-- | Apply a function to every element in the environment; values for which the
+-- function returns 'Nothing' are removed from the environment
+mapMaybeVarEnv
+  :: (a -> Maybe b)
+  -> VarEnv a
+  -> VarEnv b
+mapMaybeVarEnv = mapMaybeUniqMap
+
+-- | Extract the elements
+eltsVarEnv
+  :: VarEnv a
+  -> [a]
+eltsVarEnv = eltsUniqMap
+
+-- | Does the variable exist in the environment
+elemVarEnv
+  :: Var a
+  -> VarEnv b
+  -> Bool
+elemVarEnv = elemUniqMap
+
+-- | Does the variable not exist in the environment
+notElemVarEnv
+  :: Var a
+  -> VarEnv b
+  -> Bool
+notElemVarEnv = notElemUniqMap
+
+-- * VarSet
+
+-- | Set of variables
+type VarSet = UniqSet (Var Any)
+
+-- | The empty set
+emptyVarSet
+  :: VarSet
+emptyVarSet = emptyUniqSet
+
+-- | The set of a single variable
+unitVarSet
+  :: Var a
+  -> VarSet
+unitVarSet v = unitUniqSet (coerce v)
+
+-- | Add a variable to the set
+extendVarSet
+  :: VarSet
+  -> Var a
+  -> VarSet
+extendVarSet env v = extendUniqSet env (coerce v)
+
+-- | Union two sets
+unionVarSet
+  :: VarSet
+  -> VarSet
+  -> VarSet
+unionVarSet = unionUniqSet
+
+-- | Is the variable an element in the set
+elemVarSet
+  :: Var a
+  -> VarSet
+  -> Bool
+elemVarSet v = elemUniqSet (coerce v)
+
+-- | Is the variable not an element in the set
+notElemVarSet
+  :: Var a
+  -> VarSet
+  -> Bool
+notElemVarSet v = notElemUniqSet (coerce v)
+
+-- | Is the set of variables A a subset of the variables B
+subsetVarSet
+  :: VarSet
+  -- ^ Set of variables A
+  -> VarSet
+  -- ^ Set of variables B
+  -> Bool
+subsetVarSet = subsetUniqSet
+
+-- | Look up a variable in the set, returns it if it exists
+lookupVarSet
+  :: Var a
+  -> VarSet
+  -> Maybe (Var Any)
+lookupVarSet = lookupUniqSet
+
+-- | Remove a variable from the set based on its 'Unique'
+delVarSetByKey
+  :: Unique
+  -> VarSet
+  -> VarSet
+delVarSetByKey = delUniqSetDirectly
+
+-- | Create a set from a list of variables
+mkVarSet
+  :: [Var a]
+  -> VarSet
+mkVarSet xs = mkUniqSet (coerce xs)
+
+-- * InScopeSet
+
+-- | Set of variables that is in scope at some point
+--
+-- The 'Int' is a kind of hash-value used to generate new uniques. It should
+-- never be zero
+--
+-- See "Secrets of the Glasgow Haskell Compiler inliner" Section 3.2 for the
+-- motivation
+data InScopeSet = InScopeSet VarSet {-# UNPACK #-} !Int
+
+instance Pretty InScopeSet where
+  pretty (InScopeSet s _) = pretty s
+
+-- | The empty set
+extendInScopeSet
+  :: InScopeSet
+  -> Var a
+  -> InScopeSet
+extendInScopeSet (InScopeSet inScope n) v =
+  InScopeSet (extendVarSet inScope v) (n + 1)
+
+-- | Add a list of variables in scope
+extendInScopeSetList
+  :: InScopeSet
+  -> [Var a]
+  -> InScopeSet
+extendInScopeSetList (InScopeSet inScope n) vs =
+  InScopeSet (List.foldl' extendVarSet inScope vs) (n + length vs)
+
+-- | Union two sets of in scope variables
+unionInScope
+  :: InScopeSet
+  -> InScopeSet
+  -> InScopeSet
+unionInScope (InScopeSet s1 _) (InScopeSet s2 n2)
+  = InScopeSet (s1 `unionVarSet` s2) n2
+
+-- | Is the set of variables in scope
+varSetInScope
+  :: VarSet
+  -> InScopeSet
+  -> Bool
+varSetInScope vars (InScopeSet s1 _)
+  = vars `subsetVarSet` s1
+
+-- | Look up a variable in the 'InScopeSet'. This gives you the canonical
+-- version of the variable
+lookupInScope
+  :: InScopeSet
+  -> Var a
+  -> Maybe (Var Any)
+lookupInScope (InScopeSet s _) v = lookupVarSet v s
+
+-- | Is the variable in scope
+elemInScopeSet
+  :: Var a
+  -> InScopeSet
+  -> Bool
+elemInScopeSet v (InScopeSet s _) = elemVarSet v s
+
+-- | Is the variable not in scope
+notElemInScopeSet
+  :: Var a
+  -> InScopeSet
+  -> Bool
+notElemInScopeSet v (InScopeSet s _) = notElemVarSet v s
+
+-- | Create a set of variables in scope
+mkInScopeSet
+  :: VarSet
+  -> InScopeSet
+mkInScopeSet is = InScopeSet is 1
+
+-- | The empty set
+emptyInScopeSet
+  :: InScopeSet
+emptyInScopeSet = mkInScopeSet emptyVarSet
+
+-- | Ensure that the 'Unique' of a variable does not occur in the 'InScopeSet'
+uniqAway
+  :: InScopeSet
+  -> Var a
+  -> Var a
+uniqAway inScopeSet var
+  | var `elemInScopeSet` inScopeSet -- make a new one
+  = uniqAway' inScopeSet var
+  | otherwise                       -- Nothing to do
+  = var
+
+uniqAway'
+  :: InScopeSet
+  -> Var a
+  -> Var a
+uniqAway' (InScopeSet set n) var = try 1 where
+  origUniq = varUniq var
+  try k
+    | debugIsOn && k > 1000
+    = pprPanic "uniqAway loop:" msg
+    | uniq `elemUniqSetDirectly` set
+    = try (k + 1)
+    | k > 3
+    = pprTraceDebug "uniqAway:" msg (setVarUnique var uniq)
+    | otherwise
+    = setVarUnique var uniq
+    where
+      msg  = pretty k <+> "tries" <+> ppr (varName var) <+> pretty n
+      uniq = deriveUnique origUniq (n * k)
+
+deriveUnique
+  :: Unique
+  -> Int
+  -> Unique
+deriveUnique i delta = i + delta
+
+-- * RnEnv
+
+-- | Rename environment for e.g. alpha equivalence
+--
+-- When going under binders for e.g.
+--
+-- @
+-- \x -> e1  `aeq` \y -> e2
+-- @
+--
+-- We want to rename @[x -> y]@  or @[y -> x]@, but we have to pick a binder
+-- that is neither free in @e1@ nor @e2@ or we risk accidental capture.
+--
+-- So we must maintain:
+--
+--   1. A renaming for the left term
+--
+--   2. A renaming for the right term
+--
+--   3. A set of in scope variables
+data RnEnv
+  = RnEnv
+  { rn_envLTy  :: VarEnv TyVar
+    -- ^ Type renaming for the left term
+  , rn_envLTm  :: VarEnv Id
+    -- ^ Term renaming for the left term
+  , rn_envRTy  :: VarEnv TyVar
+    -- ^ Type renaming for the right term
+  , rn_envRTm  :: VarEnv Id
+    -- ^ Term renaming for the right term
+  , rn_inScope :: InScopeSet
+    -- ^ In scope in left or right terms
+  }
+
+-- | Create an empty renaming environment
+mkRnEnv
+  :: InScopeSet -> RnEnv
+mkRnEnv vars
+  = RnEnv
+  { rn_envLTy  = emptyVarEnv
+  , rn_envLTm  = emptyVarEnv
+  , rn_envRTy  = emptyVarEnv
+  , rn_envRTm  = emptyVarEnv
+  , rn_inScope = vars
+  }
+
+-- | Look up the renaming of an type-variable occurrence in the left term
+rnOccLTy
+  :: RnEnv -> TyVar -> TyVar
+rnOccLTy rn v = fromMaybe v (lookupVarEnv v (rn_envLTy rn))
+
+-- | Look up the renaming of an type-variable occurrence in the right term
+rnOccRTy
+  :: RnEnv -> TyVar -> TyVar
+rnOccRTy rn v = fromMaybe v (lookupVarEnv v (rn_envRTy rn))
+
+-- | Simultaneously go under the type-variable binder /bTvL/ and type-variable
+-- binder /bTvR/, finds a new binder /newTvB/, and return an environment mapping
+-- @[bTvL -> newB]@ and @[bTvR -> newB]@
+rnTyBndr
+  :: RnEnv -> TyVar -> TyVar -> RnEnv
+rnTyBndr rv@(RnEnv {rn_envLTy = lenv, rn_envRTy = renv, rn_inScope = inScope}) bL bR =
+  rv { rn_envLTy = extendVarEnv bL newB lenv -- See Note [Rebinding and shadowing]
+     , rn_envRTy = extendVarEnv bR newB renv
+     , rn_inScope = extendInScopeSet inScope newB }
+ where
+  -- Find a new type-binder not in scope in either term
+  newB | not (bL `elemInScopeSet` inScope) = bL
+       | not (bR `elemInScopeSet` inScope) = bR
+       | otherwise                         = uniqAway' inScope bL
+
+{- Note [Rebinding and shadowing]
+Imagine:
+
+@
+\x -> \x -> e1  `aeq` \y -> \x -> e2
+@
+
+Then inside
+
+@
+\x \y  { [x->p] [y->p]  {p} }
+\x \z  { [x->q] [y->p, z->q] {p,q} }
+@
+
+i.e. if the new var is the same as the old var, the renaming is deleted by
+'extendVarEnv'
+-}
+
+-- | Applies 'rnTyBndr' to several variables: the two variable lists must be of
+-- equal length.
+rnTyBndrs
+  :: RnEnv -> [TyVar] -> [TyVar] -> RnEnv
+rnTyBndrs env tvs1 tvs2 =
+  List.foldl' (\s (l,r) -> rnTyBndr s l r) env (zipEqual tvs1 tvs2)
+
+-- | Look up the renaming of an occurrence in the left term
+rnOccLId
+  :: RnEnv -> Id -> Id
+rnOccLId rn v = fromMaybe v (lookupVarEnv v (rn_envLTm rn))
+
+-- | Look up the renaming of an occurrence in the left term
+rnOccRId
+  :: RnEnv -> Id -> Id
+rnOccRId rn v = fromMaybe v (lookupVarEnv v (rn_envRTm rn))
+
+-- | Simultaneously go under the binder /bL/ and binder /bR/, finds a new binder
+-- /newTvB/, and return an environment mapping @[bL -> newB]@ and @[bR -> newB]@
+rnTmBndr
+  :: RnEnv -> Id -> Id -> RnEnv
+rnTmBndr rv@(RnEnv {rn_envLTm = lenv, rn_envRTm = renv, rn_inScope = inScope}) bL bR =
+  rv { rn_envLTm = extendVarEnv bL newB lenv -- See Note [Rebinding and shadowing]
+     , rn_envRTm = extendVarEnv bR newB renv
+     , rn_inScope = extendInScopeSet inScope newB }
+ where
+  -- Find a new type-binder not in scope in either term
+  newB | not (bL `elemInScopeSet` inScope) = bL
+       | not (bR `elemInScopeSet` inScope) = bR
+       | otherwise                         = uniqAway' inScope bL
+
+-- | Applies 'rnTmBndr' to several variables: the two variable lists must be of
+-- equal length.
+rnTmBndrs
+  :: RnEnv -> [Id] -> [Id] -> RnEnv
+rnTmBndrs env ids1 ids2 =
+  List.foldl' (\s (l,r) -> rnTmBndr s l r) env (zipEqual ids1 ids2)

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -10,31 +10,26 @@
 
 {-# LANGUAGE CPP #-}
 
-module Clash.Driver.Types
-  (module Clash.Driver.Types
-  ,SrcSpan, noSrcSpan
-  )
-where
+module Clash.Driver.Types where
 
 -- For Int/Word size
 #include "MachDeps.h"
 
-import Control.Exception (Exception)
-import Data.HashMap.Lazy (HashMap)
-import Data.Text.Lazy    (Text)
+import Data.Text         (Text)
 
 import BasicTypes        (InlineSpec)
-import SrcLoc            (SrcSpan, noSrcSpan)
+import SrcLoc            (SrcSpan)
 
-import Clash.Core.Term   (Term,TmName,TmOccName)
-import Clash.Core.Type   (Type)
+import Clash.Core.Term   (Term)
+import Clash.Core.Var    (Id)
+import Clash.Core.VarEnv (VarEnv)
 
 import Clash.Netlist.BlackBox.Types (HdlSyn (..))
 
 -- | Global function binders
 --
 -- Global functions cannot be mutually recursive, only self-recursive
-type BindingMap = HashMap TmOccName (TmName,Type,SrcSpan,InlineSpec,Term)
+type BindingMap = VarEnv (Id,SrcSpan,InlineSpec,Term)
 
 -- | Debug Message Verbosity
 data DebugLevel
@@ -81,13 +76,6 @@ defClashOpts
   , opt_importPaths         = []
   , opt_componentPrefix     = Nothing
   }
-
-data ClashException = ClashException SrcSpan String (Maybe String)
-
-instance Show ClashException where
-  show (ClashException _ s eM) = s ++ "\n" ++ maybe "" id eM
-
-instance Exception ClashException
 
 -- | Information about the generated HDL between (sub)runs of the compiler
 data Manifest

--- a/clash-lib/src/Clash/Netlist.hs-boot
+++ b/clash-lib/src/Clash/Netlist.hs-boot
@@ -15,14 +15,15 @@ module Clash.Netlist
   ) where
 
 import Clash.Core.DataCon   (DataCon)
-import Clash.Core.Term      (Alt,LetBinding,Term,TmOccName)
+import Clash.Core.Term      (Alt,LetBinding,Term)
 import Clash.Core.Type      (Type)
 import Clash.Core.Var       (Id)
-import Clash.Driver.Types   (SrcSpan)
 import Clash.Netlist.Types  (Expr, HWType, Identifier, NetlistMonad, Component,
                              Declaration)
+import SrcLoc               (SrcSpan)
 
-genComponent :: TmOccName
+
+genComponent :: Id
              -> NetlistMonad (SrcSpan,[Identifier],Component)
 
 mkExpr :: Bool

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -21,8 +21,8 @@ where
 #error MIN_VERSION_text undefined
 #endif
 
-import Data.Char      (isAsciiLower,isAsciiUpper,isDigit)
-import Data.Text.Lazy as Text
+import Data.Char (isAsciiLower,isAsciiUpper,isDigit)
+import Data.Text as Text
 
 data IdType = Basic | Extended
 

--- a/clash-lib/src/Clash/Netlist/Types.hs-boot
+++ b/clash-lib/src/Clash/Netlist/Types.hs-boot
@@ -6,7 +6,7 @@
 
 module Clash.Netlist.Types where
 
-import Data.Text.Lazy (Text)
+import Data.Text (Text)
 
 type Identifier = Text
 

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -45,37 +45,35 @@ where
 import           Control.Concurrent.Supply        (splitSupply)
 import qualified Control.Lens                     as Lens
 import           Data.Bits                        ((.&.),complement)
+import           Data.Coerce                      (coerce)
 import qualified Data.Either                      as Either
 import qualified Data.Foldable                    as Foldable
-import qualified Data.HashMap.Strict              as HashMap
 import qualified Data.IntMap.Strict               as IM
 import qualified Data.List                        as List
 import qualified Data.Map.Strict                  as Map
 import qualified Data.Maybe                       as Maybe
-import           Data.Set                         (Set)
-import qualified Data.Set                         as Set
-import qualified Data.Set.Lens                    as Lens
-
-import           Unbound.Generics.LocallyNameless
-  (Bind, bind, embed, fv, unbind, unembed, unrec)
-import qualified Unbound.Generics.LocallyNameless as Unbound
+import           Data.Monoid                      (All (..))
 
 -- internal
 import Clash.Core.DataCon    (DataCon, dcTag)
 import Clash.Core.Evaluator  (whnf')
-import Clash.Core.FreeVars   (termFreeIds, typeFreeVars)
-import Clash.Core.Name       (Name (..), string2InternalName)
+import Clash.Core.FreeVars
+  (termFreeVars', noFreeVarsOfType, varsDoNotOccurIn)
 import Clash.Core.Literal    (Literal (..))
-import Clash.Core.Term       (LetBinding, Pat (..), Term (..), TmOccName)
+import Clash.Core.Term       (LetBinding, Pat (..), Term (..))
 import Clash.Core.TyCon      (tyConDataCons)
 import Clash.Core.Type       (Type, isPolyFunTy, mkTyConApp, splitFunForallTy)
-import Clash.Core.Util       (collectArgs, mkApps, termType)
+import Clash.Core.Util       (collectArgs, mkApps, patIds, termType)
+import Clash.Core.Var        (Var (..))
+import Clash.Core.VarEnv
+  (InScopeSet, VarSet, elemInScopeSet, notElemVarSet)
 import Clash.Normalize.Types (NormalizeState)
 import Clash.Normalize.Util  (isConstant)
 import Clash.Rewrite.Types
   (RewriteMonad, bindings, evaluator, globalHeap, tcCache, tupleTcCache, uniqSupply)
 import Clash.Rewrite.Util    (mkInternalVar, mkSelectorCase,
                               isUntranslatableType)
+import Clash.Unique          (lookupUniqMap)
 import Clash.Util
 
 data CaseTree a
@@ -119,7 +117,7 @@ allEqual (x:xs) = all (== x) xs
 -- of an expression. Also substitute truly disjoint applications of globals by a
 -- reference to a lifted out application.
 collectGlobals ::
-     Set TmOccName
+     InScopeSet
   -> [(Term,Term)] -- ^ Substitution of (applications of) a global
                    -- binder by a reference to a lifted term.
   -> [Term] -- ^ List of already seen global binders
@@ -142,8 +140,8 @@ collectGlobals inScope substitution seen e@(collectArgs -> (fun, args@(_:_)))
     ids <- Lens.use uniqSupply
     let (ids1,ids2) = splitSupply ids
     uniqSupply Lens..= ids2
-    let eval = snd . whnf' primEval bndrs tcm gh ids1 False
-    eTy <- termType tcm e
+    let eval = snd . whnf' primEval bndrs tcm gh ids1 inScope False
+        eTy  = termType tcm e
     untran <- isUntranslatableType False eTy
     case untran of
       -- Don't lift out non-representable values, because they cannot be let-bound
@@ -167,13 +165,12 @@ collectGlobals inScope substitution seen e@(collectArgs -> (fun, args@(_:_)))
 -- the ANF, CSE, and DeadCodeRemoval pass all duplicates are removed.
 --
 -- I think we should be able to do better, but perhaps we cannot fix it here.
-collectGlobals inScope substitution seen (Letrec b) = do
-  (unrec -> lbs,body) <- unbind b
+collectGlobals inScope substitution seen (Letrec lbs body) = do
   (body',collected)   <- collectGlobals    inScope substitution seen body
   (lbs',collected')   <- collectGlobalsLbs inScope substitution
                                            (map fst collected ++ seen)
                                            lbs
-  return (Letrec (bind (Unbound.rec lbs') body')
+  return (Letrec lbs' body'
          ,map (second (second (LB lbs'))) (collected ++ collected')
          )
 
@@ -183,7 +180,7 @@ collectGlobals _ _ _ e = return (e,[])
 -- of a list of application arguments. Also substitute truly disjoint
 -- applications of globals by a reference to a lifted out application.
 collectGlobalsArgs ::
-     Set TmOccName
+     InScopeSet
   -> [(Term,Term)] -- ^ Substitution of (applications of) a global
                    -- binder by a reference to a lifted term.
   -> [Term] -- ^ List of already seen global binders
@@ -205,14 +202,14 @@ collectGlobalsArgs inScope substitution seen args = do
 -- of a list of alternatives. Also substitute truly disjoint applications of
 -- globals by a reference to a lifted out application.
 collectGlobalsAlts ::
-     Set TmOccName
+     InScopeSet
   -> [(Term,Term)] -- ^ Substitution of (applications of) a global
                    -- binder by a reference to a lifted term.
   -> [Term] -- ^ List of already seen global binders
   -> Term -- ^ The subject term
-  -> [Bind Pat Term] -- ^ The list of alternatives
+  -> [(Pat,Term)] -- ^ The list of alternatives
   -> RewriteMonad NormalizeState
-                  ([Bind Pat Term]
+                  ([(Pat,Term)]
                   ,[(Term,([Term],CaseTree [(Either Term Type)]))]
                   )
 collectGlobalsAlts inScope substitution seen scrut alts = do
@@ -222,15 +219,15 @@ collectGlobalsAlts inScope substitution seen scrut alts = do
         collected'  = map (second (second (Branch scrut))) (Map.toList collectedUN)
     return (alts',collected')
   where
-    go pe = do (p,e) <- unbind pe
-               (e',collected) <- collectGlobals inScope substitution seen e
-               return (bind p e',map (second (second (p,))) collected)
+    go (p,e) = do
+      (e',collected) <- collectGlobals inScope substitution seen e
+      return ((p,e'),map (second (second (p,))) collected)
 
 -- | Collect 'CaseTree's for (potentially) disjoint applications of globals out
 -- of a list of let-bindings. Also substitute truly disjoint applications of
 -- globals by a reference to a lifted out application.
 collectGlobalsLbs ::
-     Set TmOccName
+     InScopeSet
   -> [(Term,Term)] -- ^ Substitution of (applications of) a global
                    -- binder by a reference to a lifted term.
   -> [Term] -- ^ List of already seen global binders
@@ -250,9 +247,9 @@ collectGlobalsLbs inScope substitution seen lbs = do
                    ,[(Term,([Term],CaseTree [(Either Term Type)]))]
                    )
                   )
-    go s (id_,unembed -> e) = do
+    go s (id_, e) = do
       (e',collected) <- collectGlobals inScope substitution s e
-      return (map fst collected ++ s,((id_,embed e'),collected))
+      return (map fst collected ++ s,((id_,e'),collected))
 
 -- | Given a case-tree corresponding to a disjoint interesting \"term-in-a-
 -- function-position\", return a let-expression: where the let-binding holds
@@ -260,11 +257,13 @@ collectGlobalsLbs inScope substitution seen lbs = do
 -- and the body is an application of the term applied to the common arguments of
 -- the case tree, and projections of let-binding corresponding to the uncommon
 -- argument positions.
-mkDisjointGroup :: Set TmOccName -- ^ Current free variables.
-                -> (Term,([Term],CaseTree [(Either Term Type)]))
-                   -- ^ Case-tree of arguments belonging to the applied term.
-                -> RewriteMonad NormalizeState (Term,[Term])
-mkDisjointGroup fvs (fun,(seen,cs)) = do
+mkDisjointGroup
+  :: InScopeSet
+  -> VarSet -- ^ Current free variables.
+  -> (Term,([Term],CaseTree [(Either Term Type)]))
+     -- ^ Case-tree of arguments belonging to the applied term.
+  -> RewriteMonad NormalizeState (Term,[Term])
+mkDisjointGroup inScope fvs (fun,(seen,cs)) = do
     let argss    = Foldable.toList cs
         argssT   = zip [0..] (List.transpose argss)
         (commonT,uncommonT) = List.partition (isCommon fvs . snd) argssT
@@ -282,11 +281,11 @@ mkDisjointGroup fvs (fun,(seen,cs)) = do
       [] -> return (Nothing,[])
       -- Create selectors and projections
       (uc:_) -> do
-        argTys <- mapM (termType tcm) uc
-        disJointSelProj argTys cs''
+        let argTys = map (termType tcm) uc
+        disJointSelProj inScope argTys cs''
     let newArgs = mkDJArgs 0 common uncommonProjections
     case uncommonCaseM of
-      Just lb -> return (Letrec (bind (Unbound.rec [lb]) (mkApps fun newArgs)), seen)
+      Just lb -> return (Letrec [lb] (mkApps fun newArgs), seen)
       Nothing -> return (mkApps fun newArgs, seen)
 
 -- | Create a single selector for all the representable uncommon arguments by
@@ -300,11 +299,15 @@ mkDisjointGroup fvs (fun,(seen,cs)) = do
 -- * For all the representable uncommon arguments: a projection out of the tuple
 --   created by the larger selector. If this larger selector does not exist, a
 --   single selector is created for the single representable uncommon argument.
-disJointSelProj :: [Type] -- ^ Types of the arguments
-                -> CaseTree [Term] -- The case-tree of arguments
-                -> RewriteMonad NormalizeState (Maybe LetBinding,[Term])
-disJointSelProj _ (Leaf []) = return (Nothing,[])
-disJointSelProj argTys cs = do
+disJointSelProj
+  :: InScopeSet
+  -> [Type]
+  -- ^ Types of the arguments
+  -> CaseTree [Term]
+  -- The case-tree of arguments
+  -> RewriteMonad NormalizeState (Maybe LetBinding,[Term])
+disJointSelProj _ _ (Leaf []) = return (Nothing,[])
+disJointSelProj inScope argTys cs = do
     let maxIndex = length argTys - 1
         css = map (\i -> fmap ((:[]) . (!!i)) cs) [0..maxIndex]
     (untran,tran) <- partitionM (isUntranslatableType False . snd) (zip [0..] argTys)
@@ -319,16 +322,16 @@ disJointSelProj argTys cs = do
         tupTcm <- Lens.view tupleTcCache
         let m            = length tys
             Just tupTcNm = IM.lookup m tupTcm
-            Just tupTc   = HashMap.lookup (nameOcc tupTcNm) tcm
+            Just tupTc   = lookupUniqMap tupTcNm tcm
             [tupDc]      = tyConDataCons tupTc
             (tyIxs,tys') = unzip tys
             tupTy        = mkTyConApp tupTcNm tys'
             cs'          = fmap (\es -> map (es !!) tyIxs) cs
             djCase       = genCase tupTy (Just tupDc) tys' cs'
-        (scrutId,scrutVar) <- mkInternalVar (string2InternalName "tupIn") tupTy
+        scrutId <- mkInternalVar inScope "tupIn" tupTy
         projections <- mapM (mkSelectorCase ($(curLoc) ++ "disJointSelProj")
-                                            tcm scrutVar (dcTag tupDc)) [0..m-1]
-        return (Just (scrutId,embed djCase),projections)
+                                            inScope tcm (Var scrutId) (dcTag tupDc)) [0..m-1]
+        return (Just (scrutId,djCase),projections)
     let selProjs = tranOrUnTran 0 (zip (map fst untran) untranSels) projs
 
     return (lbM,selProjs)
@@ -340,12 +343,16 @@ disJointSelProj argTys cs = do
       | otherwise = p : tranOrUnTran (n+1) ((ut,s):uts) projs
 
 
-isCommon :: Set TmOccName -> [Either Term Type] -> Bool
+isCommon :: VarSet -> [Either Term Type] -> Bool
 isCommon _   []             = True
-isCommon _   (Right ty:tys) = Set.null (Lens.setOf typeFreeVars ty) &&
-                              allEqual (Right ty:tys)
-isCommon fvs (Left tm:tms)  = Set.null (Lens.setOf termFreeIds tm Set.\\ fvs) &&
-                              allEqual (Left tm:tms)
+isCommon _   (Right ty:tys) =
+  noFreeVarsOfType ty && allEqual (Right ty:tys)
+isCommon fvs (Left tm:tms) =
+  getAll (Lens.foldMapOf (termFreeVars' isFreeId) (const (All False)) tm) &&
+  allEqual (Left tm:tms)
+ where
+  isFreeId i@Id {} = i `notElemVarSet` fvs
+  isFreeId _       = False
 
 -- | Create a list of arguments given a map of positions to common arguments,
 -- and a list of arguments
@@ -374,17 +381,17 @@ genCase ty dcM argTys = go
         _ -> head tms
 
     go (LB lb ct) =
-      Letrec (bind (Unbound.rec lb) (go ct))
+      Letrec lb (go ct)
 
     go (Branch scrut [(p,ct)]) =
       let ct' = go ct
-          alt = bind p ct'
-      in  case Lens.setOf termFreeIds ct' == Lens.setOf fv alt of
-            True -> ct'
-            _    -> Case scrut ty [alt]
+          (ptvs,pids) = patIds p
+      in  if (coerce ptvs ++ coerce pids) `varsDoNotOccurIn` ct'
+             then ct'
+             else Case scrut ty [(p,ct')]
 
     go (Branch scrut pats) =
-      Case scrut ty (map (\(p,ct) -> bind p (go ct)) pats)
+      Case scrut ty (map (second go) pats)
 
 -- | Determine if a term in a function position is interesting to lift out of
 -- of a case-expression.
@@ -395,7 +402,7 @@ genCase ty dcM argTys = go
 -- * All non-power-of-two multiplications
 -- * All division-like operations with a non-power-of-two divisor
 interestingToLift
-  :: Set TmOccName
+  :: InScopeSet
   -- ^ in scope
   -> (Term -> Term)
   -- ^ Evaluator
@@ -404,8 +411,8 @@ interestingToLift
   -> [Either Term Type]
   -- ^ Arguments
   -> Maybe Term
-interestingToLift inScope _ e@(Var _ nm) _ =
-  if nameOcc nm `Set.member` inScope
+interestingToLift inScope _ e@(Var v) _ =
+  if v `elemInScopeSet` inScope
      then Just e
      else Nothing
 interestingToLift inScope eval e@(Prim nm pty) args =

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -222,7 +222,7 @@ liftNonRep.
 
 -- | Topdown traversal, stops upon first success
 topdownSucR :: Rewrite extra -> Rewrite extra
-topdownSucR r = r >-! (allR True (topdownSucR r))
+topdownSucR r = r >-! (allR (topdownSucR r))
 
 innerMost :: Rewrite extra -> Rewrite extra
 innerMost r = bottomupR (r !-> innerMost r)

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -12,11 +12,12 @@
 module Clash.Normalize.Types where
 
 import Control.Monad.State.Strict (State)
-import Data.HashMap.Strict (HashMap)
 import Data.Map            (Map)
 
-import Clash.Core.Term        (Term, TmName, TmOccName)
+import Clash.Core.Term        (Term)
 import Clash.Core.Type        (Type)
+import Clash.Core.Var         (Id)
+import Clash.Core.VarEnv      (VarEnv)
 import Clash.Driver.Types     (BindingMap)
 import Clash.Primitives.Types (CompiledPrimMap)
 import Clash.Rewrite.Types    (Rewrite, RewriteMonad)
@@ -27,17 +28,17 @@ data NormalizeState
   = NormalizeState
   { _normalized          :: BindingMap
   -- ^ Global binders
-  , _specialisationCache :: Map (TmOccName,Int,Either Term Type) (TmName,Type)
+  , _specialisationCache :: Map (Id,Int,Either Term Type) Id
   -- ^ Cache of previously specialised functions:
   --
   -- * Key: (name of the original function, argument position, specialised term/type)
   --
   -- * Elem: (name of specialised function,type of specialised function)
-  , _specialisationHistory :: HashMap TmOccName Int
+  , _specialisationHistory :: VarEnv Int
   -- ^ Cache of how many times a function was specialized
   , _specialisationLimit :: !Int
   -- ^ Number of time a function 'f' can be specialized
-  , _inlineHistory   :: HashMap TmOccName (HashMap TmOccName Int)
+  , _inlineHistory   :: VarEnv (VarEnv Int)
   -- ^ Cache of function where inlining took place:
   --
   -- * Key: function where inlining took place
@@ -51,7 +52,7 @@ data NormalizeState
   , _inlineConstantLimit :: !Word
   -- ^ Size of a constant below which it is always inlined; 0 = no limit
   , _primitives :: CompiledPrimMap -- ^ Primitive Definitions
-  , _recursiveComponents :: HashMap TmOccName Bool
+  , _recursiveComponents :: VarEnv Bool
   -- ^ Map telling whether a components is recursively defined.
   --
   -- NB: there are only no mutually-recursive component, only self-recursive

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -18,7 +18,7 @@ import Clash.Netlist.BlackBox.Util
 import Clash.Netlist.Id
 import Clash.Netlist.Types
 import Clash.Backend
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as TextS
 
 altpllTF :: TemplateFunction
 altpllTF = TemplateFunction used valid altpllTemplate
@@ -51,7 +51,7 @@ alteraPllTemplate bbCtx = do
   traverse (mkUniqueIdentifier Basic)
            ["locked", "pllLock", "alteraPll","alteraPll_inst"]
  clocks <- traverse (mkUniqueIdentifier Extended)
-                    [Text.pack ("pllOut" ++ show n) | n <- [0..length tys - 1]]
+                    [TextS.pack ("pllOut" ++ show n) | n <- [0..length tys - 1]]
  getMon $ blockDecl alteraPll $ concat
   [[ NetDecl Nothing locked  rstTy
    , NetDecl Nothing pllLock Bool]
@@ -59,7 +59,7 @@ alteraPllTemplate bbCtx = do
   ,[ InstDecl Comp Nothing compName alteraPll_inst $ concat
       [[(Identifier "refclk" Nothing,In,clkTy,clk)
        ,(Identifier "rst" Nothing,In,rstTy,rst)]
-      ,[(Identifier (Text.pack ("outclk_" ++ show n)) Nothing,Out,ty,Identifier k Nothing)
+      ,[(Identifier (TextS.pack ("outclk_" ++ show n)) Nothing,Out,ty,Identifier k Nothing)
        |(k,ty,n) <- zip3 clocks tys [(0 :: Int)..]  ]
       ,[(Identifier "locked" Nothing,Out,rstTy,Identifier locked Nothing)]]
    , CondAssignment pllLock Bool (Identifier locked Nothing) rstTy
@@ -75,7 +75,7 @@ alteraPllTemplate bbCtx = do
   [_,(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = bbInputs bbCtx
   (Identifier result Nothing,resTy@(Product _ (tail -> tys))) = bbResult bbCtx
   Just nm' = exprToString nm
-  compName = Text.pack nm'
+  compName = TextS.pack nm'
 
 altpllTemplate
   :: Backend s
@@ -106,5 +106,5 @@ altpllTemplate bbCtx = do
   [(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = bbInputs bbCtx
   (Identifier result Nothing,resTy@(Product _ [clkOutTy,_])) = bbResult bbCtx
   Just nm' = exprToString nm
-  compName = Text.pack nm'
+  compName = TextS.pack nm'
 

--- a/clash-lib/src/Clash/Rewrite/Combinators.hs
+++ b/clash-lib/src/Clash/Rewrite/Combinators.hs
@@ -7,79 +7,62 @@
 -}
 
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Clash.Rewrite.Combinators where
 
 import           Control.DeepSeq             (deepseq)
-import           Control.Monad               ((<=<), (>=>))
+import           Control.Monad               ((>=>))
 import qualified Control.Monad.Writer        as Writer
 import qualified Data.Monoid                 as Monoid
-import           Unbound.Generics.LocallyNameless (Embed, Fresh, bind, embed,
-                                                   rec, unbind, unembed, unrec)
-import           Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
-import           Clash.Core.Term             (Pat, Term (..))
+import           Clash.Core.Term             (Term (..))
 import           Clash.Core.Util             (patIds)
-import           Clash.Core.Var              (Id)
+import           Clash.Core.VarEnv
+  (extendInScopeSet, extendInScopeSetList)
 import           Clash.Rewrite.Types
 
 -- | Apply a transformation on the subtrees of an term
-allR :: forall m . (Monad m, Fresh m)
-     => Bool -- ^ Freshen variable references in abstracted terms
-     -> Transform m -- ^ The transformation to apply to the subtrees
+allR :: forall m . Monad m
+     => Transform m -- ^ The transformation to apply to the subtrees
      -> Transform m
-allR _ _ _ (Var t x)   = return (Var t x)
-allR _ _ _ (Data dc)   = return (Data dc)
-allR _ _ _ (Literal l) = return (Literal l)
-allR _ _ _ (Prim nm t) = return (Prim nm t)
+allR trans (TransformContext is c) (Lam v e) =
+  Lam v <$> trans (TransformContext (extendInScopeSet is v) (LamBody v:c)) e
 
-allR rf trans c (Lam b) = do
-  (v,e) <- if rf then unbind b else return (unsafeUnbind b)
-  e'    <- trans (LamBody v:c) e
-  return . Lam $ bind v e'
+allR trans (TransformContext is c) (TyLam tv e) =
+  TyLam tv <$> trans (TransformContext (extendInScopeSet is tv) (TyLamBody tv:c)) e
 
-allR rf trans c (TyLam b) = do
-  (tv, e) <- if rf then unbind b else return (unsafeUnbind b)
-  e' <- trans (TyLamBody tv:c) e
-  return . TyLam $ bind tv e'
+allR trans (TransformContext is c) (App e1 e2) =
+  App <$> trans (TransformContext is (AppFun:c)) e1
+      <*> trans (TransformContext is (AppArg:c)) e2
 
-allR _ trans c (App e1 e2) = do
-  e1' <- trans (AppFun:c) e1
-  e2' <- trans (AppArg:c) e2
-  return $ App e1' e2'
+allR trans (TransformContext is c) (TyApp e ty) =
+  TyApp <$> trans (TransformContext is (TyAppC:c)) e <*> pure ty
 
-allR _ trans c (TyApp e ty) = do
-  e' <- trans (TyAppC:c) e
-  return $ TyApp e' ty
+allR trans (TransformContext is c) (Cast e ty1 ty2) =
+  Cast <$> trans (TransformContext is (CastBody:c)) e <*> pure ty1 <*> pure ty2
 
-allR _ trans c (Cast e ty1 ty2) = do
-  e' <- trans (CastBody:c) e
-  return $ Cast e' ty1 ty2
+allR trans (TransformContext is c) (Letrec xes e) = do
+  e'   <- trans (TransformContext is' (LetBody bndrs:c)) e
+  xes' <- traverse rewriteBind xes
+  return (Letrec xes' e')
+  -- Letrec <$> traverse rewriteBind xes <*> trans (TransformContext is' (LetBody bndrs:c)) e
+ where
+  bndrs              = map fst xes
+  is'                = extendInScopeSetList is (map fst xes)
+  rewriteBind (b,e') = (b,) <$> trans (TransformContext is' (LetBinding b bndrs:c)) e'
 
-allR rf trans c (Letrec b) = do
-  (xesR,e) <- if rf then unbind b else return (unsafeUnbind b)
-  let xes   = unrec xesR
-  let bndrs = map fst xes
-  e' <- trans (LetBody bndrs:c) e
-  xes' <- mapM (rewriteBind bndrs) xes
-  return . Letrec $ bind (rec xes') e'
-  where
-    rewriteBind :: [Id] -> (Id,Embed Term) -> m (Id,Embed Term)
-    rewriteBind bndrs (b', e) = do
-      e' <- trans (LetBinding b' bndrs:c) (unembed e)
-      return (b',embed e')
+allR trans (TransformContext is c) (Case scrut ty alts) =
+  Case <$> trans (TransformContext is (CaseScrut:c)) scrut
+       <*> pure ty
+       <*> traverse rewriteAlt alts
+ where
+  rewriteAlt (p,e) =
+    let (tvs,ids) = patIds p
+        is'       = extendInScopeSetList (extendInScopeSetList is tvs) ids
+    in  (p,) <$> trans (TransformContext is' (CaseAlt tvs ids:c)) e
 
-allR rf trans c (Case scrut ty alts) = do
-  scrut' <- trans (CaseScrut:c) scrut
-  alts'  <- if rf then mapM (fmap (uncurry bind) . rewriteAlt <=< unbind) alts
-                  else mapM (fmap (uncurry bind) . rewriteAlt . unsafeUnbind) alts
-  return $ Case scrut' ty alts'
-  where
-    rewriteAlt :: (Pat, Term) -> m (Pat, Term)
-    rewriteAlt (p,e) = do
-      let (tvs,ids) = patIds p
-      e' <- trans (CaseAlt tvs ids:c) e
-      return (p,e')
+allR _ _ tm = pure tm
 
 infixr 6 >->
 -- | Apply two transformations in succession
@@ -119,22 +102,11 @@ Then we must repeat the transformation to let it also inline y.
 -- | Apply a transformation in a topdown traversal
 topdownR :: Rewrite m -> Rewrite m
 -- See Note [topdown repeatR]
-topdownR r = repeatR r >-> allR True (topdownR r)
-
--- | Apply a transformation in a topdown traversal. Doesn't freshen bound
--- variables
-unsafeTopdownR :: Rewrite m -> Rewrite m
--- See NOTE [topdown repeatR]
-unsafeTopdownR r = repeatR r >-> allR False (unsafeTopdownR r)
+topdownR r = repeatR r >-> allR (topdownR r)
 
 -- | Apply a transformation in a bottomup traversal
-bottomupR :: Fresh m => Transform m -> Transform m
-bottomupR r = allR True (bottomupR r) >-> r
-
--- | Apply a transformation in a bottomup traversal. Doesn't freshen bound
--- variables
-unsafeBottomupR :: Fresh m => Transform m -> Transform m
-unsafeBottomupR r = allR False (unsafeBottomupR r) >-> r
+bottomupR :: Monad m => Transform m -> Transform m
+bottomupR r = allR (bottomupR r) >-> r
 
 infixr 5 !->
 -- | Only apply the second transformation if the first one succeeds.
@@ -159,7 +131,7 @@ repeatR :: Rewrite m -> Rewrite m
 repeatR r = r !-> repeatR r
 
 whenR :: Monad m
-      => ([CoreContext] -> Term -> m Bool)
+      => (TransformContext -> Term -> m Bool)
       -> Transform m
       -> Transform m
 whenR f r1 ctx expr = do
@@ -169,12 +141,13 @@ whenR f r1 ctx expr = do
     else return expr
 
 -- | Only traverse downwards when the assertion evaluates to true
-bottomupWhenR :: Fresh m
-              => ([CoreContext] -> Term -> m Bool)
-              -> Transform m
-              -> Transform m
+bottomupWhenR
+  :: Monad m
+  => (TransformContext -> Term -> m Bool)
+  -> Transform m
+  -> Transform m
 bottomupWhenR f r ctx expr = do
   b <- f ctx expr
   if b
-    then (allR True (bottomupWhenR f r) >-> r) ctx expr
+    then (allR (bottomupWhenR f r) >-> r) ctx expr
     else r ctx expr

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -1,0 +1,384 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
+module Clash.Unique
+  ( -- * Unique
+    Unique
+  , Uniquable (..)
+    -- * UniqMap
+  , UniqMap
+    -- ** Accessors
+    -- *** Size information
+  , nullUniqMap
+    -- *** Indexing
+  , lookupUniqMap
+  , lookupUniqMap'
+    -- ** Construction
+  , emptyUniqMap
+  , unitUniqMap
+    -- ** Modification
+  , extendUniqMap
+  , extendUniqMapWith
+  , extendListUniqMap
+  , delUniqMap
+  , delListUniqMap
+  , unionUniqMap
+  , unionUniqMapWith
+  , differenceUniqMap
+    -- ** Element-wise operations
+    -- *** Mapping
+  , mapUniqMap
+  , mapMaybeUniqMap
+    -- ** Working with predicates
+    -- *** Filtering
+  , filterUniqMap
+    -- *** Searching
+  , elemUniqMap
+  , notElemUniqMap
+    -- ** Folding
+  , foldrWithUnique
+    -- ** Conversions
+    -- *** Lists
+  , eltsUniqMap
+  , keysUniqMap
+  , listToUniqMap
+    -- *** UniqSet
+  , uniqMapToUniqSet
+    -- * UniqSet
+  , UniqSet
+    -- ** Accessors
+    -- *** Indexing
+  , lookupUniqSet
+    -- ** Construction
+  , emptyUniqSet
+  , unitUniqSet
+    -- ** Modifications
+  , extendUniqSet
+  , unionUniqSet
+  , delUniqSetDirectly
+    -- ** Working with predicates
+    -- *** Searching
+  , elemUniqSet
+  , notElemUniqSet
+  , elemUniqSetDirectly
+    -- *** Misc
+  , subsetUniqSet
+    -- ** Conversions
+    -- *** Lists
+  , mkUniqSet
+  , eltsUniqSet
+  )
+where
+
+import           Control.DeepSeq (NFData)
+import           Data.Binary (Binary)
+import           Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
+import qualified Data.List   as List
+import           Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.String
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup
+#endif
+
+type Unique = Int
+
+class Uniquable a where
+  getUnique :: a -> Unique
+
+instance Uniquable Int where
+  getUnique i = i
+
+-- | Map indexed by a 'Uniquable' key
+newtype UniqMap a = UniqMap (IntMap a)
+  deriving (Functor, Foldable, Traversable, Semigroup, Monoid, NFData, Binary)
+
+instance Pretty a => Pretty (UniqMap a) where
+  pretty (UniqMap env) =
+    brackets $ fillSep $ punctuate comma $
+      [ pretty uq <+> ":->" <+> pretty elt
+      | (uq,elt) <- IntMap.toList env
+      ]
+
+instance Pretty a => Show (UniqMap a) where
+  show = renderString . layoutPretty (LayoutOptions (AvailablePerLine 80 0.6)) . pretty
+
+-- | The empty map
+emptyUniqMap
+  :: UniqMap a
+emptyUniqMap = UniqMap IntMap.empty
+
+-- | Map with a single key-value pair
+unitUniqMap
+  :: Uniquable a
+  => a
+  -> b
+  -> UniqMap b
+unitUniqMap k v = UniqMap (IntMap.singleton (getUnique k) v)
+
+-- | Check whether the map is empty
+nullUniqMap
+  :: UniqMap a
+  -> Bool
+nullUniqMap (UniqMap m) = IntMap.null m
+
+-- | Extend the map with a new key-value pair. If the key already exists in the
+-- associated value will be overwritten
+extendUniqMap
+  :: Uniquable a
+  => a
+  -> b
+  -> UniqMap b
+  -> UniqMap b
+extendUniqMap k x (UniqMap m) = UniqMap (IntMap.insert (getUnique k) x m)
+
+-- | Extend the map with a new key-value pair. If the key already exists in the
+-- associated value will be combined with the new value using the function
+-- provided
+extendUniqMapWith
+  :: Uniquable a
+  => a
+  -> b
+  -> (b -> b -> b)
+  -> UniqMap b
+  -> UniqMap b
+extendUniqMapWith k x f (UniqMap m) =
+  UniqMap (IntMap.insertWith f (getUnique k) x m)
+
+-- | Extend the map with a list of key-value pairs. Positions with existing
+-- keys will be overwritten with the new values
+extendListUniqMap
+  :: Uniquable a
+  => UniqMap b
+  -> [(a, b)]
+  -> UniqMap b
+extendListUniqMap (UniqMap env) xs =
+  UniqMap (List.foldl' (\m (k, v) -> IntMap.insert (getUnique k) v m) env xs)
+
+-- | Look up a value in the map
+lookupUniqMap
+  :: Uniquable a
+  => a
+  -> UniqMap b
+  -> Maybe b
+lookupUniqMap k (UniqMap m) = IntMap.lookup (getUnique k) m
+
+-- | Like 'lookupUniqMap'', but errors out when the key is not present
+lookupUniqMap'
+  :: Uniquable a
+  => UniqMap b
+  -> a
+  -> b
+lookupUniqMap' (UniqMap m) k = m IntMap.! getUnique k
+
+-- | Check whether a key is in the map
+elemUniqMap
+  :: Uniquable a
+  => a
+  -> UniqMap b
+  -> Bool
+elemUniqMap k (UniqMap m) = IntMap.member (getUnique k) m
+
+-- | Check whether a key is not in the map
+notElemUniqMap
+  :: Uniquable a
+  => a
+  -> UniqMap b
+  -> Bool
+notElemUniqMap k (UniqMap m) = IntMap.notMember (getUnique k) m
+
+-- | Derive a map where all the elements adhere to the predicate
+filterUniqMap
+  :: (b -> Bool)
+  -> UniqMap b
+  -> UniqMap b
+filterUniqMap f (UniqMap m) = UniqMap (IntMap.filter f m)
+
+-- | Remove a key-value pair from the map
+delUniqMap
+  :: Uniquable a
+  => UniqMap b
+  -> a
+  -> UniqMap b
+delUniqMap (UniqMap env) v = UniqMap (IntMap.delete (getUnique v) env)
+
+-- | Remove a list of key-value pairs from the map
+delListUniqMap
+  :: Uniquable a
+  => UniqMap b
+  -> [a]
+  -> UniqMap b
+delListUniqMap (UniqMap env) vs =
+  UniqMap (List.foldl' (\m v -> IntMap.delete (getUnique v) m) env vs)
+
+-- | A (left-biased) union of two maps
+unionUniqMap
+  :: UniqMap a
+  -> UniqMap a
+  -> UniqMap a
+unionUniqMap (UniqMap m1) (UniqMap m2) = UniqMap (IntMap.union m1 m2)
+
+-- | A union of two maps, key-value pairs with the same key will be merged using
+-- the given function
+unionUniqMapWith
+  :: (a -> a -> a)
+  -> UniqMap a
+  -> UniqMap a
+  -> UniqMap a
+unionUniqMapWith f (UniqMap m1) (UniqMap m2) = UniqMap (IntMap.unionWith f m1 m2)
+
+-- | Get the difference between two maps
+differenceUniqMap
+  :: UniqMap a
+  -> UniqMap a
+  -> UniqMap a
+differenceUniqMap (UniqMap m1) (UniqMap m2) = UniqMap (IntMap.difference m1 m2)
+
+-- | Convert a list of key-value pairs to a map
+listToUniqMap
+  :: Uniquable a
+  => [(a,b)]
+  -> UniqMap b
+listToUniqMap xs =
+  UniqMap (List.foldl' (\m (k, v) -> IntMap.insert (getUnique k) v m) IntMap.empty xs)
+
+-- | Extract the elements of a map into a list
+eltsUniqMap
+  :: UniqMap a
+  -> [a]
+eltsUniqMap (UniqMap m) = IntMap.elems m
+
+-- | Apply a function to every element in the map
+mapUniqMap
+  :: (a -> b)
+  -> UniqMap a
+  -> UniqMap b
+mapUniqMap f (UniqMap m) = UniqMap (IntMap.map f m)
+
+-- | Extract the keys of a map into a list
+keysUniqMap
+  :: UniqMap a
+  -> [Unique]
+keysUniqMap (UniqMap m) = IntMap.keys m
+
+-- | Apply a function to every element in the map. When the function returns
+-- 'Nothing', the key-value pair will be removed
+mapMaybeUniqMap
+  :: (a -> Maybe b)
+  -> UniqMap a
+  -> UniqMap b
+mapMaybeUniqMap f (UniqMap m) = UniqMap (IntMap.mapMaybe f m)
+
+-- | Right-fold over a map using both the key and value
+foldrWithUnique
+  :: (Unique -> a -> b -> b)
+  -> b
+  -> UniqMap a
+  -> b
+foldrWithUnique f s (UniqMap m) = IntMap.foldrWithKey f s m
+
+-- | Set of things that have a 'Unique'
+--
+-- Invariant: they keys in the map are the uniques of the values
+newtype UniqSet a = UniqSet (IntMap a)
+  deriving (Foldable, Semigroup, Monoid)
+
+instance Pretty a => Pretty (UniqSet a) where
+  pretty (UniqSet env) =
+    braces (fillSep (map pretty (IntMap.elems env)))
+
+-- | The empty set
+emptyUniqSet
+  :: UniqSet a
+emptyUniqSet = UniqSet IntMap.empty
+
+-- | Set with a single element
+unitUniqSet
+  :: Uniquable a
+  => a
+  -> UniqSet a
+unitUniqSet a = UniqSet (IntMap.singleton (getUnique a) a)
+
+-- | Add an element to the set
+extendUniqSet
+  :: Uniquable a
+  => UniqSet a
+  -> a
+  -> UniqSet a
+extendUniqSet (UniqSet env) a = UniqSet (IntMap.insert (getUnique a) a env)
+
+-- | Union two sets
+unionUniqSet
+  :: UniqSet a
+  -> UniqSet a
+  -> UniqSet a
+unionUniqSet (UniqSet env1) (UniqSet env2) = UniqSet (IntMap.union env1 env2)
+
+-- | Check whether an element exists in the set
+elemUniqSet
+  :: Uniquable a
+  => a
+  -> UniqSet a
+  -> Bool
+elemUniqSet a (UniqSet env) = IntMap.member (getUnique a) env
+
+-- | Check whether an element does not exist in the set
+notElemUniqSet
+  :: Uniquable a
+  => a
+  -> UniqSet a
+  -> Bool
+notElemUniqSet a (UniqSet env) = IntMap.notMember (getUnique a) env
+
+-- | Check whether an element exists in the set based on the `Unique` contained
+-- in that element
+elemUniqSetDirectly
+  :: Unique
+  -> UniqSet a
+  -> Bool
+elemUniqSetDirectly k (UniqSet m) = k `IntMap.member` m
+
+-- | Look up an element in the set, returns it if it exists
+lookupUniqSet
+  :: Uniquable a
+  => a
+  -> UniqSet b
+  -> Maybe b
+lookupUniqSet a (UniqSet env) = IntMap.lookup (getUnique a) env
+
+-- | Remove an element based on the `Unique` it contains
+delUniqSetDirectly
+  :: Unique
+  -> UniqSet b
+  -> UniqSet b
+delUniqSetDirectly k (UniqSet env) = UniqSet (IntMap.delete k env)
+
+-- | Get the elements of the set as a list
+eltsUniqSet
+  :: UniqSet a
+  -> [a]
+eltsUniqSet (UniqSet env) = IntMap.elems env
+
+-- | Create a set out of a list of elements that contain a 'Unique'
+mkUniqSet
+  :: Uniquable a
+  => [a]
+  -> UniqSet a
+mkUniqSet m = UniqSet (IntMap.fromList (map (\x -> (getUnique x,x)) m))
+
+-- | Convert a 'UniqMap' to a 'UniqSet'
+uniqMapToUniqSet
+  :: UniqMap a
+  -> UniqSet a
+uniqMapToUniqSet (UniqMap m) = UniqSet m
+
+-- | Check whether a A is a subset of B
+subsetUniqSet
+  :: UniqSet a
+  -- ^ Set A
+  -> UniqSet a
+  -- ^ Set B
+  -> Bool
+subsetUniqSet (UniqSet e1) (UniqSet e2) = IntMap.null (IntMap.difference e1 e2)

--- a/clash-lib/src/ClashDebug.h
+++ b/clash-lib/src/ClashDebug.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define ASSERT(e)      if debugIsOn && not (e) then (assertPanic __FILE__ __LINE__) else
+#define ASSERT2(e,msg) if debugIsOn && not (e) then (assertPprPanic __FILE__ __LINE__ (msg)) else
+#define WARN( e, msg ) (warnPprTrace (e) __FILE__ __LINE__ (msg)) $

--- a/clash-lib/src/Data/Text/Prettyprint/Doc/Extra.hs
+++ b/clash-lib/src/Data/Text/Prettyprint/Doc/Extra.hs
@@ -15,7 +15,8 @@ where
 
 import           Control.Applicative
 import           Data.String                           (IsString (..))
-import           Data.Text.Lazy                        as T
+import           Data.Text                             as T
+import           Data.Text.Lazy                        as LT
 import qualified Data.Text.Prettyprint.Doc             as PP
 import           Data.Text.Prettyprint.Doc.Internal    hiding (Doc)
 import           Data.Text.Prettyprint.Doc.Render.Text
@@ -45,7 +46,7 @@ layoutOneLine doc = scan 0 [doc]
 
 renderOneLine
   :: PP.Doc ann
-  -> Text
+  -> LT.Text
 renderOneLine = renderLazy . layoutOneLine
 
 int :: Applicative f => Int -> f Doc
@@ -139,7 +140,10 @@ softline' = pure PP.softline'
 pretty :: (Applicative f, Pretty a) => a -> f Doc
 pretty = pure . PP.pretty
 
-string :: Applicative f => Text -> f Doc
+stringS :: Applicative f => T.Text -> f Doc
+stringS = pure . PP.pretty
+
+string :: Applicative f => LT.Text -> f Doc
 string = pure . PP.pretty
 
 squotes :: Applicative f => f Doc -> f Doc

--- a/clash-lib/src/GHC/SrcLoc/Extra.hs
+++ b/clash-lib/src/GHC/SrcLoc/Extra.hs
@@ -23,13 +23,9 @@ import SrcLoc
    srcLocFile, srcLocLine, srcLocCol,
    srcSpanFile, srcSpanStartLine, srcSpanEndLine, srcSpanStartCol, srcSpanEndCol)
 import FastString                           (FastString (..), bytesFS, mkFastStringByteList)
-import Unbound.Generics.LocallyNameless     (Alpha (..))
-import Unbound.Generics.LocallyNameless.TH
 
 deriving instance Generic SrcSpan
 instance Hashable SrcSpan
-
-makeClosedAlpha ''SrcSpan
 
 instance Hashable RealSrcSpan where
   hashWithSalt salt rss =

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -29,7 +29,7 @@ import           Clash.Annotations.BitRepresentation
 import           Control.DeepSeq                          (NFData)
 import           Data.Hashable                            (Hashable)
 import qualified Data.Map                                 as Map
-import qualified Data.Text.Lazy                           as Text
+import qualified Data.Text                                as Text
 import           Data.Typeable                            (Typeable)
 import qualified Language.Haskell.TH.Syntax               as TH
 import           GHC.Generics                             (Generic)


### PR DESCRIPTION
This patch removes the use of the `unbound-generics` for names
and bound-variables, as profiling indicated that at least half
of the time of the normalisation pass was spend inside functions
concerning themselves with keep invariants alive for the
substitution functions of `unbound-generics`.

In stead we implement our own substitution, alpha-equivalence,
and free variable calculation; and use the capture-free
substitution method referred to as "The rapier" in section 3.2 of

      "Secrets of the GHC inliner"

Since we change the representation for names, this patch
touches a lot of modules, which cannot be split into multiple
commits.

As a result of this patch, we get a 10x to sometimes 50x speedup
on the normalisation pass; which is the bulk of the work done
by the Clash compiler.

### Baseline

```
examples/FIR.hs
time                 831.1 ms   (824.4 ms .. 834.2 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 829.0 ms   (825.8 ms .. 830.4 ms)
std dev              2.291 ms   (785.2 μs .. 3.110 ms)
variance introduced by outliers: 19% (moderately inflated)

examples/Queens.hs
time                 151.5 ms   (146.0 ms .. 154.1 ms)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 151.2 ms   (148.6 ms .. 153.8 ms)
std dev              3.875 ms   (2.584 ms .. 5.868 ms)
variance introduced by outliers: 12% (moderately inflated)

benchmark/tests/BundleMapRepeat.hs
time                 4.919 s    (4.907 s .. 4.933 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.918 s    (4.914 s .. 4.921 s)
std dev              4.190 ms   (2.282 ms .. 5.910 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmark/tests/PipelinesViaFolds.hs
time                 6.672 s    (5.967 s .. 7.360 s)
                     0.999 R²   (0.995 R² .. 1.000 R²)
mean                 6.863 s    (6.666 s .. 7.143 s)
std dev              270.8 ms   (76.54 ms .. 366.9 ms)
variance introduced by outliers: 19% (moderately inflated)
``` 

### The Rapier

```
examples/FIR.hs
time                 68.83 ms   (67.80 ms .. 69.76 ms) (12x speedup over baseline)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 68.38 ms   (67.73 ms .. 69.12 ms) (12x speedup over baseline)
std dev              1.294 ms   (900.2 μs .. 1.742 ms)

examples/Queens.hs
time                 12.95 ms   (12.62 ms .. 13.24 ms) (11.5x speedup over baseline)
                     0.995 R²   (0.992 R² .. 0.998 R²)
mean                 12.77 ms   (12.61 ms .. 13.03 ms) (12x speedup over baseline)
std dev              527.8 μs   (430.0 μs .. 727.1 μs)
variance introduced by outliers: 17% (moderately inflated)

benchmark/tests/BundleMapRepeat.hs
time                 122.1 ms   (119.9 ms .. 123.4 ms) (40x speedup over baseline)
                     1.000 R²   (0.998 R² .. 1.000 R²)
mean                 120.1 ms   (118.3 ms .. 121.5 ms) (41x speedup over baseline)
std dev              2.412 ms   (1.736 ms .. 3.080 ms)
variance introduced by outliers: 11% (moderately inflated)

benchmark/tests/PipelinesViaFolds.hs
time                 128.5 ms   (125.7 ms .. 131.3 ms) (52x speedup over baseline)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 128.5 ms   (127.8 ms .. 130.2 ms) (53.5x speedup over baseline)
std dev              1.887 ms   (1.356 ms .. 2.642 ms)
variance introduced by outliers: 11% (moderately inflated)
``` 