### PR TITLE
Fix compilation warnings

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,8 +7,8 @@ packages:
   ./clash-prelude/*.cabal,
   ./testsuite/*.cabal,
   ./benchmark/*.cabal
-   ./benchmark/profiling/prepare/*.cabal
-   ./benchmark/profiling/run/*.cabal
+  ./benchmark/profiling/prepare/*.cabal
+  ./benchmark/profiling/run/*.cabal
 
 allow-newer: *:Cabal, *:array, *:base, *:binary, *:^bytestring, *:containers,
   *:deepseq, *:directory, *:filepath, *:ghc, *:ghc-boot, *:ghc-boot-th,

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -48,8 +48,7 @@ import Clash.Class.Resize             (zeroExtend)
 import Clash.Sized.BitVector
   (Bit, BitVector, (++#), high, low)
 import Clash.Sized.Internal.BitVector
-  (BitVector (BV), pack#, split#, checkUnpackUndef, undefError, undefined#,
-   unpack#, unsafeToInteger)
+  (pack#, split#, checkUnpackUndef, undefined#, unpack#, unsafeToInteger)
 
 {- $setup
 >>> :set -XDataKinds

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -185,6 +185,8 @@ powUNat x (USucc y) = mulUNat x (powUNat x y)
 -- __NB__: Not synthesisable
 predUNat :: UNat (n+1) -> UNat n
 predUNat (USucc x) = x
+predUNat UZero     =
+  error "predUNat: impossible: 0 minus 1, -1 is not a natural number"
 
 -- | Subtract two unary-encoded natural numbers
 --
@@ -192,7 +194,7 @@ predUNat (USucc x) = x
 subUNat :: UNat (m+n) -> UNat n -> UNat m
 subUNat x         UZero     = x
 subUNat (USucc x) (USucc y) = subUNat x y
-subUNat UZero     _         = error "impossible: 0 + (n + 1) ~ 0"
+subUNat UZero     _         = error "subUNat: impossible: 0 + (n + 1) ~ 0"
 
 -- | Add two singleton natural numbers
 addSNat :: SNat a -> SNat b -> SNat (a+b)
@@ -393,22 +395,23 @@ predBNat (B0 x) = B1 (predBNat x)
 div2BNat :: BNat (2*n) -> BNat n
 div2BNat BT     = BT
 div2BNat (B0 x) = x
-div2BNat (B1 _) = error "impossible: 2*n ~ 2*n+1"
+div2BNat (B1 _) = error "div2BNat: impossible: 2*n ~ 2*n+1"
 
 -- | Subtract 1 and divide a base-2 encoded natural number by 2
 --
 -- __NB__: Not synthesisable
 div2Sub1BNat :: BNat (2*n+1) -> BNat n
 div2Sub1BNat (B1 x) = x
-div2Sub1BNat _      = error "impossible: 2*n+1 ~ 2*n"
+div2Sub1BNat _      = error "div2Sub1BNat: impossible: 2*n+1 ~ 2*n"
 
 -- | Get the log2 of a base-2 encoded natural number
 --
 -- __NB__: Not synthesisable
 log2BNat :: BNat (2^n) -> BNat n
+log2BNat BT = error "log2BNat: log2(0) not defined"
 log2BNat (B1 x) = case stripZeros x of
   BT -> BT
-  _  -> error "impossible: 2^n ~ 2x+1"
+  _  -> error "log2BNat: impossible: 2^n ~ 2x+1"
 log2BNat (B0 x) = succBNat (log2BNat x)
 
 -- | Strip non-contributing zero's from a base-2 encoded natural number

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -224,9 +224,6 @@ of the second argument is evaluated as soon as the tail of the result is evaluat
 -- Is currently treated as 'id' by the Clash compiler.
 joinSignal# :: Signal domain (Signal domain a) -> Signal domain a
 joinSignal# ~(xs :- xss) = head# xs :- joinSignal# (mapSignal# tail# xss)
-  where
-    head# (x' :- _ )  = x'
-    tail# (_  :- xs') = xs'
 
 instance Num a => Num (Signal domain a) where
   (+)         = liftA2 (+)

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -116,11 +116,13 @@ instance NFData a => NFData (RTree d a) where
     rnf (BR_ l r ) = rnf l `seq` rnf r
 
 textract :: RTree 0 a -> a
-textract (LR_ x) = x
+textract (LR_ x)   = x
+textract (BR_ _ _) = error $ "textract: nodes hold no values"
 {-# NOINLINE textract #-}
 
 tsplit :: RTree (d+1) a -> (RTree d a,RTree d a)
 tsplit (BR_ l r) = (l,r)
+tsplit (LR_ _)   = error $ "tsplit: leaf is atomic"
 {-# NOINLINE tsplit #-}
 
 -- | Leaf of a perfect depth tree


### PR DESCRIPTION
Compiling `clash-compiler` yields warnings as of right now. This PR fixes these errors. Requesting a review of @leonschoorl to see if I interpreted functions correctly and added understandable/correct error messages.