### PR TITLE
Use Clash length of type instead of VHDL length inference. Fix #373

### DIFF
--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.json
@@ -57,7 +57,7 @@ end generate;
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "template"  :
 "-- concat begin
-~GENSYM[concat][0] : for ~GENSYM[i][1] in ~VAR[vec][0]'range generate
+~GENSYM[concat][0] : for ~GENSYM[i][1] in 0 to (~LENGTH[~TYP[0]] - 1) generate
 begin~IF ~VIVADO ~THEN
 ~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= fromSLV(~VAR[vec][0](~SYM[1]));~ELSE
 ~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~VAR[vec][0](~SYM[1]);~FI
@@ -272,7 +272,7 @@ end block;~ELSE
   constant ~GENSYM[levels][5] : natural := natural (ceil (log2 (real (~LENGTH[~TYP[1]]))));
 begin
   -- put input array into the first half of the intermediate array~IF ~VIVADO ~THEN
-  ~SYM[6] : for ~SYM[7] in ~VAR[vec][1]'range generate
+  ~SYM[6] : for ~SYM[7] in 0 to (~LENGTH[~TYP[1]] - 1) generate
     ~SYM[3](~SYM[7]) <= fromSLV(~VAR[vec][1](~SYM[7]));
   end generate;~ELSE
   ~SYM[3](0 to ~LENGTH[~TYP[1]]-1) <= ~VAR[vec][1];~FI
@@ -370,9 +370,9 @@ end block;
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "template"  :
 "-- transpose begin
-~GENSYM[transpose_outer][2] : for ~GENSYM[row_index][3] in ~VAR[matrix][1]'range generate
+~GENSYM[transpose_outer][2] : for ~GENSYM[row_index][3] in 0 to (~LENGTH[~TYP[1]] - 1) generate
   ~GENSYM[transpose_inner][4] : for ~GENSYM[col_index][5] in ~RESULT'range generate~IF ~VIVADO ~THEN
-    ~RESULT(~SYM[5])((~VAR[matrix][1]'length-~SYM[3])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~VAR[matrix][1]'length-~SYM[3]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]) <= ~VAR[vec][1](~SYM[3])((~RESULT'length-~SYM[5])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~RESULT'length-~SYM[5]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]);~ELSE
+    ~RESULT(~SYM[5])((~LENGTH[~TYP[1]]-~SYM[3])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~LENGTH[~TYP[1]]-~SYM[3]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]) <= ~VAR[vec][1](~SYM[3])((~RESULT'length-~SYM[5])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~RESULT'length-~SYM[5]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]);~ELSE
     ~RESULT(~SYM[5])(~SYM[3]) <= ~VAR[matrix][1](~SYM[3])(~SYM[5]);~FI
   end generate;
 end generate;
@@ -385,7 +385,7 @@ end generate;
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "template"  :
 "-- reverse begin
-~GENSYM[reverse_loop][2] : for ~GENSYM[i][3] in ~VAR[vec][0]'range generate
+~GENSYM[reverse_loop][2] : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[0]] - 1) generate
   ~RESULT(~VAR[vec][0]'high - ~SYM[3]) <= ~VAR[vec][0](~SYM[3]);
 end generate;
 -- reverse end"
@@ -400,7 +400,7 @@ end generate;
                   -> BitVector (n * m)"
     , "template" :
 "-- concatBitVector begin
-~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~VAR[vec][2]'range generate
+~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[2]] - 1) generate
   ~RESULT(((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1])) <= ~TYPMO'(~VAR[vec][2](~VAR[vec][2]'high - ~SYM[3]));
 end generate;
 -- concatBitVector end"

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.json
@@ -227,7 +227,7 @@ end generate;~FI
 begin
   ~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];
 
-  foldr_loop : for ~GENSYM[i][3] in ~VAR[vec][2]'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN
+  foldr_loop : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[2]] - 1) generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN
     signal ~GENSYM[foldr_in][4] : ~TYPEL[~TYP[2]];~ELSE ~FI
   begin~IF~SIZE[~TYP[2]]~THEN
     ~SYM[4] <= fromSLV(~VAR[vec][2](~SYM[3]));~ELSE ~FI

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -460,14 +460,21 @@ renderTag b (Err Nothing)   = fmap renderOneLine . getMon . hdlTypeErrValue . sn
 renderTag b (Err (Just n))  = let (_,ty,_) = bbInputs b !! n
                               in  renderOneLine <$> getMon (hdlTypeErrValue ty)
 renderTag b (Size e)        = return . Text.pack . show . typeSize $ lineToType b [e]
-renderTag b (Length e)      = return . Text.pack . show . vecLen $ lineToType b [e]
+
+renderTag b (Length e) = return . Text.pack . show . vecLen $ lineToType b [e]
   where
-    vecLen (Vector n _) = n
-    vecLen _            = error $ $(curLoc) ++ "vecLen of a non-vector type"
-renderTag b (Depth e)      = return . Text.pack . show . treeDepth $ lineToType b [e]
+    vecLen (Vector n _)               = n
+    vecLen (Void (Just (Vector n _))) = n
+    vecLen thing =
+      error $ $(curLoc) ++ "vecLen of a non-vector type: " ++ show thing
+
+renderTag b (Depth e) = return . Text.pack . show . treeDepth $ lineToType b [e]
   where
-    treeDepth (RTree n _) = n
-    treeDepth _           = error $ $(curLoc) ++ "treeDepth of a non-tree type"
+    treeDepth (RTree n _)               = n
+    treeDepth (Void (Just (RTree n _))) = n
+    treeDepth thing =
+      error $ $(curLoc) ++ "treeDepth of a non-tree type: " ++ show thing
+
 renderTag b e@(TypElem _)   = let ty = lineToType b [e]
                               in  renderOneLine <$> getMon (hdlType Internal ty)
 renderTag _ (Gen b)         = renderOneLine <$> genStmt b

--- a/tests/shouldwork/Vector/VEmpty.hs
+++ b/tests/shouldwork/Vector/VEmpty.hs
@@ -1,0 +1,25 @@
+module VEmpty where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: HiddenClockReset System 'Source 'Asynchronous
+  => Signal System Int
+  -> Signal System Int
+topEntity x =
+  delayBy (SNat @2) x
+{-# NOINLINE topEntity #-}
+
+delayBy n signal =
+  foldr (\_ s -> s + 10) signal (replicate n ())
+{-# NOINLINE delayBy #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (2 :> 3 :> 4 :> 5 :> Nil)
+    expectedOutput = outputVerifier clk rst (22 :> 23 :> 24 :> 25 :> Nil)
+    done           = expectedOutput (withClockReset clk rst topEntity testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -215,6 +215,7 @@ main = do
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "ToList"    (["","ToList_testBench"],"ToList_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Unconcat"  (["","Unconcat_testBench"],"Unconcat_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VACC"      ([""],"VACC_topEntity",False)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VEmpty"    (["", "VEmpty_testBench"],"VEmpty_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VIndex"    ([""],"VIndex_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VFold"     (["","VFold_testBench"],"VFold_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VMapAccum" ([""],"VMapAccum_topEntity",False)


### PR DESCRIPTION
Please see [this issue](https://github.com/clash-lang/clash-compiler/issues/373). 

While all test cases perfectly pass, I wonder if this patch is actually correct:

1. Should we replace ALL such `'range` constructs with just literals? 
2. Is the `~IF ~VIVADO` construct still valid after this patch?