### PR TITLE
Add support for GHC.Natural.plusNatural

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -972,6 +972,10 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     , [i] <- intLiterals' [iV]
     -> let r = shiftLNatural (fromInteger n) (fromInteger i)
        in  reduce (Literal (NaturalLiteral (toInteger r)))
+
+  "GHC.Natural.plusNatural"
+    | Just (i,j) <- naturalLiterals args
+    -> reduce (integerToIntegerLiteral (i+j))
 #endif
 
   -- GHC.Real.^  -- XXX: Very fragile
@@ -3099,6 +3103,11 @@ integerLiterals' = typedLiterals' integerLiteral
       | dcTag dc == 3
       -> Just (Jn# (BN# ba))
     _ -> Nothing
+
+naturalLiterals :: [Value] -> Maybe (Integer,Integer)
+naturalLiterals args = case naturalLiterals' args of
+  [i,j] -> Just (i,j)
+  _ -> Nothing
 
 naturalLiterals' :: [Value] -> [Integer]
 naturalLiterals' = typedLiterals' naturalLiteral

--- a/clash-lib/prims/common/GHC_Natural.json
+++ b/clash-lib/prims/common/GHC_Natural.json
@@ -10,4 +10,11 @@
     , "template"  : "~ERRORO"
     }
   }
+, { "BlackBox" :
+    { "name"      : "GHC.Natural.plusNatural"
+    , "kind"      : "Expression"
+    , "type"      : "plusNatural :: Natural -> Natural -> Natural"
+    , "template"  : "~ARG[0] + ~ARG[1]"
+    }
+  }
 ]


### PR DESCRIPTION
This (specifically the addition to `Evaluator`) fixed (or perhaps worked-around) the invalid Verilog produced in #388.