### PR TITLE
Bind heap variables

### DIFF
--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -114,10 +114,10 @@ whnf'
   -> InScopeSet
   -> Bool
   -> Term
-  -> (GlobalHeap, Term)
+  -> (GlobalHeap, PureHeap, Term)
 whnf' eval gbl tcm gh ids is isSubj e
   = case whnf eval gbl tcm isSubj (Heap gh emptyVarEnv ids is,[],e) of
-      (Heap gh' _ _ _,_,e') -> (gh',e')
+      (Heap gh' ph' _ _,_,e') -> (gh',ph',e')
 
 -- | Evaluate to WHNF given an existing Heap and Stack
 whnf

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -140,7 +140,7 @@ collectGlobals inScope substitution seen e@(collectArgs -> (fun, args@(_:_)))
     ids <- Lens.use uniqSupply
     let (ids1,ids2) = splitSupply ids
     uniqSupply Lens..= ids2
-    let eval = snd . whnf' primEval bndrs tcm gh ids1 inScope False
+    let eval = (Lens.view Lens._3) . whnf' primEval bndrs tcm gh ids1 inScope False
         eTy  = termType tcm e
     untran <- isUntranslatableType False eTy
     case untran of

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -79,7 +79,7 @@ import           GHC.Integer.GMP.Internals   (Integer (..), BigNat (..))
 import           BasicTypes                  (InlineSpec (..))
 
 import           Clash.Core.DataCon          (DataCon (..))
-import           Clash.Core.Evaluator        (whnf')
+import           Clash.Core.Evaluator        (PureHeap, whnf')
 import           Clash.Core.Name
   (Name (..), NameSort (..), mkUnsafeSystemName)
 import           Clash.Core.FreeVars
@@ -94,12 +94,12 @@ import           Clash.Core.Type             (TypeView (..), applyFunTy,
                                               normalizeType,
                                               splitFunTy, typeKind,
                                               tyView, undefinedTy)
-import           Clash.Core.TyCon            (tyConDataCons)
+import           Clash.Core.TyCon            (TyConMap, tyConDataCons)
 import           Clash.Core.Util
   (collectArgs, isClockOrReset, isCon, isFun, isLet, isPolyFun, isPrim,
    isSignalType, isVar, mkApps, mkLams, mkVec, piResultTy, termSize, termType,
    tyNatSize, patVars)
-import           Clash.Core.Var              (Id, Var (..))
+import           Clash.Core.Var              (Id, Var (..), mkId)
 import           Clash.Core.VarEnv
   (InScopeSet, VarEnv, VarSet, elemVarSet, emptyVarEnv, emptyVarSet, extendInScopeSet,
    extendInScopeSetList, lookupVarEnv, notElemVarSet, unionVarEnvWith, unionVarSet,
@@ -118,7 +118,8 @@ import           Clash.Primitives.Types
 import           Clash.Rewrite.Combinators
 import           Clash.Rewrite.Types
 import           Clash.Rewrite.Util
-import           Clash.Unique                 (lookupUniqMap)
+import           Clash.Unique
+  (Unique, lookupUniqMap, toListUniqMap)
 import           Clash.Util
 
 inlineOrLiftNonRep :: NormRewrite
@@ -380,42 +381,44 @@ caseCon ctx@(TransformContext is0 _) e@(Case subj ty alts)
     lvl <- Lens.view dbgLevel
     is1 <- unionInScope is0 <$> Lens.use globalInScope
     case whnf' primEval bndrs tcm gh ids1 is1 True subj of
-      (gh',v) -> globalHeap Lens..= gh' >> case v of
-        Literal l -> caseCon ctx (Case (Literal l) ty alts)
-        subj' -> case collectArgs subj' of
-          (Data _,_) -> caseCon ctx (Case subj' ty alts)
+      (gh',ph',v) -> do
+        globalHeap Lens..= gh'
+        bindPureHeap tcm ph' $ case v of
+          Literal l -> caseCon ctx (Case (Literal l) ty alts)
+          subj' -> case collectArgs subj' of
+            (Data _,_) -> caseCon ctx (Case subj' ty alts)
 #if MIN_VERSION_ghc(8,2,2)
-          (Prim nm ty',_:msgOrCallStack:_)
-            | nm == "Control.Exception.Base.absentError" ->
-              let e' = mkApps (Prim nm ty') [Right ty,msgOrCallStack]
-              in  changed e'
+            (Prim nm ty',_:msgOrCallStack:_)
+              | nm == "Control.Exception.Base.absentError" ->
+                let e' = mkApps (Prim nm ty') [Right ty,msgOrCallStack]
+                in  changed e'
 #endif
 
-          (Prim nm ty',repTy:_:msgOrCallStack:_)
-            | nm `elem` ["Control.Exception.Base.patError"
+            (Prim nm ty',repTy:_:msgOrCallStack:_)
+              | nm `elem` ["Control.Exception.Base.patError"
 #if !MIN_VERSION_ghc(8,2,2)
-                        ,"Control.Exception.Base.absentError"
+                          ,"Control.Exception.Base.absentError"
 #endif
-                        ,"GHC.Err.undefined"] ->
-              let e' = mkApps (Prim nm ty') [repTy,Right ty,msgOrCallStack]
-              in  changed e'
-          (Prim nm ty',[_])
-            | nm `elem` ["Clash.Transformations.undefined"] ->
-              let e' = mkApps (Prim nm ty') [Right ty]
-              in changed e'
-          (Prim nm _,[])
-            | nm `elem` ["EmptyCase"] ->
-              changed (Prim nm ty)
-          _ -> do
-            let subjTy = termType tcm subj
-            tran <- Lens.view typeTranslator
-            case coreTypeToHWType tran reprs tcm False subjTy of
-              Right (Void (Just hty))
-                | hty `elem` [BitVector 0, Unsigned 0, Signed 0, Index 1]
-                -> caseCon ctx (Case (Literal (IntegerLiteral 0)) ty alts)
-              _ -> traceIf (lvl > DebugNone && isConstant subj)
-                     ("Irreducible constant as case subject: " ++ showPpr subj ++ "\nCan be reduced to: " ++ showPpr subj')
-                     (caseOneAlt e)
+                          ,"GHC.Err.undefined"] ->
+                let e' = mkApps (Prim nm ty') [repTy,Right ty,msgOrCallStack]
+                in  changed e'
+            (Prim nm ty',[_])
+              | nm `elem` ["Clash.Transformations.undefined"] ->
+                let e' = mkApps (Prim nm ty') [Right ty]
+                in changed e'
+            (Prim nm _,[])
+              | nm `elem` ["EmptyCase"] ->
+                changed (Prim nm ty)
+            _ -> do
+              let subjTy = termType tcm subj
+              tran <- Lens.view typeTranslator
+              case coreTypeToHWType tran reprs tcm False subjTy of
+                Right (Void (Just hty))
+                  | hty `elem` [BitVector 0, Unsigned 0, Signed 0, Index 1]
+                  -> caseCon ctx (Case (Literal (IntegerLiteral 0)) ty alts)
+                _ -> traceIf (lvl > DebugNone && isConstant subj)
+                       ("Irreducible constant as case subject: " ++ showPpr subj ++ "\nCan be reduced to: " ++ showPpr subj')
+                       (caseOneAlt e)
 
 caseCon ctx e@(Case subj ty alts) = do
   reprs <- Lens.view customReprs
@@ -429,6 +432,30 @@ caseCon ctx e@(Case subj ty alts) = do
     _ -> caseOneAlt e
 
 caseCon _ e = return e
+
+
+-- | Binds variables on the PureHeap over the result of the rewrite
+--
+-- To prevent unnecessary rewrites only do this when rewrite changed something.
+bindPureHeap :: TyConMap -> PureHeap -> RewriteMonad extra Term -> RewriteMonad extra Term
+bindPureHeap tcm heap rw = do
+  (e, Monoid.getAny -> hasChanged) <- listen rw
+  if hasChanged && not (null bndrs)
+    then return $ Letrec bndrs e
+    else return e
+  where
+    bndrs = map toLetBinding $ toListUniqMap heap
+    toLetBinding :: (Unique,Term) -> LetBinding
+    toLetBinding (uniq,term) = (nm, term)
+      where
+        ty = termType tcm term
+        nm = mkId ty (mkUnsafeSystemName "x" uniq) -- See [Note: Name re-creation]
+
+{- [Note: Name re-creation]
+The names of heap bound variables are safely generate with mkUniqSystemId in Clash.Core.Evaluator.newLetBinding.
+But only their uniqs end up in the heap, not the complete names.
+So we use mkUnsafeSystemName to recreate the same Name.
+-}
 
 matchLiteralContructor
   :: Term
@@ -1436,9 +1463,9 @@ reduceConst (TransformContext is0 _) e@(App _ _)
     gh <- Lens.use globalHeap
     is1 <- unionInScope is0 <$> Lens.use globalInScope
     case whnf' primEval bndrs tcm gh ids1 is1 False e of
-      (gh',e') -> do
+      (gh',ph',e') -> do
         globalHeap Lens..= gh'
-        case e' of
+        bindPureHeap tcm ph' $ case e' of
           (Literal _) -> changed e'
           (collectArgs -> (Prim nm _, _))
             | isFromInt nm

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -44,6 +44,7 @@ module Clash.Unique
   , eltsUniqMap
   , keysUniqMap
   , listToUniqMap
+  , toListUniqMap
     -- *** UniqSet
   , uniqMapToUniqSet
     -- * UniqSet
@@ -243,6 +244,12 @@ listToUniqMap
   -> UniqMap b
 listToUniqMap xs =
   UniqMap (List.foldl' (\m (k, v) -> IntMap.insert (getUnique k) v m) IntMap.empty xs)
+
+-- | Convert a map to a list of key-value pairs
+toListUniqMap
+  :: UniqMap a
+  -> [(Unique,a)]
+toListUniqMap (UniqMap m) = IntMap.toList m
 
 -- | Extract the elements of a map into a list
 eltsUniqMap

--- a/tests/shouldwork/Vector/FirOddSize.hs
+++ b/tests/shouldwork/Vector/FirOddSize.hs
@@ -1,0 +1,26 @@
+-- see https://github.com/clash-lang/clash-compiler/issues/383
+module FirOddSize where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+fir coeffs x = dotp coeffs (window x)
+  where
+    dotp as bs = sum (zipWith (*) as bs)
+
+topEntity
+  :: Clock  System Source
+  -> Reset  System Asynchronous
+  -> Signal System (Signed 16)
+  -> Signal System (Signed 16)
+topEntity = exposeClockReset (fir (2:>3:>(-2):>8:>0:>Nil))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (2:>3:>(-2):>8:>1:>Nil)
+    expectedOutput = outputVerifier clk rst (4:>12:>1:>20:>54:>Nil)
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/FoldlFuns.hs
+++ b/tests/shouldwork/Vector/FoldlFuns.hs
@@ -1,0 +1,30 @@
+-- see https://github.com/clash-lang/clash-compiler/issues/364
+module FoldlFuns where
+
+import Clash.Prelude
+
+func
+    :: BitVector 8
+    -> BitVector 8
+    -> BitVector 32
+func d c = 0
+
+mod'
+    :: forall dom gated sync. HiddenClockReset dom gated sync
+    => Signal dom (BitVector 32)
+mod' = o
+    where
+
+    x :: Signal dom (BitVector 8) = pure 0
+
+    f :: Signal dom (BitVector 8) -> Signal dom (BitVector 32)
+    f = foldl1 (\x y q -> liftA2 (.|.) (x q) (y q))
+        $  liftA2 func x
+        :> liftA2 func x
+        :> liftA2 func x
+        :> Nil
+
+    o :: Signal dom (BitVector 32)
+    o = f (pure 0)
+
+topEntity clk rst = withClockReset @System @Source @Synchronous clk rst mod'

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -202,7 +202,9 @@ main = do
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DTFold"    (["","DTFold_testBench"],"DTFold_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "EnumTypes" ([""],"EnumTypes_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FindIndex" (["","FindIndex_testBench"],"FindIndex_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FirOddSize" (["","FirOddSize_testBench"],"FirOddSize_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Fold"      (["","Fold_testBench"],"Fold_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FoldlFuns" ([""],"FoldlFuns_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Foldr"     (["","Foldr_testBench"],"Foldr_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FoldrEmpty" (["","FoldrEmpty_testBench"],"FoldrEmpty_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "HOClock"   ([""],"HOClock_topEntity",False) -- Broken on GHC 8.0 due to: https://ghc.haskell.org/trac/ghc/ticket/115


### PR DESCRIPTION
When the `Clash.Core.Evaluator.whnf'` returns with bindings left on the (pure)heap,
those should be bound so they are in scope for the (simplified) term returned by the evaluator.

Previously we just dropped this heap, leading to missing bindings, like in #364 and #383.