### PR TITLE
GHC 8.6.2 (subsumes #390)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,10 @@ install:
   # Overlay Hackage Package Index for GHC HEAD: https://github.com/hvr/head.hackage
   - |
     if $GHCHEAD; then
+      echo "Disabling GHC HEAD for now. Singletons does not support it, causing unreasonable test times on Travis."
+      echo "Remove these lines if you believe singletons has support for GHC HEAD."
+      exit 1
+
       sed -i.bak 's/-- allow-newer:.*/allow-newer: *:base, *:template-haskell, *:ghc, *:Cabal/' ${HOME}/.cabal/config
 
       echo 'repository head.hackage'                                                        >> ${HOME}/.cabal/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,8 +152,8 @@ install:
       (cd "." && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep all
+  - cabal new-build ${TEST} ${BENCH} --project-file="cabal.project" --dep all
+  - cabal new-build --disable-tests --disable-benchmarks --project-file="cabal.project" --dep all
   - rm -rf "."/.ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
   - SRCDIR=$PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,10 @@ jobs:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.3,ghdl,gperf,g++-multilib], sources: [hvr-ghc,pgavin-ghdl]}}
 
     - <<: *precache
+      compiler: "ghc-8.6.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.2,ghdl,gperf,g++-multilib], sources: [hvr-ghc,pgavin-ghdl]}}
+
+    - <<: *precache
       compiler: "ghc-head"
       env: GHCHEAD=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head,ghdl,gperf,g++-multilib], sources: [hvr-ghc,pgavin-ghdl]}}
@@ -68,6 +72,10 @@ jobs:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.3,ghdl,gperf,g++-multilib], sources: [hvr-ghc,pgavin-ghdl]}}
 
     - <<: *build
+      compiler: "ghc-8.6.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.2,ghdl,gperf,g++-multilib], sources: [hvr-ghc,pgavin-ghdl]}}
+
+    - <<: *build
       compiler: "ghc-head"
       env: GHCHEAD=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head,ghdl,gperf,g++-multilib], sources: [hvr-ghc,pgavin-ghdl]}}
@@ -81,6 +89,10 @@ jobs:
     - <<: *test
       compiler: "ghc-8.4.3"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.3,ghdl,gperf,g++-multilib], sources: [hvr-ghc,pgavin-ghdl]}}
+
+    - <<: *test
+      compiler: "ghc-8.6.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.2,ghdl,gperf,g++-multilib], sources: [hvr-ghc,pgavin-ghdl]}}
 
     - <<: *test
       compiler: "ghc-head"
@@ -115,10 +127,9 @@ install:
   - HADDOCK=${HADDOCK-true}
   - INSTALLED=${INSTALLED-true}
   - GHCHEAD=${GHCHEAD-false}
-  - travis_retry cabal update -v
+  - travis_retry cabal new-update -v
   - "sed -i.bak 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config"
-  - rm -fv cabal.project cabal.project.local
-  - "printf 'packages: \"./*/*.cabal\" \"./benchmark/profiling/*/*.cabal\"\\n' > cabal.project"
+  - "sed -i 's/flags: cosim/flags: travisci cosim/g' cabal.project"
   - cat cabal.project
   # Overlay Hackage Package Index for GHC HEAD: https://github.com/hvr/head.hackage
   - |
@@ -140,8 +151,8 @@ install:
       (cd "." && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep all
+  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep all
   - rm -rf "."/.ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
   - SRCDIR=$PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ cache:
     - $HOME/.cabal/packages
     - $HOME/.cabal/store
     - $HOME/iverilog
+    - dist-newstyle
 
 before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -6,7 +6,7 @@ mv "."/clash-lib/dist/clash-lib-*.tar.gz ${DISTDIR}/
 (cd "./clash-ghc" && cabal sdist && cd "..")
 mv "."/clash-ghc/dist/clash-ghc-*.tar.gz ${DISTDIR}/
 find ${DISTDIR} -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' -C ${DISTDIR} \;
-printf 'packages: %b/clash-lib-*/*.cabal %b/clash-ghc-*/*.cabal clash-prelude/*.cabal clash-cosim/*.cabal testsuite/*.cabal benchmark/*.cabal benchmark/profiling/*/*.cabal\npackage clash-testsuite\n  flags: travisci cosim\n\npackage clash-ghc\n  executable-dynamic: True\n' ${DISTDIR} ${DISTDIR} > cabal.project
+sed -i 's/flags: cosim/flags: travisci cosim/g' cabal.project
 cat cabal.project
 # this builds all libraries and executables 
 cabal new-build -w ${HC} all

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -9,10 +9,10 @@ find ${DISTDIR} -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' -C ${DISTDIR} \
 sed -i 's/flags: cosim/flags: travisci cosim/g' cabal.project
 cat cabal.project
 # this builds all libraries and executables 
-cabal new-build -w ${HC} all
+cabal new-build all
 
 # Build with installed constraints for packages in global-db
-if $INSTALLED; then echo cabal new-build -w ${HC} $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh; else echo "Not building with installed constraints"; fi
+if $INSTALLED; then echo cabal new-build $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh; else echo "Not building with installed constraints"; fi
 
 # cabal check
 (cd ${DISTDIR}/clash-lib-* && cabal check)
@@ -20,6 +20,6 @@ if $INSTALLED; then echo cabal new-build -w ${HC} $(${HCPKG} list --global --sim
 
 # haddock
 cd ${SRCDIR}
-if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
+if $HADDOCK; then cabal new-haddock ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
 set +e
 set +x

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -6,7 +6,7 @@ mv "."/clash-lib/dist/clash-lib-*.tar.gz ${DISTDIR}/
 (cd "./clash-ghc" && cabal sdist && cd "..")
 mv "."/clash-ghc/dist/clash-ghc-*.tar.gz ${DISTDIR}/
 find ${DISTDIR} -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' -C ${DISTDIR} \;
-printf 'packages: %b/clash-lib-*/*.cabal %b/clash-ghc-*/*.cabal clash-prelude/*.cabal clash-cosim/*.cabal testsuite/*.cabal\npackage clash-testsuite\n  flags: travisci cosim\n\npackage clash-ghc\n  executable-dynamic: True\n' ${DISTDIR} ${DISTDIR} > cabal.project
+sed -i 's/flags: cosim/flags: travisci cosim/g' cabal.project
 cat cabal.project
 # build & run tests, build benchmarks
 cabal new-build -w ${HC} all

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -9,7 +9,7 @@ find ${DISTDIR} -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' -C ${DISTDIR} \
 sed -i 's/flags: cosim/flags: travisci cosim/g' cabal.project
 cat cabal.project
 # build & run tests, build benchmarks
-cabal new-build -w ${HC} all
-if [ "x$TEST" = "x--enable-tests" ]; then cabal new-run -w ${HC} -- clash-testsuite -j16; fi
+cabal new-build all
+if [ "x$TEST" = "x--enable-tests" ]; then cabal new-run -- clash-testsuite -j16; fi
 set +e
 set +x

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -10,6 +10,6 @@ sed -i 's/flags: cosim/flags: travisci cosim/g' cabal.project
 cat cabal.project
 # build & run tests, build benchmarks
 cabal new-build all
-if [ "x$TEST" = "x--enable-tests" ]; then cabal new-run -- clash-testsuite -j16; fi
+if [ "x$TEST" = "x--enable-tests" ]; then cabal new-run -- clash-testsuite; fi
 set +e
 set +x

--- a/benchmark/clash-benchmark.cabal
+++ b/benchmark/clash-benchmark.cabal
@@ -29,7 +29,7 @@ executable clash-benchmark-normalization
   build-depends:       base                 >= 4.8      && < 5,
                        concurrent-supply    >= 0.1.7    && < 0.2,
                        containers           >= 0.5.4.0  && < 0.6,
-                       criterion            >= 1.1.1.0  && < 1.5,
+                       criterion            >= 1.5.0.0  && < 1.6,
                        deepseq              >= 1.4      && < 1.5,
                        filepath             >= 1.4      && < 1.5,
                        unordered-containers >= 0.2.3.3  && < 0.3,

--- a/cabal.project
+++ b/cabal.project
@@ -29,7 +29,7 @@ repository head.hackage
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2018-07-03T07:02:43Z
+index-state: 2018-10-14T17:04:37Z
 
 package clash-ghc
   executable-dynamic: True
@@ -47,12 +47,12 @@ optional-packages: singletons/th-desugar/th-desugar.cabal
 source-repository-package
   type: git
   location: https://github.com/clash-lang/ghc-typelits-extra
-  tag: b9333c256151132eb97f72b262ddb23bd6a62446
+  tag: f1cba7cebf73e429dbdfa67c88161300bc5e318e
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/ghc-typelits-knownnat
-  tag: 9731ed3ae9c87a8930dd40eedced7c0128cb5e82
+  tag: 7c866bdefff3f8353a29eebb3d35264dacb2af28
 
 source-repository-package
   type: git
@@ -62,7 +62,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/clash-lang/ghc-tcplugins-extra
-  tag: 4f2defb334da089100a16c8e75ba462b06c9d465
+  tag: ac70960df5b04ec092ea189c8d34b28ab9b41695
 
 -- Build documentation for all dependencies so we can upload docs to hackage
 -- with proper links

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -111,7 +111,7 @@ library
                       lens                      >= 4.0.5    && < 4.18,
                       mtl                       >= 2.1.1    && < 2.3,
                       text                      >= 0.11.3.1 && < 1.3,
-                      transformers              >= 0.4.2    && < 0.6,
+                      transformers              >= 0.5.2.0  && < 0.6,
                       unordered-containers      >= 0.2.1.0  && < 0.3,
 
                       clash-lib                 >= 0.7.1    && < 1.0,

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -116,7 +116,6 @@ Library
                       deepseq                 >= 1.3.0.2  && < 1.5,
                       directory               >= 1.2.0.1  && < 1.4,
                       errors                  >= 1.4.2    && < 2.4,
-                      fgl                     >= 5.4.2.4  && < 5.7,
                       filepath                >= 1.3.0.1  && < 1.5,
                       ghc                     >= 8.0.2    && < 8.8,
                       hashable                >= 1.2.1.0  && < 1.3,
@@ -192,6 +191,7 @@ Library
 
                       Clash.Unique
                       Clash.Util
+                      Clash.Util.Graph
 
                       Data.Text.Prettyprint.Doc.Extra
 

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -132,7 +132,7 @@ Library
                       temporary               >= 1.2      && < 1.4,
                       text                    >= 0.11.3.1 && < 1.3,
                       time                    >= 1.4.0.1  && < 1.10,
-                      transformers            >= 0.3.0.0  && < 0.6,
+                      transformers            >= 0.5.2.0  && < 0.6,
                       trifecta                >= 1.7.1.1  && < 2.0,
                       vector                  >= 0.11     && < 1.0,
                       vector-binary-instances >= 0.2.3.5  && < 0.3,

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -28,6 +28,7 @@ module Clash.Netlist.Types
 where
 
 import Control.DeepSeq
+import Control.Monad.Fail                   (MonadFail)
 import Control.Monad.State                  (State)
 import Control.Monad.State.Strict           (MonadIO, MonadState, StateT)
 import Data.Bits                            (testBit)
@@ -62,7 +63,7 @@ import Clash.Annotations.BitRepresentation.Internal
 -- of components that are being generated (WriterT)
 newtype NetlistMonad a =
   NetlistMonad { runNetlist :: StateT NetlistState IO a }
-  deriving newtype (Functor, Monad, Applicative, MonadState NetlistState, MonadIO)
+  deriving newtype (Functor, Monad, Applicative, MonadState NetlistState, MonadIO, MonadFail)
 
 -- | State of the NetlistMonad
 data NetlistState

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -8,13 +8,14 @@
   Utilities for converting Core Type/Term to Netlist datatypes
 -}
 
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE MultiWayIf        #-}
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE MonadFailDesugaring #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 module Clash.Netlist.Util where
 
@@ -1581,6 +1582,9 @@ nestM (Indexed (RTree d1 t1,1,n)) (Indexed (RTree d2 t2,1,m))
        | n == 0 && m == 0 -> let l = 0
                                  r = (2 ^ (d1-1)) `div` 2
                              in  Just (Indexed (RTree (-1) t1, l, r))
+       | n > 1 || n < 0   -> error $ "nestM: n should be 0 or 1, not:" ++ show n
+       | m > 1 || m < 0   -> error $ "nestM: m should be 0 or 1, not:" ++ show m
+       | otherwise        -> error $ "nestM: unexpected (n, m): " ++ show (n, m)
 nestM (Indexed (RTree (-1) t1,l,_)) (Indexed (RTree d t2,10,k))
   | t1 == t2
   , d  >= 0

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -10,6 +10,7 @@
 
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE CPP               #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE MagicHash         #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -749,7 +750,10 @@ splitCastWork ctx@(TransformContext is0 _) unchanged@(Letrec vs e') = do
   if hasChanged then changed (Letrec vs' e')
                 else return unchanged
   where
-    splitCastLetBinding :: InScopeSet -> LetBinding -> RewriteMonad extra [LetBinding]
+    splitCastLetBinding
+      :: InScopeSet
+      -> LetBinding
+      -> RewriteMonad extra [LetBinding]
     splitCastLetBinding isN x@(nm, e) = case e of
       Cast (Var {}) _ _  -> return [x]  -- already work-free
       Cast (Cast {}) _ _ -> return [x]  -- casts will be eliminated

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -7,7 +7,8 @@
   Types used in Normalize modules
 -}
 
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Clash.Normalize.Types where
 
@@ -60,6 +61,7 @@ data NormalizeState
   }
 
 makeLenses ''NormalizeState
+
 
 -- | State monad that stores specialisation and inlining information
 type NormalizeMonad = State NormalizeState

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -11,13 +11,16 @@
 
 module Clash.Primitives.Intel.ClockGen where
 
-import Control.Monad.State
-import Data.Text.Prettyprint.Doc.Extra
-import Data.Semigroup.Monad
+import Clash.Backend
 import Clash.Netlist.BlackBox.Util
 import Clash.Netlist.Id
 import Clash.Netlist.Types
-import Clash.Backend
+
+import Control.Monad.State
+
+import Data.Semigroup.Monad
+import Data.Text.Prettyprint.Doc.Extra
+
 import qualified Data.Text as TextS
 
 altpllTF :: TemplateFunction
@@ -47,9 +50,12 @@ alteraPllTemplate
   => BlackBoxContext
   -> State s Doc
 alteraPllTemplate bbCtx = do
- [locked,pllLock,alteraPll,alteraPll_inst] <-
-  traverse (mkUniqueIdentifier Basic)
-           ["locked", "pllLock", "alteraPll","alteraPll_inst"]
+ let mkId = mkUniqueIdentifier Basic
+ locked <- mkId "locked"
+ pllLock <- mkId "pllLock"
+ alteraPll <- mkId "alteraPll"
+ alteraPll_inst <- mkId "alterPll_inst"
+
  clocks <- traverse (mkUniqueIdentifier Extended)
                     [TextS.pack ("pllOut" ++ show n) | n <- [0..length tys - 1]]
  getMon $ blockDecl alteraPll $ concat
@@ -82,9 +88,12 @@ altpllTemplate
   => BlackBoxContext
   -> State s Doc
 altpllTemplate bbCtx = do
- [pllOut,locked,pllLock,alteraPll,alteraPll_inst] <-
-  traverse (mkUniqueIdentifier Basic)
-           ["pllOut","locked", "pllLock", "altpll","altpll_inst"]
+ let mkId = mkUniqueIdentifier Basic
+ pllOut <- mkId "pllOut"
+ locked <- mkId "locked"
+ pllLock <- mkId "pllLock"
+ alteraPll <- mkId "altpll"
+ alteraPll_inst <- mkId "altpll_inst"
  getMon $ blockDecl alteraPll
   [ NetDecl Nothing locked  Bit
   , NetDecl Nothing pllLock Bool

--- a/clash-lib/src/Clash/Rewrite/Combinators.hs
+++ b/clash-lib/src/Clash/Rewrite/Combinators.hs
@@ -43,8 +43,8 @@ allR trans (TransformContext is c) (Cast e ty1 ty2) =
   Cast <$> trans (TransformContext is (CastBody:c)) e <*> pure ty1 <*> pure ty2
 
 allR trans (TransformContext is c) (Letrec xes e) = do
-  e'   <- trans (TransformContext is' (LetBody bndrs:c)) e
   xes' <- traverse rewriteBind xes
+  e'   <- trans (TransformContext is' (LetBody bndrs:c)) e
   return (Letrec xes' e')
   -- Letrec <$> traverse rewriteBind xes <*> trans (TransformContext is' (LetBody bndrs:c)) e
  where

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -18,6 +18,7 @@ module Clash.Rewrite.Types where
 import Control.Concurrent.Supply             (Supply, freshId)
 import Control.Lens                          (use, (.=))
 import Control.Monad
+import Control.Monad.Fail                    (MonadFail(fail))
 import Control.Monad.Fix                     (MonadFix (..), fix)
 import Control.Monad.Reader                  (MonadReader (..))
 import Control.Monad.State                   (MonadState (..))
@@ -110,6 +111,9 @@ makeLenses ''RewriteEnv
 -- if a transformation/rewrite has been successfully applied.
 newtype RewriteMonad extra a = R
   { runR :: RewriteEnv -> RewriteState extra -> (a,RewriteState extra,Any) }
+
+instance MonadFail (RewriteMonad extra) where
+  fail err = error ("RewriteMonad.fail: " ++ err)
 
 instance Functor (RewriteMonad extra) where
   fmap f m = R (\r s -> case runR m r s of (a,s',w) -> (f a,s',w))

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE OverloadedStrings        #-}
 {-# LANGUAGE Rank2Types               #-}
+{-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE TemplateHaskell          #-}
 {-# LANGUAGE ViewPatterns             #-}
 
@@ -24,6 +25,7 @@ import           Control.Lens
   (Lens', (%=), (+=), (^.), _3, _4, _Left)
 import qualified Control.Lens                as Lens
 import qualified Control.Monad               as Monad
+import           Control.Monad.Fail          (MonadFail)
 import qualified Control.Monad.State.Strict  as State
 import qualified Control.Monad.Writer        as Writer
 import           Data.Bifunctor              (bimap)
@@ -169,7 +171,7 @@ mkDerivedName (TransformContext _ ctx) sf = case closestLetBinder ctx of
 
 -- | Make a new binder and variable reference for a term
 mkTmBinderFor
-  :: (Monad m, MonadUnique m)
+  :: (Monad m, MonadUnique m, MonadFail m)
   => InScopeSet
   -> TyConMap -- ^ TyCon cache
   -> Name a -- ^ Name of the new binder
@@ -181,7 +183,7 @@ mkTmBinderFor is tcm name e = do
 
 -- | Make a new binder and variable reference for either a term or a type
 mkBinderFor
-  :: (Monad m, MonadUnique m)
+  :: (Monad m, MonadUnique m, MonadFail m)
   => InScopeSet
   -> TyConMap -- ^ TyCon cache
   -> Name a -- ^ Name of the new binder

--- a/clash-lib/src/Clash/Util/Graph.hs
+++ b/clash-lib/src/Clash/Util/Graph.hs
@@ -1,0 +1,127 @@
+{-|
+  Copyright   :  (C) 2018, QBayLogic
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+
+  Collection of utilities
+-}
+module Clash.Util.Graph (topSort, reverseTopSort) where
+
+import           Data.Tuple            (swap)
+import           Data.Foldable         (foldlM)
+import qualified Data.IntMap.Strict    as IntMap
+import qualified Data.IntSet           as IntSet
+
+data Marker
+  = Temporary
+  | Permanent
+
+headSafe :: [a] -> Maybe a
+headSafe [] = Nothing
+headSafe (a:_) = Just a
+
+topSortVisit'
+  :: IntMap.IntMap [Int]
+  -- ^ Edges
+  -> IntSet.IntSet
+  -- ^ Unmarked nodes
+  -> IntMap.IntMap Marker
+  -- ^ Marked nodes
+  -> [Int]
+  -- ^ Sorted so far
+  -> Int
+  -- ^ Node to visit
+  -> Either String (IntSet.IntSet, IntMap.IntMap Marker, [Int])
+topSortVisit' edges unmarked marked sorted node =
+  case IntMap.lookup node marked of
+    Just Permanent -> Right (unmarked, marked, sorted)
+    Just Temporary -> Left "cycle detected: cannot topsort cyclic graph"
+    Nothing -> do
+      let marked'   = IntMap.insert node Temporary marked
+      let unmarked' = IntSet.delete node unmarked
+      let nodeToM   = IntMap.findWithDefault [] node edges
+      (unmarked'', marked'', sorted'') <-
+        foldlM visit (unmarked', marked', sorted) nodeToM
+      let marked''' = IntMap.insert node Permanent marked''
+      return (unmarked'', marked''', node : sorted'')
+  where
+    visit (unmarked', marked', sorted') node' =
+      topSortVisit' edges unmarked' marked' sorted' node'
+
+topSortVisit
+  :: IntMap.IntMap [Int]
+  -- ^ Edges
+  -> IntSet.IntSet
+  -- ^ Unmarked nodes
+  -> IntMap.IntMap Marker
+  -- ^ Marked nodes
+  -> [Int]
+  -- ^ Sorted so far
+  -> Int
+  -- ^ Node to visit
+  -> Either String (IntSet.IntSet, IntMap.IntMap Marker, [Int])
+topSortVisit edges unmarked marked sorted node = do
+  (unmarked', marked', sorted') <-
+    topSortVisit' edges unmarked marked sorted node
+
+  case headSafe (IntSet.toList unmarked') of
+    Nothing    -> return (unmarked', marked', sorted')
+    Just node' -> topSortVisit edges unmarked' marked' sorted' node'
+
+-- | See: https://en.wikipedia.org/wiki/Topological_sorting. This function
+-- errors if edges mention nodes not mentioned in the node list or if the
+-- given graph contains cycles.
+topSort
+  :: [(Int, a)]
+  -- ^ Nodes
+  -> [(Int, Int)]
+  -- ^ Edges
+  -> Either String [a]
+  -- ^ Error message or topologically sorted nodes
+topSort []             []     = Right []
+topSort []             _edges = Left "Node list was empty, but edges non-empty"
+topSort nodes@(node:_)  edges = do
+  _ <- mapM (\(n, m) -> checkNode n >> checkNode m) edges
+
+  (_, _, sorted) <-
+    topSortVisit edges' (IntMap.keysSet nodes') IntMap.empty [] (fst node)
+
+  mapM lookup' sorted
+    where
+      nodes' = IntMap.fromList nodes
+      edges' = foldl insert IntMap.empty edges
+
+      -- Construction functions for quick lookup of edges from n to m, given n
+      insert im (n, m)    = IntMap.alter (insert' m) n im
+      insert' m Nothing   = Just [m]
+      insert' m (Just ms) = Just (m:ms)
+
+      -- Lookup node in nodes map. If not present, yield error
+      lookup' n =
+        case IntMap.lookup n nodes' of
+          Nothing
+            -> Left ("Node " ++ show n ++ " in edge list, but not in node list.")
+          Just n'
+            -> Right n'
+
+      -- Check if edge is valid (i.e., mentioned nodes are in node list)
+      checkNode n
+        | IntMap.notMember n nodes' =
+            Left ("Node " ++ show n ++ " in edge list, but not in node list.")
+        | otherwise =
+            Right n
+
+-- | Same as `reverse (topSort nodes edges)` if alternative representations are
+-- considered the same. That is, topSort might produce multiple answers and
+-- still deliver on its promise of yielding a topologically sorted node list.
+-- Likewise, this function promises __one__ of those lists in reverse, but not
+-- necessarily the reverse of topSort itself.
+reverseTopSort
+  :: [(Int, a)]
+  -- ^ Nodes
+  -> [(Int, Int)]
+  -- ^ Edges
+  -> Either String [a]
+  -- ^ Reversely, topologically sorted nodes
+reverseTopSort nodes edges =
+  topSort nodes (map swap edges)

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -60,7 +60,7 @@ Extra-source-files:   README.md
 extra-doc-files:      doc/*.svg
 
 Cabal-version:        >=1.18
-Tested-with:          GHC == 8.2.2, GHC == 8.4.1, GHC == 8.5
+Tested-with:          GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1
 
 source-repository head
   type: git
@@ -227,7 +227,7 @@ Library
                       th-orphans                >= 0.13.1   && < 1.0,
                       text                      >= 0.11.3.1 && < 1.3,
                       time                      >= 1.8     && < 1.10,
-                      transformers              >= 0.4.2.0 && < 0.6,
+                      transformers              >= 0.5.2.0 && < 0.6,
                       vector                    >= 0.11    && < 1.0
 
 test-suite doctests

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -60,7 +60,7 @@ Extra-source-files:   README.md
 extra-doc-files:      doc/*.svg
 
 Cabal-version:        >=1.18
-Tested-with:          GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1
+Tested-with:          GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.2
 
 source-repository head
   type: git

--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -40,7 +40,7 @@ executable clash-testsuite
                        directory          >=1.2      && <1.4,
                        filepath           >=1.4      && <1.5,
                        process            >=1.2      && <1.7,
-                       tasty              >=0.10.1.2 && <2.0,
+                       tasty              >=1.1.0.2  && <2.0,
                        tasty-hunit,
                        neat-interpolation >=0.3      && <0.4,
                        regex-pcre-builtin >=0.9      && <1,


### PR DESCRIPTION
Most changes are a result of the decision of the GHC developers to
enable `MonadFailDesugaring` by default. See the following proposal:

https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail

Besides that, `UI.hs` in `src-bin-861` needed fixing as it had been left
uncompiled (and thus untested) for a while. A known issue is that
haddock fails to generate documentation for Clash, due to:

haskell/haddock#900

This should be fixed in newer GHC releases.

Thanks to @bgamari for providing a PR.