### PR TITLE
Add Generic Undefined

### DIFF
--- a/clash-prelude/src/Clash/Examples.hs
+++ b/clash-prelude/src/Clash/Examples.hs
@@ -6,7 +6,7 @@ Licence   : Creative Commons 4.0 (CC BY 4.0) (http://creativecommons.org/license
 
 {-# LANGUAGE NoImplicitPrelude, CPP, TemplateHaskell, DataKinds, BinaryLiterals,
              FlexibleContexts, GADTs, TypeOperators, TypeApplications,
-             RecordWildCards, DeriveAnyClass #-}
+             RecordWildCards, DeriveGeneric, DeriveAnyClass #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
@@ -171,8 +171,7 @@ data RxReg
   , _rx_d1         :: Bit
   , _rx_d2         :: Bit
   , _rx_busy       :: Bool
-  }
-  deriving Undefined
+  } deriving (Generic, Undefined)
 
 makeLenses ''RxReg
 
@@ -184,7 +183,7 @@ data TxReg
   , _tx_out      :: Bit
   , _tx_cnt      :: Unsigned 4
   }
-  deriving Undefined
+  deriving (Generic, Undefined)
 
 makeLenses ''TxReg
 

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -408,7 +408,7 @@ import Clash.XException       (Undefined, errorX, maybeX, seqX)
 {- $setup
 >>> import Clash.Explicit.Prelude as C
 >>> import qualified Data.List as L
->>> :set -XDataKinds -XRecordWildCards -XTupleSections -XDeriveAnyClass
+>>> :set -XDataKinds -XRecordWildCards -XTupleSections -XDeriveAnyClass -XDeriveGeneric
 >>> type InstrAddr = Unsigned 8
 >>> type MemAddr = Unsigned 5
 >>> type Value = Signed 8
@@ -421,7 +421,7 @@ data Reg
   | RegC
   | RegD
   | RegE
-  deriving (Eq,Show,Enum,Undefined)
+  deriving (Eq,Show,Enum,C.Generic,Undefined)
 :}
 
 >>> :{

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -90,6 +90,9 @@ module Clash.Explicit.Prelude
   , module Clash.Sized.RTree
     -- ** Annotations
   , module Clash.Annotations.TopEntity
+    -- ** Generics type-classes
+  , Generic
+  , Generic1
     -- ** Type-level natural numbers
   , module GHC.TypeLits
   , module GHC.TypeLits.Extra
@@ -123,6 +126,7 @@ where
 import Control.Applicative
 import Data.Bits
 import Data.Default.Class
+import GHC.Generics (Generic, Generic1)
 import GHC.TypeLits
 import GHC.TypeLits.Extra
 import Language.Haskell.TH.Syntax  (Lift(..))

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -71,6 +71,9 @@ module Clash.Explicit.Prelude.Safe
   , module Clash.Sized.RTree
     -- ** Annotations
   , module Clash.Annotations.TopEntity
+    -- ** Generics type-classes
+  , Generic
+  , Generic1
     -- ** Type-level natural numbers
   , module GHC.TypeLits
   , module GHC.TypeLits.Extra
@@ -100,6 +103,7 @@ where
 
 import Control.Applicative
 import Data.Bits
+import GHC.Generics (Generic, Generic1)
 import GHC.Stack
 import GHC.TypeLits
 import GHC.TypeLits.Extra

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -108,6 +108,9 @@ module Clash.Prelude
   , module Clash.Sized.RTree
     -- ** Annotations
   , module Clash.Annotations.TopEntity
+    -- ** Generics type-classes
+  , Generic
+  , Generic1
     -- ** Type-level natural numbers
   , module GHC.TypeLits
   , module GHC.TypeLits.Extra
@@ -143,6 +146,7 @@ where
 import           Control.Applicative
 import           Data.Bits
 import           Data.Default.Class
+import           GHC.Generics                (Generic, Generic1)
 import           GHC.TypeLits
 import           GHC.TypeLits.Extra
 import           Language.Haskell.TH.Syntax  (Lift(..))

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -44,7 +44,7 @@ data Reg
   | RegC
   | RegD
   | RegE
-  deriving (Eq,Show,Enum,Undefined)
+  deriving (Eq,Show,Enum,Generic,Undefined)
 
 data Operator = Add | Sub | Incr | Imm | CmpGt
   deriving (Eq,Show)
@@ -372,7 +372,8 @@ import           Clash.XException        (Undefined)
 {- $setup
 >>> import Clash.Prelude as C
 >>> import qualified Data.List as L
->>> :set -XDataKinds -XRecordWildCards -XTupleSections -XTypeApplications -XFlexibleContexts -XDeriveAnyClass
+>>> :set -XDataKinds -XRecordWildCards -XTupleSections -XTypeApplications -XFlexibleContexts
+>>> :set -XDeriveAnyClass -XDeriveGeneric
 >>> type InstrAddr = Unsigned 8
 >>> type MemAddr = Unsigned 5
 >>> type Value = Signed 8
@@ -385,7 +386,7 @@ data Reg
   | RegC
   | RegD
   | RegE
-  deriving (Eq,Show,Enum,Undefined)
+  deriving (Eq,Show,Enum,C.Generic,Undefined)
 :}
 
 >>> :{

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -85,6 +85,9 @@ module Clash.Prelude.Safe
   , module Clash.Sized.RTree
     -- ** Annotations
   , module Clash.Annotations.TopEntity
+    -- ** Generics type-classes
+  , Generic
+  , Generic1
     -- ** Type-level natural numbers
   , module GHC.TypeLits
   , module GHC.TypeLits.Extra
@@ -116,6 +119,8 @@ where
 
 import           Control.Applicative
 import           Data.Bits
+import           GHC.Generics (Generic, Generic1)
+
 import           GHC.TypeLits
 import           GHC.TypeLits.Extra
 import           Prelude hiding

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -98,7 +98,7 @@ import Clash.Prelude.BitReduction (reduceAnd, reduceOr)
 import Clash.Sized.BitVector      (BitVector, (++#))
 import Clash.Sized.Signed         (Signed)
 import Clash.Sized.Unsigned       (Unsigned)
-import Clash.XException           (ShowX (..), Undefined, showsPrecXWith)
+import Clash.XException           (ShowX (..), Undefined (..), errorX, showsPrecXWith)
 
 {- $setup
 >>> :set -XDataKinds
@@ -121,8 +121,6 @@ import Clash.XException           (ShowX (..), Undefined, showsPrecXWith)
 -- 'minBound' on underflow, and use truncation as the rounding method.
 newtype Fixed (rep :: Nat -> *) (int :: Nat) (frac :: Nat) =
   Fixed { unFixed :: rep (int + frac) }
-
-instance Undefined (Fixed rep int frac)
 
 deriving instance NFData (rep (int + frac)) => NFData (Fixed rep int frac)
 deriving instance (Typeable rep, Typeable int, Typeable frac
@@ -269,6 +267,8 @@ instance ( size ~ (int + frac), KnownNat frac, Integral (rep size)
 instance ( size ~ (int + frac), KnownNat frac, Integral (rep size)
          ) => ShowX (Fixed rep int frac) where
   showsPrecX = showsPrecXWith showsPrec
+
+instance Undefined (Fixed rep int frac) where deepErrorX = Fixed . errorX
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance (size ~ (int + frac), KnownNat frac, Bounded (rep size), Integral (rep size))

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -149,7 +149,7 @@ import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
 import Clash.Class.Resize         (Resize (..))
 import Clash.Promoted.Nat         (SNat, snatToInteger, snatToNum)
 import Clash.XException
-  (ShowX (..), Undefined, errorX, showsPrecXWith)
+  (ShowX (..), Undefined (..), errorX, showsPrecXWith)
 
 import {-# SOURCE #-} qualified Clash.Sized.Vector         as V
 import {-# SOURCE #-} qualified Clash.Sized.Internal.Index as I
@@ -172,7 +172,7 @@ data BitVector (n :: Nat) =
     BV { unsafeMask      :: Integer
        , unsafeToInteger :: Integer
        }
-  deriving (Data,Undefined)
+  deriving Data
 
 -- * Bit
 
@@ -183,7 +183,7 @@ data Bit =
   Bit { unsafeMask#      :: Integer
       , unsafeToInteger# :: Integer
       }
-  deriving (Data,Undefined)
+  deriving Data
 
 -- * Constructions
 -- ** Initialisation
@@ -211,6 +211,8 @@ instance Show Bit where
 
 instance ShowX Bit where
   showsPrecX = showsPrecXWith showsPrec
+
+instance Undefined Bit where deepErrorX = errorX
 
 instance Lift Bit where
   lift (Bit m i) = [| fromInteger## m i |]
@@ -353,6 +355,8 @@ instance KnownNat n => Show (BitVector n) where
 
 instance KnownNat n => ShowX (BitVector n) where
   showsPrecX = showsPrecXWith showsPrec
+
+instance Undefined (BitVector n) where deepErrorX = errorX
 
 -- | Create a binary literal
 --

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -93,7 +93,7 @@ import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
 import Clash.Class.Resize         (Resize (..))
 import {-# SOURCE #-} Clash.Sized.Internal.BitVector (BitVector (BV),undefError)
 import Clash.Promoted.Nat         (SNat, snatToNum, leToPlusKN)
-import Clash.XException           (ShowX (..), Undefined, showsPrecXWith)
+import Clash.XException           (ShowX (..), Undefined (..), errorX, showsPrecXWith)
 
 -- | Arbitrary-bounded unsigned integer represented by @ceil(log_2(n))@ bits.
 --
@@ -122,7 +122,7 @@ newtype Index (n :: Nat) =
     -- | The constructor, 'I', and the field, 'unsafeToInteger', are not
     -- synthesisable.
     I { unsafeToInteger :: Integer }
-  deriving (Data,Undefined)
+  deriving Data
 
 instance NFData (Index n) where
   rnf (I i) = rnf i `seq` ()
@@ -362,6 +362,8 @@ instance Show (Index n) where
 
 instance ShowX (Index n) where
   showsPrecX = showsPrecXWith showsPrec
+
+instance Undefined (Index n) where deepErrorX = errorX
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance KnownNat n => Read (Index n) where

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -107,7 +107,7 @@ import Clash.Prelude.BitIndex         ((!), msb, replaceBit, split)
 import Clash.Prelude.BitReduction     (reduceAnd, reduceOr)
 import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, (++#), high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
-import Clash.XException               (ShowX (..), Undefined, showsPrecXWith)
+import Clash.XException               (ShowX (..), Undefined (..), errorX, showsPrecXWith)
 
 -- | Arbitrary-width signed integer represented by @n@ bits, including the sign
 -- bit.
@@ -148,7 +148,9 @@ newtype Signed (n :: Nat) =
     -- | The constructor, 'S', and the field, 'unsafeToInteger', are not
     -- synthesisable.
     S { unsafeToInteger :: Integer}
-  deriving (Data, Undefined)
+  deriving Data
+
+instance Undefined (Signed n) where deepErrorX = errorX
 
 {-# NOINLINE size# #-}
 size# :: KnownNat n => Signed n -> Int

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -100,7 +100,7 @@ import Clash.Prelude.BitIndex         ((!), msb, replaceBit, split)
 import Clash.Prelude.BitReduction     (reduceOr)
 import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
-import Clash.XException               (ShowX (..), Undefined, showsPrecXWith)
+import Clash.XException               (ShowX (..), Undefined (..), errorX, showsPrecXWith)
 
 -- | Arbitrary-width unsigned integer represented by @n@ bits
 --
@@ -137,7 +137,7 @@ newtype Unsigned (n :: Nat) =
     -- | The constructor, 'U', and the field, 'unsafeToInteger', are not
     -- synthesisable.
     U { unsafeToInteger :: Integer }
-  deriving (Data, Undefined)
+  deriving Data
 
 {-# NOINLINE size# #-}
 size# :: KnownNat n => Unsigned n -> Int
@@ -155,6 +155,8 @@ instance Show (Unsigned n) where
 
 instance ShowX (Unsigned n) where
   showsPrecX = showsPrecXWith showsPrec
+
+instance Undefined (Unsigned n) where deepErrorX = errorX
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance KnownNat n => Read (Unsigned n) where

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -130,7 +130,7 @@ let testBench :: Signal System Bool
     testBench = done
       where
         testInput      = stimuliGenerator clk rst $(listToVecTH [(1,1) :: (Signed 9,Signed 9),(2,2),(3,3),(4,4)])
-        expectedOutput = outputVerifier clk rst $(listToVecTH [0 :: Signed 9,1,5,14])
+        expectedOutput = outputVerifier clk rst $(listToVecTH [0 :: Signed 9,1,5,14,14,14,14])
         done           = expectedOutput (topEntity clk rst testInput)
         clk            = tbSystemClockGen (not <$> done)
         rst            = systemResetGen
@@ -574,13 +574,12 @@ topEntity
   -> 'Signal' System ('Signed' 9, 'Signed' 9)
   -> 'Signal' System ('Signed' 9)
 topEntity = 'exposeClockReset' mac
-{\-\# NOINLINE topEntity \#-\}
 
 testBench :: 'Signal' System Bool
 testBench = done
   where
     testInput    = 'stimuliGenerator' clk rst $('listToVecTH' [(1,1) :: ('Signed' 9,'Signed' 9),(2,2),(3,3),(4,4)])
-    expectOutput = 'outputVerifier' clk rst $('listToVecTH' [0 :: 'Signed' 9,1,5,14])
+    expectOutput = 'outputVerifier' clk rst $('listToVecTH' [0 :: 'Signed' 9,1,5,14,14,14,14])
     done         = expectOutput (topEntity clk rst testInput)
     clk          = 'tbSystemClockGen' (not '<$>' done)
     rst          = 'systemResetGen'
@@ -595,13 +594,13 @@ simulate the behaviour of the /testBench/:
 [False,False,False,False
 cycle(system10000): 4, outputVerifier
 expected value: 14, not equal to actual value: 30
-,True
+,False
 cycle(system10000): 5, outputVerifier
 expected value: 14, not equal to actual value: 46
-,True
+,False
 cycle(system10000): 6, outputVerifier
 expected value: 14, not equal to actual value: 62
-,True]
+,False]
 
 We can see that for the first 4 samples, everything is working as expected,
 after which warnings are being reported. The reason is that 'stimuliGenerator'

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -375,86 +375,50 @@ instance GShowX UWord where
 class Undefined a where
   -- | Create a value where all the elements have an 'errorX', but the spine
   -- is defined.
-  deepErrorX :: HasCallStack => String -> a
-  deepErrorX = errorX
+  deepErrorX :: String -> a
+
+  default deepErrorX :: (Generic a, GUndefined (Rep a)) => String -> a
+  deepErrorX = to . gDeepErrorX
 
 instance Undefined ()
-instance (Undefined a, Undefined b) => Undefined (a,b) where
-  deepErrorX x = (deepErrorX x,deepErrorX x)
-instance (Undefined a, Undefined b, Undefined c) => Undefined (a,b,c) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x)
-instance (Undefined a, Undefined b, Undefined c, Undefined d) =>
-  Undefined (a,b,c,d) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x)
-instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e) =>
-  Undefined (a,b,c,d,e) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x)
-instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
-         ,Undefined f)
-  => Undefined (a,b,c,d,e,f) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x)
+instance (Undefined a, Undefined b) => Undefined (a,b)
+instance (Undefined a, Undefined b, Undefined c) => Undefined (a,b,c)
+instance (Undefined a, Undefined b, Undefined c, Undefined d) => Undefined (a,b,c,d)
+instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e) => Undefined (a,b,c,d,e)
+instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e ,Undefined f)
+  => Undefined (a,b,c,d,e,f)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g)
-  => Undefined (a,b,c,d,e,f,g) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g, Undefined h)
-  => Undefined (a,b,c,d,e,f,g,h) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g,h)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g, Undefined h, Undefined i)
-  => Undefined (a,b,c,d,e,f,g,h,i) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g,h,i)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g, Undefined h, Undefined i, Undefined j)
-  => Undefined (a,b,c,d,e,f,g,h,i,j) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g,h,i,j)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g, Undefined h, Undefined i, Undefined j
          ,Undefined k)
-  => Undefined (a,b,c,d,e,f,g,h,i,j,k) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g,h,i,j,k)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g, Undefined h, Undefined i, Undefined j
          ,Undefined k, Undefined l)
-  => Undefined (a,b,c,d,e,f,g,h,i,j,k,l) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g,h,i,j,k,l)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g, Undefined h, Undefined i, Undefined j
          ,Undefined k, Undefined l, Undefined m)
-  => Undefined (a,b,c,d,e,f,g,h,i,j,k,l,m) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g,h,i,j,k,l,m)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g, Undefined h, Undefined i, Undefined j
          ,Undefined k, Undefined l, Undefined m, Undefined n)
-  => Undefined (a,b,c,d,e,f,g,h,i,j,k,l,m,n) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
 instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
          ,Undefined f, Undefined g, Undefined h, Undefined i, Undefined j
          ,Undefined k, Undefined l, Undefined m, Undefined n, Undefined o)
-  => Undefined (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) where
-  deepErrorX x = (deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x,deepErrorX x
-                 ,deepErrorX x,deepErrorX x,deepErrorX x)
+  => Undefined (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
 
 instance Undefined b => Undefined (a -> b) where
   deepErrorX = pure . deepErrorX
@@ -462,24 +426,46 @@ instance Undefined b => Undefined (a -> b) where
 instance Undefined a => Undefined (Down a) where
   deepErrorX = Down . deepErrorX
 
-instance Undefined [a]
-instance Undefined Char
 instance Undefined Bool
-instance Undefined Double
+instance Undefined [a]
 instance Undefined (Either a b)
-instance Undefined Float
-instance Undefined Int
-instance Undefined Int8
-instance Undefined Int16
-instance Undefined Int32
-instance Undefined Int64
-instance Undefined Integer
-instance Undefined (Seq a)
-instance Undefined Word
-instance Undefined Word8
-instance Undefined Word16
-instance Undefined Word32
-instance Undefined Word64
 instance Undefined (Maybe a)
-instance Undefined (Ratio a)
-instance Undefined (Complex a)
+
+instance Undefined Char where deepErrorX = errorX
+instance Undefined Double where deepErrorX = errorX
+instance Undefined Float where deepErrorX = errorX
+instance Undefined Int where deepErrorX = errorX
+instance Undefined Int8 where deepErrorX = errorX
+instance Undefined Int16 where deepErrorX = errorX
+instance Undefined Int32 where deepErrorX = errorX
+instance Undefined Int64 where deepErrorX = errorX
+instance Undefined Integer where deepErrorX = errorX
+instance Undefined Word where deepErrorX = errorX
+instance Undefined Word8 where deepErrorX = errorX
+instance Undefined Word16 where deepErrorX = errorX
+instance Undefined Word32 where deepErrorX = errorX
+instance Undefined Word64 where deepErrorX = errorX
+instance Undefined (Seq a) where deepErrorX = errorX
+instance Undefined (Ratio a) where deepErrorX = errorX
+instance Undefined (Complex a) where deepErrorX = errorX
+
+class GUndefined f where
+  gDeepErrorX :: String -> f a
+
+instance GUndefined V1 where
+  gDeepErrorX = errorX
+
+instance GUndefined U1 where
+  gDeepErrorX = const U1
+
+instance (GUndefined a) => GUndefined (M1 m d a) where
+  gDeepErrorX e = M1 (gDeepErrorX e)
+
+instance (GUndefined f, GUndefined g) => GUndefined (f :*: g) where
+  gDeepErrorX e = gDeepErrorX e :*: gDeepErrorX e
+
+instance Undefined c => GUndefined (K1 i c) where
+  gDeepErrorX e = K1 (deepErrorX e)
+
+instance GUndefined (f :+: g) where
+  gDeepErrorX = errorX

--- a/examples/Reducer.hs
+++ b/examples/Reducer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass #-}
+{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
 module Reducer where
 
 import Clash.Prelude
@@ -50,7 +50,7 @@ equalDiscr _             _             = False
 data DiscrState = Discr { prevIndex :: ArrayIndex
                         , curDiscr  :: Unsigned DiscrSize
                         }
-                        deriving Undefined
+                        deriving (Generic, Undefined)
 
 type InputState = Vec (AdderDepth + 1) Cell
 
@@ -59,7 +59,7 @@ type FpState    = Vec AdderDepth Cell
 data ResState   = Res { cellMem  :: Vec DiscrRange Cell
                       , indexMem :: Vec DiscrRange ArrayIndex
                       }
-                      deriving Undefined
+                      deriving (Generic, Undefined)
 
 -- ===========================================================
 -- = Discrimintor: Hands out new discriminator to the system =

--- a/examples/i2c/I2C/BitMaster.hs
+++ b/examples/i2c/I2C/BitMaster.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass #-}
+{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
 module I2C.BitMaster (bitMaster) where
 
 import Clash.Prelude
@@ -22,7 +22,7 @@ data BitMasterS
   , _slaveWait      :: Bool            -- clock generation signal
   , _cnt            :: Unsigned 16     -- clock divider counter (synthesis)
   }
-  deriving Undefined
+  deriving (Generic, Undefined)
 
 makeLenses ''BitMasterS
 

--- a/examples/i2c/I2C/BitMaster/BusCtrl.hs
+++ b/examples/i2c/I2C/BitMaster/BusCtrl.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
 module I2C.BitMaster.BusCtrl where
 
 import Clash.Prelude
@@ -20,7 +20,7 @@ data BusStatusCtrl
   , _stopCondition  :: Bool        -- stop detected
   , _busy           :: Bool        -- internal busy signal
   , _cmdStop        :: Bool        -- STOP command
-  }
+  } deriving (Generic, Undefined)
 
 makeLenses ''BusStatusCtrl
 

--- a/examples/i2c/I2C/BitMaster/StateMachine.hs
+++ b/examples/i2c/I2C/BitMaster/StateMachine.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
 module I2C.BitMaster.StateMachine where
 
 import Clash.Prelude
@@ -13,7 +13,7 @@ data BitStateMachine
   | Stop  (Index 4)
   | Read  (Index 4)
   | Write (Index 4)
-  deriving Eq
+  deriving (Eq, Generic, Undefined)
 
 data StateMachine
   = StateMachine
@@ -22,7 +22,7 @@ data StateMachine
   , _sdaChk    :: Bool            -- check SDA status (multi-master arbiter)
   , _cmdAck    :: Bool            -- command completed
   , _bitStateM :: BitStateMachine -- State Machine
-  }
+  } deriving (Generic, Undefined)
 
 makeLenses ''StateMachine
 

--- a/examples/i2c/I2C/ByteMaster.hs
+++ b/examples/i2c/I2C/ByteMaster.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass #-}
+{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
 module I2C.ByteMaster (byteMaster) where
 
 import Clash.Prelude
@@ -12,7 +12,7 @@ import I2C.ByteMaster.ShiftRegister
 import I2C.Types
 
 data ByteStateMachine = Idle | Start | Read | Write | Ack | Stop
-  deriving Show
+  deriving (Show, Generic, Undefined)
 
 data ByteMasterS
   = ByteS
@@ -25,7 +25,7 @@ data ByteMasterS
   , _hostAck    :: Bool             -- host cmd acknowlegde register
   , _ackOut     :: Bool             -- slave ack register
   }
-  deriving Undefined
+  deriving (Generic, Undefined)
 
 makeLenses ''ByteMasterS
 

--- a/examples/i2c/I2C/ByteMaster/ShiftRegister.hs
+++ b/examples/i2c/I2C/ByteMaster/ShiftRegister.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
 module I2C.ByteMaster.ShiftRegister where
 
 import Clash.Prelude
@@ -10,7 +10,7 @@ data ShiftRegister
   = ShiftRegister
   { _sr   :: Vec 8 Bit
   , _dcnt :: Index 8
-  }
+  } deriving (Generic, Undefined)
 
 makeLenses ''ShiftRegister
 

--- a/examples/i2c/I2C/Types.hs
+++ b/examples/i2c/I2C/Types.hs
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveAnyClass, DeriveGeneric #-}
 module I2C.Types where
 
 import Clash.Prelude
 
 data I2CCommand = I2Cstart | I2Cstop | I2Cwrite | I2Cread | I2Cnop
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Generic, Undefined)
 
 type BitCtrlSig = (I2CCommand,Bit)
 type BitRespSig = (Bool,Bool,Bit)

--- a/tests/shouldwork/Basic/LotOfStates.hs
+++ b/tests/shouldwork/Basic/LotOfStates.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
 module LotOfStates where
 
 import Clash.Prelude
@@ -15,7 +16,7 @@ data States = S_0
             | S_8
             | S_9
             | S_10
-            deriving (Enum, Eq, Undefined)
+            deriving (Enum, Eq, Generic, Undefined)
 
 fsm :: States
     -> Unsigned 8

--- a/tests/shouldwork/Basic/RecordSumOfProducts.hs
+++ b/tests/shouldwork/Basic/RecordSumOfProducts.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module RecordSumOfProducts where
@@ -9,10 +10,10 @@ import Control.Applicative
 
 data DbState = DbInitDisp (Unsigned 4) | DbWriteRam (Signed 14) (Signed 14)
              | DbDone
-    deriving (Show, Eq, Undefined)
+    deriving (Show, Eq, Generic, Undefined)
 
 data DbS = DbS { dbS :: DbState }
-  deriving Undefined
+  deriving (Generic, Undefined)
 
 
 topEntity


### PR DESCRIPTION
Add a generic derivable instance to `Undefined`  which behaves as expected i.e. produces the spine of the data structure with `errorX` at any sum/primitve types.