### PR TITLE
Account for typeclasses with instances over functions in `funSubst`

### DIFF
--- a/tests/shouldwork/Polymorphism/FunctionInstances.hs
+++ b/tests/shouldwork/Polymorphism/FunctionInstances.hs
@@ -1,0 +1,30 @@
+module FunctionInstances where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+class Bus p where
+ type MasterToSlave p
+
+instance Bus (a -> b) where
+ type MasterToSlave (a -> b) = a
+
+f :: (Eq a, Num a) => a -> (MasterToSlave (a -> a))
+f x =
+  case x + 1 of
+    2 -> 3
+    _ -> 5
+{-# NOINLINE f #-}
+
+topEntity :: Signal System Int -> Signal System Int
+topEntity = fmap f
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput    = stimuliGenerator clk rst (0 :> 1 :> 2 :> Nil)
+    expectOutput = outputVerifier clk rst (5 :> 3 :> 5 :> Nil)
+    done         = expectOutput (topEntity testInput)
+    clk          = tbSystemClockGen (not <$> done)
+    rst          = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -148,9 +148,10 @@ main = do
             , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Strict"  (["","Strict_testBench"],"Strict_testBench",True)
             ]
         , testGroup "Polymorphism"
-            [ runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "ExistentialBoxed" ([""],"ExistentialBoxed_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "GADTExistential"  ([""],"GADTExistential_topEntity",False)
-            , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "LocalPoly"        ([""],"LocalPoly_topEntity",False)
+            [ runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "ExistentialBoxed"  ([""],"ExistentialBoxed_topEntity",False)
+            , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "FunctionInstances" (["","FunctionInstances_testBench"],"FunctionInstances_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "GADTExistential"   ([""],"GADTExistential_topEntity",False)
+            , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "LocalPoly"         ([""],"LocalPoly_topEntity",False)
             ]
         , testGroup "RTree"
             [ runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TFold" ([""],"TFold_topEntity",False)


### PR DESCRIPTION
Solves issue where Clash would refuse to compile typeclasses with instances having functions in their associated types. While I'm reasonably sure the patch is correct, I'm requesting a review as I'm unsure if I got the terminology right.