### PR TITLE
 Enable DeriveGeneric and DeriveAnyClass by default

### DIFF
--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -85,7 +85,6 @@ import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 import           Control.Exception (Exception(..),ErrorCall (..))
 
-import qualified GHC.LanguageExtensions as LangExt
 import           GHC.Exception ( SomeException )
 
 import qualified Clash.Backend
@@ -97,7 +96,7 @@ import           Clash.Driver.Types
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
 import           Clash.Util (ClashException (..), clashLibVersion)
-import           Clash.GHC.LoadModules (ghcLibDir)
+import           Clash.GHC.LoadModules (ghcLibDir, wantedLanguageExtensions)
 
 -----------------------------------------------------------------------------
 -- ToDo:
@@ -169,51 +168,28 @@ defaultMain = flip withArgs $ do
             GHC.runGhc (Just libDir) $ do
 
             dflags <- GHC.getSessionDynFlags
-            let dflagsExtra = foldl DynFlags.xopt_set
-                                    dflags
-                                    [ LangExt.TemplateHaskell
-                                    , LangExt.TemplateHaskellQuotes
-                                    , LangExt.DataKinds
-                                    , LangExt.MonoLocalBinds
-                                    , LangExt.TypeOperators
-                                    , LangExt.FlexibleContexts
-                                    , LangExt.ConstraintKinds
-                                    , LangExt.TypeFamilies
-                                    , LangExt.BinaryLiterals
-                                    , LangExt.ExplicitNamespaces
-                                    , LangExt.KindSignatures
-                                    , LangExt.DeriveLift
-                                    , LangExt.TypeApplications
-                                    , LangExt.ScopedTypeVariables
-                                    , LangExt.MagicHash
-                                    , LangExt.ExplicitForAll
-                                    , LangExt.QuasiQuotes
-                                    ]
-                dflagsExtra1 = foldl DynFlags.xopt_unset dflagsExtra
-                                     [ LangExt.ImplicitPrelude
-                                     , LangExt.MonomorphismRestriction
-                                     ]
+            let dflagsExtra = wantedLanguageExtensions dflags
 
                 ghcTyLitNormPlugin = GHC.mkModuleName "GHC.TypeLits.Normalise"
                 ghcTyLitExtrPlugin = GHC.mkModuleName "GHC.TypeLits.Extra.Solver"
                 ghcTyLitKNPlugin   = GHC.mkModuleName "GHC.TypeLits.KnownNat.Solver"
-                dflagsExtra2 = dflagsExtra1
+                dflagsExtra1 = dflagsExtra
                                   { DynFlags.pluginModNames = nub $
                                       ghcTyLitNormPlugin : ghcTyLitExtrPlugin :
                                       ghcTyLitKNPlugin :
-                                      DynFlags.pluginModNames dflagsExtra1
+                                      DynFlags.pluginModNames dflagsExtra
                                   }
 
             case postStartupMode of
                 Left preLoadMode ->
                     liftIO $ do
                         case preLoadMode of
-                            ShowInfo               -> showInfo dflagsExtra2
-                            ShowGhcUsage           -> showGhcUsage  dflagsExtra2
-                            ShowGhciUsage          -> showGhciUsage dflagsExtra2
-                            PrintWithDynFlags f    -> putStrLn (f dflagsExtra2)
+                            ShowInfo               -> showInfo dflagsExtra1
+                            ShowGhcUsage           -> showGhcUsage  dflagsExtra1
+                            ShowGhciUsage          -> showGhciUsage dflagsExtra1
+                            PrintWithDynFlags f    -> putStrLn (f dflagsExtra1)
                 Right postLoadMode ->
-                    main' postLoadMode dflagsExtra2 argv3 flagWarnings r
+                    main' postLoadMode dflagsExtra1 argv3 flagWarnings r
 
 main' :: PostLoadMode -> DynFlags -> [Located String] -> [Warn]
       -> IORef ClashOpts

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -86,7 +86,6 @@ import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 import           Control.Exception (Exception(..),ErrorCall (..))
 
-import qualified GHC.LanguageExtensions as LangExt
 import           GHC.Exception ( SomeException )
 
 import qualified Clash.Backend
@@ -98,7 +97,7 @@ import           Clash.Driver.Types
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
 import           Clash.Util (ClashException (..), clashLibVersion)
-import           Clash.GHC.LoadModules (ghcLibDir)
+import           Clash.GHC.LoadModules (ghcLibDir, wantedLanguageExtensions)
 
 -----------------------------------------------------------------------------
 -- ToDo:
@@ -159,51 +158,28 @@ defaultMain = flip withArgs $ do
             GHC.runGhc (Just libDir) $ do
 
             dflags <- GHC.getSessionDynFlags
-            let dflagsExtra = foldl DynFlags.xopt_set
-                                    dflags
-                                    [ LangExt.TemplateHaskell
-                                    , LangExt.TemplateHaskellQuotes
-                                    , LangExt.DataKinds
-                                    , LangExt.MonoLocalBinds
-                                    , LangExt.TypeOperators
-                                    , LangExt.FlexibleContexts
-                                    , LangExt.ConstraintKinds
-                                    , LangExt.TypeFamilies
-                                    , LangExt.BinaryLiterals
-                                    , LangExt.ExplicitNamespaces
-                                    , LangExt.KindSignatures
-                                    , LangExt.DeriveLift
-                                    , LangExt.TypeApplications
-                                    , LangExt.ScopedTypeVariables
-                                    , LangExt.MagicHash
-                                    , LangExt.ExplicitForAll
-                                    , LangExt.QuasiQuotes
-                                    ]
-                dflagsExtra1 = foldl DynFlags.xopt_unset dflagsExtra
-                                     [ LangExt.ImplicitPrelude
-                                     , LangExt.MonomorphismRestriction
-                                     ]
+            let dflagsExtra = wantedLanguageExtensions dflags
 
                 ghcTyLitNormPlugin = GHC.mkModuleName "GHC.TypeLits.Normalise"
                 ghcTyLitExtrPlugin = GHC.mkModuleName "GHC.TypeLits.Extra.Solver"
                 ghcTyLitKNPlugin   = GHC.mkModuleName "GHC.TypeLits.KnownNat.Solver"
-                dflagsExtra2 = dflagsExtra1
+                dflagsExtra1 = dflagsExtra
                                   { DynFlags.pluginModNames = nub $
                                       ghcTyLitNormPlugin : ghcTyLitExtrPlugin :
                                       ghcTyLitKNPlugin :
-                                      DynFlags.pluginModNames dflagsExtra1
+                                      DynFlags.pluginModNames dflagsExtra
                                   }
 
             case postStartupMode of
                 Left preLoadMode ->
                     liftIO $ do
                         case preLoadMode of
-                            ShowInfo               -> showInfo dflagsExtra2
-                            ShowGhcUsage           -> showGhcUsage  dflagsExtra2
-                            ShowGhciUsage          -> showGhciUsage dflagsExtra2
-                            PrintWithDynFlags f    -> putStrLn (f dflagsExtra2)
+                            ShowInfo               -> showInfo dflagsExtra1
+                            ShowGhcUsage           -> showGhcUsage  dflagsExtra1
+                            ShowGhciUsage          -> showGhciUsage dflagsExtra1
+                            PrintWithDynFlags f    -> putStrLn (f dflagsExtra1)
                 Right postLoadMode ->
-                    main' postLoadMode dflagsExtra2 argv3 flagWarnings r
+                    main' postLoadMode dflagsExtra1 argv3 flagWarnings r
 
 main' :: PostLoadMode -> DynFlags -> [Located String] -> [Warn]
       -> IORef ClashOpts

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -526,6 +526,8 @@ wantedLanguageExtensions df =
              , LangExt.MagicHash
              , LangExt.ExplicitForAll
              , LangExt.QuasiQuotes
+             , LangExt.DeriveGeneric
+             , LangExt.DeriveAnyClass
              ]
     unwanted = [ LangExt.ImplicitPrelude
                , LangExt.MonomorphismRestriction

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -62,8 +62,6 @@ class BitPack a where
   --
   -- Can be derived using `GHC.Generics`:
   --
-  -- > {-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
-  -- >
   -- > import Clash.Prelude
   -- > import GHC.Generics
   -- >

--- a/examples/Reducer.hs
+++ b/examples/Reducer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 module Reducer where
 
 import Clash.Prelude

--- a/examples/i2c/I2C/BitMaster.hs
+++ b/examples/i2c/I2C/BitMaster.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 module I2C.BitMaster (bitMaster) where
 
 import Clash.Prelude

--- a/examples/i2c/I2C/BitMaster/BusCtrl.hs
+++ b/examples/i2c/I2C/BitMaster/BusCtrl.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 module I2C.BitMaster.BusCtrl where
 
 import Clash.Prelude

--- a/examples/i2c/I2C/BitMaster/StateMachine.hs
+++ b/examples/i2c/I2C/BitMaster/StateMachine.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 module I2C.BitMaster.StateMachine where
 
 import Clash.Prelude

--- a/examples/i2c/I2C/ByteMaster.hs
+++ b/examples/i2c/I2C/ByteMaster.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 module I2C.ByteMaster (byteMaster) where
 
 import Clash.Prelude

--- a/examples/i2c/I2C/ByteMaster/ShiftRegister.hs
+++ b/examples/i2c/I2C/ByteMaster/ShiftRegister.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, DeriveAnyClass, DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 module I2C.ByteMaster.ShiftRegister where
 
 import Clash.Prelude

--- a/examples/i2c/I2C/Types.hs
+++ b/examples/i2c/I2C/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveAnyClass, DeriveGeneric #-}
 module I2C.Types where
 
 import Clash.Prelude

--- a/tests/shouldwork/Basic/LotOfStates.hs
+++ b/tests/shouldwork/Basic/LotOfStates.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
 module LotOfStates where
 
 import Clash.Prelude

--- a/tests/shouldwork/Basic/RecordSumOfProducts.hs
+++ b/tests/shouldwork/Basic/RecordSumOfProducts.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module RecordSumOfProducts where

--- a/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
+++ b/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module Rotate where
 
 import Clash.Prelude.Testbench

--- a/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module RotateC where
 
 import Clash.Prelude.Testbench

--- a/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module RotateCScrambled
   ( topEntity
   , testBench

--- a/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
+++ b/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module RotateCNested where
 
 import Clash.Prelude.Testbench

--- a/tests/shouldwork/Polymorphism/GADTExistential.hs
+++ b/tests/shouldwork/Polymorphism/GADTExistential.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE TypeApplications #-}
-
 module GADTExistential where
 
 import           Clash.Prelude


### PR DESCRIPTION
 To make it less of a hassle to derive Undefined on your own types.
