### PR TITLE
Hotfix infinite loop

### DIFF
--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -163,6 +163,9 @@ normalize' nm = do
                         -- global binder, sometimes causing the inliner to go
                         -- into a loop. Deshadowing freshens all the bindings
                         -- to avoid this.
+                        --
+                        -- TODO: See if we can remove this, now that the
+                        -- TODO: inlining functions account for global vars
                         is0 <- Lens.use globalInScope
                         let tm1 = deShadowTerm is0 tm
                         curFun .= (nm',sp)

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1851,9 +1851,9 @@ inlineCleanup _ e = return e
 --
 -- NB: must only be called in the cleaning up phase.
 flattenLet :: NormRewrite
-flattenLet (TransformContext is0 _) (Letrec binds body) = do
-  let is1 = extendInScopeSetList is0 (map fst binds)
-  is2 <- unionInScope is1 <$> Lens.use globalInScope
+flattenLet (TransformContext is0 _) letrec@(Letrec _ _) = do
+  is1 <- unionInScope is0 <$> Lens.use globalInScope
+  let (is2, Letrec binds body) = freshenTm is1 letrec
   binds' <- concat <$> mapM (go is2) binds
   case binds' of
     -- inline binders into the body when there's only a single binder

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -477,10 +477,10 @@ cloneName nm = do
   return nm {nameUniq = i}
 
 -- | Test whether a term is a variable reference to a local binder
-isLocalVar :: Term
+isNonGlobalVar :: Term
            -> RewriteMonad extra Bool
-isLocalVar (Var x) = notElemUniqMap (varName x) <$> Lens.use bindings
-isLocalVar _ = return False
+isNonGlobalVar (Var x) = notElemUniqMap (varName x) <$> Lens.use bindings
+isNonGlobalVar _ = return False
 
 {-# INLINE isUntranslatable #-}
 -- | Determine if a term cannot be represented in hardware


### PR DESCRIPTION
Some users reported that their designs would not compile on Clash. Clash seemingly entered an infinite loop. This turned out to be the case indeed, caused by Clash not accounting for shadowed variables in various transformations. This PR fixes that issues.