### PR TITLE
Refactor non-explicit DSignal functions

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -112,7 +112,6 @@ Library
                       Clash.Explicit.Prelude.Safe
                       Clash.Explicit.Signal
                       Clash.Explicit.Signal.Delayed
-                      Clash.Explicit.Signal.Delayed.Bundle
                       Clash.Explicit.Synchronizer
                       Clash.Explicit.Testbench
 
@@ -147,6 +146,8 @@ Library
                       Clash.Signal.Bundle
                       Clash.Signal.BiSignal
                       Clash.Signal.Delayed
+                      Clash.Signal.Delayed.Internal
+                      Clash.Signal.Delayed.Bundle
                       Clash.Signal.Internal
                       Clash.Signal.Trace
 

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -25,43 +25,28 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 module Clash.Explicit.Signal.Delayed
   ( -- * Delay-annotated synchronous signals
-    DSignal
-  , delayed
+    delayed
   , delayedI
-  , feedback
-    -- * Signal \<-\> DSignal conversion
-  , fromSignal
-  , toSignal
-    -- * List \<-\> DSignal conversion (not synthesisable)
-  , dfromList
-    -- ** lazy versions
-  , dfromList_lazy
-    -- * Experimental
-  , unsafeFromSignal
-  , antiDelay
   )
 where
 
-import Control.DeepSeq            (NFData)
 import Data.Coerce                (coerce)
 import Data.Default.Class         (Default(..))
-import GHC.TypeLits               (KnownNat, Nat, type (+))
-import Language.Haskell.TH.Syntax (Lift)
+import GHC.TypeLits               (KnownNat, type (+))
 import Prelude                    hiding (head, length, repeat)
-import Test.QuickCheck            (Arbitrary, CoArbitrary)
 
-import Clash.Promoted.Nat         (SNat)
 import Clash.Sized.Vector
   (Vec, head, length, repeat, shiftInAt0, singleton)
+import Clash.Signal.Delayed.Internal (DSignal(..))
 import Clash.Explicit.Signal
-  (Clock, Domain, Reset, Signal, register, fromList, fromList_lazy, bundle,
-   unbundle)
+  (Clock, Reset, Signal, register,  bundle, unbundle)
 import Clash.XException           (Undefined)
 
 {- $setup
 >>> :set -XDataKinds
 >>> :set -XTypeOperators
 >>> import Clash.Explicit.Prelude
+>>> import Clash.Signal.Delayed
 >>> let delay3 clk rst = delayed clk rst (0 :> 0 :> 0 :> Nil)
 >>> let delay2 clk rst = (delayedI clk rst :: DSignal System n Int -> DSignal System (n + 2) Int)
 >>> :{
@@ -79,39 +64,6 @@ let mac :: Clock System gated
 :}
 
 -}
-
--- | A synchronized signal with samples of type @a@, synchronized to clock
--- @clk@, that has accumulated @delay@ amount of samples delay along its path.
-newtype DSignal (domain :: Domain) (delay :: Nat) a =
-    DSignal { -- | Strip a 'DSignal' from its delay information.
-              toSignal :: Signal domain a
-            }
-  deriving (Show,Default,Functor,Applicative,Num,Fractional,
-            Foldable,Traversable,Arbitrary,CoArbitrary,Lift)
-
--- | Create a 'DSignal' from a list
---
--- Every element in the list will correspond to a value of the signal for one
--- clock cycle.
---
--- >>> sampleN 2 (dfromList [1,2,3,4,5])
--- [1,2]
---
--- __NB__: This function is not synthesisable
-dfromList :: NFData a => [a] -> DSignal domain 0 a
-dfromList = coerce . fromList
-
--- | Create a 'DSignal' from a list
---
--- Every element in the list will correspond to a value of the signal for one
--- clock cycle.
---
--- >>> sampleN 2 (dfromList [1,2,3,4,5])
--- [1,2]
---
--- __NB__: This function is not synthesisable
-dfromList_lazy :: [a] -> DSignal domain 0 a
-dfromList_lazy = coerce . fromList_lazy
 
 -- | Delay a 'DSignal' for @d@ periods.
 --
@@ -158,53 +110,3 @@ delayedI
   -> DSignal domain n a
   -> DSignal domain (n + d) a
 delayedI clk rst = delayed clk rst (repeat def)
-
--- | Feed the delayed result of a function back to its input:
---
--- @
--- mac :: Clock domain gated -> Reset domain synchronous
---     -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int
--- mac clk rst x y = 'feedback' (mac' x y)
---   where
---     mac' :: 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int
---          -> ('DSignal' domain 0 Int, 'DSignal' domain 1 Int)
---     mac' a b acc = let acc' = a * b + acc
---                    in  (acc, 'delay' clk rst ('singleton' 0) acc')
--- @
---
--- >>> sampleN 6 (mac systemClockGen systemResetGen (dfromList [1..]) (dfromList [1..]))
--- [0,1,5,14,30,55]
-feedback
-  :: (DSignal domain n a -> (DSignal domain n a,DSignal domain (n + m + 1) a))
-  -> DSignal domain n a
-feedback f = let (o,r) = f (coerce r) in o
-
--- | 'Signal's are not delayed
---
--- > sample s == dsample (fromSignal s)
-fromSignal :: Signal domain a -> DSignal domain 0 a
-fromSignal = coerce
-
--- | __EXPERIMENTAL__
---
--- __Unsafely__ convert a 'Signal' to /any/ 'DSignal' clk'.
---
--- __NB__: Should only be used to interface with functions specified in terms of
--- 'Signal'.
-unsafeFromSignal :: Signal domain a -> DSignal domain n a
-unsafeFromSignal = DSignal
-
--- | __EXPERIMENTAL__
---
--- Access a /delayed/ signal in the present.
---
--- @
--- mac :: Clock domain gated -> Reset domain synchronous
---     -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int
--- mac clk rst x y = acc'
---   where
---     acc' = (x * y) + 'antiDelay' d1 acc
---     acc  = 'delay' clk rst ('singleton' 0) acc'
--- @
-antiDelay :: SNat d -> DSignal domain (n + d) a -> DSignal domain n a
-antiDelay _ = coerce

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -36,10 +36,10 @@ where
 import           Data.Default.Class            (Default)
 import           GHC.TypeLits                  (KnownNat, type (+))
 
+import Clash.Signal.Delayed.Internal
+  (DSignal, dfromList, dfromList_lazy, fromSignal, toSignal,
+   unsafeFromSignal, antiDelay, feedback)
 import qualified Clash.Explicit.Signal.Delayed as E
-import           Clash.Explicit.Signal.Delayed
-  (DSignal, dfromList, dfromList_lazy, feedback, fromSignal, toSignal,
-   unsafeFromSignal, antiDelay)
 import            Clash.Sized.Vector           (Vec)
 import            Clash.Signal
   (HiddenClockReset, hideClockReset)

--- a/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators          #-}
 
-module Clash.Explicit.Signal.Delayed.Bundle (
+module Clash.Signal.Delayed.Bundle (
   Bundle,
   Unbundled,
   bundle,
@@ -19,8 +19,7 @@ import           Control.Applicative           (liftA2)
 import           GHC.TypeLits                  (KnownNat)
 import           Prelude                       hiding (head, map, tail)
 
-import           Clash.Explicit.Signal.Delayed (DSignal, toSignal,
-                                                unsafeFromSignal)
+import           Clash.Signal.Delayed (DSignal, toSignal, unsafeFromSignal)
 import qualified Clash.Signal.Bundle           as B
 
 import           Clash.Signal.Internal         (Domain)

--- a/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveLift                 #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE MagicHash                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+
+{-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+module Clash.Signal.Delayed.Internal
+  ( -- * Delay-annotated synchronous signals
+    DSignal(..)
+  , feedback
+  , fromSignal
+    -- * List \<-\> DSignal conversion (not synthesisable)
+  , dfromList
+    -- ** lazy versions
+  , dfromList_lazy
+    -- * Experimental
+  , unsafeFromSignal
+  , antiDelay
+  )
+where
+
+import Control.DeepSeq            (NFData)
+import Data.Coerce                (coerce)
+import Data.Default.Class         (Default(..))
+import GHC.TypeLits               (Nat, type (+))
+import Language.Haskell.TH.Syntax (Lift)
+import Test.QuickCheck            (Arbitrary, CoArbitrary)
+
+import Clash.Promoted.Nat         (SNat)
+import Clash.Explicit.Signal
+  (Domain, Signal, fromList, fromList_lazy)
+
+{- $setup
+>>> :set -XDataKinds
+>>> :set -XTypeOperators
+>>> import Clash.Explicit.Prelude
+>>> let delay3 clk rst = delayed clk rst (0 :> 0 :> 0 :> Nil)
+>>> let delay2 clk rst = (delayedI clk rst :: DSignal System n Int -> DSignal System (n + 2) Int)
+>>> :{
+let mac :: Clock System gated
+        -> Reset System synchronous
+        -> DSignal System 0 Int -> DSignal System 0 Int
+        -> DSignal System 0 Int
+    mac clk rst x y = feedback (mac' x y)
+      where
+        mac' :: DSignal System 0 Int -> DSignal System 0 Int
+             -> DSignal System 0 Int
+             -> (DSignal System 0 Int, DSignal System 1 Int)
+        mac' a b acc = let acc' = a * b + acc
+                       in  (acc, delayed clk rst (singleton 0) acc')
+:}
+
+-}
+
+-- | A synchronized signal with samples of type @a@, synchronized to clock
+-- @clk@, that has accumulated @delay@ amount of samples delay along its path.
+newtype DSignal (domain :: Domain) (delay :: Nat) a =
+    DSignal { -- | Strip a 'DSignal' from its delay information.
+              toSignal :: Signal domain a
+            }
+  deriving (Show,Default,Functor,Applicative,Num,Fractional,
+            Foldable,Traversable,Arbitrary,CoArbitrary,Lift)
+
+-- | Create a 'DSignal' from a list
+--
+-- Every element in the list will correspond to a value of the signal for one
+-- clock cycle.
+--
+-- >>> sampleN 2 (dfromList [1,2,3,4,5])
+-- [1,2]
+--
+-- __NB__: This function is not synthesisable
+dfromList :: NFData a => [a] -> DSignal domain 0 a
+dfromList = coerce . fromList
+
+-- | Create a 'DSignal' from a list
+--
+-- Every element in the list will correspond to a value of the signal for one
+-- clock cycle.
+--
+-- >>> sampleN 2 (dfromList [1,2,3,4,5])
+-- [1,2]
+--
+-- __NB__: This function is not synthesisable
+dfromList_lazy :: [a] -> DSignal domain 0 a
+dfromList_lazy = coerce . fromList_lazy
+
+-- | Feed the delayed result of a function back to its input:
+--
+-- @
+-- mac :: Clock domain gated -> Reset domain synchronous
+--     -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int
+-- mac clk rst x y = 'feedback' (mac' x y)
+--   where
+--     mac' :: 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int
+--          -> ('DSignal' domain 0 Int, 'DSignal' domain 1 Int)
+--     mac' a b acc = let acc' = a * b + acc
+--                    in  (acc, 'delay' clk rst ('singleton' 0) acc')
+-- @
+--
+-- >>> sampleN 6 (mac systemClockGen systemResetGen (dfromList [1..]) (dfromList [1..]))
+-- [0,1,5,14,30,55]
+feedback
+  :: (DSignal domain n a -> (DSignal domain n a,DSignal domain (n + m + 1) a))
+  -> DSignal domain n a
+feedback f = let (o,r) = f (coerce r) in o
+
+-- | 'Signal's are not delayed
+--
+-- > sample s == dsample (fromSignal s)
+fromSignal :: Signal domain a -> DSignal domain 0 a
+fromSignal = coerce
+
+-- | __EXPERIMENTAL__
+--
+-- __Unsafely__ convert a 'Signal' to /any/ 'DSignal' clk'.
+--
+-- __NB__: Should only be used to interface with functions specified in terms of
+-- 'Signal'.
+unsafeFromSignal :: Signal domain a -> DSignal domain n a
+unsafeFromSignal = DSignal
+
+-- | __EXPERIMENTAL__
+--
+-- Access a /delayed/ signal in the present.
+--
+-- @
+-- mac :: Clock domain gated -> Reset domain synchronous
+--     -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int -> 'DSignal' domain 0 Int
+-- mac clk rst x y = acc'
+--   where
+--     acc' = (x * y) + 'antiDelay' d1 acc
+--     acc  = 'delay' clk rst ('singleton' 0) acc'
+-- @
+antiDelay :: SNat d -> DSignal domain (n + d) a -> DSignal domain n a
+antiDelay _ = coerce


### PR DESCRIPTION
This refactors the DSignal modules to:

```
clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
clash-prelude/src/Clash/Signal/Delayed.hs
clash-prelude/src/Clash/Signal/Delayed/Internal.hs
clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
```

which is close to the Signal module layout. Specifically, it moves functions from out of Explicit hierarchy which arent relevant to it. No functions are removed or added. The choice of what is in the `Internal.hs` module was the most direct refactor of `Signal/Explicit/.../Delayed.hs`, as opposed to moving some functions into `Signal/Delayed.hs`  #403 