### PR TITLE
Additional DSignal functions

### DIFF
--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -5,20 +5,31 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE NoStarIsType #-}
+#endif
 
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
 
 module Clash.Signal.Delayed
   ( -- * Delay-annotated synchronous signals
     DSignal
   , delayed
   , delayedI
+  , delayN
+  , delayI
+  , delayedFold
   , feedback
     -- * Signal \<-\> DSignal conversion
   , fromSignal
@@ -34,28 +45,37 @@ module Clash.Signal.Delayed
 where
 
 import           Data.Default.Class            (Default)
-import           GHC.TypeLits                  (KnownNat, type (+))
+import           Data.Coerce                   (coerce)
+import           Data.Kind                     (Type)
+import           GHC.TypeLits                  (KnownNat, type (^), type (+), type (*), Nat)
+import           Data.Singletons.Prelude hiding (PNum (..), SNum (..), Undefined)
 
 import Clash.Signal.Delayed.Internal
-  (DSignal, dfromList, dfromList_lazy, fromSignal, toSignal,
+  (DSignal(..), dfromList, dfromList_lazy, fromSignal, toSignal,
    unsafeFromSignal, antiDelay, feedback)
 import qualified Clash.Explicit.Signal.Delayed as E
-import            Clash.Sized.Vector           (Vec)
+import            Clash.Sized.Vector           (Vec, dtfold)
 import            Clash.Signal
-  (HiddenClockReset, hideClockReset)
+  (HiddenClockReset, hideClockReset, Signal, delay, Domain(..))
 import            Clash.XException
+
+import Clash.Promoted.Nat         (SNat (..), snatToInteger)
 
 {- $setup
 >>> :set -XDataKinds -XTypeOperators -XTypeApplications -XFlexibleContexts
 >>> import Clash.Prelude
 >>> let delay3 = delayed (0 :> 0 :> 0 :> Nil)
 >>> let delay2 = delayedI :: HiddenClockReset domain gated synchronous => DSignal domain n Int -> DSignal domain (n + 2) Int
+>>> let delayN2 = delayN (SNat :: SNat 2)
+>>> let delayI2 = delayI :: HiddenClockReset domain gated synchronous => DSignal domain n Int -> DSignal domain (n + 2) Int
+>>> let countingSignals = Clash.Prelude.repeat (dfromList [0..]) :: Vec 4 (DSignal domain 0 Int)
 -}
 
 -- | Delay a 'DSignal' for @d@ periods.
 --
 -- @
--- delay3 :: 'DSignal' n Int -> 'DSignal' (n + 3) Int
+-- delay3 :: HiddenClockReset domain gated synchronous =>
+--          'DSignal' domain n Int -> 'DSignal' domain (n + 3) Int
 -- delay3 = 'delayed' (0 ':>' 0 ':>' 0 ':>' 'Nil')
 -- @
 --
@@ -71,7 +91,8 @@ delayed = hideClockReset E.delayed
 -- | Delay a 'DSignal' for @m@ periods, where @m@ is derived from the context.
 --
 -- @
--- delay2 :: 'DSignal' n Int -> 'DSignal' (n + 2) Int
+-- delay2 :: HiddenClockReset domain gated synchronous =>
+--          'DSignal' domain n Int -> 'DSignal' domain (n + 2) Int
 -- delay2 = 'delayedI'
 -- @
 --
@@ -82,3 +103,74 @@ delayedI
   => DSignal domain n a
   -> DSignal domain (n + d) a
 delayedI = hideClockReset E.delayedI
+
+-- | Delay a 'DSignal' for @d@ cycles, the value at time 0..d-1 is /undefined/.
+--
+-- @
+-- delay2 :: HiddenClockReset domain gated synchronous =>
+--          'DSignal' domain n Int -> 'DSignal' domain (n + 2) Int
+-- delay2 = 'delayN' (SNat :: SNat 2)
+-- @
+--
+-- >>> printX $ sampleN 6 (toSignal (delayN2 (dfromList [1..])))
+-- [X,X,1,2,3,4]
+delayN :: forall domain gated synchronous a d n .
+          (HiddenClockReset domain gated synchronous, Undefined a)
+       => SNat d
+       -> DSignal domain n a
+       -> DSignal domain (n+d) a
+delayN d = coerce . go (snatToInteger d) . coerce @_ @(Signal domain a)
+  where
+    go 0 = id
+    go i = delay . go (i-1)
+
+-- | Delay a 'DSignal' for @d@ cycles, where @d@ is derived from the context.
+-- The value at time 0..d-1 is /undefined/.
+--
+-- @
+-- delay2 :: HiddenClockReset domain gated synchronous =>
+--          'DSignal' domain n Int -> 'DSignal' domain (n + 2) Int
+-- delay2 = 'delayI'
+-- @
+--
+-- >>> printX $ sampleN 6 (toSignal (delayI2 (dfromList [1..])))
+-- [X,X,1,2,3,4]
+delayI :: forall domain gated synchronous d n a.
+          (HiddenClockReset domain gated synchronous, KnownNat d, Undefined a)
+          => DSignal domain n a
+          -> DSignal domain (n+d) a
+delayI = delayN (SNat :: SNat d)
+
+data DelayedFold (domain :: Domain) (n :: Nat) (delay :: Nat) (a :: Type) (f :: TyFun Nat Type) :: Type
+type instance Apply (DelayedFold domain n delay a) k = DSignal domain (n + (delay*k)) a
+
+-- | Tree fold over a 'Vec' of 'DSignal's with a combinatorial function,
+-- and delaying @delay@ cycles after each application.
+-- Values at times 0..(delay*k)-1 are /undefined/ after a reset.
+--
+-- @
+-- countingSignals :: Vec 4 (DSignal domain 0 Int)
+-- countingSignals = repeat (dfromList [0..])
+-- @
+--
+-- >>> printX $ sampleN 6 (toSignal (delayedFold d1 (+) countingSignals))
+-- [X,X,0,4,8,12]
+--
+-- >>> printX $ sampleN 8 (toSignal (delayedFold d2 (*) countingSignals))
+-- [X,X,X,X,0,1,16,81]
+delayedFold :: forall domain gated synchronous n delay k a.
+                ( HiddenClockReset domain gated synchronous
+                , KnownNat delay
+                , KnownNat k
+                , Undefined a)
+               => SNat delay                         -- ^ Delay applied after each step
+               -> (a -> a -> a)                      -- ^ Fold operation to apply
+               -> Vec (2^k) (DSignal domain n a)     -- ^ Vector input of size 2^k
+               -> DSignal domain (n + (delay * k)) a -- ^ Output Signal delayed by (delay * k)
+delayedFold _ op = dtfold (Proxy :: Proxy (DelayedFold domain n delay a)) id go
+  where
+    go :: SNat l
+       -> DelayedFold domain n delay a @@ l
+       -> DelayedFold domain n delay a @@ l
+       -> DelayedFold domain n delay a @@ (l+1)
+    go SNat x y = delayI (op <$> x <*> y)

--- a/tests/shouldwork/DSignal/DelayI.hs
+++ b/tests/shouldwork/DSignal/DelayI.hs
@@ -1,0 +1,26 @@
+module DelayI where
+
+import Clash.Prelude
+import qualified Clash.Signal.Delayed.Bundle as D
+import Clash.Explicit.Testbench
+
+delayer :: ( HiddenClockReset domain gated synchronous )
+        => DSignal domain 0 Int -> DSignal domain 2 Int
+delayer = delayI
+
+topEntity
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System Int
+  -> Signal System (Maybe Int)
+topEntity = exposeClockReset (fmap maybeX . toSignal . delayer . fromSignal)
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst $ 1 :> 2 :> 3 :> 10 :> Nil
+    expectedOutput = outputVerifier clk rst (Nothing:>Nothing:>Just 1:>Just 2:>Just 3:>Just 10:>Nil)
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+

--- a/tests/shouldwork/DSignal/DelayI.hs
+++ b/tests/shouldwork/DSignal/DelayI.hs
@@ -8,19 +8,25 @@ delayer :: ( HiddenClockReset domain gated synchronous )
         => DSignal domain 0 Int -> DSignal domain 2 Int
 delayer = delayI
 
+zeroFirst2
+  :: (Num a, HiddenClockReset domain gated synchronous )
+  => Signal domain a -> Signal domain a
+zeroFirst2 a = mux en a 0
+  where
+    en = register False $ register False $ pure True
+
 topEntity
   :: Clock System Source
   -> Reset System Asynchronous
   -> Signal System Int
-  -> Signal System (Maybe Int)
-topEntity = exposeClockReset (fmap maybeX . toSignal . delayer . fromSignal)
+  -> Signal System Int
+topEntity = exposeClockReset (zeroFirst2 . toSignal . delayer . fromSignal)
 
 testBench :: Signal System Bool
 testBench = done
   where
     testInput      = stimuliGenerator clk rst $ 1 :> 2 :> 3 :> 10 :> Nil
-    expectedOutput = outputVerifier clk rst (Nothing:>Nothing:>Just 1:>Just 2:>Just 3:>Just 10:>Nil)
+    expectedOutput = outputVerifier clk rst (0:>0:>1:>2:>3:>10:>Nil)
     done           = expectedOutput (topEntity clk rst testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-

--- a/tests/shouldwork/DSignal/DelayN.hs
+++ b/tests/shouldwork/DSignal/DelayN.hs
@@ -1,0 +1,26 @@
+module DelayN where
+
+import Clash.Prelude
+import qualified Clash.Signal.Delayed.Bundle as D
+import Clash.Explicit.Testbench
+
+delayer :: ( HiddenClockReset domain gated synchronous )
+        => DSignal domain 0 Int -> DSignal domain 2 Int
+delayer = delayN d2
+
+topEntity
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System Int
+  -> Signal System (Maybe Int)
+topEntity = exposeClockReset (fmap maybeX . toSignal . delayer . fromSignal)
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst $ 1 :> 2 :> 3 :> 10 :> Nil
+    expectedOutput = outputVerifier clk rst (Nothing:>Nothing:>Just 1:>Just 2:>Just 3:>Just 10:>Nil)
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+

--- a/tests/shouldwork/DSignal/DelayedFold.hs
+++ b/tests/shouldwork/DSignal/DelayedFold.hs
@@ -1,4 +1,4 @@
-module DelayedFoled where
+module DelayedFold where
 
 import Clash.Prelude
 import qualified Clash.Signal.Delayed.Bundle as D

--- a/tests/shouldwork/DSignal/DelayedFold.hs
+++ b/tests/shouldwork/DSignal/DelayedFold.hs
@@ -8,18 +8,25 @@ folder :: ( HiddenClockReset domain gated synchronous )
       => DSignal domain 0 (Vec 4 Int) -> DSignal domain 2 Int
 folder = delayedFold d1 (+) . D.unbundle
 
+zeroFirst2
+  :: (Num a, HiddenClockReset domain gated synchronous )
+  => Signal domain a -> Signal domain a
+zeroFirst2 a = mux en a 0
+  where
+    en = register False $ register False $ pure True
+
 topEntity
   :: Clock System Source
   -> Reset System Asynchronous
   -> Signal System (Vec 4 Int)
-  -> Signal System (Maybe Int)
-topEntity = exposeClockReset (fmap maybeX . toSignal . folder . fromSignal)
+  -> Signal System Int
+topEntity = exposeClockReset (zeroFirst2 . toSignal . folder . fromSignal)
 
 testBench :: Signal System Bool
 testBench = done
   where
     testInput      = stimuliGenerator clk rst $ repeat 1 :> repeat 2 :> (1:>2:>3:>4:>Nil) :> Nil
-    expectedOutput = outputVerifier clk rst (Nothing :> Nothing :>Just 4:>Just 8:>Just 10:>Nil)
+    expectedOutput = outputVerifier clk rst (0:>0:>4:>8:>10:>Nil)
     done           = expectedOutput (topEntity clk rst testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen

--- a/tests/shouldwork/DSignal/DelayedFold.hs
+++ b/tests/shouldwork/DSignal/DelayedFold.hs
@@ -1,0 +1,26 @@
+module DelayedFoled where
+
+import Clash.Prelude
+import qualified Clash.Signal.Delayed.Bundle as D
+import Clash.Explicit.Testbench
+
+folder :: ( HiddenClockReset domain gated synchronous )
+      => DSignal domain 0 (Vec 4 Int) -> DSignal domain 2 Int
+folder = delayedFold d1 (+) . D.unbundle
+
+topEntity
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System (Vec 4 Int)
+  -> Signal System (Maybe Int)
+topEntity = exposeClockReset (fmap maybeX . toSignal . folder . fromSignal)
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst $ repeat 1 :> repeat 2 :> (1:>2:>3:>4:>Nil) :> Nil
+    expectedOutput = outputVerifier clk rst (Nothing :> Nothing :>Just 4:>Just 8:>Just 10:>Nil)
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -125,6 +125,11 @@ main = do
             , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "Deriving") defBuild [] "BitPackDerivation" (["", "BitPackDerivation_testBench"],"BitPackDerivation_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "Indexed") defBuild [] "Indexed" (["", "Indexed_testBench"],"Indexed_testBench",True)
             ]
+        , testGroup "DSignal"
+            [ runTest ("tests" </> "shouldwork" </> "DSignal") defBuild [] "DelayedFold" (["","DelayedFold_testBench"],"DelayedFold_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "DSignal") defBuild [] "DelayI" (["","DelayI_testBench"],"DelayI_testBench",True)
+            , runTest ("tests" </> "shouldwork" </> "DSignal") defBuild [] "DelayN" (["","DelayN_testBench"],"DelayN_testBench",True)
+            ]
         , testGroup "Feedback"
             [ runTest ("tests" </> "shouldwork" </> "Feedback") defBuild [] "Fib" (["","Fib_testBench"],"Fib_testBench",True)
             ]


### PR DESCRIPTION
- delayN and delayI, delay a DSignal and leave the initial values after a
reset undefined. (Similar to Clash.Signal.delay)
- delayedFold, a tree fold by simple combinatorial application that
resolves its type level delay.