### PR TITLE
Plethora of fixes for BlackBox functions

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -55,7 +55,7 @@ doHDL b src = do
   -- Parse primitives:
   startTime' <- Clock.getCurrentTime
   topDir     <- ghcLibDir
-  primMap2   <- sequence $ HM.map (compilePrimitive [] topDir) primMap
+  primMap2   <- sequence $ HM.map (compilePrimitive ["."] [] topDir) primMap
   prepTime'  <- startTime `deepseq` primMap2 `seq` Clock.getCurrentTime
   let prepStartDiff' = Clock.diffUTCTime prepTime' startTime'
   putStrLn $ "Parsing primitives took " ++ show prepStartDiff'

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -60,5 +60,5 @@ runInputStage src = do
       [(topEntity,_,_)] = topEntities
       tm = topEntity
   topDir   <- ghcLibDir
-  primMap2 <- sequence $ fmap (compilePrimitive [] topDir) primMap
+  primMap2 <- sequence $ fmap (compilePrimitive [] [] topDir) primMap
   return (bindingsMap,tcm,tupTcm,topEntities, primMap2, buildCustomReprs reprs, topEntityNames,tm)

--- a/clash-ghc/src-bin-821/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-821/Clash/GHCi/UI.hs
@@ -1922,7 +1922,7 @@ makeHDL backend optsRef srcs = do
                 -- Parsing / compiling primitives:
                 startTime' <- Clock.getCurrentTime
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags ]
-                primMap'   <- sequence $ HM.map (Clash.Driver.compilePrimitive dbs (topDir dflags)) primMap
+                primMap'   <- sequence $ HM.map (Clash.Driver.compilePrimitive idirs dbs (topDir dflags)) primMap
                 prepTime'  <- startTime' `deepseq` primMap' `seq` Clock.getCurrentTime
                 let prepStartDiff' = Clock.diffUTCTime prepTime' startTime'
                 putStrLn $ "Parsing and compiling primitives took " ++ show prepStartDiff'

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -1969,7 +1969,7 @@ makeHDL backend optsRef srcs = do
                 -- Parsing / compiling primitives:
                 startTime' <- Clock.getCurrentTime
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                primMap'   <- sequence $ HM.map (Clash.Driver.compilePrimitive dbs (topDir dflags)) primMap
+                primMap'   <- sequence $ HM.map (Clash.Driver.compilePrimitive idirs dbs (topDir dflags)) primMap
                 prepTime'  <- startTime' `deepseq` primMap' `seq` Clock.getCurrentTime
                 let prepStartDiff' = Clock.diffUTCTime prepTime' startTime'
                 putStrLn $ "Parsing and compiling primitives took " ++ show prepStartDiff'

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -2016,7 +2016,7 @@ makeHDL backend optsRef srcs = do
                 -- Parsing / compiling primitives:
                 startTime' <- Clock.getCurrentTime
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags ]
-                primMap'   <- sequence $ HM.map (Clash.Driver.compilePrimitive dbs (topDir dflags)) primMap
+                primMap'   <- sequence $ HM.map (Clash.Driver.compilePrimitive idirs dbs (topDir dflags)) primMap
                 prepTime'  <- startTime' `deepseq` primMap' `seq` Clock.getCurrentTime
                 let prepStartDiff' = Clock.diffUTCTime prepTime' startTime'
                 putStrLn $ "Parsing and compiling primitives took " ++ show prepStartDiff'

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -117,6 +117,7 @@ Library
                       deepseq                 >= 1.3.0.2  && < 1.5,
                       directory               >= 1.2.0.1  && < 1.4,
                       errors                  >= 1.4.2    && < 2.4,
+                      exceptions              >= 0.10.0   && < 0.11.0,
                       filepath                >= 1.3.0.1  && < 1.5,
                       ghc                     >= 8.2.0    && < 8.8,
                       hashable                >= 1.2.1.0  && < 1.3,

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -306,11 +306,12 @@ generateHDL reprs bindingsMap hdlState primMap tcm tupTcm typeTrans eval
 loadImportAndInterpret
   :: (MonadIO m, MonadMask m)
   => [String]
-  -- ^ Extra search path
+  -- ^ Extra search path (usually passed as -i)
   -> [String]
   -- ^ Interpreter args
   -> String
-  -- ^ Top dir
+  -- ^ The folder in which the GHC bootstrap libraries (base, containers, etc.)
+  -- can be found
   -> Hint.ModuleName
   -- ^ Module function lives in
   -> String
@@ -344,10 +345,14 @@ loadImportAndInterpret iPaths0 interpreterArgs topDir qualMod funcName typ = do
 -- | Compiles blackbox functions and parses blackbox templates.
 compilePrimitive
   :: [FilePath]
+  -- ^ Import directories (-i flag)
   -> [FilePath]
-  -- ^ import directories (-i flag)
+  -- ^ Package databases
   -> FilePath
+  -- ^ The folder in which the GHC bootstrap libraries (base, containers, etc.)
+  -- can be found
   -> ResolvedPrimitive
+  -- ^ Primitive to compile
   -> IO CompiledPrimitive
 compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName bbGenName source) = do
   let interpreterArgs = concatMap (("-package-db":) . (:[])) pkgDbs

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -163,7 +163,9 @@ data Primitive a b c
   , function :: c
     -- ^ Used to indiciate type of template (declaration or expression).
   }
-  -- | A primitive that carries additional information
+  -- | A primitive that carries additional information. These are "real"
+  -- primitives, hardcoded in the compiler. For example: 'mapSignal' in
+  -- @GHC2Core.coreToTerm@.
   | Primitive
   { name     :: !S.Text
     -- ^ Name of the primitive

--- a/tests/shouldwork/BlackBox/BlackBoxFunction.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunction.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds         #-}
+
+module BlackBoxFunction where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+import Clash.Prelude
+import Clash.Netlist.Types
+import Clash.Netlist.BlackBox.Types
+import Clash.Annotations.Primitive (Primitive(..), HDL(..))
+
+myMultiplyTF :: BlackBoxFunction
+myMultiplyTF isD resId primName args ty =
+  Right ( emptyBlackBoxMeta
+        , BBTemplate [C "123456 * ", Arg 0 0, C " * ", Arg 0 1]
+        )
+
+{-# ANN myMultiply (InlinePrimitive VHDL "[ { \"BlackBoxHaskell\" : { \"name\" : \"BlackBoxFunction.myMultiply\", \"templateFunction\" : \"BlackBoxFunction.myMultiplyTF\"}} ]") #-}
+myMultiply
+  :: Signal System Int
+  -> Signal System Int
+  -> Signal System Int
+myMultiply a b =
+  a * b
+{-# NOINLINE myMultiply #-}
+
+topEntity
+  :: HiddenClockReset System Source Asynchronous
+  => Signal System Int
+  -> Signal System Int
+topEntity a = myMultiply a a
+
+-- Output tests
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+mainVHDL :: IO ()
+mainVHDL = do
+  [modDir, topFile] <- getArgs
+  content <- readFile (modDir </> topFile)
+
+  assertIn "123456" content
+
+mainVerilog = mainVHDL
+mainSystemVerilog = mainVHDL

--- a/tests/shouldwork/BlackBox/TemplateFunction.hs
+++ b/tests/shouldwork/BlackBox/TemplateFunction.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds         #-}
+
+module TemplateFunction where
+
+import qualified Prelude as P
+
+import Control.Monad.State (State)
+import Data.List (isInfixOf)
+import Data.Semigroup.Monad (getMon)
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+import Clash.Backend (mkUniqueIdentifier, blockDecl)
+import Clash.Netlist.Id (IdType(Basic))
+import Clash.Netlist.Types
+
+import Clash.Prelude
+import Clash.Backend (Backend)
+import Clash.Annotations.Primitive (Primitive(..), HDL(..))
+
+myMultiplyTF :: TemplateFunction
+myMultiplyTF = TemplateFunction used valid myMultiplyTemplate
+ where
+  used    = [0,1]
+  valid _ = True
+
+myMultiplyTemplate
+  :: Backend s
+  => BlackBoxContext
+  -> State s Doc
+myMultiplyTemplate bbCtx = do
+  x <- mkUniqueIdentifier Basic "x123456"
+  y <- mkUniqueIdentifier Basic "y123456"
+  getMon $ blockDecl x [NetDecl Nothing y Bool]
+
+
+{-# ANN myMultiply (InlinePrimitive VHDL "[ { \"BlackBox\" : { \"name\" : \"TemplateFunction.myMultiply\", \"kind\": \"Declaration\", \"format\": \"Haskell\", \"templateFunction\": \"TemplateFunction.myMultiplyTF\"}} ]") #-}
+myMultiply
+  :: Signal System Int
+  -> Signal System Int
+  -> Signal System Int
+myMultiply a b =
+  a * b
+{-# NOINLINE myMultiply #-}
+
+topEntity
+  :: HiddenClockReset System Source Asynchronous
+  => Signal System Int
+  -> Signal System Int
+topEntity a = myMultiply a a
+
+-- Output tests
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+mainVHDL :: IO ()
+mainVHDL = do
+  [modDir, topFile] <- getArgs
+  content <- readFile (modDir </> topFile)
+
+  assertIn "123456" content
+
+mainVerilog = mainVHDL
+mainSystemVerilog = mainVHDL

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -95,6 +95,10 @@ main = do
             , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "BoxGrow" (["","BoxGrow_testBench"],"BoxGrow_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "RePack"  ([""],"RePack_topEntity",False)
             ]
+        , testGroup "BlackBox"
+            [ outputTest ("tests" </> "shouldwork" </> "BlackBox") VHDL [] "TemplateFunction" ([""],"TemplateFunction_topEntity",False) "main"
+            , outputTest ("tests" </> "shouldwork" </> "BlackBox") VHDL [] "BlackBoxFunction" ([""],"BlackBoxFunction_topEntity",False) "main"
+            ]
         , testGroup "BoxedFunctions"
             [ runTest ("tests" </> "shouldwork" </> "BoxedFunctions") defBuild [] "DeadRecursiveBoxed" ([""],"DeadRecursiveBoxed_topEntity",False)
             ]

--- a/testsuite/Test/Tasty/Program.hs
+++ b/testsuite/Test/Tasty/Program.hs
@@ -264,6 +264,9 @@ runProgram program args stdO stdF workDir = do
   let cp = (proc program args) { cwd = Just workDir }
   (exitCode, stdout, stderr) <- readCreateProcessWithExitCode cp ""
 
+  -- For debugging: Uncomment this to print executable and and its arguments
+  --putStrLn $ show program ++ " " ++ concatMap (++ " ") args
+
   let stdoutT = T.pack stdout
       stderrT = T.pack stderr
 
@@ -299,6 +302,9 @@ runFailingProgram
 runFailingProgram program args stdO errOnEmptyStderr expectedCode expectedStderr workDir = do
   let cp = (proc program args) { cwd = Just workDir }
   (exitCode, stdout, stderr) <- readCreateProcessWithExitCode cp ""
+
+  -- For debugging: Uncomment this to print executable and and its arguments
+  --putStrLn $ show program ++ " " ++ concatMap (++ " ") args
 
   let stdoutT = T.pack stdout
       stderrT = T.pack stderr


### PR DESCRIPTION
This PR fixes a number of issues discovered today while debugging a related issue, while adding regression tests to make sure they don't pop up again. In short:

* Restored an erroneously removed case in `mkPrimitive` ( :bell: shame :bell: )
* When interpreting blackbox functions, Hint now also accounts for `-i` flags passed to Clash
* Both pre-compiled and local blackbox functions are now supported. I.e., the difference between having a function in one of your dependencies ("global"/pre-compiled), or one in the code you're compiling right now with Clash ("local")