### PR TITLE
Synchronously de-assert asynchronous reset

### DIFF
--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
@@ -114,7 +114,7 @@ end
 "// pragma translate_off
 initial begin
   #1    ~RESULT = 1;
-  #1999 ~RESULT = 0;
+  #3001 ~RESULT = 0;
 end
 // pragma translate_on"
     }

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.json
@@ -122,7 +122,7 @@ assign ~RESULT = ~SYM[0];
 reg ~TYPO ~GENSYM[rst][0];
 initial begin
   #1    ~SYM[0] = 1;
-  #1999 ~SYM[0] = 0;
+  #3001 ~SYM[0] = 0;
 end
 assign ~RESULT = ~SYM[0];
 // pragma translate_on"

--- a/clash-lib/prims/vhdl/Clash_Explicit_Testbench.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_Testbench.json
@@ -39,9 +39,9 @@ begin
   -- pragma translate_off
   ~SYM[2] <= ~ARG[5];
   ~SYM[3] <= ~ARG[6];
-  process(~IF ~ISGATED[2] ~THEN~SYM[4]~ELSE~ARG[2]~FI~IF ~ISSYNC[3] ~THEN ~ELSE,~ARG[3]~FI) is
+  process(~IF ~ISGATED[2] ~THEN~SYM[4]~ELSE~ARG[2]~FI) is
   begin
-    if (rising_edge(~IF ~ISGATED[2] ~THEN~SYM[4]~ELSE~ARG[2]~FI)~IF ~ISSYNC[3] ~THEN ~ELSE or falling_edge(~ARG[3])~FI) then
+    if (rising_edge(~IF ~ISGATED[2] ~THEN~SYM[4]~ELSE~ARG[2]~FI)) then
       assert (toSLV(~SYM[2]) = toSLV(~SYM[3])) report (~LIT[4] & \", expected: \" & ~SYM[1](toSLV(~SYM[3])) & \", actual: \" & ~SYM[1](toSLV(~SYM[2]))) severity error;
     end if;
   end process;

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.json
@@ -208,7 +208,7 @@ end process;
     , "template" :
 "-- pragma translate_off
 ~RESULT <= '1',
-           '0' after 2000 ps;
+           '0' after 3001 ps;
 -- pragma translate_on"
     }
   }

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -191,8 +191,8 @@ prog = -- 0 := 4
 And test our system:
 
 @
->>> sampleN 31 $ system prog systemClockGen systemResetGen
-[0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+>>> sampleN 32 $ system prog systemClockGen asyncResetGen
+[0,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 
@@ -228,8 +228,8 @@ output samples are also 'undefined'. We use the utility function 'printX' to con
 filter out the undefinedness and replace it with the string "X" in the few leading outputs.
 
 @
->>> printX $ sampleN 31 $ system2 prog systemClockGen systemResetGen
-[X,X,X,X,X,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+>>> printX $ sampleN 32 $ system2 prog systemClockGen asyncResetGen
+[X,X,X,X,X,X,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 
@@ -356,8 +356,8 @@ we need to disregard the first sample, because the initial output of a
 filter out the undefinedness and replace it with the string "X".
 
 @
->>> printX $ sampleN 33 $ system3 prog2 systemClockGen systemResetGen
-[X,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+>>> printX $ sampleN 34 $ system3 prog2 systemClockGen asyncResetGen
+[X,0,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 

--- a/clash-prelude/src/Clash/Explicit/Mealy.hs
+++ b/clash-prelude/src/Clash/Explicit/Mealy.hs
@@ -58,8 +58,8 @@ let macT s (x,y) = (s',s)
 -- mac clk rst = 'mealy' clk rst macT 0
 -- @
 --
--- >>> simulate (mac systemClockGen systemResetGen) [(1,1),(2,2),(3,3),(4,4)]
--- [0,1,5,14...
+-- >>> simulate (mac systemClockGen systemResetGen) [(0,0),(1,1),(2,2),(3,3),(4,4)]
+-- [0,0,1,5,14...
 -- ...
 --
 -- Synchronous sequential functions can be composed just like their

--- a/clash-prelude/src/Clash/Explicit/Moore.hs
+++ b/clash-prelude/src/Clash/Explicit/Moore.hs
@@ -50,8 +50,8 @@ import Clash.XException      (Undefined)
 -- mac clk rst = 'moore' clk rst macT id 0
 -- @
 --
--- >>> simulate (mac systemClockGen systemResetGen) [(1,1),(2,2),(3,3),(4,4)]
--- [0,1,5,14...
+-- >>> simulate (mac systemClockGen systemResetGen) [(0,0),(1,1),(2,2),(3,3),(4,4)]
+-- [0,0,1,5,14...
 -- ...
 --
 -- Synchronous sequential functions can be composed just like their

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -215,8 +215,8 @@ window clk rst x = res
 -- windowD3 = 'windowD'
 -- @
 --
--- >>> simulateB (windowD3 systemClockGen systemResetGen) [1::Int,2,3,4] :: [Vec 3 Int]
--- [<0,0,0>,<1,0,0>,<2,1,0>,<3,2,1>,<4,3,2>...
+-- >>> simulateB (windowD3 systemClockGen asyncResetGen) [1::Int,1,2,3,4] :: [Vec 3 Int]
+-- [<0,0,0>,<0,0,0>,<1,0,0>,<2,1,0>,<3,2,1>,<4,3,2>...
 -- ...
 windowD
   :: (KnownNat n, Default a, Undefined a)

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -161,8 +161,8 @@ import Clash.XException
 -- rP clk rst = 'registerB' clk rst (8,8)
 -- @
 --
--- >>> simulateB (rP systemClockGen systemResetGen) [(1,1),(2,2),(3,3)] :: [(Int,Int)]
--- [(8,8),(1,1),(2,2),(3,3)...
+-- >>> simulateB (rP systemClockGen systemResetGen) [(1,1),(1,1),(2,2),(3,3)] :: [(Int,Int)]
+-- [(8,8),(8,8),(1,1),(2,2),(3,3)...
 -- ...
 registerB
   :: (Bundle a, Undefined a)

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -470,8 +470,8 @@ delay = \clk i -> withFrozenCallStack (delay# clk i)
 -- | \"@'register' clk rst i s@\" delays the values in 'Signal' /s/ for one
 -- cycle, and sets the value to @i@ the moment the reset becomes 'False'.
 --
--- >>> sampleN 3 (register systemClockGen systemResetGen 8 (fromList [1,2,3,4]))
--- [8,1,2]
+-- >>> sampleN 5 (register systemClockGen asyncResetGen 8 (fromList [1,1,2,3,4]))
+-- [8,8,1,2,3]
 register
   :: (HasCallStack, Undefined a)
   => Clock domain gated
@@ -504,10 +504,10 @@ register = \clk rst initial i -> withFrozenCallStack
 --
 -- We get:
 --
--- >>> sampleN 8 (sometimes1 systemClockGen systemResetGen)
--- [Nothing,Just 1,Nothing,Just 1,Nothing,Just 1,Nothing,Just 1]
--- >>> sampleN 8 (count systemClockGen systemResetGen)
--- [0,0,1,1,2,2,3,3]
+-- >>> sampleN 9 (sometimes1 systemClockGen asyncResetGen)
+-- [Nothing,Nothing,Just 1,Nothing,Just 1,Nothing,Just 1,Nothing,Just 1]
+-- >>> sampleN 9 (count systemClockGen asyncResetGen)
+-- [0,0,0,1,1,2,2,3,3]
 regMaybe
   :: (HasCallStack, Undefined a)
   => Clock domain gated
@@ -533,10 +533,10 @@ regMaybe = \clk rst initial iM -> withFrozenCallStack
 --
 -- We get:
 --
--- >>> sampleN 8 (oscillate systemClockGen systemResetGen)
--- [False,True,False,True,False,True,False,True]
--- >>> sampleN 8 (count systemClockGen systemResetGen)
--- [0,0,1,1,2,2,3,3]
+-- >>> sampleN 9 (oscillate systemClockGen asyncResetGen)
+-- [False,False,True,False,True,False,True,False,True]
+-- >>> sampleN 9 (count systemClockGen asyncResetGen)
+-- [0,0,0,1,1,2,2,3,3]
 regEn
   :: Undefined a
   => Clock domain clk
@@ -559,8 +559,8 @@ regEn = \clk rst initial en i -> withFrozenCallStack
 -- | Simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a list of
 -- samples of type /a/
 --
--- >>> simulateB (unbundle . register systemClockGen systemResetGen (8,8) . bundle) [(1,1), (2,2), (3,3)] :: [(Int,Int)]
--- [(8,8),(1,1),(2,2),(3,3)...
+-- >>> simulateB (unbundle . register systemClockGen asyncResetGen (8,8) . bundle) [(1,1), (1,1), (2,2), (3,3)] :: [(Int,Int)]
+-- [(8,8),(8,8),(1,1),(2,2),(3,3)...
 -- ...
 --
 -- __NB__: This function is not synthesisable
@@ -576,8 +576,8 @@ simulateB f = simulate (bundle . f . unbundle)
 -- | /Lazily/ simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a
 -- list of samples of type /a/
 --
--- >>> simulateB (unbundle . register systemClockGen systemResetGen (8,8) . bundle) [(1,1), (2,2), (3,3)] :: [(Int,Int)]
--- [(8,8),(1,1),(2,2),(3,3)...
+-- >>> simulateB (unbundle . register systemClockGen asyncResetGen (8,8) . bundle) [(1,1), (1,1), (2,2), (3,3)] :: [(Int,Int)]
+-- [(8,8),(8,8),(1,1),(2,2),(3,3)...
 -- ...
 --
 -- __NB__: This function is not synthesisable

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -87,8 +87,8 @@ let mac :: Clock System gated
 -- delay3 clk rst = 'delayed' clk rst (0 ':>' 0 ':>' 0 ':>' 'Nil')
 -- @
 --
--- >>> sampleN 6 (delay3 systemClockGen systemResetGen (dfromList [1..]))
--- [0,0,0,1,2,3]
+-- >>> sampleN 7 (delay3 systemClockGen asyncResetGen (dfromList [0..]))
+-- [0,0,0,0,1,2,3]
 delayed
   :: forall domain gated synchronous a n d
    . (KnownNat d, Undefined a)
@@ -115,8 +115,8 @@ delayed clk rst m ds = coerce (delaySignal (coerce ds))
 -- delay2 = 'delayI'
 -- @
 --
--- >>> sampleN 6 (delay2 systemClockGen systemResetGen (dfromList [1..]))
--- [0,0,1,2,3,4]
+-- >>> sampleN 7 (delay2 systemClockGen asyncResetGen (dfromList ([0..])))
+-- [0,0,0,1,2,3,4]
 delayedI
   :: (Default a, KnownNat d, Undefined a)
   => Clock domain gated

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -121,8 +121,8 @@ assertBitVector clk _rst msg checked expected returned =
 -- testInput clk rst = 'stimuliGenerator' clk rst $('Clash.Sized.Vector.listToVecTH' [(1::Int),3..21])
 -- @
 --
--- >>> sampleN 13 (testInput systemClockGen systemResetGen)
--- [1,3,5,7,9,11,13,15,17,19,21,21,21]
+-- >>> sampleN 14 (testInput systemClockGen asyncResetGen)
+-- [1,1,3,5,7,9,11,13,15,17,19,21,21,21]
 stimuliGenerator
   :: forall l domain gated synchronous a
    . KnownNat l
@@ -159,26 +159,29 @@ stimuliGenerator clk rst samples =
 -- @
 --
 -- >>> import qualified Data.List as List
--- >>> sampleN 12 (expectedOutput systemClockGen systemResetGen (fromList ([0..10] List.++ [10,10,10])))
+-- >>> sampleN 12 (expectedOutput systemClockGen asyncResetGen (fromList (0:[0..10] List.++ [10,10,10])))
 -- <BLANKLINE>
 -- cycle(system10000): 0, outputVerifier
 -- expected value: 70, not equal to actual value: 0
 -- [False
 -- cycle(system10000): 1, outputVerifier
+-- expected value: 70, not equal to actual value: 0
+-- ,False
+-- cycle(system10000): 2, outputVerifier
 -- expected value: 99, not equal to actual value: 1
 -- ,False,False,False,False,False
--- cycle(system10000): 6, outputVerifier
+-- cycle(system10000): 7, outputVerifier
 -- expected value: 7, not equal to actual value: 6
 -- ,False
--- cycle(system10000): 7, outputVerifier
+-- cycle(system10000): 8, outputVerifier
 -- expected value: 8, not equal to actual value: 7
 -- ,False
--- cycle(system10000): 8, outputVerifier
+-- cycle(system10000): 9, outputVerifier
 -- expected value: 9, not equal to actual value: 8
 -- ,False
--- cycle(system10000): 9, outputVerifier
+-- cycle(system10000): 10, outputVerifier
 -- expected value: 10, not equal to actual value: 9
--- ,False,True,True]
+-- ,False,True]
 --
 -- If your working with 'BitVector's containing don't care bit you should use 'outputVerifierBitVector'.
 outputVerifier

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -178,8 +178,8 @@ prog = -- 0 := 4
 And test our system:
 
 @
->>> sampleN 31 (system prog)
-[0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+>>> sampleN 32 (system prog)
+[0,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 
@@ -210,8 +210,8 @@ output samples are also 'undefined'. We use the utility function 'printX' to con
 filter out the undefinedness and replace it with the string "X" in the few leading outputs.
 
 @
->>> printX $ sampleN 31 (system2 prog)
-[X,X,X,X,X,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+>>> printX $ sampleN 32 (system2 prog)
+[X,X,X,X,X,X,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 
@@ -330,8 +330,8 @@ we need to disregard the first sample, because the initial output of a
 filter out the undefinedness and replace it with the string "X".
 
 @
->>> printX $ sampleN 33 (system3 prog2)
-[X,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+>>> printX $ sampleN 34 (system3 prog2)
+[X,0,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -55,8 +55,8 @@ let macT s (x,y) = (s',s)
 -- mac = 'mealy' macT 0
 -- @
 --
--- >>> simulate mac [(1,1),(2,2),(3,3),(4,4)]
--- [0,1,5,14...
+-- >>> simulate mac [(0,0),(1,1),(2,2),(3,3),(4,4)]
+-- [0,0,1,5,14...
 -- ...
 --
 -- Synchronous sequential functions can be composed just like their

--- a/clash-prelude/src/Clash/Prelude/Moore.hs
+++ b/clash-prelude/src/Clash/Prelude/Moore.hs
@@ -52,8 +52,8 @@ let macT s (x,y) = x * y + s
 -- mac = 'moore' mac id 0
 -- @
 --
--- >>> simulate mac [(1,1),(2,2),(3,3),(4,4)]
--- [0,1,5,14...
+-- >>> simulate mac [(0,0),(1,1),(2,2),(3,3),(4,4)]
+-- [0,0,1,5,14,30,...
 -- ...
 --
 -- Synchronous sequential functions can be composed just like their

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -217,9 +217,9 @@ isFalling = hideClockReset E.isFalling
 -- To be precise: the given signal will be @'False'@ for the next @n-1@ cycles,
 -- followed by a single @'True'@ value:
 --
--- >>> Prelude.last (sampleN 1024 (riseEvery d1024)) == True
+-- >>> Prelude.last (sampleN 1025 (riseEvery d1024)) == True
 -- True
--- >>> Prelude.or (sampleN 1023 (riseEvery d1024)) == False
+-- >>> Prelude.or (sampleN 1024 (riseEvery d1024)) == False
 -- True
 --
 -- For example, to update a counter once every 10 million cycles:
@@ -241,13 +241,13 @@ riseEvery = hideClockReset E.riseEvery
 --
 -- To oscillate on an interval of 5 cycles:
 --
--- >>> sampleN 10 (oscillate False d5)
--- [False,False,False,False,False,True,True,True,True,True]
+-- >>> sampleN 11 (oscillate False d5)
+-- [False,False,False,False,False,False,True,True,True,True,True]
 --
 -- To oscillate between @'True'@ and @'False'@:
 --
--- >>> sampleN 10 (oscillate False d1)
--- [False,True,False,True,False,True,False,True,False,True]
+-- >>> sampleN 11 (oscillate False d1)
+-- [False,False,True,False,True,False,True,False,True,False,True]
 --
 -- An alternative definition for the above could be:
 --

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -59,8 +59,8 @@ import            Clash.XException
 -- delay3 = 'delayed' (0 ':>' 0 ':>' 0 ':>' 'Nil')
 -- @
 --
--- >>> sampleN 6 (toSignal (delay3 (dfromList [1..])))
--- [0,0,0,1,2,3]
+-- >>> sampleN 7 (toSignal (delay3 (dfromList [0..])))
+-- [0,0,0,0,1,2,3]
 delayed
   :: (KnownNat d, Undefined a, HiddenClockReset domain gated synchronous)
   => Vec d a
@@ -75,8 +75,8 @@ delayed = hideClockReset E.delayed
 -- delay2 = 'delayedI'
 -- @
 --
--- >>> sampleN 6 (toSignal (delay2 (dfromList [1..])))
--- [0,0,1,2,3,4]
+-- >>> sampleN 7 (toSignal (delay2 (dfromList [0..])))
+-- [0,0,0,1,2,3,4]
 delayedI
   :: (Default a, KnownNat d, Undefined a, HiddenClockReset domain gated synchronous)
   => DSignal domain n a

--- a/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
@@ -110,8 +110,8 @@ dfromList_lazy = coerce . fromList_lazy
 --                    in  (acc, 'delay' clk rst ('singleton' 0) acc')
 -- @
 --
--- >>> sampleN 6 (mac systemClockGen systemResetGen (dfromList [1..]) (dfromList [1..]))
--- [0,1,5,14,30,55]
+-- >>> sampleN 7 (mac systemClockGen systemResetGen (dfromList [0..]) (dfromList [0..]))
+-- [0,0,1,5,14,30,55]
 feedback
   :: (DSignal domain n a -> (DSignal domain n a,DSignal domain (n + m + 1) a))
   -> DSignal domain n a

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -405,7 +405,7 @@ examine the 'register' function by taking a look at the first 4 samples of the
 'register' functions applied to a constant signal with the value 8:
 
 >>> sampleN 4 (register 0 (pure 8))
-[0,8,8,8]
+[0,0,8,8]
 
 Where we see that the initial value of the signal is the specified 0 value,
 followed by 8's.
@@ -590,15 +590,15 @@ earlier for the simulation of the circuit, and creates an output verifier that
 compares against the results we got from our earlier simulation. We can even
 simulate the behaviour of the /testBench/:
 
->>> sampleN 7 testBench
-[False,False,False,False
-cycle(system10000): 4, outputVerifier
+>>> sampleN 8 testBench
+[False,False,False,False,False
+cycle(system10000): 5, outputVerifier
 expected value: 14, not equal to actual value: 30
 ,False
-cycle(system10000): 5, outputVerifier
+cycle(system10000): 6, outputVerifier
 expected value: 14, not equal to actual value: 46
 ,False
-cycle(system10000): 6, outputVerifier
+cycle(system10000): 7, outputVerifier
 expected value: 14, not equal to actual value: 62
 ,False]
 
@@ -1982,8 +1982,8 @@ Here is a list of Haskell features for which the CλaSH compiler has only
 
         To get the first 10 numbers, we do the following:
 
-        >>> sampleN @Source @Asynchronous 10 fibS
-        [0,1,1,2,3,5,8,13,21,34]
+        >>> sampleN @Source @Asynchronous 11 fibS
+        [0,0,1,1,2,3,5,8,13,21,34]
 
         Unlike the @fibR@ function, the above @fibS@ function /is/ synthesisable
         by the CλaSH compiler. Where the recursively defined (non-function)

--- a/tests/shouldwork/Signal/DelayedReset.hs
+++ b/tests/shouldwork/Signal/DelayedReset.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE RankNTypes #-}
+module DelayedReset where
+
+import Clash.Explicit.Prelude
+import Clash.Annotations.TopEntity
+
+topEntity
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> (Signal System (Unsigned 4), Signal System (Unsigned 4), Signal System Bool)
+topEntity clk reset = (cycleCount, countFromReset, newResetSig)
+  where
+    newReset :: Reset System Asynchronous
+    newReset
+      = unsafeToAsyncReset newResetSig
+
+    newResetSig
+      = register clk reset True
+      $ register clk reset True
+      $ pure False
+
+    countFromReset :: Signal System (Unsigned 4)
+    countFromReset' = countFromReset + 1
+    countFromReset = register clk newReset 0 countFromReset'
+
+    cycleCount :: Signal System (Unsigned 4)
+    cycleCount' = cycleCount + 1
+    cycleCount = register clk reset 0 cycleCount'
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst
+                       ((0,0,True) :>
+                        (1,0,True) :>
+                        (2,0,False) :>
+                        (3,1,False) :> Nil)
+    done           = expectedOutput (bundle (topEntity clk rst))
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Testbench/SyncTB.hs
+++ b/tests/shouldwork/Testbench/SyncTB.hs
@@ -20,9 +20,9 @@ testBench
   :: Signal Dom9 Bool
 testBench = done
   where
-    testInput      = stimuliGenerator clk7 rst7 $(listToVecTH [(1::Integer)..10])
+    testInput      = stimuliGenerator clk7 rst7 $(listToVecTH [(1::Integer)..20])
     expectedOutput = outputVerifier   clk9 rst9
-                        (0 :> 0 :>  $(listToVecTH ([2,3,4,5,7,8,9,10]::[Integer])))
+                        (0 :> 0 :>  $(listToVecTH ([2,3,4,6,7,8,9,11,12,13,15,16]::[Integer])))
     done           = expectedOutput (zeroFirst2 clk9 rst9 $ topEntity clk2 clk7 clk9 testInput)
     done'          = not <$> done
     clk2           = tbClockGen @Dom2 (unsafeSynchronizer clk9 clk2 done')

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -162,6 +162,7 @@ main = do
             , outputTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamLazy"    ([""],"BlockRamLazy_topEntity",False) "main"
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamFile"    (["","BlockRamFile_testBench"],"BlockRamFile_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamTest"    ([""],"BlockRamTest_topEntity",False)
+            , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "DelayedReset"    (["","DelayedReset_testBench"],"DelayedReset_testBench",True)
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "MAC"             ([""],"MAC_topEntity",False)
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "NoCPR"           (["example"],"example",False)
             , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Ram"             (["","Ram_testBench"],"Ram_testBench",True)


### PR DESCRIPTION
We can only model a synchronous deassertion of an asynchronous reset. This manifests itself when we use a reset synchronizer:

When we do a synchronous deassertion of the reset, the HDL simulation and Clash simulation would differ; where the HDL simulation corresponds to how the actual circuit would behave. i.e. the Clash simulation was wrong!

The reason for this is that we modeled a register with an asynchronous reset as if its reset line was always asynchronously deasserted. Given that we can only create synchronous systems in Clash, it made no sense that the model of the register behaved like this.

We now model a register with an asynchronous reset as if its reset line is always synchronously deasserted, and the HDL primitive for the `asyncResetGen` is updated accordingly (i.e. it deasserts synchronously), so that the Clash and HDL simulation agree.