### PR TITLE
New inline strategy

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -66,7 +66,7 @@ doHDL b src = do
     putStrLn $ "Parsing primitives took " ++ show prepStartDiff'
 
     generateHDL (buildCustomReprs reprs) bindingsMap (Just b) primMap2 tcm tupTcm (ghcTypeToHWType WORD_SIZE_IN_BITS True) reduceConstant topEntities
-      (ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing tmpDir HDLSYN True True ["."] Nothing) (startTime,prepTime)
+      (ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing tmpDir HDLSYN True True ["."] Nothing True) (startTime,prepTime)
    ) (do
     removeDirectoryRecursive tmpDir
    )

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -37,7 +37,7 @@ typeTrans :: (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHW
 typeTrans = ghcTypeToHWType WORD_SIZE_IN_BITS True
 
 opts :: FilePath -> ClashOpts
-opts tmpDir = ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing tmpDir HDLSYN True True ["."] Nothing
+opts tmpDir = ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing tmpDir HDLSYN True True ["."] Nothing True
 
 backend :: VHDLState
 backend = initBackend WORD_SIZE_IN_BITS HDLSYN

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -71,6 +71,7 @@ flagsClash r = [
   , defFlag "fclash-float-support"           $ NoArg (liftEwM (setFloatSupport r))
   , defFlag "fclash-allow-zero-width"        $ NoArg (setAllowZeroWidth r)
   , defFlag "fclash-component-prefix"        $ SepArg (liftEwM . setComponentPrefix r)
+  , defFlag "fclash-old-inline-strategy"     $ NoArg (liftEwM (setOldInlineStrategy r))
   ]
 
 setInlineLimit :: IORef ClashOpts
@@ -154,3 +155,6 @@ setComponentPrefix
   -> String
   -> IO ()
 setComponentPrefix r s = modifyIORef r (\c -> c {opt_componentPrefix = Just s})
+
+setOldInlineStrategy :: IORef ClashOpts -> IO ()
+setOldInlineStrategy r = modifyIORef r (\c -> c {opt_newInlineStrat = False})

--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -32,7 +32,6 @@ import           System.FilePath.Posix       ((<.>), (</>))
 -- GHC API
 import           Annotations (Annotation(..), getAnnTargetName_maybe)
 import qualified Annotations
-import qualified BasicTypes
 import qualified Class
 import qualified CoreFVs
 import qualified CoreSyn
@@ -264,14 +263,9 @@ loadExprFromTyThing bndr tyThing = case tyThing of
   GHC.AnId _id | Var.isId _id ->
     let _idInfo    = Var.idInfo _id
         unfolding  = IdInfo.unfoldingInfo _idInfo
-        inlineInfo = IdInfo.inlinePragInfo _idInfo
     in case unfolding of
       CoreSyn.CoreUnfolding {} ->
-        case (BasicTypes.inl_inline inlineInfo,BasicTypes.inl_act inlineInfo) of
-          (BasicTypes.NoInline,BasicTypes.AlwaysActive) -> Right bndr
-          (BasicTypes.NoInline,BasicTypes.NeverActive)  -> Right bndr
-          (BasicTypes.NoInline,_) -> Left (bndr, CoreSyn.unfoldingTemplate unfolding)
-          _ -> Left (bndr, CoreSyn.unfoldingTemplate unfolding)
+        Left (bndr, CoreSyn.unfoldingTemplate unfolding)
       (CoreSyn.DFunUnfolding dfbndrs dc es) ->
         let dcApp  = MkCore.mkCoreConApps dc es
             dfExpr = MkCore.mkCoreLams dfbndrs dcApp

--- a/clash-lib/prims/common/Clash_Sized_RTree.json
+++ b/clash-lib/prims/common/Clash_Sized_RTree.json
@@ -1,0 +1,6 @@
+[ { "Primitive" :
+    { "name"      : "Clash.Sized.RTree.tdfold"
+    , "primType"  : "Function"
+    }
+  }
+]

--- a/clash-lib/prims/common/Clash_Sized_Vector.json
+++ b/clash-lib/prims/common/Clash_Sized_Vector.json
@@ -5,4 +5,19 @@
     , "template"  : "~ARG[1]"
     }
   }
+, { "Primitive" :
+    { "name"      : "Clash.Sized.Vector.dfold"
+    , "primType"  : "Function"
+    }
+  }
+, { "Primitive" :
+    { "name"      : "Clash.Sized.Vector.dtfold"
+    , "primType"  : "Function"
+    }
+  }
+, { "Primitive" :
+    { "name"      : "Clash.Sized.Vector.traverse#"
+    , "primType"  : "Function"
+    }
+  }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
@@ -35,14 +35,14 @@ end~FI
 "// register begin~IF ~ISGATED[2] ~THEN
 always_ff @(posedge ~ARG[2][1]~IF ~ISSYNC[3] ~THEN ~ELSE or posedge ~ARG[3]~FI) begin : ~GENSYM[~COMPNAME_register][0]
   if (~ARG[3]) begin
-    ~RESULT <= ~ARG[4];
+    ~RESULT <= ~LITC[4];
   end else if (~ARG[2][0]) begin
     ~RESULT <= ~ARG[5];
   end
 end~ELSE
 always_ff @(posedge ~ARG[2]~IF ~ISSYNC[3] ~THEN ~ELSE or posedge ~ARG[3]~FI) begin : ~SYM[0]
   if (~ARG[3]) begin
-    ~RESULT <= ~ARG[4];
+    ~RESULT <= ~LITC[4];
   end else begin
     ~RESULT <= ~ARG[5];
   end

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.json
@@ -37,14 +37,14 @@ end~FI
 "// register begin~IF ~ISGATED[2] ~THEN
 always @(posedge ~ARG[2][1]~IF ~ISSYNC[3] ~THEN ~ELSE or posedge ~ARG[3]~FI) begin : ~GENSYM[~COMPNAME_register][1]
   if (~ARG[3]) begin
-    ~RESULT <= ~ARG[4];
+    ~RESULT <= ~LITC[4];
   end else if (~ARG[2][0]) begin
     ~RESULT <= ~ARG[5];
   end
 end~ELSE
 always @(posedge ~ARG[2]~IF ~ISSYNC[3] ~THEN ~ELSE or posedge ~ARG[3]~FI) begin : ~SYM[1]
   if (~ARG[3]) begin
-    ~RESULT <= ~ARG[4];
+    ~RESULT <= ~LITC[4];
   end else begin
     ~RESULT <= ~ARG[5];
   end

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.json
@@ -62,7 +62,7 @@ begin
   begin
     if rising_edge(~SYM[1]) then
       if ~ARG[3] = '1' then
-        ~RESULT <= ~ARG[4]
+        ~RESULT <= ~LITC[4]
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -76,10 +76,10 @@ begin
       end if;
     end if;
   end process;~ELSE
-  ~SYM[3] : process(~SYM[1],~ARG[3]~VARS[4])
+  ~SYM[3] : process(~SYM[1],~ARG[3])
   begin
     if ~ARG[3] = '1' then
-      ~RESULT <= ~ARG[4];
+      ~RESULT <= ~LITC[4];
     elsif rising_edge(~SYM[1]) then
       if ~SYM[2] then
         ~RESULT <= ~ARG[5]
@@ -95,7 +95,7 @@ end block;~ELSE ~IF ~ISSYNC[3] ~THEN
 begin
   if rising_edge(~ARG[2]) then
     if ~ARG[3] = '1' then
-      ~RESULT <= ~ARG[4]
+      ~RESULT <= ~LITC[4]
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on
@@ -109,10 +109,10 @@ begin
     end if;
   end if;
 end process;~ELSE
-~SYM[0] : process(~ARG[2],~ARG[3]~VARS[4])
+~SYM[0] : process(~ARG[2],~ARG[3])
 begin
   if ~ARG[3] = '1' then
-    ~RESULT <= ~ARG[4]
+    ~RESULT <= ~LITC[4]
     -- pragma translate_off
     after 1 ps
     -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
@@ -72,9 +72,9 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger##"
-    , "kind"      : "Declaration"
+    , "kind"      : "Expression"
     , "type"      : "fromInteger## :: Integer -> Integer -> Bit"
-    , "template"  : "~RESULT <= ~VAR[i][1](0) when '0' = ~VAR[i][0](0) else '-';"
+    , "template"  : "~IF~LIT[0]~THEN'U'~ELSE~VAR[i][1](0)~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -91,7 +91,7 @@ data VHDLState =
   , _memoryDataFiles:: [(String,String)]
   -- ^ Files to be stored: (filename, contents). These files are generated
   -- during the execution of 'genNetlist'.
-  , _idSeen    :: [Identifier]
+  , _idSeen    :: HashSet Identifier
   , _intWidth  :: Int
   -- ^ Int/Word/Integer bit-width
   , _hdlsyn    :: HdlSyn
@@ -111,7 +111,7 @@ primsRoot = return ("clash-lib" System.FilePath.</> "prims")
 #endif
 
 instance Backend VHDLState where
-  initBackend     = VHDLState HashSet.empty [] HashMap.empty "" noSrcSpan [] [] [] [] [] []
+  initBackend     = VHDLState HashSet.empty [] HashMap.empty "" noSrcSpan [] [] [] [] [] HashSet.empty
   hdlKind         = const VHDL
   primDirs        = const $ do root <- primsRoot
                                return [ root System.FilePath.</> "common"
@@ -314,7 +314,7 @@ selectProductField fieldLabels fieldTypes fieldIndex =
   "_sel" <> int fieldIndex <> "_" <> productFieldName fieldLabels fieldTypes fieldIndex
 
 -- | Generate VHDL for a Netlist component
-genVHDL :: Identifier -> SrcSpan -> [Identifier] -> Component -> VHDLM ((String,Doc),[(String,Doc)])
+genVHDL :: Identifier -> SrcSpan -> HashSet Identifier -> Component -> VHDLM ((String,Doc),[(String,Doc)])
 genVHDL nm sp seen c = preserveSeen $ do
     Mon $ idSeen .= seen
     Mon $ setSrcSpan sp

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -68,6 +68,7 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            , opt_floatSupport :: Bool
                            , opt_importPaths :: [FilePath]
                            , opt_componentPrefix :: Maybe String
+                           , opt_newInlineStrat :: Bool
                            }
 
 
@@ -94,6 +95,7 @@ defClashOpts tmpDir
   , opt_floatSupport        = False
   , opt_importPaths         = []
   , opt_componentPrefix     = Nothing
+  , opt_newInlineStrat      = True
   }
 
 -- | Information about the generated HDL between (sub)runs of the compiler

--- a/clash-lib/src/Clash/Netlist.hs-boot
+++ b/clash-lib/src/Clash/Netlist.hs-boot
@@ -14,6 +14,7 @@ module Clash.Netlist
   ,mkSelection
   ) where
 
+import Data.HashSet         (HashSet)
 import Clash.Core.DataCon   (DataCon)
 import Clash.Core.Term      (Alt,LetBinding,Term)
 import Clash.Core.Type      (Type)
@@ -24,7 +25,7 @@ import SrcLoc               (SrcSpan)
 
 
 genComponent :: Id
-             -> NetlistMonad (SrcSpan,[Identifier],Component)
+             -> NetlistMonad (SrcSpan,HashSet Identifier,Component)
 
 mkExpr :: Bool
        -> Either Identifier Id

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -72,6 +72,7 @@ pTagE =  O True            <$  string "~ERESULT"
      <|> I True            <$> (string "~EARG" *> brackets' natural')
      <|> Arg               <$> (string "~ARGN" *> brackets' natural') <*> brackets' natural'
      <|> I False           <$> (string "~ARG" *> brackets' natural')
+     <|> LC                <$> (string "~LITC" *> brackets' natural')
      <|> L                 <$> (string "~LIT" *> brackets' natural')
      <|> N                 <$> (string "~NAME" *> brackets' natural')
      <|> Var               <$> try (string "~VAR" *> brackets' pSigD) <*> brackets' natural'

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -83,6 +83,9 @@ data Element = C   !Text         -- ^ Constant
              -- ^ Generated input hole, first argument is the scoping level
              | N   !Int          -- ^ Name hole
              | L   !Int          -- ^ Literal hole
+             | LC  !Int
+             -- ^ Assert that argument is a literal, but treat it like a normal
+             -- argument otherwise
              | Var [Element] !Int    --
              | Sym !Text !Int    -- ^ Symbol hole
              | Typ !(Maybe Int)  -- ^ Type declaration hole

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -77,6 +77,9 @@ verifyBlackBoxContext bbCtx (N.BBTemplate t) = all verify' t
     verify' (L n)           = case indexMaybe (bbInputs bbCtx) n of
                                 Just (_,_,b) -> b
                                 _            -> False
+    verify' (LC n)          = case indexMaybe (bbInputs bbCtx) n of
+                                Just (_,_,b) -> b
+                                _            -> False
     verify' (Typ (Just n))  = n < length (bbInputs bbCtx)
     verify' (TypM (Just n)) = n < length (bbInputs bbCtx)
     verify' (Err (Just n))  = n < length (bbInputs bbCtx)
@@ -441,6 +444,10 @@ renderTag b (L n)           = let (e,_,_) = bbInputs b !! n
     mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Unsigned _,_)) i]) = Literal Nothing i
     mkLit i                               = i
 
+renderTag b (LC n)
+  = let (e,_,_) = bbInputs b !! n
+    in  renderOneLine <$> getMon (expr False e)
+
 renderTag b e@(N _i) =
   case elementToText b e of
       Right s  -> return s
@@ -636,6 +643,7 @@ prettyElem (D (Decl i args)) = do
 prettyElem (O b) = if b then return "~ERESULT" else return "~RESULT"
 prettyElem (I b i) = renderOneLine <$> (if b then string "~EARG" else string "~ARG" <> brackets (int i))
 prettyElem (L i) = renderOneLine <$> (string "~LIT" <> brackets (int i))
+prettyElem (LC i) = renderOneLine <$> (string "~LITC" <> brackets (int i))
 prettyElem (N i) = renderOneLine <$> (string "~NAME" <> brackets (int i))
 prettyElem (Var es i) = do
   es' <- prettyBlackBox es
@@ -792,6 +800,7 @@ usedArguments (N.BBTemplate t) = nub (concatMap (walkElement matchArg) t)
     matchArg (D (Decl i _)) = Just i
     matchArg (I _ i)        = Just i
     matchArg (L i)          = Just i
+    matchArg (LC i)         = Just i
     matchArg (N i)          = Just i
     matchArg (Var _ i)      = Just i
     matchArg _              = Nothing

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -34,6 +34,7 @@ import Control.Monad.State.Strict           (MonadIO, MonadState, StateT)
 import Data.Bits                            (testBit)
 import Data.Binary                          (Binary(..))
 import Data.Hashable
+import Data.HashSet                         (HashSet)
 import Data.IntMap                          (IntMap, empty)
 import qualified Data.Set                   as Set
 import Data.Text                            (Text, pack)
@@ -73,7 +74,7 @@ data NetlistState
   -- ^ Global binders
   , _varCount       :: !Int
   -- ^ Number of signal declarations
-  , _components     :: VarEnv (SrcSpan,[Identifier],Component)
+  , _components     :: VarEnv (SrcSpan,HashSet Identifier,Component)
   -- ^ Cached components
   , _primitives     :: CompiledPrimMap
   -- ^ Primitive Definitions
@@ -85,8 +86,8 @@ data NetlistState
   , _intWidth       :: Int
   , _mkIdentifierFn :: IdType -> Identifier -> Identifier
   , _extendIdentifierFn :: IdType -> Identifier -> Identifier -> Identifier
-  , _seenIds        :: [Identifier]
-  , _seenComps      :: [Identifier]
+  , _seenIds        :: HashSet Identifier
+  , _seenComps      :: HashSet Identifier
   , _seenPrimitives :: Set.Set Text
   -- ^ Keeps track of invocations of ´mkPrimitive´. It is currently used to
   -- filter duplicate warning invocations for dubious blackbox instantiations,

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -130,6 +130,7 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcs
                   (opt_inlineConstantLimit opts)
                   primMap
                   rcsMap
+                  (opt_newInlineStrat opts)
 
 
 normalize
@@ -323,7 +324,11 @@ flattenNode b@(CBranch (nm,(_,_,_,e)) us) = do
           Just remainder | bId `idDoesNotOccurIn` bExpr ->
                return (Right ((nm,mkApps fun (reverse remainder)),us))
           _ -> return (Right ((nm,e),us))
-      _ -> return (Right ((nm,e),us))
+      _ -> do
+        newInlineStrat <- Lens.use (extra.newInlineStrategy)
+        if newInlineStrat || isCheapFunction e
+           then return (Right ((nm,e),us))
+           else return (Left b)
 
 flattenCallTree
   :: CallTree

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -37,7 +37,6 @@ import           Clash.Annotations.BitRepresentation.Internal
 import           Clash.Core.Evaluator             (PrimEvaluator)
 import           Clash.Core.FreeVars
   (termFreeIds, idDoesNotOccurIn, idOccursIn)
-import           Clash.Core.Name                  (Name (..), NameSort (..))
 import           Clash.Core.Pretty                (showPpr, ppr)
 import           Clash.Core.Subst                 (deShadowTerm, extendIdSubstList, mkSubst, substTm)
 import           Clash.Core.Term                  (Term (..))
@@ -47,8 +46,9 @@ import           Clash.Core.TyCon
 import           Clash.Core.Util                  (collectArgs, mkApps, termType)
 import           Clash.Core.Var                   (Id, varName, varType)
 import           Clash.Core.VarEnv
-  (VarEnv, eltsVarEnv, emptyInScopeSet, emptyVarEnv,
-   extendVarEnv, lookupVarEnv, mapVarEnv, mapMaybeVarEnv, mkInScopeSet, mkVarEnv, mkVarSet, notElemVarEnv, notElemVarSet, nullVarEnv, unionVarEnv)
+  (VarEnv, elemVarSet, eltsVarEnv, emptyInScopeSet, emptyVarEnv,
+   extendVarEnv, lookupVarEnv, mapVarEnv, mapMaybeVarEnv, mkInScopeSet,
+   mkVarEnv, mkVarSet, notElemVarEnv, notElemVarSet, nullVarEnv, unionVarEnv)
 import           Clash.Driver.Types
   (BindingMap, ClashOpts (..), DebugLevel (..))
 import           Clash.Netlist.Types              (HWType (..), FilteredHWType(..))
@@ -295,34 +295,35 @@ stripArgs _ _ _ = Nothing
 flattenNode
   :: CallTree
   -> NormalizeSession (Either CallTree ((Id,Term),[CallTree]))
-flattenNode (CLeaf (nm,(nameSort . varName -> Internal,_,_,e))) =
-  return (Right ((nm,e),[]))
+flattenNode c@(CLeaf (_,(_,_,NoInline,_))) = return (Left c)
 flattenNode c@(CLeaf (nm,(_,_,_,e))) = do
-  tcm  <- Lens.view tcCache
-  let norm = splitNormalized tcm e
-  case norm of
-    Right (ids,[(bId,bExpr)],_) -> do
-      let (fun,args) = collectArgs bExpr
-      case stripArgs ids (reverse ids) (reverse args) of
-        Just remainder | bId `idDoesNotOccurIn` bExpr ->
-          return (Right ((nm,mkApps fun (reverse remainder)),[]))
-        _ -> return (Right ((nm,e),[]))
-    _ | isCheapFunction e -> return (Right ((nm,e),[]))
-      | otherwise         -> return (Left c)
-flattenNode (CBranch (nm,(nameSort . varName -> Internal,_,_,e)) us) =
-  return (Right ((nm,e),us))
+  isTopEntity <- elemVarSet nm <$> Lens.view topEntities
+  if isTopEntity then return (Left c) else do
+    tcm  <- Lens.view tcCache
+    let norm = splitNormalized tcm e
+    case norm of
+      Right (ids,[(bId,bExpr)],_) -> do
+        let (fun,args) = collectArgs bExpr
+        case stripArgs ids (reverse ids) (reverse args) of
+          Just remainder | bId `idDoesNotOccurIn` bExpr ->
+               return (Right ((nm,mkApps fun (reverse remainder)),[]))
+          _ -> return (Right ((nm,e),[]))
+      _ -> return (Right ((nm,e),[]))
+flattenNode b@(CBranch (_,(_,_,NoInline,_)) _) =
+  return (Left b)
 flattenNode b@(CBranch (nm,(_,_,_,e)) us) = do
-  tcm  <- Lens.view tcCache
-  let norm = splitNormalized tcm e
-  case norm of
-    Right (ids,[(bId,bExpr)],_) -> do
-      let (fun,args) = collectArgs bExpr
-      case stripArgs ids (reverse ids) (reverse args) of
-        Just remainder | bId `idDoesNotOccurIn` bExpr -> do
-          return (Right ((nm,mkApps fun (reverse remainder)),us))
-        _ -> return (Right ((nm,e),us))
-    _ | isCheapFunction e -> return (Right ((nm,e),us))
-      | otherwise         -> return (Left b)
+  isTopEntity <- elemVarSet nm <$> Lens.view topEntities
+  if isTopEntity then return (Left b) else do
+    tcm  <- Lens.view tcCache
+    let norm = splitNormalized tcm e
+    case norm of
+      Right (ids,[(bId,bExpr)],_) -> do
+        let (fun,args) = collectArgs bExpr
+        case stripArgs ids (reverse ids) (reverse args) of
+          Just remainder | bId `idDoesNotOccurIn` bExpr ->
+               return (Right ((nm,mkApps fun (reverse remainder)),us))
+          _ -> return (Right ((nm,e),us))
+      _ -> return (Right ((nm,e),us))
 
 flattenCallTree
   :: CallTree
@@ -345,7 +346,7 @@ flattenCallTree (CBranch (nm,(nm',sp,inl,tm)) used) = do
   -- inline all components when the resulting expression after flattening
   -- is still considered "cheap". This happens often at the topEntity which
   -- wraps another functions and has some selectors and data-constructors.
-  if isCheapFunction newExpr
+  if inl /= NoInline && isCheapFunction newExpr
      then do
         let (toInline',allUsed') = unzip (map goCheap allUsed)
             subst' = extendIdSubstList (mkSubst is) toInline'

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -20,7 +20,7 @@ normalization = rmDeadcode >-> constantPropgation >-> etaTL >-> rmUnusedExpr >-!
                 bindConst >-> letTL >-> evalConst >-!-> cse >-!-> cleanup >-> recLetRec
   where
     etaTL      = apply "etaTL" etaExpansionTL !-> innerMost (apply "applicationPropagation" appProp)
-    anf        = topdownR (apply "nonRepANF" nonRepANF) >-> apply "ANF" makeANF
+    anf        = topdownR (apply "nonRepANF" nonRepANF) >-> apply "ANF" makeANF >-> topdownR (apply "caseCon" caseCon)
     letTL      = topdownSucR (apply "topLet" topLet)
     recLetRec  = apply "recToLetRec" recToLetRec
     rmUnusedExpr = bottomupR (apply "removeUnusedExpr" removeUnusedExpr)

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -923,7 +923,7 @@ inlineWorkFree (TransformContext localScope _) e@(collectArgs -> (Var f,args))
         bndrs <- Lens.use bindings
         case lookupVarEnv f bndrs of
           -- Don't inline recursive expressions
-          Just (_,_,inl,body) | inl /= NoInline -> do
+          Just (_,_,_,body) -> do
             isRecBndr <- isRecursiveBndr f
             if isRecBndr
                then return e
@@ -955,7 +955,7 @@ inlineWorkFree (TransformContext localScope _) e@(Var f) = do
       bndrs <- Lens.use bindings
       case lookupVarEnv f bndrs of
         -- Don't inline recursive expressions
-        Just (_,_,inl,body) | inl /= NoInline -> do
+        Just (_,_,_,body) -> do
           isRecBndr <- isRecursiveBndr f
           if isRecBndr
              then return e

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -923,7 +923,7 @@ inlineWorkFree (TransformContext localScope _) e@(collectArgs -> (Var f,args))
         bndrs <- Lens.use bindings
         case lookupVarEnv f bndrs of
           -- Don't inline recursive expressions
-          Just (_,_,_,body) -> do
+          Just (_,_,inl,body) | inl /= NoInline -> do
             isRecBndr <- isRecursiveBndr f
             if isRecBndr
                then return e
@@ -955,7 +955,7 @@ inlineWorkFree (TransformContext localScope _) e@(Var f) = do
       bndrs <- Lens.use bindings
       case lookupVarEnv f bndrs of
         -- Don't inline recursive expressions
-        Just (_,_,_,body) -> do
+        Just (_,_,inl,body) | inl /= NoInline -> do
           isRecBndr <- isRecursiveBndr f
           if isRecBndr
              then return e

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -58,6 +58,8 @@ data NormalizeState
   --
   -- NB: there are only no mutually-recursive component, only self-recursive
   -- ones.
+  , _newInlineStrategy :: Bool
+  -- ^ Flattening stage should use the new (no-)inlining strategy
   }
 
 makeLenses ''NormalizeState


### PR DESCRIPTION
By default, Clash will now produce a single HDL file. To influence HDL file generation you can either:

* Add a `NOINLINE` pragma to a top-level function, so that it gets its own HDL file, except when they're constants.
* Add a `ANN Synthesize { .. }` pragma to a top-level function, so that it gets:
  * its own HDL file, 
  * in a separate directory, 
  * and a stable interface,
  * and is cached between runs.