### PR TITLE
Improve support for zero-width constructs

### DIFF
--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.json
@@ -46,21 +46,21 @@
     { "name"      : "Clash.Sized.Internal.BitVector.reduceAnd#"
     , "kind"      : "Expression"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> Bit"
-    , "template"  : "& (~ARG[1])"
+    , "template"  : "~IF~LIT[0]~THEN& (~ARG[1])~ELSE1'b1~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceOr#"
     , "kind"      : "Expression"
     , "type"      : "reduceOr# :: KnownNat n => BitVector n -> Bit"
-    , "template"  : "| (~ARG[1])"
+    , "template"  : "~IF~LIT[0]~THEN| (~ARG[1])~ELSE1'b0~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.reduceXor#"
     , "kind"      : "Expression"
     , "type"      : "reduceXor# :: KnownNat n => BitVector n -> Bit"
-    , "template"  : "^ (~ARG[1])"
+    , "template"  : "~IF~LIT[0]~THEN^ (~ARG[1])~ELSE1'b0~FI"
     }
   }
 , { "BlackBox" :
@@ -179,7 +179,7 @@
     { "name"      : "Clash.Sized.Internal.BitVector.++#"
     , "kind"      : "Expression"
     , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
-    , "template"  : "{~ARG[1],~ARG[2]}"
+    , "template"  : "~IF~AND[~SIZE[~TYP[1]],~SIZE[~TYP[2]]]~THEN{~ARG[1],~ARG[2]}~ELSE~IF~SIZE[~TYP[1]]~THEN~ARG[1]~ELSE~ARG[2]~FI~FI"
     }
   }
 , { "BlackBox" :
@@ -276,21 +276,21 @@
     { "name"      : "Clash.Sized.Internal.BitVector.plus#"
     , "kind"      : "Declaration"
     , "type"      : "plus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
-    , "template"  : "assign ~RESULT = ~ARG[2] + ~ARG[3];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[2]],~SIZE[~TYP[3]]]~THEN~ARG[2] + ~ARG[3]~ELSE~IF~SIZE[~TYP[2]]~THEN~ARG[2]~ELSE~ARG[3]~FI~FI;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.minus#"
     , "kind"      : "Declaration"
     , "type"      : "minus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
-    , "template"  : "assign ~RESULT = ~ARG[2] - ~ARG[3];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[2]],~SIZE[~TYP[3]]]~THEN~ARG[2] - ~ARG[3]~ELSE~IF~SIZE[~TYP[2]]~THEN~ARG[2]~ELSE-~ARG[3]~FI~FI;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.times#"
     , "kind"      : "Declaration"
     , "type"      : "times# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (m + n)"
-    , "template"  : "assign ~RESULT = ~ARG[2] * ~ARG[3];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[2]],~SIZE[~TYP[3]]]~THEN~ARG[2] * ~ARG[3]~ELSE~SIZE[~TYPO]'d0~FI;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Signed.json
@@ -116,21 +116,21 @@
     { "name"      : "Clash.Sized.Internal.Signed.plus#"
     , "kind"      : "Declaration"
     , "type"      : "plus# :: Signed m -> Signed n -> Signed (1 + Max m n)"
-    , "template"  : "assign ~RESULT = ~ARG[0] + ~ARG[1];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THEN~ARG[0] + ~ARG[1]~ELSE~IF~SIZE[~TYP[0]]~THEN~ARG[0]~ELSE~ARG[1]~FI~FI;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.minus#"
     , "kind"      : "Declaration"
     , "type"      : "minus# :: Signed m -> Signed n -> Signed (1 + Max m n)"
-    , "template"  : "assign ~RESULT = ~ARG[0] - ~ARG[1];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THEN ~ARG[0] - ~ARG[1]~ELSE~IF~SIZE[~TYP[0]]~THEN ~ARG[0]~ELSE - ~ARG[1] ~FI~FI;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.times#"
     , "kind"      : "Declaration"
     , "type"      : "times# :: Signed m -> Signed n -> Signed (m + n)"
-    , "template"  : "assign ~RESULT = ~ARG[0] * ~ARG[1];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THEN~ARG[0] * ~ARG[1]~ELSE~SIZE[~TYPO]'d0~FI;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Unsigned.json
@@ -107,21 +107,21 @@
     { "name"      : "Clash.Sized.Internal.Unsigned.plus#"
     , "kind"      : "Declaration"
     , "type"      : "plus# :: Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"
-    , "template"  : "assign ~RESULT = ~ARG[0] + ~ARG[1];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THEN~ARG[0] + ~ARG[1]~ELSE~IF~SIZE[~TYP[0]]~THEN~ARG[0]~ELSE~ARG[1]~FI~FI;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.minus#"
     , "kind"      : "Declaration"
     , "type"      : "minus# :: (KnownNat m, KnownNat n) => Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"
-    , "template"  : "assign ~RESULT = ~ARG[2] - ~ARG[3];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[2]],~SIZE[~TYP[3]]]~THEN ~ARG[2] - ~ARG[3]~ELSE~IF~SIZE[~TYP[2]]~THEN ~ARG[2]~ELSE - ~ARG[3]~FI~FI;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.times#"
     , "kind"      : "Declaration"
     , "type"      : "times# :: Unsigned m -> Unsigned n -> Unsigned (m + n)"
-    , "template"  : "assign ~RESULT = ~ARG[0] * ~ARG[1];"
+    , "template"  : "assign ~RESULT = ~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THEN~ARG[0] * ~ARG[1]~ELSE~SIZE[~TYPO]'d0~FI;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
@@ -109,7 +109,7 @@
     { "name"      : "Clash.Sized.Internal.BitVector.++#"
     , "kind"      : "Expression"
     , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
-    , "template"  : "std_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic_vector'(~ARG[2]))"
+    , "template"  : "~IF~AND[~SIZE[~TYP[1]],~SIZE[~TYP[2]]]~THENstd_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic_vector'(~ARG[2]))~ELSE~IF~SIZE[~TYP[1]]~THENstd_logic_vector'(~ARG[1])~ELSEstd_logic_vector'(~ARG[2])~FI~FI"
     }
   }
 , { "BlackBox" :
@@ -117,7 +117,8 @@
     , "kind"      : "Declaration"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> Bit"
     , "template"  :
-"-- reduceAnd begin
+"-- reduceAnd begin,
+~IF~SIZE[~TYP[1]]~THEN
 ~GENSYM[reduceAnd][0] : block
   function and_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -142,7 +143,8 @@
   end;
 begin
   ~RESULT <= and_reduce(~ARG[1]);
-end block;
+end block;~ELSE
+~RESULT <= '1';~FI
 -- reduceAnd end"
     }
   }
@@ -151,7 +153,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "reduceOr# :: KnownNat n => BitVector n -> Bit"
     , "template"  :
-"-- reduceOr begin
+"-- reduceOr begin ~IF~SIZE[~TYP[1]]~THEN
 ~GENSYM[reduceOr][0] : block
   function or_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -176,7 +178,8 @@ end block;
   end;
 begin
   ~RESULT <= or_reduce(~ARG[1]);
-end block;
+end block;~ELSE
+~RESULT <= '0'; ~FI
 -- reduceOr end"
     }
   }
@@ -185,7 +188,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "reduceXor# :: KnownNat n => BitVector n -> Bit"
     , "template"  :
-"-- reduceXor begin
+"-- reduceXor begin ~IF~SIZE[~TYP[1]]~THEN
 ~GENSYM[reduceXor][0] : block
   function xor_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -210,7 +213,8 @@ end block;
   end;
 begin
   ~RESULT <= xor_reduce(~ARG[1]);
-end block;
+end block;~ELSE
+~RESULT <= '0';~FI
 -- reduceXor end"
     }
   }
@@ -223,7 +227,7 @@ end block;
         -> Int         -- ARG[2]
         -> Bit"
     , "template" :
-"-- indexBitVector begin~IF ~ISVAR[1] ~THEN
+"-- indexBitVector begin ~IF~SIZE[~TYP[1]]~THEN~IF ~ISVAR[1] ~THEN
 ~GENSYM[indexBitVector][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
@@ -245,7 +249,8 @@ begin
                ;
 
   ~RESULT <= ~VAR[bv][1](~SYM[1]);
-end block;~FI
+end block;~FI~ELSE
+~RESULT <= ~ERRORO;~FI
 -- indexBitVector end"
     }
   }
@@ -259,7 +264,7 @@ end block;~FI
              -> Bit         -- ARG[3]
              -> BitVector n"
     , "template" :
-"-- replaceBit begin
+"-- replaceBit begin ~IF~SIZE[~TYP[1]]~THEN
 ~GENSYM[replaceBit][0] : block
   signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
 begin
@@ -276,7 +281,8 @@ begin
     ~SYM[2](~SYM[1]) := ~ARG[3];
     ~RESULT <= ~SYM[2];
   end process;
-end block;
+end block; ~ELSE
+~RESULT <= ~ERRORO;~FI
 -- replaceBit end"
     }
   }
@@ -436,21 +442,21 @@ end process;
     { "name"      : "Clash.Sized.Internal.BitVector.plus#"
     , "kind"      : "Expression"
     , "type"      : "plus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
-    , "template"  : "std_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) + resize(unsigned(~ARG[3]),~SIZE[~TYPO]))"
+    , "template"  : "~IF~AND[~SIZE[~TYP[2]],~SIZE[~TYP[3]]]~THENstd_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) + resize(unsigned(~ARG[3]),~SIZE[~TYPO]))~ELSE~IF~SIZE[~TYP[2]]~THENstd_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]))~ELSEstd_logic_vector(resize(unsigned(~ARG[3]),~SIZE[~TYPO]))~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.minus#"
     , "kind"      : "Expression"
     , "type"      : "minus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
-    , "template"  : "std_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) - resize(unsigned(~ARG[3]),~SIZE[~TYPO]))"
+    , "template"  : "~IF~AND[~SIZE[~TYP[2]],~SIZE[~TYP[3]]]~THENstd_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]) - resize(unsigned(~ARG[3]),~SIZE[~TYPO]))~ELSE~IF~SIZE[~TYP[2]]~THENstd_logic_vector(resize(unsigned(~ARG[2]),~SIZE[~TYPO]))~ELSEstd_logic_vector(-resize(signed(~ARG[3]),~SIZE[~TYPO]))~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.times#"
     , "kind"      : "Expression"
     , "type"      : "times# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (m + n)"
-    , "template"  : "std_logic_vector(unsigned(~ARG[2]) * unsigned(~ARG[3]))"
+    , "template"  : "~IF~AND[~SIZE[~TYP[2]],~SIZE[~TYP[3]]]~THENstd_logic_vector(unsigned(~ARG[2]) * unsigned(~ARG[3]))~ELSE(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
@@ -109,21 +109,21 @@
     { "name"      : "Clash.Sized.Internal.Signed.plus#"
     , "kind"      : "Expression"
     , "type"      : "plus# :: Signed m -> Signed n -> Signed (1 + Max m n)"
-    , "template"  : "resize(~ARG[0],~SIZE[~TYPO]) + resize(~ARG[1],~SIZE[~TYPO])"
+    , "template"  : "~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THENresize(~ARG[0],~SIZE[~TYPO]) + resize(~ARG[1],~SIZE[~TYPO])~ELSE~IF~SIZE[~TYP[0]]~THENresize(~ARG[0],~SIZE[~TYPO])~ELSEresize(~ARG[1],~SIZE[~TYPO])~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.minus#"
     , "kind"      : "Expression"
     , "type"      : "minus# :: Signed m -> Signed n -> Signed (1 + Max m n)"
-    , "template"  : "resize(~ARG[0],~SIZE[~TYPO]) - resize(~ARG[1],~SIZE[~TYPO])"
+    , "template"  : "~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THENresize(~ARG[0],~SIZE[~TYPO]) - resize(~ARG[1],~SIZE[~TYPO])~ELSE~IF~SIZE[~TYP[0]]~THENresize(~ARG[0],~SIZE[~TYPO])~ELSEresize(- ~ARG[1],~SIZE[~TYPO])~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.times#"
     , "kind"      : "Expression"
     , "type"      : "times# :: Signed m -> Signed n -> Signed (m + n)"
-    , "template"  : "~ARG[0] * ~ARG[1]"
+    , "template"  : "~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THEN~ARG[0] * ~ARG[1]~ELSEsigned'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.json
@@ -100,21 +100,21 @@
     { "name"      : "Clash.Sized.Internal.Unsigned.plus#"
     , "kind"      : "Expression"
     , "type"      : "plus# :: Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"
-    , "template"  : "resize(~ARG[0],~SIZE[~TYPO]) + resize(~ARG[1],~SIZE[~TYPO])"
+    , "template"  : "~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THENresize(~ARG[0],~SIZE[~TYPO]) + resize(~ARG[1],~SIZE[~TYPO])~ELSE~IF~SIZE[~TYP[0]]~THENresize(~ARG[0],~SIZE[~TYPO])~ELSEresize(~ARG[1],~SIZE[~TYPO])~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.minus#"
     , "kind"      : "Expression"
     , "type"      : "minus# :: (KnownNat m,KnownNat n) => Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"
-    , "template"  : "resize(~ARG[2],~SIZE[~TYPO]) - resize(~ARG[3],~SIZE[~TYPO])"
+    , "template"  : "~IF~AND[~SIZE[~TYP[2]],~SIZE[~TYP[3]]]~THENresize(~ARG[2],~SIZE[~TYPO]) - resize(~ARG[3],~SIZE[~TYPO])~ELSE~IF~SIZE[~TYP[2]]~THENresize(~ARG[2],~SIZE[~TYPO])~ELSEresize(~ARG[3],~SIZE[~TYPO])~FI~FI"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.times#"
     , "kind"      : "Expression"
     , "type"      : "times# :: Unsigned m -> Unsigned n -> Unsigned (m + n)"
-    , "template"  : "~ARG[0] * ~ARG[1]"
+    , "template"  : "~IF~AND[~SIZE[~TYP[0]],~SIZE[~TYP[1]]]~THEN~ARG[0] * ~ARG[1]~ELSEunsigned'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -351,7 +351,7 @@ renderElem b (IF c t f) = do
                 | t1 == Text.pack t2 -> 1
                 | otherwise -> 0
               Nothing -> error $ $(curLoc) ++ "Expected a string literal: " ++ show e
-      (And es)   -> if all (==1) (map (check iw syn) es)
+      (And es)   -> if all (/=0) (map (check iw syn) es)
                        then 1
                        else 0
       _ -> error $ $(curLoc) ++ "IF: condition must be: SIZE, LENGTH, IW64, LIT, ISLIT, or ISARG"

--- a/clash-prelude/src/Clash/Prelude/BitReduction.hs
+++ b/clash-prelude/src/Clash/Prelude/BitReduction.hs
@@ -34,6 +34,11 @@ import Clash.Sized.Internal.BitVector (Bit, reduceAnd#, reduceOr#, reduceXor#)
 -- 11_1111
 -- >>> reduceAnd (-1 :: Signed 6)
 -- 1
+--
+-- Zero width types will evaluate to '1':
+--
+-- >>> reduceAnd (0 :: Unsigned 0)
+-- 1
 reduceAnd :: (BitPack a, KnownNat (BitSize a)) => a -> Bit
 reduceAnd v = reduceAnd# (pack v)
 
@@ -47,6 +52,11 @@ reduceAnd v = reduceAnd# (pack v)
 -- >>> pack (0 :: Signed 6)
 -- 00_0000
 -- >>> reduceOr (0 :: Signed 6)
+-- 0
+--
+-- Zero width types will evaluate to '0':
+--
+-- >>> reduceOr (0 :: Unsigned 0)
 -- 0
 reduceOr :: (BitPack a, KnownNat (BitSize a)) => a -> Bit
 reduceOr v = reduceOr# (pack v)
@@ -66,5 +76,10 @@ reduceOr v = reduceOr# (pack v)
 -- 11_1011
 -- >>> reduceXor (-5 :: Signed 6)
 -- 1
+--
+-- Zero width types will evaluate to '0':
+--
+-- >>> reduceXor (0 :: Unsigned 0)
+-- 0
 reduceXor :: (BitPack a, KnownNat (BitSize a)) => a -> Bit
 reduceXor v = reduceXor# (pack v)

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -298,7 +298,7 @@ fromInteger# = fromInteger_INLINE
 
 {-# INLINE fromInteger_INLINE #-}
 fromInteger_INLINE :: forall n . KnownNat n => Integer -> Signed n
-fromInteger_INLINE i = mask `seq` S res
+fromInteger_INLINE i = if mask == 0 then S 0 else S res
   where
     mask = 1 `shiftL` fromInteger (natVal (Proxy @n) -1)
     res  = case divMod i mask of

--- a/tests/shouldwork/BitVector/AppendZero.hs
+++ b/tests/shouldwork/BitVector/AppendZero.hs
@@ -1,0 +1,28 @@
+module AppendZero where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import Clash.Sized.BitVector ((++#))
+
+topEntity
+  :: Clock  System Source
+  -> Reset  System Asynchronous
+  -> Signal System ( BitVector 16
+                   , BitVector 16
+                   , BitVector 32
+                   )
+topEntity clk rst =
+  pure
+    ( (22 :: BitVector 16) ++# (0  :: BitVector 0)
+    , (0  :: BitVector 0)  ++# (22 :: BitVector 16)
+    , (22 :: BitVector 16) ++# (22 :: BitVector 16)
+    )
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst ((22, 22, 1441814) :> Nil)
+    done           = expectedOutput (topEntity clk rst)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/BitVector/ExtendingNumZero.hs
+++ b/tests/shouldwork/BitVector/ExtendingNumZero.hs
@@ -1,0 +1,36 @@
+module ExtendingNumZero where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock  System Source
+  -> Reset  System Asynchronous
+  -> Signal System (BitVector 16)
+  -> Signal System ( BitVector 17
+                   , BitVector 17
+                   , BitVector 17
+                   , BitVector 17
+                   , BitVector 16
+                   , BitVector 16
+                   )
+topEntity clk rst =
+  fmap (\n ->
+    ( add (n :: BitVector 16) (0 :: BitVector 0)
+    , add (0 :: BitVector 0)  (n :: BitVector 16)
+    , sub (n :: BitVector 16) (0 :: BitVector 0)
+    , sub (0 :: BitVector 0)  (n :: BitVector 16)
+    , mul (n :: BitVector 16) (0 :: BitVector 0)
+    , mul (0 :: BitVector 0)  (n :: BitVector 16)
+    ))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    n              = 22
+    expectedOutput = outputVerifier clk rst ((n, n, n, -n, 0, 0) :> Nil)
+    done           = expectedOutput (topEntity clk rst (pure n))
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/BitVector/ReduceOne.hs
+++ b/tests/shouldwork/BitVector/ReduceOne.hs
@@ -1,0 +1,22 @@
+module ReduceOne where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock  System Source
+  -> Reset  System Asynchronous
+  -> Signal System (Signed 1)
+  -> Signal System (Bit, Bit, Bit)
+topEntity clk rst =
+  fmap (\a -> (reduceAnd a, reduceOr a, reduceXor a))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((1 :: Signed 1) :> 0 :> Nil)
+    expectedOutput = outputVerifier clk rst ((high, high, high) :> (low, low, low) :> Nil)
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/BitVector/ReduceZero.hs
+++ b/tests/shouldwork/BitVector/ReduceZero.hs
@@ -1,0 +1,23 @@
+module ReduceZero where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock  System Source
+  -> Reset  System Asynchronous
+  -> Signal System (Signed 0)
+  -> Signal System (Bit, Bit, Bit)
+topEntity clk rst =
+  fmap (\a -> (reduceAnd a, reduceOr a, reduceXor a))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((0 :: Signed 0) :> Nil)
+    expectedOutput = outputVerifier clk rst ((high, low, low) :> Nil)
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+

--- a/tests/shouldwork/Numbers/SignedZero.hs
+++ b/tests/shouldwork/Numbers/SignedZero.hs
@@ -1,0 +1,36 @@
+module SignedZero where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock  System Source
+  -> Reset  System Asynchronous
+  -> Signal System (Signed 16)
+  -> Signal System ( Signed 17
+                   , Signed 17
+                   , Signed 17
+                   , Signed 17
+                   , Signed 16
+                   , Signed 16
+                   )
+topEntity clk rst =
+  fmap (\n ->
+    ( add (n :: Signed 16) (0 :: Signed 0)
+    , add (0 :: Signed 0)  (n :: Signed 16)
+    , sub (n :: Signed 16) (0 :: Signed 0)
+    , sub (0 :: Signed 0)  (n :: Signed 16)
+    , mul (n :: Signed 16) (0 :: Signed 0)
+    , mul (0 :: Signed 0)  (n :: Signed 16)
+    ))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    n              = 22
+    expectedOutput = outputVerifier clk rst ((n, n, n, -n, 0, 0) :> Nil)
+    done           = expectedOutput (topEntity clk rst (pure n))
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Numbers/UnsignedZero.hs
+++ b/tests/shouldwork/Numbers/UnsignedZero.hs
@@ -1,0 +1,34 @@
+module UnsignedZero where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock  System Source
+  -> Reset  System Asynchronous
+  -> Signal System (Unsigned 16)
+  -> Signal System ( Unsigned 17
+                   , Unsigned 17
+                   , Unsigned 17
+                   , Unsigned 16
+                   , Unsigned 16
+                   )
+topEntity clk rst =
+  fmap (\n ->
+    ( add (n :: Unsigned 16) (0 :: Unsigned 0)
+    , add (0 :: Unsigned 0)  (n :: Unsigned 16)
+    , sub (n :: Unsigned 16) (0 :: Unsigned 0)
+    , mul (n :: Unsigned 16) (0 :: Unsigned 0)
+    , mul (0 :: Unsigned 0)  (n :: Unsigned 16)
+    ))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    n              = 22
+    expectedOutput = outputVerifier clk rst ((n, n, n, 0, 0) :> Nil)
+    done           = expectedOutput (topEntity clk rst (pure n))
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+{-# NOINLINE testBench #-}

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -90,9 +90,13 @@ runClashTest =
         -- , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursivePoly" (Just "??")
         ]
       , clashTestGroup "BitVector"
-        [ runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "Box"     (["","Box_testBench"],"Box_testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "BoxGrow" (["","BoxGrow_testBench"],"BoxGrow_testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "RePack"  ([""],"RePack_topEntity",False)
+        [ runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "Box"              (["","Box_testBench"],"Box_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "BoxGrow"          (["","BoxGrow_testBench"],"BoxGrow_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "RePack"           ([""],"RePack_topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ReduceZero"       (["","ReduceZero_testBench"],"ReduceZero_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ReduceOne"        (["","ReduceOne_testBench"],"ReduceOne_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ExtendingNumZero" (["","ExtendingNumZero_testBench"],"ExtendingNumZero_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "AppendZero"       (["","AppendZero_testBench"],"AppendZero_testBench",True)
         ]
       , clashTestGroup "BlackBox"
         [ outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   "TemplateFunction" "main"
@@ -150,11 +154,13 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "VecFun"    (["","VecFun_testBench"],"VecFun_testBench",True)
       ]
       , clashTestGroup "Numbers"
-        [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"  (["","Bounds_testBench"],"Bounds_testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize"  (["","Resize_testBench"],"Resize_testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize2" (["","Resize2_testBench"],"Resize2_testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SatMult" ([""],"SatMult_topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Strict"  (["","Strict_testBench"],"Strict_testBench",True)
+        [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"       (["","Bounds_testBench"],"Bounds_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize"       (["","Resize_testBench"],"Resize_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize2"      (["","Resize2_testBench"],"Resize2_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SatMult"      ([""],"SatMult_topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Strict"       (["","Strict_testBench"],"Strict_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "UnsignedZero" (["","UnsignedZero_testBench"],"UnsignedZero_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SignedZero"   (["","SignedZero_testBench"],"SignedZero_testBench",True)
         ]
       , clashTestGroup "Polymorphism"
         [ runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "ExistentialBoxed"  ([""],"ExistentialBoxed_topEntity",False)

--- a/testsuite/Test/Tasty/Clash.hs
+++ b/testsuite/Test/Tasty/Clash.hs
@@ -256,6 +256,9 @@ ghdlMake path modName subdirs libs entName =
   (testName, test)
   where
     args = concat [ ["-m"]
+               -- TODO: Automatically detect GCC/linker version
+               -- Enable flags when running newer versions of the (GCC) linker.
+               -- , ["-Wl,-no-pie"]
                   , ["--workdir=work"]
                   , map (\l -> "-P" ++ emptyToDot (map toLower l)) libs
                   , ["-o", map toLower (noConflict entName subdirs) ]

--- a/testsuite/Test/Tasty/Clash.hs
+++ b/testsuite/Test/Tasty/Clash.hs
@@ -87,8 +87,7 @@ tastyRelease
   :: FilePath
   -> IO ()
 tastyRelease path = do
-  return ()
---  Directory.removeDirectoryRecursive path
+  Directory.removeDirectoryRecursive path
 
 -- | Set the stage for compilation
 createDirs


### PR DESCRIPTION
This PR adds support for zero-width constructs for `BitVector`, `Signed`, and `Unsigned`.

Includes some (very minor) fixes.