### PR TITLE
`removedArg @ Clock/Reset` is a normal constant

### DIFF
--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -6,10 +6,11 @@
   Utility functions used by the normalisation transformations
 -}
 
-{-# LANGUAGE BangPatterns    #-}
-{-# LANGUAGE LambdaCase      #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 module Clash.Normalize.Util where
 
@@ -78,7 +79,9 @@ isConstantNotClockReset e = do
   tcm <- Lens.view tcCache
   let eTy = termType tcm e
   if isClockOrReset tcm eTy
-     then return False
+     then case collectArgs e of
+        (Prim nm _,_) -> return (nm == "Clash.Transformations.removedArg")
+        _ -> return False
      else return (isConstant e)
 
 -- | Assert whether a name is a reference to a recursive binder.


### PR DESCRIPTION
Normally constants with a Clock or Reset type are lifted out so
we can do CSE, so that we only get 1 clock generator, and 1
reset generator. We do this by checking the type of the constant.

However, if the constant is actually a `removedArg`, introduced
to replace arguments of primitives that are unused, we should
leave them where they are.