### PR TITLE
Fix `Clash.Netlist.BlackBox.Util.prettyElem` for `And`

### DIFF
--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -665,9 +665,9 @@ prettyElem (IF b esT esF) = do
      string "~ELSE" <>
      string esF' <>
      string "~FI")
-prettyElem (And es) =
-  (renderLazy . layoutCompact) <$>
-  (brackets (tupled $ mapM (string <=< prettyElem) es))
+prettyElem (And es) = renderOneLine <$>
+  (string "~AND" <>
+  (brackets (hcat (punctuate comma (mapM (string <=< prettyElem) es)))))
 prettyElem IW64 = return "~IW64"
 prettyElem (HdlSyn s) = case s of
   Vivado -> return "~VIVADO"

--- a/tests/shouldwork/Vector/T452.hs
+++ b/tests/shouldwork/Vector/T452.hs
@@ -1,0 +1,8 @@
+module T452 where
+
+import Clash.Prelude
+
+topEntity
+  :: Vec 4 (Unsigned 4)
+  -> Vec 4 (Unsigned 5)
+topEntity = map (add (3 :: Unsigned 4))

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -251,6 +251,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VZip"       ([""],"VZip_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VecConst"   ([""],"VecConst_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VecOfSum"   ([""],"VecOfSum_topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "T452"       ([""],"T452_topEntity",False)
         ]
       ]
     ]


### PR DESCRIPTION
It didn't render the actual "~AND" keyword.