### PR TITLE
 Account for zero-width constructs in `mkFunInput` 

### DIFF
--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -18,7 +18,7 @@ import Clash.GHC.GenerateBindings
 import Clash.GHC.LoadModules (ghcLibDir)
 import Clash.GHC.NetlistTypes
 import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
-import Clash.Netlist.Types          (HWType)
+import Clash.Netlist.Types          (FilteredHWType)
 import Clash.Primitives.Types
 
 import Util (OverridingBool(..))
@@ -33,7 +33,7 @@ defaultTests =
   , "benchmark/tests/PipelinesViaFolds.hs"
   ]
 
-typeTrans :: (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+typeTrans :: (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
 typeTrans = ghcTypeToHWType WORD_SIZE_IN_BITS True
 
 opts :: ClashOpts

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -7,6 +7,7 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 module Clash.GHC.NetlistTypes
@@ -26,8 +27,9 @@ import Clash.Core.TyCon                 (TyConMap, tyConDataCons)
 import Clash.Core.Type
   (LitTy (..), Type (..), TypeView (..), coreView, tyView)
 import Clash.Core.Util                  (tyNatSize)
-import Clash.Netlist.Util               (coreTypeToHWType)
-import Clash.Netlist.Types              (HWType(..), PortDirection (..))
+import Clash.Netlist.Util               (coreTypeToHWType, stripFiltered)
+import Clash.Netlist.Types
+  (HWType(..), FilteredHWType(..), PortDirection (..))
 import Clash.Signal.Internal            (ClockKind (..), ResetKind (..))
 import Clash.Unique                     (lookupUniqMap')
 import Clash.Util                       (curLoc)
@@ -37,23 +39,30 @@ import Clash.Annotations.BitRepresentation.Internal
 
 ghcTypeToHWType
   :: Int
+  -- ^ Integer width. The width Clash assumes an Integer to be (instead of it
+  -- begin an arbitrarily large, runtime sized construct).
   -> Bool
+  -- ^ Float support
   -> CustomReprs
+  -- ^ Custom bit representations
   -> TyConMap
-  -> Bool
+  -- ^ Type constructor map
   -> Type
-  -> Maybe (Either String HWType)
+  -- ^ Type to convert to HWType
+  -> Maybe (Either String FilteredHWType)
 ghcTypeToHWType iw floatSupport = go
   where
-    go reprs m keepVoid (AnnType attrs typ) = runExceptT $ do
-      typ' <- ExceptT $ return $ coreTypeToHWType go reprs m keepVoid typ
-      return $ Annotated attrs typ'
+    returnN t = return (FilteredHWType t [])
 
-    go reprs m keepVoid ty@(tyView -> TyConApp tc args) = runExceptT $
+    go reprs m (AnnType attrs typ) = runExceptT $ do
+      FilteredHWType typ' areVoids <- ExceptT $ return $ coreTypeToHWType go reprs m typ
+      return (FilteredHWType (Annotated attrs typ') areVoids)
+
+    go reprs m ty@(tyView -> TyConApp tc args) = runExceptT $
       case nameOcc tc of
-        "GHC.Int.Int8"                  -> return (Signed 8)
-        "GHC.Int.Int16"                 -> return (Signed 16)
-        "GHC.Int.Int32"                 -> return (Signed 32)
+        "GHC.Int.Int8"                  -> returnN (Signed 8)
+        "GHC.Int.Int16"                 -> returnN (Signed 16)
+        "GHC.Int.Int32"                 -> returnN (Signed 32)
         "GHC.Int.Int64"                 ->
           if iw < 64
              then case tyConDataCons (m `lookupUniqMap'` tc) of
@@ -64,13 +73,13 @@ ghcTypeToHWType iw floatSupport = go
                                              ,"Run Clash with `-fclash-intwidth=64`."
                                              ]
                         | nameOcc nm == "GHC.Prim.Int64#" ->
-                            return (Signed 64)
+                            returnN (Signed 64)
                       _  -> throwE $ $(curLoc) ++ "Int64 DC has unexpected amount of arguments"
                     _    -> throwE $ $(curLoc) ++ "Int64 TC has unexpected amount of DCs"
-             else return (Signed 64)
-        "GHC.Word.Word8"                -> return (Unsigned 8)
-        "GHC.Word.Word16"               -> return (Unsigned 16)
-        "GHC.Word.Word32"               -> return (Unsigned 32)
+             else returnN (Signed 64)
+        "GHC.Word.Word8"                -> returnN (Unsigned 8)
+        "GHC.Word.Word16"               -> returnN (Unsigned 16)
+        "GHC.Word.Word32"               -> returnN (Unsigned 32)
         "GHC.Word.Word64"               ->
           if iw < 64
              then case tyConDataCons (m `lookupUniqMap'` tc) of
@@ -81,104 +90,107 @@ ghcTypeToHWType iw floatSupport = go
                                              ,"Run Clash with `-fclash-intwidth=64`."
                                              ]
                         | nameOcc nm == "GHC.Prim.Word64#" ->
-                            return (Unsigned 64)
+                            returnN (Unsigned 64)
                       _  -> throwE $ $(curLoc) ++ "Word64 DC has unexpected amount of arguments"
                     _    -> throwE $ $(curLoc) ++ "Word64 TC has unexpected amount of DCs"
-             else return (Unsigned 64)
-        "GHC.Integer.Type.Integer"      -> return (Signed iw)
-        "GHC.Natural.Natural"           -> return (Unsigned iw)
-        "GHC.Prim.Char#"                -> return (Unsigned 21)
-        "GHC.Prim.Int#"                 -> return (Signed iw)
-        "GHC.Prim.Word#"                -> return (Unsigned iw)
-        "GHC.Prim.Int64#"               -> return (Signed 64)
-        "GHC.Prim.Word64#"              -> return (Unsigned 64)
-        "GHC.Prim.Float#" | floatSupport -> return (BitVector 32)
-        "GHC.Prim.Double#" | floatSupport -> return (BitVector 64)
+             else returnN (Unsigned 64)
+        "GHC.Integer.Type.Integer"      -> returnN (Signed iw)
+        "GHC.Natural.Natural"           -> returnN (Unsigned iw)
+        "GHC.Prim.Char#"                -> returnN (Unsigned 21)
+        "GHC.Prim.Int#"                 -> returnN (Signed iw)
+        "GHC.Prim.Word#"                -> returnN (Unsigned iw)
+        "GHC.Prim.Int64#"               -> returnN (Signed 64)
+        "GHC.Prim.Word64#"              -> returnN (Unsigned 64)
+        "GHC.Prim.Float#" | floatSupport -> returnN (BitVector 32)
+        "GHC.Prim.Double#" | floatSupport -> returnN (BitVector 64)
         "GHC.Prim.ByteArray#"           ->
           throwE $ "Can't translate type: " ++ showPpr ty
 
-        "GHC.Types.Bool"                -> return Bool
-        "GHC.Types.Float" | floatSupport-> return (BitVector 32)
-        "GHC.Types.Double" | floatSupport -> return (BitVector 64)
-        "GHC.Prim.~#"                   -> return (Void Nothing)
+        "GHC.Types.Bool"                -> returnN Bool
+        "GHC.Types.Float" | floatSupport-> returnN (BitVector 32)
+        "GHC.Types.Double" | floatSupport -> returnN (BitVector 64)
+        "GHC.Prim.~#"                   -> returnN (Void Nothing)
 
-        "GHC.Prim.Any" -> return (Void Nothing)
+        "GHC.Prim.Any" -> returnN (Void Nothing)
 
         "Clash.Signal.Internal.Signal" ->
-          ExceptT $ return $ coreTypeToHWType go reprs m keepVoid (args !! 1)
+          ExceptT $ return $ coreTypeToHWType go reprs m (args !! 1)
 
         "Clash.Signal.BiSignal.BiSignalIn" -> do
           let [_, _, szTy] = args
-          (BiDirectional In . BitVector . fromInteger) <$> mapExceptT (Just .coerce) (tyNatSize m szTy)
+          let fType ty1 = FilteredHWType ty1 []
+          (fType . BiDirectional In . BitVector . fromInteger) <$>
+            mapExceptT (Just .coerce) (tyNatSize m szTy)
 
         "Clash.Signal.BiSignal.BiSignalOut" -> do
           let [_, _, szTy] = args
-          (Void . Just . BiDirectional Out . BitVector . fromInteger) <$>
+          let fType ty1 = FilteredHWType ty1 []
+          (fType . Void . Just . BiDirectional Out . BitVector . fromInteger) <$>
             mapExceptT (Just .coerce) (tyNatSize m szTy)
 
         "Clash.Signal.Internal.Clock"
           | [dom,clkKind] <- args
           -> do (nm,rate) <- domain m dom
                 gated     <- clockKind m clkKind
-                return (Clock (pack nm) rate gated)
+                returnN (Clock (pack nm) rate gated)
 
         "Clash.Signal.Internal.Reset"
           | [dom,rstKind] <- args
           -> do (nm,rate)   <- domain m dom
                 synchronous <- resetKind m rstKind
-                return (Reset (pack nm) rate synchronous)
+                returnN (Reset (pack nm) rate synchronous)
 
-        "Clash.Sized.Internal.BitVector.Bit" -> return Bit
+        "Clash.Sized.Internal.BitVector.Bit" -> returnN Bit
 
         "Clash.Sized.Internal.BitVector.BitVector" -> do
           n <- mapExceptT (Just . coerce) (tyNatSize m (head args))
           case n of
-            0 -> return (Void (Just (BitVector (fromInteger n))))
-            _ -> return (BitVector (fromInteger n))
+            0 -> returnN (Void (Just (BitVector (fromInteger n))))
+            _ -> returnN (BitVector (fromInteger n))
 
         "Clash.Sized.Internal.Index.Index" -> do
           n <- mapExceptT (Just . coerce) (tyNatSize m (head args))
           if n < 2
-             then return (Void (Just (Index (fromInteger n))))
-             else return (Index (fromInteger n))
+             then returnN (Void (Just (Index (fromInteger n))))
+             else returnN (Index (fromInteger n))
 
         "Clash.Sized.Internal.Signed.Signed" -> do
           n <- mapExceptT (Just . coerce) (tyNatSize m (head args))
           if n == 0
-             then return (Void (Just (Signed (fromInteger n))))
-             else return (Signed (fromInteger n))
+             then returnN (Void (Just (Signed (fromInteger n))))
+             else returnN (Signed (fromInteger n))
 
         "Clash.Sized.Internal.Unsigned.Unsigned" -> do
           n <- mapExceptT (Just .coerce) (tyNatSize m (head args))
           if n == 0
-             then return (Void (Just (Unsigned (fromInteger n))))
-             else return (Unsigned (fromInteger n))
+             then returnN (Void (Just (Unsigned (fromInteger n))))
+             else returnN (Unsigned (fromInteger n))
 
         "Clash.Sized.Vector.Vec" -> do
           let [szTy,elTy] = args
           sz     <- mapExceptT (Just . coerce) (tyNatSize m szTy)
-          elHWTy <- ExceptT $ return $ coreTypeToHWType go reprs m keepVoid elTy
+          elHWTy <- ExceptT $ return $ stripFiltered <$> coreTypeToHWType go reprs m elTy
           case elHWTy of
-            Void {}     -> return (Void (Just (Vector (fromInteger sz) elHWTy)))
-            _ | sz == 0 -> return (Void (Just (Vector (fromInteger sz) elHWTy)))
-            _           -> return $ Vector (fromInteger sz) elHWTy
+            Void {}     -> returnN (Void (Just (Vector (fromInteger sz) elHWTy)))
+            _ | sz == 0 -> returnN (Void (Just (Vector (fromInteger sz) elHWTy)))
+            _           -> returnN $ Vector (fromInteger sz) elHWTy
 
         "Clash.Sized.RTree.RTree" -> do
           let [szTy,elTy] = args
           sz     <- mapExceptT (Just . coerce) (tyNatSize m szTy)
-          elHWTy <- ExceptT $ return $ coreTypeToHWType go reprs m keepVoid elTy
+          elHWTy <- ExceptT $ return $ stripFiltered <$> coreTypeToHWType go reprs m elTy
           case elHWTy of
-            Void {} -> return (Void (Just (RTree (fromInteger sz) elHWTy)))
-            _       -> return $ RTree (fromInteger sz) elHWTy
+            Void {} -> returnN (Void (Just (RTree (fromInteger sz) elHWTy)))
+            _       -> returnN $ RTree (fromInteger sz) elHWTy
 
-        "String" -> return String
+        "String" -> returnN String
         "GHC.Types.[]" -> case tyView (head args) of
-          (TyConApp (nameOcc -> "GHC.Types.Char") []) -> return String
+          (TyConApp (nameOcc -> "GHC.Types.Char") []) -> returnN String
           _ -> throwE $ "Can't translate type: " ++ showPpr ty
 
         _ -> ExceptT Nothing
 
-    go _ _ _ _ = Nothing
+    go _ _ _ = Nothing
 
 domain
   :: TyConMap

--- a/clash-lib/prims/systemverilog/Clash_Sized_Vector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Vector.json
@@ -141,7 +141,7 @@ genvar ~GENSYM[n][1];
 ~GENERATE
 for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
   ~INDEXTYPE[~LIT[0]] ~GENSYM[i][3];
-  assign ~SYM[3] = ~LENGTH[~TYPO] - 1 - ~SYM[1];~IF~SIZE[~TYP[2]]~THEN
+  assign ~SYM[3] = ~SYM[1];~IF~SIZE[~TYP[2]]~THEN
   ~TYPEL[~TYP[2]] ~GENSYM[imap_in][4];
   assign ~SYM[4] = ~FROMBV[~VAR[vec][2][\\~SYM[1]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI
   ~TYPEL[~TYPO] ~GENSYM[imap_out][5];
@@ -166,7 +166,7 @@ genvar ~GENSYM[n][1];
 ~GENERATE
 for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
   ~TYP[0] ~GENSYM[i][3];
-  assign ~SYM[3] = ~LENGTH[~TYPO] - 1 - ~SYM[1] + ~ARG[0];~IF~SIZE[~TYP[2]]~THEN
+  assign ~SYM[3] = ~SYM[1] + ~ARG[0];~IF~SIZE[~TYP[2]]~THEN
   ~TYPEL[~TYP[2]] ~GENSYM[imap_in][4];
   assign ~SYM[4] = ~FROMBV[~VAR[vec][2][\\~SYM[1]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI
   ~TYPEL[~TYPO] ~GENSYM[imap_out][5];

--- a/clash-lib/prims/verilog/Clash_Sized_RTree.json
+++ b/clash-lib/prims/verilog/Clash_Sized_RTree.json
@@ -2,7 +2,7 @@
     { "name"      : "Clash.Sized.RTree.treplicate"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat d -> a -> RTree d a"
-    , "template"  : "'{(2**~LIT[0]) {~ARG[1]}}"
+    , "template"  : "{(2**~LIT[0]) {~ARG[1]}}"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -76,7 +76,7 @@ import           Clash.Netlist.Util               (genComponentName, genTopCompo
 import           Clash.Netlist.BlackBox.Parser    (runParse)
 import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate, BlackBoxFunction)
 import           Clash.Netlist.Types
-  (BlackBox (..), Component (..), HWType, Identifier)
+  (BlackBox (..), Component (..), Identifier, FilteredHWType)
 import           Clash.Normalize                  (checkNonRecursive, cleanupGraph,
                                                    normalize, runNormalization)
 import           Clash.Normalize.Util             (callGraph)
@@ -103,7 +103,7 @@ generateHDL
   -- ^ TyCon cache
   -> IntMap TyConName
   -- ^ Tuple TyCon cache
-  -> (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+  -> (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
   -> PrimEvaluator
   -- ^ Hardcoded evaluator (delta-reduction)
@@ -607,7 +607,7 @@ normalizeEntity
   -- ^ TyCon cache
   -> IntMap TyConName
   -- ^ Tuple TyCon cache
-  -> (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+  -> (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
   -> PrimEvaluator
   -- ^ Hardcoded evaluator (delta-reduction)

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -257,7 +257,7 @@ genComponentT compName componentExpr = do
 mkNetDecl :: (Id, Term) -> NetlistMonad (Maybe Declaration)
 mkNetDecl (id_,tm) = do
   let typ             = varType id_
-  hwTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) typ
+  hwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) typ
   wr   <- termToWireOrReg tm
   if isVoid hwTy
      then return Nothing
@@ -297,7 +297,7 @@ mkDeclarations
   -- ^ RHS of the let-binder
   -> NetlistMonad [Declaration]
 mkDeclarations bndr e = do
-  hty <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) (varType bndr)
+  hty <- unsafeCoreTypeToHWTypeM' $(curLoc) (varType bndr)
   if isVoid hty && not (isBiSignalOut hty)
      then return []
      else mkDeclarations' bndr e
@@ -341,7 +341,7 @@ mkDeclarations' bndr app =
     -- _ | isBiSignalOut (id2type bndr) && (not $ isWriteToBiSignalPrimitive app) ->
     --     return []
     _ -> do
-      hwTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) (id2type bndr)
+      hwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) (id2type bndr)
       if isBiSignalOut hwTy && not (isWriteToBiSignalPrimitive app)
          then return []
          else do
@@ -366,8 +366,8 @@ mkSelection bndr scrut altTy alts = do
   let scrutTy            = termType tcm scrut
       alts'              = (reorderDefault . reorderCustom tcm reprs scrutTy)
                            alts
-  scrutHTy               <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
-  altHTy                 <- stripFiltered <$>  unsafeCoreTypeToHWTypeM $(curLoc) altTy
+  scrutHTy               <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
+  altHTy                 <- unsafeCoreTypeToHWTypeM' $(curLoc) altTy
   scrutId                <- extendIdentifier Extended
                                (id2identifier bndr)
                                "_selection"
@@ -463,7 +463,7 @@ mkFunApp dst fun args = do
       , length fArgTys == length args
       -> do
         let dstId = id2identifier dst
-        argHWTys <- mapM (fmap stripFiltered . unsafeCoreTypeToHWTypeM $(curLoc)) fArgTys
+        argHWTys <- mapM (unsafeCoreTypeToHWTypeM' $(curLoc)) fArgTys
         -- Filter out the arguments of hwtype `Void` and only translate them
         -- to the intermediate HDL afterwards
         let argsBundled   = zip argHWTys (zip args fArgTys)
@@ -473,7 +473,7 @@ mkFunApp dst fun args = do
         (argExprs,argDecls) <- second concat . unzip <$>
                                  mapM (\(e,t) -> mkExpr False (Left dstId) t e)
                                  argsFiltered'
-        dstHWty  <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) fResTy
+        dstHWty  <- unsafeCoreTypeToHWTypeM' $(curLoc) fResTy
         env  <- Lens.use hdlDir
         mkId <- Lens.use mkIdentifierFn
         prefixM <- Lens.use componentPrefix
@@ -493,7 +493,7 @@ mkFunApp dst fun args = do
         Just _ -> do
           (_,_,Component compName compInps co _) <- preserveVarEnv $ genComponent fun
           let argTys = map (termType tcm) args
-          argHWTys <- mapM ((fmap stripFiltered <$>) . coreTypeToHWTypeM) argTys
+          argHWTys <- mapM coreTypeToHWTypeM' argTys
           -- Filter out the arguments of hwtype `Void` and only translate
           -- them to the intermediate HDL afterwards
           let argsBundled   = zip argHWTys (zip args argTys)
@@ -529,7 +529,7 @@ toSimpleVar dst (e,ty) = do
              (id2identifier dst)
              "_fun_arg"
   argNm' <- mkUniqueIdentifier Extended argNm
-  hTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) ty
+  hTy <- unsafeCoreTypeToHWTypeM' $(curLoc) ty
   let argDecl         = NetDecl Nothing argNm' hTy
       argAssn         = Assignment argNm' e
   return (Identifier argNm' Nothing,[argDecl,argAssn])
@@ -562,7 +562,7 @@ mkExpr _ _ _ (Core.Literal l) = do
 mkExpr bbEasD bndr ty app = do
   let (appF,args) = collectArgs app
       tmArgs      = lefts args
-  hwTy    <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) ty
+  hwTy    <- unsafeCoreTypeToHWTypeM' $(curLoc) ty
   (_,sp) <- Lens.use curCompNm
   case appF of
     Data dc -> mkDcApplication hwTy bndr dc tmArgs
@@ -599,8 +599,8 @@ mkProjection mkDec bndr scrut altTy alt@(pat,v) = do
     _ -> throw (ClashException sp ($(curLoc) ++
                 "Not in normal form: RHS of case-projection is not a variable:\n\n"
                  ++ showPpr e) Nothing)
-  sHwTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
-  vHwTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) altTy
+  sHwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
+  vHwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) altTy
   (selId,modM,decls) <- do
     scrutNm <- either return
                  (\b -> extendIdentifier Extended
@@ -624,7 +624,7 @@ mkProjection mkDec bndr scrut altTy alt@(pat,v) = do
               tms'       = if any (`elem` tmsFVs) exts
                               then throw (ClashException sp ($(curLoc) ++ "Not in normal form: Pattern binds existential variables:\n\n" ++ showPpr e) Nothing)
                               else tms
-          argHWTys <- mapM ((fmap stripFiltered <$>) . coreTypeToHWTypeM) tmsTys
+          argHWTys <- mapM coreTypeToHWTypeM' tmsTys
           let tmsBundled   = zip argHWTys tms'
               tmsFiltered  = filter (maybe False (not . isVoid) . fst) tmsBundled
               tmsFiltered' = map snd tmsFiltered
@@ -667,7 +667,7 @@ mkDcApplication dstHType bndr dc args = do
   tcm                 <- Lens.use tcCache
   let argTys          = map (termType tcm) args
   argNm <- either return (\b -> extendIdentifier Extended (nameOcc (varName b)) "_dc_arg") bndr
-  argHWTys            <- mapM ((fmap stripFiltered <$>) . coreTypeToHWTypeM) argTys
+  argHWTys            <- mapM coreTypeToHWTypeM' argTys
   -- Filter out the arguments of hwtype `Void` and only translate
   -- them to the intermediate HDL afterwards
   let argsBundled   = zip argHWTys (zip args argTys)

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -89,7 +89,7 @@ genNetlist
   -- ^ Primitive definitions
   -> TyConMap
   -- ^ TyCon cache
-  -> (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+  -> (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
   -- ^ Hardcoded Type -> HWType translator
   -> Int
   -- ^ Int/Word/Integer bit-width
@@ -137,7 +137,7 @@ runNetlistMonad
   -- ^ Primitive Definitions
   -> TyConMap
   -- ^ TyCon cache
-  -> (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+  -> (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
   -- ^ Hardcode Type -> HWType translator
   -> Int
   -- ^ Int/Word/Integer bit-width
@@ -257,7 +257,7 @@ genComponentT compName componentExpr = do
 mkNetDecl :: (Id, Term) -> NetlistMonad (Maybe Declaration)
 mkNetDecl (id_,tm) = do
   let typ             = varType id_
-  hwTy <- unsafeCoreTypeToHWTypeM $(curLoc) typ
+  hwTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) typ
   wr   <- termToWireOrReg tm
   if isVoid hwTy
      then return Nothing
@@ -297,7 +297,7 @@ mkDeclarations
   -- ^ RHS of the let-binder
   -> NetlistMonad [Declaration]
 mkDeclarations bndr e = do
-  hty <- unsafeCoreTypeToHWTypeM $(curLoc) (varType bndr)
+  hty <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) (varType bndr)
   if isVoid hty && not (isBiSignalOut hty)
      then return []
      else mkDeclarations' bndr e
@@ -341,7 +341,7 @@ mkDeclarations' bndr app =
     -- _ | isBiSignalOut (id2type bndr) && (not $ isWriteToBiSignalPrimitive app) ->
     --     return []
     _ -> do
-      hwTy <- unsafeCoreTypeToHWTypeM $(curLoc) (id2type bndr)
+      hwTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) (id2type bndr)
       if isBiSignalOut hwTy && not (isWriteToBiSignalPrimitive app)
          then return []
          else do
@@ -366,8 +366,8 @@ mkSelection bndr scrut altTy alts = do
   let scrutTy            = termType tcm scrut
       alts'              = (reorderDefault . reorderCustom tcm reprs scrutTy)
                            alts
-  scrutHTy               <- unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
-  altHTy                 <- unsafeCoreTypeToHWTypeM $(curLoc) altTy
+  scrutHTy               <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
+  altHTy                 <- stripFiltered <$>  unsafeCoreTypeToHWTypeM $(curLoc) altTy
   scrutId                <- extendIdentifier Extended
                                (id2identifier bndr)
                                "_selection"
@@ -463,7 +463,7 @@ mkFunApp dst fun args = do
       , length fArgTys == length args
       -> do
         let dstId = id2identifier dst
-        argHWTys <- mapM (unsafeCoreTypeToHWTypeM $(curLoc)) fArgTys
+        argHWTys <- mapM (fmap stripFiltered . unsafeCoreTypeToHWTypeM $(curLoc)) fArgTys
         -- Filter out the arguments of hwtype `Void` and only translate them
         -- to the intermediate HDL afterwards
         let argsBundled   = zip argHWTys (zip args fArgTys)
@@ -473,7 +473,7 @@ mkFunApp dst fun args = do
         (argExprs,argDecls) <- second concat . unzip <$>
                                  mapM (\(e,t) -> mkExpr False (Left dstId) t e)
                                  argsFiltered'
-        dstHWty  <- unsafeCoreTypeToHWTypeM $(curLoc) fResTy
+        dstHWty  <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) fResTy
         env  <- Lens.use hdlDir
         mkId <- Lens.use mkIdentifierFn
         prefixM <- Lens.use componentPrefix
@@ -493,7 +493,7 @@ mkFunApp dst fun args = do
         Just _ -> do
           (_,_,Component compName compInps co _) <- preserveVarEnv $ genComponent fun
           let argTys = map (termType tcm) args
-          argHWTys <- mapM coreTypeToHWTypeM argTys
+          argHWTys <- mapM ((fmap stripFiltered <$>) . coreTypeToHWTypeM) argTys
           -- Filter out the arguments of hwtype `Void` and only translate
           -- them to the intermediate HDL afterwards
           let argsBundled   = zip argHWTys (zip args argTys)
@@ -529,7 +529,7 @@ toSimpleVar dst (e,ty) = do
              (id2identifier dst)
              "_fun_arg"
   argNm' <- mkUniqueIdentifier Extended argNm
-  hTy <- unsafeCoreTypeToHWTypeM $(curLoc) ty
+  hTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) ty
   let argDecl         = NetDecl Nothing argNm' hTy
       argAssn         = Assignment argNm' e
   return (Identifier argNm' Nothing,[argDecl,argAssn])
@@ -562,7 +562,7 @@ mkExpr _ _ _ (Core.Literal l) = do
 mkExpr bbEasD bndr ty app = do
   let (appF,args) = collectArgs app
       tmArgs      = lefts args
-  hwTy    <- unsafeCoreTypeToHWTypeM $(curLoc) ty
+  hwTy    <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) ty
   (_,sp) <- Lens.use curCompNm
   case appF of
     Data dc -> mkDcApplication hwTy bndr dc tmArgs
@@ -599,8 +599,8 @@ mkProjection mkDec bndr scrut altTy alt@(pat,v) = do
     _ -> throw (ClashException sp ($(curLoc) ++
                 "Not in normal form: RHS of case-projection is not a variable:\n\n"
                  ++ showPpr e) Nothing)
-  sHwTy <- unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
-  vHwTy <- unsafeCoreTypeToHWTypeM $(curLoc) altTy
+  sHwTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
+  vHwTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) altTy
   (selId,modM,decls) <- do
     scrutNm <- either return
                  (\b -> extendIdentifier Extended
@@ -624,7 +624,7 @@ mkProjection mkDec bndr scrut altTy alt@(pat,v) = do
               tms'       = if any (`elem` tmsFVs) exts
                               then throw (ClashException sp ($(curLoc) ++ "Not in normal form: Pattern binds existential variables:\n\n" ++ showPpr e) Nothing)
                               else tms
-          argHWTys <- mapM coreTypeToHWTypeM tmsTys
+          argHWTys <- mapM ((fmap stripFiltered <$>) . coreTypeToHWTypeM) tmsTys
           let tmsBundled   = zip argHWTys tms'
               tmsFiltered  = filter (maybe False (not . isVoid) . fst) tmsBundled
               tmsFiltered' = map snd tmsFiltered
@@ -667,7 +667,7 @@ mkDcApplication dstHType bndr dc args = do
   tcm                 <- Lens.use tcCache
   let argTys          = map (termType tcm) args
   argNm <- either return (\b -> extendIdentifier Extended (nameOcc (varName b)) "_dc_arg") bndr
-  argHWTys            <- mapM coreTypeToHWTypeM argTys
+  argHWTys            <- mapM ((fmap stripFiltered <$>) . coreTypeToHWTypeM) argTys
   -- Filter out the arguments of hwtype `Void` and only translate
   -- them to the intermediate HDL afterwards
   let argsBundled   = zip argHWTys (zip args argTys)

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -111,7 +111,7 @@ mkBlackBoxContext resId args = do
 
     -- Make context result
     let res = Identifier resNm Nothing
-    resTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) (V.varType resId)
+    resTy <- unsafeCoreTypeToHWTypeM' $(curLoc) (V.varType resId)
 
     lvl <- Lens.use curBBlvl
     (nm,_) <- Lens.use curCompNm
@@ -290,7 +290,7 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
                     Nothing -> return (Identifier "__VOID__" Nothing,[])
         Just (P.Primitive pNm _)
           | pNm == "GHC.Prim.tagToEnum#" -> do
-              hwTy <- stripFiltered <$> N.unsafeCoreTypeToHWTypeM $(curLoc) ty
+              hwTy <- N.unsafeCoreTypeToHWTypeM' $(curLoc) ty
               case args of
                 [Right (ConstTy (TyCon tcN)), Left (C.Literal (IntLiteral i))] -> do
                   tcm <- Lens.use tcCache
@@ -305,7 +305,7 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
                   case scrutExpr of
                     Identifier id_ Nothing -> return (DataTag hwTy (Left id_),scrutDecls)
                     _ -> do
-                      scrutHTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
+                      scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
                       tmpRhs <- mkUniqueIdentifier Extended "#tte_rhs"
                       let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                           netAssignRhs = Assignment tmpRhs scrutExpr
@@ -318,7 +318,7 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
               [Right _,Left scrut] -> do
                 tcm      <- Lens.use tcCache
                 let scrutTy = termType tcm scrut
-                scrutHTy <- stripFiltered <$> unsafeCoreTypeToHWTypeM $(curLoc) scrutTy
+                scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
                 (scrutExpr,scrutDecls) <- mkExpr False (Left "#dtt_rhs") scrutTy scrut
                 case scrutExpr of
                   Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
@@ -354,7 +354,7 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
           nm'' <- mkUniqueIdentifier Extended nm'
           -- TODO: check that it's okay to use `mkUnsafeInternalName`
           let nm3 = mkUnsafeSystemName nm'' 0
-          hwTy <- stripFiltered <$> N.unsafeCoreTypeToHWTypeM $(curLoc) ty
+          hwTy <- N.unsafeCoreTypeToHWTypeM' $(curLoc) ty
           let id_    = mkId ty nm3
               idDecl = NetDecl' Nothing wr nm'' (Right hwTy)
           case hwTy of

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -77,7 +77,7 @@ data NetlistState
   -- ^ Cached components
   , _primitives     :: CompiledPrimMap
   -- ^ Primitive Definitions
-  , _typeTranslator :: CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType)
+  , _typeTranslator :: CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType)
   -- ^ Hardcoded Type -> HWType translator
   , _tcCache        :: TyConMap
   -- ^ TyCon cache
@@ -126,6 +126,15 @@ instance NFData Component where
 
 -- | Size indication of a type (e.g. bit-size or number of elements)
 type Size = Int
+
+type IsVoid = Bool
+
+-- | Tree structure indicating which constructor fields were filtered from
+-- a type due to them being void. We need this information to generate stable
+-- and/or user-defined port mappings.
+data FilteredHWType =
+  FilteredHWType HWType [[(IsVoid, FilteredHWType)]]
+    deriving (Eq, Show)
 
 -- | Representable hardware types
 data HWType

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -68,9 +68,22 @@ import           Clash.Signal.Internal   (ClockKind (..))
 import           Clash.Unique
 import           Clash.Util
 
+-- | Throw away information indicating which constructor fields were filtered
+-- due to being void.
+stripFiltered :: FilteredHWType -> HWType
+stripFiltered (FilteredHWType hwty _filtered) = hwty
+
+flattenFiltered :: FilteredHWType -> [[Bool]]
+flattenFiltered (FilteredHWType _hwty filtered) = map (map fst) filtered
+
+-- | Determines if type is a zero-width construct ("void")
 isVoid :: HWType -> Bool
 isVoid Void {} = True
 isVoid _       = False
+
+-- | Same as @isVoid@, but on @FilteredHWType@ instead of @HWType@
+isFilteredVoid :: FilteredHWType -> Bool
+isFilteredVoid = isVoid . stripFiltered
 
 isBiSignalOut :: HWType -> Bool
 isBiSignalOut (Void (Just (BiDirectional Out _))) = True
@@ -112,22 +125,22 @@ splitNormalized tcm expr = case collectBndrs expr of
 -- builtin types. Errors if the Core type is not translatable.
 unsafeCoreTypeToHWType
   :: SrcSpan
+  -- ^ Approximate location in original source file
   -> String
-  -> (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+  -> (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
   -> CustomReprs
   -> TyConMap
-  -> Bool
   -> Type
-  -> HWType
-unsafeCoreTypeToHWType sp loc builtInTranslation reprs m keepVoid =
-  either (\msg -> throw (ClashException sp (loc ++ msg) Nothing)) id .
-  coreTypeToHWType builtInTranslation reprs m keepVoid
+  -> FilteredHWType
+unsafeCoreTypeToHWType sp loc builtInTranslation reprs m ty =
+  either (\msg -> throw (ClashException sp (loc ++ msg) Nothing)) id $
+  coreTypeToHWType builtInTranslation reprs m ty
 
 -- | Converts a Core type to a HWType within the NetlistMonad; errors on failure
 unsafeCoreTypeToHWTypeM
   :: String
   -> Type
-  -> NetlistMonad HWType
+  -> NetlistMonad FilteredHWType
 unsafeCoreTypeToHWTypeM loc ty =
   unsafeCoreTypeToHWType
     <$> (snd <$> Lens.use curCompNm)
@@ -135,18 +148,18 @@ unsafeCoreTypeToHWTypeM loc ty =
     <*> Lens.use typeTranslator
     <*> Lens.use customReprs
     <*> Lens.use tcCache
-    <*> pure False
     <*> pure ty
 
 -- | Converts a Core type to a HWType within the NetlistMonad; 'Nothing' on failure
 coreTypeToHWTypeM
   :: Type
-  -> NetlistMonad (Maybe HWType)
-coreTypeToHWTypeM ty = hush <$> (coreTypeToHWType <$> Lens.use typeTranslator
-                                                  <*> Lens.use customReprs
-                                                  <*> Lens.use tcCache
-                                                  <*> pure False
-                                                  <*> pure ty)
+  -- ^ Type to convert to HWType
+  -> NetlistMonad (Maybe FilteredHWType)
+coreTypeToHWTypeM ty =
+  hush <$> (coreTypeToHWType <$> Lens.use typeTranslator
+                             <*> Lens.use customReprs
+                             <*> Lens.use tcCache
+                             <*> pure ty)
 
 -- | Returns the name and period of the clock corresponding to a type
 synchronizedClk
@@ -261,88 +274,136 @@ fixCustomRepr _ _ typ = typ
 -- builtin types. Returns a string containing the error message when the Core
 -- type is not translatable.
 coreTypeToHWType
-  :: (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+  :: (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
   -> CustomReprs
   -> TyConMap
-  -> Bool
   -> Type
-  -> Either String HWType
-coreTypeToHWType builtInTranslation reprs m keepVoid ty = go' ty
+  -- ^ Type to convert to HWType
+  -> Either String FilteredHWType
+coreTypeToHWType builtInTranslation reprs m ty = go' ty
   where
     -- Try builtin translation; for now this is hardcoded to be the one in ghcTypeToHWType
-    go' :: Type -> Either String HWType
-    go' (builtInTranslation reprs m keepVoid -> Just hty) =
-      fixCustomRepr reprs ty <$> hty
+    go' :: Type -> Either String FilteredHWType
+    go' (builtInTranslation reprs m -> Just hwtyE) =
+      (\(FilteredHWType hwty filtered) ->
+        (FilteredHWType (fixCustomRepr reprs ty hwty) filtered)) <$> hwtyE
     -- Strip transparant types:
     go' (coreView m -> Just ty') =
-      coreTypeToHWType builtInTranslation reprs m keepVoid ty'
+      coreTypeToHWType builtInTranslation reprs m ty'
     -- Try to create hwtype based on AST:
     go' (tyView -> TyConApp tc args) = do
-      hwty <- mkADT builtInTranslation reprs m (showPpr ty) keepVoid tc args
-      return $ fixCustomRepr reprs ty hwty
+      FilteredHWType hwty filtered <- mkADT builtInTranslation reprs m (showPpr ty) tc args
+      return (FilteredHWType (fixCustomRepr reprs ty hwty) filtered)
     -- All methods failed:
     go' _ = Left $ "Can't translate non-tycon type: " ++ showPpr ty
 
+-- | Generates original indices in list before filtering, given a list of
+-- removed indices.
+--
+-- >>> originalIndices [False, False, True, False]
+-- [0,1,3]
+originalIndices
+  :: [Bool]
+  -- ^ Were voids. Length must be less than or equal to n.
+  -> [Int]
+  -- ^ Original indices
+originalIndices wereVoids =
+  [i | (i, void) <- zip [0..] wereVoids, not void]
 
 -- | Converts an algebraic Core type (split into a TyCon and its argument) to a HWType.
 mkADT
-  :: (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+  :: (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
   -- ^ Hardcoded Type -> HWType translator
   -> CustomReprs
   -> TyConMap
   -- ^ TyCon cache
   -> String
   -- ^ String representation of the Core type for error messages
-  -> Bool
-  -- ^ Keep Void
   -> TyConName
   -- ^ The TyCon
   -> [Type]
   -- ^ Its applied arguments
-  -> Either String HWType
-mkADT _ _ m tyString _ tc _
+  -> Either String FilteredHWType
+  -- ^ An error string or a tuple with the type and possibly a list of
+  -- removed arguments.
+mkADT _ _ m tyString tc _
   | isRecursiveTy m tc
   = Left $ $(curLoc) ++ "Can't translate recursive type: " ++ tyString
 
-mkADT builtInTranslation reprs m _tyString keepVoid tc args = case tyConDataCons (m `lookupUniqMap'` tc) of
-  []  -> return (Void Nothing)
+mkADT builtInTranslation reprs m _tyString tc args = case tyConDataCons (m `lookupUniqMap'` tc) of
+  []  -> return (FilteredHWType (Void Nothing) [])
   dcs -> do
-    let tcName       = nameOcc tc
-        substArgTyss = map substArgTys dcs
-    argHTyss         <- mapM (mapM (coreTypeToHWType builtInTranslation reprs m keepVoid)) substArgTyss
-    let areNotVoids0 = map (\tys -> zip (map (not . isVoid) tys) tys) argHTyss
-    let argHTyss1    = if keepVoid
-                          then argHTyss
-                          else map (map snd) (map (filter fst) areNotVoids0)
-    case (dcs,argHTyss1) of
-      (_:[],[[elemTy]]) ->
-        return elemTy
+    let tcName           = nameOcc tc
+        substArgTyss     = map substArgTys dcs
+    argHTyss0           <- mapM (mapM (coreTypeToHWType builtInTranslation reprs m)) substArgTyss
+    let argHTyss1        = map (\tys -> zip (map isFilteredVoid tys) tys) argHTyss0
+    let areVoids         = map (map fst) argHTyss1
+    let filteredArgHTyss = map (map snd . filter (not . fst)) argHTyss1
 
+    -- Every alternative is annotated with some examples. Be sure to read them.
+    case (dcs, filteredArgHTyss) of
+      -- Type has one constructor and that constructor has a single field,
+      -- modulo empty fields if keepVoid is False. Examples of such fields
+      -- are:
+      --
+      -- >>> data ABC = ABC Int
+      -- >>> data DEF = DEF Int ()
+      --
+      -- Notice that @DEF@'s constructor has an "empty" second argument. The
+      -- second field of FilteredHWType would then look like:
+      --
+      -- >>> [[False, True]]
+      (_:[],[[elemTy]]) ->
+        return (FilteredHWType (stripFiltered elemTy) argHTyss1)
+
+      -- Type has one constructor, but multiple fields modulo empty fields
+      -- (see previous case for more thorough explanation). Examples:
+      --
+      -- >>> data GHI = GHI Int Int
+      -- >>> data JKL = JKL Int () Int
+      --
+      -- In the second case the second field of FilteredHWType would be
+      -- [[False, True, False]]
       ([dcFieldLabels -> labels0],[elemTys@(_:_)]) -> do
         labelsM <-
           if null labels0 then
             return Nothing
-          else if not keepVoid then
-            -- Filter out labels belonging to arguments filtered due to keepVoid
-            -- being true. See argHTyss1.
-            let areNotVoids1 = map fst (head areNotVoids0) in
-            let labels1      = filter fst (zip areNotVoids1 labels0) in
-            let labels2      = map snd labels1 in
-            return (Just labels2)
           else
-            return (Just labels0)
-        return (Product tcName labelsM elemTys)
+            -- Filter out labels belonging to arguments filtered due to being
+            -- void. See argHTyss1.
+            let areNotVoids = map not (head areVoids) in
+            let labels1     = filter fst (zip areNotVoids labels0) in
+            let labels2     = map snd labels1 in
+            return (Just labels2)
+        let hwty = Product tcName labelsM (map stripFiltered elemTys)
+        return (FilteredHWType hwty argHTyss1)
 
-      (_   ,concat -> [])
-        | length dcs < 2 ->
-          return (Void Nothing)
+      -- Either none of the constructors have fields, or they have been filtered
+      -- due to them being empty. Examples:
+      --
+      -- >>> data MNO = M    | N | O
+      -- >>> data PQR = P () | Q | R ()
+      -- >>> data STU = STU
+      -- >>> data VWX
+      (_, concat -> [])
+        -- If none of the dataconstructors have fields, and there are 1 or less
+        -- of them, this type only has one inhabitant. It can therefore be
+        -- represented by zero bits, and is therefore empty:
+        | length dcs <= 1 ->
+          return (FilteredHWType (Void Nothing) argHTyss1)
+        -- None of the dataconstructors have fields. This type is therefore a
+        -- simple Sum type.
         | otherwise ->
-          return $ Sum tcName $ map (nameOcc . dcName) dcs
+          return (FilteredHWType (Sum tcName $ map (nameOcc . dcName) dcs) argHTyss1)
 
-      (_   ,elemHTys) ->
-        return $ SP tcName $ zipWith
+      -- A sum of product, due to multiple constructors, where at least one
+      -- of the constructor has one or more fields modulo empty fields. Example:
+      --
+      -- >>> data YZA = Y Int | Z () | A
+      (_,elemHTys) ->
+        return $ FilteredHWType (SP tcName $ zipWith
           (\dc tys ->  ( nameOcc (dcName dc), tys))
-          dcs elemHTys
+          dcs (map stripFiltered <$> elemHTys)) argHTyss1
  where
   argsFVs = List.foldl' unionVarSet emptyVarSet
                 (map (Lens.foldMapOf typeFreeVars unitVarSet) args)
@@ -366,7 +427,7 @@ isRecursiveTy m tc = case tyConDataCons (m `lookupUniqMap'` tc) of
 -- | Determines if a Core type is translatable to a HWType given a function that
 -- translates certain builtin types.
 representableType
-  :: (CustomReprs -> TyConMap -> Bool -> Type -> Maybe (Either String HWType))
+  :: (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHWType))
   -> CustomReprs
   -> Bool
   -- ^ String considered representable
@@ -374,7 +435,7 @@ representableType
   -> Type
   -> Bool
 representableType builtInTranslation reprs stringRepresentable m =
-    either (const False) isRepresentable . coreTypeToHWType builtInTranslation reprs m False
+    either (const False) isRepresentable . fmap stripFiltered . coreTypeToHWType builtInTranslation reprs m
   where
     isRepresentable hty = case hty of
       String            -> stringRepresentable
@@ -434,12 +495,14 @@ termHWType :: String
 termHWType loc e = do
   m <- Lens.use tcCache
   let ty = termType m e
-  unsafeCoreTypeToHWTypeM loc ty
+  stripFiltered <$> unsafeCoreTypeToHWTypeM loc ty
 
 -- | Gives the HWType corresponding to a term. Returns 'Nothing' if the term has
 -- a Core type that is not translatable to a HWType.
-termHWTypeM :: Term
-            -> NetlistMonad (Maybe HWType)
+termHWTypeM
+  :: Term
+  -- ^ Term to convert to HWType
+  -> NetlistMonad (Maybe FilteredHWType)
 termHWTypeM e = do
   m  <- Lens.use tcCache
   let ty = termType m e
@@ -485,10 +548,28 @@ collectPortNames TestBench {} = []
 collectPortNames Synthesize { t_inputs, t_output } =
   concatMap (collectPortNames' []) t_inputs ++ (collectPortNames' []) t_output
 
+-- | Remove ports having a void-type from user supplied PortName annotation
+filterVoidPorts
+  :: FilteredHWType
+  -> PortName
+  -> PortName
+filterVoidPorts _hwty (PortName s) =
+  PortName s
+filterVoidPorts (FilteredHWType _hwty [filtered]) (PortProduct s ps) =
+  PortProduct s [filterVoidPorts f p | (p, (void, f)) <- zip ps filtered, not void]
+filterVoidPorts _filtered (PortProduct _s _ps) =
+  -- TODO: Prettify errors
+  error $ $(curLoc) ++ "Ports were annotated as product, but type wasn't one."
+
 -- | Uniquely rename all the variables and their references in a normalized
 -- term
 mkUniqueNormalized
   :: Maybe (Maybe TopEntity)
+  -- ^ Top entity annotation where:
+  --
+  --     * Nothing: term is not a top entity
+  --     * Just Nothing: term is a top entity, but has no explicit annotation
+  --     * Just (Just ..): term is a top entity, and has an explicit annotation
   -> ( [Id]
      , [LetBinding]
      , Id
@@ -554,6 +635,11 @@ mkUniqueNormalized topMM (args,binds,res) = do
 mkUniqueArguments
   :: Subst
   -> Maybe (Maybe TopEntity)
+  -- ^ Top entity annotation where:
+  --
+  --     * Nothing: term is not a top entity
+  --     * Just Nothing: term is a top entity, but has no explicit annotation
+  --     * Just (Just ..): term is a top entity, and has an explicit annotation
   -> [Id]
   -> NetlistMonad
        ([(Identifier,HWType)]
@@ -578,11 +664,12 @@ mkUniqueArguments subst0 (Just teM) args = do
       typeTrans <- Lens.use typeTranslator
       reprs     <- Lens.use customReprs
       (_,sp)    <- Lens.use curCompNm
-      let i    = varName var
-          i'   = nameOcc i
-          ty   = varType var
-          hwty = unsafeCoreTypeToHWType sp $(curLoc) typeTrans reprs tcm True ty
-      (ports,decls,_,pN) <- mkInput pM (i',hwty)
+      let i     = varName var
+          i'    = nameOcc i
+          ty    = varType var
+          fHwty = unsafeCoreTypeToHWType sp $(curLoc) typeTrans reprs tcm ty
+          FilteredHWType hwty _ = fHwty
+      (ports,decls,_,pN) <- mkInput (filterVoidPorts fHwty <$> pM) (i',hwty)
       let pId  = mkId ty (repName pN i)
       if isVoid hwty
          then return Nothing
@@ -592,6 +679,11 @@ mkUniqueArguments subst0 (Just teM) args = do
 mkUniqueResult
   :: Subst
   -> Maybe (Maybe TopEntity)
+  -- ^ Top entity annotation where:
+  --
+  --     * Nothing: term is not a top entity
+  --     * Just Nothing: term is a top entity, but has no explicit annotation
+  --     * Just (Just ..): term is a top entity, and has an explicit annotation
   -> Id
   -> NetlistMonad (Maybe ([(Identifier,HWType)],[Declaration],Id,Subst))
 mkUniqueResult subst0 Nothing res = do
@@ -606,14 +698,15 @@ mkUniqueResult subst0 (Just teM) res = do
   typeTrans <- Lens.use typeTranslator
   reprs     <- Lens.use customReprs
   (_,sp)    <- Lens.use curCompNm
-  let o    = varName res
-      o'   = nameOcc o
-      ty   = varType res
-      hwty = unsafeCoreTypeToHWType sp $(curLoc) typeTrans reprs tcm True ty
+  let o     = varName res
+      o'    = nameOcc o
+      ty    = varType res
+      fHwty = unsafeCoreTypeToHWType sp $(curLoc) typeTrans reprs tcm ty
+      FilteredHWType hwty _ = fHwty
       oPortSupply = fmap t_output teM
   when (containsBiSignalIn hwty)
     (throw (ClashException sp ($(curLoc) ++ "BiSignalIn cannot be part of a function's result. Use 'readFromBiSignal'.") Nothing))
-  output <- mkOutput oPortSupply (o',hwty)
+  output <- mkOutput (filterVoidPorts fHwty <$> oPortSupply) (o',hwty)
   case output of
     Just (ports, decls, pN) -> do
       let pO = repName pN o
@@ -656,13 +749,10 @@ idToPort var = do
   reprs <- Lens.use customReprs
   let i  = varName var
       ty = varType var
-      hwTy = unsafeCoreTypeToHWType sp $(curLoc) typeTrans reprs tcm False ty
+      hwTy = stripFiltered $ unsafeCoreTypeToHWType sp $(curLoc) typeTrans reprs tcm ty
   if isVoid hwTy
     then return Nothing
-    else return . Just $
-      ( nameOcc i
-      , unsafeCoreTypeToHWType sp $(curLoc) typeTrans reprs tcm False ty
-      )
+    else return (Just (nameOcc i, hwTy))
 
 id2type :: Id -> Type
 id2type = varType
@@ -792,9 +882,8 @@ mkInput pM = case pM of
         Vector sz hwty'' -> do
           arguments <- mapM (appendIdentifier (i',hwty'')) [0..sz-1]
           (ports,_,exprs,_) <- unzip4 <$> mapM (mkInput Nothing) arguments
-          let hwty2    = filterVoid hwty''
-              netdecl  = NetDecl Nothing i' (Vector sz hwty2)
-              vecExpr  = mkVectorChain sz hwty2 exprs
+          let netdecl  = NetDecl Nothing i' (Vector sz hwty'')
+              vecExpr  = mkVectorChain sz hwty'' exprs
               netassgn = Assignment i' vecExpr
           if null attrs then
             return (concat ports,[netdecl,netassgn],vecExpr,i')
@@ -804,9 +893,8 @@ mkInput pM = case pM of
         RTree d hwty'' -> do
           arguments <- mapM (appendIdentifier (i',hwty'')) [0..2^d-1]
           (ports,_,exprs,_) <- unzip4 <$> mapM (mkInput Nothing) arguments
-          let hwty2    = filterVoid hwty''
-              netdecl  = NetDecl Nothing i' (RTree d hwty2)
-              trExpr   = mkRTreeChain d hwty2 exprs
+          let netdecl  = NetDecl Nothing i' (RTree d hwty'')
+              trExpr   = mkRTreeChain d hwty'' exprs
               netassgn = Assignment i' trExpr
           if null attrs then
             return (concat ports,[netdecl,netassgn],trExpr,i')
@@ -815,21 +903,16 @@ mkInput pM = case pM of
 
         Product _ _ hwtys -> do
           arguments <- zipWithM appendIdentifier (map (i',) hwtys) [0..]
-          let argumentsBundled   = zip hwtys arguments
-              argumentsFiltered  = filter (not . isVoid . fst) argumentsBundled
-              argumentsFiltered' = map snd argumentsFiltered
-          (ports,_,exprs,_) <- unzip4 <$> mapM (mkInput Nothing) argumentsFiltered'
+          (ports,_,exprs,_) <- unzip4 <$> mapM (mkInput Nothing) arguments
           case exprs of
             [expr] ->
-              let hwty''   = filterVoid hwty
-                  netdecl  = NetDecl Nothing i' hwty''
+              let netdecl  = NetDecl Nothing i' hwty
                   dcExpr   = expr
                   netassgn = Assignment i' expr
               in  return (concat ports,[netdecl,netassgn],dcExpr,i')
             _ ->
-              let hwty''   = filterVoid hwty
-                  netdecl  = NetDecl Nothing i' hwty''
-                  dcExpr   = DataCon hwty'' (DC (hwty'',0)) exprs
+              let netdecl  = NetDecl Nothing i' hwty
+                  dcExpr   = DataCon hwty (DC (hwty,0)) exprs
                   netassgn = Assignment i' dcExpr
               in  if null attrs then
                     return (concat ports,[netdecl,netassgn],dcExpr,i')
@@ -859,9 +942,8 @@ mkInput pM = case pM of
         Vector sz hwty'' -> do
           arguments <- mapM (appendIdentifier (pN,hwty'')) [0..sz-1]
           (ports,_,exprs,_) <- unzip4 <$> zipWithM mkInput (extendPorts $ map (prefixParent p) ps) arguments
-          let hwty2    = filterVoid hwty''
-              netdecl  = NetDecl Nothing pN (Vector sz hwty2)
-              vecExpr  = mkVectorChain sz hwty2 exprs
+          let netdecl  = NetDecl Nothing pN (Vector sz hwty'')
+              vecExpr  = mkVectorChain sz hwty'' exprs
               netassgn = Assignment pN vecExpr
           if null attrs then
             return (concat ports,[netdecl,netassgn],vecExpr,pN)
@@ -871,9 +953,8 @@ mkInput pM = case pM of
         RTree d hwty'' -> do
           arguments <- mapM (appendIdentifier (pN,hwty'')) [0..2^d-1]
           (ports,_,exprs,_) <- unzip4 <$> zipWithM mkInput (extendPorts $ map (prefixParent p) ps) arguments
-          let hwty2    = filterVoid hwty''
-              netdecl  = NetDecl Nothing pN (RTree d hwty2)
-              trExpr   = mkRTreeChain d hwty2 exprs
+          let netdecl  = NetDecl Nothing pN (RTree d hwty'')
+              trExpr   = mkRTreeChain d hwty'' exprs
               netassgn = Assignment pN trExpr
           if null attrs then
             return (concat ports,[netdecl,netassgn],trExpr,pN)
@@ -882,20 +963,16 @@ mkInput pM = case pM of
 
         Product _ _ hwtys -> do
           arguments <- zipWithM appendIdentifier (map (pN,) hwtys) [0..]
-          let argumentsBundled   = zip hwtys (zip (extendPorts $ map (prefixParent p) ps) arguments)
-              argumentsFiltered  = filter (not . isVoid . fst) argumentsBundled
-              argumentsFiltered' = unzip (map snd argumentsFiltered)
-          (ports,_,exprs,_) <- unzip4 <$> uncurry (zipWithM mkInput) argumentsFiltered'
+          let ps'            = extendPorts $ map (prefixParent p) ps
+          (ports,_,exprs,_) <- unzip4 <$> uncurry (zipWithM mkInput) (ps', arguments)
           case exprs of
             [expr] ->
-                 let hwty''   = filterVoid hwty'
-                     netdecl  = NetDecl Nothing pN hwty''
+                 let netdecl  = NetDecl Nothing pN hwty'
                      dcExpr   = expr
                      netassgn = Assignment pN expr
                  in  return (concat ports,[netdecl,netassgn],dcExpr,pN)
-            _ -> let hwty''   = filterVoid hwty'
-                     netdecl  = NetDecl Nothing pN hwty''
-                     dcExpr   = DataCon hwty'' (DC (hwty'',0)) exprs
+            _ -> let netdecl  = NetDecl Nothing pN hwty'
+                     dcExpr   = DataCon hwty' (DC (hwty',0)) exprs
                      netassgn = Assignment pN dcExpr
                  in  if null attrs then
                        return (concat ports,[netdecl,netassgn],dcExpr,pN)
@@ -911,18 +988,6 @@ mkInput pM = case pM of
           return (concat ports,[netdecl,netassgn],dcExpr,pN)
 
         _ ->  return ([(pN,hwty)],[],Identifier pN Nothing,pN)
-
-filterVoid
-  :: HWType
-  -> HWType
-filterVoid t = case t of
-  Product nm labels hwtys
-    | null hwtys'        -> Void Nothing
-    | length hwtys' == 1 -> head hwtys'
-    | otherwise          -> Product nm labels hwtys'
-    where
-      hwtys' = filter (not . isVoid) (map filterVoid hwtys)
-  _ -> t
 
 -- | Create a Vector chain for a list of 'Identifier's
 mkVectorChain :: Int
@@ -1027,9 +1092,8 @@ mkOutput' pM = case pM of
             (throwAnnotatedSplitError $(curLoc) "Vector")
           results <- mapM (appendIdentifier (o',hwty'')) [0..sz-1]
           (ports,decls,ids) <- unzip3 <$> mapM (mkOutput' Nothing) results
-          let hwty2   = Vector sz (filterVoid hwty'')
-              netdecl = NetDecl Nothing o' hwty2
-              assigns = zipWith (assignId o' hwty2 10) ids [0..]
+          let netdecl = NetDecl Nothing o' hwty'
+              assigns = zipWith (assignId o' hwty' 10) ids [0..]
           return (concat ports,netdecl:assigns ++ concat decls,o')
 
         RTree d hwty'' -> do
@@ -1037,27 +1101,21 @@ mkOutput' pM = case pM of
             (throwAnnotatedSplitError $(curLoc) "RTree")
           results <- mapM (appendIdentifier (o',hwty'')) [0..2^d-1]
           (ports,decls,ids) <- unzip3 <$> mapM (mkOutput' Nothing) results
-          let hwty2   = RTree d (filterVoid hwty'')
-              netdecl = NetDecl Nothing o' hwty2
-              assigns = zipWith (assignId o' hwty2 10) ids [0..]
+          let netdecl = NetDecl Nothing o' hwty'
+              assigns = zipWith (assignId o' hwty' 10) ids [0..]
           return (concat ports,netdecl:assigns ++ concat decls,o')
 
         Product _ _ hwtys -> do
           results <- zipWithM appendIdentifier (map (o,) hwtys) [0..]
-          let resultsBundled   = zip hwtys results
-              resultsFiltered  = filter (not . isVoid . fst) resultsBundled
-              resultsFiltered' = map snd resultsFiltered
-          (ports,decls,ids) <- unzip3 <$> mapM (mkOutput' Nothing) resultsFiltered'
+          (ports,decls,ids) <- unzip3 <$> mapM (mkOutput' Nothing) results
           case ids of
             [i] ->
-              let hwty''  = filterVoid hwty
-                  netdecl = NetDecl Nothing o' hwty''
+              let netdecl = NetDecl Nothing o' hwty
                   assign  = Assignment i (Identifier o' Nothing)
               in  return (concat ports,netdecl:assign:concat decls,o')
             _   ->
-              let hwty''  = filterVoid hwty
-                  netdecl = NetDecl Nothing o' hwty''
-                  assigns = zipWith (assignId o' hwty'' 0) ids [0..]
+              let netdecl = NetDecl Nothing o' hwty
+                  assigns = zipWith (assignId o' hwty 0) ids [0..]
               in  if null attrs then
                      return (concat ports,netdecl:assigns ++ concat decls,o')
                   else
@@ -1085,9 +1143,8 @@ mkOutput' pM = case pM of
             (throwAnnotatedSplitError $(curLoc) "Vector")
           results <- mapM (appendIdentifier (pN,hwty'')) [0..sz-1]
           (ports,decls,ids) <- unzip3 <$> zipWithM mkOutput' (extendPorts $ map (prefixParent p) ps) results
-          let hwty2   = Vector sz (filterVoid hwty'')
-              netdecl = NetDecl Nothing pN hwty2
-              assigns = zipWith (assignId pN hwty2 10) ids [0..]
+          let netdecl = NetDecl Nothing pN hwty'
+              assigns = zipWith (assignId pN hwty' 10) ids [0..]
           return (concat ports,netdecl:assigns ++ concat decls,pN)
 
         RTree d hwty'' -> do
@@ -1095,25 +1152,20 @@ mkOutput' pM = case pM of
             (throwAnnotatedSplitError $(curLoc) "RTree")
           results <- mapM (appendIdentifier (pN,hwty'')) [0..2^d-1]
           (ports,decls,ids) <- unzip3 <$> zipWithM mkOutput' (extendPorts $ map (prefixParent p) ps) results
-          let hwty2   = RTree d (filterVoid hwty'')
-              netdecl = NetDecl Nothing pN hwty2
-              assigns = zipWith (assignId pN hwty2 10) ids [0..]
+          let netdecl = NetDecl Nothing pN hwty'
+              assigns = zipWith (assignId pN hwty' 10) ids [0..]
           return (concat ports,netdecl:assigns ++ concat decls,pN)
 
         Product _ _ hwtys -> do
           results <- zipWithM appendIdentifier (map (pN,) hwtys) [0..]
-          let resultsBundled   = zip hwtys (zip (extendPorts $ map (prefixParent p) ps) results)
-              resultsFiltered  = filter (not . isVoid . fst) resultsBundled
-              resultsFiltered' = unzip (map snd resultsFiltered)
-          (ports,decls,ids) <- unzip3 <$> uncurry (zipWithM mkOutput') resultsFiltered'
+          let ps'            = extendPorts $ map (prefixParent p) ps
+          (ports,decls,ids) <- unzip3 <$> uncurry (zipWithM mkOutput') (ps', results)
           case ids of
-            [i] -> let hwty''  = filterVoid hwty'
-                       netdecl = NetDecl Nothing pN hwty''
+            [i] -> let netdecl = NetDecl Nothing pN hwty'
                        assign  = Assignment i (Identifier pN Nothing)
                    in  return (concat ports,netdecl:assign:concat decls,pN)
-            _   -> let hwty''  = filterVoid hwty'
-                       netdecl = NetDecl Nothing pN hwty''
-                       assigns = zipWith (assignId pN hwty'' 0) ids [0..]
+            _   -> let netdecl = NetDecl Nothing pN hwty'
+                       assigns = zipWith (assignId pN hwty' 0) ids [0..]
                    in  if null attrs then
                          return (concat ports,netdecl:assigns ++ concat decls,pN)
                        else

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -557,9 +557,11 @@ filterVoidPorts _hwty (PortName s) =
   PortName s
 filterVoidPorts (FilteredHWType _hwty [filtered]) (PortProduct s ps) =
   PortProduct s [filterVoidPorts f p | (p, (void, f)) <- zip ps filtered, not void]
-filterVoidPorts _filtered (PortProduct _s _ps) =
+filterVoidPorts filtered pp@(PortProduct _s _ps) =
   -- TODO: Prettify errors
-  error $ $(curLoc) ++ "Ports were annotated as product, but type wasn't one."
+  error $ $(curLoc) ++ "Ports were annotated as product, but type wasn't one: \n\n"
+                    ++ "   Filtered was: " ++ show filtered ++ "\n\n"
+                    ++ "   Ports was: " ++ show pp
 
 -- | Uniquely rename all the variables and their references in a normalized
 -- term

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -53,7 +53,7 @@ import           Clash.Driver.Types
   (BindingMap, ClashOpts (..), DebugLevel (..))
 import           Clash.Netlist.Types              (HWType (..), FilteredHWType(..))
 import           Clash.Netlist.Util
-  (splitNormalized, unsafeCoreTypeToHWType, stripFiltered)
+  (splitNormalized, unsafeCoreTypeToHWType')
 import           Clash.Normalize.Strategy
 import           Clash.Normalize.Transformations
   (appProp, bindConstantVar, caseCon, flattenLet, reduceConst, topLet)
@@ -398,7 +398,7 @@ clockResetErrors sp reprs tyTran tcm ty =
   where
     (args,_)  = splitCoreFunForallTy tcm ty
     (_,args') = partitionEithers args
-    hwArgs    = zip (map (stripFiltered . unsafeCoreTypeToHWType sp $(curLoc) tyTran reprs tcm) args') args'
+    hwArgs    = zip (map (unsafeCoreTypeToHWType' sp $(curLoc) tyTran reprs tcm) args') args'
     clks      = groupBy ((==) `on` fst) . sortBy (compare `on` fst)
               $ [ ((nm,i),ty') | (Clock nm i _,ty') <- hwArgs]
     rsts      = groupBy ((==) `on` (fst.fst)) . sortBy (compare `on` (fst.fst))

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -35,7 +35,7 @@ import Clash.Core.TyCon          (TyConName, TyConMap)
 import Clash.Core.Var            (Id, TyVar)
 import Clash.Core.VarEnv         (InScopeSet, VarSet)
 import Clash.Driver.Types        (BindingMap, DebugLevel)
-import Clash.Netlist.Types       (HWType)
+import Clash.Netlist.Types       (FilteredHWType)
 import Clash.Util
 
 import Clash.Annotations.BitRepresentation.Internal (CustomReprs)
@@ -89,10 +89,9 @@ data RewriteEnv
   -- ^ Lvl at which we print debugging messages
   , _typeTranslator :: CustomReprs
                     -> TyConMap
-                    -> Bool
                     -> Type
-                    -> Maybe (Either String HWType)
-  -- ^ Hardcode Type -> HWType translator
+                    -> Maybe (Either String FilteredHWType)
+  -- ^ Hardcode Type -> FilteredHWType translator
   , _tcCache        :: TyConMap
   -- ^ TyCon cache
   , _tupleTcCache   :: IntMap TyConName

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -268,6 +268,17 @@ clashLibVersion = Paths_clash_lib.version
 clashLibVersion = error "development version"
 #endif
 
+-- | Return number of occurrences of an item in a list
+countEq
+  :: Eq a
+  => a
+  --  ^ Needle
+  -> [a]
+  -- ^ Haystack
+  -> Int
+  -- ^ Times needle was found in haystack
+countEq a as = length (filter (== a) as)
+
 -- | \x y -> floor (logBase x y), x > 1 && y > 0
 flogBase :: Integer -> Integer -> Maybe Int
 flogBase x y | x > 1 && y > 0 = Just (I# (integerLogBase# x y))

--- a/tests/shouldwork/RTree/TRepeat.hs
+++ b/tests/shouldwork/RTree/TRepeat.hs
@@ -1,0 +1,24 @@
+module TRepeat where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+data A = A Int Int deriving (Eq, Generic, ShowX)
+data B = B Int Int Int deriving (Eq, Generic, ShowX)
+
+topEntity :: Signal System (RTree 2 Bool)
+topEntity = pure (trepeat True)
+
+-- Simulation test
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst ($([| v2t (replicate d4 True) |]) :> Nil)
+    done           = expectedOutput topEntity
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/TopEntity/PortNamesWithRTree.hs
+++ b/tests/shouldwork/TopEntity/PortNamesWithRTree.hs
@@ -1,0 +1,93 @@
+module PortNamesWithRTree where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+data A = A Int Int deriving (Eq, Generic, ShowX)
+data B = B Int Int Int deriving (Eq, Generic, ShowX)
+
+{-# ANN topEntity
+  (Synthesize
+    { t_name     = "PortNamesWithRTree_topEntity"
+    , t_inputs   = [
+        ]
+    , t_output   = PortProduct "tupje" [
+            PortName "zero",
+            PortProduct "treetje" [
+              PortProduct "elmje1" [
+                PortName "one",
+                PortName "two"
+              ],
+              PortProduct "elmje2" [
+                PortProduct "A" [
+                  PortName "ein",
+                  PortName "zwei"
+                ],
+                PortProduct "B" [
+                  PortName "ein"
+                ]
+              ]
+            ]
+        ]
+    }) #-}
+topEntity :: Signal System (Int, RTree 2 (A, B))
+topEntity = pure (0, trepeat (A 1 2, B 3 4 5))
+
+-- Simulation test
+{-# ANN testBench
+  (Synthesize
+    { t_name     = "PortNamesWithRTree_testBench"
+    , t_inputs   = [ ]
+    , t_output   = PortName "result"
+    }) #-}
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst ((0, trepeat (A 1 2, B 3 4 5)) :> Nil)
+    done           = expectedOutput topEntity
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+
+-- File content test
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | needle `isInfixOf` haystack =
+      P.error $ P.concat [ "Did not expect:\n\n  ", needle
+                         , "\n\nIn:\n\n", haystack ]
+  | otherwise = return ()
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (takeDirectory topDir </> "PortNamesWithRTree_topEntity" </> "PortNamesWithRTree_topEntity.v")
+
+  assertIn    "tupje_zero" content
+  assertIn    "tupje_treetje_elmje1_one" content
+  assertIn    "tupje_treetje_elmje1_two" content
+  assertIn    "tupje_treetje_elmje2_A_ein" content
+  assertIn    "tupje_treetje_elmje2_A_zwei" content
+  assertIn    "tupje_treetje_elmje2_B_ein" content
+  assertNotIn "tupje_treetje_elmje2_B_0" content
+  assertIn    "tupje_treetje_elmje2_B_1" content
+  assertIn    "tupje_treetje_elmje2_B_2" content
+  assertIn    "tupje_treetje_2_0_0" content
+  assertIn    "tupje_treetje_2_0_1" content
+  assertIn    "tupje_treetje_2_1_0" content
+  assertIn    "tupje_treetje_2_1_1" content
+  assertIn    "tupje_treetje_2_1_2" content
+  assertIn    "tupje_treetje_3_0_0" content
+  assertIn    "tupje_treetje_3_0_1" content
+  assertIn    "tupje_treetje_3_1_0" content
+  assertIn    "tupje_treetje_3_1_1" content
+  assertIn    "tupje_treetje_3_1_2" content

--- a/tests/shouldwork/TopEntity/PortNamesWithUnit.hs
+++ b/tests/shouldwork/TopEntity/PortNamesWithUnit.hs
@@ -1,0 +1,65 @@
+module PortNamesWithUnit where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+{-# ANN topEntity
+  (Synthesize
+    { t_name     = "PortNamesWithUnit_topEntity"
+    , t_inputs   = [
+        ]
+    , t_output   = PortProduct "top" [
+            PortName "zero",
+            PortProduct "sub" [
+              PortName "one",
+              PortName "two",
+              PortName "three"
+            ]
+        ]
+    }) #-}
+topEntity :: (Signal System Int, (Signal System (), Signal System Int, Signal System Int))
+topEntity = (pure 0, (pure (), pure 2, pure 3))
+
+-- Simulation test
+{-# ANN testBench
+  (Synthesize
+    { t_name     = "PortNamesWithUnit_testBench"
+    , t_inputs   = [ ]
+    , t_output   = PortName "result"
+    }) #-}
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst ((0, ((), 2, 3)) :> (0, ((), 2, 3)) :> Nil)
+    done           = expectedOutput (bundle $ bundle <$> topEntity)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+
+-- File content test
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | needle `isInfixOf` haystack =
+      P.error $ P.concat [ "Did not expect:\n\n  ", needle
+                         , "\n\nIn:\n\n", haystack ]
+  | otherwise = return ()
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (takeDirectory topDir </> "PortNamesWithUnit_topEntity" </> "PortNamesWithUnit_topEntity.v")
+
+  assertIn    "top_zero" content
+  assertNotIn "top_sub_one" content
+  assertIn    "top_sub_two" content
+  assertIn    "top_sub_three" content

--- a/tests/shouldwork/TopEntity/PortNamesWithVector.hs
+++ b/tests/shouldwork/TopEntity/PortNamesWithVector.hs
@@ -1,0 +1,88 @@
+module PortNamesWithVector where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+data A = A Int Int deriving (Eq, Generic, ShowX)
+data B = B Int Int Int deriving (Eq, Generic, ShowX)
+
+{-# ANN topEntity
+  (Synthesize
+    { t_name     = "PortNamesWithVector_topEntity"
+    , t_inputs   = [
+        ]
+    , t_output   = PortProduct "tupje" [
+            PortName "zero",
+            PortProduct "vecje" [
+              PortProduct "elmje1" [
+                PortName "one",
+                PortName "two"
+              ],
+              PortProduct "elmje2" [
+                PortProduct "A" [
+                  PortName "ein",
+                  PortName "zwei"
+                ],
+                PortProduct "B" [
+                  PortName "ein"
+                ]
+              ]
+            ]
+        ]
+    }) #-}
+topEntity :: Signal System (Int, Vec 3 (A, B))
+topEntity = pure (0, repeat (A 1 2, B 3 4 5))
+
+-- Simulation test
+{-# ANN testBench
+  (Synthesize
+    { t_name     = "PortNamesWithVector_testBench"
+    , t_inputs   = [ ]
+    , t_output   = PortName "result"
+    }) #-}
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst ((0, repeat (A 1 2, B 3 4 5)) :> Nil)
+    done           = expectedOutput topEntity
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+
+-- File content test
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | needle `isInfixOf` haystack =
+      P.error $ P.concat [ "Did not expect:\n\n  ", needle
+                         , "\n\nIn:\n\n", haystack ]
+  | otherwise = return ()
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (takeDirectory topDir </> "PortNamesWithVector_topEntity" </> "PortNamesWithVector_topEntity.v")
+
+  assertIn    "tupje_zero" content
+  assertIn    "tupje_vecje_elmje1_one" content
+  assertIn    "tupje_vecje_elmje1_two" content
+  assertIn    "tupje_vecje_elmje2_A_ein" content
+  assertIn    "tupje_vecje_elmje2_A_zwei" content
+  assertIn    "tupje_vecje_elmje2_B_ein" content
+  assertNotIn "tupje_vecje_elmje2_B_0" content
+  assertIn    "tupje_vecje_elmje2_B_1" content
+  assertIn    "tupje_vecje_elmje2_B_2" content
+  assertIn    "tupje_vecje_2_0_0" content
+  assertIn    "tupje_vecje_2_0_1" content
+  assertIn    "tupje_vecje_2_1_0" content
+  assertIn    "tupje_vecje_2_1_1" content
+  assertIn    "tupje_vecje_2_1_2" content

--- a/tests/shouldwork/Unit/MapConstUnit.hs
+++ b/tests/shouldwork/Unit/MapConstUnit.hs
@@ -1,0 +1,26 @@
+module MapConstUnit where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+zeroF
+  :: KnownNat n
+  => (BitVector n -> BitVector n -> (BitVector n, BitVector n))
+  -> Vec m (BitVector n)
+  -> Vec m (BitVector n)
+  -> Vec m (BitVector 8)
+zeroF f a b =
+  zipWith (zeroExtend . uncurry (++#) . f) a b
+
+topEntity :: Signal System (Vec 5 Int)
+topEntity = pure (snd (mapAccumL (\acc _ -> (succ acc, acc)) 0 (map (const ()) indicesI)))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst ((0 :> 1 :> 2 :> 3 :> 4 :> Nil) :> Nil)
+
+    done           = expectedOutput topEntity
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Unit/ZipWithTripleWithUnitMiddle.hs
+++ b/tests/shouldwork/Unit/ZipWithTripleWithUnitMiddle.hs
@@ -1,0 +1,20 @@
+module ZipWithTripleWithUnitMiddle where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Vec 2 (Int,Int)
+  -> Vec 2 ((Int,Int),(Int, (), Int))
+topEntity xs = zipWith (,) xs (repeat (fst (head xs), (), snd (head xs)))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (repeat (2, 2) :> repeat (3, 4) :> Nil)
+    expectedOutput = outputVerifier clk rst (repeat ((2, 2), (2, (), 2)) :> repeat ((3, 4), (3, (), 4)) :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Unit/ZipWithTupleWithUnitLeft.hs
+++ b/tests/shouldwork/Unit/ZipWithTupleWithUnitLeft.hs
@@ -1,0 +1,20 @@
+module ZipWithTupleWithUnitLeft where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Vec 2 (Int,Int)
+  -> Vec 2 ((Int,Int),((), Int))
+topEntity xs = zipWith (,) xs (repeat ((), fst (head xs)))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (repeat (2, 2) :> repeat (3, 4) :> Nil)
+    expectedOutput = outputVerifier clk rst (repeat ((2, 2), ((), 2)) :> repeat ((3, 4), ((), 3)) :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Unit/ZipWithTupleWithUnitRight.hs
+++ b/tests/shouldwork/Unit/ZipWithTupleWithUnitRight.hs
@@ -1,0 +1,20 @@
+module ZipWithTupleWithUnitRight where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Vec 2 (Int,Int)
+  -> Vec 2 ((Int,Int),(Int, ()))
+topEntity xs = zipWith (,) xs (repeat (fst (head xs), ()))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (repeat (2, 2) :> repeat (3, 4) :> Nil)
+    expectedOutput = outputVerifier clk rst (repeat ((2, 2), (2, ())) :> repeat ((3, 4), (3, ())) :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Unit/ZipWithUnitSP.hs
+++ b/tests/shouldwork/Unit/ZipWithUnitSP.hs
@@ -1,0 +1,24 @@
+module ZipWithUnitSP where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+data PQR = P () | Q | R () deriving (Eq, Show, Generic, ShowX)
+
+topEntity
+  :: Vec 2 PQR
+  -> Vec 2 (Index 2, PQR)
+topEntity xs = zipWith (,) indicesI xs
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (repeat (P ()) :> repeat Q :> Nil)
+    expectedOutput = outputVerifier clk rst (((0, P ()) :> (1, P ()) :> Nil)
+                                          :> ((0, Q)    :> (1, Q)    :> Nil)
+                                          :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Unit/ZipWithUnitSP2.hs
+++ b/tests/shouldwork/Unit/ZipWithUnitSP2.hs
@@ -1,0 +1,25 @@
+module ZipWithUnitSP2 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+data YZA = Y Int | Z () | A deriving (Eq, Show, Generic, ShowX)
+
+topEntity
+  :: Vec 2 YZA
+  -> Vec 2 (Index 2, YZA)
+topEntity xs = zipWith (,) indicesI xs
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (repeat (Y 2) :> repeat (Z ()) :> repeat A :> Nil)
+    expectedOutput = outputVerifier clk rst (((0, Y 2) :> (1, Y 2) :> Nil)
+                                          :> ((0, Z ()):> (1, Z ()):> Nil)
+                                          :> ((0, A)   :> (1, A)   :> Nil)
+                                          :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Unit/ZipWithUnitVector.hs
+++ b/tests/shouldwork/Unit/ZipWithUnitVector.hs
@@ -1,0 +1,20 @@
+module ZipWithUnitVector where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Vec 2 (Int,Int)
+  -> Vec 2 ((Int,Int),())
+topEntity xs = zipWith (,) xs (repeat ())
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (repeat (2, 2) :> repeat (3, 4) :> Nil)
+    expectedOutput = outputVerifier clk rst (repeat ((2, 2), ()) :> repeat ((3, 4), ()) :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Vector/VIndicesI.hs
+++ b/tests/shouldwork/Vector/VIndicesI.hs
@@ -1,0 +1,16 @@
+module VIndicesI where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity :: Signal System (Vec 4 (Index 4))
+topEntity = pure indicesI
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst ((0:>1:>2:>3:>Nil):>Nil)
+    done           = expectedOutput topEntity
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -242,6 +242,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VACC"       ([""],"VACC_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VEmpty"     (["", "VEmpty_testBench"],"VEmpty_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VIndex"     ([""],"VIndex_topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VIndicesI"  (["","VIndicesI_testBench"],"VIndicesI_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VFold"      (["","VFold_testBench"],"VFold_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VMapAccum"  ([""],"VMapAccum_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VMerge"     (["","VMerge_testBench"],"VMerge_testBench",True)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -215,6 +215,16 @@ runClashTest =
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNames" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortProducts" (["","PortProducts_topEntity","PortProducts_testBench"],"PortProducts_testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortProducts" "main"
+        , runTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithUnit" (["","PortNamesWithUnit_topEntity","PortNamesWithUnit_testBench"],"PortNamesWithUnit_testBench",True)
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithUnit" "main"
+        ]
+      , clashTestGroup "Void"
+        [ runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithUnitVector"            (["","ZipWithUnitVector_testBench"],"ZipWithUnitVector_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithTupleWithUnitLeft"     (["","ZipWithTupleWithUnitLeft_testBench"],"ZipWithTupleWithUnitLeft_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithTupleWithUnitRight"    (["","ZipWithTupleWithUnitRight_testBench"],"ZipWithTupleWithUnitRight_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithTripleWithUnitMiddle"  (["","ZipWithTripleWithUnitMiddle_testBench"],"ZipWithTripleWithUnitMiddle_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithUnitSP"                (["","ZipWithUnitSP_testBench"],"ZipWithUnitSP_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithUnitSP2"               (["","ZipWithUnitSP2_testBench"],"ZipWithUnitSP2_testBench",True)
         ]
       , clashTestGroup "Vector"
         [ runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Concat"     (["","Concat_testBench"],"Concat_testBench",True)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -171,8 +171,9 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "LocalPoly"         ([""],"LocalPoly_topEntity",False)
         ]
       , clashTestGroup "RTree"
-        [ runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TFold" ([""],"TFold_topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TZip"  ([""],"TZip_topEntity",False)
+        [ runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TFold"       ([""],"TFold_topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TRepeat"  ([""],"TRepeat_topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TZip"        ([""],"TZip_topEntity",False)
       ]
       , clashTestGroup "Signal"
         [ runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "AlwaysHigh"      ([""],"AlwaysHigh_topEntity",False)
@@ -211,12 +212,16 @@ runClashTest =
         ]
       , clashTestGroup "TopEntity"
         -- VHDL tests disabled for now: I can't figure out how to generate a static name whilst retaining the ability to actually test..
-        [ runTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNames" (["","PortNames_topEntity","PortNames_testBench"],"PortNames_testBench",True)
+        [ runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNames" (["","PortNames_topEntity","PortNames_testBench"],"PortNames_testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNames" "main"
-        , runTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortProducts" (["","PortProducts_topEntity","PortProducts_testBench"],"PortProducts_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortProducts" (["","PortProducts_topEntity","PortProducts_testBench"],"PortProducts_testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortProducts" "main"
-        , runTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithUnit" (["","PortNamesWithUnit_topEntity","PortNamesWithUnit_testBench"],"PortNamesWithUnit_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithUnit" (["","PortNamesWithUnit_topEntity","PortNamesWithUnit_testBench"],"PortNamesWithUnit_testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithUnit" "main"
+        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithVector" (["","PortNamesWithVector_topEntity","PortNamesWithVector_testBench"],"PortNamesWithVector_testBench",True)
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithVector" "main"
+        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithRTree" (["","PortNamesWithRTree_topEntity","PortNamesWithRTree_testBench"],"PortNamesWithRTree_testBench",True)
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithRTree" "main"
         ]
       , clashTestGroup "Void"
         [ runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithUnitVector"            (["","ZipWithUnitVector_testBench"],"ZipWithUnitVector_testBench",True)


### PR DESCRIPTION
`mkFunInput` doesn't account for zero-width constructs (correctly). This PR extends `coreTypeToHWType` by making it return what arguments it removes. This makes the following test case compile:

```
module Test where

import Clash.Prelude

topEntity
  :: Vec 4 (Int,Int)
  -> Vec 4 ((Int,Int),())
topEntity xs = zipWith (,) xs (repeat ())
```

`coreType*` functions now always return void removal information, thus forcing the caller to explicitly deal with it.