### PR TITLE
Add support for Vec-like GADTs

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -60,7 +60,7 @@ import           TysWiredIn          (tupleTyCon)
 import           Unique              (getKey)
 
 import           Clash.Class.BitPack (pack,unpack)
-import           Clash.Core.DataCon  (DataCon (..), dataConInstArgTys)
+import           Clash.Core.DataCon  (DataCon (..))
 import           Clash.Core.Evaluator
   (Heap (..), PrimEvaluator, Value (..), valToTerm, whnf)
 import           Clash.Core.Literal  (Literal (..))
@@ -73,7 +73,8 @@ import           Clash.Core.Type
 import           Clash.Core.TyCon
   (TyConMap, TyConName, tyConDataCons)
 import           Clash.Core.TysPrim
-import           Clash.Core.Util     (mkApps,mkRTree,mkVec,piResultTys,tyNatSize)
+import           Clash.Core.Util
+  (mkApps,mkRTree,mkVec,piResultTys,tyNatSize,dataConInstArgTys)
 import           Clash.Core.Var      (mkId, mkTyVar)
 import           Clash.GHC.GHC2Core  (modNameM)
 import           Clash.Rewrite.Util  (mkSelectorCase)

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -25,7 +25,7 @@ import Clash.Core.Name                  (Name (..))
 import Clash.Core.Pretty                (showPpr)
 import Clash.Core.TyCon                 (TyConMap, tyConDataCons)
 import Clash.Core.Type
-  (LitTy (..), Type (..), TypeView (..), coreView, tyView)
+  (LitTy (..), Type (..), TypeView (..), coreView1, tyView)
 import Clash.Core.Util                  (tyNatSize)
 import Clash.Netlist.Util               (coreTypeToHWType, stripFiltered)
 import Clash.Netlist.Types
@@ -218,7 +218,7 @@ domain
   :: TyConMap
   -> Type
   -> ExceptT String Maybe (String,Integer)
-domain m (coreView m -> Just ty') = domain m ty'
+domain m (coreView1 m -> Just ty') = domain m ty'
 domain m (tyView -> TyConApp tcNm [LitTy (SymTy nm),rateTy])
   | nameOcc tcNm == "Clash.Signal.Internal.Dom"
   = do rate <- mapExceptT (Just . coerce) (tyNatSize m rateTy)
@@ -229,7 +229,7 @@ clockKind
   :: TyConMap
   -> Type
   -> ExceptT String Maybe ClockKind
-clockKind m (coreView m -> Just ty') = clockKind m ty'
+clockKind m (coreView1 m -> Just ty') = clockKind m ty'
 clockKind _ (tyView -> TyConApp tcNm [])
   | nameOcc tcNm == "Clash.Signal.Internal.Source"
   = return Source
@@ -241,7 +241,7 @@ resetKind
   :: TyConMap
   -> Type
   -> ExceptT String Maybe ResetKind
-resetKind m (coreView m -> Just ty') = resetKind m ty'
+resetKind m (coreView1 m -> Just ty') = resetKind m ty'
 resetKind _ (tyView -> TyConApp tcNm [])
   | nameOcc tcNm == "Clash.Signal.Internal.Synchronous"
   = return Synchronous

--- a/clash-lib/src/Clash/Core/DataCon.hs
+++ b/clash-lib/src/Clash/Core/DataCon.hs
@@ -18,7 +18,6 @@ module Clash.Core.DataCon
   ( DataCon (..)
   , DcName
   , ConTag
-  , dataConInstArgTys
   )
 where
 
@@ -29,7 +28,6 @@ import qualified Data.Text                    as Text
 import GHC.Generics                           (Generic)
 
 import Clash.Core.Name                        (Name (..))
-import {-# SOURCE #-} Clash.Core.Subst        (substTyWith)
 import {-# SOURCE #-} Clash.Core.Type         (Type)
 import Clash.Core.Var                         (TyVar)
 import Clash.Unique
@@ -74,23 +72,3 @@ instance Uniquable DataCon where
 type ConTag = Int
 -- | DataCon reference
 type DcName = Name DataCon
-
--- | Given a DataCon and a list of types, the type variables of the DataCon
--- type are substituted for the list of types. The argument types are returned.
---
--- The list of types should be equal to the number of type variables, otherwise
--- @Nothing@ is returned.
-dataConInstArgTys :: DataCon -> [Type] -> Maybe [Type]
-dataConInstArgTys (MkData { dcArgTys     = arg_tys
-                          , dcUnivTyVars = univ_tvs
-                          , dcExtTyVars  = ex_tvs
-                          })
-                  inst_tys
-  | length tyvars == length inst_tys
-  = Just (map (substTyWith tyvars inst_tys) arg_tys)
-
-  | otherwise
-  = Nothing
-
-  where
-    tyvars = univ_tvs ++ ex_tvs

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -19,6 +19,8 @@ module Clash.Core.Pretty
   , ppr
   , showDoc
   , showPpr
+  , tracePprId
+  , tracePpr
   )
 where
 
@@ -28,6 +30,7 @@ import Control.Monad.Identity
 import qualified Data.Text              as T
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.String
+import Debug.Trace                      (trace)
 import GHC.Show                         (showMultiLineString)
 import Numeric                          (fromRat)
 
@@ -68,6 +71,12 @@ showDoc = renderString . layoutPretty (LayoutOptions (AvailablePerLine 80 0.6))
 
 showPpr :: PrettyPrec p => p -> String
 showPpr = showDoc . ppr
+
+tracePprId :: PrettyPrec p => p -> p
+tracePprId p = trace (showPpr p) p
+
+tracePpr :: PrettyPrec p => p -> a -> a
+tracePpr p a = trace (showPpr p) a
 
 prettyParen :: Bool -> Doc ann -> Doc ann
 prettyParen False = id

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -301,7 +301,8 @@ extendInScopeIdList (Subst inScope env tenv) ids =
 -- The substitution has to satisfy the invariant described in
 -- 'TvSubst's Note [The substitution environment]
 substTy
-  :: Subst
+  :: HasCallStack
+  => Subst
   -> Type
   -> Type
 substTy (Subst inScope _ tvS) ty
@@ -316,7 +317,8 @@ substTy (Subst inScope _ tvS) ty
 -- 'TvSubts' Note [The substitution environment]. Should be used inside this
 -- module only.
 substTyUnchecked
-  :: TvSubst
+  :: HasCallStack
+  => TvSubst
   -> Type
   -> Type
 substTyUnchecked subst@(TvSubst _ tvS) ty
@@ -328,7 +330,8 @@ substTyUnchecked subst@(TvSubst _ tvS) ty
 -- | This checks if the substitution satisfies the invariant from 'TvSbust's
 -- Note [The substitution invariant].
 checkValidSubst
-  :: TvSubst
+  :: HasCallStack
+  => TvSubst
   -> [Type]
   -> a
   -> a
@@ -364,7 +367,8 @@ isValidSubst (TvSubst inScope tenv) = tenvFVs `varSetInScope` inScope
 
 -- | The work-horse of 'substTy'
 substTy'
-  :: TvSubst
+  :: HasCallStack
+  => TvSubst
   -> Type
   -> Type
 substTy' subst = go where
@@ -427,7 +431,8 @@ substTyVarBndr subst@(TvSubst inScope tenv) oldVar =
 
 -- | Substitute within a 'Type'
 substTm
-  :: Doc ()
+  :: HasCallStack
+  => Doc ()
   -> Subst
   -> Term
   -> Term
@@ -454,7 +459,8 @@ substTm doc subst = go where
 
 -- | Find the substitution for an 'Id' in the 'Subst'
 lookupIdSubst
-  :: Doc ann
+  :: HasCallStack
+  => Doc ann
   -> Subst
   -> Id
   -> Term
@@ -469,7 +475,8 @@ lookupIdSubst doc (Subst inScope tmS _) v
 -- returning the result and an update 'Subst' that should be used in subsequent
 -- substitutions.
 substIdBndr
-  :: Subst
+  :: HasCallStack
+  => Subst
   -> Id
   -> (Subst,Id)
 substIdBndr subst@(Subst inScope env tenv) oldId =
@@ -499,7 +506,8 @@ substIdBndr subst@(Subst inScope env tenv) oldId =
 
 -- | Like 'substTyVarBndr' but takes a 'Subst' instead of a 'TvSubst'
 substTyVarBndr'
-  :: Subst
+  :: HasCallStack
+  => Subst
   -> TyVar
   -> (Subst,TyVar)
 substTyVarBndr' (Subst inScope tmS tyS) tv =
@@ -509,7 +517,8 @@ substTyVarBndr' (Subst inScope tmS tyS) tv =
 -- | Apply a substitution to an entire set of let-bindings, additionally
 -- returning an updated 'Subst' that should be used by subsequent substitutions.
 substBind
-  :: Doc ()
+  :: HasCallStack
+  => Doc ()
   -> Subst
   -> [LetBinding]
   -> (Subst,[LetBinding])
@@ -525,7 +534,8 @@ substBind doc subst xs =
 -- Works only if the domain of the substitution is superset of the type being
 -- substituted into
 substTyWith
-  :: [TyVar]
+  :: HasCallStack
+  => [TyVar]
   -> [Type]
   -> Type
   -> Type

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -27,6 +27,7 @@ module Clash.Core.Subst
     -- ** Applying substitutions
   , substTy
   , substTyWith
+  , substTyInVar
     -- * Substitution into terms
     -- ** Substitution environments
   , Subst (..)
@@ -279,11 +280,11 @@ extendInScopeId
   :: Subst
   -> Id
   -> Subst
-extendInScopeId (Subst inScope env tenv) ids =
+extendInScopeId (Subst inScope env tenv) id' =
   Subst inScope' env' tenv
  where
-  inScope' = extendInScopeSet inScope ids
-  env'     = delVarEnv env ids
+  inScope' = extendInScopeSet inScope id'
+  env'     = delVarEnv env id'
 
 -- | Add 'Id's to the in-scope set. See also 'extendInScopeId'
 extendInScopeIdList
@@ -312,6 +313,15 @@ substTy (Subst inScope _ tvS) ty
   = checkValidSubst s' [ty] (substTy' s' ty)
  where
   s' = TvSubst inScope tvS
+
+-- | Substitute within a 'TyVar'. See 'substTy'.
+substTyInVar
+  :: HasCallStack
+  => Subst
+  -> Var a
+  -> Var a
+substTyInVar subst tyVar =
+  tyVar { varType = (substTy subst (varType tyVar)) }
 
 -- | Like 'substTy', but skips the checks for the invariants described in
 -- 'TvSubts' Note [The substitution environment]. Should be used inside this

--- a/clash-lib/src/Clash/Core/Subst.hs-boot
+++ b/clash-lib/src/Clash/Core/Subst.hs-boot
@@ -1,10 +1,12 @@
 module Clash.Core.Subst where
 
+import GHC.Stack (HasCallStack)
 import {-# SOURCE #-} Clash.Core.Type (Type)
 import Clash.Core.Var (TyVar)
 
 substTyWith
-  :: [TyVar]
+  :: HasCallStack
+  => [TyVar]
   -> [Type]
   -> Type
   -> Type

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -259,7 +259,7 @@ isPolyTy _                       = False
 splitFunTy :: TyConMap
            -> Type
            -> Maybe (Type, Type)
-splitFunTy m (coreView1 m -> Just ty)   = splitFunTy m ty
+splitFunTy m (coreView1 m -> Just ty)  = splitFunTy m ty
 splitFunTy _ (tyView -> FunTy arg res) = Just (arg,res)
 splitFunTy _ _ = Nothing
 
@@ -268,7 +268,7 @@ splitFunTys :: TyConMap
             -> ([Type],Type)
 splitFunTys m ty = go [] ty ty
   where
-    go args orig_ty (coreView1 m -> Just ty')  = go args orig_ty ty'
+    go args orig_ty (coreView1 m -> Just ty') = go args orig_ty ty'
     go args _       (tyView -> FunTy arg res) = go (arg:args) res res
     go args orig_ty _                         = (reverse args, orig_ty)
 
@@ -290,9 +290,9 @@ splitCoreFunForallTy :: TyConMap
 splitCoreFunForallTy tcm ty = go [] ty ty
   where
     go args orig_ty (coreView1 tcm -> Just ty') = go args orig_ty ty'
-    go args _       (ForAllTy tv res)          = go (Left tv:args) res res
-    go args _       (tyView -> FunTy arg res)  = go (Right arg:args) res res
-    go args orig_ty _                          = (reverse args,orig_ty)
+    go args _       (ForAllTy tv res)           = go (Left tv:args) res res
+    go args _       (tyView -> FunTy arg res)   = go (Right arg:args) res res
+    go args orig_ty _                           = (reverse args,orig_ty)
 
 -- | Is a type a polymorphic or function type?
 isPolyFunTy :: Type
@@ -329,7 +329,7 @@ applyFunTy :: TyConMap
            -> Type
            -> Type
 applyFunTy m (coreView1 m -> Just ty)   arg = applyFunTy m ty arg
-applyFunTy _ (tyView -> FunTy _ resTy) _   = resTy
+applyFunTy _ (tyView -> FunTy _ resTy) _    = resTy
 applyFunTy _ _ _ = error $ $(curLoc) ++ "Report as bug: not a FunTy"
 
 -- | Split a type application in the applied type and the argument types

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -30,6 +30,7 @@ module Clash.Core.Type
   , TyVar
   , tyView
   , coreView
+  , coreView1
   , typeKind
   , mkTyConTy
   , mkFunTy
@@ -155,9 +156,19 @@ tyView t = OtherType t
 -- | A view on types in which newtypes are transparent, the Signal type is
 -- transparent, and type functions are evaluated to WHNF (when possible).
 --
+-- Strips away ALL layers. If no layers are found it returns the given type.
+coreView :: TyConMap -> Type -> Type
+coreView tcm ty =
+  case coreView1 tcm ty of
+    Nothing  -> ty
+    Just ty' -> coreView tcm ty'
+
+-- | A view on types in which newtypes are transparent, the Signal type is
+-- transparent, and type functions are evaluated to WHNF (when possible).
+--
 -- Only strips away one "layer".
-coreView :: TyConMap -> Type -> Maybe Type
-coreView tcMap ty = case tyView ty of
+coreView1 :: TyConMap -> Type -> Maybe Type
+coreView1 tcMap ty = case tyView ty of
   TyConApp tcNm args
     | nameOcc tcNm == "Clash.Signal.BiSignal.BiSignalIn"
     , [_,_,_,elTy] <- args
@@ -248,7 +259,7 @@ isPolyTy _                       = False
 splitFunTy :: TyConMap
            -> Type
            -> Maybe (Type, Type)
-splitFunTy m (coreView m -> Just ty)   = splitFunTy m ty
+splitFunTy m (coreView1 m -> Just ty)   = splitFunTy m ty
 splitFunTy _ (tyView -> FunTy arg res) = Just (arg,res)
 splitFunTy _ _ = Nothing
 
@@ -257,7 +268,7 @@ splitFunTys :: TyConMap
             -> ([Type],Type)
 splitFunTys m ty = go [] ty ty
   where
-    go args orig_ty (coreView m -> Just ty')  = go args orig_ty ty'
+    go args orig_ty (coreView1 m -> Just ty')  = go args orig_ty ty'
     go args _       (tyView -> FunTy arg res) = go (arg:args) res res
     go args orig_ty _                         = (reverse args, orig_ty)
 
@@ -278,7 +289,7 @@ splitCoreFunForallTy :: TyConMap
                      -> ([Either TyVar Type], Type)
 splitCoreFunForallTy tcm ty = go [] ty ty
   where
-    go args orig_ty (coreView tcm -> Just ty') = go args orig_ty ty'
+    go args orig_ty (coreView1 tcm -> Just ty') = go args orig_ty ty'
     go args _       (ForAllTy tv res)          = go (Left tv:args) res res
     go args _       (tyView -> FunTy arg res)  = go (Right arg:args) res res
     go args orig_ty _                          = (reverse args,orig_ty)
@@ -288,11 +299,11 @@ isPolyFunTy :: Type
             -> Bool
 isPolyFunTy = not . null . fst . splitFunForallTy
 
--- | Is a type a polymorphic or function type under 'coreView'?
+-- | Is a type a polymorphic or function type under 'coreView1'?
 isPolyFunCoreTy :: TyConMap
                 -> Type
                 -> Bool
-isPolyFunCoreTy m (coreView m -> Just ty) = isPolyFunCoreTy m ty
+isPolyFunCoreTy m (coreView1 m -> Just ty) = isPolyFunCoreTy m ty
 isPolyFunCoreTy _ ty = case tyView ty of
   FunTy _ _ -> True
   OtherType (ForAllTy _ _) -> True
@@ -317,7 +328,7 @@ applyFunTy :: TyConMap
            -> Type
            -> Type
            -> Type
-applyFunTy m (coreView m -> Just ty)   arg = applyFunTy m ty arg
+applyFunTy m (coreView1 m -> Just ty)   arg = applyFunTy m ty arg
 applyFunTy _ (tyView -> FunTy _ resTy) _   = resTy
 applyFunTy _ _ _ = error $ $(curLoc) ++ "Report as bug: not a FunTy"
 

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -141,7 +141,7 @@ piResultTyMaybe
   -> Type
   -> Maybe Type
 piResultTyMaybe m ty arg
-  | Just ty' <- coreView m ty
+  | Just ty' <- coreView1 m ty
   = piResultTyMaybe m ty' arg
   | FunTy _ res <- tyView ty
   = Just res
@@ -181,7 +181,7 @@ piResultTys
   -> Type
 piResultTys _ ty [] = ty
 piResultTys m ty origArgs@(arg:args)
-  | Just ty' <- coreView m ty
+  | Just ty' <- coreView1 m ty
   = piResultTys m ty' origArgs
   | FunTy _ res <- tyView ty
   = piResultTys m res args
@@ -194,7 +194,7 @@ piResultTys m ty origArgs@(arg:args)
 
   go env ty' [] = substTy (mkTvSubst inScope env) ty'
   go env ty' allArgs@(arg':args')
-    | Just ty'' <- coreView m ty'
+    | Just ty'' <- coreView1 m ty'
     = go env ty'' allArgs
     | FunTy _ res <- tyView ty'
     = go env res args'
@@ -581,7 +581,7 @@ isClockOrReset
   :: TyConMap
   -> Type
   -> Bool
-isClockOrReset m (coreView m -> Just ty) = isClockOrReset m ty
+isClockOrReset m (coreView1 m -> Just ty) = isClockOrReset m ty
 isClockOrReset _ (tyView -> TyConApp tcNm _) = case nameOcc tcNm of
   "Clash.Signal.Internal.Clock" -> True
   "Clash.Signal.Internal.Reset" -> True
@@ -591,7 +591,7 @@ isClockOrReset _ _ = False
 tyNatSize :: TyConMap
           -> Type
           -> Except String Integer
-tyNatSize m (coreView m -> Just ty) = tyNatSize m ty
+tyNatSize m (coreView1 m -> Just ty) = tyNatSize m ty
 tyNatSize _ (LitTy (NumTy i))       = return i
 tyNatSize _ ty = throwE $ $(curLoc) ++ "Cannot reduce to an integer:\n" ++ showDoc (ppr ty)
 

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -7,6 +7,7 @@
 -}
 
 {-# LANGUAGE CPP               #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE ViewPatterns      #-}
@@ -19,8 +20,9 @@ import Control.Monad.Trans.Except              (Except, throwE)
 import           Data.Coerce                   (coerce)
 import qualified Data.IntSet                   as IntSet
 import qualified Data.HashSet                  as HashSet
-import Data.List                               (foldl', mapAccumR)
-import Data.Maybe                              (fromJust, mapMaybe)
+import Data.List
+  (foldl', mapAccumR, elemIndices)
+import Data.Maybe                              (fromJust, mapMaybe, catMaybes)
 import qualified Data.Text                     as T
 import           Data.Text.Prettyprint.Doc     (line)
 #if !MIN_VERSION_base(4,11,0)
@@ -28,19 +30,20 @@ import           Data.Semigroup
 #endif
 
 import Clash.Core.DataCon
-  (DataCon, dcType, dataConInstArgTys)
+  (DataCon (MkData), dcType, dcUnivTyVars, dcExtTyVars, dcArgTys)
 import Clash.Core.FreeVars                     (termFreeVars, tyFVsOfTypes)
 import Clash.Core.Literal                      (literalType)
 import Clash.Core.Name
   (Name (..), OccName, mkUnsafeInternalName, mkUnsafeSystemName)
 import Clash.Core.Pretty                       (ppr, showDoc)
 import Clash.Core.Subst
-  (extendTvSubst, mkSubst, mkTvSubst, substTy)
+  (extendTvSubst, mkSubst, mkTvSubst, substTy, substTyWith,
+   substTyInVar, extendTvSubstList)
 import Clash.Core.Term
-  (LetBinding, Pat (..), Term (..))
+  (LetBinding, Pat (..), Term (..), Alt)
 import Clash.Core.Type
   (Kind, LitTy (..), Type (..), TypeView (..),
-   coreView, isFunTy, isPolyFunCoreTy, mkFunTy, splitFunTy, tyView)
+   coreView, coreView1, isFunTy, isPolyFunCoreTy, mkFunTy, splitFunTy, tyView)
 import Clash.Core.TyCon
   (TyConMap, tyConDataCons)
 import Clash.Core.TysPrim                      (typeNatKind)
@@ -48,7 +51,7 @@ import Clash.Core.Var
   (Id, TyVar, Var (..), mkId, mkTyVar)
 import Clash.Core.VarEnv
   (InScopeSet, VarEnv, emptyVarEnv, extendInScopeSet, extendVarEnv,
-   lookupVarEnv, mkInScopeSet, uniqAway)
+   lookupVarEnv, mkInScopeSet, uniqAway, extendInScopeSetList, unionInScope)
 import Clash.Unique
 import Clash.Util
 
@@ -56,6 +59,159 @@ import Clash.Util
 type Gamma = VarEnv Type
 -- | Kind environment/context
 type Delta = VarEnv Kind
+
+-- | Given the left and right side of an equation, normalize it such that
+-- equations of the following forms:
+--
+--     * 5     ~ n + 2
+--     * 5     ~ 2 + n
+--     * n + 2 ~ 5
+--     * 2 + n ~ 5
+--
+-- are returned as (5, 2, n)
+normalizeAdd
+  :: (Type, Type)
+  -> Maybe (Integer, Integer, Type)
+normalizeAdd (a, b) = do
+  (n, rhs) <- lhsLit a b
+  case tyView rhs of
+    TyConApp (nameOcc -> "GHC.TypeNats.+") [left, right] -> do
+      (m, o) <- lhsLit left right
+      return (n, m, o)
+    _ ->
+      Nothing
+ where
+  lhsLit x                 (LitTy (NumTy n)) = Just (n, x)
+  lhsLit (LitTy (NumTy n)) y                 = Just (n, y)
+  lhsLit _                 _                 = Nothing
+
+-- | Data type that indicates what kind of solution (if any) was found
+data AddSolution
+  = Solution (TyVar, Type)
+  -- ^ Solution was found. Variable equals some integer.
+  | AbsurdSolution
+  -- ^ A solution was found, but it involved negative naturals.
+  | NoSolution
+  -- ^ Given type wasn't an equation, or it was unsolvable.
+    deriving (Show)
+
+-- | Solve given equations and return the first non-absurd solution (if any)
+solveFirstNonAbsurd
+  :: [(Type, Type)]
+  -> Maybe (TyVar, Type)
+solveFirstNonAbsurd [] = Nothing
+solveFirstNonAbsurd (eq:eqs) =
+  case solveAdd eq of
+    Solution s ->
+      Just s
+    _  ->
+      solveFirstNonAbsurd eqs
+
+-- | Solve equations supported by @normalizeAdd@. See documentation of
+-- @AddSolution@ to understand the return value.
+solveAdd
+  :: (Type, Type)
+  -> AddSolution
+solveAdd ab =
+  case normalizeAdd ab of
+    Just (n, m, VarTy tyVar) ->
+      if n >= 0 && m >= 0 && n - m >= 0 then
+        Solution (tyVar, (LitTy (NumTy (n - m))))
+      else
+        AbsurdSolution
+    _ ->
+      NoSolution
+
+-- | If type is an equation, return LHS and RHS.
+typeEq
+  :: TyConMap
+  -> Type
+  -> Maybe (Type, Type)
+typeEq tcm ty =
+ case tyView (coreView tcm ty) of
+  TyConApp (nameOcc -> "GHC.Prim.~#") [_, _, left, right] ->
+    Just (coreView tcm left, coreView tcm right)
+  _ ->
+    Nothing
+
+-- | Get constraint equations
+altEqs
+  :: TyConMap
+  -> Alt
+  -> [(Type, Type)]
+altEqs tcm (pat, _term) =
+ catMaybes (map (typeEq tcm . varType) (snd (patIds pat)))
+
+-- | Tests for unreachable alternative due to types being "absurd". See
+-- @isAbsurdEq@ for more info.
+isAbsurdAlt
+  :: TyConMap
+  -> Alt
+  -> Bool
+isAbsurdAlt tcm alt =
+  any (isAbsurdEq tcm) (altEqs tcm alt)
+
+-- | Determines if an "equation" obtained through @altEqs@ or @typeEq@ is
+-- absurd. That is, it tests if two types that are definitely not equal are
+-- asserted to be equal OR if the computation of the types yield some absurd
+-- (intermediate) result such as -1.
+isAbsurdEq
+  :: TyConMap
+  -> (Type, Type)
+  -> Bool
+isAbsurdEq tcm ((left0, right0)) =
+  case (coreView tcm left0, coreView tcm right0) of
+    (ConstTy {}, ConstTy {}) ->
+      left0 /= right0
+    (LitTy {}, LitTy {}) ->
+      left0 /= right0
+    (left1, right1) ->
+      case solveAdd (left1, right1) of
+        AbsurdSolution -> True
+        _              -> False
+
+-- Safely substitute global type variables in a list of potentially
+-- shadowing type variables.
+substGlobalsInExistentials
+  :: HasCallStack
+  => InScopeSet
+  -- ^ Variables in scope
+  -> [TyVar]
+  -- ^ List of existentials to apply the substitution for
+  -> [(TyVar, Type)]
+  -- ^ Substitutions
+  -> [TyVar]
+substGlobalsInExistentials is exts substs0 = result
+  -- TODO: Is is actually possible that existentials shadow each other? If they
+  -- TODO: can't, we can remove this function
+  where
+    iss     = scanl extendInScopeSet is exts
+    substs1 = map (\is_ -> extendTvSubstList (mkSubst is_) substs0) iss
+    result  = zipWith substTyInVar substs1 exts
+
+-- | Safely substitute a type variable in a list of existentials. This function
+-- will account for cases where existentials shadow each other.
+substInExistentials
+  :: HasCallStack
+  => InScopeSet
+  -- ^ Variables in scope
+  -> [TyVar]
+  -- ^ List of existentials to apply the substitution for
+  -> (TyVar, Type)
+  -- ^ Substitution
+  -> [TyVar]
+substInExistentials is exts subst@(typeVar, _type) =
+  -- TODO: Is is actually possible that existentials shadow each other? If they
+  -- TODO: can't, we can remove this function
+  case elemIndices typeVar exts of
+    [] ->
+      -- We're not replacing any of the existentials, but a global variable
+      substGlobalsInExistentials is exts [subst]
+    (last -> i) ->
+      -- We're replacing an existential. That means we're not touching any
+      -- variables that were introduced before it. For all variables after it,
+      -- it is as we would replace global variables in them.
+      take (i+1) exts ++ substGlobalsInExistentials is (drop (i+1) exts) [subst]
 
 -- | Determine the type of a term
 termType
@@ -581,7 +737,7 @@ isClockOrReset
   :: TyConMap
   -> Type
   -> Bool
-isClockOrReset m (coreView1 m -> Just ty) = isClockOrReset m ty
+isClockOrReset m (coreView1 m -> Just ty)    = isClockOrReset m ty
 isClockOrReset _ (tyView -> TyConApp tcNm _) = case nameOcc tcNm of
   "Clash.Signal.Internal.Clock" -> True
   "Clash.Signal.Internal.Reset" -> True
@@ -592,7 +748,7 @@ tyNatSize :: TyConMap
           -> Type
           -> Except String Integer
 tyNatSize m (coreView1 m -> Just ty) = tyNatSize m ty
-tyNatSize _ (LitTy (NumTy i))       = return i
+tyNatSize _ (LitTy (NumTy i))        = return i
 tyNatSize _ ty = throwE $ $(curLoc) ++ "Cannot reduce to an integer:\n" ++ showDoc (ppr ty)
 
 
@@ -628,3 +784,61 @@ mkUniqInternalId (supply,inScope) (nm, ty) =
   (u,supply') = freshId supply
   v           = mkId ty (mkUnsafeInternalName nm u)
   v'          = uniqAway inScope v
+
+
+-- | Same as @dataConInstArgTys@, but it tries to compute existentials too,
+-- hence the extra argument @TyConMap@. WARNING: It will return the types
+-- of non-existentials only
+dataConInstArgTysE
+  :: HasCallStack
+  => InScopeSet
+  -> TyConMap
+  -> DataCon
+  -> [Type]
+  -> Maybe [Type]
+dataConInstArgTysE is0 tcm (MkData { dcArgTys, dcExtTyVars, dcUnivTyVars }) inst_tys = do
+  -- TODO: Check if all existentials were solved (they should be, or the wouldn't have
+  -- TODO: been solved in the caseElemExistentials transformation)
+  let is1   = extendInScopeSetList is0 dcExtTyVars
+      is2   = unionInScope is1 (mkInScopeSet (tyFVsOfTypes inst_tys))
+      subst = extendTvSubstList (mkSubst is2) (zip dcUnivTyVars inst_tys)
+  go
+    (substGlobalsInExistentials is0 dcExtTyVars (zip dcUnivTyVars inst_tys))
+    (map (substTy subst) dcArgTys)
+
+ where
+  go
+    :: [TyVar]
+    -- ^ Existentials
+    -> [Type]
+    -- ^ Type arguments
+    -> Maybe [Type]
+    -- ^ Maybe ([type of non-existential])
+  go exts0 args0 =
+    let eqs = catMaybes (map (typeEq tcm) args0) in
+    case solveFirstNonAbsurd eqs of
+      Just (tyVar, solution1) ->
+        go exts1 args1
+        where
+          exts1 = substInExistentials is0 exts0 (tyVar, solution1)
+          is2   = extendInScopeSetList is0 exts1
+          subst = extendTvSubst (mkSubst is2) tyVar solution1
+          args1 = map (substTy subst) args0
+      Nothing ->
+        Just args0
+
+
+-- | Given a DataCon and a list of types, the type variables of the DataCon
+-- type are substituted for the list of types. The argument types are returned.
+--
+-- The list of types should be equal to the number of type variables, otherwise
+-- @Nothing@ is returned.
+dataConInstArgTys :: DataCon -> [Type] -> Maybe [Type]
+dataConInstArgTys (MkData { dcArgTys, dcUnivTyVars, dcExtTyVars }) inst_tys =
+  -- TODO: Check if inst_tys do not contain any free variables on call sites. If
+  -- TODO: they do, this function is unsafe to use.
+  let tyvars = dcUnivTyVars ++ dcExtTyVars in
+  if length tyvars == length inst_tys then
+    Just (map (substTyWith tyvars inst_tys) dcArgTys)
+  else
+    Nothing

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -21,6 +21,7 @@ module Clash.Core.Var
   , mkId
   , mkTyVar
   , setVarUnique
+  , setVarType
   , modifyVarName
   , attrName
   )
@@ -117,3 +118,9 @@ setVarUnique
   -> Unique
   -> Var a
 setVarUnique v u = v { varUniq = u, varName = (varName v) {nameUniq = u} }
+
+setVarType
+  :: Var a
+  -> Type
+  -> Var a
+setVarType v t = v { varType = t }

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -54,7 +54,7 @@ import           Clash.Core.Term
   (Alt, Pat (..), Term (..))
 import qualified Clash.Core.Term                  as Core
 import           Clash.Core.Type
-  (Type (..), coreView, splitFunTys, splitCoreFunForallTy)
+  (Type (..), coreView1, splitFunTys, splitCoreFunForallTy)
 import           Clash.Core.TyCon                 (TyConMap)
 import           Clash.Core.Util                  (collectArgs, termType)
 import           Clash.Core.Var                   (Id, Var (..))
@@ -420,7 +420,7 @@ reorderCustom
   -> Type
   -> [(Pat, Term)]
   -> [(Pat, Term)]
-reorderCustom tcm reprs (coreView tcm -> Just ty) alts =
+reorderCustom tcm reprs (coreView1 tcm -> Just ty) alts =
   reorderCustom tcm reprs ty alts
 reorderCustom _tcm reprs (coreToType' -> Right typeName) alts =
   case getDataRepr typeName reprs of

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -56,7 +56,7 @@ import           Clash.Core.Term         (LetBinding, Term (..))
 import           Clash.Core.TyCon
   (TyConName, TyConMap, tyConDataCons)
 import           Clash.Core.Type         (Type (..), TypeView (..), LitTy (..),
-                                          coreView1, splitTyConAppM, tyView)
+                                          coreView1, splitTyConAppM, tyView, TyVar)
 import           Clash.Core.Util         (collectBndrs, termType, tyNatSize)
 import           Clash.Core.Var          (Id, Var (..), mkId, modifyVarName, Attr')
 import           Clash.Core.VarEnv
@@ -1747,3 +1747,14 @@ splitGatedClock baseNm (Clock nm rt Gated) = do
     hwtys = [Clock nm rt Source,Bool]
     partNms = ["_clk","_clken"]
 splitGatedClock _ ty = error $ $(curLoc) ++ "splitGatedClock can't split: " ++ show ty
+
+-- | Determines if any type variables (exts) are bound in any of the given
+-- type or term variables (tms). It's currently only used to detect bound
+-- existentials, hence the name.
+bindsExistentials
+  :: [TyVar]
+  -> [Var a]
+  -> Bool
+bindsExistentials exts tms = any (`elem` freeVars) exts
+ where
+  freeVars = concatMap (Lens.toListOf typeFreeVars) (map varType tms)

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -56,7 +56,7 @@ import           Clash.Core.Term         (LetBinding, Term (..))
 import           Clash.Core.TyCon
   (TyConName, TyConMap, tyConDataCons)
 import           Clash.Core.Type         (Type (..), TypeView (..), LitTy (..),
-                                          coreView, splitTyConAppM, tyView)
+                                          coreView1, splitTyConAppM, tyView)
 import           Clash.Core.Util         (collectBndrs, termType, tyNatSize)
 import           Clash.Core.Var          (Id, Var (..), mkId, modifyVarName, Attr')
 import           Clash.Core.VarEnv
@@ -330,7 +330,7 @@ coreTypeToHWType builtInTranslation reprs m ty = go' ty
       (\(FilteredHWType hwty filtered) ->
         (FilteredHWType (fixCustomRepr reprs ty hwty) filtered)) <$> hwtyE
     -- Strip transparant types:
-    go' (coreView m -> Just ty') =
+    go' (coreView1 m -> Just ty') =
       coreTypeToHWType builtInTranslation reprs m ty'
     -- Try to create hwtype based on AST:
     go' (tyView -> TyConApp tc args) = do

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -40,7 +40,7 @@ import qualified Control.Lens                     as Lens
 import           Data.List                        (mapAccumR)
 import qualified Data.Maybe                       as Maybe
 
-import           Clash.Core.DataCon               (DataCon, dataConInstArgTys)
+import           Clash.Core.DataCon               (DataCon)
 import           Clash.Core.Literal               (Literal (..))
 import           Clash.Core.Pretty                (showPpr)
 import           Clash.Core.Term                  (Term (..), Pat (..))
@@ -53,7 +53,7 @@ import           Clash.Core.TyCon                 (TyConName, tyConDataCons)
 import           Clash.Core.TysPrim               (integerPrimTy, typeNatKind)
 import           Clash.Core.Util
   (appendToVec, extractElems, extractTElems, idToVar, mkApps, mkRTree,
-   mkUniqInternalId, mkUniqSystemTyVar, mkVec, termType)
+   mkUniqInternalId, mkUniqSystemTyVar, mkVec, termType, dataConInstArgTys)
 import           Clash.Core.Var                   (Var (..))
 import           Clash.Core.VarEnv
   (InScopeSet, extendInScopeSetList)

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -45,7 +45,7 @@ import           Clash.Core.Literal               (Literal (..))
 import           Clash.Core.Pretty                (showPpr)
 import           Clash.Core.Term                  (Term (..), Pat (..))
 import           Clash.Core.Type                  (LitTy (..), Type (..),
-                                                   TypeView (..), coreView,
+                                                   TypeView (..), coreView1,
                                                    mkFunTy, mkTyConApp,
                                                    splitFunForallTy, tyView,
                                                    undefinedTy)
@@ -82,7 +82,7 @@ reduceZipWith inScope0 n lhsElTy rhsElTy resElTy fun lhsArg rhsArg = do
     let ty = termType tcm lhsArg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
@@ -116,7 +116,7 @@ reduceMap inScope n argElTy resElTy fun arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
@@ -147,7 +147,7 @@ reduceImap inScope n argElTy resElTy fun arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
@@ -196,7 +196,7 @@ reduceTraverse inScope n aTy fTy bTy dict fun arg = do
         ty = termType tcm arg
     go tcm apDictTcNm ty
   where
-    go tcm apDictTcNm (coreView tcm -> Just ty') = go tcm apDictTcNm ty'
+    go tcm apDictTcNm (coreView1 tcm -> Just ty') = go tcm apDictTcNm ty'
     go tcm apDictTcNm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
@@ -327,7 +327,7 @@ reduceFoldr inScope n aTy fun start arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [_,consCon] <- tyConDataCons vecTc
@@ -360,7 +360,7 @@ reduceFold inScope n aTy fun arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [_,consCon]  <- tyConDataCons vecTc
@@ -402,7 +402,7 @@ reduceDFold inScope n aTy fun start arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [_,consCon]  <- tyConDataCons vecTc
@@ -442,7 +442,7 @@ reduceHead inScope n aTy vArg = do
     let ty = termType tcm vArg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [_,consCon]  <- tyConDataCons vecTc
@@ -469,7 +469,7 @@ reduceTail inScope n aTy vArg = do
     let ty = termType tcm vArg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [_,consCon]  <- tyConDataCons vecTc
@@ -497,7 +497,7 @@ reduceLast inScope n aTy vArg = do
     let ty = termType tcm vArg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [_,consCon]  <- tyConDataCons vecTc
@@ -526,7 +526,7 @@ reduceInit inScope n aTy vArg = do
     let ty = termType tcm vArg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [nilCon,consCon]  <- tyConDataCons vecTc
@@ -561,7 +561,7 @@ reduceAppend inScope n m aTy lArg rArg = do
     let ty = termType tcm lArg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [_,consCon]  <- tyConDataCons vecTc
@@ -588,7 +588,7 @@ reduceUnconcat n 0 aTy arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
@@ -613,7 +613,7 @@ reduceTranspose n 0 aTy arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
@@ -634,7 +634,7 @@ reduceReplicate n aTy eTy arg = do
     tcm <- Lens.view tcCache
     go tcm eTy
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
       , [nilCon,consCon] <- tyConDataCons vecTc
@@ -658,7 +658,7 @@ reduceDTFold inScope n aTy lrFun brFun arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
       , [_,consCon]  <- tyConDataCons vecTc
@@ -705,7 +705,7 @@ reduceTFold inScope n aTy lrFun brFun arg = do
     let ty = termType tcm arg
     go tcm ty
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp treeTcNm _)
       | (Just treeTc) <- lookupUniqMap treeTcNm tcm
       , [lrCon,brCon] <- tyConDataCons treeTc
@@ -742,7 +742,7 @@ reduceTReplicate n aTy eTy arg = do
     tcm <- Lens.view tcCache
     go tcm eTy
   where
-    go tcm (coreView tcm -> Just ty') = go tcm ty'
+    go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp treeTcNm _)
       | (Just treeTc) <- lookupUniqMap treeTcNm tcm
       , [lrCon,brCon] <- tyConDataCons treeTc

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -50,11 +50,13 @@ constantPropgation = propagate >-> repeatR inlineAndPropagate >->
 
     transPropagate :: [(String,NormRewrite)]
     transPropagate =
-      [ ("applicationPropagation", appProp        )
-      , ("bindConstantVar"       , bindConstantVar)
-      , ("caseLet"               , caseLet        )
-      , ("caseCase"              , caseCase       )
-      , ("caseCon"               , caseCon        )
+      [ ("applicationPropagation", appProp              )
+      , ("bindConstantVar"       , bindConstantVar      )
+      , ("caseLet"               , caseLet              )
+      , ("caseCase"              , caseCase             )
+      , ("caseCon"               , caseCon              )
+      , ("caseElemNonReachable"  , caseElemNonReachable )
+      , ("elemExistentials"      , elemExistentials     )
       ]
 
     -- These transformations can safely be applied in a top-down traversal as

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -22,6 +22,8 @@ module Clash.Normalize.Transformations
   , caseLet
   , caseCon
   , caseCase
+  , caseElemNonReachable
+  , elemExistentials
   , inlineNonRep
   , inlineOrLiftNonRep
   , typeSpec
@@ -87,7 +89,8 @@ import           Clash.Core.FreeVars
 import           Clash.Core.Literal          (Literal (..))
 import           Clash.Core.Pretty           (showPpr)
 import           Clash.Core.Subst
-  (substTm, mkSubst, extendIdSubst, extendIdSubstList, extendTvSubst, extendTvSubstList, freshenTm)
+  (substTm, mkSubst, extendIdSubst, extendIdSubstList, extendTvSubst,
+   extendTvSubstList, freshenTm, substTyInVar)
 import           Clash.Core.Term             (LetBinding, Pat (..), Term (..))
 import           Clash.Core.Type             (TypeView (..), applyFunTy,
                                               isPolyFunCoreTy,
@@ -98,7 +101,8 @@ import           Clash.Core.TyCon            (TyConMap, tyConDataCons)
 import           Clash.Core.Util
   (collectArgs, isClockOrReset, isCon, isFun, isLet, isPolyFun, isPrim,
    isSignalType, isVar, mkApps, mkLams, mkVec, piResultTy, termSize, termType,
-   tyNatSize, patVars)
+   tyNatSize, patVars, isAbsurdAlt, altEqs, substInExistentials,
+   solveFirstNonAbsurd)
 import           Clash.Core.Var              (Id, Var (..), mkId)
 import           Clash.Core.VarEnv
   (InScopeSet, VarEnv, VarSet, elemInScopeSet, notElemInScopeSet, elemVarSet,
@@ -109,7 +113,7 @@ import           Clash.Driver.Types          (DebugLevel (..))
 import           Clash.Netlist.BlackBox.Util (usedArguments)
 import           Clash.Netlist.Types         (HWType (..), FilteredHWType(..))
 import           Clash.Netlist.Util
-  (coreTypeToHWType, representableType, splitNormalized)
+  (coreTypeToHWType, representableType, splitNormalized, bindsExistentials)
 import           Clash.Normalize.DEC
 import           Clash.Normalize.PrimitiveReductions
 import           Clash.Normalize.Types
@@ -239,6 +243,94 @@ caseLet _ (Case (Letrec xes e) ty alts) =
   changed (Letrec xes (Case e ty alts))
 
 caseLet _ e = return e
+
+-- | Remove non-reachable alternatives. For example, consider:
+--
+--    data STy ty where
+--      SInt :: Int -> STy Int
+--      SBool :: Bool -> STy Bool
+--
+--    f :: STy ty -> ty
+--    f (SInt b) = b + 1
+--    f (SBool True) = False
+--    f (SBool False) = True
+--    {-# NOINLINE f #-}
+--
+--    g :: STy Int -> Int
+--    g = f
+--
+-- @f@ is always specialized on @STy Int@. The SBool alternatives are therefore
+-- unreachable. Additional information can be found at:
+-- https://github.com/clash-lang/clash-compiler/pull/465
+caseElemNonReachable :: NormRewrite
+caseElemNonReachable _ case0@(Case scrut altsTy alts0) = do
+  tcm <- Lens.view tcCache
+
+  let (altsAbsurd, altsOther) = List.partition (isAbsurdAlt tcm) alts0
+  case altsAbsurd of
+    [] -> return case0
+    _  -> changed =<< caseOneAlt (Case scrut altsTy altsOther)
+
+caseElemNonReachable _ e = return e
+
+-- | Tries to eliminate existentials by using heuristics to determine what the
+-- existential should be. For example, consider Vec:
+--
+--    data Vec :: Nat -> Type -> Type where
+--      Nil       :: Vec 0 a
+--      Cons x xs :: a -> Vec n a -> Vec (n + 1) a
+--
+-- Thus, 'null' (annotated with existentials) could look like:
+--
+--    null :: forall n . Vec n Bool -> Bool
+--    null v =
+--      case v of
+--        Nil  {n ~ 0}                                     -> True
+--        Cons {n1:Nat} {n~n1+1} (x :: a) (xs :: Vec n1 a) -> False
+--
+-- When it's applied to a vector of length 5, this becomes:
+--
+--    null :: Vec 5 Bool -> Bool
+--    null v =
+--      case v of
+--        Nil  {5 ~ 0}                                     -> True
+--        Cons {n1:Nat} {5~n1+1} (x :: a) (xs :: Vec n1 a) -> False
+--
+-- This function solves 'n1' and replaces every occurrence with its solution. A
+-- very limited number of solutions are currently recognized: only adds (such
+-- as in the example) will be solved.
+elemExistentials :: NormRewrite
+elemExistentials (TransformContext is0 _) (Case scrut altsTy alts0) = do
+  tcm <- Lens.view tcCache
+  is1 <- unionInScope is0 <$> Lens.use globalInScope
+
+  alts1 <- mapM (go is1 tcm) alts0
+  caseOneAlt (Case scrut altsTy alts1)
+
+ where
+    -- Eliminate free type variables if possible
+    go :: InScopeSet -> TyConMap -> (Pat, Term) -> NormalizeSession (Pat, Term)
+    go is2 tcm alt@(DataPat dc exts0 xs0, term0) =
+      case solveFirstNonAbsurd (altEqs tcm alt) of
+        -- No equations solved:
+        Nothing -> return alt
+        -- One or more equations solved:
+        Just (tyVar, solution) ->
+          changed =<< go is2 tcm (DataPat dc exts1 xs1, term1)
+          where
+            -- Substitute solution in existentials and applied types
+            is3   = extendInScopeSetList is2 exts0
+            xs1   = map (substTyInVar (extendTvSubst (mkSubst is3) tyVar solution)) xs0
+            exts1 = substInExistentials is2 exts0 (tyVar, solution)
+
+            -- Substitute solution in term.
+            is4       = extendInScopeSetList is3 xs1
+            subst     = extendTvSubst (mkSubst is4) tyVar solution
+            term1     = substTm "Replacing tyVar due to solved eq" subst term0
+
+    go _ _ alt = return alt
+
+elemExistentials _ e = return e
 
 -- | Move a Case-decomposition from the subject of a Case-decomposition to the alternatives
 caseCase :: NormRewrite
@@ -1239,7 +1331,7 @@ collectANF ctx (Case subj ty alts) = do
       :: Term -> (Pat,Term)
       -> StateT ([LetBinding],InScopeSet) (RewriteMonad NormalizeState)
                 (Pat,Term)
-    doAlt subj' alt@(DataPat dc [] xs,altExpr) = do
+    doAlt subj' alt@(DataPat dc exts xs,altExpr) | not (bindsExistentials exts xs) = do
       lv  <- lift (isNonGlobalVar altExpr)
       patSels <- Monad.zipWithM (doPatBndr subj' dc) xs [0..]
       let usesXs (Var n) = any (== n) xs
@@ -1256,7 +1348,7 @@ collectANF ctx (Case subj ty alts) = do
           altId <- lift (mkTmBinderFor is1 tcm (mkDerivedName ctx "case_alt") altExpr)
           -- See Note [ANF InScopeSet]
           tellBinders ((altId,altExpr):patSels)
-          return (DataPat dc [] xs,Var altId)
+          return (DataPat dc exts xs,Var altId)
     doAlt _ alt@(DataPat {}, _) = return alt
     doAlt _ alt@(pat,altExpr) = do
       lv <- lift (isNonGlobalVar altExpr)

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1199,8 +1199,8 @@ collectANF _ (Letrec binds body) = do
 -- type by the Clash compiler, so observing its constructor leads to all kinds
 -- of problems. In this case that "Clash.Rewrite.Util.mkSelectorCase" will
 -- try to project the LHS and RHS of the ':-' constructor, however,
--- 'mkSelectorCase' uses 'coreView' to find the "real" data-constructor.
--- 'coreView' however looks through the 'Signal' type, and hence 'mkSelector'
+-- 'mkSelectorCase' uses 'coreView1' to find the "real" data-constructor.
+-- 'coreView1' however looks through the 'Signal' type, and hence 'mkSelector'
 -- finds the data constructors for the element type of Signal. This resulted in
 -- error #24 (https://github.com/christiaanb/clash2/issues/24), where we
 -- try to get the first field out of the 'Vec's 'Nil' constructor.

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -40,6 +40,7 @@ import qualified Data.Text                   as Text
 
 import           BasicTypes                  (InlineSpec (..))
 import           SrcLoc                      (SrcSpan)
+import           GHC.Stack                   (HasCallStack)
 
 import           Clash.Core.DataCon          (dataConInstArgTys)
 import           Clash.Core.FreeVars
@@ -536,7 +537,8 @@ mkWildValBinder is = mkInternalVar is "wild"
 
 -- | Make a case-decomposition that extracts a field out of a (Sum-of-)Product type
 mkSelectorCase
-  :: (Functor m, Monad m, MonadUnique m)
+  :: HasCallStack
+  => (Functor m, Monad m, MonadUnique m)
   => String -- ^ Name of the caller of this function
   -> InScopeSet
   -> TyConMap -- ^ TyCon cache

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -53,7 +53,7 @@ import           Clash.Core.Term
 import           Clash.Core.TyCon
   (TyConMap, tyConDataCons)
 import           Clash.Core.Type             (KindOrType, Type (..),
-                                              TypeView (..), coreView,
+                                              TypeView (..), coreView1,
                                               normalizeType,
                                               typeKind, tyView)
 import           Clash.Core.Util
@@ -546,7 +546,7 @@ mkSelectorCase
   -> m Term
 mkSelectorCase caller inScope tcm scrut dcI fieldI = go (termType tcm scrut)
   where
-    go (coreView tcm -> Just ty')   = go ty'
+    go (coreView1 tcm -> Just ty')   = go ty'
     go scrutTy@(tyView -> TyConApp tc args) =
       case tyConDataCons (lookupUniqMap' tcm tc) of
         [] -> cantCreate $(curLoc) ("TyCon has no DataCons: " ++ show tc ++ " " ++ showPpr tc) scrutTy

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -85,13 +85,25 @@ callStackDoc =
     (vcat (map pretty (lines (prettyCallStack callStack))))
 
 warnPprTrace
-  :: Bool -> String -> Int -> Doc ann -> a -> a
+  :: HasCallStack
+  => Bool
+  -- ^ Trigger warning?
+  -> String
+  -- ^ File name
+  -> Int
+  -- ^ Line number
+  -> Doc ann
+  -- ^ Message
+  -> a
+  -- ^ Pass value (like trace)
+  -> a
 warnPprTrace _     _ _ _ x | not debugIsOn = x
 warnPprTrace False _ _ _ x = x
 warnPprTrace True  file ln msg x =
-  pprDebugAndThen trace heading msg x
+  pprDebugAndThen trace (vcat [heading0, heading1]) msg x
  where
-  heading = hsep ["WARNING: file", pretty file <> comma, "line", pretty ln]
+  heading0 = hsep ["WARNING: file", pretty file <> comma, "line", pretty ln]
+  heading1 = "WARNING CALLSTACK:" <> line <> pretty (prettyCallStack callStack)
 
 pprTrace
   :: String -> Doc ann -> a -> a

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -36,7 +36,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 module Clash.Sized.Vector
   ( -- * 'Vec'tor data type
-    Vec(Nil,(:>),(:<))
+    Vec(Nil,(:>),(:<),Cons)
     -- * Accessors
     -- ** Length information
   , length, lengthS

--- a/tests/shouldwork/GADTs/Constrained.hs
+++ b/tests/shouldwork/GADTs/Constrained.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE GADTs #-}
+
+module Constrained where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+import Data.Bits (complement)
+
+data Bus n :: * where
+  Bus :: forall n
+       . n <= 10
+      => BitVector n
+      -> Bus n
+
+instance KnownNat n => Eq (Bus n) where
+  Bus a == Bus b = a == b
+
+instance KnownNat n => ShowX (Bus n) where
+  showsPrecX _ _ = undefined
+
+
+complementBus
+  :: KnownNat n
+  => Bus n
+  -> Bus n
+complementBus (Bus bv) = Bus (complement bv)
+{-# NOINLINE complementBus #-}
+
+topEntity :: Bus 5 -> Bus 5
+topEntity = complementBus
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (Bus 1 :> Bus 2 :> Bus 3 :> Nil)
+    expectedOutput = outputVerifier clk rst (Bus 30 :> Bus 29 :> Bus 28 :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/GADTs/Head.hs
+++ b/tests/shouldwork/GADTs/Head.hs
@@ -1,0 +1,22 @@
+module Head where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+head' :: Vec (n+1) (Signed 16) -> Signed 16
+head' (Cons x xs) = x
+{-# NOINLINE head' #-}
+
+topEntity :: Vec 3 (Signed 16) -> Signed 16
+topEntity = head'
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((1 :> 2 :> 3 :> Nil) :> Nil)
+    expectedOutput = outputVerifier clk rst (1 :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/GADTs/HeadM.hs
+++ b/tests/shouldwork/GADTs/HeadM.hs
@@ -1,0 +1,22 @@
+module HeadM where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+head' :: Vec 3 (Signed 16) -> Signed 16
+head' (Cons x xs) = x
+{-# NOINLINE head' #-}
+
+topEntity :: Vec 3 (Signed 16) -> Signed 16
+topEntity = head'
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((1 :> 2 :> 3 :> Nil) :> Nil)
+    expectedOutput = outputVerifier clk rst (1 :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/GADTs/MonomorphicTopEntity.hs
+++ b/tests/shouldwork/GADTs/MonomorphicTopEntity.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE GADTs #-}
+
+module MonomorphicTopEntity where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+data STy ty where
+  SBool  :: Bool -> STy Bool
+  SInt16 :: Signed 16 -> STy (Signed 16)
+
+sty :: STy ty -> ty
+sty (SBool b) = not b
+sty (SInt16 i) = i + 1
+{-# NOINLINE sty #-}
+
+topEntity :: STy (Signed 16) -> Signed 16
+topEntity = sty
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (SInt16 0 :> SInt16 1 :> SInt16 2 :> SInt16 3 :> Nil)
+    expectedOutput = outputVerifier clk rst (1 :> 2 :> 3 :> 4 :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/GADTs/Record.hs
+++ b/tests/shouldwork/GADTs/Record.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Record where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+-- Real-world example of a GADT stolen from:
+--   https://stackoverflow.com/questions/21505975/write-gadt-record-with-constrained-type
+class HasData (a :: *) where
+    type Data a :: *
+
+instance HasData Int where
+    type Data Int = Maybe Int
+
+data Foo :: * -> * where
+    Foo :: HasData a => {
+        getChar :: Char,
+        getData :: Data a,
+        getInt :: Int
+    } -> Foo a
+
+deriving instance Eq (Foo Int)
+
+instance ShowX (Foo Int) where
+  showsPrecX _ _ = undefined
+
+succIntChar :: Foo a -> Foo a
+succIntChar (Foo chr dt int) =
+  Foo (succ chr) dt (succ int)
+{-# NOINLINE succIntChar #-}
+
+topEntity :: Foo Int -> Foo Int
+topEntity foo = Foo chr (succ <$> dt) int
+  where
+    Foo chr dt int = succIntChar foo
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (Foo 'c' (Just 4) 6 :> Nil)
+    expectedOutput = outputVerifier clk rst (Foo 'd' (Just 5) 7 :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/GADTs/Tail.hs
+++ b/tests/shouldwork/GADTs/Tail.hs
@@ -1,0 +1,22 @@
+module Tail where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+tail' :: Vec (n+1) (Signed 16) -> Vec n (Signed 16)
+tail' (Cons x xs) = xs
+{-# NOINLINE tail' #-}
+
+topEntity :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)
+topEntity = tail'
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((1 :> 2 :> 3 :> Nil) :> Nil)
+    expectedOutput = outputVerifier clk rst ((2 :> 3 :> Nil) :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/GADTs/TailM.hs
+++ b/tests/shouldwork/GADTs/TailM.hs
@@ -1,0 +1,22 @@
+module TailM where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+tail' :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)
+tail' (Cons x xs) = xs
+{-# NOINLINE tail' #-}
+
+topEntity :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)
+topEntity = tail'
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((1 :> 2 :> 3 :> Nil) :> Nil)
+    expectedOutput = outputVerifier clk rst ((2 :> 3 :> Nil) :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/GADTs/TailOfTail.hs
+++ b/tests/shouldwork/GADTs/TailOfTail.hs
@@ -1,0 +1,22 @@
+module TailOfTail where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+tailOfTail :: Vec (n+2) (Signed 16) -> Vec n (Signed 16)
+tailOfTail (Cons _ (Cons _ xs)) = xs
+{-# NOINLINE tailOfTail #-}
+
+topEntity :: Vec 4 (Signed 16) -> Vec 2 (Signed 16)
+topEntity = tailOfTail
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((1 :> 2 :> 3 :> 4 :> Nil) :> Nil)
+    expectedOutput = outputVerifier clk rst ((3 :> 4 :> Nil) :> Nil)
+
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -151,6 +151,14 @@ runClashTest =
         [ runTest ("tests" </> "shouldwork" </> "Floating") defBuild ["-fclash-float-support"] "FloatPack" ([""],"FloatPack_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Floating") defBuild ["-fclash-float-support"] "FloatConstFolding" (["","FloatConstFolding_testBench"],"FloatConstFolding_testBench",True)
         ]
+      , clashTestGroup "GADTs"
+        [ runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "MonomorphicTopEntity" (["", "MonomorphicTopEntity_testBench"],"MonomorphicTopEntity_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Head"                 (["", "Head_testBench"],"Head_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "HeadM"                (["", "HeadM_testBench"],"HeadM_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Tail"                 (["", "Tail_testBench"],"Tail_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "TailM"                (["", "TailM_testBench"],"TailM_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "TailOfTail"           (["", "TailOfTail_testBench"],"TailOfTail_testBench",True)
+        ]
       , clashTestGroup "HOPrim"
         [ runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "HOImap"    (["","HOImap_testBench"],"HOImap_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "TestMap"   (["","TestMap_testBench"],"TestMap_testBench",True)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -152,7 +152,8 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Floating") defBuild ["-fclash-float-support"] "FloatConstFolding" (["","FloatConstFolding_testBench"],"FloatConstFolding_testBench",True)
         ]
       , clashTestGroup "GADTs"
-        [ runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "MonomorphicTopEntity" (["", "MonomorphicTopEntity_testBench"],"MonomorphicTopEntity_testBench",True)
+        [ runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Constrained"          (["", "Constrained_testBench"],"Constrained_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "MonomorphicTopEntity" (["", "MonomorphicTopEntity_testBench"],"MonomorphicTopEntity_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Head"                 (["", "Head_testBench"],"Head_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "HeadM"                (["", "HeadM_testBench"],"HeadM_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Tail"                 (["", "Tail_testBench"],"Tail_testBench",True)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -153,9 +153,10 @@ runClashTest =
         ]
       , clashTestGroup "GADTs"
         [ runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Constrained"          (["", "Constrained_testBench"],"Constrained_testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "MonomorphicTopEntity" (["", "MonomorphicTopEntity_testBench"],"MonomorphicTopEntity_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Head"                 (["", "Head_testBench"],"Head_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "HeadM"                (["", "HeadM_testBench"],"HeadM_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "MonomorphicTopEntity" (["", "MonomorphicTopEntity_testBench"],"MonomorphicTopEntity_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Record"               (["", "Record_testBench"],"Record_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Tail"                 (["", "Tail_testBench"],"Tail_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "TailM"                (["", "TailM_testBench"],"TailM_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "TailOfTail"           (["", "TailOfTail_testBench"],"TailOfTail_testBench",True)


### PR DESCRIPTION
**TODO**: confirm that `InScopeSet`s are correctly extended.

This commit adds support for Vec-like GADT constructs, as well as
simpler ones. To understand what changed, let's consider a small
example:

    data T a where
      SBool :: Bool -> T Bool
      SInt  :: Int  -> T Int

I.e., a sum-of-products with two constructors: `SBool` and `SInt`. When
`T a` is constructed with the constructor `SBool`, we're sure that
`a ~ Bool`. Likewise, whenever `T a` is constructed with `SInt`, we know
that `a ~ Int`. The inverse is true too: whenever we match on each of
the constructors we gain type information. Consider:

    f :: T a -> a
    f t =
      case t of
        SBool b -> not b
        SInt i  -> i + 1

At first it might seem that GHC would reject this program: the two
alternatives yield wildly different types. But, as alluded to earlier,
the pattern match introduces some extra information:

    f :: forall a . T a -> a
    f t =
      case t of
        SBool {dt: a ~ Bool} b -> (not (b ▶dt)) ▶sym dt
        SInt  {dt: a ~ Int}  i -> ((i ▶dt) + 1) ▶sym dt

GHC inserts a proof (inside curly braces) that `a ~ Bool` when matching
on `SBool`, and a similar proof for `SInt`. On the right hand side of
each alternative it casts the polymorphic `a` to `Bool`/`Int` with
`b ▶dt`/`i ▶dt` respectively. Thanks to the given proof (which was
obtained during construction), this typechecks. Because the type of the
case has to be `a`, a symmetric cast is applied with `▶sym dt`.

So how do we use this information to compile seemingly polymorphic
functions? Well, consider what happens when `f` is specialized such that
it is monomorphic (like every sound Clash circuit). That is:

    f @int

The function definition now looks like:

    f :: forall Int . T Int -> Int
    f t =
      case t of
        SBool {dt: Int ~ Bool} b -> (not (b ▶dt)) ▶sym dt
        SInt  {dt: Int ~ Int}  i -> ((i ▶dt) + 1) ▶sym dt

Clearly, `Int ~ Bool` is absurd! We can therefore remove it (see
transformation `caseElemNonReachable`) leaving us with:

    f :: forall Int . T Int -> Int
    f t =
      case t of
        SInt  {dt: Int ~ Int}  i -> ((i ▶dt) + 1) ▶sym dt

..a case with a single alternative.

This is not enough to support `Vec`-like GADTs though. Why not? Well,
let's look at the definition of `Vec`:

    data Vec :: Nat -> Type -> Type where
      Nil  :: Vec 0 a
      (:>) :: a -> Vec n a -> Vec (n + 1) a

Similar to our previous function `f`, we can build a function pattern
matching on `Vec`:

    g :: Vec n Bool -> Bool
    g v =
      case v of
        Nil       -> False
        Cons x xs -> True

What would the annotated version look like? Well..

    g :: forall n . Vec n Bool -> Bool
    g v =
      case v of
        Nil  {dt: n ~ 0}                                     -> False
        Cons {n1:Nat} {dt: n~n1+1} (x :: a) (xs :: Vec n1 a) -> True

Alright, so let's do the same trick again: specialize `g`.

    g @0

By filling in the `n`s we get:

    g :: Vec 0 Bool -> Bool
    g v =
      case v of
        Nil  {dt: 0 ~ 0}                                     -> False
        Cons {n1:Nat} {dt: 0~n1+1} (x :: a) (xs :: Vec n1 a) -> True

So what gives? The alternative `Cons` is not _clearly_ absurd now. Of
course, intuition dictates that if `0 ~ n1+1` then `n1 ~ 0-1 ~ -1`. As
we're operating in the domain of naturals, this _is_ absurd! Our
intuition relied the fact that `-` is the inverse of `+`. This
property (+injectivity) is not being tracked by GHC/Haskell/Clash
though, so we can't really do anything in general. This commit adds
hardcoded logic for `+`, see `elemExistentials`.

Future work: make "polymorphic" GADTs synthesizable by treating them
(in as sense) as sum-of-product types.