### PR TITLE
Fix (System)Verilog rotate primitives

### DIFF
--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
@@ -55,9 +55,9 @@ assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
 "// rotateL begin
-logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
-assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
+logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
 // rotateL end"
     }
   }
@@ -67,9 +67,9 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
 "// rotateR begin
-logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
+logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
 // rotateR end"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
@@ -56,7 +56,7 @@ assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
     , "template"  :
 "// rotateL begin
 logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
 assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
 // rotateL end"
     }
@@ -68,7 +68,7 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     , "template"  :
 "// rotateR begin
 logic [2*~LIT[0]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
 assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
 // rotateR end"
     }

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
@@ -36,9 +36,9 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
 "// rotateL begin
-logic [2*~LIT[0]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
-assign ~RESULT = $signed(~SYM[0][2*~LIT[0]-1 : ~LIT[0]]);
+logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = $signed(~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]]);
 // rotateL end"
     }
   }
@@ -48,9 +48,9 @@ assign ~RESULT = $signed(~SYM[0][2*~LIT[0]-1 : ~LIT[0]]);
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
 "// rotateR begin
-logic [2*~LIT[0]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
-assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
+logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = $signed(~SYM[0][~SIZE[~TYPO]-1 : 0]);
 // rotateR end"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
@@ -37,8 +37,8 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "template"  :
 "// rotateL begin
 logic [2*~LIT[0]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
-assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
+assign ~RESULT = $signed(~SYM[0][2*~LIT[0]-1 : ~LIT[0]]);
 // rotateL end"
     }
   }
@@ -49,7 +49,7 @@ assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
     , "template"  :
 "// rotateR begin
 logic [2*~LIT[0]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
 assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
 // rotateR end"
     }

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Unsigned.json
@@ -4,9 +4,9 @@
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
 "// rotateL begin
-logic [2*~LIT[0]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
-assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
+logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
 // rotateL end"
     }
   }
@@ -16,9 +16,9 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
 "// rotateR begin
-logic [2*~LIT[0]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
+logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
 // rotateR end"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Unsigned.json
@@ -5,8 +5,8 @@
     , "template"  :
 "// rotateL begin
 logic [2*~LIT[0]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
+assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
 // rotateL end"
     }
   }
@@ -17,7 +17,7 @@ assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
     , "template"  :
 "// rotateR begin
 logic [2*~LIT[0]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
 assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
 // rotateR end"
     }

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
@@ -52,9 +52,9 @@ end
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
 "// rotateL begin
-wire [2*~LIT[0]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
-assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
+wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
 // rotateL end"
     }
   }
@@ -64,9 +64,9 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
 "// rotateR begin
-wire [2*~LIT[0]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
+wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
 // rotateR end"
     }
   }

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
@@ -52,8 +52,8 @@ end
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
 "// rotateL begin
-wire [2*~LIT[0]-1:0] ~SYM[0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
+wire [2*~LIT[0]-1:0] ~GENSYM[bv][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
 assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
 // rotateL end"
     }
@@ -65,7 +65,7 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     , "template"  :
 "// rotateR begin
 wire [2*~LIT[0]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
 assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
 // rotateR end"
     }

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
@@ -36,9 +36,9 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
 "// rotateL begin
-wire [2*~LIT[0]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
-assign ~RESULT = $signed(~SYM[0][2*~LIT[0]-1 : ~LIT[0]]);
+wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = $signed(~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]]);
 // rotateL end"
     }
   }
@@ -48,9 +48,9 @@ assign ~RESULT = $signed(~SYM[0][2*~LIT[0]-1 : ~LIT[0]]);
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
 "// rotateR begin
-wire [2*~LIT[0]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
-assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
+wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = $signed(~SYM[0][~SIZE[~TYPO]-1 : 0]);
 // rotateR end"
     }
   }

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
@@ -36,9 +36,9 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
 "// rotateL begin
-wire [2*~LIT[0]-1:0] ~SYM[0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
-assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
+wire [2*~LIT[0]-1:0] ~GENSYM[s][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
+assign ~RESULT = $signed(~SYM[0][2*~LIT[0]-1 : ~LIT[0]]);
 // rotateL end"
     }
   }
@@ -49,7 +49,7 @@ assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
     , "template"  :
 "// rotateR begin
 wire [2*~LIT[0]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
 assign ~RESULT = $signed(~SYM[0][~LIT[0]-1 : 0]);
 // rotateR end"
     }

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Unsigned.json
@@ -4,9 +4,9 @@
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
 "// rotateL begin
-wire [2*~LIT[0]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
-assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
+wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
 // rotateL end"
     }
   }
@@ -16,9 +16,9 @@ assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
 "// rotateR begin
-wire [2*~LIT[0]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
+wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
+assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
 // rotateR end"
     }
   }

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Unsigned.json
@@ -5,8 +5,8 @@
     , "template"  :
 "// rotateL begin
 wire [2*~LIT[0]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << ~ARG[2];
-assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~LIT[0]);
+assign ~RESULT = ~SYM[0][2*~LIT[0]-1 : ~LIT[0]];
 // rotateL end"
     }
   }
@@ -17,7 +17,7 @@ assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
     , "template"  :
 "// rotateR begin
 wire [2*~LIT[0]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> ~ARG[2];
+assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~LIT[0]);
 assign ~RESULT = ~SYM[0][~LIT[0]-1 : 0];
 // rotateR end"
     }

--- a/tests/shouldwork/Numbers/ShiftRotate.hs
+++ b/tests/shouldwork/Numbers/ShiftRotate.hs
@@ -1,0 +1,35 @@
+{-
+This tests the HDL implementations of shiftL,shiftR,rotateL and rotateR
+by checking their results against compile-time evaluated calls to the same functions.
+
+So it checks that the HDL implementations have the same behaviour as the Haskell implementations.
+(And it assumes that the Haskell implementations are correct.)
+-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+module ShiftRotate where
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import Data.Int
+import Data.Word
+import ShiftRotateBase
+
+topEntity = testall
+
+expected :: Vec _ ( Vec Ops (Unsigned 8)
+                  , Vec Ops (Signed 8)
+                  , Vec Ops (BitVector 8)
+                  , Vec Ops Word8
+                  , Vec Ops Int8
+                  , Vec Ops (Unsigned 70)
+                  )
+expected = $(lift $ map (testall testpattern) amounts)
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst amounts
+    expectedOutput = outputVerifier clk rst expected
+    done           = expectedOutput ((liftA2 topEntity) (pure testpattern) testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Numbers/ShiftRotateBase.hs
+++ b/tests/shouldwork/Numbers/ShiftRotateBase.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+module ShiftRotateBase where
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import Data.Word
+import Data.Int
+
+testpattern = 0b1010011000
+
+-- test with shift/rotate amounts: 0..16,200
+amounts :: Vec _ Int
+amounts = $(listToVecTH [0::Int ..16]) :< 200
+
+testall v i
+  = ( testAs @(Unsigned 8)  v i
+    , testAs @(Signed 8)    v i
+    , testAs @(BitVector 8) v i
+    , testAs @(Word8)       v i
+    , testAs @(Int8)        v i
+    , testAs @(Unsigned 70) v i
+    )
+{-# NOINLINE testall #-}
+
+testAs
+  :: (Num b, Bits b) => Integer -> Int -> Vec Ops b
+testAs v i = map (\f -> f (fromInteger v) i) shiftsAndRots
+
+type Ops = 4
+
+shiftsAndRots :: Bits a => Vec Ops (a -> Int -> a)
+shiftsAndRots = shiftL :> shiftR :> rotateL :> rotateR :> Nil

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -162,6 +162,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize"       (["","Resize_testBench"],"Resize_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize2"      (["","Resize2_testBench"],"Resize2_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SatMult"      ([""],"SatMult_topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] "ShiftRotate"         (["","ShiftRotate_testBench"],"ShiftRotate_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Strict"       (["","Strict_testBench"],"Strict_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "UnsignedZero" (["","UnsignedZero_testBench"],"UnsignedZero_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SignedZero"   (["","SignedZero_testBench"],"SignedZero_testBench",True)


### PR DESCRIPTION
Thanks to LoneTech for spotting this

The (System)Verilog primitives for `rotateL` actually just did `shiftL`.
And `rotateR` couldn't overrotate or rotate further then the width of the input.