### PR TITLE
VHDL: signal names should not conflict with port names

### DIFF
--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -902,15 +902,22 @@ appendIdentifier
 appendIdentifier (nm,hwty) i =
   (,hwty) <$> extendIdentifier Extended nm (Text.pack ('_':show i))
 
+-- | In addition to the original port name (where the user should assert that
+-- it's a valid identifier), we also add the version of the port name that has
+-- gone through the 'mkIdentifier Basic' process. Why? so that the provided port
+-- name is copied verbatim into the generated HDL, but that in e.g.
+-- case-insensitive HDLs, a case-variant of the port name is not used as one
+-- of the signal names.
 uniquePortName
   :: String
   -> Identifier
   -> NetlistMonad Identifier
 uniquePortName [] i = mkUniqueIdentifier Extended i
 uniquePortName x  _ = do
-  let x' = Text.pack x
-  seenIds %= (x':)
-  return x'
+  let xT = Text.pack x
+  xTB <- mkIdentifier Basic xT
+  seenIds %= ([xT,xTB] ++)
+  return xT
 
 mkInput
   :: Maybe PortName

--- a/tests/shouldwork/Basic/NameOverlap.hs
+++ b/tests/shouldwork/Basic/NameOverlap.hs
@@ -1,0 +1,22 @@
+module NameOverlap where
+
+import Clash.Prelude
+
+{-# NOINLINE topEntity #-}
+{-# ANN topEntity
+  (Synthesize
+    { t_name   = "nameoverlap"
+    , t_inputs =
+          [ PortName "CLK_50MHZ"
+          , PortName "RESET"
+          ]
+    , t_output = PortName "LED"
+    }) #-}
+topEntity
+    :: Clock System Source
+    -> Reset System Asynchronous
+    -> Signal System Bit
+topEntity = exposeClockReset board
+  where
+    board = boolToBit <$> led
+    led = register True $ complement <$> led

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -73,6 +73,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "IrrefError"          ([""],"IrrefError_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LambdaDrop"          ([""],"LambdaDrop_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LotOfStates"         (["","LotOfStates_testBench"],"LotOfStates_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NameOverlap"         (["nameoverlap"],"nameoverlap",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NestedPrimitives"    ([""],"NestedPrimitives_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NestedPrimitives2"   ([""],"NestedPrimitives2_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NORX"                (["","NORX_testBench"],"NORX_testBench",True)


### PR DESCRIPTION
Fixes #476