### PR TITLE
Better json parse errors

### DIFF
--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -186,7 +186,7 @@ instance FromJSON UnresolvedPrimitive where
                  <|> (Just . TFile   <$> conVal .: "file")
                  <|> (pure Nothing)
 
-            let fName' = either error id (parseBBFN fName)
+            fName' <- either fail return (parseBBFN fName)
 
             return (BlackBoxHaskell name' fName' templ)
           "BlackBox"  ->
@@ -202,8 +202,8 @@ instance FromJSON UnresolvedPrimitive where
             Primitive <$> conVal .: "name"
                       <*> conVal .: "primType"
 
-          e -> error $ "[1] Expected: BlackBox or Primitive object, got: " ++ show e
-      e -> error $ "[2] Expected: BlackBox or Primitive object, got: " ++ show e
+          e -> fail $ "[1] Expected: BlackBox or Primitive object, got: " ++ show e
+      e -> fail $ "[2] Expected: BlackBox or Primitive object, got: " ++ show e
     where
       parseTemplate c =
         (,) <$> ((,) <$> (c .:? "format" >>= traverse parseTemplateFormat) .!= TTemplate
@@ -218,15 +218,15 @@ instance FromJSON UnresolvedPrimitive where
 
       parseTemplateKind (String "Declaration") = pure TDecl
       parseTemplateKind (String "Expression")  = pure TExpr
-      parseTemplateKind c = error ("[4] Expected: Declaration or Expression, got " ++ show c)
+      parseTemplateKind c = fail ("[4] Expected: Declaration or Expression, got " ++ show c)
 
       parseTemplateFormat (String "Template") = pure TTemplate
       parseTemplateFormat (String "Haskell")  = pure THaskell
-      parseTemplateFormat c = error ("[5] unexpected format: " ++ show c)
+      parseTemplateFormat c = fail ("[5] unexpected format: " ++ show c)
 
-      parseBBFN' = either error return . parseBBFN
+      parseBBFN' = either fail return . parseBBFN
 
       defTemplateFunction = BlackBoxFunctionName ["Template"] "template"
 
   parseJSON unexpected =
-    error $ "[3] Expected: BlackBox or Primitive object, got: " ++ show unexpected
+    fail $ "[3] Expected: BlackBox or Primitive object, got: " ++ show unexpected

--- a/tests/shouldfail/InvalidPrimitive/InvalidPrimitive.hs
+++ b/tests/shouldfail/InvalidPrimitive/InvalidPrimitive.hs
@@ -1,0 +1,4 @@
+module InvalidPrimitive where
+import Clash.Prelude
+
+topEntity = True

--- a/tests/shouldfail/InvalidPrimitive/InvalidPrimitive.json
+++ b/tests/shouldfail/InvalidPrimitive/InvalidPrimitive.json
@@ -1,0 +1,1 @@
+{ "Not a valid": "primitive" }

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -90,6 +90,7 @@ runClashTest =
         , clashTestGroup "ShouldFail" [
           runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursiveBoxed" (Just "Callgraph after normalisation contains following recursive components")
         , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursiveDatatype" (Just "Not in normal form: no Letrec")
+        , runFailingTest ("tests" </> "shouldfail" </> "InvalidPrimitive") defBuild ["-itests/shouldfail/InvalidPrimitive"] "InvalidPrimitive" (Just "InvalidPrimitive.json")
         -- Disabled, due to it eating gigabytes of memory:
         -- , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursivePoly" (Just "??")
         ]


### PR DESCRIPTION
When clash fails to parse a json file it currently prints something like:
```
<no location info>: error:
    Clash error call:
    [3] Expected: BlackBox or Primitive object, got: Number 1.0
```

With this pr this changes to:
```
./invalid.json: error:
    Could not deduce valid scheme for "./invalid.json". Error was: 

[3] Expected: BlackBox or Primitive object, got: Number 1.0
    
    NB: The source location of the error is not exact, only indicative, as it is acquired after optimisations.
    The actual location of the error can be in a function that is inlined.
    To prevent inlining of those functions, annotate them with a NOINLINE pragma.
```
Should help debug issue like #475