### PR TITLE
 Enable -Werror on the CI server

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -6,16 +6,30 @@ package *
   documentation: False
 
 package clash-lib
+  ghc-options: -Werror
   documentation: True
   flags: +debug
 package clash-prelude
+  ghc-options: -Werror
   documentation: True
   flags: +doctests
   tests: True
 package clash-cosim
+  ghc-options: -Werror
   documentation: True
   tests: True
 
 package clash-testsuite
+  ghc-options: -Werror
   -- enable cosim & disable systemverilog testing (needs modelsim)
   flags: disable-sv-tests cosim
+
+package clash-ghc
+  ghc-options: -Werror
+
+package clash-benchmark
+  ghc-options: -Werror
+package clash-profiling
+  ghc-options: -Werror
+package clash-profiling-prepare
+  ghc-options: -Werror

--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -18,4 +18,4 @@ package clash-cosim
 
 package clash-testsuite
   -- enable cosim & disable systemverilog testing (needs modelsim)
-  flags: travisci cosim
+  flags: disable-sv-tests cosim

--- a/.ci/cabal.project.local-8.6
+++ b/.ci/cabal.project.local-8.6
@@ -21,4 +21,4 @@ package clash-cosim
 
 package clash-testsuite
   -- enable cosim & disable systemverilog testing (needs modelsim)
-  flags: travisci cosim
+  flags: disable-sv-tests cosim

--- a/.ci/cabal.project.local-8.6
+++ b/.ci/cabal.project.local-8.6
@@ -9,16 +9,30 @@ package *
   documentation: False
 
 package clash-lib
+  ghc-options: -Werror
   documentation: True
   flags: +debug
 package clash-prelude
+  ghc-options: -Werror
   documentation: False
   flags: -doctests
   tests: True
 package clash-cosim
+  ghc-options: -Werror
   documentation: True
   tests: True
 
 package clash-testsuite
+  ghc-options: -Werror
   -- enable cosim & disable systemverilog testing (needs modelsim)
   flags: disable-sv-tests cosim
+
+package clash-ghc
+  ghc-options: -Werror
+
+package clash-benchmark
+  ghc-options: -Werror
+package clash-profiling
+  ghc-options: -Werror
+package clash-profiling-prepare
+  ghc-options: -Werror

--- a/clash-dev
+++ b/clash-dev
@@ -1,2 +1,2 @@
 #!/bin/sh
-ghci -fobject-code -iclash-lib/src -iclash-ghc/src-ghc -Wall -Werror -DTOOL_VERSION_ghc=\"$(ghc --numeric-version)\" Clash.hs
+ghci -fobject-code -iclash-lib/src -iclash-ghc/src-ghc -Wall -DTOOL_VERSION_ghc=\"$(ghc --numeric-version)\" Clash.hs

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -99,7 +99,9 @@ setDebugLevel :: IORef ClashOpts
               -> String
               -> EwM IO ()
 setDebugLevel r s = case readMaybe s of
-  Just dbgLvl -> liftEwM $ modifyIORef r (\c -> c {opt_dbgLevel = dbgLvl})
+  Just dbgLvl -> liftEwM $ do
+                   modifyIORef r (\c -> c {opt_dbgLevel = dbgLvl})
+                   when (dbgLvl > DebugNone) $ setNoCache r -- when debugging disable cache
   Nothing     -> addWarn (s ++ " is an invalid debug level")
 
 setNoCache :: IORef ClashOpts -> IO ()

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -47,8 +47,9 @@ where
 import           Data.Default.Class            (Default)
 import           Data.Coerce                   (coerce)
 import           Data.Kind                     (Type)
+import           Data.Proxy                    (Proxy(..))
 import           GHC.TypeLits                  (KnownNat, type (^), type (+), type (*), Nat)
-import           Data.Singletons.Prelude hiding (PNum (..), SNum (..), Undefined)
+import           Data.Singletons.Prelude       (Apply, TyFun, type (@@))
 
 import Clash.Signal.Delayed.Internal
   (DSignal(..), dfromList, dfromList_lazy, fromSignal, toSignal,

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -15,7 +15,7 @@ import System.Environment (setEnv)
 import System.Exit (exitWith, ExitCode(ExitSuccess, ExitFailure))
 
 defBuild :: [BuildTarget]
-#ifdef TRAVISBUILD
+#ifdef DISABLE_SV_TESTS
 defBuild = [VHDL, Verilog]
 #else
 defBuild = [VHDL, Verilog, SystemVerilog]

--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -16,9 +16,9 @@ build-type:          Simple
 -- extra-source-files:
 cabal-version:       >=1.10
 
-flag travisci
+flag disable-sv-tests
    description:
-     The tests are run on TravisCI
+     Don't run systemverilog tests
    default: False
    manual: True
 
@@ -61,7 +61,7 @@ executable clash-testsuite
 
   -- hs-source-dirs:
   default-language:    Haskell2010
-  if flag(travisci)
-    ghc-options:       -DTRAVISBUILD
+  if flag(disable-sv-tests)
+    cpp-options:       -DDISABLE_SV_TESTS
   if flag(cosim)
-    ghc-options:       -DCOSIM
+    cpp-options:       -DCOSIM


### PR DESCRIPTION
Enable `-Werror` on the CI server so we can't commit code with warnings anymore.
But remove `-Werror` from the `clash-dev` script so the don't get in your way when hacking on clash.

I also added some other stuff for which I didn't feel like opening separate PRs:

- make `--fclash-debug` enable `--fclash-nocache`
- rename the travisci flag