### PR TITLE
Add test for (Num) constant folding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 aliases:
   - &env
     TERM: xterm-color
-    THREADS: 2
+    THREADS: 1
     CABAL_JOBS: 1
 
   - &submodules

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -3282,8 +3282,9 @@ sizedLiteral szCon val = case val of
 bitLiterals
   :: [Value]
   -> [(Integer,Integer)]
-bitLiterals = typedLiterals' go
+bitLiterals = map normalizeBit . typedLiterals' go
  where
+  normalizeBit (msk,v) = (msk .&. 1, v .&. 1)
   go val = case val of
     PrimVal nm _ _ [Lit (IntegerLiteral m), Lit (IntegerLiteral i)]
       | nm == "Clash.Sized.Internal.BitVector.fromInteger##"
@@ -3405,7 +3406,8 @@ mkBitLit
   -- ^ Value
   -> Term
 mkBitLit ty msk val =
-  mkApps (bConPrim sTy) [Left (Literal (IntegerLiteral msk)), Left (Literal (IntegerLiteral val))]
+  mkApps (bConPrim sTy) [ Left (Literal (IntegerLiteral (msk .&. 1)))
+                        , Left (Literal (IntegerLiteral (val .&. 1)))]
   where
     (_,sTy) = splitFunForallTy ty
 

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -973,6 +973,10 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     | [Lit (WordLiteral w)] <- args
     -> reduce (Literal (IntegerLiteral w))
 
+  "GHC.Integer.Type.integerToWord"
+    | [i] <- integerLiterals' args
+    -> reduce (integerToWordLiteral i)
+
   "GHC.Natural.NatS#"
     | [Lit (WordLiteral w)] <- args
     -> reduce (Literal (NaturalLiteral w))

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -977,6 +977,10 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     | [i] <- integerLiterals' args
     -> reduce (integerToWordLiteral i)
 
+  "GHC.Integer.Type.testBitInteger" -- :: Integer -> Int# -> Bool
+    | [Lit (IntegerLiteral i), Lit (IntLiteral j)] <- args
+    -> reduce (boolToBoolLiteral tcm ty (testBit i (fromInteger j)))
+
   "GHC.Natural.NatS#"
     | [Lit (WordLiteral w)] <- args
     -> reduce (Literal (NaturalLiteral w))

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -1367,7 +1367,7 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     , [ _
       , PrimVal bvNm _ _ [_, Lit (IntegerLiteral mskBv), Lit (IntegerLiteral bv)]
       , valArgs -> Just [Literal (IntLiteral i)]
-      , PrimVal bNm  _ _ [_, Lit (IntegerLiteral mskB), Lit (IntegerLiteral b)]
+      , PrimVal bNm  _ _ [Lit (IntegerLiteral mskB), Lit (IntegerLiteral b)]
       ] <- args
     , bvNm == "Clash.Sized.Internal.BitVector.fromInteger#"
     , bNm  == "Clash.Sized.Internal.BitVector.fromInteger##"

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -283,6 +283,9 @@ coreToTerm primMap unlocs srcsp coreExpr = Reader.runReaderT (term coreExpr) src
         go "GHC.Base.$"                        args
           | length args == 5
           = term (App (args!!3) (args!!4))
+        go "GHC.Magic.noinline"                args   -- noinline :: forall a. a -> a
+          | [_ty, x] <- args
+          = term x
         -- Remove most CallStack logic
         go "GHC.Stack.Types.PushCallStack"     args = term (last args)
         go "GHC.Stack.Types.FreezeCallStack"   args = term (last args)
@@ -366,6 +369,7 @@ coreToTerm primMap unlocs srcsp coreExpr = Reader.runReaderT (term coreExpr) src
               | f == pack "Clash.Signal.Bundle.vecBundle#"   -> return (vecUnwrapTerm xType)
               | f == pack "GHC.Base.$"                       -> return (dollarTerm xType)
               | f == pack "GHC.Stack.withFrozenCallStack"    -> return (withFrozenCallStackTerm xType)
+              | f == pack "GHC.Magic.noinline"               -> return (idTerm xType)
               | f == pack "GHC.Magic.lazy"                   -> return (idTerm xType)
               | f == pack "GHC.Magic.runRW#"                 -> return (runRWTerm xType)
               | otherwise                                    -> return (C.Prim xNameS xType)

--- a/clash-lib/prims/common/GHC_Magic.json
+++ b/clash-lib/prims/common/GHC_Magic.json
@@ -4,6 +4,12 @@
     }
   }
 , { "Primitive" :
+    { "name"      : "GHC.Magic.noinline"
+    , "type"      : "forall a. a -> a"
+    , "primType"  : "Function"
+    }
+  }
+, { "Primitive" :
     { "name"      : "GHC.Magic.runRW#"
     , "primType"  : "Function"
     }

--- a/clash-lib/prims/commonverilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/commonverilog/GHC_Integer_Type.json
@@ -111,6 +111,13 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.testBitInteger"
+    , "kind"      : "Expression"
+    , "type"      : "testBitInteger :: Integer -> Int# -> Bool"
+    , "template"  : "~VAR[input][0][~ARG[1]] == 1'b1"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "GHC.Integer.Type.wordToInteger"
     , "kind"      : "Declaration"
     , "type"      : "wordToInteger :: Word# -> Integer"

--- a/clash-lib/prims/systemverilog/GHC_Prim.json
+++ b/clash-lib/prims/systemverilog/GHC_Prim.json
@@ -60,7 +60,7 @@ logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 
@@ -116,7 +116,7 @@ logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 
@@ -172,7 +172,7 @@ logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 
@@ -228,7 +228,7 @@ logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 
@@ -255,7 +255,7 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 , { "BlackBox" :
     { "name"      : "GHC.Prim.popCnt#"
     , "kind"      : "Declaration"
-    , "type"      : "popCnt8# :: Word# -> Word#"
+    , "type"      : "popCnt# :: Word# -> Word#"
     , "imports"   : ["~INCLUDENAME[0].inc"]
     , "includes" :
       [ { "name" : "depth2Index"
@@ -284,7 +284,7 @@ logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 

--- a/clash-lib/prims/verilog/GHC_Prim.json
+++ b/clash-lib/prims/verilog/GHC_Prim.json
@@ -70,7 +70,7 @@ wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 
@@ -136,7 +136,7 @@ wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 
@@ -202,7 +202,7 @@ wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 
@@ -268,7 +268,7 @@ wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 
@@ -295,7 +295,7 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
 , { "BlackBox" :
     { "name"      : "GHC.Prim.popCnt#"
     , "kind"      : "Declaration"
-    , "type"      : "popCnt8# :: Word# -> Word#"
+    , "type"      : "popCnt# :: Word# -> Word#"
     , "imports"   : ["~INCLUDENAME[0].inc"]
     , "includes" :
       [ { "name" : "popCnt"
@@ -334,7 +334,7 @@ wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
 genvar ~GENSYM[i][4];
 ~GENERATE
 for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~ARG[0][~SYM[4]]);
+  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
 end
 ~ENDGENERATE
 

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.json
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.json
@@ -134,6 +134,13 @@ end block;
     }
   }
 , { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.testBitInteger"
+    , "kind"      : "Expression"
+    , "type"      : "testBitInteger :: Integer -> Int# -> Bool"
+    , "template"  : "~VAR[input][0](to_integer(~ARG[1])) = '1'"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "GHC.Integer.Type.wordToInteger"
     , "kind"      : "Expression"
     , "type"      : "wordToInteger :: Word# -> Integer"

--- a/clash-lib/prims/vhdl/GHC_Prim.json
+++ b/clash-lib/prims/vhdl/GHC_Prim.json
@@ -313,7 +313,7 @@
 begin
   -- put input into the first half of the intermediate array
   ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
+    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
@@ -354,7 +354,7 @@ end block;
 begin
   -- put input into the first half of the intermediate array
   ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
+    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
@@ -377,7 +377,7 @@ end block;
 , { "BlackBox" :
     { "name"      : "GHC.Prim.popCnt32#"
     , "kind"      : "Declaration"
-    , "type"      : "popCnt16 :: Word# -> Word#"
+    , "type"      : "popCnt32 :: Word# -> Word#"
     , "template"  :
 "-- popCnt32 begin
 ~GENSYM[popCnt32][0] : block
@@ -395,7 +395,7 @@ end block;
 begin
   -- put input into the first half of the intermediate array
   ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
+    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
@@ -418,7 +418,7 @@ end block;
 , { "BlackBox" :
     { "name"      : "GHC.Prim.popCnt64#"
     , "kind"      : "Declaration"
-    , "type"      : "popCnt16 :: Word# -> Word#"
+    , "type"      : "popCnt64 :: Word# -> Word#"
     , "template"  :
 "-- popCnt64 begin
 ~GENSYM[popCnt64][0] : block
@@ -436,7 +436,7 @@ end block;
 begin
   -- put input into the first half of the intermediate array
   ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
+    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders
@@ -477,7 +477,7 @@ end block;
 begin
   -- put input into the first half of the intermediate array
   ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](i) <= resize(~ARG[0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
+    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
   end generate;
 
   -- Create the tree of adders

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -205,9 +205,9 @@ instance NFData Bit where
 
 instance Show Bit where
   show (Bit 0 b) =
-    case b of
-      0 -> "0"
-      _ -> "1"
+    case testBit b 0 of
+      True  -> "1"
+      False -> "0"
   show (Bit _ _) = "."
 
 instance ShowX Bit where
@@ -290,8 +290,8 @@ instance Bits Bit where
   complement        = complement##
   zeroBits          = low
   bit i             = if i == 0 then high else low
-  setBit _ i        = if i == 0 then high else low
-  clearBit _ i      = if i == 0 then low  else high
+  setBit b i        = if i == 0 then high else b
+  clearBit b i      = if i == 0 then low  else b
   complementBit b i = if i == 0 then complement## b else b
   testBit b i       = if i == 0 then eq## b high else False
   bitSizeMaybe _    = Just 1
@@ -713,7 +713,7 @@ slice# (BV msk i) m n = BV (shiftR (msk .&. mask) n')
 replaceBit# :: KnownNat n => BitVector n -> Int -> Bit -> BitVector n
 replaceBit# bv@(BV m v) i (Bit mb b)
     | i >= 0 && i < sz = BV (clearBit m i  .|. (mb `shiftL` i))
-                            (if b == 1 && mb == 0 then setBit v i else clearBit v i)
+                            (if testBit b 0 && mb == 0 then setBit v i else clearBit v i)
     | otherwise        = err
   where
     sz   = fromInteger (natVal bv)

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -297,9 +297,8 @@ instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
   satMul SatWrap a b =
     leToPlusKN @1 @n $
       case times# a b of
-        z | let m = fromInteger# (natVal (Proxy @ n))
-          , z >= m -> resize# (z - m)
-        z -> resize# z
+        z -> let m = fromInteger# (natVal (Proxy @ n))
+             in resize# (z `mod` m)
   satMul SatZero a b =
     leToPlusKN @1 @n $
       case times# a b of

--- a/tests/shouldwork/Basic/PopCount.hs
+++ b/tests/shouldwork/Basic/PopCount.hs
@@ -1,20 +1,39 @@
-{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE PartialTypeSignatures           #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
 module PopCount where
 
 import Clash.Prelude
 import Clash.Explicit.Testbench
 import GHC.Word
+import GHC.Int
 import Data.Bits
 
-topEntity :: Word -> Int
-topEntity = popCount
+topEntity :: Integer -> Vec _ Int
+topEntity i =  popCount @Word j
+            :> popCount @Word8 j
+            :> popCount @Word16 j
+            :> popCount @Word32 j
+            :> popCount @Word64 j
+            :> popCount @Int j
+            :> popCount @Int8 j
+            :> popCount @Int16 j
+            :> popCount @Int32 j
+            :> popCount @Int64 j
+            :> popCount @(BitVector 7) j
+            :> popCount @(Signed 9) j
+            :> popCount @(Unsigned 11) j
+            :> Nil
+  where
+    j :: Num a => a
+    j = fromInteger i
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
   where
-    testInput      = stimuliGenerator clk rst $(listToVecTH [1::Word,3,8,50,0])
-    expectedOutput = outputVerifier   clk rst $(listToVecTH ([1,2,1,3,0]::[Int]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH [1::Integer,3,8,50,0])
+    expectedOutput = outputVerifier   clk rst $ fmap repeat $(listToVecTH ([1,2,1,3,0]::[Int]))
     done           = expectedOutput (topEntity <$> testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen

--- a/tests/shouldwork/Numbers/NumConstantFolding.hs
+++ b/tests/shouldwork/Numbers/NumConstantFolding.hs
@@ -1,0 +1,419 @@
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
+
+-- | Test constant folding of most primitives on "Num" types
+--
+-- Any number found in the HDL between [22000,22999] in considered unfolded
+-- and produces an error.
+
+module NumConstantFolding where
+import Clash.Prelude
+
+import Data.Semigroup ((<>))
+import Data.Int
+import Data.Word
+import GHC.Natural
+
+import Control.Monad (when)
+import Data.Char (toLower,toUpper)
+import qualified Data.List as L
+import Data.Maybe
+import System.Environment (getArgs)
+import System.Exit
+import System.IO
+import Text.Parser.Combinators
+import Text.Trifecta
+import Text.Trifecta.Delta
+
+-----------------------------
+-- Tests for specific classes
+-----------------------------
+
+cNum :: forall n. Num n => _
+cNum = (rPlus,rMin,rTimes,rAbsP,rAbsZ, rSignumP,rSignumZ)
+  where
+    rPlus    = (+)    @n 22101 22102
+    rMin     = (-)    @n 22104 22103
+    rTimes   = (*)    @n 22105 2
+    rAbsP    = abs    @n 22106 + 1000
+    rAbsZ    = (22107 + abs    @n 0) + 1000
+    -- rAbsN    = abs    @n (-22108) + 1000
+    rSignumP = signum @n 22109
+    rSignumZ = signum @n 0 * 22110
+    -- rSignumN = signum @n (-22111)
+    -- fromInteger?
+
+cEq :: forall n. (Num n, Eq n) => (Bool,Bool)
+cEq = (eq,neq)
+  where
+    eq  = (==) @n 22120 22121
+    neq = (/=) @n 22122 22123
+
+cOrd :: forall n. (Num n, Ord n) => _
+cOrd = (rCompare,rLt,rLe,rGt,rGe,rMin,rMax)
+  where
+    rCompare = compare @n 22130 22131
+    rLt      = (<)     @n 22132 22133
+    rLe      = (<=)    @n 22134 22135
+    rGt      = (>)     @n 22136 22137
+    rGe      = (>=)    @n 22138 22139
+    rMin     = min     @n 22140 1234
+    rMax     = max     @n 22141 29931
+
+cIntegral :: forall n. (Num n, Integral n) => _
+cIntegral = (rQuot,rRem,rDiv,rMod,rQuotRem,rDivMod)
+  where
+    rQuot    = quot    @n 22150 41
+    rRem     = rem     @n 22151 42
+    rDiv     = div     @n 22152 43
+    rMod     = mod     @n 22153 44
+    rQuotRem = quotRem @n 22154 45
+    rDivMod  = divMod  @n 22155 46
+    -- toInteger?
+
+cBitsNoPopCount :: forall n. (Num n, Bits n) => _
+-- the nested tuple here is so we can still 'show' the result
+cBitsNoPopCount = ((r00,r01,r02,r03,r04,r05,r06,r07,r08,r09,r10),r11,r12,r13,r14,r15,r16,r17,r18,r19)
+  where
+    r00 = (.&.)         @n 22160 51
+    r01 = (.|.)         @n 22161 6144
+    r02 = xor           @n 22162 22153
+    r03 = complement    @n 22163 + 1000
+    r04 = shift         @n 22164 3
+    r05 = rotate        @n 22165 4
+    r06 = (22156 + zeroBits @n) + 1000
+    r07 = bit           @n 10 + 22167
+    r08 = setBit        @n 22168 11
+    r09 = clearBit      @n 22169 14
+    r10 = complementBit @n 22170 12
+    r11 = testBit       @n 22171 1
+    r12 = bitSizeMaybe  @n 22172
+    r13 = isSigned      @n 22173
+    r14 = shiftL        @n 22174 5
+    r15 = unsafeShiftL  @n 22175 7
+    r16 = shiftR        @n 22176 9
+    r17 = unsafeShiftR  @n 22177 11
+    r18 = rotateL       @n 22178 13
+    r19 = rotateR       @n 22179 15
+
+cBits :: forall n. (Num n, Bits n) => _
+cBits = (cBitsNoPopCount @n, r20)
+  where
+    r20 = popCount      @n 22180
+
+
+cFiniteBits :: forall n. (Num n, FiniteBits n) => _
+cFiniteBits = (r1,r2,r3)
+  where
+    r1 = finiteBitSize      @n 22190
+    r2 = countLeadingZeros  @n 22191
+    r3 = countTrailingZeros @n 22192
+    -- TODO countLeadingZeros and countTrailingZeros for all clash types
+    -- are implemented with folds and bv2v both of which don't constantfold
+
+
+cExtendingNum :: forall a b. (Num a, Num b, ExtendingNum a b) => _
+cExtendingNum = (r1,r2,r3)
+  where
+    r1 = add @a @b 22200 22201
+    r2 = sub @a @b 22203 22202
+    r3 = mul @a @b 22204 2
+
+cSaturatingNum :: forall n. (Num n, SaturatingNum n) => _
+cSaturatingNum = (r1a,r1b,r1c,r1d, r2a,r2b,r2c,r2d, r3a,r3b,r3c,r3d)
+  where
+    r1a = satAdd @n SatWrap      22210 22211
+    r2a = satSub @n SatWrap      22212 22213
+    r3a = satMul @n SatWrap      22214 22215
+    r1b = satAdd @n SatBound     22220 22221
+    r2b = satSub @n SatBound     22222 22223
+    r3b = satMul @n SatBound     22224 22225
+    r1c = satAdd @n SatZero      22230 22231
+    r2c = satSub @n SatZero      22232 22233
+    r3c = satMul @n SatZero      22234 22235
+    r1d = satAdd @n SatSymmetric 22240 22241
+    r2d = satSub @n SatSymmetric 22242 22243
+    r3d = satMul @n SatSymmetric 22244 22245
+
+cBitPack :: forall n. (Num n, BitPack n, KnownNat (BitSize n)) => _
+cBitPack = (r1,r2)
+  where
+    r1 = pack @n 22250 + 1000
+    r2 = unpack @n 22251 + 1000
+
+cResize :: forall ty rep size. (ty ~ rep size, Resize rep, KnownNat size, Num (rep size), Num (rep (1+size)), Num (rep (size+1))) => _
+cResize = (r1,r2,r3,r4,r5,r6)
+  where
+    r1 = resize     @rep @size @(size+1) 22260 + 1000
+    r2 = resize     @rep @(size+1) @size 22261 + 1000
+    r3 = extend     @rep @size @1        22262 + 1000
+    r4 = zeroExtend @rep @size @1        22263 + 1000
+    r5 = signExtend @rep @size @1        22264 + 1000
+    r6 = truncateB  @rep @size @1        22265 + 1000
+
+-- TODO classes
+-- Real?
+-- Enum?
+
+-- functions from module Clash.Prelude.BitIndex
+--
+
+
+--------------------------------
+-- Group certain classes together
+---------------------------------
+csGenericHaskell :: forall n. (Num n, Ord n, Integral n, Bits n, FiniteBits n) => _
+csGenericHaskell
+  = ( cNum        @n
+    , cEq         @n
+    , cOrd        @n
+    , cIntegral   @n
+    , cBits       @n
+    , cFiniteBits @n
+    )
+
+csClashSpecific :: forall n. (Num n, BitPack n, KnownNat (BitSize n), ExtendingNum n n, SaturatingNum n) => _
+csClashSpecific = (cBitPack @n, cExtendingNum @n @n, cSaturatingNum @n)
+
+
+------------------------
+-- Test individual types
+------------------------
+tUnsigned16
+  = ( cNum            @(Unsigned 16)
+    , cEq             @(Unsigned 16)
+    , cOrd            @(Unsigned 16)
+    , cIntegral       @(Unsigned 16)
+    , cBits           @(Unsigned 16)
+    -- , cFiniteBits  @(Unsigned 16) -- broken
+    , csClashSpecific @(Unsigned 16)
+    , cResize         @(Unsigned 16)
+    )
+
+tSigned16
+  = ( cNum            @(Signed 16)
+    , cEq             @(Signed 16)
+    , cOrd            @(Signed 16)
+    , cIntegral       @(Signed 16)
+    , cBits           @(Signed 16)
+    -- , cFiniteBits  @(Signed 16) -- broken
+    , csClashSpecific @(Signed 16)
+    , cResize         @(Signed 16)
+    )
+
+tBitVector16
+  = ( cNum            @(BitVector 16)
+    , cEq             @(BitVector 16)
+    , cOrd            @(BitVector 16)
+    , cIntegral       @(BitVector 16)
+    , cBits           @(BitVector 16)
+    -- , cFiniteBits  @(BitVector 16) -- broken
+    , csClashSpecific @(BitVector 16)
+    , cResize         @(BitVector 16)
+    )
+
+tIndex
+  = ( cNum        @(Index 50000)
+    , cEq         @(Index 50000)
+    , cOrd        @(Index 50000)
+    , cIntegral   @(Index 50000)
+    -- no Bits, FiniteBits
+    , csClashSpecific @(Index 50000)
+    , cResize         @(Index 50000)
+    )
+tSFixed
+  = ( cNum            @(SFixed 16 0)
+    , cEq             @(SFixed 16 0)
+    , cOrd            @(SFixed 16 0)
+    -- no Integral
+    , cBits           @(SFixed 16 0)
+    -- , cFiniteBits     @(SFixed 16 0) -- broken
+    , csClashSpecific @(SFixed 16 0)
+    )
+tUFixed
+  = ( cNum            @(UFixed 16 0)
+    , cEq             @(UFixed 16 0)
+    , cOrd            @(UFixed 16 0)
+    -- no Integral
+    , cBits           @(UFixed 16 0)
+    -- , cFiniteBits     @(UFixed 16 0) -- broken
+    , csClashSpecific @(UFixed 16 0)
+    )
+
+-- TODO Types
+-- Bit?
+
+tInt         = csGenericHaskell @Int
+tInt16       = csGenericHaskell @Int16
+tWord16      = csGenericHaskell @Word16
+
+tInteger
+  = ( cNum            @Integer
+    , cEq             @Integer
+    , cOrd            @Integer
+    , cIntegral       @Integer
+    , cBitsNoPopCount @Integer -- popCount @Integer is just crazy
+    -- no FiniteBits
+    )
+tNatural
+  = ( cNum        @Natural
+    , cEq         @Natural
+    , cOrd        @Natural
+    , cIntegral   @Natural
+    -- , cBits       @Natural -- broken
+    -- no FiniteBits
+    )
+
+
+
+bvSpecific = (r1,r2,r3,r4)
+  where
+    r1 = (22001 :: BitVector 16) ++# (22002 :: BitVector 16)
+    r2 = 22003 - size# (22004::BitVector 16)
+    r3 = 22005 - maxIndex# (22006::BitVector 16)
+    r4 = (22007 :: BitVector 16) ! 0
+
+
+fromIntegralConversions
+  = ( convertTo @Integer
+    , convertTo @Int
+    , convertTo @Int8
+    , convertTo @Int16
+    , convertTo @Int32
+    , convertTo @Int64
+    , convertTo @Word
+    , convertTo @Word8
+    , convertTo @Word16
+    , convertTo @Word32
+    , convertTo @Word64
+    , convertTo @(Signed 16)
+    , convertTo @(Unsigned 16)
+    , convertTo @(BitVector 16)
+    , convertTo @(Index 30000)
+    )
+    where
+      convertTo :: forall b. Num b => _
+      convertTo = ((r00,r01,r02,r03,r04,r05,r06,r07,r08,r09,r10),r11,r12,r13,r14)
+        where
+          r00 = 22010 - fromIntegral @Integer        @b 100
+          r01 = 22011 - fromIntegral @Int            @b 100
+          r02 = 22012 - fromIntegral @Int8           @b 100
+          r03 = 22013 - fromIntegral @Int16          @b 100
+          r04 = 22014 - fromIntegral @Int32          @b 100
+          r05 = 22015 - fromIntegral @Int64          @b 100
+          r06 = 22016 - fromIntegral @Word           @b 100
+          r07 = 22017 - fromIntegral @Word8          @b 100
+          r08 = 22018 - fromIntegral @Word16         @b 100
+          r09 = 22019 - fromIntegral @Word32         @b 100
+          r10 = 22020 - fromIntegral @Word64         @b 100
+          r11 = 22021 - fromIntegral @(Signed 17)    @b 100
+          r12 = 22022 - fromIntegral @(Unsigned 17)  @b 100
+          r13 = 22023 - fromIntegral @(BitVector 17) @b 100
+          r14 = 22024 - fromIntegral @(Index 30000)  @b 100
+
+
+topEntity
+ = ( tUnsigned16
+   , tSigned16
+   , tBitVector16
+   , tIndex
+   , tSFixed
+   , tUFixed
+   , tInt
+   , tInt16
+   , tWord16
+   , tInteger
+   , tNatural
+   , bvSpecific
+   , fromIntegralConversions
+   )
+{-# NOINLINE topEntity #-}
+
+
+---------------
+-- output tests
+---------------
+mainVHDL = checkForUnfolded vhdlNr
+mainVerilog = checkForUnfolded verilogNr
+mainSystemVerilog = checkForUnfolded verilogNr
+
+checkForUnfolded nrParser = do
+  [topFile] <- getArgs
+  content <- readFile topFile
+  case parseString (allNrs nrParser) mempty content of
+    Failure err -> die ("Parsing failed with: " <> show err)
+    Success nrs -> case filter isUnfolded nrs of
+                     [] -> hPutStrLn stderr ("Checked: " <> show (L.length nrs) <> " literals")
+                     unfolded -> die ("Error: found unfolded constants:" <> show unfolded)
+
+readDec,readHex,readBin :: String -> Integer
+readDec = read
+readHex = read . ("0x" <>)
+readBin = go 0
+  where
+    go x [] = x
+    go x ('0':bs) = go (x*2) bs
+    go x ('1':bs) = go (x*2+1) bs
+
+data Nr = Dec String
+        | Hex String
+        | Bin String
+        deriving Show
+
+nrValue :: Nr -> Integer
+nrValue nr = case nr of
+  Bin ds -> readBin ds
+  Dec ds -> readDec ds
+  Hex ds -> readHex ds
+
+decNr = Dec <$> some digit
+
+binDigit = satisfyRange '0' '1'
+
+verilogBinNr = char '\'' *> skipOptional (chari 's') *> chari 'b' *> (Bin <$> some binDigit)
+verilogHexNr = char '\'' *> skipOptional (chari 's') *> chari 'h' *> (Hex <$> some hexDigit)
+verilogNr = choice [verilogBinNr, verilogHexNr, decNr]
+
+vhdlHexNr = chari 'x' *> char '"' *> (Hex <$> some hexDigit) <* char '"'
+vhdlBinNr = char '"' *> (Hex <$> some binDigit) <* char '"'
+vhdlNr = choice [vhdlHexNr, vhdlBinNr, decNr]
+
+-- | Parse char case-insensitive
+chari c = oneOf [toLower c, toUpper c]
+
+isUnfolded :: Nr -> Bool
+isUnfolded (nrValue -> n) = 22000 <= n && n < 23000
+
+allNrs :: CharParsing m => m Nr -> m [Nr]
+allNrs nrParser = catMaybes <$> many maybeNr <* eof
+  where
+    maybeNr = Just <$> try nrParser
+              <|> const Nothing <$> anyChar
+
+
+
+
+-- Lift for 8-15 tuples
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h)
+      => Lift (a,b,c,d,e,f,g,h)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i)
+      => Lift (a,b,c,d,e,f,g,h,i)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j)
+      => Lift (a,b,c,d,e,f,g,h,i,j)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k,l)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m, Lift n)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m, Lift n, Lift o)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
+deriving instance Lift Ordering

--- a/tests/shouldwork/Numbers/NumConstantFoldingTB.hs
+++ b/tests/shouldwork/Numbers/NumConstantFoldingTB.hs
@@ -1,0 +1,18 @@
+module NumConstantFoldingTB where
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import qualified NumConstantFolding
+
+instance ShowX Ordering
+
+expected = $(lift NumConstantFolding.topEntity) :> Nil
+
+topEntity = NumConstantFolding.topEntity
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier clk rst expected
+    done           = expectedOutput (pure topEntity)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -173,6 +173,8 @@ runClashTest =
       ]
       , clashTestGroup "Numbers"
         [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"       (["","Bounds_testBench"],"Bounds_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers","-fclash-inline-limit=300"] "NumConstantFoldingTB"       (["","NumConstantFoldingTB_testBench"],"NumConstantFoldingTB_testBench",True)
+        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fclash-inline-limit=300"] "NumConstantFolding"  "main"
 #if MIN_VERSION_base(4,12,0)
         -- Naturals are broken on GHC <= 8.4. See https://github.com/clash-lang/clash-compiler/pull/473
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Naturals"     (["","Naturals_testBench"],"Naturals_testBench",True)
@@ -252,7 +254,6 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithRTree" (["","PortNamesWithRTree_topEntity","PortNamesWithRTree_testBench"],"PortNamesWithRTree_testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithRTree" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    defBuild [] "TopEntHOArg" (["f","g"],"f",False)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithRTree" "main"
         ]
       , clashTestGroup "Void"
         [ runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "Imap"                         (["","Imap_testBench"],"Imap_testBench",True)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -105,9 +105,9 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "AppendZero"       (["","AppendZero_testBench"],"AppendZero_testBench",True)
         ]
       , clashTestGroup "BlackBox"
-        [ outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   "TemplateFunction" "main"
-        , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   "BlackBoxFunction" "main"
-        , outputTest ("tests" </> "shouldwork" </> "Signal")   defBuild "BlockRamLazy"     "main"
+        [ outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] "TemplateFunction" "main"
+        , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] "BlackBoxFunction" "main"
+        , outputTest ("tests" </> "shouldwork" </> "Signal")   defBuild [] "BlockRamLazy"     "main"
         ]
       , clashTestGroup "BoxedFunctions"
         [ runTest ("tests" </> "shouldwork" </> "BoxedFunctions") defBuild [] "DeadRecursiveBoxed" ([""],"DeadRecursiveBoxed_topEntity",False)
@@ -203,7 +203,7 @@ runClashTest =
       ]
       , clashTestGroup "Signal"
         [ runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "AlwaysHigh"      ([""],"AlwaysHigh_topEntity",False)
-        , outputTest ("tests" </> "shouldwork" </> "Signal") defBuild "BlockRamLazy"    "main"
+        , outputTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamLazy"    "main"
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamFile"    (["","BlockRamFile_testBench"],"BlockRamFile_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild ["-fclash-no-prim-warn"] "GatedClock" (["gated","source","testbench"],"testbench",True)
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "GatedClockWidth"                  (["","GatedClockWidth_testBench"],"GatedClockWidth_testBench",True)
@@ -224,8 +224,8 @@ runClashTest =
         , runFailingTest ("tests" </> "shouldfail" </> "Signal") defBuild [] "MAC" (Just "Can't match template for \"Clash.Signal.Internal.register#\"")
         ]
       , clashTestGroup "SynthesisAttributes"
-        [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild "Simple"  "main"
-        , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild "Product" "main"
+        [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Simple"  "main"
+        , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild []  "Product" "main"
         , runTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Product" (["", "Product_testBench"],"Product_testBench",True)
         , clashTestGroup "ShouldFail" [
             runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInArgs"   (Just "Attempted to split Product into a number of HDL ports.")
@@ -242,16 +242,17 @@ runClashTest =
       , clashTestGroup "TopEntity"
         -- VHDL tests disabled for now: I can't figure out how to generate a static name whilst retaining the ability to actually test..
         [ runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNames" (["","PortNames_topEntity","PortNames_testBench"],"PortNames_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNames" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNames" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortProducts" (["","PortProducts_topEntity","PortProducts_testBench"],"PortProducts_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortProducts" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortProducts" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithUnit" (["","PortNamesWithUnit_topEntity","PortNamesWithUnit_testBench"],"PortNamesWithUnit_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithUnit" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithUnit" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithVector" (["","PortNamesWithVector_topEntity","PortNamesWithVector_testBench"],"PortNamesWithVector_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithVector" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithVector" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithRTree" (["","PortNamesWithRTree_topEntity","PortNamesWithRTree_testBench"],"PortNamesWithRTree_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithRTree" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithRTree" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    defBuild [] "TopEntHOArg" (["f","g"],"f",False)
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithRTree" "main"
         ]
       , clashTestGroup "Void"
         [ runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "Imap"                         (["","Imap_testBench"],"Imap_testBench",True)

--- a/testsuite/Test/Tasty/Clash.hs
+++ b/testsuite/Test/Tasty/Clash.hs
@@ -531,6 +531,8 @@ outputTest'
   -- ^ Work directory
   -> BuildTarget
   -- ^ Build target
+  -> [String]
+  -- ^ Extra clash arguments
   -> String
   -- ^ Module name
   -> String
@@ -540,7 +542,7 @@ outputTest'
   -- item in the list will be the root node, while the first one will be the
   -- one closest to the test.
   -> TestTree
-outputTest' env target modName funcName path =
+outputTest' env target extraArgs modName funcName path =
   withResource acquire tastyRelease (const seqTests)
     where
       path' = show target:path
@@ -595,7 +597,7 @@ outputTest' env target modName funcName path =
       workDir = testDirectory path'
 
       seqTests = testGroup (show target) $ sequenceTests path' $
-        [ clashHDL target (sourceDirectory </> env) [] modName workDir
+        [ clashHDL target (sourceDirectory </> env) extraArgs modName workDir
         , ("runghc", testProgram "runghc" "cabal" args NoGlob PrintStdErr False Nothing)
         ]
 
@@ -604,6 +606,8 @@ outputTest
   -- ^ Work directory
   -> [BuildTarget]
   -- ^ Build targets
+  -> [String]
+  -- ^ Extra clash arguments
   -> String
   -- ^ Module name
   -> String
@@ -613,8 +617,8 @@ outputTest
   -- item in the list will be the root node, while the first one will be the
   -- one closest to the test.
   -> TestTree
-outputTest env targets modName funcName path =
+outputTest env targets extraArgs modName funcName path =
   let testName = modName ++ " [output test]" in
   let path' = testName : path in
   testGroup testName
-    [outputTest' env target modName funcName path' | target <- targets]
+    [outputTest' env target extraArgs modName funcName path' | target <- targets]


### PR DESCRIPTION
And fix various issues encountered along the way.

----
Evaluation doesn't work for:
* ~~`countLeadingZeros` and `countTrailingZeros` on any Sized Clash type
  These are implemented in terms of maps and folds which don't evaluate (well).
  An option could be to make them primitives, just like they are for general Haskell numbers.~~
  edit @martijnbastiaan : This has been implemented in https://github.com/clash-lang/clash-compiler/pull/501/commits/44f4dc7b6b88ed9814ab18bb179836aeb06d2298

* `popCount @Integer`
  And there is no blackbox either.
  There isn't really a sensible implementation possible.
  In Haskell `popCount (-3::Integer)` is  `-2`, while popCount is documentated as: "Return the number of set bits in the argument"

* Bits Natural