### PR TITLE
Only use one thread on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 aliases:
   - &env
     TERM: xterm-color
-    THREADS: 2
+    THREADS: 1
 
   - &submodules
     run:


### PR DESCRIPTION
haskell-src-exts fails to build now, hopefully switching to one thread reduces memory pressure.