### PR TITLE
Class selectors for newtype dicts are id

### DIFF
--- a/clash-lib/src/Clash/Core/TyCon.hs
+++ b/clash-lib/src/Clash/Core/TyCon.hs
@@ -19,6 +19,7 @@ module Clash.Core.TyCon
   , AlgTyConRhs (..)
   , mkKindTyCon
   , isTupleTyConLike
+  , isNewTypeTc
   , tyConDataCons
   )
 where
@@ -123,3 +124,9 @@ tyConDataCons :: TyCon -> [DataCon]
 tyConDataCons (AlgTyCon {algTcRhs = DataTyCon { dataCons = cons}}) = cons
 tyConDataCons (AlgTyCon {algTcRhs = NewTyCon  { dataCon  = con }}) = [con]
 tyConDataCons _                                                    = []
+
+isNewTypeTc
+  :: TyCon
+  -> Bool
+isNewTypeTc (AlgTyCon {algTcRhs = NewTyCon {}}) = True
+isNewTypeTc _ = False


### PR DESCRIPTION
`mkSelectorCase`, which is used for most dictionaries, fails on newtype dictionaries because it looks through newtypes.

You get newtype dictionaries for single method classes without superclasses.