### PR TITLE
Small patches to allow building Debian packages

### DIFF
--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -55,10 +55,18 @@ source-repository head
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
 
+flag dynamic
+  description:
+    Build Clash binaries with GHC flag `-dynamic`. This flag should only be used for packaging purposes. Installations using cabal should use `--enable-executable-dynamic`!
+  default: False
+  manual: True
+
 executable clash
   Main-Is:            src-ghc/Batch.hs
   Build-Depends:      base, clash-ghc
   GHC-Options:        -Wall
+  if flag(dynamic)
+    GHC-Options: -dynamic
   extra-libraries:    pthread
   default-language:   Haskell2010
 
@@ -66,6 +74,8 @@ executable clashi
   Main-Is:            src-ghc/Interactive.hs
   Build-Depends:      base, clash-ghc
   GHC-Options:        -Wall
+  if flag(dynamic)
+    GHC-Options: -dynamic
   extra-libraries:    pthread
   default-language:   Haskell2010
 

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -117,7 +117,7 @@ Library
                       deepseq                 >= 1.3.0.2  && < 1.5,
                       directory               >= 1.2.0.1  && < 1.4,
                       errors                  >= 1.4.2    && < 2.4,
-                      exceptions              >= 0.10.0   && < 0.11.0,
+                      exceptions              >= 0.8.3    && < 0.11.0,
                       filepath                >= 1.3.0.1  && < 1.5,
                       ghc                     >= 8.2.0    && < 8.8,
                       hashable                >= 1.2.1.0  && < 1.3,


### PR DESCRIPTION
* Ubuntu 18.10 packages `exceptions` 0.10, so we need it to build binary package
* ~~Enable `-dynamic` by default, as we need it for speedy builds (can be disabled by `-f-dynamic`)~~ Add flag to enable `-dynamic`. Default is false.