### PR TITLE
Improve verilog basic id generation

### DIFF
--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -137,20 +137,20 @@ instance Backend SystemVerilogState where
   hdlSyn          = use hdlsyn
   mkIdentifier    = return go
     where
-      go Basic    nm = (TextS.take 1024 . filterReserved) (mkBasicId' True nm)
+      go Basic    nm = (TextS.take 1024 . filterReserved) (mkBasicId' SystemVerilog True nm)
       go Extended (rmSlash . escapeTemplate -> nm) = case go Basic nm of
         nm' | nm /= nm' -> TextS.concat ["\\",nm," "]
             |otherwise  -> nm'
   extendIdentifier = return go
     where
       go Basic nm ext = (TextS.take 1024 . filterReserved)
-                        (mkBasicId' True (nm `TextS.append` ext))
+                        (mkBasicId' SystemVerilog True (nm `TextS.append` ext))
       go Extended (rmSlash -> nm) ext =
         let nmExt = nm `TextS.append` ext
         in  case go Basic nm ext of
-              nm' | nm' /= nmExt -> case TextS.head nmExt of
-                      '#' -> TextS.concat ["\\",nmExt," "]
-                      _   -> TextS.concat ["\\#",nmExt," "]
+              nm' | nm' /= nmExt -> case TextS.isPrefixOf "c$" nmExt of
+                      True -> TextS.concat ["\\",nmExt," "]
+                      _    -> TextS.concat ["\\c$",nmExt," "]
                   | otherwise    -> nm'
 
   setModName nm s = s {_modNm = nm}

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -151,20 +151,20 @@ instance Backend VHDLState where
   mkIdentifier    = return go
     where
       go Basic nm = (stripTrailingUnderscore . filterReserved)
-                    (TextS.toLower (mkBasicId' True nm))
+                    (TextS.toLower (mkBasicId' VHDL True nm))
       go Extended (rmSlash -> nm) = case go Basic nm of
         nm' | nm /= nm' -> TextS.concat ["\\",nm,"\\"]
             |otherwise  -> nm'
   extendIdentifier = return go
     where
       go Basic nm ext = (stripTrailingUnderscore . filterReserved)
-                        (TextS.toLower (mkBasicId' True (nm `TextS.append` ext)))
+                        (TextS.toLower (mkBasicId' VHDL True (nm `TextS.append` ext)))
       go Extended ((rmSlash . escapeTemplate) -> nm) ext =
         let nmExt = nm `TextS.append` ext
         in  case go Basic nm ext of
-              nm' | nm' /= nmExt -> case TextS.head nmExt of
-                      '#' -> TextS.concat ["\\",nmExt,"\\"]
-                      _   -> TextS.concat ["\\#",nmExt,"\\"]
+              nm' | nm' /= nmExt -> case TextS.isPrefixOf "c$" nmExt of
+                      True -> TextS.concat ["\\",nmExt,"\\"]
+                      _    -> TextS.concat ["\\c$",nmExt,"\\"]
                   | otherwise    -> nm'
 
   setModName nm s = s {_modNm = nm}

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -142,20 +142,20 @@ instance Backend VerilogState where
   hdlSyn          = use hdlsyn
   mkIdentifier    = return go
     where
-      go Basic    nm = (TextS.take 1024 . filterReserved) (mkBasicId' True nm)
+      go Basic    nm = (TextS.take 1024 . filterReserved) (mkBasicId' Verilog True nm)
       go Extended (rmSlash -> nm) = case go Basic nm of
         nm' | nm /= nm' -> TextS.concat ["\\",nm," "]
             |otherwise  -> nm'
   extendIdentifier = return go
     where
       go Basic nm ext = (TextS.take 1024 . filterReserved)
-                        (mkBasicId' True (nm `TextS.append` ext))
+                        (mkBasicId' Verilog True (nm `TextS.append` ext))
       go Extended (rmSlash . escapeTemplate -> nm) ext =
         let nmExt = nm `TextS.append` ext
         in  case go Basic nm ext of
-              nm' | nm' /= nmExt -> case TextS.head nmExt of
-                      '#' -> TextS.concat ["\\",nmExt," "]
-                      _   -> TextS.concat ["\\#",nmExt," "]
+              nm' | nm' /= nmExt -> case TextS.isPrefixOf "c$" nmExt of
+                      True -> TextS.concat ["\\",nmExt," "]
+                      _    -> TextS.concat ["\\c$",nmExt," "]
                   | otherwise    -> nm'
 
   setModName _    = id

--- a/clash-lib/src/Clash/Core/Name.hs
+++ b/clash-lib/src/Clash/Core/Name.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TemplateHaskell       #-}
 
 module Clash.Core.Name
@@ -22,7 +23,7 @@ import           Control.DeepSeq                        (NFData)
 import           Data.Binary                            (Binary)
 import           Data.Function                          (on)
 import           Data.Hashable                          (Hashable (..))
-import           Data.Text                              (Text, append, cons)
+import           Data.Text                              (Text, append)
 import           GHC.BasicTypes.Extra                   ()
 import           GHC.Generics                           (Generic)
 import           GHC.SrcLoc.Extra                       ()
@@ -70,10 +71,10 @@ mkUnsafeInternalName
   :: Text
   -> Unique
   -> Name a
-mkUnsafeInternalName s i = Name Internal ('#' `cons` s) i noSrcSpan
+mkUnsafeInternalName s i = Name Internal ("c$" `append` s) i noSrcSpan
 
 appendToName :: Name a -> Text -> Name a
 appendToName (Name sort nm uniq loc) s = Name Internal nm2 uniq loc
   where
-    nm1 = case sort of {Internal -> nm; _ -> '#' `cons` nm}
+    nm1 = case sort of {Internal -> nm; _ -> "c$" `append` nm}
     nm2 = nm1 `append` s

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -308,12 +308,12 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
                 [Right _, Left scrut] -> do
                   tcm     <- Lens.use tcCache
                   let scrutTy = termType tcm scrut
-                  (scrutExpr,scrutDecls) <- mkExpr False (Left "#tte_rhs") scrutTy scrut
+                  (scrutExpr,scrutDecls) <- mkExpr False (Left "c$tte_rhs") scrutTy scrut
                   case scrutExpr of
                     Identifier id_ Nothing -> return (DataTag hwTy (Left id_),scrutDecls)
                     _ -> do
                       scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-                      tmpRhs <- mkUniqueIdentifier Extended "#tte_rhs"
+                      tmpRhs <- mkUniqueIdentifier Extended "c$tte_rhs"
                       let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                           netAssignRhs = Assignment tmpRhs scrutExpr
                       return (DataTag hwTy (Left tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
@@ -326,11 +326,11 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
                 tcm      <- Lens.use tcCache
                 let scrutTy = termType tcm scrut
                 scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-                (scrutExpr,scrutDecls) <- mkExpr False (Left "#dtt_rhs") scrutTy scrut
+                (scrutExpr,scrutDecls) <- mkExpr False (Left "c$dtt_rhs") scrutTy scrut
                 case scrutExpr of
                   Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
                   _ -> do
-                    tmpRhs  <- mkUniqueIdentifier Extended "#dtt_rhs"
+                    tmpRhs  <- mkUniqueIdentifier Extended "c$dtt_rhs"
                     let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                         netAssignRhs = Assignment tmpRhs scrutExpr
                     return (DataTag scrutHTy (Right tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
@@ -537,7 +537,7 @@ mkFunInput resId e = do
     goExpr e' = do
       tcm <- Lens.use tcCache
       let eType = termType tcm e'
-      (appExpr,appDecls) <- mkExpr False (Left "#bb_res") eType e'
+      (appExpr,appDecls) <- mkExpr False (Left "c$bb_res") eType e'
       let assn = Assignment "~RESULT" appExpr
       nm <- if null appDecls
                then return ""
@@ -559,7 +559,7 @@ mkFunInput resId e = do
       return (Right (("",[assn]),Wire))
 
     go _ _ (Case scrut ty [alt]) = do
-      (projection,decls) <- mkProjection False (Left "#bb_res") scrut ty alt
+      (projection,decls) <- mkProjection False (Left "c$bb_res") scrut ty alt
       let assn = Assignment "~RESULT" projection
       nm <- if null decls
                then return ""

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -144,7 +144,7 @@ setSym mkUniqueIdentifierM bbCtx l = do
           varM <- IntMap.lookup i <$> use _2
           case varM of
             Nothing -> do
-              nm' <- lift (mkUniqueIdentifierM Extended (Text.toStrict (concatT (Text "#":nm))))
+              nm' <- lift (mkUniqueIdentifierM Extended (Text.toStrict (concatT (Text "c$":nm))))
               let decls = case typeSize hwTy of
                     0 -> []
                     _ -> [N.NetDecl Nothing nm' hwTy
@@ -157,7 +157,7 @@ setSym mkUniqueIdentifierM bbCtx l = do
         symM <- IntMap.lookup i <$> use _1
         case symM of
           Nothing -> do
-            t <- lift (mkUniqueIdentifierM Extended "#n")
+            t <- lift (mkUniqueIdentifierM Extended "c$n")
             _1 %= (IntMap.insert i t)
             return (Sym (Text.fromStrict t) i)
           Just t -> return (Sym (Text.fromStrict t) i)

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -17,23 +17,29 @@ module Clash.Netlist.Id
   )
 where
 
+import Clash.Annotations.Primitive (HDL (..))
 import Data.Char (isAsciiLower,isAsciiUpper,isDigit)
 import Data.Text as Text
 
 data IdType = Basic | Extended
 
-mkBasicId' :: Bool
-           -> Text
-           -> Text
-mkBasicId' tupEncode = stripMultiscore . stripLeading . zEncode tupEncode
+mkBasicId'
+  :: HDL
+  -> Bool
+  -> Text
+  -> Text
+mkBasicId' hdl tupEncode = stripMultiscore hdl . stripLeading hdl . zEncode hdl tupEncode
   where
-    stripLeading    = Text.dropWhile (`elem` ('_':['0'..'9']))
-    stripMultiscore = Text.concat
-                    . Prelude.map (\cs -> case Text.head cs of
-                                            '_' -> "_"
-                                            _   -> cs
-                                  )
-                    . Text.group
+    stripLeading VHDL = Text.dropWhile (`elem` ('_':['0'..'9']))
+    stripLeading _    = Text.dropWhile (`elem` ('$':['0'..'9']))
+    stripMultiscore VHDL
+      = Text.concat
+      . Prelude.map (\cs -> case Text.head cs of
+                              '_' -> "_"
+                              _   -> cs
+                    )
+      . Text.group
+    stripMultiscore _ = id
 
 stripDollarPrefixes :: Text -> Text
 stripDollarPrefixes = stripWorkerPrefix . stripSpecPrefix . stripConPrefix
@@ -59,38 +65,40 @@ stripDollarPrefixes = stripWorkerPrefix . stripSpecPrefix . stripConPrefix
 type UserString    = Text -- As the user typed it
 type EncodedString = Text -- Encoded form
 
-zEncode :: Bool -> UserString -> EncodedString
-zEncode False cs = go (uncons cs)
+zEncode :: HDL -> Bool -> UserString -> EncodedString
+zEncode hdl False cs = go (uncons cs)
   where
     go Nothing         = empty
-    go (Just (c,cs'))  = append (encodeDigitCh c) (go' $ uncons cs')
+    go (Just (c,cs'))  = append (encodeDigitCh hdl c) (go' $ uncons cs')
     go' Nothing        = empty
-    go' (Just (c,cs')) = append (encodeCh c) (go' $ uncons cs')
+    go' (Just (c,cs')) = append (encodeCh hdl c) (go' $ uncons cs')
 
-zEncode True cs = case maybeTuple cs of
+zEncode hdl True cs = case maybeTuple cs of
                     Just (n,cs') -> append n (go' (uncons cs'))
                     Nothing      -> go (uncons cs)
   where
     go Nothing         = empty
-    go (Just (c,cs'))  = append (encodeDigitCh c) (go' $ uncons cs')
+    go (Just (c,cs'))  = append (encodeDigitCh hdl c) (go' $ uncons cs')
     go' Nothing        = empty
     go' (Just (c,cs')) = case maybeTuple (cons c cs') of
                            Just (n,cs2) -> append n (go' $ uncons cs2)
-                           Nothing      -> append (encodeCh c) (go' $ uncons cs')
+                           Nothing      -> append (encodeCh hdl c) (go' $ uncons cs')
 
-encodeDigitCh :: Char -> EncodedString
-encodeDigitCh c | isDigit c = Text.empty -- encodeAsUnicodeChar c
-encodeDigitCh c             = encodeCh c
+encodeDigitCh :: HDL -> Char -> EncodedString
+encodeDigitCh _   c | isDigit c = Text.empty -- encodeAsUnicodeChar c
+encodeDigitCh hdl c             = encodeCh hdl c
 
-encodeCh :: Char -> EncodedString
-encodeCh c | unencodedChar c = singleton c     -- Common case first
-           | otherwise       = Text.empty
+encodeCh :: HDL -> Char -> EncodedString
+encodeCh hdl c | unencodedChar hdl c = singleton c     -- Common case first
+               | otherwise           = Text.empty
 
-unencodedChar :: Char -> Bool   -- True for chars that don't need encoding
-unencodedChar c  = or [ isAsciiLower c
-                      , isAsciiUpper c
-                      , isDigit c
-                      , c == '_']
+unencodedChar :: HDL -> Char -> Bool   -- True for chars that don't need encoding
+unencodedChar hdl c  =
+  or [ isAsciiLower c
+     , isAsciiUpper c
+     , isDigit c
+     , if hdl == VHDL then c == '_' else c `elem` ['_','$']
+     ]
 
 maybeTuple :: UserString -> Maybe (EncodedString,UserString)
 maybeTuple "(# #)" = Just ("Unit",empty)


### PR DESCRIPTION
1. Clash no longer unnecessarily escapes basic ids
2. Clash picks `c$` instead of `#` as a prefix for internal names, so that we don't have to escape the internal names