### PR TITLE
Improve verilog basic id generation

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -28,17 +28,17 @@ import Util (OverridingBool(..))
 genSystemVerilog
   :: String
   -> IO ()
-genSystemVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN :: SystemVerilogState)
+genSystemVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True :: SystemVerilogState)
 
 genVHDL
   :: String
   -> IO ()
-genVHDL = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN :: VHDLState)
+genVHDL = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True :: VHDLState)
 
 genVerilog
   :: String
   -> IO ()
-genVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN :: VerilogState)
+genVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True :: VerilogState)
 
 doHDL
   :: HasCallStack
@@ -66,7 +66,7 @@ doHDL b src = do
     putStrLn $ "Parsing primitives took " ++ show prepStartDiff'
 
     generateHDL (buildCustomReprs reprs) bindingsMap (Just b) primMap2 tcm tupTcm (ghcTypeToHWType WORD_SIZE_IN_BITS True) reduceConstant topEntities
-      (ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing tmpDir HDLSYN True True ["."] Nothing True) (startTime,prepTime)
+      (ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing tmpDir HDLSYN True True ["."] Nothing True True) (startTime,prepTime)
    ) (do
     removeDirectoryRecursive tmpDir
    )

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -37,10 +37,10 @@ typeTrans :: (CustomReprs -> TyConMap -> Type -> Maybe (Either String FilteredHW
 typeTrans = ghcTypeToHWType WORD_SIZE_IN_BITS True
 
 opts :: FilePath -> ClashOpts
-opts tmpDir = ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing tmpDir HDLSYN True True ["."] Nothing True
+opts tmpDir = ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing tmpDir HDLSYN True True ["."] Nothing True True
 
 backend :: VHDLState
-backend = initBackend WORD_SIZE_IN_BITS HDLSYN
+backend = initBackend WORD_SIZE_IN_BITS HDLSYN True
 
 runInputStage
   :: FilePath

--- a/clash-ghc/src-bin-821/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-821/Clash/GHCi/UI.hs
@@ -1867,7 +1867,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> backend)
+         => (Int -> HdlSyn -> Bool -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -1882,7 +1882,7 @@ makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> backend)
+        => (Int -> HdlSyn -> Bool -> backend)
         -> IORef ClashOpts
         -> [FilePath]
         -> m ()
@@ -1896,6 +1896,7 @@ makeHDL backend optsRef srcs = do
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
                   tmpDir = opt_tmpDir opts1
+                  esc    = opt_escapedIds opts1
                   hdl    = Clash.Backend.hdlKind backend'
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -1908,7 +1909,7 @@ makeHDL backend optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn
+                  backend' = backend iw syn esc
 
               primDirs <- Clash.Backend.primDirs backend'
 
@@ -1943,13 +1944,13 @@ makeHDL backend optsRef srcs = do
                   (startTime,prepTime)
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-821/Clash/Main.hs
+++ b/clash-ghc/src-bin-821/Clash/Main.hs
@@ -998,18 +998,18 @@ abiHash strs = do
 -----------------------------------------------------------------------------
 -- VHDL Generation
 
-makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> backend) ->  IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
+makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> backend) ->  IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs
 
 makeVHDL :: IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VHDLState)
 
 makeVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VerilogState)
 
 makeSystemVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -1913,7 +1913,7 @@ exceptT = ExceptT . pure
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> backend)
+  => (Int -> HdlSyn -> Bool -> backend)
   -> IORef ClashOpts
   -> [FilePath]
   -> InputT GHCi ()
@@ -1929,7 +1929,7 @@ makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
 makeHDL
   :: GHC.GhcMonad m
   => Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> backend)
+  => (Int -> HdlSyn -> Bool -> backend)
   -> IORef ClashOpts
   -> [FilePath]
   -> m ()
@@ -1943,6 +1943,7 @@ makeHDL backend optsRef srcs = do
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
                   tmpDir = opt_tmpDir opts1
+                  esc    = opt_escapedIds opts1
                   hdl    = Clash.Backend.hdlKind backend'
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -1955,7 +1956,7 @@ makeHDL backend optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn
+                  backend' = backend iw syn esc
 
               primDirs <- Clash.Backend.primDirs backend'
 
@@ -1990,13 +1991,13 @@ makeHDL backend optsRef srcs = do
                   (startTime,prepTime)
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -1011,18 +1011,18 @@ abiHash strs = do
 -----------------------------------------------------------------------------
 -- VHDL Generation
 
-makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> backend) ->  IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
+makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> backend) ->  IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs
 
 makeVHDL :: IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VHDLState)
 
 makeVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VerilogState)
 
 makeSystemVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -1961,7 +1961,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> backend)
+         => (Int -> HdlSyn -> Bool -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -1976,7 +1976,7 @@ makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> backend)
+        => (Int -> HdlSyn -> Bool -> backend)
         -> IORef ClashOpts
         -> [FilePath]
         -> m ()
@@ -1990,6 +1990,7 @@ makeHDL backend optsRef srcs = do
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
                   tmpDir = opt_tmpDir opts1
+                  esc    = opt_escapedIds opts1
                   hdl    = Clash.Backend.hdlKind backend'
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2002,7 +2003,7 @@ makeHDL backend optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn
+                  backend' = backend iw syn esc
 
               primDirs <- Clash.Backend.primDirs backend'
 
@@ -2037,13 +2038,13 @@ makeHDL backend optsRef srcs = do
                   (startTime,prepTime)
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -1001,18 +1001,18 @@ abiHash strs = do
 -----------------------------------------------------------------------------
 -- HDL Generation
 
-makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> backend) ->  IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
+makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> backend) ->  IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs
 
 makeVHDL :: IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VHDLState)
 
 makeVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> VerilogState)
 
 makeSystemVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -74,6 +74,7 @@ flagsClash r = [
   , defFlag "fclash-allow-zero-width"        $ NoArg (setAllowZeroWidth r)
   , defFlag "fclash-component-prefix"        $ SepArg (liftEwM . setComponentPrefix r)
   , defFlag "fclash-old-inline-strategy"     $ NoArg (liftEwM (setOldInlineStrategy r))
+  , defFlag "fclash-no-escaped-identifiers"  $ NoArg (liftEwM (setNoEscapedIds r))
   ]
 
 -- | Print deprecated flag warning
@@ -176,3 +177,6 @@ setComponentPrefix r s = modifyIORef r (\c -> c {opt_componentPrefix = Just s})
 
 setOldInlineStrategy :: IORef ClashOpts -> IO ()
 setOldInlineStrategy r = modifyIORef r (\c -> c {opt_newInlineStrat = False})
+
+setNoEscapedIds :: IORef ClashOpts -> IO ()
+setNoEscapedIds r = modifyIORef r (\c -> c {opt_escapedIds = False})

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -40,7 +40,7 @@ data Usage
 
 class Backend state where
   -- | Initial state for state monad
-  initBackend :: Int -> HdlSyn -> state
+  initBackend :: Int -> HdlSyn -> Bool -> state
 
   -- | What HDL is the backend generating
   hdlKind :: state -> HDL

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -96,6 +96,7 @@ data VHDLState =
   -- ^ Int/Word/Integer bit-width
   , _hdlsyn    :: HdlSyn
   -- ^ For which HDL synthesis tool are we generating VHDL
+  , _extendedIds :: Bool
   }
 
 makeLenses ''VHDLState
@@ -148,24 +149,28 @@ instance Backend VHDLState where
     nm <- Mon $ use modNm
     pretty (TextS.toLower nm) <> "_types.fromSLV" <> parens (pretty id_)
   hdlSyn          = use hdlsyn
-  mkIdentifier    = return go
+  mkIdentifier    = do
+      allowExtended <- use extendedIds
+      return (go allowExtended)
     where
-      go Basic nm = (stripTrailingUnderscore . filterReserved)
-                    (TextS.toLower (mkBasicId' True nm))
-      go Extended (rmSlash -> nm) = case go Basic nm of
-        nm' | nm /= nm' -> TextS.concat ["\\",nm,"\\"]
-            |otherwise  -> nm'
-  extendIdentifier = return go
+      go _ Basic nm = (stripTrailingUnderscore . filterReserved)
+                    (TextS.toLower (mkBasicId' VHDL True nm))
+      go esc Extended (rmSlash -> nm) = case go esc Basic nm of
+        nm' | esc && nm /= nm' -> TextS.concat ["\\",nm,"\\"]
+            | otherwise -> nm'
+  extendIdentifier = do
+      allowExtended <- use extendedIds
+      return (go allowExtended)
     where
-      go Basic nm ext = (stripTrailingUnderscore . filterReserved)
-                        (TextS.toLower (mkBasicId' True (nm `TextS.append` ext)))
-      go Extended ((rmSlash . escapeTemplate) -> nm) ext =
+      go _ Basic nm ext = (stripTrailingUnderscore . filterReserved)
+                        (TextS.toLower (mkBasicId' VHDL True (nm `TextS.append` ext)))
+      go esc Extended ((rmSlash . escapeTemplate) -> nm) ext =
         let nmExt = nm `TextS.append` ext
-        in  case go Basic nm ext of
-              nm' | nm' /= nmExt -> case TextS.head nmExt of
-                      '#' -> TextS.concat ["\\",nmExt,"\\"]
-                      _   -> TextS.concat ["\\#",nmExt,"\\"]
-                  | otherwise    -> nm'
+        in  case go esc Basic nm ext of
+              nm' | esc && nm' /= nmExt -> case TextS.isPrefixOf "c$" nmExt of
+                      True -> TextS.concat ["\\",nmExt,"\\"]
+                      _    -> TextS.concat ["\\c$",nmExt,"\\"]
+                  | otherwise -> nm'
 
   setModName nm s = s {_modNm = nm}
   setSrcSpan      = (srcSpan .=)

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -91,6 +91,7 @@ data VerilogState =
     -- during the execution of 'genNetlist'.
     , _intWidth  :: Int -- ^ Int/Word/Integer bit-width
     , _hdlsyn    :: HdlSyn
+    , _escapedIds :: Bool
     }
 
 makeLenses ''VerilogState
@@ -140,23 +141,27 @@ instance Backend VerilogState where
   toBV _          = string
   fromBV _        = string
   hdlSyn          = use hdlsyn
-  mkIdentifier    = return go
+  mkIdentifier    = do
+      allowEscaped <- use escapedIds
+      return (go allowEscaped)
     where
-      go Basic    nm = (TextS.take 1024 . filterReserved) (mkBasicId' True nm)
-      go Extended (rmSlash -> nm) = case go Basic nm of
-        nm' | nm /= nm' -> TextS.concat ["\\",nm," "]
-            |otherwise  -> nm'
-  extendIdentifier = return go
+      go _ Basic    nm = (TextS.take 1024 . filterReserved) (mkBasicId' Verilog True nm)
+      go esc Extended (rmSlash -> nm) = case go esc Basic nm of
+        nm' | esc && nm /= nm' -> TextS.concat ["\\",nm," "]
+            | otherwise -> nm'
+  extendIdentifier = do
+      allowEscaped <- use escapedIds
+      return (go allowEscaped)
     where
-      go Basic nm ext = (TextS.take 1024 . filterReserved)
-                        (mkBasicId' True (nm `TextS.append` ext))
-      go Extended (rmSlash . escapeTemplate -> nm) ext =
+      go _ Basic nm ext = (TextS.take 1024 . filterReserved)
+                        (mkBasicId' Verilog True (nm `TextS.append` ext))
+      go esc Extended (rmSlash . escapeTemplate -> nm) ext =
         let nmExt = nm `TextS.append` ext
-        in  case go Basic nm ext of
-              nm' | nm' /= nmExt -> case TextS.head nmExt of
-                      '#' -> TextS.concat ["\\",nmExt," "]
-                      _   -> TextS.concat ["\\#",nmExt," "]
-                  | otherwise    -> nm'
+        in  case go esc Basic nm ext of
+              nm' | esc && nm' /= nmExt -> case TextS.isPrefixOf "c$" nmExt of
+                      True -> TextS.concat ["\\",nmExt," "]
+                      _    -> TextS.concat ["\\c$",nmExt," "]
+                  | otherwise -> nm'
 
   setModName _    = id
   setSrcSpan      = (srcSpan .=)

--- a/clash-lib/src/Clash/Core/Name.hs
+++ b/clash-lib/src/Clash/Core/Name.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TemplateHaskell       #-}
 
 module Clash.Core.Name
@@ -22,7 +23,7 @@ import           Control.DeepSeq                        (NFData)
 import           Data.Binary                            (Binary)
 import           Data.Function                          (on)
 import           Data.Hashable                          (Hashable (..))
-import           Data.Text                              (Text, append, cons)
+import           Data.Text                              (Text, append)
 import           GHC.BasicTypes.Extra                   ()
 import           GHC.Generics                           (Generic)
 import           GHC.SrcLoc.Extra                       ()
@@ -70,10 +71,10 @@ mkUnsafeInternalName
   :: Text
   -> Unique
   -> Name a
-mkUnsafeInternalName s i = Name Internal ('#' `cons` s) i noSrcSpan
+mkUnsafeInternalName s i = Name Internal ("c$" `append` s) i noSrcSpan
 
 appendToName :: Name a -> Text -> Name a
 appendToName (Name sort nm uniq loc) s = Name Internal nm2 uniq loc
   where
-    nm1 = case sort of {Internal -> nm; _ -> '#' `cons` nm}
+    nm1 = case sort of {Internal -> nm; _ -> "c$" `append` nm}
     nm2 = nm1 `append` s

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -155,8 +155,9 @@ generateHDL reprs bindingsMap hdlState primMap tcm tupTcm typeTrans eval
           _ -> (modName1, (Nothing,Nothing))
       iw        = opt_intWidth opts
       hdlsyn    = opt_hdlSyn opts
+      escpIds   = opt_escapedIds opts
       hdlState' = setModName (Data.Text.pack modName)
-                $ fromMaybe (initBackend iw hdlsyn :: backend) hdlState
+                $ fromMaybe (initBackend iw hdlsyn escpIds :: backend) hdlState
       hdlDir    = fromMaybe "." (opt_hdlDir opts) </>
                         Clash.Backend.name hdlState' </>
                         takeWhile (/= '.') topEntityS

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -69,6 +69,7 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            , opt_importPaths :: [FilePath]
                            , opt_componentPrefix :: Maybe String
                            , opt_newInlineStrat :: Bool
+                           , opt_escapedIds :: Bool
                            }
 
 
@@ -96,6 +97,7 @@ defClashOpts tmpDir
   , opt_importPaths         = []
   , opt_componentPrefix     = Nothing
   , opt_newInlineStrat      = True
+  , opt_escapedIds          = True
   }
 
 -- | Information about the generated HDL between (sub)runs of the compiler

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -308,12 +308,12 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
                 [Right _, Left scrut] -> do
                   tcm     <- Lens.use tcCache
                   let scrutTy = termType tcm scrut
-                  (scrutExpr,scrutDecls) <- mkExpr False (Left "#tte_rhs") scrutTy scrut
+                  (scrutExpr,scrutDecls) <- mkExpr False (Left "c$tte_rhs") scrutTy scrut
                   case scrutExpr of
                     Identifier id_ Nothing -> return (DataTag hwTy (Left id_),scrutDecls)
                     _ -> do
                       scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-                      tmpRhs <- mkUniqueIdentifier Extended "#tte_rhs"
+                      tmpRhs <- mkUniqueIdentifier Extended "c$tte_rhs"
                       let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                           netAssignRhs = Assignment tmpRhs scrutExpr
                       return (DataTag hwTy (Left tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
@@ -326,11 +326,11 @@ mkPrimitive bbEParen bbEasD dst nm args ty = do
                 tcm      <- Lens.use tcCache
                 let scrutTy = termType tcm scrut
                 scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-                (scrutExpr,scrutDecls) <- mkExpr False (Left "#dtt_rhs") scrutTy scrut
+                (scrutExpr,scrutDecls) <- mkExpr False (Left "c$dtt_rhs") scrutTy scrut
                 case scrutExpr of
                   Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
                   _ -> do
-                    tmpRhs  <- mkUniqueIdentifier Extended "#dtt_rhs"
+                    tmpRhs  <- mkUniqueIdentifier Extended "c$dtt_rhs"
                     let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                         netAssignRhs = Assignment tmpRhs scrutExpr
                     return (DataTag scrutHTy (Right tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
@@ -537,7 +537,7 @@ mkFunInput resId e = do
     goExpr e' = do
       tcm <- Lens.use tcCache
       let eType = termType tcm e'
-      (appExpr,appDecls) <- mkExpr False (Left "#bb_res") eType e'
+      (appExpr,appDecls) <- mkExpr False (Left "c$bb_res") eType e'
       let assn = Assignment "~RESULT" appExpr
       nm <- if null appDecls
                then return ""
@@ -559,7 +559,7 @@ mkFunInput resId e = do
       return (Right (("",[assn]),Wire))
 
     go _ _ (Case scrut ty [alt]) = do
-      (projection,decls) <- mkProjection False (Left "#bb_res") scrut ty alt
+      (projection,decls) <- mkProjection False (Left "c$bb_res") scrut ty alt
       let assn = Assignment "~RESULT" projection
       nm <- if null decls
                then return ""

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -144,7 +144,7 @@ setSym mkUniqueIdentifierM bbCtx l = do
           varM <- IntMap.lookup i <$> use _2
           case varM of
             Nothing -> do
-              nm' <- lift (mkUniqueIdentifierM Extended (Text.toStrict (concatT (Text "#":nm))))
+              nm' <- lift (mkUniqueIdentifierM Extended (Text.toStrict (concatT (Text "c$":nm))))
               let decls = case typeSize hwTy of
                     0 -> []
                     _ -> [N.NetDecl Nothing nm' hwTy
@@ -157,7 +157,7 @@ setSym mkUniqueIdentifierM bbCtx l = do
         symM <- IntMap.lookup i <$> use _1
         case symM of
           Nothing -> do
-            t <- lift (mkUniqueIdentifierM Extended "#n")
+            t <- lift (mkUniqueIdentifierM Extended "c$n")
             _1 %= (IntMap.insert i t)
             return (Sym (Text.fromStrict t) i)
           Just t -> return (Sym (Text.fromStrict t) i)

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -17,23 +17,29 @@ module Clash.Netlist.Id
   )
 where
 
+import Clash.Annotations.Primitive (HDL (..))
 import Data.Char (isAsciiLower,isAsciiUpper,isDigit)
 import Data.Text as Text
 
 data IdType = Basic | Extended
 
-mkBasicId' :: Bool
-           -> Text
-           -> Text
-mkBasicId' tupEncode = stripMultiscore . stripLeading . zEncode tupEncode
+mkBasicId'
+  :: HDL
+  -> Bool
+  -> Text
+  -> Text
+mkBasicId' hdl tupEncode = stripMultiscore hdl . stripLeading hdl . zEncode hdl tupEncode
   where
-    stripLeading    = Text.dropWhile (`elem` ('_':['0'..'9']))
-    stripMultiscore = Text.concat
-                    . Prelude.map (\cs -> case Text.head cs of
-                                            '_' -> "_"
-                                            _   -> cs
-                                  )
-                    . Text.group
+    stripLeading VHDL = Text.dropWhile (`elem` ('_':['0'..'9']))
+    stripLeading _    = Text.dropWhile (`elem` ('$':['0'..'9']))
+    stripMultiscore VHDL
+      = Text.concat
+      . Prelude.map (\cs -> case Text.head cs of
+                              '_' -> "_"
+                              _   -> cs
+                    )
+      . Text.group
+    stripMultiscore _ = id
 
 stripDollarPrefixes :: Text -> Text
 stripDollarPrefixes = stripWorkerPrefix . stripSpecPrefix . stripConPrefix
@@ -59,38 +65,40 @@ stripDollarPrefixes = stripWorkerPrefix . stripSpecPrefix . stripConPrefix
 type UserString    = Text -- As the user typed it
 type EncodedString = Text -- Encoded form
 
-zEncode :: Bool -> UserString -> EncodedString
-zEncode False cs = go (uncons cs)
+zEncode :: HDL -> Bool -> UserString -> EncodedString
+zEncode hdl False cs = go (uncons cs)
   where
     go Nothing         = empty
-    go (Just (c,cs'))  = append (encodeDigitCh c) (go' $ uncons cs')
+    go (Just (c,cs'))  = append (encodeDigitCh hdl c) (go' $ uncons cs')
     go' Nothing        = empty
-    go' (Just (c,cs')) = append (encodeCh c) (go' $ uncons cs')
+    go' (Just (c,cs')) = append (encodeCh hdl c) (go' $ uncons cs')
 
-zEncode True cs = case maybeTuple cs of
+zEncode hdl True cs = case maybeTuple cs of
                     Just (n,cs') -> append n (go' (uncons cs'))
                     Nothing      -> go (uncons cs)
   where
     go Nothing         = empty
-    go (Just (c,cs'))  = append (encodeDigitCh c) (go' $ uncons cs')
+    go (Just (c,cs'))  = append (encodeDigitCh hdl c) (go' $ uncons cs')
     go' Nothing        = empty
     go' (Just (c,cs')) = case maybeTuple (cons c cs') of
                            Just (n,cs2) -> append n (go' $ uncons cs2)
-                           Nothing      -> append (encodeCh c) (go' $ uncons cs')
+                           Nothing      -> append (encodeCh hdl c) (go' $ uncons cs')
 
-encodeDigitCh :: Char -> EncodedString
-encodeDigitCh c | isDigit c = Text.empty -- encodeAsUnicodeChar c
-encodeDigitCh c             = encodeCh c
+encodeDigitCh :: HDL -> Char -> EncodedString
+encodeDigitCh _   c | isDigit c = Text.empty -- encodeAsUnicodeChar c
+encodeDigitCh hdl c             = encodeCh hdl c
 
-encodeCh :: Char -> EncodedString
-encodeCh c | unencodedChar c = singleton c     -- Common case first
-           | otherwise       = Text.empty
+encodeCh :: HDL -> Char -> EncodedString
+encodeCh hdl c | unencodedChar hdl c = singleton c     -- Common case first
+               | otherwise           = Text.empty
 
-unencodedChar :: Char -> Bool   -- True for chars that don't need encoding
-unencodedChar c  = or [ isAsciiLower c
-                      , isAsciiUpper c
-                      , isDigit c
-                      , c == '_']
+unencodedChar :: HDL -> Char -> Bool   -- True for chars that don't need encoding
+unencodedChar hdl c  =
+  or [ isAsciiLower c
+     , isAsciiUpper c
+     , isDigit c
+     , if hdl == VHDL then c == '_' else c `elem` ['_','$']
+     ]
 
 maybeTuple :: UserString -> Maybe (EncodedString,UserString)
 maybeTuple "(# #)" = Just ("Unit",empty)


### PR DESCRIPTION
1. Clash no longer unnecessarily escapes basic ids
2. Clash pick `c$` instead of `#` as a prefix for internal names, so that we don't have to escape the internal names
3. Allow users to force basic id generation using: `-fclash-no-escaped-identifiers`