### PR TITLE
Use explicit bitvector resize in generated verilog

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -1429,11 +1429,17 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
 -- Eq
   -- eq#, neq# :: KnownNat n => BitVector n -> BitVector n -> Bool
   "Clash.Sized.Internal.BitVector.eq#"
+    | nTy : _ <- tys
+    , Right 0 <- runExcept (tyNatSize tcm nTy)
+    -> reduce (boolToBoolLiteral tcm ty True)
     | Just (_, kn) <- extractKnownNat tcm tys
     , Just val <- reifyNat kn (liftBitVector2Bool BitVector.eq# ty tcm args)
     -> reduce val
 
   "Clash.Sized.Internal.BitVector.neq#"
+    | nTy : _ <- tys
+    , Right 0 <- runExcept (tyNatSize tcm nTy)
+    -> reduce (boolToBoolLiteral tcm ty False)
     | Just (_, kn) <- extractKnownNat tcm tys
     , Just val <- reifyNat kn (liftBitVector2Bool BitVector.neq# ty tcm args)
     -> reduce val
@@ -1441,18 +1447,30 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
 -- Ord
   -- lt#,ge#,gt#,le# :: KnownNat n => BitVector n -> BitVector n -> Bool
   "Clash.Sized.Internal.BitVector.lt#"
+    | nTy : _ <- tys
+    , Right 0 <- runExcept (tyNatSize tcm nTy)
+    -> reduce (boolToBoolLiteral tcm ty False)
     | Just (_, kn) <- extractKnownNat tcm tys
     , Just val <- reifyNat kn (liftBitVector2Bool BitVector.lt# ty tcm args)
     -> reduce val
   "Clash.Sized.Internal.BitVector.ge#"
+    | nTy : _ <- tys
+    , Right 0 <- runExcept (tyNatSize tcm nTy)
+    -> reduce (boolToBoolLiteral tcm ty True)
     | Just (_, kn) <- extractKnownNat tcm tys
     , Just val <- reifyNat kn (liftBitVector2Bool BitVector.ge# ty tcm args)
     -> reduce val
   "Clash.Sized.Internal.BitVector.gt#"
+    | nTy : _ <- tys
+    , Right 0 <- runExcept (tyNatSize tcm nTy)
+    -> reduce (boolToBoolLiteral tcm ty False)
     | Just (_, kn) <- extractKnownNat tcm tys
     , Just val <- reifyNat kn (liftBitVector2Bool BitVector.gt# ty tcm args)
     -> reduce val
   "Clash.Sized.Internal.BitVector.le#"
+    | nTy : _ <- tys
+    , Right 0 <- runExcept (tyNatSize tcm nTy)
+    -> reduce (boolToBoolLiteral tcm ty True)
     | Just (_, kn) <- extractKnownNat tcm tys
     , Just val <- reifyNat kn (liftBitVector2Bool BitVector.le# ty tcm args)
     -> reduce val

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -1605,15 +1605,15 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
         op :: KnownNat n => BitVector n -> Int -> Proxy n -> (Integer,Integer)
         op u i _ = splitBV (BitVector.rotateR# u i)
 
--- Resize
-  "Clash.Sized.Internal.BitVector.resize#" -- forall n m . KnownNat m => BitVector n -> BitVector m
-    | _ : mTy : _ <- tys
-    , Right km <- runExcept (tyNatSize tcm mTy)
+-- truncateB
+  "Clash.Sized.Internal.BitVector.truncateB#" -- forall a b . KnownNat a => BitVector (a + b) -> BitVector a
+    | aTy  : _ <- tys
+    , Right ka <- runExcept (tyNatSize tcm aTy)
     , [(mski,i)] <- bitVectorLiterals' args
-    -> let bitsKeep = (bit (fromInteger km)) - 1
+    -> let bitsKeep = (bit (fromInteger ka)) - 1
            val = i .&. bitsKeep
            msk = mski .&. bitsKeep
-    in reduce (mkBitVectorLit ty mTy km msk val)
+    in reduce (mkBitVectorLit ty aTy ka msk val)
 
 --------
 -- Index

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -223,8 +223,9 @@ mkClassSelector inScope0 tcm ty sel = newExpr
 mkTupTyCons :: GHC2CoreState -> (GHC2CoreState,IntMap TyConName)
 mkTupTyCons tcMap = (tcMap'',tupTcCache)
   where
-    tupTyCons        = map (GHC.tupleTyCon GHC.Boxed) [2..62]
+    tupTyCons        = GHC.promotedTrueDataCon : GHC.promotedFalseDataCon
+                     : map (GHC.tupleTyCon GHC.Boxed) [2..62]
     (tcNames,tcMap') = State.runState (mapM (\tc -> coreToName GHC.tyConName GHC.tyConUnique qualfiedNameString tc) tupTyCons) tcMap
-    tupTcCache       = IMS.fromList (zip [2..62] tcNames)
+    tupTcCache       = IMS.fromList (zip [2..62] (drop 2 tcNames))
     tupHM            = listToUniqMap (zip tcNames tupTyCons)
     tcMap''          = tcMap' & tyConMap %~ (`unionUniqMap` tupHM)

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.json
@@ -350,10 +350,10 @@
     }
   }
 , { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.BitVector.resize#"
-    , "kind"      : "Declaration"
-    , "type"      : "resize# :: KnownNat m => BitVector n -> BitVector m"
-    , "template"  : "assign ~RESULT = ~IF~SIZE[~TYP[1]]~THEN$unsigned(~ARG[1])~ELSE~SIZE[~TYPO]'d0~FI;"
+    { "name"      : "Clash.Sized.Internal.BitVector.truncateB#"
+    , "kind"      : "Expression"
+    , "type"      : "truncateB# :: forall a b . KnownNat a => BitVector (a + b) -> BitVector a"
+    , "template"  : "~VAR[bv][1][0+:~SIZE[~TYPO]]"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
@@ -537,10 +537,10 @@ end process;
     }
   }
 , { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.BitVector.resize#"
+    { "name"      : "Clash.Sized.Internal.BitVector.truncateB#"
     , "kind"      : "Expression"
-    , "type"      : "resize# :: KnownNat m => BitVector n -> BitVector m"
-    , "template"  : "~IF~SIZE[~TYP[1]]~THENstd_logic_vector(resize(unsigned(~ARG[1]),~SIZE[~TYPO]))~ELSEstd_logic_vector'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
+    , "type"      : "truncateB# :: forall a b . KnownNat a => BitVector (a + b) -> BitVector a"
+    , "template"  : "std_logic_vector(resize(unsigned(~ARG[1]),~SIZE[~TYPO]))"
     }
   }
 ]

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -83,6 +83,7 @@ import Data.Text.Prettyprint.Doc.Render.String
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
 #endif
+import           GHC.Stack
 
 type Unique = Int
 
@@ -168,11 +169,15 @@ lookupUniqMap k (UniqMap m) = IntMap.lookup (getUnique k) m
 
 -- | Like 'lookupUniqMap'', but errors out when the key is not present
 lookupUniqMap'
-  :: Uniquable a
+  :: (HasCallStack, Uniquable a)
   => UniqMap b
   -> a
   -> b
-lookupUniqMap' (UniqMap m) k = m IntMap.! getUnique k
+lookupUniqMap' (UniqMap m) k =
+  IntMap.findWithDefault d k' m
+ where
+  k' = getUnique k
+  d  = error ("lookupUniqMap': key " ++ show k' ++ " is not an element of the map")
 
 -- | Check whether a key is in the map
 elemUniqMap

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -42,6 +42,8 @@ module Clash.Promoted.Nat
   , subSNat, divSNat, modSNat, flogBaseSNat, clogBaseSNat, logBaseSNat
     -- *** Specialised
   , pow2SNat
+    -- *** Comparison
+  , SNatLE (..), compareSNat
     -- * Unary/Peano-encoded natural numbers
     -- ** Data type
   , UNat (..)
@@ -262,6 +264,18 @@ logBaseSNat SNat SNat = SNat
 pow2SNat :: SNat a -> SNat (2^a)
 pow2SNat SNat = SNat
 {-# INLINE pow2SNat #-}
+
+-- | Ordering relation between two Nats
+data SNatLE a b where
+  SNatLE :: forall a b . a <= b => SNatLE a b
+  SNatGT :: forall a b . (b+1) <= a => SNatLE a b
+
+-- | Get an ordering relation between two SNats
+compareSNat :: forall a b . SNat a -> SNat b -> SNatLE a b
+compareSNat a b =
+  if snatToInteger a <= snatToInteger b
+     then unsafeCoerce (SNatLE @0 @0)
+     else unsafeCoerce (SNatGT @1 @0)
 
 -- | Base-2 encoded natural number
 --


### PR DESCRIPTION
Lint tools complain about implicit resizing in Verilog, and readability is also improved.