### PR TITLE
Synthesize-ann functions can appear as HO-argument

### DIFF
--- a/clash-lib/src/Clash/Netlist.hs-boot
+++ b/clash-lib/src/Clash/Netlist.hs-boot
@@ -12,6 +12,7 @@ module Clash.Netlist
   ,mkNetDecl
   ,mkProjection
   ,mkSelection
+  ,mkFunApp
   ) where
 
 import Data.HashSet         (HashSet)
@@ -57,3 +58,9 @@ mkSelection
 mkNetDecl :: LetBinding -> NetlistMonad (Maybe Declaration)
 
 mkDeclarations :: Id -> Term -> NetlistMonad [Declaration]
+
+mkFunApp
+  :: Identifier -- ^ LHS of the let-binder
+  -> Id -- ^ Name of the applied function
+  -> [Term] -- ^ Function arguments
+  -> NetlistMonad [Declaration]

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -28,7 +28,8 @@ normalization = rmDeadcode >-> constantPropgation >-> etaTL >-> rmUnusedExpr >-!
     bindConst  = topdownR (apply "bindConstantVar" bindConstantVar)
     evalConst  = topdownR (apply "evalConst" reduceConst)
     cse        = topdownR (apply "CSE" simpleCSE)
-    cleanup    = topdownSucR (apply "inlineCleanup" inlineCleanup) !->
+    cleanup    = topdownR (apply "etaExpandSyn" etaExpandSyn) >->
+                 topdownSucR (apply "inlineCleanup" inlineCleanup) !->
                  innerMost (applyMany [("caseCon"        , caseCon)
                                       ,("bindConstantVar", bindConstantVar)
                                       ,("letFlat"        , flattenLet)])

--- a/tests/shouldwork/TopEntity/TopEntHOArg.hs
+++ b/tests/shouldwork/TopEntity/TopEntHOArg.hs
@@ -1,0 +1,19 @@
+module TopEntHOArg where
+
+import Clash.Prelude
+
+f :: Bit
+  -> (Bool,(Bit,Bool),Maybe Bit)
+  -> Bool
+  -> (Bit,Bool,Maybe Bit,(Bit, Bool),Bool)
+f z (a,b,c) d = (z,a,c,b,d)
+{-# ANN f Synthesize {t_name = "f", t_inputs = [PortName "z",PortProduct "" []], t_output = PortProduct "" []} #-}
+{-# NOINLINE f #-}
+
+g
+  :: Bit
+  -> Vec 2 (Bool,(Bit,Bool),Maybe Bit)
+  -> Vec 2 Bool
+  -> Vec 2 (Bit,Bool,Maybe Bit,(Bit, Bool), Bool)
+g b = zipWith (f b)
+{-# ANN g Synthesize {t_name = "g", t_inputs = [PortName "z", PortProduct "" []], t_output = PortProduct "" []} #-}

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -251,6 +251,7 @@ runClashTest =
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithVector" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithRTree" (["","PortNamesWithRTree_topEntity","PortNamesWithRTree_testBench"],"PortNamesWithRTree_testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] "PortNamesWithRTree" "main"
+        , runTest ("tests" </> "shouldwork" </> "TopEntity")    defBuild [] "TopEntHOArg" (["f","g"],"f",False)
         ]
       , clashTestGroup "Void"
         [ runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "Imap"                         (["","Imap_testBench"],"Imap_testBench",True)


### PR DESCRIPTION
Before, the netlist generator couldn't handle when functions with a Synthesize annotation would end up as an argument to a higher-order primitive.