### PR TITLE
Add eval rule for `Data.Singletons.TypeLits.Internal.$s^_f`

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -1044,6 +1044,11 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     | [Lit (IntLiteral i), Lit (IntLiteral j)] <- args
     -> reduce (integerToIntLiteral $ i ^ j)
 
+  -- XXX: Very fragile. /$s^_f/ is a specialized version of ^_f. That means that
+  -- it is type applied to some specific type.
+  "Data.Singletons.TypeLits.Internal.$s^_f"
+    | Just (i,j) <- naturalLiterals args
+    -> reduce (Literal (NaturalLiteral (i ^ j)))
 
   "GHC.TypeLits.natVal"
     | [Lit (NaturalLiteral n), _] <- args


### PR DESCRIPTION

edit: Circle CI interprets the `$s` in the branch name as a variable so it fails to test this :1st_place_medal: 