### PR TITLE
CircleCI: Only test external PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,11 @@ aliases:
   - &setup
     run:
       name: Setup system
-      command: .ci/setup.sh
+      command: |
+        # Only test on external pull requests
+        if [ -n "$CIRCLE_PR_NUMBER" ]; then
+          .ci/setup.sh
+        fi
   - &cache_restore
     restore_cache:
       keys:
@@ -26,10 +30,22 @@ aliases:
         - cabal-store
 
   - &build
-    run: .ci/build.sh
-
+    run:
+      name: Build dependencies and Clash itself
+      command: |
+        # Only test on external pull requests
+        if [ -n "$CIRCLE_PR_NUMBER" ]; then
+          .ci/build.sh
+        fi
+            
   - &run_tests
-    run: .ci/test.sh
+    run: 
+      name: Run tests
+      command: |
+        # Only test on external pull requests
+        if [ -n "$CIRCLE_PR_NUMBER" ]; then
+          .ci/test.sh
+        fi
 
   # When testing a pull request on CircleCI,
   # fetch the result of merging it in.


### PR DESCRIPTION
Internal PRs are tested on GitLab CI; we don't need CircleCI to run on those too. This doesn't prevent CircleCI from running at all, it just short-circuits when jobs have started. To clarify:

Internal  PRs: PRs based on a branch on `clash-lang/clash-compiler`
External PRs: PRs not based on a branch on `clash-lang/clash-compiler` (usually from external contributors)