### PR TITLE
pack _|_ = undefined#

### DIFF
--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -62,7 +62,8 @@ import Clash.Annotations.BitRepresentation.Util
 import qualified Clash.Annotations.BitRepresentation.Util
   as Util
 
-import           Clash.Class.BitPack        (BitPack, BitSize, pack, unpack)
+import           Clash.Class.BitPack
+  (BitPack, BitSize, pack, packXWith, unpack)
 import           Clash.Class.Resize         (resize)
 import           Clash.Sized.BitVector      (BitVector, low, (++#))
 import           Clash.Sized.Internal.BitVector (undefined#)
@@ -796,7 +797,7 @@ buildPack dataRepr@(DataReprAnn _name _size constrs) = do
   constrs'     <- mapM (buildPackMatch dataRepr) constrs
   let packBody    = CaseE (VarE argName) constrs'
   let packLambda  = LamE [VarP argName] packBody
-  let packApplied = (VarE 'dontApplyInHDL) `AppE` packLambda `AppE` (VarE argNameIn)
+  let packApplied = (VarE 'dontApplyInHDL) `AppE` (VarE 'packXWith `AppE` packLambda) `AppE` (VarE argNameIn)
   let func        = FunD 'pack [Clause [VarP argNameIn] (NormalB packApplied) []]
   return [func]
 

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -30,9 +30,11 @@ module Clash.Class.BitPack
   , boolToBV
   , boolToBit
   , bitToBool
+  , packXWith
   )
 where
 
+import Control.Exception              (catch, evaluate)
 import Data.Binary.IEEE754            (doubleToWord, floatToWord, wordToDouble,
                                        wordToFloat)
 import Data.Int
@@ -42,6 +44,7 @@ import GHC.TypeLits                   (KnownNat, Nat, type (+))
 import Numeric.Half                   (Half (..))
 import GHC.Generics
 import Prelude                        hiding (map)
+import System.IO.Unsafe               (unsafeDupablePerformIO)
 
 import Clash.Class.BitPack.Internal   (deriveBitPackTuples)
 import Clash.Class.Resize             (zeroExtend)
@@ -49,6 +52,7 @@ import Clash.Sized.BitVector
   (Bit, BitVector, (++#), high, low)
 import Clash.Sized.Internal.BitVector
   (pack#, split#, checkUnpackUndef, undefined#, unpack#, unsafeToInteger)
+import Clash.XException
 
 {- $setup
 >>> :set -XDataKinds
@@ -93,6 +97,16 @@ class BitPack a where
     => BitVector (BitSize a) -> a
   unpack = to . gunpack
 
+packXWith
+  :: KnownNat n
+  => (a -> BitVector n)
+  -> a
+  -> BitVector n
+packXWith f x =
+  unsafeDupablePerformIO (catch (f <$> evaluate x)
+                                (\(XException _) -> return undefined#))
+{-# NOINLINE packXWith #-}
+
 {-# INLINE bitCoerce #-}
 -- | Coerce a value from one type to another through its bit representation.
 --
@@ -109,78 +123,76 @@ bitCoerce = unpack . pack
 
 instance BitPack Bool where
   type BitSize Bool = 1
-  pack True  = 1
-  pack False = 0
-
+  pack   = let go b = if b then 1 else 0 in packXWith go
   unpack = checkUnpackUndef $ \bv -> if bv == 1 then True else False
 
-instance BitPack (BitVector n) where
+instance KnownNat n => BitPack (BitVector n) where
   type BitSize (BitVector n) = n
-  pack   v = v
+  pack     = packXWith id
   unpack v = v
 
 instance BitPack Bit where
   type BitSize Bit = 1
-  pack   = pack#
+  pack   = packXWith pack#
   unpack = unpack#
 
 instance BitPack Int where
   type BitSize Int = WORD_SIZE_IN_BITS
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Int8 where
   type BitSize Int8 = 8
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Int16 where
   type BitSize Int16 = 16
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Int32 where
   type BitSize Int32 = 32
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 #if WORD_SIZE_IN_BITS >= 64
 instance BitPack Int64 where
   type BitSize Int64 = 64
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 #endif
 
 instance BitPack Word where
   type BitSize Word = WORD_SIZE_IN_BITS
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Word8 where
   type BitSize Word8 = 8
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Word16 where
   type BitSize Word16 = 16
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Word32 where
   type BitSize Word32 = 32
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 #if WORD_SIZE_IN_BITS >= 64
 instance BitPack Word64 where
   type BitSize Word64 = 64
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 #endif
 
 instance BitPack Float where
   type BitSize Float = 32
-  pack   = packFloat#
+  pack   = packXWith packFloat#
   unpack = checkUnpackUndef unpackFloat#
 
 packFloat# :: Float -> BitVector 32
@@ -193,7 +205,7 @@ unpackFloat# = wordToFloat . fromInteger . unsafeToInteger
 
 instance BitPack Double where
   type BitSize Double = 64
-  pack   = packDouble#
+  pack   = packXWith packDouble#
   unpack = checkUnpackUndef unpackDouble#
 
 packDouble# :: Double -> BitVector 64
@@ -206,7 +218,7 @@ unpackDouble# = wordToDouble . fromInteger . unsafeToInteger
 
 instance BitPack CUShort where
   type BitSize CUShort = 16
-  pack   = fromIntegral
+  pack   = packXWith fromIntegral
   unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Half where
@@ -219,16 +231,17 @@ instance BitPack () where
   pack   _ = minBound
   unpack _ = ()
 
-instance (KnownNat (BitSize b), BitPack a, BitPack b) =>
+instance (KnownNat (BitSize a), KnownNat (BitSize b), BitPack a, BitPack b) =>
     BitPack (a,b) where
   type BitSize (a,b) = BitSize a + BitSize b
-  pack (a,b) = pack a ++# pack b
+  pack = let go (a,b) = pack a ++# pack b in packXWith go
   unpack ab  = let (a,b) = split# ab in (unpack a, unpack b)
 
 instance (BitPack a, KnownNat (BitSize a)) => BitPack (Maybe a) where
   type BitSize (Maybe a) = 1 + BitSize a
-  pack Nothing  = pack# low ++# undefined#
-  pack (Just x) = pack# high ++# pack x
+  pack = let go Nothing  = pack# low ++# undefined#
+             go (Just x) = pack# high ++# pack x
+         in  packXWith go
   unpack x = case split# x of
     (c,rest) | checkUnpackUndef unpack# c == low -> Nothing
              | otherwise                         -> Just (unpack rest)
@@ -243,9 +256,9 @@ instance (GBitPack a) => GBitPack (M1 m d a) where
   gpack (M1 m1)            = gpack m1
   gunpack b                = M1 (gunpack b)
 
-instance (KnownNat (GBitSize g), GBitPack f, GBitPack g) => GBitPack (f :*: g) where
+instance (KnownNat (GBitSize g), KnownNat (GBitSize f), GBitPack f, GBitPack g) => GBitPack (f :*: g) where
   type GBitSize (f :*: g) = GBitSize f + GBitSize g
-  gpack (m :*: ms)        = gpack m ++# gpack ms
+  gpack = let go (m :*: ms) = gpack m ++# gpack ms in packXWith go
   gunpack b               = gunpack front :*: gunpack back
     where
       (front, back) = split# b
@@ -273,4 +286,4 @@ bitToBool :: Bit -> Bool
 bitToBool = bitCoerce
 
 -- Derive the BitPack instance for tuples of size 3 to 62
-deriveBitPackTuples ''BitPack ''BitSize 'pack 'unpack '(++#)
+deriveBitPackTuples ''BitPack ''BitSize 'pack 'unpack

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -88,7 +88,7 @@ import Test.QuickCheck.Arbitrary  (Arbitrary (..), CoArbitrary (..),
                                    arbitraryBoundedIntegral,
                                    coarbitraryIntegral, shrinkIntegral)
 
-import Clash.Class.BitPack        (BitPack (..))
+import Clash.Class.BitPack        (BitPack (..), packXWith)
 import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
                                    SaturationMode (..))
 import Clash.Class.Resize         (Resize (..))
@@ -133,7 +133,7 @@ instance NFData (Index n) where
 
 instance (KnownNat n, 1 <= n) => BitPack (Index n) where
   type BitSize (Index n) = CLog 2 n
-  pack   = pack#
+  pack   = packXWith pack#
   unpack = unpack#
 
 -- | Safely convert an `SNat` value to an `Index`

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -99,7 +99,7 @@ import Test.QuickCheck.Arbitrary      (Arbitrary (..), CoArbitrary (..),
                                        arbitraryBoundedIntegral,
                                        coarbitraryIntegral, shrinkIntegral)
 
-import Clash.Class.BitPack            (BitPack (..))
+import Clash.Class.BitPack            (BitPack (..), packXWith)
 import Clash.Class.Num                (ExtendingNum (..), SaturatingNum (..),
                                        SaturationMode (..))
 import Clash.Class.Resize             (Resize (..))
@@ -175,7 +175,7 @@ instance KnownNat n => Read (Signed n) where
 
 instance KnownNat n => BitPack (Signed n) where
   type BitSize (Signed n) = n
-  pack   = pack#
+  pack   = packXWith pack#
   unpack = unpack#
 
 {-# NOINLINE pack# #-}

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -92,7 +92,7 @@ import Test.QuickCheck.Arbitrary      (Arbitrary (..), CoArbitrary (..),
                                        arbitraryBoundedIntegral,
                                        coarbitraryIntegral)
 
-import Clash.Class.BitPack            (BitPack (..))
+import Clash.Class.BitPack            (BitPack (..), packXWith)
 import Clash.Class.Num                (ExtendingNum (..), SaturatingNum (..),
                                        SaturationMode (..))
 import Clash.Class.Resize             (Resize (..))
@@ -164,7 +164,7 @@ instance KnownNat n => Read (Unsigned n) where
 
 instance KnownNat n => BitPack (Unsigned n) where
   type BitSize (Unsigned n) = n
-  pack   = pack#
+  pack   = packXWith pack#
   unpack = unpack#
 
 {-# NOINLINE pack# #-}

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -29,7 +29,7 @@ CallStack (from HasCallStack):
 
 module Clash.XException
   ( -- * 'X': An exception for uninitialized values
-    XException, errorX, isX, maybeX
+    XException (..), errorX, isX, maybeX
     -- * Printing 'X' exceptions as \"X\"
   , ShowX (..), showsX, printX, showsPrecXWith
     -- * Strict evaluation


### PR DESCRIPTION
Ensures that packing something that throws an `XException` doesn't throw an `XException` itself, but creates a BitVector with it's "undfinedness" bitmask set to all 1's.

So:

```
pack XException = undefined#
pack _|_ = _|_
```