### PR TITLE
Add Generic instance for BitVector

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -54,3 +54,10 @@ package *
 -- The fail package is empty for GHC 8+, and haddock errors out on it
 package fail
   documentation: False
+
+-- | We need: a <=? Max a b ~ True
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/ghc-typelits-extra
+  tag: a8de0b68b8216411cb862195354f251cd41bae50
+

--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -1,6 +1,11 @@
+{-|
+Copyright  :  (C) 2019, QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Clash.Class.BitPack.Internal where
+module Clash.Class.BitPack.Internal (deriveBitPackTuples) where
 
 import           Control.Monad         (replicateM)
 import           Data.List             (foldl')

--- a/tests/shouldwork/BitVector/GenericBitPack.hs
+++ b/tests/shouldwork/BitVector/GenericBitPack.hs
@@ -19,9 +19,10 @@ topEntity
      , FooSP2 U1 U2
      , FooSP2 U1 U2
      , FooSP2 U1 U2
+     , (U1, U2)
      )
-  -> BitVector 136
-topEntity (a, b, c, d, e, f, g, h, i, j) =
+  -> BitVector 152
+topEntity (a, b, c, d, e, f, g, h, i, j, k) =
   packed ++# packed
  where
   packed =
@@ -36,6 +37,7 @@ topEntity (a, b, c, d, e, f, g, h, i, j) =
       , pack h
       , pack i
       , pack j
+      , pack k
       )
 {-# NOINLINE topEntity #-}
 
@@ -56,6 +58,7 @@ testBench = done
           , hT
           , iT
           , jT
+          , kT
           ) :> Nil)
 
     expectedOutput =
@@ -72,6 +75,7 @@ testBench = done
               , $(lift (pack hT))
               , $(lift (pack iT))
               , $(lift (pack jT))
+              , $(lift (pack kT))
 
               , $$(bLit "00100010")  :: BitVector 8
               , $$(bLit "000")       :: BitVector 3
@@ -83,6 +87,7 @@ testBench = done
               , $$(bLit "0001000001") :: BitVector 10
               , $$(bLit "01010.....") :: BitVector 10
               , $$(bLit "1000001...") :: BitVector 10
+              , $$(bLit "00100010")  :: BitVector 8
 
               ) :> Nil)
 

--- a/tests/shouldwork/BitVector/GenericBitPack.hs
+++ b/tests/shouldwork/BitVector/GenericBitPack.hs
@@ -9,30 +9,34 @@ import Clash.Prelude
 import Clash.Explicit.Testbench
 
 topEntity
-  :: ( FooProduct (Unsigned 2) (Unsigned 2)
+  :: ( FooProduct U1 U2
      , FooSum
      , FooSum
      , FooSum
      , FooSum
-     , FooSP1 (Unsigned 3) (Unsigned 5)
-     , FooSP1 (Unsigned 3) (Unsigned 5)
-     , FooSP2 (Unsigned 3) (Unsigned 5)
-     , FooSP2 (Unsigned 3) (Unsigned 5)
-     , FooSP2 (Unsigned 3) (Unsigned 5)
+     , FooSP1 U1 U2
+     , FooSP1 U1 U2
+     , FooSP2 U1 U2
+     , FooSP2 U1 U2
+     , FooSP2 U1 U2
      )
-  -> BitVector 64
-topEntity (a, b, c, d, e, f, g, h, i, j) = pack $
-  ( pack a
-  , pack b
-  , pack c
-  , pack d
-  , pack e
-  , pack f
-  , pack g
-  , pack h
-  , pack i
-  , pack j
-  )
+  -> BitVector 136
+topEntity (a, b, c, d, e, f, g, h, i, j) =
+  packed ++# packed
+ where
+  packed =
+    pack $
+      ( pack a
+      , pack b
+      , pack c
+      , pack d
+      , pack e
+      , pack f
+      , pack g
+      , pack h
+      , pack i
+      , pack j
+      )
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
@@ -42,33 +46,46 @@ testBench = done
       stimuliGenerator
         clk
         rst
-        (( FooProduct (1 :: Unsigned 2) (2 :: Unsigned 2)
-         , FooSumA
-         , FooSumB
-         , FooSumC
-         , FooSumG
-         , FooSP1_AB (1 :: Unsigned 3) (2 :: Unsigned 5)
-         , FooSP1_BA (2 :: Unsigned 5) (1 :: Unsigned 3)
-         , FooSP2_AB (2 :: Unsigned 3) (1 :: Unsigned 5)
-         , FooSP2_A (2 :: Unsigned 3)
-         , FooSP2_B (1 :: Unsigned 5)
-         ) :> Nil)
+        ( ( aT
+          , bT
+          , cT
+          , dT
+          , eT
+          , fT
+          , gT
+          , hT
+          , iT
+          , jT
+          ) :> Nil)
+
     expectedOutput =
       outputVerifierBitVector
         clk
         rst
-        (pack ( $(lift (pack (FooProduct (1 :: Unsigned 2) (2 :: Unsigned 2))))
-              , $(lift (pack FooSumA))
-              , $(lift (pack FooSumB))
-              , $(lift (pack FooSumC))
-              , $(lift (pack FooSumG))
-              , $(lift (pack (FooSP1_AB (1 :: Unsigned 3) (2 :: Unsigned 5))))
-              , $(lift (pack (FooSP1_BA (2 :: Unsigned 5) (1 :: Unsigned 3))))
+        (pack ( $(lift (pack aT))
+              , $(lift (pack bT))
+              , $(lift (pack cT))
+              , $(lift (pack dT))
+              , $(lift (pack eT))
+              , $(lift (pack fT))
+              , $(lift (pack gT))
+              , $(lift (pack hT))
+              , $(lift (pack iT))
+              , $(lift (pack jT))
 
-              , $(lift (pack (FooSP2_AB (2 :: Unsigned 3) (1 :: Unsigned 5))))
-              , $(lift (pack (FooSP2_A (2 :: Unsigned 3) :: FooSP2 (Unsigned 3) (Unsigned 5))))
-              , $(lift (pack (FooSP2_B (1 :: Unsigned 5) :: FooSP2 (Unsigned 3) (Unsigned 5))))
+              , $$(bLit "00100010")  :: BitVector 8
+              , $$(bLit "000")       :: BitVector 3
+              , $$(bLit "001")       :: BitVector 3
+              , $$(bLit "010")       :: BitVector 3
+              , $$(bLit "110")       :: BitVector 3
+              , $$(bLit "000100010") :: BitVector 9
+              , $$(bLit "100001010") :: BitVector 9
+              , $$(bLit "0001000001") :: BitVector 10
+              , $$(bLit "01010.....") :: BitVector 10
+              , $$(bLit "1000001...") :: BitVector 10
+
               ) :> Nil)
+
     done           = expectedOutput (topEntity <$> testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen

--- a/tests/shouldwork/BitVector/GenericBitPack.hs
+++ b/tests/shouldwork/BitVector/GenericBitPack.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module GenericBitPack where
+
+import GenericBitPackTypes
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: ( FooProduct (Unsigned 2) (Unsigned 2)
+     , FooSum
+     , FooSum
+     , FooSum
+     , FooSum
+     , FooSP1 (Unsigned 3) (Unsigned 5)
+     , FooSP1 (Unsigned 3) (Unsigned 5)
+     , FooSP2 (Unsigned 3) (Unsigned 5)
+     , FooSP2 (Unsigned 3) (Unsigned 5)
+     , FooSP2 (Unsigned 3) (Unsigned 5)
+     )
+  -> BitVector 64
+topEntity (a, b, c, d, e, f, g, h, i, j) = pack $
+  ( pack a
+  , pack b
+  , pack c
+  , pack d
+  , pack e
+  , pack f
+  , pack g
+  , pack h
+  , pack i
+  , pack j
+  )
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput =
+      stimuliGenerator
+        clk
+        rst
+        (( FooProduct (1 :: Unsigned 2) (2 :: Unsigned 2)
+         , FooSumA
+         , FooSumB
+         , FooSumC
+         , FooSumG
+         , FooSP1_AB (1 :: Unsigned 3) (2 :: Unsigned 5)
+         , FooSP1_BA (2 :: Unsigned 5) (1 :: Unsigned 3)
+         , FooSP2_AB (2 :: Unsigned 3) (1 :: Unsigned 5)
+         , FooSP2_A (2 :: Unsigned 3)
+         , FooSP2_B (1 :: Unsigned 5)
+         ) :> Nil)
+    expectedOutput =
+      outputVerifierBitVector
+        clk
+        rst
+        (pack ( $(lift (pack (FooProduct (1 :: Unsigned 2) (2 :: Unsigned 2))))
+              , $(lift (pack FooSumA))
+              , $(lift (pack FooSumB))
+              , $(lift (pack FooSumC))
+              , $(lift (pack FooSumG))
+              , $(lift (pack (FooSP1_AB (1 :: Unsigned 3) (2 :: Unsigned 5))))
+              , $(lift (pack (FooSP1_BA (2 :: Unsigned 5) (1 :: Unsigned 3))))
+
+              , $(lift (pack (FooSP2_AB (2 :: Unsigned 3) (1 :: Unsigned 5))))
+              , $(lift (pack (FooSP2_A (2 :: Unsigned 3) :: FooSP2 (Unsigned 3) (Unsigned 5))))
+              , $(lift (pack (FooSP2_B (1 :: Unsigned 5) :: FooSP2 (Unsigned 3) (Unsigned 5))))
+              ) :> Nil)
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/BitVector/GenericBitPackTypes.hs
+++ b/tests/shouldwork/BitVector/GenericBitPackTypes.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module GenericBitPackTypes where
+
+import Clash.Prelude
+
+--type MyTuple = (Int, Int, Char)
+
+-- | Product type
+data FooProduct a b
+  = FooProduct a b
+    deriving Generic
+
+instance ( BitPack a
+         , BitPack b
+         , KnownNat (BitSize a)
+         , KnownNat (BitSize b)
+         ) => BitPack (FooProduct a b)
+
+
+-- | Sum type
+data FooSum
+  = FooSumA
+  | FooSumB
+  | FooSumC
+  | FooSumD
+  | FooSumE
+  | FooSumF
+  | FooSumG
+    deriving (Generic, BitPack)
+
+-- | Foo sum-of-products aligned
+data FooSP1 a b
+  = FooSP1_AB a b
+  | FooSP1_BA b a
+    deriving (Generic)
+
+instance ( BitPack a
+         , BitPack b
+         , KnownNat (BitSize a)
+         , KnownNat (BitSize b)
+         ) => BitPack (FooSP1 a b)
+--
+-- | Foo sum-of-products non-aligned
+data FooSP2 a b
+  = FooSP2_AB a b
+  | FooSP2_A a
+  | FooSP2_B b
+    deriving (Generic)
+
+
+instance ( BitPack a
+         , BitPack b
+         , KnownNat (BitSize a)
+         , KnownNat (BitSize b)
+         ) => BitPack (FooSP2 a b)

--- a/tests/shouldwork/BitVector/GenericBitPackTypes.hs
+++ b/tests/shouldwork/BitVector/GenericBitPackTypes.hs
@@ -56,3 +56,31 @@ instance ( BitPack a
          , KnownNat (BitSize a)
          , KnownNat (BitSize b)
          ) => BitPack (FooSP2 a b)
+
+-- Testsuite data (in separate module to circumvent TH stage restrictions):
+type U1 = Unsigned 3
+type U2 = Unsigned 5
+
+aT :: FooProduct U1 U2
+aT = FooProduct 1 2
+
+bT = FooSumA
+cT = FooSumB
+dT = FooSumC
+eT = FooSumG
+
+fT :: FooSP1 U1 U2
+fT = FooSP1_AB 1 2
+
+gT :: FooSP1 U1 U2
+gT = FooSP1_BA 1 2
+
+hT :: FooSP2 U1 U2
+hT = FooSP2_AB 2 1
+
+iT :: FooSP2 U1 U2
+iT = FooSP2_A 2
+
+
+jT :: FooSP2 U1 U2
+jT = FooSP2_B 1

--- a/tests/shouldwork/BitVector/GenericBitPackTypes.hs
+++ b/tests/shouldwork/BitVector/GenericBitPackTypes.hs
@@ -84,3 +84,6 @@ iT = FooSP2_A 2
 
 jT :: FooSP2 U1 U2
 jT = FooSP2_B 1
+
+kT :: (U1, U2)
+kT = (1, 2)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -104,6 +104,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ReduceZero"       (["","ReduceZero_testBench"],"ReduceZero_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ReduceOne"        (["","ReduceOne_testBench"],"ReduceOne_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ExtendingNumZero" (["","ExtendingNumZero_testBench"],"ExtendingNumZero_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild ["-fconstraint-solver-iterations=15"] "GenericBitPack"   (["","GenericBitPack_testBench"],"GenericBitPack_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "AppendZero"       (["","AppendZero_testBench"],"AppendZero_testBench",True)
         ]
       , clashTestGroup "BlackBox"


### PR DESCRIPTION
The instance in this PR will generate `pack`/`unpack` functions that match Clash's behavior when converting to `std_logic_vector`-like in HDL.

- [X] Create Generic instance
- [X] Write tests for a number of interesting datatypes
- [x] Test against manually written bitvectors (that is, don't use template haskell, but manually write `$$(bLit "0100....")`)
- [X] ~~Create Seperate module with "orphan" instances~~