### PR TITLE
Add `rnfX` to `Undefined`

### DIFF
--- a/clash-lib/prims/common/Clash_Sized_Vector.json
+++ b/clash-lib/prims/common/Clash_Sized_Vector.json
@@ -1,8 +1,26 @@
-[ { "BlackBox" :
-    { "name"      : "Clash.Sized.Vector.lazyV"
-    , "kind"      : "Expression"
-    , "type"      : "lazyV :: KnownNat n => Vec n a -> Vec n a"
-    , "template"  : "~ARG[1]"
+[
+  {
+    "BlackBox": {
+      "name": "Clash.Sized.Vector.lazyV",
+      "kind": "Expression",
+      "type": "lazyV :: KnownNat n => Vec n a -> Vec n a",
+      "template": "~ARG[1]"
+    }
+  },
+  {
+    "BlackBox": {
+      "name": "Clash.Sized.Vector.seqV",
+      "kind": "Expression",
+      "type": "seqV :: KnownNat n => Vec n a -> b -> b",
+      "template": "~ARG[2]"
+    }
+  },
+  {
+    "BlackBox": {
+      "name": "Clash.Sized.Vector.seqVX",
+      "kind": "Expression",
+      "type": "seqVX :: KnownNat n => Vec n a -> b -> b",
+      "template": "~ARG[2]"
     }
   }
 , { "Primitive" :

--- a/clash-lib/prims/common/Clash_XException.json
+++ b/clash-lib/prims/common/Clash_XException.json
@@ -12,4 +12,11 @@
     , "template"  : "~ERRORO"
     }
   }
+, { "BlackBox" :
+     { "name"      : "Clash.XException.deepseqX"
+     , "kind"      : "Expression"
+     , "type"      : "deepseqX :: Undefined a => a -> b -> b"
+     , "template"  : "~ARG[2]"
+     }
+  }
 ]

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -273,6 +273,7 @@ test-suite unittests
 
   Other-Modules: Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes
+                 Clash.Tests.Undefined
 
 
 benchmark benchmark-clash-prelude

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -404,7 +404,7 @@ import Clash.Signal.Internal
 import Clash.Signal.Bundle    (unbundle)
 import Clash.Sized.Unsigned   (Unsigned)
 import Clash.Sized.Vector     (Vec, toList)
-import Clash.XException       (maybeX, seqX, Undefined, deepErrorX)
+import Clash.XException       (maybeIsX, seqX, Undefined, deepErrorX)
 
 {- $setup
 >>> import Clash.Explicit.Prelude as C
@@ -779,11 +779,11 @@ blockRam# clk content rd wen = case clockEnable clk of
           o'   = if re then ram V.! r else o
       in  o `seqX` o :- (ret `seq` rt `seq` et `seq` wt `seq` dt `seq` go' ram' o' res rs en wr din)
 
-    upd ram we waddr d = case maybeX we of
-      Nothing -> case maybeX waddr of
+    upd ram we waddr d = case maybeIsX we of
+      Nothing -> case maybeIsX waddr of
         Nothing -> V.map (const (seq waddr d)) ram
         Just wa -> ram V.// [(wa,d)]
-      Just True -> case maybeX waddr of
+      Just True -> case maybeIsX waddr of
         Nothing -> V.map (const (seq waddr d)) ram
         Just wa -> ram V.// [(wa,d)]
       _ -> ram

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -110,7 +110,7 @@ import Clash.Sized.BitVector (BitVector)
 import Clash.Signal.Internal (Clock, Signal (..), (.&&.), clockEnable)
 import Clash.Signal.Bundle   (unbundle)
 import Clash.Sized.Unsigned  (Unsigned)
-import Clash.XException      (errorX, maybeX, seqX)
+import Clash.XException      (errorX, maybeIsX, seqX)
 
 
 -- | Create a blockRAM with space for 2^@n@ elements
@@ -243,11 +243,11 @@ blockRamFile# clk _sz file rd wen = case clockEnable clk of
           o'   = if re then ram V.! r else o
       in  o `seqX` o :- go' ram' o' res rs en wr din
 
-    upd ram we waddr d = case maybeX we of
-      Nothing -> case maybeX waddr of
+    upd ram we waddr d = case maybeIsX we of
+      Nothing -> case maybeIsX waddr of
         Nothing -> V.map (const (seq waddr d)) ram
         Just wa -> ram V.// [(wa,d)]
-      Just True -> case maybeX waddr of
+      Just True -> case maybeIsX waddr of
         Nothing -> V.map (const (seq waddr d)) ram
         Just wa -> ram V.// [(wa,d)]
       _ -> ram

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -43,7 +43,7 @@ import Clash.Explicit.Signal ((.&&.), unbundle, unsafeSynchronizer)
 import Clash.Promoted.Nat    (SNat (..), snatToNum, pow2SNat)
 import Clash.Signal.Internal (Clock (..), Signal (..), clockEnable)
 import Clash.Sized.Unsigned  (Unsigned)
-import Clash.XException      (errorX, maybeX)
+import Clash.XException      (errorX, maybeIsX)
 
 -- | Create a RAM with space for 2^@n@ elements
 --
@@ -132,11 +132,11 @@ asyncRam# wclk rclk sz rd en wr din =
           o    = ram V.! r
       in  o :- go ram' rs es ws ds
 
-    upd ram we waddr d = case maybeX we of
-      Nothing -> case maybeX waddr of
+    upd ram we waddr d = case maybeIsX we of
+      Nothing -> case maybeIsX waddr of
         Nothing -> V.map (const (seq waddr d)) ram
         Just wa -> ram V.// [(wa,d)]
-      Just True -> case maybeX waddr of
+      Just True -> case maybeIsX waddr of
         Nothing -> V.map (const (seq waddr d)) ram
         Just wa -> ram V.// [(wa,d)]
       _ -> ram

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -196,11 +196,11 @@ module Clash.Explicit.Signal
   )
 where
 
-import Control.DeepSeq       (NFData)
 import Data.Maybe            (isJust, fromJust)
 
 import Clash.Signal.Internal
 import Clash.Signal.Bundle   (Bundle (..))
+import Clash.XException      (Undefined)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -605,7 +605,7 @@ regEn clk rst initial en i =
 --
 -- __NB__: This function is not synthesisable
 simulateB
-  :: (Bundle a, Bundle b, NFData a, NFData b)
+  :: (Bundle a, Bundle b, Undefined a, Undefined b)
   => (Unbundled domain1 a -> Unbundled domain2 b)
   -- ^ The function we want to simulate
   -> [a]

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -138,7 +138,6 @@ module Clash.Signal
   )
 where
 
-import           Control.DeepSeq       (NFData)
 import           GHC.TypeLits          (KnownNat, KnownSymbol)
 import           Data.Bits             (Bits) -- Haddock only
 import           Data.Maybe            (isJust, fromJust)
@@ -612,7 +611,7 @@ regEn initial en i =
 -- __NB__: This function is not synthesisable
 sample
   :: forall gated synchronous domain a
-   . NFData a
+   . Undefined a
   => (HiddenClockReset domain gated synchronous => Signal domain a)
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
   -- (and reset)
@@ -637,7 +636,7 @@ sample s =
 -- __NB__: This function is not synthesisable
 sampleN
   :: forall gated synchronous domain a
-   . NFData a
+   . Undefined a
   => Int
   -- ^ The number of samples we want to see
   -> (HiddenClockReset domain gated synchronous => Signal domain a)
@@ -715,7 +714,7 @@ sampleN_lazy n s =
 -- __NB__: This function is not synthesisable
 simulate
   :: forall gated synchronous domain a b
-   . (NFData a, NFData b)
+   . (Undefined a, Undefined b)
   => (HiddenClockReset domain gated synchronous =>
       Signal domain a -> Signal domain b)
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
@@ -768,7 +767,7 @@ simulate_lazy f =
 -- __NB__: This function is not synthesisable
 simulateB
   :: forall gated synchronous domain a b
-   . (Bundle a, Bundle b, NFData a, NFData b)
+   . (Bundle a, Bundle b, Undefined a, Undefined b)
   => (HiddenClockReset domain gated synchronous =>
       Unbundled domain a -> Unbundled domain b)
   -- ^ Function we want to simulate, whose components potentially have a hidden

--- a/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
@@ -30,7 +30,6 @@ module Clash.Signal.Delayed.Internal
   )
 where
 
-import Control.DeepSeq            (NFData)
 import Data.Coerce                (coerce)
 import Data.Default.Class         (Default(..))
 import GHC.TypeLits               (Nat, type (+))
@@ -40,6 +39,7 @@ import Test.QuickCheck            (Arbitrary, CoArbitrary)
 import Clash.Promoted.Nat         (SNat)
 import Clash.Explicit.Signal
   (Domain, Signal, fromList, fromList_lazy)
+import Clash.XException           (Undefined)
 
 {- $setup
 >>> :set -XDataKinds
@@ -79,7 +79,7 @@ newtype DSignal (domain :: Domain) (delay :: Nat) a =
 -- [1,2]
 --
 -- __NB__: This function is not synthesisable
-dfromList :: NFData a => [a] -> DSignal domain 0 a
+dfromList :: Undefined a => [a] -> DSignal domain 0 a
 dfromList = coerce . fromList
 
 -- | Create a 'DSignal' from a list

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -92,7 +92,7 @@ where
 
 import Type.Reflection            (Typeable)
 import Control.Applicative        (liftA2, liftA3)
-import Control.DeepSeq            (NFData, rnf)
+import Control.DeepSeq            (NFData)
 import Data.Default.Class         (Default (..))
 import GHC.Generics               (Generic)
 import GHC.TypeLits               (KnownNat, KnownSymbol, Nat, Symbol)
@@ -102,7 +102,7 @@ import Test.QuickCheck            (Arbitrary (..), CoArbitrary(..), Property,
 
 import Clash.Promoted.Nat         (SNat (..), snatToInteger, snatToNum)
 import Clash.Promoted.Symbol      (SSymbol (..))
-import Clash.XException           (errorX, seqX)
+import Clash.XException           (Undefined, errorX, seqX, deepseqX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -757,8 +757,8 @@ testFor n = property . and . take n . sample
 -- > sample s == [s0, s1, s2, s3, ...
 --
 -- __NB__: This function is not synthesisable
-sample :: (Foldable f, NFData a) => f a -> [a]
-sample = foldr (\a b -> rnf a `seqX` (a : b)) []
+sample :: (Foldable f, Undefined a) => f a -> [a]
+sample = foldr (\a b -> deepseqX a (a : b)) []
 
 -- | The above type is a generalisation for:
 --
@@ -774,7 +774,7 @@ sample = foldr (\a b -> rnf a `seqX` (a : b)) []
 -- > sampleN 3 s == [s0, s1, s2]
 --
 -- __NB__: This function is not synthesisable
-sampleN :: (Foldable f, NFData a) => Int -> f a -> [a]
+sampleN :: (Foldable f, Undefined a) => Int -> f a -> [a]
 sampleN n = take n . sample
 
 -- | Create a 'Clash.Signal.Signal' from a list
@@ -786,8 +786,8 @@ sampleN n = take n . sample
 -- [1,2]
 --
 -- __NB__: This function is not synthesisable
-fromList :: NFData a => [a] -> Signal domain a
-fromList = Prelude.foldr (\a b -> rnf a `seqX` (a :- b)) (errorX "finite list")
+fromList :: Undefined a => [a] -> Signal domain a
+fromList = Prelude.foldr (\a b -> deepseqX a (a :- b)) (errorX "finite list")
 
 -- * Simulation functions (not synthesisable)
 
@@ -799,7 +799,7 @@ fromList = Prelude.foldr (\a b -> rnf a `seqX` (a :- b)) (errorX "finite list")
 -- ...
 --
 -- __NB__: This function is not synthesisable
-simulate :: (NFData a, NFData b) => (Signal domain1 a -> Signal domain2 b) -> [a] -> [b]
+simulate :: (Undefined a, Undefined b) => (Signal domain1 a -> Signal domain2 b) -> [a] -> [b]
 simulate f = sample . f . fromList
 
 -- | The above type is a generalisation for:

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -74,6 +74,7 @@ import Control.Arrow              ((***), second)
 import Data.Bits                  (Bits (..), FiniteBits)
 import Data.Data                  (Data)
 import Data.Default.Class         (Default (..))
+import Data.Either                (isLeft)
 import Text.Read                  (Read(..))
 import Data.List                  (find)
 import Data.Maybe                 (fromJust)
@@ -98,7 +99,8 @@ import Clash.Prelude.BitReduction (reduceAnd, reduceOr)
 import Clash.Sized.BitVector      (BitVector, (++#))
 import Clash.Sized.Signed         (Signed)
 import Clash.Sized.Unsigned       (Unsigned)
-import Clash.XException           (ShowX (..), Undefined (..), errorX, showsPrecXWith)
+import Clash.XException
+  (ShowX (..), Undefined (..), isX, errorX, showsPrecXWith)
 
 {- $setup
 >>> :set -XDataKinds
@@ -268,7 +270,9 @@ instance ( size ~ (int + frac), KnownNat frac, Integral (rep size)
          ) => ShowX (Fixed rep int frac) where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined (Fixed rep int frac) where deepErrorX = Fixed . errorX
+instance Undefined (rep (int + frac)) => Undefined (Fixed rep int frac) where
+  deepErrorX = Fixed . errorX
+  rnfX f@(~(Fixed x)) = if isLeft (isX f) then () else rnfX x
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance (size ~ (int + frac), KnownNat frac, Bounded (rep size), Integral (rep size))

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -170,8 +170,8 @@ import                qualified Data.List                  as L
 data BitVector (n :: Nat) =
     -- | The constructor, 'BV', and  the field, 'unsafeToInteger', are not
     -- synthesisable.
-    BV { unsafeMask      :: Integer
-       , unsafeToInteger :: Integer
+    BV { unsafeMask      :: !Integer
+       , unsafeToInteger :: !Integer
        }
   deriving Data
 
@@ -181,8 +181,8 @@ data BitVector (n :: Nat) =
 data Bit =
   -- | The constructor, 'Bit', and  the field, 'unsafeToInteger#', are not
   -- synthesisable.
-  Bit { unsafeMask#      :: Integer
-      , unsafeToInteger# :: Integer
+  Bit { unsafeMask#      :: !Integer
+      , unsafeToInteger# :: !Integer
       }
   deriving Data
 

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -150,7 +150,7 @@ import Clash.Class.Resize         (Resize (..))
 import Clash.Promoted.Nat
   (SNat (..), SNatLE (..), compareSNat, snatToInteger, snatToNum)
 import Clash.XException
-  (ShowX (..), Undefined (..), errorX, showsPrecXWith)
+  (ShowX (..), Undefined (..), errorX, showsPrecXWith, rwhnfX)
 
 import {-# SOURCE #-} qualified Clash.Sized.Vector         as V
 import {-# SOURCE #-} qualified Clash.Sized.Internal.Index as I
@@ -213,7 +213,9 @@ instance Show Bit where
 instance ShowX Bit where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined Bit where deepErrorX = errorX
+instance Undefined Bit where
+  deepErrorX = errorX
+  rnfX = rwhnfX
 
 instance Lift Bit where
   lift (Bit m i) = [| fromInteger## m i |]
@@ -357,7 +359,9 @@ instance KnownNat n => Show (BitVector n) where
 instance KnownNat n => ShowX (BitVector n) where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined (BitVector n) where deepErrorX = errorX
+instance Undefined (BitVector n) where
+  deepErrorX = errorX
+  rnfX = rwhnfX
 
 -- | Create a binary literal
 --

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -94,7 +94,8 @@ import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
 import Clash.Class.Resize         (Resize (..))
 import {-# SOURCE #-} Clash.Sized.Internal.BitVector (BitVector (BV),undefError)
 import Clash.Promoted.Nat         (SNat, snatToNum, leToPlusKN)
-import Clash.XException           (ShowX (..), Undefined (..), errorX, showsPrecXWith)
+import Clash.XException
+  (ShowX (..), Undefined (..), errorX, showsPrecXWith, rwhnfX)
 
 -- | Arbitrary-bounded unsigned integer represented by @ceil(log_2(n))@ bits.
 --
@@ -357,7 +358,9 @@ instance Show (Index n) where
 instance ShowX (Index n) where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined (Index n) where deepErrorX = errorX
+instance Undefined (Index n) where
+  deepErrorX = errorX
+  rnfX = rwhnfX
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance KnownNat n => Read (Index n) where

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -107,7 +107,8 @@ import Clash.Prelude.BitIndex         ((!), msb, replaceBit, split)
 import Clash.Prelude.BitReduction     (reduceAnd, reduceOr)
 import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, (++#), high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
-import Clash.XException               (ShowX (..), Undefined (..), errorX, showsPrecXWith)
+import Clash.XException
+  (ShowX (..), Undefined (..), errorX, showsPrecXWith, rwhnfX)
 
 -- | Arbitrary-width signed integer represented by @n@ bits, including the sign
 -- bit.
@@ -150,7 +151,9 @@ newtype Signed (n :: Nat) =
     S { unsafeToInteger :: Integer}
   deriving Data
 
-instance Undefined (Signed n) where deepErrorX = errorX
+instance Undefined (Signed n) where
+  deepErrorX = errorX
+  rnfX = rwhnfX
 
 {-# NOINLINE size# #-}
 size# :: KnownNat n => Signed n -> Int

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -100,7 +100,8 @@ import Clash.Prelude.BitIndex         ((!), msb, replaceBit, split)
 import Clash.Prelude.BitReduction     (reduceOr)
 import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
-import Clash.XException               (ShowX (..), Undefined (..), errorX, showsPrecXWith)
+import Clash.XException
+  (ShowX (..), Undefined (..), errorX, showsPrecXWith, rwhnfX)
 
 -- | Arbitrary-width unsigned integer represented by @n@ bits
 --
@@ -156,7 +157,9 @@ instance Show (Unsigned n) where
 instance ShowX (Unsigned n) where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined (Unsigned n) where deepErrorX = errorX
+instance Undefined (Unsigned n) where
+  deepErrorX = errorX
+  rnfX = rwhnfX
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance KnownNat n => Read (Unsigned n) where

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -63,6 +63,7 @@ import Control.Applicative         (liftA2)
 import Control.DeepSeq             (NFData(..))
 import qualified Control.Lens      as Lens
 import Data.Default.Class          (Default (..))
+import Data.Either                 (isLeft)
 import Data.Foldable               (toList)
 import Data.Kind                   (Type)
 import Data.Singletons.Prelude     (Apply, TyFun, type (@@))
@@ -80,7 +81,7 @@ import Clash.Promoted.Nat.Literals (d1)
 import Clash.Sized.Index           (Index)
 import Clash.Sized.Vector          (Vec (..), (!!), (++), dtfold, replace)
 import Clash.XException
-  (ShowX (..), Undefined (..), showsX, showsPrecXWith)
+  (ShowX (..), Undefined (..), isX, showsX, showsPrecXWith)
 
 {- $setup
 >>> :set -XDataKinds
@@ -228,6 +229,13 @@ instance (KnownNat d, CoArbitrary a) => CoArbitrary (RTree d a) where
 
 instance (KnownNat d, Undefined a) => Undefined (RTree d a) where
   deepErrorX x = pure (deepErrorX x)
+
+  rnfX t = if isLeft (isX t) then () else go t
+   where
+    go :: RTree d a -> ()
+    go (LR_ x)   = rnfX x
+    go (BR_ l r) = rnfX l `seq` rnfX r
+
 
 -- | A /dependently/ typed fold over trees.
 --

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -94,7 +94,7 @@ module Clash.Sized.Vector
   , bv2v
   , v2bv
     -- * Misc
-  , lazyV, VCons, asNatProxy
+  , lazyV, VCons, asNatProxy, seqV, forceV, seqVX, forceVX
     -- * Primitives
     -- ** 'Traversable' instance
   , traverse#
@@ -2125,6 +2125,49 @@ bv2v = unpack
 -- 0001_0010
 v2bv :: KnownNat n => Vec n Bit -> BitVector n
 v2bv = pack
+
+-- | Evaluate all elements of a vector to WHNF, returning the second argument
+seqV
+  :: KnownNat n
+  => Vec n a
+  -> b
+  -> b
+seqV v b =
+  let s () e = seq e () in
+  foldl s () v `seq` b
+{-# NOINLINE seqV #-}
+infixr 0 `seqV`
+
+-- | Evaluate all elements of a vector to WHNF
+forceV
+  :: KnownNat n
+  => Vec n a
+  -> Vec n a
+forceV v =
+  v `seqV` v
+{-# INLINE forceV #-}
+
+-- | Evaluate all elements of a vector to WHNF, returning the second argument.
+-- Does not propagate 'XException's.
+seqVX
+  :: KnownNat n
+  => Vec n a
+  -> b
+  -> b
+seqVX v b =
+  let s () e = seqX e () in
+  foldl s () v `seqX` b
+{-# NOINLINE seqVX #-}
+infixr 0 `seqVX`
+
+-- | Evaluate all elements of a vector to WHNF. Does not propagate 'XException's.
+forceVX
+  :: KnownNat n
+  => Vec n a
+  -> Vec n a
+forceVX v =
+  v `seqVX` v
+{-# INLINE forceVX #-}
 
 instance Lift a => Lift (Vec n a) where
   lift Nil           = [| Nil |]

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -51,6 +51,7 @@ import Data.Foldable     (toList)
 import Data.Int          (Int8,Int16,Int32,Int64)
 import Data.Ord          (Down (Down))
 import Data.Ratio        (Ratio, numerator, denominator)
+import qualified Data.Semigroup as SG
 import Data.Sequence     (Seq(Empty, (:<|)))
 import Data.Word         (Word8,Word16,Word32,Word64)
 import GHC.Exts          (Char (C#), Double (D#), Float (F#), Int (I#), Word (W#))
@@ -670,6 +671,19 @@ instance Undefined a => Undefined (Ratio a) where
 
 instance Undefined a => Undefined (Complex a) where
   deepErrorX = errorX
+
+instance (Undefined a, Undefined b) => Undefined (SG.Arg a b)
+instance Undefined (SG.All)
+instance Undefined (SG.Any)
+instance Undefined a => Undefined (SG.Dual a)
+instance Undefined a => Undefined (SG.Endo a)
+instance Undefined a => Undefined (SG.First a)
+instance Undefined a => Undefined (SG.Last a)
+instance Undefined a => Undefined (SG.Max a)
+instance Undefined a => Undefined (SG.Min a)
+instance Undefined a => Undefined (SG.Option a)
+instance Undefined a => Undefined (SG.Product a)
+instance Undefined a => Undefined (SG.Sum a)
 
 class GUndefined f where
   gDeepErrorX :: HasCallStack => String -> f a

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -1,6 +1,7 @@
 {-|
-Copyright  :  (C) 2016, University of Twente,
-                  2017, Myrtle Software Ltd, QBayLogic, Google Inc.
+Copyright  :  (C) 2016,      University of Twente,
+                  2017,      QBayLogic, Google Inc.
+                  2017-2019, Myrtle Software Ltd
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
@@ -14,14 +15,17 @@ CallStack (from HasCallStack):
 "(X,4)"
 -}
 
-{-# LANGUAGE DefaultSignatures   #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE DefaultSignatures     #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MagicHash             #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeOperators         #-}
 
 {-# LANGUAGE Trustworthy #-}
 
@@ -29,24 +33,25 @@ CallStack (from HasCallStack):
 
 module Clash.XException
   ( -- * 'X': An exception for uninitialized values
-    XException (..), errorX, isX, maybeX
+    XException(..), errorX, isX, hasX, maybeIsX, maybeHasX
     -- * Printing 'X' exceptions as \"X\"
   , ShowX (..), showsX, printX, showsPrecXWith
     -- * Strict evaluation
-  , seqX
+  , seqX, forceX, deepseqX, rwhnfX
     -- * Structured undefined
-  , Undefined (..)
+  , Undefined (rnfX, deepErrorX)
   )
 where
 
 import Control.Exception (Exception, catch, evaluate, throw)
 import Control.DeepSeq   (NFData, rnf)
 import Data.Complex      (Complex)
+import Data.Either       (isLeft)
 import Data.Foldable     (toList)
 import Data.Int          (Int8,Int16,Int32,Int64)
 import Data.Ord          (Down (Down))
-import Data.Ratio        (Ratio)
-import Data.Sequence     (Seq)
+import Data.Ratio        (Ratio, numerator, denominator)
+import Data.Sequence     (Seq(Empty, (:<|)))
 import Data.Word         (Word8,Word16,Word32,Word64)
 import GHC.Exts          (Char (C#), Double (D#), Float (F#), Int (I#), Word (W#))
 import GHC.Generics
@@ -84,22 +89,76 @@ seqX a b = unsafeDupablePerformIO
 {-# NOINLINE seqX #-}
 infixr 0 `seqX`
 
--- | Fully evaluate a value, returning 'Nothing' if is throws 'XException'.
+-- | Evaluate a value with given function, returning 'Nothing' if it throws
+-- 'XException'.
 --
--- > maybeX 42               = Just 42
--- > maybeX (XException msg) = Nothing
--- > maybeX _|_              = _|_
-maybeX :: NFData a => a -> Maybe a
-maybeX = either (const Nothing) Just . isX
+-- > maybeX hasX 42                  = Just 42
+-- > maybeX hasX (XException msg)    = Nothing
+-- > maybeX hasX (3, XException msg) = Nothing
+-- > maybeX hasX (3, _|_)            = _|_
+-- > maybeX hasX _|_                 = _|_
+-- >
+-- > maybeX isX 42                  = Just 42
+-- > maybeX isX (XException msg)    = Nothing
+-- > maybeX isX (3, XException msg) = Just (3, XException msg)
+-- > maybeX isX (3, _|_)            = Just (3, _|_)
+-- > maybeX isX _|_                 = _|_
+--
+maybeX :: NFData a => (a -> Either String a) -> a -> Maybe a
+maybeX f a = either (const Nothing) Just (f a)
 
--- | Fully evaluate a value, returning @'Left' msg@ if is throws 'XException'.
+-- | Fully evaluate a value, returning 'Nothing' if it throws 'XException'.
 --
--- > isX 42               = Right 42
--- > isX (XException msg) = Left msg
--- > isX _|_              = _|_
-isX :: NFData a => a -> Either String a
-isX a = unsafeDupablePerformIO
-  (catch (evaluate (rnf a) >> return (Right a)) (\(XException msg) -> return (Left msg)))
+-- > maybeX 42                  = Just 42
+-- > maybeX (XException msg)    = Nothing
+-- > maybeX (3, XException msg) = Nothing
+-- > maybeX (3, _|_)            = _|_
+-- > maybeX _|_                 = _|_
+--
+maybeHasX :: NFData a => a -> Maybe a
+maybeHasX = maybeX hasX
+
+-- | Evaluate a value to WHNF, returning 'Nothing' if it throws 'XException'.
+--
+-- > maybeIsX 42                  = Just 42
+-- > maybeIsX (XException msg)    = Nothing
+-- > maybeIsX (3, XException msg) = Just (3, XException msg)
+-- > maybeIsX (3, _|_)            = Just (3, _|_)
+-- > maybeIsX _|_                 = _|_
+maybeIsX :: NFData a => a -> Maybe a
+maybeIsX = maybeX isX
+
+-- | Fully evaluate a value, returning @'Left' msg@ if it throws 'XException'.
+--
+-- > hasX 42                  = Right 42
+-- > hasX (XException msg)    = Left msg
+-- > hasX (3, XException msg) = Left msg
+-- > hasX (3, _|_)            = _|_
+-- > hasX _|_                 = _|_
+--
+-- If a data structure contains multiple 'XException's, the "first" message is
+-- picked according to the implementation of 'rnf'.
+hasX :: NFData a => a -> Either String a
+hasX a =
+  unsafeDupablePerformIO
+    (catch
+      (evaluate (rnf a) >> return (Right a))
+      (\(XException msg) -> return (Left msg)))
+{-# NOINLINE hasX #-}
+
+-- | Evaluate a value to WHNF, returning @'Left' msg@ if is a 'XException'.
+--
+-- > isX 42                  = Right 42
+-- > isX (XException msg)    = Left msg
+-- > isX (3, XException msg) = Right (3, XException msg)
+-- > isX (3, _|_)            = (3, _|_)
+-- > isX _|_                 = _|_
+isX :: a -> Either String a
+isX a =
+  unsafeDupablePerformIO
+    (catch
+      (evaluate a >> return (Right a))
+      (\(XException msg) -> return (Left msg)))
 {-# NOINLINE isX #-}
 
 showXWith :: (a -> ShowS) -> a -> ShowS
@@ -374,8 +433,101 @@ instance GShowX UInt where
 instance GShowX UWord where
   gshowsPrecX _ _ (UWord w)   = showsPrec 0 (W# w) . showString "##"
 
--- | Create a value where all the elements have an 'errorX', but the spine
--- is defined.
+-- | a variant of 'deepseqX' that is useful in some circumstances:
+--
+-- > forceX x = x `deepseqX` x
+forceX :: Undefined a => a -> a
+forceX x = x `deepseqX` x
+{-# INLINE forceX #-}
+
+-- | 'deepseqX': fully evaluates the first argument, before returning the
+-- second. Does not propagate 'XException's.
+deepseqX :: Undefined a => a -> b -> b
+deepseqX a b = rnfX a `seq` b
+{-# NOINLINE deepseqX #-}
+
+-- | Reduce to weak head normal form
+--
+-- Equivalent to @\\x -> 'seqX' x ()@.
+--
+-- Useful for defining 'Undefined.rnfX' for types for which NF=WHNF holds.
+rwhnfX :: a -> ()
+rwhnfX = (`seqX` ())
+{-# INLINE rwhnfX #-}
+
+-- | Hidden internal type-class. Adds a generic implementation for the "NFDataX"
+-- part of 'Undefined'
+class GNFDataX arity f where
+  grnfX :: RnfArgs arity a -> f a -> ()
+
+instance GNFDataX arity V1 where
+  grnfX _ x = case x of {}
+
+data Zero
+data One
+
+data RnfArgs arity a where
+  RnfArgs0 :: RnfArgs Zero a
+  RnfArgs1  :: (a -> ()) -> RnfArgs One a
+
+instance GNFDataX arity U1 where
+  grnfX _ u = if isLeft (isX u) then () else case u of U1 -> ()
+
+instance Undefined a => GNFDataX arity (K1 i a) where
+  grnfX _ = rnfX . unK1
+  {-# INLINEABLE grnfX #-}
+
+instance GNFDataX arity a => GNFDataX arity (M1 i c a) where
+  grnfX args a =
+    -- Check for X needed to handle edge-case "data Void"
+    if isLeft (isX a) then
+      ()
+    else
+      grnfX args (unM1 a)
+  {-# INLINEABLE grnfX #-}
+
+instance (GNFDataX arity a, GNFDataX arity b) => GNFDataX arity (a :*: b) where
+  grnfX args xy@(~(x :*: y)) =
+    if isLeft (isX xy) then
+      ()
+    else
+      grnfX args x `seq` grnfX args y
+  {-# INLINEABLE grnfX #-}
+
+instance (GNFDataX arity a, GNFDataX arity b) => GNFDataX arity (a :+: b) where
+  grnfX args lrx =
+    if isLeft (isX lrx) then
+      ()
+    else
+      case lrx of
+        L1 x -> grnfX args x
+        R1 x -> grnfX args x
+  {-# INLINEABLE grnfX #-}
+
+instance GNFDataX One Par1 where
+  grnfX (RnfArgs1 r) = r . unPar1
+
+instance NFDataX1 f => GNFDataX One (Rec1 f) where
+  grnfX (RnfArgs1 r) = liftRnfX r . unRec1
+
+instance (NFDataX1 f, GNFDataX One g) => GNFDataX One (f :.: g) where
+  grnfX args = liftRnfX (grnfX args) . unComp1
+
+-- | A class of functors that can be fully evaluated, according to semantics
+-- of NFDataX.
+class NFDataX1 f where
+  -- | 'liftRnfX' should reduce its argument to normal form (that is, fully
+  -- evaluate all sub-components), given an argument to reduce @a@ arguments,
+  -- and then return '()'.
+  --
+  -- See 'rnfX' for the generic deriving.
+  liftRnfX :: (a -> ()) -> f a -> ()
+
+  default liftRnfX :: (Generic1 f, GNFDataX One (Rep1 f)) => (a -> ()) -> f a -> ()
+  liftRnfX r = grnfX (RnfArgs1 r) . from1
+
+-- | Create a value where all the elements have an 'errorX' but the spine
+-- is defined, and fully evaluate a value with 'errorX's in it.
 class Undefined a where
   -- | Create a value where all the elements have an 'errorX', but the spine
   -- is defined.
@@ -383,6 +535,13 @@ class Undefined a where
 
   default deepErrorX :: (HasCallStack, Generic a, GUndefined (Rep a)) => String -> a
   deepErrorX = withFrozenCallStack $ to . gDeepErrorX
+
+  -- | Evaluate a value to NF. As opposed to 'NFData's 'rnf', it does not bubble
+  -- up 'XException's.
+  rnfX :: a -> ()
+
+  default rnfX :: (Generic a, GNFDataX Zero (Rep a)) => a -> ()
+  rnfX = grnfX RnfArgs0 . from
 
 instance Undefined ()
 instance (Undefined a, Undefined b) => Undefined (a,b)
@@ -426,33 +585,91 @@ instance (Undefined a, Undefined b, Undefined c, Undefined d, Undefined e
 
 instance Undefined b => Undefined (a -> b) where
   deepErrorX = pure . deepErrorX
+  rnfX = rwhnfX
 
 instance Undefined a => Undefined (Down a) where
   deepErrorX = Down . deepErrorX
+  rnfX d@(~(Down x))= if isLeft (isX d) then rnfX x else ()
 
 instance Undefined Bool
-instance Undefined [a]
-instance Undefined (Either a b)
-instance Undefined (Maybe a)
+instance Undefined a => Undefined [a]
+instance (Undefined a, Undefined b) => Undefined (Either a b)
+instance Undefined a => Undefined (Maybe a)
 
-instance Undefined Char where deepErrorX = errorX
-instance Undefined Double where deepErrorX = errorX
-instance Undefined Float where deepErrorX = errorX
-instance Undefined Int where deepErrorX = errorX
-instance Undefined Int8 where deepErrorX = errorX
-instance Undefined Int16 where deepErrorX = errorX
-instance Undefined Int32 where deepErrorX = errorX
-instance Undefined Int64 where deepErrorX = errorX
-instance Undefined Integer where deepErrorX = errorX
-instance Undefined Natural where deepErrorX = errorX
-instance Undefined Word where deepErrorX = errorX
-instance Undefined Word8 where deepErrorX = errorX
-instance Undefined Word16 where deepErrorX = errorX
-instance Undefined Word32 where deepErrorX = errorX
-instance Undefined Word64 where deepErrorX = errorX
-instance Undefined (Seq a) where deepErrorX = errorX
-instance Undefined (Ratio a) where deepErrorX = errorX
-instance Undefined (Complex a) where deepErrorX = errorX
+instance Undefined Char where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Double where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Float where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Int where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Int8 where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Int16 where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Int32 where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Int64 where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Integer where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Natural where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Word where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Word8 where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Word16 where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Word32 where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined Word64 where
+  deepErrorX = errorX
+  rnfX = rwhnfX
+
+instance Undefined a => Undefined (Seq a) where
+  deepErrorX = errorX
+  rnfX s =
+    if isLeft (isX s) then () else go s
+   where
+    go Empty = ()
+    go (x :<| xs) = rnfX x `seq` go xs
+
+instance Undefined a => Undefined (Ratio a) where
+  deepErrorX = errorX
+  rnfX r = rnfX (numerator r) `seq` rnfX (denominator r)
+
+instance Undefined a => Undefined (Complex a) where
+  deepErrorX = errorX
 
 class GUndefined f where
   gDeepErrorX :: HasCallStack => String -> f a

--- a/clash-prelude/tests/Clash/Tests/Undefined.hs
+++ b/clash-prelude/tests/Clash/Tests/Undefined.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE CPP            #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE MagicHash      #-}
+
+module Clash.Tests.Undefined where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import GHC.Generics (Generic)
+import Clash.XException (Undefined(rnfX), errorX)
+
+data Void                                  deriving (Generic, Undefined)
+data Unit    = Unit                        deriving (Generic, Undefined)
+data Wrapper = Wrapper Int                 deriving (Generic, Undefined)
+data Sum     = SumTypeA | SumTypeB         deriving (Generic, Undefined)
+data Product = Product Int Int             deriving (Generic, Undefined)
+data SP      = S Int Int | P Int           deriving (Generic, Undefined)
+data Rec0    = Rec0 {  }                   deriving (Generic, Undefined)
+data Rec1    = Rec1 { a :: Int }           deriving (Generic, Undefined)
+data Rec2    = Rec2 { b :: Int, c :: Int } deriving (Generic, Undefined)
+
+undef :: a
+undef = errorX "!"
+{-# NOINLINE undef #-}
+
+tests :: TestTree
+tests =
+  testGroup
+    "Undefined"
+    [ testGroup
+        "Generic"
+        [ testCase "Unit"     $ rnfX (undef :: Unit)                  @?= ()
+        , testCase "Wrapper1" $ rnfX (undef :: Wrapper)               @?= ()
+        , testCase "Wrapper2" $ rnfX (Wrapper undef)                  @?= ()
+        , testCase "Sum"      $ rnfX (undef :: Sum)                   @?= ()
+        , testCase "Product1" $ rnfX (undef :: Product)               @?= ()
+        , testCase "Product2" $ rnfX (Product undef undef :: Product) @?= ()
+        , testCase "Product3" $ rnfX (Product 3 undef :: Product)     @?= ()
+        , testCase "Product4" $ rnfX (Product undef 5 :: Product)     @?= ()
+        , testCase "SP1"      $ rnfX (undef :: SP)                    @?= ()
+        , testCase "SP2"      $ rnfX (S undef undef :: SP)            @?= ()
+        , testCase "SP3"      $ rnfX (S 3 undef :: SP)                @?= ()
+        , testCase "SP3"      $ rnfX (S undef 5 :: SP)                @?= ()
+        , testCase "SP4"      $ rnfX (P undef :: SP)                  @?= ()
+        , testCase "Rec0"     $ rnfX (undef :: Rec0)                  @?= ()
+        , testCase "Rec1_1"   $ rnfX (undef :: Rec1)                  @?= ()
+        , testCase "Rec1_2"   $ rnfX (Rec1 undef)                     @?= ()
+        , testCase "Rec2_1"   $ rnfX (undef :: Rec2)                  @?= ()
+        , testCase "Rec2_2"   $ rnfX (Rec2 3 undef)                   @?= ()
+        , testCase "Rec2_3"   $ rnfX (Rec2 undef 5)                   @?= ()
+--          Test case broken on 8.2.2:
+--        , testCase "Void"     $ rnfX (undef :: Void)                  @?= ()
+        ]
+    , testGroup
+        "Manual"
+        [ testCase "List1"     $ rnfX (undef :: [Int])                @?= ()
+        , testCase "List2"     $ rnfX ([undef] :: [Int])              @?= ()
+        , testCase "Maybe1"    $ rnfX (undef :: Maybe Int)            @?= ()
+        , testCase "Maybe2"    $ rnfX (Just undef :: Maybe Int)       @?= ()
+        , testCase "Either1"   $ rnfX (undef :: Either Int Int)       @?= ()
+        , testCase "Either2"   $ rnfX (Left undef :: Either Int Int)  @?= ()
+        , testCase "Either3"   $ rnfX (Right undef :: Either Int Int) @?= ()
+        ]
+    ]
+

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -3,10 +3,12 @@ module Main where
 import Test.Tasty
 
 import qualified Clash.Tests.DerivingDataRepr
+import qualified Clash.Tests.Undefined
 
 tests :: TestTree
 tests = testGroup "Unittests"
   [ Clash.Tests.DerivingDataRepr.tests
+  , Clash.Tests.Undefined.tests
   ]
 
 main :: IO ()

--- a/tests/shouldwork/Basic/DeepseqX.hs
+++ b/tests/shouldwork/Basic/DeepseqX.hs
@@ -1,0 +1,17 @@
+module DeepseqX where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity :: (Vec 2 Int, Vec 3 Int) -> Vec 3 Int
+topEntity (a, b) = deepseqX a (map (+1) b)
+
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((10 :> 11 :> Nil, 5 :> 6 :> 7 :> Nil) :> Nil)
+    expectedOutput = outputVerifier   clk rst ((6 :> 7 :> 8 :> Nil) :> Nil)
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -71,6 +71,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CharTest"            (["","CharTest_testBench"],"CharTest_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "ClassOps"            (["","ClassOps_testBench"],"ClassOps_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CountTrailingZeros"  (["","CountTrailingZeros_testBench"],"CountTrailingZeros_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "DeepseqX"            (["","DeepseqX_testBench"],"DeepseqX_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "DivMod"              ([""],"DivMod_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "IrrefError"          ([""],"IrrefError_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LambdaDrop"          ([""],"LambdaDrop_topEntity",False)


### PR DESCRIPTION
`NFDataX` enables users to use fully evaluate a structure containing `XException`s, without the `XException` bubbling  up. Piggybacked commits:

* Strictify Bitvector: WHNF now evaluates to NF.
* Add `Clash.Sized.Vector.seqV(X)` and `Clash.Sized.Vector.forceV(X)`: useful when one wants to evaluate all elements of a vector to WHNF. (Maybe we need `Clash.Sized.Vector.Strict`?)