### PR TITLE
 Add `dumpReplayable` and `replay` to `Clash.Signal.Trace` 

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -214,6 +214,7 @@ Library
                       base                      >= 4.8.0.0 && < 5,
                       bifunctors                >= 5.4.0   && < 6.0,
                       binary                    >= 0.8.5   && < 0.11,
+                      bytestring                >= 0.10.8  && < 0.10.9,
                       constraints               >= 0.9     && < 1.0,
                       containers                >= 0.4.0   && < 0.7,
                       data-binary-ieee754       >= 0.4.4   && < 0.6,

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -72,6 +72,10 @@ module Clash.Signal.Trace
   -- * VCD dump functions
   , dumpVCD
 
+  -- * Replay functions
+  , dumpReplayable
+  , replay
+
   -- * Internal
   -- ** Types
   , Period
@@ -89,11 +93,11 @@ module Clash.Signal.Trace
   ) where
 
 -- Clash:
-import           Clash.Signal.Internal (Domain (..))
+import           Clash.Signal.Internal (Domain (..), fromList)
 import           Clash.Signal          (Signal, bundle, unbundle)
 import           Clash.Sized.Vector    (Vec, iterateI)
 import qualified Clash.Sized.Vector    as Vector
-import           Clash.Class.BitPack   (BitPack, BitSize, pack)
+import           Clash.Class.BitPack   (BitPack, BitSize, pack, unpack)
 import           Clash.Promoted.Nat    (snatToNum, SNat(..))
 import           Clash.Signal.Internal (sample)
 import           Clash.XException      (deepseqX, Undefined)
@@ -103,6 +107,9 @@ import           Clash.Sized.Internal.BitVector
 -- Haskell / GHC:
 import           Control.Monad         (foldM)
 import           Data.Bits             (testBit)
+import           Data.Binary           (encode, decodeOrFail)
+import           Data.ByteString.Lazy  (ByteString)
+import qualified Data.ByteString.Lazy  as ByteStringLazy
 import           Data.Char             (ord, chr)
 import           Data.IORef
   (IORef, atomicModifyIORef', atomicWriteIORef, newIORef, readIORef)
@@ -115,6 +122,7 @@ import           Data.Time.Format      (formatTime, defaultTimeLocale)
 import           GHC.Stack             (HasCallStack)
 import           GHC.TypeLits          (KnownNat, type (+))
 import           System.IO.Unsafe      (unsafePerformIO)
+import           Type.Reflection       (Typeable, TypeRep, typeRep)
 
 #ifdef CABAL
 import qualified Data.Version
@@ -125,7 +133,11 @@ type Period   = Int
 type Changed  = Bool
 type Value    = (Integer, Integer) -- (Mask, Value)
 type Width    = Int
-type TraceMap = Map.Map String (Period, Width, [Value])
+
+-- | Serialized TypeRep we need to store for dumpReplayable / replay
+type TypeRepBS = ByteString
+
+type TraceMap  = Map.Map String (TypeRepBS, Period, Width, [Value])
 
 -- | Map of traces used by the non-internal trace and dumpvcd functions.
 traceMap# :: IORef TraceMap
@@ -149,7 +161,8 @@ traceSignal#
   :: forall domain a
    . ( KnownNat (BitSize a)
      , BitPack a
-     , Undefined a )
+     , Undefined a
+     , Typeable a )
   => IORef TraceMap
   -- ^ Map to store the trace
   -> Int
@@ -164,7 +177,14 @@ traceSignal# traceMap period traceName signal =
     if Map.member traceName m then
       error $ "Already tracing a signal with the name: '" ++ traceName ++ "'."
     else
-      (Map.insert traceName (period, width, mkTrace signal) m, signal)
+      ( Map.insert
+          traceName
+          ( encode (typeRep @a)
+          , period
+          , width
+          , mkTrace signal)
+          m
+      , signal)
  where
   width = snatToNum (SNat @ (BitSize a))
 {-# NOINLINE traceSignal# #-}
@@ -177,7 +197,8 @@ traceVecSignal#
    . ( KnownNat (BitSize a)
      , KnownNat n
      , BitPack a
-     , Undefined a )
+     , Undefined a
+     , Typeable a )
   => IORef TraceMap
   -- ^ Map to store the traces
   -> Int
@@ -207,7 +228,8 @@ traceSignal
      , KnownNat period
      , KnownNat (BitSize a)
      , BitPack a
-     , Undefined a )
+     , Undefined a
+     , Typeable a )
   => String
   -- ^ Name of signal in the VCD output
   -> Signal domain a
@@ -228,7 +250,8 @@ traceSignal traceName signal =
 traceSignal1
   :: ( KnownNat (BitSize a)
      , BitPack a
-     , Undefined a )
+     , Undefined a
+     , Typeable a )
   => String
   -- ^ Name of signal in the VCD output
   -> Signal domain a
@@ -252,7 +275,8 @@ traceVecSignal
      , KnownNat period
      , KnownNat n
      , BitPack a
-     , Undefined a )
+     , Undefined a
+     , Typeable a )
   => String
   -- ^ Name of signal in debugging output. Will be appended by _0, _1, ..., _n.
   -> Signal domain (Vec (n+1) a)
@@ -275,7 +299,8 @@ traceVecSignal1
   :: ( KnownNat (BitSize a)
      , KnownNat n
      , BitPack a
-     , Undefined a )
+     , Undefined a
+     , Typeable a )
   => String
   -- ^ Name of signal in debugging output. Will be appended by _0, _1, ..., _n.
   -> Signal domain (Vec (n+1) a)
@@ -291,7 +316,7 @@ iso8601Format = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S"
 toPeriodMap :: TraceMap -> Map.Map Period [(String, Width, [Value])]
 toPeriodMap m = foldl' go Map.empty (Map.assocs m)
   where
-    go periodMap (traceName, (period, width, values)) =
+    go periodMap (traceName, (_rep, period, width, values)) =
       Map.alter (Just . go') period periodMap
         where
           go' = ((traceName, width, values):) . (fromMaybe [])
@@ -468,11 +493,69 @@ dumpVCD
   => (Int, Int)
   -- ^ (offset, number of samples)
   -> Signal domain a
-  -- ^ (One of) the output the circuit containing the traces
+  -- ^ (One of) the outputs of the circuit containing the traces
   -> [String]
   -- ^ The names of the traces you definitely want to be dumped in the VCD file
   -> IO (Either String Text.Text)
 dumpVCD = dumpVCD# traceMap#
+
+-- | Dump a number of samples to a replayable bytestring.
+dumpReplayable
+  :: forall a domain
+   . Undefined a
+  => Int
+  -- ^ Number of samples
+  -> Signal domain a
+  -- ^ (One of) the outputs of the circuit containing the traces
+  -> String
+  -- ^ Name of trace to dump
+  -> IO ByteString
+dumpReplayable n oSignal traceName = do
+  waitForTraces# traceMap# oSignal [traceName]
+  replaySignal <- (Map.! traceName) <$> readIORef traceMap#
+  let (tRep, _period, _width, samples) = replaySignal
+  pure (ByteStringLazy.concat (tRep : map encode (take n samples)))
+
+-- | Take a serialized signal (dumped with @dumpReplayable@) and convert it
+-- back into a signal. Will error if dumped type does not match requested
+-- type. The first value in the signal that fails to decode will stop the
+-- decoding process and yield an error. Not that this always happens if you
+-- evaluate more values than were originally dumped.
+replay
+  :: forall a domain n
+   . ( Typeable a
+     , Undefined a
+     , BitPack a
+     , KnownNat n 
+     , n ~ BitSize a )
+  => ByteString
+  -> Either String (Signal domain a)
+replay bytes0 = samples1
+ where
+  samples1 =
+    case decodeOrFail bytes0 of
+      Left (_, _, err) ->
+        Left ("Failed to decode typeRep. Parser reported:\n\n" ++ err)
+      Right (bytes1, _, _ :: TypeRep a) ->
+        let samples0 = decodeSamples bytes1 in
+        let err = "Failed to decode value in signal. Parser reported:\n\n " in
+        Right (fromList (map (either (error . (err ++)) id) samples0))
+
+-- | Helper function of 'replay'. Decodes ByteString to some type with
+-- BitVector as an intermediate type.
+decodeSamples
+  :: forall a n
+   . ( BitPack a
+     , KnownNat n
+     , n ~ BitSize a )
+  => ByteString
+  -> [Either String a]
+decodeSamples bytes0 =
+  case decodeOrFail bytes0 of
+    Left (_, _, err) ->
+      [Left err]
+    Right (bytes1, _, (m, v)) ->
+      (Right (unpack (BV m v))) : decodeSamples bytes1
 
 -- | Keep evaluating given signal until all trace names are present.
 waitForTraces#


### PR DESCRIPTION
These functions have been primarily added to aid debugging space leaks
in larger designs, whenever its hard or cumbersome to come up with
realistic test data. A typical debugging session would look like:

 * Record the inputs to a subcircuit of an existing design that exhibits
 space leaks.

 * Replay these values in a new session to only the subcircuit. Evaluate
 only parts of the output (if applicable) and determine whether the
 design still contains space leaks. If so, fix them, is not, goto the
 first step.