### PR TITLE
Add Cabal flag `-fsuper-strict`

### DIFF
--- a/clash-lib/prims/systemverilog/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_DDR.json
@@ -73,52 +73,53 @@ assign ~RESULT = {~SYM[3], ~SYM[1]};
     , "kind" : "Declaration"
     , "type" :
 "ddrOut# :: ( HasCallStack               -- ARG[0]
-            , fast ~ Dom n pFast         -- ARG[1]
-            , slow ~ Dom n (2*pFast))    -- ARG[2]
-         => Clock slow gated             -- ARG[3]
-         -> Reset slow synchronous       -- ARG[4]
-         -> a                            -- ARG[5]
-         -> Signal slow a                -- ARG[6]
+            , Undefined a                -- ARG[1]
+            , fast ~ Dom n pFast         -- ARG[2]
+            , slow ~ Dom n (2*pFast))    -- ARG[3]
+         => Clock slow gated             -- ARG[4]
+         -> Reset slow synchronous       -- ARG[5]
+         -> a                            -- ARG[6]
          -> Signal slow a                -- ARG[7]
+         -> Signal slow a                -- ARG[8]
          -> Signal fast a"
     , "template" :
 "// ddrOut begin
 ~SIGD[~GENSYM[data_Pos][1]][5];
 ~SIGD[~GENSYM[data_Neg][2]][5];
-~IF ~ISGATED[3] ~THEN
-always @(posedge ~ARG[3][1]~IF ~ISSYNC[4] ~THEN ~ELSE or posedge ~ARG[4]~FI) begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
-  if (~ARG[4]) begin
-    ~SYM[1] <= ~ARG[5];
-  end else if (~ARG[3][0]) begin
+~IF ~ISGATED[4] ~THEN
+always @(posedge ~ARG[4][1]~IF ~ISSYNC[5] ~THEN ~ELSE or posedge ~ARG[5]~FI) begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
+  if (~ARG[5]) begin
     ~SYM[1] <= ~ARG[6];
+  end else if (~ARG[4][0]) begin
+    ~SYM[1] <= ~ARG[7];
   end
 end~ELSE
-always @(posedge ~ARG[3]~IF ~ISSYNC[4] ~THEN ~ELSE or posedge ~ARG[4]~FI) begin : ~SYM[5]
-  if (~ARG[4]) begin
-    ~SYM[1] <= ~ARG[5];
-  end else begin
+always @(posedge ~ARG[4]~IF ~ISSYNC[5] ~THEN ~ELSE or posedge ~ARG[5]~FI) begin : ~SYM[5]
+  if (~ARG[5]) begin
     ~SYM[1] <= ~ARG[6];
+  end else begin
+    ~SYM[1] <= ~ARG[7];
   end
 end~FI
-~IF ~ISGATED[3] ~THEN
-always @(posedge ~ARG[3][1]~IF ~ISSYNC[4] ~THEN ~ELSE or posedge ~ARG[4]~FI) begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~ARG[5];
-  end else if (~ARG[3][0]) begin
-    ~SYM[2] <= ~ARG[7];
+~IF ~ISGATED[4] ~THEN
+always @(posedge ~ARG[4][1]~IF ~ISSYNC[5] ~THEN ~ELSE or posedge ~ARG[5]~FI) begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
+  if (~ARG[5]) begin
+    ~SYM[2] <= ~ARG[6];
+  end else if (~ARG[4][0]) begin
+    ~SYM[2] <= ~ARG[8];
   end
 end~ELSE
-always @(posedge ~ARG[3]~IF ~ISSYNC[4] ~THEN ~ELSE or posedge ~ARG[4]~FI) begin : ~SYM[6]
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~ARG[5];
+always @(posedge ~ARG[4]~IF ~ISSYNC[5] ~THEN ~ELSE or posedge ~ARG[5]~FI) begin : ~SYM[6]
+  if (~ARG[5]) begin
+    ~SYM[2] <= ~ARG[6];
   end else begin
-    ~SYM[2] <= ~ARG[7];
+    ~SYM[2] <= ~ARG[8];
   end
 end~FI
 
-always @(*) begin ~IF ~ISGATED[3] ~THEN
-  if (~ARG[3][1]) begin~ELSE
-  if (~ARG[3]) begin~FI
+always @(*) begin ~IF ~ISGATED[4] ~THEN
+  if (~ARG[4][1]) begin~ELSE
+  if (~ARG[4]) begin~FI
     ~RESULT = ~SYM[1];
   end else begin
     ~RESULT = ~SYM[2];

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
@@ -3,20 +3,21 @@
     , "kind" : "Declaration"
     , "type" :
 "delay#
-  :: Clock domain gated       -- ARG[0]
-  -> a                        -- ARG[1]
-  -> Signal clk a             -- ARG[2]
+  :: Undefined a              -- ARG[0]
+  => Clock domain gated       -- ARG[1]
+  -> a                        -- ARG[2]
+  -> Signal clk a             -- ARG[3]
   -> Signal clk a"
     , "template" :
 "// delay begin,
-~TYPO ~GENSYM[~RESULT_reg][0] = ~CONST[1];~IF ~ISGATED[0] ~THEN
-always_ff @(posedge ~ARG[0][1]) begin : ~GENSYM[~RESULT_delay][1]
-  if (~ARG[0][0]) begin
-    ~SYM[0] <= ~ARG[2];
+~TYPO ~GENSYM[~RESULT_reg][0] = ~CONST[2];~IF ~ISGATED[1] ~THEN
+always_ff @(posedge ~ARG[1][1]) begin : ~GENSYM[~RESULT_delay][1]
+  if (~ARG[1][0]) begin
+    ~SYM[0] <= ~ARG[3];
   end
 end~ELSE
-always_ff @(posedge ~ARG[0]) begin : ~SYM[1]
-  ~SYM[0] <= ~ARG[2];
+always_ff @(posedge ~ARG[1]) begin : ~SYM[1]
+  ~SYM[0] <= ~ARG[3];
 end~FI
 assign ~RESULT = ~SYM[0];
 // delay end"
@@ -27,27 +28,28 @@ assign ~RESULT = ~SYM[0];
     , "kind" : "Declaration"
     , "type" :
 "register#
-  :: Clock domain gated       -- ARG[0]
-  -> Reset domain synchronous -- ARG[1]
-  -> a                        -- ARG[2] (powerup value)
-  -> a                        -- ARG[3] (reset value)
-  -> Signal clk a             -- ARG[4]
+  :: Undefined a              -- ARG[0]
+  => Clock domain gated       -- ARG[1]
+  -> Reset domain synchronous -- ARG[2]
+  -> a                        -- ARG[3] (powerup value)
+  -> a                        -- ARG[4] (reset value)
+  -> Signal clk a             -- ARG[5]
   -> Signal clk a"
     , "template" :
 "// register begin
-~TYPO ~GENSYM[~RESULT_reg][0] = ~CONST[2];~IF ~ISGATED[0] ~THEN
-always_ff @(posedge ~ARG[0][1]~IF ~ISSYNC[1] ~THEN ~ELSE or posedge ~ARG[1]~FI) begin : ~GENSYM[~RESULT_register][1]
-  if (~ARG[1]) begin
-    ~SYM[0] <= ~CONST[3];
-  end else if (~ARG[0][0]) begin
-    ~SYM[0] <= ~ARG[4];
+~TYPO ~GENSYM[~RESULT_reg][0] = ~CONST[3];~IF ~ISGATED[1] ~THEN
+always_ff @(posedge ~ARG[1][1]~IF ~ISSYNC[2] ~THEN ~ELSE or posedge ~ARG[2]~FI) begin : ~GENSYM[~RESULT_register][1]
+  if (~ARG[2]) begin
+    ~SYM[0] <= ~CONST[4];
+  end else if (~ARG[1][0]) begin
+    ~SYM[0] <= ~ARG[5];
   end
 end~ELSE
-always_ff @(posedge ~ARG[0]~IF ~ISSYNC[1] ~THEN ~ELSE or posedge ~ARG[1]~FI) begin : ~SYM[1]
-  if (~ARG[1]) begin
-    ~SYM[0] <= ~CONST[3];
+always_ff @(posedge ~ARG[1]~IF ~ISSYNC[2] ~THEN ~ELSE or posedge ~ARG[2]~FI) begin : ~SYM[1]
+  if (~ARG[2]) begin
+    ~SYM[0] <= ~CONST[4];
   end else begin
-    ~SYM[0] <= ~ARG[4];
+    ~SYM[0] <= ~ARG[5];
   end
 end~FI
 assign ~RESULT = ~SYM[0];

--- a/clash-lib/prims/verilog/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_DDR.json
@@ -73,53 +73,54 @@ assign ~RESULT = {~SYM[3], ~SYM[1]};
     , "kind" : "Declaration"
     , "type" :
 "ddrOut# :: ( HasCallStack               -- ARG[0]
-            , fast ~ Dom n pFast         -- ARG[1]
-            , slow ~ Dom n (2*pFast))    -- ARG[2]
-         => Clock slow gated             -- ARG[3]
-         -> Reset slow synchronous       -- ARG[4]
-         -> a                            -- ARG[5]
-         -> Signal slow a                -- ARG[6]
+            , Undefined a                -- ARG[1]
+            , fast ~ Dom n pFast         -- ARG[2]
+            , slow ~ Dom n (2*pFast))    -- ARG[3]
+         => Clock slow gated             -- ARG[4]
+         -> Reset slow synchronous       -- ARG[5]
+         -> a                            -- ARG[6]
          -> Signal slow a                -- ARG[7]
+         -> Signal slow a                -- ARG[8]
          -> Signal fast a"
     , "template" :
 "// ddrOut begin
 reg ~SIGD[~GENSYM[data_Pos][1]][5];
 reg ~SIGD[~GENSYM[data_Neg][2]][5];
 reg ~SIGD[~GENSYM[data_Out][3]][5];
-~IF ~ISGATED[3] ~THEN
-always @(posedge ~ARG[3][1]~IF ~ISSYNC[4] ~THEN ~ELSE or posedge ~ARG[4]~FI) begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
-  if (~ARG[4]) begin
-    ~SYM[1] <= ~ARG[5];
-  end else if (~ARG[3][0]) begin
+~IF ~ISGATED[4] ~THEN
+always @(posedge ~ARG[4][1]~IF ~ISSYNC[5] ~THEN ~ELSE or posedge ~ARG[5]~FI) begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
+  if (~ARG[5]) begin
     ~SYM[1] <= ~ARG[6];
+  end else if (~ARG[4][0]) begin
+    ~SYM[1] <= ~ARG[7];
   end
 end~ELSE
-always @(posedge ~ARG[3]~IF ~ISSYNC[4] ~THEN ~ELSE or posedge ~ARG[4]~FI) begin : ~SYM[5]
-  if (~ARG[4]) begin
-    ~SYM[1] <= ~ARG[5];
-  end else begin
+always @(posedge ~ARG[4]~IF ~ISSYNC[5] ~THEN ~ELSE or posedge ~ARG[5]~FI) begin : ~SYM[5]
+  if (~ARG[5]) begin
     ~SYM[1] <= ~ARG[6];
+  end else begin
+    ~SYM[1] <= ~ARG[7];
   end
 end~FI
 ~IF ~ISGATED[3] ~THEN
-always @(posedge ~ARG[3][1]~IF ~ISSYNC[4] ~THEN ~ELSE or posedge ~ARG[4]~FI) begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~ARG[5];
-  end else if (~ARG[3][0]) begin
-    ~SYM[2] <= ~ARG[7];
+always @(posedge ~ARG[4][1]~IF ~ISSYNC[5] ~THEN ~ELSE or posedge ~ARG[5]~FI) begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
+  if (~ARG[5]) begin
+    ~SYM[2] <= ~ARG[6];
+  end else if (~ARG[4][0]) begin
+    ~SYM[2] <= ~ARG[8];
   end
 end~ELSE
-always @(posedge ~ARG[3]~IF ~ISSYNC[4] ~THEN ~ELSE or posedge ~ARG[4]~FI) begin : ~SYM[6]
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~ARG[5];
+always @(posedge ~ARG[4]~IF ~ISSYNC[5] ~THEN ~ELSE or posedge ~ARG[5]~FI) begin : ~SYM[6]
+  if (~ARG[5]) begin
+    ~SYM[2] <= ~ARG[6];
   end else begin
-    ~SYM[2] <= ~ARG[7];
+    ~SYM[2] <= ~ARG[8];
   end
 end~FI
 
-always @(*) begin ~IF ~ISGATED[3] ~THEN
-  if (~ARG[3][1]) begin~ELSE
-  if (~ARG[3]) begin~FI
+always @(*) begin ~IF ~ISGATED[4] ~THEN
+  if (~ARG[4][1]) begin~ELSE
+  if (~ARG[4]) begin~FI
     ~SYM[3] = ~SYM[1];
   end else begin
     ~SYM[3] = ~SYM[2];

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.json
@@ -3,20 +3,21 @@
     , "kind" : "Declaration"
     , "type" :
 "delay#
-  :: Clock domain gated       -- ARG[0]
-  -> a                        -- ARG[1]
-  -> Signal clk a             -- ARG[2]
+  :: Undefined a              -- ARG[0]
+  => Clock domain gated       -- ARG[1]
+  -> a                        -- ARG[2]
+  -> Signal clk a             -- ARG[3]
   -> Signal clk a"
     , "template" :
 "// delay begin,
-reg ~TYPO ~GENSYM[~RESULT_reg][0] = ~CONST[1];~IF ~ISGATED[0] ~THEN
-always @(posedge ~ARG[0][1]) begin : ~GENSYM[~RESULT_delay][1]
-  if (~ARG[0][0]) begin
-    ~SYM[0] <= ~ARG[2];
+reg ~TYPO ~GENSYM[~RESULT_reg][0] = ~CONST[2];~IF ~ISGATED[1] ~THEN
+always @(posedge ~ARG[1][1]) begin : ~GENSYM[~RESULT_delay][1]
+  if (~ARG[1][0]) begin
+    ~SYM[0] <= ~ARG[3];
   end
 end~ELSE
-always @(posedge ~ARG[0]) begin : ~SYM[1]
-  ~SYM[0] <= ~ARG[2];
+always @(posedge ~ARG[1]) begin : ~SYM[1]
+  ~SYM[0] <= ~ARG[3];
 end~FI
 assign ~RESULT = ~SYM[0];
 // delay end"
@@ -27,27 +28,28 @@ assign ~RESULT = ~SYM[0];
     , "kind" : "Declaration"
     , "type" :
 "register#
-  :: Clock domain gated       -- ARG[0]
-  -> Reset domain synchronous -- ARG[1]
-  -> a                        -- ARG[2] (powerup value)
-  -> a                        -- ARG[3] (reset value)
-  -> Signal clk a             -- ARG[4]
+  :: Undefined a              -- ARG[0]
+  => Clock domain gated       -- ARG[1]
+  -> Reset domain synchronous -- ARG[2]
+  -> a                        -- ARG[3] (powerup value)
+  -> a                        -- ARG[4] (reset value)
+  -> Signal clk a             -- ARG[5]
   -> Signal clk a"
     , "template" :
 "// register begin
-reg ~TYPO ~GENSYM[~RESULT_reg][0] = ~CONST[2];~IF ~ISGATED[0] ~THEN
-always @(posedge ~ARG[0][1]~IF ~ISSYNC[1] ~THEN ~ELSE or posedge ~ARG[1]~FI) begin : ~GENSYM[~RESULT_register][1]
-  if (~ARG[1]) begin
-    ~SYM[0] <= ~CONST[3];
-  end else if (~ARG[0][0]) begin
-    ~SYM[0] <= ~ARG[4];
+reg ~TYPO ~GENSYM[~RESULT_reg][0] = ~CONST[3];~IF ~ISGATED[1] ~THEN
+always @(posedge ~ARG[1][1]~IF ~ISSYNC[2] ~THEN ~ELSE or posedge ~ARG[2]~FI) begin : ~GENSYM[~RESULT_register][1]
+  if (~ARG[2]) begin
+    ~SYM[0] <= ~CONST[4];
+  end else if (~ARG[1][0]) begin
+    ~SYM[0] <= ~ARG[5];
   end
 end~ELSE
-always @(posedge ~ARG[0]~IF ~ISSYNC[1] ~THEN ~ELSE or posedge ~ARG[1]~FI) begin : ~SYM[1]
-  if (~ARG[1]) begin
-    ~SYM[0] <= ~CONST[3];
+always @(posedge ~ARG[1]~IF ~ISSYNC[2] ~THEN ~ELSE or posedge ~ARG[2]~FI) begin : ~SYM[1]
+  if (~ARG[2]) begin
+    ~SYM[0] <= ~CONST[4];
   end else begin
-    ~SYM[0] <= ~ARG[4];
+    ~SYM[0] <= ~ARG[5];
   end
 end~FI
 assign ~RESULT = ~SYM[0];

--- a/clash-lib/prims/vhdl/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_DDR.json
@@ -170,35 +170,36 @@ end block;
     , "kind" : "Declaration"
     , "type" :
 "ddrOut# :: ( HasCallStack               -- ARG[0]
-            , fast ~ Dom n pFast         -- ARG[1]
-            , slow ~ Dom n (2*pFast))    -- ARG[2]
-         => Clock slow gated             -- ARG[3]
-         -> Reset slow synchronous       -- ARG[4]
-         -> a                            -- ARG[5]
-         -> Signal slow a                -- ARG[6]
+            , Undefined a                -- ARG[0]
+            , fast ~ Dom n pFast         -- ARG[2]
+            , slow ~ Dom n (2*pFast))    -- ARG[3]
+         => Clock slow gated             -- ARG[4]
+         -> Reset slow synchronous       -- ARG[5]
+         -> a                            -- ARG[6]
          -> Signal slow a                -- ARG[7]
+         -> Signal slow a                -- ARG[8]
          -> Signal fast a"
     , "template" :
 "-- ddrOut begin
 ~GENSYM[~COMPNAME_ddrIn][0] : block
-  signal ~GENSYM[data_Pos][1] : ~TYP[5];
-  signal ~GENSYM[data_Neg][2] : ~TYP[5];
-~IF ~ISGATED[3] ~THEN
+  signal ~GENSYM[data_Pos][1] : ~TYP[6];
+  signal ~GENSYM[data_Neg][2] : ~TYP[6];
+~IF ~ISGATED[4] ~THEN
   signal ~GENSYM[clk][3]      : std_logic;
   signal ~GENSYM[ce][4]       : boolean;
 ~ELSE ~FI
 begin
-~IF ~ISGATED[3] ~THEN
- ~IF ~ISSYNC[4] ~THEN
+~IF ~ISGATED[4] ~THEN
+ ~IF ~ISSYNC[5] ~THEN
   -- gated sync
   -------------
   ~GENSYM[~COMPNAME_ddrOut_pos][5] : process(~SYM[3])
   begin
-    if rising_edge(~SYM[3]) then
-      if ~ARG[4] = '1' then
-        ~SYM[1] <= ~ARG[5];
-      elsif ~SYM[4] then
+    if rising_edge(~SYM[4]) then
+      if ~ARG[5] = '1' then
         ~SYM[1] <= ~ARG[6];
+      elsif ~SYM[4] then
+        ~SYM[1] <= ~ARG[7];
       end if;
     end if;
   end process;
@@ -206,86 +207,86 @@ begin
   ~GENSYM[~COMPNAME_ddrOut_neg][6] : process(~SYM[3])
   begin
     if rising_edge(~SYM[3]) then
-      if ~ARG[4] = '1' then
-        ~SYM[2] <= ~ARG[5];
+      if ~ARG[5] = '1' then
+        ~SYM[2] <= ~ARG[6];
       elsif ~SYM[4] then
-        ~SYM[2] <= ~ARG[7];
+        ~SYM[2] <= ~ARG[8];
       end if;
     end if;
   end process;
  ~ELSE
   -- gated async
   --------------
-  ~SYM[5] : process(~SYM[3],~ARG[4]~VARS[6])
+  ~SYM[5] : process(~SYM[3],~ARG[5]~VARS[7])
   begin
-    if ~ARG[4] = '1' then
-      ~SYM[1] <= ~ARG[5];
-    elsif rising_edge(~SYM[3]) then
+    if ~ARG[5] = '1' then
       ~SYM[1] <= ~ARG[6];
+    elsif rising_edge(~SYM[3]) then
+      ~SYM[1] <= ~ARG[7];
     end if;
   end process;
 
-  ~SYM[6] : process(~SYM[3],~ARG[4]~VARS[7])
+  ~SYM[6] : process(~SYM[3],~ARG[5]~VARS[8])
   begin
-    if ~ARG[4] = '1' then
-      ~SYM[2] <= ~ARG[5];
+    if ~ARG[5] = '1' then
+      ~SYM[2] <= ~ARG[6];
     elsif rising_edge(~SYM[3]) then
-      ~SYM[2] <= ~ARG[7];
+      ~SYM[2] <= ~ARG[8];
     end if;
   end process;
  ~FI
 ~ELSE
- ~IF ~ISSYNC[4] ~THEN
+ ~IF ~ISSYNC[5] ~THEN
   -- ungated sync
   ---------------
-  ~SYM[5] : process(~ARG[3])
+  ~SYM[5] : process(~ARG[4])
   begin
-    if rising_edge(~ARG[3]) then
-      if ~ARG[4] = '1' then
-        ~SYM[1] <= ~ARG[5];
-      else
+    if rising_edge(~ARG[4]) then
+      if ~ARG[5] = '1' then
         ~SYM[1] <= ~ARG[6];
+      else
+        ~SYM[1] <= ~ARG[7];
       end if;
     end if;
   end process;
 
-  ~SYM[6] : process(~ARG[3])
+  ~SYM[6] : process(~ARG[4])
   begin
-    if rising_edge(~ARG[3]) then
-      if ~ARG[4] = '1' then
-        ~SYM[2] <= ~ARG[5];
+    if rising_edge(~ARG[4]) then
+      if ~ARG[5] = '1' then
+        ~SYM[2] <= ~ARG[6];
       else
-        ~SYM[2] <= ~ARG[7];
+        ~SYM[2] <= ~ARG[8];
       end if;
     end if;
   end process;
  ~ELSE
   -- ungated async
   ----------------
-  ~SYM[5] : process(~ARG[3],~ARG[4]~VARS[6])
+  ~SYM[5] : process(~ARG[4],~ARG[5]~VARS[7])
   begin
-    if ~ARG[4] = '1' then
-      ~SYM[1] <= ~ARG[5];
-    elsif rising_edge(~ARG[3]) then
+    if ~ARG[5] = '1' then
       ~SYM[1] <= ~ARG[6];
+    elsif rising_edge(~ARG[4]) then
+      ~SYM[1] <= ~ARG[7];
     end if;
   end process;
 
-  ~SYM[6] : process(~ARG[3],~ARG[4]~VARS[7])
+  ~SYM[6] : process(~ARG[4],~ARG[5]~VARS[8])
   begin
-    if ~ARG[4] = '1' then
-      ~SYM[2] <= ~ARG[5];
-    elsif rising_edge(~ARG[3]) then
-      ~SYM[2] <= ~ARG[7];
+    if ~ARG[5] = '1' then
+      ~SYM[2] <= ~ARG[6];
+    elsif rising_edge(~ARG[4]) then
+      ~SYM[2] <= ~ARG[8];
     end if;
   end process;
  ~FI
 ~FI
-~IF ~ISGATED[3] ~THEN
-  (~SYM[3],~SYM[4]) <= ~ARG[3];
+~IF ~ISGATED[4] ~THEN
+  (~SYM[3],~SYM[4]) <= ~ARG[4];
   ~RESULT <= ~SYM[1] when (~SYM[3] = '1' and ~SYM[4]) else ~SYM[2];
 ~ELSE
-  ~RESULT <= ~SYM[1] when (~ARG[3] = '1') else ~SYM[2];
+  ~RESULT <= ~SYM[1] when (~ARG[4] = '1') else ~SYM[2];
 ~FI
 end block;
 -- ddrOut end"

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.json
@@ -3,23 +3,24 @@
     , "kind" : "Declaration"
     , "type" :
 "delay#
-  :: Clock domain gated       -- ARG[0]
-  -> a                        -- ARG[1]
-  -> Signal clk a             -- ARG[2]
+  :: Undefined a              -- ARG[0]
+  => Clock domain gated       -- ARG[1]
+  -> a                        -- ARG[2]
+  -> Signal clk a             -- ARG[3]
   -> Signal clk a"
     , "template" :
-"-- delay begin~IF ~ISGATED[0] ~THEN
+"-- delay begin~IF ~ISGATED[1] ~THEN
 ~GENSYM[~RESULT_delay][0] : block
   signal ~GENSYM[clk][1] : std_logic;
   signal ~GENSYM[ce][2]  : boolean;
-  signal ~GENSYM[~RESULT_reg][3]   : ~TYPO := ~CONST[1];
+  signal ~GENSYM[~RESULT_reg][3]   : ~TYPO := ~CONST[2];
 begin
-  (~SYM[1],~SYM[2]) <= ~ARG[0];
+  (~SYM[1],~SYM[2]) <= ~ARG[1];
   ~GENSYM[~RESULT_dly][4] : process(~SYM[1])
   begin
     if rising_edge(~SYM[1]) then
       if ~SYM[2] then
-        ~RESULT <= ~ARG[2]
+        ~RESULT <= ~ARG[3]
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -29,13 +30,13 @@ begin
   end process;
 end block;~ELSE
 ~SYM[0] : block
-  signal ~SYM[3] : ~TYPO := ~CONST[1];
+  signal ~SYM[3] : ~TYPO := ~CONST[2];
 begin
   ~RESULT <= ~SYM[3];
-  ~SYM[4] : process(~ARG[0])
+  ~SYM[4] : process(~ARG[1])
   begin
-    if rising_edge(~ARG[0]) then
-      ~SYM[3] <= ~ARG[2]
+    if rising_edge(~ARG[1]) then
+      ~SYM[3] <= ~ARG[3]
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on
@@ -51,32 +52,33 @@ end block;~FI
     , "kind" : "Declaration"
     , "type" :
 "register#
-  :: Clock domain gated       -- ARG[0]
-  -> Reset domain synchronous -- ARG[1]
-  -> a                        -- ARG[2] (powerup value)
-  -> a                        -- ARG[3] (reset value)
-  -> Signal clk a             -- ARG[4]
+  :: Undefined a              -- ARG[0]
+  => Clock domain gated       -- ARG[1]
+  -> Reset domain synchronous -- ARG[2]
+  -> a                        -- ARG[3] (powerup value)
+  -> a                        -- ARG[4] (reset value)
+  -> Signal clk a             -- ARG[5]
   -> Signal clk a"
     , "template" :
-"-- register begin~IF ~ISGATED[0] ~THEN
+"-- register begin~IF ~ISGATED[1] ~THEN
 ~GENSYM[~COMPNAME_register][0] : block
   signal ~GENSYM[clk][1] : std_logic;
   signal ~GENSYM[ce][2] : boolean;
-  signal ~GENSYM[~RESULT_reg][3] : ~TYPO := ~CONST[2];
+  signal ~GENSYM[~RESULT_reg][3] : ~TYPO := ~CONST[3];
 begin
-  (~SYM[1],~SYM[2]) <= ~ARG[0];
-  ~RESULT <= ~SYM[3]; ~IF ~ISSYNC[1] ~THEN
+  (~SYM[1],~SYM[2]) <= ~ARG[1];
+  ~RESULT <= ~SYM[3]; ~IF ~ISSYNC[2] ~THEN
   ~GENSYM[~RESULT_r][4] : process(~SYM[1])
   begin
     if rising_edge(~SYM[1]) then
-      if ~ARG[1] = '1' then
-        ~SYM[3] <= ~CONST[3]
+      if ~ARG[2] = '1' then
+        ~SYM[3] <= ~CONST[4]
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
         ;
       elsif ~SYM[2] then
-        ~SYM[3] <= ~ARG[4]
+        ~SYM[3] <= ~ARG[5]
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -84,13 +86,13 @@ begin
       end if;
     end if;
   end process;~ELSE
-  ~SYM[4] : process(~SYM[1],~ARG[1])
+  ~SYM[4] : process(~SYM[1],~ARG[2])
   begin
-    if ~ARG[1] = '1' then
-      ~SYM[3] <= ~CONST[3];
+    if ~ARG[2] = '1' then
+      ~SYM[3] <= ~CONST[4];
     elsif rising_edge(~SYM[1]) then
       if ~SYM[2] then
-        ~SYM[3] <= ~ARG[4]
+        ~SYM[3] <= ~ARG[5]
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -100,20 +102,20 @@ begin
   end process;~FI
 end block;~ELSE
 ~SYM[0] : block
-  signal ~SYM[3] : ~TYPO := ~CONST[2];
+  signal ~SYM[3] : ~TYPO := ~CONST[3];
 begin
-  ~RESULT <= ~SYM[3]; ~IF ~ISSYNC[1] ~THEN
-  ~SYM[4] : process(~ARG[0])
+  ~RESULT <= ~SYM[3]; ~IF ~ISSYNC[2] ~THEN
+  ~SYM[4] : process(~ARG[1])
   begin
-    if rising_edge(~ARG[0]) then
-      if ~ARG[1] = '1' then
-        ~SYM[3] <= ~CONST[3]
+    if rising_edge(~ARG[1]) then
+      if ~ARG[2] = '1' then
+        ~SYM[3] <= ~CONST[4]
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
         ;
       else
-        ~SYM[3] <= ~ARG[4]
+        ~SYM[3] <= ~ARG[5]
         -- pragma translate_off
         after 1 ps
         -- pragma translate_on
@@ -121,16 +123,16 @@ begin
       end if;
     end if;
   end process;~ELSE
-  ~SYM[4] : process(~ARG[0],~ARG[1])
+  ~SYM[4] : process(~ARG[1],~ARG[2])
   begin
-    if ~ARG[1] = '1' then
-      ~SYM[3] <= ~CONST[3]
+    if ~ARG[2] = '1' then
+      ~SYM[3] <= ~CONST[4]
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on
       ;
-    elsif rising_edge(~ARG[0]) then
-      ~SYM[3] <= ~ARG[4]
+    elsif rising_edge(~ARG[1]) then
+      ~SYM[3] <= ~ARG[5]
       -- pragma translate_off
       after 1 ps
       -- pragma translate_on

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -66,6 +66,15 @@ source-repository head
   type: git
   location: https://github.com/clash-lang/clash-prelude.git
 
+flag super-strict
+  description:
+    Use `deepseqX` (instead of `seqX`) in register-like constructs. This can
+    help to eliminate space leaks when using lazy data structures in
+    registers-like constructs. This potentially slows down Clash hardware
+    simulation.
+  default: False
+  manual: True
+
 flag doctests
   description:
     You can disable testing with doctests using `-f-doctests`.
@@ -90,6 +99,9 @@ Library
   default-language:   Haskell2010
   ghc-options:        -Wall -fexpose-all-unfoldings -fno-worker-wrapper
   CPP-Options:        -DCABAL
+
+  if flag(super-strict)
+    CPP-Options: -DCLASH_SUPER_STRICT
 
   Exposed-modules:    Clash.Annotations.TopEntity
                       Clash.Annotations.Primitive

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -791,7 +791,7 @@ blockRam# clk content rd wen = case clockEnable clk of
 
 -- | Create read-after-write blockRAM from a read-before-write one
 readNew
-  :: Eq addr
+  :: (Undefined a, Eq addr)
   => Reset domain synchronous
   -> Clock domain gated
   -> (Signal domain addr -> Signal domain (Maybe (addr, a)) -> Signal domain a)

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -131,26 +131,30 @@ ddrIn# (GatedClock _ _ ena) (Async rst) i0 i1 i2 =
 -- | DDR output primitive
 --
 -- Produces a DDR output signal from a normal signal of pairs of input.
-ddrOut :: ( HasCallStack
-          , fast ~ 'Dom n pFast
-          , slow ~ 'Dom n (2*pFast))
-       => Clock slow gated            -- ^ clock
-       -> Reset slow synchronous      -- ^ reset
-       -> a                           -- ^ reset value
-       -> Signal slow (a,a)           -- ^ normal speed input pairs
-       -> Signal fast a               -- ^ DDR output signal
+ddrOut
+  :: ( HasCallStack
+     , Undefined a
+     , fast ~ 'Dom n pFast
+     , slow ~ 'Dom n (2*pFast))
+  => Clock slow gated            -- ^ clock
+  -> Reset slow synchronous      -- ^ reset
+  -> a                           -- ^ reset value
+  -> Signal slow (a,a)           -- ^ normal speed input pairs
+  -> Signal fast a               -- ^ DDR output signal
 ddrOut clk rst i0 = uncurry (withFrozenCallStack $ ddrOut# clk rst i0) . unbundle
 
 
-ddrOut# :: ( HasCallStack
-           , fast ~ 'Dom n pFast
-           , slow ~ 'Dom n (2*pFast))
-        => Clock slow gated
-        -> Reset slow synchronous
-        -> a
-        -> Signal slow a
-        -> Signal slow a
-        -> Signal fast a
+ddrOut#
+  :: ( HasCallStack
+     , Undefined a
+     , fast ~ 'Dom n pFast
+     , slow ~ 'Dom n (2*pFast))
+  => Clock slow gated
+  -> Reset slow synchronous
+  -> a
+  -> Signal slow a
+  -> Signal slow a
+  -> Signal fast a
 ddrOut# clk rst i0 xs ys =
     -- We only observe one reset value, because when the mux switches on the
     -- next clock level, the second register will already be outputting its

--- a/clash-prelude/src/Clash/Explicit/Mealy.hs
+++ b/clash-prelude/src/Clash/Explicit/Mealy.hs
@@ -20,7 +20,9 @@ module Clash.Explicit.Mealy
   )
 where
 
-import Clash.Explicit.Signal (Bundle (..), Clock, Reset, Signal, register)
+import           Clash.Explicit.Signal
+  (Bundle (..), Clock, Reset, Signal, register)
+import           Clash.XException      (Undefined)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -76,7 +78,8 @@ let macT s (x,y) = (s',s)
 --     s2 = 'mealy' clk rst mac 0 ('bundle' (b,y))
 -- @
 mealy
-  :: Clock dom gated
+  :: Undefined s
+  => Clock dom gated
   -- ^ 'Clock' to synchronize to
   -> Reset dom synchronous
   -> (s -> i -> (s,o))
@@ -119,8 +122,9 @@ mealy clk rst f iS =
 --     (i2,b2) = 'mealyB' clk rst f 3 (i1,c)
 -- @
 mealyB
-  :: Bundle i
-  => Bundle o
+  :: ( Undefined s
+     , Bundle i
+     , Bundle o )
   => Clock dom gated
   -> Reset dom synchronous
   -> (s -> i -> (s,o))

--- a/clash-prelude/src/Clash/Explicit/Moore.hs
+++ b/clash-prelude/src/Clash/Explicit/Moore.hs
@@ -22,7 +22,9 @@ module Clash.Explicit.Moore
   )
 where
 
-import Clash.Explicit.Signal (Bundle (..), Clock, Reset, Signal, register)
+import           Clash.Explicit.Signal
+  (Bundle (..), Clock, Reset, Signal, register)
+import           Clash.XException                 (Undefined)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -69,7 +71,8 @@ import Clash.Explicit.Signal (Bundle (..), Clock, Reset, Signal, register)
 --     s2 = 'moore' clk rst mac id 0 ('bundle' (b,y))
 -- @
 moore
-  :: Clock domain gated
+  :: Undefined s
+  => Clock domain gated
   -- ^ 'Clock' to synchronize to
   -> Reset domain synchronous
   -> (s -> i -> s)
@@ -90,7 +93,8 @@ moore clk rst ft fo iS =
 -- | Create a synchronous function from a combinational function describing
 -- a moore machine without any output logic
 medvedev
-  :: Clock domain gated
+  :: Undefined s
+  => Clock domain gated
   -> Reset domain synchronous
   -> (s -> i -> s)
   -> s
@@ -126,8 +130,9 @@ medvedev clk rst tr st = moore clk rst tr id st
 --     (i2,b2) = 'mooreB' clk rst t o 3 (i1,c)
 -- @
 mooreB
-  :: Bundle i
-  => Bundle o
+  :: ( Undefined s
+     , Bundle i
+     , Bundle o )
   => Clock domain gated
   -> Reset domain synchronous
   -> (s -> i -> s) -- ^ Transfer function in moore machine form:
@@ -143,8 +148,9 @@ mooreB clk rst ft fo iS i = unbundle (moore clk rst ft fo iS (bundle i))
 
 -- | A version of 'medvedev' that does automatic 'Bundle'ing
 medvedevB
-  :: Bundle i
-  => Bundle s
+  :: ( Undefined s
+     , Bundle i
+     , Bundle s )
   => Clock domain gated
   -> Reset domain synchronous
   -> (s -> i -> s)

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -192,7 +192,7 @@ import Clash.XException
 -- [<1,0,0,0>,<2,1,0,0>,<3,2,1,0>,<4,3,2,1>,<5,4,3,2>...
 -- ...
 window
-  :: (KnownNat n, Default a)
+  :: (KnownNat n, Undefined a, Default a)
   => Clock domain gated
   -- ^ Clock to which the incoming signal is synchronized
   -> Reset domain synchronous
@@ -219,7 +219,7 @@ window clk rst x = res
 -- [<0,0,0>,<0,0,0>,<1,0,0>,<2,1,0>,<3,2,1>,<4,3,2>...
 -- ...
 windowD
-  :: (KnownNat n, Default a)
+  :: (KnownNat n, Undefined a, Default a)
   => Clock domain gated
   -- ^ Clock to which the incoming signal is synchronized
   -> Reset domain synchronous

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -165,7 +165,7 @@ import Clash.XException
 -- [(8,8),(8,8),(1,1),(2,2),(3,3)...
 -- ...
 registerB
-  :: Bundle a
+  :: (Undefined a, Bundle a)
   => Clock domain gated
   -> Reset domain synchronous
   -> a
@@ -176,7 +176,7 @@ registerB clk rst i = unbundle Prelude.. register clk rst i Prelude.. bundle
 
 -- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
 isRising
-  :: (Bounded a, Eq a)
+  :: (Undefined a, Bounded a, Eq a)
   => Clock domain gated
   -> Reset domain synchronous
   -> a -- ^ Starting value
@@ -190,7 +190,7 @@ isRising clk rst is s = liftA2 edgeDetect prev s
 
 -- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
 isFalling
-  :: (Bounded a, Eq a)
+  :: (Undefined a, Bounded a, Eq a)
   => Clock domain gated
   -> Reset domain synchronous
   -> a -- ^ Starting value

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -465,7 +465,8 @@ repSchedule high low = take low $ repSchedule' low high 1
 -- >>> sampleN 3 (delay systemClockGen 0 (fromList [1,2,3,4]))
 -- [0,1,2]
 delay
-  :: Clock domain gated
+  :: Undefined a
+  => Clock domain gated
   -- ^ Clock
   -> a
   -- ^ Default value
@@ -481,7 +482,8 @@ delay = delay#
 -- >>> sampleN 7 (delayMaybe systemClockGen 0 input)
 -- [0,1,2,2,2,5,6]
 delayMaybe
-  :: Clock domain gated
+  :: Undefined a
+  => Clock domain gated
   -- ^ Clock
   -> a
   -- ^ Initial value
@@ -498,7 +500,8 @@ delayMaybe clk dflt i =
 -- >>> sampleN 7 (delayEn systemClockGen 0 enable input)
 -- [0,1,2,2,2,5,6]
 delayEn
-  :: Clock domain gated
+  :: Undefined a
+  => Clock domain gated
   -- ^ Clock
   -> a
   -- ^ Initial value
@@ -516,7 +519,8 @@ delayEn clk dflt en i =
 -- >>> sampleN 5 (register systemClockGen asyncResetGen 8 (fromList [1,1,2,3,4]))
 -- [8,8,1,2,3]
 register
-  :: Clock domain gated
+  :: Undefined a
+  => Clock domain gated
   -- ^ clock
   -> Reset domain synchronous
   -- ^ Reset (active-high), 'register' outputs the reset value when the
@@ -551,7 +555,8 @@ register clk rst initial i =
 -- >>> sampleN 9 (count systemClockGen asyncResetGen)
 -- [0,0,0,1,1,2,2,3,3]
 regMaybe
-  :: Clock domain gated
+  :: Undefined a
+  => Clock domain gated
   -- ^ Clock
   -> Reset domain synchronous
   -- ^ Reset (active-high), 'regMaybe' outputs the reset value when the
@@ -579,7 +584,8 @@ regMaybe clk rst initial iM =
 -- >>> sampleN 9 (count systemClockGen asyncResetGen)
 -- [0,0,0,1,1,2,2,3,3]
 regEn
-  :: Clock domain clk
+  :: Undefined a
+  => Clock domain clk
   -- ^ Clock
   -> Reset domain synchronous
   -- ^ Reset (active-high), 'regEn' outputs the reset value when the

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -50,6 +50,8 @@ import Clash.Signal.Delayed.Internal
 import Clash.Explicit.Signal
   (Clock, Reset, Signal, register,  bundle, unbundle)
 
+import Clash.XException (Undefined)
+
 {- $setup
 >>> :set -XDataKinds
 >>> :set -XTypeOperators
@@ -89,6 +91,7 @@ let mac :: Clock System gated
 delayed
   :: forall domain gated synchronous a n d
    . KnownNat d
+  => Undefined a
   => Clock domain gated
   -> Reset domain synchronous
   -> Vec d a
@@ -124,13 +127,15 @@ delayed clk rst m ds = coerce (delaySignal (coerce ds))
 --
 -- >>> :t delayedI @3
 -- delayedI @3
---   :: Clock domain gated
+--   :: Undefined a =>
+--      Clock domain gated
 --      -> Reset domain synchronous
 --      -> a
 --      -> DSignal domain n a
 --      -> DSignal domain (n + 3) a
 delayedI
   :: KnownNat d
+  => Undefined a
   => Clock domain gated
   -> Reset domain synchronous
   -> a

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -47,6 +47,7 @@ import Clash.Promoted.Nat          (SNat (..), pow2SNat)
 import Clash.Promoted.Nat.Literals (d0)
 import Clash.Signal                (mux)
 import Clash.Sized.BitVector       (BitVector, (++#))
+import Clash.XException            (Undefined)
 
 -- * Dual flip-flop synchronizer
 
@@ -73,7 +74,8 @@ import Clash.Sized.BitVector       (BitVector, (++#))
 --      If you want to have /safe/ __word__-synchronisation use
 --      'asyncFIFOSynchronizer'.
 dualFlipFlopSynchronizer
-  :: Clock domain1 gated1
+  :: Undefined a
+  => Clock domain1 gated1
   -- ^ 'Clock' to which the incoming  data is synchronised
   -> Clock domain2 gated2
   -- ^ 'Clock' to which the outgoing data is synchronised

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -211,7 +211,10 @@ It instead exports the identically named functions defined in terms of
 -- [<1,0,0,0>,<2,1,0,0>,<3,2,1,0>,<4,3,2,1>,<5,4,3,2>...
 -- ...
 window
-  :: (KnownNat n, Default a, HiddenClockReset domain gated synchronous)
+  :: ( HiddenClockReset domain gated synchronous
+     , KnownNat n
+     , Default a
+     , Undefined a )
   => Signal domain a                -- ^ Signal to create a window over
   -> Vec (n + 1) (Signal domain a)  -- ^ Window of at least size 1
 window = hideClockReset E.window
@@ -227,7 +230,10 @@ window = hideClockReset E.window
 -- [<0,0,0>,<1,0,0>,<2,1,0>,<3,2,1>,<4,3,2>...
 -- ...
 windowD
-  :: (KnownNat n, Default a, HiddenClockReset domain gated synchronous)
+  :: ( HiddenClockReset domain gated synchronous
+     , KnownNat n
+     , Default a
+     , Undefined a )
   => Signal domain a               -- ^ Signal to create a window over
   -> Vec (n + 1) (Signal domain a) -- ^ Window of at least size 1
 windowD = hideClockReset E.windowD

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -704,13 +704,17 @@ blockRamPow2 = \cnt rd wrM -> withFrozenCallStack
 --      ... =>
 --      Signal domain addr
 --      -> Signal domain (Maybe (addr, a)) -> Signal domain a
-readNew :: (Eq addr, HiddenClockReset domain gated synchronous)
-        => (Signal domain addr -> Signal domain (Maybe (addr, a)) -> Signal domain a)
-        -- ^ The @ram@ component
-        -> Signal domain addr              -- ^ Read address @r@
-        -> Signal domain (Maybe (addr, a)) -- ^ (Write address @w@, value to write)
-        -> Signal domain a
-        -- ^ Value of the @ram@ at address @r@ from the previous clock
-        -- cycle
+readNew
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined a
+     , Eq addr )
+  => (Signal domain addr -> Signal domain (Maybe (addr, a)) -> Signal domain a)
+  -- ^ The @ram@ component
+  -> Signal domain addr
+  -- ^ Read address @r@
+  -> Signal domain (Maybe (addr, a))
+  -- ^ (Write address @w@, value to write)
+  -> Signal domain a
+  -- ^ Value of the @ram@ at address @r@ from the previous clock cycle
 readNew = hideClockReset (\clk rst -> E.readNew rst clk)
 {-# INLINE readNew #-}

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -25,6 +25,7 @@ where
 
 import qualified Clash.Explicit.Mealy as E
 import           Clash.Signal
+import           Clash.XException           (Undefined)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -73,7 +74,8 @@ let macT s (x,y) = (s',s)
 --     s2 = 'mealy' mac 0 ('Clash.Signal.bundle' (b,y))
 -- @
 mealy
-  :: HiddenClockReset domain gated synchronous
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined s )
   => (s -> i -> (s,o))
   -- ^ Transfer function in mealy machine form: @state -> input -> (newstate,output)@
   -> s
@@ -111,9 +113,8 @@ mealy = hideClockReset E.mealy
 --     (i2,b2) = 'mealyB' f 3 (i1,c)
 -- @
 mealyB
-  :: HiddenClockReset domain gated synchronous
-  => Bundle i
-  => Bundle o
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined s, Bundle i, Bundle o )
   => (s -> i -> (s,o))
   -- ^ Transfer function in mealy machine form: @state -> input -> (newstate,output)@
   -> s
@@ -126,9 +127,8 @@ mealyB = hideClockReset E.mealyB
 
 -- | Infix version of 'mealyB'
 (<^>)
-  :: HiddenClockReset domain gated synchronous
-  => Bundle i
-  => Bundle o
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined s, Bundle i, Bundle o )
   => (s -> i -> (s,o))
   -- ^ Transfer function in mealy machine form: @state -> input -> (newstate,output)@
   -> s

--- a/clash-prelude/src/Clash/Prelude/Moore.hs
+++ b/clash-prelude/src/Clash/Prelude/Moore.hs
@@ -26,6 +26,7 @@ where
 
 import qualified Clash.Explicit.Moore as E
 import           Clash.Signal
+import           Clash.XException                     (Undefined)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -70,7 +71,8 @@ let macT s (x,y) = x * y + s
 --     s2 = 'moore' mac id 0 ('Clash.Signal.bundle' (b,y))
 -- @
 moore
-  :: HiddenClockReset domain gated synchronous
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined s )
   => (s -> i -> s) -- ^ Transfer function in moore machine form:
                    -- @state -> input -> newstate@
   -> (s -> o)      -- ^ Output function in moore machine form:
@@ -86,7 +88,8 @@ moore = hideClockReset E.moore
 -- | Create a synchronous function from a combinational function describing
 -- a moore machine without any output logic
 medvedev
-  :: HiddenClockReset domain gated synchronous
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined s )
   => (s -> i -> s)
   -> s
   -> (Signal domain i -> Signal domain s)
@@ -121,9 +124,10 @@ medvedev tr st = moore tr id st
 --     (i2,b2) = 'mooreB' t o 3 (i1,c)
 -- @
 mooreB
-  :: HiddenClockReset domain gated synchronous
-  => Bundle i
-  => Bundle o
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined s
+     , Bundle i
+     , Bundle o )
   => (s -> i -> s) -- ^ Transfer function in moore machine form:
                    -- @state -> input -> newstate@
   -> (s -> o)      -- ^ Output function in moore machine form:
@@ -137,9 +141,10 @@ mooreB = hideClockReset E.mooreB
 
 -- | A version of 'medvedev' that does automatic 'Bundle'ing
 medvedevB
-  :: HiddenClockReset domain gated synchronous
-  => Bundle i
-  => Bundle s
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined s
+     , Bundle i
+     , Bundle s )
   => (s -> i -> s)
   -> s
   -> (Unbundled domain i -> Unbundled domain s)

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -184,7 +184,9 @@ It instead exports the identically named functions defined in terms of
 -- [(8,8),(1,1),(2,2),(3,3)...
 -- ...
 registerB
-  :: (Bundle a, HiddenClockReset domain gated synchronous)
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined a
+     , Bundle a )
   => a
   -> Unbundled domain a
   -> Unbundled domain a
@@ -194,7 +196,10 @@ infixr 3 `registerB`
 
 -- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
 isRising
-  :: (Bounded a, Eq a, HiddenClockReset domain gated synchronous)
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined a
+     , Bounded a
+     , Eq a )
   => a -- ^ Starting value
   -> Signal domain a
   -> Signal domain Bool
@@ -203,7 +208,10 @@ isRising = hideClockReset E.isRising
 
 -- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
 isFalling
-  :: (Bounded a, Eq a, HiddenClockReset domain gated synchronous)
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined a
+     , Bounded a
+     , Eq a )
   => a -- ^ Starting value
   -> Signal domain a
   -> Signal domain Bool

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -473,7 +473,8 @@ withClockReset = \clk rst f -> expose @"rst" (expose @"clk" f clk) rst
 -- >>> sampleN 3 (delay 0 (fromList [1,2,3,4]))
 -- [0,1,2]
 delay
-  :: HiddenClock domain gated
+  :: ( Undefined a
+     , HiddenClock domain gated )
   => a
   -- ^ Default value
   -> Signal domain a
@@ -490,7 +491,8 @@ delay dflt i =
 -- >>> sampleN 7 (delayMaybe 0 input)
 -- [0,1,2,2,2,5,6]
 delayMaybe
-  :: HiddenClock domain gated
+  :: ( Undefined a
+     , HiddenClock domain gated )
   => a
   -- ^ Initial value
   -> Signal domain (Maybe a)
@@ -506,7 +508,8 @@ delayMaybe dflt i =
 -- >>> sampleN 7 (delayEn 0 enable input)
 -- [0,1,2,2,2,5,6]
 delayEn
-  :: HiddenClock domain gated
+  :: ( Undefined a
+     , HiddenClock domain gated )
   => a
   -- ^ Initial value
   -> Signal domain Bool
@@ -523,7 +526,8 @@ delayEn dflt en i =
 -- >>> sampleN 5 (register 8 (fromList [1,1,2,3,4]))
 -- [8,8,1,2,3]
 register
-  :: HiddenClockReset domain gated synchronous
+  :: ( Undefined a
+     , HiddenClockReset domain gated synchronous )
   => a
   -- ^ Reset value
   --
@@ -558,7 +562,8 @@ infixr 3 `register`
 -- >>> sampleN 9 countSometimes
 -- [0,0,0,1,1,2,2,3,3]
 regMaybe
-  :: HiddenClockReset domain gated synchronous
+  :: ( Undefined a
+     , HiddenClockReset domain gated synchronous )
   => a
   -- ^ Reset value
   --
@@ -586,7 +591,8 @@ infixr 3 `regMaybe`
 -- >>> sampleN 9 count
 -- [0,0,0,1,1,2,2,3,3]
 regEn
-  :: HiddenClockReset domain gated synchronous
+  :: ( Undefined a
+     , HiddenClockReset domain gated synchronous )
   => a
   -- ^ Reset value
   --

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -54,11 +54,12 @@ import Clash.Signal.Delayed.Internal
   (DSignal(..), dfromList, dfromList_lazy, fromSignal, toSignal,
    unsafeFromSignal, antiDelay, feedback)
 import qualified Clash.Explicit.Signal.Delayed as E
-import            Clash.Sized.Vector           (Vec, dtfold)
-import            Clash.Signal
+import           Clash.Sized.Vector            (Vec, dtfold)
+import           Clash.Signal
   (HiddenClockReset, hideClockReset, Signal, delay, Domain(..))
 
-import Clash.Promoted.Nat         (SNat (..), snatToInteger)
+import           Clash.Promoted.Nat            (SNat (..), snatToInteger)
+import           Clash.XException              (Undefined)
 
 {- $setup
 >>> :set -XDataKinds -XTypeOperators -XTypeApplications -XFlexibleContexts
@@ -83,8 +84,10 @@ import Clash.Promoted.Nat         (SNat (..), snatToInteger)
 -- >>> sampleN 7 (toSignal (delay3 (dfromList [0..])))
 -- [-1,-1,-1,-1,1,2,3]
 delayed
-  :: HiddenClockReset domain gated synchronous
-  => KnownNat d
+  :: ( KnownNat d
+     , HiddenClockReset domain gated synchronous
+     , Undefined a
+     )
   => Vec d a
   -> DSignal domain n a
   -> DSignal domain (n + d) a
@@ -108,11 +111,13 @@ delayed = hideClockReset E.delayed
 --
 -- >>> :t delayedI @3
 -- delayedI @3
---   :: (...) =>
+--   :: (...
+--       ...) =>
 --      a -> DSignal domain n a -> DSignal domain (n + 3) a
 delayedI
-  :: KnownNat d
-  => HiddenClockReset domain gated synchronous
+  :: ( KnownNat d
+     , Undefined a
+     , HiddenClockReset domain gated synchronous )
   => a
   -- ^ Default value
   -> DSignal domain n a
@@ -134,7 +139,8 @@ delayedI = hideClockReset E.delayedI
 -- [-1,-1,1,2,3,4]
 delayN
   :: forall domain gated synchronous a d n
-   . HiddenClockReset domain gated synchronous
+   . ( HiddenClockReset domain gated synchronous
+     , Undefined a )
   => SNat d
   -> a
   -- ^ Default value
@@ -165,8 +171,9 @@ delayN d dflt = coerce . go (snatToInteger d) . coerce @_ @(Signal domain a)
 -- [-1,-1,1,2,3,4]
 delayI
   :: forall d n a domain gated synchronous
-   . HiddenClockReset domain gated synchronous
-  => KnownNat d
+   . ( HiddenClockReset domain gated synchronous
+     , Undefined a
+     , KnownNat d )
   => a
   -- ^ Default value
   -> DSignal domain n a
@@ -192,9 +199,10 @@ type instance Apply (DelayedFold domain n delay a) k = DSignal domain (n + (dela
 -- [-1,-1,1,1,0,1,16,81]
 delayedFold
   :: forall domain gated synchronous n delay k a
-   . HiddenClockReset domain gated synchronous
-  => KnownNat delay
-  => KnownNat k
+   . ( HiddenClockReset domain gated synchronous
+     , Undefined a
+     , KnownNat delay
+     , KnownNat k )
   => SNat delay
   -- ^ Delay applied after each step
   -> a

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -102,7 +102,7 @@ import Test.QuickCheck            (Arbitrary (..), CoArbitrary(..), Property,
 
 import Clash.Promoted.Nat         (SNat (..), snatToInteger, snatToNum)
 import Clash.Promoted.Symbol      (SSymbol (..))
-import Clash.XException           (Undefined, errorX, seqX, deepseqX)
+import Clash.XException           (Undefined, errorX, deepseqX, defaultSeqX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -582,7 +582,7 @@ delay# (GatedClock _ _ en) dflt =
     go o (e :- es) as@(~(x :- xs)) =
       let o' = if e then x else o
       -- See [Note: register strictness annotations]
-      in  o `seqX` o :- (as `seq` go o' es xs)
+      in  o `defaultSeqX` o :- (as `seq` go o' es xs)
 {-# NOINLINE delay# #-}
 
 -- | A register with a power up and reset value. Power up values are not
@@ -612,7 +612,7 @@ register# Clock {} (Sync rst) powerUpVal resetVal =
     go o rt@(~(r :- rs)) as@(~(x :- xs)) =
       let o' = if r then resetVal else x
           -- [Note: register strictness annotations]
-      in  o `seqX` o :- (rt `seq` as `seq` go o' rs xs)
+      in  o `defaultSeqX` o :- (rt `seq` as `seq` go o' rs xs)
 
 register# Clock {} (Async rst) powerUpVal resetVal =
     go powerUpVal rst
@@ -621,7 +621,7 @@ register# Clock {} (Async rst) powerUpVal resetVal =
       let o1 = if r then resetVal else o0
           oN = if r then resetVal else x
           -- [Note: register strictness annotations]
-      in  o1 `seqX` o1 :- (as `seq` go oN rs xs)
+      in  o1 `defaultSeqX` o1 :- (as `seq` go oN rs xs)
 
 register# (GatedClock _ _ ena) (Sync rst) powerUpVal resetVal =
     go powerUpVal rst ena
@@ -630,7 +630,7 @@ register# (GatedClock _ _ ena) (Sync rst) powerUpVal resetVal =
       let oE = if e then x else o
           oR = if r then resetVal else oE
           -- [Note: register strictness annotations]
-      in  o `seqX` o :- (rt `seq` enas `seq` as `seq` go oR rs es xs)
+      in  o `defaultSeqX` o :- (rt `seq` enas `seq` as `seq` go oR rs es xs)
 
 register# (GatedClock _ _ ena) (Async rst) powerUpVal resetVal =
     go powerUpVal rst ena
@@ -639,7 +639,7 @@ register# (GatedClock _ _ ena) (Async rst) powerUpVal resetVal =
       let oR = if r then resetVal else o
           oE = if r then resetVal else (if e then x else o)
           -- [Note: register strictness annotations]
-      in  oR `seqX` oR :- (as `seq` enas `seq` go oE rs es xs)
+      in  oR `defaultSeqX` oR :- (as `seq` enas `seq` go oE rs es xs)
 {-# NOINLINE register# #-}
 
 -- | The above type is a generalisation for:

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -568,7 +568,8 @@ infixr 3 .&&.
 -- need to 'seq' it explicitly.
 
 delay#
-  :: Clock  domain gated
+  :: Undefined a
+  => Clock  domain gated
   -> a
   -> Signal domain a
   -> Signal domain a
@@ -596,7 +597,8 @@ delay# (GatedClock _ _ en) dflt =
 -- the Intel tooling __will ignore the power up value__ and use the reset value
 -- instead.
 register#
-  :: Clock domain gated
+  :: Undefined a
+  => Clock domain gated
   -> Reset domain synchronous
   -> a
   -- ^ Power up value

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -1091,7 +1091,7 @@ import           GHC.Stack             (HasCallStack, withFrozenCallStack)
 import Clash.Signal.Internal
   (Clock, Signal (..), (.&&.), clockEnable)
 import Clash.Sized.Vector     (Vec, toList)
-import Clash.XException       (errorX, seqX)
+import Clash.XException       (errorX, defaultSeqX)
 
 -- | blockRAM primitive
 blockRam#
@@ -1122,12 +1122,12 @@ blockRam# clk content rd wen = case 'Clash.Signal.Internal.clockEnable' clk of
     go !ram o (r :- rs) (e :- en) (w :- wr) (d :- din) =
       let ram' = upd ram e w d
           o'   = ram V.! r
-      in  o ``seqX`` o :- go ram' o' rs en wr din
+      in  o ``defaultSeqX`` o :- go ram' o' rs en wr din
     -- clock enable
     go' !ram o (re :- res) (r :- rs) (e :- en) (w :- wr) (d :- din) =
       let ram' = upd ram e w d
           o'   = if re then ram V.! r else o
-      in  o ``seqX`` o :- go' ram' o' res rs en wr din
+      in  o ``defaultSeqX`` o :- go' ram' o' res rs en wr din
 
     upd ram True  addr d = ram V.// [(addr,d)]
     upd ram False _    _ = ram

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -15,6 +15,7 @@ CallStack (from HasCallStack):
 "(X,4)"
 -}
 
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE EmptyCase             #-}
@@ -37,8 +38,8 @@ module Clash.XException
     -- * Printing 'X' exceptions as \"X\"
   , ShowX (..), showsX, printX, showsPrecXWith
     -- * Strict evaluation
-  , seqX, forceX, deepseqX, rwhnfX
-    -- * Structured undefined
+  , seqX, forceX, deepseqX, rwhnfX, defaultSeqX
+    -- * Structured undefined / deep evaluation with undefined values
   , Undefined (rnfX, deepErrorX)
   )
 where
@@ -68,6 +69,17 @@ instance Show XException where
   show (XException s) = s
 
 instance Exception XException
+
+-- | Either 'seqX' or 'deepSeqX' depending on the value of the cabal flag
+-- '-fsuper-strict'. If enabled, 'defaultSeqX' will be 'deepseqX', otherwise
+-- 'seqX'. Flag defaults to /false/ and thus 'seqX'.
+defaultSeqX :: Undefined a => a -> b -> b
+#ifdef CLASH_SUPER_STRICT
+defaultSeqX = deepseqX
+#else
+defaultSeqX = seqX
+#endif
+{-# INLINE defaultSeqX #-}
 
 -- | Like 'error', but throwing an 'XException' instead of an 'ErrorCall'
 --

--- a/examples/CHIP8.hs
+++ b/examples/CHIP8.hs
@@ -23,8 +23,12 @@ topEntity = exposeClockReset output
     cpuOut = mealyState (runCPU defaultOut cpu) initState cpuIn
     output = boolToBit . (== 0x00) . cpuOutMemAddr <$> cpuOut
 
-mealyState :: (HiddenClockReset domain gated synchronous)
-           => (i -> State s o) -> s -> (Signal domain i -> Signal domain o)
+mealyState
+  :: ( HiddenClockReset domain gated synchronous
+     , Undefined s )
+  => (i -> State s o)
+  -> s
+  -> (Signal domain i -> Signal domain o)
 mealyState f = mealy $ \s x -> let (y, s') = runState (f x) s in (s', y)
 
 data Phase

--- a/examples/FIR.hs
+++ b/examples/FIR.hs
@@ -10,7 +10,11 @@ dotp :: SaturatingNum a
 dotp as bs = fold boundedAdd (zipWith boundedMul as bs)
 
 fir
-  :: (Default a, KnownNat n, SaturatingNum a, HiddenClockReset domain gated synchronous)
+  :: ( HiddenClockReset domain gated synchronous
+     , Default a
+     , KnownNat n
+     , SaturatingNum a
+     , Undefined a )
   => Vec (n + 1) a -> Signal domain a -> Signal domain a
 fir coeffs x_t = y_t
   where

--- a/tests/shouldwork/Vector/MovingAvg.hs
+++ b/tests/shouldwork/Vector/MovingAvg.hs
@@ -3,7 +3,10 @@ module MovingAvg where
 import Clash.Prelude
 
 windowN
-  :: (Default a, KnownNat n, HiddenClockReset domain gated synchronous)
+  :: HiddenClockReset domain gated synchronous
+  => Default a
+  => KnownNat n
+  => Undefined a
   => SNat (n+1)
   -> Signal domain a
   -> Vec (n + 1) (Signal domain a)


### PR DESCRIPTION
Enabling this makes Clash use `deepseqX` in register-like primitives,
instead of `seqX`. This can help to fight space leaks.