### PR TITLE
Fix unittests bounds on doctest

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -267,7 +267,7 @@ test-suite unittests
       clash-prelude,
 
       base          >= 4        && < 5,
-      doctest       >= 0.9.1    && < 0.16,
+      doctest       >= 0.9.1    && < 0.17,
       tasty         >= 1.2      && < 1.3,
       tasty-hunit
 


### PR DESCRIPTION
This was already done in the `doctests` test-suite, but not the `unittest` one.

Signed-off-by: Austin Seipp <aseipp@pobox.com>