### PR TITLE
Pretty-printer: Annotations

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -198,6 +198,7 @@ Library
                       Clash.Unique
                       Clash.Util
                       Clash.Util.Graph
+                      Clash.Pretty
 
                       Data.Text.Prettyprint.Doc.Extra
 

--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -42,6 +42,7 @@ import           Clash.Driver.Types                      (BindingMap)
 import           Prelude                                 hiding (lookup)
 import           Clash.Unique
 import           Clash.Util                              (curLoc)
+import           Clash.Pretty
 
 -- | The heap
 data Heap = Heap GlobalHeap PureHeap Supply InScopeSet
@@ -62,17 +63,18 @@ data StackFrame
   | Scrutinise Type [Alt]
   deriving Show
 
-instance Pretty StackFrame where
-  pretty (Update i) = hsep ["Update", ppr i]
-  pretty (Apply i) = hsep ["Apply", ppr i]
-  pretty (Instantiate t) = hsep ["Instantiate", ppr t]
-  pretty (PrimApply a b c d e) = do
-    hsep ["PrimApply", pretty a, "::", ppr b,
-          "; type args=", ppr c,
-          "; val args=", ppr (map valToTerm d),
-          "term args=", ppr e]
-  pretty (Scrutinise a b) =
-    hsep ["Scrutinise ", ppr a, ppr (Case (Literal (CharLiteral '_')) a b)]
+instance ClashPretty StackFrame where
+  clashPretty (Update i) = hsep ["Update", fromPpr i]
+  clashPretty (Apply i) = hsep ["Apply", fromPpr i]
+  clashPretty (Instantiate t) = hsep ["Instantiate", fromPpr t]
+  clashPretty (PrimApply a b c d e) = do
+    hsep ["PrimApply", fromPretty a, "::", fromPpr b,
+          "; type args=", fromPpr c,
+          "; val args=", fromPpr (map valToTerm d),
+          "term args=", fromPpr e]
+  clashPretty (Scrutinise a b) =
+    hsep ["Scrutinise ", fromPpr a,
+          fromPpr (Case (Literal (CharLiteral '_')) a b)]
 
 -- Values
 data Value
@@ -170,13 +172,13 @@ unwindStack (h@(Heap _ h' _ _),(kf:k'),e) = case kf of
                        $ [ "Clash.Core.Evaluator.unwindStack:"
                          , "Stack:"
                          ] ++
-                         [ "  "++ showDoc (pretty frame) | frame <- kf:k'] ++
+                         [ "  "++ showDoc (clashPretty frame) | frame <- kf:k'] ++
                          [ ""
                          , "Expression:"
-                         , showDoc $ ppr e
+                         , showPpr e
                          , ""
                          , "Heap:"
-                         , showDoc (pretty h')
+                         , showDoc (clashPretty h')
                          ]
   Scrutinise _ [] ->
     unwindStack (h,k',e)

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -11,17 +11,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE LambdaCase        #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Clash.Core.Pretty
   ( PrettyPrec (..)
-  , PrettyOptions (..), defPrettyOptions
+  , PrettyOptions (..)
+  , ClashAnnotation (..)
+  , SyntaxElement (..)
   , ppr, ppr'
-  , showDoc
   , showPpr, showPpr'
   , tracePprId
   , tracePpr
+  , fromPpr
   )
 where
 
@@ -30,7 +33,7 @@ import Data.Text                        (Text)
 import Control.Monad.Identity
 import qualified Data.Text              as T
 import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.String
+import Data.Text.Prettyprint.Doc.Internal
 import Debug.Trace                      (trace)
 import GHC.Show                         (showMultiLineString)
 import Numeric                          (fromRat)
@@ -38,34 +41,80 @@ import Numeric                          (fromRat)
 import Clash.Core.DataCon               (DataCon (..))
 import Clash.Core.Literal               (Literal (..))
 import Clash.Core.Name                  (Name (..))
-import Clash.Core.Term                  (Pat (..), Term (..))
+import Clash.Core.Term                  (Pat (..), Term (..), CoreContext (..), primArg)
 import Clash.Core.TyCon                 (TyCon (..), TyConName, isTupleTyConLike)
 import Clash.Core.Type                  (ConstTy (..), Kind, LitTy (..),
                                          Type (..), TypeView (..), tyView)
 import Clash.Core.Var                   (Id, TyVar, Var (..))
 import Clash.Util
+import Clash.Pretty
+
+-- | Options for the pretty-printer, controlling which elements to hide.
+data PrettyOptions = PrettyOptions
+  { displayUniques    :: Bool
+  -- ^ whether to display unique identifiers
+  , displayTypes      :: Bool
+  -- ^ whether to display type information
+  , displayQualifiers :: Bool
+  -- ^ whether to display module qualifiers
+  }
+
+-- | Annotations carried on pretty-printed code.
+data ClashAnnotation
+  = AnnContext CoreContext
+  -- ^ marking navigation to a different context
+  | AnnSyntax  SyntaxElement
+  -- ^ marking a specific sort of syntax
+  deriving Eq
+
+-- | Specific places in the program syntax.
+data SyntaxElement = Keyword | LitS | Type | Unique | Qualifier
+  deriving (Eq, Show)
+
+-- | Clash's specialized @Doc@ type holds metadata of type @ClashAnnotation@.
+type ClashDoc = Doc ClashAnnotation
 
 -- | PrettyPrec printing Show-like typeclass
 class PrettyPrec p where
-  pprPrec :: Monad m => PrettyOptions -> Rational -> p -> m (Doc ann)
 
-data PrettyOptions = PrettyOptions
-  { displayUniques    :: Bool
-  , displayTypes      :: Bool
-  , displayQualifiers :: Bool
-  }
+  -- default pretty-printing without hiding
+  pprPrec :: Monad m => Rational -> p -> m ClashDoc
 
-defPrettyOptions :: PrettyOptions
-defPrettyOptions = PrettyOptions True True True
+  -- pretty-printing with hiding options
+  -- NB: we utilise the syntax annotations to hide the requested parts of syntax
+  pprPrec' :: Monad m => PrettyOptions -> Rational -> p -> m ClashDoc
+  pprPrec' opts p = fmap hide . pprPrec p
+    where
+      hide = \case
+        FlatAlt d d'         -> FlatAlt (hide d) (hide d')
+        Cat d d'             -> Cat (hide d) (hide d')
+        Nest i d             -> Nest i (hide d)
+        Union d d'           -> Union (hide d) (hide d')
+        Column f             -> Column (hide . f)
+        WithPageWidth f      -> WithPageWidth (hide . f)
+        Nesting f            -> Nesting (hide . f)
+        Annotated ann d'     ->
+          if not (displayTypes opts)      && ann == AnnSyntax Type
+          || not (displayUniques opts)    && ann == AnnSyntax Unique
+          || not (displayQualifiers opts) && ann == AnnSyntax Qualifier
+            then Empty
+            else Annotated ann (hide d')
+        d -> d
 
-pprM :: (Monad m, PrettyPrec p) => PrettyOptions -> p -> m (Doc ann)
-pprM opts = pprPrec opts 0
+pprM :: (Monad m, PrettyPrec p) => p -> m ClashDoc
+pprM = pprPrec 0
 
-ppr :: PrettyPrec p => p -> Doc ann
-ppr = runIdentity . pprM defPrettyOptions
+pprM' :: (Monad m, PrettyPrec p) => PrettyOptions -> p -> m ClashDoc
+pprM' opts = pprPrec' opts 0
 
-ppr' :: PrettyPrec p => PrettyOptions -> p -> Doc ann
-ppr' opts = runIdentity . pprM opts
+ppr :: PrettyPrec p => p -> ClashDoc
+ppr = runIdentity . pprM
+
+ppr' :: PrettyPrec p => PrettyOptions -> p -> ClashDoc
+ppr' opts = runIdentity . pprM' opts
+
+fromPpr :: PrettyPrec a => a -> Doc ()
+fromPpr = removeAnnotations . ppr
 
 noPrec, opPrec, appPrec :: Num a => a
 noPrec = 0
@@ -73,9 +122,6 @@ opPrec = 1
 appPrec = 2
 
 -- | Print a PrettyPrec thing to a String
-showDoc :: Doc ann -> String
-showDoc = renderString . layoutPretty (LayoutOptions (AvailablePerLine 80 0.6))
-
 showPpr :: PrettyPrec p => p -> String
 showPpr = showDoc . ppr
 
@@ -88,328 +134,304 @@ tracePprId p = trace (showPpr p) p
 tracePpr :: PrettyPrec p => p -> a -> a
 tracePpr p a = trace (showPpr p) a
 
-prettyParen :: Bool -> Doc ann -> Doc ann
-prettyParen False = id
-prettyParen True  = parens
+parensIf :: Bool -> ClashDoc -> ClashDoc
+parensIf False = id
+parensIf True  = parens
 
-removeQualifiers :: PrettyOptions -> Text -> Text
-removeQualifiers opts | displayQualifiers opts = id
-                      | otherwise              = snd . T.breakOnEnd "."
+tyParens :: ClashDoc -> ClashDoc
+tyParens = enclose (annotate (AnnSyntax Type) lparen)
+                   (annotate (AnnSyntax Type) rparen)
 
-nameOcc' :: PrettyOptions -> Name a -> Text
-nameOcc' opts = removeQualifiers opts . nameOcc
+tyParensIf :: Bool -> ClashDoc -> ClashDoc
+tyParensIf False = id
+tyParensIf True  = tyParens
+
+vsepHard :: [ClashDoc] -> ClashDoc
+vsepHard = concatWith (\x y -> x <> hardline <> y)
+
+viewName :: Name a -> (Text, Text, Text)
+viewName n = (qual, occ, T.pack $ show $ nameUniq n)
+  where (qual, occ) = T.breakOnEnd "." $ nameOcc n
 
 instance PrettyPrec (Name a) where
-  pprPrec opts p n
-    | displayUniques opts
-    = pprPrec opts p (nameOcc' opts n `T.append` T.pack (show (nameUniq n)))
-    | otherwise
-    = pprPrec opts p (nameOcc' opts n)
+  pprPrec p (viewName -> (qual, occ, uniq)) = do
+    qual' <- annotate (AnnSyntax Qualifier) <$> pprPrec p qual
+    occ'  <- pprPrec p occ
+    uniq' <- annotate (AnnSyntax Unique) <$> pprPrec p uniq
+    return $ qual' <> occ' <> uniq'
+
+instance ClashPretty (Name a) where
+  clashPretty = fromPpr
 
 instance PrettyPrec a => PrettyPrec [a] where
-  pprPrec opts prec xs = do
-    xs' <- mapM (pprPrec opts prec) xs
-    return $ vcat xs'
+  pprPrec prec = fmap vcat . mapM (pprPrec prec)
 
 instance PrettyPrec (Id, Term) where
-  pprPrec opts _ = pprTopLevelBndr opts
+  pprPrec _ = pprTopLevelBndr
 
-pprTopLevelBndr :: Monad m => PrettyOptions -> (Id,Term) -> m (Doc ann)
-pprTopLevelBndr opts (bndr,expr) = do
-  bndr' <- pprM opts bndr
-  bndrName <- pprM opts (varName bndr)
-  expr' <- pprM opts expr
+pprTopLevelBndr :: Monad m => (Id,Term) -> m ClashDoc
+pprTopLevelBndr (bndr,expr) = do
+  bndr'    <- pprM bndr
+  bndrName <- pprM (varName bndr)
+  expr'    <- pprM expr
   return $ bndr' <> line <> hang 2 (sep [(bndrName <+> equals), expr']) <> line
 
-dcolon :: (Doc ann)
-dcolon = "::"
-
-rarrow :: (Doc ann)
-rarrow = "->"
+dcolon, rarrow, lam, tylam, at, cast, coerce, letrec, in_, case_, of_, forall_
+  :: ClashDoc
+[dcolon, rarrow, lam, tylam, at, cast, coerce, letrec, in_, case_, of_, forall_]
+  = annotate (AnnSyntax Keyword) <$>
+    ["::", "->", "λ", "Λ", "@", "▷", "~", "letrec", "in", "case", "of", "forall"]
 
 instance PrettyPrec Text where
-  pprPrec opts _ = pure . pretty . removeQualifiers opts
+  pprPrec _ = pure . pretty
 
 instance PrettyPrec Type where
-  pprPrec opts _ t | displayTypes opts = pprType opts t
-                   | otherwise         = pure emptyDoc
+  pprPrec _ t = annotate (AnnSyntax Type) <$> pprType t
 
-instance Pretty Type where
-  pretty = ppr
+instance ClashPretty Type where
+  clashPretty = fromPpr
 
 instance PrettyPrec TyCon where
-  pprPrec opts _ tc = pprM opts $ tyConName tc
+  pprPrec _ t = pprM (tyConName t)
+
+instance Pretty LitTy where
+  pretty (NumTy i) = pretty i
+  pretty (SymTy s) = dquotes $ pretty s
 
 instance PrettyPrec LitTy where
-  pprPrec _ _ (NumTy i) = return $ pretty i
-  pprPrec _ _ (SymTy s) = return $ dquotes $ pretty s
+  pprPrec _ = return . annotate (AnnSyntax LitS) . pretty
 
 instance PrettyPrec Term where
-  pprPrec opts prec e = case e of
-    Var x           -> pprPrec opts prec (varName x)
-    Data dc         -> pprPrec opts prec dc
-    Literal l       -> pprPrec opts prec l
-    Prim nm _       -> pprPrec opts prec nm
-    Lam v e1        -> pprPrecLam opts prec [v] e1
-    TyLam tv e1     -> pprPrecTyLam opts prec [tv] e1
-    App fun arg     -> pprPrecApp opts prec fun arg
-    TyApp e' ty     -> pprPrecTyApp opts prec e' ty
-    Letrec xes e1   -> pprPrecLetrec opts prec xes e1
-    Case e' _ alts  -> pprPrecCase opts prec e' alts
-    Cast e' ty1 ty2 -> pprPrecCast opts prec e' ty1 ty2
+  pprPrec prec e = case e of
+    Var x           -> pprPrec prec (varName x)
+    Data dc         -> pprPrec prec dc
+    Literal l       -> pprPrec prec l
+    Prim nm _       -> pprPrecPrim prec nm
+    Lam  v e1       -> annotate (AnnContext $ LamBody v) <$>
+                         pprPrecLam prec [v] e1
+    TyLam tv e1     -> annotate (AnnContext $ TyLamBody tv) <$>
+                         pprPrecTyLam prec [tv] e1
+    App fun arg     -> pprPrecApp prec fun arg
+    TyApp e' ty     -> annotate (AnnContext TyAppC) <$>
+                         pprPrecTyApp prec e' ty
+    Letrec xes e1   -> pprPrecLetrec prec xes e1
+    Case e' _ alts  -> pprPrecCase prec e' alts
+    Cast e' ty1 ty2 -> pprPrecCast prec e' ty1 ty2
 
-instance Pretty Term where
-  pretty = ppr
+instance ClashPretty Term where
+  clashPretty = fromPpr
 
-data BindingSite
-  = LambdaBind
-  | CaseBind
-  | LetBind
+data BindingSite = LambdaBind | CaseBind | LetBind
 
 instance PrettyPrec (Var a) where
-  pprPrec opts _ v@(TyVar {}) = pprM opts $ varName v
-  pprPrec opts _ v@(Id {})
-    | displayTypes opts
-    = do v'  <- pprM opts (varName v)
-         ty' <- pprM opts (varType v)
-         return $ v' <+> align (dcolon <+> ty')
-    | otherwise
-    = pprM opts (varName v)
+  pprPrec _ v@(TyVar {}) = pprM $ varName v
+  pprPrec _ v@(Id {})    = do
+    v'  <- pprM (varName v)
+    ty' <- pprM (varType v)
+    return $ v' <> (annotate (AnnSyntax Type) $ align (space <> dcolon <+> ty'))
 
-instance Pretty (Var a) where
-  pretty = ppr
+instance ClashPretty (Var a) where
+  clashPretty = fromPpr
 
 instance PrettyPrec DataCon where
-  pprPrec opts _ dc = pprM opts $ dcName dc
+  pprPrec _ = pprM . dcName
 
 instance PrettyPrec Literal where
-  pprPrec _ _ l = case l of
+  pprPrec _ l = return $ annotate (AnnSyntax LitS) $ case l of
     IntegerLiteral i
-      | i < 0         -> return $ parens (pretty i)
-      | otherwise     -> return $ pretty i
+      | i < 0          -> parens (pretty i)
+      | otherwise      -> pretty i
     IntLiteral i
-      | i < 0         -> return $ parens (pretty i)
-      | otherwise     -> return $ pretty i
+      | i < 0          -> parens (pretty i)
+      | otherwise      -> pretty i
     Int64Literal i
-      | i < 0         -> return $ parens (pretty i)
-      | otherwise     -> return $ pretty i
-    WordLiteral w     -> return $ pretty w
-    Word64Literal w   -> return $ pretty w
-    FloatLiteral r    -> return $ pretty (fromRat r :: Float)
-    DoubleLiteral r   -> return $ pretty (fromRat r :: Double)
-    CharLiteral c     -> return $ pretty c
-    StringLiteral s   -> return $ vcat $ map pretty $ showMultiLineString s
-    NaturalLiteral n  -> return $ pretty n
-    ByteArrayLiteral s -> return $ pretty $ show s
+      | i < 0          -> parens (pretty i)
+      | otherwise      -> pretty i
+    WordLiteral w      -> pretty w
+    Word64Literal w    -> pretty w
+    FloatLiteral r     -> pretty (fromRat r :: Float)
+    DoubleLiteral r    -> pretty (fromRat r :: Double)
+    CharLiteral c      -> pretty c
+    StringLiteral s    -> vcat $ map pretty $ showMultiLineString s
+    NaturalLiteral n   -> pretty n
+    ByteArrayLiteral s -> pretty $ show s
 
 instance PrettyPrec Pat where
-  pprPrec opts prec pat = case pat of
+  pprPrec prec pat = case pat of
     DataPat dc txs xs -> do
-      dc'  <- pprM opts dc
-      txs' <- mapM (pprBndr opts LetBind) txs
-      xs'  <- mapM (pprBndr opts CaseBind) xs
-      return $ prettyParen (prec >= appPrec) $ dc' <+> hsep txs' <> softline <> (nest 2 (vcat xs'))
-    LitPat l   -> pprM opts l
-    DefaultPat -> return $ pretty '_'
+      dc'  <- pprM dc
+      txs' <- mapM (pprBndr LetBind) txs
+      xs'  <- mapM (pprBndr CaseBind) xs
+      return $ parensIf (prec >= appPrec) $
+        sep [ hsep (dc':txs')
+            , nest 2 (sep xs') ]
+    LitPat l   -> pprM l
+    DefaultPat -> return "_"
 
-pprPrecLam :: Monad m => PrettyOptions -> Rational -> [Id] -> Term -> m (Doc ann)
-pprPrecLam opts prec xs e = do
-  xs' <- mapM (pprBndr opts LambdaBind) xs
-  e'  <- pprPrec opts noPrec e
-  return $ prettyParen (prec > noPrec) $
-    pretty 'λ' <> hsep xs' <+> rarrow <> line <> e'
+pprPrecPrim :: Monad m => Rational -> Text -> m ClashDoc
+pprPrecPrim prec nm =
+  (<>) <$> (annotate (AnnSyntax Qualifier) <$> pprPrec prec qual)
+       <*> pprPrec prec occ
+  where (qual, occ) = T.breakOnEnd "." nm
 
-pprPrecTyLam :: Monad m => PrettyOptions -> Rational -> [TyVar] -> Term -> m (Doc ann)
-pprPrecTyLam opts prec tvs e
-  | displayTypes opts
-  = do tvs' <- mapM (pprM opts) tvs
-       e'   <- pprPrec opts noPrec e
-       return $ prettyParen (prec > noPrec) $
-         pretty 'Λ' <> hsep tvs' <+> rarrow <> line <> e'
-  | otherwise
-  = pprPrec opts prec e
+pprPrecLam :: Monad m => Rational -> [Id] -> Term -> m ClashDoc
+pprPrecLam prec xs e = do
+  xs' <- mapM (pprBndr LambdaBind) xs
+  e'  <- pprPrec noPrec e
+  return $ parensIf (prec > noPrec) $
+    lam <> hsep xs' <+> rarrow <> line <> e'
 
-pprPrecApp :: Monad m => PrettyOptions -> Rational -> Term -> Term -> m (Doc ann)
-pprPrecApp opts prec e1 e2 = do
-  e1' <- pprPrec opts opPrec e1
-  e2' <- pprPrec opts appPrec e2
-  return $ prettyParen (prec >= appPrec) $
-    hang 2 (vsep [e1',e2'])
+pprPrecTyLam :: Monad m => Rational -> [TyVar] -> Term -> m ClashDoc
+pprPrecTyLam prec tvs e = do
+  tvs' <- mapM pprM tvs
+  e'   <- pprPrec noPrec e
+  return $ tyParensIf (prec > noPrec) $
+    annotate (AnnSyntax Type) (tylam <> hsep tvs' <+> rarrow <> line) <> e'
 
-pprPrecTyApp :: Monad m => PrettyOptions -> Rational -> Term -> Type -> m (Doc ann)
-pprPrecTyApp opts prec e ty
-  | displayTypes opts
-  = do e' <- pprPrec opts opPrec e
-       ty' <- pprParendType opts ty
-       return $ prettyParen (prec >= appPrec) $
-         hang 2 (sep [e', (pretty '@' <> ty')])
-  | otherwise
-  = pprPrec opts prec e
+pprPrecApp :: Monad m => Rational -> Term -> Term -> m ClashDoc
+pprPrecApp prec e1 e2 = do
+  e1' <- annotate (AnnContext AppFun) <$> pprPrec opPrec e1
+  e2' <- annotate (AnnContext $ AppArg $ primArg e2) <$> pprPrec appPrec e2
+  return $ parensIf (prec >= appPrec) $
+    hang 2 (sep [e1',e2'])
 
--- TODO use more conventional cast operator (|> or ▷) ?
-pprPrecCast :: Monad m => PrettyOptions -> Rational -> Term -> Type -> Type -> m (Doc ann)
-pprPrecCast opts prec e ty1 ty2
-  | displayTypes opts
-  = do e' <- pprPrec opts appPrec e
-       ty1' <- pprType opts ty1
-       ty2' <- pprType opts ty2
-       return $ prettyParen (prec >= appPrec) $
-         parens ("cast" <> softline <> nest 5 (vcat [dcolon <+> ty1', rarrow <+> ty2']))
-           <> softline <> nest 2 e'
-  | otherwise
-  = pprPrec opts prec e
+pprPrecTyApp :: Monad m => Rational -> Term -> Type -> m ClashDoc
+pprPrecTyApp prec e ty = do
+  e'  <- pprPrec opPrec e
+  ty' <- pprParendType ty
+  return $ tyParensIf (prec >= appPrec) $
+    hang 2 $ group $
+      e' <> annotate (AnnSyntax Type) (line <> at <> ty')
 
-pprPrecLetrec :: Monad m => PrettyOptions -> Rational -> [(Id, Term)] -> Term -> m (Doc ann)
-pprPrecLetrec opts prec xes body = do
-  body' <- pprPrec opts noPrec body
+pprPrecCast :: Monad m => Rational -> Term -> Type -> Type -> m ClashDoc
+pprPrecCast prec e ty1 ty2 = do
+  e'   <- annotate (AnnContext CastBody) <$> pprPrec appPrec e
+  ty1' <- pprType ty1
+  ty2' <- pprType ty2
+  return $ tyParensIf (prec >= appPrec) $
+    e' <> annotate (AnnSyntax Type)
+                   (softline <> nest 2 (vsep [cast, ty1', coerce, ty2']))
+
+pprPrecLetrec :: Monad m => Rational -> [(Id, Term)] -> Term -> m ClashDoc
+pprPrecLetrec prec xes body = do
+  let bndrs = fst <$> xes
+  body' <- annotate (AnnContext $ LetBody bndrs) <$> pprPrec noPrec body
   xes'  <- mapM (\(x,e) -> do
-                  x' <- pprBndr opts LetBind x
-                  e' <- pprPrec opts noPrec e
-                  return $ x' <> line <> equals <+> e'
+                  x' <- pprBndr LetBind x
+                  e' <- pprPrec noPrec e
+                  return $ annotate (AnnContext $ LetBinding x bndrs) $
+                    vsepHard [x', equals <+> e']
                 ) xes
-  let xes'' = case xes' of
-                [] -> ["EmptyLetrec"]
-                _  -> xes'
-  return $ prettyParen (prec > noPrec) $
-    hang 2 (vcat ("letrec":xes'')) <> line <> "in" <+> body'
+  let xes'' = case xes' of { [] -> ["EmptyLetrec"]; _  -> xes' }
+  return $ parensIf (prec > noPrec) $
+    vsepHard [hang 2 (vsepHard $ letrec : xes''), in_ <+> body']
 
-pprPrecCase :: Monad m => PrettyOptions -> Rational -> Term -> [(Pat,Term)] -> m (Doc ann)
-pprPrecCase opts prec e alts = do
-  e' <- pprPrec opts prec e
-  alts' <- mapM (pprPrecAlt opts noPrec) alts
-  return $ prettyParen (prec > noPrec) $
-    hang 2 (vcat (("case" <+> e' <+> "of"):alts'))
+pprPrecCase :: Monad m => Rational -> Term -> [(Pat,Term)] -> m ClashDoc
+pprPrecCase prec e alts = do
+  e'    <- annotate (AnnContext CaseScrut) <$> pprPrec prec e
+  alts' <- mapM (pprPrecAlt noPrec) alts
+  return $ parensIf (prec > noPrec) $
+    hang 2 $ vsepHard $ (case_ <+> e' <+> of_) : alts'
 
-pprPrecAlt :: Monad m => PrettyOptions -> Rational -> (Pat,Term) -> m (Doc ann)
-pprPrecAlt opts _ (altPat, altE) = do
-  altPat' <- pprPrec opts noPrec altPat
-  altE'   <- pprPrec opts noPrec altE
-  return $ hang 2 (vcat [(altPat' <+> rarrow), altE'])
+pprPrecAlt :: Monad m => Rational -> (Pat,Term) -> m ClashDoc
+pprPrecAlt _ (altPat, altE) = do
+  altPat' <- pprPrec noPrec altPat
+  altE'   <- pprPrec noPrec altE
+  return $ annotate (AnnContext $ CaseAlt altPat) $
+    hang 2 $ vsepHard [(altPat' <+> rarrow), altE']
 
-pprBndr :: (Monad m, PrettyPrec a) => PrettyOptions -> BindingSite -> a -> m (Doc ann)
-pprBndr opts bs x = prettyParen needsParen <$> pprM opts x
+pprBndr :: (Monad m, PrettyPrec a) => BindingSite -> a -> m ClashDoc
+pprBndr LetBind = pprM
+pprBndr _       = fmap tyParens . pprM
+
+data TypePrec = TopPrec | FunPrec | TyConPrec deriving (Eq,Ord)
+
+maybeParen :: TypePrec -> TypePrec -> ClashDoc -> ClashDoc
+maybeParen ctxt_prec inner_prec = parensIf (ctxt_prec >= inner_prec)
+
+pprType :: Monad m => Type -> m ClashDoc
+pprType = ppr_type TopPrec
+
+pprParendType :: Monad m => Type -> m ClashDoc
+pprParendType = ppr_type TyConPrec
+
+ppr_type :: Monad m => TypePrec -> Type -> m ClashDoc
+ppr_type _ (VarTy tv)                   = pprM tv
+ppr_type _ (LitTy tyLit)                = pprM tyLit
+ppr_type p ty@(ForAllTy {})             = pprForAllType p ty
+ppr_type p (ConstTy (TyCon tc))         = pprTcApp p ppr_type tc []
+ppr_type p (AnnType _ann typ)           = ppr_type p typ
+ppr_type p (tyView -> TyConApp tc args) = pprTcApp p ppr_type tc args
+ppr_type p (tyView -> FunTy ty1 ty2)
+  = pprArrowChain <$> ppr_type FunPrec ty1 <:> pprFunTail ty2
   where
-    needsParen = case bs of
-      LambdaBind -> displayTypes opts
-      CaseBind   -> True
-      LetBind    -> False
+    pprFunTail (tyView -> FunTy ty1' ty2')
+      = ppr_type FunPrec ty1' <:> pprFunTail ty2'
+    pprFunTail otherTy
+      = ppr_type TopPrec otherTy <:> pure []
 
-data TypePrec
-  = TopPrec
-  | FunPrec
-  | TyConPrec
-  deriving (Eq,Ord)
+    pprArrowChain []
+      = emptyDoc
+    pprArrowChain (arg:args)
+      = maybeParen p FunPrec $ sep [arg, sep (map (rarrow <+>) args)]
 
-maybeParen :: TypePrec -> TypePrec -> (Doc ann) -> (Doc ann)
-maybeParen ctxt_prec inner_prec = prettyParen (ctxt_prec >= inner_prec)
+ppr_type p (AppTy ty1 ty2) = maybeParen p TyConPrec <$> ((<+>) <$> pprType ty1
+                                                               <*> ppr_type TyConPrec ty2)
+ppr_type _ (ConstTy Arrow) = return (parens rarrow)
 
-pprType :: Monad m => PrettyOptions -> Type -> m (Doc ann)
-pprType opts = ppr_type opts TopPrec
+pprForAllType :: Monad m => TypePrec -> Type -> m ClashDoc
+pprForAllType p ty = maybeParen p FunPrec <$> pprSigmaType True ty
 
-pprParendType :: Monad m => PrettyOptions -> Type -> m (Doc ann)
-pprParendType opts = ppr_type opts TyConPrec
-
-ppr_type :: Monad m => PrettyOptions -> TypePrec -> Type -> m (Doc ann)
-ppr_type opts _ (VarTy tv)                   = pprM opts tv
-ppr_type opts _ (LitTy tyLit)                = pprM opts tyLit
-ppr_type opts p ty@(ForAllTy {})             = pprForAllType opts p ty
-ppr_type opts p (ConstTy (TyCon tc))         = pprTcApp opts p (ppr_type opts) tc []
-ppr_type opts p (AnnType _ann typ)           = ppr_type opts p typ
-ppr_type opts p (tyView -> TyConApp tc args) = pprTcApp opts p (ppr_type opts) tc args
-ppr_type opts p (tyView -> FunTy ty1 ty2)    = pprArrowChain p <$> ppr_type opts FunPrec ty1 <:> pprFunTail ty2
-  where
-    pprFunTail (tyView -> FunTy ty1' ty2') = ppr_type opts FunPrec ty1' <:> pprFunTail ty2'
-    pprFunTail otherTy                     = ppr_type opts TopPrec otherTy <:> pure []
-
-ppr_type opts p (AppTy ty1 ty2) = maybeParen p TyConPrec <$> ((<+>) <$> pprType opts ty1
-                                                                    <*> ppr_type opts TyConPrec ty2)
-ppr_type _    _ (ConstTy Arrow) = return (parens rarrow)
-
-pprForAllType :: Monad m => PrettyOptions -> TypePrec -> Type -> m (Doc ann)
-pprForAllType opts p ty = maybeParen p FunPrec <$> pprSigmaType opts True ty
-
-pprSigmaType :: Monad m => PrettyOptions -> Bool -> Type -> m (Doc ann)
-pprSigmaType opts showForalls ty = do
+pprSigmaType :: Monad m => Bool -> Type -> m ClashDoc
+pprSigmaType showForalls ty = do
     (tvs, rho)     <- split1 [] ty
-    sep <$> sequenceA [ if showForalls then pprForAll opts tvs else pure emptyDoc
-                      , pprType opts rho
+    sep <$> sequenceA [ if showForalls then pprForAll tvs else pure emptyDoc
+                      , pprType rho
                       ]
   where
     split1 tvs (ForAllTy tv resTy) = split1 (tv:tvs) resTy
     split1 tvs resTy               = return (reverse tvs,resTy)
 
-pprForAll :: Monad m => PrettyOptions -> [TyVar] -> m (Doc ann)
-pprForAll _    []  = return emptyDoc
-pprForAll opts tvs = do
-  tvs' <- mapM (pprTvBndr opts) tvs
-  return $ pretty '∀' <+> sep tvs' <> dot
+pprForAll :: Monad m => [TyVar] -> m ClashDoc
+pprForAll []  = return emptyDoc
+pprForAll tvs = do
+  tvs' <- mapM pprTvBndr tvs
+  return $ forall_ <+> sep tvs' <> dot
 
-pprTvBndr :: Monad m => PrettyOptions -> TyVar -> m (Doc ann)
-pprTvBndr opts tv
-  | displayTypes opts
-  = do tv'   <- pprM opts tv
-       kind' <- pprKind opts (varType tv)
-       return $ parens (tv' <+> dcolon <+> kind')
-  | otherwise
-  = pprM opts tv
+pprTvBndr :: Monad m => TyVar -> m ClashDoc
+pprTvBndr tv = do
+  tv'   <- pprM tv
+  kind' <- pprKind (varType tv)
+  return $ tyParens $ tv' <> (annotate (AnnSyntax Type) $ space <> dcolon <+> kind')
 
-pprKind :: Monad m => PrettyOptions -> Kind -> m (Doc ann)
-pprKind opts = pprType opts
+pprKind :: Monad m => Kind -> m ClashDoc
+pprKind = pprType
 
-pprTcApp :: Monad m => PrettyOptions -> TypePrec -> (TypePrec -> Type -> m (Doc ann))
-  -> TyConName -> [Type] -> m (Doc ann)
-pprTcApp opts _ _  tc []
-  = return . pretty $ nameOcc' opts tc
+pprTcApp :: Monad m => TypePrec -> (TypePrec -> Type -> m ClashDoc)
+  -> TyConName -> [Type] -> m ClashDoc
+pprTcApp p pp tc tys
+  | null tys
+  = pprM tc
 
-pprTcApp opts p pp tc tys
   | isTupleTyConLike tc
-  = do
-    tys' <- mapM (pp TopPrec) tys
-    return $ parens $ sep $ punctuate comma tys'
+  = do tys' <- mapM (pp TopPrec) tys
+       return $ parens $ sep $ punctuate comma tys'
 
-  | otherwise
-  = pprTypeNameApp opts p pp tc tys
-
-pprTypeNameApp :: Monad m => PrettyOptions -> TypePrec -> (TypePrec -> Type -> m (Doc ann))
-  -> Name a -> [Type] -> m (Doc ann)
-pprTypeNameApp opts p pp name tys
   | isSym
-  , [ty1,ty2] <- tys
-  = pprInfixApp opts p pp name ty1 ty2
+  , [ty1, ty2] <- tys
+  = do ty1' <- pp FunPrec ty1
+       ty2' <- pp FunPrec ty2
+       tc' <- pprM tc
+       return $ maybeParen p FunPrec $
+         sep [ty1', enclose "`" "`" tc' <+> ty2']
+
   | otherwise
-  = do
-    tys' <- mapM (pp TyConPrec) tys
-    let name' = pretty $ nameOcc' opts name
-    return $ pprPrefixApp p (pprPrefixVar isSym name') tys'
-  where
-    isSym = isSymName name
+  = do tys' <- mapM (pp TyConPrec) tys
+       tc' <- parensIf isSym <$> pprM tc
+       return $ maybeParen p TyConPrec $
+         hang 2 $ sep (tc':tys')
 
-pprInfixApp :: Monad m => PrettyOptions -> TypePrec -> (TypePrec -> Type -> m (Doc ann))
-  -> Name a -> Type -> Type -> m (Doc ann)
-pprInfixApp opts p pp name ty1 ty2 = do
-  ty1'  <- pp FunPrec ty1
-  ty2'  <- pp FunPrec ty2
-  let name' = pretty $ nameOcc' opts name
-  return $ maybeParen p FunPrec $ sep [ty1', pprInfixVar True name' <+> ty2']
-
-pprPrefixApp :: TypePrec -> (Doc ann) -> [(Doc ann)] -> (Doc ann)
-pprPrefixApp p pp_fun pp_tys = maybeParen p TyConPrec $
-                                 hang 2 (sep (pp_fun:pp_tys))
-
-pprPrefixVar :: Bool -> (Doc ann) -> (Doc ann)
-pprPrefixVar is_operator pp_v
-  | is_operator = parens pp_v
-  | otherwise   = pp_v
-
-pprInfixVar :: Bool -> (Doc ann) -> (Doc ann)
-pprInfixVar is_operator pp_v
-  | is_operator = pp_v
-  | otherwise   = pretty '`' <> pp_v <> pretty '`'
-
-pprArrowChain :: TypePrec -> [(Doc ann)] -> (Doc ann)
-pprArrowChain _ []         = emptyDoc
-pprArrowChain p (arg:args) = maybeParen p FunPrec $
-                               sep [arg, sep (map (rarrow <+>) args)]
+  where isSym = isSymName tc
 
 isSymName :: Name a -> Bool
 isSymName n = go (nameOcc n)
@@ -436,3 +458,4 @@ startsVarSym c = isSymbolASCII c || (ord c > 0x7f && isSymbol c)
 
 isSymbolASCII :: Char -> Bool
 isSymbolASCII c = c `elem` ("!#$%&*+./<=>?@\\^|~-" :: String)
+

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -96,10 +96,11 @@ import           Data.Text.Prettyprint.Doc
 import           GHC.Exts                  (Any)
 import           GHC.Generics
 
-import           Clash.Core.Pretty
+import           Clash.Core.Pretty         ()
 import           Clash.Core.Var
 import           Clash.Unique
 import           Clash.Util
+import           Clash.Pretty
 
 -- * VarEnv
 
@@ -323,8 +324,8 @@ mkVarSet xs = mkUniqSet (coerce xs)
 data InScopeSet = InScopeSet VarSet {-# UNPACK #-} !Int
   deriving (Generic, Binary)
 
-instance Pretty InScopeSet where
-  pretty (InScopeSet s _) = pretty s
+instance ClashPretty InScopeSet where
+  clashPretty (InScopeSet s _) = clashPretty s
 
 -- | The empty set
 extendInScopeSet
@@ -418,7 +419,7 @@ uniqAway' (InScopeSet set n) var = try 1 where
     | otherwise
     = setVarUnique var uniq
     where
-      msg  = pretty k <+> "tries" <+> ppr (varName var) <+> pretty n
+      msg  = fromPretty k <+> "tries" <+> clashPretty (varName var) <+> fromPretty n
       uniq = deriveUnique origUniq (n * k)
 
 deriveUnique

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -53,12 +53,12 @@ import           Clash.Core.Literal               (Literal (..))
 import           Clash.Core.Name                  (Name(..))
 import           Clash.Core.Pretty                (showPpr)
 import           Clash.Core.Term
-  (Alt, Pat (..), Term (..))
+  (Alt, Pat (..), Term (..), collectArgs)
 import qualified Clash.Core.Term                  as Core
 import           Clash.Core.Type
   (Type (..), coreView1, splitFunTys, splitCoreFunForallTy)
 import           Clash.Core.TyCon                 (TyConMap)
-import           Clash.Core.Util                  (collectArgs, termType)
+import           Clash.Core.Util                  (termType)
 import           Clash.Core.Var                   (Id, Var (..))
 import           Clash.Core.VarEnv
   (InScopeSet, VarEnv, eltsVarEnv, emptyVarEnv, extendVarEnv, lookupVarEnv, lookupVarEnv',

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -53,11 +53,11 @@ import           Clash.Core.Name
   (Name (..), mkUnsafeSystemName)
 import           Clash.Core.Pretty             (showPpr)
 import           Clash.Core.Subst              (extendIdSubst, mkSubst, substTm)
-import           Clash.Core.Term               as C (Term (..))
+import           Clash.Core.Term               as C (Term (..), collectArgs)
 import           Clash.Core.Type               as C (Type (..), ConstTy (..),
                                                 splitFunTys)
 import           Clash.Core.TyCon              as C (tyConDataCons)
-import           Clash.Core.Util               (collectArgs, isFun, termType)
+import           Clash.Core.Util               (isFun, termType)
 import           Clash.Core.Var                as V (Id, Var (..), mkId, modifyVarName)
 import           Clash.Core.VarEnv
   (extendInScopeSet, mkInScopeSet, lookupVarEnv, unionInScope, uniqAway, unitVarSet)

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -44,11 +44,11 @@ import           Clash.Core.FreeVars
   (termFreeIds, idDoesNotOccurIn, idOccursIn)
 import           Clash.Core.Pretty                (showPpr, ppr)
 import           Clash.Core.Subst                 (deShadowTerm, extendIdSubstList, mkSubst, substTm)
-import           Clash.Core.Term                  (Term (..))
+import           Clash.Core.Term                  (Term (..), collectArgs)
 import           Clash.Core.Type                  (Type, splitCoreFunForallTy)
 import           Clash.Core.TyCon
   (TyConMap, TyConName)
-import           Clash.Core.Util                  (collectArgs, mkApps, termType)
+import           Clash.Core.Util                  (mkApps, termType)
 import           Clash.Core.Var                   (Id, varName, varType)
 import           Clash.Core.VarEnv
   (VarEnv, elemVarSet, eltsVarEnv, emptyInScopeSet, emptyVarEnv,

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -61,10 +61,10 @@ import Clash.Core.Evaluator  (whnf')
 import Clash.Core.FreeVars
   (termFreeVars', typeFreeVars', varsDoNotOccurIn)
 import Clash.Core.Literal    (Literal (..))
-import Clash.Core.Term       (LetBinding, Pat (..), Term (..))
+import Clash.Core.Term       (LetBinding, Pat (..), Term (..), collectArgs)
 import Clash.Core.TyCon      (tyConDataCons)
 import Clash.Core.Type       (Type, isPolyFunTy, mkTyConApp, splitFunForallTy)
-import Clash.Core.Util       (collectArgs, mkApps, patIds, termType)
+import Clash.Core.Util       (mkApps, patIds, termType)
 import Clash.Core.VarEnv
   (InScopeSet, elemInScopeSet, notElemInScopeSet)
 import Clash.Normalize.Types (NormalizeState)

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -93,7 +93,9 @@ import           Clash.Core.Pretty           (showPpr)
 import           Clash.Core.Subst
   (substTm, mkSubst, extendIdSubst, extendIdSubstList, extendTvSubst,
    extendTvSubstList, freshenTm, substTyInVar, deShadowTerm)
-import           Clash.Core.Term             (LetBinding, Pat (..), Term (..))
+import           Clash.Core.Term
+  (LetBinding, Pat (..), Term (..), CoreContext (..), isLambdaBodyCtx,
+   collectArgs)
 import           Clash.Core.Type             (TypeView (..), applyFunTy,
                                               isPolyFunCoreTy,
                                               normalizeType,
@@ -101,7 +103,7 @@ import           Clash.Core.Type             (TypeView (..), applyFunTy,
                                               tyView, undefinedTy)
 import           Clash.Core.TyCon            (TyConMap, tyConDataCons)
 import           Clash.Core.Util
-  (collectArgs, isCon, isFun, isLet, isPolyFun, isPrim,
+  (isCon, isFun, isLet, isPolyFun, isPrim,
    isSignalType, isVar, mkApps, mkLams, mkVec, piResultTy, termSize, termType,
    tyNatSize, patVars, isAbsurdAlt, altEqs, substInExistentials,
    solveFirstNonAbsurd)

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -36,17 +36,18 @@ import           Data.Text               (Text)
 
 import           Clash.Annotations.Primitive (extractPrim)
 import           Clash.Core.FreeVars     (idOccursIn, termFreeIds)
-import           Clash.Core.Term         (Term (..))
+import           Clash.Core.Term
+  (Term (..), Context, CoreContext(AppArg), collectArgs)
 import           Clash.Core.TyCon        (TyConMap)
 import           Clash.Core.Var          (Id, Var (..))
 import           Clash.Core.VarEnv
 import           Clash.Core.Util
-  (collectArgs, isPolyFun, termType, isClockOrReset)
+  (isPolyFun, termType, isClockOrReset)
 import           Clash.Driver.Types      (BindingMap)
 import           Clash.Normalize.Types
 import           Clash.Primitives.Util   (constantArgs)
 import           Clash.Rewrite.Types
-  (bindings,extra,RewriteMonad,CoreContext(AppArg), tcCache, curFun)
+  (bindings,extra,RewriteMonad, tcCache, curFun)
 import           Clash.Rewrite.Util      (specialise, hasLocalFreeVars)
 import           Clash.Unique
 import           Clash.Util              (anyM)
@@ -84,7 +85,7 @@ isConstantArg nm i = do
 -- | Given a list of transformation contexts, determine if any of the contexts
 -- indicates that the current arg is to be reduced to a constant / literal.
 shouldReduce
-  :: [CoreContext]
+  :: Context
   -- ^ ..in the current transformcontext
   -> RewriteMonad NormalizeState Bool
 shouldReduce = anyM isConstantArg'

--- a/clash-lib/src/Clash/Pretty.hs
+++ b/clash-lib/src/Clash/Pretty.hs
@@ -1,0 +1,20 @@
+module Clash.Pretty where
+
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.String
+
+showDoc :: Doc ann -> String
+showDoc = renderString . layoutPretty (LayoutOptions (AvailablePerLine 80 0.6))
+
+removeAnnotations :: Doc ann -> Doc ()
+removeAnnotations = reAnnotate $ const ()
+
+-- | A variant of @Pretty@ that is not polymorphic on the type of annotations.
+-- This is needed to derive instances from Clash's pretty printer (PrettyPrec),
+-- which annotates documents with Clash-specific information and, therefore,
+-- fixes the type of annotations.
+class ClashPretty a where
+  clashPretty :: a -> Doc ()
+
+fromPretty :: Pretty a => a -> Doc ()
+fromPretty = removeAnnotations . pretty

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -51,7 +51,8 @@ import           Clash.Core.Pretty           (showPpr)
 import           Clash.Core.Subst
   (aeqTerm, aeqType, extendIdSubst, mkSubst, substTm)
 import           Clash.Core.Term
-  (LetBinding, Pat (..), Term (..), TmName)
+  (LetBinding, Pat (..), Term (..), CoreContext (..), Context, TmName,
+   collectArgs)
 import           Clash.Core.TyCon
   (TyConMap, tyConDataCons)
 import           Clash.Core.Type             (KindOrType, Type (..),
@@ -59,7 +60,7 @@ import           Clash.Core.Type             (KindOrType, Type (..),
                                               normalizeType,
                                               typeKind, tyView)
 import           Clash.Core.Util
-  (collectArgs, isPolyFun, mkAbstraction, mkApps, mkLams,
+  (isPolyFun, mkAbstraction, mkApps, mkLams,
    mkTmApps, mkTyApps, mkTyLams, termType, dataConInstArgTysE, isClockOrReset)
 import           Clash.Core.Var
   (Id, TyVar, Var (..), mkId, mkTyVar)
@@ -217,7 +218,7 @@ changed val = do
   Writer.tell (Monoid.Any True)
   return val
 
-closestLetBinder :: [CoreContext] -> Maybe Id
+closestLetBinder :: Context -> Maybe Id
 closestLetBinder [] = Nothing
 closestLetBinder (LetBinding id_ _:_) = Just id_
 closestLetBinder (_:ctx)              = closestLetBinder ctx
@@ -606,12 +607,6 @@ isUntranslatableType stringRepresentable ty =
                              <*> pure stringRepresentable
                              <*> Lens.view tcCache
                              <*> pure ty)
-
--- | Is the Context a Lambda/Term-abstraction context?
-isLambdaBodyCtx :: CoreContext
-                -> Bool
-isLambdaBodyCtx (LamBody _) = True
-isLambdaBodyCtx _           = False
 
 -- | Make a binder that should not be referenced
 mkWildValBinder

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -79,11 +79,12 @@ import           Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import qualified Data.List   as List
 import           Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.String
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
 #endif
 import           GHC.Stack
+
+import           Clash.Pretty
 
 type Unique = Int
 
@@ -97,15 +98,15 @@ instance Uniquable Int where
 newtype UniqMap a = UniqMap (IntMap a)
   deriving (Functor, Foldable, Traversable, Semigroup, Monoid, NFData, Binary)
 
-instance Pretty a => Pretty (UniqMap a) where
-  pretty (UniqMap env) =
+instance ClashPretty a => ClashPretty (UniqMap a) where
+  clashPretty (UniqMap env) =
     brackets $ fillSep $ punctuate comma $
-      [ pretty uq <+> ":->" <+> pretty elt
+      [ fromPretty uq <+> ":->" <+> clashPretty elt
       | (uq,elt) <- IntMap.toList env
       ]
 
-instance Pretty a => Show (UniqMap a) where
-  show = renderString . layoutPretty (LayoutOptions (AvailablePerLine 80 0.6)) . pretty
+instance ClashPretty a => Show (UniqMap a) where
+  show = showDoc . clashPretty
 
 -- | The empty map
 emptyUniqMap
@@ -297,9 +298,9 @@ foldrWithUnique f s (UniqMap m) = IntMap.foldrWithKey f s m
 newtype UniqSet a = UniqSet (IntMap a)
   deriving (Foldable, Semigroup, Monoid, Binary)
 
-instance Pretty a => Pretty (UniqSet a) where
-  pretty (UniqSet env) =
-    braces (fillSep (map pretty (IntMap.elems env)))
+instance ClashPretty a => ClashPretty (UniqSet a) where
+  clashPretty (UniqSet env) =
+    braces (fillSep (map clashPretty (IntMap.elems env)))
 
 -- | The empty set
 emptyUniqSet


### PR DESCRIPTION
  * When pretty printing, we annotate the document
    with information regarding the current expression context
    and classify expressions in different types of syntax.

  * Hide options can now be realised as a post-processing step
    that simply hides sub-expressions marked with a specific
    type of syntax (e.g. qualifiers).

  * Since we require a fixed type of annotations `ClashAnnotation`,
    the method signature of `PprPrec` is changed, leading to
    cascading changes on usages of pretty-printing across the codebase.

  * Provide a manual `Eq` instance for `CoreContext`, since `AppArg`
    now contains information about the argument, which shouldn't
    influence equality of the surrounding contexts.