### PR TITLE
Fix pack/unpack bug in evaluator

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -3399,7 +3399,7 @@ mkSizedLit
   -> Integer -- value
   -> Term
 mkSizedLit conPrim ty nTy kn val
-  = mkApps (conPrim sTy) [Right nTy,Left (Literal (NaturalLiteral kn)),Left (Literal (IntegerLiteral ( val)))]
+  = mkApps (conPrim sTy) [Right nTy,Left (Literal (NaturalLiteral kn)),Left (Literal (IntegerLiteral val))]
   where
     (_,sTy) = splitFunForallTy ty
 
@@ -3466,10 +3466,7 @@ mkSizedLit'
      ,Integer) -- KnownNat n
   -> Integer -- value
   -> Term
-mkSizedLit' conPrim (ty,nTy,kn) val
-  = mkApps (conPrim sTy) [Right nTy,Left (Literal (NaturalLiteral kn)),Left (Literal (IntegerLiteral ( val)))]
-  where
-    (_,sTy) = splitFunForallTy ty
+mkSizedLit' conPrim (ty,nTy,kn) = mkSizedLit conPrim ty nTy kn
 
 mkSignedLit', mkUnsignedLit'
   :: (Type     -- result type
@@ -3487,14 +3484,7 @@ mkBitVectorLit'
   -> Integer -- Mask
   -> Integer -- value
   -> Term
-mkBitVectorLit' (ty,nTy,kn) mask val
-  = mkApps (bvConPrim sTy)
-           [Right nTy
-           ,Left (Literal (NaturalLiteral kn))
-           ,Left (Literal (IntegerLiteral mask))
-           ,Left (Literal (IntegerLiteral val))]
-  where
-    (_,sTy) = splitFunForallTy ty
+mkBitVectorLit' (ty,nTy,kn) = mkBitVectorLit ty nTy kn
 
 mkIndexLit'
   :: (Type     -- result type
@@ -3502,17 +3492,7 @@ mkIndexLit'
      ,Integer) -- KnownNat n
   -> Integer -- value
   -> Term
-mkIndexLit' res@(rTy,nTy,kn) val
-  | val >= 0
-  , val < kn
-  = mkSizedLit' indexConPrim res val
-  | otherwise
-  = TyApp (Prim "Clash.GHC.Evaluator.undefined" undefinedTy)
-          (mkTyConApp indexTcNm [nTy])
-  where
-    TyConApp indexTcNm _ = tyView (snd (splitFunForallTy rTy))
-
-
+mkIndexLit' (rTy,nTy,kn) = mkIndexLit rTy nTy kn
 
 -- | Create a vector of supplied elements
 mkVecCons

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -1739,11 +1739,19 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
   "Clash.Sized.Internal.Signed.pack#"
     | Just (nTy, kn) <- extractKnownNat tcm tys
     , [i] <- signedLiterals' args
-    -> reduce (mkBitVectorLit ty nTy kn 0 i)
+    -> let val = reifyNat kn (op (fromInteger i))
+       in reduce (mkBitVectorLit ty nTy kn 0 val)
+    where
+        op :: KnownNat n => Signed n -> Proxy n -> Integer
+        op s _ = toInteger (Signed.pack# s)
   "Clash.Sized.Internal.Signed.unpack#"
     | Just (nTy, kn) <- extractKnownNat tcm tys
     , [(0,i)] <- bitVectorLiterals' args
-    -> reduce (mkSignedLit ty nTy kn i)
+    -> let val = reifyNat kn (op (fromInteger i))
+       in reduce (mkSignedLit ty nTy kn val)
+    where
+        op :: KnownNat n => BitVector n -> Proxy n -> Integer
+        op s _ = toInteger (Signed.unpack# s)
 
 -- Eq
   "Clash.Sized.Internal.Signed.eq#" | Just (i,j) <- signedLiterals args

--- a/tests/shouldwork/Numbers/Resize3.hs
+++ b/tests/shouldwork/Numbers/Resize3.hs
@@ -1,0 +1,22 @@
+module Resize3 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity :: Signed 8
+topEntity = unpack (resize (pack (-2 :: Signed 4)))
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput =
+      outputVerifier
+        clk
+        rst
+        (    14
+          :> $(lift (unpack (resize (pack (-2 :: Signed 4))) :: Signed 8))
+          :>  Nil)
+    done           = expectedOutput (pure topEntity)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -187,6 +187,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "NegativeLits" (["","NegativeLits_testBench"],"NegativeLits_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize"       (["","Resize_testBench"],"Resize_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize2"      (["","Resize2_testBench"],"Resize2_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize3"      (["","Resize3_testBench"],"Resize3_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SatMult"      ([""],"SatMult_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] "ShiftRotate"         (["","ShiftRotate_testBench"],"ShiftRotate_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Strict"       (["","Strict_testBench"],"Strict_testBench",True)


### PR DESCRIPTION
Some users reported erroneous HDL output when using saturating multiplication with negative numbers. This was caused by an evaluator bug explained below.

---------------------

The following case would produce wrong results after being picked up by
the evaluator:

    unpack (resize (pack (-2 :: Signed 4)))

The evaluator stores literals as an `Integer`s, assuming that `pack`
would therefore be a no-op. In case of negative literals this isn't true
however. For example: `-2 :: Signed 4` its bit-representation is `1110`.
After packing/resizing to `Signed 8` it should now read `00001110`.
Clearly, this is a positive number, so leaving the original literal
integer untouched is wrong!

------------------------

This issue still needs some more work. We should modify `mk[Bitvector,Signed,Unsigned,...]Lit` such that it normalizes incoming `Integer`s to the correct width. This is not part of this PR though. It will be picked up in https://github.com/clash-lang/clash-compiler/issues/582.