### PR TITLE
 Add `Clash.Class.Exp` for exponentiation calculations 

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -9,12 +9,14 @@
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE KindSignatures    #-}
 {-# LANGUAGE MagicHash         #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE UnboxedTuples     #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.GHC.Evaluator where
 
@@ -36,7 +38,6 @@ import           Data.Text           (Text)
 import qualified Data.Text           as Text
 import qualified Data.Vector.Primitive as Vector
 import           Debug.Trace         (trace)
-import           GHC.Stack           (HasCallStack)
 import           GHC.Float
 import           GHC.Int
 import           GHC.Integer
@@ -46,6 +47,7 @@ import           GHC.Integer.GMP.Internals (Integer (..), BigNat (..))
 import           GHC.Natural
 import           GHC.Prim
 import           GHC.Real            (Ratio (..))
+import           GHC.Stack           (HasCallStack)
 import           GHC.TypeLits        (KnownNat)
 import           GHC.Types           (IO (..))
 import           GHC.Word
@@ -1243,6 +1245,35 @@ reduceConstant isSubj gbl tcm h k nm ty tys args = case nm of
     | [i] <- bitVectorLiterals' args
     -> reduce (Literal (DoubleLiteral (toRational $ (unpack :: BitVector 64 -> Double) (toBV i))))
 
+  -- expIndex#
+  --   :: KnownNat m
+  --   => Index m
+  --   -> SNat n
+  --   -> Index (n^m)
+  "Clash.Class.Exp.expIndex#"
+    | [b] <- indexLiterals' args
+    , [(_mTy, km), (_, e)] <- extractKnownNats tcm tys
+    -> reduce (mkIndexLit ty (LitTy (NumTy (km^e))) (km^e) (b^e))
+
+  -- expSigned#
+  --   :: KnownNat m
+  --   => Signed m
+  --   -> SNat n
+  --   -> Signed (n*m)
+  "Clash.Class.Exp.expSigned#"
+    | [b] <- signedLiterals' args
+    , [(_mTy, km), (_, e)] <- extractKnownNats tcm tys
+    -> reduce (mkSignedLit ty (LitTy (NumTy (km*e))) (km*e) (b^e))
+
+  -- expUnsigned#
+  --   :: KnownNat m
+  --   => Unsigned m
+  --   -> SNat n
+  --   -> Unsigned m
+  "Clash.Class.Exp.expUnsigned#"
+    | [b] <- unsignedLiterals' args
+    , [(_mTy, km), (_, e)] <- extractKnownNats tcm tys
+    -> reduce (mkUnsignedLit ty (LitTy (NumTy (km*e))) (km*e) (b^e))
 
   "Clash.Promoted.Nat.powSNat"
     | [Right a, Right b] <- map (runExcept . tyNatSize tcm) tys
@@ -3461,17 +3492,41 @@ extractKnownNat tcm tys = case tys of
     -> Just (nTy, nInt)
   _ -> Nothing
 
+extractKnownNatVal :: TyConMap -> [Type] -> Maybe Integer
+extractKnownNatVal tcm tys = fmap snd (extractKnownNat tcm tys)
+
+-- From an argument list to function of type
+--   forall n m o .. . (KnownNat n, KnownNat m, KnownNat o, ..) => ...
+-- extract [(nTy,nInt), (mTy,mInt), (oTy,oInt)]
+-- where nTy is the Type of n
+-- and   nInt is its value as an Integer
+extractKnownNats :: TyConMap -> [Type] -> [(Type, Integer)]
+extractKnownNats tcm tys =
+  catMaybes (map (extractKnownNat tcm . pure)  tys)
+
+extractKnownNatVals :: TyConMap -> [Type] -> [Integer]
+extractKnownNatVals tcm tys = map snd (extractKnownNats tcm tys)
+
 -- Construct a constant term of a sized type
 mkSizedLit
-  :: (Type -> Term)    -- type constructor?
-  -> Type    -- result type
-  -> Type    -- forall n.
-  -> Integer -- KnownNat n
-  -> Integer -- value
+  :: (Type -> Term)
+  -- ^ Type constructor?
+  -> Type
+  -- ^ Result type
+  -> Type
+  -- ^ forall n.
+  -> Integer
+  -- ^ KnownNat n
+  -> Integer
+  -- ^ Value to construct
   -> Term
-mkSizedLit conPrim ty nTy kn val
-  = mkApps (conPrim sTy) [Right nTy,Left (Literal (NaturalLiteral kn)),Left (Literal (IntegerLiteral val))]
-  where
+mkSizedLit conPrim ty nTy kn val =
+  mkApps
+    (conPrim sTy)
+    [ Right nTy
+    , Left (Literal (NaturalLiteral kn))
+    , Left (Literal (IntegerLiteral val)) ]
+ where
     (_,sTy) = splitFunForallTy ty
 
 mkBitLit
@@ -3489,20 +3544,29 @@ mkBitLit ty msk val =
     (_,sTy) = splitFunForallTy ty
 
 mkSignedLit, mkUnsignedLit
-  :: Type    -- result type
-  -> Type    -- forall n.
-  -> Integer -- KnownNat n
-  -> Integer -- value
+  :: Type
+  -- Result type
+  -> Type
+  -- forall n.
+  -> Integer
+  -- KnownNat n
+  -> Integer
+  -- Value
   -> Term
 mkSignedLit    = mkSizedLit signedConPrim
 mkUnsignedLit  = mkSizedLit unsignedConPrim
 
 mkBitVectorLit
-  :: Type    -- result type
-  -> Type    -- forall n.
-  -> Integer -- KnownNat n
-  -> Integer -- mask
-  -> Integer -- value
+  :: Type
+  -- ^ Result type
+  -> Type
+  -- ^ forall n.
+  -> Integer
+  -- ^ KnownNat n
+  -> Integer
+  -- ^ mask
+  -> Integer
+  -- ^ Value to construct
   -> Term
 mkBitVectorLit ty nTy kn mask val
   = mkApps (bvConPrim sTy)
@@ -3513,65 +3577,93 @@ mkBitVectorLit ty nTy kn mask val
   where
     (_,sTy) = splitFunForallTy ty
 
-mkIndexLit
-  :: Type    -- result type
-  -> Type    -- forall n.
-  -> Integer -- KnownNat n
-  -> Integer -- value
-  -> Term
-mkIndexLit rTy nTy kn val
+mkIndexLitE
+  :: Type
+  -- ^ Result type
+  -> Type
+  -- ^ forall n.
+  -> Integer
+  -- ^ KnownNat n
+  -> Integer
+  -- ^ Value to construct
+  -> Either Term Term
+  -- ^ Either undefined (if given value is out of bounds of given type) or term
+  -- representing literal
+mkIndexLitE rTy nTy kn val
   | val >= 0
   , val < kn
-  = mkSizedLit indexConPrim rTy nTy kn val
+  = Right (mkSizedLit indexConPrim rTy nTy kn val)
   | otherwise
-  = TyApp (Prim "Clash.GHC.Evaluator.undefined" undefinedTy)
-          (mkTyConApp indexTcNm [nTy])
+  = Left
+      ( TyApp
+          (Prim "Clash.GHC.Evaluator.undefined" undefinedTy)
+          (mkTyConApp indexTcNm [nTy]) )
   where
     TyConApp indexTcNm _ = tyView (snd (splitFunForallTy rTy))
 
--- Construct a constant term of a sized type
+mkIndexLit
+  :: Type
+  -- ^ Result type
+  -> Type
+  -- ^ forall n.
+  -> Integer
+  -- ^ KnownNat n
+  -> Integer
+  -- ^ Value to construct
+  -> Term
+mkIndexLit rTy nTy kn val =
+  either id id (mkIndexLitE rTy nTy kn val)
+
+-- | Construct a constant term of a sized type
 mkSizedLit'
-  :: (Type -> Term)    -- type constructor?
-  -> (Type     -- result type
-     ,Type     -- forall n.
-     ,Integer) -- KnownNat n
-  -> Integer -- value
+  :: (Type -> Term)
+  -- ^ Type constructor?
+  -> (Type, Type, Integer)
+  -- ^ (result type, forall n., KnownNat n)
+  -> Integer
+  -- ^ Value to construct
   -> Term
 mkSizedLit' conPrim (ty,nTy,kn) = mkSizedLit conPrim ty nTy kn
 
 mkSignedLit', mkUnsignedLit'
-  :: (Type     -- result type
-     ,Type     -- forall n.
-     ,Integer) -- KnownNat n
-  -> Integer -- value
+  :: (Type, Type, Integer)
+  -- ^ (result type, forall n., KnownNat n)
+  -> Integer
+  -- ^ Value to construct
   -> Term
 mkSignedLit'    = mkSizedLit' signedConPrim
 mkUnsignedLit'  = mkSizedLit' unsignedConPrim
 
 mkBitVectorLit'
-  :: (Type     -- result type
-     ,Type     -- forall n.
-     ,Integer) -- KnownNat n
-  -> Integer -- Mask
-  -> Integer -- value
+  :: (Type, Type, Integer)
+  -- ^ (result type, forall n., KnownNat n)
+  -> Integer
+  -- ^ Mask
+  -> Integer
+  -- ^ Value
   -> Term
 mkBitVectorLit' (ty,nTy,kn) = mkBitVectorLit ty nTy kn
 
 mkIndexLit'
-  :: (Type     -- result type
-     ,Type     -- forall n.
-     ,Integer) -- KnownNat n
-  -> Integer -- value
+  :: (Type, Type, Integer)
+  -- ^ (result type, forall n., KnownNat n)
+  -> Integer
+  -- ^ value
   -> Term
 mkIndexLit' (rTy,nTy,kn) = mkIndexLit rTy nTy kn
 
 -- | Create a vector of supplied elements
 mkVecCons
-  :: DataCon -- ^ The Cons (:>) constructor
-  -> Type    -- ^ Element type
-  -> Integer -- ^ Length of the vector
-  -> Term    -- ^ head of the vector
-  -> Term    -- ^ tail of the vector
+  :: DataCon
+  -- ^ The Cons (:>) constructor
+  -> Type
+  -- ^ Element type
+  -> Integer
+  -- ^ Length of the vector
+  -> Term
+  -- ^ head of the vector
+  -> Term
+  -- ^ tail of the vector
   -> Term
 mkVecCons consCon resTy n h t =
   mkApps (Data consCon) [Right (LitTy (NumTy n))
@@ -3746,9 +3838,12 @@ liftSized2 extractLitArgs mkLit f ty tcm tys args p
 -- The resulting function must be executed with reifyNat
 runSizedF
   :: (KnownNat n, Integral (sized n))
-  => (sized n -> sized n -> sized n)   -- ^ function to run
-  -> Integer                           -- ^ first  argument
-  -> Integer                           -- ^ second argument
+  => (sized n -> sized n -> sized n)
+  -- ^ function to run
+  -> Integer
+  -- ^ first  argument
+  -> Integer
+  -- ^ second argument
   -> (Proxy n -> Integer)
 runSizedF f i j _ = toInteger $ f (fromInteger i) (fromInteger j)
 

--- a/clash-lib/prims/commonverilog/Clash_Class_Exp.json
+++ b/clash-lib/prims/commonverilog/Clash_Class_Exp.json
@@ -1,0 +1,29 @@
+[
+  {
+    "BlackBox": {
+      "name": "Clash.Class.Exp.expIndex#",
+      "kind": "Declaration",
+      "type": "expIndex# :: KnownNat m => Index m -> SNat n -> Index (m^n)",
+      "template": "assign ~RESULT = ~DEVNULL[~ARG[0]]$signed(~ARG[1] ** ~LIT[2]);",
+      "warning": "Exponentiation is only supported on relatively small constructs (< 32 bits). Ideally, Clash should have constant folded your expression. See https://github.com/clash-lang/clash-compiler/issues/593."
+    }
+  },
+  {
+    "BlackBox": {
+      "name": "Clash.Class.Exp.expSigned#",
+      "kind": "Declaration",
+      "type": "expSigned# :: KnownNat m => Signed m -> SNat n -> Signed (m*n)",
+      "template": "assign ~RESULT = ~DEVNULL[~ARG[0]]$signed(~ARG[1] ** ~LIT[2]);",
+      "warning": "Exponentiation is only supported on relatively small constructs (< 32 bits). Ideally, Clash should have constant folded your expression. See https://github.com/clash-lang/clash-compiler/issues/593."
+    }
+  },
+  {
+    "BlackBox": {
+      "name": "Clash.Class.Exp.expUnsigned#",
+      "kind": "Declaration",
+      "type": "expUnsigned# :: KnownNat m => Unsigned m -> SNat n -> Unsigned (m*n)",
+      "template": "assign ~RESULT = ~DEVNULL[~ARG[0]]$unsigned(~ARG[1] ** ~LIT[2]);",
+      "warning": "Exponentiation is only supported on relatively small constructs (< 32 bits). Ideally, Clash should have constant folded your expression. See https://github.com/clash-lang/clash-compiler/issues/593."
+    }
+  }
+]

--- a/clash-lib/prims/commonverilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/commonverilog/GHC_Integer_Type.json
@@ -131,4 +131,46 @@
     , "template"  : "assign ~RESULT = $unsigned(~ARG[0]);"
     }
   }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.bitInteger"
+    , "kind"      : "Expression"
+    , "type"      : "bitInteger :: Int -> Integer"
+    , "template"  : "1 << ~ARG[0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.complementInteger"
+    , "kind"      : "Expression"
+    , "type"      : "complementInteger :: Integer -> Integer"
+    , "template"  : "~ ~ARG[0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.xorInteger"
+    , "kind"      : "Expression"
+    , "type"      : "xorInteger :: Integer -> Integer -> Integer"
+    , "template"  : "~ARG[0] ^ ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.orInteger"
+    , "kind"      : "Expression"
+    , "type"      : "orInteger :: Integer -> Integer -> Integer"
+    , "template"  : "~ARG[0] | ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.andInteger"
+    , "kind"      : "Expression"
+    , "type"      : "andInteger :: Integer -> Integer -> Integer"
+    , "template"  : "~ARG[0] & ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.$wsignumInteger"
+    , "kind"      : "Expression"
+    , "type"      : "$wsignumInteger :: Integer -> Integer"
+    , "template"  : "(~ARG[0] < ~SIZE[~TYPO]'sd0) ? -~SIZE[~TYPO]'sd1 : ((~ARG[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SIZE[~TYPO]'sd1)"
+    }
+  }
 ]

--- a/clash-lib/prims/vhdl/Clash_Class_Exp.json
+++ b/clash-lib/prims/vhdl/Clash_Class_Exp.json
@@ -1,0 +1,29 @@
+[
+  {
+    "BlackBox": {
+      "name": "Clash.Class.Exp.expIndex#",
+      "kind": "Expression",
+      "type": "expIndex# :: KnownNat m => Index m -> SNat n -> Index (m^n)",
+      "template": "~DEVNULL[~ARG[0]]to_unsigned(to_integer(~ARG[1]) ** ~LIT[2], ~SIZE[~TYPO])",
+      "warning": "Exponentiation is only supported on relatively small constructs (< 32 bits). Ideally, Clash should have constant folded your expression. See https://github.com/clash-lang/clash-compiler/issues/593."
+    }
+  },
+  {
+    "BlackBox": {
+      "name": "Clash.Class.Exp.expSigned#",
+      "kind": "Expression",
+      "type": "expSigned# :: KnownNat m => Signed m -> SNat n -> Signed (m*n)",
+      "template": "~DEVNULL[~ARG[0]]to_signed(to_integer(~ARG[1]) ** ~LIT[2], ~SIZE[~TYPO])",
+      "warning": "Exponentiation is only supported on relatively small constructs (< 32 bits). Ideally, Clash should have constant folded your expression. See https://github.com/clash-lang/clash-compiler/issues/593."
+    }
+  },
+  {
+    "BlackBox": {
+      "name": "Clash.Class.Exp.expUnsigned#",
+      "kind": "Expression",
+      "type": "expUnsigned# :: KnownNat m => Unsigned m -> SNat n -> Unsigned (m*n)",
+      "template": "~DEVNULL[~ARG[0]]to_unsigned(to_integer(~ARG[1]) ** ~LIT[2], ~SIZE[~TYPO])",
+      "warning": "Exponentiation is only supported on relatively small constructs (< 32 bits). Ideally, Clash should have constant folded your expression. See https://github.com/clash-lang/clash-compiler/issues/593."
+    }
+  }
+]

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.json
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.json
@@ -154,4 +154,52 @@ end block;
     , "template"  : "unsigned(std_logic_vector(~ARG[0]))"
     }
   }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.bitInteger"
+    , "kind"      : "Expression"
+    , "type"      : "bitInteger :: Int -> Integer"
+    , "template"  : "shift_left(to_signed(1, ~SIZE[~TYPO]),to_integer(~ARG[0]))"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.complementInteger"
+    , "kind"      : "Expression"
+    , "type"      : "complementInteger :: Integer -> Integer"
+    , "template"  : "not ~ARG[0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.xorInteger"
+    , "kind"      : "Expression"
+    , "type"      : "xorInteger :: Integer -> Integer -> Integer"
+    , "template"  : "~ARG[0] xor ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.orInteger"
+    , "kind"      : "Expression"
+    , "type"      : "orInteger :: Integer -> Integer -> Integer"
+    , "template"  : "~ARG[0] or ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.andInteger"
+    , "kind"      : "Expression"
+    , "type"      : "andInteger :: Integer -> Integer -> Integer"
+    , "template"  : "~ARG[0] and ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.$wsignumInteger"
+    , "kind"      : "Declaration"
+    , "type"      : "$wsignumInteger :: Integer -> Integer"
+    , "template"  : "
+-- begin signumInteger
+~RESULT <= to_signed(-1, ~SIZE[~TYPO]) when ~ARG[0] < 0
+  else to_signed(0, ~SIZE[~TYPO])  when ~ARG[0] = 0
+  else to_signed(1, ~SIZE[~TYPO]);
+-- end signumInteger
+"
+    }
+  }
 ]

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -247,7 +247,9 @@ extractPrimWarnOrFail nm = do
     when (primWarn && not seen)
       $ liftIO
       $ warn opts
-      $ "Dubious primitive instantiation: "
+      $ "Dubious primitive instantiation for "
+     ++ unpack nm
+     ++ ": "
      ++ warning
      ++ " (disable with -fclash-no-prim-warn)"
 

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -112,6 +112,7 @@ Library
                       Clash.Annotations.SynthesisAttributes
 
                       Clash.Class.BitPack
+                      Clash.Class.Exp
                       Clash.Class.Num
                       Clash.Class.Resize
 

--- a/clash-prelude/src/Clash/Class/Exp.hs
+++ b/clash-prelude/src/Clash/Class/Exp.hs
@@ -1,0 +1,92 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE CPP           #-}
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE MagicHash     #-}
+{-# LANGUAGE TypeFamilies  #-}
+{-# LANGUAGE TypeOperators #-}
+
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE NoStarIsType  #-}
+#endif
+
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
+
+module Clash.Class.Exp (Exp, ExpResult, (^)) where
+
+import qualified Prelude                       as P
+import           Prelude                       hiding ((^))
+
+import           Clash.Annotations.Primitive   (hasBlackBox)
+import           Clash.Promoted.Nat            (SNat(..), snatToInteger)
+import           Clash.Sized.Internal.Index    (Index)
+import           Clash.Sized.Internal.Signed   (Signed)
+import           Clash.Sized.Internal.Unsigned (Unsigned)
+
+import           GHC.TypeLits
+  (KnownNat, Nat, type (^), type (*))
+
+-- | Type class implementing exponentiation with explicitly resizing results.
+class Exp a where
+  type ExpResult a (n :: Nat)
+
+  -- | Exponentiation with known exponent.
+  (^)
+    :: a
+    -- ^ Base
+    -> SNat n
+    -- ^ Exponent
+    -> ExpResult a n
+    -- ^ Resized result, guaranteed to not have overflown
+
+instance KnownNat m => Exp (Index m) where
+  type ExpResult (Index m) n = Index (m ^ n)
+
+  (^) = expIndex#
+  {-# INLINE (^) #-}
+
+instance KnownNat m => Exp (Signed m) where
+  type ExpResult (Signed m) n = Signed (m * n)
+
+  (^) = expSigned#
+  {-# INLINE (^) #-}
+
+instance KnownNat m => Exp (Unsigned m) where
+  type ExpResult (Unsigned m) n = Unsigned (m * n)
+
+  (^) = expUnsigned#
+  {-# INLINE (^) #-}
+
+expIndex#
+  :: KnownNat m
+  => Index m
+  -> SNat n
+  -> Index (m ^ n)
+expIndex# b e@SNat =
+  fromInteger (toInteger b P.^ snatToInteger e)
+{-# NOINLINE expIndex# #-}
+{-# ANN expIndex# hasBlackBox #-}
+
+expSigned#
+  :: KnownNat m
+  => Signed m
+  -> SNat n
+  -> Signed (m * n)
+expSigned# b e@SNat =
+  fromInteger (toInteger b P.^ snatToInteger e)
+{-# NOINLINE expSigned# #-}
+{-# ANN expSigned# hasBlackBox #-}
+
+expUnsigned#
+  :: KnownNat m
+  => Unsigned m
+  -> SNat n
+  -> Unsigned (m * n)
+expUnsigned# b e@SNat =
+  fromInteger (toInteger b P.^ snatToInteger e)
+{-# NOINLINE expUnsigned# #-}
+{-# ANN expUnsigned# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -106,6 +106,7 @@ module Clash.Explicit.Prelude
     -- ** Type classes
     -- *** Clash
   , module Clash.Class.BitPack
+  , module Clash.Class.Exp
   , module Clash.Class.Num
   , module Clash.Class.Resize
     -- *** Other
@@ -133,10 +134,11 @@ import Language.Haskell.TH.Syntax  (Lift(..))
 import Prelude hiding
   ((++), (!!), concat, concatMap, drop, foldl, foldl1, foldr, foldr1, head, init,
    iterate, last, length, map, repeat, replicate, reverse, scanl, scanr, splitAt,
-   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined)
+   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined, (^))
 
 import Clash.Annotations.TopEntity
 import Clash.Class.BitPack
+import Clash.Class.Exp
 import Clash.Class.Num
 import Clash.Class.Resize
 import Clash.NamedTypes

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -124,6 +124,7 @@ module Clash.Prelude
     -- ** Type classes
     -- *** Clash
   , module Clash.Class.BitPack
+  , module Clash.Class.Exp
   , module Clash.Class.Num
   , module Clash.Class.Resize
     -- *** Other
@@ -153,10 +154,11 @@ import           Language.Haskell.TH.Syntax  (Lift(..))
 import           Prelude hiding
   ((++), (!!), concat, concatMap, drop, foldl, foldl1, foldr, foldr1, head, init,
    iterate, last, length, map, repeat, replicate, reverse, scanl, scanr, splitAt,
-   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined)
+   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined, (^))
 
 import           Clash.Annotations.TopEntity
 import           Clash.Class.BitPack
+import           Clash.Class.Exp
 import           Clash.Class.Num
 import           Clash.Class.Resize
 import qualified Clash.Explicit.Prelude      as E

--- a/tests/shouldwork/Numbers/BitInteger.hs
+++ b/tests/shouldwork/Numbers/BitInteger.hs
@@ -1,0 +1,49 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+module BitInteger where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+import Data.Bits
+
+topEntity :: Int -> Integer
+topEntity = bit
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput =
+      stimuliGenerator
+        clk
+        rst
+        ( 0 :>
+          1 :>
+          2 :>
+          3 :>
+          4 :>
+          5 :>
+          Nil
+        )
+
+    expectedOutput =
+      outputVerifier
+        clk
+        rst
+        ( 1 :>
+          2 :>
+          4 :>
+          8 :>
+          16 :>
+          32 :>
+          Nil
+        )
+
+    done = expectedOutput (topEntity <$> testInput)
+    clk  = tbSystemClockGen (not <$> done)
+    rst  = systemResetGen

--- a/tests/shouldwork/Numbers/Exp.hs
+++ b/tests/shouldwork/Numbers/Exp.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=15 #-}
+
+module Exp (testInput, topEntity, expectedOutputs, packedExpectedOutputs) where
+
+import Clash.Prelude
+import NumConstantFolding (lit)
+
+
+testInput :: Vec _ Integer
+testInput =
+     lit 0
+  :> lit 1
+  :> lit 2
+  :> lit 22101  -- for constant folding
+  :> Nil
+
+
+topEntity :: Integer -> _
+topEntity b =
+  ( -- We can only test really small exponents: VHDL only supports
+    -- exponentiations up to 31 bits, and we need a large base (22101) to
+    -- check constant folding.
+    resize ((fromInteger b :: Signed 64) ^ d2) :: Signed 64
+  , resize ((fromInteger b :: Unsigned 64) ^ d2) :: Unsigned 64
+  , resize ((fromInteger b :: Index (2^64)) ^ d2) :: Index (2^64)
+  )
+{-# NOINLINE topEntity #-}
+
+
+-- Should be constant folded, and yield the same results as topEntity
+expectedOutputs =
+     topEntity (testInput !! 0)
+  :> topEntity (testInput !! 1)
+  :> topEntity (testInput !! 2)
+  :> topEntity (testInput !! 3)
+  :> Nil
+
+packedExpectedOutputs :: Vec 4 (BitVector 192)
+packedExpectedOutputs =
+     pack (topEntity (testInput !! 0))
+  :> pack (topEntity (testInput !! 1))
+  :> pack (topEntity (testInput !! 2))
+  :> pack (topEntity (testInput !! 3))
+  :> Nil

--- a/tests/shouldwork/Numbers/ExpWithClashCF.hs
+++ b/tests/shouldwork/Numbers/ExpWithClashCF.hs
@@ -1,0 +1,27 @@
+module ExpWithClashCF where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+import qualified Exp
+import qualified NumConstantFolding as NCF
+
+
+-- Constant folded topEntity (GHC/TemplateHaskell)
+expected = $(lift (pack Exp.packedExpectedOutputs))
+
+-- Constant folded (?) topEntity (Clash)
+topEntity = pack Exp.packedExpectedOutputs -- map Exp.topEntity Exp.testInput
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifierBitVector clk rst (expected :> Nil)
+    done           = expectedOutput (pure topEntity)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+
+
+mainVHDL = NCF.checkForUnfolded NCF.vhdlNr
+mainVerilog = NCF.checkForUnfolded NCF.verilogNr
+mainSystemVerilog = NCF.checkForUnfolded NCF.verilogNr

--- a/tests/shouldwork/Numbers/ExpWithGhcCF.hs
+++ b/tests/shouldwork/Numbers/ExpWithGhcCF.hs
@@ -1,0 +1,20 @@
+module ExpWithGhcCF where
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import qualified Exp
+
+-- Constant folded topEntity (GHC/TemplateHaskell)
+expected = $(lift (map pack Exp.expectedOutputs))
+
+-- Constant folded (?) topEntity (Clash)
+topEntity = Exp.topEntity
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst Exp.testInput
+    expectedOutput = outputVerifierBitVector clk rst expected
+    done           = expectedOutput ((pack . topEntity) <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Numbers/NumConstantFolding.hs
+++ b/tests/shouldwork/Numbers/NumConstantFolding.hs
@@ -35,85 +35,93 @@ import Text.Trifecta.Delta
 -- Tests for specific classes
 -----------------------------
 
+-- | Prevent GHC from constant folding operations. Clash should be able to
+-- do it though.
+lit
+  :: Num a
+  => Signed 64
+  -> a
+lit = fromIntegral
+
 cNum :: forall n. Num n => _
 cNum = (rPlus,rMin,rTimes,rAbsP,rAbsZ, rSignumP,rSignumZ)
   where
-    rPlus    = (+)    @n 22101 22102
-    rMin     = (-)    @n 22104 22103
-    rTimes   = (*)    @n 22105 2
-    rAbsP    = abs    @n 22106 + 1000
-    rAbsZ    = (22107 + abs    @n 0) + 1000
+    rPlus    = (+)    @n (lit 22101) (lit 22102)
+    rMin     = (-)    @n (lit 22104) (lit 22103)
+    rTimes   = (*)    @n (lit 22105) (lit 2)
+    rAbsP    = abs    @n (lit 22106) + (lit 1000)
+    rAbsZ    = (lit 22107 + abs    @n (lit 0)) + lit 1000
     -- rAbsN    = abs    @n (-22108) + 1000
-    rSignumP = signum @n 22109
-    rSignumZ = signum @n 0 * 22110
+    rSignumP = signum @n (lit 22109)
+    rSignumZ = signum @n (lit 0) * (lit 22110)
     -- rSignumN = signum @n (-22111)
     -- fromInteger?
 
 cEq :: forall n. (Num n, Eq n) => (Bool,Bool)
 cEq = (eq,neq)
   where
-    eq  = (==) @n 22120 22121
-    neq = (/=) @n 22122 22123
+    eq  = (==) @n (lit 22120) (lit 22121)
+    neq = (/=) @n (lit 22122) (lit 22123)
 
 cOrd :: forall n. (Num n, Ord n) => _
 cOrd = (rCompare,rLt,rLe,rGt,rGe,rMin,rMax)
   where
-    rCompare = compare @n 22130 22131
-    rLt      = (<)     @n 22132 22133
-    rLe      = (<=)    @n 22134 22135
-    rGt      = (>)     @n 22136 22137
-    rGe      = (>=)    @n 22138 22139
-    rMin     = min     @n 22140 1234
-    rMax     = max     @n 22141 29931
+    rCompare = compare @n (lit 22130) (lit 22131)
+    rLt      = (<)     @n (lit 22132) (lit 22133)
+    rLe      = (<=)    @n (lit 22134) (lit 22135)
+    rGt      = (>)     @n (lit 22136) (lit 22137)
+    rGe      = (>=)    @n (lit 22138) (lit 22139)
+    rMin     = min     @n (lit 22140) (lit 1234)
+    rMax     = max     @n (lit 22141) (lit 29931)
 
 cIntegral :: forall n. (Num n, Integral n) => _
 cIntegral = (rQuot,rRem,rDiv,rMod,rQuotRem,rDivMod)
   where
-    rQuot    = quot    @n 22150 41
-    rRem     = rem     @n 22151 42
-    rDiv     = div     @n 22152 43
-    rMod     = mod     @n 22153 44
-    rQuotRem = quotRem @n 22154 45
-    rDivMod  = divMod  @n 22155 46
+    rQuot    = quot    @n (lit 22150) (lit 41)
+    rRem     = rem     @n (lit 22151) (lit 42)
+    rDiv     = div     @n (lit 22152) (lit 43)
+    rMod     = mod     @n (lit 22153) (lit 44)
+    rQuotRem = quotRem @n (lit 22154) (lit 45)
+    rDivMod  = divMod  @n (lit 22155) (lit 46)
     -- toInteger?
 
 cBitsNoPopCount :: forall n. (Num n, Bits n) => _
 -- the nested tuple here is so we can still 'show' the result
 cBitsNoPopCount = ((r00,r01,r02,r03,r04,r05,r06,r07,r08,r09,r10),r11,r12,r13,r14,r15,r16,r17,r18,r19)
   where
-    r00 = (.&.)         @n 22160 51
-    r01 = (.|.)         @n 22161 6144
-    r02 = xor           @n 22162 22153
-    r03 = complement    @n 22163 + 1000
-    r04 = shift         @n 22164 3
-    r05 = rotate        @n 22165 4
-    r06 = (22156 + zeroBits @n) + 1000
-    r07 = bit           @n 10 + 22167
-    r08 = setBit        @n 22168 11
-    r09 = clearBit      @n 22169 14
-    r10 = complementBit @n 22170 12
-    r11 = testBit       @n 22171 1
-    r12 = bitSizeMaybe  @n 22172
-    r13 = isSigned      @n 22173
-    r14 = shiftL        @n 22174 5
-    r15 = unsafeShiftL  @n 22175 7
-    r16 = shiftR        @n 22176 9
-    r17 = unsafeShiftR  @n 22177 11
-    r18 = rotateL       @n 22178 13
-    r19 = rotateR       @n 22179 15
+    r00 = (.&.)         @n (lit 22160) (lit 51)
+    r01 = (.|.)         @n (lit 22161) (lit 6144)
+    r02 = xor           @n (lit 22162) (lit 22181)
+    r03 = complement    @n (lit 22163) + (lit 1000)
+    r04 = shift         @n (lit 22164) (lit 3)
+    r05 = rotate        @n (lit 22165) (lit 4)
+    r06 = (22156 + zeroBits @n) + (lit 1000)
+    r07 = bit           @n (lit 10) + (lit 22167)
+    r08 = setBit        @n (lit 22168) (lit 11)
+    r09 = clearBit      @n (lit 22169) (lit 14)
+    r10 = complementBit @n (lit 22170) (lit 12)
+    r11 = testBit       @n (lit 22171) (lit 1)
+    r12 = bitSizeMaybe  @n (lit 22172)
+    r13 = isSigned      @n (lit 22173)
+    r14 = shiftL        @n (lit 22174) (lit 5)
+    r15 = unsafeShiftL  @n (lit 22175) (lit 7)
+    r16 = shiftR        @n (lit 22176) (lit 9)
+    r17 = unsafeShiftR  @n (lit 22177) (lit 11)
+    r18 = rotateL       @n (lit 22178) (lit 13)
+    r19 = rotateR       @n (lit 22179) (lit 15)
 
 cBits :: forall n. (Num n, Bits n) => _
 cBits = (cBitsNoPopCount @n, r20)
   where
-    r20 = popCount      @n 22180
+    r20 = popCount      @n (lit 22180)
 
 
 cFiniteBits :: forall n. (Num n, FiniteBits n) => _
 cFiniteBits = (r1,r2,r3)
   where
-    r1 = finiteBitSize      @n 22190
-    r2 = countLeadingZeros  @n 22191
-    r3 = countTrailingZeros @n 22192
+    r1 = finiteBitSize      @n (lit 22190)
+    r2 = countLeadingZeros  @n (lit 22191)
+    r3 = countTrailingZeros @n (lit 22192)
     -- TODO countLeadingZeros and countTrailingZeros for all clash types
     -- are implemented with folds and bv2v both of which don't constantfold
 
@@ -121,41 +129,41 @@ cFiniteBits = (r1,r2,r3)
 cExtendingNum :: forall a b. (Num a, Num b, ExtendingNum a b) => _
 cExtendingNum = (r1,r2,r3)
   where
-    r1 = add @a @b 22200 22201
-    r2 = sub @a @b 22203 22202
-    r3 = mul @a @b 22204 2
+    r1 = add @a @b (lit 22200) (lit 22201)
+    r2 = sub @a @b (lit 22203) (lit 22202)
+    r3 = mul @a @b (lit 22204) (lit 2)
 
 cSaturatingNum :: forall n. (Num n, SaturatingNum n) => _
 cSaturatingNum = (r1a,r1b,r1c,r1d, r2a,r2b,r2c,r2d, r3a,r3b,r3c,r3d)
   where
-    r1a = satAdd @n SatWrap      22210 22211
-    r2a = satSub @n SatWrap      22212 22213
-    r3a = satMul @n SatWrap      22214 22215
-    r1b = satAdd @n SatBound     22220 22221
-    r2b = satSub @n SatBound     22222 22223
-    r3b = satMul @n SatBound     22224 22225
-    r1c = satAdd @n SatZero      22230 22231
-    r2c = satSub @n SatZero      22232 22233
-    r3c = satMul @n SatZero      22234 22235
-    r1d = satAdd @n SatSymmetric 22240 22241
-    r2d = satSub @n SatSymmetric 22242 22243
-    r3d = satMul @n SatSymmetric 22244 22245
+    r1a = satAdd @n SatWrap      (lit 22210) (lit 22211)
+    r2a = satSub @n SatWrap      (lit 22212) (lit 22213)
+    r3a = satMul @n SatWrap      (lit 22214) (lit 22215)
+    r1b = satAdd @n SatBound     (lit 22220) (lit 22221)
+    r2b = satSub @n SatBound     (lit 22222) (lit 22223)
+    r3b = satMul @n SatBound     (lit 22224) (lit 22225)
+    r1c = satAdd @n SatZero      (lit 22230) (lit 22231)
+    r2c = satSub @n SatZero      (lit 22232) (lit 22233)
+    r3c = satMul @n SatZero      (lit 22234) (lit 22235)
+    r1d = satAdd @n SatSymmetric (lit 22240) (lit 22241)
+    r2d = satSub @n SatSymmetric (lit 22242) (lit 22243)
+    r3d = satMul @n SatSymmetric (lit 22244) (lit 22245)
 
 cBitPack :: forall n. (Num n, BitPack n, KnownNat (BitSize n)) => _
 cBitPack = (r1,r2)
   where
-    r1 = pack @n 22250 + 1000
-    r2 = unpack @n 22251 + 1000
+    r1 = pack @n (lit 22250) + (lit 1000)
+    r2 = unpack @n (lit 22251) + (lit 1000)
 
 cResize :: forall ty rep size. (ty ~ rep size, Resize rep, KnownNat size, Num (rep size), Num (rep (1+size)), Num (rep (size+1))) => _
 cResize = (r1,r2,r3,r4,r5,r6)
   where
-    r1 = resize     @rep @size @(size+1) 22260 + 1000
-    r2 = resize     @rep @(size+1) @size 22261 + 1000
-    r3 = extend     @rep @size @1        22262 + 1000
-    r4 = zeroExtend @rep @size @1        22263 + 1000
-    r5 = signExtend @rep @size @1        22264 + 1000
-    r6 = truncateB  @rep @size @1        22265 + 1000
+    r1 = resize     @rep @size @(size+1) (lit 22260) + (lit 1000)
+    r2 = resize     @rep @(size+1) @size (lit 22261) + (lit 1000)
+    r3 = extend     @rep @size @1        (lit 22262) + (lit 1000)
+    r4 = zeroExtend @rep @size @1        (lit 22263) + (lit 1000)
+    r5 = signExtend @rep @size @1        (lit 22264) + (lit 1000)
+    r6 = truncateB  @rep @size @1        (lit 22265) + (lit 1000)
 
 -- TODO classes
 -- Real?
@@ -274,10 +282,10 @@ tNatural
 
 bvSpecific = (r1,r2,r3,r4)
   where
-    r1 = (22001 :: BitVector 16) ++# (22002 :: BitVector 16)
-    r2 = 22003 - size# (22004::BitVector 16)
-    r3 = 22005 - maxIndex# (22006::BitVector 16)
-    r4 = (22007 :: BitVector 16) ! 0
+    r1 = (lit 22001 :: BitVector 16) ++# (lit 22002 :: BitVector 16)
+    r2 = lit 22003 - size# (lit 22004::BitVector 16)
+    r3 = lit 22005 - maxIndex# (lit 22006::BitVector 16)
+    r4 = (lit 22007 :: BitVector 16) ! 0
 
 
 fromIntegralConversions
@@ -301,22 +309,21 @@ fromIntegralConversions
       convertTo :: forall b. Num b => _
       convertTo = ((r00,r01,r02,r03,r04,r05,r06,r07,r08,r09,r10),r11,r12,r13,r14)
         where
-          r00 = 22010 - fromIntegral @Integer        @b 100
-          r01 = 22011 - fromIntegral @Int            @b 100
-          r02 = 22012 - fromIntegral @Int8           @b 100
-          r03 = 22013 - fromIntegral @Int16          @b 100
-          r04 = 22014 - fromIntegral @Int32          @b 100
-          r05 = 22015 - fromIntegral @Int64          @b 100
-          r06 = 22016 - fromIntegral @Word           @b 100
-          r07 = 22017 - fromIntegral @Word8          @b 100
-          r08 = 22018 - fromIntegral @Word16         @b 100
-          r09 = 22019 - fromIntegral @Word32         @b 100
-          r10 = 22020 - fromIntegral @Word64         @b 100
-          r11 = 22021 - fromIntegral @(Signed 17)    @b 100
-          r12 = 22022 - fromIntegral @(Unsigned 17)  @b 100
-          r13 = 22023 - fromIntegral @(BitVector 17) @b 100
-          r14 = 22024 - fromIntegral @(Index 30000)  @b 100
-
+          r00 = lit 22010 - fromIntegral @Integer        @b (lit 100)
+          r01 = lit 22011 - fromIntegral @Int            @b (lit 100)
+          r02 = lit 22012 - fromIntegral @Int8           @b (lit 100)
+          r03 = lit 22013 - fromIntegral @Int16          @b (lit 100)
+          r04 = lit 22014 - fromIntegral @Int32          @b (lit 100)
+          r05 = lit 22015 - fromIntegral @Int64          @b (lit 100)
+          r06 = lit 22016 - fromIntegral @Word           @b (lit 100)
+          r07 = lit 22017 - fromIntegral @Word8          @b (lit 100)
+          r08 = lit 22018 - fromIntegral @Word16         @b (lit 100)
+          r09 = lit 22019 - fromIntegral @Word32         @b (lit 100)
+          r10 = lit 22020 - fromIntegral @Word64         @b (lit 100)
+          r11 = lit 22021 - fromIntegral @(Signed 17)    @b (lit 100)
+          r12 = lit 22022 - fromIntegral @(Unsigned 17)  @b (lit 100)
+          r13 = lit 22023 - fromIntegral @(BitVector 17) @b (lit 100)
+          r14 = lit 22024 - fromIntegral @(Index 30000)  @b (lit 100)
 
 topEntity
  = ( tUnsigned16

--- a/tests/shouldwork/Numbers/Signum.hs
+++ b/tests/shouldwork/Numbers/Signum.hs
@@ -1,0 +1,43 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+module Signum where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: (Integer, Int, Index 5, Signed 5)
+  -> (Integer, Int, Index 5, Signed 5)
+topEntity (a, b, c, d) = (signum a, signum b, signum c, signum d)
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput =
+      stimuliGenerator
+        clk
+        rst
+        ( (0, 0, 0, 0) :>
+          (-2, -2, 0, -2) :>
+          (2, 2, 2, 2) :>
+          Nil
+        )
+
+    expectedOutput =
+      outputVerifier
+        clk
+        rst
+        ( (0, 0, 0, 0) :>
+          (-1, -1, 0, -1) :>
+          (1, 1, 1, 1) :>
+          Nil
+        )
+
+    done = expectedOutput (topEntity <$> testInput)
+    clk  = tbSystemClockGen (not <$> done)
+    rst  = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -91,13 +91,13 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TestIndex"           ([""],"TestIndex_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TwoFunctions"        ([""],"TwoFunctions_topEntity",False)
         ]
-        , clashTestGroup "ShouldFail" [
-          runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursiveBoxed" (Just "Callgraph after normalisation contains following recursive components")
-        , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursiveDatatype" (Just "Not in normal form: no Letrec")
-        , runFailingTest ("tests" </> "shouldfail" </> "InvalidPrimitive") defBuild ["-itests/shouldfail/InvalidPrimitive"] "InvalidPrimitive" (Just "InvalidPrimitive.json")
-        -- Disabled, due to it eating gigabytes of memory:
-        -- , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursivePoly" (Just "??")
-        ]
+        , clashTestGroup "ShouldFail"
+          [ runFailingTest ("tests" </> "shouldfail") [VHDL] [] "RecursiveBoxed" (Just "Callgraph after normalisation contains following recursive components")
+          , runFailingTest ("tests" </> "shouldfail") [VHDL] [] "RecursiveDatatype" (Just "Not in normal form: no Letrec")
+          , runFailingTest ("tests" </> "shouldfail" </> "InvalidPrimitive") [VHDL] ["-itests/shouldfail/InvalidPrimitive"] "InvalidPrimitive" (Just "InvalidPrimitive.json")
+          -- Disabled, due to it eating gigabytes of memory:
+          -- , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursivePoly" (Just "??")
+          ]
       , clashTestGroup "BitVector"
         [ runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "Box"              (["","Box_testBench"],"Box_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "BoxGrow"          (["","BoxGrow_testBench"],"BoxGrow_testBench",True)
@@ -109,9 +109,9 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "AppendZero"       (["","AppendZero_testBench"],"AppendZero_testBench",True)
         ]
       , clashTestGroup "BlackBox"
-        [ outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] "TemplateFunction" "main"
-        , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] "BlackBoxFunction" "main"
-        , outputTest ("tests" </> "shouldwork" </> "Signal")   defBuild [] "BlockRamLazy"     "main"
+        [ outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "TemplateFunction" "main"
+        , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "BlackBoxFunction" "main"
+        , outputTest ("tests" </> "shouldwork" </> "Signal")   defBuild [] [] "BlockRamLazy"     "main"
         ]
       , clashTestGroup "BoxedFunctions"
         [ runTest ("tests" </> "shouldwork" </> "BoxedFunctions") defBuild [] "DeadRecursiveBoxed" ([""],"DeadRecursiveBoxed_topEntity",False)
@@ -178,9 +178,12 @@ runClashTest =
       , clashTestGroup "Numbers"
         [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "BitInteger"   (["","BitInteger_testBench"],"BitInteger_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"       (["","Bounds_testBench"],"Bounds_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"] "ExpWithGhcCF"        (["","ExpWithGhcCF_testBench"],"ExpWithGhcCF_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"] "ExpWithClashCF"        (["","ExpWithClashCF_testBench"],"ExpWithClashCF_testBench",True)
+        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] ["-itests/shouldwork/Numbers"] "ExpWithClashCF"  "main"
         -- TODO: re-enable for Verilog
         , runTest ("tests" </> "shouldwork" </> "Numbers") (defBuild \\ [Verilog]) ["-itests/shouldwork/Numbers","-fclash-inline-limit=300"] "NumConstantFoldingTB"       (["","NumConstantFoldingTB_testBench"],"NumConstantFoldingTB_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fclash-inline-limit=300"] "NumConstantFolding"  "main"
+        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fclash-inline-limit=300", "-fconstraint-solver-iterations=15"] [] "NumConstantFolding"  "main"
 #if MIN_VERSION_base(4,12,0)
         -- Naturals are broken on GHC <= 8.4. See https://github.com/clash-lang/clash-compiler/pull/473
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Naturals"     (["","Naturals_testBench"],"Naturals_testBench",True)
@@ -219,7 +222,7 @@ runClashTest =
       ]
       , clashTestGroup "Signal"
         [ runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "AlwaysHigh"      ([""],"AlwaysHigh_topEntity",False)
-        , outputTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamLazy"    "main"
+        , outputTest ("tests" </> "shouldwork" </> "Signal") defBuild [] [] "BlockRamLazy"    "main"
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamFile"    (["","BlockRamFile_testBench"],"BlockRamFile_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild ["-fclash-no-prim-warn"] "GatedClock" (["gated","source","testbench"],"testbench",True)
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "GatedClockWidth"                  (["","GatedClockWidth_testBench"],"GatedClockWidth_testBench",True)
@@ -240,8 +243,8 @@ runClashTest =
         , runFailingTest ("tests" </> "shouldfail" </> "Signal") defBuild [] "MAC" (Just "Can't match template for \"Clash.Signal.Internal.register#\"")
         ]
       , clashTestGroup "SynthesisAttributes"
-        [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Simple"  "main"
-        , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild []  "Product" "main"
+        [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] [] "Simple"  "main"
+        , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] [] "Product" "main"
         , runTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Product" (["", "Product_testBench"],"Product_testBench",True)
         , clashTestGroup "ShouldFail" [
             runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInArgs"   (Just "Attempted to split Product into a number of HDL ports.")
@@ -258,17 +261,17 @@ runClashTest =
       , clashTestGroup "TopEntity"
         -- VHDL tests disabled for now: I can't figure out how to generate a static name whilst retaining the ability to actually test..
         [ runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNames" (["","PortNames_topEntity","PortNames_testBench"],"PortNames_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNames" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNames" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortProducts" (["","PortProducts_topEntity","PortProducts_testBench"],"PortProducts_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortProducts" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortProducts" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortProductsSum" (["","PortProductsSum_topEntity","PortProductsSum_testBench"],"PortProductsSum_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortProductsSum" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortProductsSum" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithUnit" (["","PortNamesWithUnit_topEntity","PortNamesWithUnit_testBench"],"PortNamesWithUnit_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithUnit" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithUnit" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithVector" (["","PortNamesWithVector_topEntity","PortNamesWithVector_testBench"],"PortNamesWithVector_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithVector" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithVector" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithRTree" (["","PortNamesWithRTree_topEntity","PortNamesWithRTree_testBench"],"PortNamesWithRTree_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] "PortNamesWithRTree" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithRTree" "main"
         , runTest ("tests" </> "shouldwork" </> "TopEntity")    defBuild [] "TopEntHOArg" (["f","g"],"f",False)
         ]
       , clashTestGroup "Void"

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -176,9 +176,10 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "VecFun"    (["","VecFun_testBench"],"VecFun_testBench",True)
       ]
       , clashTestGroup "Numbers"
-        [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"       (["","Bounds_testBench"],"Bounds_testBench",True)
+        [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "BitInteger"   (["","BitInteger_testBench"],"BitInteger_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"       (["","Bounds_testBench"],"Bounds_testBench",True)
         -- TODO: re-enable for Verilog
-        , runTest ("tests" </> "shouldwork" </> "Numbers") [VHDL] ["-itests/shouldwork/Numbers","-fclash-inline-limit=300"] "NumConstantFoldingTB"       (["","NumConstantFoldingTB_testBench"],"NumConstantFoldingTB_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") (defBuild \\ [Verilog]) ["-itests/shouldwork/Numbers","-fclash-inline-limit=300"] "NumConstantFoldingTB"       (["","NumConstantFoldingTB_testBench"],"NumConstantFoldingTB_testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fclash-inline-limit=300"] "NumConstantFolding"  "main"
 #if MIN_VERSION_base(4,12,0)
         -- Naturals are broken on GHC <= 8.4. See https://github.com/clash-lang/clash-compiler/pull/473
@@ -190,9 +191,10 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize3"      (["","Resize3_testBench"],"Resize3_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SatMult"      ([""],"SatMult_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] "ShiftRotate"         (["","ShiftRotate_testBench"],"ShiftRotate_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SignedZero"   (["","SignedZero_testBench"],"SignedZero_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Signum"   (["","Signum_testBench"],"Signum_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Strict"       (["","Strict_testBench"],"Strict_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "UnsignedZero" (["","UnsignedZero_testBench"],"UnsignedZero_testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SignedZero"   (["","SignedZero_testBench"],"SignedZero_testBench",True)
         ]
       , clashTestGroup "Polymorphism"
         [ runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "ExistentialBoxed"  ([""],"ExistentialBoxed_topEntity",False)


### PR DESCRIPTION
Some users reported issues when using `^` in Clash: the compiler would slow down to a crawl trying to translate it. As a solution, this PR adds an extra typeclass `Exp`, implementing a version of `^` that can't overflow. More info can be found in the comments below.

This PR could be better in a couple of ways, but I can't realistically spend more time on it:

* I'm not sure what to do with `Integer` and `Int`. Should they have an implementation? 

* As we always know the exponent (`SNat n`) a synthesizable implementation always exists in the form of `foldl (*) 1 (replicate n (resize b))`. If we want to keep constant folding though, we need an actual blackbox for it - which is relatively difficult to write. Even if we could let Clash generate the definition mentioned earlier if it can't constant fold, we'd still be introducing a very slow version of exponentiation in simulation.. For now, whenever a exponentiation blackbox is instantiated it emits a warning pointing users to https://github.com/clash-lang/clash-compiler/issues/593.

* Tests could be more extensive.

Despite the issues I'm still going to request this PR to be merged, due to earlier mentioned time constraints. 

----------------

During the implementation of this PR I found a subtle oversight in one of the tests testing constant folding of operations on various number types. The fixes are piggybacked to this PR.

------------------

PR also adds minor cleanups / missing functions to `Evaluator.hs`.