### PR TITLE
Enable DerivingStrategies by default

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -612,6 +612,7 @@ wantedLanguageExtensions df =
              , LangExt.DeriveAnyClass
              , LangExt.DeriveGeneric
              , LangExt.DeriveLift
+             , LangExt.DerivingStrategies
              , LangExt.ExplicitForAll
              , LangExt.ExplicitNamespaces
              , LangExt.FlexibleContexts

--- a/testsuite/Test/Tasty/Clash.hs
+++ b/testsuite/Test/Tasty/Clash.hs
@@ -591,6 +591,7 @@ outputTest' env target extraClashArgs extraGhcArgs modName funcName path =
              , "-XDataKinds"
              , "-XDeriveAnyClass"
              , "-XDeriveGeneric"
+             , "-XDerivingStrategies"
              , "-XDeriveLift"
              , "-XExplicitForAll"
              , "-XExplicitNamespaces"


### PR DESCRIPTION
So that you can choose instances for newtypes derived using GeneralizedNewtypeDeriving; as it can conflict with DeriveAnyClass