### PR TITLE
Enable naming entity/module instantiations

### DIFF
--- a/clash-lib/prims/common/Clash_Magic.json
+++ b/clash-lib/prims/common/Clash_Magic.json
@@ -1,0 +1,16 @@
+[ { "Primitive" :
+    { "name"      : "Clash.Magic.prefixName"
+    , "primType"  : "Function"
+    }
+  }
+, { "Primitive" :
+    { "name"      : "Clash.Magic.suffixName"
+    , "primType"  : "Function"
+    }
+  }
+, { "Primitive" :
+    { "name"      : "Clash.Magic.setName"
+    , "primType"  : "Function"
+    }
+  }
+]

--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -48,7 +48,7 @@ import           Clash.Core.VarEnv
 import           Clash.Driver.Types                      (BindingMap)
 import           Prelude                                 hiding (lookup)
 import           Clash.Unique
-import           Clash.Util                              (SrcSpan, curLoc)
+import           Clash.Util                              (curLoc)
 import           Clash.Pretty
 
 -- | The heap
@@ -70,7 +70,7 @@ data StackFrame
   | Instantiate Type
   | PrimApply  Text PrimInfo [Type] [Value] [Term]
   | Scrutinise Type [Alt]
-  | Tickish SrcSpan
+  | Tickish TickInfo
   deriving Show
 
 instance ClashPretty StackFrame where
@@ -91,7 +91,7 @@ instance ClashPretty StackFrame where
 
 mkTickish
   :: Stack
-  -> [SrcSpan]
+  -> [TickInfo]
   -> Stack
 mkTickish s sps = map Tickish sps ++ s
 

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -43,7 +43,8 @@ import qualified Outputable             as GHC
 import Clash.Core.DataCon               (DataCon (..))
 import Clash.Core.Literal               (Literal (..))
 import Clash.Core.Name                  (Name (..))
-import Clash.Core.Term                  (Pat (..), Term (..), CoreContext (..), primArg)
+import Clash.Core.Term
+  (Pat (..), Term (..), TickInfo (..), ModName (..), CoreContext (..), primArg)
 import Clash.Core.TyCon                 (TyCon (..), TyConName, isTupleTyConLike)
 import Clash.Core.Type                  (ConstTy (..), Kind, LitTy (..),
                                          Type (..), TypeView (..), tyView)
@@ -223,6 +224,12 @@ instance PrettyPrec Term where
       tDoc <- pprPrec prec t
       eDoc <- pprPrec prec e'
       return (tDoc <> line' <> eDoc)
+
+instance PrettyPrec TickInfo where
+  pprPrec prec (SrcSpan sp)   = pprPrec prec sp
+  pprPrec prec (ModName PrefixName t) = ("<prefixName>" <>) <$> pprPrec prec t
+  pprPrec prec (ModName SuffixName t) = ("<suffixName>" <>) <$> pprPrec prec t
+  pprPrec prec (ModName SetName t)    = ("<setName>" <>) <$> pprPrec prec t
 
 instance PrettyPrec SrcSpan where
   pprPrec _ sp = return ("<src>"<>pretty (GHC.showSDocUnsafe (GHC.ppr sp)))

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -64,7 +64,7 @@ import           Clash.Core.Subst
   (aeqTerm, aeqType, extendIdSubst, mkSubst, substTm)
 import           Clash.Core.Term
   (LetBinding, Pat (..), Term (..), CoreContext (..), Context, PrimInfo (..),
-   TmName, WorkInfo (..), collectArgs, collectArgsTicks)
+   TmName, WorkInfo (..), TickInfo, collectArgs, collectArgsTicks)
 import           Clash.Core.TyCon
   (TyConMap, tyConDataCons)
 import           Clash.Core.Type             (KindOrType, Type (..),
@@ -712,7 +712,7 @@ specialise' :: Lens' extra (Map.Map (Id, Int, Either Term Type) Id) -- ^ Lens in
             -> Lens' extra Int -- ^ Lens into the specialisation limit
             -> TransformContext -- Transformation context
             -> Term -- ^ Original term
-            -> (Term, [Either Term Type], [SrcSpan]) -- ^ Function part of the term, split into root and applied arguments
+            -> (Term, [Either Term Type], [TickInfo]) -- ^ Function part of the term, split into root and applied arguments
             -> Either Term Type -- ^ Argument to specialize on
             -> RewriteMonad extra Term
 specialise' specMapLbl specHistLbl specLimitLbl (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -144,6 +144,8 @@ Library
                       Clash.Intel.ClockGen
                       Clash.Intel.DDR
 
+                      Clash.Magic
+
                       Clash.NamedTypes
 
                       Clash.Prelude

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -120,6 +120,8 @@ module Clash.Explicit.Prelude
   , undefined
     -- ** Named types
   , module Clash.NamedTypes
+    -- ** Magic
+  , module Clash.Magic
     -- ** Haskell Prelude
     -- $hiding
   , module Prelude
@@ -143,6 +145,7 @@ import Clash.Class.BitPack
 import Clash.Class.Exp
 import Clash.Class.Num
 import Clash.Class.Resize
+import Clash.Magic
 import Clash.NamedTypes
 import Clash.Explicit.BlockRam
 import Clash.Explicit.BlockRam.File

--- a/clash-prelude/src/Clash/Magic.hs
+++ b/clash-prelude/src/Clash/Magic.hs
@@ -1,0 +1,38 @@
+{-|
+  Copyright   :  (C) 2019, Myrtle Software Ltd
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <clash@qbaylogic.com>
+
+Control module instance, and register, names in generated HDL code.
+-}
+
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeOperators  #-}
+
+module Clash.Magic where
+
+import Clash.NamedTypes ((:::))
+import GHC.TypeLits     (Symbol)
+
+-- | Prefix instance and register names with the given 'Symbol'
+prefixName
+  :: forall (name :: Symbol) a . a -> name ::: a
+prefixName = id
+{-# NOINLINE prefixName #-}
+
+-- | Suffix instance and register names with the given 'Symbol'
+suffixName
+  :: forall (name :: Symbol) a . a -> name ::: a
+suffixName = id
+{-# NOINLINE suffixName #-}
+
+-- | Name the instance or register with the given 'Symbol', instead of using
+-- an auto-generated name. Pre- and suffixes annotated with 'prefixName' and
+-- 'suffixName' will be added to both instances and registers named with
+-- 'setName' and instances and registers that are auto-named.
+setName
+  :: forall (name :: Symbol) a . a -> name ::: a
+setName = id
+{-# NOINLINE setName #-}

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -141,6 +141,8 @@ module Clash.Prelude
   , module Clash.NamedTypes
     -- ** Hidden arguments
   , module Clash.Hidden
+    -- ** Magic
+  , module Clash.Magic
     -- ** Haskell Prelude
     -- $hiding
   , module Prelude
@@ -166,6 +168,7 @@ import           Clash.Class.Num
 import           Clash.Class.Resize
 import qualified Clash.Explicit.Prelude      as E
 import           Clash.Hidden
+import           Clash.Magic
 import           Clash.NamedTypes
 import           Clash.Prelude.BitIndex
 import           Clash.Prelude.BitReduction

--- a/tests/shouldwork/Basic/NameInstance.hs
+++ b/tests/shouldwork/Basic/NameInstance.hs
@@ -1,0 +1,28 @@
+module NameInstance where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+
+topEntity :: Bool -> Bool -> (Bool,Bool)
+topEntity = suffixName @"after" $ setName @"foo" $ prefixName @"before" f
+
+f :: Bool -> Bool -> (Bool,Bool)
+f x y = (y,x)
+{-# NOINLINE f #-}
+
+-- File content test
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (takeDirectory topDir </> "NameInstance_topEntity.v")
+  assertIn "before_foo_after" content

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -78,6 +78,8 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LotOfStates"         (["","LotOfStates_testBench"],"LotOfStates_testBench",True)
         -- TODO: Fix for VHDL. ModelSim / GHDL simulate _extremely_ slowly
         , runTest ("tests" </> "shouldwork" </> "Basic") (defBuild \\ [VHDL]) [] "MultipleHidden"      (["","MultipleHidden_testBench"],"MultipleHidden_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NameInstance"         ([""],"NameInstance_topEntity",False)
+        , outputTest ("tests" </> "shouldwork" </> "Basic") [Verilog]   [] [] "NameInstance" "main"
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NameOverlap"         (["nameoverlap"],"nameoverlap",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NestedPrimitives"    ([""],"NestedPrimitives_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NestedPrimitives2"   ([""],"NestedPrimitives2_topEntity",False)


### PR DESCRIPTION
i.e.

```
suffixName @"after" $
setName @"foo" $
prefixName @"before" $ f x y z
```

labels the instantiation of `f` with "before_foo_after"