### PR TITLE
Count term instead of type arguments to calculate arity

### DIFF
--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -760,7 +760,7 @@ removeUnusedExpr _ e@(collectArgs -> (p@(Prim nm pty),args)) = do
          else changed (mkApps p args')
     _ -> return e
   where
-    arity = length . Either.lefts . fst $ splitFunForallTy pty
+    arity = length . Either.rights . fst $ splitFunForallTy pty
 
     go _ _ _ [] = return []
     go tcm n used (Right ty:args') = do


### PR DESCRIPTION
`removeUnusedExpr` wasn't removing enough unused expresssions
because it counted type arguments instead of term arguments
to determine the arity of a primitive.

NB we need the arity so that `removeUnusedExpr` doesn't remove
arguments in over-applied expressions.

Fixes #607