### PR TITLE
Prevent Clash from generating signal names with same name as time units

### DIFF
--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -219,6 +219,11 @@ rmSlash nm = fromMaybe nm $ do
 
 type VHDLM a = Mon (State VHDLState) a
 
+-- | Time units: are added to 'reservedWords' as simulators trip over signals
+-- named after them.
+timeUnits :: [Identifier]
+timeUnits = ["fs", "ps", "ns", "us", "ms", "sec", "min"]
+
 -- List of reserved VHDL-2008 keywords
 -- + used internal names: toslv, fromslv, tagtoenum, datatotag
 -- + used IEEE library names: integer, boolean, std_logic, std_logic_vector,
@@ -239,7 +244,7 @@ reservedWords = ["abs","access","after","alias","all","and","architecture"
   ,"unaffected","units","until","use","variable","vmode","vprop","vunit","wait"
   ,"when","while","with","xnor","xor","toslv","fromslv","tagtoenum","datatotag"
   ,"integer", "boolean", "std_logic", "std_logic_vector", "signed", "unsigned"
-  ,"to_integer", "to_signed", "to_unsigned", "string"]
+  ,"to_integer", "to_signed", "to_unsigned", "string"] ++ timeUnits
 
 filterReserved :: Identifier -> Identifier
 filterReserved s = if s `elem` reservedWords

--- a/tests/shouldwork/Basic/Time.hs
+++ b/tests/shouldwork/Basic/Time.hs
@@ -1,0 +1,21 @@
+module Time where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock System Source
+  -> Reset System Asynchronous
+  -> Signal System Int
+  -> Signal System Int
+topEntity clk rst ps = register clk rst 0 (ps + 1)
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (1 :> 2 :> 3 :> Nil)
+    expectedOutput = outputVerifier clk rst (0 :> 2 :> 3 :> Nil)
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -89,6 +89,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "SimpleConstructor"   ([""],"SimpleConstructor_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TagToEnum"           ([""],"TagToEnum_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TestIndex"           ([""],"TestIndex_topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "Time"                (["","Time_testBench"],"Time_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TwoFunctions"        ([""],"TwoFunctions_topEntity",False)
         ]
         , clashTestGroup "ShouldFail"


### PR DESCRIPTION
GHDL, ModelSim, and Vivado reject programs with mixed ps-as-time-unit
and ps-as-signal.