### PR TITLE
Increase a lower bound to temporary-1.2.1 instead of 1.2.

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -132,7 +132,7 @@ Library
                       process                 >= 1.1.0.2  && < 1.7,
                       reducers                >= 3.12.2   && < 4.0,
                       template-haskell        >= 2.8.0.0  && < 2.15,
-                      temporary               >= 1.2      && < 1.4,
+                      temporary               >= 1.2.1    && < 1.4,
                       text                    >= 1.2.2    && < 1.3,
                       text-show               >= 3.7      && < 3.9,
                       time                    >= 1.4.0.1  && < 1.10,


### PR DESCRIPTION
Version 1.2.0.* of the temporary package doesn't  contain the function
`getCanonicalTemporaryDirectory`.