### PR TITLE
AppPropFast: inline, instead of let-bind, work-free arguments

### DIFF
--- a/clash-lib/prims/common/Clash_Annotations_BitRepresentation_Deriving.json
+++ b/clash-lib/prims/common/Clash_Annotations_BitRepresentation_Deriving.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Annotations.BitRepresentation.Deriving.dontApplyInHDL"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "dontApplyInHDL :: (a -> b) -> a -> b"
     , "template"  : "~ARG[1]"

--- a/clash-lib/prims/common/Clash_Class_BitPack.json
+++ b/clash-lib/prims/common/Clash_Class_BitPack.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Class.BitPack.packFloat#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type" :
 "packFloat# :: Float -> BitVector 32"
@@ -8,6 +9,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Class.BitPack.unpackFloat#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type" :
 "packFloat# :: BitVector 32 -> Float"
@@ -16,6 +18,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Class.BitPack.packDouble#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type" :
 "packFloat# :: Double -> BitVector 64"
@@ -24,6 +27,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Class.BitPack.unpackDouble#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type" :
 "packFloat# :: BitVector 64 -> Double"

--- a/clash-lib/prims/common/Clash_Explicit_Signal.json
+++ b/clash-lib/prims/common/Clash_Explicit_Signal.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Explicit.Signal.unsafeSynchronizer"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type" :
 "unsafeSynchronizer

--- a/clash-lib/prims/common/Clash_GHC_GHC2Core.json
+++ b/clash-lib/prims/common/Clash_GHC_GHC2Core.json
@@ -1,16 +1,19 @@
 [ { "BlackBox" :
     { "name"      : "EmptyCase"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "template"  : "~ERRORO"
     }
   }
 , { "Primitive" :
     { "name"     : "_CO_"
+    , "workInfo"  : "Constant"
     , "primType" : "Constructor"
     }
   }
 , { "Primitive" :
     { "name"     : "_TY_"
+    , "workInfo"  : "Constant"
     , "primType" : "Constructor"
     }
   }

--- a/clash-lib/prims/common/Clash_Intel_ClockGen.json
+++ b/clash-lib/prims/common/Clash_Intel_ClockGen.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Intel.ClockGen.altpll"
+    , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "format"    : "Haskell"
     , "templateFunction" : "Clash.Primitives.Intel.ClockGen.altpllTF"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Intel.ClockGen.alteraPll"
+    , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "format"    : "Haskell"
     , "templateFunction" : "Clash.Primitives.Intel.ClockGen.alteraPllTF"

--- a/clash-lib/prims/common/Clash_Promoted_Nat.json
+++ b/clash-lib/prims/common/Clash_Promoted_Nat.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Promoted.Nat.powSNat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Clash.Promoted.Nat.powSNat :: SNat a -> SNat b -> SNat (a^b)"
     , "template"  : "~LIT[0] ** ~LIT[1]"

--- a/clash-lib/prims/common/Clash_Promoted_Nat_Unsafe.json
+++ b/clash-lib/prims/common/Clash_Promoted_Nat_Unsafe.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Promoted.Nat.Unsafe.unsafeSNat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Clash.Promoted.Nat.Unsafe.unsafeSNat :: Integer -> SNat k"
     , "template"  : "~LIT[0]"

--- a/clash-lib/prims/common/Clash_Promoted_Symbol.json
+++ b/clash-lib/prims/common/Clash_Promoted_Symbol.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Promoted.Symbol.SSymbol"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "SSymbol :: KnownNat n => Proxy n -> SSymbol n"
     , "template"  : "~LIT[0]"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Promoted.Symbol.symbolToString"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "symbolToString :: SSymbol n -> String"
     , "template"  : "~LIT[0]"

--- a/clash-lib/prims/common/Clash_Signal_BiSignal.json
+++ b/clash-lib/prims/common/Clash_Signal_BiSignal.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.veryUnsafeToBiSignalIn"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "veryUnsafeToBiSignalIn
@@ -14,6 +15,7 @@
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.mergeBiSignalOuts"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "mergeBiSignalOuts

--- a/clash-lib/prims/common/Clash_Signal_Bundle.json
+++ b/clash-lib/prims/common/Clash_Signal_Bundle.json
@@ -1,5 +1,6 @@
 [ { "Primitive" :
     { "name"      : "Clash.Signal.Bundle.vecBundle#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }

--- a/clash-lib/prims/common/Clash_Signal_Internal.json
+++ b/clash-lib/prims/common/Clash_Signal_Internal.json
@@ -1,30 +1,36 @@
 [ { "Primitive" :
     { "name"      : "Clash.Signal.Internal.signal#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "Clash.Signal.Internal.mapSignal#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "Clash.Signal.Internal.appSignal#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "Clash.Signal.Internal.foldr#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "Clash.Signal.Internal.traverse#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "Clash.Signal.Internal.joinSignal#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }

--- a/clash-lib/prims/common/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/common/Clash_Sized_Internal_BitVector.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.undefined#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "undefined# :: forall n . KnownNat n => BitVector n"
     , "template"  : "~ERRORO"
@@ -7,6 +8,7 @@
   }
 , { "Primitive" :
     { "name"      : "Clash.Sized.Internal.BitVector.checkUnpackUndef"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }

--- a/clash-lib/prims/common/Clash_Sized_RTree.json
+++ b/clash-lib/prims/common/Clash_Sized_RTree.json
@@ -1,5 +1,6 @@
 [ { "Primitive" :
     { "name"      : "Clash.Sized.RTree.tdfold"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }

--- a/clash-lib/prims/common/Clash_Sized_Vector.json
+++ b/clash-lib/prims/common/Clash_Sized_Vector.json
@@ -2,6 +2,7 @@
   {
     "BlackBox": {
       "name": "Clash.Sized.Vector.lazyV",
+      "workInfo" : "Never",
       "kind": "Expression",
       "type": "lazyV :: KnownNat n => Vec n a -> Vec n a",
       "template": "~ARG[1]"
@@ -10,6 +11,7 @@
   {
     "BlackBox": {
       "name": "Clash.Sized.Vector.seqV",
+      "workInfo" : "Never",
       "kind": "Expression",
       "type": "seqV :: KnownNat n => Vec n a -> b -> b",
       "template": "~ARG[2]"
@@ -18,6 +20,7 @@
   {
     "BlackBox": {
       "name": "Clash.Sized.Vector.seqVX",
+      "workInfo" : "Never",
       "kind": "Expression",
       "type": "seqVX :: KnownNat n => Vec n a -> b -> b",
       "template": "~ARG[2]"
@@ -25,16 +28,19 @@
   }
 , { "Primitive" :
     { "name"      : "Clash.Sized.Vector.dfold"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "Clash.Sized.Vector.dtfold"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "Clash.Sized.Vector.traverse#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }

--- a/clash-lib/prims/common/Clash_Transformations.json
+++ b/clash-lib/prims/common/Clash_Transformations.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Transformations.removedArg"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "removedArg :: a"
     , "template"  : "~ERRORO"

--- a/clash-lib/prims/common/Clash_XException.json
+++ b/clash-lib/prims/common/Clash_XException.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.XException.seqX"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "seqX :: a -> b -> b"
     , "template"  : "~ARG[1]"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.XException.errorX"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "errorX :: HasCallStack -> String -> a"
     , "template"  : "~ERRORO"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
      { "name"      : "Clash.XException.deepseqX"
+     , "workInfo"  : "Never"
      , "kind"      : "Expression"
      , "type"      : "deepseqX :: Undefined a => a -> b -> b"
      , "template"  : "~ARG[2]"

--- a/clash-lib/prims/common/Control_Exception_Base.json
+++ b/clash-lib/prims/common/Control_Exception_Base.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Control.Exception.Base.recSelError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "recSelError :: Addr# -> a"
     , "template"  : "~ERRORO"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
    { "name"      : "Control.Exception.Base.recConError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "recConError :: Addr# -> a"
     , "template"  : "~ERRORO"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.irrefutPatError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "irrefutPatError :: Addr# -> a"
     , "template"  : "~ERRORO"
@@ -21,6 +24,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.runtimeError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "runtimeError :: Addr# -> a"
     , "template"  : "~ERRORO"
@@ -28,6 +32,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.nonExhaustiveGuardsError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "nonExhaustiveGuardsError :: Addr# -> a"
     , "template"  : "~ERRORO"
@@ -35,6 +40,7 @@
   }
 , { "BlackBox" :
    { "name"      : "Control.Exception.Base.patError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "patError :: Addr# -> a"
     , "template"  : "~ERRORO"
@@ -42,6 +48,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.noMethodBindingError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "noMethodBindingError :: Addr# -> a"
     , "template"  : "~ERRORO"
@@ -49,6 +56,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.absentError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "absentError :: Addr# -> a"
     , "template"  : "~ERRORO"
@@ -56,6 +64,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.typeError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "typeError :: Addr# -> a"
     , "template"  : "~ERRORO"

--- a/clash-lib/prims/common/Debug_Trace.json
+++ b/clash-lib/prims/common/Debug_Trace.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Debug.Trace.trace"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "trace :: String -> a -> a"
     , "template"  : "~ARG[1]"

--- a/clash-lib/prims/common/GHC_Base.json
+++ b/clash-lib/prims/common/GHC_Base.json
@@ -1,5 +1,6 @@
 [ { "Primitive" :
     { "name"      : "GHC.Base.$"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }

--- a/clash-lib/prims/common/GHC_CString.json
+++ b/clash-lib/prims/common/GHC_CString.json
@@ -1,17 +1,20 @@
 [ { "BlackBox" :
     { "name"      : "GHC.CString.unpackCString#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "template"  : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.CString.unpackFoldrCString#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "template"  : "~LIT[0]"
     }
   }
 , { "Primitive" :
     { "name"     : "GHC.CString.unpackCStringUtf8#"
+    , "workInfo"  : "Never"
     , "primType" : "Function"
     }
   }

--- a/clash-lib/prims/common/GHC_Err.json
+++ b/clash-lib/prims/common/GHC_Err.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Err.error"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "error :: [Char] -> a"
     , "template"  : "~ERRORO"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Err.errorWithoutStackTrace"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "errorWithoutStackTrace :: [Char] -> a"
     , "template"  : "~ERRORO"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Err.undefined"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "undefined :: a"
     , "template"  : "~ERRORO"

--- a/clash-lib/prims/common/GHC_IO_Exception.json
+++ b/clash-lib/prims/common/GHC_IO_Exception.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.IO.Exception.assertError"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "assertError :: HasCallStack => Bool -> a -> a"
     , "comment"   : "It would be nice if we could use a HDL assertion, however,

--- a/clash-lib/prims/common/GHC_Magic.json
+++ b/clash-lib/prims/common/GHC_Magic.json
@@ -1,16 +1,19 @@
 [ { "Primitive" :
     { "name"      : "GHC.Magic.lazy"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "GHC.Magic.noinline"
+    , "workInfo"  : "Never"
     , "type"      : "forall a. a -> a"
     , "primType"  : "Function"
     }
   }
 , { "Primitive" :
     { "name"      : "GHC.Magic.runRW#"
+    , "workInfo"  : "Never"
     , "primType"  : "Function"
     }
   }

--- a/clash-lib/prims/common/GHC_Natural.json
+++ b/clash-lib/prims/common/GHC_Natural.json
@@ -2,12 +2,14 @@
   {
     "Primitive": {
       "name": "GHC.Natural.NatS#",
+      "workInfo" : "Never",
       "primType": "Constructor"
     }
   },
   {
     "BlackBox": {
       "name": "GHC.Natural.underflowError",
+      "workInfo" : "Constant",
       "kind": "Expression",
       "type": "underflowError :: a",
       "template": "~ERRORO"

--- a/clash-lib/prims/common/GHC_Prim.json
+++ b/clash-lib/prims/common/GHC_Prim.json
@@ -10,6 +10,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.unsafeCoerce#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unsafeCoerce# :: a -> b"
     , "template"  : "~ARG[0]"

--- a/clash-lib/prims/common/GHC_Real.json
+++ b/clash-lib/prims/common/GHC_Real.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Real.divZeroError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "divZeroError :: a"
     , "template"  : "~ERRORO"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Real.ratioZeroDenominatorError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "ratioZeroDenominatorError :: a"
     , "template"  : "~ERRORO"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Real.overflowError"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "overflowError :: a"
     , "template"  : "~ERRORO"

--- a/clash-lib/prims/common/GHC_TypeNats.json
+++ b/clash-lib/prims/common/GHC_TypeNats.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.TypeNats.natVal"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "natVal :: forall n proxy. KnownNat n => proxy n -> Natural"
     , "template"  : "~ARG[0]"

--- a/clash-lib/prims/common/GHC_Typelits.json
+++ b/clash-lib/prims/common/GHC_Typelits.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.TypeLits.natVal"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "natVal :: forall n proxy. KnownNat n => proxy n -> Integer"
     , "template"  : "~ARG[0]"

--- a/clash-lib/prims/common/GHC_Types.json
+++ b/clash-lib/prims/common/GHC_Types.json
@@ -1,10 +1,12 @@
 [ { "Primitive" :
     { "name"      : "GHC.Types.MkCoercible"
+    , "workInfo"  : "Never"
     , "primType"  : "Constructor"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Types.C#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "I# :: Char# -> Char"
     , "template"  : "~ARG[0]"
@@ -12,6 +14,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Types.I#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "I# :: Int# -> Int"
     , "template"  : "~ARG[0]"
@@ -19,6 +22,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Types.W#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "W# :: Word# -> Word"
     , "template"  : "~ARG[0]"

--- a/clash-lib/prims/common/Unsafe_Coerce.json
+++ b/clash-lib/prims/common/Unsafe_Coerce.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Unsafe.Coerce.unsafeCoerce"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unsafeCoerce :: a -> b"
     , "template"  : "~ARG[0]"

--- a/clash-lib/prims/commonverilog/Clash_Promoted_Nat.json
+++ b/clash-lib/prims/commonverilog/Clash_Promoted_Nat.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Promoted.Nat.flogBaseSNat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Clash.Promoted.Nat.flogBaseSNat :: (2 <= base, 1 <= x)
                                                      => SNat base -- ARG[2]
@@ -25,6 +26,7 @@ endfunction"
   }
 , { "BlackBox" :
     { "name"      : "Clash.Promoted.Nat.clogBaseSNat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Clash.Promoted.Nat.clogBaseSNat :: (2 <= base, 1 <= x)
                                                      => SNat base -- ARG[2]
@@ -49,6 +51,7 @@ endfunction"
   }
 , { "BlackBox" :
     { "name"      : "Clash.Promoted.Nat.logBaseSNat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Clash.Promoted.Nat.logBaseSNat :: (FLog base x ~ CLog base x)
                                                     => SNat base -- ARG[1]

--- a/clash-lib/prims/commonverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/commonverilog/Clash_Signal_Internal.json
@@ -15,6 +15,7 @@ assign ~RESULT = {~ARG[0],~ARG[1]};~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.unsafeFromAsyncReset"
+    , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
 "unsafeFromAsyncReset :: Reset domain Asynchronous -> Signal domain Bool"
@@ -23,6 +24,7 @@ assign ~RESULT = {~ARG[0],~ARG[1]};~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.unsafeToAsyncReset"
+    , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
 "unsafeToAsyncReset :: Signal domain Bool -> Reset domain Asynchronous"
@@ -31,6 +33,7 @@ assign ~RESULT = {~ARG[0],~ARG[1]};~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.fromSyncReset"
+    , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
 "fromSyncReset :: Reset domain Synchronous -> Signal domain Bool"
@@ -39,6 +42,7 @@ assign ~RESULT = {~ARG[0],~ARG[1]};~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.unsafeToSyncReset"
+    , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
 "unsafeToSyncReset :: Signal domain Bool -> Reset domain Synchronous"

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.BV"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "BV :: Integer -> Integer -> BitVector n"
     , "comment"   : "THIS IS ONLY USED WHEN WW EXPOSES BITVECTOR INTERNALS"
@@ -8,6 +9,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.Bit"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Bit :: Integer -> Integer -> BitVector n"
     , "comment"   : "THIS IS ONLY USED WHEN WW EXPOSES BIT INTERNALS"
@@ -16,6 +18,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.high"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "high :: Bit"
     , "template"  : "1'b1"
@@ -23,6 +26,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.low"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "low :: Bit"
     , "template"  : "1'b0"
@@ -30,6 +34,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.pack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "pack# :: Bit -> BitVector 1"
     , "template"  : "~ARG[0]"
@@ -37,6 +42,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.unpack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unpack# :: BitVector 1 -> Bit"
     , "template"  : "~ARG[0]"
@@ -79,6 +85,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger##"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger## :: Integer -> Integer -> Bit"
     , "template"  : "~ARG[0][0] ? 1'bx : ~ARG[1][0]"
@@ -156,6 +163,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.toInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "toInteger# :: KnownNat n => BitVector n -> Integer"
     , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$signed(~VAR[bv][1][0+:~SIZE[~TYPO]])~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[bv][1]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"
@@ -163,6 +171,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.size#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "size# :: KnownNat n => BitVector n -> Int"
     , "template"  : "~SIZE[~TYPO]'sd~SIZE[~TYP[1]]"
@@ -170,6 +179,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxIndex#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxIndex# :: KnownNat n => BitVector n -> Int"
     , "template"  : "~SIZE[~TYPO]'sd~SIZE[~TYP[1]] - ~SIZE[~TYPO]'sd1"
@@ -177,6 +187,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.++#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
     , "template"  : "~IF~AND[~SIZE[~TYP[1]],~SIZE[~TYP[2]]]~THEN{~ARG[1],~ARG[2]}~ELSE~IF~SIZE[~TYP[1]]~THEN~ARG[1]~ELSE~ARG[2]~FI~FI"
@@ -195,6 +206,7 @@
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.slice#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "slice# :: BitVector (m + 1 + i) -- ARG[0]
@@ -206,6 +218,7 @@
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.msb#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "msb# :: KnownNat n  -- ARG[0]
@@ -216,6 +229,7 @@
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.lsb#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "lsb# :: BitVector n -- ARG[0]
@@ -225,6 +239,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.minBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "minBound# :: BitVector n"
     , "template"  : "~SIZE[~TYPO]'d0"
@@ -232,6 +247,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxBound# :: KnownNat n => BitVector n"
     , "template"  : "{~SIZE[~TYPO] {1'b1}}"
@@ -267,6 +283,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Integer -> BitVector n"
     , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[2]]]~THEN$unsigned(~VAR[i][2][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[2]]) {1'b0}},~VAR[i][2]})~FI"
@@ -351,6 +368,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.truncateB#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "truncateB# :: forall a b . KnownNat a => BitVector (a + b) -> BitVector a"
     , "template"  : "~VAR[bv][1][0+:~SIZE[~TYPO]]"

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Index.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Index.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.pack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "pack# :: Index n -> BitVector (CLog 2 n)"
     , "template"  : "~ARG[0]"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.unpack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unpack# :: (KnownNat n, 1 <= n) => BitVector (CLog 2 n) -> Index n"
     , "template"  : "~ARG[2]"
@@ -56,6 +58,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.maxBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxBound# :: KnownNat n => Index n"
     , "template"  : "~ARG[0]-~SIZE[~TYPO]'d1"
@@ -84,6 +87,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.fromInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Index n"
     , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
@@ -119,6 +123,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.toInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "toInteger# :: Index n -> Integer"
     , "template"  : "~IF~SIZE[~TYP[0]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[0]]]~THEN$signed(~VAR[i][0][0+:~SIZE[~TYPO]])~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[0]]) {1'b0}},~VAR[i][0]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"
@@ -126,6 +131,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.resize#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "resize# :: KnownNat m => Index n -> Index m"
     , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN~VAR[bv][1][0+:~SIZE[~TYPO]]~ELSE{{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~ARG[1]}~FI~ELSE~SIZE[~TYPO]'d0~FI"

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Signed.json
@@ -42,6 +42,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.toInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "toInteger# :: Signed n -> Integer"
     , "template"  : "~IF~SIZE[~TYP[0]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[0]]]~THEN$signed(~VAR[i][0][0+:~SIZE[~TYPO]])~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[0]]) {1'b0}},~VAR[i][0]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"
@@ -49,6 +50,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.size#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "size# :: KnownNat n => Signed n -> Int"
     , "template"  : "~SIZE[~TYPO]'sd~LIT[0]"
@@ -56,6 +58,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.pack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "pack# :: KnownNat n => Signed n -> BitVector n"
     , "template"  : "$unsigned(~ARG[1])"
@@ -63,6 +66,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.unpack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unpack# :: KnownNat n => BitVector n -> Signed n"
     , "template"  : "$signed(~ARG[1])"
@@ -70,6 +74,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.minBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "minBound# :: KnownNat n => Signed n"
     , "comment"   : "Generates incorrect SV for n=0"
@@ -78,6 +83,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.maxBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxBound# :: KnownNat n => Signed n"
     , "comment"   : "Generates incorrect SV for n=0"
@@ -107,6 +113,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.fromInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Signed (n :: Nat)"
     , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$signed(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
@@ -184,6 +191,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.truncateB#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "truncateB# :: KnownNat m => Signed (n + m) -> Signed m"
     , "template"  : "$signed(~VAR[s][1][0+:~SIZE[~TYPO]])"
@@ -191,6 +199,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.resize#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "resize# :: (KnownNat n, KnownNat m) => Signed n -> Signed m"
     , "template"  : "~IF~SIZE[~TYP[2]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[2]]]~THEN$signed({~VAR[s][2][~LIT[0]-1],~VAR[s][2][0+:(~SIZE[~TYPO]-1)]})~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[2]]) {~VAR[s][2][~LIT[0]-1]}},~VAR[s][2]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Unsigned.json
@@ -42,6 +42,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.toInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "toInteger# :: Unsigned n -> Integer"
     , "template"  : "~IF~SIZE[~TYP[0]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[0]]]~THEN$signed(~VAR[i][0][0+:~SIZE[~TYPO]])~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[0]]) {1'b0}},~VAR[i][0]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"
@@ -49,6 +50,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.size#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "size# :: KnownNat n => Unsigned n -> Int"
     , "template"  : "~SIZE[~TYPO]'sd~LIT[0]"
@@ -56,6 +58,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.pack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "pack# :: Unsigned n -> BitVector n"
     , "template"  : "~ARG[0]"
@@ -63,6 +66,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.unpack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unpack# :: KnownNat n => BitVector n -> Unsigned n"
     , "template"  : "~ARG[1]"
@@ -70,6 +74,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.minBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "minBound# :: Unsigned n"
     , "template"  : "~SIZE[~TYPO]'d0"
@@ -77,6 +82,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.maxBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxBound# :: KnownNat n => Unsigned n"
     , "template"  : "{~LIT[0] {1'b1}}"
@@ -98,6 +104,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.fromInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Unsigned n"
     , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
@@ -175,6 +182,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.resize#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "resize# :: KnownNat m => Unsigned n -> Unsigned m"
     , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN~VAR[bv][1][0+:~SIZE[~TYPO]]~ELSE{{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~ARG[1]}~FI~ELSE~SIZE[~TYPO]'d0~FI"

--- a/clash-lib/prims/commonverilog/Clash_Sized_Vector.json
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Vector.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.maxIndex"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxIndex :: KnownNat n => Vec n a -> Int"
     , "template"  : "~SIZE[~TYPO]'sd~LIT[0] - ~SIZE[~TYPO]'sd1"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.length"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "length :: KnownNat n => Vec n a -> Int"
     , "template"  : "~SIZE[~TYPO]'sd~LIT[0]"

--- a/clash-lib/prims/commonverilog/Clash_Xilinx_ClockGen.json
+++ b/clash-lib/prims/commonverilog/Clash_Xilinx_ClockGen.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Xilinx.ClockGen.clockWizard"
+    , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "type"      :
 "clockWizard
@@ -19,6 +20,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Xilinx.ClockGen.clockWizardDifferential"
+    , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "type"      :
 "clockWizardDifferential

--- a/clash-lib/prims/commonverilog/GHC_Int.json
+++ b/clash-lib/prims/commonverilog/GHC_Int.json
@@ -2,24 +2,28 @@
   {
     "BlackBoxHaskell": {
       "name": "GHC.Int.I8#",
+      "workInfo" : "Never",
       "templateFunction": "Clash.Primitives.GHC.Int.intTF"
     }
   },
   {
     "BlackBoxHaskell": {
       "name": "GHC.Int.I16#",
+      "workInfo" : "Never",
       "templateFunction": "Clash.Primitives.GHC.Int.intTF"
     }
   },
   {
     "BlackBoxHaskell": {
       "name": "GHC.Int.I32#",
+      "workInfo" : "Never",
       "templateFunction": "Clash.Primitives.GHC.Int.intTF"
     }
   },
   {
     "BlackBoxHaskell": {
       "name": "GHC.Int.I64#",
+      "workInfo" : "Never",
       "templateFunction": "Clash.Primitives.GHC.Int.intTF"
     }
   }

--- a/clash-lib/prims/commonverilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/commonverilog/GHC_Integer_Type.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Integer.Type.smallInteger"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "smallInteger :: Int# -> Integer"
     , "template"  : "assign ~RESULT = $signed(~ARG[0]);"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.integerToInt"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "integerToInt :: Integer -> Int#"
     , "template"  : "assign ~RESULT = $signed(~ARG[0]);"
@@ -119,6 +121,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.wordToInteger"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "wordToInteger :: Word# -> Integer"
     , "template"  : "assign ~RESULT = $signed(~ARG[0]);"
@@ -126,6 +129,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.integerToWord"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "integerToWord :: Integer -> Word#"
     , "template"  : "assign ~RESULT = $unsigned(~ARG[0]);"

--- a/clash-lib/prims/commonverilog/GHC_Natural.json
+++ b/clash-lib/prims/commonverilog/GHC_Natural.json
@@ -2,6 +2,7 @@
   {
     "BlackBox": {
       "name": "GHC.Natural.naturalFromInteger",
+      "workInfo" : "Never",
       "kind": "Expression",
       "type": "naturalFromInteger :: Integer -> Natural",
       "template": "$unsigned(~VAR[n][0][(~SIZE[~TYPO]-1):0])",
@@ -20,6 +21,7 @@
   {
     "BlackBox": {
       "name": "GHC.Natural.wordToNatural#",
+      "workInfo" : "Never",
       "kind": "Declaration",
       "type": "wordToNatural# :: Word# -> Natural",
       "template": "assign ~RESULT = $unsigned(~ARG[0]);",

--- a/clash-lib/prims/commonverilog/GHC_Prim.json
+++ b/clash-lib/prims/commonverilog/GHC_Prim.json
@@ -147,6 +147,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.int2Word#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "int2Word# :: Int# -> Word#"
     , "template"  : "$unsigned(~ARG[0])"
@@ -231,6 +232,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.word2Int#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "int2Word# :: Word# -> Int#"
     , "template"  : "$signed(~ARG[0])"
@@ -280,6 +282,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.byteSwap16#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "template"  :
@@ -291,6 +294,7 @@ assign ~RESULT = {~VAR[w][0][31:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~FI
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.byteSwap32#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "template"  :
@@ -302,6 +306,7 @@ assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.byteSwap64#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "template"  :
@@ -313,6 +318,7 @@ assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.byteSwap#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "template"  :
@@ -325,6 +331,7 @@ assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow8Int#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "narrow8Int# :: Int# -> Int#"
     , "template"  :
@@ -335,6 +342,7 @@ assign ~RESULT = $signed(~VAR[i][0][7:0]);
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow16Int#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "narrow16Int# :: Int# -> Int#"
     , "template"  :
@@ -345,6 +353,7 @@ assign ~RESULT = $signed(~VAR[i][0][15:0]);
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow32Int#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "narrow32Int# :: Int# -> Int#"
     , "template"  :
@@ -355,6 +364,7 @@ assign ~RESULT = $signed(~VAR[i][0][31:0]);
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow8Word#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "narrow8Int# :: Word# -> Word#"
     , "template"  :
@@ -365,6 +375,7 @@ assign ~RESULT = $unsigned(~VAR[w][0][7:0]);
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow16Word#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "narrow16Word# :: Word# -> Word#"
     , "template"  :
@@ -375,6 +386,7 @@ assign ~RESULT = $unsigned(~VAR[w][0][15:0]);
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow32Word#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "narrow32Int# :: Word# -> Word#"
     , "template"  :

--- a/clash-lib/prims/commonverilog/GHC_Word.json
+++ b/clash-lib/prims/commonverilog/GHC_Word.json
@@ -2,24 +2,28 @@
   {
     "BlackBoxHaskell": {
       "name": "GHC.Word.W8#",
+      "workInfo" : "Never",
       "templateFunction": "Clash.Primitives.GHC.Word.wordTF"
     }
   },
   {
     "BlackBoxHaskell": {
       "name": "GHC.Word.W16#",
+      "workInfo" : "Never",
       "templateFunction": "Clash.Primitives.GHC.Word.wordTF"
     }
   },
   {
     "BlackBoxHaskell": {
       "name": "GHC.Word.W32#",
+      "workInfo" : "Never",
       "templateFunction": "Clash.Primitives.GHC.Word.wordTF"
     }
   },
   {
     "BlackBoxHaskell": {
       "name": "GHC.Word.W64#",
+      "workInfo" : "Never",
       "templateFunction": "Clash.Primitives.GHC.Word.wordTF"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Signal_BiSignal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_BiSignal.json
@@ -17,6 +17,7 @@ assign ~ARG[1] = (~ARG[3] == 1'b1) ? ~ARG[4] : {~SIZE[~TYP[1]] {1'bz}};
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.readFromBiSignal#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "readFromBiSignal#

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
@@ -58,6 +58,7 @@ assign ~RESULT = ~SYM[0];
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.clockGen"
+    , "workInfo" : "Always"
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
@@ -86,6 +87,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.tbClockGen"
+    , "workInfo" : "Always"
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
@@ -118,6 +120,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.asyncResetGen"
+    , "workInfo" : "Always"
     , "kind" : "Declaration"
     , "type" : "asyncResetGen :: Reset domain Asynchronous"
     , "template" :
@@ -133,6 +136,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.syncResetGen"
+    , "workInfo" : "Always"
     , "kind" : "Declaration"
     , "type" :
 "syncResetGen

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.json
@@ -18,6 +18,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.setSlice#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "setSlice# :: BitVector (m + 1 + i) -- ARG[0]
@@ -36,6 +37,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.split#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "split# :: KnownNat n        -- ARG[0]

--- a/clash-lib/prims/systemverilog/Clash_Sized_RTree.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_RTree.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.treplicate"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat d -> a -> RTree d a"
     , "template"  : "'{(2**~LIT[0]) {~TOBV[~ARG[1]][~TYP[1]]}}"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.textract"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "textract :: RTree 0 a -> a"
     , "template"  : "~FROMBV[~VAR[tree][0][\\0\\]][~TYPO]"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.tsplit"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "tsplit:: RTree (d+1) a -> (RTree d a,RTree d a)"
     , "template"  : "~TOBV[~VAR[tree][0]][~TYP[0]]"

--- a/clash-lib/prims/systemverilog/Clash_Sized_Vector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Vector.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.head"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "head :: Vec (n + 1) a -> a"
     , "template"  : "~FROMBV[~VAR[vec][0][\\0\\]][~TYPO]"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.tail"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
     , "template"  : "~VAR[vec][0][1 : $high(~VAR[vec][0])]"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.last"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Vec (n + 1) a -> a"
     , "template"  : "~FROMBV[~VAR[vec][0][\\$high(~VAR[vec][0])\\]][~TYPO]"
@@ -21,6 +24,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.init"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Vec (n + 1) a -> Vec n a"
     , "template"  : "~VAR[vec][0][0 : $high(~VAR[vec][0]) - 1]"
@@ -28,6 +32,7 @@
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.select"
+    , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
 "select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
@@ -49,6 +54,7 @@ genvar ~GENSYM[n][1];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.++"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "(++) :: Vec n a -> Vec m a -> Vec (n + m) a"
     , "template"  : "~FROMBV[{~TOBV[~ARG[0]][~TYP[0]],~TOBV[~ARG[1]][~TYP[1]]}][~TYPO]"
@@ -56,6 +62,7 @@ genvar ~GENSYM[n][1];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.concat"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "template"  :
@@ -71,6 +78,7 @@ genvar ~GENSYM[n][1];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.splitAt"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
     , "template"  :
@@ -92,6 +100,7 @@ assign ~SYM[0] = ~TOBV[~ARG[1]][~TYP[1]];
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.unconcat"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type" :
  "unconcat :: KnownNat n     -- ARG[0]
@@ -111,6 +120,7 @@ genvar ~GENSYM[n][1];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.map"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "template" :
@@ -133,6 +143,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.imap"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "template"  :
@@ -158,6 +169,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.imap_go"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "imap_go :: Index n -> (Index n -> a -> b) -> Vec m a -> Vec m b"
     , "template"  :
@@ -183,6 +195,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.zipWith"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "template"  :
@@ -208,6 +221,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.foldr"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "template"  :
@@ -236,6 +250,7 @@ assign ~RESULT = ~ARG[1];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.fold"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "fold :: (a -> a -> a) -> Vec (n+1) a -> a"
     , "comment"   : "THIS ONLY WORKS FOR POWER OF TWO LENGTH VECTORS"
@@ -307,6 +322,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.replicate"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat n -> a -> Vec n a"
     , "template"  : "'{~LIT[0] {~TOBV[~ARG[1]][~TYP[1]]}}"
@@ -314,6 +330,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.transpose"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "template"  :
@@ -333,6 +350,7 @@ genvar ~GENSYM[col_index][2];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.reverse"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "template"  :
@@ -348,6 +366,7 @@ genvar ~GENSYM[n][1];
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.concatBitVector#"
+    , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
 "concatBitVector# :: (KnownNat n,KnownNat m) -- (ARG[0],ARG[1])
@@ -358,6 +377,7 @@ genvar ~GENSYM[n][1];
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.unconcatBitVector#"
+    , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
 "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
@@ -368,6 +388,7 @@ genvar ~GENSYM[n][1];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.rotateLeftS"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
@@ -387,6 +408,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.rotateRightS"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :

--- a/clash-lib/prims/verilog/Clash_Signal_BiSignal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_BiSignal.json
@@ -17,6 +17,7 @@ assign ~ARG[1] = (~ARG[3] == 1'b1) ? ~ARG[4] : {~SIZE[~TYP[1]] {1'bz}};
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.readFromBiSignal#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "readFromBiSignal#

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.json
@@ -58,6 +58,7 @@ assign ~RESULT = ~SYM[0];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.clockGen"
+    , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
@@ -88,6 +89,7 @@ assign ~RESULT = ~SYM[0];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.tbClockGen"
+    , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
@@ -122,6 +124,7 @@ assign ~RESULT = ~SYM[0];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.asyncResetGen"
+    , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "type" :
 "asyncResetGen :: Reset domain 'Asynchronous"
@@ -140,6 +143,7 @@ assign ~RESULT = ~SYM[0];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.syncResetGen"
+    , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "type" :
 "syncResetGen

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.json
@@ -19,6 +19,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.setSlice#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "setSlice# :: BitVector (m + 1 + i) -- ARG[0]

--- a/clash-lib/prims/verilog/Clash_Sized_RTree.json
+++ b/clash-lib/prims/verilog/Clash_Sized_RTree.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.treplicate"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat d -> a -> RTree d a"
     , "template"  : "{(2**~LIT[0]) {~ARG[1]}}"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.textract"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "textract :: RTree 0 a -> a"
     , "template"  : "~VAR[tree][0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]]"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.tsplit"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "tsplit:: RTree (d+1) a -> (RTree d a,RTree d a)"
     , "template"  : "~ARG[0]"

--- a/clash-lib/prims/verilog/Clash_Sized_Vector.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Vector.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.head"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "head :: Vec (n + 1) a -> a"
     , "template"  : "~VAR[vec][0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]]"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.tail"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
     , "template"  : "~VAR[vec][0][~SIZE[~TYPO]-1 : 0]"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.last"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Vec (n + 1) a -> a"
     , "template"  : "~VAR[vec][0][~SIZE[~TYPO]-1:0]"
@@ -21,6 +24,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.init"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Vec (n + 1) a -> Vec n a"
     , "template"  : "~VAR[vec][0][~SIZE[~TYP[0]]-1 : ~SIZE[~TYPEL[~TYP[0]]]]"
@@ -28,6 +32,7 @@
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.select"
+    , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
 "select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
@@ -57,6 +62,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.++"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "(++) :: Vec n a -> Vec m a -> Vec (n + m) a"
     , "template"  : "{~ARG[0],~ARG[1]}"
@@ -64,6 +70,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.concat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "template"  : "~ARG[0]"
@@ -71,6 +78,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.splitAt"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
     , "template"  : "~ARG[1]"
@@ -78,6 +86,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.unconcat"
+    , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
  "unconcat :: KnownNat n     -- ARG[0]
@@ -89,6 +98,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.map"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "template"  :
@@ -111,6 +121,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.imap"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "template"  :
@@ -137,6 +148,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.imap_go"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "imap :: Index n -> (Index n -> a -> b) -> Vec m a -> Vec m b"
     , "template"  :
@@ -163,6 +175,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.zipWith"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "template"  :
@@ -188,6 +201,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.foldr"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "template"  :
@@ -221,6 +235,7 @@ assign ~RESULT = ~ARG[1];
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.fold"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "fold :: (a -> a -> a) -> Vec (n+1) a -> a"
     , "comment"   : "THIS ONLY WORKS FOR POWER OF TWO LENGTH VECTORS"
@@ -315,6 +330,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.maxIndex"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxIndex :: KnownNat n => Vec n a -> Int"
     , "template"  : "~SIZE[~TYPO]'sd~LIT[0] - ~SIZE[~TYPO]'d1"
@@ -322,6 +338,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.length"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "length :: KnownNat n => Vec n a -> Int"
     , "template"  : "~SIZE[~TYPO]'sd~LIT[0]"
@@ -329,6 +346,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.replicate"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat n -> a -> Vec n a"
     , "template"  : "{~LIT[0] {~ARG[1]}}"
@@ -336,6 +354,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.transpose"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "template"  :
@@ -354,6 +373,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.reverse"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "template"  :
@@ -369,6 +389,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.concatBitVector#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "concatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
@@ -379,6 +400,7 @@ end
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.unconcatBitVector#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
@@ -389,6 +411,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.rotateLeftS"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
@@ -409,6 +432,7 @@ end
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.rotateRightS"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :

--- a/clash-lib/prims/vhdl/Clash_Promoted_Nat.json
+++ b/clash-lib/prims/vhdl/Clash_Promoted_Nat.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Promoted.Nat.flogBaseSNat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Clash.Promoted.Nat.flogBaseSNat :: (2 <= base, 1 <= x)
                                                      => SNat base -- ARG[2]
@@ -10,6 +11,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Promoted.Nat.clogBaseSNat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Clash.Promoted.Nat.clogBaseSNat :: (2 <= base, 1 <= x)
                                                      => SNat base -- ARG[2]
@@ -20,6 +22,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Promoted.Nat.logBaseSNat"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Clash.Promoted.Nat.logBaseSNat :: (FLog base x ~ CLog base x)
                                                     => SNat base -- ARG[1]

--- a/clash-lib/prims/vhdl/Clash_Signal_BiSignal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_BiSignal.json
@@ -17,6 +17,7 @@
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.readFromBiSignal#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "readFromBiSignal#

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.json
@@ -145,6 +145,7 @@ end block;~FI
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.clockGate"
+    , "workInfo" : "Always"
     , "kind" : "Declaration"
     , "type" :
 "clockGate
@@ -166,6 +167,7 @@ end block;~ELSE
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.clockGen"
+    , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
@@ -199,6 +201,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.tbClockGen"
+    , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
@@ -231,6 +234,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.asyncResetGen"
+    , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "type" :
 "asyncResetGen :: Reset domain 'Asynchronous"
@@ -245,6 +249,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.syncResetGen"
+    , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "type" :
 "syncResetGen :: ( domain ~ 'Dom n clkPeriod
@@ -261,6 +266,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.unsafeFromAsyncReset"
+    , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
 "unsafeFromAsyncReset :: Reset domain Asynchronous -> Signal domain Bool"
@@ -269,6 +275,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.unsafeToAsyncReset"
+    , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
 "unsafeToAsyncReset :: Signal domain Bool -> Reset domain Asynchronous"
@@ -277,6 +284,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.fromSyncReset"
+    , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
 "fromSyncReset :: Reset domain Synchronous -> Signal domain Bool"
@@ -285,6 +293,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Signal.Internal.unsafeToSyncReset"
+    , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
 "unsafeToSyncReset :: Signal domain Bool -> Reset domain Synchronous"

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.BV"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "BV :: Integer -> Integer -> BitVector n"
     , "comment"   : "THIS IS ONLY USED WHEN WW EXPOSES BITVECTOR INTERNALS"
@@ -8,6 +9,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.Bit"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Bit :: Integer -> Integer -> BitVector n"
     , "comment"   : "THIS IS ONLY USED WHEN WW EXPOSES BIT INTERNALS"
@@ -16,6 +18,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.size#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "size# :: KnownNat n => BitVector n -> Int"
     , "template"  : "to_signed(~SIZE[~TYP[1]],~SIZE[~TYPO])"
@@ -23,6 +26,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxIndex#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxIndex# :: KnownNat n => BitVector n -> Int"
     , "template"  : "to_signed(~SIZE[~TYP[1]] - 1,~SIZE[~TYPO])"
@@ -30,6 +34,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.high"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "high :: Bit"
     , "template"  : "'1'"
@@ -37,6 +42,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.low"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "low :: Bit"
     , "template"  : "'0'"
@@ -44,6 +50,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.pack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "pack# :: Bit -> BitVector 1"
     , "template"  : "std_logic_vector'(0 => ~ARG[0])"
@@ -51,6 +58,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.unpack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unpack# :: BitVector 1 -> Bit"
     , "template"  : "~VAR[bv][0](0)"
@@ -72,6 +80,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger##"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger## :: Integer -> Integer -> Bit"
     , "template"  : "~IF~LIT[0]~THEN'U'~ELSE~ARG[1](0)~FI"
@@ -107,6 +116,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.++#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
     , "template"  : "~IF~AND[~SIZE[~TYP[1]],~SIZE[~TYP[2]]]~THENstd_logic_vector'(std_logic_vector'(~ARG[1]) & std_logic_vector'(~ARG[2]))~ELSE~IF~SIZE[~TYP[1]]~THENstd_logic_vector'(~ARG[1])~ELSEstd_logic_vector'(~ARG[2])~FI~FI"
@@ -288,6 +298,7 @@ end block; ~ELSE
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.setSlice#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "setSlice# :: BitVector (m + 1 + i) -- ARG[0]
@@ -309,6 +320,7 @@ end process;
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.slice#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "slice# :: BitVector (m + 1 + i) -- ARG[0]
@@ -320,6 +332,7 @@ end process;
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.split#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "split# :: KnownNat n        -- ARG[0]
@@ -330,6 +343,7 @@ end process;
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.msb#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "msb# :: KnownNat n  -- ARG[0]
@@ -340,6 +354,7 @@ end process;
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.lsb#"
+    , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
 "lsb# :: BitVector n -- ARG[0]
@@ -391,6 +406,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.minBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "minBound# :: BitVector n"
     , "template"  : "~IF~SIZE[~TYPO]~THENstd_logic_vector'(~SIZE[~TYPO]-1 downto 0 => '0')~ELSEstd_logic_vector'(0 downto 1 => '0')~FI"
@@ -398,6 +414,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.maxBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxBound# :: KnownNat n => BitVector n"
     , "template"  : "~IF~SIZE[~TYPO]~THENstd_logic_vector'(~SIZE[~TYPO]-1 downto 0 => '1')~ELSEstd_logic_vector'(0 downto 1 => '1')~FI"
@@ -433,6 +450,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.fromInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Integer -> BitVector n"
     , "template"  : "std_logic_vector(resize(unsigned(std_logic_vector(~ARG[2])),~SIZE[~TYPO]))"
@@ -475,6 +493,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.toInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "toInteger# :: KnownNat n => BitVector n -> Integer"
     , "template"  : "~IF~SIZE[~TYP[1]]~THENsigned(std_logic_vector(resize(unsigned(~ARG[1]),~SIZE[~TYPO])))~ELSEto_signed(0,64)~FI"
@@ -538,6 +557,7 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.truncateB#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "truncateB# :: forall a b . KnownNat a => BitVector (a + b) -> BitVector a"
     , "template"  : "std_logic_vector(resize(unsigned(~ARG[1]),~SIZE[~TYPO]))"

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.pack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "pack# :: Index n -> BitVector (CLog 2 n)"
     , "template"  : "std_logic_vector(~ARG[0])"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.unpack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unpack# :: (KnownNat n, 1 <= n) => BitVector (CLog 2 n) -> Index n"
     , "template"  : "unsigned(~ARG[2])"
@@ -56,6 +58,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.maxBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxBound# :: KnownNat n => Index n"
     , "template"  : "to_unsigned(~LIT[0]-1,~SIZE[~TYPO])"
@@ -84,6 +87,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.fromInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Index n"
     , "template"  : "resize(unsigned(std_logic_vector(~ARG[1])),~SIZE[~TYPO])"
@@ -119,6 +123,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.toInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "toInteger# :: Index n -> Integer"
     , "template"  : "~IF~SIZE[~TYP[0]]~THENsigned(std_logic_vector(resize(~ARG[0],~SIZE[~TYPO])))~ELSEto_signed(0,64)~FI"
@@ -126,6 +131,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.resize#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "resize# :: KnownNat m => Index n -> Index m"
     , "template"  : "~IF~SIZE[~TYP[1]]~THENresize(~ARG[1],~SIZE[~TYPO])~ELSEunsigned'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.size#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "size# :: KnownNat n => Signed n -> Int"
     , "template"   : "to_signed(~LIT[0],~SIZE[~TYPO])"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.pack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "pack# :: KnownNat n => Signed n -> BitVector n"
     , "template"  : "std_logic_vector(~ARG[1])"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.unpack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unpack# :: KnownNat n => BitVector n -> Signed n"
     , "template"  : "signed(~ARG[1])"
@@ -63,6 +66,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.minBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "minBound# :: KnownNat n => Signed n"
     , "comment"   : "the quantification with signed gives the array an ascending index"
@@ -71,6 +75,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.maxBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxBound# :: KnownNat n => Signed n"
     , "comment"   : "the quantification with signed gives the array an ascending index"
@@ -100,6 +105,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.fromInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Signed (n :: Nat)"
     , "template"  : "resize(~ARG[1],~LIT[0])"
@@ -158,6 +164,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.toInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "toInteger# :: Signed n -> Integer"
     , "template"  : "~IF~SIZE[~TYP[0]]~THENresize(~ARG[0],~SIZE[~TYPO])~ELSEto_signed(0,64)~FI"
@@ -221,6 +228,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.resize#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "resize# :: (KnownNat n, KnownNat m) => Signed n -> Signed m"
     , "template"  : "~IF~SIZE[~TYP[2]]~THENresize(~ARG[2],~LIT[1])~ELSEsigned'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
@@ -228,6 +236,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.truncateB#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "truncateB# :: KnownNat m => Signed (n + m) -> Signed m"
     , "template"  : "~IF~SIZE[~TYPO]~THEN~VAR[s][1](~LIT[0]-1 downto 0)~ELSEsigned'(0 downto 1 => '0')~FI"

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.size#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "size# :: KnownNat n => Unsigned n -> Int"
     , "template"  : "to_signed(~LIT[0],~SIZE[~TYPO])"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.pack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "pack# :: Unsigned n -> BitVector n"
     , "template"  : "std_logic_vector(~ARG[0])"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.unpack#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "unpack# :: KnownNat n => BitVector n -> Unsigned n"
     , "template"  : "unsigned(~ARG[1])"
@@ -63,6 +66,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.minBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "minBound# :: Unsigned n"
     , "template"  : "~IF~SIZE[~TYPO]~THENunsigned'(~SIZE[~TYPO]-1 downto 0 => '0')~ELSEunsigned'(0 downto 1 => '0')~FI"
@@ -70,6 +74,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.maxBound#"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxBound# :: KnownNat n => Unsigned n"
     , "template"  : "~IF~SIZE[~TYPO]~THENunsigned'(~LIT[0]-1 downto 0 => '1')~ELSEunsigned'(0 downto 1 => '1')~FI"
@@ -91,6 +96,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.fromInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Unsigned n"
     , "template"  : "resize(unsigned(std_logic_vector(~ARG[1])),~LIT[0])"
@@ -126,6 +132,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.toInteger#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "toInteger# :: Unsigned n -> Integer"
     , "template"  : "~IF~SIZE[~TYP[0]]~THENsigned(std_logic_vector(resize(~ARG[0],~SIZE[~TYPO])))~ELSEto_signed(0,64)~FI"
@@ -189,6 +196,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.resize#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "resize# :: KnownNat m => Unsigned n -> Unsigned m"
     , "template"  : "~IF~SIZE[~TYP[1]]~THENresize(~ARG[1],~LIT[0])~ELSEunsigned'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"

--- a/clash-lib/prims/vhdl/Clash_Sized_RTree.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_RTree.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.treplicate"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat n -> a -> RTree d a"
     , "template"  : "~TYPMO'(0 to (2**~LIT[0])-1 => ~ARG[1])"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.textract"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "textract :: RTree 0 a -> a"
     , "template"  : "~IF ~VIVADO ~THEN ~FROMBV[~VAR[t][0]][~TYPO] ~ELSE ~VAR[t][0](0) ~FI"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.RTree.tsplit"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "tsplit:: RTree (d+1) a -> (RTree d a,RTree d a)"
     , "template"  : "(~VAR[t][0](0 to (2**(~DEPTH[~TYP[0]]-1))-1) ,~VAR[t][0](2**(~DEPTH[~TYP[0]]-1) to (2**~DEPTH[~TYP[0]])-1))"

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.head"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "head :: Vec (n + 1) a -> a"
     , "template"  : "~IF ~VIVADO ~THEN ~TYPMO'(fromSLV(~VAR[vec][0](0))) ~ELSE ~VAR[vec][0](0) ~FI"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.tail"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
     , "template"  : "~VAR[vec][0](1 to ~VAR[vec][0]'high)"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.last"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Vec (n + 1) a -> a"
     , "template"  : "~IF ~VIVADO ~THEN ~TYPMO'(fromSLV(~VAR[vec][0](~VAR[vec][0]'high))) ~ELSE ~VAR[vec][0](~VAR[vec][0]'high) ~FI"
@@ -21,6 +24,7 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.init"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Vec (n + 1) a -> Vec n a"
     , "template"  : "~VAR[vec][0](0 to ~VAR[vec][0]'high - 1)"
@@ -28,6 +32,7 @@
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.select"
+    , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
 "select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
@@ -46,6 +51,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.++"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "(++) :: Vec n a -> Vec m a -> Vec (n + m) a"
     , "template"  : "~TYPMO'(~TYPM[0]'(~ARG[0]) & ~TYPM[1]'(~ARG[1]))"
@@ -53,6 +59,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.concat"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "template"  :
@@ -67,6 +74,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.splitAt"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
     , "template"  : "~IF~LENGTH[~TYPO]~THEN~ARG[1]~ELSE(~VAR[vec][1](0 to ~LIT[0]-1),~VAR[vec][1](~LIT[0] to ~VAR[vec][1]'high))~FI"
@@ -74,6 +82,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.unconcat"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "unconcat :: KnownNat n     -- ARG[0]
@@ -92,6 +101,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.map"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "template"  :
@@ -118,6 +128,7 @@ end generate;~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.imap"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "template"  :
@@ -155,6 +166,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.imap_go"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "imap_go :: Index n -> (Index n -> a -> b) -> Vec m a -> Vec m b"
     , "template"  :
@@ -187,6 +199,7 @@ end generate;~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.zipWith"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "template"  :
@@ -217,6 +230,7 @@ end generate;~FI
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.foldr"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "template"  :
@@ -253,6 +267,7 @@ end block;~ELSE
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.fold"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "fold :: (a -> a -> a) -> Vec (n+1) a -> a"
     , "comment"   : "THIS ONLY WORKS FOR POWER OF TWO LENGTH VECTORS"
@@ -345,6 +360,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.maxIndex"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "maxIndex :: KnownNat n => Vec n a -> Int"
     , "template"  : "to_signed(~LIT[0] - 1,~SIZE[~TYPO])"
@@ -352,6 +368,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.length"
+    , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "length :: KnownNat n => Vec n a -> Int"
     , "template"  : "to_signed(~LIT[0],~SIZE[~TYPO])"
@@ -359,6 +376,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.replicate"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat n -> a -> Vec n a"
     , "template"  : "~TYPMO'(0 to ~LIT[0]-1 => ~IF ~VIVADO ~THEN ~TOBV[~TYPM[1]'(~ARG[1])][~TYP[1]] ~ELSE ~ARG[1] ~FI)"
@@ -366,6 +384,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.transpose"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "template"  :
@@ -381,6 +400,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.reverse"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "template"  :
@@ -393,6 +413,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.concatBitVector#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "concatBitVector# :: (KnownNat n,KnownNat m) -- (ARG[0],ARG[1])
@@ -408,6 +429,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Vector.unconcatBitVector#"
+    , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
 "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
@@ -423,6 +445,7 @@ end generate;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.rotateLeftS"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
@@ -444,6 +467,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.rotateRightS"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :

--- a/clash-lib/prims/vhdl/Clash_Xilinx_ClockGen.json
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_ClockGen.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Xilinx.ClockGen.clockWizard"
+    , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "type"      :
 "clockWizard
@@ -30,6 +31,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Xilinx.ClockGen.clockWizardDifferential"
+    , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "type"      :
 "clockWizardDifferential

--- a/clash-lib/prims/vhdl/GHC_Int.json
+++ b/clash-lib/prims/vhdl/GHC_Int.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Int.I8#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "I8# :: Int# -> Int8"
     , "template"  : "resize(~ARG[0],8)"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Int.I16#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "I16# :: Int# -> Int16"
     , "template"  : "resize(~ARG[0],16)"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Int.I32#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "I32# :: Int# -> Int32"
     , "template"  : "resize(~ARG[0],32)"
@@ -21,6 +24,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Int.I64#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "I64# :: Int# -> Int64"
     , "template"  : "resize(~ARG[0],64)"

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.json
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Integer.Type.smallInteger"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "smallInteger :: Int# -> Integer"
     , "template"  : "~ARG[0]"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.integerToInt"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "integerToInt :: Integer -> Int#"
     , "template"  : "~ARG[0]"
@@ -142,6 +144,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.wordToInteger"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "wordToInteger :: Word# -> Integer"
     , "template"  : "signed(std_logic_vector(~ARG[0]))"
@@ -149,6 +152,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.integerToWord"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "integerToWord :: Integer -> Word#"
     , "template"  : "unsigned(std_logic_vector(~ARG[0]))"

--- a/clash-lib/prims/vhdl/GHC_Natural.json
+++ b/clash-lib/prims/vhdl/GHC_Natural.json
@@ -2,6 +2,7 @@
   {
     "BlackBox": {
       "name": "GHC.Natural.naturalFromInteger",
+      "workInfo" : "Never",
       "kind": "Expression",
       "type": "naturalFromInteger :: Integer -> Natural",
       "template": "resize(unsigned(std_logic_vector(~ARG[0])),~SIZE[~TYPO])",
@@ -11,6 +12,7 @@
   {
     "BlackBox": {
       "name": "GHC.Natural.timesNatural",
+      "workInfo" : "Never",
       "kind": "Expression",
       "type": "timesNatural :: Natural -> Natural -> Natural",
       "template": "resize(~ARG[0] * ~ARG[1],~SIZE[~TYPO])",
@@ -20,6 +22,7 @@
   {
     "BlackBox": {
       "name": "GHC.Natural.wordToNatural#",
+      "workInfo" : "Never",
       "kind": "Expression",
       "type": "wordToNatural# :: Word# -> Natural",
       "template": "unsigned(std_logic_vector(~ARG[0]))",

--- a/clash-lib/prims/vhdl/GHC_Prim.json
+++ b/clash-lib/prims/vhdl/GHC_Prim.json
@@ -147,6 +147,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.chr#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "ord# :: Int# -> Chr#"
     , "template"  : "resize(unsigned(std_logic_vector(~ARG[0])),21)"
@@ -154,6 +155,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.int2Word#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "word2Int# :: Int# -> Word#"
     , "template"  : "unsigned(std_logic_vector(~ARG[0]))"
@@ -245,6 +247,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.word2Int#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "word2Int# :: word# -> Int#"
     , "template"  : "signed(std_logic_vector(~ARG[0]))"
@@ -1040,6 +1043,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.byteSwap16#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "template"  :
@@ -1051,6 +1055,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.byteSwap32#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "template"  :
@@ -1064,6 +1069,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.byteSwap64#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "template"  :
@@ -1077,6 +1083,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.byteSwap#"
+    , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "template"  :
@@ -1092,6 +1099,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow8Int#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "narrow8Int# :: Int# -> Int#"
     , "template"  : "resize(~VAR[i][0](7 downto 0),~SIZE[~TYPO])"
@@ -1099,6 +1107,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow16Int#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "narrow16Int# :: Int# -> Int#"
     , "template"  : "resize(~VAR[i][0](15 downto 0),~SIZE[~TYPO])"
@@ -1106,6 +1115,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow32Int#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "narrow32Int# :: Int# -> Int#"
     , "template"  : "resize(~VAR[i][0](31 downto 0),~SIZE[~TYPO])"
@@ -1113,6 +1123,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow8Word#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "narrow8Word# :: Word# -> Word#"
     , "template"  : "resize(~VAR[w][0](7 downto 0),~SIZE[~TYPO])"
@@ -1120,6 +1131,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow16Word#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "narrow16Word# :: Word# -> Word#"
     , "template"  : "resize(~VAR[w][0](15 downto 0),~SIZE[~TYPO])"
@@ -1127,6 +1139,7 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.narrow32Word#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "narrow32Word# :: Word# -> Word#"
     , "template"  : "resize(~VAR[w][0](31 downto 0),~SIZE[~TYPO])"

--- a/clash-lib/prims/vhdl/GHC_Word.json
+++ b/clash-lib/prims/vhdl/GHC_Word.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Word.W8#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "W8# :: Word# -> Word8"
     , "template"  : "resize(~ARG[0],8)"
@@ -7,6 +8,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Word.W16#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "W16# :: Word# -> Word16"
     , "template"  : "resize(~ARG[0],16)"
@@ -14,6 +16,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Word.W32#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "W32# :: Word# -> Word32"
     , "template"  : "resize(~ARG[0],32)"
@@ -21,6 +24,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Word.W64#"
+    , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "W64# :: Word# -> Word64"
     , "template"  : "resize(~ARG[0],64)"

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -20,6 +20,8 @@ module Clash.Core.Term
   , LetBinding
   , Pat (..)
   , Alt
+  , PrimInfo (..)
+  , WorkInfo (..)
   , CoreContext (..), Context, isLambdaBodyCtx
   , collectArgs, primArg
   )
@@ -45,7 +47,7 @@ data Term
   = Var     !Id                             -- ^ Variable reference
   | Data    !DataCon                        -- ^ Datatype constructor
   | Literal !Literal                        -- ^ Literal
-  | Prim    !Text !Type                     -- ^ Primitive
+  | Prim    !Text !PrimInfo                 -- ^ Primitive
   | Lam     !Id Term                        -- ^ Term-abstraction
   | TyLam   !TyVar Term                     -- ^ Type-abstraction
   | App     !Term !Term                     -- ^ Application
@@ -54,6 +56,25 @@ data Term
   | Case    !Term !Type [Alt]               -- ^ Case-expression: subject, type of
                                             -- alternatives, list of alternatives
   | Cast    !Term !Type !Type               -- ^ Cast a term from one type to another
+  deriving (Show,Generic,NFData,Hashable,Binary)
+
+data PrimInfo
+  = PrimInfo
+  { primType     :: !Type
+  , primWorkInfo :: !WorkInfo
+  }
+  deriving (Show,Generic,NFData,Hashable,Binary)
+
+data WorkInfo
+  = WorkConstant
+  -- ^ Ignores its arguments, and outputs a constant
+  | WorkNever
+  -- ^ Never adds any work
+  | WorkVariable
+  -- ^ Does work when the arguments are variable
+  | WorkAlways
+  -- ^ Performs work regardless of whether the variables are constant or
+  -- variable; these are things like clock or reset generators
   deriving (Show,Generic,NFData,Hashable,Binary)
 
 -- | Term reference

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -362,14 +362,14 @@ compilePrimitive
   -> ResolvedPrimitive
   -- ^ Primitive to compile
   -> IO CompiledPrimitive
-compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName bbGenName source) = do
+compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf bbGenName source) = do
   let interpreterArgs = concatMap (("-package-db":) . (:[])) pkgDbs
   -- Compile a blackbox template function or fetch it from an already compiled file.
   r <- go interpreterArgs source
   processHintError
     (show bbGenName)
     bbName
-    (\bbFunc -> BlackBoxHaskell bbName bbGenName (hash source, bbFunc))
+    (\bbFunc -> BlackBoxHaskell bbName wf bbGenName (hash source, bbFunc))
     r
   where
     qualMod = intercalate "." modNames
@@ -402,12 +402,12 @@ compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName bbGenName source) =
     go args Nothing = do
       loadImportAndInterpret idirs args topDir qualMod funcName "BlackBoxFunction"
 
-compilePrimitive idirs pkgDbs topDir (BlackBox pNm tkind () oReg libM imps incs templ) = do
+compilePrimitive idirs pkgDbs topDir (BlackBox pNm wf tkind () oReg libM imps incs templ) = do
   libM'  <- mapM parseTempl libM
   imps'  <- mapM parseTempl imps
   incs'  <- mapM (traverse parseBB) incs
   templ' <- parseBB templ
-  return (BlackBox pNm tkind () oReg libM' imps' incs' templ')
+  return (BlackBox pNm wf tkind () oReg libM' imps' incs' templ')
  where
   iArgs = concatMap (("-package-db":) . (:[])) pkgDbs
 
@@ -445,8 +445,8 @@ compilePrimitive idirs pkgDbs topDir (BlackBox pNm tkind () oReg libM imps incs 
     r <- loadImportAndInterpret idirs iArgs topDir qualMod funcName "TemplateFunction"
     processHintError (show bbGenName) pNm (BBFunction (Data.Text.unpack pNm) hsh) r
 
-compilePrimitive _ _ _ (Primitive pNm typ) =
-  return (Primitive pNm typ)
+compilePrimitive _ _ _ (Primitive pNm wf typ) =
+  return (Primitive pNm wf typ)
 
 processHintError
   :: Monad m


### PR DESCRIPTION
Normally `AppPropFast` let-binds arguments that are non-constant, because they might perform work, which we do not want to duplicate.

This patch allows us to describe exactly entails "work", including all the primitives. AppPropFast uses this information to determine whether to inline (substitute) or let-bind arguments,instead of using "constantness" as a heuristic.