### PR TITLE
Use American English

### DIFF
--- a/clash-ghc/src-bin-821/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-821/Clash/GHCi/UI.hs
@@ -1439,7 +1439,7 @@ changeDirectory dir = do
   liftIO $ setCurrentDirectory dir'
   dflags <- getDynFlags
   -- With -fexternal-interpreter, we have to change the directory of the subprocess too.
-  -- (this gives consistent behaviour with and without -fexternal-interpreter)
+  -- (this gives consistent behavior with and without -fexternal-interpreter)
   when (gopt Opt_ExternalInterpreter dflags) $
     lift $ enqueueCommands ["System.Directory.setCurrentDirectory " ++ show dir']
 

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -1446,7 +1446,7 @@ changeDirectory dir = do
   liftIO $ setCurrentDirectory dir'
   dflags <- getDynFlags
   -- With -fexternal-interpreter, we have to change the directory of the subprocess too.
-  -- (this gives consistent behaviour with and without -fexternal-interpreter)
+  -- (this gives consistent behavior with and without -fexternal-interpreter)
   when (gopt Opt_ExternalInterpreter dflags) $
     lift $ enqueueCommands ["System.Directory.setCurrentDirectory " ++ show dir']
 

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -1452,7 +1452,7 @@ changeDirectory dir = do
   liftIO $ setCurrentDirectory dir'
   dflags <- getDynFlags
   -- With -fexternal-interpreter, we have to change the directory of the subprocess too.
-  -- (this gives consistent behaviour with and without -fexternal-interpreter)
+  -- (this gives consistent behavior with and without -fexternal-interpreter)
   when (gopt Opt_ExternalInterpreter dflags) $
     lift $ enqueueCommands ["System.Directory.setCurrentDirectory " ++ show dir']
 

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -216,7 +216,7 @@ reduceConstant isSubj tcm h k nm pInfo tys args = case nm of
 
   "GHC.Prim.int2Word#"
     | [Lit (IntLiteral i)] <- args
-    -> reduce . Literal . WordLiteral . toInteger $ (fromInteger :: Integer -> Word) i -- for overflow behaviour
+    -> reduce . Literal . WordLiteral . toInteger $ (fromInteger :: Integer -> Word) i -- for overflow behavior
 
   "GHC.Prim.int2Float#"
     | [Lit (IntLiteral i)] <- args
@@ -343,7 +343,7 @@ reduceConstant isSubj tcm h k nm pInfo tys args = case nm of
 
   "GHC.Prim.word2Int#"
     | [Lit (WordLiteral i)] <- args
-    -> reduce . Literal . IntLiteral . toInteger $ (fromInteger :: Integer -> Int) i -- for overflow behaviour
+    -> reduce . Literal . IntLiteral . toInteger $ (fromInteger :: Integer -> Int) i -- for overflow behavior
 
   "GHC.Prim.gtWord#" | Just (i,j) <- wordLiterals args
     -> reduce (boolToIntLiteral (i > j))
@@ -2628,7 +2628,7 @@ reduceConstant isSubj tcm h k nm pInfo tys args = case nm of
       ] <- args
     -> reduce (boolToBoolLiteral tcm ty (i == j))
 
--- - specialised permutations
+-- - specialized permutations
   "Clash.Sized.Vector.reverse" -- :: Vec n a -> Vec n a
     | isSubj
     , nTy : aTy : _  <- tys
@@ -3721,10 +3721,10 @@ charToCharLiteral :: Char -> Term
 charToCharLiteral = Literal . CharLiteral
 
 integerToIntLiteral :: Integer -> Term
-integerToIntLiteral = Literal . IntLiteral . toInteger . (fromInteger :: Integer -> Int) -- for overflow behaviour
+integerToIntLiteral = Literal . IntLiteral . toInteger . (fromInteger :: Integer -> Int) -- for overflow behavior
 
 integerToWordLiteral :: Integer -> Term
-integerToWordLiteral = Literal . WordLiteral . toInteger . (fromInteger :: Integer -> Word) -- for overflow behaviour
+integerToWordLiteral = Literal . WordLiteral . toInteger . (fromInteger :: Integer -> Word) -- for overflow behavior
 
 integerToIntegerLiteral :: Integer -> Term
 integerToIntegerLiteral = Literal . IntegerLiteral

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -569,7 +569,7 @@ wantedOptimizationFlags df =
                ]
 
     -- Coercions between Integer and Clash' numeric primitives cause Clash to
-    -- fail. As strictness only affects simulation behaviour, removing them
+    -- fail. As strictness only affects simulation behavior, removing them
     -- is perfectly safe.
     unwantedLang = [ LangExt.Strict
                    , LangExt.StrictData
@@ -650,7 +650,7 @@ wantedLanguageExtensions df =
 -- we could lose bits when the original numeric type had more bits than 64.
 --
 -- Removing these strictness annotations is perfectly safe, as they only
--- affect simulation behaviour.
+-- affect simulation behavior.
 removeStrictnessAnnotations ::
      GHC.ParsedModule
   -> GHC.ParsedModule

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -218,7 +218,7 @@ bindNonRep will now lead to:
 > f    = \a x -> (a x) && (f a x)
 > f'   = \x -> (not x) && (f not x)
 
-Because `f` has already been specialised on the alpha-equivalent-to-itself `not`
+Because `f` has already been specialized on the alpha-equivalent-to-itself `not`
 function, liftNonRep leads to:
 
 > main = f'

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -224,7 +224,7 @@ nonRepSpec ctx@(TransformContext is0 _) e@(App e1 e2)
     --
     -- We need to do this because otherwise the specialisation history won't
     -- recognize the new specialisation argument as something the function has
-    -- already been specialised on
+    -- already been specialized on
     inlineInternalSpecialisationArgument
       :: Term
       -> NormalizeSession Term

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -31,11 +31,11 @@ data NormalizeState
   { _normalized          :: BindingMap
   -- ^ Global binders
   , _specialisationCache :: Map (Id,Int,Either Term Type) Id
-  -- ^ Cache of previously specialised functions:
+  -- ^ Cache of previously specialized functions:
   --
-  -- * Key: (name of the original function, argument position, specialised term/type)
+  -- * Key: (name of the original function, argument position, specialized term/type)
   --
-  -- * Elem: (name of specialised function,type of specialised function)
+  -- * Elem: (name of specialized function,type of specialized function)
   , _specialisationHistory :: VarEnv Int
   -- ^ Cache of how many times a function was specialized
   , _specialisationLimit :: !Int

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -748,14 +748,14 @@ specialise' specMapLbl specHistLbl specLimitLbl (TransformContext is0 _) e (Var 
                                        (mkBinderFor is0 tcm)
                                        (existingNames ++ newNames)
                                        args
-              -- Determine name the resulting specialised function, and the
-              -- form of the specialised-on argument
+              -- Determine name the resulting specialized function, and the
+              -- form of the specialized-on argument
               (fId,inl',specArg') <- case specArg of
                 Left a@(collectArgs -> (Var g,gArgs)) -> if isPolyFun tcm a
                     then do
                       -- In case we are specialising on an argument that is a
                       -- global function then we use that function's name as the
-                      -- name of the specialised higher-order function.
+                      -- name of the specialized higher-order function.
                       -- Additionally, we will return the body of the global
                       -- function, instead of a variable reference to the
                       -- global function.
@@ -798,7 +798,7 @@ specialise' _ _ _ _ctx _ (appE,args) (Left specArg) = do
   -- Create specialized function
   let newBody = mkAbstraction specArg specBndrs
   -- See if there's an existing binder that's alpha-equivalent to the
-  -- specialised function
+  -- specialized function
   existing <- filterUniqMap ((`aeqTerm` newBody) . (^. _4)) <$> Lens.use bindings
   -- Create a new function if an alpha-equivalent binder doesn't exist
   newf <- case eltsUniqMap existing of

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -128,7 +128,7 @@ data FieldsType
   -- constructor bits). Overlap is left-biased, i.e. don't care bits are padded
   -- to the right.
   --
-  -- This is the default behaviour of Clash.
+  -- This is the default behavior of Clash.
   | OverlapR
   -- ^ Store fields of different constructors at (possibly) overlapping bit
   -- positions. That is, a data type with two constructors with each two fields

--- a/clash-prelude/src/Clash/Annotations/TopEntity.hs
+++ b/clash-prelude/src/Clash/Annotations/TopEntity.hs
@@ -18,7 +18,7 @@ The 'Synthesize' annotation allows us to:
       (sub)entities that have not changed since the last run. Caching is based
       on a @.manifest@ which is generated alongside the HDL; deleting this file
       means deleting the cache; changing this file will result in /undefined/
-      behaviour.
+      behavior.
 
 Functions with a 'Synthesize' annotation must adhere to the following
 restrictions:
@@ -37,7 +37,7 @@ Also take the following into account when using 'Synthesize' annotations.
       subsequently decide to inline those functions. You should therefor also
       add a @{\-\# NOINLINE f \#-\}@ pragma to the functions which you give
       a 'Synthesize' functions.
-    * Functions with a 'Synthesize' annotation will not be specialised
+    * Functions with a 'Synthesize' annotation will not be specialized
       on constants.
 
 Finally, the root module, the module which you pass as an argument to the

--- a/clash-prelude/src/Clash/Class/Num.hs
+++ b/clash-prelude/src/Clash/Class/Num.hs
@@ -55,14 +55,14 @@ data SaturationMode
                  -- numbers.
   deriving Eq
 
--- | 'Num' operators in which overflow and underflow behaviour can be specified
+-- | 'Num' operators in which overflow and underflow behavior can be specified
 -- using 'SaturationMode'.
 class (Bounded a, Num a) => SaturatingNum a where
-  -- | Addition with parametrisable over- and underflow behaviour
+  -- | Addition with parametrizable over- and underflow behavior
   satAdd :: SaturationMode -> a -> a -> a
-  -- | Subtraction with parametrisable over- and underflow behaviour
+  -- | Subtraction with parametrizable over- and underflow behavior
   satSub  :: SaturationMode -> a -> a -> a
-  -- | Multiplication with parametrisable over- and underflow behaviour
+  -- | Multiplication with parametrizable over- and underflow behavior
   satMul :: SaturationMode -> a -> a -> a
 
 {-# INLINE boundedAdd #-}

--- a/clash-prelude/src/Clash/Examples.hs
+++ b/clash-prelude/src/Clash/Examples.hs
@@ -208,7 +208,7 @@ uartTX t@(TxReg {..}) ld_tx_data tx_data tx_enable = flip execState t $ do
     tx_cnt .= 0
 
 uartRX r@(RxReg {..}) rx_in uld_rx_data rx_enable = flip execState r $ do
-  -- Synchronise the async signal
+  -- Synchronize the async signal
   rx_d1 .= rx_in
   rx_d2 .= _rx_d1
   -- Uload the rx data
@@ -552,7 +552,7 @@ data RxReg
 makeLenses ''RxReg
 
 uartRX r\@(RxReg {..}) rx_in uld_rx_data rx_enable = 'flip' 'execState' r $ do
-  -- Synchronise the async signal
+  -- Synchronize the async signal
   rx_d1 '.=' rx_in
   rx_d2 '.=' _rx_d1
   -- Uload the rx data

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -242,7 +242,7 @@ especially as the memories we need for our application get bigger. The
 'blockRam' function will be translated to such a /Block RAM/.
 
 One important aspect of Block RAMs have a /synchronous/ read port, meaning that,
-unlike the behaviour of 'Clash.Prelude.RAM.asyncRam', given a read address @r@
+unlike the behavior of 'Clash.Prelude.RAM.asyncRam', given a read address @r@
 at time @t@, the value @v@ in the RAM at address @r@ is only available at time
 @t+1@.
 
@@ -382,7 +382,7 @@ This concludes the short introduction to using 'blockRam'.
 {-# OPTIONS_GHC -fno-cpr-anal #-}
 
 module Clash.Explicit.BlockRam
-  ( -- * BlockRAM synchronised to the system clock
+  ( -- * BlockRAM synchronized to the system clock
     blockRam
   , blockRamPow2
     -- * Read/Write conflict resolution

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -4,9 +4,9 @@ Copyright  :  (C) 2015-2016, University of Twente,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
-= Initialising a BlockRAM with a data file #usingramfiles#
+= Initializing a BlockRAM with a data file #usingramfiles#
 
-BlockRAM primitives that can be initialised with a data file. The BNF grammar
+BlockRAM primitives that can be initialized with a data file. The BNF grammar
 for this data file is simple:
 
 @
@@ -88,7 +88,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 {-# OPTIONS_GHC -fno-cpr-anal #-}
 
 module Clash.Explicit.BlockRam.File
-  ( -- * BlockRAM synchronised to an arbitrary clock
+  ( -- * BlockRAM synchronized to an arbitrary clock
     blockRamFile
   , blockRamFilePow2
     -- * Internal
@@ -256,7 +256,7 @@ blockRamFile# clk _sz file rd wen = case clockEnable clk of
     ramI    = V.fromList content
 {-# NOINLINE blockRamFile# #-}
 
--- | __NB:__ Not synthesisable
+-- | __NB:__ Not synthesizable
 initMem :: KnownNat n => FilePath -> IO [BitVector n]
 initMem = fmap (map parseBV . lines) . readFile
   where

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -6,7 +6,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 We simulate DDR signal by using 'Signal's which have exactly half the period
 (or double the speed) of our normal 'Signal's.
 
-The primives in this module can be used to produce of consume DDR signals.
+The primitives in this module can be used to produce of consume DDR signals.
 
 DDR signals are not meant to be used internally in a design,
 but only to communicate with the outside world.

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -33,7 +33,7 @@ module Clash.Explicit.Prelude
   , asyncRomPow2
   , rom
   , romPow2
-    -- ** ROMs initialised with a data file
+    -- ** ROMs initialized with a data file
   , asyncRomFile
   , asyncRomFilePow2
   , romFile
@@ -44,7 +44,7 @@ module Clash.Explicit.Prelude
     -- * BlockRAM primitives
   , blockRam
   , blockRamPow2
-    -- ** BlockRAM primitives initialised with a data file
+    -- ** BlockRAM primitives initialized with a data file
   , blockRamFile
   , blockRamFilePow2
   -- ** BlockRAM read/write conflict resolution

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -26,7 +26,7 @@ RAM primitives with a combinational read port.
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Explicit.RAM
-  ( -- * RAM synchronised to an arbitrary clock
+  ( -- * RAM synchronized to an arbitrary clock
     asyncRam
   , asyncRamPow2
     -- * Internal
@@ -59,7 +59,7 @@ asyncRamPow2
   => Clock wdom wgated
   -- ^ 'Clock' to which to synchronise the write port of the RAM
   -> Clock rdom rgated
-  -- ^ 'Clock' to which the read address signal, @r@, is synchronised
+  -- ^ 'Clock' to which the read address signal, @r@, is synchronized
   -> Signal rdom (Unsigned n)
   -- ^ Read address @r@
   -> Signal wdom (Maybe (Unsigned n, a))
@@ -84,7 +84,7 @@ asyncRam
   => Clock wdom wgated
    -- ^ 'Clock' to which to synchronise the write port of the RAM
   -> Clock rdom rgated
-   -- ^ 'Clock' to which the read address signal, @r@, is synchronised
+   -- ^ 'Clock' to which the read address signal, @r@, is synchronized
   -> SNat n
   -- ^ Size @n@ of the RAM
   -> Signal rdom addr
@@ -106,7 +106,7 @@ asyncRam#
   => Clock wdom wgated
   -- ^ 'Clock' to which to synchronise the write port of the RAM
   -> Clock rdom rgated
-  -- ^ 'Clock' to which the read address signal, @r@, is synchronised
+  -- ^ 'Clock' to which the read address signal, @r@, is synchronized
   -> SNat n            -- ^ Size @n@ of the RAM
   -> Signal rdom Int  -- ^ Read address @r@
   -> Signal wdom Bool -- ^ Write enable

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -18,7 +18,7 @@ ROMs
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Explicit.ROM
-  ( -- * Synchronous ROM synchronised to an arbitrary clock
+  ( -- * Synchronous ROM synchronized to an arbitrary clock
     rom
   , romPow2
     -- * Internal

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -4,9 +4,9 @@ Copyright  :  (C) 2015-2016, University of Twente,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
-= Initialising a ROM with a data file #usingromfiles#
+= Initializing a ROM with a data file #usingromfiles#
 
-ROMs initialised with a data file. The BNF grammar for this data file is simple:
+ROMs initialized with a data file. The BNF grammar for this data file is simple:
 
 @
 FILE = LINE+
@@ -80,7 +80,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Explicit.ROM.File
-  ( -- * Synchronous ROM synchronised to an arbitrary clock
+  ( -- * Synchronous ROM synchronized to an arbitrary clock
     romFile
   , romFilePow2
     -- * Internal

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -174,13 +174,13 @@ module Clash.Explicit.Signal
   , (.&&.), (.||.)
     -- * Product/Signal isomorphism
   , Bundle(..)
-    -- * Simulation functions (not synthesisable)
+    -- * Simulation functions (not synthesizable)
   , simulate
   , simulateB
     -- ** lazy versions
   , simulate_lazy
   , simulateB_lazy
-    -- * List \<-\> Signal conversion (not synthesisable)
+    -- * List \<-\> Signal conversion (not synthesizable)
   , sample
   , sampleN
   , fromList
@@ -339,7 +339,7 @@ resetSynchronizer clk rst  =
 -- >>> freqCalc 240e6
 -- 4167
 --
--- __NB__: This function is /not/ synthesisable
+-- __NB__: This function is /not/ synthesizable
 freqCalc :: Double -> Integer
 freqCalc freq = ceiling ((1.0 / freq) / 1.0e-12)
 
@@ -611,7 +611,7 @@ regEn clk rst initial en i =
 -- [(8,8),(8,8),(1,1),(2,2),(3,3)...
 -- ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 simulateB
   :: (Bundle a, Bundle b, Undefined a, Undefined b)
   => (Unbundled domain1 a -> Unbundled domain2 b)
@@ -628,7 +628,7 @@ simulateB f = simulate (bundle . f . unbundle)
 -- [(8,8),(8,8),(1,1),(2,2),(3,3)...
 -- ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 simulateB_lazy
   :: (Bundle a, Bundle b)
   => (Unbundled domain1 a -> Unbundled domain2 b)

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -27,7 +27,7 @@ module Clash.Explicit.Signal.Delayed
     -- * Signal \<-\> DSignal conversion
   , fromSignal
   , toSignal
-    -- * List \<-\> DSignal conversion (not synthesisable)
+    -- * List \<-\> DSignal conversion (not synthesizable)
   , dfromList
     -- ** lazy versions
   , dfromList_lazy

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -51,7 +51,7 @@ import Clash.XException            (Undefined)
 
 -- * Dual flip-flop synchronizer
 
--- | Synchroniser based on two sequentially connected flip-flops.
+-- | Synchronizer based on two sequentially connected flip-flops.
 --
 --  * __NB__: This synchroniser can be used for __bit__-synchronization.
 --
@@ -76,15 +76,15 @@ import Clash.XException            (Undefined)
 dualFlipFlopSynchronizer
   :: Undefined a
   => Clock domain1 gated1
-  -- ^ 'Clock' to which the incoming  data is synchronised
+  -- ^ 'Clock' to which the incoming  data is synchronized
   -> Clock domain2 gated2
-  -- ^ 'Clock' to which the outgoing data is synchronised
+  -- ^ 'Clock' to which the outgoing data is synchronized
   -> Reset domain2 synchronous
   -- ^ 'Reset' for registers on the outgoing domain
   -> a
   -- ^ Initial value of the two synchronisation registers
   -> Signal domain1 a -- ^ Incoming data
-  -> Signal domain2 a -- ^ Outgoing, synchronised, data
+  -> Signal domain2 a -- ^ Outgoing, synchronized, data
 dualFlipFlopSynchronizer clk1 clk2 rst i =
   register clk2 rst i . register clk2 rst i . unsafeSynchronizer clk1 clk2
 
@@ -133,7 +133,7 @@ isFull addrSize@SNat ptr s_ptr = case leTrans @1 @2 @addrSize of
         a2 = SNat @(addrSize - 2)
     in  ptr == (complement (slice addrSize a1 s_ptr) ++# slice a2 d0 s_ptr)
 
--- | Synchroniser implemented as a FIFO around an asynchronous RAM. Based on the
+-- | Synchronizer implemented as a FIFO around an asynchronous RAM. Based on the
 -- design described in "Clash.Tutorial#multiclock", which is itself based on the
 -- design described in <http://www.sunburst-design.com/papers/CummingsSNUG2002SJ_FIFO1.pdf>.
 --
@@ -144,9 +144,9 @@ asyncFIFOSynchronizer
   -- ^ Size of the internally used addresses, the  FIFO contains @2^addrSize@
   -- elements.
   -> Clock wdomain wgated
-  -- ^ 'Clock' to which the write port is synchronised
+  -- ^ 'Clock' to which the write port is synchronized
   -> Clock rdomain rgated
-  -- ^ 'Clock' to which the read port is synchronised
+  -- ^ 'Clock' to which the read port is synchronized
   -> Reset wdomain synchronous
   -> Reset rdomain synchronous
   -> Signal rdomain Bool

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -53,7 +53,7 @@ module Clash.Prelude
   , asyncRomPow2
   , rom
   , romPow2
-    -- ** ROMs initialised with a data file
+    -- ** ROMs initialized with a data file
   , asyncRomFile
   , asyncRomFilePow2
   , romFile
@@ -64,7 +64,7 @@ module Clash.Prelude
     -- * BlockRAM primitives
   , blockRam
   , blockRamPow2
-    -- ** BlockRAM primitives initialised with a data file
+    -- ** BlockRAM primitives initialized with a data file
   , blockRamFile
   , blockRamFilePow2
     -- ** BlockRAM read/write conflict resolution

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -224,7 +224,7 @@ especially as the memories we need for our application get bigger. The
 'blockRam' function will be translated to such a /Block RAM/.
 
 One important aspect of Block RAMs have a /synchronous/ read port, meaning that,
-unlike the behaviour of 'Clash.Prelude.RAM.asyncRam', given a read address @r@
+unlike the behavior of 'Clash.Prelude.RAM.asyncRam', given a read address @r@
 at time @t@, the value @v@ in the RAM at address @r@ is only available at time
 @t+1@.
 
@@ -350,7 +350,7 @@ This concludes the short introduction to using 'blockRam'.
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Prelude.BlockRam
-  ( -- * BlockRAM synchronised to the system clock
+  ( -- * BlockRAM synchronized to the system clock
     blockRam
   , blockRamPow2
     -- * Read/Write conflict resolution
@@ -695,7 +695,7 @@ blockRamPow2 = \cnt rd wrM -> withFrozenCallStack
   (hideClock E.blockRamPow2 cnt rd wrM)
 {-# INLINE blockRamPow2 #-}
 
--- | Create read-after-write blockRAM from a read-before-write one (synchronised to system clock)
+-- | Create read-after-write blockRAM from a read-before-write one (synchronized to system clock)
 --
 -- >>> import Clash.Prelude
 -- >>> :t readNew (blockRam (0 :> 1 :> Nil))

--- a/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
@@ -4,9 +4,9 @@ Copyright  :  (C) 2015-2016, University of Twente,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
-= Initialising a BlockRAM with a data file #usingramfiles#
+= Initializing a BlockRAM with a data file #usingramfiles#
 
-BlockRAM primitives that can be initialised with a data file. The BNF grammar
+BlockRAM primitives that can be initialized with a data file. The BNF grammar
 for this data file is simple:
 
 @
@@ -78,7 +78,7 @@ __>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Prelude.BlockRam.File
-  ( -- * BlockRAM synchronised to an arbitrary clock
+  ( -- * BlockRAM synchronized to an arbitrary clock
     blockRamFile
   , blockRamFilePow2
   )

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -88,7 +88,7 @@ newtype DataFlow' dom iEn oEn i o
 
 where:
 
- * @dom@ is the clock to which the circuit is synchronised.
+ * @dom@ is the clock to which the circuit is synchronized.
  * @iEn@ is the type of the bidirectional incoming synchronisation channel.
  * @oEn@ is the type of the bidirectional outgoing synchronisation channel.
  * @i@ is the incoming data type.
@@ -116,7 +116,7 @@ newtype DataFlow domain iEn oEn i o
           )
   }
 
--- | Dataflow circuit synchronised to the 'systemClockGen'.
+-- | Dataflow circuit synchronized to the 'systemClockGen'.
 -- type DataFlow iEn oEn i o = DataFlow' systemClockGen iEn oEn i o
 
 -- | Create a 'DataFlow' circuit from a circuit description with the appropriate
@@ -222,7 +222,7 @@ fifoDF
   -> Reset domain synchronous
   -> SNat (m + n) -- ^ Depth of the FIFO buffer. Must be a power of two.
   -> Vec m a      -- ^ Initial content. Can be smaller than the size of the
-                  -- FIFO. Empty spaces are initialised with 'undefined'.
+                  -- FIFO. Empty spaces are initialized with 'undefined'.
   -> DataFlow domain Bool Bool a a
 fifoDF clk rst _ iS = DF $ \i iV oR ->
   let initRdPtr      = 0
@@ -360,7 +360,7 @@ loopDF
   -- ^ Depth of the FIFO buffer. Must be a power of two
   -> Vec m d
   -- ^ Initial content of the FIFO buffer. Can be smaller than the size of the
-  -- FIFO. Empty spaces are initialised with 'undefined'.
+  -- FIFO. Empty spaces are initialized with 'undefined'.
   -> DataFlow dom (Bool,Bool) (Bool,Bool) (a,d) (b,d)
   -> DataFlow dom Bool Bool   a           b
 loopDF clk rst sz is (DF f) =

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -16,7 +16,7 @@
 {-# LANGUAGE Safe #-}
 
 module Clash.Prelude.Mealy
-  ( -- * Mealy machine synchronised to the system clock
+  ( -- * Mealy machine synchronized to the system clock
     mealy
   , mealyB
   , (<^>)

--- a/clash-prelude/src/Clash/Prelude/RAM.hs
+++ b/clash-prelude/src/Clash/Prelude/RAM.hs
@@ -22,7 +22,7 @@ RAM primitives with a combinational read port.
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Prelude.RAM
-  ( -- * RAM synchronised to an arbitrary clock
+  ( -- * RAM synchronized to an arbitrary clock
     asyncRam
   , asyncRamPow2
   )

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -21,7 +21,7 @@ module Clash.Prelude.ROM
   ( -- * Asynchronous ROM
     asyncRom
   , asyncRomPow2
-    -- * Synchronous ROM synchronised to an arbitrary clock
+    -- * Synchronous ROM synchronized to an arbitrary clock
   , rom
   , romPow2
     -- * Internal

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -4,9 +4,9 @@ Copyright  :  (C) 2015-2016, University of Twente,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
-= Initialising a ROM with a data file #usingromfiles#
+= Initializing a ROM with a data file #usingromfiles#
 
-ROMs initialised with a data file. The BNF grammar for this data file is simple:
+ROMs initialized with a data file. The BNF grammar for this data file is simple:
 
 @
 FILE = LINE+
@@ -77,7 +77,7 @@ module Clash.Prelude.ROM.File
   ( -- * Asynchronous ROM
     asyncRomFile
   , asyncRomFilePow2
-    -- * Synchronous ROM synchronised to an arbitrary clock
+    -- * Synchronous ROM synchronized to an arbitrary clock
   , romFile
   , romFilePow2
     -- * Internal

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -129,7 +129,7 @@ snatToNum p@SNat = fromInteger (natVal p)
 
 -- | Unary representation of a type-level natural
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 data UNat :: Nat -> Type where
   UZero :: UNat 0
   USucc :: UNat n -> UNat (n + 1)
@@ -142,7 +142,7 @@ instance KnownNat n => ShowX (UNat n) where
 
 -- | Convert a singleton natural number to its unary representation
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 toUNat :: forall n . SNat n -> UNat n
 toUNat p@SNat = fromI @n (natVal p)
   where
@@ -152,14 +152,14 @@ toUNat p@SNat = fromI @n (natVal p)
 
 -- | Convert a unary-encoded natural number to its singleton representation
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 fromUNat :: UNat n -> SNat n
 fromUNat UZero     = SNat :: SNat 0
 fromUNat (USucc x) = addSNat (fromUNat x) (SNat :: SNat 1)
 
 -- | Add two unary-encoded natural numbers
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 addUNat :: UNat n -> UNat m -> UNat (n + m)
 addUNat UZero     y     = y
 addUNat x         UZero = x
@@ -167,7 +167,7 @@ addUNat (USucc x) y     = USucc (addUNat x y)
 
 -- | Multiply two unary-encoded natural numbers
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 mulUNat :: UNat n -> UNat m -> UNat (n * m)
 mulUNat UZero      _     = UZero
 mulUNat _          UZero = UZero
@@ -175,14 +175,14 @@ mulUNat (USucc x) y      = addUNat y (mulUNat x y)
 
 -- | Power of two unary-encoded natural numbers
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 powUNat :: UNat n -> UNat m -> UNat (n ^ m)
 powUNat _ UZero     = USucc UZero
 powUNat x (USucc y) = mulUNat x (powUNat x y)
 
 -- | Predecessor of a unary-encoded natural number
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 predUNat :: UNat (n+1) -> UNat n
 predUNat (USucc x) = x
 predUNat UZero     =
@@ -190,7 +190,7 @@ predUNat UZero     =
 
 -- | Subtract two unary-encoded natural numbers
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 subUNat :: UNat (m+n) -> UNat n -> UNat m
 subUNat x         UZero     = x
 subUNat (USucc x) (USucc y) = subUNat x y
@@ -278,7 +278,7 @@ compareSNat a b =
 -- | Base-2 encoded natural number
 --
 --    * __NB__: The LSB is the left/outer-most constructor:
---    * __NB__: Not synthesisable
+--    * __NB__: Not synthesizable
 --
 -- >>> B0 (B1 (B1 BT))
 -- b6
@@ -335,7 +335,7 @@ showBNat = go []
 
 -- | Convert a singleton natural number to its base-2 representation
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 toBNat :: SNat n -> BNat n
 toBNat s@SNat = toBNat' (natVal s)
   where
@@ -347,7 +347,7 @@ toBNat s@SNat = toBNat' (natVal s)
 
 -- | Convert a base-2 encoded natural number to its singleton representation
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 fromBNat :: BNat n -> SNat n
 fromBNat BT     = SNat :: SNat 0
 fromBNat (B0 x) = mulSNat (SNat :: SNat 2) (fromBNat x)
@@ -356,7 +356,7 @@ fromBNat (B1 x) = addSNat (mulSNat (SNat :: SNat 2) (fromBNat x))
 
 -- | Add two base-2 encoded natural numbers
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 addBNat :: BNat n -> BNat m -> BNat (n+m)
 addBNat (B0 a) (B0 b) = B0 (addBNat a b)
 addBNat (B0 a) (B1 b) = B1 (addBNat a b)
@@ -367,7 +367,7 @@ addBNat a      BT     = a
 
 -- | Multiply two base-2 encoded natural numbers
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 mulBNat :: BNat n -> BNat m -> BNat (n*m)
 mulBNat BT      _  = BT
 mulBNat _       BT = BT
@@ -376,7 +376,7 @@ mulBNat (B1 a)  b  = addBNat (B0 (mulBNat a b)) b
 
 -- | Power of two base-2 encoded natural numbers
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 powBNat :: BNat n -> BNat m -> BNat (n^m)
 powBNat _  BT      = B1 BT
 powBNat a  (B0 b)  = let z = powBNat a b
@@ -386,7 +386,7 @@ powBNat a  (B1 b)  = let z = powBNat a b
 
 -- | Successor of a base-2 encoded natural number
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 succBNat :: BNat n -> BNat (n+1)
 succBNat BT     = B1 BT
 succBNat (B0 a) = B1 a
@@ -394,7 +394,7 @@ succBNat (B1 a) = B0 (succBNat a)
 
 -- | Predecessor of a base-2 encoded natural number
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 predBNat :: (1 <= n) => BNat n -> BNat (n-1)
 predBNat (B1 a) = case stripZeros a of
   BT -> BT
@@ -403,7 +403,7 @@ predBNat (B0 x) = B1 (predBNat x)
 
 -- | Divide a base-2 encoded natural number by 2
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 div2BNat :: BNat (2*n) -> BNat n
 div2BNat BT     = BT
 div2BNat (B0 x) = x
@@ -411,14 +411,14 @@ div2BNat (B1 _) = error "div2BNat: impossible: 2*n ~ 2*n+1"
 
 -- | Subtract 1 and divide a base-2 encoded natural number by 2
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 div2Sub1BNat :: BNat (2*n+1) -> BNat n
 div2Sub1BNat (B1 x) = x
 div2Sub1BNat _      = error "div2Sub1BNat: impossible: 2*n+1 ~ 2*n"
 
 -- | Get the log2 of a base-2 encoded natural number
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 log2BNat :: BNat (2^n) -> BNat n
 log2BNat BT = error "log2BNat: log2(0) not defined"
 log2BNat (B1 x) = case stripZeros x of
@@ -437,7 +437,7 @@ log2BNat (B0 x) = succBNat (log2BNat x)
 -- >>> stripZeros (B1 (B0 (B0 (B0 BT))))
 -- b1
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 stripZeros :: BNat n -> BNat n
 stripZeros BT      = BT
 stripZeros (B1 x)  = B1 (stripZeros x)

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -109,13 +109,13 @@ module Clash.Signal
   , (.&&.), (.||.)
     -- * Product/Signal isomorphism
   , Bundle(..)
-    -- * Simulation functions (not synthesisable)
+    -- * Simulation functions (not synthesizable)
   , simulate
   , simulateB
     -- ** lazy versions
   , simulate_lazy
   , simulateB_lazy
-    -- * List \<-\> Signal conversion (not synthesisable)
+    -- * List \<-\> Signal conversion (not synthesizable)
   , sample
   , sampleN
   , fromList
@@ -614,7 +614,7 @@ regEn initial en i =
 --
 -- > sample s == [s0, s1, s2, s3, ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 sample
   :: forall gated synchronous domain a
    . Undefined a
@@ -639,7 +639,7 @@ sample s =
 --
 -- > sampleN 3 s == [s0, s1, s2]
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 sampleN
   :: forall gated synchronous domain a
    . Undefined a
@@ -666,7 +666,7 @@ sampleN n s =
 --
 -- > sample s == [s0, s1, s2, s3, ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 sample_lazy
   :: forall gated synchronous domain a
    . (HiddenClockReset domain gated synchronous => Signal domain a)
@@ -690,7 +690,7 @@ sample_lazy s =
 --
 -- > sampleN 3 s == [s0, s1, s2]
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 sampleN_lazy
   :: forall gated synchronous domain a
    . Int
@@ -717,7 +717,7 @@ sampleN_lazy n s =
 -- [8,1,2,3...
 -- ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 simulate
   :: forall gated synchronous domain a b
    . (Undefined a, Undefined b)
@@ -744,7 +744,7 @@ simulate f =
 -- [8,1,2,3...
 -- ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 simulate_lazy
   :: forall gated synchronous domain a b
    . (HiddenClockReset domain gated synchronous =>
@@ -770,7 +770,7 @@ simulate_lazy f =
 -- [(8,8),(1,1),(2,2),(3,3)...
 -- ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 simulateB
   :: forall gated synchronous domain a b
    . (Bundle a, Bundle b, Undefined a, Undefined b)
@@ -797,7 +797,7 @@ simulateB f =
 -- [(8,8),(1,1),(2,2),(3,3)...
 -- ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 simulateB_lazy
   :: forall gated synchronous domain a b
    . (Bundle a, Bundle b)

--- a/clash-prelude/src/Clash/Signal/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle.hs
@@ -136,7 +136,7 @@ deriveBundleTuples ''Bundle ''Unbundled 'bundle 'unbundle
 
 instance KnownNat n => Bundle (Vec n a) where
   type Unbundled t (Vec n a) = Vec n (Signal t a)
-  -- The 'Traversable' instance of 'Vec' is not synthesisable, so we must
+  -- The 'Traversable' instance of 'Vec' is not synthesizable, so we must
   -- define 'bundle' as a primitive.
   bundle   = vecBundle#
   unbundle = sequenceA . fmap lazyV

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -34,7 +34,7 @@ module Clash.Signal.Delayed
     -- * Signal \<-\> DSignal conversion
   , fromSignal
   , toSignal
-    -- * List \<-\> DSignal conversion (not synthesisable)
+    -- * List \<-\> DSignal conversion (not synthesizable)
   , dfromList
     -- ** lazy versions
   , dfromList_lazy

--- a/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
@@ -20,7 +20,7 @@ module Clash.Signal.Delayed.Internal
     DSignal(..)
   , feedback
   , fromSignal
-    -- * List \<-\> DSignal conversion (not synthesisable)
+    -- * List \<-\> DSignal conversion (not synthesizable)
   , dfromList
     -- ** lazy versions
   , dfromList_lazy
@@ -78,7 +78,7 @@ newtype DSignal (domain :: Domain) (delay :: Nat) a =
 -- >>> sampleN 2 (dfromList [1,2,3,4,5])
 -- [1,2]
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 dfromList :: Undefined a => [a] -> DSignal domain 0 a
 dfromList = coerce . fromList
 
@@ -90,7 +90,7 @@ dfromList = coerce . fromList
 -- >>> sampleN 2 (dfromList [1,2,3,4,5])
 -- [1,2]
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 dfromList_lazy :: [a] -> DSignal domain 0 a
 dfromList_lazy = coerce . fromList_lazy
 

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -57,11 +57,11 @@ module Clash.Signal.Internal
   , syncResetGen
     -- * Boolean connectives
   , (.&&.), (.||.)
-    -- * Simulation functions (not synthesisable)
+    -- * Simulation functions (not synthesizable)
   , simulate
     -- ** lazy version
   , simulate_lazy
-    -- * List \<-\> Signal conversion (not synthesisable)
+    -- * List \<-\> Signal conversion (not synthesizable)
   , sample
   , sampleN
   , fromList
@@ -155,7 +155,7 @@ never create a clock that goes any faster!
 because some VHDL simulators don't support fractions of picoseconds.
 -}
 data Signal (domain :: Domain) a
-  -- | The constructor, @(':-')@, is __not__ synthesisable.
+  -- | The constructor, @(':-')@, is __not__ synthesizable.
   = a :- Signal domain a
 
 head# :: Signal dom a -> a
@@ -233,7 +233,7 @@ instance Num a => Num (Signal domain a) where
   signum      = fmap signum
   fromInteger = signal# . fromInteger
 
--- | __NB__: Not synthesisable
+-- | __NB__: Not synthesizable
 --
 -- __NB__: In \"@'foldr' f z s@\":
 --
@@ -243,7 +243,7 @@ instance Foldable (Signal domain) where
   foldr = foldr#
 
 {-# NOINLINE foldr# #-}
--- | __NB__: Not synthesisable
+-- | __NB__: Not synthesizable
 --
 -- __NB__: In \"@'foldr#' f z s@\":
 --
@@ -530,7 +530,7 @@ unsafeToSyncReset r = Sync r
 {-# NOINLINE unsafeToSyncReset #-}
 
 infixr 2 .||.
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __(.||.)__ :: 'Clash.Signal.Signal' 'Bool' -> 'Clash.Signal.Signal' 'Bool' -> 'Clash.Signal.Signal' 'Bool'
@@ -541,7 +541,7 @@ infixr 2 .||.
 (.||.) = liftA2 (||)
 
 infixr 3 .&&.
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __(.&&.)__ :: 'Clash.Signal.Signal' 'Bool' -> 'Clash.Signal.Signal' 'Bool' -> 'Clash.Signal.Signal' 'Bool'
@@ -644,7 +644,7 @@ register# (GatedClock _ _ ena) (Async rst) powerUpVal resetVal =
       in  oR `defaultSeqX` oR :- (as `seq` enas `seq` go oE rs es xs)
 {-# NOINLINE register# #-}
 
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __mux__ :: 'Clash.Signal.Signal' 'Bool' -> 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' a
@@ -657,7 +657,7 @@ mux = liftA3 (\b t f -> if b then t else f)
 {-# INLINE mux #-}
 
 infix 4 .==.
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __(.==.)__ :: 'Eq' a => 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' 'Bool'
@@ -668,7 +668,7 @@ infix 4 .==.
 (.==.) = liftA2 (==)
 
 infix 4 ./=.
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __(./=.)__ :: 'Eq' a => 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' 'Bool'
@@ -679,7 +679,7 @@ infix 4 ./=.
 (./=.) = liftA2 (/=)
 
 infix 4 .<.
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __(.<.)__ :: 'Ord' a => 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' 'Bool'
@@ -690,7 +690,7 @@ infix 4 .<.
 (.<.) = liftA2 (<)
 
 infix 4 .<=.
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __(.<=.)__ :: 'Ord' a => 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' 'Bool'
@@ -701,7 +701,7 @@ infix 4 .<=.
 (.<=.) = liftA2 (<=)
 
 infix 4 .>.
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __(.>.)__ :: 'Ord' a => 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' 'Bool'
@@ -712,7 +712,7 @@ infix 4 .>.
 (.>.) = liftA2 (>)
 
 infix 4 .>=.
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __(.>=.)__ :: 'Ord' a => 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' 'Bool'
@@ -735,7 +735,7 @@ instance CoArbitrary a => CoArbitrary (Signal domain a) where
     n <- arbitrary
     coarbitrary (take (abs n) (sample_lazy xs)) gen
 
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __testFor__ :: 'Int' -> 'Clash.Signal.Signal' Bool -> 'Property'
@@ -745,9 +745,9 @@ instance CoArbitrary a => CoArbitrary (Signal domain a) where
 testFor :: Foldable f => Int -> f Bool -> Property
 testFor n = property . and . take n . sample
 
--- * List \<-\> Signal conversion (not synthesisable)
+-- * List \<-\> Signal conversion (not synthesizable)
 
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __sample__ :: 'Clash.Signal.Signal' a -> [a]
@@ -760,11 +760,11 @@ testFor n = property . and . take n . sample
 --
 -- > sample s == [s0, s1, s2, s3, ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 sample :: (Foldable f, Undefined a) => f a -> [a]
 sample = foldr (\a b -> deepseqX a (a : b)) []
 
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __sampleN__ :: Int -> 'Clash.Signal.Signal' a -> [a]
@@ -777,7 +777,7 @@ sample = foldr (\a b -> deepseqX a (a : b)) []
 --
 -- > sampleN 3 s == [s0, s1, s2]
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 sampleN :: (Foldable f, Undefined a) => Int -> f a -> [a]
 sampleN n = take n . sample
 
@@ -789,11 +789,11 @@ sampleN n = take n . sample
 -- >>> sampleN 2 (fromList [1,2,3,4,5])
 -- [1,2]
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 fromList :: Undefined a => [a] -> Signal domain a
 fromList = Prelude.foldr (\a b -> deepseqX a (a :- b)) (errorX "finite list")
 
--- * Simulation functions (not synthesisable)
+-- * Simulation functions (not synthesizable)
 
 -- | Simulate a (@'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' b@) function
 -- given a list of samples of type @a@
@@ -802,11 +802,11 @@ fromList = Prelude.foldr (\a b -> deepseqX a (a :- b)) (errorX "finite list")
 -- [8,8,1,2,3...
 -- ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 simulate :: (Undefined a, Undefined b) => (Signal domain1 a -> Signal domain2 b) -> [a] -> [b]
 simulate f = sample . f . fromList
 
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __sample__ :: 'Clash.Signal.Signal' a -> [a]
@@ -819,11 +819,11 @@ simulate f = sample . f . fromList
 --
 -- > sample s == [s0, s1, s2, s3, ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 sample_lazy :: Foldable f => f a -> [a]
 sample_lazy = foldr (:) []
 
--- | The above type is a generalisation for:
+-- | The above type is a generalization for:
 --
 -- @
 -- __sampleN__ :: Int -> 'Clash.Signal.Signal' a -> [a]
@@ -836,7 +836,7 @@ sample_lazy = foldr (:) []
 --
 -- > sampleN 3 s == [s0, s1, s2]
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 sampleN_lazy :: Foldable f => Int -> f a -> [a]
 sampleN_lazy n = take n . sample_lazy
 
@@ -848,11 +848,11 @@ sampleN_lazy n = take n . sample_lazy
 -- >>> sampleN 2 (fromList [1,2,3,4,5])
 -- [1,2]
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 fromList_lazy :: [a] -> Signal domain a
 fromList_lazy = Prelude.foldr (:-) (error "finite list")
 
--- * Simulation functions (not synthesisable)
+-- * Simulation functions (not synthesizable)
 
 -- | Simulate a (@'Clash.Signal.Signal' a -> 'Clash.Signal.Signal' b@) function
 -- given a list of samples of type @a@
@@ -861,6 +861,6 @@ fromList_lazy = Prelude.foldr (:-) (error "finite list")
 -- [8,8,1,2,3...
 -- ...
 --
--- __NB__: This function is not synthesisable
+-- __NB__: This function is not synthesizable
 simulate_lazy :: (Signal domain1 a -> Signal domain2 b) -> [a] -> [b]
 simulate_lazy f = sample_lazy . f . fromList_lazy

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -51,7 +51,7 @@ module Clash.Sized.Fixed
   , divide
     -- * Compile-time 'Double' conversion
   , fLit
-    -- * Run-time 'Double' conversion (not synthesisable)
+    -- * Run-time 'Double' conversion (not synthesizable)
   , fLitR
     -- * 'Fixed' point wrapper
   , Fixed (..), resizeF, fracShift
@@ -274,7 +274,7 @@ instance Undefined (rep (int + frac)) => Undefined (Fixed rep int frac) where
   deepErrorX = Fixed . errorX
   rnfX f@(~(Fixed x)) = if isLeft (isX f) then () else rnfX x
 
--- | None of the 'Read' class' methods are synthesisable.
+-- | None of the 'Read' class' methods are synthesizable.
 instance (size ~ (int + frac), KnownNat frac, Bounded (rep size), Integral (rep size))
       => Read (Fixed rep int frac) where
   readPrec = fLitR <$> readPrec
@@ -648,13 +648,13 @@ fLit a = [|| Fixed (fromInteger sat) ||]
 
 -- | Convert, at run-time, a 'Double' to a 'Fixed'-point.
 --
--- __NB__: this functions is /not/ synthesisable
+-- __NB__: this functions is /not/ synthesizable
 --
 -- = Creating data-files #creatingdatafiles#
 --
 -- An example usage of this function is for example to convert a data file
 -- containing 'Double's to a data file with ASCI-encoded binary numbers to be
--- used by a synthesisable function like 'Clash.Prelude.ROM.File.asyncRomFile'.
+-- used by a synthesizable function like 'Clash.Prelude.ROM.File.asyncRomFile'.
 -- For example, given a file @Data.txt@ containing:
 --
 -- @

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -82,7 +82,7 @@ module Clash.Sized.Internal.BitVector
   , ge#
   , gt#
   , le#
-    -- *** Enum (not synthesisable)
+    -- *** Enum (not synthesizable)
   , enumFrom#
   , enumFromThen#
   , enumFromTo#
@@ -171,7 +171,7 @@ import                qualified Data.List                  as L
 -- * 'Num' instance performs /unsigned/ arithmetic.
 data BitVector (n :: Nat) =
     -- | The constructor, 'BV', and  the field, 'unsafeToInteger', are not
-    -- synthesisable.
+    -- synthesizable.
     BV { unsafeMask      :: !Integer
        , unsafeToInteger :: !Integer
        }
@@ -182,7 +182,7 @@ data BitVector (n :: Nat) =
 -- | Bit
 data Bit =
   -- | The constructor, 'Bit', and  the field, 'unsafeToInteger#', are not
-  -- synthesisable.
+  -- synthesizable.
   Bit { unsafeMask#      :: !Integer
       , unsafeToInteger# :: !Integer
       }
@@ -446,7 +446,7 @@ le# (BV 0 n) (BV 0 m) = n <= m
 le#  bv1 bv2 = undefErrorI "<=" bv1 bv2
 
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
--- 'enumFromThenTo', are not synthesisable.
+-- 'enumFromThenTo', are not synthesizable.
 instance KnownNat n => Enum (BitVector n) where
   succ           = (+# fromInteger# 0 1)
   pred           = (-# fromInteger# 0 1)
@@ -973,7 +973,7 @@ undefined# =
 -- >>> expected `isLike` checked
 -- False
 --
--- __NB__: Not synthesisable
+-- __NB__: Not synthesizable
 isLike :: BitVector n -> BitVector n -> Bool
 isLike (BV cMask c) (BV eMask e) = e' == c' && e' == c''
   where

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -48,7 +48,7 @@ module Clash.Sized.Internal.Index
   , ge#
   , gt#
   , le#
-    -- ** Enum (not synthesisable)
+    -- ** Enum (not synthesizable)
   , enumFrom#
   , enumFromThen#
   , enumFromTo#
@@ -124,7 +124,7 @@ import Clash.XException
 -- ...
 newtype Index (n :: Nat) =
     -- | The constructor, 'I', and the field, 'unsafeToInteger', are not
-    -- synthesisable.
+    -- synthesizable.
     I { unsafeToInteger :: Integer }
   deriving (Data, Generic)
 
@@ -181,7 +181,7 @@ gt# (I n) (I m) = n > m
 le# (I n) (I m) = n <= m
 
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
--- 'enumFromThenTo', are not synthesisable.
+-- 'enumFromThenTo', are not synthesizable.
 instance KnownNat n => Enum (Index n) where
   succ           = (+# fromInteger# 1)
   pred           = (-# fromInteger# 1)
@@ -364,7 +364,7 @@ instance Undefined (Index n) where
   deepErrorX = errorX
   rnfX = rwhnfX
 
--- | None of the 'Read' class' methods are synthesisable.
+-- | None of the 'Read' class' methods are synthesizable.
 instance KnownNat n => Read (Index n) where
   readPrec = fromIntegral <$> (readPrec :: ReadPrec Natural)
 

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -43,7 +43,7 @@ module Clash.Sized.Internal.Signed
   , ge#
   , gt#
   , le#
-    -- ** Enum (not synthesisable)
+    -- ** Enum (not synthesizable)
   , enumFrom#
   , enumFromThen#
   , enumFromTo#
@@ -149,7 +149,7 @@ import Clash.XException
 -- -3
 newtype Signed (n :: Nat) =
     -- | The constructor, 'S', and the field, 'unsafeToInteger', are not
-    -- synthesisable.
+    -- synthesizable.
     S { unsafeToInteger :: Integer}
   deriving (Data, Generic)
 
@@ -174,7 +174,7 @@ instance Show (Signed n) where
 instance ShowX (Signed n) where
   showsPrecX = showsPrecXWith showsPrec
 
--- | None of the 'Read' class' methods are synthesisable.
+-- | None of the 'Read' class' methods are synthesizable.
 instance KnownNat n => Read (Signed n) where
   readPrec = fromIntegral <$> (readPrec :: ReadPrec Integer)
 
@@ -224,7 +224,7 @@ gt# (S n) (S m) = n > m
 le# (S n) (S m) = n <= m
 
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
--- 'enumFromThenTo', are not synthesisable.
+-- 'enumFromThenTo', are not synthesizable.
 instance KnownNat n => Enum (Signed n) where
   succ           = (+# fromInteger# 1)
   pred           = (-# fromInteger# 1)

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -41,7 +41,7 @@ module Clash.Sized.Internal.Unsigned
   , ge#
   , gt#
   , le#
-    -- ** Enum (not synthesisable)
+    -- ** Enum (not synthesizable)
   , enumFrom#
   , enumFromThen#
   , enumFromTo#
@@ -138,7 +138,7 @@ import Clash.XException
 -- 0
 newtype Unsigned (n :: Nat) =
     -- | The constructor, 'U', and the field, 'unsafeToInteger', are not
-    -- synthesisable.
+    -- synthesizable.
     U { unsafeToInteger :: Integer }
   deriving (Data, Generic)
 
@@ -163,7 +163,7 @@ instance Undefined (Unsigned n) where
   deepErrorX = errorX
   rnfX = rwhnfX
 
--- | None of the 'Read' class' methods are synthesisable.
+-- | None of the 'Read' class' methods are synthesizable.
 instance KnownNat n => Read (Unsigned n) where
   readPrec = fromIntegral <$> (readPrec :: ReadPrec Natural)
 
@@ -210,7 +210,7 @@ gt# (U n) (U m) = n > m
 le# (U n) (U m) = n <= m
 
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
--- 'enumFromThenTo', are not synthesisable.
+-- 'enumFromThenTo', are not synthesizable.
 instance KnownNat n => Enum (Unsigned n) where
   succ           = (+# fromInteger# 1)
   pred           = (-# fromInteger# 1)

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -456,7 +456,7 @@ replaceTree i a = v2t . replace i a . t2v
 data ZipWithTree (b :: Type) (c :: Type) (f :: TyFun Nat Type) :: Type
 type instance Apply (ZipWithTree b c) d = RTree d b -> RTree d c
 
--- | 'tzipWith' generalises 'tzip' by zipping with the function given as the
+-- | 'tzipWith' generalizes 'tzip' by zipping with the function given as the
 -- first argument, instead of a tupling function. For example, "tzipWith (+)"
 -- applied to two trees produces the tree of corresponding sums.
 --

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -780,7 +780,7 @@ elemIndex :: (KnownNat n, Eq a) => a -> Vec n a -> Maybe (Index n)
 elemIndex x = findIndex (x ==)
 {-# INLINE elemIndex #-}
 
--- | 'zipWith' generalises 'zip' by zipping with the function given
+-- | 'zipWith' generalizes 'zip' by zipping with the function given
 -- as the first argument, instead of a tupling function.
 -- For example, \"'zipWith' @(+)@\" applied to two vectors produces the
 -- vector of corresponding sums.
@@ -799,7 +799,7 @@ zipWith _ Nil           _  = Nil
 zipWith f (x `Cons` xs) ys = f x (head ys) `Cons` zipWith f xs (tail ys)
 {-# NOINLINE zipWith #-}
 
--- | 'zipWith3' generalises 'zip3' by zipping with the function given
+-- | 'zipWith3' generalizes 'zip3' by zipping with the function given
 -- as the first argument, instead of a tupling function.
 --
 -- > zipWith3 f (x1 :> x2 :> ... xn :> Nil) (y1 :> y2 :> ... :> yn :> Nil) (z1 :> z2 :> ... :> zn :> Nil) == (f x1 y1 z1 :> f x2 y2 z2 :> ... :> f xn yn zn :> Nil)
@@ -1603,7 +1603,7 @@ windows2d stY stX xss = map (transpose . (map (windows1d stX))) (windows1d stY x
 {-# INLINE windows2d #-}
 
 -- | Forward permutation specified by an index mapping, /ix/. The result vector
--- is initialised by the given defaults, /def/, and an further values that are
+-- is initialized by the given defaults, /def/, and an further values that are
 -- permuted into the result are added to the current value using the given
 -- combination function, /f/.
 --

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -548,10 +548,10 @@ containing the top level entity.
 There are multiple reasons as to why might you want to create a so-called
 /test bench/ for the generated HDL:
 
-  * You want to compare post-synthesis / post-place&route behaviour to that of
-    the behaviour of the original generated HDL.
+  * You want to compare post-synthesis / post-place&route behavior to that of
+    the behavior of the original generated HDL.
   * Need representative stimuli for your dynamic power calculations
-  * Verify that the HDL output of the Clash compiler has the same behaviour as
+  * Verify that the HDL output of the Clash compiler has the same behavior as
     the Haskell / Clash specification.
 
 For these purposes, you can have Clash compiler generate a /test bench/. In
@@ -587,7 +587,7 @@ testBench = done
 This will create a stimulus generator that creates the same inputs as we used
 earlier for the simulation of the circuit, and creates an output verifier that
 compares against the results we got from our earlier simulation. We can even
-simulate the behaviour of the /testBench/:
+simulate the behavior of the /testBench/:
 
 >>> sampleN 8 testBench
 [False,False,False,False,False
@@ -862,7 +862,7 @@ Clash compiler, specifically, they allow us to:
       (sub)entities that have not changed since the last run. Caching is based
       on a @.manifest@ which is generated alongside the HDL; deleting this file
       means deleting the cache; changing this file will result in /undefined/
-      behaviour.
+      behavior.
 
 Functions with a 'Synthesize' annotation do must adhere to the following
 restrictions:
@@ -881,7 +881,7 @@ Also take the following into account when using 'Synthesize' annotations.
       subsequently decide to inline those functions. You should therefor also
       add a @{\-\# NOINLINE f \#-\}@ pragma to the functions which you give
       a 'Synthesize' functions.
-    * Functions with a 'Synthesize' annotation will not be specialised
+    * Functions with a 'Synthesize' annotation will not be specialized
       on constants.
 
 Finally, the root module, the module which you pass as an argument to the
@@ -1292,7 +1292,7 @@ definitions that are normally not synthesizable by the Clash compiler. However,
 VHDL primitives do not give us /co-simulation/: where you would be able to
 simulate VHDL and Haskell in a /single/ environment. If you still want to
 simulate your design in Haskell, you will have to describe, in a cycle- and
-bit-accurate way, the behaviour of that (potentially complex) IP you are trying
+bit-accurate way, the behavior of that (potentially complex) IP you are trying
 to include in your design.
 
 Perhaps in the future, someone will figure out how to connect the two simulation
@@ -1482,7 +1482,7 @@ What is /not/ possible is:
   @
 
   And then create a HDL primitive, as described in later on in
-  this <#primitives tutorial>, to implement the desired behaviour in HDL.
+  this <#primitives tutorial>, to implement the desired behavior in HDL.
 
 What this means is that when Clash converts your design to VHDL/(System)Verilog,
 you end up with a top-level module/entity with multiple clock and reset ports
@@ -1501,7 +1501,7 @@ word-synchronisation.
 The explicitly clocked versions of all synchronous functions and primitives can
 be found in "Clash.Explicit.Prelude", which also re-exports the functions in
 "Clash.Signal.Explicit". We will use those functions to create a FIFO where
-the read and write port are synchronised to different clocks. Below you can find
+the read and write port are synchronized to different clocks. Below you can find
 the code to build the FIFO synchroniser based on the design described in:
 <http://www.sunburst-design.com/papers/CummingsSNUG2002SJ_FIFO1.pdf>
 
@@ -1520,7 +1520,7 @@ import Data.Constraint.Nat    (leTrans)
 
 Then we'll start with the /heart/ of the FIFO synchroniser, an asynchronous RAM
 in the form of 'asyncRam''. It's called an asynchronous RAM because the read
-port is not synchronised to any clock (though the write port is). Note that in
+port is not synchronized to any clock (though the write port is). Note that in
 Clash we don't really have asynchronous logic, there is only combinational and
 synchronous logic. As a consequence, we see in the type signature of
 'Clash.Explicit.Prelude.asyncRam':
@@ -1531,7 +1531,7 @@ __asyncRam__
   => 'Clock' wdom wgated
    -- ^ Clock to which to synchronise the write port of the RAM
   -> 'Clock' rdom rgated
-   -- ^ Clock to which the read address signal, __r__, is synchronised
+   -- ^ Clock to which the read address signal, __r__, is synchronized
   -> SNat n
   -- ^ Size __n__ of the RAM
   -> Signal rdom addr
@@ -1542,7 +1542,7 @@ __asyncRam__
    -- ^ Value of the __RAM__ at address __r__
 @
 
-that the signal containing the read address __r__ is synchronised to a different
+that the signal containing the read address __r__ is synchronized to a different
 clock. That is, there is __no__ such thing as an @AsyncSignal@ in Clash.
 
 We continue by instantiating the 'Clash.Explicit.Prelude.asyncRam':
@@ -1578,11 +1578,11 @@ ptrCompareT addrSize\@SNat flagGen (bin,ptr,flag) (s_ptr,inc) =
 @
 
 It is parametrised in both address size, @addrSize@, and status flag generator,
-@flagGen@. It has two inputs, @s_ptr@, the synchronised pointer from the other
+@flagGen@. It has two inputs, @s_ptr@, the synchronized pointer from the other
 clock domain, and @inc@, which indicates we want to perform a write or read of
 the FIFO. It creates three outputs: @flag@, the full or empty flag, @addr@, the
 read or write address into the RAM, and @ptr@, the Gray-encoded version of the
-read or write address which will be synchronised between the two clock domains.
+read or write address which will be synchronized between the two clock domains.
 
 Next follow the initial states of address generators, and the flag generators
 for the empty and full flags:
@@ -1616,7 +1616,7 @@ ptrSync clk1 clk2 rst2 =
   'Clash.Explicit.Signal.register' clk2 rst2 0 . 'Clash.Explicit.Signal.register' clk2 rst2 0 . 'Clash.Explicit.Signal.unsafeSynchronizer' clk1 clk2
 @
 
-It uses the 'unsafeSynchroniser' primitive, which is needed to go from one clock
+It uses the 'unsafeSynchronizer' primitive, which is needed to go from one clock
 domain to the other. All synchronizers are specified in terms of
 'unsafeSynchronizer' (see for example the <src/Clash-Prelude-RAM.html#line-103 source of asyncRam>).
 The 'unsafeSynchronizer' primitive is turned into a (bundle of) wire(s) by the
@@ -1632,9 +1632,9 @@ asyncFIFOSynchronizer
   -- ^ Size of the internally used addresses, the  FIFO contains @2^addrSize@
   -- elements.
   -> 'Clock' wdomain wgated
-  -- ^ Clock to which the write port is synchronised
+  -- ^ Clock to which the write port is synchronized
   -> 'Clock' rdomain rgated
-  -- ^ Clock to which the read port is synchronised
+  -- ^ Clock to which the read port is synchronized
   -> 'Reset' wdomain synchronous
   -> 'Reset' rdomain synchronous
   -> Signal rdomain Bool
@@ -1719,9 +1719,9 @@ asyncFIFOSynchronizer
   -- ^ Size of the internally used addresses, the  FIFO contains @2^addrSize@
   -- elements.
   -> 'Clock' wdomain wgated
-  -- ^ Clock to which the write port is synchronised
+  -- ^ Clock to which the write port is synchronized
   -> 'Clock' rdomain rgated
-  -- ^ Clock to which the read port is synchronised
+  -- ^ Clock to which the read port is synchronized
   -> 'Reset' wdomain synchronous
   -> 'Reset' rdomain synchronous
   -> Signal rdomain Bool
@@ -1939,8 +1939,8 @@ Here is a list of Haskell features for which the Clash compiler has only
     cannot synthesize recursively defined functions to circuits. However, when
     viewing your functions as a /structural/ specification of a circuit, this
     /feature/ of the Clash compiler makes sense. Also, only certain types of
-    recursion are considered non-synthesisable; recursively defined values are
-    for example synthesisable: they are (often) synthesized to feedback loops.
+    recursion are considered non-synthesizable; recursively defined values are
+    for example synthesizable: they are (often) synthesized to feedback loops.
 
     Let us distinguish between three variants of recursion:
 
@@ -1968,7 +1968,7 @@ Here is a list of Haskell features for which the Clash compiler has only
         In principal, descriptions like the above could be synthesized to a
         circuit, but it would have to be a /sequential/ circuit. Where the most
         general synthesis would then require a stack. Such a synthesis approach
-        is also known as /behavioural/ synthesis, something which the Clash
+        is also known as /behavioral/ synthesis, something which the Clash
         compiler simply does not do. One reason that Clash does not do this is
         because it does not fit the paradigm that only functions working on
         values of type 'Signal' result in sequential circuits, and all other
@@ -1993,7 +1993,7 @@ Here is a list of Haskell features for which the Clash compiler has only
         >>> sampleN @Source @Asynchronous 11 fibS
         [0,0,1,1,2,3,5,8,13,21,34]
 
-        Unlike the @fibR@ function, the above @fibS@ function /is/ synthesisable
+        Unlike the @fibR@ function, the above @fibS@ function /is/ synthesizable
         by the Clash compiler. Where the recursively defined (non-function)
         value /r/ is synthesized to a feedback loop containing three registers
         and one adder.
@@ -2012,7 +2012,7 @@ Here is a list of Haskell features for which the Clash compiler has only
         @
 
         Where we can clearly see that 'lefts' and 'sorted' are defined in terms
-        of each other. Also the above @sortV@ function /is/ synthesisable.
+        of each other. Also the above @sortV@ function /is/ synthesizable.
 
     * __Static/Structure-dependent recursion__
 
@@ -2037,7 +2037,7 @@ Here is a list of Haskell features for which the Clash compiler has only
         @mapV@ four times, knowing that the @topEntity@ function applies @mapV@
         to a 'Vec' of length 4. Sadly, the compile-time evaluation mechanisms in
         the Clash compiler are very poor, and a user-defined function such as
-        the @mapV@ function defined above, is /currently/ not synthesisable.
+        the @mapV@ function defined above, is /currently/ not synthesizable.
         We /do/ plan to add support for this in the future. In the mean time,
         this poor support for user-defined recursive functions is amortized by
         the fact that the Clash compiler has built-in support for the

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -62,7 +62,7 @@ import GHC.Show          (appPrec)
 import GHC.Stack         (HasCallStack, callStack, prettyCallStack, withFrozenCallStack)
 import System.IO.Unsafe  (unsafeDupablePerformIO)
 
--- | An exception representing an \"uninitialised\" value.
+-- | An exception representing an \"uninitialized\" value.
 newtype XException = XException String
 
 instance Show XException where

--- a/clash-prelude/src/Clash/Xilinx/DDR.hs
+++ b/clash-prelude/src/Clash/Xilinx/DDR.hs
@@ -34,7 +34,7 @@ import GHC.Stack (HasCallStack, withFrozenCallStack)
 import Clash.Explicit.Prelude
 import Clash.Explicit.DDR
 
--- | Xilinx specific variant of 'ddrIn' implementend using the Xilinx IDDR
+-- | Xilinx specific variant of 'ddrIn' implemented using the Xilinx IDDR
 -- primitive.
 --
 -- Reset values are @0@
@@ -54,7 +54,7 @@ iddr
 iddr clk rst = withFrozenCallStack ddrIn# clk rst 0 0 0
 {-# NOINLINE iddr #-}
 
--- | Xilinx specific variant of 'ddrOut' implementend using the Xilinx ODDR
+-- | Xilinx specific variant of 'ddrOut' implemented using the Xilinx ODDR
 -- primitive.
 --
 -- Reset value is @0@

--- a/tests/shouldwork/Numbers/ShiftRotate.hs
+++ b/tests/shouldwork/Numbers/ShiftRotate.hs
@@ -2,7 +2,7 @@
 This tests the HDL implementations of shiftL,shiftR,rotateL and rotateR
 by checking their results against compile-time evaluated calls to the same functions.
 
-So it checks that the HDL implementations have the same behaviour as the Haskell implementations.
+So it checks that the HDL implementations have the same behavior as the Haskell implementations.
 (And it assumes that the Haskell implementations are correct.)
 -}
 {-# LANGUAGE PartialTypeSignatures #-}


### PR DESCRIPTION
While going over the whole Prelude after reworking it for #527 I noticed inconsistent use of American / British English. I don't mind too much for code, but our (user) documentation inherited the same inconsistency. As per the style guide I've changed it to American English.