### PR TITLE
Save stack install script to file first to prevent buffer issues

### DIFF
--- a/.ci/stack_build.sh
+++ b/.ci/stack_build.sh
@@ -3,5 +3,6 @@ set -xeo pipefail
 
 apt update
 apt install wget -y
-wget -qO- https://get.haskellstack.org/ | sh
+wget -q https://get.haskellstack.org/ -O stack_install.sh
+sh stack_install.sh
 stack build


### PR DESCRIPTION
We use Circle CI to check if Clash still builds with `stack` after changes. For some reason the installation instructions on haskellstack.org don't work reliably in a non-interactive environment. This PR makes `stack_build.sh` only execute the install script after a full download.