### PR TITLE
Make `eqArg` recognize more complex cases

### DIFF
--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -271,6 +271,16 @@ indexNote :: String
           -> a
 indexNote note = \xs i -> fromMaybe (error note) (indexMaybe xs i)
 
+-- | Safe version of 'head'
+headMaybe :: [a] -> Maybe a
+headMaybe (a:_) = Just a
+headMaybe _ = Nothing
+
+-- | Safe version of 'tail'
+tailMaybe :: [a] -> Maybe [a]
+tailMaybe (_:as) = Just as
+tailMaybe _ = Nothing
+
 -- | Split the second list at the length of the first list
 splitAtList :: [b] -> [a] -> ([a], [a])
 splitAtList [] xs         = ([], xs)


### PR DESCRIPTION
In order for `recToLetRec` to do its work, it needs to determine if constructs are equal to some variable. For example, it needs to know that:

```a ~ (fst a, snd a)```

This PR adds the ability for `eqArg` to determine these properties for nested projections as well as type classes (which term-level constructs are equal if their types are equal).