### PR TITLE
Synchronous deassert asynchronous reset in `assertBitVector`

### DIFF
--- a/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.json
@@ -14,7 +14,7 @@
     , "template" :
 "// assert begin
 // pragma translate_off
-always @(posedge ~IF ~ISGATED[2] ~THEN ~ARG[2][1] ~ELSE ~ARG[2] ~FI~IF ~ISSYNC[3] ~THEN ~ELSE or negedge ~ARG[3]~FI) begin
+always @(posedge ~IF ~ISGATED[2] ~THEN ~ARG[2][1] ~ELSE ~ARG[2] ~FI) begin
   if (~ARG[5] !== ~ARG[6]) begin
     $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[4], ~TOBV[~ARG[6]][~TYP[6]], ~TOBV[~ARG[5]][~TYP[5]]);
     $stop;
@@ -45,7 +45,7 @@ wire ~TYP[5] ~GENSYM[maskXor][0]  = ~ARG[5] ^ ~ARG[5];
 wire ~TYP[5] ~GENSYM[checked][1]  = ~ARG[4] ^ ~SYM[0];
 wire ~TYP[5] ~GENSYM[expected][2] = ~ARG[5] ^ ~SYM[0];
 
-always @(posedge ~IF ~ISGATED[1] ~THEN ~ARG[1][1] ~ELSE ~ARG[1] ~FI~IF ~ISSYNC[2] ~THEN ~ELSE or negedge ~ARG[2]~FI) begin
+always @(posedge ~IF ~ISGATED[1] ~THEN ~ARG[1][1] ~ELSE ~ARG[1] ~FI) begin
   if (~SYM[1] !== ~SYM[2]) begin
     $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[3], ~TOBV[~ARG[5]][~TYP[5]], ~TOBV[~ARG[4]][~TYP[4]]);
     $stop;

--- a/clash-lib/prims/verilog/Clash_Explicit_Testbench.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_Testbench.json
@@ -14,7 +14,7 @@
     , "template" :
 "// assert begin
 // pragma translate_off
-always @(posedge ~IF ~ISGATED[2] ~THEN ~ARG[2][1] ~ELSE ~ARG[2] ~FI~IF ~ISSYNC[3] ~THEN ~ELSE or negedge ~ARG[3]~FI) begin
+always @(posedge ~IF ~ISGATED[2] ~THEN ~ARG[2][1] ~ELSE ~ARG[2] ~FI) begin
   if (~ARG[5] !== ~ARG[6]) begin
     $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[4], ~ARG[6], ~ARG[5]);
     $finish;
@@ -45,7 +45,7 @@ wire ~TYP[5] ~GENSYM[maskXor][0]  = ~ARG[5] ^ ~ARG[5];
 wire ~TYP[5] ~GENSYM[checked][1]  = ~ARG[4] ^ ~SYM[0];
 wire ~TYP[5] ~GENSYM[expected][2] = ~ARG[5] ^ ~SYM[0];
 
-always @(posedge ~IF ~ISGATED[1] ~THEN ~ARG[1][1] ~ELSE ~ARG[1] ~FI~IF ~ISSYNC[2] ~THEN ~ELSE or negedge ~ARG[2]~FI) begin
+always @(posedge ~IF ~ISGATED[1] ~THEN ~ARG[1][1] ~ELSE ~ARG[1] ~FI) begin
   if (~SYM[1] !== ~SYM[2]) begin
     $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[3], ~ARG[5], ~ARG[4]);
     $finish;

--- a/clash-lib/prims/vhdl/Clash_Explicit_Testbench.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_Testbench.json
@@ -152,9 +152,9 @@ begin
   -- pragma translate_off
   ~SYM[2] <= ~ARG[4];
   ~SYM[3] <= ~ARG[5];
-  process(~IF ~ISGATED[1] ~THEN~SYM[4]~ELSE~ARG[1]~FI~IF ~ISSYNC[2] ~THEN ~ELSE,~ARG[2]~FI) is
+  process(~IF ~ISGATED[1] ~THEN~SYM[4]~ELSE~ARG[1]~FI) is
   begin
-    if (rising_edge(~IF ~ISGATED[1] ~THEN~SYM[4]~ELSE~ARG[1]~FI)~IF ~ISSYNC[2] ~THEN ~ELSE or falling_edge(~ARG[2])~FI) then
+    if (rising_edge(~IF ~ISGATED[1] ~THEN~SYM[4]~ELSE~ARG[1]~FI)) then
       assert (~INCLUDENAME[0].non_std_match(toSLV(~SYM[2]),toSLV(~SYM[3]))) report (~LIT[3] & \", expected: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[3])) & \", actual: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[2]))) severity error;
     end if;
   end process;


### PR DESCRIPTION
PR #428 does this for `assert`, but didn't account for `assertBitVector`.