### PR TITLE
Add a TH macro for efficient bit-by-bit pattern matching.

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -285,7 +285,8 @@ test-suite unittests
       tasty         >= 1.2      && < 1.3,
       tasty-hunit
 
-  Other-Modules: Clash.Tests.DerivingDataRepr
+  Other-Modules: Clash.Tests.BitVector
+                 Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes
                  Clash.Tests.Undefined
 

--- a/clash-prelude/src/Clash/Sized/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/BitVector.hs
@@ -27,6 +27,8 @@ module Clash.Sized.BitVector
   , bLit
     -- ** Concatenation
   , (++#)
+    -- ** Pattern matching
+  , bitPattern
   )
 where
 

--- a/clash-prelude/tests/Clash/Tests/BitVector.hs
+++ b/clash-prelude/tests/Clash/Tests/BitVector.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE BinaryLiterals  #-}
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE ViewPatterns    #-}
+
+module Clash.Tests.BitVector where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Clash.Prelude (BitVector, bitPattern)
+
+test1 :: BitVector 8 -> Int
+test1 =
+  \case
+    $(bitPattern "0.......") -> 0
+    $(bitPattern "01......") -> 1
+    $(bitPattern "11....01") -> 2
+    $(bitPattern "11111110") -> 3
+    $(bitPattern "........") -> 4
+    _                        -> 5  -- To keep exhaustiveness checker happy
+
+tests :: TestTree
+tests =
+  testGroup
+    "bitPattern"
+    [ testCase "case0-0" $ test1 0b00000000 @?= 0
+    , testCase "case0-1" $ test1 0b00011001 @?= 0
+    , testCase "case0-2" $ test1 0b01111111 @?= 0
+    , testCase "case0-3" $ test1 0b01100000 @?= 0
+    , testCase "case2-0" $ test1 0b11111101 @?= 2
+    , testCase "case2-1" $ test1 0b11100001 @?= 2
+    , testCase "case3-0" $ test1 0b11111110 @?= 3
+    , testCase "case3-1" $ test1 0b11111111 @?= 4
+    , testCase "case3-2" $ test1 0b11010110 @?= 4
+    ]
+

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -2,12 +2,14 @@ module Main where
 
 import Test.Tasty
 
+import qualified Clash.Tests.BitVector
 import qualified Clash.Tests.DerivingDataRepr
 import qualified Clash.Tests.Undefined
 
 tests :: TestTree
 tests = testGroup "Unittests"
-  [ Clash.Tests.DerivingDataRepr.tests
+  [ Clash.Tests.BitVector.tests
+  , Clash.Tests.DerivingDataRepr.tests
   , Clash.Tests.Undefined.tests
   ]
 


### PR DESCRIPTION
See https://github.com/clash-lang/clash-compiler/issues/624#issuecomment-499858228
onwards for discussion.