### PR TITLE
Add a flag to optionally use the ghc-paths library (off by default).

### DIFF
--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -61,6 +61,12 @@ flag dynamic
   default: False
   manual: True
 
+flag use-ghc-paths
+  description:
+    Locate the GHC core libraries using the `ghc-paths` package.  Note: this flag may make binaries less relocatable, by hard-coding an absolute path to the core libraries.
+  default: False
+  manual: True
+
 executable clash
   Main-Is:            src-ghc/Batch.hs
   Build-Depends:      base, clash-ghc
@@ -144,6 +150,9 @@ library
                       primitive                 >= 0.5.0.1  && < 1.0,
                       template-haskell          >= 2.8.0.0  && < 2.15,
                       vector                    >= 0.11     && < 1.0
+  if flag(use-ghc-paths)
+    Build-Depends:    ghc-paths
+    CPP-Options:      -DUSE_GHC_PATHS=1
 
   if os(windows)
     Build-Depends:    Win32                     >= 2.3.1    && < 2.9

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -20,8 +20,10 @@ module Clash.GHC.LoadModules
   )
 where
 
+#ifndef USE_GHC_PATHS
 #ifndef TOOL_VERSION_ghc
 #error TOOL_VERSION_ghc undefined
+#endif
 #endif
 
 -- External Modules
@@ -44,11 +46,16 @@ import           Data.Maybe                      (catMaybes, listToMaybe, mapMay
 import qualified Data.Text                       as Text
 import qualified Data.Time.Clock                 as Clock
 import           Language.Haskell.TH.Syntax      (lift)
+
+#ifdef USE_GHC_PATHS
+import           GHC.Paths                       (libdir)
+#else
 import           System.Exit                     (ExitCode (..))
 import           System.IO                       (hGetLine)
 import           System.IO.Error                 (tryIOError)
 import           System.Process                  (runInteractiveCommand,
                                                   waitForProcess)
+#endif
 
 -- GHC API
 import qualified Annotations
@@ -90,6 +97,9 @@ import           Clash.Annotations.BitRepresentation.Internal
   (DataRepr', dataReprAnnToDataRepr')
 
 ghcLibDir :: IO FilePath
+#ifdef USE_GHC_PATHS
+ghcLibDir = return libdir
+#else
 ghcLibDir = do
   (libDirM,exitCode) <- getProcessOutput $ "ghc-" ++ TOOL_VERSION_ghc ++ " --print-libdir"
   case exitCode of
@@ -113,6 +123,7 @@ getProcessOutput command =
      output   <- either (const Nothing) Just <$> tryIOError (hGetLine pOut)
      -- return both the output and the exit code.
      return (output, exitCode)
+#endif
 
 loadModules
   :: FilePath


### PR DESCRIPTION
Adds a new flag, "use-ghc-paths", which adds the `ghc-paths` library as a
dependency of ghc-paths and uses it to locate the GHC libdir.

This functionality used to be present, but was removed a few years ago:
b1af2bcf91163269983de0914f0dd54912c2db0b
Since then the code has been refactored so that the change is smaller.

The flag is off by default, since it makes the binaries not prefix-independent.
More specifically, it embeds in them a full, absolute path to the GHC libdir.