### PR TITLE
Do not create documentation by default

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,11 +46,6 @@ package clash-lib
 
 optional-packages: clash-cosim/clash-cosim.cabal
 
--- Build documentation for all dependencies so we can upload docs to hackage
--- with proper links
-package *
-  documentation: True
-
 -- The fail package is empty for GHC 8+, and haddock errors out on it
 package fail
   documentation: False


### PR DESCRIPTION
Cabal rebuilds dependencies just fine now if you use `--enable-documentation`.