### PR TITLE
Fix `gUnpack` constructor index bug in `instance GBitPack (f :+: g)`

### DIFF
--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -326,10 +326,10 @@ instance ( KnownNat (GFieldSize g)
     (sc, packed ++# padding)
 
   gUnpack c cc b =
-    if c <= cc then
+    let cLeft = snatToNum (SNat @(GConstructorCount f)) in
+    if c < cc + cLeft then
       L1 (gUnpack c cc f)
     else
-      let cLeft = snatToNum (SNat @(GConstructorCount f)) in
       R1 (gUnpack c (cc + cLeft) g)
 
    where


### PR DESCRIPTION
The implementation of `gUnpack` in `instance GBitPack (f :+: g)` is returning the wrong `Rep` for larger sum types, and was only correct by coincidence for smaller (<= 3) numbers of constructors. Here's a minimal example:
```
module BitPackGeneric where

import Clash.Prelude

data T = A | B | C | D
    deriving (Generic, Enum, Bounded, Show, BitPack)

main :: IO ()
main = flip mapM_ [minBound .. maxBound :: T] $ \ t -> do
    let p = pack t
    print (t, p, unpack p :: T)
```
which outputs:
```
*BitPackGeneric> main
(A,00,A)
(B,01,C)
(C,10,C)
(D,11,D)
```

I think this change fixes it. (Ping @martijnbastiaan.)