### PR TITLE
Up lower bound ghc-typelits-extra to 0.3.1

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -235,7 +235,7 @@ Library
                       integer-gmp               >= 0.5.1.0 && < 1.1,
                       deepseq                   >= 1.4.1.0 && < 1.5,
                       ghc-prim                  >= 0.3.1.0 && < 0.6,
-                      ghc-typelits-extra        >= 0.3     && < 0.4,
+                      ghc-typelits-extra        >= 0.3.1   && < 0.4,
                       ghc-typelits-knownnat     >= 0.6     && < 0.7,
                       ghc-typelits-natnormalise >= 0.6     && < 0.8,
                       hashable                  >= 1.2.1.0  && < 1.3,


### PR DESCRIPTION
Since 8a4e436ecbbcc0df8f2acfd4e12fd6ab15e3186d we require
ghc-typelits-extra-0.3.1 to compile clash-prelude

Thanks LumiGuide for reporting this