### PR TITLE
Throw an error if inline primitives refer to wrong primitive

### DIFF
--- a/benchmark/profiling/prepare/profile-netlist-prepare.hs
+++ b/benchmark/profiling/prepare/profile-netlist-prepare.hs
@@ -3,12 +3,9 @@
 import           System.Environment           (getArgs)
 import           System.FilePath              (FilePath)
 
-import           Clash.Driver                 (createTemporaryClashDirectory)
-import           Control.Exception            (finally)
 import           Data.Binary (encode)
 import qualified Data.ByteString.Lazy as B
 import           Data.List                    (partition)
-import           System.Directory             (removeDirectoryRecursive)
 
 import           SerialiseInstances
 import           BenchmarkCommon
@@ -21,20 +18,14 @@ main = do
              | otherwise   = tests0
       idirs1 = ".":map (drop 2) idirs0
 
-  tmpDir <- createTemporaryClashDirectory
-
-  finally (do
-    mapM_ (prepareFile tmpDir idirs1) tests1
-   ) (
-    removeDirectoryRecursive tmpDir
-   )
+  mapM_ (prepareFile idirs1) tests1
 
 
-prepareFile :: FilePath -> [FilePath] -> FilePath -> IO ()
-prepareFile tmpDir idirs fIn = do
+prepareFile :: [FilePath] -> FilePath -> IO ()
+prepareFile idirs fIn = do
   putStrLn $ "Preparing: " ++ fIn
   let fOut = fIn ++ ".bin"
-  inp <- runNormalisationStage tmpDir idirs fIn
+  inp <- runNormalisationStage idirs fIn
   let (transformedBindings,topEntities,primMap,tcm,reprs,topEntity) = inp
       inp' = (transformedBindings,topEntities,fmap (fmap removeBBfunc) primMap,tcm,reprs,topEntity)
   putStrLn $ "Serialising to : " ++ fOut

--- a/benchmark/profiling/prepare/profile-normalization-prepare.hs
+++ b/benchmark/profiling/prepare/profile-normalization-prepare.hs
@@ -3,12 +3,9 @@
 import           System.Environment           (getArgs)
 import           System.FilePath              (FilePath)
 
-import           Clash.Driver                 (createTemporaryClashDirectory)
-import           Control.Exception            (finally)
 import           Data.Binary (encode)
 import qualified Data.ByteString.Lazy as B
 import           Data.List                    (partition)
-import           System.Directory             (removeDirectoryRecursive)
 
 import           SerialiseInstances
 import           BenchmarkCommon
@@ -21,20 +18,13 @@ main = do
              | otherwise   = tests0
       idirs1 = ".":map (drop 2) idirs0
 
-  tmpDir <- createTemporaryClashDirectory
+  mapM_ (prepareFile idirs1) tests1
 
-  finally (do
-    mapM_ (prepareFile tmpDir idirs1) tests1
-   ) (
-    removeDirectoryRecursive tmpDir
-   )
-
-
-prepareFile :: FilePath -> [FilePath] -> FilePath -> IO ()
-prepareFile tmpDir idirs fIn = do
+prepareFile :: [FilePath] -> FilePath -> IO ()
+prepareFile idirs fIn = do
   putStrLn $ "Preparing: " ++ fIn
   let fOut = fIn ++ ".bin"
-  inp <- runInputStage tmpDir idirs fIn
+  inp <- runInputStage idirs fIn
   let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity) = inp
       inp' = (bindingsMap,tcm,tupTcm,_topEntities, fmap (fmap removeBBfunc) primMap, reprs,topEntityNames,topEntity)
   putStrLn $ "Serialising to : " ++ fOut

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -149,6 +149,7 @@ library
                       integer-gmp               >= 1.0.1.0  && < 2.0,
                       primitive                 >= 0.5.0.1  && < 1.0,
                       template-haskell          >= 2.8.0.0  && < 2.15,
+                      utf8-string               >= 1.0.0.0  && < 1.1.0.0,
                       vector                    >= 0.11     && < 1.0
   if flag(use-ghc-paths)
     Build-Depends:    ghc-paths

--- a/clash-ghc/src-bin-821/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-821/Clash/GHCi/UI.hs
@@ -1895,7 +1895,6 @@ makeHDL backend optsRef srcs = do
                   fp     = opt_floatSupport opts1
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
-                  tmpDir = opt_tmpDir opts1
                   esc    = opt_escapedIds opts1
                   frcUdf = opt_forceUndefined opts1
                   hdl    = Clash.Backend.hdlKind backend'
@@ -1921,7 +1920,7 @@ makeHDL backend optsRef srcs = do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
-                  generateBindings tmpDir color primDirs idirs dbs hdl src (Just dflags)
+                  generateBindings color primDirs idirs dbs hdl src (Just dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff

--- a/clash-ghc/src-bin-821/Clash/Main.hs
+++ b/clash-ghc/src-bin-821/Clash/Main.hs
@@ -83,14 +83,11 @@ import           Clash.GHCi.UI (makeHDL)
 import           Exception (gcatch)
 import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
-import           Control.Exception (finally)
-import           System.Directory (removeDirectoryRecursive)
 
 import qualified Clash.Backend
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
-import           Clash.Driver (createTemporaryClashDirectory)
 import           Clash.Driver.Types (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
@@ -133,61 +130,55 @@ defaultMain = flip withArgs $ do
     libDir <- ghcLibDir
 
     let argv1 = map (mkGeneralLocated "on the commandline") argv0
-    tmpDir <- createTemporaryClashDirectory
+    r <- newIORef defClashOpts
+    (argv2, clashFlagWarnings) <- parseClashFlags r argv1
 
-    finally (do
-      r <- newIORef (defClashOpts tmpDir)
-      (argv2, clashFlagWarnings) <- parseClashFlags r argv1
+    -- 2. Parse the "mode" flags (--make, --interactive etc.)
+    (mode, argv3, modeFlagWarnings) <- parseModeFlags argv2
+    let flagWarnings = modeFlagWarnings ++ clashFlagWarnings
 
-      -- 2. Parse the "mode" flags (--make, --interactive etc.)
-      (mode, argv3, modeFlagWarnings) <- parseModeFlags argv2
-      let flagWarnings = modeFlagWarnings ++ clashFlagWarnings
+    -- If all we want to do is something like showing the version number
+    -- then do it now, before we start a GHC session etc. This makes
+    -- getting basic information much more resilient.
 
-      -- If all we want to do is something like showing the version number
-      -- then do it now, before we start a GHC session etc. This makes
-      -- getting basic information much more resilient.
+    -- In particular, if we wait until later before giving the version
+    -- number then bootstrapping gets confused, as it tries to find out
+    -- what version of GHC it's using before package.conf exists, so
+    -- starting the session fails.
+    case mode of
+        Left preStartupMode ->
+            do case preStartupMode of
+                   ShowSupportedExtensions   -> showSupportedExtensions
+                   ShowVersion               -> showVersion
+                   ShowNumVersion            -> putStrLn cProjectVersion
+                   ShowOptions isInteractive -> showOptions isInteractive
+        Right postStartupMode ->
+            -- start our GHC session
+            GHC.runGhc (Just libDir) $ do
 
-      -- In particular, if we wait until later before giving the version
-      -- number then bootstrapping gets confused, as it tries to find out
-      -- what version of GHC it's using before package.conf exists, so
-      -- starting the session fails.
-      case mode of
-          Left preStartupMode ->
-              do case preStartupMode of
-                     ShowSupportedExtensions   -> showSupportedExtensions
-                     ShowVersion               -> showVersion
-                     ShowNumVersion            -> putStrLn cProjectVersion
-                     ShowOptions isInteractive -> showOptions isInteractive
-          Right postStartupMode ->
-              -- start our GHC session
-              GHC.runGhc (Just libDir) $ do
+            dflags <- GHC.getSessionDynFlags
+            let dflagsExtra = wantedLanguageExtensions dflags
 
-              dflags <- GHC.getSessionDynFlags
-              let dflagsExtra = wantedLanguageExtensions dflags
+                ghcTyLitNormPlugin = GHC.mkModuleName "GHC.TypeLits.Normalise"
+                ghcTyLitExtrPlugin = GHC.mkModuleName "GHC.TypeLits.Extra.Solver"
+                ghcTyLitKNPlugin   = GHC.mkModuleName "GHC.TypeLits.KnownNat.Solver"
+                dflagsExtra1 = dflagsExtra
+                                  { DynFlags.pluginModNames = nub $
+                                      ghcTyLitNormPlugin : ghcTyLitExtrPlugin :
+                                      ghcTyLitKNPlugin :
+                                      DynFlags.pluginModNames dflagsExtra
+                                  }
 
-                  ghcTyLitNormPlugin = GHC.mkModuleName "GHC.TypeLits.Normalise"
-                  ghcTyLitExtrPlugin = GHC.mkModuleName "GHC.TypeLits.Extra.Solver"
-                  ghcTyLitKNPlugin   = GHC.mkModuleName "GHC.TypeLits.KnownNat.Solver"
-                  dflagsExtra1 = dflagsExtra
-                                    { DynFlags.pluginModNames = nub $
-                                        ghcTyLitNormPlugin : ghcTyLitExtrPlugin :
-                                        ghcTyLitKNPlugin :
-                                        DynFlags.pluginModNames dflagsExtra
-                                    }
-
-              case postStartupMode of
-                  Left preLoadMode ->
-                      liftIO $ do
-                          case preLoadMode of
-                              ShowInfo               -> showInfo dflagsExtra1
-                              ShowGhcUsage           -> showGhcUsage  dflagsExtra1
-                              ShowGhciUsage          -> showGhciUsage dflagsExtra1
-                              PrintWithDynFlags f    -> putStrLn (f dflagsExtra1)
-                  Right postLoadMode ->
-                      main' postLoadMode dflagsExtra1 argv3 flagWarnings r
-     ) (
-      removeDirectoryRecursive tmpDir
-     )
+            case postStartupMode of
+                Left preLoadMode ->
+                    liftIO $ do
+                        case preLoadMode of
+                            ShowInfo               -> showInfo dflagsExtra1
+                            ShowGhcUsage           -> showGhcUsage  dflagsExtra1
+                            ShowGhciUsage          -> showGhciUsage dflagsExtra1
+                            PrintWithDynFlags f    -> putStrLn (f dflagsExtra1)
+                Right postLoadMode ->
+                    main' postLoadMode dflagsExtra1 argv3 flagWarnings r
 
 
 main' :: PostLoadMode -> DynFlags -> [Located String] -> [Located String]

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -1942,7 +1942,6 @@ makeHDL backend optsRef srcs = do
                   fp     = opt_floatSupport opts1
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
-                  tmpDir = opt_tmpDir opts1
                   esc    = opt_escapedIds opts1
                   frcUdf = opt_forceUndefined opts1
                   hdl    = Clash.Backend.hdlKind backend'
@@ -1968,7 +1967,7 @@ makeHDL backend optsRef srcs = do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
-                  generateBindings tmpDir color primDirs idirs dbs hdl src (Just dflags)
+                  generateBindings color primDirs idirs dbs hdl src (Just dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff

--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -83,14 +83,11 @@ import           Clash.GHCi.UI (makeHDL)
 import           Exception (gcatch)
 import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
-import           Control.Exception (finally)
-import           System.Directory (removeDirectoryRecursive)
 
 import qualified Clash.Backend
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
-import           Clash.Driver (createTemporaryClashDirectory)
 import           Clash.Driver.Types (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
@@ -140,62 +137,57 @@ defaultMain = flip withArgs $ do
     libDir <- ghcLibDir
 
     let argv1 = map (mkGeneralLocated "on the commandline") argv0
-    tmpDir <- createTemporaryClashDirectory
-    finally (do
-      r <- newIORef (defClashOpts tmpDir)
+    r <- newIORef defClashOpts
 
-      (argv2, clashFlagWarnings) <- parseClashFlags r argv1
+    (argv2, clashFlagWarnings) <- parseClashFlags r argv1
 
-      -- 2. Parse the "mode" flags (--make, --interactive etc.)
-      -- (mode, argv3, flagWarnings) <- parseModeFlags argv2
-      (mode, argv3, modeFlagWarnings) <- parseModeFlags argv2
-      let flagWarnings = modeFlagWarnings ++ clashFlagWarnings
+    -- 2. Parse the "mode" flags (--make, --interactive etc.)
+    -- (mode, argv3, flagWarnings) <- parseModeFlags argv2
+    (mode, argv3, modeFlagWarnings) <- parseModeFlags argv2
+    let flagWarnings = modeFlagWarnings ++ clashFlagWarnings
 
-      -- If all we want to do is something like showing the version number
-      -- then do it now, before we start a GHC session etc. This makes
-      -- getting basic information much more resilient.
+    -- If all we want to do is something like showing the version number
+    -- then do it now, before we start a GHC session etc. This makes
+    -- getting basic information much more resilient.
 
-      -- In particular, if we wait until later before giving the version
-      -- number then bootstrapping gets confused, as it tries to find out
-      -- what version of GHC it's using before package.conf exists, so
-      -- starting the session fails.
-      case mode of
-          Left preStartupMode ->
-              do case preStartupMode of
-                     ShowSupportedExtensions   -> showSupportedExtensions
-                     ShowVersion               -> showVersion
-                     ShowNumVersion            -> putStrLn cProjectVersion
-                     ShowOptions isInteractive -> showOptions isInteractive
-          Right postStartupMode ->
-              -- start our GHC session
-              GHC.runGhc (Just libDir) $ do
+    -- In particular, if we wait until later before giving the version
+    -- number then bootstrapping gets confused, as it tries to find out
+    -- what version of GHC it's using before package.conf exists, so
+    -- starting the session fails.
+    case mode of
+        Left preStartupMode ->
+            do case preStartupMode of
+                   ShowSupportedExtensions   -> showSupportedExtensions
+                   ShowVersion               -> showVersion
+                   ShowNumVersion            -> putStrLn cProjectVersion
+                   ShowOptions isInteractive -> showOptions isInteractive
+        Right postStartupMode ->
+            -- start our GHC session
+            GHC.runGhc (Just libDir) $ do
 
-              dflags <- GHC.getSessionDynFlags
-              let dflagsExtra = wantedLanguageExtensions dflags
+            dflags <- GHC.getSessionDynFlags
+            let dflagsExtra = wantedLanguageExtensions dflags
 
-                  ghcTyLitNormPlugin = GHC.mkModuleName "GHC.TypeLits.Normalise"
-                  ghcTyLitExtrPlugin = GHC.mkModuleName "GHC.TypeLits.Extra.Solver"
-                  ghcTyLitKNPlugin   = GHC.mkModuleName "GHC.TypeLits.KnownNat.Solver"
-                  dflagsExtra1 = dflagsExtra
-                                    { DynFlags.pluginModNames = nub $
-                                        ghcTyLitNormPlugin : ghcTyLitExtrPlugin :
-                                        ghcTyLitKNPlugin :
-                                        DynFlags.pluginModNames dflagsExtra
-                                    }
+                ghcTyLitNormPlugin = GHC.mkModuleName "GHC.TypeLits.Normalise"
+                ghcTyLitExtrPlugin = GHC.mkModuleName "GHC.TypeLits.Extra.Solver"
+                ghcTyLitKNPlugin   = GHC.mkModuleName "GHC.TypeLits.KnownNat.Solver"
+                dflagsExtra1 = dflagsExtra
+                                  { DynFlags.pluginModNames = nub $
+                                      ghcTyLitNormPlugin : ghcTyLitExtrPlugin :
+                                      ghcTyLitKNPlugin :
+                                      DynFlags.pluginModNames dflagsExtra
+                                  }
 
-              case postStartupMode of
-                  Left preLoadMode ->
-                      liftIO $ do
-                          case preLoadMode of
-                              ShowInfo               -> showInfo dflagsExtra1
-                              ShowGhcUsage           -> showGhcUsage  dflagsExtra1
-                              ShowGhciUsage          -> showGhciUsage dflagsExtra1
-                              PrintWithDynFlags f    -> putStrLn (f dflagsExtra1)
-                  Right postLoadMode ->
-                      main' postLoadMode dflagsExtra1 argv3 flagWarnings r
-      ) (
-       removeDirectoryRecursive tmpDir
-      )
+            case postStartupMode of
+                Left preLoadMode ->
+                    liftIO $ do
+                        case preLoadMode of
+                            ShowInfo               -> showInfo dflagsExtra1
+                            ShowGhcUsage           -> showGhcUsage  dflagsExtra1
+                            ShowGhciUsage          -> showGhciUsage dflagsExtra1
+                            PrintWithDynFlags f    -> putStrLn (f dflagsExtra1)
+                Right postLoadMode ->
+                    main' postLoadMode dflagsExtra1 argv3 flagWarnings r
 
 main' :: PostLoadMode -> DynFlags -> [Located String] -> [Warn]
       -> IORef ClashOpts

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -1991,7 +1991,6 @@ makeHDL backend optsRef srcs = do
                   fp     = opt_floatSupport opts1
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
-                  tmpDir = opt_tmpDir opts1
                   esc    = opt_escapedIds opts1
                   frcUdf = opt_forceUndefined opts1
                   hdl    = Clash.Backend.hdlKind backend'
@@ -2017,7 +2016,7 @@ makeHDL backend optsRef srcs = do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
-                  generateBindings tmpDir color primDirs idirs dbs hdl src (Just dflags)
+                  generateBindings color primDirs idirs dbs hdl src (Just dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -85,14 +85,11 @@ import           Clash.GHCi.UI (makeHDL)
 import           Exception (gcatch)
 import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
-import           Control.Exception (finally)
-import           System.Directory (removeDirectoryRecursive)
 
 import qualified Clash.Backend
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
-import           Clash.Driver (createTemporaryClashDirectory)
 import           Clash.Driver.Types
   (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
@@ -132,61 +129,56 @@ defaultMain = flip withArgs $ do
     libDir <- ghcLibDir
 
     let argv1 = map (mkGeneralLocated "on the commandline") argv0
-    tmpDir <- createTemporaryClashDirectory
-    finally (do
-      r <- newIORef (defClashOpts tmpDir)
-      (argv2, clashFlagWarnings) <- parseClashFlags r argv1
+    r <- newIORef defClashOpts
+    (argv2, clashFlagWarnings) <- parseClashFlags r argv1
 
-      -- 2. Parse the "mode" flags (--make, --interactive etc.)
-      -- (mode, argv3, flagWarnings) <- parseModeFlags argv2
-      (mode, argv3, modeFlagWarnings) <- parseModeFlags argv2
-      let flagWarnings = modeFlagWarnings ++ clashFlagWarnings
+    -- 2. Parse the "mode" flags (--make, --interactive etc.)
+    -- (mode, argv3, flagWarnings) <- parseModeFlags argv2
+    (mode, argv3, modeFlagWarnings) <- parseModeFlags argv2
+    let flagWarnings = modeFlagWarnings ++ clashFlagWarnings
 
-      -- If all we want to do is something like showing the version number
-      -- then do it now, before we start a GHC session etc. This makes
-      -- getting basic information much more resilient.
+    -- If all we want to do is something like showing the version number
+    -- then do it now, before we start a GHC session etc. This makes
+    -- getting basic information much more resilient.
 
-      -- In particular, if we wait until later before giving the version
-      -- number then bootstrapping gets confused, as it tries to find out
-      -- what version of GHC it's using before package.conf exists, so
-      -- starting the session fails.
-      case mode of
-          Left preStartupMode ->
-              do case preStartupMode of
-                     ShowSupportedExtensions   -> showSupportedExtensions
-                     ShowVersion               -> showVersion
-                     ShowNumVersion            -> putStrLn cProjectVersion
-                     ShowOptions isInteractive -> showOptions isInteractive
-          Right postStartupMode ->
-              -- start our GHC session
-              GHC.runGhc (Just libDir) $ do
+    -- In particular, if we wait until later before giving the version
+    -- number then bootstrapping gets confused, as it tries to find out
+    -- what version of GHC it's using before package.conf exists, so
+    -- starting the session fails.
+    case mode of
+        Left preStartupMode ->
+            do case preStartupMode of
+                   ShowSupportedExtensions   -> showSupportedExtensions
+                   ShowVersion               -> showVersion
+                   ShowNumVersion            -> putStrLn cProjectVersion
+                   ShowOptions isInteractive -> showOptions isInteractive
+        Right postStartupMode ->
+            -- start our GHC session
+            GHC.runGhc (Just libDir) $ do
 
-              dflags <- GHC.getSessionDynFlags
-              let dflagsExtra = wantedLanguageExtensions dflags
+            dflags <- GHC.getSessionDynFlags
+            let dflagsExtra = wantedLanguageExtensions dflags
 
-                  ghcTyLitNormPlugin = GHC.mkModuleName "GHC.TypeLits.Normalise"
-                  ghcTyLitExtrPlugin = GHC.mkModuleName "GHC.TypeLits.Extra.Solver"
-                  ghcTyLitKNPlugin   = GHC.mkModuleName "GHC.TypeLits.KnownNat.Solver"
-                  dflagsExtra1 = dflagsExtra
-                                    { DynFlags.pluginModNames = nub $
-                                        ghcTyLitNormPlugin : ghcTyLitExtrPlugin :
-                                        ghcTyLitKNPlugin :
-                                        DynFlags.pluginModNames dflagsExtra
-                                    }
+                ghcTyLitNormPlugin = GHC.mkModuleName "GHC.TypeLits.Normalise"
+                ghcTyLitExtrPlugin = GHC.mkModuleName "GHC.TypeLits.Extra.Solver"
+                ghcTyLitKNPlugin   = GHC.mkModuleName "GHC.TypeLits.KnownNat.Solver"
+                dflagsExtra1 = dflagsExtra
+                                  { DynFlags.pluginModNames = nub $
+                                      ghcTyLitNormPlugin : ghcTyLitExtrPlugin :
+                                      ghcTyLitKNPlugin :
+                                      DynFlags.pluginModNames dflagsExtra
+                                  }
 
-              case postStartupMode of
-                  Left preLoadMode ->
-                      liftIO $ do
-                          case preLoadMode of
-                              ShowInfo               -> showInfo dflagsExtra1
-                              ShowGhcUsage           -> showGhcUsage  dflagsExtra1
-                              ShowGhciUsage          -> showGhciUsage dflagsExtra1
-                              PrintWithDynFlags f    -> putStrLn (f dflagsExtra1)
-                  Right postLoadMode ->
-                      main' postLoadMode dflagsExtra1 argv3 flagWarnings r
-      ) (
-        removeDirectoryRecursive tmpDir
-      )
+            case postStartupMode of
+                Left preLoadMode ->
+                    liftIO $ do
+                        case preLoadMode of
+                            ShowInfo               -> showInfo dflagsExtra1
+                            ShowGhcUsage           -> showGhcUsage  dflagsExtra1
+                            ShowGhciUsage          -> showGhciUsage dflagsExtra1
+                            PrintWithDynFlags f    -> putStrLn (f dflagsExtra1)
+                Right postLoadMode ->
+                    main' postLoadMode dflagsExtra1 argv3 flagWarnings r
 
 main' :: PostLoadMode -> DynFlags -> [Located String] -> [Warn]
       -> IORef ClashOpts

--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -14,20 +14,20 @@
 
 module Clash.GHC.LoadInterfaceFiles
   ( loadExternalExprs
-  , primitiveFilePath
+  , unresolvedPrimitives
   )
 where
 
 -- External Modules
 import           Control.Monad.IO.Class      (MonadIO (..))
-import           Data.Char                   (toLower)
+import qualified Data.ByteString.Lazy.UTF8   as BLU
+import qualified Data.ByteString.Lazy        as BL
 import           Data.Either                 (partitionEithers)
 import           Data.List                   (elemIndex, foldl', partition)
+import qualified Data.Text                   as Text
 import           Data.Maybe                  (isJust, isNothing,
                                               mapMaybe, catMaybes)
 import           Data.Word                   (Word8)
-import           System.Directory            (createDirectoryIfMissing)
-import           System.FilePath.Posix       ((<.>), (</>))
 
 -- GHC API
 import           Annotations (Annotation(..), getAnnTargetName_maybe)
@@ -61,6 +61,9 @@ import           Clash.Annotations.BitRepresentation.Internal
   (DataRepr', dataReprAnnToDataRepr')
 import           Clash.Annotations.Primitive
 import           Clash.Annotations.BitRepresentation (DataReprAnn)
+import           Clash.Primitives.Types              (UnresolvedPrimitive, name)
+import           Clash.Primitives.Util               (decodeOrErr)
+import           Clash.GHC.GHC2Core                  (qualifiedNameString')
 import           Clash.Util                          (curLoc, traceIf)
 
 runIfl :: GHC.GhcMonad m => GHC.Module -> TcRnTypes.IfL a -> m a
@@ -91,17 +94,16 @@ loadIface foundMod = do
 
 loadExternalExprs
   :: GHC.GhcMonad m
-  => FilePath
-  -> HDL
+  => HDL
   -> UniqSet.UniqSet CoreSyn.CoreBndr
   -> [CoreSyn.CoreBind]
   -> m ( [(CoreSyn.CoreBndr,CoreSyn.CoreExpr)] -- Binders
        , [(CoreSyn.CoreBndr,Int)]              -- Class Ops
        , [CoreSyn.CoreBndr]                    -- Unlocatable
-       , [FilePath]
+       , [Either UnresolvedPrimitive FilePath]
        , [DataRepr']
        )
-loadExternalExprs tmpDir hdl = go [] [] [] [] []
+loadExternalExprs hdl = go [] [] [] [] []
   where
     go locatedExprs clsOps unlocated pFP reprs _ [] =
       return (locatedExprs,clsOps,unlocated,pFP,reprs)
@@ -136,7 +138,7 @@ loadExternalExprs tmpDir hdl = go [] [] [] [] []
                           (elemIndex v clsIds)
             ) clsOps'
 
-      (locatedAndUnlocated, pFP', reprs') <- unzip3 <$> mapM (loadExprFromIface tmpDir hdl) fvs'
+      (locatedAndUnlocated, pFP', reprs') <- unzip3 <$> mapM (loadExprFromIface hdl) fvs'
       let (locatedExprs', unlocated') = partitionEithers locatedAndUnlocated
 
       let visited' = foldl' UniqSet.addListToUniqSet visited
@@ -155,16 +157,15 @@ loadExternalExprs tmpDir hdl = go [] [] [] [] []
 
 loadExprFromIface ::
   GHC.GhcMonad m
-  => FilePath
-  -> HDL
+  => HDL
   -> CoreSyn.CoreBndr
   -> m (Either
           (CoreSyn.CoreBndr,CoreSyn.CoreExpr) -- Located
           CoreSyn.CoreBndr                    -- Unlocated
-       ,[FilePath]
+       ,[Either UnresolvedPrimitive FilePath]
        ,[DataRepr']
        )
-loadExprFromIface tmpDir hdl bndr = do
+loadExprFromIface hdl bndr = do
   let moduleM = Name.nameModule_maybe $ Var.varName bndr
   case moduleM of
     Just nameMod -> runIfl nameMod $ do
@@ -176,7 +177,7 @@ loadExprFromIface tmpDir hdl bndr = do
           let nameFun = GHC.getOccName $ Var.varName bndr
           let declM = filter ((== nameFun) . Name.nameOccName . IfaceSyn.ifName) decls
           anns <- TcIface.tcIfaceAnnotations (GHC.mi_anns iface)
-          primFPs   <- loadPrimitiveAnnotations hdl tmpDir anns
+          primFPs   <- loadPrimitiveAnnotations hdl anns
           let reprs  = loadCustomReprAnnotations anns
           case declM of
             [namedDecl] -> do
@@ -217,11 +218,10 @@ loadCustomReprAnnotations anns =
 loadPrimitiveAnnotations ::
   MonadIO m
   => HDL
-  -> FilePath
   -> [Annotations.Annotation]
-  -> m [FilePath]
-loadPrimitiveAnnotations hdl tmpDir anns =
-  sequence $ mapMaybe (primitiveFilePath hdl tmpDir) prims
+  -> m [Either UnresolvedPrimitive FilePath]
+loadPrimitiveAnnotations hdl anns =
+  concat <$> mapM (unresolvedPrimitives hdl) prims
   where
     prims = mapMaybe filterPrim anns
     filterPrim (Annotations.Annotation target value) =
@@ -230,35 +230,51 @@ loadPrimitiveAnnotations hdl tmpDir anns =
       GhcPlugins.fromSerialized
         (GhcPlugins.deserializeWithData :: [Word8] -> Primitive)
 
-primitiveFilePath ::
-  MonadIO m
+unresolvedPrimitives
+  :: MonadIO m
   => HDL
-  -> FilePath
   -> (Annotations.CoreAnnTarget, Primitive)
-  -> Maybe (m FilePath)
-primitiveFilePath hdl tmpDir targetPrim =
+  -> m ([Either UnresolvedPrimitive FilePath])
+unresolvedPrimitives hdl targetPrim =
   case targetPrim of
-    (_, Primitive hdl' fp)
-      | hdl == hdl' -> Just $ pure fp
-    (target, InlinePrimitive hdl' content)
-      | hdl == hdl' -> Just . liftIO $ do
-        let qualifiedName =
-              case target of
-                Annotations.NamedTarget name -> Name.nameStableString name
-                Annotations.ModuleTarget mod' -> Module.moduleStableString mod'
-            inlinePrimsDir =
-              tmpDir </> "inline_primitives" </> map toLower (show hdl)
-            primFile = inlinePrimsDir </> qualifiedName <.> "json"
-        createDirectoryIfMissing True inlinePrimsDir
-        writeFile primFile content
-        return inlinePrimsDir
-    _ -> Nothing
+    (_, Primitive hdl' fp) | hdl == hdl' -> pure [Right fp]
 
-loadExprFromTyThing :: CoreSyn.CoreBndr
-                    -> GHC.TyThing
-                    -> Either
-                         (CoreSyn.CoreBndr,CoreSyn.CoreExpr)  -- Located Binder
-                         CoreSyn.CoreBndr                     -- unlocatable Var
+    (target, InlinePrimitive hdl' contentOrFp) | hdl == hdl' ->
+      case target of
+        -- Module annotation, can house many primitives
+        Annotations.ModuleTarget _ ->
+          liftIO (decodeOrErr contentOrFp <$> BL.readFile contentOrFp)
+        Annotations.NamedTarget targetName0 ->
+          let targetName1 = Text.unpack (qualifiedNameString' targetName0)
+              prim =
+                case decodeOrErr targetName1 (BLU.fromString contentOrFp) of
+                  [] -> error $ "No annotations found for " ++ targetName1
+                     ++ " even though it had an InlinePrimitive annotation."
+                  [p] -> p
+                  _ -> error $ "Multiple primitive definitions found in "
+                    ++ "InlinePrimitive annotation for " ++ targetName1 ++ ". "
+                    ++ "Expected a single one."
+
+              primName = Text.unpack (name prim) in
+
+          if primName /= targetName1 then
+            error $ concat
+              [ "Function " ++ targetName1 ++ " was annotated with an inline "
+              , "primitive for " ++ primName ++ ". These names "
+              , "should be the same." ]
+          else
+            pure [Left prim]
+    _ ->
+      -- Only consider the HDL (Verilog/SystemVerilog/VHDL) annotation we're
+      -- currently targeting.
+      pure []
+
+loadExprFromTyThing
+  :: CoreSyn.CoreBndr
+  -> GHC.TyThing
+  -> Either
+       (CoreSyn.CoreBndr,CoreSyn.CoreExpr)  -- Located Binder
+       CoreSyn.CoreBndr                     -- unlocatable Var
 loadExprFromTyThing bndr tyThing = case tyThing of
   GHC.AnId _id | Var.isId _id ->
     let _idInfo    = Var.idInfo _id

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -49,7 +49,7 @@ import qualified System.FilePath                  as FilePath
 import qualified System.IO                        as IO
 import           System.IO.Error                  (isDoesNotExistError)
 import           System.IO.Temp
-  (getCanonicalTemporaryDirectory, withTempDirectory, createTempDirectory)
+  (getCanonicalTemporaryDirectory, withTempDirectory)
 import qualified Text.PrettyPrint.ANSI.Leijen     as ANSI
 import           Text.Trifecta.Result
   (Result(Success, Failure), _errDoc)
@@ -89,12 +89,6 @@ import           Clash.Util                       (first, reportTimeDiff)
 -- | Get modification data of current clash binary.
 getClashModificationDate :: IO Clock.UTCTime
 getClashModificationDate = Directory.getModificationTime =<< getExecutablePath
-
--- | Creates a directory for all Clash's temporary files
-createTemporaryClashDirectory :: IO FilePath
-createTemporaryClashDirectory = do
-  tmp <- getCanonicalTemporaryDirectory
-  createTempDirectory tmp "clash"
 
 -- | Create a set of target HDL files for a set of functions
 generateHDL

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -60,7 +60,6 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            , opt_color       :: OverridingBool
                            , opt_intWidth    :: Int
                            , opt_hdlDir      :: Maybe String
-                           , opt_tmpDir      :: String
                            -- ^ Directory to store temporary files in. Will be
                            -- cleaned after Clash has finished executing.
                            , opt_hdlSyn      :: HdlSyn
@@ -91,11 +90,8 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            }
 
 
+defClashOpts :: ClashOpts
 defClashOpts
-  :: FilePath
-  -- ^ Temporary directory
-  -> ClashOpts
-defClashOpts tmpDir
   = ClashOpts
   { opt_dbgLevel            = DebugNone
   , opt_inlineLimit         = 20
@@ -108,7 +104,6 @@ defClashOpts tmpDir
   , opt_color               = Auto
   , opt_intWidth            = WORD_SIZE_IN_BITS
   , opt_hdlDir              = Nothing
-  , opt_tmpDir              = tmpDir
   , opt_hdlSyn              = Other
   , opt_errorExtra          = False
   , opt_floatSupport        = False

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -125,7 +125,7 @@ data TemplateSource
   -- ^ Template source stored in file on filesystem
   | TInline Text
   -- ^ Template stored inline
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic, NFData)
 
 
 data TemplateFormat
@@ -171,7 +171,8 @@ data Primitive a b c d
     -- ^ Whether the primitive does any work, i.e. takes chip area
   , functionName :: BlackBoxFunctionName
   , function :: d
-    -- ^ Used to indicate type of template (declaration or expression).
+  -- ^ Holds blackbox function and its hash, (Int, BlackBoxFunction), in a
+  -- CompiledPrimitive.
   }
   -- | A primitive that carries additional information. These are "real"
   -- primitives, hardcoded in the compiler. For example: 'mapSignal' in
@@ -198,9 +199,7 @@ instance FromJSON UnresolvedPrimitive where
             templ <- (Just . TInline <$> conVal .: "template")
                  <|> (Just . TFile   <$> conVal .: "file")
                  <|> (pure Nothing)
-
             fName' <- either fail return (parseBBFN fName)
-
             return (BlackBoxHaskell name' wf fName' templ)
           "BlackBox"  ->
             BlackBox <$> conVal .: "name"

--- a/tests/shouldfail/BlackBox/WrongReference.hs
+++ b/tests/shouldfail/BlackBox/WrongReference.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds         #-}
+
+module WrongReference where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+import Clash.Prelude hiding (Text)
+import Clash.Netlist.Types
+import Clash.Netlist.BlackBox.Types
+import Clash.Annotations.Primitive (Primitive(..), HDL(..))
+
+{-# ANN myMultiply (InlinePrimitive VHDL "[ { \"BlackBoxHaskell\" : { \"name\" : \"WrongReference.myMultiplyX\", \"templateFunction\" : \"Foo.bar\"}} ]") #-}
+myMultiply
+  :: Signal System Int
+  -> Signal System Int
+  -> Signal System Int
+myMultiply a b =
+  a * b
+{-# NOINLINE myMultiply #-}
+
+topEntity
+  :: HiddenClockResetEnable System
+  => Signal System Int
+  -> Signal System Int
+topEntity a = myMultiply a a

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -117,6 +117,7 @@ runClashTest =
         , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "BlackBoxFunction"   "main"
         , runTest    ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   []    "BlackBoxFunctionHO" (["","testBench"],"testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "Signal")   defBuild [] [] "BlockRamLazy"       "main"
+        , runFailingTest ("tests" </> "shouldfail" </> "BlackBox") [VHDL] [] "WrongReference" (Just "Function WrongReference.myMultiply was annotated with an inline primitive for WrongReference.myMultiplyX. These names should be the same.")
         ]
       , clashTestGroup "BoxedFunctions"
         [ runTest ("tests" </> "shouldwork" </> "BoxedFunctions") defBuild [] "DeadRecursiveBoxed" ([""],"topEntity",False)


### PR DESCRIPTION
Fixes issue #588. It should be noted that this merely "fixes" the issue
in the sense that users will be told to correct their mistake, while
they shouldn't have been able to make the mistake in the first place. We
should seriously think about ditching json-primitives entirely, and
offer a much more ergonomic API.

As a happy side-effect, this removes the inline_primitives hack that was
around to support inline primitives. ~~This commit also explicitly removes
the ability to use file references in inline primitives, as we can't
reliably determine where they are.~~