### PR TITLE
Use sourceticks to annotate hdl with source locations

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -374,7 +374,8 @@ coreToTerm primMap unlocs = term
         Just _ | ty1_I || ty2_I
           -> C.Cast <$> term e <*> coreToType ty1 <*> coreToType ty2
         _ -> term e
-    term' (Tick (SourceNote rsp _) e) = addUsefull (RealSrcSpan rsp) (term e)
+    term' (Tick (SourceNote rsp _) e) =
+      C.Tick (RealSrcSpan rsp) <$> addUsefull (RealSrcSpan rsp) (term e)
     term' (Tick _ e)        = term e
     term' (Type t)          = C.TyApp (C.Prim (pack "_TY_") (C.PrimInfo C.undefinedTy C.WorkNever)) <$>
                                 coreToType t

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -16,7 +16,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Clash.GHC.GHC2Core
-  ( GHC2CoreState
+  ( C2C
+  , GHC2CoreState
   , tyConMap
   , coreToTerm
   , coreToId
@@ -31,17 +32,17 @@ where
 
 -- External Modules
 import           Control.Lens                ((^.), (%~), (&), (%=))
-import           Control.Monad.Trans.Class   (lift)
-import           Control.Monad.Trans.Reader  (ReaderT)
-import qualified Control.Monad.Trans.Reader  as Reader
-import           Control.Monad.State         (State)
-import qualified Control.Monad.State.Lazy    as State
+import           Control.Monad.RWS.Lazy      (RWS)
+import qualified Control.Monad.RWS.Lazy      as RWS
 import qualified Data.ByteString.Char8       as Char8
 import           Data.Hashable               (Hashable (..))
 import           Data.HashMap.Lazy           (HashMap)
 import qualified Data.HashMap.Lazy           as HashMap
 import qualified Data.HashMap.Strict         as HSM
 import           Data.Maybe                  (catMaybes,fromMaybe,listToMaybe)
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup
+#endif
 import           Data.Text                   (Text, isInfixOf,pack)
 import qualified Data.Text                   as Text
 import           Data.Text.Encoding          (decodeUtf8)
@@ -53,8 +54,8 @@ import CoAxiom    (CoAxiom (co_ax_branches), CoAxBranch (cab_lhs,cab_rhs),
 import Coercion   (coercionType,coercionKind)
 import CoreFVs    (exprSomeFreeVars)
 import CoreSyn
-  (AltCon (..), Bind (..), CoreExpr, Expr (..), Unfolding (..), collectArgs,
-   rhssOfAlts, unfoldingTemplate)
+  (AltCon (..), Bind (..), CoreExpr, Expr (..), Unfolding (..), Tickish (..),
+   collectArgs, rhssOfAlts, unfoldingTemplate)
 import DataCon    (DataCon, dataConExTyVars,
                    dataConName, dataConRepArgTys,
                    dataConTag, dataConTyCon,
@@ -77,7 +78,7 @@ import PrelNames  (tYPETyConKey)
 import OccName    (occNameString)
 import Outputable (showPpr)
 import Pair       (Pair (..))
-import SrcLoc     (SrcSpan, isGoodSrcSpan)
+import SrcLoc     (SrcSpan (..), isGoodSrcSpan, noSrcSpan)
 import TyCon      (AlgTyConRhs (..), TyCon, tyConName,
                    algTyConRhs, isAlgTyCon, isFamilyTyCon,
                    isFunTyCon, isNewTyCon,
@@ -123,6 +124,22 @@ makeLenses ''GHC2CoreState
 emptyGHC2CoreState :: GHC2CoreState
 emptyGHC2CoreState = GHC2CoreState C.emptyUniqMap HSM.empty
 
+newtype SrcSpanRB = SrcSpanRB {unSrcSpanRB :: SrcSpan}
+
+instance Semigroup SrcSpanRB where
+  (SrcSpanRB l) <> (SrcSpanRB r) =
+    if   isGoodSrcSpan r
+    then SrcSpanRB r
+    else SrcSpanRB l
+
+instance Monoid SrcSpanRB where
+  mempty = SrcSpanRB noSrcSpan
+#if !MIN_VERSION_base(4,11,0)
+  mappend = (<>)
+#endif
+
+type C2C = RWS SrcSpan SrcSpanRB GHC2CoreState
+
 makeAllTyCons
   :: GHC2CoreState
   -> FamInstEnvs
@@ -133,12 +150,12 @@ makeAllTyCons hm fiEnvs = go hm hm
         | C.nullUniqMap (new ^. tyConMap) = C.emptyUniqMap
         | otherwise                       = tcm `C.unionUniqMap` tcm'
       where
-        (tcm,old') = State.runState (T.mapM (makeTyCon fiEnvs) (new ^. tyConMap)) old
-        tcm'       = go old' (old' & tyConMap %~ (`C.differenceUniqMap` (old ^. tyConMap)))
+        (tcm,old', _) = RWS.runRWS (T.mapM (makeTyCon fiEnvs) (new ^. tyConMap)) noSrcSpan old
+        tcm'          = go old' (old' & tyConMap %~ (`C.differenceUniqMap` (old ^. tyConMap)))
 
 makeTyCon :: FamInstEnvs
           -> TyCon
-          -> State GHC2CoreState C.TyCon
+          -> C2C C.TyCon
 makeTyCon fiEnvs tc = tycon
   where
     tycon
@@ -224,14 +241,14 @@ makeTyCon fiEnvs tc = tycon
           tcKind <- coreToType (tyConKind tc)
           return (C.PrimTyCon (C.nameUniq tcName) tcName tcKind tcArity)
 
-        famInstToSubst :: FamInst -> State GHC2CoreState ([C.Type],C.Type)
+        famInstToSubst :: FamInst -> C2C ([C.Type],C.Type)
         famInstToSubst fi = do
           tys <- mapM coreToType  (fi_tys fi)
           ty  <- coreToType (fi_rhs fi)
           return (tys,ty)
 
 makeAlgTyConRhs :: AlgTyConRhs
-                -> State GHC2CoreState (Maybe C.AlgTyConRhs)
+                -> C2C (Maybe C.AlgTyConRhs)
 makeAlgTyConRhs algTcRhs = case algTcRhs of
 #if MIN_VERSION_ghc(8,6,0)
   DataTyCon dcs _ _ -> Just <$> C.DataTyCon <$> mapM coreToDataCon dcs
@@ -254,15 +271,16 @@ makeAlgTyConRhs algTcRhs = case algTcRhs of
 coreToTerm
   :: ResolvedPrimMap
   -> [Var]
-  -> SrcSpan
   -> CoreExpr
-  -> State GHC2CoreState C.Term
-coreToTerm primMap unlocs srcsp coreExpr = Reader.runReaderT (term coreExpr) srcsp
+  -> C2C C.Term
+coreToTerm primMap unlocs = term
   where
-    term :: CoreExpr -> ReaderT SrcSpan (State GHC2CoreState) C.Term
+    term :: CoreExpr -> C2C C.Term
     term e
       | (Var x,args) <- collectArgs e
-      , let nm = State.evalState (qualifiedNameString (varName x)) emptyGHC2CoreState
+      , let (nm, _) = RWS.evalRWS (qualifiedNameString (varName x))
+                                  noSrcSpan
+                                  emptyGHC2CoreState
       = go nm args
       | otherwise
       = term' e
@@ -303,38 +321,44 @@ coreToTerm primMap unlocs srcsp coreExpr = Reader.runReaderT (term coreExpr) src
           | [_nTy,_aTy,_kn,_typ,f] <- args
           = term f
         go _ _ = term' e
-    term' (Var x)                 = do
-      srcsp' <- Reader.ask
-      lift (var srcsp' x)
+    term' (Var x)                 = var x
     term' (Lit l)                 = return $ C.Literal (coreToLiteral l)
-    term' (App eFun (Type tyArg)) = C.TyApp <$> term eFun <*> lift (coreToType tyArg)
+    term' (App eFun (Type tyArg)) = C.TyApp <$> term eFun <*> coreToType tyArg
     term' (App eFun eArg)         = C.App   <$> term eFun <*> term eArg
-    term' (Lam x e) | isTyVar x   = C.TyLam <$> lift (coreToTyVar x) <*> addUsefull (getSrcSpan x) (term e)
-                    | otherwise   = C.Lam   <$> lift (coreToId x) <*> addUsefull (getSrcSpan x) (term e)
+    term' (Lam x e)
+      | isTyVar x
+      = C.TyLam <$> coreToTyVar x <*> addUsefull (getSrcSpan x) (term e)
+      | otherwise
+      = do
+        (e',sp) <- termSP (getSrcSpan x) e
+        x' <- coreToIdSP sp x
+        return (C.Lam  x' e')
     term' (Let (NonRec x e1) e2)  = do
-      x'  <- lift (coreToId x)
-      e1' <- addUsefull (getSrcSpan x) (term e1)
+      (e1',sp) <- termSP (getSrcSpan x) e1
+      x'  <- coreToIdSP sp x
       e2' <- term e2
       return (C.Letrec [(x', e1')] e2')
 
     term' (Let (Rec xes) e) = do
-      xes' <- mapM (\(x,b) -> (,) <$> lift (coreToId x)
-                                  <*> addUsefull (getSrcSpan x)
-                                                 (term b))
-                   xes
+      xes' <- mapM go xes
       e'   <- term e
       return (C.Letrec xes' e')
+     where
+      go (x,b) = do
+        (b',sp) <- termSP (getSrcSpan x) b
+        x' <- coreToIdSP sp x
+        return (x',b')
 
     term' (Case _ _ ty [])  = C.TyApp (C.Prim (pack "EmptyCase") (C.PrimInfo C.undefinedTy C.WorkNever))
-                                <$> lift (coreToType ty)
+                                <$> coreToType ty
     term' (Case e b ty alts) = do
      let usesBndr = any ( not . isEmptyVarSet . exprSomeFreeVars (== b))
                   $ rhssOfAlts alts
-     b'  <- lift (coreToId b)
-     e'  <- addUsefull (getSrcSpan b) (term e)
-     ty' <- lift (coreToType ty)
+     (e',sp) <- termSP (getSrcSpan b) e
+     b'  <- coreToIdSP sp b
+     ty' <- coreToType ty
      let caseTerm v =
-             C.Case v ty' <$> mapM (addUsefull (getSrcSpan b) . alt) alts
+             C.Case v ty' <$> mapM (addUsefull sp . alt sp) alts
      if usesBndr
       then do
         ct <- caseTerm (C.Var b')
@@ -343,24 +367,30 @@ coreToTerm primMap unlocs srcsp coreExpr = Reader.runReaderT (term coreExpr) src
 
     term' (Cast e co) = do
       let (Pair ty1 ty2) = coercionKind co
-      hasPrimCoM <- lift (hasPrimCo co)
-      ty1_I <- lift (isIntegerTy ty1)
-      ty2_I <- lift (isIntegerTy ty2)
+      hasPrimCoM <- hasPrimCo co
+      ty1_I <- isIntegerTy ty1
+      ty2_I <- isIntegerTy ty2
       case hasPrimCoM of
         Just _ | ty1_I || ty2_I
-          -> C.Cast <$> term e <*> lift (coreToType ty1) <*> lift (coreToType ty2)
+          -> C.Cast <$> term e <*> coreToType ty1 <*> coreToType ty2
         _ -> term e
+    term' (Tick (SourceNote rsp _) e) = addUsefull (RealSrcSpan rsp) (term e)
     term' (Tick _ e)        = term e
     term' (Type t)          = C.TyApp (C.Prim (pack "_TY_") (C.PrimInfo C.undefinedTy C.WorkNever)) <$>
-                                lift (coreToType t)
+                                coreToType t
     term' (Coercion co)     = C.TyApp (C.Prim (pack "_CO_") (C.PrimInfo C.undefinedTy C.WorkNever)) <$>
-                                lift (coreToType (coercionType co))
+                                coreToType (coercionType co)
+
+
+    termSP sp = fmap (second unSrcSpanRB) . RWS.listen . addUsefullR sp . term
+    coreToIdSP sp = RWS.local (\r -> if isGoodSrcSpan sp then sp else r) . coreToId
+
 
     lookupPrim :: Text -> Maybe (Maybe ResolvedPrimitive)
     lookupPrim nm = extractPrim <$> HashMap.lookup nm primMap
 
-    var srcsp' x = do
-        xPrim  <- coreToPrimVar x
+    var x = do
+        xPrim <- if isGlobalId x then coreToPrimVar x else coreToVar x
         let xNameS = C.nameOcc xPrim
         xType  <- coreToType (varType x)
         case isDataConId_maybe x of
@@ -370,7 +400,9 @@ coreToTerm primMap unlocs srcsp coreExpr = Reader.runReaderT (term coreExpr) src
               then let xInfo = idInfo x
                        unfolding = unfoldingInfo xInfo
                    in  case unfolding of
-                          CoreUnfolding {} -> Reader.runReaderT (term (unfoldingTemplate unfolding)) srcsp'
+                          CoreUnfolding {} -> do
+                            sp <- RWS.ask
+                            RWS.censor (const (SrcSpanRB sp)) (term (unfoldingTemplate unfolding))
                           NoUnfolding -> error ("No unfolding for DC wrapper: " ++ showPpr unsafeGlobalDynFlags x)
                           _ -> error ("Unexpected unfolding for DC wrapper: " ++ showPpr unsafeGlobalDynFlags x)
               else C.Data <$> coreToDataCon dc
@@ -406,14 +438,15 @@ coreToTerm primMap unlocs srcsp coreExpr = Reader.runReaderT (term coreExpr) src
               | otherwise
               -> C.Var <$> coreToId x
 
-    alt (DEFAULT   , _ , e) = (C.DefaultPat,) <$> term e
-    alt (LitAlt l  , _ , e) = (C.LitPat (coreToLiteral l),) <$> term e
-    alt (DataAlt dc, xs, e) = case span isTyVar xs of
-      (tyvs,tmvs) -> (,) <$> (C.DataPat <$>
-                                lift (coreToDataCon dc) <*>
-                                lift (mapM coreToTyVar tyvs) <*>
-                                lift (mapM coreToId tmvs))
-                         <*> term e
+    alt _   (DEFAULT   , _ , e) = (C.DefaultPat,) <$> term e
+    alt _   (LitAlt l  , _ , e) = (C.LitPat (coreToLiteral l),) <$> term e
+    alt sp0 (DataAlt dc, xs, e) = case span isTyVar xs of
+      (tyvs,tmvs) -> do
+        (e',sp1) <- termSP sp0 e
+        (,) <$> (C.DataPat <$> coreToDataCon dc
+                           <*> mapM coreToTyVar tyvs
+                           <*> mapM (coreToIdSP sp1) tmvs)
+            <*> pure e'
 
     coreToLiteral :: Literal
                   -> C.Literal
@@ -440,17 +473,31 @@ coreToTerm primMap unlocs srcsp coreExpr = Reader.runReaderT (term coreExpr) src
       MachNullAddr   -> C.StringLiteral []
       MachLabel fs _ _ -> C.StringLiteral (unpackFS fs)
 
-addUsefull :: SrcSpan -> ReaderT SrcSpan (State GHC2CoreState) a
-           -> ReaderT SrcSpan (State GHC2CoreState) a
-addUsefull x = Reader.local (\r -> if isGoodSrcSpan x then x else r)
+addUsefull :: SrcSpan
+           -> C2C a
+           -> C2C a
+addUsefull x m =
+  if isGoodSrcSpan x
+  then do a <- RWS.local (const x) m
+          RWS.tell (SrcSpanRB x)
+          return a
+  else m
 
-isIntegerTy :: Type -> State GHC2CoreState Bool
+addUsefullR :: SrcSpan
+            -> C2C a
+            -> C2C a
+addUsefullR x m =
+  if isGoodSrcSpan x
+  then RWS.local (const x) m
+  else m
+
+isIntegerTy :: Type -> C2C Bool
 isIntegerTy (TyConApp tc []) = do
   tcNm <- qualifiedNameString (tyConName tc)
   return (tcNm == "GHC.Integer.Type.Integer")
 isIntegerTy _ = return False
 
-hasPrimCo :: Coercion -> State GHC2CoreState (Maybe Type)
+hasPrimCo :: Coercion -> C2C (Maybe Type)
 hasPrimCo (TyConAppCo _ _ coers) = do
   tcs <- catMaybes <$> mapM hasPrimCo coers
   return (listToMaybe tcs)
@@ -505,7 +552,7 @@ hasPrimCo (SubCo co)    = hasPrimCo co
 hasPrimCo _ = return Nothing
 
 coreToDataCon :: DataCon
-              -> State GHC2CoreState C.DataCon
+              -> C2C C.DataCon
 coreToDataCon dc = do
     repTys <- mapM coreToType (dataConRepArgTys dc)
     dcTy   <- coreToType (varType $ dataConWorkId dc)
@@ -531,7 +578,7 @@ coreToDataCon dc = do
 
 typeConstructorToString
   :: TyCon
-  -> State GHC2CoreState String
+  -> C2C String
 typeConstructorToString constructor =
    Text.unpack . C.nameOcc <$> coreToName tyConName tyConUnique qualifiedNameString constructor
 
@@ -544,7 +591,7 @@ listTypeToListOfTypes (TyConApp _ [_, a, as]) = a : listTypeToListOfTypes as
 listTypeToListOfTypes _                       = []
 
 -- | Try to determine boolean value by looking at constructor name of type.
-boolTypeToBool :: Type -> State GHC2CoreState Bool
+boolTypeToBool :: Type -> C2C Bool
 boolTypeToBool (TyConApp constructor _args) = do
   constructorName <- typeConstructorToString constructor
   return $ case constructorName of
@@ -570,7 +617,7 @@ tyLitToInteger s = error $ unwords [ "Could not unpack given type to integer:"
 -- | Try to interpret a Type as an Attr
 coreToAttr
   :: Type
-  -> State GHC2CoreState C.Attr'
+  -> C2C C.Attr'
 coreToAttr (TyConApp ty args) = do
   let key   = args !! 0
   let value = args !! 1
@@ -595,7 +642,7 @@ coreToAttr t =
 
 coreToAttrs'
     :: [Type]
-    -> State GHC2CoreState [C.Attr']
+    -> C2C [C.Attr']
 coreToAttrs' [annotationType, _star, realType, attributes] = allAttrs
  where
   allAttrs = (++) <$> attrs <*> subAttrs
@@ -650,7 +697,7 @@ coreToAttrs' illegal =
 -- | If this type has an annotate type synonym, return list of attributes.
 coreToAttrs
   :: Type
-  -> State GHC2CoreState [C.Attr']
+  -> C2C [C.Attr']
 coreToAttrs (TyConApp tycon kindsOrTypes) = do
   name' <- typeConstructorToString tycon
 
@@ -668,7 +715,7 @@ coreToAttrs _ =
 annotateType
   :: Type
   -> C.Type
-  -> State GHC2CoreState C.Type
+  -> C2C C.Type
 annotateType ty cty = do
   attrs <- coreToAttrs ty
   case attrs of
@@ -679,7 +726,7 @@ annotateType ty cty = do
 -- exception of newtypes used as annotations (see: SynthesisAttributes).
 coreToType
   :: Type
-  -> State GHC2CoreState C.Type
+  -> C2C C.Type
 coreToType ty = ty'' >>= annotateType ty
   where
     ty'' =
@@ -689,7 +736,7 @@ coreToType ty = ty'' >>= annotateType ty
 
 coreToType'
   :: Type
-  -> State GHC2CoreState C.Type
+  -> C2C C.Type
 coreToType' (TyVarTy tv) = C.VarTy <$> coreToTyVar tv
 coreToType' (TyConApp tc args)
   | isFunTyCon tc = foldl C.AppTy (C.ConstTy C.Arrow) <$> mapM coreToType args
@@ -715,39 +762,41 @@ coreToTyLit (NumTyLit i) = C.NumTy (fromInteger i)
 coreToTyLit (StrTyLit s) = C.SymTy (unpackFS s)
 
 coreToTyVar :: TyVar
-            -> State GHC2CoreState C.TyVar
+            -> C2C C.TyVar
 coreToTyVar tv =
   C.mkTyVar <$> coreToType (varType tv) <*> coreToVar tv
 
 coreToId :: Id
-         -> State GHC2CoreState C.Id
-coreToId i =
+         -> C2C C.Id
+coreToId i = do
   C.mkId <$> coreToType (varType i) <*> pure scope <*> coreToVar i
  where
   scope = if isGlobalId i then C.GlobalId else C.LocalId
 
 coreToVar :: Var
-          -> State GHC2CoreState (C.Name a)
+          -> C2C (C.Name a)
 coreToVar = coreToName varName varUnique qualifiedNameStringM
 
 coreToPrimVar :: Var
-              -> State GHC2CoreState (C.Name C.Term)
+              -> C2C (C.Name C.Term)
 coreToPrimVar = coreToName varName varUnique qualifiedNameString
 
 coreToName
   :: (b -> Name)
   -> (b -> Unique)
-  -> (Name -> State GHC2CoreState Text)
+  -> (Name -> C2C Text)
   -> b
-  -> State GHC2CoreState (C.Name a)
+  -> C2C (C.Name a)
 coreToName toName toUnique toString v = do
   ns <- toString (toName v)
   let key  = getKey (toUnique v)
-      loc  = getSrcSpan (toName v)
+      locI = getSrcSpan (toName v)
       sort | ns == "ds" || Text.isPrefixOf "$" ns
            = C.System
            | otherwise
            = C.User
+  locR <- RWS.ask
+  let loc = if isGoodSrcSpan locI then locI else locR
   return (C.Name sort ns key loc)
 
 qualifiedNameString'
@@ -760,7 +809,7 @@ qualifiedNameString' n =
 
 qualifiedNameString
   :: Name
-  -> State GHC2CoreState Text
+  -> C2C Text
 qualifiedNameString n =
   makeCached n nameMap $
   return (fromMaybe "_INTERNAL_" (modNameM n) `Text.append` ('.' `Text.cons` occName))
@@ -769,7 +818,7 @@ qualifiedNameString n =
 
 qualifiedNameStringM
   :: Name
-  -> State GHC2CoreState Text
+  -> C2C Text
 qualifiedNameStringM n =
   makeCached n nameMap $
   return (maybe occName (\modName -> modName `Text.append` ('.' `Text.cons` occName)) (modNameM n))

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1293,7 +1293,12 @@ patLitCustom _ x y = error $ $(curLoc) ++ unwords
 
 insts :: [Declaration] -> VHDLM Doc
 insts [] = emptyDoc
-insts is = vcat . punctuate line . fmap catMaybes $ mapM inst_ is
+insts (TickDecl id_:ds) = "--" <+> stringS id_ <> line <> insts ds
+insts (d:ds) = do
+  d' <- inst_ d
+  case d' of
+    Just doc -> pure doc <> line <> line <> insts ds
+    _ -> insts ds
 
 -- | Helper function for inst_, handling CustomSP and CustomSum
 inst_' :: TextS.Text -> Expr -> HWType -> [(Maybe Literal, Expr)] -> VHDLM (Maybe Doc)

--- a/clash-lib/src/Clash/Core/FreeVars.hs
+++ b/clash-lib/src/Clash/Core/FreeVars.hs
@@ -274,6 +274,7 @@ termFreeVars' interesting f = go IntSet.empty where
     Cast tm t1 t2 -> Cast <$> go inScope tm
                           <*> typeFreeVars' interesting inScope f t1
                           <*> typeFreeVars' interesting inScope f t2
+    Tick sp tm -> Tick sp <$> go inScope tm
     tm -> pure tm
 
   goBndr inScope v =

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -38,6 +38,7 @@ import Data.Text.Prettyprint.Doc.Internal
 import Debug.Trace                      (trace)
 import GHC.Show                         (showMultiLineString)
 import Numeric                          (fromRat)
+import qualified Outputable             as GHC
 
 import Clash.Core.DataCon               (DataCon (..))
 import Clash.Core.Literal               (Literal (..))
@@ -218,6 +219,13 @@ instance PrettyPrec Term where
     Letrec xes e1   -> pprPrecLetrec prec xes e1
     Case e' _ alts  -> pprPrecCase prec e' alts
     Cast e' ty1 ty2 -> pprPrecCast prec e' ty1 ty2
+    Tick t e'       -> do
+      tDoc <- pprPrec prec t
+      eDoc <- pprPrec prec e'
+      return (tDoc <> line' <> eDoc)
+
+instance PrettyPrec SrcSpan where
+  pprPrec _ sp = return ("<src>"<>pretty (GHC.showSDocUnsafe (GHC.ppr sp)))
 
 instance ClashPretty Term where
   clashPretty = fromPpr

--- a/clash-lib/src/Clash/Netlist.hs-boot
+++ b/clash-lib/src/Clash/Netlist.hs-boot
@@ -57,6 +57,7 @@ mkSelection
   -> Term
   -> Type
   -> [Alt]
+  -> [Declaration]
   -> NetlistMonad [Declaration]
 
 mkNetDecl :: LetBinding -> NetlistMonad (Maybe Declaration)
@@ -68,4 +69,5 @@ mkFunApp
   => Identifier -- ^ LHS of the let-binder
   -> Id -- ^ Name of the applied function
   -> [Term] -- ^ Function arguments
+  -> [Declaration] -- ^ Tick declarations
   -> NetlistMonad [Declaration]

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -246,6 +246,9 @@ data Declaration
       WireOrReg                  -- FIELD Wire or register
       !Identifier                -- FIELD Name of signal
       (Either Identifier HWType) -- FIELD Pointer to type of signal or type of signal
+      -- ^ Signal declaration
+  | TickDecl Comment
+  -- ^ HDL tick corresponding to a Core tick
   deriving Show
 
 data EntityOrComponent = Entity | Comp | Empty

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -62,10 +62,10 @@ import Clash.Core.FreeVars
   (termFreeVars', typeFreeVars', localVarsDoNotOccurIn)
 import Clash.Core.Literal    (Literal (..))
 import Clash.Core.Term
-  (LetBinding, Pat (..), PrimInfo (..), Term (..), collectArgs)
+  (LetBinding, Pat (..), PrimInfo (..), Term (..), collectArgs, collectArgsTicks)
 import Clash.Core.TyCon      (tyConDataCons)
 import Clash.Core.Type       (Type, isPolyFunTy, mkTyConApp, splitFunForallTy)
-import Clash.Core.Util       (mkApps, patIds, termType)
+import Clash.Core.Util       (mkApps, mkTicks, patIds, termType)
 import Clash.Core.Var        (isGlobalId)
 import Clash.Core.VarEnv
   (InScopeSet, elemInScopeSet, notElemInScopeSet)
@@ -138,7 +138,7 @@ collectGlobals' inScope substitution seen (Case scrut ty alts) _eIsConstant = do
                                             (map fst collected ++ seen) scrut
   return (Case scrut' ty alts',collected ++ collected')
 
-collectGlobals' inScope substitution seen e@(collectArgs -> (fun, args@(_:_))) eIsconstant
+collectGlobals' inScope substitution seen e@(collectArgsTicks -> (fun, args@(_:_), ticks)) eIsconstant
   | not eIsconstant = do
     tcm <- Lens.view tcCache
     bndrs <- Lens.use bindings
@@ -167,7 +167,7 @@ collectGlobals' inScope substitution seen e@(collectArgs -> (fun, args@(_:_))) e
             return (e',(fun',(seen,Leaf args')):collected)
           _ -> do (args',collected) <- collectGlobalsArgs inScope substitution
                                                           seen args
-                  return (mkApps fun args',collected)
+                  return (mkApps (mkTicks fun ticks) args',collected)
       _ -> return (e,[])
 
 -- FIXME: This duplicates A LOT of let-bindings, where I just pray that after

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -238,6 +238,7 @@ classifyFunction = go (TermClassification 0 0 0)
     go !c (Case _ _ alts) = case alts of
       (_:_:_) -> c & selection  +~ 1
       _ -> c
+    go !c (Tick _ e) = go c e
     go c _ = c
 
 -- | Determine whether a function adds a lot of hardware or not.

--- a/clash-lib/src/Clash/Rewrite/Combinators.hs
+++ b/clash-lib/src/Clash/Rewrite/Combinators.hs
@@ -79,6 +79,9 @@ allR trans (TransformContext is c) (Case scrut ty alts) =
         is'       = extendInScopeSetList (extendInScopeSetList is tvs) ids
     in  (p,) <$> trans (TransformContext is' (CaseAlt p : c)) e
 
+allR trans (TransformContext is c) (Tick sp e) =
+  Tick sp <$> trans (TransformContext is (TickC sp:c)) e
+
 allR _ _ tm = pure tm
 
 infixr 6 >->

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -393,3 +393,11 @@ reportTimeDiff start end =
        = "%-Mm%-S%03Qs"
        | otherwise
        = "%-S%03Qs"
+
+-- | Converts a curried function to a function on a triple
+uncurry3
+  :: (a -> b -> c -> d)
+  -> (a,b,c)
+  -> d
+uncurry3 = \f (a,b,c) -> f a b c
+{-# INLINE uncurry3 #-}


### PR DESCRIPTION
Only enabled when compiling with `-g`, as the compile-time overhead can be significant. For the `PilelinesViaFolds` the normalization step goes from:

```
Clash: Applied 89 transformations
time                 161.5 ms   (154.0 ms .. 167.5 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 155.6 ms   (145.9 ms .. 159.6 ms)
std dev              9.076 ms   (2.285 ms .. 13.69 ms)
variance introduced by outliers: 13% (moderately inflated)
```

to:

```
Clash: Applied 97 transformations
time                 233.7 ms   (230.2 ms .. 237.3 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 237.5 ms   (235.9 ms .. 239.2 ms)
std dev              2.257 ms   (1.436 ms .. 3.823 ms)
variance introduced by outliers: 14% (moderately inflated)
```