### PR TITLE
Add `blockRam1`

### DIFF
--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.json
@@ -45,4 +45,52 @@ assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[9]];
 // blockRam end"
     }
   }
+, { "BlackBox" :
+    { "name" : "Clash.Explicit.BlockRam.blockRam1#"
+    , "kind" : "Declaration"
+    , "type" :
+"blockRam1#
+  :: ( KnownDomain dom conf   ARG[0]
+     , HasCallStack  --       ARG[1]
+     , Undefined a ) --       ARG[2]
+  => Clock dom       -- clk,  ARG[3]
+  -> Enable dom      -- en,   ARG[4]
+  -> SNat n          -- len,  ARG[5]
+  -> a               -- init, ARG[6]
+  -> Signal dom Int  -- rd,   ARG[7]
+  -> Signal dom Bool -- wren, ARG[8]
+  -> Signal dom Int  -- wr,   ARG[9]
+  -> Signal dom a    -- din,  ARG[10]
+  -> Signal dom a"
+    , "template" :
+"// blockRam1 begin,
+~TYPO ~GENSYM[~RESULT_RAM][1] [0:~LIT[5]-1];
+logic [~SIZE[~TYP[10]]-1:0] ~GENSYM[~RESULT_q][2];
+initial begin
+  ~SYM[1] = '{default: ~CONST[6]};
+end~IF ~ISALWAYSENABLED[4] ~THEN
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN
+  if (~ARG[4]) begin
+    if (~ARG[8]) begin
+      ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];
+    end
+    ~SYM[2] <= ~SYM[1][~ARG[7]];
+  end~ELSE
+  if (~ARG[8] & ~ARG[4]) begin
+    ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];
+  end
+  if (~ARG[4]) begin
+    ~SYM[2] <= ~SYM[1][~ARG[7]];
+  end~FI
+end~ELSE
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]
+  if (~ARG[8]) begin
+    ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];
+  end
+  ~SYM[2] <= ~SYM[1][~ARG[7]];
+end~FI
+assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[10]];
+// blockRam1 end"
+    }
+  }
 ]

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam.json
@@ -51,4 +51,56 @@ end~FI
 // blockRam end"
     }
   }
+, { "BlackBox" :
+    { "name" : "Clash.Explicit.BlockRam.blockRam1#"
+    , "kind" : "Declaration"
+    , "type" :
+"blockRam1#
+  :: ( KnownDomain dom conf   ARG[0]
+     , HasCallStack  --       ARG[1]
+     , Undefined a ) --       ARG[2]
+  => Clock dom       -- clk,  ARG[3]
+  -> Enable dom      -- en,   ARG[4]
+  -> SNat n          -- len,  ARG[5]
+  -> a               -- init, ARG[6]
+  -> Signal dom Int  -- rd,   ARG[7]
+  -> Signal dom Bool -- wren, ARG[8]
+  -> Signal dom Int  -- wr,   ARG[9]
+  -> Signal dom a    -- din,  ARG[10]
+  -> Signal dom a"
+    , "outputReg" : true
+    , "template" :
+"// blockRam1 begin
+reg ~TYPO ~GENSYM[~RESULT_RAM][0] [0:~LIT[5]-1];
+integer ~GENSYM[i][1];
+initial begin
+    for (~SYM[1]=0;~SYM[1]<~LIT[5];~SYM[1]=~SYM[1]+1) begin
+        ~SYM[0][~SYM[1]] = ~CONST[6];
+    end
+end
+
+~IF ~ISALWAYSENABLED[4] ~THEN
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN
+  if (~ARG[4]) begin
+    if (~ARG[8]) begin
+      ~SYM[0][~ARG[9]] <= ~ARG[10];
+    end
+    ~RESULT <= ~SYM[0][~ARG[7]];
+  end~ELSE
+  if (~ARG[8] & ~ARG[4]) begin
+    ~SYM[0][~ARG[9]] <= ~ARG[10];
+  end
+  if (~ARG[4]) begin
+    ~RESULT <= ~SYM[0][~ARG[7]];
+  end~FI
+end~ELSE
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]
+  if (~ARG[8]) begin
+    ~SYM[0][~ARG[9]] <= ~ARG[10];
+  end
+  ~RESULT <= ~SYM[0][~ARG[7]];
+end~FI
+// blockRam1 end"
+    }
+  }
 ]

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.json
@@ -63,4 +63,71 @@ end block;
 --end blockRam"
     }
   }
+, { "BlackBox" :
+    { "name" : "Clash.Explicit.BlockRam.blockRam1#"
+    , "kind" : "Declaration"
+    , "type" :
+"blockRam1#
+  :: ( KnownDomain dom conf   ARG[0]
+     , HasCallStack  --       ARG[1]
+     , Undefined a ) --       ARG[2]
+  => Clock dom       -- clk,  ARG[3]
+  -> Enable dom      -- en,   ARG[4]
+  -> SNat n          -- len,  ARG[5]
+  -> a               -- init, ARG[6]
+  -> Signal dom Int  -- rd,   ARG[7]
+  -> Signal dom Bool -- wren, ARG[8]
+  -> Signal dom Int  -- wr,   ARG[9]
+  -> Signal dom a    -- din,  ARG[10]
+  -> Signal dom a"
+    , "template" :
+"-- blockRam1 begin
+~GENSYM[~RESULT_blockRam][1] : block
+  type ~GENSYM[ram_t][8] is array (0 to integer'(~LIT[5])-1) of ~TYP[6];
+  signal ~GENSYM[~RESULT_RAM][2] : ~SYM[8] := (others => ~CONST[6]);
+  signal ~GENSYM[rd][4]  : integer range 0 to ~LIT[5] - 1;
+  signal ~GENSYM[wr][5]  : integer range 0 to ~LIT[5] - 1;
+begin
+  ~SYM[4] <= to_integer(~ARG[7])
+  -- pragma translate_off
+                mod ~LIT[5]
+  -- pragma translate_on
+                ;
+
+  ~SYM[5] <= to_integer(~ARG[9])
+  -- pragma translate_off
+                mod ~LIT[5]
+  -- pragma translate_on
+                ;
+~IF ~VIVADO ~THEN
+  ~SYM[6] : process(~ARG[3])
+  begin
+    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
+      if ~ARG[8] ~IF ~ISALWAYSENABLED[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+        ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[10]][~TYP[10]];
+      end if;
+      ~RESULT <= fromSLV(~SYM[2](~SYM[4]))
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
+    end if;
+  end process; ~ELSE
+  ~SYM[6] : process(~ARG[3])
+  begin
+    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
+      if ~ARG[8] ~IF ~ISALWAYSENABLED[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+        ~SYM[2](~SYM[5]) <= ~ARG[10];
+      end if;
+      ~RESULT <= ~SYM[2](~SYM[4])
+      -- pragma translate_off
+      after 1 ps
+      -- pragma translate_on
+      ;
+    end if;
+  end process; ~FI
+end block;
+--end blockRam1"
+    }
+  }
 ]

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -44,6 +44,8 @@ module Clash.Explicit.Prelude
     -- * BlockRAM primitives
   , blockRam
   , blockRamPow2
+  , blockRam1
+  , ResetStrategy(..)
     -- ** BlockRAM primitives initialized with a data file
   , blockRamFile
   , blockRamFilePow2

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -65,6 +65,8 @@ module Clash.Prelude
     -- * BlockRAM primitives
   , blockRam
   , blockRamPow2
+  , blockRam1
+  , E.ResetStrategy(..)
     -- ** BlockRAM primitives initialized with a data file
   , blockRamFile
   , blockRamFilePow2
@@ -167,6 +169,7 @@ import           Clash.Hidden
 import           Clash.NamedTypes
 import           Clash.Prelude.BitIndex
 import           Clash.Prelude.BitReduction
+import           Clash.Prelude.BlockRam
 import           Clash.Prelude.BlockRam.File
 import           Clash.Prelude.DataFlow
 import           Clash.Prelude.ROM.File

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -89,6 +89,7 @@ module Clash.Signal.Internal
   , unsafeToLowPolarity
   , unsafeFromHighPolarity
   , unsafeFromLowPolarity
+  , invertReset
     -- * Basic circuits
   , delay#
   , register#
@@ -973,6 +974,10 @@ unsafeFromLowPolarity
   -> Reset dom
 unsafeFromLowPolarity r =
   unsafeToReset (if isActiveHigh @dom then not <$> r else r)
+
+-- | Invert reset signal
+invertReset :: KnownDomain dom conf => Reset dom -> Reset dom
+invertReset = unsafeToReset . fmap not . unsafeFromReset
 
 
 infixr 2 .||.

--- a/tests/shouldwork/Signal/BlockRam1.hs
+++ b/tests/shouldwork/Signal/BlockRam1.hs
@@ -1,0 +1,110 @@
+module BlockRam1 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import qualified Clash.Explicit.Prelude as Explicit
+
+zeroAt0
+  :: HiddenClockResetEnable dom conf
+  => Signal dom (Unsigned 8)
+  -> Signal dom (Unsigned 8)
+zeroAt0 a = mux en a 0
+  where
+    en = register False (pure True)
+
+topEntity
+  :: Clock System
+  -> Reset System
+  -> Enable System
+  -> Signal System (Index 1024)
+  -> Signal System (Maybe (Index 1024, Unsigned 8))
+  -> Signal System (Unsigned 8)
+topEntity = exposeClockResetEnable go where
+
+  go rd wr = zeroAt0 dout where
+    dout =
+      blockRam1
+        ClearOnReset
+        (SNat @1024)
+        (3 :: Unsigned 8)
+        rd
+        wr
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    (rst0, rd, wr) =
+      unbundle $ stimuliGenerator
+        clk rst
+        (    (True,  0, Nothing)
+
+          -- Confirm initial values
+          :> (False, 0, Nothing)
+          :> (False, 1, Nothing)
+          :> (False, 2, Nothing)
+          :> (False, 3, Nothing)
+
+          -- Write some values
+          :> (False, 0, Just (0, 8))
+          :> (False, 0, Just (1, 9))
+          :> (False, 0, Just (2, 10))
+          :> (False, 0, Just (3, 11))
+
+          -- Read written values
+          :> (False, 0, Nothing)
+          :> (False, 1, Nothing)
+          :> (False, 2, Nothing)
+          :> (False, 3, Nothing)
+
+          -- Reset for two cycles
+          :> (True, 0, Nothing)
+          :> (True, 0, Nothing)
+
+          -- Check whether first two values were reset
+          :> (False, 0, Nothing)
+          :> (False, 1, Nothing)
+          :> (False, 2, Nothing)
+          :> (False, 3, Nothing)
+
+          :> Nil
+
+          )
+
+    expectedOutput =
+      outputVerifier clk rst
+        (    0 :> 0
+
+          -- Initial values should be all threes
+          :> 3
+          :> 3
+          :> 3
+          :> 3
+
+          -- Read address zero while writing data
+          :> 3
+          :> 8
+          :> 8
+          :> 8
+
+          -- Read written values back from BRAM
+          :> 8
+          :> 9
+          :> 10
+          :> 0   -- < Reset is high, so we won't read '11'
+
+          -- Reset for two cycles
+          :> 0
+          :> 0
+
+          -- Check whether reset worked
+          :> 3
+          :> 3
+          :> 10
+          :> 11
+
+          :> Nil)
+
+    done           = expectedOutput (topEntity clk (unsafeFromHighPolarity rst0) enableGen rd wr)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -238,6 +238,7 @@ runClashTest =
         [ runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "AlwaysHigh"      ([""],"AlwaysHigh_topEntity",False)
         , outputTest ("tests" </> "shouldwork" </> "Signal") defBuild [] [] "BlockRamLazy"    "main"
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamFile"    (["","BlockRamFile_testBench"],"BlockRamFile_testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRam1"        (["","BlockRam1_testBench"],"BlockRam1_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamTest"    ([""],"BlockRamTest_topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "DelayedReset"    (["","DelayedReset_testBench"],"DelayedReset_testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "NoCPR"           (["example"],"example",False)


### PR DESCRIPTION
Adds version of `blockRam` that has a single initial value for _all_ elements in the blockram. As opposed to `blockRam`, `blockRam1` has (configurable) reset logic. If the reset is asserted long enough, the whole blockram will be reset to its original state.

Fixes #638