### PR TITLE
unconcat template needs to reference all arguments

### DIFF
--- a/clash-lib/prims/systemverilog/Clash_Sized_Vector.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Vector.json
@@ -108,7 +108,7 @@ assign ~SYM[0] = ~TOBV[~ARG[1]][~TYP[1]];
            -> Vec (n * m) a  -- ARG[2]
            -> Vec n (Vec m a)"
     , "template" :
-"// unconcat begin
+"// unconcat begin~DEVNULL[~ARG[0]]
 genvar ~GENSYM[n][1];
 ~GENERATE
   for (~SYM[1] = 0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[unconcat][2]

--- a/clash-lib/prims/verilog/Clash_Sized_Vector.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Vector.json
@@ -93,7 +93,7 @@ end
            => SNat m         -- ARG[1]
            -> Vec (n * m) a  -- ARG[2]
            -> Vec n (Vec m a)"
-    , "template" : "~ARG[2]"
+    , "template" : "~ARG[2]~DEVNULL[~ARG[0]]~DEVNULL[~ARG[1]]"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.json
@@ -90,7 +90,7 @@ end generate;
           -> Vec (n * m) a  -- ARG[2]
           -> Vec n (Vec m a)"
     , "template" :
-"-- unconcat begin
+"-- unconcat begin~DEVNULL[~ARG[0]]
 ~GENSYM[unconcat][0] : for ~GENSYM[i][2] in ~RESULT'range generate
 begin~IF ~VIVADO ~THEN
   ~RESULT(~SYM[2]) <= ~TOBV[~VAR[vec][2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];~ELSE


### PR DESCRIPTION
Otherwise, `removeUnusedArguments` removes the arguments and the
compile-time evaluator can no longer fire because it's lacking
the constants.

Fixes #637