### PR TITLE
Make `KnownDomain` a single parameter class

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -630,7 +630,6 @@ wantedLanguageExtensions df =
              , LangExt.FlexibleInstances
              , LangExt.KindSignatures
              , LangExt.MagicHash
-             , LangExt.MultiParamTypeClasses
              , LangExt.MonoLocalBinds
              , LangExt.QuasiQuotes
              , LangExt.ScopedTypeVariables

--- a/clash-lib/prims/commonverilog/Clash_Intel_DDR.json
+++ b/clash-lib/prims/commonverilog/Clash_Intel_DDR.json
@@ -4,8 +4,8 @@
     , "type" :
 "altddioOut#
   :: ( HasCallStack             -- ARG[0]
-     , KnownDomain fast domf    -- ARG[1]
-     , KnownDomain slow doms    -- ARG[2]
+     , KnownConfi~ fast domf    -- ARG[1]
+     , KnownConfi~ slow doms    -- ARG[2]
      , KnownNat m )             -- ARG[3]
   => SSymbol deviceFamily       -- ARG[4]
   -> Clock slow                 -- ARG[5]

--- a/clash-lib/prims/commonverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/commonverilog/Clash_Signal_Internal.json
@@ -12,7 +12,7 @@
     , "kind" : "Expression"
     , "workInfo"  : "Never"
     , "type" :
-"unsafeToReset :: KnownDomain dom conf => Signal dom Bool -> Reset dom"
+"unsafeToReset :: KnownDomain dom      => Signal dom Bool -> Reset dom"
     , "template" : "~ARG[1]"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "blockRam#
-  :: ( KnownDomain dom conf   ARG[0]
+  :: ( KnownDomain dom        ARG[0]
      , HasCallStack  --       ARG[1]
      , Undefined a ) --       ARG[2]
   => Clock dom       -- clk,  ARG[3]
@@ -50,7 +50,7 @@ assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[9]];
     , "kind" : "Declaration"
     , "type" :
 "blockRam1#
-  :: ( KnownDomain dom conf   ARG[0]
+  :: ( KnownDomain dom        ARG[0]
      , HasCallStack  --       ARG[1]
      , Undefined a ) --       ARG[2]
   => Clock dom       -- clk,  ARG[3]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam_File.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "blockRamFile#
-  :: ( KnownDomain dom conf    --       ARG[0]
+  :: ( KnownDomain dom         --       ARG[0]
      , KnownNat m              --       ARG[1]
      , HasCallStack )          --       ARG[2]
   => Clock dom                 -- clk,  ARG[3]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_DDR.json
@@ -5,8 +5,8 @@
 "ddrIn# :: forall a slow fast n pFast gated synchronous.
            ( HasCallStack          -- ARG[0]
            , Undefined a           -- ARG[1]
-           , KnownDomain fast domf -- ARG[2]
-           , KnownDomain slow doms -- ARG[3]
+           , KnownConfi~ fast domf -- ARG[2]
+           , KnownConfi~ slow doms -- ARG[3]
         => Clock slow              -- ARG[4], clk
         -> Reset slow              -- ARG[5], rst
         -> Enable slow             -- ARG[6], en
@@ -52,8 +52,8 @@ assign ~RESULT = {~SYM[3], ~SYM[1]};
     , "type" :
 "ddrOut# :: ( HasCallStack               -- ARG[0]
             , Undefined a                -- ARG[1]
-            , KnownDomain fast domf      -- ARG[2]
-            , KnownDomain slow doms      -- ARG[3]
+            , KnownConfi~ fast domf      -- ARG[2]
+            , KnownConfi~ slow doms      -- ARG[3]
          => Clock slow                   -- ARG[4]
          -> Reset slow                   -- ARG[5]
          -> Enable slow                  -- ARG[6]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_ROM.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_ROM.json
@@ -2,7 +2,7 @@
     { "name" : "Clash.Explicit.ROM.rom#"
     , "kind" : "Declaration"
     , "type" :
-"rom# :: ( KnownDomain dom conf   ARG[0]
+"rom# :: ( KnownDomain dom        ARG[0]
          , KnownNat n    --       ARG[1]
          , Undefined a ) --       ARG[2]
       => Clock dom       -- clk,  ARG[3]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_ROM_File.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "romFile# :: ( KnownNat m             --       ARG[0]
-             , KnownDomain dom conf )--       ARG[1]
+             , KnownDomain dom )      --       ARG[1]
           => Clock dom                -- clk,  ARG[2]
           -> Enable dom               -- en,   ARG[3]
           -> SNat n                   -- sz,   ARG[4]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "assert
-  :: (KnownDomain dom conf, Eq a, ShowX a)-- (ARG[0], ARG[1], ARG[2])
+  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0], ARG[1], ARG[2])
   => Clock dom                             -- ARG[3]
   -> Reset dom                             -- ARG[4]
   -> String                                -- ARG[5]
@@ -30,7 +30,7 @@ assign ~RESULT = ~ARG[8];
     , "kind" : "Declaration"
     , "type" :
 "assertBitVector
-  :: ( KnownDomain dom conf   --                 ARG[0]
+  :: ( KnownDomain dom        --                 ARG[0]
      , KnownNat n )           --                 ARG[1]
   => Clock dom                --                 ARG[2]
   -> Reset dom                --                 ARG[3]

--- a/clash-lib/prims/systemverilog/Clash_Intel_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Intel_DDR.json
@@ -4,8 +4,8 @@
     , "type" :
 "altddioIn
   :: ( HasCallStack               -- ARG[0]
-     , KnownDomain fast domf      -- ARG[1]
-     , KnownDomain slow doms      -- ARG[2]
+     , KnownConfi~ fast domf      -- ARG[1]
+     , KnownConfi~ slow doms      -- ARG[2]
      , KnownNat m )               -- ARG[3]
   => SSymbol deviceFamily         -- ARG[4]
   -> Clock slow                   -- ARG[5]

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "delay#
-  :: ( KnownDomain dom conf  -- ARG[0]
+  :: ( KnownDomain dom        -- ARG[0]
      , Undefined a )          -- ARG[1]
   => Clock dom                -- ARG[2]
   -> Enable dom               -- ARG[3]
@@ -30,7 +30,7 @@ assign ~RESULT = ~SYM[0];
     , "kind" : "Declaration"
     , "type" :
 "register#
-  :: ( KnownDomain dom conf   -- ARG[0]
+  :: ( KnownDomain dom        -- ARG[0]
      , Undefined a )          -- ARG[1]
   => Clock dom                -- ARG[2]
   -> Reset dom                -- ARG[3]
@@ -60,7 +60,7 @@ assign ~RESULT = ~SYM[0];
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
 "clockGen
-  :: KnownDomain dom conf-- ARG[0]
+  :: KnownDomain dom     -- ARG[0]
   => Clock dom"
     , "template" :
 "// clockGen begin
@@ -87,7 +87,7 @@ end
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
 "tbClockGen
-  :: KnownDomain dom conf-- ARG[0]
+  :: KnownDomain dom     -- ARG[0]
   => Signal dom Bool      -- ARG[1]
   -> Clock dom"
     , "template" :
@@ -115,7 +115,7 @@ end
     { "name" : "Clash.Signal.Internal.resetGen"
     , "workInfo" : "Always"
     , "kind" : "Declaration"
-    , "type" : "resetGen :: KnownDomain dom conf => Reset dom"
+    , "type" : "resetGen :: KnownDomain dom      => Reset dom"
     , "template" :
 "// resetGen begin
 // pragma translate_off

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.json
@@ -4,8 +4,8 @@
     , "type" :
 "iddr
   :: ( HasCallStack               -- ARG[0]
-     , KnownDomain fast domf      -- ARG[1]
-     , KnownDomain slow doms      -- ARG[2]
+     , KnownConfi~ fast domf      -- ARG[1]
+     , KnownConfi~ slow doms      -- ARG[2]
      , KnownNat m )               -- ARG[3]
   -> Clock slow                   -- ARG[4]
   -> Reset slow                   -- ARG[5]
@@ -48,8 +48,8 @@ assign ~RESULT = {~SYM[2],~SYM[1]};
     , "kind" : "Declaration"
     , "type" :
 "oddr#
-  :: ( KnownDomain fast domf      -- ARG[0]
-     , KnownDomain slow doms      -- ARG[1]
+  :: ( KnownConfi~ fast domf      -- ARG[0]
+     , KnownConfi~ slow doms      -- ARG[1]
      , KnownNat m )               -- ARG[2]
   => Clock slow                   -- ARG[3]
   -> Reset slow                   -- ARG[4]

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "blockRam#
-  :: ( KnownDomain dom conf   ARG[0]
+  :: ( KnownDomain dom        ARG[0]
      , HasCallStack  --       ARG[1]
      , Undefined a ) --       ARG[2]
   => Clock dom       -- clk,  ARG[3]
@@ -56,7 +56,7 @@ end~FI
     , "kind" : "Declaration"
     , "type" :
 "blockRam1#
-  :: ( KnownDomain dom conf   ARG[0]
+  :: ( KnownDomain dom        ARG[0]
      , HasCallStack  --       ARG[1]
      , Undefined a ) --       ARG[2]
   => Clock dom       -- clk,  ARG[3]

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam_File.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "blockRamFile#
-  :: ( KnownDomain dom conf    --       ARG[0]
+  :: ( KnownDomain dom         --       ARG[0]
      , KnownNat m              --       ARG[1]
      , HasCallStack )          --       ARG[2]
   => Clock dom                 -- clk,  ARG[3]

--- a/clash-lib/prims/verilog/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_DDR.json
@@ -5,8 +5,8 @@
 "ddrIn# :: forall a slow fast n pFast gated synchronous.
            ( HasCallStack          -- ARG[0]
            , Undefined a           -- ARG[1]
-           , KnownDomain fast domf -- ARG[2]
-           , KnownDomain slow doms -- ARG[3]
+           , KnownConfi~ fast domf -- ARG[2]
+           , KnownConfi~ slow doms -- ARG[3]
         => Clock slow              -- ARG[4]
         -> Reset slow              -- ARG[5]
         -> Enable slow             -- ARG[6]
@@ -52,8 +52,8 @@ assign ~RESULT = {~SYM[3], ~SYM[1]};
     , "type" :
 "ddrOut# :: ( HasCallStack               -- ARG[0]
             , Undefined a                -- ARG[1]
-            , KnownDomain fast domf      -- ARG[2]
-            , KnownDomain slow doms      -- ARG[3]
+            , KnownConfi~ fast domf      -- ARG[2]
+            , KnownConfi~ slow doms      -- ARG[3]
          => Clock slow                   -- ARG[4]
          -> Reset slow                   -- ARG[5]
          -> Enable slow                  -- ARG[6]

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM.json
@@ -2,7 +2,7 @@
     { "name" : "Clash.Explicit.ROM.rom#"
     , "kind" : "Declaration"
     , "type" :
-"rom# :: ( KnownDomain dom conf   ARG[0]
+"rom# :: ( KnownDomain dom        ARG[0]
          , KnownNat n    --       ARG[1]
          , Undefined a ) --       ARG[2]
       => Clock dom       -- clk,  ARG[3]

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM_File.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "romFile# :: ( KnownNat m             --       ARG[0]
-             , KnownDomain dom conf )--       ARG[1]
+             , KnownDomain dom      ) --       ARG[1]
           => Clock dom                -- clk,  ARG[2]
           -> Enable dom               -- en,   ARG[3]
           -> SNat n                   -- sz,   ARG[4]

--- a/clash-lib/prims/verilog/Clash_Explicit_Testbench.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_Testbench.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "assert
-  :: (KnownDomain dom conf, Eq a, ShowX a) -- (ARG[0], ARG[1], ARG[2])
+  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0], ARG[1], ARG[2])
   => Clock dom                             -- ARG[3]
   -> Reset dom                             -- ARG[4]
   -> String                                -- ARG[5]
@@ -30,7 +30,7 @@ assign ~RESULT = ~ARG[8];
     , "kind" : "Declaration"
     , "type" :
 "assertBitVector
-  :: ( KnownDomain dom conf   --                 ARG[0]
+  :: ( KnownDomain dom        --                 ARG[0]
      , KnownNat n             --                 ARG[1]
   => Clock dom                --                 ARG[2]
   -> Reset dom                --                 ARG[3]

--- a/clash-lib/prims/verilog/Clash_Intel_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Intel_DDR.json
@@ -4,8 +4,8 @@
     , "type" :
 "altddioIn
   :: ( HasCallStack               -- ARG[0]
-     , KnownDomain fast domf      -- ARG[1]
-     , KnownDomain slow doms      -- ARG[2]
+     , KnownConfi~ fast domf      -- ARG[1]
+     , KnownConfi~ slow doms      -- ARG[2]
      , KnownNat m )               -- ARG[3]
   => SSymbol deviceFamily         -- ARG[4]
   -> Clock slow                   -- ARG[5]

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "delay#
-  :: ( KnownDomain dom conf  -- ARG[0]
+  :: ( KnownDomain dom        -- ARG[0]
      , Undefined a )          -- ARG[1]
   => Clock dom                -- ARG[2]
   -> Enable dom               -- ARG[3]
@@ -30,7 +30,7 @@ assign ~RESULT = ~SYM[0];
     , "kind" : "Declaration"
     , "type" :
 "register#
-  :: ( KnownDomain dom conf   -- ARG[0]
+  :: ( KnownDomain dom        -- ARG[0]
      , Undefined a )          -- ARG[1]
   => Clock dom                -- ARG[2]
   -> Reset dom                -- ARG[3]
@@ -60,7 +60,7 @@ assign ~RESULT = ~SYM[0];
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
 "clockGen
-  :: KnownDomain dom conf-- ARG[0]
+  :: KnownDomain dom     -- ARG[0]
   => Clock dom"
     , "template" :
 "// clockGen begin
@@ -89,7 +89,7 @@ assign ~RESULT = ~SYM[0];
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
 "tbClockGen
-  :: KnownDomain dom conf-- ARG[0]
+  :: KnownDomain dom     -- ARG[0]
   => Signal dom Bool      -- ARG[1]
   -> Clock dom"
     , "template" :
@@ -120,7 +120,7 @@ assign ~RESULT = ~SYM[0];
     , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "type" :
-"resetGen :: KnownDomain dom conf => Reset dom"
+"resetGen :: KnownDomain dom      => Reset dom"
     , "template" :
 "// resetGen on
 // pragma translate_off

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.json
@@ -4,8 +4,8 @@
     , "type" :
 "iddr
   :: ( HasCallStack            -- ARG[0]
-     , KnownDomain fast domf   -- ARG[1]
-     , KnownDomain slow doms   -- ARG[2]
+     , KnownConfi~ fast domf   -- ARG[1]
+     , KnownConfi~ slow doms   -- ARG[2]
      , KnownNat m )            -- ARG[3]
   -> Clock slow                -- ARG[4]
   -> Reset slow                -- ARG[5]
@@ -48,8 +48,8 @@ assign ~RESULT = {~SYM[2],~SYM[1]};
     , "kind" : "Declaration"
     , "type" :
 "oddr#
-  :: ( KnownDomain fast domf    -- ARG[0]
-     , KnownDomain slow doms    -- ARG[1]
+  :: ( KnownConfi~ fast domf    -- ARG[0]
+     , KnownConfi~ slow doms    -- ARG[1]
      , KnownNat m )             -- ARG[2]
   => Clock slow                 -- ARG[3]
   -> Reset slow                 -- ARG[4]

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "blockRam#
-  :: ( KnownDomain dom conf   ARG[0]
+  :: ( KnownDomain dom        ARG[0]
      , HasCallStack  --       ARG[1]
      , Undefined a ) --       ARG[2]
   => Clock dom       -- clk,  ARG[3]
@@ -68,7 +68,7 @@ end block;
     , "kind" : "Declaration"
     , "type" :
 "blockRam1#
-  :: ( KnownDomain dom conf   ARG[0]
+  :: ( KnownDomain dom        ARG[0]
      , HasCallStack  --       ARG[1]
      , Undefined a ) --       ARG[2]
   => Clock dom       -- clk,  ARG[3]

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "blockRamFile#
-  :: ( KnownDomain dom conf   -- ARG[0]
+  :: ( KnownDomain dom        -- ARG[0]
      , KnownNat m             -- ARG[1]
      , HasCallStack )         -- ARG[2]
   => Clock dom                -- clk,  ARG[3]

--- a/clash-lib/prims/vhdl/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_DDR.json
@@ -5,8 +5,8 @@
 "ddrIn# :: forall a slow fast n pFast enabled synchronous.
            ( HasCallStack           -- ARG[0]
            , Undefined a            -- ARG[1]
-           , KnownDomain fast domf  -- ARG[2]
-           , KnownDomain slow doms  -- ARG[3]
+           , KnownConfi~ fast domf  -- ARG[2]
+           , KnownConfi~ slow doms  -- ARG[3]
         => Clock slow               -- ARG[4]
         -> Reset slow               -- ARG[5]
         -> Enable slow              -- ARG[6]
@@ -98,8 +98,8 @@ end block;
     , "type" :
 "ddrOut# :: ( HasCallStack               -- ARG[0]
             , Undefined a                -- ARG[1]
-            , KnownDomain fast domf      -- ARG[2]
-            , KnownDomain slow doms      -- ARG[3]
+            , KnownConfi~ fast domf      -- ARG[2]
+            , KnownConfi~ slow doms      -- ARG[3]
          => Clock slow                   -- ARG[4]
          -> Reset slow                   -- ARG[5]
          -> Enable slow                  -- ARG[6]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM.json
@@ -2,7 +2,7 @@
     { "name" : "Clash.Explicit.ROM.rom#"
     , "kind" : "Declaration"
     , "type" :
-"rom# :: ( KnownDomain dom conf   ARG[0]
+"rom# :: ( KnownDomain dom        ARG[0]
          , KnownNat n    --       ARG[1]
          , Undefined a ) --       ARG[2]
       => Clock dom       -- clk,  ARG[3]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "romFile# :: ( KnownNat m           --       ARG[0]
-             , KnownDomain dom conf--       ARG[1]
+             , KnownDomain dom      --       ARG[1]
           => Clock dom              -- clk,  ARG[2]
           -> Enable dom             -- en,   ARG[3]
           -> SNat n                 -- sz,   ARG[4]

--- a/clash-lib/prims/vhdl/Clash_Explicit_Testbench.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_Testbench.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "assert
-  :: (KnownDomain dom conf, Eq a, ShowX a)-- (ARG[0],ARG[1],ARG[2])
+  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0],ARG[1],ARG[2])
   => Clock dom                             -- ARG[3]
   -> Reset dom                             -- ARG[4]
   -> String                                -- ARG[5]
@@ -69,7 +69,7 @@ end block;
     , "kind" : "Declaration"
     , "type" :
 "assertBitVector
-  :: ( KnownDomain dom conf   --                 ARG[0]
+  :: ( KnownDomain dom        --                 ARG[0]
      , KnownNat n )           --                 ARG[1]
   => Clock dom                --                 ARG[2]
   -> Reset dom                --                 ARG[3]

--- a/clash-lib/prims/vhdl/Clash_Intel_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Intel_DDR.json
@@ -4,8 +4,8 @@
     , "type" :
 "altddioIn
   :: ( HasCallStack               -- ARG[0]
-     , KnownDomain fast domf      -- ARG[1]
-     , KnownDomain slow doms      -- ARG[2]
+     , KnownConfi~ fast domf      -- ARG[1]
+     , KnownConfi~ slow doms      -- ARG[2]
      , KnownNat m )               -- ARG[3]
   => SSymbol deviceFamily         -- ARG[4]
   -> Clock slow                   -- ARG[5]
@@ -52,8 +52,8 @@ end block;
     , "type" :
 "altddioOut#
   :: ( HasCallStack             -- ARG[0]
-     , KnownDomain fast domf    -- ARG[1]
-     , KnownDomain slow doms    -- ARG[2]
+     , KnownConfi~ fast domf    -- ARG[1]
+     , KnownConfi~ slow doms    -- ARG[2]
      , KnownNat m )             -- ARG[3]
   => SSymbol deviceFamily       -- ARG[4]
   -> Clock slow                 -- ARG[5]

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.json
@@ -3,7 +3,7 @@
     , "kind" : "Declaration"
     , "type" :
 "delay#
-  :: ( KnownDomain dom conf  -- ARG[0]
+  :: ( KnownDomain dom        -- ARG[0]
      , Undefined a )          -- ARG[1]
   => Clock dom                -- ARG[2]
   -> Enable dom               -- ARG[3]
@@ -52,7 +52,7 @@ end block;~FI
     , "kind" : "Declaration"
     , "type" :
 "register#
-  :: ( KnownDomain dom conf   -- ARG[0]
+  :: ( KnownDomain dom        -- ARG[0]
      , Undefined a )          -- ARG[1]
   => Clock dom                -- ARG[2]
   -> Reset dom                -- ARG[3]
@@ -149,7 +149,7 @@ end block;~FI
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
 "clockGen
-  :: KnownDomain dom conf-- ARG[0]
+  :: KnownDomain dom     -- ARG[0]
   => Clock dom"
     , "comment" :
         "ModelSim and Vivado seem to round time values to an integer number of picoseconds.
@@ -182,7 +182,7 @@ end process;
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
 "tbClockGen
-  :: KnownDomain dom conf-- ARG[0]
+  :: KnownDomain dom     -- ARG[0]
   => Signal dom Bool     -- ARG[1]
   -> Clock dom"
     , "template" :
@@ -211,7 +211,7 @@ end process;
     , "workInfo"  : "Always"
     , "kind" : "Declaration"
     , "type" :
-"resetGen :: KnownDomain dom conf => Reset dom"
+"resetGen :: KnownDomain dom      => Reset dom"
     , "template" :
 "-- resetGen begin
 -- pragma translate_off
@@ -235,7 +235,7 @@ end process;
     , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
-"unsafeToReset :: KnownDomain dom conf => Signal dom Bool -> Reset dom"
+"unsafeToReset :: KnownDomain dom => Signal dom Bool -> Reset dom"
     , "template" : "~RESULT <= '1' when ~ARG[1] = true else '0';"
     }
   }

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.json
@@ -4,8 +4,8 @@
     , "type" :
 "iddr
   :: ( HasCallStack             -- ARG[0]
-     , KnownDomain fast domf    -- ARG[1]
-     , KnownDomain slow doms    -- ARG[2]
+     , KnownConfi~ fast domf    -- ARG[1]
+     , KnownConfi~ slow doms    -- ARG[2]
      , KnownNat m )             -- ARG[3]
   -> Clock slow                 -- ARG[4]
   -> Reset slow                 -- ARG[5]
@@ -54,8 +54,8 @@ end block;
     , "kind" : "Declaration"
     , "type" :
 "oddr#
-  :: ( KnownDomain fast domf     -- ARG[0]
-     , KnownDomain slow doms     -- ARG[1]
+  :: ( KnownConfi~ fast domf     -- ARG[0]
+     , KnownConfi~ slow doms     -- ARG[1]
      , KnownNat m )              -- ARG[2]
   => Clock slow                  -- ARG[3]
   -> Reset slow                  -- ARG[4]

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -342,7 +342,7 @@ renderElem b (Period n) = do
     KnownDomain _ period _ _ _ _ ->
       return $ const $ Text.pack $ show period
     _ ->
-      error $ $(curLoc) ++ "Period: Expected KnownDomain, not: " ++ show ty
+      error $ $(curLoc) ++ "Period: Expected `KnownDomain` or `KnownConfiguration`, not: " ++ show ty
 
 renderElem b (Tag n) = do
   let (_, ty, _) = bbInputs b !! n
@@ -354,7 +354,7 @@ renderElem b (Tag n) = do
     Clock dom ->
       return (const (Text.pack (Data.Text.unpack dom)))
     _ ->
-      error $ $(curLoc) ++ "Tag: Expected KnownDomain, not: " ++ show ty
+      error $ $(curLoc) ++ "Tag: Expected `KnownDomain` or `KnownConfiguration`, not: " ++ show ty
 
 
 renderElem b (IF c t f) = do
@@ -422,28 +422,28 @@ renderElem b (IF c t f) = do
           KnownDomain _ _ edgeActual _ _ _ ->
             if edgeRequested == edgeActual then 1 else 0
           _ ->
-            error $ $(curLoc) ++ "ActiveEdge: Expected KnownDomain, not: " ++ show ty
+            error $ $(curLoc) ++ "ActiveEdge: Expected `KnownDomain` or `KnownConfiguration`, not: " ++ show ty
 
       (IsSync n) ->
         let (_, ty, _) = bbInputs b !! n in
         case stripVoid ty of
           KnownDomain _ _ _ Synchronous _ _ -> 1
           KnownDomain _ _ _ Asynchronous _ _ -> 0
-          _ -> error $ $(curLoc) ++ "IsSync: Expected KnownDomain, not: " ++ show ty
+          _ -> error $ $(curLoc) ++ "IsSync: Expected `KnownDomain` or `KnownConfiguration`, not: " ++ show ty
 
       (IsInitDefined n) ->
         let (_, ty, _) = bbInputs b !! n in
         case stripVoid ty of
           KnownDomain _ _ _ _ Defined _ -> 1
           KnownDomain _ _ _ _ Unknown _ -> 0
-          _ -> error $ $(curLoc) ++ "IsInitDefined: Expected KnownDomain, not: " ++ show ty
+          _ -> error $ $(curLoc) ++ "IsInitDefined: Expected `KnownDomain` or `KnownConfiguration`, not: " ++ show ty
 
       (IsActiveHigh n) ->
         let (_, ty, _) = bbInputs b !! n in
         case stripVoid ty of
           KnownDomain _ _ _ _ _ ActiveHigh -> 1
           KnownDomain _ _ _ _ _ ActiveLow -> 0
-          _ -> error $ $(curLoc) ++ "IsActiveHigh: Expected KnownDomain, not: " ++ show ty
+          _ -> error $ $(curLoc) ++ "IsActiveHigh: Expected `KnownDomain` or `KnownConfiguration`, not: " ++ show ty
 
       (StrCmp [Text t1] n) ->
         let (e,_,_) = bbInputs b !! n

--- a/clash-prelude/src/Clash/Examples.hs
+++ b/clash-prelude/src/Clash/Examples.hs
@@ -83,7 +83,7 @@ encoderCase enable binaryIn | enable =
 encoderCase _ _ = 0
 
 upCounter
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom (Unsigned 8)
 upCounter enable = s
@@ -99,13 +99,13 @@ upCounterLdT s (ld,en,dIn) = (s',s)
        | otherwise = s
 
 upCounterLd
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom (Bool, Bool, Unsigned 8)
   -> Signal dom (Unsigned 8)
 upCounterLd = mealy upCounterLdT 0
 
 upDownCounter
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom (Unsigned 8)
 upDownCounter upDown = s
@@ -118,7 +118,7 @@ lfsrF' s = pack feedback ++# slice d15 d1 s
     feedback = s!5 `xor` s!3 `xor` s!2 `xor` s!0
 
 lfsrF
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => BitVector 16 -> Signal dom Bit
 lfsrF seed = msb <$> r
   where r = register seed (lfsrF' <$> r)
@@ -135,21 +135,21 @@ lfsrGP taps regs = zipWith xorM taps (fb +>> regs)
              | otherwise = x
 
 lfsrG
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => BitVector 16
   -> Signal dom Bit
 lfsrG seed = last (unbundle r)
   where r = register (unpack seed) (lfsrGP (unpack 0b0011010000000000) <$> r)
 
 grayCounter
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom (BitVector 8)
 grayCounter en = gray <$> upCounter en
   where gray xs = pack (msb xs) ++# xor (slice d7 d1 xs) (slice d6 d0 xs)
 
 oneHotCounter
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom (BitVector 8)
 oneHotCounter enable = s
@@ -174,7 +174,7 @@ crcT bv dIn = replaceBit 0  dInXor
     fb      = msb bv
 
 crc
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom Bool
   -> Signal dom Bit
@@ -394,7 +394,7 @@ Using `register`:
 
 @
 upCounter
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom (Unsigned 8)
 upCounter enable = s
@@ -408,7 +408,7 @@ Using `mealy`:
 
 @
 upCounterLd
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom (Bool,Bool,Unsigned 8)
   -> Signal dom (Unsigned 8)
 upCounterLd = `mealy` upCounterLdT 0
@@ -426,7 +426,7 @@ Using `register` and `mux`:
 
 @
 upDownCounter
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom (Unsigned 8)
 upDownCounter upDown = s
@@ -449,7 +449,7 @@ lfsrF' s = 'pack' feedback '++#' 'slice' d15 d1 s
     feedback = s'!'5 ``xor`` s'!'3 ``xor`` s'!'2 ``xor`` s'!'0
 
 lfsrF
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => BitVector 16
   -> Signal dom Bit
 lfsrF seed = 'msb' '<$>' r
@@ -470,7 +470,7 @@ lfsrGP taps regs = 'zipWith' xorM taps (fb '+>>' regs)
 Then we can instantiate a 16-bit LFSR as follows:
 
 @
-lfsrG :: HiddenClockResetEnable dom conf => BitVector 16 -> Signal dom Bit
+lfsrG :: HiddenClockResetEnable dom  => BitVector 16 -> Signal dom Bit
 lfsrG seed = 'last' ('unbundle' r)
   where r = 'register' ('unpack' seed) (lfsrGP ('unpack' 0b0011010000000000) '<$>' r)
 @
@@ -485,7 +485,7 @@ Using the previously defined @upCounter@:
 
 @
 grayCounter
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom (BitVector 8)
 grayCounter en = gray '<$>' upCounter en
@@ -498,7 +498,7 @@ Basically a barrel-shifter:
 
 @
 oneHotCounter
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom (BitVector 8)
 oneHotCounter enable = s
@@ -537,7 +537,7 @@ crcT bv dIn = 'replaceBit' 0  dInXor
     fb      = 'msb' bv
 
 crc
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom Bool
   -> Signal dom Bool
   -> Signal dom Bit

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -120,7 +120,7 @@ We initially create a memory out of simple registers:
 
 @
 dataMem
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -144,7 +144,7 @@ And then connect everything:
 
 @
 system
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , KnownNat n )
   => Vec n Instruction
   -> Clock dom
@@ -213,7 +213,7 @@ has the potential to be translated to a more efficient structure:
 
 @
 system2
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , KnownNat n )
   => Vec n Instruction
   -> Clock dom
@@ -305,7 +305,7 @@ We can now finally instantiate our system with a 'blockRam':
 
 @
 system3
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , KnownNat n )
   => Vec n Instruction
   -> Clock dom
@@ -523,7 +523,7 @@ cpu regbank (memOut,instr) = (regbank',(rdAddr,(,aluOut) <$> wrAddrM,fromIntegra
 
 >>> :{
 dataMem
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock  dom
   -> Reset  dom
   -> Enable dom
@@ -542,7 +542,7 @@ dataMem clk rst en rd wrM = mealy clk rst en dataMemT (C.replicate d32 0) (bundl
 
 >>> :{
 system
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , KnownNat n )
   => Vec n Instruction
   -> Clock dom
@@ -590,7 +590,7 @@ prog = -- 0 := 4
 
 >>> :{
 system2
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , KnownNat n )
   => Vec n Instruction
   -> Clock dom
@@ -641,7 +641,7 @@ cpu2 (regbank,ldRegD) (memOut,instr) = ((regbank',ldRegD'),(rdAddr,(,aluOut) <$>
 
 >>> :{
 system3
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , KnownNat n )
   => Vec n Instruction
   -> Clock dom
@@ -714,7 +714,7 @@ fromJustX (Just x) = x
 -- Block RAM.
 -- * Use the adapter 'readNew' for obtaining write-before-read semantics like this: @'readNew' clk rst ('blockRam' clk inits) rd wrM@.
 blockRam
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , HasCallStack
      , Undefined a
      , Enum addr )
@@ -760,7 +760,7 @@ blockRam = \clk gen content rd wrM ->
 -- Block RAM.
 -- * Use the adapter 'readNew' for obtaining write-before-read semantics like this: @'readNew' clk rst ('blockRamPow2' clk inits) rd wrM@.
 blockRamPow2
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , HasCallStack
      , Undefined a
      , KnownNat n )
@@ -792,8 +792,8 @@ data ResetStrategy (r :: Bool) where
 -- | Version of blockram that is initialized with the same value on all
 -- memory positions.
 blockRam1
-   :: forall n dom a r addr conf
-   . ( KnownDomain dom conf
+   :: forall n dom a r addr
+   . ( KnownDomain dom
      , HasCallStack
      , Undefined a
      , Enum addr
@@ -849,8 +849,8 @@ blockRam1 clk rst0 en rstStrategy n@SNat a rd0 mw0 =
 
 -- | blockRAM1 primitive
 blockRam1#
-  :: forall n dom a conf
-   . ( KnownDomain dom conf
+  :: forall n dom a
+   . ( KnownDomain dom
      , HasCallStack
      , Undefined a )
   => Clock dom
@@ -879,7 +879,7 @@ blockRam1# clk en n a =
 
 -- | blockRAM primitive
 blockRam#
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , HasCallStack
      , Undefined a )
   => Clock dom
@@ -927,7 +927,7 @@ blockRam# (Clock _) gen content rd wen =
 
 -- | Create read-after-write blockRAM from a read-before-write one
 readNew
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a
      , Eq addr )
   => Reset dom

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -142,8 +142,8 @@ import Clash.XException      (errorX, maybeIsX, seqX)
 -- * See "Clash.Explicit.Fixed#creatingdatafiles" for ideas on how to create your
 -- own data files.
 blockRamFilePow2
-  :: forall dom n m conf
-   . (KnownDomain dom conf, KnownNat m, KnownNat n, HasCallStack)
+  :: forall dom n m
+   . (KnownDomain dom, KnownNat m, KnownNat n, HasCallStack)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -187,7 +187,7 @@ blockRamFilePow2 = \clk en file rd wrM -> withFrozenCallStack
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
 -- own data files.
 blockRamFile
-  :: (KnownDomain dom conf, KnownNat m, Enum addr, HasCallStack)
+  :: (KnownDomain dom, KnownNat m, Enum addr, HasCallStack)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -212,8 +212,8 @@ blockRamFile = \clk gen sz file rd wrM ->
 
 -- | blockRamFile primitive
 blockRamFile#
-  :: forall m dom n conf
-   . (KnownDomain dom conf, KnownNat m, HasCallStack)
+  :: forall m dom n
+   . (KnownDomain dom, KnownNat m, HasCallStack)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -57,8 +57,8 @@ import Clash.Signal.Internal
 ddrIn
   :: ( HasCallStack
      , Undefined a
-     , KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
   -- ^ clock
   -> Reset slow
@@ -80,8 +80,8 @@ ddrIn#
   :: forall a slow fast fPeriod polarity edge reset init
    . ( HasCallStack
      , Undefined a
-     , KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
   -> Reset slow
   -> Enable slow
@@ -134,8 +134,8 @@ ddrIn# (Clock _) (unsafeToHighPolarity -> hRst) (fromEnable -> ena) i0 i1 i2 =
 ddrOut
   :: ( HasCallStack
      , Undefined a
-     , KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
   -> Reset slow
   -> Enable slow
@@ -152,8 +152,8 @@ ddrOut clk rst en i0 =
 ddrOut#
   :: ( HasCallStack
      , Undefined a
-     , KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
   -> Reset slow
   -> Enable slow

--- a/clash-prelude/src/Clash/Explicit/Mealy.hs
+++ b/clash-prelude/src/Clash/Explicit/Mealy.hs
@@ -53,7 +53,7 @@ let macT s (x,y) = (s',s)
 --     s' = x * y + s
 --
 -- mac
---   :: 'KnownDomain' dom conf
+--   :: 'KnownDomain' dom
 --   => 'Clock' dom
 --   -> 'Reset' dom
 --   -> 'Enable' dom
@@ -71,7 +71,7 @@ let macT s (x,y) = (s',s)
 --
 -- @
 -- dualMac
---   :: 'KnownDomain' dom conf
+--   :: 'KnownDomain' dom
 --   => 'Clock' dom
 --   -> 'Reset' dom
 --   -> 'Enable' dom
@@ -84,7 +84,7 @@ let macT s (x,y) = (s',s)
 --     s2 = 'mealy' clk rst en mac 0 ('bundle' (b,y))
 -- @
 mealy
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined s )
   => Clock dom
   -- ^ 'Clock' to synchronize to
@@ -131,7 +131,7 @@ mealy clk rst en f iS =
 --     (i2,b2) = 'mealyB' clk rst en f 3 (i1,c)
 -- @
 mealyB
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined s
      , Bundle i
      , Bundle o )

--- a/clash-prelude/src/Clash/Explicit/Moore.hs
+++ b/clash-prelude/src/Clash/Explicit/Moore.hs
@@ -45,7 +45,7 @@ import           Clash.XException                 (Undefined)
 -- macT s (x,y) = x * y + s
 --
 -- mac
---   :: 'KnownDomain' dom conf
+--   :: 'KnownDomain' dom
 --   => 'Clock' dom
 --   -> 'Reset' dom
 --   -> 'Enable' dom
@@ -63,7 +63,7 @@ import           Clash.XException                 (Undefined)
 --
 -- @
 -- dualMac
---   :: 'KnownDomain' dom conf
+--   :: 'KnownDomain' dom
 --   => 'Clock' dom
 --   -> 'Reset' dom
 --   -> 'Enable' dom
@@ -76,7 +76,7 @@ import           Clash.XException                 (Undefined)
 --     s2 = 'moore' clk rst en mac id 0 ('bundle' (b,y))
 -- @
 moore
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined s )
   => Clock dom
   -- ^ 'Clock' to synchronize to
@@ -100,7 +100,7 @@ moore clk rst en ft fo iS =
 -- | Create a synchronous function from a combinational function describing
 -- a moore machine without any output logic
 medvedev
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined s )
   => Clock dom
   -> Reset dom
@@ -139,7 +139,7 @@ medvedev clk rst en tr st = moore clk rst en tr id st
 --     (i2,b2) = 'mooreB' clk rst en t o 3 (i1,c)
 -- @
 mooreB
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined s
      , Bundle i
      , Bundle o )
@@ -162,7 +162,7 @@ mooreB clk rst en ft fo iS i = unbundle (moore clk rst en ft fo iS (bundle i))
 
 -- | A version of 'medvedev' that does automatic 'Bundle'ing
 medvedevB
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined s
      , Bundle i
      , Bundle s )

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -200,7 +200,7 @@ import Clash.XException
 -- ...
 window
   :: ( KnownNat n
-     , KnownDomain dom conf
+     , KnownDomain dom
      , Undefined a
      , Default a
      )
@@ -225,7 +225,7 @@ window clk rst en x = res
 --
 -- @
 -- windowD3
---   :: KnownDomain dom conf
+--   :: KnownDomain dom
 --   -> Clock dom
 --   -> Enable dom
 --   -> Reset dom
@@ -241,7 +241,7 @@ windowD
   :: ( KnownNat n
      , Undefined a
      , Default a
-     , KnownDomain dom conf )
+     , KnownDomain dom )
   => Clock dom
   -- ^ Clock to which the incoming signal is synchronized
   -> Reset dom

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -165,7 +165,7 @@ import Clash.XException
 -- [(8,8),(8,8),(1,1),(2,2),(3,3)...
 -- ...
 registerB
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a
      , Bundle a )
   => Clock dom
@@ -180,7 +180,7 @@ registerB clk rst en i =
 
 -- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
 isRising
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a
      , Bounded a
      , Eq a )
@@ -198,7 +198,7 @@ isRising clk rst en is s = liftA2 edgeDetect prev s
 
 -- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
 isFalling
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a
      , Bounded a
      , Eq a )
@@ -218,8 +218,8 @@ isFalling clk rst en is s = liftA2 edgeDetect prev s
 -- combined with functions like @'Clash.Explicit.Signal.regEn'@ or
 -- @'Clash.Explicit.Signal.mux'@, in order to delay a register by a known amount.
 riseEvery
-  :: forall dom conf n
-   . KnownDomain dom conf
+  :: forall dom  n
+   . KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -236,8 +236,8 @@ riseEvery clk rst en SNat = moore clk rst en transfer output 0 (pure ())
 
 -- | Oscillate a @'Bool'@ for a given number of cycles, given the starting state.
 oscillate
-  :: forall dom conf n
-   . KnownDomain dom conf
+  :: forall dom  n
+   . KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -56,11 +56,11 @@ import Clash.XException      (errorX, maybeIsX)
 -- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
 -- RAM.
 asyncRamPow2
-  :: forall wdom rdom wconf rconf n a
+  :: forall wdom rdom n a
    . ( KnownNat n
      , HasCallStack
-     , KnownDomain wdom wconf
-     , KnownDomain rdom rconf
+     , KnownDomain wdom
+     , KnownDomain rdom
      )
   => Clock wdom
   -- ^ 'Clock' to which to synchronize the write port of the RAM
@@ -90,8 +90,8 @@ asyncRamPow2 = \wclk rclk en rd wrM -> withFrozenCallStack
 asyncRam
   :: ( Enum addr
      , HasCallStack
-     , KnownDomain wdom wconf
-     , KnownDomain rdom rconf
+     , KnownDomain wdom
+     , KnownDomain rdom
      )
   => Clock wdom
    -- ^ 'Clock' to which to synchronize the write port of the RAM
@@ -117,8 +117,8 @@ asyncRam = \wclk rclk gen sz rd wrM ->
 -- | RAM primitive
 asyncRam#
   :: ( HasCallStack
-     , KnownDomain wdom wconf
-     , KnownDomain rdom rconf )
+     , KnownDomain wdom
+     , KnownDomain rdom )
   => Clock wdom
   -- ^ 'Clock' to which to synchronize the write port of the RAM
   -> Clock rdom

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -50,7 +50,7 @@ import Clash.XException       (deepErrorX, seqX, Undefined)
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Explicit.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
 romPow2
-  :: (KnownDomain dom conf, KnownNat n, Undefined a)
+  :: (KnownDomain dom, KnownNat n, Undefined a)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -76,7 +76,7 @@ romPow2 = rom
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Explicit.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
 rom
-  :: (KnownDomain dom conf, KnownNat n, Undefined a, Enum addr)
+  :: (KnownDomain dom, KnownNat n, Undefined a, Enum addr)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -94,8 +94,8 @@ rom = \clk en content rd -> rom# clk en content (fromEnum <$> rd)
 
 -- | ROM primitive
 rom#
-  :: forall dom n a conf
-   . (KnownDomain dom conf, KnownNat n, Undefined a)
+  :: forall dom n a
+   . (KnownDomain dom, KnownNat n, Undefined a)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -125,8 +125,8 @@ import Clash.XException             (Undefined(deepErrorX))
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
 -- own data files.
 romFilePow2
-  :: forall dom conf n m
-   . (KnownNat m, KnownNat n, KnownDomain dom conf)
+  :: forall dom  n m
+   . (KnownNat m, KnownNat n, KnownDomain dom)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -165,7 +165,7 @@ romFilePow2 = \clk en -> romFile clk en (pow2SNat (SNat @ n))
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
 -- own data files.
 romFile
-  :: (KnownNat m, Enum addr, KnownDomain dom conf)
+  :: (KnownNat m, Enum addr, KnownDomain dom)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -183,7 +183,7 @@ romFile = \clk en sz file rd -> romFile# clk en sz file (fromEnum <$> rd)
 
 -- | romFile primitive
 romFile#
-  :: (KnownNat m, KnownDomain dom conf)
+  :: (KnownNat m, KnownDomain dom)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -145,6 +145,7 @@ module Clash.Explicit.Signal
     -- * Domain
   , Domain
   , KnownDomain(..)
+  , KnownConfiguration
   , ActiveEdge(..)
   , SActiveEdge(..)
   , InitBehavior(..)
@@ -241,16 +242,18 @@ import Clash.Signal.Internal
 import Clash.XException               (Undefined, deepErrorX)
 
 {- $setup
->>> :set -XDataKinds -XTypeApplications -XFlexibleInstances -XMultiParamTypeClasses
+>>> :set -XDataKinds -XTypeApplications -XFlexibleInstances -XMultiParamTypeClasses -XTypeFamilies
 >>> import Clash.Explicit.Prelude
 >>> import qualified Data.List as L
 >>> :{
-instance KnownDomain "Dom2" ('DomainConfiguration "Dom2" 2 'Rising 'Asynchronous 'Defined 'ActiveHigh) where
+instance KnownDomain "Dom2" where
+  type KnownConf "Dom2" = 'DomainConfiguration "Dom2" 2 'Rising 'Asynchronous 'Defined 'ActiveHigh
   knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
 :}
 
 >>> :{
-instance KnownDomain "Dom7" ('DomainConfiguration "Dom7" 7 'Rising 'Asynchronous 'Defined 'ActiveHigh) where
+instance KnownDomain "Dom7" where
+  type KnownConf "Dom7" = 'DomainConfiguration "Dom7" 7 'Rising 'Asynchronous 'Defined 'ActiveHigh
   knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
 :}
 
@@ -365,8 +368,8 @@ systemResetGen = resetGen
 --     leds   = mealy blinkerT (1, False, 0) key1R
 -- @
 resetSynchronizer
-  :: forall dom conf
-   . KnownDomain dom conf
+  :: forall dom
+   . KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -470,9 +473,9 @@ freqCalc freq = ceiling ((1.0 / freq) / 1.0e-12)
 -- >>> sampleN 12 (almostId clk2 clk7 en2 en7 0 (fromList [(1::Int)..10]))
 -- [0,0,1,2,3,4,5,6,7,8,9,10]
 unsafeSynchronizer
-  :: forall dom1 dom2 conf1 conf2 a
-   . ( KnownDomain dom1 conf1
-     , KnownDomain dom2 conf2 )
+  :: forall dom1 dom2 a
+   . ( KnownDomain dom1
+     , KnownDomain dom2 )
   => Clock dom1
   -- ^ 'Clock' of the incoming signal
   -> Clock dom2
@@ -536,7 +539,7 @@ enable e0 e1 =
 -- | Special version of 'delay' that doesn't take enable signals of any kind.
 -- Initial value will be undefined.
 dflipflop
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a )
   => Clock dom
   -> Signal dom a
@@ -555,7 +558,7 @@ dflipflop clk i =
 -- >>> sampleN 3 (delay systemClockGen enableGen 0 (fromList [1,2,3,4]))
 -- [0,1,2]
 delay
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a )
   => Clock dom
   -- ^ Clock
@@ -575,7 +578,7 @@ delay = delay#
 -- >>> sampleN 7 (delayMaybe systemClockGen enableGen 0 input)
 -- [0,1,2,2,2,5,6]
 delayMaybe
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a )
   => Clock dom
   -- ^ Clock
@@ -596,7 +599,7 @@ delayMaybe clk gen dflt i =
 -- >>> sampleN 7 (delayEn systemClockGen enableGen 0 enable input)
 -- [0,1,2,2,2,5,6]
 delayEn
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a )
   => Clock dom
   -- ^ Clock
@@ -618,7 +621,7 @@ delayEn clk gen dflt en i =
 -- >>> sampleN 5 (register systemClockGen resetGen enableGen 8 (fromList [1,1,2,3,4]))
 -- [8,8,1,2,3]
 register
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a )
   => Clock dom
   -- ^ clock
@@ -657,7 +660,7 @@ register clk rst gen initial i =
 -- >>> sampleN 9 (count systemClockGen resetGen enableGen)
 -- [0,0,0,1,1,2,2,3,3]
 regMaybe
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a )
   => Clock dom
   -- ^ Clock
@@ -689,7 +692,7 @@ regMaybe clk rst en initial iM =
 -- >>> sampleN 9 (count systemClockGen resetGen enableGen)
 -- [0,0,0,1,1,2,2,3,3]
 regEn
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined a
      )
   => Clock dom

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -44,15 +44,19 @@ made. Clash provides a standard implementation, called 'System', that is
 configured as follows:
 
 @
-instance 'KnownDomain' \"System\" (''Domain' \"System\" 10000 ''Rising' ''Asynchronous' ''Defined' ''ActiveHigh') where
+instance KnownDomain "System" where
+  type KnownConf "System" = 'DomainConfiguration "System" 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
   knownDomain = 'SDomainConfiguration' SSymbol SNat 'SRising' 'SAsynchronous' 'SDefined' 'SActiveHigh'
 @
 
 In words, \"System\" is a synthesis domain with a clock running with a period
 of 10000 /ps/ (100 MHz). Memory elements update their state on the rising edge
 of the clock, can be reset asynchronously with regards to the clock, and have
-defined power up values if applicable. To conveniently create domains use
-'createDomain'.
+defined power up values if applicable.
+
+In order to create a new domain, you don't have to instantiate it explicitly.
+Instead, you can have 'createDomain' create a domain for you. You can also use
+the same function to subclass existing domains.
 
 * __NB__: \"Bad things\"™  happen when you actually use a clock period of @0@,
 so do __not__ do that!

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -92,8 +92,8 @@ let mac :: Clock System
 -- >>> sampleN 7 (delay3 systemClockGen resetGen enableGen (dfromList [0..]))
 -- [-1,-1,-1,-1,1,2,3]
 delayed
-  :: forall dom conf a n d
-   . ( KnownDomain dom conf
+  :: forall dom  a n d
+   . ( KnownDomain dom
      , KnownNat d
      , Undefined a )
   => Clock dom
@@ -142,7 +142,7 @@ delayed clk rst en m ds = coerce (delaySignal (coerce ds))
 --      -> DSignal dom (n + 3) a
 delayedI
   :: ( KnownNat d
-     , KnownDomain dom conf
+     , KnownDomain dom
      , Undefined a )
   => Clock dom
   -> Reset dom

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -75,8 +75,8 @@ import Clash.XException            (Undefined)
 --      'asyncFIFOSynchronizer'.
 dualFlipFlopSynchronizer
   :: ( Undefined a
-     , KnownDomain dom1 conf1
-     , KnownDomain dom2 conf2 )
+     , KnownDomain dom1
+     , KnownDomain dom2 )
   => Clock dom1
   -- ^ 'Clock' to which the incoming  data is synchronized
   -> Clock dom2
@@ -99,8 +99,8 @@ dualFlipFlopSynchronizer clk1 clk2 rst en i =
 -- * Asynchronous FIFO synchronizer
 
 fifoMem
-  :: ( KnownDomain wdom conf1
-     , KnownDomain rdom conf2 )
+  :: ( KnownDomain wdom
+     , KnownDomain rdom )
   => Clock wdom
   -> Clock rdom
   -> Enable wdom
@@ -163,8 +163,8 @@ isFull addrSize@SNat ptr s_ptr =
 --
 -- __NB__: This synchronizer can be used for __word__-synchronization.
 asyncFIFOSynchronizer
-  :: ( KnownDomain wdom wconf
-     , KnownDomain rdom rconf
+  :: ( KnownDomain wdom
+     , KnownDomain rdom
      , 2 <= addrSize )
   => SNat addrSize
   -- ^ Size of the internally used addresses, the  FIFO contains @2^addrSize@

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -60,7 +60,7 @@ import Clash.XException      (ShowX (..), XException)
 --
 -- __NB__: This function /can/ be used in synthesizable designs.
 assert
-  :: (KnownDomain dom conf, Eq a, ShowX a)
+  :: (KnownDomain dom, Eq a, ShowX a)
   => Clock dom
   -> Reset dom
   -> String
@@ -94,7 +94,7 @@ assert clk (Reset _) msg checked expected returned =
 
 -- | The same as 'assert', but can handle don't care bits in it's expected value.
 assertBitVector
-  :: (KnownDomain dom conf, KnownNat n)
+  :: (KnownDomain dom, KnownNat n)
   => Clock dom
   -> Reset dom
   -> String
@@ -136,7 +136,7 @@ assertBitVector clk (Reset _) msg checked expected returned =
 --
 -- @
 -- testInput
---   :: KnownDomain dom conf
+--   :: KnownDomain dom
 --   => Clock dom
 --   -> Reset dom
 --   -> 'Signal' dom Int
@@ -146,9 +146,9 @@ assertBitVector clk (Reset _) msg checked expected returned =
 -- >>> sampleN 14 (testInput systemClockGen resetGen)
 -- [1,1,3,5,7,9,11,13,15,17,19,21,21,21]
 stimuliGenerator
-  :: forall l dom conf  a
+  :: forall l dom   a
    . ( KnownNat l
-     , KnownDomain dom conf )
+     , KnownDomain dom )
   => Clock dom
   -- ^ Clock to which to synchronize the output signal
   -> Reset dom
@@ -210,9 +210,9 @@ stimuliGenerator clk rst samples =
 --
 -- If your working with 'BitVector's containing don't care bit you should use 'outputVerifierBitVector'.
 outputVerifier
-  :: forall l dom conf  a
+  :: forall l dom   a
    . ( KnownNat l
-     , KnownDomain dom conf
+     , KnownDomain dom
      , Eq a
      , ShowX a )
   => Clock dom
@@ -247,10 +247,10 @@ outputVerifier clk rst samples i =
 -- | Same as 'outputVerifier', but can handle don't care bits in it's expected
 -- values.
 outputVerifierBitVector
-  :: forall l n dom conf
+  :: forall l n dom
    . ( KnownNat l
      , KnownNat n
-     , KnownDomain dom conf
+     , KnownDomain dom
      )
   => Clock dom
   -- ^ Clock to which the input signal is synchronized to
@@ -283,8 +283,8 @@ outputVerifierBitVector clk rst samples i =
 
 -- | Ignore signal for a number of cycles, while outputting a static value.
 ignoreFor
-  :: forall dom conf n a
-   . KnownDomain dom conf
+  :: forall dom  n a
+   . KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom

--- a/clash-prelude/src/Clash/Intel/DDR.hs
+++ b/clash-prelude/src/Clash/Intel/DDR.hs
@@ -40,8 +40,8 @@ import Clash.Explicit.DDR
 -- Reset values are @0@
 altddioIn
   :: ( HasCallStack
-     , KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
   => SSymbol deviceFamily
   -- ^ The FPGA family
@@ -68,8 +68,8 @@ altddioIn _devFam clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
 -- Reset value is @0@
 altddioOut
   :: ( HasCallStack
-     , KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
   => SSymbol deviceFamily
   -- ^ The FPGA family
@@ -92,8 +92,8 @@ altddioOut devFam clk rst en =
 
 altddioOut#
   :: ( HasCallStack
-     , KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
   => SSymbol deviceFamily
   -> Clock slow

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -192,8 +192,8 @@ import           Clash.XException
 
 {- $setup
 >>> :set -XDataKinds -XFlexibleContexts -XTypeApplications
->>> let window4  = window  :: HiddenClockResetEnable dom conf => Signal dom Int -> Vec 4 (Signal dom Int)
->>> let windowD3 = windowD :: HiddenClockResetEnable dom conf => Signal dom Int -> Vec 3 (Signal dom Int)
+>>> let window4  = window  :: HiddenClockResetEnable dom  => Signal dom Int -> Vec 4 (Signal dom Int)
+>>> let windowD3 = windowD :: HiddenClockResetEnable dom  => Signal dom Int -> Vec 3 (Signal dom Int)
 -}
 
 {- $hiding
@@ -209,7 +209,7 @@ It instead exports the identically named functions defined in terms of
 
 -- | Give a window over a 'Signal'
 --
--- > window4 :: HiddenClockResetEnable dom conf
+-- > window4 :: HiddenClockResetEnable dom
 -- >         => Signal dom Int -> Vec 4 (Signal dom Int)
 -- > window4 = window
 --
@@ -217,7 +217,7 @@ It instead exports the identically named functions defined in terms of
 -- [<1,0,0,0>,<2,1,0,0>,<3,2,1,0>,<4,3,2,1>,<5,4,3,2>...
 -- ...
 window
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , KnownNat n
      , Default a
      , Undefined a )
@@ -231,7 +231,7 @@ window = hideClockResetEnable E.window
 -- | Give a delayed window over a 'Signal'
 --
 -- > windowD3
--- >   :: HiddenClockResetEnable dom conf
+-- >   :: HiddenClockResetEnable dom
 -- >   => Signal dom Int
 -- >   -> Vec 3 (Signal dom Int)
 -- > windowD3 = windowD
@@ -240,7 +240,7 @@ window = hideClockResetEnable E.window
 -- [<0,0,0>,<1,0,0>,<2,1,0>,<3,2,1>,<4,3,2>...
 -- ...
 windowD
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , KnownNat n
      , Default a
      , Undefined a )

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -126,7 +126,7 @@ We initially create a memory out of simple registers:
 
 @
 dataMem
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom MemAddr
   -- ^ Read address
   -> Signal dom (Maybe (MemAddr,Value))
@@ -150,7 +150,7 @@ And then connect everything:
 @
 system
   :: ( KnownNat n
-     , HiddenClockResetEnable dom conf
+     , HiddenClockResetEnable dom
      )
   => Vec n Instruction
   -> Signal dom Value
@@ -217,7 +217,7 @@ has the potential to be translated to a more efficient structure:
 @
 system2
   :: ( KnownNat n
-     , HiddenClockResetEnable dom conf )
+     , HiddenClockResetEnable dom  )
   => Vec n Instruction
   -> Signal dom Value
 system2 instrs = memOut
@@ -308,7 +308,7 @@ We can now finally instantiate our system with a 'blockRam':
 @
 system3
   :: (KnownNat n
-     , HiddenClockResetEnable dom conf )
+     , HiddenClockResetEnable dom  )
   => Vec n Instruction
   -> Signal dom Value
 system3 instrs = memOut
@@ -504,7 +504,7 @@ cpu regbank (memOut,instr) = (regbank',(rdAddr,(,aluOut) <$> wrAddrM,fromIntegra
 
 >>> :{
 dataMem
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom MemAddr
   -> Signal dom (Maybe (MemAddr,Value))
   -> Signal dom Value
@@ -520,7 +520,7 @@ dataMem rd wrM = mealy dataMemT (C.replicate d32 0) (bundle (rd,wrM))
 
 >>> :{
 system
-  :: (KnownNat n, HiddenClockResetEnable dom conf)
+  :: (KnownNat n, HiddenClockResetEnable dom )
   => Vec n Instruction
   -> Signal dom Value
 system instrs = memOut
@@ -565,7 +565,7 @@ prog = -- 0 := 4
 >>> :{
 system2
   :: ( KnownNat n
-     , HiddenClockResetEnable dom conf )
+     , HiddenClockResetEnable dom  )
   => Vec n Instruction
   -> Signal dom Value
 system2 instrs = memOut
@@ -618,7 +618,7 @@ cpu2 (regbank,ldRegD) (memOut,instr) =
 >>> :{
 system3
   :: ( KnownNat n
-     , HiddenClockResetEnable dom conf )
+     , HiddenClockResetEnable dom  )
   => Vec n Instruction
   -> Signal dom Value
 system3 instrs = memOut
@@ -683,8 +683,8 @@ prog2 = -- 0 := 4
 -- * Use the adapter 'readNew' for obtaining write-before-read semantics like this: @readNew (blockRam inits) rd wrM@.
 blockRam
   :: ( HasCallStack
-     , HiddenClock dom conf
-     , HiddenEnable dom conf
+     , HiddenClock dom
+     , HiddenEnable dom
      , Undefined a
      , Enum addr
      )
@@ -706,9 +706,9 @@ blockRam = \cnt rd wrM -> withFrozenCallStack
 -- | Version of blockram that is initialized with the same value on all
 -- memory positions.
 blockRam1
-   :: forall n dom a r addr conf
+   :: forall n dom a r addr
    . ( HasCallStack
-     , HiddenClockResetEnable dom conf
+     , HiddenClockResetEnable dom
      , Undefined a
      , Enum addr
      , 1 <= n )
@@ -752,8 +752,8 @@ blockRam1 =
 -- * Use the adapter 'readNew' for obtaining write-before-read semantics like this: @readNew (blockRamPow2 inits) rd wrM@.
 blockRamPow2
   :: ( HasCallStack
-     , HiddenClock dom conf
-     , HiddenEnable dom conf
+     , HiddenClock dom
+     , HiddenEnable dom
      , Undefined a
      , KnownNat n
      )
@@ -784,7 +784,7 @@ blockRamPow2 = \cnt rd wrM -> withFrozenCallStack
 --      ... =>
 --      Signal dom addr -> Signal dom (Maybe (addr, a)) -> Signal dom a
 readNew
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined a
      , Eq addr )
   => (Signal dom addr -> Signal dom (Maybe (addr, a)) -> Signal dom a)

--- a/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
@@ -34,7 +34,7 @@ For example, a data file @memory.bin@ containing the 9-bit unsigned number
 We can instantiate a BlockRAM using the content of the above file like so:
 
 @
-f :: HiddenClock dom conf -> Signal dom (Unsigned 3) -> Signal dom (Unsigned 9)
+f :: HiddenClock dom  -> Signal dom (Unsigned 3) -> Signal dom (Unsigned 9)
 f rd = 'Clash.Class.BitPack.unpack' '<$>' exposeClock 'blockRamFile' clk d7 \"memory.bin\" rd (signal Nothing)
 @
 
@@ -51,7 +51,7 @@ However, we can also interpret the same data as a tuple of a 6-bit unsigned
 number, and a 3-bit signed number:
 
 @
-g :: HiddenClock dom conf -> Signal dom (Unsigned 3) -> Signal dom (Unsigned 6,Signed 3)
+g :: HiddenClock dom  -> Signal dom (Unsigned 3) -> Signal dom (Unsigned 6,Signed 3)
 g clk rd = 'Clash.Class.BitPack.unpack' '<$>' exposeClock 'blockRamFile' clk d7 \"memory.bin\" rd (signal Nothing)
 @
 
@@ -123,11 +123,11 @@ import           Clash.Sized.Unsigned         (Unsigned)
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
 -- own data files.
 blockRamFilePow2
-  :: forall dom conf n m
+  :: forall dom  n m
    . ( KnownNat m
      , KnownNat n
-     , HiddenClock dom conf
-     , HiddenEnable dom conf
+     , HiddenClock dom
+     , HiddenEnable dom
      , HasCallStack )
   => FilePath
   -- ^ File describing the initial content of the blockRAM
@@ -171,8 +171,8 @@ blockRamFilePow2 = \fp rd wrM -> withFrozenCallStack
 blockRamFile
   :: ( KnownNat m
      , Enum addr
-     , HiddenClock dom conf
-     , HiddenEnable dom conf
+     , HiddenClock dom
+     , HiddenEnable dom
      , HasCallStack )
   => SNat n
   -- ^ Size of the blockRAM

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -154,7 +154,7 @@ pureDF f = DF (\i iV oR -> (fmap f i,iV,oR))
 -- | Create a 'DataFlow' circuit from a Mealy machine description as those of
 -- "Clash.Prelude.Mealy"
 mealyDF
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined s )
   => Clock dom
   -> Reset dom
@@ -171,7 +171,7 @@ mealyDF clk rst gen f iS =
 -- | Create a 'DataFlow' circuit from a Moore machine description as those of
 -- "Clash.Prelude.Moore"
 mooreDF
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined s )
   => Clock dom
   -> Reset dom
@@ -218,8 +218,8 @@ fifoDF_mealy (mem,rptr,wptr) (wdata,winc,rinc) =
 -- fifo4 = 'fifoDF' d4 (2 :> 3 :> Nil)
 -- @
 fifoDF
-  :: forall addrSize m n a dom conf
-   . ( KnownDomain dom conf
+  :: forall addrSize m n a dom
+   . ( KnownDomain dom
      , Undefined a
      , KnownNat addrSize
      , KnownNat n
@@ -358,7 +358,7 @@ parNDF fs =
 --
 -- <<doc/loopDF_sync.svg>>
 loopDF
-  :: ( KnownDomain dom conf
+  :: ( KnownDomain dom
      , Undefined d
      , KnownNat m
      , KnownNat n

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -52,7 +52,7 @@ let macT s (x,y) = (s',s)
 --   where
 --     s' = x * y + s
 --
--- mac :: HiddenClockResetEnable dom conf => 'Signal' dom (Int, Int) -> 'Signal' dom Int
+-- mac :: HiddenClockResetEnable dom  => 'Signal' dom (Int, Int) -> 'Signal' dom Int
 -- mac = 'mealy' macT 0
 -- @
 --
@@ -65,7 +65,7 @@ let macT s (x,y) = (s',s)
 --
 -- @
 -- dualMac
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   => ('Signal' dom Int, 'Signal' dom Int)
 --   -> ('Signal' dom Int, 'Signal' dom Int)
 --   -> 'Signal' dom Int
@@ -75,7 +75,7 @@ let macT s (x,y) = (s',s)
 --     s2 = 'mealy' mac 0 ('Clash.Signal.bundle' (b,y))
 -- @
 mealy
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined s )
   => (s -> i -> (s,o))
   -- ^ Transfer function in mealy machine form: @state -> input -> (newstate,output)@
@@ -114,7 +114,7 @@ mealy = hideClockResetEnable E.mealy
 --     (i2,b2) = 'mealyB' f 3 (i1,c)
 -- @
 mealyB
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined s
      , Bundle i
      , Bundle o )
@@ -130,7 +130,7 @@ mealyB = hideClockResetEnable E.mealyB
 
 -- | Infix version of 'mealyB'
 (<^>)
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined s
      , Bundle i
      , Bundle o )

--- a/clash-prelude/src/Clash/Prelude/Moore.hs
+++ b/clash-prelude/src/Clash/Prelude/Moore.hs
@@ -51,7 +51,7 @@ let macT s (x,y) = x * y + s
 -- macT s (x,y) = x * y + s
 --
 -- mac
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   => 'Signal' dom (Int, Int)
 --   -> 'Signal' dom Int
 -- mac = 'moore' mac id 0
@@ -66,7 +66,7 @@ let macT s (x,y) = x * y + s
 --
 -- @
 -- dualMac
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   => ('Signal' dom Int, 'Signal' dom Int)
 --   -> ('Signal' dom Int, 'Signal' dom Int)
 --   -> 'Signal' dom Int
@@ -76,7 +76,7 @@ let macT s (x,y) = x * y + s
 --     s2 = 'moore' mac id 0 ('Clash.Signal.bundle' (b,y))
 -- @
 moore
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined s )
   => (s -> i -> s)
   -- ^ Transfer function in moore machine form: @state -> input -> newstate@
@@ -94,7 +94,7 @@ moore = hideClockResetEnable E.moore
 -- | Create a synchronous function from a combinational function describing
 -- a moore machine without any output logic
 medvedev
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined s )
   => (s -> i -> s)
   -> s
@@ -130,7 +130,7 @@ medvedev tr st = moore tr id st
 --     (i2,b2) = 'mooreB' t o 3 (i1,c)
 -- @
 mooreB
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined s
      , Bundle i
      , Bundle o )
@@ -148,7 +148,7 @@ mooreB = hideClockResetEnable E.mooreB
 
 -- | A version of 'medvedev' that does automatic 'Bundle'ing
 medvedevB
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined s
      , Bundle i
      , Bundle s )

--- a/clash-prelude/src/Clash/Prelude/RAM.hs
+++ b/clash-prelude/src/Clash/Prelude/RAM.hs
@@ -48,8 +48,8 @@ import           Clash.Sized.Unsigned (Unsigned)
 -- RAM.
 asyncRam
   :: ( Enum addr
-     , HiddenClock dom conf
-     , HiddenEnable dom conf
+     , HiddenClock dom
+     , HiddenEnable dom
      , HasCallStack
      )
   => SNat n
@@ -74,8 +74,8 @@ asyncRam = \sz rd wrM -> withFrozenCallStack
 -- RAM.
 asyncRamPow2
   :: ( KnownNat n
-     , HiddenClock dom conf
-     , HiddenEnable dom conf
+     , HiddenClock dom
+     , HiddenEnable dom
      , HasCallStack )
   => Signal dom (Unsigned n)
   -- ^ Read address @r@

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -107,12 +107,12 @@ asyncRom# content rd = arr ! rd
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
 rom
-  :: forall dom n m a conf
+  :: forall dom n m a
    . ( Undefined a
      , KnownNat n
      , KnownNat m
-     , HiddenClock dom conf
-     , HiddenEnable dom conf )
+     , HiddenClock dom
+     , HiddenEnable dom  )
   => Vec n a
   -- ^ ROM content
   --
@@ -134,11 +134,11 @@ rom = hideEnable (hideClock E.rom)
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
 romPow2
-  :: forall dom n a conf
+  :: forall dom n a
    . ( KnownNat n
      , Undefined a
-     , HiddenClock dom conf
-     , HiddenEnable dom conf )
+     , HiddenClock dom
+     , HiddenEnable dom  )
   => Vec (2^n) a
   -- ^ ROM content
   --

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -34,7 +34,7 @@ We can instantiate a synchronous ROM using the content of the above file like
 so:
 
 @
-f :: HiddenClock dom conf => Signal dom (Unsigned 3) -> Signal dom (Unsigned 9)
+f :: HiddenClock dom  => Signal dom (Unsigned 3) -> Signal dom (Unsigned 9)
 f rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' d7 \"memory.bin\" rd
 @
 
@@ -50,7 +50,7 @@ However, we can also interpret the same data as a tuple of a 6-bit unsigned
 number, and a 3-bit signed number:
 
 @
-g :: HiddenClock dom conf => Signal dom (Unsigned 3) -> Signal dom (Unsigned 6,Signed 3)
+g :: HiddenClock dom  => Signal dom (Unsigned 3) -> Signal dom (Unsigned 6,Signed 3)
 g rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' d7 \"memory.bin\" rd
 @
 
@@ -272,8 +272,8 @@ asyncRomFile# sz file = (content !) -- Leave "(content !)" eta-reduced, see
 romFile
   :: ( KnownNat m
      , KnownNat n
-     , HiddenClock dom conf
-     , HiddenEnable dom conf
+     , HiddenClock dom
+     , HiddenEnable dom
      )
   => SNat n
   -- ^ Size of the ROM
@@ -310,11 +310,11 @@ romFile = hideEnable (hideClock E.romFile)
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
 -- own data files.
 romFilePow2
-  :: forall n m dom conf
+  :: forall n m dom
    . ( KnownNat m
      , KnownNat n
-     , HiddenClock dom conf
-     , HiddenEnable dom conf
+     , HiddenClock dom
+     , HiddenEnable dom
      )
   => FilePath
   -- ^ File describing the content of the ROM

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -176,7 +176,7 @@ It instead exports the identically named functions defined in terms of
 
 -- | Create a 'register' function for product-type like signals (e.g. '(Signal a, Signal b)')
 --
--- > rP :: HiddenClockResetEnable dom conf
+-- > rP :: HiddenClockResetEnable dom
 -- >    => (Signal dom Int, Signal dom Int)
 -- >    -> (Signal dom Int, Signal dom Int)
 -- > rP = registerB (8,8)
@@ -185,7 +185,7 @@ It instead exports the identically named functions defined in terms of
 -- [(8,8),(1,1),(2,2),(3,3)...
 -- ...
 registerB
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined a
      , Bundle a )
   => a
@@ -197,7 +197,7 @@ infixr 3 `registerB`
 
 -- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
 isRising
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined a
      , Bounded a
      , Eq a )
@@ -210,7 +210,7 @@ isRising = hideClockResetEnable E.isRising
 
 -- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
 isFalling
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Undefined a
      , Bounded a
      , Eq a )
@@ -239,7 +239,7 @@ isFalling = hideClockResetEnable E.isFalling
 -- counter = 'Clash.Signal.regEn' 0 ('riseEvery' ('SNat' :: 'SNat' 10000000)) (counter + 1)
 -- @
 riseEvery
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => SNat n
   -> Signal dom Bool
 riseEvery = hideClockResetEnable E.riseEvery
@@ -266,7 +266,7 @@ riseEvery = hideClockResetEnable E.riseEvery
 -- >>> sampleN @System 200 (oscillate False d1) == sampleN @System 200 osc'
 -- True
 oscillate
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Bool
   -> SNat n
   -> Signal dom Bool

--- a/clash-prelude/src/Clash/Prelude/Testbench.hs
+++ b/clash-prelude/src/Clash/Prelude/Testbench.hs
@@ -49,7 +49,7 @@ import Clash.XException                   (ShowX)
 --
 -- __NB__: This function /can/ be used in synthesizable designs.
 assert
-  :: (Eq a, ShowX a, HiddenClock dom conf, HiddenReset dom conf)
+  :: (Eq a, ShowX a, HiddenClock dom , HiddenReset dom )
   => String
   -- ^ Additional message
   -> Signal dom a
@@ -74,7 +74,7 @@ assert msg actual expected ret =
 --
 -- @
 -- testInput
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   => 'Signal' dom Int
 -- testInput = 'stimuliGenerator' $('Clash.Sized.Vector.listToVecTH' [(1::Int),3..21])
 -- @
@@ -83,8 +83,8 @@ assert msg actual expected ret =
 -- [1,3,5,7,9,11,13,15,17,19,21,21,21]
 stimuliGenerator
   :: ( KnownNat l
-     , HiddenClock dom conf
-     , HiddenReset dom conf )
+     , HiddenClock dom
+     , HiddenReset dom  )
   => Vec l a
   -- ^ Samples to generate
   -> Signal dom a
@@ -100,7 +100,7 @@ stimuliGenerator = hideReset (hideClock E.stimuliGenerator)
 --
 -- @
 -- expectedOutput
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   -> 'Signal' dom Int -> 'Signal' dom Bool
 -- expectedOutput = 'outputVerifier' $('Clash.Sized.Vector.listToVecTH' ([70,99,2,3,4,5,7,8,9,10]::[Int]))
 -- @
@@ -132,8 +132,8 @@ outputVerifier
   :: ( KnownNat l
      , Eq a
      , ShowX a
-     , HiddenClock dom conf
-     , HiddenReset dom conf )
+     , HiddenClock dom
+     , HiddenReset dom  )
   => Vec l a
   -- ^ Samples to compare with
   -> Signal dom a
@@ -149,8 +149,8 @@ outputVerifier = hideReset (hideClock E.outputVerifier)
 outputVerifierBitVector
   :: ( KnownNat l
      , KnownNat n
-     , HiddenClock dom conf
-     , HiddenReset dom conf )
+     , HiddenClock dom
+     , HiddenReset dom  )
   => Vec l (BitVector n)
   -- ^ Samples to compare with
   -> Signal dom (BitVector n)
@@ -162,7 +162,7 @@ outputVerifierBitVector = hideReset (hideClock E.outputVerifierBitVector)
 
 -- | Ignore signal for a number of cycles, while outputting a static value.
 ignoreFor
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => SNat n
   -- ^ Number of cycles to ignore incoming signal
   -> a

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -44,7 +44,8 @@ made. Clash provides an implementation 'System' with some common options
 chosen:
 
 @
-instance KnownDomain "System" ('DomainConfiguration "System" 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh) where
+instance KnownDomain "System" where
+  type KnownConf "System" = 'DomainConfiguration "System" 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
   knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
 @
 
@@ -52,6 +53,10 @@ In words, "System" is a synthesis domain with a clock running with a period
 of 10000 /ps/. Memory elements respond to the rising edge of the clock,
 asynchronously to changes in their resets, and have defined power up values
 if applicable.
+
+In order to create a new domain, you don't have to instantiate it explicitly.
+Instead, you can have 'createDomain' create a domain for you. You can also use
+the same function to subclass existing domains.
 
 * __NB__: \"Bad things\"™  happen when you actually use a clock period of @0@,
 so do __not__ do that!

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -295,7 +295,7 @@ g = 'hideClockReset' f
 Or, alternatively, by:
 
 @
--- h :: HiddenClockResetEnable dom conf => Signal dom a -> ...
+-- h :: HiddenClockResetEnable dom  => Signal dom a -> ...
 h = f 'hasClock' 'hasReset'
 @
 
@@ -304,7 +304,7 @@ h = f 'hasClock' 'hasReset'
 Given a component:
 
 @
-f :: HiddenClockResetEnable dom conf
+f :: HiddenClockResetEnable dom
   => Signal dom Int
   -> Signal dom Int
 @
@@ -366,32 +366,32 @@ type HiddenEnableName dom = AppendSymbol dom "_en"
 -- | A /constraint/ that indicates the component has a hidden 'Clock'
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
-type HiddenClock dom conf =
+type HiddenClock dom =
   ( Hidden (HiddenClockName dom) (Clock dom)
-  , KnownDomain dom conf )
+  , KnownDomain dom )
 
 -- | A /constraint/ that indicates the component needs a 'Reset'
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
-type HiddenReset dom conf =
+type HiddenReset dom =
   ( Hidden (HiddenResetName dom) (Reset dom)
-  , KnownDomain dom conf )
+  , KnownDomain dom )
 
 -- | A /constraint/ that indicates the component needs a 'Enable'
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
-type HiddenEnable dom conf =
+type HiddenEnable dom =
   ( Hidden (HiddenEnableName dom) (Enable dom)
-  , KnownDomain dom conf )
+  , KnownDomain dom )
 
 -- | A /constraint/ that indicates the component needs a 'Clock', a 'Reset',
 -- and an 'Enable' belonging to the same dom.
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
-type HiddenClockResetEnable dom conf =
-  ( HiddenClock dom conf
-  , HiddenReset dom conf
-  , HiddenEnable dom conf
+type HiddenClockResetEnable dom  =
+  ( HiddenClock dom
+  , HiddenReset dom
+  , HiddenEnable dom
   )
 
 -- | A /constraint/ that indicates the component needs a 'Clock', a 'Reset',
@@ -409,10 +409,10 @@ type SystemClockResetEnable =
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 exposeClock
-  :: forall dom conf  r
-   . (HiddenClock dom conf => r)
+  :: forall dom  r
+   . (HiddenClock dom  => r)
   -- ^ The component with a hidden clock
-  -> (KnownDomain dom conf => Clock dom -> r)
+  -> (KnownDomain dom => Clock dom -> r)
   -- ^ The component with its clock argument exposed
 exposeClock = \f clk -> expose @(HiddenClockName dom) f clk
 {-# INLINE exposeClock #-}
@@ -421,8 +421,8 @@ exposeClock = \f clk -> expose @(HiddenClockName dom) f clk
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 hideClock
-  :: forall dom conf  r
-   . HiddenClock dom conf
+  :: forall dom r
+   . HiddenClock dom
   => (Clock dom -> r)
   -- ^ Function whose clock argument you want to hide
   -> r
@@ -435,11 +435,11 @@ hideClock = \f -> f (fromLabel @(HiddenClockName dom))
 -- withClock = 'flip' exposeClock
 -- @
 withClock
-  :: forall dom conf  r
-   . KnownDomain dom conf
+  :: forall dom r
+   . KnownDomain dom
   => Clock dom
   -- ^ The 'Clock' we want to connect
-  -> (HiddenClock dom conf => r)
+  -> (HiddenClock dom  => r)
   -- ^ The function with a hidden 'Clock' argument
   -> r
 withClock = \clk f -> expose @(HiddenClockName dom) f clk
@@ -450,8 +450,8 @@ withClock = \clk f -> expose @(HiddenClockName dom) f clk
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 hasClock
-  :: forall dom conf
-   . HiddenClock dom conf
+  :: forall dom
+   . HiddenClock dom
   => Clock dom
 hasClock = fromLabel @(HiddenClockName dom)
 {-# INLINE hasClock #-}
@@ -461,10 +461,10 @@ hasClock = fromLabel @(HiddenClockName dom)
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 exposeReset
-  :: forall dom conf r
-   . (HiddenReset dom conf => r)
+  :: forall dom r
+   . (HiddenReset dom  => r)
   -- ^ The component with a hidden reset
-  -> (KnownDomain dom conf => Reset dom -> r)
+  -> (KnownDomain dom => Reset dom -> r)
   -- ^ The component with its reset argument exposed
 exposeReset = \f rst -> expose @(HiddenResetName dom) f rst
 {-# INLINE exposeReset #-}
@@ -473,8 +473,8 @@ exposeReset = \f rst -> expose @(HiddenResetName dom) f rst
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 hideReset
-  :: forall dom conf r
-   . HiddenReset dom conf
+  :: forall dom r
+   . HiddenReset dom
   => (Reset dom -> r)
   -- ^ Component whose reset argument you want to hide
   -> r
@@ -489,11 +489,11 @@ hideReset = \f -> f (fromLabel @(HiddenResetName dom))
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 withReset
-  :: forall dom conf r
-   . KnownDomain dom conf
+  :: forall dom r
+   . KnownDomain dom
   => Reset dom
   -- ^ The 'Reset' we want to connect
-  -> (HiddenReset dom conf => r)
+  -> (HiddenReset dom  => r)
   -- ^ The function with a hidden 'Reset' argument
   -> r
 withReset = \rst f -> expose @(HiddenResetName dom) f rst
@@ -504,8 +504,8 @@ withReset = \rst f -> expose @(HiddenResetName dom) f rst
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 hasReset
-  :: forall dom conf
-   . HiddenReset dom conf
+  :: forall dom
+   . HiddenReset dom
   => Reset dom
 hasReset = fromLabel @(HiddenResetName dom)
 {-# INLINE hasReset #-}
@@ -515,10 +515,10 @@ hasReset = fromLabel @(HiddenResetName dom)
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 exposeEnable
-  :: forall dom conf r
-   . (HiddenEnable dom conf => r)
+  :: forall dom  r
+   . (HiddenEnable dom => r)
   -- ^ The component with a hidden reset
-  -> (KnownDomain dom conf => Enable dom -> r)
+  -> (KnownDomain dom => Enable dom -> r)
   -- ^ The component with its reset argument exposed
 exposeEnable = \f rst -> expose @(HiddenEnableName dom) f rst
 {-# INLINE exposeEnable #-}
@@ -527,8 +527,8 @@ exposeEnable = \f rst -> expose @(HiddenEnableName dom) f rst
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 hideEnable
-  :: forall dom conf r
-   . HiddenEnable dom conf
+  :: forall dom r
+   . HiddenEnable dom
   => (Enable dom -> r)
   -- ^ Component whose reset argument you want to hide
   -> r
@@ -543,11 +543,11 @@ hideEnable = \f -> f (fromLabel @(HiddenEnableName dom))
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 withEnable
-  :: forall dom conf r
-   . KnownDomain dom conf
+  :: forall dom r
+   . KnownDomain dom
   => Enable dom
   -- ^ The 'Enable' we want to connect
-  -> (HiddenEnable dom conf => r)
+  -> (HiddenEnable dom  => r)
   -- ^ The function with a hidden 'Enable' argument
   -> r
 withEnable = \rst f -> expose @(HiddenEnableName dom) f rst
@@ -558,8 +558,8 @@ withEnable = \rst f -> expose @(HiddenEnableName dom) f rst
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 hasEnable
-  :: forall dom conf
-   . HiddenEnable dom conf
+  :: forall dom
+   . HiddenEnable dom
   => Enable dom
 hasEnable = fromLabel @(HiddenEnableName dom)
 {-# INLINE hasEnable #-}
@@ -586,10 +586,10 @@ hasEnable = fromLabel @(HiddenEnableName dom)
 --     rst            = systemResetGen
 -- @
 exposeClockResetEnable
-  :: forall dom conf r
-   . (HiddenClockResetEnable dom conf => r)
+  :: forall dom  r
+   . (HiddenClockResetEnable dom => r)
   -- ^ The component with hidden clock, reset, and enable arguments
-  -> (KnownDomain dom conf => Clock dom -> Reset dom -> Enable dom -> r)
+  -> (KnownDomain dom => Clock dom -> Reset dom -> Enable dom -> r)
   -- ^ The component with its clock, reset, and enable arguments exposed
 exposeClockResetEnable =
   \f clk rst en ->
@@ -611,9 +611,9 @@ exposeClockResetEnable =
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 hideClockResetEnable
-  :: forall dom conf r
-   . HiddenClockResetEnable dom conf
-  => (KnownDomain dom conf => Clock dom -> Reset dom -> Enable dom -> r)
+  :: forall dom r
+   . HiddenClockResetEnable dom
+  => (KnownDomain dom => Clock dom -> Reset dom -> Enable dom -> r)
   -- ^ Component whose clock, reset, and enable argument you want to hide
   -> r
 hideClockResetEnable =
@@ -659,15 +659,15 @@ hideClockResetEnable =
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 withClockResetEnable
-  :: forall dom r conf
-   . KnownDomain dom conf
+  :: forall dom r
+   . KnownDomain dom
   => Clock dom
   -- ^ The 'Clock' we want to connect
   -> Reset dom
   -- ^ The 'Reset' we want to connect
   -> Enable dom
   -- ^ The 'Enable' we want to connect
-  -> (HiddenClockResetEnable dom conf => r)
+  -> (HiddenClockResetEnable dom => r)
   -- ^ The function with a hidden 'Clock', hidden 'Reset', and hidden
   -- 'Enable' argument
   -> r
@@ -690,8 +690,8 @@ withClockResetEnable =
 -- | Special version of 'delay' that doesn't take enable signals of any kind.
 -- Initial value will be undefined.
 dflipflop
-  :: forall dom conf a
-   . ( HiddenClock dom conf
+  :: forall dom a
+   . ( HiddenClock dom
      , Undefined a )
   => Signal dom a
   -> Signal dom a
@@ -705,10 +705,10 @@ dflipflop =
 -- >>> sampleN @System 3 (delay 0 (fromList [1,2,3,4]))
 -- [0,1,2]
 delay
-  :: forall dom conf  a
+  :: forall dom a
    . ( Undefined a
-     , HiddenClock dom conf
-     , HiddenEnable dom conf )
+     , HiddenClock dom
+     , HiddenEnable dom  )
   => a
   -- ^ Initial value
   -> Signal dom a
@@ -729,10 +729,10 @@ delay dflt i =
 -- >>> sampleN @System 7 (delayMaybe 0 input)
 -- [0,1,2,2,2,5,6]
 delayMaybe
-  :: forall dom conf  a
+  :: forall dom a
    . ( Undefined a
-     , HiddenClock dom conf
-     , HiddenEnable dom conf )
+     , HiddenClock dom
+     , HiddenEnable dom  )
   => a
   -- ^ Initial value
   -> Signal dom (Maybe a)
@@ -752,10 +752,10 @@ delayMaybe dflt i =
 -- >>> sampleN @System 7 (delayEn 0 enable input)
 -- [0,1,2,2,2,5,6]
 delayEn
-  :: forall dom conf  a
+  :: forall dom a
    . ( Undefined a
-     , HiddenClock dom conf
-     , HiddenEnable dom conf )
+     , HiddenClock dom
+     , HiddenEnable dom  )
   => a
   -- ^ Initial value
   -> Signal dom Bool
@@ -777,8 +777,8 @@ delayEn dflt en i =
 -- >>> sampleN @System 5 (register 8 (fromList [1,1,2,3,4]))
 -- [8,8,1,2,3]
 register
-  :: forall dom conf a
-   . ( HiddenClockResetEnable dom conf
+  :: forall dom a
+   . ( HiddenClockResetEnable dom
      , Undefined a )
   => a
   -- ^ Reset value
@@ -818,8 +818,8 @@ infixr 3 `register`
 -- >>> sampleN @System 9 countSometimes
 -- [0,0,0,1,1,2,2,3,3]
 regMaybe
-  :: forall dom conf a
-   . ( HiddenClockResetEnable dom conf
+  :: forall dom a
+   . ( HiddenClockResetEnable dom
      , Undefined a )
   => a
   -- ^ Reset value. 'regMaybe' outputs the reset value when the reset is active.
@@ -850,8 +850,8 @@ infixr 3 `regMaybe`
 -- >>> sampleN @System 9 count
 -- [0,0,0,1,1,2,2,3,3]
 regEn
-  :: forall dom conf a
-   . ( HiddenClockResetEnable dom conf
+  :: forall dom a
+   . ( HiddenClockResetEnable dom
      , Undefined a )
   => a
   -- ^ Reset value
@@ -881,10 +881,10 @@ regEn initial en i =
 --
 -- __NB__: This function is not synthesizable
 sample
-  :: forall dom conf a
-   . ( KnownDomain dom conf
+  :: forall dom a
+   . ( KnownDomain dom
      , Undefined a )
-  => (HiddenClockResetEnable dom conf => Signal dom a)
+  => (HiddenClockResetEnable dom  => Signal dom a)
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
   -- (and reset)
   -> [a]
@@ -906,12 +906,12 @@ sample s =
 --
 -- __NB__: This function is not synthesizable
 sampleN
-  :: forall dom conf a
-   . ( KnownDomain dom conf
+  :: forall dom a
+   . ( KnownDomain dom
      , Undefined a )
   => Int
   -- ^ The number of samples we want to see
-  -> (HiddenClockResetEnable dom conf => Signal dom a)
+  -> (HiddenClockResetEnable dom  => Signal dom a)
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
   -- (and reset)
   -> [a]
@@ -933,9 +933,9 @@ sampleN n s =
 --
 -- __NB__: This function is not synthesizable
 sample_lazy
-  :: forall dom conf a
-   . KnownDomain dom conf
-  => (HiddenClockResetEnable dom conf => Signal dom a)
+  :: forall dom a
+   . KnownDomain dom
+  => (HiddenClockResetEnable dom  => Signal dom a)
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
   -- (and reset)
   -> [a]
@@ -957,10 +957,10 @@ sample_lazy s =
 --
 -- __NB__: This function is not synthesizable
 sampleN_lazy
-  :: forall dom conf a
-   . KnownDomain dom conf
+  :: forall dom a
+   . KnownDomain dom
   => Int
-  -> (HiddenClockResetEnable dom conf => Signal dom a)
+  -> (HiddenClockResetEnable dom  => Signal dom a)
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
   -- (and reset)
   -> [a]
@@ -986,11 +986,11 @@ sampleN_lazy n s =
 --
 -- __NB__: This function is not synthesizable
 simulate
-  :: forall dom conf a b
-   . ( KnownDomain dom conf
+  :: forall dom a b
+   . ( KnownDomain dom
      , Undefined a
      , Undefined b )
-  => (HiddenClockResetEnable dom conf =>
+  => (HiddenClockResetEnable dom  =>
       Signal dom a -> Signal dom b)
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
   -- (and reset)
@@ -1015,9 +1015,9 @@ simulate f =
 --
 -- __NB__: This function is not synthesizable
 simulate_lazy
-  :: forall dom conf a b
-   . KnownDomain dom conf
-  => (HiddenClockResetEnable dom conf =>
+  :: forall dom a b
+   . KnownDomain dom
+  => (HiddenClockResetEnable dom  =>
       Signal dom a -> Signal dom b)
   -- ^ Function we want to simulate, whose components potentially have a hidden
   -- clock (and reset)
@@ -1041,13 +1041,13 @@ simulate_lazy f =
 --
 -- __NB__: This function is not synthesizable
 simulateB
-  :: forall dom conf a b
-   . ( KnownDomain dom conf
+  :: forall dom a b
+   . ( KnownDomain dom
      , Bundle a
      , Bundle b
      , Undefined a
      , Undefined b )
-  => (HiddenClockResetEnable dom conf =>
+  => (HiddenClockResetEnable dom  =>
       Unbundled dom a -> Unbundled dom b)
   -- ^ Function we want to simulate, whose components potentially have a hidden
   -- clock (and reset)
@@ -1071,11 +1071,11 @@ simulateB f =
 --
 -- __NB__: This function is not synthesizable
 simulateB_lazy
-  :: forall dom conf a b
-   . ( KnownDomain dom conf
+  :: forall dom a b
+   . ( KnownDomain dom
      , Bundle a
      , Bundle b )
-  => (HiddenClockResetEnable dom conf =>
+  => (HiddenClockResetEnable dom  =>
       Unbundled dom a -> Unbundled dom b)
   -- ^ Function we want to simulate, whose components potentially have a hidden
   -- clock (and reset)
@@ -1098,10 +1098,10 @@ dup1 _      = error "empty list"
 
 -- |  @testFor n s@ tests the signal /s/ for /n/ cycles.
 testFor
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Int
   -- ^ The number of cycles we want to test for
-  -> (HiddenClockResetEnable dom conf => Signal dom Bool)
+  -> (HiddenClockResetEnable dom  => Signal dom Bool)
   -- ^ 'Signal' we want to evaluate, whose source potentially has a hidden clock
   -- (and reset)
   -> Property
@@ -1110,9 +1110,9 @@ testFor n s = property (and (Clash.Signal.sampleN n s))
 -- ** Synchronization primitive
 -- | Implicit version of 'Clash.Explicit.Signal.unsafeSynchronizer'.
 unsafeSynchronizer
-  :: forall dom1 dom2 conf1 conf2 a
-   . ( HiddenClock dom1 conf1
-     , HiddenClock dom2 conf2 )
+  :: forall dom1 dom2 a
+   . ( HiddenClock dom1
+     , HiddenClock dom2 )
   => Signal dom1 a
   -> Signal dom2 a
 unsafeSynchronizer =

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -95,6 +95,7 @@ module Clash.Signal
   , ResetKind(..)
   , SResetKind(..)
   , ResetPolarity(..)
+  , SResetPolarity(..)
   , DomainConfiguration(..)
   , SDomainConfiguration(..)
     -- ** Default domains

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -71,9 +71,9 @@ import           Clash.XException              (Undefined)
 >>> :set -XDataKinds -XTypeOperators -XTypeApplications -XFlexibleContexts
 >>> import Clash.Prelude
 >>> let delay3 = delayed (-1 :> -1 :> -1 :> Nil)
->>> let delay2 = delayedI :: HiddenClockResetEnable dom conf => Int -> DSignal dom n Int -> DSignal dom (n + 2) Int
+>>> let delay2 = delayedI :: HiddenClockResetEnable dom  => Int -> DSignal dom n Int -> DSignal dom (n + 2) Int
 >>> let delayN2 = delayN d2
->>> let delayI2 = delayI :: HiddenClockResetEnable dom conf => Int -> DSignal dom n Int -> DSignal dom (n + 2) Int
+>>> let delayI2 = delayI :: HiddenClockResetEnable dom  => Int -> DSignal dom n Int -> DSignal dom (n + 2) Int
 >>> let countingSignals = Clash.Prelude.repeat (dfromList [0..]) :: Vec 4 (DSignal dom 0 Int)
 -}
 
@@ -81,7 +81,7 @@ import           Clash.XException              (Undefined)
 --
 -- @
 -- delay3
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   => 'DSignal' dom n Int
 --   -> 'DSignal' dom (n + 3) Int
 -- delay3 = 'delayed' (-1 ':>' -1 ':>' -1 ':>' 'Nil')
@@ -91,7 +91,7 @@ import           Clash.XException              (Undefined)
 -- [-1,-1,-1,-1,1,2,3]
 delayed
   :: ( KnownNat d
-     , HiddenClockResetEnable dom conf
+     , HiddenClockResetEnable dom
      , Undefined a
      )
   => Vec d a
@@ -103,7 +103,7 @@ delayed = hideClockResetEnable E.delayed
 --
 -- @
 -- delay2
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   => Int
 --   -> 'DSignal' dom n Int
 --   -> 'DSignal' dom (n + 2) Int
@@ -125,7 +125,7 @@ delayed = hideClockResetEnable E.delayed
 delayedI
   :: ( KnownNat d
      , Undefined a
-     , HiddenClockResetEnable dom conf )
+     , HiddenClockResetEnable dom  )
   => a
   -- ^ Initial value
   -> DSignal dom n a
@@ -136,7 +136,7 @@ delayedI = hideClockResetEnable E.delayedI
 --
 -- @
 -- delay2
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   => Int
 --   -> 'DSignal' dom n Int
 --   -> 'DSignal' dom (n + 2) Int
@@ -146,8 +146,8 @@ delayedI = hideClockResetEnable E.delayedI
 -- >>> printX $ sampleN @System 6 (toSignal (delayN2 (-1) (dfromList [1..])))
 -- [-1,-1,1,2,3,4]
 delayN
-  :: forall dom conf a d n
-   . ( HiddenClockResetEnable dom conf
+  :: forall dom  a d n
+   . ( HiddenClockResetEnable dom
      , Undefined a )
   => SNat d
   -> a
@@ -164,7 +164,7 @@ delayN d dflt = coerce . go (snatToInteger d) . coerce @_ @(Signal dom a)
 --
 -- @
 -- delayI2
---   :: HiddenClockResetEnable dom conf
+--   :: HiddenClockResetEnable dom
 --   => Int
 --   -> 'DSignal' dom n Int
 --   -> 'DSignal' dom (n + 2) Int
@@ -178,8 +178,8 @@ delayN d dflt = coerce . go (snatToInteger d) . coerce @_ @(Signal dom a)
 -- >>> sampleN @System 6 (toSignal (delayI @2 (-1) (dfromList [1..])))
 -- [-1,-1,1,2,3,4]
 delayI
-  :: forall d n a dom  conf
-   . ( HiddenClockResetEnable dom conf
+  :: forall d n a dom
+   . ( HiddenClockResetEnable dom
      , Undefined a
      , KnownNat d )
   => a
@@ -206,8 +206,8 @@ type instance Apply (DelayedFold dom n delay a) k = DSignal dom (n + (delay*k)) 
 -- >>> printX $ sampleN @System 8 (toSignal (delayedFold d2 (-1) (*) countingSignals))
 -- [-1,-1,1,1,0,1,16,81]
 delayedFold
-  :: forall dom conf n delay k a
-   . ( HiddenClockResetEnable dom conf
+  :: forall dom  n delay k a
+   . ( HiddenClockResetEnable dom
      , Undefined a
      , KnownNat delay
      , KnownNat k )

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -15,11 +15,8 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE DeriveGeneric          #-}
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE KindSignatures         #-}
 {-# LANGUAGE MagicHash              #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE StandaloneDeriving     #-}
 {-# LANGUAGE TemplateHaskell        #-}

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -224,8 +224,8 @@ traceVecSignal# traceMap period vecTraceName (unbundle -> vecSignal) =
 -- multi-clock circuits. However 'traceSignal1' might be more convenient to
 -- use when the domain of your circuit is polymorphic.
 traceSignal
-  :: forall dom conf a
-   . ( KnownDomain dom conf
+  :: forall dom  a
+   . ( KnownDomain dom
      , KnownNat (BitSize a)
      , BitPack a
      , Undefined a
@@ -271,8 +271,8 @@ traceSignal1 traceName signal =
 -- multi-clock circuits. However 'traceSignal1' might be more convinient to
 -- use when the domain of your circuit is polymorphic.
 traceVecSignal
-  :: forall dom a conf n
-   . ( KnownDomain dom conf
+  :: forall dom a  n
+   . ( KnownDomain dom
      , KnownNat (BitSize a)
      , KnownNat n
      , BitPack a

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -1330,16 +1330,16 @@ a general listing of the available template holes:
 * @~TAG[N]@: Name of given domain. Errors when called on an argument which is not
   a 'KnownDomain', 'Reset', or 'Clock'.
 * @~PERIOD[N]@: Clock period of given domain. Errors when called on an argument
-  which is not a 'KnownDomain'.
+  which is not a 'KnownDomain' or 'KnownConf'.
 * @~ISALWAYSENABLED[N]@: Is the @(N+1)@'th argument a an Enable line set to a constant
   True. Errors when called on an argument which is not an 'Enable'.
 * @~ISSYNC[N]@: Does synthesis domain at the @(N+1)@'th argument have synchronous resets. Errors
-  when called on an argument which is not a 'KnownDomain'.
+  when called on an argument which is not a 'KnownDomain' or 'KnownConf'.
 * @~ISINITDEFINED[N]@: Does synthesis domain at the @(N+1)@'th argument have defined initial
-  values. Errors when called on an argument which is not a 'KnownDomain'.
+  values. Errors when called on an argument which is not a 'KnownDomain' or 'KnownConf'.
 * @~ACTIVEEDGE[edge][N]@: Does synthesis domain at the @(N+1)@'th argument respond to
   /edge/. /edge/ must be one of 'Falling' or 'Rising'. Errors when called on an
-  argument which is not a 'KnownDomain'.
+  argument which is not a 'KnownDomain' or 'KnownConf'.
 * @~AND[\<HOLE1\>,\<HOLE2\>,..]@: Logically /and/ the conditions in the @\<HOLE\>@'s
 * @~VARS[N]@: VHDL: Return the variables at the @(N+1)@'th argument argument.
 * @~NAME[N]@: Render the @(N+1)@'th string literal argument as an identifier
@@ -1517,11 +1517,11 @@ What is /not/ possible is:
 
   @
   pow2Clocks
-    :: ( 'KnownDomain' domIn (''Domain' domIn pIn eIn rIn iIn polIn)
-       , 'KnownDomain' dom2  (''Domain' dom2 (2*pIn) e2 r2 i2 p2)
-       , 'KnownDomain' dom4  (''Domain' dom4 (4*pIn) e4 r4 i4 p4)
-       , 'KnownDomain' dom8  (''Domain' dom8 (8*pIn) e8 r8 i8 p8)
-       , 'KnownDomain' dom16 (''Domain' dom16 (16*pIn) e16 r16 i16 p16)
+    :: ( 'KnownConfiguration' domIn (''DomainConfiguration' domIn pIn eIn rIn iIn polIn)
+       , 'KnownConfiguration' dom2  (''DomainConfiguration' dom2 (2*pIn) e2 r2 i2 p2)
+       , 'KnownConfiguration' dom4  (''DomainConfiguration' dom4 (4*pIn) e4 r4 i4 p4)
+       , 'KnownConfiguration' dom8  (''DomainConfiguration' dom8 (8*pIn) e8 r8 i8 p8)
+       , 'KnownConfiguration' dom16 (''DomainConfiguration' dom16 (16*pIn) e16 r16 i16 p16)
     => 'Clock' domIn
     -> 'Reset' domIn
     -> ( 'Clock' dom16
@@ -1539,11 +1539,11 @@ What is /not/ possible is:
 
   @
   pow2Clocks'
-    :: ( 'KnownDomain' domIn (''Domain' domIn pIn eIn rIn iIn polIn)
-       , 'KnownDomain' dom2  (''Domain' dom2 (2*pIn) e2 r2 i2 p2)
-       , 'KnownDomain' dom4  (''Domain' dom4 (4*pIn) e4 r4 i4 p4)
-       , 'KnownDomain' dom8  (''Domain' dom8 (8*pIn) e8 r8 i8 p8)
-       , 'KnownDomain' dom16 (''Domain' dom16 (16*pIn) e16 r16 i16 p16)
+    :: ( 'KnownConfiguration' domIn (''DomainConfiguration' domIn pIn eIn rIn iIn polIn)
+       , 'KnownConfiguration' dom2  (''DomainConfiguration' dom2 (2*pIn) e2 r2 i2 p2)
+       , 'KnownConfiguration' dom4  (''DomainConfiguration' dom4 (4*pIn) e4 r4 i4 p4)
+       , 'KnownConfiguration' dom8  (''DomainConfiguration' dom8 (8*pIn) e8 r8 i8 p8)
+       , 'KnownConfiguration' dom16 (''DomainConfiguration' dom16 (16*pIn) e16 r16 i16 p16)
     => 'Clock' domIn
     -> 'Reset' domIn
     -> ( 'Clock' dom16

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -2427,7 +2427,7 @@ dotp :: SaturatingNum a
 dotp as bs = fold boundedAdd (zipWith boundedMul as bs)
 
 fir
-  :: ( HiddenClockResetEnable dom conf
+  :: ( HiddenClockResetEnable dom
      , Default a
      , KnownNat n
      , SaturatingNum a

--- a/clash-prelude/src/Clash/Xilinx/ClockGen.hs
+++ b/clash-prelude/src/Clash/Xilinx/ClockGen.hs
@@ -38,8 +38,8 @@ import Unsafe.Coerce
 -- @
 clockWizard
   :: forall domIn domOut periodIn periodOut edge init polarity name
-   . ( KnownDomain domIn ('DomainConfiguration domIn periodIn edge 'Asynchronous init polarity)
-     , KnownDomain domOut ('DomainConfiguration domOut periodOut edge 'Asynchronous init polarity) )
+   . ( KnownConfiguration domIn  ('DomainConfiguration domIn periodIn edge 'Asynchronous init polarity)
+     , KnownConfiguration domOut ('DomainConfiguration domOut periodOut edge 'Asynchronous init polarity) )
   => SSymbol name
   -- ^ Name of the component, must correspond to the name entered in the
   -- \"Clock Wizard\" dialog.
@@ -79,8 +79,8 @@ clockWizard _ clk rst =
 -- @
 clockWizardDifferential
   :: forall domIn domOut periodIn periodOut edge init polarity name
-   . ( KnownDomain domIn ('DomainConfiguration domIn periodIn edge 'Asynchronous init polarity)
-     , KnownDomain domOut ('DomainConfiguration domOut periodOut edge 'Asynchronous init polarity) )
+   . ( KnownConfiguration domIn ('DomainConfiguration domIn periodIn edge 'Asynchronous init polarity)
+     , KnownConfiguration domOut ('DomainConfiguration domOut periodOut edge 'Asynchronous init polarity) )
   => SSymbol name
   -- ^ Name of the component, must correspond to the name entered in the
   -- \"Clock Wizard\" dialog.

--- a/clash-prelude/src/Clash/Xilinx/DDR.hs
+++ b/clash-prelude/src/Clash/Xilinx/DDR.hs
@@ -42,8 +42,8 @@ import Clash.Explicit.DDR
 -- Reset values are @0@
 iddr
   :: ( HasCallStack
-     , KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
   => Clock slow
   -- ^ clock
@@ -64,8 +64,8 @@ iddr clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
 --
 -- Reset value is @0@
 oddr
-  :: ( KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
+  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
   => Clock slow
   -- ^ clock
@@ -80,8 +80,8 @@ oddr
 oddr clk rst en = uncurry (withFrozenCallStack oddr# clk rst en) . unbundle
 
 oddr#
-  :: ( KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
+  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
   => Clock slow
   -> Reset slow

--- a/examples/CHIP8.hs
+++ b/examples/CHIP8.hs
@@ -25,7 +25,7 @@ topEntity = exposeClockResetEnable output
     output = boolToBit . (== 0x00) . cpuOutMemAddr <$> cpuOut
 
 mealyState
-  :: ( HiddenClockResetEnable tag dom
+  :: ( HiddenClockResetEnable tag
      , Undefined s )
   => (i -> State s o)
   -> s

--- a/examples/FIR.hs
+++ b/examples/FIR.hs
@@ -10,7 +10,7 @@ dotp :: SaturatingNum a
 dotp as bs = fold boundedAdd (zipWith boundedMul as bs)
 
 fir
-  :: ( HiddenClockResetEnable tag dom
+  :: ( HiddenClockResetEnable tag
      , Default a
      , KnownNat n
      , SaturatingNum a

--- a/examples/crc32/CRC32.hs
+++ b/examples/crc32/CRC32.hs
@@ -15,7 +15,7 @@ crc32Step prevCRC byte = entry `xor` (prevCRC `shiftR` 8)
     entry = asyncRom $(lift crc32Table) (truncateB prevCRC `xor` byte)
 
 crc32
-  :: HiddenClockResetEnable tag dom
+  :: HiddenClockResetEnable tag
   => Signal tag (BitVector 8) -> Signal tag (BitVector 32)
 crc32 = moore crc32Step complement 0xFFFFFFFF . register 0
 

--- a/tests/shouldwork/Basic/AES.hs
+++ b/tests/shouldwork/Basic/AES.hs
@@ -69,8 +69,8 @@ roundLast :: Vec 4 (BitVector 32) -> AESState -> AESState
 roundLast roundKey = addRoundKey roundKey . shiftRows . subBytes
 
 keyExpander
-    :: forall dom conf
-    .  HiddenClockResetEnable dom conf
+    :: forall dom
+    .  HiddenClockResetEnable dom
     => Signal dom Bool
     -> Signal dom (BitVector 128)
     -> Signal dom (Vec 4 (BitVector 32))
@@ -83,8 +83,8 @@ keyExpander start key = keyState
     rc =  register (unpack 1) $ mux start (pure $ unpack 1) (gfDouble <$> rc)
 
 aes
-    :: forall dom conf
-    .  HiddenClockResetEnable dom conf
+    :: forall dom
+    .  HiddenClockResetEnable dom
     => Signal dom Bool
     -> Signal dom (BitVector 128)
     -> Signal dom (BitVector 128)

--- a/tests/shouldwork/Basic/MultipleHidden.hs
+++ b/tests/shouldwork/Basic/MultipleHidden.hs
@@ -9,8 +9,8 @@ createDomain vSystem{vTag="DomA"}
 createDomain vSystem{vTag="DomB"}
 
 multiClockAdd
-  :: ( HiddenClockResetEnable domA confA
-     , HiddenClockResetEnable domB confB )
+  :: ( HiddenClockResetEnable domA
+     , HiddenClockResetEnable domB )
   => Signal domA (Unsigned 16)
   -> Signal domB (Unsigned 16)
   -> Signal domA (Unsigned 16)
@@ -22,9 +22,9 @@ multiClockAdd a0 b0 = a1 + unsafeSynchronizer b2
   b2 = register 0 b1
 
 topEntityI
-  :: forall domA domB confA confB
-   . ( HiddenClockResetEnable domA confA
-     , HiddenClockResetEnable domB confB )
+  :: forall domA domB
+   . ( HiddenClockResetEnable domA
+     , HiddenClockResetEnable domB )
   => Signal domA (Unsigned 16)
   -> Signal domB (Unsigned 16)
   -> Signal domA (Unsigned 16)

--- a/tests/shouldwork/CoSim/Multiply.hs
+++ b/tests/shouldwork/CoSim/Multiply.hs
@@ -4,7 +4,7 @@ import Clash.CoSim
 import Clash.Explicit.Prelude
 
 verilog_mult
-  :: KnownDomain d dom
+  :: KnownDomain d
   => Signal d (Signed 64)
   -> Signal d (Signed 64)
   -> Signal d (Signed 64)

--- a/tests/shouldwork/CoSim/Register.hs
+++ b/tests/shouldwork/CoSim/Register.hs
@@ -5,7 +5,7 @@ import Clash.CoSim
 import Clash.Explicit.Prelude
 
 verilog_register
-  :: KnownDomain d dom
+  :: KnownDomain d
   => Clock  d
   -> Reset d
   -> Signal d (Signed 64)

--- a/tests/shouldwork/DDR/DDRin.hs
+++ b/tests/shouldwork/DDR/DDRin.hs
@@ -18,8 +18,8 @@ The four variants defined here are all the combinations of
 -}
 
 topEntityGeneric
-  :: ( KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
+  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
   -> Reset slow
   -> Enable slow

--- a/tests/shouldwork/DDR/DDRout.hs
+++ b/tests/shouldwork/DDR/DDRout.hs
@@ -18,8 +18,8 @@ The four variants defined here are all the combinations of
 -}
 
 topEntityGeneric
-  :: ( KnownDomain fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownDomain slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
+  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
   -> Reset slow
   -> Enable slow

--- a/tests/shouldwork/DSignal/DelayI.hs
+++ b/tests/shouldwork/DSignal/DelayI.hs
@@ -5,7 +5,7 @@ import qualified Clash.Signal.Delayed.Bundle as D
 import Clash.Explicit.Testbench
 
 zeroAt0
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => DSignal dom n Int
   -> DSignal dom n Int
 zeroAt0 a = unsafeFromSignal (mux en (toSignal a) 0)
@@ -13,7 +13,7 @@ zeroAt0 a = unsafeFromSignal (mux en (toSignal a) 0)
     en = register False (pure True)
 
 delayer
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => DSignal dom 0 Int
   -> DSignal dom 2 Int
 delayer = zeroAt0 . delayI 0

--- a/tests/shouldwork/DSignal/DelayN.hs
+++ b/tests/shouldwork/DSignal/DelayN.hs
@@ -5,7 +5,7 @@ import qualified Clash.Signal.Delayed.Bundle as D
 import Clash.Explicit.Testbench
 
 zeroAt0
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => DSignal dom n Int
   -> DSignal dom n Int
 zeroAt0 a = unsafeFromSignal (mux en (toSignal a) 0)
@@ -13,7 +13,7 @@ zeroAt0 a = unsafeFromSignal (mux en (toSignal a) 0)
     en = register False (pure True)
 
 delayer
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => DSignal dom 0 Int
   -> DSignal dom 2 Int
 delayer = zeroAt0 . delayN d2 0

--- a/tests/shouldwork/DSignal/DelayedFold.hs
+++ b/tests/shouldwork/DSignal/DelayedFold.hs
@@ -5,7 +5,7 @@ import qualified Clash.Signal.Delayed.Bundle as D
 import Clash.Explicit.Testbench
 
 zeroAt0
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => DSignal dom n Int
   -> DSignal dom n Int
 zeroAt0 a = unsafeFromSignal (mux en (toSignal a) 0)
@@ -13,7 +13,7 @@ zeroAt0 a = unsafeFromSignal (mux en (toSignal a) 0)
     en = register False (pure True)
 
 folder
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => DSignal dom 0 (Vec 4 Int)
   -> DSignal dom 2 Int
 folder = zeroAt0 . delayedFold d1 0 (+) . D.unbundle

--- a/tests/shouldwork/Feedback/Fib.hs
+++ b/tests/shouldwork/Feedback/Fib.hs
@@ -3,7 +3,7 @@ module Fib where
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
-fib :: HiddenClockResetEnable dom conf => Signal dom (Unsigned 64)
+fib :: HiddenClockResetEnable dom => Signal dom (Unsigned 64)
 fib = register 1 fib + register 0 (register 0 fib)
 
 topEntity

--- a/tests/shouldwork/Signal/BlockRam1.hs
+++ b/tests/shouldwork/Signal/BlockRam1.hs
@@ -5,7 +5,7 @@ import Clash.Explicit.Testbench
 import qualified Clash.Explicit.Prelude as Explicit
 
 zeroAt0
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom (Unsigned 8)
   -> Signal dom (Unsigned 8)
 zeroAt0 a = mux en a 0

--- a/tests/shouldwork/Signal/BlockRamFile.hs
+++ b/tests/shouldwork/Signal/BlockRamFile.hs
@@ -5,7 +5,7 @@ import Clash.Explicit.Testbench
 import qualified Clash.Explicit.Prelude as Explicit
 
 zeroAt0
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom (Unsigned 8) -> Signal dom (Unsigned 8)
 zeroAt0 a = mux en a 0
   where

--- a/tests/shouldwork/Signal/Ram.hs
+++ b/tests/shouldwork/Signal/Ram.hs
@@ -6,7 +6,7 @@ import Clash.Explicit.Testbench
 import qualified Data.List as L
 
 zeroAt0
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom (Unsigned 8,Unsigned 8)
   -> Signal dom (Unsigned 8,Unsigned 8)
 zeroAt0 a = mux en a (bundle (0,0))

--- a/tests/shouldwork/Signal/RegisterAE.hs
+++ b/tests/shouldwork/Signal/RegisterAE.hs
@@ -8,7 +8,7 @@ testInput :: Vec 7 (Signed 8)
 testInput = 1 :> 2 :> 3 :> 4 :> 5 :> 6 :> 7 :> Nil
 
 resetInput
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -21,7 +21,7 @@ resetInput clk reset en
   $ pure False
 
 enableInput
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom

--- a/tests/shouldwork/Signal/RegisterAR.hs
+++ b/tests/shouldwork/Signal/RegisterAR.hs
@@ -8,7 +8,7 @@ testInput :: Vec 7 (Signed 8)
 testInput = 1 :> 2 :> 3 :> 4 :> 5 :> 6 :> 7 :> Nil
 
 resetInput
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom

--- a/tests/shouldwork/Signal/RegisterSE.hs
+++ b/tests/shouldwork/Signal/RegisterSE.hs
@@ -8,7 +8,7 @@ testInput :: Vec 7 (Signed 8)
 testInput = 1 :> 2 :> 3 :> 4 :> 5 :> 6 :> 7 :> Nil
 
 resetInput
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -21,7 +21,7 @@ resetInput clk reset en
   $ pure False
 
 enableInput
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom

--- a/tests/shouldwork/Signal/RegisterSR.hs
+++ b/tests/shouldwork/Signal/RegisterSR.hs
@@ -8,7 +8,7 @@ testInput :: Vec 7 (Signed 8)
 testInput = 1 :> 2 :> 3 :> 4 :> 5 :> 6 :> 7 :> Nil
 
 resetInput
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom

--- a/tests/shouldwork/Signal/ResetLow.hs
+++ b/tests/shouldwork/Signal/ResetLow.hs
@@ -8,7 +8,7 @@ testInput :: Vec 7 (Signed 8)
 testInput = 1 :> 2 :> 3 :> 4 :> 5 :> 6 :> 7 :> Nil
 
 resetInput
-  :: KnownDomain dom conf
+  :: KnownDomain dom
   => Clock dom
   -> Reset dom
   -> Enable dom

--- a/tests/shouldwork/Signal/Rom.hs
+++ b/tests/shouldwork/Signal/Rom.hs
@@ -6,7 +6,7 @@ import Clash.Explicit.Testbench
 import qualified Data.List as L
 
 zeroAt0
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom (Unsigned 8,Unsigned 8)
   -> Signal dom (Unsigned 8,Unsigned 8)
 zeroAt0 a = mux en a (bundle (0,0))

--- a/tests/shouldwork/Signal/RomFile.hs
+++ b/tests/shouldwork/Signal/RomFile.hs
@@ -5,7 +5,7 @@ import qualified Clash.Explicit.Prelude as Explicit
 import Clash.Explicit.Testbench
 
 zeroAt0
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Signal dom (Unsigned 8)
   -> Signal dom (Unsigned 8)
 zeroAt0 a = mux en a 0

--- a/tests/shouldwork/Testbench/SyncTB.hs
+++ b/tests/shouldwork/Testbench/SyncTB.hs
@@ -10,8 +10,8 @@ createDomain vSystem{vTag="Dom7", vPeriod=7}
 createDomain vSystem{vTag="Dom9", vPeriod=9}
 
 zeroAt0
-  :: forall dom a conf
-   . (KnownDomain dom conf, Num a)
+  :: forall dom a
+   . (KnownDomain dom, Num a)
   => Clock dom
   -> Reset dom
   -> Signal dom a

--- a/tests/shouldwork/Vector/FoldlFuns.hs
+++ b/tests/shouldwork/Vector/FoldlFuns.hs
@@ -10,8 +10,8 @@ func
 func d c = 0
 
 mod'
-    :: forall dom conf
-     . HiddenClockResetEnable dom conf
+    :: forall dom
+     . HiddenClockResetEnable dom
     => Signal dom (BitVector 32)
 mod' = o
     where

--- a/tests/shouldwork/Vector/MovingAvg.hs
+++ b/tests/shouldwork/Vector/MovingAvg.hs
@@ -3,7 +3,7 @@ module MovingAvg where
 import Clash.Prelude
 
 windowN
-  :: HiddenClockResetEnable dom conf
+  :: HiddenClockResetEnable dom
   => Default a
   => KnownNat n
   => Undefined a

--- a/testsuite/Test/Tasty/Clash.hs
+++ b/testsuite/Test/Tasty/Clash.hs
@@ -600,7 +600,6 @@ outputTest' env target extraClashArgs extraGhcArgs modName funcName path =
              , "-XKindSignatures"
              , "-XMagicHash"
              , "-XMonoLocalBinds"
-             , "-XMultiParamTypeClasses"
              , "-XNoImplicitPrelude"
              , "-XNoMonomorphismRestriction"
 #if __GLASGOW_HASKELL__ < 806


### PR DESCRIPTION
And make the configuration for a domain an associated type family. This simplifies usage of the new API.