### PR TITLE
Hide successes in CI

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -6,4 +6,4 @@ set -xeo pipefail
 cabal --write-ghc-environment-files=always new-build all
 
 cabal new-test clash-cosim clash-prelude
-cabal new-run -- clash-testsuite -j$THREADS
+cabal new-run -- clash-testsuite -j$THREADS --hide-successes


### PR DESCRIPTION
Loading a CI log on GitLab currently kills Firefox for a solid 30 seconds. This patch hides output produced by successful tests. This therefore also hides warnings produced by Clash/simulators, which might not be what we want. But, I'd argue that if we want our testbenches to compile without warnings, we should check for it explicitly and throw an error if it does.