### PR TITLE
 Reliably handle hidden resets in 'withReset' and siblings 

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -291,6 +291,7 @@ test-suite unittests
                  Clash.Tests.BitVector
                  Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes
+                 Clash.Tests.Signal
                  Clash.Tests.Undefined
 
 

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -895,12 +895,7 @@ sample
   -- (and reset)
   -> [a]
 sample s =
-  case knownDomain @dom of
-    SDomainConfiguration dom _ _ _ _ _ ->
-      let clk = Clock dom in
-      let rst = Reset (True :- pure False) in
-      let en = S.enableGen in
-      S.sample (exposeClockResetEnable s clk rst en)
+  S.sample (exposeClockResetEnable s clockGen (resetGen @dom) enableGen)
 {-# NOINLINE sample #-}
 
 -- | Get a list of /n/ samples from a 'Signal'
@@ -921,13 +916,9 @@ sampleN
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
   -- (and reset)
   -> [a]
-sampleN n s =
-  case knownDomain @dom of
-    SDomainConfiguration dom _ _ _ _ _ ->
-      let clk = Clock dom in
-      let rst = Reset (True :- pure False) in
-      let en = S.enableGen in
-      S.sampleN n (exposeClockResetEnable s clk rst en)
+sampleN n s0 =
+  let s1 = exposeClockResetEnable s0 clockGen (resetGen @dom) enableGen in
+  S.sampleN n s1
 {-# NOINLINE sampleN #-}
 
 -- | /Lazily/ get an infinite list of samples from a 'Clash.Signal.Signal'
@@ -946,12 +937,7 @@ sample_lazy
   -- (and reset)
   -> [a]
 sample_lazy s =
-  case knownDomain @dom of
-    SDomainConfiguration dom _ _ _ _ _ ->
-      let clk = Clock dom in
-      let rst = Reset (True :- pure False) in
-      let en = S.enableGen in
-      S.sample_lazy (exposeClockResetEnable s clk rst en)
+  S.sample_lazy (exposeClockResetEnable s clockGen (resetGen @dom) enableGen)
 {-# NOINLINE sample_lazy #-}
 
 -- | Lazily get a list of /n/ samples from a 'Signal'
@@ -971,12 +957,7 @@ sampleN_lazy
   -- (and reset)
   -> [a]
 sampleN_lazy n s =
-  case knownDomain @dom of
-    SDomainConfiguration dom _ _ _ _ _ ->
-      let clk = Clock dom in
-      let rst = Reset (True :- pure False) in
-      let en = S.enableGen in
-      S.sampleN_lazy n (exposeClockResetEnable s clk rst en)
+  S.sampleN_lazy n (exposeClockResetEnable s clockGen (resetGen @dom) enableGen)
 {-# NOINLINE sampleN_lazy #-}
 
 -- * Simulation functions
@@ -1002,14 +983,9 @@ simulate
   -- (and reset)
   -> [a]
   -> [b]
-simulate f =
-  case knownDomain @dom of
-    SDomainConfiguration dom _ _ _ _ _ ->
-      let clk = Clock dom in
-      let rst = Reset (True :- pure False) in
-      let en = S.enableGen in
-      -- TODO: Explain why we skip the the first value here
-      tail . S.simulate (exposeClockResetEnable f clk rst en) . dup1
+simulate f0 =
+  let f1 = exposeClockResetEnable f0 clockGen (resetGen @dom) enableGen in
+  tail . S.simulate f1 . dup1
 {-# NOINLINE simulate #-}
 
 -- | /Lazily/ simulate a (@'Signal' a -> 'Signal' b@) function given a list of
@@ -1029,13 +1005,9 @@ simulate_lazy
   -- clock (and reset)
   -> [a]
   -> [b]
-simulate_lazy f =
-  case knownDomain @dom of
-    SDomainConfiguration dom _ _ _ _ _ ->
-      let clk = Clock dom in
-      let rst = Reset (True :- pure False) in
-      let en = S.enableGen in
-      tail . S.simulate_lazy (exposeClockResetEnable f clk rst en) . dup1
+simulate_lazy f0 =
+  let f1 = exposeClockResetEnable f0 clockGen (resetGen @dom) enableGen in
+  tail . S.simulate_lazy f1 . dup1
 {-# NOINLINE simulate_lazy #-}
 
 -- | Simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a list of
@@ -1059,13 +1031,9 @@ simulateB
   -- clock (and reset)
   -> [a]
   -> [b]
-simulateB f =
-  case knownDomain @dom of
-    SDomainConfiguration dom _ _ _ _ _ ->
-      let clk = Clock dom in
-      let rst = Reset (True :- pure False) in
-      let en = S.enableGen in
-      tail . S.simulateB (exposeClockResetEnable f clk rst en) . dup1
+simulateB f0 =
+  let f1 = exposeClockResetEnable f0 clockGen (resetGen @dom) enableGen in
+  tail . S.simulateB f1 . dup1
 {-# NOINLINE simulateB #-}
 
 -- | /Lazily/ simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a
@@ -1087,13 +1055,9 @@ simulateB_lazy
   -- clock (and reset)
   -> [a]
   -> [b]
-simulateB_lazy f =
-  case knownDomain @dom of
-    SDomainConfiguration dom _ _ _ _ _ ->
-      let clk = Clock dom in
-      let rst = Reset (True :- pure False) in
-      let en = S.enableGen in
-      tail . S.simulateB_lazy (exposeClockResetEnable f clk rst en) . dup1
+simulateB_lazy f0 =
+  let f1 = exposeClockResetEnable f0 clockGen (resetGen @dom) enableGen in
+  tail . S.simulateB_lazy f1 . dup1
 {-# NOINLINE simulateB_lazy #-}
 
 dup1 :: [a] -> [a]

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -141,24 +141,32 @@ module Clash.Signal
   , hideClock
   , exposeClock
   , withClock
+  , withClock0
+  , withClockProxy
   , hasClock
     -- ** Hidden reset
   , HiddenReset
   , hideReset
   , exposeReset
   , withReset
+  , withReset0
+  , withResetProxy
   , hasReset
     -- ** Hidden enable
   , HiddenEnable
   , hideEnable
   , exposeEnable
   , withEnable
+  , withEnable0
+  , withEnableProxy
   , hasEnable
     -- ** Hidden clock, reset, and enable
   , HiddenClockResetEnable
   , hideClockResetEnable
   , exposeClockResetEnable
   , withClockResetEnable
+  , withClockResetEnable0
+  , withClockResetEnableProxy
   , SystemClockResetEnable
     -- * Basic circuit functions
   , dflipflop
@@ -214,6 +222,7 @@ import           GHC.TypeLits
   (KnownNat, KnownSymbol, AppendSymbol, Symbol)
 import           Data.Bits             (Bits) -- Haddock only
 import           Data.Maybe            (isJust, fromJust)
+import           Data.Proxy            (Proxy(..))
 import           Prelude
 import           Test.QuickCheck       (Property, property)
 
@@ -435,21 +444,51 @@ hideClock
 hideClock = \f -> f (fromLabel @(HiddenClockName dom))
 {-# INLINE hideClock #-}
 
--- | Connect an explicit 'Clock' to a function with a hidden 'Clock' argument.
+-- | Connect an explicit 'Clock' to a function with a hidden 'Clock'. This
+-- version (also see: 'withClockProxy' and 'withClock') applies a clock to
+-- a @Signal dom a@.
 --
--- @
--- withClock = 'flip' exposeClock
--- @
-withClock
-  :: forall dom r
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withClock0
+  :: forall dom a
    . KnownDomain dom
   => Clock dom
   -- ^ The 'Clock' we want to connect
-  -> (HiddenClock dom  => r)
+  -> (HiddenClock dom => Signal dom a)
   -- ^ The function with a hidden 'Clock' argument
-  -> r
-withClock = \clk f -> expose @(HiddenClockName dom) f clk
+  -> Signal dom a
+withClock0 = \rst f -> expose @(HiddenClockName dom) f rst
+{-# INLINE withClock0 #-}
+
+-- | Connect an explicit 'Clock' to a function with a hidden 'Clock'. This
+-- version (also see: 'withClockProxy' and 'withClock0') takes a function
+-- taking at least one argument of type @Signal dom a@.
+--
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withClock
+  :: forall dom r a
+   . KnownDomain dom
+  => Clock dom
+  -- ^ The 'Clock' we want to connect
+  -> (HiddenClock dom => Signal dom a -> r)
+  -- ^ The function with a hidden 'Clock' argument
+  -> (Signal dom a -> r)
+withClock = \rst f -> expose @(HiddenClockName dom) f rst
 {-# INLINE withClock #-}
+
+-- | Connect an explicit 'Clock' to a function with a hidden 'Clock'. This
+-- version (also see: 'withClock' and 'withClock0') takes a function
+-- taking a proxy argument witnessing /dom/.
+--
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withClockProxy
+  :: forall dom r
+   . KnownDomain dom
+  => Clock dom
+  -> (HiddenClock dom => Proxy dom -> r)
+  -> r
+withClockProxy = \rst f -> expose @(HiddenClockName dom) (f (Proxy @dom)) rst
+{-# INLINE withClockProxy #-}
 
 -- | Connect a hidden 'Clock' to an argument where a normal 'Clock' argument
 -- was expected.
@@ -468,7 +507,7 @@ hasClock = fromLabel @(HiddenClockName dom)
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 exposeReset
   :: forall dom r
-   . (HiddenReset dom  => r)
+   . (HiddenReset dom => r)
   -- ^ The component with a hidden reset
   -> (KnownDomain dom => Reset dom -> r)
   -- ^ The component with its reset argument exposed
@@ -487,23 +526,51 @@ hideReset
 hideReset = \f -> f (fromLabel @(HiddenResetName dom))
 {-# INLINE hideReset #-}
 
--- | Connect an explicit 'Reset' to a function with a hidden 'Reset' argument.
---
--- @
--- withReset = 'flip' exposeReset
--- @
+-- | Connect an explicit 'Reset' to a function with a hidden 'Reset'. This
+-- version (also see: 'withResetProxy' and 'withReset') applies a reset to
+-- a @Signal dom a@.
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
-withReset
-  :: forall dom r
+withReset0
+  :: forall dom a
    . KnownDomain dom
   => Reset dom
   -- ^ The 'Reset' we want to connect
-  -> (HiddenReset dom  => r)
+  -> (HiddenReset dom => Signal dom a)
   -- ^ The function with a hidden 'Reset' argument
-  -> r
+  -> Signal dom a
+withReset0 = \rst f -> expose @(HiddenResetName dom) f rst
+{-# INLINE withReset0 #-}
+
+-- | Connect an explicit 'Reset' to a function with a hidden 'Reset'. This
+-- version (also see: 'withResetProxy' and 'withReset0') takes a function
+-- taking at least one argument of type @Signal dom a@.
+--
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withReset
+  :: forall dom r a
+   . KnownDomain dom
+  => Reset dom
+  -- ^ The 'Reset' we want to connect
+  -> (HiddenReset dom => Signal dom a -> r)
+  -- ^ The function with a hidden 'Reset' argument
+  -> (Signal dom a -> r)
 withReset = \rst f -> expose @(HiddenResetName dom) f rst
 {-# INLINE withReset #-}
+
+-- | Connect an explicit 'Reset' to a function with a hidden 'Reset'. This
+-- version (also see: 'withReset' and 'withReset0') takes a function
+-- taking a proxy argument witnessing /dom/.
+--
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withResetProxy
+  :: forall dom r
+   . KnownDomain dom
+  => Reset dom
+  -> (HiddenReset dom => Proxy dom -> r)
+  -> r
+withResetProxy = \rst f -> expose @(HiddenResetName dom) (f (Proxy @dom)) rst
+{-# INLINE withResetProxy #-}
 
 -- | Connect a hidden 'Reset' to an argument where a normal 'Reset' argument
 -- was expected.
@@ -541,23 +608,51 @@ hideEnable
 hideEnable = \f -> f (fromLabel @(HiddenEnableName dom))
 {-# INLINE hideEnable #-}
 
--- | Connect an explicit 'Enable' to a function with a hidden 'Enable' argument.
---
--- @
--- withEnable = 'flip' exposeEnable
--- @
+-- | Connect an explicit 'Enable' to a function with a hidden 'Enable'. This
+-- version (also see: 'withEnableProxy' and 'withEnable') applies an enable to
+-- a @Signal dom a@.
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
-withEnable
-  :: forall dom r
+withEnable0
+  :: forall dom a
    . KnownDomain dom
   => Enable dom
   -- ^ The 'Enable' we want to connect
-  -> (HiddenEnable dom  => r)
+  -> (HiddenEnable dom => Signal dom a)
   -- ^ The function with a hidden 'Enable' argument
-  -> r
+  -> Signal dom a
+withEnable0 = \rst f -> expose @(HiddenEnableName dom) f rst
+{-# INLINE withEnable0 #-}
+
+-- | Connect an explicit 'Enable' to a function with a hidden 'Enable'. This
+-- version (also see: 'withEnableProxy' and 'withEnable0') takes a function
+-- taking at least one argument of type @Signal dom a@.
+--
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withEnable
+  :: forall dom r a
+   . KnownDomain dom
+  => Enable dom
+  -- ^ The 'Enable' we want to connect
+  -> (HiddenEnable dom => Signal dom a -> r)
+  -- ^ The function with a hidden 'Enable' argument
+  -> (Signal dom a -> r)
 withEnable = \rst f -> expose @(HiddenEnableName dom) f rst
 {-# INLINE withEnable #-}
+
+-- | Connect an explicit 'Enable' to a function with a hidden 'Enable'. This
+-- version (also see: 'withEnable' and 'withEnable0') takes a function
+-- taking a proxy argument witnessing /dom/.
+--
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withEnableProxy
+  :: forall dom r
+   . KnownDomain dom
+  => Enable dom
+  -> (HiddenEnable dom => Proxy dom -> r)
+  -> r
+withEnableProxy = \rst f -> expose @(HiddenEnableName dom) (f (Proxy @dom)) rst
+{-# INLINE withEnableProxy #-}
 
 -- | Connect a hidden 'Enable' to an argument where a normal 'Enable' argument
 -- was expected.
@@ -631,41 +726,13 @@ hideClockResetEnable =
 {-# INLINE hideClockResetEnable #-}
 
 -- | Connect an explicit 'Clock' and 'Reset' to a function with a hidden
--- 'Clock' and 'Reset' argument. In order for this function to work as
--- expected, you need to explicitly relate the /dom/ in the arguments with
--- the result. You can do this either by supplying a type signature:
---
--- @
--- h :: Clock System -> Reset System -> Signal System Int
--- h = withClockReset clk rst f
--- @
---
--- Or by type applying both sides:
---
--- @
--- g = withClockReset @System clk rst (f @System)
--- @
---
--- If omitted, GHC / Clash will fail to infer the type you might expect. This
--- is a known limitation in GHC / Haskell for now. Monomorphism isn't
--- a requirement. I.e., the following is fine:
---
--- @
--- i :: Clock dom -> Reset dom -> Signal dom Int
--- i = withClockReset clk rst f
--- @
---
--- as well as
---
--- @
--- j = withClockReset @dom clk rst (f @dom)
--- @
---
--- .. as they both explicitly "connect" the /dom/ in the arguments and result.
+-- 'Clock' and 'Reset' argument. This version takes a signal that has yet
+-- to be applied to clock/reset/enable. Also see: 'withClockResetEnable'
+-- and 'withClockResetEnableProxy'.
 --
 -- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
-withClockResetEnable
-  :: forall dom r
+withClockResetEnable0
+  :: forall dom a
    . KnownDomain dom
   => Clock dom
   -- ^ The 'Clock' we want to connect
@@ -673,10 +740,43 @@ withClockResetEnable
   -- ^ The 'Reset' we want to connect
   -> Enable dom
   -- ^ The 'Enable' we want to connect
-  -> (HiddenClockResetEnable dom => r)
+  -> (HiddenClockResetEnable dom => Signal dom a)
   -- ^ The function with a hidden 'Clock', hidden 'Reset', and hidden
   -- 'Enable' argument
-  -> r
+  -> Signal dom a
+withClockResetEnable0 =
+  \clk rst en f ->
+    expose
+      @(HiddenEnableName dom)
+      ( expose
+          @(HiddenResetName dom)
+          ( expose
+              @(HiddenClockName dom)
+              f
+              clk)
+          rst )
+      en
+{-# INLINE withClockResetEnable0 #-}
+
+-- | Connect an explicit 'Clock' and 'Reset' to a function with a hidden
+-- 'Clock' and 'Reset' argument. This version takes a function whose first
+-- argument is of type @Signal dom a@. Also see: 'withClockResetEnable0'
+-- and 'withClockResetEnableProxy'.
+--
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withClockResetEnable
+  :: forall dom r a
+   . KnownDomain dom
+  => Clock dom
+  -- ^ The 'Clock' we want to connect
+  -> Reset dom
+  -- ^ The 'Reset' we want to connect
+  -> Enable dom
+  -- ^ The 'Enable' we want to connect
+  -> (HiddenClockResetEnable dom => Signal dom a -> r)
+  -- ^ The function with a hidden 'Clock', hidden 'Reset', and hidden
+  -- 'Enable' argument
+  -> (Signal dom a -> r)
 withClockResetEnable =
   \clk rst en f ->
     expose
@@ -690,6 +790,37 @@ withClockResetEnable =
           rst )
       en
 {-# INLINE withClockResetEnable #-}
+
+-- | Connect an explicit 'Clock', 'Reset', and 'Enable' to a function with a
+-- hidden 'Clock', 'Reset', and 'Enable' argument.
+--
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
+withClockResetEnableProxy
+  :: forall dom r
+   . KnownDomain dom
+  => Clock dom
+  -- ^ The 'Clock' we want to connect
+  -> Reset dom
+  -- ^ The 'Reset' we want to connect
+  -> Enable dom
+  -- ^ The 'Enable' we want to connect
+  -> (HiddenClockResetEnable dom => Proxy dom -> r)
+  -- ^ The function with a hidden 'Clock', hidden 'Reset', and hidden
+  -- 'Enable' argument
+  -> r
+withClockResetEnableProxy =
+  \clk rst en f ->
+    expose
+      @(HiddenEnableName dom)
+      ( expose
+          @(HiddenResetName dom)
+          ( expose
+              @(HiddenClockName dom)
+              (f (Proxy @dom))
+              clk)
+          rst )
+      en
+{-# INLINE withClockResetEnableProxy #-}
 
 -- * Basic circuit functions
 

--- a/clash-prelude/tests/Clash/Tests/Signal.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+
+module Clash.Tests.Signal where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Clash.Signal
+
+
+tests :: TestTree
+tests =
+  testGroup
+    "Signal"
+    [ testGroup
+        "Implicit"
+        [ -- See: https://github.com/clash-lang/clash-compiler/pull/655
+          let rst0 = fromList [True, True, False, False, True, True]
+              rst1 = unsafeFromHighPolarity rst0
+              reg  = register 'a' (pure 'b')
+              sig = withReset0 rst1 reg
+          in  testCase "withReset0" (sampleN @System 6 sig @?= "aaabaa")
+        ]
+    ]

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import qualified Clash.Tests.BitPack
 import qualified Clash.Tests.BitVector
 import qualified Clash.Tests.DerivingDataRepr
+import qualified Clash.Tests.Signal
 import qualified Clash.Tests.Undefined
 
 tests :: TestTree
@@ -12,6 +13,7 @@ tests = testGroup "Unittests"
   [ Clash.Tests.BitPack.tests
   , Clash.Tests.BitVector.tests
   , Clash.Tests.DerivingDataRepr.tests
+  , Clash.Tests.Signal.tests
   , Clash.Tests.Undefined.tests
   ]
 

--- a/tests/shouldwork/CustomReprs/Deriving/BitPackDerivation.hs
+++ b/tests/shouldwork/CustomReprs/Deriving/BitPackDerivation.hs
@@ -47,7 +47,7 @@ testBench = done'
                                             :> Nil
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable
+      withClockResetEnable0
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
+++ b/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
@@ -37,7 +37,7 @@ testBench = done'
 
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable
+      withClockResetEnable0
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
+++ b/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
@@ -91,7 +91,7 @@ testBench = done'
 
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable
+      withClockResetEnable0
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
@@ -58,7 +58,7 @@ testBench = done'
 
     done = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable
+      withClockResetEnable0
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
@@ -102,7 +102,7 @@ testBench = done'
 
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable
+      withClockResetEnable0
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
+++ b/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
@@ -98,7 +98,7 @@ testBench = done'
 
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable
+      withClockResetEnable0
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/SynthesisAttributes/Product.hs
+++ b/tests/shouldwork/SynthesisAttributes/Product.hs
@@ -100,4 +100,4 @@ testBench = done'
                                                   ])
 
     done           = expectedOutput (topEntity testInput)
-    done'          = withClockResetEnable (tbSystemClockGen (not <$> done')) systemResetGen enableGen done
+    done'          = withClockResetEnable0 (tbSystemClockGen (not <$> done')) systemResetGen enableGen done

--- a/tests/shouldwork/Vector/FoldlFuns.hs
+++ b/tests/shouldwork/Vector/FoldlFuns.hs
@@ -28,4 +28,4 @@ mod' = o
     o :: Signal dom (BitVector 32)
     o = f (pure 0)
 
-topEntity clk rst en = withClockResetEnable @System clk rst en (mod' @System)
+topEntity clk rst en = withClockResetEnable0 @System clk rst en (mod' @System)


### PR DESCRIPTION
I was bitten by the surprising behavior of `withReset` today. This led @leonschoorl and I chasing lots of red herrings, even though -in retrospect- I had seen the issue before in an only slightly different context. The commit below describes what we did in order to mitigate the issues we found. Note that we don't have a satisfactory answer for bundled types yet.. 

-----------------

Before this commit, 'withReset' would behave very surprisingly in
combination with 'simulate' or 'sample':

    >>> rst0 = fromList [True, True, False, False, True, True]
    >>> rst1 = unsafeFromHighPolarity @System rst0
    >>> sig = withReset rst1 (register 'a' (pure 'b'))
    >>> sampleN @System 6 sig
    "aabbbb"

Even though rst1 is asserted on the 5th and 6th clock cycle, we never
see the reset value, a, after the initial two. But even the first two
as are suspicious. We'd expect to see three as (one powerup, two
reset) instead! It seems that 'sampleN' is generating a default reset
value and using that one. Indeed, when we inspect the type of sig we
see it is as we never applied the reset at all:

    >>> :t sig
    (HiddenReset dom, ..) => Signal dom Char

To figure out what's going on, let's inspect the type signature of
'withReset':

    withReset
      :: KnownDomain dom
      => Reset dom
      -> (HiddenReset dom => r)
      -> r

It turns out that GHC is perfectly happy to /only/ resolve r when
given the following as its second argument:

    reg :: (HiddenReset dom, ..) => Signal dom Char
    reg = register 'a' (pure 'b')

i.e., withReset would conceptually resolve to something like:

    withReset*
      :: forall dom r
       . KnownDomain dom
      => Reset dom
      -> (HiddenReset dom  => (HiddenReset dom0 => Signal dom0 Char))
      -> (HiddenReset dom0 => Signal dom0 Char)

thus completely discarding its given reset, and leaving it up to
sample to actually generate the reset. The reason GHC is free to do
this, is that nothing in r ties dom to the "dom inside r" simply
because it's not mentioned in the type signature.

This commit adds a few variants of 'withReset' that explicitly take
an argument, thus "tying" the `dom` in that argument to the result of
the function given to it.

'withReset0' behaves exactly like we expect it would:

    >>> rst0 = fromList [True, True, False, False, True, True]
    >>> rst1 = unsafeFromHighPolarity rst0
    >>> sig = withReset0 rst1 (register 'a' (pure 'b'))
    >>> sampleN @System 6 sig
    "aaabaa"

