### PR TITLE
clash-term: Terminal UI for inspecting rewrites

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,7 @@ packages:
   ./benchmark/*.cabal
   ./benchmark/profiling/prepare/*.cabal
   ./benchmark/profiling/run/*.cabal
+  ./clash-term/*.cabal
 
 allow-newer: *:Cabal, *:array, *:base, *:binary, *:^bytestring, *:containers,
   *:deepseq, *:directory, *:filepath, *:ghc, *:ghc-boot, *:ghc-boot-th,
@@ -46,7 +47,9 @@ package clash-testsuite
 package clash-lib
   flags: debug
 
-optional-packages: clash-cosim/clash-cosim.cabal
+optional-packages:
+  clash-cosim/clash-cosim.cabal,
+  clash-term/clash-term.cabal
 
 -- The fail package is empty for GHC 8+, and haddock errors out on it
 package fail

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -78,6 +78,12 @@ flag debug
    default: False
    manual: True
 
+flag history
+   description:
+     Emit rewrite history to disk
+   default: False
+   manual: True
+
 Library
   HS-Source-Dirs:     src
 
@@ -214,3 +220,6 @@ Library
 
   if flag(debug)
     cpp-options:      -DDEBUG
+
+  if flag(history)
+    cpp-options:      -DHISTORY

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -18,6 +18,7 @@
 module Clash.Core.Pretty
   ( PrettyPrec (..)
   , PrettyOptions (..)
+  , ClashDoc
   , ClashAnnotation (..)
   , SyntaxElement (..)
   , ppr, ppr'

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -12,10 +12,13 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
 
 module Clash.Rewrite.Types where
 
 import Control.Concurrent.Supply             (Supply, freshId)
+import Control.DeepSeq                       (NFData)
 import Control.Lens                          (use, (.=))
 import Control.Monad.Fail                    (MonadFail(fail))
 import Control.Monad.Fix                     (MonadFix (..), fix)
@@ -23,8 +26,11 @@ import Control.Monad.Reader                  (MonadReader (..))
 import Control.Monad.State                   (MonadState (..))
 import Control.Monad.State.Strict            (State)
 import Control.Monad.Writer                  (MonadWriter (..))
+import Data.Binary                           (Binary)
+import Data.Hashable                         (Hashable)
 import Data.IntMap.Strict                    (IntMap)
 import Data.Monoid                           (Any)
+import GHC.Generics
 
 import SrcLoc (SrcSpan)
 
@@ -39,6 +45,21 @@ import Clash.Netlist.Types       (FilteredHWType, HWMap)
 import Clash.Util
 
 import Clash.Annotations.BitRepresentation.Internal (CustomReprs)
+
+-- | State used by the inspection mechanism for recording rewrite steps.
+data RewriteStep
+  = RewriteStep
+  { t_ctx    :: Context
+  -- ^ current context
+  , t_name   :: String
+  -- ^ Name of the transformation
+  , t_bndrS  :: String
+  -- ^ Name of the current binder
+  , t_before :: Term
+  -- ^ Term before `apply`
+  , t_after  :: Term
+  -- ^ Term after `apply`
+  } deriving (Show, Generic, NFData, Hashable, Binary)
 
 -- | State of a rewriting session
 data RewriteState extra

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -374,6 +374,7 @@ anyM p (x:xs) = do
   else
     anyM p xs
 
+
 -- | Get the package id of the type of a value
 -- >>> pkgIdFromTypeable (undefined :: TopEntity)
 -- "clash-prelude-0.99.3-64904d90747cb49e17166bbc86fec8678918e4ead3847193a395b258e680373c"

--- a/clash-term/LICENSE
+++ b/clash-term/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2012-2016, University of Twente,
+              2016-2017, Myrtle Software Ltd,
+              2017     , QBayLogic, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/clash-term/LICENSE_GHC
+++ b/clash-term/LICENSE_GHC
@@ -1,0 +1,31 @@
+The Glasgow Haskell Compiler License
+
+Copyright 2002, The University Court of the University of Glasgow. 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+ 
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+ 
+- Neither name of the University nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
+GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+UNIVERSITY COURT OF THE UNIVERSITY OF GLASGOW OR THE CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/clash-term/Main.hs
+++ b/clash-term/Main.hs
@@ -1,0 +1,138 @@
+{-|
+  Copyright   :  (C) 2019, QBayLogic
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  Orestis Melkonian <melkon.or@gmail.com>
+
+  Entry point for the @clash-term@ executable.
+-}
+{-# LANGUAGE ScopedTypeVariables, TypeApplications, TypeFamilies, InstanceSigs, ExplicitForAll #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Main (main) where
+
+import Data.Binary (Binary, decodeOrFail)
+import Data.List   (find)
+import Data.Maybe  (fromJust)
+import qualified Data.ByteString.Lazy as BL
+
+import Clash.Core.Term     ( Term (..), LetBinding, Pat (..), Alt
+                           , Context, CoreContext (..) )
+import Clash.Core.Var      (Id)
+import Clash.Rewrite.Types (RewriteStep (..))
+import Clash.Core.Pretty   ( ClashDoc, ClashAnnotation (..), SyntaxElement (..)
+                           , PrettyOptions (..) )
+import qualified Clash.Core.Pretty as Pr
+
+import RewriteInspector (Diff (..), History, HStep (..), Syntax)
+import qualified RewriteInspector as RW
+
+main :: IO ()
+main = RW.runTerminal @Term "clash-term/theme.ini"
+
+-------------------------------
+-- Cλash instance for Diff.
+decodeList :: forall a. Binary a => FilePath -> IO [a]
+decodeList fn = do
+  bytes <- BL.readFile fn
+  return (go bytes)
+  where
+    go :: BL.ByteString -> [a]
+    go s
+      | BL.null s
+      = []
+      | otherwise
+      = case decodeOrFail @a s of
+          Right (s', _, x) -> x : go s'
+          Left  _          -> error "malformed history"
+
+instance Diff Term where
+  type Ann     Term = ClashAnnotation
+  type Options Term = PrettyOptions
+  type Ctx     Term = CoreContext
+
+  readHistory :: FilePath -> IO (History Term CoreContext)
+  readHistory fname = map go <$> decodeList @RewriteStep fname
+    where
+      go :: RewriteStep -> HStep Term CoreContext
+      go st@(RewriteStep {}) = HStep { _ctx    = reverse (t_ctx st)
+                                     , _bndrS  = t_bndrS st
+                                     , _name   = t_name st
+                                     , _before = t_before st
+                                     , _after  = t_after st }
+
+  initialExpr :: History Term CoreContext -> Term
+  initialExpr = _before . fromJust . find ((== "normalization") . _name)
+
+  topEntity :: String
+  topEntity = "topEntity"
+
+  handleAnn :: ClashAnnotation -> Either Syntax CoreContext
+  handleAnn (AnnContext c) = Right c
+  handleAnn (AnnSyntax s)  = Left $ case s of
+    Keyword   -> RW.Keyword
+    LitS      -> RW.Literal
+    Type      -> RW.Type
+    Unique    -> RW.Unique
+    Qualifier -> RW.Qualifier
+
+  ppr' :: PrettyOptions -> Term -> ClashDoc
+  ppr' = Pr.ppr'
+
+  initOptions :: PrettyOptions
+  initOptions = PrettyOptions True True True
+
+  flagFields :: [(PrettyOptions -> Bool, PrettyOptions -> Bool -> PrettyOptions, String)]
+  flagFields =
+    [ (displayUniques, \opt b -> opt {displayUniques = b}, "display uniques")
+    , (displayTypes, \opt b -> opt {displayTypes = b}, "display types")
+    , (displayQualifiers, \opt b -> opt {displayQualifiers = b}, "display qualifiers")
+    ]
+
+  patch :: Term -> Context -> Term -> Term
+  patch _ [] t = t
+  patch curE (c:cs) t' =
+    case (curE, c) of
+        (App l r, AppFun) ->
+          App (go l) r
+        (App l r, AppArg _) ->
+          App l (go r)
+        (TyApp e ty, TyAppC) ->
+          TyApp (go e) ty
+        (Letrec bnds body, LetBinding i' _) ->
+          Letrec (mapBindings i' bnds) body
+        (Letrec bnds t, LetBody is) ->
+          if (fst <$> bnds) == is
+            then Letrec bnds (go t)
+            else error "Ctx.LetBody: different bindings"
+        (Lam i t, LamBody i') ->
+          if i == i'
+            then Lam i (go t)
+            else error $ "Ctx.Lam: different identifiers " ++ show (i, i')
+        (TyLam tyVar t, TyLamBody tyVar') ->
+          if tyVar == tyVar'
+            then TyLam tyVar (go t)
+            else error "Ctx.TyLam: different type variables"
+        (Case scrut ty alts, CaseAlt pat) ->
+          Case scrut ty (mapAlternatives pat alts)
+        (Case t ty alts, CaseScrut) ->
+          Case (go t) ty alts
+        (Cast t ty ty', CastBody) ->
+          Cast (go t) ty ty'
+        _ -> error "patch: context does not agree with term"
+    where
+      go :: Term -> Term
+      go = \t -> patch t cs t'
+
+      mapBindings :: Id -> [LetBinding] -> [LetBinding]
+      mapBindings i ((i', t) : bs)
+        | i == i'   = (i', go t) : bs
+        | otherwise = (i', t)    : mapBindings i bs
+      mapBindings _ [] = error "Ctx.LetBinding: no such binding"
+
+      mapAlternatives :: Pat -> [Alt] -> [Alt]
+      mapAlternatives pat ((pat', t) : alts)
+        | pat == pat' = (pat', go t) : alts
+        | otherwise   = (pat', t)    : mapAlternatives pat alts
+      mapAlternatives _ [] = error "Ctx.Case: no such alternative"

--- a/clash-term/README.md
+++ b/clash-term/README.md
@@ -1,0 +1,21 @@
+# Inspection mechanism for optimizations in the CλaSH compiler
+
+Terminal-based interactive UI, where you replay the optimization performed
+by a previous run of the normalization phase.
+
+The implementation is based on the `rewrite-inspector` library, available on [Hackage](http://hackage.haskell.org/package/rewrite-inspector).
+For detailed documentation and example visualizations, see the following [README](https://github.com/omelkonian/rewrite-inspector/blob/master/README.md).
+
+## Usage Instructions
+
+1. Run `clash` with the 'history' flag, which will write the rewrite history in `history.dat`:
+```bash
+> cabal new-run -- clash --vhdl -f history DebugName examples/ALU.hs
+```
+
+2. The rewrite history has now been dumped to the file system, in `history.dat`.
+
+3. Run the terminal UI with the `clash-term` executable, giving the history file as input:
+```bash
+> cabal new-run -- clash-term history.dat
+```

--- a/clash-term/Setup.hs
+++ b/clash-term/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/clash-term/clash-term.cabal
+++ b/clash-term/clash-term.cabal
@@ -1,0 +1,36 @@
+Name:                 clash-term
+Version:              0.99
+Synopsis:             CAES Language for Synchronous Hardware
+Description:          Terminal-based inspection mechanism for optimization phases.
+Homepage:             http://www.clash-lang.org/
+bug-reports:          http://github.com/clash-lang/clash-compiler/issues
+License:              BSD2
+License-file:         LICENSE
+Author:               Orestis Melkonian
+Maintainer:           Orestis Melkonian <melkon.or@gmail.com>
+Copyright:            Copyright © 2019, QBayLogic
+Category:             Terminal
+Build-type:           Simple
+
+Extra-source-files:   README.md
+                      LICENSE_GHC
+                      theme.ini
+
+Cabal-version:        >=1.10
+
+source-repository head
+  type: git
+  location: https://github.com/clash-lang/clash-compiler.git
+
+executable clash-term
+  Main-Is:            Main.hs
+  Build-Depends:      base              >= 4.3.1.0  && < 5,
+                      clash-lib         >= 0.7.1    && < 1.0,
+                      binary            >= 0.8.5    && < 0.11,
+                      prettyprinter     >= 1.2.0.1  && < 2.0,
+                      bytestring        >= 0.10.0.2 && < 0.11,
+                      rewrite-inspector == 0.1.0.9
+
+  GHC-Options:        -Wall -threaded
+  extra-libraries:    pthread
+  default-language:   Haskell2010

--- a/clash-term/theme.ini
+++ b/clash-term/theme.ini
@@ -1,0 +1,15 @@
+[default]
+default.fg = #ffffff
+default.bg = #000000
+
+[other]
+focus.bg        = #2f4f4f
+title.style     = bold
+emph.style      = bold
+Type.fg         = brightYellow
+Keyword.fg      = #ffa500
+LitS.fg         = brightCyan
+Unique.fg       = #606060
+Unique.style    = [italic]
+Qualifier.style = italic
+search.style    = [underline, italic]


### PR DESCRIPTION
 * `clash-lib`: Record rewrite steps and serialize the results to disk
   - only enabled when DEBUG is on

 * `clash-term`: the terminal UI implementation
   - uses the `rewrite-inspector` library, that generates the UI for any language of experssions
   - `Main.hs` defines the necessary instances `Clash.Core.Term` should implement,
      namely the `RewriteInspector.Diff` typeclass