### PR TITLE
Rename ~ISALWAYSENABLED to ~ISACTIVEENABLE

### DIFF
--- a/clash-lib/prims/commonverilog/Clash_Intel_DDR.json
+++ b/clash-lib/prims/commonverilog/Clash_Intel_DDR.json
@@ -36,7 +36,7 @@ altddio_out
     .datain_h (~ARG[8]),
     .datain_l (~ARG[9]),
     .outclock (~ARG[5]),
-    .outclocken (~IF ~ISALWAYSENABLED[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),
+    .outclocken (~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),
     .dataout (~RESULT),
     .aset (1'b0),
     .sset (1'b0),

--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.json
@@ -20,7 +20,7 @@
 logic [~SIZE[~TYP[9]]-1:0] ~GENSYM[~RESULT_q][2];
 initial begin
   ~SYM[1] = ~CONST[5];
-end~IF ~ISALWAYSENABLED[4] ~THEN
+end~IF ~ISACTIVEENABLE[4] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN
   if (~ARG[4]) begin
     if (~ARG[7]) begin
@@ -68,7 +68,7 @@ assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[9]];
 logic [~SIZE[~TYP[10]]-1:0] ~GENSYM[~RESULT_q][2];
 initial begin
   ~SYM[1] = '{default: ~CONST[6]};
-end~IF ~ISALWAYSENABLED[4] ~THEN
+end~IF ~ISACTIVEENABLE[4] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN
   if (~ARG[4]) begin
     if (~ARG[8]) begin

--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam_File.json
@@ -23,7 +23,7 @@
 initial begin
   $readmemb(~FILE[~LIT[6]],~SYM[1]);
 end
-~IF ~ISALWAYSENABLED[4] ~THEN
+~IF ~ISACTIVEENABLE[4] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRamFile][3]~IF ~VIVADO ~THEN
   if (~ARG[4]) begin
     if (~ARG[8]) begin

--- a/clash-lib/prims/systemverilog/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_DDR.json
@@ -23,21 +23,21 @@
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[1] <= ~ARG[8];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[1] <= ~ARG[10];
   end
 end
 always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[2] <= ~ARG[9];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[2] <= ~ARG[10];
   end
 end
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[3] <= ~ARG[7];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[3] <= ~SYM[2];
   end
 end
@@ -68,14 +68,14 @@ assign ~RESULT = {~SYM[3], ~SYM[1]};
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[1] <= ~ARG[7];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[1] <= ~ARG[8];
   end
 end
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[2] <= ~ARG[7];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[2] <= ~ARG[9];
   end
 end

--- a/clash-lib/prims/systemverilog/Clash_Explicit_RAM.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_RAM.json
@@ -19,7 +19,7 @@
 "// asyncRam begin
 logic [~SIZE[~TYP[10]]-1:0] ~GENSYM[RAM][0] [0:~LIT[6]-1];
 always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_Ram][1]
-  if (~IF ~ISALWAYSENABLED[5] ~THEN ~ARG[5] & ~ELSE ~FI ~ARG[8]) begin
+  if (~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] & ~ELSE ~FI ~ARG[8]) begin
     ~SYM[0][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];
   end
 end

--- a/clash-lib/prims/systemverilog/Clash_Explicit_ROM.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_ROM.json
@@ -15,7 +15,7 @@
 ~SIGD[~GENSYM[ROM][1]][5];
 assign ~SYM[1] = ~LIT[5];
 
-logic [~SIZE[~TYPO]-1:0] ~GENSYM[~RESULT_q][2];~IF ~ISALWAYSENABLED[4] ~THEN
+logic [~SIZE[~TYPO]-1:0] ~GENSYM[~RESULT_q][2];~IF ~ISACTIVEENABLE[4] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_rom][3]
   if (~ARG[4]) begin
     ~SYM[2] <= ~SYM[1][~ARG[6]];

--- a/clash-lib/prims/systemverilog/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_ROM_File.json
@@ -18,7 +18,7 @@ initial begin
   $readmemb(~FILE[~LIT[5]],~SYM[0]);
 end
 
-~SIGDO[~GENSYM[~RESULT_q][1]];~IF ~ISALWAYSENABLED[3] ~THEN
+~SIGDO[~GENSYM[~RESULT_q][1]];~IF ~ISACTIVEENABLE[3] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~COMPNAME_romFile][2]
   if (~ARG[3]) begin
     ~SYM[1] <= ~SYM[0][~ARG[6]];

--- a/clash-lib/prims/systemverilog/Clash_Intel_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Intel_DDR.json
@@ -35,7 +35,7 @@ altddio_in
     .sclr (1'b0),~FI
     .datain (~ARG[8]),
     .inclock (~ARG[5]),
-    .inclocken (~IF ~ISALWAYSENABLED[7] ~THEN~ARG[7]~ELSE1'b1,~FI),
+    .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN~ARG[7]~ELSE1'b1,~FI),
     .dataout_h (~SYM[2]),
     .dataout_l (~SYM[1]),
     .aset (1'b0),

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.json
@@ -12,7 +12,7 @@
   -> Signal clk a"
     , "template" :
 "// delay begin,
-~TYPO ~GENSYM[~RESULT_reg][0] ~IF ~ISINITDEFINED[0] ~THEN = ~CONST[4] ~ELSE ~FI;~IF ~ISALWAYSENABLED[3] ~THEN
+~TYPO ~GENSYM[~RESULT_reg][0] ~IF ~ISINITDEFINED[0] ~THEN = ~CONST[4] ~ELSE ~FI;~IF ~ISACTIVEENABLE[3] ~THEN
 always_ff @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~RESULT_delay][1]
   if (~ARG[3]) begin
     ~SYM[0] <= ~ARG[5];
@@ -45,7 +45,7 @@ assign ~RESULT = ~SYM[0];
 always_ff @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISSYNC[0] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~ARG[3]~FI) begin : ~GENSYM[~RESULT_register][1]
   if (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~ARG[3]) begin
     ~SYM[0] <= ~CONST[6];
-  end else ~IF ~ISALWAYSENABLED[4] ~THEN if (~ARG[4]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[4] ~THEN if (~ARG[4]) ~ELSE ~FI begin
     ~SYM[0] <= ~ARG[7];
   end
 end

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.json
@@ -31,7 +31,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .Q1(~SYM[1][~SYM[8]]),
     .Q2(~SYM[2][~SYM[8]]),
     .C(~ARG[4]),
-    .CE(~IF ~ISALWAYSENABLED[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),
+    .CE(~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),
     .D(~SYM[3][~SYM[8]]),
     .R(~ARG[5]),
     .S(1'b0)
@@ -76,7 +76,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
   ) ~GENSYM[~COMPNAME_ODDR][9] (
     .Q(~SYM[3][~SYM[8]]),
     .C(~ARG[3]),
-    .CE(~IF ~ISALWAYSENABLED[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),
+    .CE(~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),
     .D1(~SYM[1][~SYM[8]]),
     .D2(~SYM[2][~SYM[8]]),
     .R(~ARG[4]),

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam.json
@@ -27,7 +27,7 @@ initial begin
     ~SYM[1][~LENGTH[~TYP[5]]-1-~SYM[4]] = ~SYM[3][~SYM[4]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
   end
 end
-~IF ~ISALWAYSENABLED[4] ~THEN
+~IF ~ISACTIVEENABLE[4] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN
   if (~ARG[4]) begin
     if (~ARG[7]) begin
@@ -79,7 +79,7 @@ initial begin
     end
 end
 
-~IF ~ISALWAYSENABLED[4] ~THEN
+~IF ~ISACTIVEENABLE[4] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN
   if (~ARG[4]) begin
     if (~ARG[8]) begin

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam_File.json
@@ -23,7 +23,7 @@ reg ~TYPO ~GENSYM[RAM][1] [0:~LIT[5]-1];
 initial begin
   $readmemb(~FILE[~LIT[6]],~SYM[1]);
 end
-~IF ~ISALWAYSENABLED[4] ~THEN
+~IF ~ISACTIVEENABLE[4] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRamFile][3]~IF ~VIVADO ~THEN
   if (~ARG[4]) begin
     if (~ARG[8]) begin

--- a/clash-lib/prims/verilog/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_DDR.json
@@ -23,21 +23,21 @@ reg ~SIGD[~GENSYM[data_Neg_Latch][3]][9];
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[1] <= ~ARG[8];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[1] <= ~ARG[10];
   end
 end
 always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[2] <= ~ARG[9];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[2] <= ~ARG[10];
   end
 end
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[3] <= ~ARG[7];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[3] <= ~SYM[2];
   end
 end
@@ -68,14 +68,14 @@ reg ~SIGD[~GENSYM[data_Neg][2]][7];
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[1] <= ~ARG[7];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[1] <= ~ARG[8];
   end
 end
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
   if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
     ~SYM[2] <= ~ARG[7];
-  end else ~IF ~ISALWAYSENABLED[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
     ~SYM[2] <= ~ARG[9];
   end
 end

--- a/clash-lib/prims/verilog/Clash_Explicit_RAM.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_RAM.json
@@ -19,7 +19,7 @@
 "// asyncRam begin
 reg ~TYPO ~GENSYM[RAM][0] [0:~LIT[6]-1];
 always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_Ram][1]
-  if (~ARG[8] ~IF ~ISALWAYSENABLED[5] ~THEN & ~ARG[5] ~ELSE ~FI) begin
+  if (~ARG[8] ~IF ~ISACTIVEENABLE[5] ~THEN & ~ARG[5] ~ELSE ~FI) begin
     ~SYM[0][~ARG[9]] <= ~ARG[10];
   end
 end

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM.json
@@ -23,7 +23,7 @@ initial begin
     ~SYM[1][~LIT[1]-1-~SYM[4]] = ~SYM[3][~SYM[4]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
   end
 end
-~IF ~ISALWAYSENABLED[4] ~THEN
+~IF ~ISACTIVEENABLE[4] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_rom][5]
   if (~ARG[4]) begin
     ~RESULT <= ~SYM[1][~ARG[6]];

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM_File.json
@@ -18,7 +18,7 @@ reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[4]-1];
 initial begin
   $readmemb(~FILE[~LIT[5]],~SYM[0]);
 end
-~IF ~ISALWAYSENABLED[3] ~THEN
+~IF ~ISACTIVEENABLE[3] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~COMPNAME_romFile][2]
   if (~ARG[3]) begin
     ~RESULT <= ~SYM[0][~ARG[6]];

--- a/clash-lib/prims/verilog/Clash_Intel_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Intel_DDR.json
@@ -35,7 +35,7 @@ altddio_in
     .sclr (1'b0),~FI
     .datain (~ARG[8]),~
     .inclock (~ARG[5]),
-    .inclocken (~IF ~ISALWAYSENABLED[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),
+    .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),
     .dataout_h (~SYM[2]),
     .dataout_l (~SYM[1]),
     .aset (1'b0),

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.json
@@ -12,7 +12,7 @@
   -> Signal clk a"
     , "template" :
 "// delay begin,
-reg ~TYPO ~GENSYM[~RESULT_reg][0] ~IF ~ISINITDEFINED[0] ~THEN = ~CONST[4] ~ELSE ~FI;~IF ~ISALWAYSENABLED[3] ~THEN
+reg ~TYPO ~GENSYM[~RESULT_reg][0] ~IF ~ISINITDEFINED[0] ~THEN = ~CONST[4] ~ELSE ~FI;~IF ~ISACTIVEENABLE[3] ~THEN
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~RESULT_delay][1]
   if (~ARG[3]) begin
     ~SYM[0] <= ~ARG[5];
@@ -45,7 +45,7 @@ reg ~TYPO ~GENSYM[~RESULT_reg][0] ~IF ~ISINITDEFINED[0] ~THEN = ~CONST[5] ~ELSE 
 always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISSYNC[0] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~ARG[3]~FI) begin : ~GENSYM[~RESULT_register][1]
   if (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~ARG[3]) begin
     ~SYM[0] <= ~CONST[6];
-  end else ~IF ~ISALWAYSENABLED[4] ~THEN if (~ARG[4]) ~ELSE ~FI begin
+  end else ~IF ~ISACTIVEENABLE[4] ~THEN if (~ARG[4]) ~ELSE ~FI begin
     ~SYM[0] <= ~ARG[7];
   end
 end

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.json
@@ -31,7 +31,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
     .Q1(~SYM[1][~SYM[8]]),
     .Q2(~SYM[2][~SYM[8]]),
     .C(~ARG[4]),
-    .CE(~IF ~ISALWAYSENABLED[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),
+    .CE(~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),
     .D(~SYM[3][~SYM[8]]),
     .R(~ARG[5]),
     .S(1'b0)
@@ -76,7 +76,7 @@ for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddr
   ) ~GENSYM[~COMPNAME_ODDR][9] (
     .Q(~SYM[3][~SYM[8]]),
     .C(~ARG[3]),
-    .CE(~IF ~ISALWAYSENABLED[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),
+    .CE(~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),
     .D1(~SYM[1][~SYM[8]]),
     .D2(~SYM[2][~SYM[8]]),
     .R(~ARG[4]),

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.json
@@ -36,7 +36,7 @@ begin
   ~SYM[6] : process(~ARG[3])
   begin
     if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[7] ~IF ~ISALWAYSENABLED[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];
       end if;
       ~RESULT <= fromSLV(~SYM[2](~SYM[4]))
@@ -49,7 +49,7 @@ begin
   ~SYM[6] : process(~ARG[3])
   begin
     if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[7] ~IF ~ISALWAYSENABLED[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~ARG[9];
       end if;
       ~RESULT <= ~SYM[2](~SYM[4])
@@ -103,7 +103,7 @@ begin
   ~SYM[6] : process(~ARG[3])
   begin
     if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[8] ~IF ~ISALWAYSENABLED[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+      if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[10]][~TYP[10]];
       end if;
       ~RESULT <= fromSLV(~SYM[2](~SYM[4]))
@@ -116,7 +116,7 @@ begin
   ~SYM[6] : process(~ARG[3])
   begin
     if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[8] ~IF ~ISALWAYSENABLED[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+      if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~ARG[10];
       end if;
       ~RESULT <= ~SYM[2](~SYM[4])

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
@@ -47,7 +47,7 @@ begin
                 mod ~LIT[5]
   -- pragma translate_on
                 ;
-  ~IF ~VIVADO ~THEN ~IF ~ISALWAYSENABLED[4] ~THEN
+  ~IF ~VIVADO ~THEN ~IF ~ISACTIVEENABLE[4] ~THEN
   ~GENSYM[blockRamFile_sync][10] : process(~ARG[3])
   begin
     if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
@@ -75,7 +75,7 @@ begin
       -- pragma translate_on
       ;
     end if;
-  end process;~FI ~ELSE ~IF ~ISALWAYSENABLED[4] ~THEN
+  end process;~FI ~ELSE ~IF ~ISACTIVEENABLE[4] ~THEN
   ~SYM[10] : process(~ARG[3])
   begin
     if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then

--- a/clash-lib/prims/vhdl/Clash_Explicit_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_DDR.json
@@ -30,7 +30,7 @@ begin
     if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
       if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
         ~SYM[1] <= ~ARG[8];
-      els~IF ~ISALWAYSENABLED[6] ~THENif ~ARG[6] then~ELSEe~FI
+      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
         ~SYM[1] <= ~ARG[10];
       end if;
     end if;
@@ -41,7 +41,7 @@ begin
     if ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then
       if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
         ~SYM[2] <= ~ARG[9];
-      els~IF ~ISALWAYSENABLED[6] ~THENif ~ARG[6] then~ELSEe~FI
+      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
         ~SYM[2] <= ~ARG[10];
       end if;
     end if;
@@ -52,7 +52,7 @@ begin
     if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
       if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
         ~SYM[3] <= ~ARG[7];
-      els~IF ~ISALWAYSENABLED[6] ~THENif ~ARG[6] then~ELSEe~FI
+      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
         ~SYM[3] <= ~SYM[2];
       end if;
     end if;
@@ -64,7 +64,7 @@ begin
   begin
     if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
       ~SYM[1] <= ~ARG[8];
-    elsif ~IF ~ISALWAYSENABLED[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
+    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
       ~SYM[1] <= ~ARG[10];
     end if;
   end process;
@@ -73,7 +73,7 @@ begin
   begin
     if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
       ~SYM[2] <= ~ARG[9];
-    elsif ~IF ~ISALWAYSENABLED[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then
+    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then
       ~SYM[2] <= ~ARG[10];
     end if;
   end process;
@@ -82,7 +82,7 @@ begin
   begin
     if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
       ~SYM[3] <= ~ARG[7];
-    elsif ~IF ~ISALWAYSENABLED[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
+    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
       ~SYM[3] <= ~SYM[2];
     end if;
   end process;
@@ -121,7 +121,7 @@ begin
     if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
       if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
         ~SYM[1] <= ~ARG[7];
-      els~IF ~ISALWAYSENABLED[6] ~THENif ~ARG[6] then~ELSEe~FI
+      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
         ~SYM[1] <= ~ARG[8];
       end if;
     end if;
@@ -132,7 +132,7 @@ begin
     if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
       if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
         ~SYM[2] <= ~ARG[7];
-      els~IF ~ISALWAYSENABLED[6] ~THENif ~ARG[6] then~ELSEe~FI
+      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
         ~SYM[2] <= ~ARG[9];
       end if;
     end if;
@@ -158,7 +158,7 @@ begin
     end if;
   end process;
  ~FI
-  ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1' ~IF ~ISALWAYSENABLED[6] ~THEN and ~ARG[6] ~ELSE ~FI) else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
+  ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1' ~IF ~ISACTIVEENABLE[6] ~THEN and ~ARG[6] ~ELSE ~FI) else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
 end block;
 -- ddrOut end"
     }

--- a/clash-lib/prims/vhdl/Clash_Explicit_RAM.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_RAM.json
@@ -38,7 +38,7 @@ begin
   ~GENSYM[asyncRam_sync][7] : process(~ARG[3])
   begin
     if ~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if (~ARG[8] ~IF ~ISALWAYSENABLED[5] ~THEN and ~ARG[5] ~ELSE ~FI) then~IF ~VIVADO ~THEN
+      if (~ARG[8] ~IF ~ISACTIVEENABLE[5] ~THEN and ~ARG[5] ~ELSE ~FI) then~IF ~VIVADO ~THEN
         ~SYM[1](~SYM[3]) <= ~TOBV[~ARG[10]][~TYP[10]];~ELSE
         ~SYM[1](~SYM[3]) <= ~ARG[10];~FI
       end if;

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM.json
@@ -25,7 +25,7 @@ begin
                 ;
   ~GENSYM[romSync][6] : process (~ARG[3])
   begin
-    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])~IF ~ISALWAYSENABLED[4] ~THEN and ~ARG[4] ~ELSE ~FI) then~IF ~VIVADO ~THEN
+    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI) then~IF ~VIVADO ~THEN
       ~RESULT <= ~FROMBV[~SYM[2](~SYM[3])][~TYPO]
       -- pragma translate_off
       after 1 ps

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
@@ -35,7 +35,7 @@ begin
                 mod ~LIT[4]
   -- pragma translate_on
                 ;
-  ~IF ~ISALWAYSENABLED[3] ~THEN
+  ~IF ~ISACTIVEENABLE[3] ~THEN
   ~GENSYM[romFileSync][7] : process (~ARG[2])
   begin
     if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then

--- a/clash-lib/prims/vhdl/Clash_Intel_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Intel_DDR.json
@@ -19,9 +19,9 @@
 "-- altddioIn begin
 ~GENSYM[~COMPNAME_ALTDDIO_IN][0] : block
   signal ~GENSYM[dataout_l][1] : ~TYP[8];
-  signal ~GENSYM[dataout_h][2] : ~TYP[8];~IF ~ISALWAYSENABLED[7] ~THEN
+  signal ~GENSYM[dataout_h][2] : ~TYP[8];~IF ~ISACTIVEENABLE[7] ~THEN
   signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
-begin~IF ~ISALWAYSENABLED[5] ~THEN
+begin~IF ~ISACTIVEENABLE[5] ~THEN
   ~SYM[4] <= '1' when (~ARG[7]) else '0';~ELSE ~FI
   ~GENSYM[~COMPNAME_ALTDDIO_IN][7] : ALTDDIO_IN
   GENERIC MAP (
@@ -35,7 +35,7 @@ begin~IF ~ISALWAYSENABLED[5] ~THEN
   PORT MAP (~IF ~ISSYNC[6] ~THEN
     sclr      => ~ARG[6],~ELSE
     aclr      => ~ARG[6],~FI
-    datain    => ~ARG[8],~IF ~ISALWAYSENABLED[5] ~THEN
+    datain    => ~ARG[8],~IF ~ISACTIVEENABLE[5] ~THEN
     inclocken => ~SYM[4],~ELSE ~FI
     inclock   => ~ARG[5],
     dataout_h => ~SYM[2],
@@ -66,9 +66,9 @@ end block;
     , "imports" : ["altera_mf.altera_mf_components.all"]
     , "template" :
 "-- altddioOut begin
-~GENSYM[~COMPNAME_ALTDDIO_OUT][0] : block ~IF ~ISALWAYSENABLED[7] ~THEN
+~GENSYM[~COMPNAME_ALTDDIO_OUT][0] : block ~IF ~ISACTIVEENABLE[7] ~THEN
   signal ~GENSYM[ce_logic][1] : std_logic; ~ELSE ~FI
-begin~IF ~ISALWAYSENABLED[7] ~THEN
+begin~IF ~ISACTIVEENABLE[7] ~THEN
   ~SYM[3] <= '1' when (~ARG[7]) else '0'; ~ELSE ~FI
   ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] : ALTDDIO_OUT
     GENERIC MAP (
@@ -83,7 +83,7 @@ begin~IF ~ISALWAYSENABLED[7] ~THEN
     )
     PORT MAP (~IF ~ISSYNC[2] ~THEN
       sclr       => ~ARG[6],~ELSE
-      aclr       => ~ARG[6],~FI ~IF ~ISALWAYSENABLED[7] ~THEN
+      aclr       => ~ARG[6],~FI ~IF ~ISACTIVEENABLE[7] ~THEN
       outclocken => ~SYM[1],~ELSE ~FI
       outclock   => ~ARG[5],
       datain_h   => ~ARG[7],

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.json
@@ -11,7 +11,7 @@
   -> Signal clk a             -- ARG[5]
   -> Signal clk a"
     , "template" :
-"-- delay begin~IF ~ISALWAYSENABLED[3] ~THEN
+"-- delay begin~IF ~ISACTIVEENABLE[3] ~THEN
 ~GENSYM[~RESULT_delay][0] : block
   signal ~GENSYM[~RESULT_reg][1]   : ~TYPO ~IF ~ISINITDEFINED[0] ~THEN := ~CONST[4] ~ELSE ~FI;
 begin
@@ -62,7 +62,7 @@ end block;~FI
   -> Signal clk a             -- ARG[7]
   -> Signal clk a"
     , "template" :
-"-- register begin~IF ~ISALWAYSENABLED[4] ~THEN
+"-- register begin~IF ~ISACTIVEENABLE[4] ~THEN
 ~GENSYM[~COMPNAME_register][0] : block
   signal ~GENSYM[~RESULT_reg][1] : ~TYPO ~IF ~ISINITDEFINED[0] ~THEN := ~CONST[5] ~ELSE ~FI;
 begin

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.json
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.json
@@ -19,9 +19,9 @@
 ~GENSYM[~COMPNAME_IDDR][0] : block
   signal ~GENSYM[dataout_l][1] : ~TYP[7];
   signal ~GENSYM[dataout_h][2] : ~TYP[7];
-  signal ~GENSYM[d][3]         : ~TYP[7];~IF ~ISALWAYSENABLED[4] ~THEN
+  signal ~GENSYM[d][3]         : ~TYP[7];~IF ~ISACTIVEENABLE[4] ~THEN
   signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
-begin~IF ~ISALWAYSENABLED[4] ~THEN
+begin~IF ~ISACTIVEENABLE[4] ~THEN
   ~SYM[4] <= '1' when (~ARG[6]) else '0';~ELSE ~FI
   ~SYM[3] <= ~ARG[7];
 
@@ -37,7 +37,7 @@ begin~IF ~ISALWAYSENABLED[4] ~THEN
       Q1 => ~SYM[1](~SYM[8]),   -- 1-bit output for positive edge of clock
       Q2 => ~SYM[2](~SYM[8]),   -- 1-bit output for negative edge of clock
       C  => ~ARG[4],   -- 1-bit clock input
-      CE => ~IF ~ISALWAYSENABLED[6] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
+      CE => ~IF ~ISACTIVEENABLE[6] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
       D  => ~SYM[3](~SYM[8]),   -- 1-bit DDR data input
       R  => ~ARG[5],   -- 1-bit reset
       S  => '0'        -- 1-bit set
@@ -70,9 +70,9 @@ end block;
 ~GENSYM[~COMPNAME_ODDR][0] : block
   signal ~GENSYM[dataout_l][1] : ~TYPO;
   signal ~GENSYM[dataout_h][2] : ~TYPO;
-  signal ~GENSYM[q][3]         : ~TYPO;~IF ~ISALWAYSENABLED[5] ~THEN
+  signal ~GENSYM[q][3]         : ~TYPO;~IF ~ISACTIVEENABLE[5] ~THEN
   signal ~GENSYM[ce_logic][4]  : std_logic;~ELSE ~FI
-begin~IF ~ISALWAYSENABLED[5] ~THEN
+begin~IF ~ISACTIVEENABLE[5] ~THEN
   ~SYM[4] <= '1' when (~ARG[5]) else '0';~ELSE ~FI
   ~SYM[1] <= ~ARG[6];
   ~SYM[2] <= ~ARG[7];
@@ -87,7 +87,7 @@ begin~IF ~ISALWAYSENABLED[5] ~THEN
     port map (
       Q  => ~SYM[3](~SYM[8]),    -- 1-bit DDR output
       C  => ~ARG[3],   -- 1-bit clock input
-      CE => ~IF ~ISALWAYSENABLED[5] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
+      CE => ~IF ~ISACTIVEENABLE[5] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
       D1 => ~SYM[1](~SYM[8]),    -- 1-bit data input (positive edge)
       D2 => ~SYM[2](~SYM[8]),    -- 1-bit data input (negative edge)
       R  => ~ARG[4],    -- 1-bit reset input

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -113,7 +113,7 @@ pTagE =  Result True       <$  string "~ERESULT"
      <|> IsLit             <$> (string "~ISLIT" *> brackets' natural')
      <|> IsVar             <$> (string "~ISVAR" *> brackets' natural')
      <|> IsActiveHigh      <$> (string "~ISACTIVEHIGH" *> brackets' natural')
-     <|> IsAlwaysEnabled   <$> (string "~ISALWAYSENABLED" *> brackets' natural')
+     <|> IsActiveEnable    <$> (string "~ISACTIVEENABLE" *> brackets' natural')
      <|> StrCmp            <$> (string "~STRCMP" *> brackets' pSigD) <*> brackets' natural'
      <|> OutputWireReg     <$> (string "~OUTPUTWIREREG" *> brackets' natural')
      <|> GenSym            <$> (string "~GENSYM" *> brackets' pSigD) <*> brackets' natural'

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -163,8 +163,9 @@ data Element
   -- ^ Whether a domain's reset lines are synchronous. Errors if not applied to
   -- a KnownDomain.
   | IsInitDefined !Int
-  | IsAlwaysEnabled !Int
-  -- ^ Whether reset line is constantly enabled
+  | IsActiveEnable !Int
+  -- ^ Whether given enable line is active. More specifically, whether the
+  -- enable line is NOT set to a constant 'True'.
   | StrCmp [Element] !Int
   | OutputWireReg !Int
   | Vars !Int

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -402,7 +402,7 @@ renderElem b (IF c t f) = do
                       BlackBoxE {} -> 1
                       _            -> 0
 
-      (IsAlwaysEnabled n) ->
+      (IsActiveEnable n) ->
         let (e, ty, _) = bbInputs b !! n in
         case (e, ty) of
           (Literal Nothing (BoolLit True), Bool)  -> 0
@@ -412,9 +412,7 @@ renderElem b (IF c t f) = do
           (Literal Nothing (BoolLit False), Bool) -> 1
           (_, Bool)                               -> 1
           _ ->
-            error $ $(curLoc) ++ "IsAlwaysEnabled: Expected Bool, not: " ++ show ty
-
---        error $ show (e, ty, isLit, bbName b)
+            error $ $(curLoc) ++ "IsActiveEnable: Expected Bool, not: " ++ show ty
 
       (ActiveEdge edgeRequested n) ->
         let (_, ty, _) = bbInputs b !! n in
@@ -810,7 +808,7 @@ prettyElem (Sel e i) = do
 prettyElem (IsLit i) = renderOneLine <$> (string "~ISLIT" <> brackets (int i))
 prettyElem (IsVar i) = renderOneLine <$> (string "~ISVAR" <> brackets (int i))
 prettyElem (IsActiveHigh i) = renderOneLine <$> (string "~ISACTIVEHIGH" <> brackets (int i))
-prettyElem (IsAlwaysEnabled i) = renderOneLine <$> (string "~ISALWAYSENABLED" <> brackets (int i))
+prettyElem (IsActiveEnable i) = renderOneLine <$> (string "~ISACTIVEENABLE" <> brackets (int i))
 
 -- Domain attributes:
 prettyElem (Tag i) = renderOneLine <$> (string "~TAG" <> brackets (int i))
@@ -918,7 +916,7 @@ walkElement f el = maybeToList (f el) ++ walked
         IsSync _ -> []
         IsInitDefined _ -> []
         IsActiveHigh _ -> []
-        IsAlwaysEnabled _ -> []
+        IsActiveEnable _ -> []
         StrCmp es _ -> concatMap go es
         OutputWireReg _ -> []
         Vars _ -> []
@@ -958,7 +956,7 @@ usedArguments (N.BBTemplate t) = nub (concatMap (walkElement matchArg) t)
         Component (Decl i _) -> Just i
         Const i -> Just i
         IsLit i -> Just i
-        IsAlwaysEnabled i -> Just i
+        IsActiveEnable i -> Just i
         Lit i -> Just i
         Name i -> Just i
         Var _ i -> Just i

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -1235,7 +1235,7 @@ begin
   ~SYM[5] : process(~ARG[2])
   begin
     if rising_edge(~ARG[2]) then
-      if ~ARG[6] ~IF ~ISALWAYSENABLED[3] ~THEN and ~ARG[3] ~ELSE ~FI then
+      if ~ARG[6] ~IF ~ISACTIVEENABLE[3] ~THEN and ~ARG[3] ~ELSE ~FI then
         ~SYM[1](~SYM[4]) <= ~TOBV[~ARG[8]][~TYP[8]];
       end if;
       ~RESULT <= fromSLV(~SYM[1](~SYM[3]))
@@ -1248,7 +1248,7 @@ begin
   ~SYM[5] : process(~ARG[2])
   begin
     if rising_edge(~ARG[2]) then
-      if ~ARG[6] ~IF ~ISALWAYSENABLED[3] ~THEN and ~ARG[3] ~ELSE ~FI then
+      if ~ARG[6] ~IF ~ISACTIVEENABLE[3] ~THEN and ~ARG[3] ~ELSE ~FI then
         ~SYM[1](~SYM[4]) <= ~ARG[8];
       end if;
       ~RESULT <= ~SYM[1](~SYM[3])
@@ -1304,7 +1304,7 @@ a general listing of the available template holes:
 * @~IF \<CONDITION\> ~THEN \<THEN\> ~ELSE \<ELSE\> ~FI@: renders the \<ELSE\>
   part when \<CONDITION\> evaluates to /0/, and renders the \<THEN\> in all
   other cases. Valid @\<CONDITION\>@s are @~LENGTH[\<HOLE\>]@, @~SIZE[\<HOLE\>]@,
-  @~DEPTH[\<HOLE\>]@, @~VIVADO@, @~IW64@, @~ISLIT[N]@, @~ISVAR[N], @~ISALWAYSENABLED[N]@,
+  @~DEPTH[\<HOLE\>]@, @~VIVADO@, @~IW64@, @~ISLIT[N]@, @~ISVAR[N], @~ISACTIVEENABLE[N]@,
   @~ISSYNC[N]@, and @~AND[\<HOLE1\>,\<HOLE2\>,..]@.
 * @~VIVADO@: /1/ when Clash compiler is invoked with the @-fclash-xilinx@ or
   @-fclash-vivado@ flag. To be used with in an @~IF .. ~THEN .. ~ElSE .. ~FI@
@@ -1331,8 +1331,9 @@ a general listing of the available template holes:
   a 'KnownDomain', 'Reset', or 'Clock'.
 * @~PERIOD[N]@: Clock period of given domain. Errors when called on an argument
   which is not a 'KnownDomain' or 'KnownConf'.
-* @~ISALWAYSENABLED[N]@: Is the @(N+1)@'th argument a an Enable line set to a constant
-  True. Errors when called on an argument which is not an 'Enable'.
+* @~ISACTIVEENABLE[N]@: Is the @(N+1)@'th argument a an Enable line NOT set to a
+  constant True. Can be used instead of deprecated (and removed) template tag
+  ~ISGATED. Errors when called on an argument which is not a signal of bools.
 * @~ISSYNC[N]@: Does synthesis domain at the @(N+1)@'th argument have synchronous resets. Errors
   when called on an argument which is not a 'KnownDomain' or 'KnownConf'.
 * @~ISINITDEFINED[N]@: Does synthesis domain at the @(N+1)@'th argument have defined initial
@@ -1407,7 +1408,7 @@ initial begin
     ~SYM[0][~LENGTH[~TYP[4]]-1-~SYM[3]] = ~SYM[2][~SYM[3]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
   end
 end
-~IF ~ISALWAYSENABLED[3] ~THEN
+~IF ~ISACTIVEENABLE[3] ~THEN
 always @(posedge ~ARG[2]) begin : ~GENSYM[~RESULT_blockRam][4]~IF ~VIVADO ~THEN
   if (~ARG[3]) begin
     if (~ARG[6]) begin
@@ -1471,7 +1472,7 @@ and
 logic [~SIZE[~TYP[8]]-1:0] ~GENSYM[~RESULT_q][1];
 initial begin
   ~SYM[0] = ~CONST[4];
-end~IF ~ISALWAYSENABLED[3] ~THEN
+end~IF ~ISACTIVEENABLE[3] ~THEN
 always @(posedge ~ARG[2]) begin : ~GENSYM[~COMPNAME_blockRam][2]~IF ~VIVADO ~THEN
   if (~ARG[3]) begin
     if (~ARG[6]) begin


### PR DESCRIPTION
Commit [c3e3a9e4526f4fec66ae5a0793ef82c969bb4fa2](https://github.com/clash-lang/clash-compiler/commit/c3e3a9e4526f4fec66ae5a0793ef82c969bb4fa2) renamed ~ISENABLED to
~ISALWAYSENABLED. While the name change implies a behavioral change, the
actual implementation didn't change. Instead of changing the behavior of
the template tag, this commit changes the name again for two reasons:

  1. So I don't have to change all the blackboxes using the tag again

  2. To make it easier to port code that used to use ~ISGATED, as
  ~ISACTIVEENABLE is _almost_ a drop-in replacement for it.