### PR TITLE
Add type classes to reliably use hidden constructs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -29,7 +29,7 @@ repository head.hackage
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2019-02-18T09:58:03Z
+index-state: 2019-07-12T19:15:41Z
 
 package clash-ghc
   executable-dynamic: True

--- a/clash-cosim/src/Clash/CoSim.hs
+++ b/clash-cosim/src/Clash/CoSim.hs
@@ -56,7 +56,7 @@ compileVerilog explicitSettings source = do
   --
   --   coSimWrapper :: a1 -> a2 -> .. -> CoSimSettings -> aa1 -> aa2 -> r
   --
-  -- where a1, a2, .. are explicitely named arguments and aa1, aa2, .. are
+  -- where a1, a2, .. are explicitly named arguments and aa1, aa2, .. are
   -- anonymous arugments (thus allowing dot-free notation).
   settingsArg   <- newName "settings"
   namedClocks   <- mapM newName clkNames

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -113,6 +113,11 @@ Library
 
                       Clash.Class.BitPack
                       Clash.Class.Exp
+                      Clash.Class.HasDomain
+                      Clash.Class.HasDomain.HasSingleDomain
+                      Clash.Class.HasDomain.HasSpecificDomain
+                      Clash.Class.HasDomain.CodeGen
+                      Clash.Class.HasDomain.Common
                       Clash.Class.Num
                       Clash.Class.Resize
 
@@ -250,6 +255,7 @@ Library
                       text                      >= 0.11.3.1 && < 1.3,
                       time                      >= 1.8     && < 1.10,
                       transformers              >= 0.5.2.0 && < 0.6,
+                      type-errors               >= 0.2.0.0 && < 0.3,
                       vector                    >= 0.11    && < 1.0
 
 test-suite doctests
@@ -284,6 +290,7 @@ test-suite unittests
 
       base          >= 4        && < 5,
       doctest       >= 0.9.1    && < 0.17,
+      hint          >= 0.7      && < 0.10,
       tasty         >= 1.2      && < 1.3,
       tasty-hunit
 

--- a/clash-prelude/src/Clash/Class/HasDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain.hs
@@ -1,0 +1,8 @@
+module Clash.Class.HasDomain
+  ( WithSpecificDomain
+  , WithSingleDomain
+  ) where
+
+-- Compilation is split across modules to maximize GHC parallelism
+import Clash.Class.HasDomain.HasSingleDomain
+import Clash.Class.HasDomain.HasSpecificDomain

--- a/clash-prelude/src/Clash/Class/HasDomain/CodeGen.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/CodeGen.hs
@@ -1,0 +1,66 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE ViewPatterns #-}
+
+module Clash.Class.HasDomain.CodeGen
+  ( mkTryDomainTuples
+  , mkHasDomainTuples
+  ) where
+
+import           Language.Haskell.TH.Syntax
+
+mkTup :: [Type] -> Type
+mkTup names@(length -> n) =
+  foldl AppT (TupleT n) names
+
+-- | Creates an instance of the form:
+--
+--  type instance TryDomain t (a, b, c, d, e) = Merge t a (b, c, d, e)
+--
+-- With /n/ number of variables on the LHS.
+mkTryDomainTupleInstance :: Name -> Name -> Int -> Dec
+mkTryDomainTupleInstance tryDomainName mergeName n =
+  TySynInstD tryDomainName (TySynEqn [t, tupPat] tupBody)
+ where
+  bcde = map (VarT . mkName . ("a"++) . show) [1..n-1]
+  a    = VarT (mkName "a0")
+  t    = VarT (mkName "t")
+
+  -- Merge t a (b, c, d, e)
+  tupBody = ConT mergeName `AppT` t `AppT` a `AppT` (mkTup bcde)
+
+  -- (a, b, c, d, e)
+  tupPat = mkTup (a : bcde)
+
+mkTryDomainTuples :: Name -> Name -> Q [Dec]
+mkTryDomainTuples tryDomainName mergeName =
+  pure (map (mkTryDomainTupleInstance tryDomainName mergeName) [3..62])
+
+
+-- | Creates an instance of the form:
+--
+--  type instance HasDomain' dom (a, b, c, d, e) =
+--    Merge' (HasDomain' dom a) (HasDomain' dom (b, c, d, e))
+--
+-- With /n/ number of variables on the LHS.
+mkHasDomainTupleInstance :: Name -> Name -> Int -> Dec
+mkHasDomainTupleInstance hasDomainName mergeName n =
+  TySynInstD hasDomainName (TySynEqn [dom, tupPat] merge)
+ where
+  bcde = map (VarT . mkName . ("a"++) . show) [1..n-1]
+  a    = VarT (mkName "a0")
+  dom  = VarT (mkName "dom")
+
+  -- Merge dom a (b, c, d, e)
+  merge = ConT mergeName `AppT` dom `AppT` a `AppT` mkTup bcde
+
+  -- (a, b, c, d, e)
+  tupPat = mkTup (a : bcde)
+
+mkHasDomainTuples :: Name -> Name -> Q [Dec]
+mkHasDomainTuples hasDomainName mergeName =
+  pure (map (mkHasDomainTupleInstance hasDomainName mergeName) [3..62])

--- a/clash-prelude/src/Clash/Class/HasDomain/Common.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/Common.hs
@@ -1,0 +1,46 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE TypeOperators      #-}
+
+module Clash.Class.HasDomain.Common
+  ( Unlines
+  , (:<<>>:)
+  , (:$$$:)
+  , (:++:)
+  ) where
+
+import           GHC.TypeLits               (Symbol)
+import           Type.Errors
+  (ErrorMessage(Text, ShowType, (:<>:), (:$$:)))
+
+type family ToEM (k :: t) :: ErrorMessage where
+  ToEM (k :: Symbol)       = 'Text k
+  ToEM (k :: ErrorMessage) = k
+  ToEM (k :: t)            = 'ShowType k
+
+infixl 5 :<<>>:
+type (:<<>>:) (k1 :: t1) (k2 :: t2) = ToEM k1 ':<>: ToEM k2
+
+infixl 4 :$$$:
+type (:$$$:) (k1 :: t1) (k2 :: t2) = ToEM k1 ':$$: ToEM k2
+
+
+{- | Combine multiple lines with line break. Type-level version of the @unlines@
+function but for ErrorMessage. -}
+type family Unlines (ln :: [k]) :: ErrorMessage where
+  Unlines '[] = 'Text ""
+  Unlines ((x :: Symbol) ': xs) = 'Text x ':$$: Unlines xs
+  Unlines ((x :: ErrorMessage) ': xs) = x ':$$: Unlines xs
+
+infixl 4 :++:
+type family (:++:) (as :: [k]) (bs :: [k]) :: [k] where
+  (:++:) a '[] = a
+  (:++:) '[] b = b
+  (:++:) (a ': as) bs = a ': (as :++: bs)

--- a/clash-prelude/src/Clash/Class/HasDomain/HasSingleDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/HasSingleDomain.hs
@@ -1,0 +1,179 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+#if __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
+
+{-# OPTIONS_GHC -Wno-missing-methods #-}
+
+module Clash.Class.HasDomain.HasSingleDomain where
+
+import           Clash.Class.HasDomain.Common
+import           Clash.Class.HasDomain.CodeGen    (mkTryDomainTuples)
+
+import           Clash.Sized.Vector               (Vec)
+import           Clash.Sized.RTree                (RTree)
+import           Clash.Signal.Internal
+  (Signal, Domain, Clock, Reset, Enable)
+import           Clash.Signal.Delayed.Internal    (DSignal)
+
+import           Data.Kind                        (Type)
+import           Data.Proxy                       (Proxy)
+import           Type.Errors
+  (DelayError, TypeError, IfStuck, Pure)
+
+type MissingInstance =
+        "This might happen if an instance for TryDomain is missing. Try to determine"
+  :$$$: "which of the types miss an instance, and add them. Example implementations:"
+  :$$$: ""
+  :$$$: " * type instance HasDomain t (MyVector n a)    = TryDomain t a"
+  :$$$: " * type instance HasDomain t (MyCircuit dom a) = Found dom"
+  :$$$: " * type instance HasDomain t Terminal          = NotFound"
+  :$$$: ""
+  :$$$: "Alternatively, use one of the withSpecific* functions."
+
+type Outro =
+         ""
+   :$$$: "------"
+   :$$$: ""
+   :$$$: "You tried to apply an explicitly routed clock, reset, or enable line"
+   :$$$: "to a construct with, possibly, an implicitly routed one. Clash failed to"
+   :$$$: "unambigously determine a single domain and could therefore not route it."
+   :$$$: "You possibly used one of these sets of functions:"
+   :$$$: ""
+   :$$$: " * with{ClockResetEnable,Clock,Reset,Enable}"
+   :$$$: " * expose{ClockResetEnable,Clock,Reset,Enable}"
+   :$$$: ""
+   :$$$: "These functions are suitable for components defined over a single domain"
+   :$$$: "only. If you want to use multiple domains, use the following instead:"
+   :$$$: ""
+   :$$$: " * withSpecific{ClockResetEnable,Clock,Reset,Enable}"
+   :$$$: " * exposeSpecific{ClockResetEnable,Clock,Reset,Enable}"
+   :$$$: ""
+
+type NotFoundError (t :: Type) =
+       "Could not find a domain in the following type:"
+  :$$$: ""
+  :$$$: "  " :<<>>: t
+  :$$$: ""
+  :$$$: MissingInstance
+  :$$$: Outro
+
+type AmbiguousError (t :: Type) (dom1 :: Domain) (dom2 :: Domain) =
+        "Could not determine that the domain '" :<<>>: dom1 :<<>>: "'"
+  :$$$: "was equal to the domain '" :<<>>: dom2 :<<>>: "' in the type:"
+  :$$$: ""
+  :$$$: "  " :<<>>: t
+  :$$$: ""
+  :$$$: "This is usually resolved by adding explicit type signatures."
+  :$$$: Outro
+
+type StuckErrorMsg (orig :: Type) (n :: Type) =
+        "Could not determine whether the following type contained a domain:"
+  :$$$: ""
+  :$$$: "  " :<<>>: n
+  :$$$: ""
+  :$$$: "In the full type:"
+  :$$$: ""
+  :$$$: "  " :<<>>: orig
+  :$$$: ""
+  :$$$: MissingInstance
+  :$$$: Outro
+
+-- | Type that forces /dom/ to be the same in all subtypes of /r/ that might
+-- contain a domain. If given a polymorphic domain not tied to /r/, GHC will
+-- be allowed to infer that that domain is equal to the one in /r/ on the
+-- condition that /r/ contains just a single domain.
+type WithSingleDomain dom r =
+  (HasSingleDomain r, dom ~ GetDomain r)
+
+data TryDomainResult
+  = NotFound
+  | Ambiguous Domain Domain
+  | Found Domain
+
+-- | Type family to resolve type conflicts (if any)
+type family Merge' (n :: TryDomainResult) (m :: TryDomainResult) :: TryDomainResult where
+  Merge' 'NotFound              b                      = b
+  Merge' ('Ambiguous dom1 dom2) b                      = 'Ambiguous dom1 dom2
+  Merge' a                      'NotFound              = a
+  Merge' a                      ('Ambiguous dom1 dom2) = 'Ambiguous dom1 dom2
+  Merge' ('Found dom)           ('Found dom)           = 'Found dom
+  Merge' ('Found dom1)          ('Found dom2)          = 'Ambiguous dom1 dom2
+
+-- | Same as Merge', but will insert a type error if Merge' got stuck.
+type family Merge (orig :: Type) (n :: Type) (m :: Type) :: TryDomainResult where
+  Merge orig n m =
+    IfStuck
+      (TryDomain orig n)
+      (DelayError (StuckErrorMsg orig n))
+      (Pure
+        (IfStuck
+          (TryDomain orig m)
+          (DelayError (StuckErrorMsg orig m))
+          (Pure (Merge' (TryDomain orig n) (TryDomain orig m)))
+         ))
+
+type family ErrOnConflict (t :: Type) (n :: TryDomainResult) :: Domain where
+  ErrOnConflict t 'NotFound              = TypeError (NotFoundError t)
+  ErrOnConflict t ('Ambiguous dom1 dom2) = TypeError (AmbiguousError t dom1 dom2)
+  ErrOnConflict t ('Found dom)           = dom
+
+type family TryDomain (orig :: Type) (n :: Type) :: TryDomainResult
+
+type instance TryDomain t (DSignal dom delay a) = 'Found dom
+type instance TryDomain t (Signal dom a)        = 'Found dom
+type instance TryDomain t (Clock dom)           = 'Found dom
+type instance TryDomain t (Reset dom)           = 'Found dom
+type instance TryDomain t (Enable dom)          = 'Found dom
+type instance TryDomain t (Proxy dom)           = 'Found dom
+type instance TryDomain t (Vec n a)             = TryDomain t a
+type instance TryDomain t (RTree d a)           = TryDomain t a
+type instance TryDomain t (a -> b)              = Merge t a b
+type instance TryDomain t (a, b)                = Merge t a b
+
+type instance TryDomain t Bool                  = 'NotFound
+type instance TryDomain t Integer               = 'NotFound
+type instance TryDomain t Int                   = 'NotFound
+type instance TryDomain t Float                 = 'NotFound
+type instance TryDomain t Double                = 'NotFound
+type instance TryDomain t (Maybe a)             = TryDomain t a
+type instance TryDomain t (Either a b)          = Merge t a b
+
+-- TODO: Add more instances, including:
+--type instance TryDomain t Bit                   = 'NotFound
+--type instance TryDomain t (BitVector n)         = 'NotFound
+--type instance TryDomain t (Index n)             = 'NotFound
+--type instance TryDomain t (Fixed rep int frac)  = 'NotFound
+--type instance TryDomain t (Signed n)            = 'NotFound
+--type instance TryDomain t (Unsigned n)          = 'NotFound
+
+-- | Type family that searches a type and checks whether all subtypes that can
+-- contain a domain (for example, Signal) contain the /same/ domain. Its
+-- associated type, GetDomain, will yield a type error if that doesn't hold OR
+-- if it can't check it.
+class HasSingleDomain (r :: Type) where
+  type GetDomain r :: Domain
+  type GetDomain r =
+    -- Handle types not in TryDomain type family
+    IfStuck
+      (TryDomain r r)
+      (DelayError (StuckErrorMsg r r))
+      (Pure (ErrOnConflict r (TryDomain r r)))
+
+instance HasSingleDomain a
+
+mkTryDomainTuples ''TryDomain ''Merge

--- a/clash-prelude/src/Clash/Class/HasDomain/HasSpecificDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/HasSpecificDomain.hs
@@ -1,0 +1,145 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+#if __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
+
+{-# OPTIONS_GHC -Wno-missing-methods #-}
+
+module Clash.Class.HasDomain.HasSpecificDomain where
+
+import           Clash.Class.HasDomain.CodeGen  (mkHasDomainTuples)
+import           Clash.Class.HasDomain.Common
+
+import           Clash.Sized.Vector             (Vec)
+import           Clash.Signal.Internal
+  (Signal, Domain, Clock, Reset, Enable)
+import           Clash.Signal.Delayed.Internal  (DSignal)
+
+import           Data.Proxy                     (Proxy)
+import           Data.Kind                      (Type)
+import           Type.Errors
+  (IfStuck, DelayError, Pure, ErrorMessage(ShowType))
+
+type Outro =
+         ""
+   :$$$: "------"
+   :$$$: ""
+   :$$$: "You tried to apply an explicitly routed clock, reset, or enable line"
+   :$$$: "to a construct with, possibly, an implicitly routed one. Clash failed to"
+   :$$$: "unambigously link the given domain (by passing in a 'Clock', 'Reset', or"
+   :$$$: "'Enable') to the component passed in."
+   :$$$: ""
+
+type NotFoundError (dom :: Domain) (t :: Type) =
+       "Could not find domain '" :<<>>: 'ShowType dom :<<>>: "' in the following type:"
+  :$$$: ""
+  :$$$: "  " :<<>>: t
+  :$$$: ""
+  :$$$: "If that type contains that domain anyway, you might need to provide an"
+  :$$$: "additional type instance of HasDomain. Example implementations:"
+  :$$$: ""
+  :$$$: " * type instance HasDomain dom  (MyVector n a)     = HasDomain a"
+  :$$$: " * type instance HasDomain dom1 (MyCircuit dom2 a) = DomEq dom1 dom2"
+  :$$$: ""
+  :$$$: Outro
+
+-- | Type that forces /dom/ to be present in /r/ at least once. Will resolve to
+-- a type error if it doesn't. It will always fail if given /dom/ is completely
+-- polymorphic and can't be tied to /r/ in any way.
+type WithSpecificDomain dom r =
+  (HasSpecificDomain dom r, dom ~ GetDomain dom r)
+
+-- TODO: Extend HasDomainWrapperResult such that it keeps track of what it found /
+-- TODO: which types are stuck, so that we can report better errors.
+data HasDomainWrapperResult
+  = NotFound
+  -- ^ No domain found
+  | Found
+  -- ^ Found the specific domain caller was looking for
+
+-- | Merge two 'HasDomainWrapperResult's according to the semantics of 'HasDomain.
+type family MergeWorker (n :: HasDomainWrapperResult) (m :: HasDomainWrapperResult) :: HasDomainWrapperResult where
+  MergeWorker 'Found b = 'Found
+  MergeWorker a 'Found = 'Found
+  MergeWorker 'NotFound 'NotFound = 'NotFound
+
+type Merge (dom :: Domain) (n :: Type) (m :: Type) =
+  MergeWorker (HasDomainWrapper dom n) (HasDomainWrapper dom m)
+
+type family DomEqWorker (n :: Domain) (m :: Domain) :: HasDomainWrapperResult where
+  DomEqWorker n n = 'Found
+  DomEqWorker n m = 'NotFound
+
+-- | Check domain for equality. Return 'Found if so, return 'NotFound if not.
+-- The reason d'etre for this type family is that _open_ type families don't
+-- allow overlapping types. We therefore defer equality checking to a closed
+-- type family.
+type DomEq (n :: Domain) (m :: Domain) =
+  IfStuck (DomEqWorker n m) ('NotFound) (Pure (DomEqWorker n m))
+
+-- | Type family that searches a type and checks whether a specific domain is
+-- present. Will result in either "domain not found, and no others either",
+-- "domain not found, but found another", or "found domain".
+type family HasDomain (dom :: Domain) (n :: Type) :: HasDomainWrapperResult
+
+type instance HasDomain dom1 (Proxy dom2)           = DomEq dom1 dom2
+type instance HasDomain dom1 (Signal dom2 a)        = DomEq dom1 dom2
+type instance HasDomain dom1 (DSignal dom2 delay a) = DomEq dom1 dom2
+type instance HasDomain dom1 (Clock dom2)           = DomEq dom1 dom2
+type instance HasDomain dom1 (Reset dom2)           = DomEq dom1 dom2
+type instance HasDomain dom1 (Enable dom2)          = DomEq dom1 dom2
+type instance HasDomain dom (Vec n a)               = HasDomain dom a
+type instance HasDomain dom (a, b)                  = Merge dom a b
+type instance HasDomain dom (a -> b)                = Merge dom a b
+
+type family ErrOnNotFound (dom :: Domain) (n :: HasDomainWrapperResult) (t :: Type) :: Domain where
+  ErrOnNotFound dom  'NotFound t = DelayError (NotFoundError dom t)
+  ErrOnNotFound dom  'Found    t = dom
+
+-- | Wrapper that checks for stuckness and returns "NotFound" if so
+type family HasDomainWrapper (dom :: Domain) (n :: Type) :: HasDomainWrapperResult where
+  HasDomainWrapper dom n =
+    IfStuck
+      (HasDomain dom n)
+      ('NotFound)
+      (Pure (HasDomain dom n))
+
+-- | Helper function for HasSpecificDomain class (I don't really understand
+-- why this one is necessary. HasDomainWrapper _should_ check for stuckness
+-- and does so according to tests..
+type family ResolveOrErr (dom :: Domain) (t :: Type) :: Domain where
+  ResolveOrErr dom t =
+    IfStuck
+      (HasDomainWrapper dom t)
+      (ErrOnNotFound dom 'NotFound t)
+      (Pure (ErrOnNotFound dom (HasDomainWrapper dom t) t))
+
+-- | Type class that specifies that a certain domain, /dom/, needs to be present
+-- in some other type, /r/. This is used to disambiguate what hidden clock,
+-- reset, and enable lines should be exposed in functions such as
+-- 'withSpecificReset'.
+--
+-- Functions in need of this class should use 'WithSpecificDomain' though, to
+-- force Clash to display an error instead of letting it silently pass.
+class HasSpecificDomain (dom :: Domain) (r :: Type) where
+  type GetDomain dom r :: Domain
+  type GetDomain dom r = ResolveOrErr dom r
+
+instance HasSpecificDomain dom a
+
+mkHasDomainTuples ''HasDomain ''Merge

--- a/clash-prelude/tests/Clash/Tests/Signal.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal.hs
@@ -1,12 +1,90 @@
-{-# LANGUAGE TypeApplications #-}
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
+
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
 
 module Clash.Tests.Signal where
 
-import Test.Tasty
-import Test.Tasty.HUnit
-import Clash.Signal
+import           Clash.Signal
 
+import           Data.List                      (isInfixOf)
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import qualified Language.Haskell.Interpreter   as Hint
+import           Language.Haskell.Interpreter   (OptionVal((:=)))
+
+customTypeMark :: String
+customTypeMark = "You tried to apply an explicitly routed clock, reset, or enable line"
+
+typeCheck
+  :: String
+  -> IO (Either Hint.InterpreterError ())
+typeCheck expr =
+  Hint.runInterpreter $ do
+    Hint.setImports ["Clash.Prelude"]
+    Hint.set [Hint.languageExtensions := [Hint.RankNTypes, Hint.TypeApplications]]
+    mapM_ Hint.runStmt [test0s, test1s, test2s, test3s, test4s]
+    Hint.interpret expr (Hint.as :: ())
+
+assertCustomTypeError :: String -> String -> Assertion
+assertCustomTypeError expectedErr expr = do
+  result <- typeCheck expr
+  case result of
+    Left err ->
+      if expectedErr `isInfixOf` show err then
+        pure ()
+      else
+        assertFailure $
+             "Expression failed to typecheck as expected, but did not contain "
+          ++ "expected type error. Instead it contained: " ++ show err
+    Right () ->
+      assertFailure "Expression should have failed to typecheck, but succeeded."
+
+main :: IO ()
+main = defaultMain tests
+
+test0s, test1s, test2s, test3s :: String
+test0s = "let test0 = undefined :: Signal dom1 a -> Signal dom2 Int"
+test1s = "let test1 = undefined :: Int -> Char -> Int"
+test2s = "let test2 = undefined :: Signal System a -> Signal XilinxSystem Int"
+test3s = "let test3 = () :: ()"
+test4s = "let test4 = undefined :: ((Signal dom1 a, Signal dom2 a), Signal dom3 a)"
+test5s = "let test5 = undefined :: ((Char, Signal dom1 a), Signal dom2 a)"
+
+test0 :: forall dom1 dom2. Signal dom1 Int -> Signal dom2 Int
+test0 = undefined
+
+test1 :: Int -> Char -> Int
+test1 = undefined
+
+test2 :: Signal System a -> Signal XilinxSystem Int
+test2 = undefined
+
+test3 :: ()
+test3 = ()
+
+test4
+  :: forall dom1 dom2 dom3 dom4 a
+   . ((Signal dom1 a, Signal dom2 a), Signal dom3 a)
+  -> Signal dom4 a
+test4 = undefined
+
+test5
+  :: forall dom1 dom2 a b
+   . ((b, Signal dom1 a), Signal dom2 a)
+test5 = undefined
+
+acte :: String -> Assertion
+acte = assertCustomTypeError customTypeMark
 
 tests :: TestTree
 tests =
@@ -18,7 +96,74 @@ tests =
           let rst0 = fromList [True, True, False, False, True, True]
               rst1 = unsafeFromHighPolarity rst0
               reg  = register 'a' (pure 'b')
-              sig = withReset0 rst1 reg
-          in  testCase "withReset0" (sampleN @System 6 sig @?= "aaabaa")
+              sig = withReset rst1 reg
+          in  testCase "withReset behavior" (sampleN @System 6 sig @?= "aaabaa")
+
+          -- See: https://github.com/clash-lang/clash-compiler/pull/669
+        , testCase "test0nok_0" (acte "withReset resetGen test0")
+        , testCase "test0nok_1" (acte "withReset (resetGen @System) test0")
+        , testCase "test0nok_2" (acte "withReset @System (resetGen @System) test0")
+        , testCase
+            "test0nok_3"
+            (acte
+              (unwords
+                [ "withReset", "@System", "(resetGen @System)"
+                , "(test0 :: Signal System a -> Signal dom Int)"
+                ]))
+
+        , testCase "test0nok_4" (acte "withSpecificReset resetGen test0")
+        , testCase "test0nok_5" (acte "withSpecificReset (resetGen @System) test0")
+
+        , testCase "test1nok_0" (acte "withReset resetGen test1")
+        , testCase "test1nok_1" (acte "withReset (resetGen @System) test1")
+        , testCase "test1nok_2" (acte "withSpecificReset resetGen test1")
+        , testCase "test1nok_3" (acte "withSpecificReset (resetGen @System) test1")
+
+        , testCase "test2nok_0" (acte "withReset resetGen test2")
+        , testCase "test2nok_1" (acte "withReset (resetGen @System) test2")
+        , testCase "test2nok_2" (acte "withSpecificReset resetGen test2")
+
+        , testCase "test3nok_0" (acte "withReset resetGen test3")
+        , testCase "test3nok_1" (acte "withReset (resetGen @System) test3")
+        , testCase "test3nok_2" (acte "withSpecificReset resetGen test3")
+        , testCase "test3nok_3" (acte "withSpecificReset (resetGen @System) test3")
+
+        , testCase "test4nok_0" (acte $
+             "withSpecificReset resetGen (test4 :: "
+          ++ "((Signal System a, Signal dom2 a), Signal dom3 a)"
+          ++ "-> Signal dom4 a)" )
+
+        , testCase "test4nok_1" (acte $
+             "withSpecificReset resetGen (test4 :: "
+          ++ "((Signal dom1 a, Signal System a), Signal dom3 a)"
+          ++ "-> Signal dom4 a)" )
+
+        , testCase "test4nok_2" (acte $
+             "withReset resetGen (test4 :: "
+          ++ "((Signal System a, Signal dom2 a), Signal dom3 a)"
+          ++ "-> Signal dom4 a)" )
+
+        , testCase "test4nok_3" (acte $
+             "withReset resetGen (test4 :: "
+          ++ "((Signal dom1 a, Signal System a), Signal dom3 a)"
+          ++ "-> Signal dom4 a)" )
+
+        , testCase "test5nok_0" (acte "withSpecificReset resetGen test5")
         ]
     ]
+
+-- Tests below should survive compilation:
+test0ok_0 = withReset @System (resetGen @System) (test0 @System @System)
+test0ok_1 = withReset resetGen (test0 @System @System)
+test0ok_2 = withSpecificReset (resetGen @System) (test0 @System)
+test0ok_3 = withSpecificReset (resetGen @System) (test0 @_ @System)
+
+test2ok_0 = withSpecificReset (resetGen @System) test2
+test2ok_1 = withSpecificReset @System resetGen test2
+
+test4ok_0 = withReset resetGen (test4 @System @System @System @System)
+test4ok_1 = withSpecificReset (resetGen @System) (test4 @System @_ @_ @_)
+test4ok_2 = withSpecificReset (resetGen @System) (test4 @_ @System @_ @_)
+test4ok_3 = withSpecificReset (resetGen @System) (test4 @_ @_ @System @_)
+
+test5ok_0 = withSpecificReset (resetGen @System) (test5 @System @_)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.3
+resolver: lts-13.28
 
 packages:
 - clash-prelude
@@ -8,6 +8,8 @@ packages:
 
 extra-deps:
 - ./clash-cosim
+- type-errors-0.2.0.0@sha256:b8f97a0cf72f4fcdc9bfd02d753f84e65e5e5d165d53f82947a95cdcbd7f2945
+- first-class-families-0.5.0.0@sha256:6e1488c502d5b1e780739a53edab65a307c6bf94d4232fab70e696e87f0fa087
 
 - git: https://github.com/clash-lang/ghc-typelits-extra
   commit: a8de0b68b8216411cb862195354f251cd41bae50

--- a/tests/shouldwork/Basic/MultipleHidden.hs
+++ b/tests/shouldwork/Basic/MultipleHidden.hs
@@ -45,10 +45,7 @@ topEntity
   -> Signal DomB (Unsigned 16)
   -> Signal DomA (Unsigned 16)
 topEntity clkA rstA enA clkB rstB enB a b =
-  exposeClockResetEnable
-    (exposeClockResetEnable (topEntityI @DomA @DomB) clkA rstA enA)
-    clkB rstB enB
-    a b
+  withSpecificClockResetEnable clkA rstA enA $ withSpecificClockResetEnable clkB rstB enB (topEntityI a) b
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal DomA Bool

--- a/tests/shouldwork/CustomReprs/Deriving/BitPackDerivation.hs
+++ b/tests/shouldwork/CustomReprs/Deriving/BitPackDerivation.hs
@@ -47,7 +47,7 @@ testBench = done'
                                             :> Nil
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable0
+      withClockResetEnable
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
+++ b/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
@@ -37,7 +37,7 @@ testBench = done'
 
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable0
+      withClockResetEnable
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
+++ b/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
@@ -91,7 +91,7 @@ testBench = done'
 
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable0
+      withClockResetEnable
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
@@ -58,7 +58,7 @@ testBench = done'
 
     done = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable0
+      withClockResetEnable
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
@@ -102,7 +102,7 @@ testBench = done'
 
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable0
+      withClockResetEnable
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
+++ b/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
@@ -98,7 +98,7 @@ testBench = done'
 
     done  = expectedOutput (topEntity testInput)
     done' =
-      withClockResetEnable0
+      withClockResetEnable
         (tbSystemClockGen (not <$> done'))
         systemResetGen
         enableGen

--- a/tests/shouldwork/SynthesisAttributes/Product.hs
+++ b/tests/shouldwork/SynthesisAttributes/Product.hs
@@ -100,4 +100,4 @@ testBench = done'
                                                   ])
 
     done           = expectedOutput (topEntity testInput)
-    done'          = withClockResetEnable0 (tbSystemClockGen (not <$> done')) systemResetGen enableGen done
+    done'          = withClockResetEnable (tbSystemClockGen (not <$> done')) systemResetGen enableGen done

--- a/tests/shouldwork/Vector/FoldlFuns.hs
+++ b/tests/shouldwork/Vector/FoldlFuns.hs
@@ -28,4 +28,4 @@ mod' = o
     o :: Signal dom (BitVector 32)
     o = f (pure 0)
 
-topEntity clk rst en = withClockResetEnable0 @System clk rst en (mod' @System)
+topEntity clk rst en = withClockResetEnable @System clk rst en mod'


### PR DESCRIPTION
Rewritten: 2019-07-17

----------------------------------

This is a follow-up of PR #655. That PR identified unexpected behavior
when using 'withReset' in combination with 'sample'. It originally
proposed a solution with a type class "HasDomain" that solved the
unexpected behavior, but potentially introduced confusing error reports
if misused. We therefore settled on a simpler, though more cumbersome,
way of dealing with the issue: we introduced 'withReset0', 'withReset' -
that only worked on Signal dom a -> r -, and 'withResetProxy'. After
testing this change on larger codebases we concluded that this wasn't
satisfactory either. Upgrading to the new API still triggered confusing
errors and the new API seemed worse for no obvious reason.

This commit revisits the originally proposed solution. Once more, we
introduce type classes: HasSingleDomain and HasSpecificDomain. Both
type classes aim to tie the domain provided by the explicitely passed
clock, reset, or enable lines to the domain in the given construct.
This change differs from the original solution in that it tries to
generate clear error messages if the functions using it can't resolve
the constraint. For example, if a user tries to use 'withReset' on a
function whose first argument does not contain a domain, they will
get an error message explaining what happened:

	>>> withReset resetGen (3 :: Int)
	error:
	    • Could not find a domain in the following type:

		Int

	      This might happen if an instance for TryDomain is missing. Try to determine
	      which of the types miss an instance, and add them. Example implementations:

	       * type instance HasDomain t (MyVector n a)    = TryDomain t a
	       * type instance HasDomain t (MyCircuit dom a) = Found dom
	       * type instance HasDomain t Terminal          = NotFound

	      Alternatively, use one of the withSpecific* functions.

	      ------

	      You tried to apply an explicitely routed clock, reset, or enable line
	      to a construct with, possibly, an implicitely routed one. Clash failed to
	      unambigously determine a single domain and could therefore not route it.
	      You possibly used one of these sets of functions:

	       * with{ClockResetEnable,Clock,Reset,Enable}
	       * expose{ClockResetEnable,Clock,Reset,Enable}

	      These functions are suitable for components defined over a single domain
	      only. If you want to use multiple domains, use the following instead:

	       * withSpecific{ClockResetEnable,Clock,Reset,Enable}
	       * exposeSpecifc{ClockResetEnable,Clock,Reset,Enable}

	    • In the expression: withReset resetGen (3 :: Int)
	      In an equation for ‘it’: it = withReset resetGen (3 :: Int)

Error messages will try to be specific, although there is still a lot of
work to do.

	>>> withReset resetGen (Prelude.undefined :: Int -> Index n -> Signal XilinxSystem b)

	error:
	    • Could not determine whether the following type contained a domain:

		Index n

	      In the full type:

		Int -> Index n -> Signal XilinxSystem b

	      This might happen if an instance for TryDomain is missing. Try to determine
	      which of the types miss an instance, and add them. Example implementations:

	       * type instance HasDomain t (MyVector n a)    = TryDomain t a
	       * type instance HasDomain t (MyCircuit dom a) = Found dom
	       * type instance HasDomain t Terminal          = NotFound

	      Alternatively, use one of the withSpecific* functions.

	      ------

	      You tried to apply an explicitely routed clock, reset, or enable line
	      to a construct with, possibly, an implicitely routed one. Clash failed to
	      unambigously determine a single domain and could therefore not route it.
	      You possibly used one of these sets of functions:

	       * with{ClockResetEnable,Clock,Reset,Enable}
	       * expose{ClockResetEnable,Clock,Reset,Enable}

	      These functions are suitable for components defined over a single domain
	      only. If you want to use multiple domains, use the following instead:

	       * withSpecific{ClockResetEnable,Clock,Reset,Enable}
	       * exposeSpecifc{ClockResetEnable,Clock,Reset,Enable}

	    • When checking the inferred type [..]

Two `withReset` (and Clock/Enable) strategies now exist:

 1. `withReset`: will only work if it can determine a _single_ domain
    in a given type. Allows given reset domain to be inferred. That is
    a call such as `withReset resetGen f` will work as long as `f`
    contains a single domain.

 2. `withSpecific`: will look for a _specific_ domain in a given type.
    That is, the domain of the given clock/reset/enable must be known
    and present in the given type.

These two strategies should strike a happy balance between simple for
beginners, and fully usable for advanced users. Most importantly, it's
always safe to use.