### PR TITLE
Constant-memory writer-part of RewriteMonad

### DIFF
--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -67,7 +67,7 @@ import qualified Control.Lens                as Lens
 import qualified Control.Monad               as Monad
 import           Control.Monad.State         (StateT (..), modify)
 import           Control.Monad.State.Strict  (evalState)
-import           Control.Monad.Writer        (censor, lift, listen)
+import           Control.Monad.Writer        (lift, listen)
 import           Control.Monad.Trans.Except  (runExcept)
 import           Data.Bits                   ((.&.), complement)
 import           Data.Coerce                 (coerce)

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -80,8 +80,8 @@ import           Clash.Util
 -- | Lift an action working in the '_extra' state to the 'RewriteMonad'
 zoomExtra :: State.State extra a
           -> RewriteMonad extra a
-zoomExtra m = R (\_ s -> case State.runState m (s ^. extra) of
-                           (a,s') -> (a,s {_extra = s'},mempty))
+zoomExtra m = R (\_ s w -> case State.runState m (s ^. extra) of
+                            (a,s') -> (a,s {_extra = s'},w))
 
 -- | Some transformations might erroneously introduce shadowing. For example,
 -- a transformation might result in:


### PR DESCRIPTION
Uses the CPS version for the writer part as found in: http://hackage.haskell.org/package/transformers-0.5.6.2/docs/Control-Monad-Trans-RWS-CPS.html