### PR TITLE
Add CPP flag to decrease number of TH generated tuple instances

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -197,6 +197,7 @@ Library
                       Clash.Examples
 
   other-modules:      Clash.Class.BitPack.Internal
+                      Clash.CPP
                       Clash.Signal.Bundle.Internal
                       Paths_clash_prelude
 

--- a/clash-prelude/src/Clash/CPP.hs
+++ b/clash-prelude/src/Clash/CPP.hs
@@ -1,0 +1,19 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE CPP#-}
+{-# OPTIONS_HADDOCK hide #-}
+
+#ifndef MAX_TUPLE_SIZE
+#define MAX_TUPLE_SIZE 62
+#endif
+
+module Clash.CPP
+ ( maxTupleSize
+ ) where
+
+maxTupleSize :: Num a => a
+maxTupleSize = MAX_TUPLE_SIZE

--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -3,10 +3,12 @@ Copyright  :  (C) 2019, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Class.BitPack.Internal (deriveBitPackTuples) where
 
+import           Clash.CPP             (maxTupleSize)
 import           Control.Monad         (replicateM)
 import           Data.List             (foldl')
 import           GHC.TypeLits          (KnownNat)
@@ -29,13 +31,13 @@ deriveBitPackTuples bitPackName bitSizeName packName unpackName = do
       knownNat = ConT ''KnownNat
       plus     = ConT $ mkName "+"
 
-  allNames <- replicateM 62 (newName "a")
+  allNames <- replicateM maxTupleSize (newName "a")
   retupName <- newName "retup"
   x <- newName "x"
   y <- newName "y"
   tup <- newName "tup"
 
-  pure $ flip map [3..62] $ \tupleNum ->
+  pure $ flip map [3..maxTupleSize] $ \tupleNum ->
     let names  = take tupleNum allNames
         (v:vs) = fmap VarT names
         tuple xs = foldl' AppT (TupleT $ length xs) xs

--- a/clash-prelude/src/Clash/Class/HasDomain/CodeGen.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/CodeGen.hs
@@ -12,6 +12,7 @@ module Clash.Class.HasDomain.CodeGen
   ) where
 
 import           Language.Haskell.TH.Syntax
+import           Clash.CPP                    (maxTupleSize)
 
 mkTup :: [Type] -> Type
 mkTup names@(length -> n) =
@@ -38,7 +39,7 @@ mkTryDomainTupleInstance tryDomainName mergeName n =
 
 mkTryDomainTuples :: Name -> Name -> Q [Dec]
 mkTryDomainTuples tryDomainName mergeName =
-  pure (map (mkTryDomainTupleInstance tryDomainName mergeName) [3..62])
+  pure (map (mkTryDomainTupleInstance tryDomainName mergeName) [3..maxTupleSize])
 
 
 -- | Creates an instance of the form:
@@ -63,4 +64,4 @@ mkHasDomainTupleInstance hasDomainName mergeName n =
 
 mkHasDomainTuples :: Name -> Name -> Q [Dec]
 mkHasDomainTuples hasDomainName mergeName =
-  pure (map (mkHasDomainTupleInstance hasDomainName mergeName) [3..62])
+  pure (map (mkHasDomainTupleInstance hasDomainName mergeName) [3..maxTupleSize])

--- a/clash-prelude/src/Clash/Signal/Bundle/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle/Internal.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Signal.Bundle.Internal where
 
+import           Clash.CPP             (maxTupleSize)
 import           Clash.Signal.Internal (Signal)
 import           Control.Monad         (replicateM)
 import           Data.List             (foldl')
@@ -22,13 +24,13 @@ deriveBundleTuples bundleTyName unbundledTyName bundleName unbundleName = do
   let bundleTy = ConT bundleTyName
       signal   = ConT ''Signal
 
-  allNames <- replicateM 62 (newName "a")
-  tempNames <- replicateM 62 (newName "b")
+  allNames <- replicateM maxTupleSize (newName "a")
+  tempNames <- replicateM maxTupleSize (newName "b")
   t <- newName "t"
   x <- newName "x"
   tup <- newName "tup"
 
-  pure $ flip map [2..62] $ \tupleNum ->
+  pure $ flip map [2..maxTupleSize] $ \tupleNum ->
     let names = take tupleNum allNames
         temps = take tupleNum tempNames
         vars  = fmap VarT names


### PR DESCRIPTION
By default, all tuple instances will still be build. This CPP flag gives developers the option to reduce the number of tuple instance will be generated. To do this, add the following to `cabal.project.local`:

```
package clash-prelude
  ghc-options: -DMAX_TUPLE_SIZE=7
```

This halves compilation time on my machine.