### PR TITLE
Always inline class dictionaries

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -86,7 +86,7 @@ import TyCon      (AlgTyConRhs (..), TyCon, tyConName,
                    expandSynTyCon_maybe,
                    tyConArity,
                    tyConDataCons, tyConKind,
-                   tyConName, tyConUnique)
+                   tyConName, tyConUnique, isClassTyCon)
 import Type       (mkTvSubstPrs, substTy, coreView)
 import TyCoRep    (Coercion (..), TyLit (..), Type (..))
 import Unique     (Uniquable (..), Unique, getKey, hasKey)
@@ -164,6 +164,7 @@ makeTyCon fiEnvs tc = tycon
                 , C.tyConKind   = tcKind
                 , C.tyConArity  = tcArity
                 , C.algTcRhs    = tcRhs
+                , C.isClassTc   = isClassTyCon tc
                 }
             Nothing -> return (C.PrimTyCon (C.nameUniq tcName) tcName tcKind tcArity)
 
@@ -197,6 +198,7 @@ makeTyCon fiEnvs tc = tycon
             , C.tyConKind   = tcKind
             , C.tyConArity  = tcArity
             , C.algTcRhs    = tcDc
+            , C.isClassTc   = isClassTyCon tc
             }
 
         mkPrimTyCon = do

--- a/clash-lib/src/Clash/Core/TyCon.hs
+++ b/clash-lib/src/Clash/Core/TyCon.hs
@@ -47,6 +47,7 @@ data TyCon
   , tyConKind   :: !Kind        -- ^ Kind of the TyCon
   , tyConArity  :: !Int         -- ^ Number of type arguments
   , algTcRhs    :: !AlgTyConRhs -- ^ DataCon definitions
+  , isClassTc   :: !Bool        -- ^ Is this a class dictionary?
   }
   -- | Function TyCons (e.g. type families)
   | FunTyCon

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -44,6 +44,7 @@ module Clash.Core.Type
   , isPolyFunCoreTy
   , isPolyTy
   , isFunTy
+  , isClassTy
   , applyFunTy
   , findFunSubst
   , reduceTypeFamily
@@ -560,3 +561,12 @@ normalizeType tcMap = go
     OtherType (ForAllTy tyvar ty')
       -> ForAllTy tyvar (go ty')
     _ -> ty
+
+isClassTy
+  :: TyConMap
+  -> Type
+  -> Bool
+isClassTy tcm (tyView -> TyConApp tcNm _) = case lookupUniqMap tcNm tcm of
+  Just tc -> isClassTc tc
+  Nothing -> False
+isClassTy _ _ = False

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -101,9 +101,9 @@ import           Clash.Core.Term
   (LetBinding, Pat (..), Term (..), CoreContext (..), PrimInfo (..),
    isLambdaBodyCtx, collectArgs)
 import           Clash.Core.Type             (Type, TypeView (..), applyFunTy,
-                                              isPolyFunCoreTy,
+                                              isPolyFunCoreTy, isClassTy,
                                               normalizeType, splitFunForallTy,
-                                              splitFunTy, typeKind,
+                                              splitFunTy,
                                               tyView)
 import           Clash.Core.TyCon            (TyConMap, tyConDataCons)
 import           Clash.Core.Util
@@ -398,8 +398,7 @@ inlineNonRep (TransformContext localScope _) e@(Case scrut altsTy alts)
             changed $ Case (mkApps scrutBody1 args) altsTy alts
           _ -> return e
   where
-    exception tcm ((tyView . typeKind tcm) -> TyConApp (nameOcc -> "GHC.Types.Constraint") _) = True
-    exception _ _ = False
+    exception = isClassTy
 
 inlineNonRep _ e = return e
 

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -195,8 +195,8 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"] "ExpWithClashCF"        (["","ExpWithClashCF_testBench"],"ExpWithClashCF_testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] ["-itests/shouldwork/Numbers"] "ExpWithClashCF"  "main"
         -- TODO: re-enable for Verilog
-        , runTest ("tests" </> "shouldwork" </> "Numbers") (defBuild \\ [Verilog]) ["-itests/shouldwork/Numbers","-fclash-inline-limit=300"] "NumConstantFoldingTB"       (["","NumConstantFoldingTB_testBench"],"NumConstantFoldingTB_testBench",True)
-        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fclash-inline-limit=300", "-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding"  "main"
+        , runTest ("tests" </> "shouldwork" </> "Numbers") (defBuild \\ [Verilog]) ["-itests/shouldwork/Numbers"] "NumConstantFoldingTB"       (["","NumConstantFoldingTB_testBench"],"NumConstantFoldingTB_testBench",True)
+        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding"  "main"
 #if MIN_VERSION_base(4,12,0)
         -- Naturals are broken on GHC <= 8.4. See https://github.com/clash-lang/clash-compiler/pull/473
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Naturals"     (["","Naturals_testBench"],"Naturals_testBench",True)


### PR DESCRIPTION
Previously, in inlineNonRep, we checked whether the type of the scrutinee that we were inlining was of kind "Constraint". However, somewhere along the way in one of the GHC releases, it has become impossible to determine if something is of kind "Constraint"; it's always of kind "TYPE" basically.

So now, we just check whether something is a class dictionary, and if so, always inline it.