### PR TITLE
Fix clash-dev

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -5,5 +5,9 @@ set -xeo pipefail
 # On cabal>=2.4.1.0 and ghc<8.4.4 this isn't done automaticly
 cabal --write-ghc-environment-files=always new-build all
 
+# Check that clash-dev compiles
+sed "s/^ghci/ghc -fno-code/" clash-dev > clash-dev-test
+sh clash-dev-test
+
 cabal new-test clash-cosim clash-prelude
 cabal new-run -- clash-testsuite -j$THREADS --hide-successes

--- a/Clash.hs
+++ b/Clash.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
 
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
 #include "MachDeps.h"
 #define HDLSYN Other
 
@@ -68,8 +70,7 @@ doHDL b src = do
 
     generateHDL (buildCustomReprs reprs) bindingsMap (Just b) primMap2 tcm tupTcm
       (ghcTypeToHWType WORD_SIZE_IN_BITS True) reduceConstant topEntities
-      (ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS
-        Nothing tmpDir HDLSYN True True ["."] Nothing True True False Nothing)
+      (defClashOpts tmpDir){opt_cachehdl = False, opt_dbgLevel = DebugSilent}
       (startTime,prepTime)
    ) (do
     removeDirectoryRecursive tmpDir

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -42,8 +42,7 @@ typeTrans = ghcTypeToHWType WORD_SIZE_IN_BITS True
 
 opts :: FilePath -> [FilePath] -> ClashOpts
 opts tmpDir idirs =
-  ClashOpts 20 20 15 0 DebugNone False True True Auto WORD_SIZE_IN_BITS Nothing
-    tmpDir HDLSYN True True idirs Nothing True True False Nothing True
+  (defClashOpts tmpDir){opt_cachehdl=False, opt_errorExtra = True, opt_floatSupport = True, opt_importPaths=idirs}
 
 backend :: VHDLState
 backend = initBackend WORD_SIZE_IN_BITS HDLSYN True Nothing


### PR DESCRIPTION
Which was broken by the extra field in ClashOpts added for
-fclash-no-check-inaccessible-idirs in #670

By using defClashOpts we should be protected from this in the future.
Also use defClashOpts in BenchmarkCommon.