### PR TITLE
Only report NoDemand for arguments used in BlackBox

### DIFF
--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -16,7 +16,6 @@ import Clash.Driver
 import Clash.Driver.Types
 import Clash.GHC.Evaluator (reduceConstant)
 import Clash.GHC.GenerateBindings
-import Clash.GHC.LoadModules (ghcLibDir)
 import Clash.GHC.NetlistTypes
 import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
 import Clash.Netlist.Types          (HWMap, FilteredHWType)
@@ -64,13 +63,11 @@ runInputStage
         )
 runInputStage tmpDir idirs src = do
   pds <- primDirs backend
-  (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <- generateBindings tmpDir Auto pds idirs (hdlKind backend) src Nothing
+  (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <- generateBindings tmpDir Auto pds idirs [] (hdlKind backend) src Nothing
   let topEntityNames = map (\(x,_,_) -> x) topEntities
       ((topEntity,_,_):_) = topEntities
       tm = topEntity
-  topDir   <- ghcLibDir
-  primMap2 <- sequence $ fmap (sequence . fmap (compilePrimitive [] [] topDir)) primMap
-  return (bindingsMap,tcm,tupTcm,topEntities, primMap2, buildCustomReprs reprs, topEntityNames,tm)
+  return (bindingsMap,tcm,tupTcm,topEntities, primMap, buildCustomReprs reprs, topEntityNames,tm)
 
 runNormalisationStage
   :: FilePath

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -147,7 +147,6 @@ import           Clash.GHC.NetlistTypes
 import           Clash.GHCi.Common
 import           Clash.Netlist.BlackBox.Types (HdlSyn)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
-import qualified Data.HashMap.Strict as HM
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
 
@@ -1967,26 +1966,19 @@ makeHDL backend optsRef srcs = do
 
               forM_ srcs $ \src -> do
                 -- Generate bindings:
+                let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
-                  generateBindings tmpDir color primDirs idirs hdl src (Just dflags)
+                  generateBindings tmpDir color primDirs idirs dbs hdl src (Just dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
-
-                -- Parsing / compiling primitives:
-                startTime' <- Clock.getCurrentTime
-                let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                primMap'   <- sequence $ HM.map (sequence . fmap (Clash.Driver.compilePrimitive idirs dbs (topDir dflags))) primMap
-                prepTime'  <- startTime' `deepseq` primMap' `seq` Clock.getCurrentTime
-                let prepStartDiff' = reportTimeDiff prepTime' startTime'
-                putStrLn $ "Clash: Parsing and compiling primitives took " ++ prepStartDiff'
 
                 -- Generate HDL:
                 Clash.Driver.generateHDL
                   (buildCustomReprs reprs)
                   bindingsMap
                   (Just backend')
-                  primMap'
+                  primMap
                   tcm
                   tupTcm
                   (ghcTypeToHWType iw fp)

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -153,7 +153,6 @@ import           Clash.GHC.NetlistTypes
 import           Clash.GHCi.Common
 import           Clash.Netlist.BlackBox.Types (HdlSyn)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
-import qualified Data.HashMap.Strict as HM
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
 
@@ -2016,26 +2015,19 @@ makeHDL backend optsRef srcs = do
 
               forM_ srcs $ \src -> do
                 -- Generate bindings:
+                let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
-                  generateBindings tmpDir color primDirs idirs hdl src (Just dflags)
+                  generateBindings tmpDir color primDirs idirs dbs hdl src (Just dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
-
-                -- Parsing / compiling primitives:
-                startTime' <- Clock.getCurrentTime
-                let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags ]
-                primMap'   <- sequence $ HM.map (sequence . fmap (Clash.Driver.compilePrimitive idirs dbs (topDir dflags))) primMap
-                prepTime'  <- startTime' `deepseq` primMap' `seq` Clock.getCurrentTime
-                let prepStartDiff' = reportTimeDiff prepTime' startTime'
-                putStrLn $ "Clash: Parsing and compiling primitives took " ++ prepStartDiff'
 
                 -- Generate HDL:
                 Clash.Driver.generateHDL
                   (buildCustomReprs reprs)
                   bindingsMap
                   (Just backend')
-                  primMap'
+                  primMap
                   tcm
                   tupTcm
                   (ghcTypeToHWType iw fp)

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -269,7 +269,7 @@ makeAlgTyConRhs algTcRhs = case algTcRhs of
   TupleTyCon {}    -> error "Cannot handle tuple tycons"
 
 coreToTerm
-  :: ResolvedPrimMap
+  :: CompiledPrimMap
   -> [Var]
   -> CoreExpr
   -> C2C C.Term
@@ -397,7 +397,7 @@ coreToTerm primMap unlocs = term
     coreToIdSP sp = RWS.local (\r -> if isGoodSrcSpan sp then sp else r) . coreToId
 
 
-    lookupPrim :: Text -> Maybe (Maybe ResolvedPrimitive)
+    lookupPrim :: Text -> Maybe (Maybe CompiledPrimitive)
     lookupPrim nm = extractPrim <$> HashMap.lookup nm primMap
 
     var x = do

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -6,6 +6,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -46,9 +47,11 @@ import System.IO.Unsafe      (unsafeDupablePerformIO)
 import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Class.Num       (satSucc, SaturationMode(SatBound))
 import Clash.Promoted.Nat    (SNat(..), snatToNum)
+import Clash.Promoted.Symbol (SSymbol (..))
 import Clash.Explicit.Signal
   (Clock, Reset, System, Signal, clockPeriod, toEnable, fromList, register,
-  unbundle, unsafeSynchronizer, veryUnsafeSynchronizer, clockGen)
+  unbundle, unsafeSynchronizer, veryUnsafeSynchronizer)
+import Clash.Signal.Internal (Clock (..))
 import Clash.Signal
   (mux, DomainResetKind, ResetKind(Asynchronous), KnownDomain, Reset(..),
   Enable)
@@ -445,7 +448,7 @@ tbClockGen
   :: KnownDomain testDom
   => Signal testDom Bool
   -> Clock testDom
-tbClockGen _done = clockGen
+tbClockGen done = Clock (done `seq` SSymbol)
 {-# NOINLINE tbClockGen #-}
 {-# ANN tbClockGen hasBlackBox #-}
 


### PR DESCRIPTION
Previously, we received warnings when any of the arguments of the Haskell implementation of a primitive had a `Absent` demand signature; even if those arguments weren't used in the
BlackBox for the primitive either.

Now we only get a warning when an argument that's used in the BlackBox has an `Absent` demand signature. The reason why this situation is problematic is that expressions occurring in the
argument position of applications of this primitive are sometimes replaced by `absentArg` by GHC; because the Haskell implementation wasn't using those arguments anyway. However,
the BlackBox might actually want to use the literal/constant in that "absent" position, leading to compile failures if that argument is replaced by `absentArg`.

Fixes #320 insofar that Clash now gives warning when the Haskell model of a primitive can lead to compile failures with the Blackbox implementation of the model.