### PR TITLE
Clashi uses `-fobject-code` by default

### DIFF
--- a/clash-ghc/src-ghc/Interactive.hs
+++ b/clash-ghc/src-ghc/Interactive.hs
@@ -13,4 +13,4 @@ import           System.Environment ( getArgs )
 import           Clash.Main         ( defaultMain )
 
 main :: IO ()
-main = getArgs >>= defaultMain . ("--interactive":)
+main = getArgs >>= defaultMain . (["--interactive","-fobject-code"]++)


### PR DESCRIPTION
As a work-around for #439 until we find a better solution.