### PR TITLE
Check a var's idScope in 'specArgBndrsAndVars'

### DIFF
--- a/tests/shouldwork/Feedback/MutuallyRecursive.hs
+++ b/tests/shouldwork/Feedback/MutuallyRecursive.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE RankNTypes #-}
+
+module MutuallyRecursive where
+
+import           Clash.Explicit.Testbench (biTbClockGen, outputVerifier)
+import           Clash.Prelude.Testbench  (stimuliGenerator)
+import qualified Clash.Explicit.Prelude   as Explicit
+import           Clash.Prelude
+import           Data.Proxy               (Proxy (..))
+
+hdlSimTest
+  :: forall dom a b n
+   . (1 <= n, KnownDomain dom)
+  => SNat n
+  -- ^ Reset for /n/ cycles
+  -> (HiddenClockResetEnable dom => a -> Signal dom b)
+  -- ^ Top entity
+  -> (HiddenClockResetEnable dom => Proxy dom -> a)
+  -- ^ Test input
+  -> ((HiddenClockResetEnable dom, SystemClockResetEnable) => Signal dom b -> Signal System Bool)
+  -- ^ Expected output
+  -> Signal System Bool
+hdlSimTest n topEntity testInput expectedOutput = done
+  where
+    (tbClk, dutClk) = biTbClockGen (not <$> done)
+    (tbRst, dutRst) = (resetGenN @System n, resetGenN @dom n)
+    (tbEn, dutEn)   = (enableGen, enableGen)
+
+    topEntity' = withSpecificClockResetEnable dutClk dutRst dutEn topEntity
+    testInput' = withSpecificClockResetEnable dutClk dutRst dutEn testInput Proxy
+
+    expectedOutput' =
+      withSpecificClockResetEnable dutClk dutRst dutEn $
+        withSpecificClockResetEnable tbClk tbRst tbEn expectedOutput
+
+    done = expectedOutput' (topEntity' testInput')
+{-# NOINLINE hdlSimTest #-}
+
+testBench :: Signal System Bool
+testBench = done
+ where
+  (_, clk) = biTbClockGen (not <$> done)
+  done     = hdlSimTest d1 (topEntity clk) testInput expectedOutput
+
+topEntity
+  :: Clock System
+  -> Signal System (BitVector 8)
+  -> Signal System (BitVector 8)
+topEntity clk =
+  Explicit.register clk resetGen enableGen 0
+
+testInput
+  :: SystemClockResetEnable
+  => Proxy System
+  -> Signal System (BitVector 8)
+testInput _proxy = stimuliGenerator (0 :> 1 :> 2 :> Nil)
+
+expectedOutput
+  :: SystemClockResetEnable
+  => Signal System (BitVector 8)
+  -> Signal System Bool
+expectedOutput =
+  outputVerifier hasClock hasReset (0 :> 0 :> 1 :> Nil)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -161,6 +161,7 @@ runClashTest =
         ]
       , clashTestGroup "Feedback"
         [ runTest ("tests" </> "shouldwork" </> "Feedback") defBuild [] "Fib" (["","testBench"],"testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "Feedback") defBuild [] "MutuallyRecursive" (["","testBench"],"testBench",True)
         ]
       , clashTestGroup "Fixed"
         [ runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "Mixer"      (["","testBench"],"testBench",True)


### PR DESCRIPTION
`specArgBndrsAndVars` tries to find a list of locally free variables,
excluding any global ones. Before this patch, it would erroneously treat
local variables shadowing a global one, as global. The test case defines
mutually recursive binders that Clash will let-bind:
    
https://github.com/clash-lang/clash-compiler/blob/707696781f99b677f8e1deb77c40a15dac8b1ca1/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs#L178-L184
    
The identifiers in the let-bind will carry the same uniques as
the global ones, but marked as local. The global binders will live on in
case another function refers to them - therefore triggering the issue.
    
Co-authored-by: Christiaan Baaij <christiaan.baaij@gmail.com>