### PR TITLE
Make replicate and replace_int blackboxes lazy in last argument

### DIFF
--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -457,10 +457,13 @@ primop eval tcm h k nm ty tys vs v []
               -- The above primitives are actually values, and not operations.
   = unwind eval tcm h k (PrimVal nm ty tys (vs ++ [v]))
   | otherwise = eval (isScrut k) tcm h k nm ty tys (vs ++ [v])
-primop eval tcm h0 k nm ty tys [] v [e]
-  | nm == "Clash.Sized.Vector.lazyV"
+primop eval tcm h0 k nm ty tys vs v [e]
+  | nm `elem` [ "Clash.Sized.Vector.lazyV"
+              , "Clash.Sized.Vector.replicate"
+              , "Clash.Sized.Vector.replace_int"
+              ]
   = let (h1,i) = newLetBinding tcm h0 e
-    in  eval (isScrut k) tcm h1 k nm ty tys [v,Suspend (Var i)]
+    in  eval (isScrut k) tcm h1 k nm ty tys (vs ++ [v,Suspend (Var i)])
 primop _ _ h k nm ty tys vs v (e:es) =
   Just (h,PrimApply nm ty tys (vs ++ [v]) es:k,e)
 

--- a/tests/shouldwork/Numbers/HalfAsBlackboxArg.hs
+++ b/tests/shouldwork/Numbers/HalfAsBlackboxArg.hs
@@ -1,0 +1,17 @@
+module HalfAsBlackboxArg where
+
+import Clash.Prelude
+import Numeric.Half
+import Clash.Explicit.Testbench
+import Foreign.C.Types
+
+g :: KnownNat n => Vec n Half -> Half
+g v =
+  case v of
+    Nil -> Half 5
+    Cons a as -> a
+
+topEntity =
+  ( g (replicate d3 (Half 7))
+  , g (replace 0 (Half 8) (replicate d3 (Half 7)))
+  )

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -197,6 +197,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"] "ExpWithGhcCF"        (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"] "ExpWithClashCF"        (["","testBench"],"testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] ["-itests/shouldwork/Numbers"] "ExpWithClashCF"  "main"
+        , runTest ("tests" </> "shouldwork" </> "Numbers") [VHDL] [] "HalfAsBlackboxArg" ([""],"topEntity",False)
         -- TODO: re-enable for Verilog
         , runTest ("tests" </> "shouldwork" </> "Numbers") (defBuild \\ [Verilog]) ["-itests/shouldwork/Numbers"] "NumConstantFoldingTB_1"        (["","testBench"],"testBench",True)
         , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding_1"  "main"


### PR DESCRIPTION
Not doing so exposes W16# due to the evaluator creating it if it's ever
a case subject.