### PR TITLE
Perform reduceConst before ANF

### DIFF
--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -28,7 +28,8 @@ import Clash.Rewrite.Util
 
 -- | Normalisation transformation
 normalization :: NormRewrite
-normalization = rmDeadcode >-> constantPropagation >-> etaTL >-> rmUnusedExpr >-!-> anf >-!-> rmDeadcode >->
+normalization = rmDeadcode >-> constantPropagation >-> etaTL >-> rmUnusedExpr >-!->
+                evalConst >-> anf >-!-> rmDeadcode >->
                 bindConst >-> letTL >-> evalConst >-!-> cse >-!-> cleanup >-> recLetRec
   where
     etaTL      = apply "etaTL" etaExpansionTL !-> topdownR (apply "applicationPropagation" appPropFast)


### PR DESCRIPTION
Also reduce try and reduce anything that looks like a constant, i.e. has no local FVs, not just applications of primitives.

This allows e.g. the constant reduction of CTZ; and obviates #530