### PR TITLE
Add ghc plugins to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,13 @@ mkShell {
     niv
 
     # For quick clash experimentation
-    pkgs.haskellPackages.clash-ghc
+    (pkgs.haskellPackages.ghcWithPackages (p: with p; [
+      clash-ghc
+
+      ghc-typelits-extra
+      ghc-typelits-knownnat
+      ghc-typelits-natnormalise
+    ])
+    )
   ];
 }


### PR DESCRIPTION
This tiny PR adds the ghc type plugins to the nix shell context. i.e. This addresses an issues that after entering nix-shell, running clash may result in the error `<command line>: Could not find module ‘GHC.TypeLits.Normalise’` if the type checker plugins aren't available from some larger nix context. 