### PR TITLE
Refuse to compare types with type families

### DIFF
--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -44,6 +44,7 @@ module Clash.Core.Type
   , isPolyFunTy
   , isPolyFunCoreTy
   , isPolyTy
+  , isTypeFamilyApplication
   , isFunTy
   , isClassTy
   , applyFunTy
@@ -535,6 +536,12 @@ reduceTypeFamily tcm (tyView -> TyConApp tc tys)
   = findFunSubst tcm tcSubst tys
 
 reduceTypeFamily _ _ = Nothing
+
+-- |
+isTypeFamilyApplication ::  TyConMap -> Type -> Bool
+isTypeFamilyApplication tcm (tyView -> TyConApp tcNm _args)
+  | Just (FunTyCon {}) <- lookupUniqMap tcNm tcm = True
+isTypeFamilyApplication _tcm _type = False
 
 litView :: TyConMap -> Type -> Maybe Integer
 litView _ (LitTy (NumTy i))                = Just i

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -323,7 +323,7 @@ elemExistentials (TransformContext is0 _) (Case scrut altsTy alts0) = do
     -- Eliminate free type variables if possible
     go :: InScopeSet -> TyConMap -> (Pat, Term) -> NormalizeSession (Pat, Term)
     go is2 tcm alt@(DataPat dc exts0 xs0, term0) =
-      case solveNonAbsurds (altEqs tcm alt) of
+      case solveNonAbsurds tcm (altEqs tcm alt) of
         -- No equations solved:
         [] -> return alt
         -- One or more equations solved:


### PR DESCRIPTION
'caseElemNonReachable' considers a branch unreachable when a branch
coerces a type to another. For example, a branch coercing `Bool ~ Int`
would be considered unreachable. It would also consider `F Char ~ Int` to
be unreachable, even if `F` was a type family eventually resolving to
`Int`.

Regrettably, I haven't been able to find a small test case.