### PR TITLE
Fix clash dependencies in the top nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,8 @@
 
 with nixpkgs;
 
+let clash = pkgs.haskellPackages.ghcWithPackages (pkgs: [ pkgs.clash-ghc ]);
+in
 mkShell {
   name = "clash-compiler-shell";
   buildInputs = [
@@ -9,6 +11,6 @@ mkShell {
     niv
 
     # For quick clash experimentation
-    pkgs.haskellPackages.clash-ghc
+    clash
   ];
 }


### PR DESCRIPTION
Before this, we could open clashi in the nix-shell but clash-prelude wouldn't be available