### PR TITLE
Fix treplicate

### DIFF
--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -46,6 +46,7 @@ import           Unique                           (getKey)
 
 import           Clash.Core.DataCon               (DataCon)
 import           Clash.Core.Literal               (Literal (..))
+import           Clash.Core.Name                  (nameOcc)
 import           Clash.Core.Pretty                (showPpr)
 import           Clash.Core.Term
   (CoreContext (..), PrimInfo (..), Term (..), WorkInfo (..), Pat (..))
@@ -90,6 +91,7 @@ reduceReverse inScope0 n elTy vArg = do
   go tcm (coreView1 tcm -> Just ty') = go tcm ty'
   go tcm (tyView -> TyConApp vecTcNm _)
     | Just vecTc <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
     , [nilCon, consCon] <- tyConDataCons vecTc
     = do
       uniqs0 <- Lens.use uniqSupply
@@ -122,6 +124,7 @@ reduceZipWith (TransformContext is0 ctx) n lhsElTy rhsElTy resElTy fun lhsArg rh
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [nilCon,consCon] <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -157,6 +160,7 @@ reduceMap (TransformContext is0 ctx) n argElTy resElTy fun arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [nilCon,consCon] <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -189,6 +193,7 @@ reduceImap (TransformContext is0 ctx) n argElTy resElTy fun arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [nilCon,consCon] <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -238,6 +243,7 @@ reduceTraverse (TransformContext is0 ctx) n aTy fTy bTy dict fun arg = do
     go tcm apDictTcNm (coreView1 tcm -> Just ty') = go tcm apDictTcNm ty'
     go tcm apDictTcNm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [nilCon,consCon] <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -370,6 +376,7 @@ reduceFoldr (TransformContext is0 ctx) n aTy fun start arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [_,consCon] <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -404,6 +411,7 @@ reduceFold (TransformContext is0 ctx) n aTy fun arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [_,consCon]  <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -447,6 +455,7 @@ reduceDFold inScope n aTy fun start arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [_,consCon]  <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -487,6 +496,7 @@ reduceHead inScope n aTy vArg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [_,consCon]  <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -514,6 +524,7 @@ reduceTail inScope n aTy vArg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [_,consCon]  <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -542,6 +553,7 @@ reduceLast inScope n aTy vArg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [_,consCon]  <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -571,6 +583,7 @@ reduceInit inScope n aTy vArg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [nilCon,consCon]  <- tyConDataCons vecTc
       = do
         uniqs0 <- Lens.use uniqSupply
@@ -606,6 +619,7 @@ reduceAppend inScope n m aTy lArg rArg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [_,consCon]  <- tyConDataCons vecTc
       = do uniqs0 <- Lens.use uniqSupply
            let (uniqs1,(vars,elems)) = second (second concat . unzip)
@@ -633,6 +647,7 @@ reduceUnconcat n 0 aTy arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [nilCon,consCon] <- tyConDataCons vecTc
       = let nilVec           = mkVec nilCon consCon aTy 0 []
             innerVecTy       = mkTyConApp vecTcNm [LitTy (NumTy 0), aTy]
@@ -658,6 +673,7 @@ reduceTranspose n 0 aTy arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [nilCon,consCon] <- tyConDataCons vecTc
       = let nilVec           = mkVec nilCon consCon aTy 0 []
             innerVecTy       = mkTyConApp vecTcNm [LitTy (NumTy 0), aTy]
@@ -679,6 +695,7 @@ reduceReplicate n aTy eTy arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [nilCon,consCon] <- tyConDataCons vecTc
       = let retVec = mkVec nilCon consCon aTy n (replicate (fromInteger n) arg)
         in  changed retVec
@@ -758,6 +775,7 @@ reduceReplace_int is0 n aTy vTy v i newA = do
   go tcm (coreView1 tcm -> Just ty') = go tcm ty'
   go tcm (tyView -> TyConApp vecTcNm _)
     | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
     , [nilCon,consCon] <- tyConDataCons vecTc
     = do
       -- Get data constructors of 'Int'
@@ -858,6 +876,7 @@ reduceIndex_int is0 n aTy v i = do
   go tcm (coreView1 tcm -> Just ty') = go tcm ty'
   go tcm (tyView -> TyConApp vecTcNm _)
     | (Just vecTc)     <- lookupUniqMap vecTcNm tcm
+    , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
     , [_nilCon,consCon] <- tyConDataCons vecTc
     = do
       -- Get data constructors of 'Int'
@@ -907,6 +926,7 @@ reduceDTFold inScope n aTy lrFun brFun arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp vecTcNm _)
       | (Just vecTc) <- lookupUniqMap vecTcNm tcm
+      , nameOcc vecTcNm == "Clash.Sized.Vector.Vec"
       , [_,consCon]  <- tyConDataCons vecTc
       = do uniqs0 <- Lens.use uniqSupply
            let (uniqs1,(vars,elems)) = second (second concat . unzip)
@@ -954,6 +974,7 @@ reduceTFold inScope n aTy lrFun brFun arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp treeTcNm _)
       | (Just treeTc) <- lookupUniqMap treeTcNm tcm
+      , nameOcc treeTcNm == "Clash.Sized.RTree.RTree"
       , [lrCon,brCon] <- tyConDataCons treeTc
       = do uniqs0 <- Lens.use uniqSupply
            let (uniqs1,(vars,elems)) = extractTElems uniqs0 inScope lrCon brCon aTy 'T' n arg
@@ -991,6 +1012,7 @@ reduceTReplicate n aTy eTy arg = do
     go tcm (coreView1 tcm -> Just ty') = go tcm ty'
     go tcm (tyView -> TyConApp treeTcNm _)
       | (Just treeTc) <- lookupUniqMap treeTcNm tcm
+      , nameOcc treeTcNm == "Clash.Sized.RTree.RTree"
       , [lrCon,brCon] <- tyConDataCons treeTc
       = let retVec = mkRTree lrCon brCon aTy n (replicate (2^n) arg)
         in  changed retVec

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -994,7 +994,7 @@ reduceTReplicate n aTy eTy arg = do
       , [lrCon,brCon] <- tyConDataCons treeTc
       = let retVec = mkRTree lrCon brCon aTy n (replicate (2^n) arg)
         in  changed retVec
-    go _ ty = error $ $(curLoc) ++ "reduceTReplicate: argument does not have a vector type: " ++ showPpr ty
+    go _ ty = error $ $(curLoc) ++ "reduceTReplicate: argument does not have a RTree type: " ++ showPpr ty
 
 buildSNat :: DataCon -> Integer -> Term
 buildSNat snatDc i =

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -2040,7 +2040,7 @@ reduceNonRepPrim c@(TransformContext is0 ctx) e@(App _ _) | (Prim nm _, args, ti
           Right n -> do
             untranslatableTy <- isUntranslatableType False aTy
             if untranslatableTy || shouldReduce1
-               then (`mkTicks` ticks) <$> reduceReplicate n aTy eTy vArg
+               then (`mkTicks` ticks) <$> reduceTReplicate n aTy eTy vArg
                else return e
           _ -> return e
       "Clash.Sized.Internal.BitVector.split#" | length args == 4 -> do

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1835,19 +1835,27 @@ reduceConst _ e = return e
 --
 -- Currently, it only handles the following functions:
 --
--- * Clash.Sized.Vector.map
 -- * Clash.Sized.Vector.zipWith
+-- * Clash.Sized.Vector.map
 -- * Clash.Sized.Vector.traverse#
--- * Clash.Sized.Vector.foldr
 -- * Clash.Sized.Vector.fold
+-- * Clash.Sized.Vector.foldr
 -- * Clash.Sized.Vector.dfold
 -- * Clash.Sized.Vector.(++)
 -- * Clash.Sized.Vector.head
 -- * Clash.Sized.Vector.tail
+-- * Clash.Sized.Vector.last
+-- * Clash.Sized.Vector.init
 -- * Clash.Sized.Vector.unconcat
 -- * Clash.Sized.Vector.transpose
 -- * Clash.Sized.Vector.replicate
+-- * Clash.Sized.Vector.replace_int
+-- * Clash.Sized.Vector.imap
 -- * Clash.Sized.Vector.dtfold
+-- * Clash.Sized.RTree.tdfold
+-- * Clash.Sized.RTree.treplicate
+-- * Clash.Sized.Internal.BitVector.split#
+-- * Clash.Sized.Internal.BitVector.eq#
 reduceNonRepPrim :: HasCallStack => NormRewrite
 reduceNonRepPrim c@(TransformContext is0 ctx) e@(App _ _) | (Prim nm _, args, ticks) <- collectArgsTicks e = do
   tcm <- Lens.view tcCache

--- a/tests/shouldwork/RTree/TRepeat.hs
+++ b/tests/shouldwork/RTree/TRepeat.hs
@@ -1,15 +1,7 @@
 module TRepeat where
 
-import qualified Prelude as P
-import Data.List (isInfixOf)
-import System.Environment (getArgs)
-import System.FilePath ((</>), takeDirectory)
-
 import Clash.Prelude
 import Clash.Explicit.Testbench
-
-data A = A Int Int deriving (Eq, Generic, ShowX)
-data B = B Int Int Int deriving (Eq, Generic, ShowX)
 
 topEntity :: Signal System (RTree 2 Bool)
 topEntity = pure (trepeat True)

--- a/tests/shouldwork/RTree/TRepeat2.hs
+++ b/tests/shouldwork/RTree/TRepeat2.hs
@@ -1,0 +1,20 @@
+module TRepeat2 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity = register @System (trepeat @2 True)
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst input
+    expectedOutput = outputVerifier' clk rst expected
+    done           = expectedOutput $ withClockResetEnable clk rst en topEntity testInput
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+    en             = enableGen
+
+input = replicate d2 $([| v2t (replicate d4 False) |])
+expected = $([| v2t (replicate d4 $ True) :> v2t (replicate d4 (False))  :> Nil |])

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -244,7 +244,8 @@ runClashTest =
         ]
       , clashTestGroup "RTree"
         [ runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TFold"       ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TRepeat"  ([""],"topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TRepeat"  (["","testBench"],"testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TRepeat2"  (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TZip"        ([""],"topEntity",False)
       ]
       , clashTestGroup "Signal"


### PR DESCRIPTION
When `reduceNonRepPrim` tried to reduce an call to `treplicate` to a `~CONST` it failed because it was calling `reduceReplicate` instead of `reduceTReplicate`.
