### PR TITLE
Fix name inconsistency in "Clash.Signal.Internal"

### DIFF
--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -414,10 +414,10 @@ biTbClockGen done = (testClk, circuitClk)
 -- import "Clash.Explicit.Testbench"
 --
 -- -- Fast domain: twice as fast as \"Slow\"
--- 'createDomain' 'vSystem'{vTag=\"Fast\", vPeriod=10}
+-- 'createDomain' 'vSystem'{vName=\"Fast\", vPeriod=10}
 --
 -- -- Slow domain: twice as slow as "Fast"
--- 'createDomain' 'vSystem'{vTag=\"Slow\", vPeriod=20}
+-- 'createDomain' 'vSystem'{vName=\"Slow\", vPeriod=20}
 --
 -- topEntity
 --   :: 'Clock' \"Fast\"

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -961,8 +961,8 @@ import "Clash.Signal"
 import "Clash.Prelude"
 import "Clash.Intel.ClockGen"
 
-'createDomain' vSystem{vTag=\"DomInput\", vPeriod=20000}
-'createDomain' vSystem{vTag=\"Dom50\", vPeriod=50000}
+'createDomain' vSystem{vName=\"DomInput\", vPeriod=20000}
+'createDomain' vSystem{vName=\"Dom50\", vPeriod=50000}
 
 topEntity
   :: Clock \"DomInput\"
@@ -1905,8 +1905,8 @@ We can calculate the clock periods using 'hzToPeriod':
 We can then create the clock and reset domains:
 
 @
-'createDomain' vSystem{vTag=\"ADC\", vPeriod=hzToPeriod 20e6}
-'createDomain' vSystem{vTag=\"FFT\", vPeriod=hzToPeriod 9e6}
+'createDomain' vSystem{vName=\"ADC\", vPeriod=hzToPeriod 20e6}
+'createDomain' vSystem{vName=\"FFT\", vPeriod=hzToPeriod 9e6}
 @
 
 and subsequently a 256-space FIFO synchronizer that safely bridges the ADC clock
@@ -2508,8 +2508,8 @@ import "Clash.Signal"
 import "Clash.Prelude"
 import "Clash.Intel.ClockGen"
 
-'createDomain' 'vSystem'{vTag="DomInput", vPeriod=20000}
-'createDomain' 'vSystem'{vTag="Dom50", vPeriod=50000}
+'createDomain' 'vSystem'{vName="DomInput", vPeriod=20000}
+'createDomain' 'vSystem'{vName="Dom50", vPeriod=50000}
 
 {\-\# ANN topEntity
   ('Synthesize'

--- a/examples/Blinker.hs
+++ b/examples/Blinker.hs
@@ -11,10 +11,10 @@ data LedMode
   deriving (Generic, Undefined)
 
 -- Define a synthesis domain with a clock with a period of 20000 /ps/.
-createDomain vSystem{vTag="Input", vPeriod=20000}
+createDomain vSystem{vName="Input", vPeriod=20000}
 
 -- Define a synthesis domain with a clock with a period of 50000 /ps/.
-createDomain vSystem{vTag="Dom50", vPeriod=50000}
+createDomain vSystem{vName="Dom50", vPeriod=50000}
 
 {-# ANN topEntity
   (Synthesize

--- a/tests/shouldwork/Basic/MultipleHidden.hs
+++ b/tests/shouldwork/Basic/MultipleHidden.hs
@@ -6,8 +6,8 @@ import Clash.Explicit.Testbench
 
 import Unsafe.Coerce (unsafeCoerce)
 
-createDomain vSystem{vTag="DomA"}
-createDomain vSystem{vTag="DomB"}
+createDomain vSystem{vName="DomA"}
+createDomain vSystem{vName="DomB"}
 
 multiClockAdd
   :: ( HiddenClockResetEnable domA

--- a/tests/shouldwork/CSignal/CBlockRamTest.hs
+++ b/tests/shouldwork/CSignal/CBlockRamTest.hs
@@ -2,7 +2,7 @@ module CBlockRamTest where
 
 import Clash.Explicit.Prelude
 
-createDomain vSystem{vTag="DomA10", vPeriod=10}
+createDomain vSystem{vName="DomA10", vPeriod=10}
 
 topEntity
   :: Clock  DomA10

--- a/tests/shouldwork/CSignal/MAC.hs
+++ b/tests/shouldwork/CSignal/MAC.hs
@@ -2,7 +2,7 @@ module MAC where
 
 import Clash.Explicit.Prelude
 
-createDomain vSystem{vTag="DomA101", vPeriod=101}
+createDomain vSystem{vName="DomA101", vPeriod=101}
 
 topEntity
   :: Clock DomA101

--- a/tests/shouldwork/DDR/DDRin.hs
+++ b/tests/shouldwork/DDR/DDRin.hs
@@ -6,13 +6,13 @@ import Clash.Explicit.Testbench
 import Clash.Intel.DDR
 import Clash.Xilinx.DDR
 
---createDomain vSystem{vTag="AsyncReal", vPeriod=2000, vReset=Asynchronous}  -- real clock domain (same as TB)
-createDomain vSystem{vTag="AsyncDDR", vPeriod=1000, vReset=Asynchronous}  -- fake ddr domain
-createDomain vSystem{vTag="SyncReal", vPeriod=2000, vReset=Synchronous}  -- real clock domain
-createDomain vSystem{vTag="SyncDDR", vPeriod=1000, vReset=Synchronous}  -- fake ddr domain
+--createDomain vSystem{vName="AsyncReal", vPeriod=2000, vResetKind=Asynchronous}  -- real clock domain (same as TB)
+createDomain vSystem{vName="AsyncDDR", vPeriod=1000, vResetKind=Asynchronous}  -- fake ddr domain
+createDomain vSystem{vName="SyncReal", vPeriod=2000, vResetKind=Synchronous}  -- real clock domain
+createDomain vSystem{vName="SyncDDR", vPeriod=1000, vResetKind=Synchronous}  -- fake ddr domain
 
 -- | Domain used for testbench itself
-createDomain vSystem{vTag="TB", vPeriod=2000, vReset=Asynchronous}
+createDomain vSystem{vName="TB", vPeriod=2000, vResetKind=Asynchronous}
 type AsyncReal = TB
 
 {-

--- a/tests/shouldwork/DDR/DDRout.hs
+++ b/tests/shouldwork/DDR/DDRout.hs
@@ -6,13 +6,13 @@ import Clash.Explicit.Testbench
 import Clash.Intel.DDR
 import Clash.Xilinx.DDR
 
-createDomain vSystem{vTag="AsyncReal", vPeriod=2000, vReset=Asynchronous}  -- real clock domain
---createDomain vSystem{vTag="AsyncDDR", vPeriod=1000, vReset=Asynchronous}  -- fake ddr domain (same as TB)
-createDomain vSystem{vTag="SyncReal", vPeriod=2000, vReset=Synchronous}  -- real clock domain
-createDomain vSystem{vTag="SyncDDR", vPeriod=1000, vReset=Synchronous}  -- fake ddr domain
+createDomain vSystem{vName="AsyncReal", vPeriod=2000, vResetKind=Asynchronous}  -- real clock domain
+--createDomain vSystem{vName="AsyncDDR", vPeriod=1000, vResetKind=Asynchronous}  -- fake ddr domain (same as TB)
+createDomain vSystem{vName="SyncReal", vPeriod=2000, vResetKind=Synchronous}  -- real clock domain
+createDomain vSystem{vName="SyncDDR", vPeriod=1000, vResetKind=Synchronous}  -- fake ddr domain
 
 -- | Domain used for testbench itself
-createDomain vSystem{vTag="TB", vPeriod=1000, vReset=Asynchronous}
+createDomain vSystem{vName="TB", vPeriod=1000, vResetKind=Asynchronous}
 type AsyncDDR = TB
 
 {-

--- a/tests/shouldwork/HOPrim/TestMap.hs
+++ b/tests/shouldwork/HOPrim/TestMap.hs
@@ -3,7 +3,7 @@ module TestMap where
 import Clash.Explicit.Prelude
 import Clash.Explicit.Testbench
 
-createDomain vSystem{vTag="System50", vPeriod=50000}
+createDomain vSystem{vName="System50", vPeriod=50000}
 
 type Word1 = Signed 18 -- SFixed 9 9
 type RomFunction = (Unsigned 9 -> Word1)

--- a/tests/shouldwork/Signal/ResetLow.hs
+++ b/tests/shouldwork/Signal/ResetLow.hs
@@ -5,7 +5,7 @@ module ResetLow where
 import Clash.Explicit.Prelude
 import Clash.Explicit.Testbench
 
-createDomain vSystem{vTag="SystemLow", vPolarity=ActiveLow}
+createDomain vSystem{vName="SystemLow", vResetPolarity=ActiveLow}
 
 testInput :: Vec 7 (Signed 8)
 testInput = 1 :> 2 :> 3 :> 4 :> 5 :> 6 :> 7 :> Nil

--- a/tests/shouldwork/Testbench/SyncTB.hs
+++ b/tests/shouldwork/Testbench/SyncTB.hs
@@ -6,9 +6,9 @@ import Clash.Signal (mux)
 
 import Unsafe.Coerce
 
-createDomain vSystem{vTag="Dom2", vPeriod=2}
-createDomain vSystem{vTag="Dom7", vPeriod=7}
-createDomain vSystem{vTag="Dom9", vPeriod=9}
+createDomain vSystem{vName="Dom2", vPeriod=2}
+createDomain vSystem{vName="Dom7", vPeriod=7}
+createDomain vSystem{vName="Dom9", vPeriod=9}
 
 zeroAt0
   :: forall dom a


### PR DESCRIPTION
Maybe `period` -> `clockPeriod` and `name` -> `domainName` too?