### PR TITLE
Don't allow failures on GHC 8.8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,6 @@ ghc-8.6.5:
   extends: .tests
 ghc-8.8.1:
   extends: .tests
-  allow_failure: true
 ghc-8.4.4-singular-hidden:
   extends: .tests
   variables:


### PR DESCRIPTION
[With 8.8 having been released](https://www.haskell.org/ghc/blog/20190825-ghc-8.8.1-released.html), our CI should not allow failures on it.