### PR TITLE
Auto release Clash on Hackage

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 set -xeo pipefail
 
-# run new-update first to generate the cabal config file that we can then modify
-# retry 5 times, as hackage servers are not perfectly reliable
-NEXT_WAIT_TIME=0
-until cabal new-update || [ $NEXT_WAIT_TIME -eq 5 ]; do
-   sleep $(( NEXT_WAIT_TIME++ ))
-done
-
-sed -i "s/-- ghc-options:/ghc-options: -j$THREADS/g" ${HOME}/.cabal/config
-sed -i "s/^[- ]*jobs:.*/jobs: $CABAL_JOBS/g" ${HOME}/.cabal/config
-echo "store-dir: ${PWD}/cabal-store" >> ${HOME}/.cabal/config
-
 cabal new-build all
 
 # Build with installed constraints for packages in global-db

--- a/.ci/build_sdist.sh
+++ b/.ci/build_sdist.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -x -euf -o pipefail
+
+cd $(dirname $0)/..
+
+# Enable documentation building for all dependencies
+sed -i 's/documentation: False/documentation: True/g' cabal.project.local
+
+# Build source distribution
+cabal sdist $1 |& tee sdist.log
+
+# Build documentation
+cabal new-haddock $1 \
+    --haddock-for-hackage \
+    --haddock-hyperlinked-source \
+    --enable-documentation |& tee haddock.log
+
+# Extract location of sdist tarball
+SDIST=$(grep "Wrote tarball sdist to" -A 1 sdist.log | tail -n 1)
+
+# Extract location of documentation tarball
+DDIST=$(grep "Documentation tarball created:" -A 1 haddock.log | tail -n 1)
+
+# Copy 
+cd -
+cp $SDIST $(basename $SDIST)  # Example: clash-prelude-0.9999.tar.gz
+cp $DDIST $(basename $DDIST)  # Example: clash-prelude-0.9999-docs.tar.gz

--- a/.ci/publish_sdist.sh
+++ b/.ci/publish_sdist.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eu -o pipefail
+
+PASSWORD=$(echo $HACKAGE_PASSWORD | base64 --decode --ignore-garbage)
+
+SDIST=$(find $1-*.tar.gz | grep -v docs)
+DDIST=$(find $1-*.tar.gz | grep docs)
+
+set +u
+
+if [[ "$HACKAGE_RELEASE" == "yes" ]]; then
+    # Release tag set, upload as release.
+    # TODO: Right now, this branch will do the same as the other: make a
+    # release candidate. We can change it to actually have it release after
+    # we've gained enough trust in the release logic.
+    echo "XXX: Release logic activated!"
+    cabal upload --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST} 
+    cabal upload --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST} 
+elif [[ "$HACKAGE_RELEASE" == "no" ]]; then
+    # Upload as release candidate
+    cabal upload --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST} 
+    cabal upload --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST} 
+else
+    echo "Unrecognized \$HACAKGE_RELEASE: $HACAKGE_RELEASE"
+    exit 1;
+fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -24,3 +24,14 @@ elif [[ "$MULTIPLE_HIDDEN" == "no" ]]; then
 fi
 
 cat cabal.project.local
+
+# run new-update first to generate the cabal config file that we can then modify
+# retry 5 times, as hackage servers are not perfectly reliable
+NEXT_WAIT_TIME=0
+until cabal new-update || [ $NEXT_WAIT_TIME -eq 5 ]; do
+   sleep $(( NEXT_WAIT_TIME++ ))
+done
+
+sed -i "s/-- ghc-options:/ghc-options: -j$THREADS/g" ${HOME}/.cabal/config
+sed -i "s/^[- ]*jobs:.*/jobs: $CABAL_JOBS/g" ${HOME}/.cabal/config
+echo "store-dir: ${PWD}/cabal-store" >> ${HOME}/.cabal/config

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -9,5 +9,38 @@ cabal --write-ghc-environment-files=always new-build all
 sed "s/^ghci/ghc -fno-code/" clash-dev > clash-dev-test
 sh clash-dev-test
 
+# Check whether version numbers in snap / clash-{prelude,lib,ghc} are the same
+cabal_files="clash-prelude/clash-prelude.cabal clash-lib/clash-lib.cabal clash-ghc/clash-ghc.cabal"
+snapcraft_file="bindist/linux/snap/snap/snapcraft.yaml"
+versions=$(grep "^[vV]ersion" $cabal_files $snapcraft_file | grep -Eo '[0-9]+\.[0-9]+')
+
+if [[ $(echo $versions | tr ' ' '\n' | wc -l) == 4 ]]; then
+    if [[ $(echo $versions | tr ' ' '\n' | uniq | wc -l) != 1 ]]; then
+        echo "Expected all distributions to have the same version number. Found: $versions"
+        exit 1;
+    fi
+else
+    echo "Expected to find version number in all distributions. Found: $versions";
+    exit 1;
+fi
+
+# You'd think comparing v${version} with ${CI_COMMIT_TAG} would do the
+# trick, but no..
+version=$(echo $versions | tr ' ' '\n' | head -n 1)
+tag_version=${CI_COMMIT_TAG:1:${#CI_COMMIT_TAG}-1}  # Strip first character (v0.99 -> 0.99)
+
+if [[ ${tag_version} != "" && ${version} != ${tag_version} ]]; then
+    if [[ "${CI_COMMIT_TAG:0:1}" == "v" ]]; then
+        echo "Tag name and distribution's release number should match:"
+        echo "  Tag version:          ${CI_COMMIT_TAG}"
+        echo "  Distribution version: v${version}"
+        exit 1;
+    else
+        echo "\$CI_COMMIT_TAG should start with a 'v'. Found: ${CI_COMMIT_TAG}"
+        exit 1;
+    fi
+fi   
+
+# Run actual tests
 cabal new-test clash-cosim clash-prelude
 cabal new-run -- clash-testsuite -j$THREADS --hide-successes

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ cabal.config
 *.aux
 *.hp
 *.bin
+*.log
+*.tar.gz
 
 *~
 *.DS_Store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,9 +119,6 @@ snap-bindist:
     - snapcraft login --with snapcraft.login
     - snapcraft
     - snapcraft push *.snap --release ${RELEASE_CHANNEL}
-  only:
-    - schedules
-    - triggers
 
 snap-edge:
   extends: .snap

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ stages:
       - cabal-store/
   script:
     - unset SNAPCRAFT_LOGIN_FILE
+    - unset HACKAGE_PASSWORD
     - export GHC="${GHC:-$CI_JOB_NAME}"
     - export THREADS=$(nproc)
     - export CABAL_JOBS=$(nproc)
@@ -49,6 +50,64 @@ ghc-head:
     # Awaiting issue: https://github.com/goldfirere/singletons/issues/357
     - echo "GHC head currently disabled, because singletons doesn't build on ghc head"
     - exit 1
+
+hackage-sdist:
+  extends: .tests
+  variables:
+    GHC: ghc-8.8.1
+  script:
+    - export GHC="${GHC:-$CI_JOB_NAME}"
+    - export THREADS=$(nproc)
+    - export CABAL_JOBS=$(nproc)
+    - .ci/setup.sh
+    - .ci/build_sdist.sh clash-prelude
+    - .ci/build_sdist.sh clash-lib
+    - .ci/build_sdist.sh clash-ghc
+  artifacts:
+    paths:
+      - clash-*.tar.gz  # clash-{prelude,lib,ghc}-$version{-docs,}.tar.gz
+    expire_in: 1 week
+  only:
+    - tags
+    - schedules
+    - triggers
+
+.hackage:
+  extends: .tests
+  stage: publish
+  cache:
+    key: hackage
+  variables:
+    GHC: ghc-8.8.1
+  script:
+    - export GHC="${GHC:-$CI_JOB_NAME}"
+    - export THREADS=$(nproc)
+    - export CABAL_JOBS=$(nproc)
+    - .ci/setup.sh
+    - .ci/publish_sdist.sh clash-prelude
+    - .ci/publish_sdist.sh clash-lib
+    - .ci/publish_sdist.sh clash-ghc
+
+# "Publish" a release candidate
+hackage-release-candidate:
+  extends: .hackage
+
+  variables:
+    HACKAGE_RELEASE: "no"
+
+  only:
+    - schedules
+    - triggers
+
+# Release new version of Clash to Hackage
+hackage-release:
+  extends: .hackage
+
+  variables:
+    HACKAGE_RELEASE: "yes"
+
+  only:
+    - tags
 
 # Create a binary distribution using nix, and store it in a tarball. A special
 # nix distribution is used that has its store installed on /usr/nix/store,


### PR DESCRIPTION
This PR will make the CI release a candidate version of Clash every night. When a tag is added, a full release is made. (For the moment, it will release a candidate version when tagged too. I'm taking a conservative approach here as we can't delete anything once published..)

--------------------

I propose we add a check making sure `clash-prelude`, `clash-lib`, and `clash-ghc` always have the same version number for a single commit. While it's _technically_ true they're separate packages, changes often span multiple packages, and it might very well lead to confusion among users. This also makes more sense from a monorepo perspective, as we only have a single tag to handout for a given commit. Not coincidentally, this also fits the current release logic better. 

Edit: I've added the check.