### PR TITLE
Mark clash prelude as not home

### DIFF
--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -16,7 +16,7 @@ defined in "Clash.Prelude".
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
-{-# OPTIONS_HADDOCK show-extensions #-}
+{-# OPTIONS_HADDOCK show-extensions, not-home #-}
 
 module Clash.Explicit.Prelude
   ( -- * Creating synchronous sequential circuits

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -18,7 +18,7 @@ defined in "Clash.Prelude".
 
 {-# LANGUAGE Safe #-}
 
-{-# OPTIONS_HADDOCK show-extensions #-}
+{-# OPTIONS_HADDOCK show-extensions, not-home #-}
 
 module Clash.Explicit.Prelude.Safe
   ( -- * Creating synchronous sequential circuits

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -39,7 +39,7 @@
 
 {-# LANGUAGE Unsafe #-}
 
-{-# OPTIONS_HADDOCK show-extensions #-}
+{-# OPTIONS_HADDOCK show-extensions, not-home #-}
 
 module Clash.Prelude
   ( -- * Creating synchronous sequential circuits

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -35,7 +35,7 @@
 
 {-# LANGUAGE Safe #-}
 
-{-# OPTIONS_HADDOCK show-extensions #-}
+{-# OPTIONS_HADDOCK show-extensions, not-home #-}
 
 module Clash.Prelude.Safe
   ( -- * Creating synchronous sequential circuits


### PR DESCRIPTION
With the intention to have haddock link to the original module that defines the function, and not the clash prelude module that re-exports it.