### PR TITLE
Simplify unsafe synchronizer

### DIFF
--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -507,8 +507,13 @@ veryUnsafeSynchronizer
   -- ^ Period of clock belonging to 'dom2'
   -> Signal dom1 a
   -> Signal dom2 a
-veryUnsafeSynchronizer t1 t2 = go 0
+veryUnsafeSynchronizer t1 t2
+  | t1 == t2 = same
+  | otherwise = go 0
   where
+  same :: Signal dom1 a -> Signal dom2 a
+  same (s :- ss) = s :- same ss
+
   go :: Int -> Signal dom1 a -> Signal dom2 a
   go relativeTime (a :- s)
     | relativeTime < t1 = a :- go (relativeTime + t2) (a :- s)


### PR DESCRIPTION
**Edit:** It is impossible to avoid the following behaviour, the potential replacement is considerably simpler though.

The current "unsafeSynchronizer" sometimes can end up ahead of time. The function
```
unsafeSynchronizer @slowDomain @fastDomain . unsafeSynchronizer @fastDomain @slowDomain
```
currently results in a signal which is sometimes ahead of the original signal.

The proposed replacement is never ahead of time (but is still as "close" to the original signal) and is still idempotent when the clock period is the same.
