### PR TITLE
Import Prelude bindings in a seperate module

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -154,6 +154,8 @@ Library
                       Clash.Explicit.Synchronizer
                       Clash.Explicit.Testbench
 
+                      Clash.HaskellPrelude
+
                       Clash.Hidden
 
                       Clash.Intel.ClockGen

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -125,7 +125,7 @@ module Clash.Explicit.Prelude
   , module Clash.Magic
     -- ** Haskell Prelude
     -- $hiding
-  , module Prelude
+  , module Clash.HaskellPrelude
   )
 where
 
@@ -135,10 +135,7 @@ import Data.Default.Class
 import GHC.TypeLits
 import GHC.TypeLits.Extra
 import Language.Haskell.TH.Syntax  (Lift(..))
-import Prelude hiding
-  ((++), (!!), concat, concatMap, drop, foldl, foldl1, foldr, foldr1, head, init,
-   iterate, last, length, map, repeat, replicate, reverse, scanl, scanr, splitAt,
-   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined, (^))
+import Clash.HaskellPrelude
 
 import Clash.Annotations.TopEntity
 import Clash.Class.BitPack

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -13,6 +13,7 @@ defined in "Clash.Prelude".
 
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -97,7 +98,7 @@ module Clash.Explicit.Prelude.Safe
   , module Clash.NamedTypes
     -- ** Haskell Prelude
     -- $hiding
-  , module Prelude
+  , module Clash.HaskellPrelude
   )
 where
 
@@ -107,10 +108,8 @@ import GHC.Generics (Generic, Generic1)
 import GHC.Stack
 import GHC.TypeLits
 import GHC.TypeLits.Extra
-import Prelude hiding
-  ((++), (!!), concat, concatMap, drop, foldl, foldl1, foldr, foldr1, head, init,
-   iterate, last, length, map, repeat, replicate, reverse, scanl, scanr, splitAt,
-   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined)
+import Clash.HaskellPrelude
+import qualified Prelude
 
 import Clash.Annotations.TopEntity
 import Clash.Class.BitPack

--- a/clash-prelude/src/Clash/HaskellPrelude.hs
+++ b/clash-prelude/src/Clash/HaskellPrelude.hs
@@ -1,0 +1,23 @@
+{-|
+  Copyright   :  (C) 2019, QBayLogic B.V.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V <devops@qbaylogic.com>
+
+"Clash.HaskellPrelude" re-exports most of the Haskell "Prelude" with the exception of
+the following: (++), (!!), concat, drop, foldl, foldl1, foldr, foldr1, head,
+init, iterate, last, length, map, repeat, replicate, reverse, scanl, scanr,
+splitAt, tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3.
+-}
+
+{-# LANGUAGE Safe #-}
+
+{-# OPTIONS_HADDOCK show-extensions, not-home #-}
+
+module Clash.HaskellPrelude
+  (module Prelude)
+where
+
+import Prelude hiding
+  ((++), (!!), concat, concatMap, drop, foldl, foldl1, foldr, foldr1, head, init,
+   iterate, last, length, map, repeat, replicate, reverse, scanl, scanr, splitAt,
+   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined, (^))

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -32,10 +32,11 @@
   Some circuit examples can be found in "Clash.Examples".
 -}
 
-{-# LANGUAGE CPP              #-}
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TypeOperators     #-}
 
 {-# LANGUAGE Unsafe #-}
 
@@ -151,7 +152,7 @@ module Clash.Prelude
   , module Clash.Magic
     -- ** Haskell Prelude
     -- $hiding
-  , module Prelude
+  , module Clash.HaskellPrelude
   )
 where
 
@@ -161,10 +162,7 @@ import           Data.Default.Class
 import           GHC.TypeLits
 import           GHC.TypeLits.Extra
 import           Language.Haskell.TH.Syntax  (Lift(..))
-import           Prelude hiding
-  ((++), (!!), concat, concatMap, drop, foldl, foldl1, foldr, foldr1, head, init,
-   iterate, last, length, map, repeat, replicate, reverse, scanl, scanr, splitAt,
-   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined, (^))
+import           Clash.HaskellPrelude
 
 import           Clash.Annotations.TopEntity
 import           Clash.Class.BitPack

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -31,6 +31,7 @@
 
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE TypeOperators       #-}
 
 {-# LANGUAGE Safe #-}
@@ -114,7 +115,7 @@ module Clash.Prelude.Safe
   , module Clash.Hidden
     -- ** Haskell Prelude
     -- $hiding
-  , module Prelude
+  , module Clash.HaskellPrelude
   )
 where
 
@@ -124,10 +125,7 @@ import           GHC.Generics (Generic, Generic1)
 
 import           GHC.TypeLits
 import           GHC.TypeLits.Extra
-import           Prelude hiding
-  ((++), (!!), concat, concatMap, drop, foldl, foldl1, foldr, foldr1, head, init,
-   iterate, last, length, map, repeat, replicate, reverse, scanl, scanr, splitAt,
-   tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined)
+import           Clash.HaskellPrelude
 
 import           Clash.Annotations.TopEntity
 import           Clash.Class.BitPack


### PR DESCRIPTION
This cleans up the haddock for `Clash.Prelude`