### PR TITLE
Documentation fixes

### DIFF
--- a/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
@@ -81,7 +81,7 @@ liftQ = (>>= TH.lift)
 -- @
 --
 -- This specifies that @R@ should be encoded as 0b00, @G@ as 0b01, and
--- @B@ as 0b10. The first binary value in every @ConstRepr@ in this example
+-- @B@ as 0b10. The first binary value in every @ConstrRepr@ in this example
 -- is a mask, indicating which bits in the data type are relevant. In this case
 -- all of the bits are.
 --
@@ -91,19 +91,20 @@ liftQ = (>>= TH.lift)
 -- {-# ANN module ( DataReprAnn
 --                    $(liftQ [t|Maybe Color|])
 --                    2
---                    [ ConstRepr 'Nothing 0b11 0b11 []
---                    , ConstRepr 'Just 0b00 0b00 [0b11]
+--                    [ ConstrRepr 'Nothing 0b11 0b11 []
+--                    , ConstrRepr 'Just 0b00 0b00 [0b11]
 --                    ] ) #-}
 -- @
 --
 -- By default, @Maybe Color@ is a data type which consumes 3 bits. A single bit
 -- to indicate the constructor (either @Just@ or @Nothing@), and two bits to encode
--- the first field of @Just@. Notice that we saved a single bit, by exploiting
+-- the first field of @Just@. Notice that we saved a single bit by exploiting
 -- the fact that @Color@ only uses three values (0, 1, 2), but takes two bits
 -- to encode it. We can therefore use the last - unused - value (3), to encode
 -- one of the constructors of @Maybe@. We indicate which bits encode the
--- underlying @Color@ by passing /[0b11]/ to ConstRepr. This indicates that the
--- first field is encoded in the first and second bit of the whole datatype (0b11).
+-- underlying @Color@ field of @Just@ by passing /[0b11]/ to ConstrRepr. This
+-- indicates that the first field is encoded in the first and second bit of the
+-- whole datatype (0b11).
 data DataReprAnn =
   DataReprAnn
     -- Type this annotation is for:

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -7,7 +7,7 @@ This module contains:
 
   * Template Haskell functions for deriving 'BitPack' instances given a
     custom bit representation as those defined in
-    'Clash.Annotations.BitRepresentation'.
+    "Clash.Annotations.BitRepresentation".
 
   * Template Haskell functions for deriving custom bit representations,
     e.g. one-hot, for a data type.

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -56,7 +56,7 @@ data DataRepr' =
     [ConstrRepr']
       deriving (Show, Generic, NFData, Eq, Typeable, Hashable, Ord)
 
--- | Internal version of ConstRepr
+-- | Internal version of ConstrRepr
 data ConstrRepr' =
   ConstrRepr'
     -- Qualified name of constructor:

--- a/clash-prelude/src/Clash/Explicit/Mealy.hs
+++ b/clash-prelude/src/Clash/Explicit/Mealy.hs
@@ -119,7 +119,7 @@ mealy clk rst en f iS =
 -- g clk rst en a b c = (b1,b2,i2)
 --   where
 --     (i1,b1) = 'unbundle' (mealy clk rst en f 0 ('bundle' (a,b)))
---     (i2,b2) = 'unbundle' (mealy clk rst en f 3 ('bundle' (i1,c)))
+--     (i2,b2) = 'unbundle' (mealy clk rst en f 3 ('bundle' (c,i1)))
 -- @
 --
 -- Using 'mealyB'' however we can write:
@@ -128,7 +128,7 @@ mealy clk rst en f iS =
 -- g clk rst en a b c = (b1,b2,i2)
 --   where
 --     (i1,b1) = 'mealyB' clk rst en f 0 (a,b)
---     (i2,b2) = 'mealyB' clk rst en f 3 (i1,c)
+--     (i2,b2) = 'mealyB' clk rst en f 3 (c,i1)
 -- @
 mealyB
   :: ( KnownDomain dom

--- a/clash-prelude/src/Clash/Explicit/Moore.hs
+++ b/clash-prelude/src/Clash/Explicit/Moore.hs
@@ -127,7 +127,7 @@ medvedev clk rst en tr st = moore clk rst en tr id st
 -- g clk rst en a b c = (b1,b2,i2)
 --   where
 --     (i1,b1) = 'unbundle' (moore clk rst en t o 0 ('bundle' (a,b)))
---     (i2,b2) = 'unbundle' (moore clk rst en t o 3 ('bundle' (i1,c)))
+--     (i2,b2) = 'unbundle' (moore clk rst en t o 3 ('bundle' (c,i1)))
 -- @
 --
 -- Using 'mooreB'' however we can write:
@@ -136,7 +136,7 @@ medvedev clk rst en tr st = moore clk rst en tr id st
 -- g clk rst en a b c = (b1,b2,i2)
 --   where
 --     (i1,b1) = 'mooreB' clk rst en t o 0 (a,b)
---     (i2,b2) = 'mooreB' clk rst en t o 3 (i1,c)
+--     (i2,b2) = 'mooreB' clk rst en t o 3 (c,i1)
 -- @
 mooreB
   :: ( KnownDomain dom

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -102,7 +102,7 @@ mealy = hideClockResetEnable E.mealy
 -- g a b c = (b1,b2,i2)
 --   where
 --     (i1,b1) = 'Clash.Signal.unbundle' ('mealy' f 0 ('Clash.Signal.bundle' (a,b)))
---     (i2,b2) = 'Clash.Signal.unbundle' ('mealy' f 3 ('Clash.Signal.bundle' (i1,c)))
+--     (i2,b2) = 'Clash.Signal.unbundle' ('mealy' f 3 ('Clash.Signal.bundle' (c,i1)))
 -- @
 --
 -- Using 'mealyB' however we can write:
@@ -111,7 +111,7 @@ mealy = hideClockResetEnable E.mealy
 -- g a b c = (b1,b2,i2)
 --   where
 --     (i1,b1) = 'mealyB' f 0 (a,b)
---     (i2,b2) = 'mealyB' f 3 (i1,c)
+--     (i2,b2) = 'mealyB' f 3 (c,i1)
 -- @
 mealyB
   :: ( HiddenClockResetEnable dom

--- a/clash-prelude/src/Clash/Prelude/Moore.hs
+++ b/clash-prelude/src/Clash/Prelude/Moore.hs
@@ -118,7 +118,7 @@ medvedev tr st = moore tr id st
 -- g a b c = (b1,b2,i2)
 --   where
 --     (i1,b1) = 'Clash.Signal.unbundle' ('moore' t o 0 ('Clash.Signal.bundle' (a,b)))
---     (i2,b2) = 'Clash.Signal.unbundle' ('moore' t o 3 ('Clash.Signal.bundle' (i1,c)))
+--     (i2,b2) = 'Clash.Signal.unbundle' ('moore' t o 3 ('Clash.Signal.bundle' (c,i1)))
 -- @
 --
 -- Using 'mooreB' however we can write:
@@ -127,7 +127,7 @@ medvedev tr st = moore tr id st
 -- g a b c = (b1,b2,i2)
 --   where
 --     (i1,b1) = 'mooreB' t o 0 (a,b)
---     (i2,b2) = 'mooreB' t o 3 (i1,c)
+--     (i2,b2) = 'mooreB' t o 3 (c,i1)
 -- @
 mooreB
   :: ( HiddenClockResetEnable dom


### PR DESCRIPTION
Makes examples of `{mealy, moore}B` compilable and fixes some typos in  `Clash.Annotations.BitRepresentation.*`.