### PR TITLE
Add 'hasUndefined'

### DIFF
--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -279,6 +279,7 @@ instance ( size ~ (int + frac), KnownNat frac, Integral (rep size)
 instance NFDataX (rep (int + frac)) => NFDataX (Fixed rep int frac) where
   deepErrorX = Fixed . errorX
   rnfX f@(~(Fixed x)) = if isLeft (isX f) then () else rnfX x
+  hasUndefined f@(~(Fixed x)) = if isLeft (isX f) then True else hasUndefined x
 
 -- | None of the 'Read' class' methods are synthesizable.
 instance (size ~ (int + frac), KnownNat frac, Bounded (rep size), Integral (rep size))

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -135,6 +135,7 @@ import Control.Lens               (Index, Ixed (..), IxValue)
 import Data.Bits                  (Bits (..), FiniteBits (..))
 import Data.Data                  (Data)
 import Data.Default.Class         (Default (..))
+import Data.Either                (isLeft)
 import Data.Proxy                 (Proxy (..))
 import Data.Typeable              (Typeable, typeOf)
 import GHC.Generics               (Generic)
@@ -156,7 +157,7 @@ import Clash.Class.Resize         (Resize (..))
 import Clash.Promoted.Nat
   (SNat (..), SNatLE (..), compareSNat, snatToInteger, snatToNum)
 import Clash.XException
-  (ShowX (..), NFDataX (..), errorX, showsPrecXWith, rwhnfX)
+  (ShowX (..), NFDataX (..), errorX, isX, showsPrecXWith, rwhnfX)
 
 import {-# SOURCE #-} qualified Clash.Sized.Vector         as V
 import {-# SOURCE #-} qualified Clash.Sized.Internal.Index as I
@@ -222,6 +223,7 @@ instance ShowX Bit where
 instance NFDataX Bit where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined bv = isLeft (isX bv) || unsafeMask# bv /= 0
 
 instance Lift Bit where
   lift (Bit m i) = [| fromInteger## m i |]
@@ -368,6 +370,7 @@ instance KnownNat n => ShowX (BitVector n) where
 instance NFDataX (BitVector n) where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined bv = isLeft (isX bv) || unsafeMask bv /= 0
 
 -- | Create a binary literal
 --

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -235,6 +235,12 @@ instance (KnownNat d, NFDataX a) => NFDataX (RTree d a) where
     go (LR_ x)   = rnfX x
     go (BR_ l r) = rnfX l `seq` rnfX r
 
+  hasUndefined t = if isLeft (isX t) then True else go t
+   where
+    go :: RTree d a -> Bool
+    go (LR_ x)   = hasUndefined x
+    go (BR_ l r) = hasUndefined l || hasUndefined r
+
 
 -- | A /dependently/ typed fold over trees.
 --

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -111,6 +111,7 @@ import Data.Constraint            ((:-)(..), Dict (..))
 import Data.Constraint.Nat        (leZero)
 import Data.Data
   (Data (..), Constr, DataType, Fixity (..), Typeable, mkConstr, mkDataType)
+import Data.Either                (isLeft)
 import Data.Default.Class         (Default (..))
 import qualified Data.Foldable    as F
 import Data.Kind                  (Type)
@@ -142,7 +143,7 @@ import Clash.Sized.Index          (Index)
 
 import Clash.Class.BitPack        (packXWith, BitPack (..))
 import Clash.XException
-  (ShowX (..), NFDataX (..), showsX, showsPrecXWith, seqX)
+  (ShowX (..), NFDataX (..), showsX, showsPrecXWith, seqX, isX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -357,6 +358,12 @@ instance (NFDataX a, KnownNat n) => NFDataX (Vec n a) where
     -- a recursive function.
     seqX (foldl (\() -> rnfX) () v) ()
 
+  hasUndefined v =
+    if isLeft (isX v) then True else go v
+   where
+    go :: forall m b . (NFDataX b, KnownNat m) => Vec m b -> Bool
+    go Nil = False
+    go (x `Cons` xs) = hasUndefined x || hasUndefined xs
 
 {-# INLINE singleton #-}
 -- | Create a vector of one element

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -40,7 +40,7 @@ module Clash.XException
     -- * Strict evaluation
   , seqX, forceX, deepseqX, rwhnfX, defaultSeqX
     -- * Structured undefined / deep evaluation with undefined values
-  , NFDataX (rnfX, deepErrorX)
+  , NFDataX (rnfX, deepErrorX, hasUndefined)
   )
 where
 
@@ -62,6 +62,11 @@ import GHC.Show          (appPrec)
 import GHC.Stack         (HasCallStack, callStack, prettyCallStack, withFrozenCallStack)
 import Numeric.Half      (Half)
 import System.IO.Unsafe  (unsafeDupablePerformIO)
+
+-- $setup
+-- >>> import Clash.Class.BitPack (pack)
+-- >>> :set -fplugin GHC.TypeLits.Normalise
+-- >>> :set -fplugin GHC.TypeLits.KnownNat.Solver
 
 -- | An exception representing an \"uninitialized\" value.
 newtype XException = XException String
@@ -143,6 +148,8 @@ maybeIsX :: NFData a => a -> Maybe a
 maybeIsX = maybeX isX
 
 -- | Fully evaluate a value, returning @'Left' msg@ if it throws 'XException'.
+-- If you want to determine if a value contains undefined parts, use
+-- 'hasUndefined' instead.
 --
 -- > hasX 42                  = Right 42
 -- > hasX (XException msg)    = Left msg
@@ -540,6 +547,47 @@ class NFDataX1 f where
   default liftRnfX :: (Generic1 f, GNFDataX One (Rep1 f)) => (a -> ()) -> f a -> ()
   liftRnfX r = grnfX (RnfArgs1 r) . from1
 
+
+class GHasUndefined f where
+  gHasUndefined :: f a -> Bool
+
+instance GHasUndefined U1 where
+  gHasUndefined u = if isLeft (isX u) then True else case u of U1 -> False
+
+instance NFDataX a => GHasUndefined (K1 i a) where
+  gHasUndefined = hasUndefined . unK1
+  {-# INLINEABLE gHasUndefined #-}
+
+instance GHasUndefined a => GHasUndefined (M1 i c a) where
+  gHasUndefined a =
+    -- Check for X needed to handle edge-case "data Void"
+    if isLeft (isX a) then
+      True
+    else
+      gHasUndefined (unM1 a)
+  {-# INLINEABLE gHasUndefined #-}
+
+instance (GHasUndefined a, GHasUndefined b) => GHasUndefined (a :*: b) where
+  gHasUndefined xy@(~(x :*: y)) =
+    if isLeft (isX xy) then
+      True
+    else
+      gHasUndefined x || gHasUndefined y
+  {-# INLINEABLE gHasUndefined #-}
+
+instance (GHasUndefined a, GHasUndefined b) => GHasUndefined (a :+: b) where
+  gHasUndefined lrx =
+    if isLeft (isX lrx) then
+      True
+    else
+      case lrx of
+        L1 x -> gHasUndefined x
+        R1 x -> gHasUndefined x
+  {-# INLINEABLE gHasUndefined #-}
+
+instance GHasUndefined V1 where
+  gHasUndefined _ = error "Unreachable code?"
+
 -- | Class that houses functions dealing with /undefined/ values in Clash. See
 -- 'deepErrorX' and 'rnfX'.
 class NFDataX a where
@@ -549,6 +597,23 @@ class NFDataX a where
 
   default deepErrorX :: (HasCallStack, Generic a, GDeepErrorX (Rep a)) => String -> a
   deepErrorX = withFrozenCallStack $ to . gDeepErrorX
+
+  -- | Determines whether any of parts of a given construct contain undefined
+  -- parts. Note that a negative answer does not mean its bit representation
+  -- is fully defined. For example:
+  --
+  -- >>> m = Nothing :: Maybe Bool
+  -- >>> hasUndefined m
+  -- False
+  -- >>> pack m
+  -- 0.
+  -- >>> hasUndefined (pack m)
+  -- True
+  --
+  hasUndefined :: a -> Bool
+
+  default hasUndefined :: (Generic a, GHasUndefined (Rep a)) => a -> Bool
+  hasUndefined = gHasUndefined . from
 
   -- | Evaluate a value to NF. As opposed to 'NFData's 'rnf', it does not bubble
   -- up 'XException's.
@@ -600,10 +665,12 @@ instance (NFDataX a, NFDataX b, NFDataX c, NFDataX d, NFDataX e
 instance NFDataX b => NFDataX (a -> b) where
   deepErrorX = pure . deepErrorX
   rnfX = rwhnfX
+  hasUndefined = error "hasUndefined on Undefined (a -> b): Not Yet Implemented"
 
 instance NFDataX a => NFDataX (Down a) where
   deepErrorX = Down . deepErrorX
   rnfX d@(~(Down x)) = if isLeft (isX d) then () else rnfX x
+  hasUndefined d@(~(Down x))= if isLeft (isX d) then True else hasUndefined x
 
 instance NFDataX Bool
 instance NFDataX a => NFDataX [a]
@@ -613,66 +680,82 @@ instance NFDataX a => NFDataX (Maybe a)
 instance NFDataX Char where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Double where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Float where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Int where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Int8 where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Int16 where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Int32 where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Int64 where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Integer where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Natural where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Word where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Word8 where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Word16 where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Word32 where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Word64 where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX Half where
   deepErrorX = errorX
   rnfX = rwhnfX
+  hasUndefined = isLeft . isX
 
 instance NFDataX a => NFDataX (Seq a) where
   deepErrorX = errorX
@@ -682,9 +765,16 @@ instance NFDataX a => NFDataX (Seq a) where
     go Empty = ()
     go (x :<| xs) = rnfX x `seq` go xs
 
+  hasUndefined s =
+    if isLeft (isX s) then True else go s
+   where
+    go Empty = False
+    go (x :<| xs) = hasUndefined x || hasUndefined xs
+
 instance NFDataX a => NFDataX (Ratio a) where
   deepErrorX = errorX
   rnfX r = rnfX (numerator r) `seq` rnfX (denominator r)
+  hasUndefined r = isLeft (isX (numerator r)) || isLeft (isX (denominator r))
 
 instance NFDataX a => NFDataX (Complex a) where
   deepErrorX = errorX

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -603,7 +603,7 @@ instance NFDataX b => NFDataX (a -> b) where
 
 instance NFDataX a => NFDataX (Down a) where
   deepErrorX = Down . deepErrorX
-  rnfX d@(~(Down x))= if isLeft (isX d) then rnfX x else ()
+  rnfX d@(~(Down x)) = if isLeft (isX d) then () else rnfX x
 
 instance NFDataX Bool
 instance NFDataX a => NFDataX [a]

--- a/clash-prelude/tests/Clash/Tests/NFDataX.hs
+++ b/clash-prelude/tests/Clash/Tests/NFDataX.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP            #-}
+{-# LANGUAGE DataKinds      #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric  #-}
 {-# LANGUAGE MagicHash      #-}
@@ -34,7 +35,7 @@ tests =
   testGroup
     "NFDataX"
     [ testGroup
-        "Generic"
+        "GenericRnf"
         [ testCase "Unit"     $ rnfX (undef :: Unit)                  @?= ()
         , testCase "Wrapper1" $ rnfX (undef :: Wrapper)               @?= ()
         , testCase "Wrapper2" $ rnfX (Wrapper undef)                  @?= ()
@@ -59,7 +60,7 @@ tests =
 --        , testCase "Void"     $ rnfX (undef :: Void)                  @?= ()
         ]
     , testGroup
-        "Manual"
+        "ManualRnf"
         [ testCase "List1"     $ rnfX (undef :: [Int])                @?= ()
         , testCase "List2"     $ rnfX ([undef] :: [Int])              @?= ()
         , testCase "Maybe1"    $ rnfX (undef :: Maybe Int)            @?= ()
@@ -69,6 +70,55 @@ tests =
         , testCase "Either3"   $ rnfX (Right undef :: Either Int Int) @?= ()
         , testCase "Down1"     $ rnfX (Down undef :: Down Int)        @?= ()
         , testCase "Down2"     $ rnfX (undef :: Down Int)             @?= ()
+        ]
+    , testGroup
+        "GenericHasUndefinedTrue"
+        [ testCase "Unit"     $ hasUndefined (undef :: Unit)                  @?= True
+        , testCase "Wrapper1" $ hasUndefined (undef :: Wrapper)               @?= True
+        , testCase "Wrapper2" $ hasUndefined (Wrapper undef)                  @?= True
+        , testCase "Sum"      $ hasUndefined (undef :: Sum)                   @?= True
+        , testCase "BigSum"   $ hasUndefined (undef :: BigSum)                @?= True
+        , testCase "Product1" $ hasUndefined (undef :: Product)               @?= True
+        , testCase "Product2" $ hasUndefined (Product undef undef :: Product) @?= True
+        , testCase "Product3" $ hasUndefined (Product 3 undef :: Product)     @?= True
+        , testCase "Product4" $ hasUndefined (Product undef 5 :: Product)     @?= True
+        , testCase "SP1"      $ hasUndefined (undef :: SP)                    @?= True
+        , testCase "SP2"      $ hasUndefined (S undef undef :: SP)            @?= True
+        , testCase "SP3"      $ hasUndefined (S 3 undef :: SP)                @?= True
+        , testCase "SP3"      $ hasUndefined (S undef 5 :: SP)                @?= True
+        , testCase "SP4"      $ hasUndefined (P undef :: SP)                  @?= True
+        , testCase "Rec0"     $ hasUndefined (undef :: Rec0)                  @?= True
+        , testCase "Rec1_1"   $ hasUndefined (undef :: Rec1)                  @?= True
+        , testCase "Rec1_2"   $ hasUndefined (Rec1 undef)                     @?= True
+        , testCase "Rec2_1"   $ hasUndefined (undef :: Rec2)                  @?= True
+        , testCase "Rec2_2"   $ hasUndefined (Rec2 3 undef)                   @?= True
+        , testCase "Rec2_3"   $ hasUndefined (Rec2 undef 5)                   @?= True
+--          Test case broken on 8.2.2:
+--        , testCase "Void"     $ rnfX (undef :: Void)                  @?= True
+        ]
+    , testGroup
+        "GenericHasUndefinedFalse"
+        [ testCase "Unit"     $ hasUndefined ()                               @?= False
+        , testCase "Wrapper"  $ hasUndefined (Wrapper 0:: Wrapper)            @?= False
+        , testCase "SumA"     $ hasUndefined (SumTypeA :: Sum)                @?= False
+        , testCase "SumB"     $ hasUndefined (SumTypeB :: Sum)                @?= False
+        , testCase "BigSum1"  $ hasUndefined (BS1 :: BigSum)                  @?= False
+        , testCase "BigSum2"  $ hasUndefined (BS2 :: BigSum)                  @?= False
+        , testCase "BigSum3"  $ hasUndefined (BS3 :: BigSum)                  @?= False
+        , testCase "BigSum4"  $ hasUndefined (BS4 :: BigSum)                  @?= False
+        , testCase "BigSum5"  $ hasUndefined (BS5 :: BigSum)                  @?= False
+        , testCase "Product"  $ hasUndefined (Product 3 5 :: Product)         @?= False
+        , testCase "SP1"      $ hasUndefined (S 3 5 :: SP)                    @?= False
+        , testCase "SP2"      $ hasUndefined (P 5 :: SP)                      @?= False
+        , testCase "Rec2_3"   $ hasUndefined (Rec2 3 5)                       @?= False
+        ]
+    , testGroup
+        "ManualHasUndefined"
+        [ testCase "Vec1"       $ hasUndefined (3 :> errorX "X" :: Vec 5 Int)   @?= True
+        , testCase "Vec2"       $ hasUndefined (errorX "X" :: Vec 5 Int)        @?= True
+        , testCase "Maybe"      $ hasUndefined (Nothing :: Maybe Bool)          @?= False
+        , testCase "BitVector1" $ hasUndefined (pack (Nothing :: Maybe Bool))   @?= True
+        , testCase "BitVector2" $ hasUndefined (pack (Just True:: Maybe Bool))  @?= False
         ]
     ]
 

--- a/clash-prelude/tests/Clash/Tests/NFDataX.hs
+++ b/clash-prelude/tests/Clash/Tests/NFDataX.hs
@@ -5,11 +5,14 @@
 
 module Clash.Tests.NFDataX where
 
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
-import GHC.Generics (Generic)
-import Clash.XException (NFDataX(rnfX), errorX)
+import           GHC.Generics         (Generic)
+import           Clash.Class.BitPack  (pack)
+import           Clash.Sized.Vector   (Vec(..))
+import           Clash.XException     (NFDataX(rnfX, hasUndefined), errorX)
+import           Data.Ord             (Down (Down))
 
 data Void                                  deriving (Generic, NFDataX)
 data Unit    = Unit                        deriving (Generic, NFDataX)
@@ -64,6 +67,8 @@ tests =
         , testCase "Either1"   $ rnfX (undef :: Either Int Int)       @?= ()
         , testCase "Either2"   $ rnfX (Left undef :: Either Int Int)  @?= ()
         , testCase "Either3"   $ rnfX (Right undef :: Either Int Int) @?= ()
+        , testCase "Down1"     $ rnfX (Down undef :: Down Int)        @?= ()
+        , testCase "Down2"     $ rnfX (undef :: Down Int)             @?= ()
         ]
     ]
 


### PR DESCRIPTION
Some users were using `hasX` to determine whether a data structure had
undefined parts. With the introduction of masks in `BitVector`s this
lead to some unexpected results: even though part the bitvector would be
partly made up of undefined parts, it wouldn't contain an `XException`.
`hasX` would therefore not catch it.

--------------------------

After discussion, this is back to WIP. TODO:

- [x] Add `hasUndefined`
- [x] ~~Add `isUndefined`~~ In retrospect: this is probably not very useful. If you'd want to do anything with the answer of this function, you'd need to know the structure of the data types anyway.
- [x] ~~Rework functions such that they collect (and merge?) the errors instead~~ For another PR.
- [x] ~~(Under discussion) Deprecate `hasX`, `isX`, ..~~ I don't think this is a good idea. The functions are well-defined as they are, useful in certain situations, and part of our stable API.