### PR TITLE
Mark Callstacks as synthesizable to 0-bit Void

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -238,6 +238,10 @@ ghcTypeToHWType iw floatSupport = go
           (TyConApp (nameOcc -> "GHC.Types.Char") []) -> returnN String
           _ -> throwE $ "Can't translate type: " ++ showPpr ty
 
+        -- To ensure that Clash doesn't get stuck working away callstacks that
+        -- never end up being used in the generated HDL.
+        "GHC.Stack.Types.CallStack" -> returnN (Void Nothing)
+
         _ -> ExceptT (MaybeT (pure Nothing))
 
     go _ _ _ = pure Nothing


### PR DESCRIPTION
Callstacks are recursive types and are by default marked as
non-synthesisable by Clash because of this. As a result,
transformations like inlineNonRep, bindOrInlineNonRep etc
would work very hard to progagate and get ride of Callstacks.
However, the CallStacks usually end up being used by `error`,
where the HDL template doesn't use the CallStack argument, thus
being thrown away by `removeUnusedArgument`. Any remaining
CallStacks simply shouldn't be rendered, that's why we make
them 0-bit Voids.