### PR TITLE
Rename `Undefined` to `NFDataX`

### DIFF
--- a/clash-cosim/src/Clash/CoSim/Types.hs
+++ b/clash-cosim/src/Clash/CoSim/Types.hs
@@ -14,7 +14,7 @@ module Clash.CoSim.Types where
 import Data.Data (Data, Typeable)
 
 import Clash.Prelude (BitPack, BitSize, KnownNat)
-import Clash.XException (Undefined)
+import Clash.XException (NFDataX)
 
 -- | Settings passed to the simulator. Does not affect synthetization.
 data CoSimSettings = CoSimSettings
@@ -45,7 +45,7 @@ defaultSettings = CoSimSettings
 -- can be simultated.
 type ClashType a = ( BitPack a
                    , KnownNat (BitSize a)
-                   , Undefined a
+                   , NFDataX a
                    )
 
 -- | Supported simulators

--- a/clash-cosim/tests/test.hs
+++ b/clash-cosim/tests/test.hs
@@ -28,7 +28,7 @@ tests = testGroup "Inline verilog"
 -- "normal" Haskell types.
 bin
     :: forall t a
-     . (t ~ Signal System a, Undefined a)
+     . (t ~ Signal System a, NFDataX a)
     => (t -> t -> t)
     -> a
     -> a

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -323,7 +323,7 @@ test-suite unittests
                  Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes
                  Clash.Tests.Signal
-                 Clash.Tests.Undefined
+                 Clash.Tests.NFDataX
 
 
 benchmark benchmark-clash-prelude

--- a/clash-prelude/src/Clash/Examples.hs
+++ b/clash-prelude/src/Clash/Examples.hs
@@ -195,7 +195,7 @@ data RxReg
   , _rx_d1         :: Bit
   , _rx_d2         :: Bit
   , _rx_busy       :: Bool
-  } deriving (Generic, Undefined)
+  } deriving (Generic, NFDataX)
 
 makeLenses ''RxReg
 
@@ -207,7 +207,7 @@ data TxReg
   , _tx_out      :: Bit
   , _tx_cnt      :: Unsigned 4
   }
-  deriving (Generic, Undefined)
+  deriving (Generic, NFDataX)
 
 makeLenses ''TxReg
 

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -424,7 +424,7 @@ import           Clash.Sized.Index      (Index)
 import           Clash.Sized.Vector     (Vec, replicate, toList, iterateI)
 import qualified Clash.Sized.Vector     as CV
 import           Clash.XException
-  (maybeIsX, seqX, Undefined, deepErrorX, defaultSeqX, errorX)
+  (maybeIsX, seqX, NFDataX, deepErrorX, defaultSeqX, errorX)
 
 {- $setup
 >>> import Clash.Explicit.Prelude as C
@@ -442,7 +442,7 @@ data Reg
   | RegC
   | RegD
   | RegE
-  deriving (Eq,Show,Enum,C.Generic,Undefined)
+  deriving (Eq,Show,Enum,C.Generic,NFDataX)
 :}
 
 >>> :{
@@ -719,7 +719,7 @@ fromJustX (Just x) = x
 blockRam
   :: ( KnownDomain dom
      , HasCallStack
-     , Undefined a
+     , NFDataX a
      , Enum addr )
   => Clock dom
   -- ^ 'Clock' to synchronize to
@@ -765,7 +765,7 @@ blockRam = \clk gen content rd wrM ->
 blockRamPow2
   :: ( KnownDomain dom
      , HasCallStack
-     , Undefined a
+     , NFDataX a
      , KnownNat n )
   => Clock dom
   -- ^ 'Clock' to synchronize to
@@ -798,7 +798,7 @@ blockRamU
    :: forall n dom a r addr
    . ( KnownDomain dom
      , HasCallStack
-     , Undefined a
+     , NFDataX a
      , Enum addr
      , 1 <= n )
   => Clock dom
@@ -855,7 +855,7 @@ blockRamU#
   :: forall n dom a
    . ( KnownDomain dom
      , HasCallStack
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -889,7 +889,7 @@ blockRam1
    :: forall n dom a r addr
    . ( KnownDomain dom
      , HasCallStack
-     , Undefined a
+     , NFDataX a
      , Enum addr
      , 1 <= n )
   => Clock dom
@@ -946,7 +946,7 @@ blockRam1#
   :: forall n dom a
    . ( KnownDomain dom
      , HasCallStack
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -975,7 +975,7 @@ blockRam1# clk en n a =
 blockRam#
   :: ( KnownDomain dom
      , HasCallStack
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -1022,7 +1022,7 @@ blockRam# (Clock _) gen content rd wen =
 -- | Create read-after-write blockRAM from a read-before-write one
 readNew
   :: ( KnownDomain dom
-     , Undefined a
+     , NFDataX a
      , Eq addr )
   => Clock dom
   -> Reset dom

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -56,7 +56,7 @@ import Clash.Signal.Internal
 -- [(X,X),((-1),(-2)),((-3),2),(3,4),(5,6)]
 ddrIn
   :: ( HasCallStack
-     , Undefined a
+     , NFDataX a
      , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
      , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
@@ -79,7 +79,7 @@ ddrIn clk rst en (i0,i1,i2) =
 ddrIn#
   :: forall a slow fast fPeriod polarity edge reset init
    . ( HasCallStack
-     , Undefined a
+     , NFDataX a
      , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
      , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
@@ -142,7 +142,7 @@ ddrIn# (Clock _) (unsafeToHighPolarity -> hRst) (fromEnable -> ena) i0 i1 i2 =
 -- [-1,-1,-1,2,3,4,5]
 ddrOut
   :: ( HasCallStack
-     , Undefined a
+     , NFDataX a
      , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
      , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow
@@ -160,7 +160,7 @@ ddrOut clk rst en i0 =
 
 ddrOut#
   :: ( HasCallStack
-     , Undefined a
+     , NFDataX a
      , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
      , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
   => Clock slow

--- a/clash-prelude/src/Clash/Explicit/Mealy.hs
+++ b/clash-prelude/src/Clash/Explicit/Mealy.hs
@@ -23,7 +23,7 @@ where
 
 import           Clash.Explicit.Signal
   (KnownDomain, Bundle (..), Clock, Reset, Signal, Enable, register)
-import           Clash.XException      (Undefined)
+import           Clash.XException      (NFDataX)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -85,7 +85,7 @@ let macT s (x,y) = (s',s)
 -- @
 mealy
   :: ( KnownDomain dom
-     , Undefined s )
+     , NFDataX s )
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Reset dom
@@ -132,7 +132,7 @@ mealy clk rst en f iS =
 -- @
 mealyB
   :: ( KnownDomain dom
-     , Undefined s
+     , NFDataX s
      , Bundle i
      , Bundle o )
   => Clock dom

--- a/clash-prelude/src/Clash/Explicit/Moore.hs
+++ b/clash-prelude/src/Clash/Explicit/Moore.hs
@@ -25,7 +25,7 @@ where
 
 import           Clash.Explicit.Signal
   (KnownDomain, Bundle (..), Clock, Reset, Signal, Enable, register)
-import           Clash.XException                 (Undefined)
+import           Clash.XException                 (NFDataX)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -77,7 +77,7 @@ import           Clash.XException                 (Undefined)
 -- @
 moore
   :: ( KnownDomain dom
-     , Undefined s )
+     , NFDataX s )
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Reset dom
@@ -101,7 +101,7 @@ moore clk rst en ft fo iS =
 -- a moore machine without any output logic
 medvedev
   :: ( KnownDomain dom
-     , Undefined s )
+     , NFDataX s )
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -140,7 +140,7 @@ medvedev clk rst en tr st = moore clk rst en tr id st
 -- @
 mooreB
   :: ( KnownDomain dom
-     , Undefined s
+     , NFDataX s
      , Bundle i
      , Bundle o )
   => Clock dom
@@ -163,7 +163,7 @@ mooreB clk rst en ft fo iS i = unbundle (moore clk rst en ft fo iS (bundle i))
 -- | A version of 'medvedev' that does automatic 'Bundle'ing
 medvedevB
   :: ( KnownDomain dom
-     , Undefined s
+     , NFDataX s
      , Bundle i
      , Bundle s )
   => Clock dom

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -198,7 +198,7 @@ import Clash.XException
 window
   :: ( KnownNat n
      , KnownDomain dom
-     , Undefined a
+     , NFDataX a
      , Default a
      )
   => Clock dom
@@ -236,7 +236,7 @@ window clk rst en x = res
 -- ...
 windowD
   :: ( KnownNat n
-     , Undefined a
+     , NFDataX a
      , Default a
      , KnownDomain dom )
   => Clock dom

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -165,7 +165,7 @@ import Clash.XException
 -- ...
 registerB
   :: ( KnownDomain dom
-     , Undefined a
+     , NFDataX a
      , Bundle a )
   => Clock dom
   -> Reset dom
@@ -180,7 +180,7 @@ registerB clk rst en i =
 -- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
 isRising
   :: ( KnownDomain dom
-     , Undefined a
+     , NFDataX a
      , Bounded a
      , Eq a )
   => Clock dom
@@ -198,7 +198,7 @@ isRising clk rst en is s = liftA2 edgeDetect prev s
 -- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
 isFalling
   :: ( KnownDomain dom
-     , Undefined a
+     , NFDataX a
      , Bounded a
      , Eq a )
   => Clock dom

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -38,7 +38,7 @@ import Clash.Signal.Internal
   (Clock (..), KnownDomain, Signal (..), Enable, fromEnable)
 import Clash.Sized.Unsigned   (Unsigned)
 import Clash.Sized.Vector     (Vec, length, toList)
-import Clash.XException       (deepErrorX, seqX, Undefined)
+import Clash.XException       (deepErrorX, seqX, NFDataX)
 
 -- | A ROM with a synchronous read port, with space for 2^@n@ elements
 --
@@ -50,7 +50,7 @@ import Clash.XException       (deepErrorX, seqX, Undefined)
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Explicit.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
 romPow2
-  :: (KnownDomain dom, KnownNat n, Undefined a)
+  :: (KnownDomain dom, KnownNat n, NFDataX a)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -76,7 +76,7 @@ romPow2 = rom
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Explicit.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
 rom
-  :: (KnownDomain dom, KnownNat n, Undefined a, Enum addr)
+  :: (KnownDomain dom, KnownNat n, NFDataX a, Enum addr)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom
@@ -95,7 +95,7 @@ rom = \clk en content rd -> rom# clk en content (fromEnum <$> rd)
 -- | ROM primitive
 rom#
   :: forall dom n a
-   . (KnownDomain dom, KnownNat n, Undefined a)
+   . (KnownDomain dom, KnownNat n, NFDataX a)
   => Clock dom
   -- ^ 'Clock' to synchronize to
   -> Enable dom

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -98,7 +98,7 @@ import Clash.Promoted.Nat           (SNat (..), pow2SNat, snatToNum)
 import Clash.Sized.BitVector        (BitVector)
 import Clash.Explicit.Signal        (Clock, Enable, Signal, KnownDomain, delay)
 import Clash.Sized.Unsigned         (Unsigned)
-import Clash.XException             (Undefined(deepErrorX))
+import Clash.XException             (NFDataX(deepErrorX))
 
 
 -- | A ROM with a synchronous read port, with space for 2^@n@ elements

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -269,7 +269,7 @@ import           Clash.Signal.Internal
 import           Clash.Signal.Internal.Ambiguous
   (knownVDomain, clockPeriod, activeEdge, resetKind, initBehavior, resetPolarity)
 import           Clash.Sized.Index              (Index)
-import           Clash.XException               (Undefined, deepErrorX)
+import           Clash.XException               (NFDataX, deepErrorX)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications -XFlexibleInstances -XMultiParamTypeClasses -XTypeFamilies
@@ -552,7 +552,7 @@ enable e0 e1 =
 -- Initial value will be undefined.
 dflipflop
   :: ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -> Signal dom a
   -> Signal dom a
@@ -571,7 +571,7 @@ dflipflop clk i =
 -- [0,1,2]
 delay
   :: ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -- ^ Clock
   -> Enable dom
@@ -591,7 +591,7 @@ delay = delay#
 -- [0,1,2,2,2,5,6]
 delayMaybe
   :: ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -- ^ Clock
   -> Enable dom
@@ -612,7 +612,7 @@ delayMaybe clk gen dflt i =
 -- [0,1,2,2,2,5,6]
 delayEn
   :: ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -- ^ Clock
   -> Enable dom
@@ -634,7 +634,7 @@ delayEn clk gen dflt en i =
 -- [8,8,1,2,3]
 register
   :: ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -- ^ clock
   -> Reset dom
@@ -673,7 +673,7 @@ register clk rst gen initial i =
 -- [0,0,0,1,1,2,2,3,3]
 regMaybe
   :: ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -- ^ Clock
   -> Reset dom
@@ -705,7 +705,7 @@ regMaybe clk rst en initial iM =
 -- [0,0,0,1,1,2,2,3,3]
 regEn
   :: ( KnownDomain dom
-     , Undefined a
+     , NFDataX a
      )
   => Clock dom
   -- ^ Clock
@@ -733,8 +733,8 @@ regEn clk rst gen initial en i =
 simulateWithReset
   :: forall dom a b m
    . ( KnownDomain dom
-     , Undefined a
-     , Undefined b
+     , NFDataX a
+     , NFDataX b
      , 1 <= m )
   => SNat m
   -- ^ Number of cycles to assert the reset
@@ -762,8 +762,8 @@ simulateWithReset m resetVal f as =
 -- | Same as 'simulateWithReset', but only sample the first /Int/ output values.
 simulateWithResetN
   :: ( KnownDomain dom
-     , Undefined a
-     , Undefined b
+     , NFDataX a
+     , NFDataX b
      , 1 <= m )
   => SNat m
   -- ^ Number of cycles to assert the reset
@@ -793,7 +793,7 @@ simulateWithResetN nReset resetVal nSamples f as =
 --
 -- __NB__: This function is not synthesizable
 simulateB
-  :: (Bundle a, Bundle b, Undefined a, Undefined b)
+  :: (Bundle a, Bundle b, NFDataX a, NFDataX b)
   => (Unbundled dom1 a -> Unbundled dom2 b)
   -- ^ The function we want to simulate
   -> [a]
@@ -863,7 +863,7 @@ holdReset clk en SNat rst =
 -- __NB__: This function is not synthesizable
 fromListWithReset
   :: forall dom a
-   . (KnownDomain dom, Undefined a)
+   . (KnownDomain dom, NFDataX a)
   => Reset dom
   -> a
   -> [a]

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -51,7 +51,7 @@ import Clash.Signal.Delayed.Internal
 import Clash.Explicit.Signal
   (KnownDomain, Clock, Reset, Signal, Enable, register,  bundle, unbundle)
 
-import Clash.XException           (Undefined)
+import Clash.XException           (NFDataX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -95,7 +95,7 @@ delayed
   :: forall dom  a n d
    . ( KnownDomain dom
      , KnownNat d
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -143,7 +143,7 @@ delayed clk rst en m ds = coerce (delaySignal (coerce ds))
 delayedI
   :: ( KnownNat d
      , KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -> Reset dom
   -> Enable dom

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -47,7 +47,7 @@ import Clash.Promoted.Nat          (SNat (..), pow2SNat)
 import Clash.Promoted.Nat.Literals (d0)
 import Clash.Signal                (mux, KnownDomain)
 import Clash.Sized.BitVector       (BitVector, (++#))
-import Clash.XException            (Undefined)
+import Clash.XException            (NFDataX)
 
 -- * Dual flip-flop synchronizer
 
@@ -74,7 +74,7 @@ import Clash.XException            (Undefined)
 --      If you want to have /safe/ __word__-synchronization use
 --      'asyncFIFOSynchronizer'.
 dualFlipFlopSynchronizer
-  :: ( Undefined a
+  :: ( NFDataX a
      , KnownDomain dom1
      , KnownDomain dom2 )
   => Clock dom1

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -229,7 +229,7 @@ window
   :: ( HiddenClockResetEnable dom
      , KnownNat n
      , Default a
-     , Undefined a )
+     , NFDataX a )
   => Signal dom a
   -- ^ Signal to create a window over
   -> Vec (n + 1) (Signal dom a)
@@ -252,7 +252,7 @@ windowD
   :: ( HiddenClockResetEnable dom
      , KnownNat n
      , Default a
-     , Undefined a )
+     , NFDataX a )
   => Signal dom a
   -- ^ Signal to create a window over
   -> Vec (n + 1) (Signal dom a)

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -44,7 +44,7 @@ data Reg
   | RegC
   | RegD
   | RegE
-  deriving (Eq, Show, Enum, Generic, Undefined)
+  deriving (Eq, Show, Enum, Generic, NFDataX)
 
 data Operator = Add | Sub | Incr | Imm | CmpGt
   deriving (Eq, Show)
@@ -403,7 +403,7 @@ import           Clash.Signal
 import           Clash.Sized.Index       (Index)
 import           Clash.Sized.Unsigned    (Unsigned)
 import           Clash.Sized.Vector      (Vec)
-import           Clash.XException        (Undefined)
+import           Clash.XException        (NFDataX)
 
 {- $setup
 >>> import Clash.Prelude as C
@@ -422,7 +422,7 @@ data Reg
   | RegC
   | RegD
   | RegE
-  deriving (Eq,Show,Enum,C.Generic,Undefined)
+  deriving (Eq,Show,Enum,C.Generic,NFDataX)
 :}
 
 >>> :{
@@ -687,7 +687,7 @@ blockRam
   :: ( HasCallStack
      , HiddenClock dom
      , HiddenEnable dom
-     , Undefined a
+     , NFDataX a
      , Enum addr
      )
   => Vec n a
@@ -711,7 +711,7 @@ blockRamU
    :: forall n dom a r addr
    . ( HasCallStack
      , HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      , Enum addr
      , 1 <= n )
   => E.ResetStrategy r
@@ -739,7 +739,7 @@ blockRam1
    :: forall n dom a r addr
    . ( HasCallStack
      , HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      , Enum addr
      , 1 <= n )
   => E.ResetStrategy r
@@ -784,7 +784,7 @@ blockRamPow2
   :: ( HasCallStack
      , HiddenClock dom
      , HiddenEnable dom
-     , Undefined a
+     , NFDataX a
      , KnownNat n
      )
   => Vec (2^n) a
@@ -815,7 +815,7 @@ blockRamPow2 = \cnt rd wrM -> withFrozenCallStack
 --      Signal dom addr -> Signal dom (Maybe (addr, a)) -> Signal dom a
 readNew
   :: ( HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      , Eq addr )
   => (Signal dom addr -> Signal dom (Maybe (addr, a)) -> Signal dom a)
   -- ^ The @ram@ component

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -60,7 +60,7 @@ import Clash.Signal.Bundle    (Bundle (..))
 import Clash.Explicit.Signal  (Clock, Reset, Signal, Enable, enable, register)
 import Clash.Sized.BitVector  (BitVector)
 import Clash.Sized.Vector
-import Clash.XException       (errorX, Undefined)
+import Clash.XException       (errorX, NFDataX)
 
 {- | Dataflow circuit with bidirectional synchronization channels.
 
@@ -155,7 +155,7 @@ pureDF f = DF (\i iV oR -> (fmap f i,iV,oR))
 -- "Clash.Prelude.Mealy"
 mealyDF
   :: ( KnownDomain dom
-     , Undefined s )
+     , NFDataX s )
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -172,7 +172,7 @@ mealyDF clk rst gen f iS =
 -- "Clash.Prelude.Moore"
 mooreDF
   :: ( KnownDomain dom
-     , Undefined s )
+     , NFDataX s )
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -220,7 +220,7 @@ fifoDF_mealy (mem,rptr,wptr) (wdata,winc,rinc) =
 fifoDF
   :: forall addrSize m n a dom
    . ( KnownDomain dom
-     , Undefined a
+     , NFDataX a
      , KnownNat addrSize
      , KnownNat n
      , KnownNat m
@@ -359,7 +359,7 @@ parNDF fs =
 -- <<doc/loopDF_sync.svg>>
 loopDF
   :: ( KnownDomain dom
-     , Undefined d
+     , NFDataX d
      , KnownNat m
      , KnownNat n
      , KnownNat addrSize

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -26,7 +26,7 @@ where
 
 import qualified Clash.Explicit.Mealy as E
 import           Clash.Signal
-import           Clash.XException           (Undefined)
+import           Clash.XException           (NFDataX)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -76,7 +76,7 @@ let macT s (x,y) = (s',s)
 -- @
 mealy
   :: ( HiddenClockResetEnable dom
-     , Undefined s )
+     , NFDataX s )
   => (s -> i -> (s,o))
   -- ^ Transfer function in mealy machine form: @state -> input -> (newstate,output)@
   -> s
@@ -115,7 +115,7 @@ mealy = hideClockResetEnable E.mealy
 -- @
 mealyB
   :: ( HiddenClockResetEnable dom
-     , Undefined s
+     , NFDataX s
      , Bundle i
      , Bundle o )
   => (s -> i -> (s,o))
@@ -131,7 +131,7 @@ mealyB = hideClockResetEnable E.mealyB
 -- | Infix version of 'mealyB'
 (<^>)
   :: ( HiddenClockResetEnable dom
-     , Undefined s
+     , NFDataX s
      , Bundle i
      , Bundle o )
   => (s -> i -> (s,o))

--- a/clash-prelude/src/Clash/Prelude/Moore.hs
+++ b/clash-prelude/src/Clash/Prelude/Moore.hs
@@ -27,7 +27,7 @@ where
 
 import qualified Clash.Explicit.Moore as E
 import           Clash.Signal
-import           Clash.XException                     (Undefined)
+import           Clash.XException                     (NFDataX)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
@@ -77,7 +77,7 @@ let macT s (x,y) = x * y + s
 -- @
 moore
   :: ( HiddenClockResetEnable dom
-     , Undefined s )
+     , NFDataX s )
   => (s -> i -> s)
   -- ^ Transfer function in moore machine form: @state -> input -> newstate@
   -> (s -> o)
@@ -95,7 +95,7 @@ moore = hideClockResetEnable E.moore
 -- a moore machine without any output logic
 medvedev
   :: ( HiddenClockResetEnable dom
-     , Undefined s )
+     , NFDataX s )
   => (s -> i -> s)
   -> s
   -> (Signal dom i -> Signal dom s)
@@ -131,7 +131,7 @@ medvedev tr st = moore tr id st
 -- @
 mooreB
   :: ( HiddenClockResetEnable dom
-     , Undefined s
+     , NFDataX s
      , Bundle i
      , Bundle o )
   => (s -> i -> s)
@@ -149,7 +149,7 @@ mooreB = hideClockResetEnable E.mooreB
 -- | A version of 'medvedev' that does automatic 'Bundle'ing
 medvedevB
   :: ( HiddenClockResetEnable dom
-     , Undefined s
+     , NFDataX s
      , Bundle i
      , Bundle s )
   => (s -> i -> s)

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -40,7 +40,7 @@ import           Clash.Signal
 import           Clash.Sized.Unsigned (Unsigned)
 import           Clash.Sized.Vector   (Vec, length, toList)
 
-import           Clash.XException     (Undefined)
+import           Clash.XException     (NFDataX)
 
 -- | An asynchronous/combinational ROM with space for @n@ elements
 --
@@ -108,7 +108,7 @@ asyncRom# content rd = arr ! rd
 -- for ideas on how to use ROMs and RAMs
 rom
   :: forall dom n m a
-   . ( Undefined a
+   . ( NFDataX a
      , KnownNat n
      , KnownNat m
      , HiddenClock dom
@@ -136,7 +136,7 @@ rom = hideEnable (hideClock E.rom)
 romPow2
   :: forall dom n a
    . ( KnownNat n
-     , Undefined a
+     , NFDataX a
      , HiddenClock dom
      , HiddenEnable dom  )
   => Vec (2^n) a

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -184,7 +184,7 @@ It instead exports the identically named functions defined in terms of
 -- ...
 registerB
   :: ( HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      , Bundle a )
   => a
   -> Unbundled dom a
@@ -196,7 +196,7 @@ infixr 3 `registerB`
 -- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
 isRising
   :: ( HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      , Bounded a
      , Eq a )
   => a
@@ -209,7 +209,7 @@ isRising = hideClockResetEnable E.isRising
 -- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
 isFalling
   :: ( HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      , Bounded a
      , Eq a )
   => a

--- a/clash-prelude/src/Clash/Prelude/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Prelude/Synchronizer.hs
@@ -21,7 +21,7 @@ import qualified Clash.Explicit.Synchronizer as E
 import           Clash.Promoted.Nat          (SNat)
 import           Clash.Signal
   (HiddenClockResetEnable, HiddenClock, Signal, hasClock, hasReset, hasEnable)
-import           Clash.XException            (Undefined)
+import           Clash.XException            (NFDataX)
 import           GHC.TypeLits                (type (<=))
 
 -- | Synchronizer based on two sequentially connected flip-flops.
@@ -47,7 +47,7 @@ import           GHC.TypeLits                (type (<=))
 --      If you want to have /safe/ __word__-synchronization use
 --      'asyncFIFOSynchronizer'.
 dualFlipFlopSynchronizer
-  :: ( Undefined a
+  :: ( NFDataX a
      , HiddenClock dom1
      , HiddenClockResetEnable dom2
      )

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -278,7 +278,7 @@ import           Clash.Signal.Internal hiding
 import           Clash.Signal.Internal.Ambiguous
   (knownVDomain, clockPeriod, activeEdge, resetKind, initBehavior, resetPolarity)
 import qualified Clash.Signal.Internal as S
-import           Clash.XException      (Undefined)
+import           Clash.XException      (NFDataX)
 
 {- $setup
 >>> :set -XFlexibleContexts -XTypeApplications
@@ -1281,7 +1281,7 @@ withSpecificClockResetEnable =
 dflipflop
   :: forall dom a
    . ( HiddenClock dom
-     , Undefined a )
+     , NFDataX a )
   => Signal dom a
   -> Signal dom a
 dflipflop =
@@ -1295,7 +1295,7 @@ dflipflop =
 -- [0,1,2]
 delay
   :: forall dom a
-   . ( Undefined a
+   . ( NFDataX a
      , HiddenClock dom
      , HiddenEnable dom  )
   => a
@@ -1319,7 +1319,7 @@ delay dflt i =
 -- [0,1,2,2,2,5,6]
 delayMaybe
   :: forall dom a
-   . ( Undefined a
+   . ( NFDataX a
      , HiddenClock dom
      , HiddenEnable dom  )
   => a
@@ -1342,7 +1342,7 @@ delayMaybe dflt i =
 -- [0,1,2,2,2,5,6]
 delayEn
   :: forall dom a
-   . ( Undefined a
+   . ( NFDataX a
      , HiddenClock dom
      , HiddenEnable dom  )
   => a
@@ -1368,7 +1368,7 @@ delayEn dflt en i =
 register
   :: forall dom a
    . ( HiddenClockResetEnable dom
-     , Undefined a )
+     , NFDataX a )
   => a
   -- ^ Reset value
   --
@@ -1409,7 +1409,7 @@ infixr 3 `register`
 regMaybe
   :: forall dom a
    . ( HiddenClockResetEnable dom
-     , Undefined a )
+     , NFDataX a )
   => a
   -- ^ Reset value. 'regMaybe' outputs the reset value when the reset is active.
   -> Signal dom (Maybe a)
@@ -1441,7 +1441,7 @@ infixr 3 `regMaybe`
 regEn
   :: forall dom a
    . ( HiddenClockResetEnable dom
-     , Undefined a )
+     , NFDataX a )
   => a
   -- ^ Reset value
   --
@@ -1478,7 +1478,7 @@ regEn initial en i =
 sample
   :: forall dom a
    . ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => (HiddenClockResetEnable dom  => Signal dom a)
   -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
   -- (and reset)
@@ -1504,7 +1504,7 @@ sample s =
 sampleN
   :: forall dom a
    . ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Int
   -- ^ Number of samples to produce
   -> (HiddenClockResetEnable dom => Signal dom a)
@@ -1524,7 +1524,7 @@ sampleN n s0 =
 sampleWithReset
   :: forall dom a m
    . ( KnownDomain dom
-     , Undefined a
+     , NFDataX a
      , 1 <= m )
   => SNat m
   -- ^ Number of cycles to assert the reset
@@ -1545,7 +1545,7 @@ sampleWithReset nReset f0 =
 sampleWithResetN
   :: forall dom a m
    . ( KnownDomain dom
-     , Undefined a
+     , NFDataX a
      , 1 <= m )
   => SNat m
   -- ^ Number of cycles to assert the reset
@@ -1629,8 +1629,8 @@ sampleN_lazy n s =
 simulate
   :: forall dom a b
    . ( KnownDomain dom
-     , Undefined a
-     , Undefined b )
+     , NFDataX a
+     , NFDataX b )
   => (HiddenClockResetEnable dom => Signal dom a -> Signal dom b)
   -- ^ Circuit to simulate, whose source potentially has a hidden clock, reset,
   -- and/or enable.
@@ -1645,8 +1645,8 @@ simulate f as = simulateWithReset (SNat @1) (head as) f as
 simulateN
   :: forall dom a b
    . ( KnownDomain dom
-     , Undefined a
-     , Undefined b )
+     , NFDataX a
+     , NFDataX b )
   => Int
   -- ^ Number of cycles to simulate (excluding cycle spent in reset)
   -> (HiddenClockResetEnable dom => Signal dom a -> Signal dom b)
@@ -1664,8 +1664,8 @@ simulateN n f as = simulateWithResetN (SNat @1) (head as) n f as
 simulateWithReset
   :: forall dom a b m
    . ( KnownDomain dom
-     , Undefined a
-     , Undefined b
+     , NFDataX a
+     , NFDataX b
      , 1 <= m )
   => SNat m
   -- ^ Number of cycles to assert the reset
@@ -1684,8 +1684,8 @@ simulateWithReset n resetVal f as =
 simulateWithResetN
   :: forall dom a b m
    . ( KnownDomain dom
-     , Undefined a
-     , Undefined b
+     , NFDataX a
+     , NFDataX b
      , 1 <= m )
   => SNat m
   -- ^ Number of cycles to assert the reset
@@ -1738,8 +1738,8 @@ simulateB
    . ( KnownDomain dom
      , Bundle a
      , Bundle b
-     , Undefined a
-     , Undefined b
+     , NFDataX a
+     , NFDataX b
      )
   => (HiddenClockResetEnable dom  =>
       Unbundled dom a -> Unbundled dom b)
@@ -1854,7 +1854,7 @@ holdReset m =
 -- __NB__: This function is not synthesizable
 fromListWithReset
   :: forall dom a
-   . (HiddenReset dom, Undefined a)
+   . (HiddenReset dom, NFDataX a)
   => a
   -> [a]
   -> Signal dom a

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -65,7 +65,7 @@ import           Clash.Signal
   (HiddenClockResetEnable , hideClockResetEnable, Signal, delay)
 
 import           Clash.Promoted.Nat            (SNat (..), snatToInteger)
-import           Clash.XException              (Undefined)
+import           Clash.XException              (NFDataX)
 
 {- $setup
 >>> :set -XDataKinds -XTypeOperators -XTypeApplications -XFlexibleContexts
@@ -92,7 +92,7 @@ import           Clash.XException              (Undefined)
 delayed
   :: ( KnownNat d
      , HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      )
   => Vec d a
   -> DSignal dom n a
@@ -124,7 +124,7 @@ delayed = hideClockResetEnable E.delayed
 --      a -> DSignal dom n a -> DSignal dom (n + 3) a
 delayedI
   :: ( KnownNat d
-     , Undefined a
+     , NFDataX a
      , HiddenClockResetEnable dom  )
   => a
   -- ^ Initial value
@@ -148,7 +148,7 @@ delayedI = hideClockResetEnable E.delayedI
 delayN
   :: forall dom  a d n
    . ( HiddenClockResetEnable dom
-     , Undefined a )
+     , NFDataX a )
   => SNat d
   -> a
   -- ^ Initial value
@@ -180,7 +180,7 @@ delayN d dflt = coerce . go (snatToInteger d) . coerce @_ @(Signal dom a)
 delayI
   :: forall d n a dom
    . ( HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      , KnownNat d )
   => a
   -- ^ Initial value
@@ -208,7 +208,7 @@ type instance Apply (DelayedFold dom n delay a) k = DSignal dom (n + (delay*k)) 
 delayedFold
   :: forall dom  n delay k a
    . ( HiddenClockResetEnable dom
-     , Undefined a
+     , NFDataX a
      , KnownNat delay
      , KnownNat k )
   => SNat delay

--- a/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
@@ -50,7 +50,7 @@ import Clash.Promoted.Nat         (SNat)
 import Clash.Signal.Internal      (Domain)
 import Clash.Explicit.Signal
   (Signal, fromList, fromList_lazy)
-import Clash.XException           (Undefined)
+import Clash.XException           (NFDataX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -91,7 +91,7 @@ newtype DSignal (dom :: Domain) (delay :: Nat) a =
 -- [1,2]
 --
 -- __NB__: This function is not synthesizable
-dfromList :: Undefined a => [a] -> DSignal dom 0 a
+dfromList :: NFDataX a => [a] -> DSignal dom 0 a
 dfromList = coerce . fromList
 
 -- | Create a 'DSignal' from a list

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -164,7 +164,7 @@ import Test.QuickCheck            (Arbitrary (..), CoArbitrary(..), Property,
 import Clash.Promoted.Nat         (SNat (..), snatToNum, snatToNatural)
 import Clash.Promoted.Symbol      (SSymbol (..), ssymbolToString)
 import Clash.XException
-  (Undefined, errorX, deepseqX, defaultSeqX, deepErrorX)
+  (NFDataX, errorX, deepseqX, defaultSeqX, deepErrorX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -1027,7 +1027,7 @@ infixr 3 .&&.
 delay#
   :: forall dom a
    . ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -> Enable dom
   -> a
@@ -1065,7 +1065,7 @@ delay# (Clock dom) (fromEnable -> en) powerUpVal0 =
 register#
   :: forall dom  a
    . ( KnownDomain dom
-     , Undefined a )
+     , NFDataX a )
   => Clock dom
   -> Reset dom
   -> Enable dom
@@ -1235,7 +1235,7 @@ testFor n = property . and . take n . sample
 -- > sample s == [s0, s1, s2, s3, ...
 --
 -- __NB__: This function is not synthesizable
-sample :: (Foldable f, Undefined a) => f a -> [a]
+sample :: (Foldable f, NFDataX a) => f a -> [a]
 sample = foldr (\a b -> deepseqX a (a : b)) []
 
 -- | The above type is a generalization for:
@@ -1252,7 +1252,7 @@ sample = foldr (\a b -> deepseqX a (a : b)) []
 -- > sampleN 3 s == [s0, s1, s2]
 --
 -- __NB__: This function is not synthesizable
-sampleN :: (Foldable f, Undefined a) => Int -> f a -> [a]
+sampleN :: (Foldable f, NFDataX a) => Int -> f a -> [a]
 sampleN n = take n . sample
 
 -- | Create a 'Clash.Signal.Signal' from a list
@@ -1264,7 +1264,7 @@ sampleN n = take n . sample
 -- [1,2]
 --
 -- __NB__: This function is not synthesizable
-fromList :: Undefined a => [a] -> Signal dom a
+fromList :: NFDataX a => [a] -> Signal dom a
 fromList = Prelude.foldr (\a b -> deepseqX a (a :- b)) (errorX "finite list")
 
 -- * Simulation functions (not synthesizable)
@@ -1277,7 +1277,7 @@ fromList = Prelude.foldr (\a b -> deepseqX a (a :- b)) (errorX "finite list")
 -- ...
 --
 -- __NB__: This function is not synthesizable
-simulate :: (Undefined a, Undefined b) => (Signal dom1 a -> Signal dom2 b) -> [a] -> [b]
+simulate :: (NFDataX a, NFDataX b) => (Signal dom1 a -> Signal dom2 b) -> [a] -> [b]
 simulate f = sample . f . fromList
 
 -- | The above type is a generalization for:

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -101,7 +101,7 @@ import qualified Clash.Sized.Vector    as Vector
 import           Clash.Class.BitPack   (BitPack, BitSize, pack, unpack)
 import           Clash.Promoted.Nat    (snatToNum, SNat(..))
 import           Clash.Signal.Internal (sample)
-import           Clash.XException      (deepseqX, Undefined)
+import           Clash.XException      (deepseqX, NFDataX)
 import           Clash.Sized.Internal.BitVector
   (BitVector(BV))
 
@@ -149,7 +149,7 @@ mkTrace
   :: HasCallStack
   => KnownNat (BitSize a)
   => BitPack a
-  => Undefined a
+  => NFDataX a
   => Signal dom a
   -> [Value]
 mkTrace signal = sample (unsafeToTup . pack <$> signal)
@@ -162,7 +162,7 @@ traceSignal#
   :: forall dom a
    . ( KnownNat (BitSize a)
      , BitPack a
-     , Undefined a
+     , NFDataX a
      , Typeable a )
   => IORef TraceMap
   -- ^ Map to store the trace
@@ -198,7 +198,7 @@ traceVecSignal#
    . ( KnownNat (BitSize a)
      , KnownNat n
      , BitPack a
-     , Undefined a
+     , NFDataX a
      , Typeable a )
   => IORef TraceMap
   -- ^ Map to store the traces
@@ -228,7 +228,7 @@ traceSignal
    . ( KnownDomain dom
      , KnownNat (BitSize a)
      , BitPack a
-     , Undefined a
+     , NFDataX a
      , Typeable a )
   => String
   -- ^ Name of signal in the VCD output
@@ -252,7 +252,7 @@ traceSignal traceName signal =
 traceSignal1
   :: ( KnownNat (BitSize a)
      , BitPack a
-     , Undefined a
+     , NFDataX a
      , Typeable a )
   => String
   -- ^ Name of signal in the VCD output
@@ -276,7 +276,7 @@ traceVecSignal
      , KnownNat (BitSize a)
      , KnownNat n
      , BitPack a
-     , Undefined a
+     , NFDataX a
      , Typeable a )
   => String
   -- ^ Name of signal in debugging output. Will be appended by _0, _1, ..., _n.
@@ -302,7 +302,7 @@ traceVecSignal1
   :: ( KnownNat (BitSize a)
      , KnownNat n
      , BitPack a
-     , Undefined a
+     , NFDataX a
      , Typeable a )
   => String
   -- ^ Name of signal in debugging output. Will be appended by _0, _1, ..., _n.
@@ -460,7 +460,7 @@ dumpVCD## (offset, cycles) traceMap now
 
 -- | Same as @dumpVCD@, but supplied with a custom tracemap
 dumpVCD#
-  :: Undefined a
+  :: NFDataX a
   => IORef TraceMap
   -- ^ Map with collected traces
   -> (Int, Int)
@@ -492,7 +492,7 @@ dumpVCD# traceMap slice signal traceNames = do
 -- Evaluates /cntrOut/ long enough in order for to guarantee that the @main@,
 -- and @sub@ traces end up in the generated VCD file.
 dumpVCD
-  :: Undefined a
+  :: NFDataX a
   => (Int, Int)
   -- ^ (offset, number of samples)
   -> Signal dom a
@@ -505,7 +505,7 @@ dumpVCD = dumpVCD# traceMap#
 -- | Dump a number of samples to a replayable bytestring.
 dumpReplayable
   :: forall a dom
-   . Undefined a
+   . NFDataX a
   => Int
   -- ^ Number of samples
   -> Signal dom a
@@ -527,7 +527,7 @@ dumpReplayable n oSignal traceName = do
 replay
   :: forall a dom n
    . ( Typeable a
-     , Undefined a
+     , NFDataX a
      , BitPack a
      , KnownNat n
      , n ~ BitSize a )
@@ -562,7 +562,7 @@ decodeSamples bytes0 =
 
 -- | Keep evaluating given signal until all trace names are present.
 waitForTraces#
-  :: Undefined a
+  :: NFDataX a
   => IORef TraceMap
   -- ^ Map with collected traces
   -> Signal dom a

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -100,7 +100,7 @@ import Clash.Sized.BitVector      (BitVector, (++#))
 import Clash.Sized.Signed         (Signed)
 import Clash.Sized.Unsigned       (Unsigned)
 import Clash.XException
-  (ShowX (..), Undefined (..), isX, errorX, showsPrecXWith)
+  (ShowX (..), NFDataX (..), isX, errorX, showsPrecXWith)
 
 {- $setup
 >>> :set -XDataKinds
@@ -276,7 +276,7 @@ instance ( size ~ (int + frac), KnownNat frac, Integral (rep size)
          ) => ShowX (Fixed rep int frac) where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined (rep (int + frac)) => Undefined (Fixed rep int frac) where
+instance NFDataX (rep (int + frac)) => NFDataX (Fixed rep int frac) where
   deepErrorX = Fixed . errorX
   rnfX f@(~(Fixed x)) = if isLeft (isX f) then () else rnfX x
 

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -156,7 +156,7 @@ import Clash.Class.Resize         (Resize (..))
 import Clash.Promoted.Nat
   (SNat (..), SNatLE (..), compareSNat, snatToInteger, snatToNum)
 import Clash.XException
-  (ShowX (..), Undefined (..), errorX, showsPrecXWith, rwhnfX)
+  (ShowX (..), NFDataX (..), errorX, showsPrecXWith, rwhnfX)
 
 import {-# SOURCE #-} qualified Clash.Sized.Vector         as V
 import {-# SOURCE #-} qualified Clash.Sized.Internal.Index as I
@@ -219,7 +219,7 @@ instance Show Bit where
 instance ShowX Bit where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined Bit where
+instance NFDataX Bit where
   deepErrorX = errorX
   rnfX = rwhnfX
 
@@ -365,7 +365,7 @@ instance KnownNat n => Show (BitVector n) where
 instance KnownNat n => ShowX (BitVector n) where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined (BitVector n) where
+instance NFDataX (BitVector n) where
   deepErrorX = errorX
   rnfX = rwhnfX
 
@@ -975,7 +975,7 @@ undefined# =
 {-# NOINLINE undefined# #-}
 
 -- | Check if one BitVector is like another.
--- Undefined bits in the second argument are interpreted as don't care bits.
+-- NFDataX bits in the second argument are interpreted as don't care bits.
 --
 -- >>> let expected = $$(bLit "1.") :: BitVector 2
 -- >>> let checked  = $$(bLit "11") :: BitVector 2

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -104,7 +104,7 @@ import {-# SOURCE #-} Clash.Sized.Internal.BitVector (BitVector (BV), high, low,
 import qualified Clash.Sized.Internal.BitVector as BV
 import Clash.Promoted.Nat         (SNat(..), snatToNum, leToPlusKN)
 import Clash.XException
-  (ShowX (..), Undefined (..), errorX, showsPrecXWith, rwhnfX)
+  (ShowX (..), NFDataX (..), errorX, showsPrecXWith, rwhnfX)
 
 -- | Arbitrary-bounded unsigned integer represented by @ceil(log_2(n))@ bits.
 --
@@ -400,7 +400,7 @@ instance Show (Index n) where
 instance ShowX (Index n) where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined (Index n) where
+instance NFDataX (Index n) where
   deepErrorX = errorX
   rnfX = rwhnfX
 

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -110,7 +110,7 @@ import Clash.Prelude.BitReduction     (reduceAnd, reduceOr)
 import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, (++#), high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
 import Clash.XException
-  (ShowX (..), Undefined (..), errorX, showsPrecXWith, rwhnfX)
+  (ShowX (..), NFDataX (..), errorX, showsPrecXWith, rwhnfX)
 
 -- | Arbitrary-width signed integer represented by @n@ bits, including the sign
 -- bit.
@@ -153,7 +153,7 @@ newtype Signed (n :: Nat) =
     S { unsafeToInteger :: Integer}
   deriving (Data, Generic)
 
-instance Undefined (Signed n) where
+instance NFDataX (Signed n) where
   deepErrorX = errorX
   rnfX = rwhnfX
 

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -103,7 +103,7 @@ import Clash.Prelude.BitReduction     (reduceOr)
 import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
 import Clash.XException
-  (ShowX (..), Undefined (..), errorX, showsPrecXWith, rwhnfX)
+  (ShowX (..), NFDataX (..), errorX, showsPrecXWith, rwhnfX)
 
 -- | Arbitrary-width unsigned integer represented by @n@ bits
 --
@@ -159,7 +159,7 @@ instance Show (Unsigned n) where
 instance ShowX (Unsigned n) where
   showsPrecX = showsPrecXWith showsPrec
 
-instance Undefined (Unsigned n) where
+instance NFDataX (Unsigned n) where
   deepErrorX = errorX
   rnfX = rwhnfX
 

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -80,7 +80,7 @@ import Clash.Promoted.Nat.Literals (d1)
 import Clash.Sized.Index           (Index)
 import Clash.Sized.Vector          (Vec (..), (!!), (++), dtfold, replace)
 import Clash.XException
-  (ShowX (..), Undefined (..), isX, showsX, showsPrecXWith)
+  (ShowX (..), NFDataX (..), isX, showsX, showsPrecXWith)
 
 {- $setup
 >>> :set -XDataKinds
@@ -226,7 +226,7 @@ instance (KnownNat d, Arbitrary a) => Arbitrary (RTree d a) where
 instance (KnownNat d, CoArbitrary a) => CoArbitrary (RTree d a) where
   coarbitrary = coarbitrary . toList
 
-instance (KnownNat d, Undefined a) => Undefined (RTree d a) where
+instance (KnownNat d, NFDataX a) => NFDataX (RTree d a) where
   deepErrorX x = pure (deepErrorX x)
 
   rnfX t = if isLeft (isX t) then () else go t

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -142,7 +142,7 @@ import Clash.Sized.Index          (Index)
 
 import Clash.Class.BitPack        (packXWith, BitPack (..))
 import Clash.XException
-  (ShowX (..), Undefined (..), showsX, showsPrecXWith, seqX)
+  (ShowX (..), NFDataX (..), showsX, showsPrecXWith, seqX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -348,7 +348,7 @@ traverse# f (x `Cons` xs) = Cons <$> f x <*> traverse# f xs
 instance (Default a, KnownNat n) => Default (Vec n a) where
   def = repeat def
 
-instance (Undefined a, KnownNat n) => Undefined (Vec n a) where
+instance (NFDataX a, KnownNat n) => NFDataX (Vec n a) where
   deepErrorX x = repeat (deepErrorX x)
 
   rnfX v =

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -76,7 +76,7 @@ where
 
 import Clash.Prelude
 import Clash.Explicit.Testbench
-import Clash.XException (Undefined)
+import Clash.XException (NFDataX)
 import Control.Monad.ST
 import Data.Array
 import Data.Char
@@ -339,7 +339,7 @@ the definition of one of the sequential primitives, the @'register'@ function:
 @
 register
      ( 'HiddenClockResetEnable' dom dom
-     , 'Clash.XException.Undefined' a )
+     , 'Clash.XException.NFDataX' a )
   => a
   -> 'Signal' dom a
   -> 'Signal' dom a
@@ -427,7 +427,7 @@ shape of @macT@:
 
 @
 mealy
-  :: ('HiddenClockResetEnable' dom dom, 'Clash.XException.Undefined' s)
+  :: ('HiddenClockResetEnable' dom dom, 'Clash.XException.NFDataX' s)
   => (s -> i -> (s,o))
   -> s
   -> ('Signal' dom i -> 'Signal' dom o)
@@ -668,7 +668,7 @@ structure.
     @
     asStateM
       :: ( 'HiddenClockResetEnable' dom dom
-         , 'Undefined' s )
+         , 'NFDataX' s )
       => (i -> 'Control.Monad.State.Lazy.State' s o)
       -> s
       -> ('Signal' dom i -> 'Signal' dom o)
@@ -1080,7 +1080,7 @@ import Clash.XException       (defaultSeqX)
 
 blockRam#
   :: ( HasCallStack
-     , Undefined a )
+     , NFDataX a )
   => 'Clock' dom           -- ^ 'Clock' to synchronize to
   -> 'Enable' dom          -- ^ Global enable
   -> 'Vec' n a             -- ^ Initial content of the BRAM, also
@@ -1126,7 +1126,7 @@ And for which the /declaration/ primitive is:
   , "type" :
 "blockRam#
   :: ( HasCallStack  --       ARG[0]
-     , Undefined a ) --       ARG[1]
+     , NFDataX a ) --       ARG[1]
   => Clock dom       -- clk,  ARG[2]
   -> Enable dom      -- en,   ARG[3]
   -> Vec n a         -- init, ARG[4]
@@ -1308,7 +1308,7 @@ and
   , "type" :
 "blockRam#
   :: ( HasCallStack  --       ARG[0]
-     , Undefined a ) --       ARG[1]
+     , NFDataX a ) --       ARG[1]
   => Clock dom       -- clk,  ARG[2]
   => Enable dom      -- en,   ARG[3]
   -> Vec n a         -- init, ARG[4]
@@ -1379,7 +1379,7 @@ and
   , "type" :
 "blockRam#
   :: ( HasCallStack  --       ARG[0]
-     , Undefined a ) --       ARG[1]
+     , NFDataX a ) --       ARG[1]
   => Clock dom       -- clk,  ARG[2]
   -> Enable dom      -- en,   ARG[3]
   -> Vec n a         -- init, ARG[4]
@@ -2362,7 +2362,7 @@ fir
      , Default a
      , KnownNat n
      , SaturatingNum a
-     , Undefined a )
+     , NFDataX a )
   => Vec (n + 1) a -> Signal dom a -> Signal dom a
 fir coeffs x_t = y_t
   where

--- a/clash-prelude/tests/Clash/Tests/NFDataX.hs
+++ b/clash-prelude/tests/Clash/Tests/NFDataX.hs
@@ -3,24 +3,24 @@
 {-# LANGUAGE DeriveGeneric  #-}
 {-# LANGUAGE MagicHash      #-}
 
-module Clash.Tests.Undefined where
+module Clash.Tests.NFDataX where
 
 import Test.Tasty
 import Test.Tasty.HUnit
 
 import GHC.Generics (Generic)
-import Clash.XException (Undefined(rnfX), errorX)
+import Clash.XException (NFDataX(rnfX), errorX)
 
-data Void                                  deriving (Generic, Undefined)
-data Unit    = Unit                        deriving (Generic, Undefined)
-data Wrapper = Wrapper Int                 deriving (Generic, Undefined)
-data Sum     = SumTypeA | SumTypeB         deriving (Generic, Undefined)
-data BigSum  = BS1 | BS2 | BS3 | BS4 | BS5 deriving (Generic, Undefined)
-data Product = Product Int Int             deriving (Generic, Undefined)
-data SP      = S Int Int | P Int           deriving (Generic, Undefined)
-data Rec0    = Rec0 {  }                   deriving (Generic, Undefined)
-data Rec1    = Rec1 { a :: Int }           deriving (Generic, Undefined)
-data Rec2    = Rec2 { b :: Int, c :: Int } deriving (Generic, Undefined)
+data Void                                  deriving (Generic, NFDataX)
+data Unit    = Unit                        deriving (Generic, NFDataX)
+data Wrapper = Wrapper Int                 deriving (Generic, NFDataX)
+data Sum     = SumTypeA | SumTypeB         deriving (Generic, NFDataX)
+data BigSum  = BS1 | BS2 | BS3 | BS4 | BS5 deriving (Generic, NFDataX)
+data Product = Product Int Int             deriving (Generic, NFDataX)
+data SP      = S Int Int | P Int           deriving (Generic, NFDataX)
+data Rec0    = Rec0 {  }                   deriving (Generic, NFDataX)
+data Rec1    = Rec1 { a :: Int }           deriving (Generic, NFDataX)
+data Rec2    = Rec2 { b :: Int, c :: Int } deriving (Generic, NFDataX)
 
 undef :: a
 undef = errorX "!"
@@ -29,7 +29,7 @@ undef = errorX "!"
 tests :: TestTree
 tests =
   testGroup
-    "Undefined"
+    "NFDataX"
     [ testGroup
         "Generic"
         [ testCase "Unit"     $ rnfX (undef :: Unit)                  @?= ()

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -6,7 +6,7 @@ import qualified Clash.Tests.BitPack
 import qualified Clash.Tests.BitVector
 import qualified Clash.Tests.DerivingDataRepr
 import qualified Clash.Tests.Signal
-import qualified Clash.Tests.Undefined
+import qualified Clash.Tests.NFDataX
 
 tests :: TestTree
 tests = testGroup "Unittests"
@@ -14,7 +14,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.BitVector.tests
   , Clash.Tests.DerivingDataRepr.tests
   , Clash.Tests.Signal.tests
-  , Clash.Tests.Undefined.tests
+  , Clash.Tests.NFDataX.tests
   ]
 
 main :: IO ()

--- a/examples/Blinker.hs
+++ b/examples/Blinker.hs
@@ -8,7 +8,7 @@ data LedMode
   -- ^ After some period, rotate active led to the left
   | Complement
   -- ^ After some period, turn on all disable LEDs, and vice versa
-  deriving (Generic, Undefined)
+  deriving (Generic, NFDataX)
 
 -- Define a synthesis domain with a clock with a period of 20000 /ps/.
 createDomain vSystem{vName="Input", vPeriod=20000}

--- a/examples/CHIP8.hs
+++ b/examples/CHIP8.hs
@@ -26,7 +26,7 @@ topEntity = exposeClockResetEnable output
 
 mealyState
   :: ( HiddenClockResetEnable tag
-     , Undefined s )
+     , NFDataX s )
   => (i -> State s o)
   -> s
   -> (Signal tag i -> Signal tag o)
@@ -36,7 +36,7 @@ data Phase
     = Init
     | Fetch1
     | Exec
-    deriving (Generic, Undefined)
+    deriving (Generic, NFDataX)
 
 data CPUIn = CPUIn
     { cpuInMem :: Word8
@@ -46,7 +46,7 @@ data CPUState = CPUState
     { pc :: Word8
     , phase :: Phase
     }
-    deriving (Generic, Undefined)
+    deriving (Generic, NFDataX)
 
 initState :: CPUState
 initState = CPUState

--- a/examples/FIR.hs
+++ b/examples/FIR.hs
@@ -14,7 +14,7 @@ fir
      , Default a
      , KnownNat n
      , SaturatingNum a
-     , Undefined a )
+     , NFDataX a )
   => Vec (n + 1) a -> Signal tag a -> Signal tag a
 fir coeffs x_t = y_t
   where

--- a/examples/Reducer.hs
+++ b/examples/Reducer.hs
@@ -50,7 +50,7 @@ equalDiscr _             _             = False
 data DiscrState = Discr { prevIndex :: ArrayIndex
                         , curDiscr  :: Unsigned DiscrSize
                         }
-                        deriving (Generic, Undefined)
+                        deriving (Generic, NFDataX)
 
 type InputState = Vec (AdderDepth + 1) Cell
 
@@ -59,7 +59,7 @@ type FpState    = Vec AdderDepth Cell
 data ResState   = Res { cellMem  :: Vec DiscrRange Cell
                       , indexMem :: Vec DiscrRange ArrayIndex
                       }
-                      deriving (Generic, Undefined)
+                      deriving (Generic, NFDataX)
 
 -- ===========================================================
 -- = Discrimintor: Hands out new discriminator to the system =

--- a/examples/i2c/I2C/BitMaster.hs
+++ b/examples/i2c/I2C/BitMaster.hs
@@ -22,7 +22,7 @@ data BitMasterS
   , _slaveWait      :: Bool            -- clock generation signal
   , _cnt            :: Unsigned 16     -- clock divider counter (synthesis)
   }
-  deriving (Generic, Undefined)
+  deriving (Generic, NFDataX)
 
 makeLenses ''BitMasterS
 

--- a/examples/i2c/I2C/BitMaster/BusCtrl.hs
+++ b/examples/i2c/I2C/BitMaster/BusCtrl.hs
@@ -20,7 +20,7 @@ data BusStatusCtrl
   , _stopCondition  :: Bool        -- stop detected
   , _busy           :: Bool        -- internal busy signal
   , _cmdStop        :: Bool        -- STOP command
-  } deriving (Generic, Undefined)
+  } deriving (Generic, NFDataX)
 
 makeLenses ''BusStatusCtrl
 

--- a/examples/i2c/I2C/BitMaster/StateMachine.hs
+++ b/examples/i2c/I2C/BitMaster/StateMachine.hs
@@ -13,7 +13,7 @@ data BitStateMachine
   | Stop  (Index 4)
   | Read  (Index 4)
   | Write (Index 4)
-  deriving (Eq, Generic, Undefined)
+  deriving (Eq, Generic, NFDataX)
 
 data StateMachine
   = StateMachine
@@ -22,7 +22,7 @@ data StateMachine
   , _sdaChk    :: Bool            -- check SDA status (multi-master arbiter)
   , _cmdAck    :: Bool            -- command completed
   , _bitStateM :: BitStateMachine -- State Machine
-  } deriving (Generic, Undefined)
+  } deriving (Generic, NFDataX)
 
 makeLenses ''StateMachine
 

--- a/examples/i2c/I2C/ByteMaster.hs
+++ b/examples/i2c/I2C/ByteMaster.hs
@@ -12,7 +12,7 @@ import I2C.ByteMaster.ShiftRegister
 import I2C.Types
 
 data ByteStateMachine = Idle | Start | Read | Write | Ack | Stop
-  deriving (Show, Generic, Undefined)
+  deriving (Show, Generic, NFDataX)
 
 data ByteMasterS
   = ByteS
@@ -25,7 +25,7 @@ data ByteMasterS
   , _hostAck    :: Bool             -- host cmd acknowlegde register
   , _ackOut     :: Bool             -- slave ack register
   }
-  deriving (Generic, Undefined)
+  deriving (Generic, NFDataX)
 
 makeLenses ''ByteMasterS
 

--- a/examples/i2c/I2C/ByteMaster/ShiftRegister.hs
+++ b/examples/i2c/I2C/ByteMaster/ShiftRegister.hs
@@ -10,7 +10,7 @@ data ShiftRegister
   = ShiftRegister
   { _sr   :: Vec 8 Bit
   , _dcnt :: Index 8
-  } deriving (Generic, Undefined)
+  } deriving (Generic, NFDataX)
 
 makeLenses ''ShiftRegister
 

--- a/examples/i2c/I2C/Types.hs
+++ b/examples/i2c/I2C/Types.hs
@@ -3,7 +3,7 @@ module I2C.Types where
 import Clash.Prelude
 
 data I2CCommand = I2Cstart | I2Cstop | I2Cwrite | I2Cread | I2Cnop
-  deriving (Eq, Ord, Generic, Undefined)
+  deriving (Eq, Ord, Generic, NFDataX)
 
 type BitCtrlSig = (I2CCommand,Bit)
 type BitRespSig = (Bool,Bool,Bit)

--- a/tests/shouldwork/Basic/LotOfStates.hs
+++ b/tests/shouldwork/Basic/LotOfStates.hs
@@ -14,7 +14,7 @@ data States = S_0
             | S_8
             | S_9
             | S_10
-            deriving (Enum, Eq, Generic, Undefined)
+            deriving (Enum, Eq, Generic, NFDataX)
 
 fsm :: States
     -> Unsigned 8

--- a/tests/shouldwork/Basic/RecordSumOfProducts.hs
+++ b/tests/shouldwork/Basic/RecordSumOfProducts.hs
@@ -8,10 +8,10 @@ import Control.Applicative
 
 data DbState = DbInitDisp (Unsigned 4) | DbWriteRam (Signed 14) (Signed 14)
              | DbDone
-    deriving (Show, Eq, Generic, Undefined)
+    deriving (Show, Eq, Generic, NFDataX)
 
 data DbS = DbS { dbS :: DbState }
-  deriving (Generic, Undefined)
+  deriving (Generic, NFDataX)
 
 
 topEntity

--- a/tests/shouldwork/Numbers/SignedProjection.hs
+++ b/tests/shouldwork/Numbers/SignedProjection.hs
@@ -10,7 +10,7 @@ module SignedProjection where
 import qualified Prelude
 import Clash.Prelude
 
-data Complex a = a :+ a deriving (Show, Lift, Generic, ShowX, Undefined, Functor)
+data Complex a = a :+ a deriving (Show, Lift, Generic, ShowX, NFDataX, Functor)
 
 realPart :: Complex a -> a
 realPart (x :+ _) = x

--- a/tests/shouldwork/Vector/MovingAvg.hs
+++ b/tests/shouldwork/Vector/MovingAvg.hs
@@ -6,7 +6,7 @@ windowN
   :: HiddenClockResetEnable dom
   => Default a
   => KnownNat n
-  => Undefined a
+  => NFDataX a
   => SNat (n+1)
   -> Signal dom a
   -> Vec (n + 1) (Signal dom a)


### PR DESCRIPTION
We didn't like the name `Undefined` because:

1. We were creating unknown values, not undefined values
2. Also, not the entire value is unkown, just the leafs
3. It also traverses data-structures, without touching
   unknown values (which throw XExceptions)

We went through multiple alternatives: `Unknown`, `Spine`,
`SpineX`, `LeafX`, `ClashData`, etc. all somewhat horrible.

Ultimately we decided to call it `NFDataX`, because it has some
`NFData`-like functionality.