### PR TITLE
Auto release full releases on Hackage

### DIFF
--- a/.ci/publish_sdist.sh
+++ b/.ci/publish_sdist.sh
@@ -10,12 +10,8 @@ set +u
 
 if [[ "$HACKAGE_RELEASE" == "yes" ]]; then
     # Release tag set, upload as release.
-    # TODO: Right now, this branch will do the same as the other: make a
-    # release candidate. We can change it to actually have it release after
-    # we've gained enough trust in the release logic.
-    echo "XXX: Release logic activated!"
-    cabal upload --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST} 
-    cabal upload --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST} 
+    cabal upload --publish --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST}
+    cabal upload --publish --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST}
 elif [[ "$HACKAGE_RELEASE" == "no" ]]; then
     # Upload as release candidate
     cabal upload --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST} 


### PR DESCRIPTION
The release logic in the CI works as intended as witnessed by the following job:

https://gitlab.com/clash-lang/clash-compiler/-/jobs/286852569

Note the `XXX: Release logic activated!` Non-tagged releases do not show this message:

https://gitlab.com/clash-lang/clash-compiler/-/jobs/285933311

Time to remove the safeguard!