### PR TITLE
Fix d864286 fallout

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -8,6 +8,7 @@ package *
 package clash-lib
   ghc-options: -Werror
   documentation: True
+  tests: True
   flags: +debug
 package clash-prelude
   ghc-options: -Werror

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -39,8 +39,8 @@ if [[ ${tag_version} != "" && ${version} != ${tag_version} ]]; then
         echo "\$CI_COMMIT_TAG should start with a 'v'. Found: ${CI_COMMIT_TAG}"
         exit 1;
     fi
-fi   
+fi
 
 # Run actual tests
-cabal new-test clash-cosim clash-prelude
+cabal new-test clash-cosim clash-prelude clash-lib
 cabal new-run -- clash-testsuite -j$THREADS --hide-successes

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -85,6 +85,12 @@ flag history
    default: False
    manual: True
 
+flag unittests
+  description:
+    You can disable testing with unittests using `-f-unittests`.
+  default: True
+  manual: True
+
 Library
   HS-Source-Dirs:     src
 
@@ -224,3 +230,27 @@ Library
 
   if flag(history)
     cpp-options:      -DHISTORY
+
+test-suite unittests
+  type:             exitcode-stdio-1.0
+  default-language: Haskell2010
+  main-is:          unittests.hs
+  ghc-options:      -Wall
+  hs-source-dirs:   tests
+
+  if !flag(unittests)
+    buildable: False
+  else
+    build-depends:
+      clash-prelude,
+      clash-lib,
+
+      ghc-typelits-knownnat,
+
+      base,
+      ghc,
+      lens,
+      tasty         >= 1.2      && < 1.3,
+      tasty-hunit
+
+  Other-Modules: Clash.Tests.Core.FreeVars

--- a/clash-lib/src/Clash/Core/FreeVars.hs
+++ b/clash-lib/src/Clash/Core/FreeVars.hs
@@ -13,7 +13,6 @@
 module Clash.Core.FreeVars
   (-- * Free variable calculation
     typeFreeVars
-  , termFreeVarsX
   , freeIds
   , freeLocalVars
   , freeLocalIds
@@ -196,19 +195,6 @@ termFreeTyVars :: Fold Term TyVar
 termFreeTyVars = termFreeVars' isTV where
   isTV (TyVar {}) = True
   isTV _          = False
-
--- | Gives the free variables of a Term, implemented as a 'Fold'
---
--- The 'Fold' is closed over the types of variables, so:
---
--- @
--- foldMapOf termFreeVars unitVarSet (case (x : (a:* -> k) Int)) of {}) = {x, a, k}
--- @
---
--- __NB__ this collects both global and local IDs, and you almost __NEVER__ want
--- to use this. Use one of the other FV calculations instead
-termFreeVarsX :: Fold Term (Var a)
-termFreeVarsX = termFreeVars' (const True)
 
 -- | Gives the "interesting" free variables in a Term, implemented as a 'Fold'
 --

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -18,7 +18,6 @@ import           Control.Concurrent.Supply     (Supply, freshId)
 import qualified Control.Lens                  as Lens
 import Control.Monad.Trans.Except              (Except, throwE)
 import           Data.Coerce                   (coerce)
-import qualified Data.IntSet                   as IntSet
 import qualified Data.HashSet                  as HashSet
 import Data.List
   (foldl', mapAccumR, elemIndices, nub)
@@ -32,7 +31,7 @@ import           Data.Semigroup
 import Clash.Core.DataCon
   (DataCon (MkData), dcType, dcUnivTyVars, dcExtTyVars, dcArgTys)
 import Clash.Core.FreeVars
-  (termFreeVarsX, tyFVsOfTypes, typeFreeVars)
+  (tyFVsOfTypes, typeFreeVars)
 import Clash.Core.Literal                      (literalType)
 import Clash.Core.Name
   (Name (..), OccName, mkUnsafeInternalName, mkUnsafeSystemName)
@@ -591,15 +590,6 @@ appendToVec consCon resTy vec = go
                                                    [(LitTy (NumTy n))
                                                    ,resTy
                                                    ,(LitTy (NumTy (n-1)))])
-
-
-availableUniques
-  :: Term
-  -> [Unique]
-availableUniques t = [ n | n <- [0..] , n `IntSet.notMember` avoid ]
- where
-  avoid = Lens.foldMapOf termFreeVarsX (\a i -> IntSet.insert (varUniq a) i) t
-            IntSet.empty
 
 -- | Create let-bindings with case-statements that select elements out of a
 -- vector. Returns both the variables to which element-selections are bound

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE ExplicitForAll        #-}
 {-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RankNTypes            #-}
 
 module Clash.Core.Var
@@ -79,18 +80,24 @@ data Var a
   }
   deriving (Show,Generic,NFData,Hashable,Binary)
 
+-- | Gets a _key_ in the DBMS sense: a value that uniquely identifies a
+-- Var. In case of a "Var" that is its unique and (if applicable) scope
+varKey :: Var a -> (Unique, Maybe IdScope)
+varKey TyVar{varUniq} = (varUniq, Nothing)
+varKey Id{varUniq,idScope} = (varUniq, Just idScope)
+
 instance Eq (Var a) where
-  (==) = (==) `on` varUniq
-  (/=) = (/=) `on` varUniq
+  (==) = (==) `on` varKey
+  (/=) = (/=) `on` varKey
 
 instance Ord (Var a) where
-  compare = compare `on` varUniq
+  compare = compare `on` varKey
 
 instance Uniquable (Var a) where
   getUnique = varUniq
 
 data IdScope = GlobalId | LocalId
-  deriving (Show,Generic,NFData,Hashable,Binary)
+  deriving (Show,Generic,NFData,Hashable,Binary,Eq,Ord)
 
 -- | Term variable
 type Id    = Var Term

--- a/clash-lib/tests/Clash/Tests/Core/FreeVars.hs
+++ b/clash-lib/tests/Clash/Tests/Core/FreeVars.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Tests.Core.FreeVars (tests) where
+
+import           SrcLoc                  (noSrcSpan)
+import qualified Control.Lens            as Lens
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Clash.Core.FreeVars     (globalIds)
+import           Clash.Core.Name         (Name(..), NameSort(..))
+import           Clash.Core.Term         (Term(Var, App, Lam))
+import           Clash.Core.Type         (ConstTy(..), Type(ConstTy))
+import           Clash.Core.Var          (IdScope(..), Var(..))
+
+-- TODO: We need tooling to create these mock constructs
+fakeName :: Name a
+fakeName =
+  Name
+    { nameSort=User
+    , nameOcc="fake"
+    , nameUniq=0
+    , nameLoc=noSrcSpan
+    }
+
+f :: IdScope -> Var Term
+f scope =
+  let unique = 20 in
+  Id { varName = Name { nameSort=User
+                      , nameOcc="f"
+                      , nameUniq=unique
+                      , nameLoc=noSrcSpan }
+     , varUniq = unique
+     , varType = ConstTy (TyCon fakeName)
+     , idScope = scope }
+
+fLocalId, fGlobalId :: Var Term
+fLocalId = f LocalId
+fGlobalId = f GlobalId
+
+-- 'term1' is a simple lambda function:
+--
+--   \f -> g f
+--
+-- where f and g have the same unique, but f has been marked as _local_ while
+-- g is _global_. In other words:
+--
+--   \f[l] -> f[g] f[l]
+--
+-- This term is tested against to check whether various functions account for
+-- the distinction between local/global variables correctly.
+term1 :: Term
+term1 =
+  Lam fLocalId (Var fGlobalId `App` Var fLocalId)
+
+tests :: TestTree
+tests =
+  let globs1 = Lens.toListOf globalIds term1 in
+  testGroup
+    "Clash.Tests.Core.FreeVars"
+    [ testCase "globalIds1" $ globs1 @=? [fGlobalId]
+    , testCase "globalIds2" $
+        assertBool
+          "Global and local id can't BOTH be in globs1"
+          (fLocalId `notElem` globs1)
+    ]

--- a/clash-lib/tests/unittests.hs
+++ b/clash-lib/tests/unittests.hs
@@ -1,0 +1,13 @@
+module Main where
+
+import Test.Tasty
+
+import qualified Clash.Tests.Core.FreeVars
+
+tests :: TestTree
+tests = testGroup "Unittests"
+  [ Clash.Tests.Core.FreeVars.tests
+  ]
+
+main :: IO ()
+main = defaultMain tests


### PR DESCRIPTION
https://github.com/clash-lang/clash-compiler/commit/d997cb6314372803c036da1bba7f1807706d0728 introduced the distinction between local and global variables. These two patches fix the behavior of local/global vars in a number of functions.