### PR TITLE
Export 'Clash.Sized.Index.fromSNat' and simplify constraint (#797)

### DIFF
--- a/clash-prelude/src/Clash/Sized/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Index.hs
@@ -16,7 +16,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Sized.Index
-  (Index, bv2i)
+  (Index, bv2i, fromSNat)
 where
 
 import GHC.TypeLits               (KnownNat, type (^))

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -88,7 +88,7 @@ import Language.Haskell.TH.Syntax (Lift(..))
 import Numeric.Natural            (Natural)
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack)
-import GHC.TypeLits               (CmpNat, KnownNat, Nat, type (+), type (-),
+import GHC.TypeLits               (KnownNat, Nat, type (+), type (-),
                                    type (*), type (<=), natVal)
 import GHC.TypeLits.Extra         (CLog)
 import Test.QuickCheck.Arbitrary  (Arbitrary (..), CoArbitrary (..),
@@ -151,7 +151,7 @@ instance (KnownNat n, 1 <= n) => BitPack (Index n) where
   unpack = unpack#
 
 -- | Safely convert an `SNat` value to an `Index`
-fromSNat :: (KnownNat m, CmpNat n m ~ 'LT) => SNat n -> Index m
+fromSNat :: (KnownNat m, n <= m + 1) => SNat n -> Index m
 fromSNat = snatToNum
 
 {-# NOINLINE pack# #-}


### PR DESCRIPTION
See #797. Waiting on CI as this might require test fixes (due to changing CmpNat).