### PR TITLE
Fix caching on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,23 @@ aliases:
         if [ -n "$CIRCLE_PR_NUMBER" ]; then
           .ci/setup.sh
         fi
+  - &cache_calc_key
+    run:
+      name: Calculate cache key
+      command: |
+        if [ -n "$CIRCLE_PR_NUMBER" ]; then
+          md5sum .circleci/config.yml cabal.project .ci/cabal.project.local */*.cabal > .circleci_cachekey
+        else
+          echo not running > .circleci_cachekey
+        fi
   - &cache_restore
     restore_cache:
       keys:
-        - cabal-store-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-{{ checksum "cabal.project" }}
-        - cabal-store-{{ .Environment.CIRCLE_JOB }}-
+        - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci_cachekey" }}
+        - cache-{{ .Environment.CIRCLE_JOB }}-
   - &cache_save
     save_cache:
-      key: cabal-store-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-{{ checksum "cabal.project" }}
+      key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci_cachekey" }}
       paths:
         - cabal-store
         - ~/.stack
@@ -89,10 +98,11 @@ aliases:
       - *merge_pullrequest
       - *submodules
       - *setup
+      - *cache_calc_key
       - *cache_restore
       - *build
-      - *run_tests
       - *cache_save
+      - *run_tests
   - &build_with_stack
     docker:
       - image: leonschoorl/clash-ci-image:trusty
@@ -100,6 +110,7 @@ aliases:
       - checkout
       - *merge_pullrequest
       - *submodules
+      - *cache_calc_key
       - *cache_restore
       - *stack_build
       - *cache_save


### PR DESCRIPTION
On CircleCI each cache key can only be written to once.

Since #534 we're not running jobs on CircleCI anymore for "internal" 
pull requests.
But we couldn't stop the jobs from being dispatched to CircleCI, so we 
made the jobs do nothing when they are internal.

The problem with this is that the `cache_save` step still runs, and it 
permanently caches the result of doing nothing.
Any future job now starts with this empty cache and has to build all 
dependencies.
And when it's done it can't save its results to the cache because that 
cache key already exists :(

To fix this I added a separate `cache_calc_key` step which, when we are 
running tests,
calculates a key with:
    ```md5sum .circleci/config.yml cabal.project cabal.project.local 
*/*.cabal```
Otherwise is just a static dummy string.

I also moved the `cache_save` step to just before `run_tests`, so even 
if the tests fail it will cache the built dependencies.