### PR TITLE
Add 'NFDataX.ensureSpine`

### DIFF
--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -280,6 +280,7 @@ instance NFDataX (rep (int + frac)) => NFDataX (Fixed rep int frac) where
   deepErrorX = Fixed . errorX
   rnfX f@(~(Fixed x)) = if isLeft (isX f) then () else rnfX x
   hasUndefined f@(~(Fixed x)) = if isLeft (isX f) then True else hasUndefined x
+  ensureSpine ~(Fixed x) = Fixed x
 
 -- | None of the 'Read' class' methods are synthesizable.
 instance (size ~ (int + frac), KnownNat frac, Bounded (rep size), Integral (rep size))

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -241,6 +241,8 @@ instance (KnownNat d, NFDataX a) => NFDataX (RTree d a) where
     go (LR_ x)   = hasUndefined x
     go (BR_ l r) = hasUndefined l || hasUndefined r
 
+  ensureSpine = fmap ensureSpine . lazyT
+
 
 -- | A /dependently/ typed fold over trees.
 --

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -365,6 +365,8 @@ instance (NFDataX a, KnownNat n) => NFDataX (Vec n a) where
     go Nil = False
     go (x `Cons` xs) = hasUndefined x || hasUndefined xs
 
+  ensureSpine = map ensureSpine . lazyV
+
 {-# INLINE singleton #-}
 -- | Create a vector of one element
 --


### PR DESCRIPTION
~~**Wanted**: a new name for `spinify`! Feel free to comment below~~ `ensureSpine` it is!

-----------------

Consider the following example:

```haskell
>>> x = undefined :: Vec 3 Char
>>> y = map (\_ -> 3) x
>>> y
<error>
```

Currently, this would fail, as `map` tries to pattern match on the constructor of vector `Cons`. This constructor doesn't exist however, and resolves to `undefined`. In this specific instance we could use `lazyV` to create the "spine" of `Vec` for us:

```haskell
>>> z = map (\_ -> 3) (lazyV x)
>>> z
<3,3,3>
```

`spinify` generalizes this behavior to all data structures having an instance for `NFDataX`.

-----------------

Fixes https://github.com/clash-lang/clash-compiler/issues/748