### PR TITLE
Add Evaluator rule for BitVector.undefined#

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -1463,6 +1463,12 @@ reduceConstant tcm isSubj pInfo tys args mach = case primName pInfo of
   "Clash.Sized.Internal.BitVector.low"
     -> reduce (mkBitLit ty 0 0)
 
+  "Clash.Sized.Internal.BitVector.undefined#"
+    | Just (_, kn) <- extractKnownNat tcm tys
+    -> let resTyInfo = extractTySizeInfo tcm ty tys
+           mask = bit (fromInteger kn) - 1
+       in reduce (mkBitVectorLit' resTyInfo mask 0)
+
 -- Eq
   "Clash.Sized.Internal.BitVector.eq##" | [(0,i),(0,j)] <- bitLiterals args
     -> reduce (boolToBoolLiteral tcm ty (i == j))

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -1487,18 +1487,22 @@ reduceConstant tcm isSubj pInfo tys args mach = case primName pInfo of
 
 -- Bits
   "Clash.Sized.Internal.BitVector.and##"
-    | [(0,i),(0,j)] <- bitLiterals args
-    -> reduce (mkBitLit ty 0 (i .&. j))
+    | [i,j] <- bitLiterals args
+    -> let Bit msk val = BitVector.and## (toBit i) (toBit j)
+       in reduce (mkBitLit ty msk val)
   "Clash.Sized.Internal.BitVector.or##"
-    | [(0,i),(0,j)] <- bitLiterals args
-    -> reduce (mkBitLit ty 0 (i .|. j))
+    | [i,j] <- bitLiterals args
+    -> let Bit msk val = BitVector.or## (toBit i) (toBit j)
+       in reduce (mkBitLit ty msk val)
   "Clash.Sized.Internal.BitVector.xor##"
-    | [(0,i),(0,j)] <- bitLiterals args
-    -> reduce (mkBitLit ty 0 (i `xor` j))
+    | [i,j] <- bitLiterals args
+    -> let Bit msk val = BitVector.xor## (toBit i) (toBit j)
+       in reduce (mkBitLit ty msk val)
 
   "Clash.Sized.Internal.BitVector.complement##"
-    | [(0,i)] <- bitLiterals args
-    -> reduce (mkBitLit ty 0 (complement i))
+    | [i] <- bitLiterals args
+    -> let Bit msk val = BitVector.complement## (toBit i)
+       in reduce (mkBitLit ty msk val)
 
 -- Pack
   "Clash.Sized.Internal.BitVector.pack#"
@@ -3575,6 +3579,9 @@ toBV = uncurry BV
 
 splitBV :: BitVector n -> (Integer,Integer)
 splitBV (BV msk val) = (msk,val)
+
+toBit :: (Integer,Integer) -> Bit
+toBit = uncurry Bit
 
 valArgs
   :: Value

--- a/tests/shouldwork/BitVector/UnpackUndefined.hs
+++ b/tests/shouldwork/BitVector/UnpackUndefined.hs
@@ -1,0 +1,7 @@
+module UnpackUndefined where
+import Clash.Prelude
+import Clash.Sized.Internal.BitVector
+
+-- https://github.com/clash-lang/clash-compiler/issues/804
+state = unpack undefined#    :: Vec 3 Bit
+topEntity = register @System state

--- a/tests/shouldwork/Numbers/UndefinedConstantFolding.hs
+++ b/tests/shouldwork/Numbers/UndefinedConstantFolding.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+
+module UndefinedConstantFolding (topEntity, module ConstantFoldingUtil) where
+
+import Clash.Prelude
+import Clash.Sized.Internal.BitVector
+
+import ConstantFoldingUtil
+
+
+undefBit :: Bit
+undefBit = unpack undefined#
+
+
+-- Test functions bits take an undefined bit as input
+-- but produce a defined bit as output
+bitTests :: Vec _ (Unsigned 16)
+bitTests =
+  (if bitToBool (undefBit .&. 0)            then 22000 else     0)   :>
+  (if bitToBool (undefBit .|. 1)            then     1 else 22001)   :>
+  (if bitToBool ((undefBit `xor` 1) .|. 1)  then     2 else 22002)   :>
+  (if bitToBool (shift undefBit 1)          then 22003 else     3)   :>
+  (if bitToBool (setBit undefBit 0)         then     4 else 22004)   :>
+  (if bitToBool (clearBit undefBit 0)       then 22005 else     5)   :>
+  (if bitToBool (shiftL undefBit 1)         then 22006 else     6)   :>
+  (if bitToBool (shiftR undefBit 1)         then 22007 else     7)   :>
+  Nil
+
+
+undefBv :: BitVector 5
+undefBv = undefined#
+
+-- allIndices =
+--   iterate d5 succ 0
+
+bvTests :: Vec _ (Unsigned 16)
+bvTests =
+  (if bvToBool (undefBv .&. 0)                      then 22100 else     0)   :>
+  (if bvToBool (undefBv .|. 0b11111)                then     1 else 22101)   :>
+  (if bvToBool ((undefBv `xor` 0b11111).|. 0b11111) then     2 else 22102)   :>
+  (if bvToBool (shift undefBv 5)                    then 22103 else     3)   :>
+
+  (if bvToBool (setBit' 0 . setBit' 1 . setBit' 2 . setBit' 3 . setBit' 4 $ undefBv)            then     4 else 22104)   :>
+  (if bvToBool (clearBit' 0 . clearBit' 1 . clearBit' 2 . clearBit' 3 . clearBit' 4 $ undefBv)  then 22105 else     5)   :>
+  -- (if bvToBool (foldl (setBit) undefBv allIndices)    then     4 else 22104)   :>
+  -- (if bvToBool (foldl (clearBit) undefBv allIndices)  then 22105 else     5)   :>
+
+  (if bvToBool (shiftL undefBv 5)                   then 22106 else     6)   :>
+  (if bvToBool (shiftR undefBv 5)                   then 22107 else     7)   :>
+  (if bvToBool (zeroExtend (truncateB undefBv :: BitVector 0)) then 22108 else     8)   :>
+  (if bvToBool (setSlice d4 d0 0 undefBv)                      then 22109 else     9)   :>
+  Nil
+
+-- Should we test this in this way?
+-- In run in haskell the testBench fails on this
+partialDefined :: Vec _ (BitVector 16)
+partialDefined =
+  (replaceBit 0 undefBit 22200) :>
+  Nil
+
+bvToBool :: BitVector 5 -> Bool
+bvToBool = (== 0b11111)
+
+setBit' = flip setBit
+clearBit' = flip clearBit
+
+topEntity = (bitTests, bvTests, partialDefined)

--- a/tests/shouldwork/Numbers/UndefinedConstantFoldingTB.hs
+++ b/tests/shouldwork/Numbers/UndefinedConstantFoldingTB.hs
@@ -1,0 +1,18 @@
+module UndefinedConstantFoldingTB where
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import qualified UndefinedConstantFolding
+
+instance ShowX Ordering
+
+expected = $(lift UndefinedConstantFolding.topEntity) :> Nil
+
+topEntity = UndefinedConstantFolding.topEntity
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput = outputVerifier' clk rst expected
+    done           = expectedOutput (pure topEntity)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -250,6 +250,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "ExtendingNumZero" def
         , runTest "GenericBitPack" def{clashFlags=["-fconstraint-solver-iterations=15"]}
         , runTest "AppendZero" def
+        , runTest "UnpackUndefined" def{hdlSim=False}
         ]
       , clashTestGroup "BlackBox"
         [ outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "TemplateFunction"   "main"
@@ -376,6 +377,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "Signum" def
         , runTest "Strict" def
         , runTest "T1019" def{hdlSim=False}
+        , outputTest ("tests" </> "shouldwork" </> "Numbers") allTargets [] ["-itests/shouldwork/Numbers"] "UndefinedConstantFolding"  "main"
         , runTest "UnsignedZero" def
         ]
       , clashTestGroup "Polymorphism"


### PR DESCRIPTION
- [x] Fix #804
- [x] Add a test

~- [ ] Figure out constant folding of `foldl`, `foldr`, `iterate`~ This has nothing to do with BitVector's and should be handled separately