### PR TITLE
Add "DebugTry"

### DIFF
--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -42,7 +42,9 @@ data DebugLevel
   | DebugFinal
   -- ^ Show completely normalized expressions
   | DebugName
-  -- ^ Names of applied transformations
+  -- ^ Show names of applied transformations
+  | DebugTry
+  -- ^ Show names of tried AND applied transformations
   | DebugApplied
   -- ^ Show sub-expressions after a successful rewrite
   | DebugAll

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -178,6 +178,7 @@ applyDebug
   -- ^ New expression
   -> RewriteMonad extra Term
 applyDebug lvl name exprOld hasChanged exprNew =
+ traceIf (lvl == DebugTry) ("Trying: " ++ name) $
  traceIf (lvl >= DebugAll) ("Trying: " ++ name ++ " on:\n" ++ before) $ do
   Monad.when (lvl > DebugNone && hasChanged) $ do
     tcm                  <- Lens.view tcCache


### PR DESCRIPTION
Prints the names of all transformations before trying them. This can
help to track down very slow (or stuck) transformations in cases where
"DebugAll" generates too much output.