### PR TITLE
ClockGens use their name at the Haskell level

### DIFF
--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -7,6 +7,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Intel (Altera) FPGAs
 -}
 
+{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE ExplicitForAll    #-}
@@ -53,7 +54,7 @@ altpll
   -- ^ Reset for the PLL
   -> (Clock domOut, Signal domOut Bool)
   -- ^ (Stable PLL clock, PLL lock)
-altpll _ = clocks
+altpll !_ = clocks
 {-# NOINLINE altpll #-}
 
 -- | A clock source that corresponds to the Intel/Quartus \"Altera PLL\"
@@ -95,5 +96,5 @@ alteraPll
   -> Reset domIn
   -- ^ Reset for the PLL
   -> t
-alteraPll _ = clocks
+alteraPll !_ = clocks
 {-# NOINLINE alteraPll #-}

--- a/clash-prelude/src/Clash/Xilinx/ClockGen.hs
+++ b/clash-prelude/src/Clash/Xilinx/ClockGen.hs
@@ -6,6 +6,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Xilinx FPGAs
 -}
 
+{-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ExplicitForAll   #-}
@@ -53,7 +54,7 @@ clockWizard
   -- ^ Reset for the PLL
   -> (Clock domOut, Enable domOut)
   -- ^ (Stable PLL clock, PLL lock)
-clockWizard _ clk rst =
+clockWizard !_ clk rst =
   (unsafeCoerce clk, unsafeCoerce (toEnable (unsafeToHighPolarity rst)))
 {-# NOINLINE clockWizard #-}
 {-# ANN clockWizard hasBlackBox #-}
@@ -96,7 +97,7 @@ clockWizardDifferential
   -- ^ Reset for the PLL
   -> (Clock domOut, Enable domOut)
   -- ^ (Stable PLL clock, PLL lock)
-clockWizardDifferential _name (Clock _) (Clock _) rst =
+clockWizardDifferential !_name (Clock _) (Clock _) rst =
   (Clock SSymbol, unsafeCoerce (toEnable (unsafeToHighPolarity rst)))
 {-# NOINLINE clockWizardDifferential #-}
 {-# ANN clockWizardDifferential hasBlackBox #-}


### PR DESCRIPTION
Prevents GHC from potentially replacing the argument supplied at that position by `absentArg`.