### PR TITLE
1.0 backports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,23 @@ aliases:
         if [ -n "$CIRCLE_PR_NUMBER" ]; then
           .ci/setup.sh
         fi
+  - &cache_calc_key
+    run:
+      name: Calculate cache key
+      command: |
+        if [ -n "$CIRCLE_PR_NUMBER" ]; then
+          md5sum .circleci/config.yml cabal.project .ci/cabal.project.local */*.cabal > .circleci_cachekey
+        else
+          echo not running > .circleci_cachekey
+        fi
   - &cache_restore
     restore_cache:
       keys:
-        - cabal-store-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-{{ checksum "cabal.project" }}
-        - cabal-store-{{ .Environment.CIRCLE_JOB }}-
+        - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci_cachekey" }}
+        - cache-{{ .Environment.CIRCLE_JOB }}-
   - &cache_save
     save_cache:
-      key: cabal-store-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-{{ checksum "cabal.project" }}
+      key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci_cachekey" }}
       paths:
         - cabal-store
         - ~/.stack
@@ -89,10 +98,11 @@ aliases:
       - *merge_pullrequest
       - *submodules
       - *setup
+      - *cache_calc_key
       - *cache_restore
       - *build
-      - *run_tests
       - *cache_save
+      - *run_tests
   - &build_with_stack
     docker:
       - image: leonschoorl/clash-ci-image:trusty
@@ -100,6 +110,7 @@ aliases:
       - checkout
       - *merge_pullrequest
       - *submodules
+      - *cache_calc_key
       - *cache_restore
       - *stack_build
       - *cache_save

--- a/cabal.project
+++ b/cabal.project
@@ -51,3 +51,7 @@ package clash-lib
 optional-packages:
   clash-cosim/clash-cosim.cabal,
   clash-term/clash-term.cabal
+
+-- rewrite-inspector is currently failing because it lacks an upper bound
+-- and the API for vty has changed
+constraints: vty < 5.26

--- a/cabal.project
+++ b/cabal.project
@@ -13,9 +13,7 @@ packages:
 
 
 allow-newer:
-  vector-th-unbox:base, vector-th-unbox:template-haskell
-  , concurrent-supply:hashable
-  , hint:ghc
+    concurrent-supply:hashable
 
   -- needed by clash-term
   , rewrite-inspector:hashable
@@ -33,7 +31,7 @@ repository head.hackage.ghc.haskell.org
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2019-09-19T07:38:42Z
+index-state: 2019-09-30T07:38:42Z
 
 package clash-ghc
   executable-dynamic: True

--- a/cabal.project
+++ b/cabal.project
@@ -16,16 +16,10 @@ allow-newer:
   vector-th-unbox:base, vector-th-unbox:template-haskell
   , concurrent-supply:hashable
   , hint:ghc
-  , first-class-families:base
 
   -- needed by clash-term
   , rewrite-inspector:hashable
   , brick:base
-  -- needed by criterion for benchmark
-  , microstache:base
-
-  -- doesn't work yet with 8.8
-  , prettyprinter:base
 
 repository head.hackage.ghc.haskell.org
    url: https://ghc.gitlab.haskell.org/head.hackage/
@@ -39,7 +33,7 @@ repository head.hackage.ghc.haskell.org
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2019-09-11T01:34:34Z
+index-state: 2019-09-19T07:38:42Z
 
 package clash-ghc
   executable-dynamic: True

--- a/clash-ghc/CHANGELOG.md
+++ b/clash-ghc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for the [`clash-ghc`](http://hackage.haskell.org/package/clash-ghc) package
 
+## 1.1.0
+* Fixes issues:
+  * [#811](https://github.com/clash-lang/clash-compiler/issues/811)
+
 ## 1.0.0 *September 3rd 2019*
 * 10x - 50x faster compile times
 * New features:

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -1917,7 +1917,7 @@ makeHDL'
   -> IORef ClashOpts
   -> [FilePath]
   -> InputT GHCi ()
-makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
+makeHDL' backend opts lst = go =<< case lst of
   srcs@(_:_) -> return srcs
   []         -> do
     modGraph <- GHC.getModuleGraph
@@ -1925,6 +1925,25 @@ makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
     return $ case (reverse sortedGraph) of
       ((AcyclicSCC top) : _) -> maybeToList $ (GHC.ml_hs_file . GHC.ms_location) top
       _                      -> []
+ where
+  go srcs = do
+    dflags <- GHC.getSessionDynFlags
+    goX dflags srcs `gfinally` recover dflags
+
+  goX dflags srcs = do
+    (dflagsX,_,_) <- parseDynamicFlagsCmdLine dflags
+                       [ noLoc "-fobject-code"   -- For #439
+                       , noLoc "-fforce-recomp"  -- Actually compile to object-code
+                       , noLoc "-keep-tmp-files" -- To prevent linker errors from
+                                                 -- multiple calls to :hdl command
+                       ]
+    _ <- GHC.setSessionDynFlags dflagsX
+    reloadModule ""
+    makeHDL backend opts srcs
+
+  recover dflags = do
+    _ <- GHC.setSessionDynFlags dflags
+    reloadModule ""
 
 makeHDL
   :: GHC.GhcMonad m

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -1967,7 +1967,7 @@ makeHDL' :: Clash.Backend.Backend backend
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
-makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
+makeHDL' backend opts lst = go =<< case lst of
   srcs@(_:_) -> return srcs
   []         -> do
     modGraph <- GHC.getModuleGraph
@@ -1975,6 +1975,25 @@ makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
     return $ case (reverse sortedGraph) of
       ((AcyclicSCC top) : _) -> maybeToList $ (GHC.ml_hs_file . GHC.ms_location) top
       _                      -> []
+ where
+  go srcs = do
+    dflags <- GHC.getSessionDynFlags
+    goX dflags srcs `gfinally` recover dflags
+
+  goX dflags srcs = do
+    (dflagsX,_,_) <- parseDynamicFlagsCmdLine dflags
+                       [ noLoc "-fobject-code"   -- For #439
+                       , noLoc "-fforce-recomp"  -- Actually compile to object-code
+                       , noLoc "-keep-tmp-files" -- To prevent linker errors from
+                                                 -- multiple calls to :hdl command
+                       ]
+    _ <- GHC.setSessionDynFlags dflagsX
+    reloadModule ""
+    makeHDL backend opts srcs
+
+  recover dflags = do
+    _ <- GHC.setSessionDynFlags dflags
+    reloadModule ""
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -2059,7 +2059,7 @@ makeHDL' :: Clash.Backend.Backend backend
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
-makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
+makeHDL' backend opts lst = go =<< case lst of
   srcs@(_:_) -> return srcs
   []         -> do
     modGraph <- GHC.getModuleGraph
@@ -2067,6 +2067,25 @@ makeHDL' backend opts lst = makeHDL backend opts =<< case lst of
     return $ case (reverse sortedGraph) of
       ((AcyclicSCC top) : _) -> maybeToList $ (GHC.ml_hs_file . GHC.ms_location) top
       _                      -> []
+ where
+  go srcs = do
+    dflags <- GHC.getSessionDynFlags
+    goX dflags srcs `gfinally` recover dflags
+
+  goX dflags srcs = do
+    (dflagsX,_,_) <- parseDynamicFlagsCmdLine dflags
+                       [ noLoc "-fobject-code"   -- For #439
+                       , noLoc "-fforce-recomp"  -- Actually compile to object-code
+                       , noLoc "-keep-tmp-files" -- To prevent linker errors from
+                                                 -- multiple calls to :hdl command
+                       ]
+    _ <- GHC.setSessionDynFlags dflagsX
+    reloadModule ""
+    makeHDL backend opts srcs
+
+  recover dflags = do
+    _ <- GHC.setSessionDynFlags dflags
+    reloadModule ""
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend

--- a/clash-ghc/src-ghc/Interactive.hs
+++ b/clash-ghc/src-ghc/Interactive.hs
@@ -13,4 +13,4 @@ import           System.Environment ( getArgs )
 import           Clash.Main         ( defaultMain )
 
 main :: IO ()
-main = getArgs >>= defaultMain . (["--interactive","-fobject-code"]++)
+main = getArgs >>= defaultMain . ("--interactive":)

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -117,7 +117,6 @@ Library
 
   Build-depends:      aeson                   >= 0.6.2.0  && < 1.5,
                       ansi-terminal           >= 0.8.0.0  && < 0.10,
-                      ansi-wl-pprint          >= 0.6.8.2  && < 1.0,
                       attoparsec              >= 0.10.4.0 && < 0.14,
                       base                    >= 4.10     && < 5,
                       binary                  >= 0.8.5    && < 0.11,
@@ -149,7 +148,7 @@ Library
                       text-show               >= 3.7      && < 3.9,
                       time                    >= 1.4.0.1  && < 1.10,
                       transformers            >= 0.5.2.0  && < 0.6,
-                      trifecta                >= 1.7.1.1  && < 2.1,
+                      trifecta                >= 1.7.1.1  && < 2.2,
                       vector                  >= 0.11     && < 1.0,
                       vector-binary-instances >= 0.2.3.5  && < 0.3,
                       unordered-containers    >= 0.2.3.3  && < 0.3

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -50,7 +50,6 @@ import qualified System.IO                        as IO
 import           System.IO.Error                  (isDoesNotExistError)
 import           System.IO.Temp
   (getCanonicalTemporaryDirectory, withTempDirectory)
-import qualified Text.PrettyPrint.ANSI.Leijen     as ANSI
 import           Text.Trifecta.Result
   (Result(Success, Failure), _errDoc)
 import           Text.Read                        (readMaybe)
@@ -425,7 +424,8 @@ compilePrimitive idirs pkgDbs topDir (BlackBox pNm wf tkind () oReg libM imps in
     -> m BlackBoxTemplate
   parseTempl t = case runParse t of
     Failure errInfo
-      -> error (ANSI.displayS (ANSI.renderCompact (_errDoc errInfo)) "")
+      -> error ("Parsing template for blackbox " ++ Data.Text.unpack pNm ++ " failed:\n"
+               ++ show (_errDoc errInfo))
     Success t'
       -> pure t'
 

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -40,7 +40,6 @@ import qualified Data.Text.Prettyprint.Doc       as PP
 import           Data.Text.Prettyprint.Doc.Extra
 import           System.FilePath                 (replaceBaseName, takeBaseName,
                                                   takeFileName, (<.>))
-import qualified Text.PrettyPrint.ANSI.Leijen    as ANSI
 import           Text.Printf
 import           Text.Read                       (readEither)
 import           Text.Trifecta.Result            hiding (Err)
@@ -463,7 +462,7 @@ renderElem b e = fmap const (renderTag b e)
 parseFail :: Text -> BlackBoxTemplate
 parseFail t = case runParse t of
   Failure errInfo ->
-    error (ANSI.displayS (ANSI.renderCompact (_errDoc errInfo)) "")
+    error (show (_errDoc errInfo))
   Success templ -> templ
 
 idToExpr

--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -7,6 +7,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Intel (Altera) FPGAs
 -}
 
+{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE ExplicitForAll    #-}
@@ -53,7 +54,7 @@ altpll
   -- ^ Reset for the PLL
   -> (Clock domOut, Signal domOut Bool)
   -- ^ (Stable PLL clock, PLL lock)
-altpll _ = clocks
+altpll !_ = clocks
 {-# NOINLINE altpll #-}
 
 -- | A clock source that corresponds to the Intel/Quartus \"Altera PLL\"
@@ -95,5 +96,5 @@ alteraPll
   -> Reset domIn
   -- ^ Reset for the PLL
   -> t
-alteraPll _ = clocks
+alteraPll !_ = clocks
 {-# NOINLINE alteraPll #-}

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -26,16 +26,16 @@ mainCounter :: SystemClockResetEnable => Signal System (Signed 64)
 mainCounter = traceSignal1 "main" counter
   where
     counter =
-      register 0 (fmap succ' $ bundle (subcounter,counter))
+      register 0 (fmap succ' $ bundle (subCounter,counter))
 
     succ' (sc, c)
       | sc == maxBound = c + 1
       | otherwise      = c
 
 -- | Collect traces, and dump them to a VCD file.
-main :: SystemClockResetEnable => IO ()
+main :: IO ()
 main = do
-  let cntrOut = exposeClockResetEnable mainCounter systemClockGen systemResetGen
+  let cntrOut = exposeClockResetEnable mainCounter systemClockGen systemResetGen enableGen
   vcd <- dumpVCD (0, 100) cntrOut ["main", "sub"]
   case vcd of
     Left msg ->

--- a/clash-prelude/src/Clash/Xilinx/ClockGen.hs
+++ b/clash-prelude/src/Clash/Xilinx/ClockGen.hs
@@ -6,6 +6,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Xilinx FPGAs
 -}
 
+{-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ExplicitForAll   #-}
@@ -53,7 +54,7 @@ clockWizard
   -- ^ Reset for the PLL
   -> (Clock domOut, Enable domOut)
   -- ^ (Stable PLL clock, PLL lock)
-clockWizard _ clk rst =
+clockWizard !_ clk rst =
   (unsafeCoerce clk, unsafeCoerce (toEnable (unsafeToHighPolarity rst)))
 {-# NOINLINE clockWizard #-}
 {-# ANN clockWizard hasBlackBox #-}
@@ -96,7 +97,7 @@ clockWizardDifferential
   -- ^ Reset for the PLL
   -> (Clock domOut, Enable domOut)
   -- ^ (Stable PLL clock, PLL lock)
-clockWizardDifferential _name (Clock _) (Clock _) rst =
+clockWizardDifferential !_name (Clock _) (Clock _) rst =
   (Clock SSymbol, unsafeCoerce (toEnable (unsafeToHighPolarity rst)))
 {-# NOINLINE clockWizardDifferential #-}
 {-# ANN clockWizardDifferential hasBlackBox #-}


### PR DESCRIPTION
Nightlies currently fail due to incorrect version bounds on 1.0. These have been fixed in master, so it seems like a good time to do some backports.