### PR TITLE
Use new hackage index for local dev.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,7 +31,7 @@ repository head.hackage.ghc.haskell.org
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2019-09-30T07:38:42Z
+index-state: 2019-10-04T05:02:39Z
 
 package clash-ghc
   executable-dynamic: True


### PR DESCRIPTION
Needed for the vty-5.25.1 patch on 8.8.1; this wasn't picked up by CI because it always uses the HEAD index.