### PR TITLE
Examine work content of global binders in 'isWorkFree' 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,7 +31,7 @@ repository head.hackage.ghc.haskell.org
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2019-10-04T05:02:39Z
+index-state: 2019-10-14T08:39:40Z
 
 package clash-ghc
   executable-dynamic: True

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -579,7 +579,7 @@ substTyWith tvs tys =
   substTy (zipTvSubst tvs tys)
 
 -- | Ensure that non of the binders in an expression shadow each-other, nor
--- conflict with he in-scope set
+-- conflict with the in-scope set
 deShadowTerm
   :: HasCallStack
   => InScopeSet

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -35,6 +35,7 @@ module Clash.Core.Type
   , typeKind
   , mkTyConTy
   , mkFunTy
+  , mkFunTy'
   , mkTyConApp
   , splitFunTy
   , splitFunTys
@@ -220,8 +221,18 @@ newTyConInstRhs (tvs,ty) tys
     (tys1, tys2) = splitAtList tvs tys
 
 -- | Make a function type of an argument and result type
-mkFunTy :: Type -> Type -> Type
+mkFunTy
+  :: Type -- ^ a
+  -> Type -- ^ b
+  -> Type -- ^ a -> b
 mkFunTy t1 = AppTy (AppTy (ConstTy Arrow) t1)
+
+-- | Make a function type of argument types and a result type
+mkFunTy'
+  :: [Type] -- ^ [a, b, c, ..]
+  -> Type   -- ^ r
+  -> Type   -- ^ a -> b -> c -> r
+mkFunTy' = flip (foldr mkFunTy)
 
 -- | Make a TyCon Application out of a TyCon and a list of argument types
 mkTyConApp :: TyConName -> [Type] -> Type

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -648,4 +648,4 @@ normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans eval topEntities
                 return cleaned
     transformedBindings = runNormalization opts supply bindingsMap
                             typeTrans reprs tcm tupTcm eval primMap emptyVarEnv
-                            topEntities doNorm
+                            emptyVarEnv topEntities doNorm

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -360,7 +360,10 @@ flattenCallTree (CBranch (nm,(nm',sp,inl,tm)) used) = do
                  apply "bindConstantVar" bindConstantVar >->
                  apply "caseCon" caseCon >->
                  apply "reduceConst" reduceConst >->
-                 apply "reduceNonRepPrim" reduceNonRepPrim >->
+                 -- We expect the term to be in Clash's normal form. Introducing
+                 -- new let-bindings would break that invariant. We therefore
+                 -- ask 'reduceNonRepPrim' to not generate them:
+                 apply "reduceNonRepPrim" (reduceNonRepPrim False) >->
                  apply "removeUnusedExpr" removeUnusedExpr >->
                  apply "flattenLet" flattenLet) !->
       topdownSucR (apply "topLet" topLet)

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -105,13 +105,15 @@ runNormalization
   -> CompiledPrimMap
   -- ^ Primitive Definitions
   -> VarEnv Bool
-  -- ^ Map telling whether a components is part of a recursive group
+  -- ^ Map telling whether a component is part of a recursive group
+  -> VarEnv Bool
+  -- ^ Map telling whether a component is work free
   -> [Id]
   -- ^ topEntities
   -> NormalizeSession a
   -- ^ NormalizeSession to run
   -> a
-runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcsMap topEnts
+runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcsMap wfMap topEnts
   = runRewriteSession rwEnv rwState
   where
     rwEnv     = RewriteEnv
@@ -144,6 +146,7 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcs
                   primMap
                   Map.empty
                   rcsMap
+                  wfMap
                   (opt_newInlineStrat opts)
                   (opt_ultra opts)
 

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -78,7 +78,7 @@ constantPropagation = inlineAndPropagate >->
       , ("inlineSmall"     , inlineSmall)
       , ("bindOrLiftNonRep", inlineOrLiftNonRep) -- See: [Note] bindNonRep before liftNonRep
                                                  -- See: [Note] bottom-up traversal for liftNonRep
-      , ("reduceNonRepPrim", reduceNonRepPrim)
+      , ("reduceNonRepPrim", reduceNonRepPrim True)
 
 
       , ("caseCast"        , caseCast)

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -58,10 +58,12 @@ data NormalizeState
   , _primitiveArgs :: Map Text (Set Int)
   -- ^ Cache for looking up constantness of blackbox arguments
   , _recursiveComponents :: VarEnv Bool
-  -- ^ Map telling whether a components is recursively defined.
+  -- ^ Map telling whether a component is recursively defined.
   --
   -- NB: there are only no mutually-recursive component, only self-recursive
   -- ones.
+  , _workFreeComponents :: VarEnv Bool
+  -- ^ Map telling whether a component is work free
   , _newInlineStrategy :: Bool
   -- ^ Flattening stage should use the new (no-)inlining strategy
   , _normalizeUltra :: Bool

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -194,7 +194,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Map"       (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Map2"      (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "TestMap"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild ["-fclash-inline-limit=100"] "Transpose" (["","testBench"],"testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild ["-fclash-inline-limit=30"] "Transpose" (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "VecFun"    (["","testBench"],"testBench",True)
       ]
       , clashTestGroup "Numbers"

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -194,7 +194,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Map"       (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Map2"      (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "TestMap"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Transpose" (["","testBench"],"testBench",True)
+        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild ["-fclash-inline-limit=100"] "Transpose" (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "VecFun"    (["","testBench"],"testBench",True)
       ]
       , clashTestGroup "Numbers"


### PR DESCRIPTION
Edit: **I'll test this on a larger codebase later this week. Please postpone merging until then.**

..and prevent new let-bindings in `flattenCallTree`, as this breaks Clash's NF. 