### PR TITLE
Upgrade to Cabal 2.2

### DIFF
--- a/clash-cosim/clash-cosim.cabal
+++ b/clash-cosim/clash-cosim.cabal
@@ -1,7 +1,7 @@
+Cabal-Version:  2.2
 Name:           clash-cosim
 Version:        0.1
-Cabal-Version:  2.0
-License:        BSD2
+License:        BSD-2-Clause
 License-File:   LICENSE
 Author:         John Verheij <https://github.com/jgjverheij>
 Maintainer:     Martijn Bastiaan <martijn@qbaylogic.com>
@@ -80,6 +80,8 @@ Library
                     random                    >= 1.0.0,
                     template-haskell          >= 2.0.0,
                     text
+
+  Autogen-Modules:  Paths_clash_cosim
 
   Exposed-Modules:  Clash.CoSim.CodeGeneration,
                     Clash.CoSim.CoSimInstances,

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -159,6 +159,8 @@ library
   Include-dirs:       cbits
   C-Sources:          cbits/hschooks.c
 
+  Autogen-Modules:    Paths_clash_ghc
+
   Exposed-Modules:    Clash.Main
 
                       -- exposed for use by the benchmarks

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -1,3 +1,4 @@
+Cabal-version:        2.2
 Name:                 clash-lib
 Version:              1.1.0
 Synopsis:             CAES Language for Synchronous Hardware - As a Library
@@ -44,7 +45,7 @@ Description:
   Prelude library: <https://hackage.haskell.org/package/clash-prelude>
 Homepage:             https://clash-lang.org/
 bug-reports:          https://github.com/clash-lang/clash-compiler/issues
-License:              BSD2
+License:              BSD-2-Clause
 License-file:         LICENSE
 Author:               The Clash Authors
 Maintainer:           QBayLogic B.V. <devops@qbaylogic.com>
@@ -65,8 +66,6 @@ Data-files:
   prims/verilog/*.json,
   prims/systemverilog/*.json,
   prims/vhdl/*.json
-
-Cabal-version:        >=1.10
 
 source-repository head
   type: git
@@ -153,6 +152,8 @@ Library
                       vector                  >= 0.11     && < 1.0,
                       vector-binary-instances >= 0.2.3.5  && < 0.3,
                       unordered-containers    >= 0.2.3.3  && < 0.3
+
+  Autogen-Modules:    Paths_clash_lib
 
   Exposed-modules:    Clash.Annotations.BitRepresentation.ClashLib
 

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -1,3 +1,4 @@
+Cabal-version:        2.2
 Name:                 clash-prelude
 Version:              1.1.0
 Synopsis:             CAES Language for Synchronous Hardware - Prelude library
@@ -43,7 +44,7 @@ Description:
   Some circuit examples can be found in "Clash.Examples".
 Homepage:             https://clash-lang.org/
 bug-reports:          https://github.com/clash-lang/clash-compiler/issues
-License:              BSD2
+License:              BSD-2-Clause
 License-file:         LICENSE
 Author:               The Clash Authors
 Maintainer:           QBayLogic B.V. <devops@qbaylogic.com>
@@ -58,8 +59,6 @@ Extra-source-files:   README.md
                       AUTHORS.md
 
 extra-doc-files:      doc/*.svg
-
-Cabal-version:        >=1.18
 
 source-repository head
   type: git
@@ -117,6 +116,8 @@ Library
 
   if flag(multiple-hidden)
     Exposed-modules:  Clash.Prelude.Synchronizer
+
+  Autogen-Modules:    Paths_clash_prelude
 
   Exposed-modules:    Clash.Annotations.TopEntity
                       Clash.Annotations.Primitive


### PR DESCRIPTION
Nightlies currently fail due to partial upgrade