### PR TITLE
Add ability to specify transformations of interest when debugging

### DIFF
--- a/clash-ghc/CHANGELOG.md
+++ b/clash-ghc/CHANGELOG.md
@@ -6,7 +6,8 @@
   * Added tools to generate top entity annotations, see [#795](https://github.com/clash-lang/clash-compiler/pull/795). Thanks @blaxill!
   
 * New internal features:
-  * Add `DebugTry`: print name of all tried transformations, even if they didn't succeed
+  * [#821](https://github.com/clash-lang/clash-compiler/pull/821): Add `DebugTry`: print name of all tried transformations, even if they didn't succeed
+  * [#856](https://github.com/clash-lang/clash-compiler/pull/856): Add `-fclash-debug-transformations`: only print debug info for specific transformations
 
 * Fixes issues:
   * [#810](https://github.com/clash-lang/clash-compiler/issues/810)

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -125,6 +125,7 @@ library
                       haskeline                 >= 0.7.0.3  && < 0.8,
                       lens                      >= 4.0.5    && < 4.19,
                       mtl                       >= 2.1.1    && < 2.3,
+                      split                     >= 0.2.3    && < 0.3,
                       text                      >= 1.2.2    && < 1.3,
                       transformers              >= 0.5.2.0  && < 0.6,
                       unordered-containers      >= 0.2.1.0  && < 0.3,

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -14,15 +14,20 @@ module Clash.GHC.ClashFlags
   )
 where
 
-import CmdLineParser
-import Panic
-import SrcLoc
+import           CmdLineParser
+import           Panic
+import           SrcLoc
 
-import Data.IORef
-import Control.Monad
-import Clash.Driver.Types
-import Clash.Netlist.BlackBox.Types (HdlSyn (..))
-import Text.Read (readMaybe)
+import           Control.Monad
+import           Data.Char                      (isSpace)
+import           Data.IORef
+import           Data.List                      (dropWhileEnd)
+import           Data.List.Split                (splitOn)
+import qualified Data.Set                       as Set
+import           Text.Read                      (readMaybe)
+
+import           Clash.Driver.Types
+import           Clash.Netlist.BlackBox.Types   (HdlSyn (..))
 
 parseClashFlags :: IORef ClashOpts -> [Located String]
                 -> IO ([Located String]
@@ -57,6 +62,7 @@ parseClashFlagsFull flagsAvialable args = do
 flagsClash :: IORef ClashOpts -> [Flag IO]
 flagsClash r = [
     defFlag "fclash-debug"                       $ SepArg (setDebugLevel r)
+  , defFlag "fclash-debug-transformations"       $ SepArg (setDebugTransformations r)
   , defFlag "fclash-hdldir"                      $ SepArg (setHdlDir r)
   , defFlag "fclash-hdlsyn"                      $ SepArg (setHdlSyn r)
   , defFlag "fclash-nocache"                     $ NoArg (deprecated "nocache" "no-cache" setNoCache r)
@@ -117,6 +123,13 @@ setSpecLimit :: IORef ClashOpts
              -> Int
              -> IO ()
 setSpecLimit r n = modifyIORef r (\c -> c {opt_specLimit = n})
+
+setDebugTransformations :: IORef ClashOpts -> String -> EwM IO ()
+setDebugTransformations r s =
+  liftEwM (modifyIORef r (\c -> c {opt_dbgTransformations = transformations}))
+ where
+  transformations = Set.fromList (filter (not . null) (map trim (splitOn "," s)))
+  trim = dropWhileEnd isSpace . dropWhile isSpace
 
 setDebugLevel :: IORef ClashOpts
               -> String

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -15,18 +15,17 @@ module Clash.Driver.Types where
 -- For Int/Word size
 #include "MachDeps.h"
 
-import Data.Text         (Text)
+import           BasicTypes                     (InlineSpec)
+import qualified Data.Set                       as Set
+import           Data.Text                      (Text)
+import           SrcLoc                         (SrcSpan)
+import           Util                           (OverridingBool(..))
 
-import BasicTypes        (InlineSpec)
-import SrcLoc            (SrcSpan)
+import           Clash.Core.Term                (Term)
+import           Clash.Core.Var                 (Id)
+import           Clash.Core.VarEnv              (VarEnv)
 
-import Clash.Core.Term   (Term)
-import Clash.Core.Var    (Id)
-import Clash.Core.VarEnv (VarEnv)
-
-import Clash.Netlist.BlackBox.Types (HdlSyn (..))
-
-import Util (OverridingBool(..))
+import           Clash.Netlist.BlackBox.Types   (HdlSyn (..))
 
 -- | Global function binders
 --
@@ -56,6 +55,7 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            , opt_inlineFunctionLimit :: Word
                            , opt_inlineConstantLimit :: Word
                            , opt_dbgLevel    :: DebugLevel
+                           , opt_dbgTransformations :: Set.Set String
                            , opt_cachehdl    :: Bool
                            , opt_cleanhdl    :: Bool
                            , opt_primWarn    :: Bool
@@ -96,6 +96,7 @@ defClashOpts :: ClashOpts
 defClashOpts
   = ClashOpts
   { opt_dbgLevel            = DebugNone
+  , opt_dbgTransformations  = Set.empty
   , opt_inlineLimit         = 20
   , opt_specLimit           = 20
   , opt_inlineFunctionLimit = 15

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -116,6 +116,7 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcs
   where
     rwEnv     = RewriteEnv
                   (opt_dbgLevel opts)
+                  (opt_dbgTransformations opts)
                   typeTrans
                   tcm
                   tupTcm

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -33,6 +33,7 @@ import Data.Binary                           (Binary)
 import Data.Hashable                         (Hashable)
 import Data.IntMap.Strict                    (IntMap)
 import Data.Monoid                           (Any)
+import qualified Data.Set                    as Set
 import GHC.Generics
 
 import Clash.Core.Evaluator      (GlobalHeap, PrimEvaluator)
@@ -87,7 +88,9 @@ makeLenses ''RewriteState
 data RewriteEnv
   = RewriteEnv
   { _dbgLevel       :: DebugLevel
-  -- ^ Lvl at which we print debugging messages
+  -- ^ Level at which we print debugging messages
+  , _dbgTransformations :: Set.Set String
+  -- ^ Transformations to print debugging info for
   , _typeTranslator :: CustomReprs
                     -> TyConMap
                     -> Type


### PR DESCRIPTION
For example, if you suspect 'bindConstantVar' is up to no good, you'd
run Clash as follows:

    clash -fclash-debug-transformations=bindConstantVar

You can specify multiple transformations separated by commas:

    clash -fclash-debug-transformations=bindConstantVar,constantSpec