### PR TITLE
Improve error messages of 'verifyBlackBoxContext'. Fix #837

### DIFF
--- a/clash-ghc/CHANGELOG.md
+++ b/clash-ghc/CHANGELOG.md
@@ -16,6 +16,7 @@
   * [#439](https://github.com/clash-lang/clash-compiler/issues/439): Template Haskell splices and TopEntity annotations can now be used in clashi
   * [#662](https://github.com/clash-lang/clash-compiler/issues/662): Clash will now constant specialize partially constant constructs
   * [#700](https://github.com/clash-lang/clash-compiler/issues/700): Check work content of expression in cast before warning users. Should eliminate a lot of (superfluous) warnings about "specializing on non work-free cast"s.
+  * [#837](https://github.com/clash-lang/clash-compiler/issues/837): Blackboxes will now report clearer error messages if they're given unexpected arguments.
 
 * Small fixes without issue reports:
   * Fix bug in `rnfX` defined for `Down` ([baef30e](https://github.com/clash-lang/clash-compiler/commit/baef30eae03dc02ba847ffbb8fae7f365c5287c2))

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -164,23 +164,21 @@ prepareBlackBox
   -> BlackBox
   -> BlackBoxContext
   -> NetlistMonad (BlackBox,[Declaration])
-prepareBlackBox pNm templ bbCtx =
-  if verifyBlackBoxContext bbCtx templ
-     then do
-        (t2,decls) <-
-          onBlackBox
-            (fmap (first BBTemplate) . setSym mkUniqueIdentifier bbCtx)
-            (\bbName bbHash bbFunc -> pure (BBFunction bbName bbHash bbFunc, []))
-            templ
-        return (t2,decls)
-     else do
-       (_,sp) <- Lens.use curCompNm
-       templ' <- onBlackBox (getMon . prettyBlackBox)
-                            (\n h f -> return $ Text.pack $ show (BBFunction n h f))
-                            templ
-       let msg = $(curLoc) ++ "Can't match template for " ++ show pNm ++ " :\n\n" ++ Text.unpack templ' ++
-                "\n\nwith context:\n\n" ++ show bbCtx
-       throw (ClashException sp msg Nothing)
+prepareBlackBox _pNm templ bbCtx =
+  case verifyBlackBoxContext bbCtx templ of
+    Nothing -> do
+      (t2,decls) <-
+        onBlackBox
+          (fmap (first BBTemplate) . setSym mkUniqueIdentifier bbCtx)
+          (\bbName bbHash bbFunc -> pure (BBFunction bbName bbHash bbFunc, []))
+          templ
+      return (t2,decls)
+    Just err0 -> do
+      (_,sp) <- Lens.use curCompNm
+      let err1 = concat [ "Couldn't instantiate blackbox for "
+                        , Data.Text.unpack (bbName bbCtx), ". Verification "
+                        , "procedure reported:\n\n" ++ err0 ]
+      throw (ClashException sp ($(curLoc) ++ err1) Nothing)
 
 -- | Determine if a term represents a literal
 isLiteral :: Term -> Bool

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -85,35 +85,60 @@ verifyBlackBoxContext
   -- ^ Blackbox to verify
   -> N.BlackBox
   -- ^ Template to check against
-  -> Bool
-verifyBlackBoxContext bbCtx (N.BBFunction _ _ (N.TemplateFunction _ f _)) = f bbCtx
-verifyBlackBoxContext bbCtx (N.BBTemplate t) = and (concatMap (walkElement verify') t)
+  -> Maybe String
+verifyBlackBoxContext bbCtx (N.BBFunction _ _ (N.TemplateFunction _ f _)) =
+  if f bbCtx then
+    Nothing
+  else
+    -- TODO: Make TemplateFunction return a string
+    Just ("Template function for returned False")
+verifyBlackBoxContext bbCtx (N.BBTemplate t) =
+  orElses (concatMap (walkElement verify') t)
   where
+    concatTups = concatMap (\(x, y) -> [x, y])
+
     verify' e =
       Just $
       case e of
         Lit n ->
           case indexMaybe (bbInputs bbCtx) n of
-            Just (_, _, b) -> b
-            _              -> False
+            Just (inp, _, False) ->
+              Just ( "Argument " ++ show n ++ " should be literal, as blackbox "
+                  ++ "used ~LIT[" ++ show n ++ "], but was:\n\n" ++ show inp)
+            _ -> Nothing
         Const n ->
           case indexMaybe (bbInputs bbCtx) n of
-            Just (_, _, b) -> b
-            _              -> False
-        Component (Decl n _subn l') ->
+            Just (inp, _, False) ->
+              Just ( "Argument " ++ show n ++ " should be literal, as blackbox "
+                  ++ "used ~CONST[" ++ show n ++ "], but was:\n\n" ++ show inp)
+            _ -> Nothing
+        Component (Decl n subn l') ->
           case IntMap.lookup n (bbFunctions bbCtx) of
-            Just _ ->
-              all (\(x,y) ->
-                      verifyBlackBoxContext bbCtx (N.BBTemplate x) &&
-                         verifyBlackBoxContext bbCtx (N.BBTemplate y)) l'
+            Just funcs ->
+              case indexMaybe funcs subn of
+                Nothing ->
+                  Just ( "Blackbox requested at least " ++ show (subn+1)
+                      ++ " renders of function at argument " ++ show n ++ " but "
+                      ++ "found only " ++ show (length funcs) )
+                Just _ ->
+                  orElses $
+                    map
+                      (verifyBlackBoxContext bbCtx . N.BBTemplate)
+                      (concatTups l')
             Nothing ->
-              False
+              Just ( "Blackbox requested instantiation of function at argument "
+                  ++ show n ++ ", but BlackBoxContext did not contain one.")
         _ ->
           case inputHole e of
             Nothing ->
-              True
+              Nothing
             Just n ->
-              n < length (bbInputs bbCtx)
+              case indexMaybe (bbInputs bbCtx) n of
+                Just _ -> Nothing
+                Nothing ->
+                  Just ( "Blackbox required at least " ++ show (n+1)
+                      ++ " arguments, but only " ++ show (length (bbInputs bbCtx))
+                      ++ " were passed." )
 
 extractLiterals :: BlackBoxContext
                 -> [Expr]
@@ -341,15 +366,16 @@ renderElem b (Component (Decl n subN (l:ls))) = do
             block <- getMon (blockDecl nm2 (templDecls ++ [bbD]))
             return (render block)
 
-  if verifyBlackBoxContext b' templ4
-    then do
+  case verifyBlackBoxContext b' templ4 of
+    Nothing -> do
       bb <- renderBlackBox libs imps inc templ4 b'
       return (renderLazy . layoutPretty layoutOptions . bb)
-    else do
+    Just err0 -> do
       sp <- getSrcSpan
-      throw (ClashException sp ($(curLoc) ++ "\nCan't match context:\n"
-                                          ++ show b' ++ "\nwith template:\n"
-                                          ++ show templ0) Nothing)
+      let err1 = concat [ "Couldn't instantiate blackbox for "
+                        , Data.Text.unpack (bbName b), ". Verification procedure "
+                        , "reported:\n\n" ++ err0 ]
+      throw (ClashException sp ($(curLoc) ++ err1) Nothing)
 
 renderElem b (SigD e m) = do
   e' <- Text.concat <$> mapM (fmap ($ 0) . renderElem b) e

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -36,7 +36,7 @@ import Data.Function                  as X (on)
 import Data.Hashable                  (Hashable)
 import Data.HashMap.Lazy              (HashMap)
 import qualified Data.HashMap.Lazy    as HashMapL
-import Data.Maybe                     (fromMaybe)
+import Data.Maybe                     (fromMaybe, listToMaybe, catMaybes)
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.String
 import Data.Version                   (Version)
@@ -435,3 +435,12 @@ traceWith f a = trace (f a) a
 
 traceShowWith :: Show b => (a -> b) -> a -> a
 traceShowWith f a = trace (show (f a)) a
+
+-- | Left-biased choice on maybes
+orElse :: Maybe a -> Maybe a -> Maybe a
+orElse x@(Just _) _y = x
+orElse _x y = y
+
+-- | Left-biased choice on maybes
+orElses :: [Maybe a] -> Maybe a
+orElses = listToMaybe . catMaybes

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -274,7 +274,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Signal" </> "BiSignal") defBuild [] "CounterHalfTuple" (["","testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "Signal" </> "BiSignal") defBuild [] "CounterHalfTupleRev" (["","testBench"],"testBench",True)
 
-        , runFailingTest ("tests" </> "shouldfail" </> "Signal") defBuild [] "MAC" (Just "Can't match template for \"Clash.Signal.Internal.register#\"")
+        , runFailingTest ("tests" </> "shouldfail" </> "Signal") defBuild [] "MAC" (Just "Couldn't instantiate blackbox for Clash.Signal.Internal.register#")
         ]
       , clashTestGroup "SynthesisAttributes"
         [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] [] "Simple"  "main"


### PR DESCRIPTION
The error messages can still be a bit confusing as constraints are
counted as "real" arguments, but it's a big improvement over the status
quo.