### PR TITLE
Seperate out clock arguments from product types

### DIFF
--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.json
@@ -39,11 +39,7 @@ begin
       if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];
       end if;
-      ~RESULT <= fromSLV(~SYM[2](~SYM[4]))
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
     end if;
   end process; ~ELSE
   ~SYM[6] : process(~ARG[3])
@@ -52,11 +48,7 @@ begin
       if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~ARG[9];
       end if;
-      ~RESULT <= ~SYM[2](~SYM[4])
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~SYM[2](~SYM[4]);
     end if;
   end process; ~FI
 end block;
@@ -105,11 +97,7 @@ begin
       if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];
       end if;
-      ~RESULT <= fromSLV(~SYM[2](~SYM[4]))
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
     end if;
   end process; ~ELSE
   ~SYM[6] : process(~ARG[3])
@@ -118,11 +106,7 @@ begin
       if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~ARG[9];
       end if;
-      ~RESULT <= ~SYM[2](~SYM[4])
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~SYM[2](~SYM[4]);
     end if;
   end process; ~FI
 end block;
@@ -172,11 +156,7 @@ begin
       if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[10]][~TYP[10]];
       end if;
-      ~RESULT <= fromSLV(~SYM[2](~SYM[4]))
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
     end if;
   end process; ~ELSE
   ~SYM[6] : process(~ARG[3])
@@ -185,11 +165,7 @@ begin
       if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
         ~SYM[2](~SYM[5]) <= ~ARG[10];
       end if;
-      ~RESULT <= ~SYM[2](~SYM[4])
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~SYM[2](~SYM[4]);
     end if;
   end process; ~FI
 end block;

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.json
@@ -55,11 +55,7 @@ begin
         if ~ARG[8] then
           ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
         end if;
-        ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]))
-        -- pragma translate_off
-        after 1 ps
-        -- pragma translate_on
-        ;
+        ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
       end if;
     end if;
   end process;~ELSE
@@ -69,11 +65,7 @@ begin
       if ~ARG[8] then
         ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
       end if;
-      ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]))
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
     end if;
   end process;~FI ~ELSE ~IF ~ISACTIVEENABLE[4] ~THEN
   ~SYM[10] : process(~ARG[3])
@@ -83,11 +75,7 @@ begin
         ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
       end if;
       if ~ARG[4] then
-        ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]))
-        -- pragma translate_off
-        after 1 ps
-        -- pragma translate_on
-        ;
+        ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
       end if;
     end if;
   end process;~ELSE
@@ -97,11 +85,7 @@ begin
       if ~ARG[8] then
         ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
       end if;
-      ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]))
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
     end if;
   end process;~FI ~FI
 end block;

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM.json
@@ -26,16 +26,8 @@ begin
   ~GENSYM[romSync][6] : process (~ARG[3])
   begin
     if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI) then~IF ~VIVADO ~THEN
-      ~RESULT <= ~FROMBV[~SYM[2](~SYM[3])][~TYPO]
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;~ELSE
-      ~RESULT <= ~SYM[2](~SYM[3])
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;~FI
+      ~RESULT <= ~FROMBV[~SYM[2](~SYM[3])][~TYPO];~ELSE
+      ~RESULT <= ~SYM[2](~SYM[3]);~FI
     end if;
   end process;
 end block;

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.json
@@ -40,22 +40,14 @@ begin
   begin
     if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then
       if ~ARG[3] then
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))
-        -- pragma translate_off
-        after 1 ps
-        -- pragma translate_on
-        ;
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
       end if;
     end if;
   end process;~ELSE
   ~SYM[7] : process (~ARG[2])
   begin
     if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]))
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
     end if;
   end process;~FI
 end block;

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.json
@@ -18,22 +18,14 @@
 begin
   if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
     if ~ARG[3] then
-      ~RESULT <= ~ARG[5]
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~ARG[5];
     end if;
   end if;
 end process;~ELSE
 ~SYM[4] : process(~ARG[2])
 begin
   if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    ~RESULT <= ~ARG[5]
-    -- pragma translate_off
-    after 1 ps
-    -- pragma translate_on
-    ;
+    ~RESULT <= ~ARG[5];
   end if;
 end process;~FI
 -- delay end"
@@ -61,17 +53,9 @@ end process;~FI
 begin
   if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
     if ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
-      ~RESULT <= ~CONST[6]
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~CONST[6];
     elsif ~ARG[4] then
-      ~RESULT <= ~ARG[7]
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~ARG[7];
     end if;
   end if;
 end process;~ELSE
@@ -81,11 +65,7 @@ begin
     ~RESULT <= ~CONST[6];
   elsif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
     if ~ARG[4] then
-      ~RESULT <= ~ARG[7]
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~ARG[7];
     end if;
   end if;
 end process;~FI~ELSE ~IF ~ISSYNC[0] ~THEN
@@ -93,34 +73,18 @@ end process;~FI~ELSE ~IF ~ISSYNC[0] ~THEN
 begin
   if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
     if ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
-      ~RESULT <= ~CONST[6]
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~CONST[6];
     else
-      ~RESULT <= ~ARG[7]
-      -- pragma translate_off
-      after 1 ps
-      -- pragma translate_on
-      ;
+      ~RESULT <= ~ARG[7];
     end if;
   end if;
 end process;~ELSE
 ~SYM[2] : process(~ARG[2],~ARG[3])
 begin
   if ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
-    ~RESULT <= ~CONST[6]
-    -- pragma translate_off
-    after 1 ps
-    -- pragma translate_on
-    ;
+    ~RESULT <= ~CONST[6];
   elsif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    ~RESULT <= ~ARG[7]
-    -- pragma translate_off
-    after 1 ps
-    -- pragma translate_on
-    ;
+    ~RESULT <= ~ARG[7];
   end if;
 end process;~FI~FI
 -- register end"

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -35,6 +35,7 @@ module Clash.Core.Type
   , typeKind
   , mkTyConTy
   , mkFunTy
+  , mkPolyFunTy
   , mkTyConApp
   , splitFunTy
   , splitFunTys
@@ -302,6 +303,16 @@ splitFunForallTy = go []
     go args (ForAllTy tv ty)          = go (Left tv:args) ty
     go args (tyView -> FunTy arg res) = go (Right arg:args) res
     go args ty                        = (reverse args,ty)
+
+-- | Make a polymorphic function type out of a result type and a list of
+-- quantifiers and function argument types
+mkPolyFunTy
+  :: Type
+  -- ^ Result type
+  -> [Either TyVar Type]
+  -- ^ List of quantifiers and function argument types
+  -> Type
+mkPolyFunTy = foldr (either ForAllTy mkFunTy)
 
 -- | Split a poly-function type in a: list of type-binders and argument types,
 -- and the result type. Looks through 'Signal' and type functions.

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -21,7 +21,8 @@ import           Data.Coerce                   (coerce)
 import qualified Data.HashSet                  as HashSet
 import Data.List
   (foldl', mapAccumR, elemIndices, nub)
-import Data.Maybe                              (fromJust, mapMaybe, catMaybes)
+import Data.Maybe
+  (fromJust, isJust, mapMaybe, catMaybes)
 import qualified Data.Text                     as T
 import           Data.Text.Prettyprint.Doc     (line)
 #if !MIN_VERSION_base(4,11,0)
@@ -933,3 +934,73 @@ tyLitShow m (coreView1 m -> Just ty) = tyLitShow m ty
 tyLitShow _ (LitTy (SymTy s))        = return s
 tyLitShow _ (LitTy (NumTy s))        = return (show s)
 tyLitShow _ ty = throwE $ $(curLoc) ++ "Cannot reduce to a string:\n" ++ showPpr ty
+
+-- | Determine whether we should split away types from a product type, i.e.
+-- clocks should always be separate arguments, and not part of a product.
+shouldSplit
+  :: TyConMap
+  -> Type
+  -- ^ Type to examine
+  -> Maybe (Term,[Type])
+  -- ^ If we want to split values of the given type then we have /Just/:
+  --
+  -- 1. The (type-applied) data-constructor which, when applied to values of
+  --    the types in 2., creates a value of the examined type
+  --
+  -- 2. The arguments types of the product we are trying to split.
+  --
+  -- Note that we only split one level at a time (although we check all the way
+  -- down), e.g. given /(Int, (Clock, Bool))/ we return:
+  --
+  -- > Just ((,) @Int @(Clock, Bool), [Int, (Clock, Bool)])
+  --
+  -- An outer loop is required to subsequently split the /(Clock, Bool)/ tuple.
+shouldSplit tcm = shouldSplit0 tcm . tyView . coreView tcm
+
+-- | Worker of 'shouldSplit', works on 'TypeView' instead of 'Type'
+shouldSplit0
+  :: TyConMap
+  -> TypeView
+  -> Maybe (Term,[Type])
+shouldSplit0 tcm (TyConApp tcNm tyArgs)
+  | Just tc <- lookupUniqMap tcNm tcm
+  , [dc] <- tyConDataCons tc
+  , let dcArgs  = substArgTys dc tyArgs
+  , let dcArgVs = map (tyView . coreView tcm) dcArgs
+  = if any (\ty -> isJust (shouldSplit0 tcm ty) || splitTy ty) dcArgVs then
+      Just (mkApps (Data dc) (map Right tyArgs), dcArgs)
+    else
+      Nothing
+ where
+  -- Currently we're only interested in splitting of Clock, Reset, and Enable
+  splitTy (TyConApp tcNm0 _)
+    = nameOcc tcNm0 `elem` [ "Clash.Signal.Internal.Clock"
+                           , "Clash.Signal.Internal.Reset"
+                           , "Clash.Signal.Internal.Enable"
+                           ]
+  splitTy _ = False
+
+shouldSplit0 _ _ = Nothing
+
+-- | Potentially split apart a list of function argument types. e.g. given:
+--
+-- > [Int,(Clock,(Reset,Bool)),Char]
+--
+-- we return
+--
+-- > [Int,Clock,Reset,Bool,Char]
+--
+-- But we would leave
+--
+-- > [Int, (Bool,Int), Char]
+--
+-- unchanged.
+splitShouldSplit
+  :: TyConMap
+  -> [Type]
+  -> [Type]
+splitShouldSplit tcm = foldr go []
+ where
+  go ty rest = case shouldSplit tcm ty of
+    Just (_,tys) -> splitShouldSplit tcm tys ++ rest
+    Nothing      -> ty : rest

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -29,7 +29,8 @@ import Clash.Rewrite.Util
 -- | Normalisation transformation
 normalization :: NormRewrite
 normalization = rmDeadcode >-> constantPropagation >-> etaTL >-> rmUnusedExpr >-!-> anf >-!-> rmDeadcode >->
-                bindConst >-> letTL >-> evalConst >-!-> cse >-!-> cleanup >-> recLetRec
+                bindConst >-> letTL >-> evalConst >-!-> cse >-!-> cleanup >->
+                recLetRec >-> splitArgs
   where
     etaTL      = apply "etaTL" etaExpansionTL !-> topdownR (apply "applicationPropagation" appPropFast)
     anf        = topdownR (apply "nonRepANF" nonRepANF) >-> apply "ANF" makeANF >-> topdownR (apply "caseCon" caseCon)
@@ -47,6 +48,8 @@ normalization = rmDeadcode >-> constantPropagation >-> etaTL >-> rmUnusedExpr >-
                                       ,("bindConstantVar", bindConstantVar)
                                       ,("letFlat"        , flattenLet)])
                  >-> rmDeadcode >-> letTL
+    splitArgs  = topdownR (apply "separateArguments" separateArguments) !->
+                 topdownR (apply "caseCon" caseCon)
 
 
 constantPropagation :: NormRewrite


### PR DESCRIPTION
Turns e.g.

```    
f :: (Clock System, Reset System) -> Signal System Int
```

into    

``` 
f :: Clock System -> Reset System -> Signal System Int
```

We need this because HDL synthesis tools don't like it when clocks and resets end up in structs or bitvectors, which product types are usually mapped to. This also solves an annoyance in VHDL where we had to delay register assignment by 1ps to avoid delta-cycle weirdness.
    
Fixes #477
Partially solves #418
