### PR TITLE
Add assertion and coverage functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for the Clash project
 -----
 -  New features (API):
 
-   -  No new features yet!
+   -  Added basic support for writing PSL/SVA assertions in `Clash.Verification`
 
 -  New features (Compiler):
 

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -235,6 +235,7 @@ Library
                       Clash.Primitives.Intel.ClockGen
                       Clash.Primitives.Sized.ToInteger
                       Clash.Primitives.Sized.Vector
+                      Clash.Primitives.Verification
 
                       Clash.Rewrite.Combinators
                       Clash.Rewrite.Types

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -101,6 +101,7 @@ import qualified Clash.Primitives.Sized.Vector    as P
 import qualified Clash.Primitives.GHC.Int         as P
 import qualified Clash.Primitives.GHC.Word        as P
 import qualified Clash.Primitives.Intel.ClockGen  as P
+import qualified Clash.Primitives.Verification    as P
 import           Clash.Primitives.Types
 import           Clash.Primitives.Util            (hashCompiledPrimMap)
 import           Clash.Unique                     (keysUniqMap, lookupUniqMap')
@@ -528,7 +529,8 @@ loadImportAndInterpret iPaths0 interpreterArgs topDir qualMod funcName typ = do
 knownBlackBoxFunctions :: HashMap String BlackBoxFunction
 knownBlackBoxFunctions =
   HashMap.fromList $ map (first show) $
-    [ ('P.bvToIntegerVHDL, P.bvToIntegerVHDL)
+    [ ('P.checkBBF, P.checkBBF)
+    , ('P.bvToIntegerVHDL, P.bvToIntegerVHDL)
     , ('P.bvToIntegerVerilog, P.bvToIntegerVerilog)
     , ('P.foldBBF, P.foldBBF)
     , ('P.indexIntVerilog, P.indexIntVerilog)

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Primitives.Verification (checkBBF) where
+
+import Data.Either
+
+
+import qualified Control.Lens                    as Lens
+import           Control.Monad.State             (State)
+import           Data.Text.Prettyprint.Doc.Extra (Doc)
+import qualified Data.Text                       as Text
+import           Data.Semigroup.Monad            (getMon)
+import           GHC.Stack                       (HasCallStack)
+
+import           Clash.Annotations.Primitive     (HDL(..))
+import qualified Clash.Backend
+import           Clash.Backend
+  (Backend, blockDecl, hdlKind)
+import           Clash.Core.Term                 (Term(Var))
+import           Clash.Core.TermLiteral          (termToDataError)
+import           Clash.Core.Util                 (termType)
+import           Clash.Util                      (indexNote)
+import           Clash.Netlist                   (mkExpr)
+import           Clash.Netlist.Util              (stripVoid)
+import qualified Clash.Netlist.Util
+import           Clash.Netlist.Util              (id2identifier)
+import           Clash.Netlist.Id                (IdType(Basic))
+import           Clash.Netlist.Types
+  (BlackBox(BBFunction), TemplateFunction(..), BlackBoxContext, Identifier,
+   NetlistMonad, Declaration(Assignment, NetDecl', TickDecl),
+   HWType(Bool, KnownDomain), WireOrReg(Wire), NetlistId(..),
+   DeclarationType(Concurrent), tcCache, bbInputs)
+import           Clash.Netlist.BlackBox.Types
+  (BlackBoxFunction, BlackBoxMeta(..), TemplateKind(TDecl), RenderVoid(..),
+   emptyBlackBoxMeta)
+
+import           Clash.Verification.Internal
+import           Clash.Verification.PrettyPrinters
+
+checkBBF :: BlackBoxFunction
+checkBBF _isD _primName args _ty =
+  case litArgs of
+    Left err -> pure (Left err)
+    Right (propName, renderAs, cvProperty0) -> do
+      cvProperty1 <- mapM (uncurry bindMaybe) cvProperty0
+      let decls = concatMap snd cvProperty1
+          cvProperty2 = fmap fst cvProperty1
+      pure (Right (meta, bb (checkTF decls clkId propName renderAs cvProperty2)))
+ where
+  -- TODO: Improve error handling; currently errors don't indicate what
+  -- TODO: blackbox generated them.
+  (Var (id2identifier -> clkId)) = indexNote "clk" (lefts args) 1
+  (Var (id2identifier -> _clkId)) = indexNote "rst" (lefts args) 2
+
+  litArgs = do
+    propName <- termToDataError (indexNote "propName" (lefts args) 3)
+    renderAs <- termToDataError (indexNote "renderAs" (lefts args) 4)
+    cvProperty <- termToDataError (indexNote "propArg" (lefts args) 5)
+    Right (propName, renderAs, cvProperty)
+
+  bb = BBFunction "Clash.Primitives.Verification.checkTF" 0
+  meta = emptyBlackBoxMeta {bbKind=TDecl, bbRenderVoid=RenderVoid}
+  mkId = Clash.Netlist.Util.mkUniqueIdentifier Basic . Text.pack
+
+  bindMaybe
+    :: Maybe String
+    -- ^ Hint for new identifier
+    -> Term
+    -- ^ Term to bind. Does not bind if it's already a reference to a signal
+    -> NetlistMonad (Identifier, [Declaration])
+    -- ^ ([new] reference to signal, [declarations need to get it in scope])
+  bindMaybe _ (Var vId) = pure (id2identifier vId, [])
+  bindMaybe Nothing t = bindMaybe (Just "s") t
+  bindMaybe (Just nm) t = do
+    tcm <- Lens.use tcCache
+    newId <- mkId nm
+    (expr0, decls) <- mkExpr False Concurrent (NetlistId newId (termType tcm t)) t
+    pure
+      ( newId
+      , decls ++ [sigDecl Bool newId, Assignment newId expr0] )
+
+  -- Simple wire without comment
+  sigDecl :: HWType -> Identifier -> Declaration
+  sigDecl typ nm = NetDecl' Nothing Wire nm (Right typ) Nothing
+
+checkTF
+  :: [Declaration]
+  -> Identifier
+  -> Text.Text
+  -> RenderAs
+  -> Property' Identifier
+  -> TemplateFunction
+checkTF decls clkId propName renderAs prop =
+  TemplateFunction [] (const True) (checkTF' decls clkId propName renderAs prop)
+
+checkTF'
+  :: forall s
+   . (HasCallStack, Backend s)
+  => [Declaration]
+  -- ^ Extra decls needed
+  -> Identifier
+  -- ^ Clock
+  -> Text.Text
+  -- ^ Prop name
+  -> RenderAs
+  -> Property' Identifier
+  -> BlackBoxContext
+  -> State s Doc
+checkTF' decls clkId propName renderAs prop bbCtx = do
+  blockName <- Clash.Backend.mkUniqueIdentifier Basic (propName <> "_block")
+  getMon (blockDecl blockName (TickDecl renderedPslProperty : decls))
+
+ where
+  hdl = hdlKind (undefined :: s)
+
+  edge =
+    case head (bbInputs bbCtx) of
+      (_, stripVoid -> KnownDomain _nm _period e _rst _init _polarity, _) -> e
+      _ -> error $ "Unexpected first argument: " ++ show (head (bbInputs bbCtx))
+
+  renderedPslProperty
+    | renderAs == SVA || hdl == SystemVerilog = sva
+    | otherwise = psl
+   where
+    sva = pprSvaProperty propName clkId edge prop
+    psl = pprPslProperty hdl propName clkId edge prop

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -271,7 +271,7 @@ runRewriteSession :: RewriteEnv
                   -> RewriteMonad extra a
                   -> a
 runRewriteSession r s m =
-  traceIf (_dbgLevel r > DebugNone)
+  traceIf (_dbgLevel r > DebugSilent)
     ("Clash: Applied " ++ show (s' ^. transformCounter) ++ " transformations")
     a
   where

--- a/clash-lib/src/Clash/Util/TermLiteral/TH.hs
+++ b/clash-lib/src/Clash/Util/TermLiteral/TH.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE ViewPatterns          #-}
 
-module Clash.Core.TermLiteral.TH
+module Clash.Util.TermLiteral.TH
   (  deriveTermToData
   ) where
 
@@ -22,7 +23,7 @@ dcName' :: DataCon -> String
 dcName' = Text.unpack . nameOcc . dcName
 
 termToDataName :: Name
-termToDataName = mkName "Clash.Core.TermLiteral.termToData"
+termToDataName = mkName "Clash.Util.TermLiteral.termToData"
 
 deriveTermToData :: Name -> Q Exp
 deriveTermToData typName = do
@@ -34,11 +35,9 @@ deriveTermToData typName = do
 
 deriveTermToData1 :: [(Name, Int)] -> Exp
 deriveTermToData1 constrs =
-  LamCaseE
-    [ Match pat (NormalB (if null args then theCase else LetE args theCase)) []
-    , Match (VarP termName) (NormalB ((ConE 'Left `AppE` VarE termName))) []
-
-    ]
+  LamE
+    [pat]
+    (if null args then theCase else LetE args theCase)
  where
   nArgs = maximum (map snd constrs)
 

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -207,6 +207,7 @@ Library
                       Clash.Explicit.Signal.Delayed
                       Clash.Explicit.Synchronizer
                       Clash.Explicit.Testbench
+                      Clash.Explicit.Verification
 
                       Clash.HaskellPrelude
 
@@ -261,6 +262,11 @@ Library
                       Clash.Sized.Internal.Index
                       Clash.Sized.Internal.Signed
                       Clash.Sized.Internal.Unsigned
+
+                      Clash.Verification
+                      Clash.Verification.DSL
+                      Clash.Verification.PrettyPrinters
+                      Clash.Verification.Internal
 
                       Clash.XException
                       Clash.XException.TH

--- a/clash-prelude/src/Clash/Explicit/Verification.hs
+++ b/clash-prelude/src/Clash/Explicit/Verification.hs
@@ -1,0 +1,254 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Verification primitives for Clash. Currently implements PSL (Property
+Specification Language) and SVA (SystemVerilog Assertions). For a good overview
+of PSL and an introduction to the concepts of property checking, read
+<https://standards.ieee.org/standard/62531-2012.html>.
+
+The verification API is currently experimental and subject to change.
+-}
+
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Clash.Explicit.Verification
+  ( -- * Types
+    Assertion
+  , Property
+  , AssertionValue
+  , RenderAs(..)
+
+    -- * Bootstrapping functions
+  , name
+  , lit
+
+    -- * Functions to build a PSL/SVA expressions
+  , not
+  , and
+  , or
+  , implies
+  , next
+  , nextN
+  , before
+  , timplies
+  , timpliesOverlapping
+  , always
+  , never
+
+  -- * Asserts
+  , assert
+  , cover
+
+  -- * Assertion checking
+  , check
+  , checkI
+
+  -- * Functions to deal with assertion results
+  , hideAssertion
+  )
+ where
+
+import           Prelude
+  (Bool, Word, (.), pure, max, concat)
+
+import           Data.Text  (Text)
+import           Data.Maybe (Maybe(Just))
+
+import           Clash.Annotations.Primitive
+  (Primitive(InlinePrimitive), HDL(..))
+import           Clash.Signal.Internal (KnownDomain, Signal, Clock, Reset)
+import           Clash.XException      (errorX, hwSeqX)
+
+import           Clash.Verification.Internal
+
+-- | Convert a signal to a cv expression with a name hint. Clash will try its
+-- best to use this name in the rendered assertion, but might run into
+-- collisions. You can skip using 'name' altogether. Clash will then try its
+-- best to get a readable name from context.
+name :: Text -> Signal dom Bool -> Assertion dom
+name nm signal = Assertion IsNotTemporal (CvPure (Just nm, signal))
+{-# INLINE name #-}
+
+-- | For using a literal (either True or False) in assertions
+lit :: Bool -> Assertion dom
+lit = Assertion IsNotTemporal . CvLit
+{-# INLINE lit #-}
+
+-- | Truth table for 'not':
+--
+-- a     | not a
+-- ------------
+-- True  | False
+-- False | True
+not :: AssertionValue dom a => a -> Assertion dom
+not (toAssertionValue -> a) = Assertion (isTemporal a) (CvNot (assertion a))
+{-# INLINE not #-}
+
+-- | Truth table for 'and':
+--
+-- a     | b     | a `and` b
+-- --------------|----------
+-- False | False | False
+-- False | True  | False
+-- True  | False | False
+-- True  | True  | True
+and :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+and (toAssertionValue -> a) (toAssertionValue -> b) =
+  Assertion
+    (max (isTemporal a) (isTemporal b))
+    (CvAnd (assertion a) (assertion b))
+{-# INLINE and #-}
+
+-- | Truth table for 'or':
+--
+-- a     | b     | a `or` b
+-- --------------|---------
+-- False | False | False
+-- False | True  | True
+-- True  | False | True
+-- True  | True  | True
+or :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+or (toAssertionValue -> a) (toAssertionValue -> b) =
+  Assertion
+    (max (isTemporal a) (isTemporal b))
+    (CvOr (assertion a) (assertion b))
+{-# INLINE or #-}
+
+-- |
+-- Truth table for 'implies':
+--
+-- a     | b     | a `implies` b
+-- --------------|--------------
+-- False | False | True
+-- False | True  | True
+-- True  | False | False
+-- True  | True  | True
+implies :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+implies (toAssertionValue -> Assertion aTmp a) (toAssertionValue -> Assertion bTmp b) =
+  Assertion (max aTmp bTmp) (CvImplies a b)
+{-# INLINE implies #-}
+
+-- | Truth table for 'next':
+--
+-- a[n]  | a[n+1] | a `implies` next a
+-- ---------------|-------------------
+-- False | False  | True
+-- False | True   | True
+-- True  | False  | False
+-- True  | True   | True
+--
+-- where a[n] represents the value of 'a' at cycle 'n' and a[n+1] represents
+-- the value of 'a' at cycle 'n+1'. Cycle n is an arbitrary cycle.
+next :: AssertionValue dom a => a -> Assertion dom
+next = nextN 1
+{-# INLINE next #-}
+
+-- | Truth table for 'nextN':
+--
+-- a[n]  | a[n+m] | a `implies` next m a
+-- ---------------|---------------------
+-- False | False  | True
+-- False | True   | True
+-- True  | False  | False
+-- True  | True   | True
+--
+-- where a[n] represents the value of 'a' at cycle 'n' and a[n+m] represents
+-- the value of 'a' at cycle 'n+m'. Cycle n is an arbitrary cycle.
+nextN :: AssertionValue dom a => Word -> a -> Assertion dom
+nextN n = Assertion IsTemporal . CvNext n . assertion . toAssertionValue
+{-# INLINE nextN #-}
+
+-- | Same as @a && next b@ but with a nice syntax. E.g., @a && next b@ could
+-- be written as @a `before` b@. Might be read as "a happens one cycle before b".
+before :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+before a0 b0 = Assertion IsTemporal (CvBefore a1 b1)
+ where
+  a1 = assertion (toAssertionValue a0)
+  b1 = assertion (toAssertionValue b0)
+{-# INLINE before #-}
+
+-- | Same as @a `implies` next b@ but with a nice syntax. E.g.,
+-- @a `implies` next b@ could be written as @a `timplies` b@. Might be read
+-- as "a at cycle n implies b at cycle n+1".
+timplies :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+timplies a0 b0 = Assertion IsTemporal (CvTemporalImplies 1 a1 b1)
+ where
+  a1 = toTemporal (toAssertionValue a0)
+  b1 = toTemporal (toAssertionValue b0)
+{-# INLINE timplies #-}
+
+-- | Same as 'implies' but strictly temporal.
+timpliesOverlapping
+  :: (AssertionValue dom a, AssertionValue dom b)
+  => a
+  -> b
+  -> Assertion dom
+timpliesOverlapping a0 b0 =
+  Assertion IsTemporal (CvTemporalImplies 0 a1 b1)
+ where
+  a1 = toTemporal (toAssertionValue a0)
+  b1 = toTemporal (toAssertionValue b0)
+{-# INLINE timpliesOverlapping #-}
+
+-- | Specify assertion should _always_ hold
+always :: AssertionValue dom a => a -> Assertion dom
+always = Assertion IsTemporal . CvAlways . assertion . toAssertionValue
+{-# INLINE always #-}
+
+-- | Specify assertion should _never_ hold
+never :: AssertionValue dom a => a -> Assertion dom
+never = Assertion IsTemporal . CvNever . assertion . toAssertionValue
+{-# INLINE never #-}
+
+-- | Check whether given assertion always holds. Results can be collected with
+-- 'check'.
+assert :: AssertionValue dom a => a -> Property dom
+assert = Property . CvAssert . assertion . toAssertionValue
+{-# INLINE assert #-}
+
+-- | Check whether given assertion holds for at least a single cycle. Results
+-- can be collected with 'check'.
+cover :: AssertionValue dom a => a -> Property dom
+cover = Property . CvCover . assertion . toAssertionValue
+{-# INLINE cover #-}
+
+-- | Print property as PSL/SVA in HDL. Clash simulation support not yet
+-- implemented.
+check
+  :: KnownDomain dom
+  => Clock dom
+  -> Reset dom
+  -> Text
+  -- ^ Property name (used in reports and error messages)
+  -> RenderAs
+  -- ^ Assertion language to use in HDL
+  -> Property dom
+  -> Signal dom AssertionResult
+check !_clk !_rst !_propName !_renderAs !_prop =
+  pure (errorX (concat [
+      "Simulation for Clash.Verification not yet implemented. If you need this,"
+    , " create an issue at https://github.com/clash-compiler/clash-lang/issues." ]))
+{-# NOINLINE check #-}
+{-# ANN check (InlinePrimitive [Verilog, SystemVerilog, VHDL] "[ { \"BlackBoxHaskell\" : { \"name\" : \"Clash.Explicit.Verification.check\", \"templateFunction\" : \"Clash.Primitives.Verification.checkBBF\"}} ]") #-}
+
+-- | Same as 'check', but doesn't require a design to explicitly carried to
+-- top-level.
+checkI
+  :: KnownDomain dom
+  => Clock dom
+  -> Reset dom
+  -> Text
+  -- ^ Property name (used in reports and error messages)
+  -> RenderAs
+  -- ^ Assertion language to use in HDL
+  -> Property dom
+  -> Signal dom a
+  -> Signal dom a
+checkI clk rst propName renderAs prop =
+  hideAssertion (check clk rst propName renderAs prop)
+
+-- | Print assertions in HDL
+hideAssertion :: Signal dom AssertionResult -> Signal dom a -> Signal dom a
+hideAssertion = hwSeqX

--- a/clash-prelude/src/Clash/Verification.hs
+++ b/clash-prelude/src/Clash/Verification.hs
@@ -1,0 +1,79 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+See "Clash.Explicit.Verification" for an introduction.
+
+The verification API is currently experimental and subject to change.
+
+-}
+
+module Clash.Verification
+  ( -- * Types
+    Assertion
+  , Property
+  , RenderAs(..)
+
+    -- * Bootstrapping functions
+  , EV.name
+  , EV.lit
+
+    -- * Functions to build a PSL/SVA expressions
+  , EV.not
+  , EV.and
+  , EV.or
+  , EV.implies
+  , EV.next
+  , EV.nextN
+  , EV.before
+  , EV.timplies
+  , EV.timpliesOverlapping
+  , EV.always
+  , EV.never
+
+  -- * Asserts
+  , EV.assert
+  , EV.cover
+
+  -- * Assertion checking
+  , check
+  , checkI
+
+  -- * Functions to deal with assertion results
+  , EV.hideAssertion
+  ) where
+
+
+import qualified Clash.Explicit.Verification     as EV
+import           Clash.Signal
+  (KnownDomain, HiddenClock, HiddenReset, Signal, hasClock, hasReset)
+import           Clash.Verification.Internal
+import           Data.Text                       (Text)
+
+check
+  :: ( KnownDomain dom
+     , HiddenClock dom
+     , HiddenReset dom
+     )
+  => Text
+  -- ^ Property name (used in reports and error messages)
+  -> RenderAs
+  -- ^ Assertion language to use in HDL
+  -> Property dom
+  -> Signal dom AssertionResult
+check = EV.check hasClock hasReset
+
+checkI
+  :: ( KnownDomain dom
+     , HiddenClock dom
+     , HiddenReset dom
+     )
+  => Text
+  -- ^ Property name (used in reports and error messages)
+  -> RenderAs
+  -- ^ Assertion language to use in HDL
+  -> Property dom
+  -> Signal dom a
+  -> Signal dom a
+checkI = EV.checkI hasClock hasReset

--- a/clash-prelude/src/Clash/Verification/DSL.hs
+++ b/clash-prelude/src/Clash/Verification/DSL.hs
@@ -1,0 +1,42 @@
+module Clash.Verification.DSL where
+
+import qualified Clash.Verification           as Cv
+import           Clash.Verification.Internal
+
+-- Precedences taken from:
+--
+--   Table 2—FL operator precedence and associativity
+--
+-- of
+--
+--   IEEE Std 1850-2010a, Annex B.1, p149
+
+infixr 5 |&|
+(|&|) :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+a |&| b = Cv.and a b
+{-# INLINE (|&|) #-}
+
+infixr 4 |||
+(|||) :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+a ||| b = Cv.or a b
+{-# INLINE (|||) #-}
+
+(~>) :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+a ~> b = Cv.implies a b
+{-# INLINE (~>) #-}
+infixr 0 ~>
+
+(|=>) :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+a |=> b = Cv.timplies a b
+{-# INLINE (|=>) #-}
+infixr 1 |=>
+
+(|->) :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+a |-> b = Cv.timpliesOverlapping a b
+{-# INLINE (|->) #-}
+infixr 1 |->
+
+(#|#) :: (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom
+a #|# b = Cv.before a b
+{-# INLINE (#|#) #-}
+infixr 3 #|#

--- a/clash-prelude/src/Clash/Verification/Internal.hs
+++ b/clash-prelude/src/Clash/Verification/Internal.hs
@@ -1,0 +1,152 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Verification
+-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+#if __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
+
+module Clash.Verification.Internal
+ ( AssertionResult(..)
+ , Property(..)
+ , Assertion(..)
+ , RenderAs(..)
+ , IsTemporal(..)
+ , AssertionValue(toAssertionValue)
+ , Assertion'(..)
+ , Property'(..)
+ , toTemporal
+ , isTemporal
+ , assertion
+ )
+ where
+
+import           Data.Text                      (Text)
+
+import Clash.Annotations.BitRepresentation
+  (ConstrRepr(..), DataReprAnn(..), liftQ)
+import           Clash.Signal.Internal          (Domain, Signal)
+
+-- | Render target for HDL
+data RenderAs
+  = PSL
+  -- ^ Property Specification Language
+  | SVA
+  -- ^ SystemVerilog Assertions
+  | AutoRenderAs
+  -- ^ Use SVA for SystemVerilog, PSL for others
+  deriving (Show, Eq)
+
+data IsTemporal
+  = IsNotTemporal
+  | IsTemporal
+  deriving (Eq, Ord)
+
+-- | Internal version of "Assertion".
+data Assertion' a
+  = CvPure a
+  -- ^ (Bootstrapping) signal of booleans
+  | CvToTemporal (Assertion' a)
+  -- ^ Tag to force a non-temporal assertion to a temporal one
+  | CvLit Bool
+  -- ^ Boolean literal
+
+  | CvNot (Assertion' a)
+  -- ^ Logical not
+  | CvAnd (Assertion' a) (Assertion' a)
+  -- ^ Logical and
+  | CvOr (Assertion' a) (Assertion' a)
+  -- ^ Logical or
+  | CvImplies (Assertion' a) (Assertion' a)
+  -- ^ Logical implies
+
+  | CvNext Word (Assertion' a)
+  -- ^ Moves start point of assertion /n/ cycles forward
+  | CvBefore (Assertion' a) (Assertion' a)
+  -- ^ Before @CvBefore a b@ is the same as @CvAnd a (CvNext 1 b)@
+  | CvTemporalImplies Word (Assertion' a) (Assertion' a)
+  -- ^ Temporal implies @CvTemporalImplies n a b@:
+  --
+  --   n | n == 0    -> same as @CvImplies a b@
+  --     | otherwise -> same as @CvImplies a (CvNextN n b)@
+  --
+  | CvAlways (Assertion' a)
+  -- ^ Assertion should _always_ hold
+  | CvNever (Assertion' a)
+  -- ^ Assertion should _never_ hold (not supported by SVA)
+  deriving (Show, Functor, Foldable, Traversable)
+
+-- | Internal version of "Property". All user facing will instantiate @a@
+-- with @(Maybe Text, Signal dom Bool)@. Blackboxes will instantiate it with
+-- @(Maybe Text, Term)@ instead.
+data Property' a
+  = CvAssert (Assertion' a)
+  | CvCover (Assertion' a)
+  deriving (Show, Functor, Foldable, Traversable)
+
+data Assertion (dom :: Domain) =
+  Assertion IsTemporal (Assertion' (Maybe Text, Signal dom Bool))
+
+toTemporal :: Assertion dom -> Assertion' (Maybe Text, Signal dom Bool)
+toTemporal (Assertion IsTemporal a) = a
+toTemporal (Assertion IsNotTemporal a) = CvToTemporal a
+{-# INLINE toTemporal #-}
+
+isTemporal :: Assertion dom -> IsTemporal
+isTemporal (Assertion it _assert) = it
+{-# INLINE isTemporal #-}
+
+assertion :: Assertion dom -> Assertion' (Maybe Text, Signal dom Bool)
+assertion (Assertion _it assert) = assert
+{-# INLINE assertion #-}
+
+-- | A property is a temporal or basic assertion that's specified to either
+-- used as an _assert_ or _cover_ statement. See
+-- 'Clash.Explicit.Verification.assert' and 'Clash.Explicit.Verification.cover'.
+newtype Property (dom :: Domain) =
+  Property (Property' (Maybe Text, Signal dom Bool))
+
+-- | A result of some property. Besides carrying the actual boolean result, it
+-- carries some properties used to make reports.
+data AssertionResult = AssertionResult
+  { cvPropName :: !String  -- I'd like text, but Clash complains :[
+  -- ^ Name of property belonging to this result
+  , cvPass :: !Bool
+  -- ^ False whenever property is violated, True otherwise
+  }
+  deriving (Eq)
+{-# ANN module (
+  DataReprAnn
+    $(liftQ [t| AssertionResult |])
+    0
+    [ ConstrRepr 'AssertionResult 0 0 [0b0, 0b0]
+    ]) #-}
+{- Marked as zero-width so Clash won't stumble on the fact it's unrepresentable. ^ -}
+
+-- | An AssertionValue is a bool-like value or stream that can be used in
+-- property specifications. Clash implements two: a stream of booleans
+-- (Signal dom Bool), and the result of a property expression (Assertion
+-- dom).
+class AssertionValue dom a | a -> dom where
+  -- | Convert given type into a Assertion.
+  toAssertionValue :: a -> Assertion dom
+
+-- | Stream of booleans, originating from a circuit
+instance AssertionValue dom (Signal dom Bool) where
+  toAssertionValue s = Assertion IsNotTemporal (CvPure (Nothing, s))
+  {-# INLINE toAssertionValue #-}
+
+-- | Result of a property specification
+instance AssertionValue dom (Assertion dom) where
+  toAssertionValue = id
+  {-# INLINE toAssertionValue #-}
+

--- a/clash-prelude/src/Clash/Verification/PrettyPrinters.hs
+++ b/clash-prelude/src/Clash/Verification/PrettyPrinters.hs
@@ -1,0 +1,244 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Verification
+-}
+
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Verification.PrettyPrinters
+  ( pprPslProperty
+  , pprSvaProperty
+
+  -- * Debugging functions
+  , pprProperty
+  ) where
+
+import           Clash.Annotations.Primitive      (HDL(..))
+import           Clash.Signal.Internal            (ActiveEdge, ActiveEdge(..))
+import           Clash.Verification.Internal      hiding (assertion)
+import           Data.Maybe                       (fromMaybe)
+import           Data.Text                        (Text)
+import           TextShow                         (showt)
+
+data Symbol
+  = TImpliesOverlapping
+  | TImplies
+  | Implies
+  | BiImplies
+  | Not
+  | And
+  | Or
+  | To
+  | Equals
+  -- + [] ?
+  | Assign
+  | Is
+
+------------------------------------------
+--                 UTIL                 --
+------------------------------------------
+-- | Collapse constructs such as `next (next a)` down to `next[2] a`
+squashBefore :: Assertion' a -> [Assertion' a]
+squashBefore (CvBefore e1 e2) = e1s ++ e2s
+ where
+  e1s = case squashBefore e1 of {[] -> [e1]; es -> es}
+  e2s = case squashBefore e2 of {[] -> [e2]; es -> es}
+squashBefore _ = []
+
+parensIf :: Bool -> Text -> Text
+parensIf True s = "(" <> s <> ")"
+parensIf False s = s
+
+---------------------------------------
+--                PSL                --
+---------------------------------------
+pslBinOp
+  :: HDL
+  -> Bool
+  -> Symbol
+  -> Assertion' Text
+  -> Assertion' Text
+  -> Text
+pslBinOp hdl parens op e1 e2 =
+  parensIf parens (e1' <> symbol hdl op <> e2')
+ where
+  e1' = pprPslAssertion hdl True e1
+  e2' = pprPslAssertion hdl True e2
+
+pslEdge :: HDL -> ActiveEdge -> Text -> Text
+pslEdge SystemVerilog activeEdge clkId = pslEdge Verilog activeEdge clkId
+pslEdge Verilog Rising clkId = "posedge " <> clkId
+pslEdge Verilog Falling clkId = "negedge " <> clkId
+pslEdge VHDL Rising clkId = "rising_edge(" <> clkId <> ")"
+pslEdge VHDL Falling clkId = "falling_edge(" <> clkId <> ")"
+
+-- | Taken from IEEE Std 1850-2010a, Annex B.1, p149
+symbol :: HDL -> Symbol -> Text
+symbol SystemVerilog = symbol Verilog
+symbol Verilog = \case
+  TImpliesOverlapping -> "|->"
+  TImplies  -> "|=>"
+  Implies   -> "->"
+  BiImplies -> "<->"
+  Not       -> "!"
+  And       -> "&&"
+  Or        -> "||"
+  To        -> ":"
+  Assign    -> "<="
+  Is        -> "="
+  Equals    -> "=="
+
+symbol VHDL = \case
+  TImpliesOverlapping -> "|->"
+  TImplies  -> "|=>"
+  Implies   -> " -> "
+  BiImplies -> " <-> "
+  Not       -> "not"
+  And       -> " and "
+  Or        -> " or "
+  To        -> " to "
+  Assign    -> "<="
+  Is        -> "is"
+  Equals    -> "="
+
+-- | Pretty print Property. Doesn't print valid HDL, but can be used for
+-- debugging purposes.
+pprProperty :: Property dom -> Text
+pprProperty (Property prop0) =
+  let prop1 = fromMaybe "__autogen__" . fst <$> prop0 in
+  pprPslProperty VHDL "prop" "clk" Rising prop1
+
+pprPslProperty
+  :: HDL
+  -- ^ HDL to generate PSL expression for
+  -> Text
+  -- ^ Property name
+  -> Text
+  -- ^ Clock name
+  -> ActiveEdge
+  -- ^ Edge property should be sensitive to
+  -> Property' Text
+  -- ^ Assertion / Cover statement
+  -> Text
+pprPslProperty hdl propName clkId edge assertion =
+  "psl property " <> propName <> " " <> symbol hdl Is <> "\n" <>
+  "(" <> prop <> ") @(" <> pslEdge hdl edge clkId <> ")" <>
+  ";\n" <> "psl " <> coverOrAssert <> " " <>
+  propName <> ";"
+ where
+  (coverOrAssert, prop) =
+    case assertion of
+      CvCover e -> ("cover", pprPslAssertion hdl False e)
+      CvAssert e -> ("assert", pprPslAssertion hdl False e)
+
+pprPslAssertion :: HDL -> Bool -> Assertion' Text -> Text
+pprPslAssertion hdl parens e =
+  case e of
+    (CvPure p) -> p
+
+    -- ModelSim/QuastaSim doesn't support booleans in PSL. Anytime we want to
+    -- use a boolean literal we use (0 == 0) or (0 == 1) instead.
+    (CvLit False) -> parensIf parens ("0" <> symbol hdl Equals <> "1")
+    (CvLit True) -> parensIf parens ("0" <> symbol hdl Equals <> "0")
+
+    (CvNot e1) ->
+      parensIf parens (symbol hdl Not <> " " <> pprPslAssertion hdl True e1)
+    (CvAnd e1 e2) -> pslBinOp1 And e1 e2
+    (CvOr e1 e2) -> pslBinOp1 Or e1 e2
+    (CvImplies e1 e2) -> pslBinOp1 Implies e1 e2
+
+    (CvToTemporal e1) -> "{" <> pprPslAssertion hdl False e1 <> "}"
+
+    (CvNext 0 e1) -> pprPslAssertion hdl parens e1
+    (CvNext 1 e1) -> " ## " <> pprPslAssertion hdl True e1
+    (CvNext n e1) -> " ##" <> showt n <> " " <> pprPslAssertion hdl False e1
+
+    (CvBefore _ _) -> "{" <> afters1 <> "}"
+     where
+      afters0 = map (pprPslAssertion hdl False) (squashBefore e)
+      afters1 = foldl1 (\e1 e2 -> e1 <> "; " <> e2) afters0
+
+    (CvTemporalImplies 0 e1 e2) -> pslBinOp1 TImpliesOverlapping e1 e2
+    (CvTemporalImplies 1 e1 e2) -> pslBinOp1 TImplies e1 e2
+    (CvTemporalImplies n e1 e2) -> pslBinOp1 TImplies e1 (CvNext n e2)
+
+    (CvAlways e1) -> "always " <> pprPslAssertion hdl True e1
+    (CvNever e1) -> "never " <> pprPslAssertion hdl True e1
+ where
+  pslBinOp1 = pslBinOp hdl True
+
+
+---------------------------------------
+--                SVA                --
+---------------------------------------
+svaEdge :: ActiveEdge -> Text -> Text
+svaEdge Rising clkId = "posedge " <> clkId
+svaEdge Falling clkId = "negedge " <> clkId
+
+svaBinOp
+  :: Bool
+  -> Symbol
+  -> Assertion' Text
+  -> Assertion' Text
+  -> Text
+svaBinOp parens op e1 e2 =
+  parensIf parens (e1' <> symbol SystemVerilog op <> e2')
+ where
+  e1' = pprSvaAssertion True e1
+  e2' = pprSvaAssertion True e2
+
+pprSvaAssertion :: Bool -> Assertion' Text -> Text
+pprSvaAssertion parens e =
+  case e of
+    (CvPure p) -> p
+    (CvLit False) -> "false"
+    (CvLit True) -> "true"
+
+    (CvNot e1) ->
+      parensIf parens (symbol' Not <> pprSvaAssertion True e1)
+    (CvAnd e1 e2) -> svaBinOp1 And e1 e2
+    (CvOr e1 e2) -> svaBinOp1 Or e1 e2
+    (CvImplies e1 e2) -> svaBinOp1 Implies e1 e2
+
+    (CvToTemporal e1) -> "{" <> pprSvaAssertion False e1 <> "}"
+
+    (CvNext 0 e1) -> pprSvaAssertion parens e1
+    (CvNext n e1) -> "nexttime[" <> showt n <> "] " <> pprSvaAssertion False e1
+
+    (CvBefore _ _) -> "{" <> afters1 <> "}"
+     where
+      afters0 = map (pprSvaAssertion False) (squashBefore e)
+      afters1 = foldl1 (\e1 e2 -> "(" <> e1 <> ") ##1 (" <> e2 <> ")") afters0
+
+    (CvTemporalImplies 0 e1 e2) -> svaBinOp1 TImpliesOverlapping e1 e2
+    (CvTemporalImplies 1 e1 e2) -> svaBinOp1 TImplies e1 e2
+    (CvTemporalImplies n e1 e2) -> svaBinOp1 TImplies e1 (CvNext n e2)
+
+    (CvAlways e1) -> "always (" <> pprSvaAssertion False e1 <> ")"
+    (CvNever _e) -> error "'never' not supported in SVA"
+ where
+  svaBinOp1 = svaBinOp parens
+  symbol' = symbol SystemVerilog
+
+pprSvaProperty
+  :: Text
+  -- ^ Property name
+  -> Text
+  -- ^ Clock name
+  -> ActiveEdge
+  -- ^ Edge property should be sensitive to
+  -> Property' Text
+  -- ^ Assertion / Cover statement
+  -> Text
+pprSvaProperty propName clkId edge assertion =
+  propName <> ": " <> coverOrAssert <> " property (@(" <>
+  svaEdge edge clkId <> ") " <> prop <> ");"
+ where
+  (coverOrAssert, prop) =
+    case assertion of
+      CvCover e -> ("cover", pprSvaAssertion False e)
+      CvAssert e -> ("assert", pprSvaAssertion False e)

--- a/tests/shouldfail/Verification/NonTemporal.hs
+++ b/tests/shouldfail/Verification/NonTemporal.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module NonTemporal where
+
+import           Data.Coerce
+
+import qualified Prelude                         as P
+
+import           Clash.Explicit.Prelude          hiding (assert, (&&), (||), not)
+import           Clash.Explicit.Testbench        hiding (assert, (&&), (||))
+import qualified Clash.Explicit.Verification     as V
+import           Clash.Explicit.Verification
+import           Clash.Verification.DSL
+import           Clash.Verification.Internal
+import           Clash.XException                (hwSeqX)
+
+assertCvResult
+  :: forall n dom
+   . (Bounded n, Enum n, Eq n, NFDataX n, KnownDomain dom)
+  => Clock dom -> Reset dom -> Enable dom
+  -> n
+  -> Signal dom AssertionResult
+  -> Signal dom Bool
+assertCvResult clk rst gen max results = done
+ where
+  counter = register clk rst gen (minBound :: n) (succ <$> counter)
+  done = hideAssertion results (counter .==. pure maxBound)
+{-# INLINE assertCvResult #-}
+
+binaryTest
+  :: ( dom ~ System
+     , AssertionValue dom x
+     , AssertionValue dom y
+     )
+  => RenderAs
+  -> x
+  -> y
+  -> (forall a b. (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom)
+  -> Signal dom Bool
+binaryTest t x y f = done
+ where
+  done = outputVerifier' clk rst (False :> True :> Nil) asserted
+  asserted = assertCvResult clk rst enableGen (1 :: Index 2) assertion
+  assertion = check clk rst "propName" t (assert (f x y))
+  clk = tbSystemClockGen (P.not <$> done)
+  rst = resetGen
+{-# INLINE binaryTest #-}
+
+-- Tests below are single cycle non-temporal tests testing basic operators such
+-- as "&&", "||", "->", ..
+
+
+-- == && ==
+fails1 :: RenderAs -> Signal System Bool
+fails1 t = binaryTest t (lit False) (lit True) (|&|)
+
+fails2 :: RenderAs -> Signal System Bool
+fails2 t = binaryTest t (lit True) (lit False) (|&|)
+
+fails3 :: RenderAs -> Signal System Bool
+fails3 t = binaryTest t (lit False) (lit False) (|&|)
+
+fails4 :: RenderAs -> Signal System Bool
+fails4 t = binaryTest t (lit True) (lit True) (\a b -> not (a |&| b))
+
+-- == || ==
+fails5 :: RenderAs -> Signal System Bool
+fails5 t = binaryTest t (lit False) (lit False) (|||)
+
+fails6 :: RenderAs -> Signal System Bool
+fails6 t = binaryTest t (lit True) (lit True) (\a b -> not (a ||| b))
+
+fails7 :: RenderAs -> Signal System Bool
+fails7 t = binaryTest t (lit False) (lit True) (\a b -> not (a ||| b))
+
+fails8 :: RenderAs -> Signal System Bool
+fails8 t = binaryTest t (lit True) (lit False) (\a b -> not (a ||| b))
+
+-- == ~> ==
+fails9 :: RenderAs -> Signal System Bool
+fails9 t = binaryTest t (lit True) (lit False) (~>)
+
+-- Not supported by GHDL:
+fails10 :: RenderAs -> Signal System Bool
+fails10 t = binaryTest t (lit False) (lit False) (\a b -> not (a ~> b))
+
+fails11 :: RenderAs -> Signal System Bool
+fails11 t = binaryTest t (lit False) (lit True) (\a b -> not (a ~> b))
+
+fails12 :: RenderAs -> Signal System Bool
+fails12 t = binaryTest t (lit True) (lit True) (\a b -> not (a ~> b))
+
+fails13 :: RenderAs -> Signal System Bool
+fails13 t = binaryTest t (lit True) (lit False) (\a b -> a ~> b)

--- a/tests/shouldfail/Verification/NonTemporalPSL.hs
+++ b/tests/shouldfail/Verification/NonTemporalPSL.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module NonTemporalPSL where
+
+import Clash.Prelude
+import Clash.Verification.Internal
+import qualified NonTemporal as NT
+
+fails1 = NT.fails1 PSL
+{-# ANN fails1 (defSyn "fails1") #-}
+
+fails2 = NT.fails2 PSL
+{-# ANN fails2 (defSyn "fails2") #-}
+
+fails3 = NT.fails3 PSL
+{-# ANN fails3 (defSyn "fails3") #-}
+
+fails4 = NT.fails4 PSL
+{-# ANN fails4 (defSyn "fails4") #-}
+
+fails5 = NT.fails5 PSL
+{-# ANN fails5 (defSyn "fails5") #-}
+
+fails6 = NT.fails6 PSL
+{-# ANN fails6 (defSyn "fails6") #-}
+
+fails7 = NT.fails7 PSL
+{-# ANN fails7 (defSyn "fails7") #-}
+
+fails8 = NT.fails8 PSL
+{-# ANN fails8 (defSyn "fails8") #-}
+
+fails9 = NT.fails9 PSL
+{-# ANN fails9 (defSyn "fails9") #-}
+
+fails10 = NT.fails10 PSL
+{-# ANN fails10 (defSyn "fails10") #-}
+
+fails11 = NT.fails11 PSL
+{-# ANN fails11 (defSyn "fails11") #-}
+
+fails12 = NT.fails12 PSL
+{-# ANN fails12 (defSyn "fails12") #-}
+
+fails13 = NT.fails13 PSL
+{-# ANN fails13 (defSyn "fails13") #-}

--- a/tests/shouldfail/Verification/NonTemporalSVA.hs
+++ b/tests/shouldfail/Verification/NonTemporalSVA.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module NonTemporalSVA where
+
+import Clash.Prelude
+import Clash.Verification.Internal
+import qualified NonTemporal as NT
+
+-- Uncommented tests: SVA does not support "never" keyword
+
+fails1 = NT.fails1 SVA
+{-# ANN fails1 (defSyn "fails1") #-}
+
+fails2 = NT.fails2 SVA
+{-# ANN fails2 (defSyn "fails2") #-}
+
+fails3 = NT.fails3 SVA
+{-# ANN fails3 (defSyn "fails3") #-}
+
+--fails4 = NT.fails4 SVA
+--{-# ANN fails4 (defSyn "fails4") #-}
+
+fails5 = NT.fails5 SVA
+{-# ANN fails5 (defSyn "fails5") #-}
+
+--fails6 = NT.fails6 SVA
+--{-# ANN fails6 (defSyn "fails6") #-}
+--
+--fails7 = NT.fails7 SVA
+--{-# ANN fails7 (defSyn "fails7") #-}
+--
+--fails8 = NT.fails8 SVA
+--{-# ANN fails8 (defSyn "fails8") #-}
+
+fails9 = NT.fails9 SVA
+{-# ANN fails9 (defSyn "fails9") #-}
+
+--fails10 = NT.fails10 SVA
+--{-# ANN fails10 (defSyn "fails10") #-}
+--
+--fails11 = NT.fails11 SVA
+--{-# ANN fails11 (defSyn "fails11") #-}
+--
+--fails12 = NT.fails12 SVA
+--{-# ANN fails12 (defSyn "fails12") #-}
+
+fails13 = NT.fails13 SVA
+{-# ANN fails13 (defSyn "fails13") #-}

--- a/tests/shouldfail/Verification/Temporal.hs
+++ b/tests/shouldfail/Verification/Temporal.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Temporal where
+
+import           Data.Coerce
+
+import qualified Prelude                         as P
+
+import           Clash.Explicit.Prelude          hiding (assert, (&&), (||), not)
+import           Clash.Explicit.Testbench        hiding (assert, (&&), (||))
+import qualified Clash.Explicit.Verification     as V
+import           Clash.Explicit.Verification
+import           Clash.Verification.DSL
+import           Clash.Verification.Internal
+import           Clash.XException                (hwSeqX)
+
+assertCvResult
+  :: forall n dom
+   . (Bounded n, Enum n, Eq n, NFDataX n, KnownDomain dom)
+  => Clock dom -> Reset dom -> Enable dom
+  -> n
+  -> Signal dom AssertionResult
+  -> Signal dom Bool
+assertCvResult clk rst gen max results = done
+ where
+  counter = register clk rst gen (minBound :: n) (succ <$> counter)
+  done = (\(cvRes, c) -> cvRes `hwSeqX` c == max) <$> bundle (results, counter)
+{-# INLINE assertCvResult #-}
+
+binaryTest
+  :: ( dom ~ System
+     , AssertionValue dom x
+     , AssertionValue dom y
+     )
+  => RenderAs
+  -> x
+  -> y
+  -> (forall a b. (AssertionValue dom a, AssertionValue dom b) => a -> b -> Assertion dom)
+  -> Signal dom Bool
+binaryTest t x y f = done
+ where
+  done = outputVerifier' clk rst (False :> True :> Nil) asserted
+  asserted = assertCvResult clk rst enableGen (0 :: Index 3) assertion
+  assertion = check clk rst "propName" t (assert (f x y))
+  clk = tbSystemClockGen (P.not <$> done)
+  rst = resetGen
+{-# INLINE binaryTest #-}
+
+-- Tests below are single cycle non-temporal tests testing basic operators such
+-- as "&&", "||", "->", ..
+
+
+-- == |-> ==
+fails1 :: Signal System Bool
+fails1 = binaryTest PSL (lit True) (fromList [True, False]) (|->)
+{-# ANN fails1 (defSyn "fails1") #-}

--- a/testsuite/src/Test/Tasty/Clash.hs
+++ b/testsuite/src/Test/Tasty/Clash.hs
@@ -365,7 +365,7 @@ ghdlMake
 ghdlMake path modName subdirs libs entName =
   (testName, test)
   where
-    args = concat [ ["-m"]
+    args = concat [ ["-m", "-fpsl"]
                -- TODO: Automatically detect GCC/linker version
                -- Enable flags when running newer versions of the (GCC) linker.
                -- , ["-Wl,-no-pie"]
@@ -429,7 +429,7 @@ noConflict nm seen
   where
     go n
       | (nm ++ show n) `elem` seen = go (n+1)
-      | otherwise                  = (nm ++ show n)
+      | otherwise                  = (nm ++ "_" ++ show n)
 
 vvp
   :: Maybe (TestExitCode, T.Text)


### PR DESCRIPTION
Proof of concept code for assertion and coverage functionality in Clash. This tries to do the same as #828, but using a ADT keeping track of the combinators used. The ADT is later interpreted and pretty printed by a Haskell blackbox.

Example input:

```haskell
topEntity
  :: Clock System
  -> Signal System Bool
  -> Signal System Bool
  -> Signal System CvResult
topEntity clk a b =
  assert clk "MY_PROP" PSL 
    $ always 
    $ ((a .&&. b) ## b) |-> nextN 2 b
```

results in:

```vhdl
[..]
begin
  my_prop_block : block
    signal s : boolean;
  begin
    s <= a and b;

    -- psl property MY_PROP is
    -- (always {s; b} |-> next[2] b) @ clk;


  end block;
[..]
```

TODO:

- [x] More docs
- [ ] More tests
- [ ] Run it through QuestaSim?