### PR TITLE
Feature AutoReg

### DIFF
--- a/clash-ghc/CHANGELOG.md
+++ b/clash-ghc/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Added `NFDataX CUShort` instance`
   * Clash's internal type family solver now recognizes `AppendSymbol` and `CmpSymbol`
   * Added `Clash.Magic.suffixNameFromNat`: can be used in cases where `suffixName` is too slow
+  * Added `Clash.Class.AutoReg`. Improves the chances of synthesis tools inferring clock-gated registers, when used. See [#873](https://github.com/clash-lang/clash-compiler/pull/873).
   
 * New internal features:
   * [#821](https://github.com/clash-lang/clash-compiler/pull/821): Add `DebugTry`: print name of all tried transformations, even if they didn't succeed

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -325,9 +325,12 @@ test-suite unittests
       hint          >= 0.7      && < 0.10,
       tasty         >= 1.2      && < 1.3,
       tasty-hunit,
+      tasty-quickcheck,
       template-haskell
 
-  Other-Modules: Clash.Tests.BitPack
+  Other-Modules:
+                 Clash.Tests.AutoReg
+                 Clash.Tests.BitPack
                  Clash.Tests.BitVector
                  Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -128,6 +128,7 @@ Library
                       Clash.Annotations.SynthesisAttributes
                       Clash.Annotations.TH
 
+                      Clash.Class.AutoReg
                       Clash.Class.BitPack
                       Clash.Class.Exp
                       Clash.Class.HasDomain
@@ -218,7 +219,10 @@ Library
                       Clash.Tutorial
                       Clash.Examples
 
-  other-modules:      Clash.Class.BitPack.Internal
+  other-modules:
+                      Clash.Class.AutoReg.Instances
+                      Clash.Class.AutoReg.Internal
+                      Clash.Class.BitPack.Internal
                       Clash.CPP
                       Clash.Signal.Bundle.Internal
                       Language.Haskell.TH.Compat

--- a/clash-prelude/src/Clash/Class/AutoReg.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg.hs
@@ -1,0 +1,12 @@
+{-|
+  Copyright   :  (C) 2019, Google Inc.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+module Clash.Class.AutoReg
+  ( AutoReg (autoReg)
+  , deriveAutoReg
+  ) where
+
+import Clash.Class.AutoReg.Internal
+import Clash.Class.AutoReg.Instances ()

--- a/clash-prelude/src/Clash/Class/AutoReg/Instances.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Instances.hs
@@ -1,0 +1,35 @@
+{-|
+  Copyright   :  (C) 2019, Google Inc.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Clash.Class.AutoReg.Instances where
+
+import           Clash.Class.AutoReg.Internal
+import           Clash.CPP                           (maxTupleSize)
+
+#if MIN_VERSION_base(4,12,0)
+import           Data.Complex (Complex)
+import           Data.Ord (Down)
+#endif
+
+import           Data.Ratio (Ratio)
+
+#if MIN_VERSION_base(4,12,0)
+deriveAutoReg ''Complex
+deriveAutoReg ''Down
+#endif
+
+deriveAutoReg ''Ratio
+
+-- TODO: this needs NFDataX instances to maxTupleSize that in turn need
+-- TODO: generic instances for large tuples, but this slows GHC down by a
+-- TODO: lot. See: https://phabricator.haskell.org/D2899. Maybe we could add
+-- TODO: -flarge-tuples to clash-prelude?
+-- deriveAutoRegTuples [2..maxTupleSize]
+deriveAutoRegTuples [2..min maxTupleSize 15]

--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -1,0 +1,473 @@
+{-|
+  Copyright   :  (C) 2019, Google Inc.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE InstanceSigs         #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-} -- needed for constraint on the Fixed instance
+{-# LANGUAGE ViewPatterns         #-}
+
+#if __GLASGOW_HASKELL__ < 806
+{-# OPTIONS_GHC -Wwarn=unused-pattern-binds #-}
+#endif
+
+module Clash.Class.AutoReg.Internal
+  ( AutoReg (..)
+  , deriveAutoReg
+  , deriveAutoRegTuples
+  )
+  where
+
+import           Data.List                    (nub,zipWith4)
+import           Data.Maybe                   (fromMaybe,isJust)
+
+import           GHC.Stack                    (HasCallStack)
+import           GHC.TypeNats                 (KnownNat,Nat,type (+))
+import           Clash.Explicit.Signal
+import           Clash.Promoted.Nat
+import           Clash.Magic
+import           Clash.XException             (NFDataX, deepErrorX)
+
+import           Clash.Sized.BitVector
+import           Clash.Sized.Fixed
+import           Clash.Sized.Index
+import           Clash.Sized.RTree
+import           Clash.Sized.Signed
+import           Clash.Sized.Unsigned
+import           Clash.Sized.Vector           (Vec, lazyV, smap)
+
+import           Data.Int
+import           Data.Word
+import           Foreign.C.Types              (CUShort)
+import           Numeric.Half                 (Half)
+
+import           Language.Haskell.TH.Datatype
+import           Language.Haskell.TH.Syntax
+import           Language.Haskell.TH.Lib
+import           Language.Haskell.TH.Ppr
+
+import           Control.Lens.Internal.TH     (bndrName, conAppsT)
+
+-- $setup
+-- >>> import Data.Maybe
+-- >>> import Clash.Class.BitPack (pack)
+-- >>> :set -fplugin GHC.TypeLits.Normalise
+-- >>> :set -fplugin GHC.TypeLits.KnownNat.Solver
+
+-- | 'autoReg' is a "smart" version of 'register'. It does two things:
+--
+--   1. It splits product types over their fields. For example, given a 3-tuple,
+--   the corresponding HDL will end up with three instances of a register (or
+--   more if the three fields can be split up similarly).
+--
+--   2. Given a data type where a constructor indicates (parts) of the data will
+--   (not) be updated a given cycle, it will split the data in two parts. The
+--   first part will contain the "always interesting" parts (the constructor
+--   bits). The second holds the "potentially uninteresting" data (the rest).
+--   Both parts will be stored in separate registers. The register holding the
+--   "potentially uninteresting" part will only be enabled if the constructor
+--   bits indicate they're interesting.
+--
+--   The most important example of this is "Maybe". Consider "Maybe Byte)";
+--   when viewed as bits, a 'Nothing' would look like:
+--
+--     >>> pack @(Maybe (Signed 16)) Nothing
+--     0_...._...._...._....
+--
+--   and 'Just'
+--
+--     >>> pack @(Maybe (Signed 16)) (Just 3)
+--     1_0000_0000_0000_0011
+--
+--   In the first case, Nothing, we don't particularly care about updating the
+--   register holding the "Signed 16" field, as they'll be unknown anyway. We
+--   can therefore deassert its enable line.
+--
+-- Making Clash lay it out like this increases the chances of synthesis tools
+-- clock gating the registers, saving energy.
+--
+-- This version of 'autoReg' will split the given data type up recursively. For
+-- example, given "a :: Maybe (Maybe Int, Maybe Int)", a total of five registers
+-- will be rendered. Both the "interesting" and "uninteresting" enable lines of
+-- the inner Maybe types will be controlled by the outer one, in addition to
+-- the inner parts controlling their "uninteresting" parts as described in (2).
+--
+-- The default implementation is just 'register'. If you don't need or want
+-- the special features of "AutoReg", you can use that by writing an empty instance.
+--
+-- > data MyDataType = ...
+-- > instance AutoReg MyDataType
+--
+-- If you have a product type you can use 'deriveAutoReg' to derive an instance.
+--
+-- "Clash.Prelude" exports an implicit version of this: 'Clash.Prelude.autoReg'
+class NFDataX a => AutoReg a where
+  autoReg
+    :: (HasCallStack, KnownDomain dom)
+    => Clock dom -> Reset dom -> Enable dom
+    -> a  -- ^ Reset value
+    -> Signal dom a
+    -> Signal dom a
+  autoReg = register
+
+instance AutoReg ()
+instance AutoReg Bool
+
+instance AutoReg Double
+instance AutoReg Float
+instance AutoReg CUShort
+instance AutoReg Half
+
+instance AutoReg Char
+
+instance AutoReg Integer
+instance AutoReg Int
+instance AutoReg Int8
+instance AutoReg Int16
+instance AutoReg Int32
+instance AutoReg Int64
+instance AutoReg Word
+instance AutoReg Word8
+instance AutoReg Word16
+instance AutoReg Word32
+instance AutoReg Word64
+
+instance AutoReg Bit
+instance AutoReg (BitVector n)
+instance AutoReg (Signed n)
+instance AutoReg (Unsigned n)
+instance AutoReg (Index n)
+instance NFDataX (rep (int + frac)) => AutoReg (Fixed rep int frac)
+
+instance AutoReg a => AutoReg (Maybe a) where
+  autoReg clk rst en initVal input =
+    createMaybe <$> tagR <*> valR
+   where
+     tag = isJust <$> input
+     tagInit = isJust initVal
+     tagR = register clk rst en tagInit tag
+
+     val = fromMaybe (deepErrorX "autoReg'.val") <$> input
+     valInit = fromMaybe (deepErrorX "autoReg'.valInit") initVal
+
+     valR = autoReg clk rst (enable en tag) valInit val
+
+     createMaybe t v = case t of
+       True -> Just v
+       False -> Nothing
+
+instance (KnownNat n, AutoReg a) => AutoReg (Vec n a) where
+  autoReg
+    :: forall dom. (HasCallStack, KnownDomain dom)
+    => Clock dom -> Reset dom -> Enable dom
+    -> Vec n a -- ^ Reset value
+    -> Signal dom (Vec n a)
+    -> Signal dom (Vec n a)
+  autoReg clk rst en initVal xs =
+    bundle $ smap go (lazyV initVal) <*> unbundle xs
+   where
+    go :: forall (i :: Nat). SNat i -> a  -> Signal dom a -> Signal dom a
+    go SNat = suffixNameFromNat @i . autoReg clk rst en
+
+instance (KnownNat d, AutoReg a) => AutoReg (RTree d a) where
+  autoReg clk rst en initVal xs =
+    bundle $ (autoReg clk rst en) <$> lazyT initVal <*> unbundle xs
+
+
+-- | Decompose an applied type into its individual components. For example, this:
+--
+-- @
+-- Either Int Char
+-- @
+--
+-- would be unfolded to this:
+--
+-- @
+-- ('ConT' ''Either, ['ConT' ''Int, 'ConT' ''Char])
+-- @
+--
+-- This function ignores explicit parentheses and visible kind applications.
+--
+-- NOTE: Copied from "Control.Lens.Internal.TH".
+-- TODO: Remove this function. Can be removed once we can upgrade to lens 4.18.
+-- TODO: This is currently difficult due to issue with nix.
+unfoldType :: Type -> (Type, [Type])
+unfoldType = go []
+  where
+    go :: [Type] -> Type -> (Type, [Type])
+    go acc (ForallT _ _ ty) = go acc ty
+    go acc (AppT ty1 ty2)   = go (ty2:acc) ty1
+    go acc (SigT ty _)      = go acc ty
+#if MIN_VERSION_template_haskell(2,11,0)
+    go acc (ParensT ty)     = go acc ty
+#endif
+#if MIN_VERSION_template_haskell(2,15,0)
+    go acc (AppKindT ty _)  = go acc ty
+#endif
+    go acc ty               = (ty, acc)
+
+-- | Automatically derives an 'AutoReg' instance for a product type
+--
+-- Usage:
+--
+-- > data Pair a b = MkPair { getA :: a, getB :: b } deriving (Generic, NFDataX)
+-- > data Tup3 a b c = MkTup3 { getAB :: Pair a b, getC :: c } deriving (Generic, NFDataX)
+-- > deriveAutoReg ''Pair
+-- > deriveAutoReg ''Tup3
+--
+-- __NB__: Because of the way template haskell works the order here matters,
+-- if you try to @deriveAutoReg ''Tup3@ before @Pair@ it will complain
+-- about missing an @instance AutoReg (Pair a b)@.
+deriveAutoReg :: Name -> DecsQ
+deriveAutoReg tyNm = do
+  tyInfo <- reifyDatatype tyNm
+  case datatypeCons tyInfo of
+    [] -> fail "Can't deriveAutoReg for empty types"
+    [conInfo] -> deriveAutoRegProduct tyInfo conInfo
+    _ -> fail "Can't deriveAutoReg for sum types"
+
+
+
+{-
+For a type like:
+   data Product a b .. = MkProduct { getA :: a, getB :: b, .. }
+This generates the following instance:
+
+instance (AutoReg a, AutoReg b, ..) => AutoReg (Product a b ..) where
+  autoReg clk rst en initVal input =
+    MkProduct <$> sig0 <*> sig1 ...
+    where
+      field0 = (\(MkProduct x _ ...) -> x) <$> input
+      field1 = (\(MkProduct _ x ...) -> x) <$> input
+      ...
+      MkProduct initVal0 initVal1 ... = initVal
+      sig0 = suffixName @"getA" autoReg clk rst en initVal0 field0
+      sig1 = suffixName @"getB" autoReg clk rst en initVal1 field1
+      ...
+-}
+deriveAutoRegProduct :: DatatypeInfo -> ConstructorInfo -> DecsQ
+deriveAutoRegProduct tyInfo conInfo = go (constructorName conInfo) fieldInfos
+ where
+  tyNm = datatypeName tyInfo
+  tyVarBndrs = datatypeVars tyInfo
+
+#if MIN_VERSION_th_abstraction(0,3,0)
+  toTyVar = VarT . bndrName
+#else
+  toTyVar t = case t of
+    VarT _ -> t
+    SigT t' _ -> toTyVar t'
+    _ -> error "deriveAutoRegProduct.toTv"
+#endif
+
+  tyVars = map toTyVar tyVarBndrs
+  ty = conAppsT tyNm tyVars
+
+  fieldInfos =
+    zip fieldNames (constructorFields conInfo)
+   where
+    fieldNames =
+      case constructorVariant conInfo of
+        RecordConstructor nms -> map Just nms
+        _ -> repeat Nothing
+
+  go :: Name -> [(Maybe Name,Type)] -> Q [Dec]
+  go dcNm fields = do
+    args <- mapM newName ["clk", "rst", "en", "initVal", "input"]
+    let
+      [clkE, rstE, enE, initValE, inputE] = map varE args
+      argsP = map varP args
+      fieldNames = map fst fields
+
+      field :: Name -> Int -> DecQ
+      field nm nr =
+        valD (varP nm) (normalB [| $fieldSel <$> $inputE |]) []
+       where
+        fieldSel = do
+          xNm <- newName "x"
+          let fieldP = [ if nr == n then varP xNm else wildP
+                       | (n,_) <- zip [0..] fields]
+          lamE [conP dcNm fieldP] (varE xNm)   -- "\(Dc _ _ .. x _ ..) -> x"
+
+    parts <- generateNames "field" fields
+    fieldDecls <- sequence $ zipWith field parts [0..]
+    sigs <- generateNames "sig" fields
+    initVals <- generateNames "initVal" fields
+    let initPat = conP dcNm (map varP initVals)
+    initDecl <- valD initPat (normalB initValE) []
+
+    let
+      genAutoRegDecl :: PatQ -> ExpQ -> ExpQ -> Maybe Name -> DecsQ
+      genAutoRegDecl s v i nameM =
+        [d| $s = $nameMe autoReg $clkE $rstE $enE $i $v |]
+       where
+        nameMe = case nameM of
+          Nothing -> [| id |]
+          Just nm -> let nmSym = litT $ strTyLit (nameBase nm)
+                     in [| suffixName @($nmSym) |]
+
+    partDecls <- concat <$> (sequence $ zipWith4 genAutoRegDecl
+                                                 (varP <$> sigs)
+                                                 (varE <$> parts)
+                                                 (varE <$> initVals)
+                                                 (fieldNames)
+                            )
+    let
+        decls :: [DecQ]
+        decls = map pure (initDecl : fieldDecls ++ partDecls)
+        tyConE = conE dcNm
+        body =
+          case map varE sigs of
+            (sig0:rest) -> foldl
+                             (\acc sigN -> [| $acc <*> $sigN |])
+                             [| $tyConE <$> $sig0 |]
+                             rest
+            [] -> [| $tyConE |]
+
+    autoRegDec <- funD 'autoReg [clause argsP (normalB body) decls]
+    ctx <- calculateRequiredContext conInfo
+    return [InstanceD Nothing ctx (AppT (ConT ''AutoReg) ty) [autoRegDec]]
+
+-- Calculate the required constraint to call autoReg on all the fields of a
+-- given constructor
+calculateRequiredContext :: ConstructorInfo -> Q Cxt
+calculateRequiredContext conInfo = do
+  let fieldTys = constructorFields conInfo
+  wantedInstances <- mapM (\ty -> constraintsWantedFor ''AutoReg [ty]) (nub fieldTys)
+  return $ nub (concat wantedInstances)
+
+constraintsWantedFor :: Name -> [Type] -> Q Cxt
+constraintsWantedFor clsNm tys
+  | show clsNm == "GHC.TypeNats.KnownNat" = do
+  -- KnownNat is special, you can't just lookup instances with reifyInstances.
+  -- So we just pass KnownNat constraints.
+  -- This will most likely require UndecidableInstances.
+    return [conAppsT clsNm tys]
+
+constraintsWantedFor clsNm [ty] = case ty of
+  VarT _ -> return [AppT (ConT clsNm) ty]
+  ConT _ -> return []
+  _ -> do
+    insts <- reifyInstances clsNm [ty]
+    case insts of
+      [InstanceD _ cxtInst (AppT autoRegCls instTy) _]
+        | autoRegCls == ConT clsNm -> do
+          let substs = findTyVarSubsts instTy ty
+              cxt2 = map (applyTyVarSubsts substs) cxtInst
+              okCxt = filter isOk cxt2
+              recurseCxt = filter needRecurse cxt2
+          recursed <- mapM recurse recurseCxt
+          return (okCxt ++ concat recursed)
+      []      -> fail $ "Missing instance " ++ show clsNm ++ " (" ++ pprint ty ++ ")"
+      (_:_:_) -> fail $ "There are multiple " ++ show clsNm ++ " instances for "
+                     ++ pprint ty ++ ":\n" ++ pprint insts
+      _ -> fail $ "Got unexpected instance: " ++ pprint insts
+ where
+  isOk :: Type -> Bool
+  isOk (unfoldType -> (_cls,tys)) =
+    case tys of
+      [VarT _] -> True
+      [_] -> False
+      _ -> True -- see [NOTE: MultiParamTypeClasses]
+  needRecurse :: Type -> Bool
+  needRecurse (unfoldType -> (cls,tys)) =
+    case tys of
+      [VarT _] -> False
+      [ConT _] -> False  -- we can just drop constraints like: "AutoReg Bool => ..."
+      [AppT _ _] -> True
+      [_] -> error ( "Error while deriveAutoReg: don't know how to handle: "
+                  ++ pprint cls ++ " (" ++ pprint tys ++ ")" )
+      _ -> False  -- see [NOTE: MultiParamTypeClasses]
+
+  recurse :: Type -> Q Cxt
+  recurse (unfoldType -> (ConT cls,tys)) = constraintsWantedFor cls tys
+  recurse t =
+    fail ("Expected a class applied to some arguments but got " ++ pprint t)
+
+constraintsWantedFor clsNm tys =
+  return [conAppsT clsNm tys] -- see [NOTE: MultiParamTypeClasses]
+
+-- [NOTE: MultiParamTypeClasses]
+-- The constraint calculation code doesn't handle MultiParamTypeClasses
+-- "properly", but it will try to pass them on, so the resulting instance should
+-- still compile with UndecidableInstances enabled.
+
+
+-- | Find tyVar substitutions between a general type and a second possibly less
+-- general type. For example:
+--
+-- @
+-- findTyVarSubsts "Either a b" "Either c [Bool]"
+--   == "[(a,c), (b,[Bool])]"
+-- @
+findTyVarSubsts :: Type -> Type -> [(Name,Type)]
+findTyVarSubsts = go
+ where
+  go ty1 ty2 = case (ty1,ty2) of
+    (VarT nm1       , VarT nm2) | nm1 == nm2 -> []
+    (VarT nm        , t)                     -> [(nm,t)]
+    (ConT _         , ConT _)                -> []
+    (AppT x1 y1     , AppT x2 y2)            -> go x1 x2 ++ go y1 y2
+    (SigT t1 k1     , SigT t2 k2)            -> go t1 t2 ++ go k1 k2
+    (InfixT x1 _ y1 , InfixT x2 _ y2)        -> go x1 x2 ++ go y1 y2
+    (UInfixT x1 _ y1, UInfixT x2 _ y2)       -> go x1 x2 ++ go y1 y2
+    (ParensT x1     , ParensT x2)            -> go x1 x2
+
+#if __GLASGOW_HASKELL__ >= 808
+    (AppKindT t1 k1     , AppKindT t2 k2)      -> go t1 t2 ++ go k1 k2
+    (ImplicitParamT _ x1, ImplicitParamT _ x2) -> go x1 x2
+#endif
+
+    (PromotedT _          , PromotedT _          ) -> []
+    (TupleT _             , TupleT _             ) -> []
+    (UnboxedTupleT _      , UnboxedTupleT _      ) -> []
+    (UnboxedSumT _        , UnboxedSumT _        ) -> []
+    (ArrowT               , ArrowT               ) -> []
+    (EqualityT            , EqualityT            ) -> []
+    (ListT                , ListT                ) -> []
+    (PromotedTupleT _     , PromotedTupleT _     ) -> []
+    (PromotedNilT         , PromotedNilT         ) -> []
+    (PromotedConsT        , PromotedConsT        ) -> []
+    (StarT                , StarT                ) -> []
+    (ConstraintT          , ConstraintT          ) -> []
+    (LitT _               , LitT _               ) -> []
+    (WildCardT            , WildCardT            ) -> []
+    _ -> error $ unlines [ "findTyVarSubsts: Unexpected types"
+                         , "ty1:", pprint ty1,"ty2:", pprint ty2]
+
+applyTyVarSubsts :: [(Name,Type)] -> Type -> Type
+applyTyVarSubsts substs ty = go ty
+  where
+    go ty' = case ty' of
+      VarT n -> case lookup n substs of
+                  Nothing -> ty'
+                  Just m  -> m
+      ConT _ -> ty'
+      AppT ty1 ty2 -> AppT (go ty1) (go ty2)
+      _ -> error $ "TODO applyTyVarSubsts: " ++ show ty'
+
+
+-- | Generate a list of fresh Name's:
+-- prefix0_.., prefix1_.., prefix2_.., ..
+generateNames :: String -> [a] -> Q [Name]
+generateNames prefix xs =
+  sequence (zipWith (\n _ -> newName $ prefix ++ show @Int n) [0..] xs)
+
+deriveAutoRegTuples :: [Int] -> DecsQ
+deriveAutoRegTuples xs = concat <$> mapM deriveAutoRegTuple xs
+
+deriveAutoRegTuple :: Int -> DecsQ
+deriveAutoRegTuple n
+  | n < 2 = fail $ "deriveAutoRegTuple doesn't work for " ++ show n ++ "-tuples"
+  | otherwise = deriveAutoReg tupN
+  where
+    tupN = mkName $ "(" ++ replicate (n-1) ',' ++ ")"

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -108,6 +108,7 @@ module Clash.Explicit.Prelude
   , Lift (..)
     -- ** Type classes
     -- *** Clash
+  , module Clash.Class.AutoReg
   , module Clash.Class.BitPack
   , module Clash.Class.Exp
   , module Clash.Class.Num
@@ -138,6 +139,7 @@ import Language.Haskell.TH.Syntax  (Lift(..))
 import Clash.HaskellPrelude
 
 import Clash.Annotations.TopEntity
+import Clash.Class.AutoReg
 import Clash.Class.BitPack
 import Clash.Class.Exp
 import Clash.Class.Num

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -35,6 +35,7 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE MonoLocalBinds    #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators     #-}
 
@@ -133,6 +134,8 @@ module Clash.Prelude
   , Lift (..)
     -- ** Type classes
     -- *** Clash
+  -- , module Clash.Class.AutoReg
+  , autoReg, deriveAutoReg
   , module Clash.Class.BitPack
   , module Clash.Class.Exp
   , module Clash.Class.Num
@@ -159,12 +162,14 @@ where
 import           Control.Applicative
 import           Data.Bits
 import           Data.Default.Class
+import           GHC.Stack                   (HasCallStack)
 import           GHC.TypeLits
 import           GHC.TypeLits.Extra
 import           Language.Haskell.TH.Syntax  (Lift(..))
 import           Clash.HaskellPrelude
 
 import           Clash.Annotations.TopEntity
+import           Clash.Class.AutoReg         (AutoReg, deriveAutoReg)
 import           Clash.Class.BitPack
 import           Clash.Class.Exp
 import           Clash.Class.Num
@@ -259,3 +264,11 @@ windowD
   -- ^ Window of at least size 1
 windowD = hideClockResetEnable E.windowD
 {-# INLINE windowD #-}
+
+-- | Implicit version of 'Clash.Class.AutoReg.autoReg'
+autoReg
+  :: (HasCallStack, HiddenClockResetEnable dom, AutoReg a)
+  => a
+  -> Signal dom a
+  -> Signal dom a
+autoReg = hideClockResetEnable E.autoReg

--- a/clash-prelude/tests/Clash/Tests/AutoReg.hs
+++ b/clash-prelude/tests/Clash/Tests/AutoReg.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Clash.Tests.AutoReg where
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import qualified Data.List as L
+import Clash.Prelude
+import Clash.Class.AutoReg (AutoReg)
+
+test :: (Eq a, Show a, AutoReg a, Arbitrary a) => a -> [a] -> Property
+test initVal xs = testFor (L.length xs) $ register initVal input .==. autoReg initVal input
+  where input = fromList @_ @System xs
+
+tests :: TestTree
+tests =
+  testGroup
+    "AutoReg"
+      [ testGroup "autoReg === register"
+        [ testProperty "Int" $ test @Int
+        , testProperty "(Unsigned 4, Bool)" $ test @(Unsigned 4, Bool)
+        , testProperty "Maybe Bool" $ test @(Maybe Bool)
+        -- , testProperty "Either Bool (Unsigned 3)" $ test @(Either Bool (Unsigned 3))
+
+        , testProperty "Vec 4 Bool" $ test @(Vec 4 Bool)
+        , testProperty "Vec 4 (Maybe Bool)" $ test @(Vec 4 (Maybe Bool))
+
+        , testProperty "Maybe (Vec 4 Bool)" $ test @(Maybe (Vec 4 Bool))
+        , testProperty "Maybe (Maybe (Vec 4 Bool))" $ test @(Maybe (Maybe (Vec 4 Bool)))
+
+        , testProperty "RTree 2 Bool" $ test @(RTree 2 Bool)
+        , testProperty "Maybe (RTree 2 Bool)" $ test @(Maybe (RTree 2 Bool))
+        , testProperty "Maybe (Maybe (RTree 2 Bool))" $ test @(Maybe (Maybe (RTree 2 Bool)))
+
+        , testProperty "Maybe (Vec 4 (Maybe (Vec 3 Bool)))" $ test @(Maybe (Vec 4 (Maybe (Vec 3 Bool))))
+        ]
+      ]

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Test.Tasty
 
+import qualified Clash.Tests.AutoReg
 import qualified Clash.Tests.BitPack
 import qualified Clash.Tests.BitVector
 import qualified Clash.Tests.DerivingDataRepr
@@ -11,7 +12,8 @@ import qualified Clash.Tests.TopEntityGeneration
 
 tests :: TestTree
 tests = testGroup "Unittests"
-  [ Clash.Tests.BitPack.tests
+  [ Clash.Tests.AutoReg.tests
+  , Clash.Tests.BitPack.tests
   , Clash.Tests.BitVector.tests
   , Clash.Tests.DerivingDataRepr.tests
   , Clash.Tests.Signal.tests

--- a/tests/shouldwork/AutoReg/AutoReg.hs
+++ b/tests/shouldwork/AutoReg/AutoReg.hs
@@ -1,0 +1,127 @@
+{-|
+  Copyright   :  (C) 2019, Google Inc.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
+
+-- Plugins don't load automatically when running the output tests
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
+
+module AutoReg where
+import Data.Int
+import Clash.Prelude
+import Clash.Class.AutoReg (AutoReg)
+import Clash.Sized.Internal.BitVector
+import Control.Monad (when)
+import qualified Data.List as L
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+#ifndef OUTPUTTEST
+data Tup2 a b = MkTup2 { getA :: a, getB :: b } deriving (Generic,NFDataX)
+instance (BitPack a,BitPack b, KnownNat (BitSize a),KnownNat (BitSize b)) => BitPack (Tup2 a b)
+deriveAutoReg ''Tup2
+
+
+data Tup3 a b c = MkTup3 { fieldA :: a, fieldB :: b, fieldC :: c } deriving (Generic,NFDataX)
+instance
+  ( BitPack a,BitPack b,BitPack c
+  , KnownNat (BitSize a), KnownNat (BitSize b), KnownNat (BitSize c)
+  )
+    => BitPack (Tup3 a b c)
+deriveAutoReg ''Tup3
+
+
+newtype OtherPair a b = OtherPair (Tup2 a b) deriving (Generic,NFDataX)
+instance (BitPack a,BitPack b, KnownNat (BitSize a),KnownNat (BitSize b)) => BitPack (OtherPair a b)
+deriveAutoReg ''OtherPair
+
+data Tup2_ a b c = MkTup2_ a b deriving (Generic,NFDataX)
+instance (BitPack a,BitPack b, KnownNat (BitSize a),KnownNat (BitSize b)) => BitPack (Tup2_ a b c)
+deriveAutoReg ''Tup2_
+-- NOTE: For some reason this deriveAutoReg ''Tup2_ creates invalid code when
+-- run by runghc-8.4.4 for the output test. (newer versions are ok)
+-- Since output test only cares about main[VHDL,...] we can #ifndef the rest away.
+
+data Concrete = BoolAndInt Bool Int8 deriving (Generic,NFDataX,BitPack)
+deriveAutoReg ''Concrete
+
+data InfixDataCon a b = a :-.- b deriving (Generic,NFDataX)
+instance (BitPack a,BitPack b,KnownNat (BitSize a),KnownNat (BitSize b)) => BitPack (InfixDataCon a b)
+deriveAutoReg ''InfixDataCon
+
+
+test
+  :: forall a dom n rest
+   . ( HiddenClockResetEnable dom
+     , AutoReg a, BitPack a
+     , KnownNat (BitSize a), KnownNat n, KnownNat rest
+     , rest ~ (n-(BitSize a))
+     )
+  => Signal dom (BitVector n) -> Signal dom a
+test = autoReg (unpack 0) . fmap (unpack . fst . split# @rest)
+
+topEntity
+  :: Clock System -> Reset System
+  -> Signal System (BitVector 32)
+  -> _
+topEntity clk rst xs = withClockResetEnable clk rst enableGen $ bundle $
+  ( test @(Unsigned 16) xs
+  , test @Bool xs
+  , test @(Tup2 Bool Bool) xs
+  , test @(Tup3 Bool Bool Bool) xs
+  , test @(Maybe Bool) xs
+  , test @(Maybe (Maybe Bool)) xs
+  , test @(OtherPair Int8 Int16) xs
+  , test @Concrete xs
+  , test @(InfixDataCon Bool Bool) xs
+  , test @((),Bool) xs
+  , test @(Vec 2 Bool) xs
+  , test @(Vec 2 (Maybe Bool)) xs
+  , test @(Maybe (Vec 2 (Maybe Bool))) xs
+  )
+#endif
+
+expectedRegCount = sum
+  [ 1   -- Unsigned
+  , 1   -- Bool
+  , 2   -- Tup2
+  , 3   -- Tup3
+  , 2   -- Maybe Bool
+  , 3   -- Maybe (Maybe Bool)
+  , 2   -- OtherPair Int8 Int16
+  , 2   -- Concrete
+  , 2   -- InfixDataCon Bool Bool
+  , 1   -- ((),Bool)
+  , 2   -- Vec 2 Bool
+  , 2*2 -- Vec 2 (Maybe Bool)
+  , 1+2*2 -- Maybe (Vec 2 (Maybe Bool))
+  ]
+
+countLinesContaining :: String -> String -> Int
+countLinesContaining needle haystack = L.length $ L.filter (needle `L.isInfixOf`) $ lines haystack
+
+mainHDL :: String -> IO ()
+mainHDL topFile = do
+  [topDir] <- getArgs
+  content <- readFile (takeDirectory topDir </> topFile)
+  let regCount = countLinesContaining "register begin" content
+  when (expectedRegCount /= regCount)
+    (error $ unlines
+      [ ""
+      , "Error: Found " <> show regCount <> " registers in " <> topFile
+      , "But expected " <> show expectedRegCount
+      ])
+
+mainSystemVerilog, mainVerilog, mainVHDL :: IO ()
+mainSystemVerilog = mainHDL "topEntity.sv"
+mainVerilog       = mainHDL "topEntity.v"
+mainVHDL          = mainHDL "topentity.vhdl"

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -62,7 +62,10 @@ runClashTest =
       , runTest ("examples" </> "i2c")   defBuild ["-O2","-fclash-component-prefix","test"] "I2C"          (["test_i2c","test_bitmaster","test_bytemaster"],"test_i2c",False)
       ]
     , clashTestGroup "Unit"
-      [ clashTestGroup "Basic"
+      [ clashTestGroup "AutoReg"
+        [ outputTest ("tests" </> "shouldwork" </> "AutoReg") defBuild [] [] "AutoReg" "main"
+        ]
+      , clashTestGroup "Basic"
         [ -- TODO: Enable AES test on SystemVerilog. See issue #569.
           runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "AES"                 ([""],"topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "BangData"            ([""],"topEntity",False)

--- a/testsuite/Test/Tasty/Clash.hs
+++ b/testsuite/Test/Tasty/Clash.hs
@@ -617,6 +617,7 @@ outputTest' env target extraClashArgs extraGhcArgs modName funcName path =
              , "-XTypeApplications"
              , "-XTypeFamilies"
              , "-XTypeOperators"
+             , "-DOUTPUTTEST"
              , "--ghc-arg=-main-is"
              , "--ghc-arg=" ++ modName ++ "." ++ funcName ++ show target
              ] ++ map ("--ghc-arg="++) extraGhcArgs ++


### PR DESCRIPTION
`autoReg` is a "smart" version of `register`. It does two things:

  1. It splits product types over their fields. For example, given a 3-tuple,
  the corresponding HDL will end up with three instances of a register (or
  more if the three fields can be split up similarly).

  2. Given a data type where a constructor indicates (parts) of the data will
  (not) be updated a given cycle, it will split the data in two parts. The
  first part will contain the "always interesting" parts (the constructor
  bits). The second holds the "potentially uninteresting" data (the rest).
  Both parts will be stored in separate registers. The register holding the
  "potentially uninteresting" part will only be enabled if the constructor
  bits indicate they're interesting.

  The most important example of this is `Maybe`. Consider `Maybe Byte`;
  when viewed as bits, a `Nothing` would look like:

    >>> pack @(Maybe (Signed 16)) Nothing
    0_...._...._...._....

  and `Just`

    >>> pack @(Maybe (Signed 16)) (Just 3)
    1_0000_0000_0000_0011

  In the first case, Nothing, we don't particularly care about updating the
  register holding the `Signed 16` field, as they'll be unknown anyway. We
  can therefore deassert its enable line.

Making Clash lay it out like this increases the chances of synthesis tools
clock gating the registers, saving energy.

This version of `autoReg` will split the given data type up recursively. For
example, given `a :: Maybe (Maybe Int, Maybe Int)`, a total of five registers
will be rendered. Both the "interesting" and "uninteresting" enable lines of
the inner Maybe types will be controlled by the outer one, in addition to
the inner parts controlling their "uninteresting" parts as described in (2).

The default implementation is just `register`. If you don't need or want the special features of `AutoReg`, you can use that by writing an empty instance.

```haskell
data MyDataType = ...
instance AutoReg MyDataType
```

If you have a product type you can use `deriveAutoReg` to derive an instance.