### PR TITLE
Add '-fclash-no-catch-errors'

### DIFF
--- a/clash-ghc/CHANGELOG.md
+++ b/clash-ghc/CHANGELOG.md
@@ -9,6 +9,7 @@
 * New internal features:
   * [#821](https://github.com/clash-lang/clash-compiler/pull/821): Add `DebugTry`: print name of all tried transformations, even if they didn't succeed
   * [#856](https://github.com/clash-lang/clash-compiler/pull/856): Add `-fclash-debug-transformations`: only print debug info for specific transformations
+  * [#879](https://github.com/clash-lang/clash-compiler/pull/879): Add `-fclash-no-catch-errors`: don't try and catch errors in Clash compiler; let GHC handle it instead
 
 * Fixes issues:
   * [#810](https://github.com/clash-lang/clash-compiler/issues/810): Verilog backend now correctly specifies type of `BitVector 1`

--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -294,7 +294,12 @@ main' postLoadMode dflags0 args flagWarnings clashOpts = do
        GHC.printException e
        liftIO $ exitWith (ExitFailure 1)) $ do
     clashOpts' <- liftIO (readIORef clashOpts)
-    let clash fun = gcatch (fun clashOpts srcs) (handleClashException dflags6 clashOpts')
+    let
+      clash fun =
+        if opt_catchErrors clashOpts' then
+          gcatch (fun clashOpts srcs) (handleClashException dflags6 clashOpts')
+        else
+          fun clashOpts srcs
     case postLoadMode of
        ShowInterface f        -> liftIO $ doShowIface dflags6 f
        DoMake                 -> doMake srcs

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -285,7 +285,12 @@ main' postLoadMode dflags0 args flagWarnings clashOpts = do
        GHC.printException e
        liftIO $ exitWith (ExitFailure 1)) $ do
     clashOpts' <- liftIO (readIORef clashOpts)
-    let clash fun = gcatch (fun clashOpts srcs) (handleClashException dflags6 clashOpts')
+    let
+      clash fun =
+        if opt_catchErrors clashOpts' then
+          gcatch (fun clashOpts srcs) (handleClashException dflags6 clashOpts')
+        else
+          fun clashOpts srcs
     case postLoadMode of
        ShowInterface f        -> liftIO $ doShowIface dflags6 f
        DoMake                 -> doMake srcs

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -295,7 +295,12 @@ main' postLoadMode dflags0 args flagWarnings clashOpts = do
        GHC.printException e
        liftIO $ exitWith (ExitFailure 1)) $ do
     clashOpts' <- liftIO (readIORef clashOpts)
-    let clash fun = gcatch (fun clashOpts srcs) (handleClashException dflags6 clashOpts')
+    let
+      clash fun =
+        if opt_catchErrors clashOpts' then
+          gcatch (fun clashOpts srcs) (handleClashException dflags6 clashOpts')
+        else
+          fun clashOpts srcs
     case postLoadMode of
        ShowInterface f        -> liftIO $ doShowIface dflags6 f
        DoMake                 -> doMake srcs

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -84,6 +84,7 @@ flagsClash r = [
   , defFlag "fclash-no-escaped-identifiers"      $ NoArg (liftEwM (setNoEscapedIds r))
   , defFlag "fclash-compile-ultra"               $ NoArg (liftEwM (setUltra r))
   , defFlag "fclash-force-undefined"             $ OptIntSuffix (setUndefined r)
+  , defFlag "fclash-no-catch-errors"             $ NoArg (liftEwM (setNoCatchErrors r))
   ]
 
 -- | Print deprecated flag warning
@@ -145,6 +146,9 @@ setNoCache r = modifyIORef r (\c -> c {opt_cachehdl = False})
 
 setNoIDirCheck :: IORef ClashOpts -> IO ()
 setNoIDirCheck r = modifyIORef r (\c -> c {opt_checkIDir = False})
+
+setNoCatchErrors :: IORef ClashOpts -> IO ()
+setNoCatchErrors r = modifyIORef r (\c -> c {opt_catchErrors = False})
 
 setNoClean :: IORef ClashOpts -> IO ()
 setNoClean r = modifyIORef r (\c -> c {opt_cleanhdl = False})

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -89,6 +89,12 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            -- * /Just (Just x)/: replace undefined's by /x/ in
                            -- the HDL
                            , opt_checkIDir   :: Bool
+                           , opt_catchErrors :: Bool
+                           -- ^ Whether to catch errors in Clash. Settings this
+                           -- to false might cause 'please report as GHC bug' to
+                           -- appear. On the flipside, it might generate more
+                           -- informative error messages when debugging the
+                           -- compiler - especially on profiling builds.
                            }
 
 
@@ -117,6 +123,7 @@ defClashOpts
   , opt_ultra               = False
   , opt_forceUndefined      = Nothing
   , opt_checkIDir           = True
+  , opt_catchErrors         = True
   }
 
 -- | Information about the generated HDL between (sub)runs of the compiler


### PR DESCRIPTION
Whether to catch errors in Clash. Settings this to false might cause
'please report as GHC bug' to appear. On the flipside, it might generate
more informative error messages when debugging the compiler - especially
on profiling builds.