### PR TITLE
Add Clash.Magic.suffixNameFromNat

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -335,6 +335,9 @@ coreToTerm primMap unlocs = term
         go "Clash.Magic.suffixName" args
           | [Type nmTy,_aTy,f] <- args
           = C.Tick <$> (C.NameMod C.SuffixName <$> coreToType nmTy) <*> term f
+        go "Clash.Magic.suffixNameFromNat" args
+          | [Type nmTy,_aTy,f] <- args
+          = C.Tick <$> (C.NameMod C.SuffixName <$> coreToType nmTy) <*> term f
         go "Clash.Magic.setName" args
           | [Type nmTy,_aTy,f] <- args
           = C.Tick <$> (C.NameMod C.SetName <$> coreToType nmTy) <*> term f

--- a/clash-lib/prims/common/Clash_Magic.json
+++ b/clash-lib/prims/common/Clash_Magic.json
@@ -9,6 +9,11 @@
     }
   }
 , { "Primitive" :
+    { "name"      : "Clash.Magic.suffixNameFromNat"
+    , "primType"  : "Function"
+    }
+  }
+, { "Primitive" :
     { "name"      : "Clash.Magic.setName"
     , "primType"  : "Function"
     }

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -923,12 +923,13 @@ stripTicks :: Term -> Term
 stripTicks (Tick _ e) = stripTicks e
 stripTicks e = e
 
--- | Try to reduce an arbitrary type to a Symbol, and subsequently extract its
--- String representation
-tySym
+-- | Try to reduce an arbitrary type to a literal type (Symbol or Nat),
+-- and subsequently extract its String representation
+tyLitShow
   :: TyConMap
   -> Type
   -> Except String String
-tySym m (coreView1 m -> Just ty) = tySym m ty
-tySym _ (LitTy (SymTy s))        = return s
-tySym _ ty = throwE $ $(curLoc) ++ "Cannot reduce to a string:\n" ++ showPpr ty
+tyLitShow m (coreView1 m -> Just ty) = tyLitShow m ty
+tyLitShow _ (LitTy (SymTy s))        = return s
+tyLitShow _ (LitTy (NumTy s))        = return (show s)
+tyLitShow _ ty = throwE $ $(curLoc) ++ "Cannot reduce to a string:\n" ++ showPpr ty

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -75,7 +75,7 @@ import           Clash.Core.TyCon
 import           Clash.Core.Type         (Type (..), TypeView (..),
                                           coreView1, splitTyConAppM, tyView, TyVar)
 import           Clash.Core.Util
-  (collectBndrs, stripTicks, substArgTys, termType, tySym)
+  (collectBndrs, stripTicks, substArgTys, termType, tyLitShow)
 import           Clash.Core.Var
   (Id, Var (..), mkLocalId, modifyVarName, Attr')
 import           Clash.Core.VarEnv
@@ -1868,7 +1868,7 @@ withTicks ticks0 k = do
 
   go decls (NameMod m nm0:ticks) = do
     tcm <- Lens.use tcCache
-    case runExcept (tySym tcm nm0) of
+    case runExcept (tyLitShow tcm nm0) of
       Right nm1 -> local (modName m nm1) (go decls ticks)
       _ -> go decls ticks
 

--- a/clash-prelude/src/Clash/Magic.hs
+++ b/clash-prelude/src/Clash/Magic.hs
@@ -14,7 +14,7 @@ Control module instance, and register, names in generated HDL code.
 module Clash.Magic where
 
 import Clash.NamedTypes ((:::))
-import GHC.TypeLits     (Symbol)
+import GHC.TypeLits     (Nat,Symbol)
 
 -- | Prefix instance and register names with the given 'Symbol'
 prefixName
@@ -27,6 +27,12 @@ suffixName
   :: forall (name :: Symbol) a . a -> name ::: a
 suffixName = id
 {-# NOINLINE suffixName #-}
+
+-- | Suffix instance and register names with the given 'Nat'
+suffixNameFromNat
+  :: forall (name :: Nat) a . a -> name ::: a
+suffixNameFromNat = id
+{-# NOINLINE suffixNameFromNat #-}
 
 -- | Name the instance or register with the given 'Symbol', instead of using
 -- an auto-generated name. Pre- and suffixes annotated with 'prefixName' and


### PR DESCRIPTION
It's the same as suffixName but it take a Nat instead of on a Symbol.
By supporting Nat's directly we can avoid using the Show_ type family.

Which clash can solve, but it takes a long time to do so.
A couple of minutes to go from `Show_ (3 :: Nat)`
 to  `"3" :: Symbol`.