### PR TITLE
Generate NFDataX tuple instances with TemplateHaskell

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -212,6 +212,7 @@ Library
                       Clash.Sized.Internal.Unsigned
 
                       Clash.XException
+                      Clash.XException.TH
 
                       Clash.Xilinx.ClockGen
                       Clash.Xilinx.DDR

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -65,6 +65,16 @@ source-repository head
   location: https://github.com/clash-lang/clash-compiler.git
   subdir: clash-prelude
 
+flag large-tuples
+  description:
+    Generate instances for classes such as `NFDataX` and `BitPack` for tuples
+    up to and including 62 elements - the GHC imposed maximum. This greatly
+    increases compile times for `clash-prelude` and therefore mostly impacts the
+    Clash developers themselves. Hence its default is set to disabled on
+    development versions and enabled on releases.
+  default: False
+  manual: True
+
 flag super-strict
   description:
     Use `deepseqX` (instead of `seqX`) in register-like constructs. This can
@@ -107,6 +117,9 @@ Library
   default-language:   Haskell2010
   ghc-options:        -Wall -fexpose-all-unfoldings -fno-worker-wrapper
   CPP-Options:        -DCABAL
+
+  if flag(large-tuples)
+    CPP-Options: -DLARGE_TUPLES
 
   if flag(super-strict)
     CPP-Options: -DCLASH_SUPER_STRICT

--- a/clash-prelude/src/Clash/CPP.hs
+++ b/clash-prelude/src/Clash/CPP.hs
@@ -4,11 +4,15 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP#-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK hide #-}
 
 #ifndef MAX_TUPLE_SIZE
+#ifdef LARGE_TUPLES
 #define MAX_TUPLE_SIZE 62
+#else
+#define MAX_TUPLE_SIZE 12
+#endif
 #endif
 
 module Clash.CPP

--- a/clash-prelude/src/Clash/Class/AutoReg/Instances.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Instances.hs
@@ -27,9 +27,4 @@ deriveAutoReg ''Down
 
 deriveAutoReg ''Ratio
 
--- TODO: this needs NFDataX instances to maxTupleSize that in turn need
--- TODO: generic instances for large tuples, but this slows GHC down by a
--- TODO: lot. See: https://phabricator.haskell.org/D2899. Maybe we could add
--- TODO: -flarge-tuples to clash-prelude?
--- deriveAutoRegTuples [2..maxTupleSize]
-deriveAutoRegTuples [2..min maxTupleSize 15]
+deriveAutoRegTuples [2..maxTupleSize]

--- a/clash-prelude/src/Clash/XException/TH.hs
+++ b/clash-prelude/src/Clash/XException/TH.hs
@@ -1,0 +1,100 @@
+{-|
+Copyright  :  (C) 2019, Myrtle Software Ltd
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Clash.XException.TH (mkNFDataXTupleInstances) where
+
+import           Language.Haskell.TH.Syntax
+import           Data.Either                  (isLeft)
+
+-- Spliced in in XException, so these names should be in scope:
+isXName, hasUndefinedName, deepErrorXName, rnfXName, ensureSpineName :: Name
+isXName = mkName "isX"
+hasUndefinedName = mkName "hasUndefined"
+deepErrorXName = mkName "deepErrorX"
+rnfXName = mkName "rnfX"
+ensureSpineName = mkName "ensureSpine"
+
+nfdataxName :: Name
+nfdataxName = mkName "NFDataX"
+
+mkTup :: [Type] -> Type
+mkTup names@(length -> n) =
+  foldl AppT (TupleT n) names
+
+-- | Creates an instance of the form:
+--
+--  instance (NFDataX a0, NFDataX a1) => NFDataX (a0, a1)
+--
+-- With /n/ number of variables.
+mkNFDataXTupleInstance :: Int -> Dec
+mkNFDataXTupleInstance n =
+  InstanceD
+    Nothing
+    constraints
+    instanceTyp
+    [ ensureSpineDecl
+    , hasUndefinedDecl
+    , deepErrorXDecl
+    , rnfXDecl
+    ]
+ where
+  constraints = map (AppT (ConT nfdataxName)) vars
+  instanceTyp = ConT nfdataxName `AppT` mkTup vars
+  names = map (mkName . ('a':) . show) [0..n-1]
+  vars = map VarT names
+
+  t = mkName "t"
+  s = mkName "s"
+
+  rnfXDecl = FunD rnfXName [
+    Clause
+      [AsP t (TildeP (TupP (map VarP names)))]
+      (NormalB (
+        CondE
+          (VarE 'isLeft `AppE` (VarE isXName `AppE` VarE t))
+          (TupE [])
+          (foldl
+            (\e1 e2 -> UInfixE e1 (VarE 'seq) (VarE rnfXName `AppE` e2))
+            (VarE rnfXName `AppE` VarE (head names))
+            (map VarE (tail names)))
+      ))
+      []
+    ]
+
+  hasUndefinedDecl = FunD hasUndefinedName [
+    Clause
+      [AsP t (TildeP (TupP (map VarP names)))]
+      (NormalB (
+        CondE
+          (VarE 'isLeft `AppE` (VarE isXName `AppE` VarE t))
+          (ConE 'True)
+          (VarE 'or `AppE` ListE
+            (map ((VarE hasUndefinedName `AppE`) . VarE) names))
+      ))
+      []
+    ]
+
+  ensureSpineDecl = FunD ensureSpineName  [
+    Clause
+      [TildeP (TupP (map VarP names))]
+      (NormalB (TupE (map (AppE (VarE ensureSpineName) . VarE) names)))
+      []
+    ]
+
+  deepErrorXDecl = FunD deepErrorXName [
+     Clause
+       [VarP s]
+       (NormalB (TupE (replicate n (VarE deepErrorXName `AppE` VarE s))))
+       []
+     ]
+
+
+mkNFDataXTupleInstances :: [Int] -> Q [Dec]
+mkNFDataXTupleInstances tupSizes =
+  pure (map mkNFDataXTupleInstance tupSizes)

--- a/tests/shouldwork/AutoReg/AutoReg.hs
+++ b/tests/shouldwork/AutoReg/AutoReg.hs
@@ -68,20 +68,25 @@ topEntity
   :: Clock System -> Reset System
   -> Signal System (BitVector 32)
   -> _
-topEntity clk rst xs = withClockResetEnable clk rst enableGen $ bundle $
-  ( test @(Unsigned 16) xs
-  , test @Bool xs
-  , test @(Tup2 Bool Bool) xs
-  , test @(Tup3 Bool Bool Bool) xs
-  , test @(Maybe Bool) xs
-  , test @(Maybe (Maybe Bool)) xs
-  , test @(OtherPair Int8 Int16) xs
-  , test @Concrete xs
-  , test @(InfixDataCon Bool Bool) xs
-  , test @((),Bool) xs
-  , test @(Vec 2 Bool) xs
-  , test @(Vec 2 (Maybe Bool)) xs
-  , test @(Maybe (Vec 2 (Maybe Bool))) xs
+topEntity clk rst xs = withClockResetEnable clk rst enableGen $
+  -- This used to be one big tuple. We split it up so we can get away with
+  -- -DMAX_TUPLE_SIZE=12, which considerably improves compilation speed of
+  -- clash-prelude
+  ( ( test @(Unsigned 16) xs
+    , test @Bool xs
+    , test @(Tup2 Bool Bool) xs
+    , test @(Tup3 Bool Bool Bool) xs
+    , test @(Maybe Bool) xs
+    , test @(Maybe (Maybe Bool)) xs
+    , test @(OtherPair Int8 Int16) xs
+    )
+  , ( test @Concrete xs
+    , test @(InfixDataCon Bool Bool) xs
+    , test @((),Bool) xs
+    , test @(Vec 2 Bool) xs
+    , test @(Vec 2 (Maybe Bool)) xs
+    , test @(Maybe (Vec 2 (Maybe Bool))) xs
+    )
   )
 #endif
 

--- a/tests/shouldwork/BitVector/GenericBitPack.hs
+++ b/tests/shouldwork/BitVector/GenericBitPack.hs
@@ -65,30 +65,33 @@ testBench = done
       outputVerifierBitVector'
         clk
         rst
-        (pack ( $(lift (pack aT))
-              , $(lift (pack bT))
-              , $(lift (pack cT))
-              , $(lift (pack dT))
-              , $(lift (pack eT))
-              , $(lift (pack fT))
-              , $(lift (pack gT))
-              , $(lift (pack hT))
-              , $(lift (pack iT))
-              , $(lift (pack jT))
-              , $(lift (pack kT))
-
-              , $$(bLit "00100010")  :: BitVector 8
-              , $$(bLit "000")       :: BitVector 3
-              , $$(bLit "001")       :: BitVector 3
-              , $$(bLit "010")       :: BitVector 3
-              , $$(bLit "110")       :: BitVector 3
-              , $$(bLit "000100010") :: BitVector 9
-              , $$(bLit "100001010") :: BitVector 9
-              , $$(bLit "0001000001") :: BitVector 10
-              , $$(bLit "01010.....") :: BitVector 10
-              , $$(bLit "1000001...") :: BitVector 10
-              , $$(bLit "00100010")  :: BitVector 8
-
+        -- This used to be one big tuple. We split it up so we can get away with
+        -- -DMAX_TUPLE_SIZE=12, which considerably improves compilation speed of
+        -- clash-prelude
+        (pack ( ( $(lift (pack aT))
+                , $(lift (pack bT))
+                , $(lift (pack cT))
+                , $(lift (pack dT))
+                , $(lift (pack eT))
+                , $(lift (pack fT))
+                , $(lift (pack gT))
+                , $(lift (pack hT))
+                , $(lift (pack iT))
+                , $(lift (pack jT))
+                , $(lift (pack kT))
+                )
+              , ( $$(bLit "00100010")  :: BitVector 8
+                , $$(bLit "000")       :: BitVector 3
+                , $$(bLit "001")       :: BitVector 3
+                , $$(bLit "010")       :: BitVector 3
+                , $$(bLit "110")       :: BitVector 3
+                , $$(bLit "000100010") :: BitVector 9
+                , $$(bLit "100001010") :: BitVector 9
+                , $$(bLit "0001000001") :: BitVector 10
+                , $$(bLit "01010.....") :: BitVector 10
+                , $$(bLit "1000001...") :: BitVector 10
+                , $$(bLit "00100010")  :: BitVector 8
+                )
               ) :> Nil)
 
     done           = expectedOutput (topEntity <$> testInput)


### PR DESCRIPTION
TODO: 

- [x] Allow users to use `mkNFDataXTupleInstances`, so they can generate more instances if needed
- [x] ~~As a consequence of ^, use fully qualified names~~ Doesn't actually help. Users should just import the right functions/classes.
- [x] Make sure large tuples don't influence Clash developer ergonomics
- [x] ~~Integrate ^ with CI~~ We don't need to. Default should just be different on release branches.