### PR TITLE
Enable shared executables

### DIFF
--- a/clash-ghc/CHANGELOG.md
+++ b/clash-ghc/CHANGELOG.md
@@ -32,6 +32,7 @@
   * Fix blackbox issues causing Clash to generate invalid HDL ([#865](https://github.com/clash-lang/clash-compiler/pull/865))
   * Treat types with a zero-width custom bit representation like other zero-width constructs ([#874](https://github.com/clash-lang/clash-compiler/pull/874))
   * TH code for auto deriving bit representations now produces nicer error messages ([7190793](https://github.com/clash-lang/clash-compiler/commit/7190793928545f85157f9b8d4b8ec2edb2cd8a26))
+  * Adds '--enable-shared-executables' for nix builds; this should make Clash run _much_ faster ([#894](https://github.com/clash-lang/clash-compiler/pull/894))
   
 * Deprecations & removals:
   * Removed support for GHC 8.2 ([#842](https://github.com/clash-lang/clash-compiler/pull/842))

--- a/clash-ghc/default.nix
+++ b/clash-ghc/default.nix
@@ -3,4 +3,8 @@
 with nixpkgs.pkgs;
 with gitignore;
 
-haskellPackages.callCabal2nix "clash-ghc" (gitignoreSource ./.) {}
+haskell.lib.overrideCabal
+  (haskellPackages.callCabal2nix "clash-ghc" (gitignoreSource ./.) {})
+  (_: {
+    enableSharedExecutables = true;
+  })

--- a/clash-ghc/default.nix
+++ b/clash-ghc/default.nix
@@ -3,8 +3,5 @@
 with nixpkgs.pkgs;
 with gitignore;
 
-haskell.lib.overrideCabal
+haskell.lib.enableSharedExecutables
   (haskellPackages.callCabal2nix "clash-ghc" (gitignoreSource ./.) {})
-  (_: {
-    enableSharedExecutables = true;
-  })


### PR DESCRIPTION
This makes executing Clash on Nix _much_ faster.