### PR TITLE
VHDL: ToSLV don't split Vec newtype wrapper

### DIFF
--- a/clash-ghc/CHANGELOG.md
+++ b/clash-ghc/CHANGELOG.md
@@ -24,6 +24,7 @@
   * [#869](https://github.com/clash-lang/clash-compiler/issues/869): PLL is no longer duplicated in Blinker.hs example
   * [#749](https://github.com/clash-lang/clash-compiler/issues/749): Clash's dependencies now all work with GHC 8.8, allowing `clash-{prelude,lib,ghc}` to be compiled from Hackage soon.
   * [#871](https://github.com/clash-lang/clash-compiler/issues/871): RTree Bundle instance is now properly lazy
+  * [#895](https://github.com/clash-lang/clash-compiler/issues/895): VHDL type error when generating `Maybe (Vec 2 (Signed 8), Index 1)`
 
 * Small fixes without issue reports:
   * Fix bug in `rnfX` defined for `Down` ([baef30e](https://github.com/clash-lang/clash-compiler/commit/baef30eae03dc02ba847ffbb8fae7f365c5287c2))

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1940,6 +1940,10 @@ toSLV (Vector n elTy) (Identifier id_ Nothing) = do
   where
     selNames = map (fmap (T.toStrict . renderOneLine) ) $ [pretty id_ <> parens (int i) | i <- [0 .. (n-1)]]
     selIds   = map (fmap (`Identifier` Nothing)) selNames
+-- Don't split up newtype wrappers, or void-filtered types
+toSLV (Vector _ _) e@(DataCon _ (DC (Void Nothing, -1)) _) = do
+  nm <- Mon $ use modNm
+  pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)
 toSLV (Vector n elTy) (DataCon _ _ es) =
   "std_logic_vector'" <> (parens $ vcat $ punctuate " & " (zipWithM toSLV [elTy,Vector (n-1) elTy] es))
 toSLV (Vector _ _) e = do

--- a/tests/shouldwork/Vector/T895.hs
+++ b/tests/shouldwork/Vector/T895.hs
@@ -1,0 +1,6 @@
+module T895 where
+
+import Clash.Prelude
+
+topEntity :: Maybe (Vec 2 (Signed 8), Index 1)
+topEntity = Just (pure 0, 0)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -359,6 +359,7 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VecConst"   ([""],"topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VecOfSum"   ([""],"topEntity",False)
         , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "T452"       ([""],"topEntity",False)
+        , runTest ("tests" </> "shouldwork" </> "Vector") [VHDL]   [] "T895"       ([""],"topEntity",False)
         ]
       ]
     ]


### PR DESCRIPTION
Fixes #895