### PR TITLE
Handle product types with custom bit representation. Fix #880

### DIFF
--- a/clash-ghc/CHANGELOG.md
+++ b/clash-ghc/CHANGELOG.md
@@ -26,8 +26,9 @@
   * [#749](https://github.com/clash-lang/clash-compiler/issues/749): Clash's dependencies now all work with GHC 8.8, allowing `clash-{prelude,lib,ghc}` to be compiled from Hackage soon.
   * [#871](https://github.com/clash-lang/clash-compiler/issues/871): RTree Bundle instance is now properly lazy
   * [#895](https://github.com/clash-lang/clash-compiler/issues/895): VHDL type error when generating `Maybe (Vec 2 (Signed 8), Index 1)`
+  * [#880](https://github.com/clash-lang/clash-compiler/issues/880): Custom bit representations can now be used on product types too
 
-* Small fixes without issue reports:
+* Fixes without issue reports:
   * Fix bug in `rnfX` defined for `Down` ([baef30e](https://github.com/clash-lang/clash-compiler/commit/baef30eae03dc02ba847ffbb8fae7f365c5287c2))
   * Render numbers inside gensym ([bc76f0f](https://github.com/clash-lang/clash-compiler/commit/bc76f0f1934fd6e6ed9c33bcf950dae21e2f7903))
   * Report blackbox name when encountering an error in 'setSym' ([#858](https://github.com/clash-lang/clash-compiler/pull/858))
@@ -35,6 +36,7 @@
   * Treat types with a zero-width custom bit representation like other zero-width constructs ([#874](https://github.com/clash-lang/clash-compiler/pull/874))
   * TH code for auto deriving bit representations now produces nicer error messages ([7190793](https://github.com/clash-lang/clash-compiler/commit/7190793928545f85157f9b8d4b8ec2edb2cd8a26))
   * Adds '--enable-shared-executables' for nix builds; this should make Clash run _much_ faster ([#894](https://github.com/clash-lang/clash-compiler/pull/894))
+  * Custom bit representations can now mark fields as zero-width without crashing the compiler ([#898](https://github.com/clash-lang/clash-compiler/pull/898))
   
 * Deprecations & removals:
   * Removed support for GHC 8.2 ([#842](https://github.com/clash-lang/clash-compiler/pull/842))

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -53,6 +53,7 @@ import Language.Haskell.TH.Syntax           (Lift)
 
 import SrcLoc                               (SrcSpan)
 
+import Clash.Annotations.BitRepresentation  (FieldAnn)
 import Clash.Annotations.TopEntity          (TopEntity)
 import Clash.Backend                        (Backend)
 import Clash.Core.Type                      (Type)
@@ -216,6 +217,9 @@ data HWType
   | CustomSum !Identifier !DataRepr' !Size [(ConstrRepr', Identifier)]
   -- ^ Same as Sum, but with a user specified bit representation. For more info,
   -- see: Clash.Annotations.BitRepresentations.
+  | CustomProduct !Identifier !DataRepr' !Size (Maybe [Text]) [(FieldAnn, HWType)]
+  -- ^ Same as Product, but with a user specified bit representation. For more
+  -- info, see: Clash.Annotations.BitRepresentations.
   | Annotated [Attr'] !HWType
   -- ^ Annotated with HDL attributes
   | KnownDomain !Identifier !Integer !ActiveEdge !ResetKind !InitBehavior !ResetPolarity

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -283,6 +283,7 @@ Library
                       th-lift                   >= 0.7.0    && < 0.9,
                       th-orphans                >= 0.13.1   && < 1.0,
                       text                      >= 0.11.3.1 && < 1.3,
+                      text-show                 >= 3.8     && < 3.9,
                       time                      >= 1.8     && < 1.10,
                       transformers              >= 0.5.2.0 && < 0.6,
                       type-errors               >= 0.2.0.0 && < 0.3,

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
@@ -43,6 +43,7 @@ type BitMask  = Integer
 type Value    = Integer
 type Size     = Int
 
+-- | BitMask used to mask fields
 type FieldAnn = BitMask
 
 -- | Lift values inside of 'TH.Q' to a Template Haskell expression

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -8,11 +8,10 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia        #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeApplications   #-}
 
 module Clash.Annotations.BitRepresentation.Internal
   ( buildCustomReprs
@@ -31,6 +30,7 @@ module Clash.Annotations.BitRepresentation.Internal
 import           Clash.Annotations.BitRepresentation
   (BitMask, Value, Size, FieldAnn, DataReprAnn(..), ConstrRepr(..))
 import           Control.DeepSeq                          (NFData)
+import           Data.Coerce                              (coerce)
 import           Data.Hashable                            (Hashable)
 import qualified Data.Map                                 as Map
 import           Data.Maybe                               (fromMaybe)
@@ -52,7 +52,15 @@ data Type'
   | LitTy' Integer
   -- ^ Numeral literal (used in BitVector 10, for example)
     deriving (Generic, NFData, Eq, Typeable, Hashable, Ord, Show)
-    deriving TS.TextShow via TS.FromGeneric (Type')
+
+-- Replace with
+--
+--   deriving TS.TextShow via TS.FromGeneric (Type')
+--
+-- after dropping support for GHC 8.4
+instance TS.TextShow Type' where
+  showt = TS.showt . coerce @_ @(TS.FromGeneric (Type'))
+  showb = TS.showb . coerce @_ @(TS.FromGeneric (Type'))
 
 -- | Internal version of DataRepr
 data DataRepr' = DataRepr'

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -11,14 +11,10 @@ let
     haskellPackages = nixpkgs.haskellPackages.override {
       overrides = self: super: {
         # External overrides
-        ghc-typelits-extra =
-          self.callCabal2nix "ghc-typelits-extra" sources.ghc-typelits-extra {};
 
-        type-errors =
-          self.callCabal2nix "type-errors" sources.type-errors {};
-
-        first-class-families =
-          self.callCabal2nix "first-class-families" sources.first-class-families {};
+        # Example:
+        # ghc-typelits-extra =
+        #  self.callCabal2nix "ghc-typelits-extra" sources.ghc-typelits-extra {};
 
         # Internal overrides
         clash-lib = import ../clash-lib { inherit nixpkgs; };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,40 +1,4 @@
 {
-    "type-errors": {
-        "branch": "master",
-        "description": "tools for writing better type errors ",
-        "homepage": null,
-        "owner": "isovector",
-        "repo": "type-errors",
-        "rev": "f171628f607d83de18bd96c1d4247674fece6b15",
-        "sha256": "1pkrns559mh1psp2ic4dybk8x91vcx04xpjx7m7msqx7xypfz2il",
-        "type": "tarball",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
-        "url": "https://github.com/isovector/type-errors/archive/f171628f607d83de18bd96c1d4247674fece6b15.tar.gz"
-    },
-    "first-class-families": {
-        "branch": "master",
-        "description": "First-class type families",
-        "homepage": null,
-        "owner": "Lysxia",
-        "repo": "first-class-families",
-        "rev": "bb6487804594c6d6cdc383011d81dc425e5a456c",
-        "sha256": "1y1a6fi2307z04bzl5jw38zqrzzhjfb59kp47xj0ibnmqqr7xyka",
-        "type": "tarball",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
-        "url": "https://github.com/Lysxia/first-class-families/archive/bb6487804594c6d6cdc383011d81dc425e5a456c.tar.gz"
-    },
-    "ghc-typelits-extra": {
-        "branch": "master",
-        "description": "Extra type-level operations on GHC.TypeLits.Nat and a custom solver",
-        "homepage": null,
-        "owner": "clash-lang",
-        "repo": "ghc-typelits-extra",
-        "rev": "a8de0b68b8216411cb862195354f251cd41bae50",
-        "sha256": "19iggfs1m6vn9q8wxx4d3g993933nribmm6qa106lj6qr7d5jqil",
-        "type": "tarball",
-        "url": "https://github.com/clash-lang/ghc-typelits-extra/archive/a8de0b68b8216411cb862195354f251cd41bae50.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "gitignore": {
         "branch": "master",
         "description": "Nix function for filtering local git sources",
@@ -60,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-19.03",
+        "branch": "nixos-19.09",
         "description": "Nixpkgs/NixOS branches that track the Nixpkgs/NixOS channels",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "8634c3b619909db7fc747faf8c03592986626e21",
-        "sha256": "0hcpy4q64vbqmlmnfcavfxilyygyzpwdsss8g3p73ikpic0j6ziq",
+        "rev": "d5291756487d70bc336e33512a9baf9fa1788faf",
+        "sha256": "0mhqhq21y5vrr1f30qd2bvydv4bbbslvyzclhw0kdxmkgg3z4c92",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/8634c3b619909db7fc747faf8c03592986626e21.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/d5291756487d70bc336e33512a9baf9fa1788faf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/tests/shouldwork/CustomReprs/ZeroWidth/FailGracefully1.hs
+++ b/tests/shouldwork/CustomReprs/ZeroWidth/FailGracefully1.hs
@@ -1,0 +1,22 @@
+-- See ZeroWidth.hs
+module FailGracefully1 where
+
+import Clash.Prelude.Testbench
+import Clash.Prelude
+import GHC.Generics
+import Clash.Annotations.BitRepresentation
+import Data.Maybe
+
+data SProduct
+  = S Bool String
+  | P Bool String Bool
+{-# ANN module ( DataReprAnn
+                   $(liftQ [t|SProduct|])
+                   3
+                   [ ConstrRepr 'S 0b100 0b100 [0b001, 0b000]
+                   , ConstrRepr 'P 0b100 0b000 [0b010, 0b000, 0b001]
+                   ] ) #-}
+
+topEntity :: SProduct -> SProduct
+topEntity (S b s) = S (not b) s
+topEntity (P b1 s b2) = P (not b1) s (not b2)

--- a/tests/shouldwork/CustomReprs/ZeroWidth/FailGracefully2.hs
+++ b/tests/shouldwork/CustomReprs/ZeroWidth/FailGracefully2.hs
@@ -1,0 +1,17 @@
+-- See ZeroWidth.hs
+module FailGracefully2 where
+
+import Clash.Prelude.Testbench
+import Clash.Prelude
+import GHC.Generics
+import Clash.Annotations.BitRepresentation
+import Data.Maybe
+
+data Product = Product Bool String
+{-# ANN module ( DataReprAnn
+                   $(liftQ [t|Product|])
+                   1
+                   [ ConstrRepr 'Product 0b0 0b0 [0b1, 0b0] ] ) #-}
+
+topEntity :: Product -> Product
+topEntity (Product b s) = Product (not b) s

--- a/tests/shouldwork/CustomReprs/ZeroWidth/FailGracefully3.hs
+++ b/tests/shouldwork/CustomReprs/ZeroWidth/FailGracefully3.hs
@@ -1,0 +1,17 @@
+-- See ZeroWidth.hs
+module FailGracefully3 where
+
+import Clash.Prelude.Testbench
+import Clash.Prelude
+import GHC.Generics
+import Clash.Annotations.BitRepresentation
+import Data.Maybe
+
+data Record = Record { myBool :: Bool, myString :: String }
+{-# ANN module ( DataReprAnn
+                   $(liftQ [t|Record|])
+                   1
+                   [ ConstrRepr 'Record 0b0 0b0 [0b1, 0b0] ] ) #-}
+
+topEntity :: Record -> Record
+topEntity (Record b s) = Record (not b) s

--- a/tests/shouldwork/CustomReprs/ZeroWidth/ZeroWidth.hs
+++ b/tests/shouldwork/CustomReprs/ZeroWidth/ZeroWidth.hs
@@ -1,0 +1,76 @@
+-- Tests what should happen when data types have fields marked as zero-width
+-- with custom bit representations.
+--
+-- At the time of writing, 2019-nov-01, we don't handle the following case:
+--
+--    myFunc (Product bool nonRepresentable) =
+--      Product (not bool) nonRepresentable
+--
+-- Clash will try to project 'nonRepresentable' from the Product type as it
+-- want to construct a new Product type with it later on. It doesn't have to,
+-- as the construction won't try to include the non-representable type anyway,
+-- but Clash doesn't (can't easily?) know this in time.
+--
+-- In ZeroWidthFailGracefully*.hs we test whether Clash tells the user what's wrong.
+
+module ZeroWidth where
+
+import Clash.Prelude.Testbench
+import Clash.Prelude
+import GHC.Generics
+import Clash.Annotations.BitRepresentation
+import Data.Maybe
+
+data SProduct
+  = S Bool String
+  | P Bool String Bool
+{-# ANN module ( DataReprAnn
+                   $(liftQ [t|SProduct|])
+                   3
+                   [ ConstrRepr 'S 0b100 0b100 [0b001, 0b000]
+                   , ConstrRepr 'P 0b100 0b000 [0b010, 0b000, 0b001]
+                   ] ) #-}
+
+data Product = Product Bool String
+{-# ANN module ( DataReprAnn
+                   $(liftQ [t|Product|])
+                   1
+                   [ ConstrRepr 'Product 0b0 0b0 [0b1, 0b0] ] ) #-}
+
+data Record = Record { myBool :: Bool, myString :: String }
+{-# ANN module ( DataReprAnn
+                   $(liftQ [t|Record|])
+                   1
+                   [ ConstrRepr 'Record 0b0 0b0 [0b1, 0b0] ] ) #-}
+
+topEntity
+  :: SProduct
+  -> Product
+  -> Record
+  -> ( SProduct
+     , SProduct
+     , Product
+     , Product
+     , Record
+     , Record
+     , Record
+     )
+topEntity sp (Product pb ps) r@(Record rb rs) =
+  ( sp1
+  , sp2
+  , Product pb ps
+  , Product (not pb) "xx"
+  , Record rb rs
+  , Record (not rb) "xx"
+  , Record (not (myBool r)) "xx"
+  )
+ where
+  sp2 =
+    case sp of
+      S b s -> S b s
+      P b1 s b2 -> P b1 s b2
+
+  sp1 =
+    case sp of
+      S b _ -> S (not b) "xx"
+      P b1 _ b2 -> P (not b1) "xx" (not b2)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -150,6 +150,11 @@ runClashTest =
         , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "Rotate")        defBuild [] "Rotate"                 (["", "testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "Deriving")      defBuild [] "BitPackDerivation"      (["", "testBench"],"testBench",True)
         , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "Indexed")       defBuild [] "Indexed"                (["", "testBench"],"testBench",True)
+
+        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "ZeroWidth" ([""],"topEntity",False)
+        , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully1" (Just "Unexpected projection of zero-width type")
+        , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully2" (Just "Unexpected projection of zero-width type")
+        , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully3" (Just "Unexpected projection of zero-width type")
         ]
       , clashTestGroup "DDR"
         [ runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRinGA" (["","testBench"],"testBench",True)


### PR DESCRIPTION
Additionally fixes and tests fields marked as zero-width with a custom bit representation. It currently tries to gracefully error if it detects cases it cannot handle.