### PR TITLE
Close #903 - Refactor Tests in clash-cores

### DIFF
--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -110,3 +110,4 @@ test-suite unittests
       tasty-hunit
 
   Other-Modules: Test.Cores.SPI
+

--- a/clash-cores/src/Clash/Cores/SPI.hs
+++ b/clash-cores/src/Clash/Cores/SPI.hs
@@ -18,6 +18,7 @@ module Clash.Cores.SPI
 where
 
 import Data.Maybe (fromMaybe, isJust)
+
 import Clash.Prelude
 import Clash.Sized.Internal.BitVector
 
@@ -49,9 +50,8 @@ data SPIMode
   --
   -- Clock is idle high, data is sampled on falling edge of SCK,
   -- data is shifted on falling edge of SCK.
-  deriving (Eq)
+  deriving (Eq, Show)
 
--- | SPI slave configuration
 data SPISlaveConfig ds dom
   = SPISlaveConfig
   { spiSlaveConfigMode :: SPIMode


### PR DESCRIPTION
The test suite in `clash-cores` has been refactored to make it more understandable / less repetitive. While the result still isn't ideal, the test suite will be revisited anyway when extending SPI to send acknowledge signals (see #908).