### PR TITLE
Refactor testsuite

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -22,8 +22,8 @@ package clash-cosim
 
 package clash-testsuite
   ghc-options: -Werror
-  -- enable cosim & disable systemverilog testing (needs modelsim)
-  flags: disable-sv-tests cosim
+  -- enable cosim
+  flags: cosim
 
 package clash-ghc
   ghc-options: -Werror

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -43,4 +43,4 @@ fi
 
 # Run actual tests
 cabal new-test clash-cosim clash-prelude clash-lib
-cabal new-run -- clash-testsuite -j$THREADS --hide-successes
+cabal new-run -- clash-testsuite -j$THREADS --hide-successes -p "/.VHDL./ || /.Verilog./"

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -1,31 +1,27 @@
 {-# LANGUAGE CPP #-}
 module Main (main) where
 
-import Control.Exception (finally)
-import Data.List (isSuffixOf, (\\))
-import System.Directory (createDirectoryIfMissing, removeDirectoryRecursive)
-import System.Process (readCreateProcessWithExitCode, proc)
-import GHC.Conc (numCapabilities)
+import           Control.Exception         (finally)
+import           Data.Default              (def)
+import           Data.List                 (isSuffixOf)
+import           System.Directory
+  (createDirectoryIfMissing, removeDirectoryRecursive)
+import           System.Environment        (setEnv)
+import           System.Exit
+  (exitWith, ExitCode(ExitSuccess, ExitFailure))
+import           System.FilePath           ((</>))
+import           System.Process            (readCreateProcessWithExitCode, proc)
+import           GHC.Conc                  (numCapabilities)
 
-import Test.Tasty
-import Test.Tasty.Clash
+import           Test.Tasty
+import           Test.Tasty.Clash
 
-import System.FilePath ((</>))
-import System.Environment (setEnv)
-import System.Exit (exitWith, ExitCode(ExitSuccess, ExitFailure))
-
-defBuild :: [BuildTarget]
-#ifdef DISABLE_SV_TESTS
-defBuild = [VHDL, Verilog]
-#else
-defBuild = [VHDL, Verilog, SystemVerilog]
-#endif
 
 clashTestRoot
   :: [[TestName] -> TestTree]
   -> TestTree
 clashTestRoot testTrees =
-  clashTestGroup "Tests" testTrees []
+  clashTestGroup "." testTrees []
 
 -- | `clashTestGroup` and `clashTestRoot` make sure that each test knows its
 -- fully qualified test name at construction time. This is used to create
@@ -39,207 +35,230 @@ clashTestGroup testName testTrees =
     testGroup testName $
       zipWith ($) testTrees (repeat (testName : parentNames))
 
-
 runClashTest :: IO ()
-runClashTest =
-  defaultMain $ clashTestRoot
-    [ clashTestGroup "Examples"
-      [ runTest "examples"               defBuild []                                        "ALU"          ([""],"topEntity",False)
-      , runTest "examples"               [VHDL]   []                                        "Blinker"      (["blinker"],"blinker",False)
-      , runTest "examples"               defBuild []                                        "BlockRamTest" ([""],"topEntity",False)
-      , runTest "examples"               defBuild []                                        "Calculator"   (["","testBench"],"testBench",True )
-      , runTest "examples"               defBuild []                                        "CHIP8"        ([""],"topEntity", False)
-      , runTest "examples"               defBuild []                                        "CochleaPlus"  ([""],"topEntity",False)
-      , runTest "examples"               defBuild ["-fclash-component-prefix","test"]       "FIR"          (["","test_testBench"],"test_testBench",True )
-      , runTest "examples"               defBuild []                                        "Fifo"         ([""],"topEntity",False)
-      , runTest "examples"               defBuild []                                        "MAC"          (["","testBench"],"testBench",True)
-      , runTest "examples"               defBuild []                                        "MatrixVect"   (["","testBench"],"testBench",True)
-      , runTest "examples"               defBuild []                                        "Queens"       ([""],"topEntity",False)
-      , runTest "examples"               defBuild []                                        "Reducer"      ([""],"topEntity",False)
-      , runTest "examples"               defBuild []                                        "Sprockell"    ([""],"topEntity",False)
-      , runTest "examples"               defBuild []                                        "Windows"      ([""],"topEntity",False)
-      , runTest ("examples" </> "crc32") defBuild []                                        "CRC32"        (["","testBench"],"testBench",True)
-      , runTest ("examples" </> "i2c")   defBuild ["-O2","-fclash-component-prefix","test"] "I2C"          (["test_i2c","test_bitmaster","test_bytemaster"],"test_i2c",False)
+runClashTest = defaultMain $ clashTestRoot
+  [ clashTestGroup "examples"
+    [ runTest "ALU" def{hdlSim=False}
+    , runTest "Blinker" def{
+        hdlSim=False
+      , hdlTargets=[VHDL]
+      , entities=Entities ["blinker"]
+      , topEntity=TopEntity "blinker"
+      }
+    , runTest "BlockRamTest" def{hdlSim=False}
+    , runTest "Calculator" def
+    , runTest "CHIP8" def{hdlSim=False}
+    , runTest "CochleaPlus" def{hdlSim=False}
+    , runTest "FIR" def{
+        clashFlags=["-fclash-component-prefix", "test"]
+      , entities=Entities ["","test_testBench"]
+      , topEntity=TopEntity "test_testBench"
+      }
+    , runTest "Fifo" def{hdlSim=False}
+    , runTest "MAC" def
+    , runTest "MatrixVect" def
+    , runTest "Queens" def{hdlSim=False}
+    , runTest "Reducer" def{hdlSim=False}
+    , runTest "Sprockell" def{hdlSim=False}
+    , runTest "Windows" def{hdlSim=False}
+    , clashTestGroup "crc32" [ runTest "CRC32" def ]
+    , clashTestGroup "i2c"
+      [ runTest "I2C" def{
+          clashFlags=["-O2","-fclash-component-prefix","test"]
+        , entities=Entities ["test_i2c","test_bitmaster","test_bytemaster"]
+        , topEntity=TopEntity "test_i2c"
+        , hdlSim=False
+        }
       ]
-    , clashTestGroup "Unit"
+    ]
+  , clashTestGroup "tests"
+    [ clashTestGroup "shouldfail"
+      [ runFailingTest ("tests" </> "shouldfail") [VHDL] [] "RecursiveBoxed" (Just "Callgraph after normalisation contains following recursive components")
+      , runFailingTest ("tests" </> "shouldfail") [VHDL] [] "RecursiveDatatype" (Just "Not in normal form: no Letrec")
+      , runFailingTest ("tests" </> "shouldfail" </> "InvalidPrimitive") [VHDL] ["-itests/shouldfail/InvalidPrimitive"] "InvalidPrimitive" (Just "InvalidPrimitive.json")
+      -- Disabled, due to it eating gigabytes of memory:
+      -- , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursivePoly" (Just "??")
+      ]
+    , clashTestGroup "shouldwork"
       [ clashTestGroup "AutoReg"
         [ outputTest ("tests" </> "shouldwork" </> "AutoReg") defBuild [] [] "AutoReg" "main"
         ]
       , clashTestGroup "Basic"
         [ -- TODO: Enable AES test on SystemVerilog. See issue #569.
-          runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "AES"                 ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "BangData"            ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "Trace"               ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "ByteSwap32"          (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CharTest"            (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "ClassOps"            (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "CountTrailingZeros"  (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "DeepseqX"            (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "DivMod"              ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "IrrefError"          ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LambdaDrop"          ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "LotOfStates"         (["","testBench"],"testBench",True)
+          runTest "AES" def{hdlSim=False}
+        , runTest "BangData" def{hdlSim=False}
+        , runTest "Trace" def{hdlSim=False}
+        , runTest "ByteSwap32" def
+        , runTest "CharTest" def
+        , runTest "ClassOps" def
+        , runTest "CountTrailingZeros" def
+        , runTest "DeepseqX" def
+        , runTest "DivMod" def{hdlSim=False}
+        , runTest "IrrefError" def{hdlSim=False}
+        , runTest "LambdaDrop" def{hdlSim=False}
+        , runTest "LotOfStates" def
 #ifdef CLASH_MULTIPLE_HIDDEN
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "MultipleHidden"      (["","testBench"],"testBench",True)
+        , runTest "MultipleHidden" def
 #endif
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NameInstance"         ([""],"topEntity",False)
+        , runTest "NameInstance" def{hdlSim=False}
         , outputTest ("tests" </> "shouldwork" </> "Basic") defBuild [] [] "NameInstance" "main"
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NameOverlap"         (["nameoverlap"],"nameoverlap",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NestedPrimitives"    ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NestedPrimitives2"   ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "NORX"                (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") [VHDL]   [] "Parameters"          (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "PatError"            ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "PopCount"            (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "RecordSumOfProducts" ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "Replace"             (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "Shift"               ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "SimpleConstructor"   ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TagToEnum"           ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TestIndex"           ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "Time"                (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Basic") defBuild [] "TwoFunctions"        ([""],"topEntity",False)
+        , runTest "NameOverlap" def{
+            entities=Entities ["nameoverlap"]
+          , topEntity=TopEntity "nameoverlap"
+          , hdlSim=False
+          }
+        , runTest "NestedPrimitives" def{hdlSim=False}
+        , runTest "NestedPrimitives2" def{hdlSim=False}
+        , runTest "NORX" def
+        , runTest "Parameters" def{hdlTargets=[VHDL]}
+        , runTest "PatError" def{hdlSim=False}
+        , runTest "PopCount" def
+        , runTest "RecordSumOfProducts" def{hdlSim=False}
+        , runTest "Replace" def
+        , runTest "Shift" def{hdlSim=False}
+        , runTest "SimpleConstructor" def{hdlSim=False}
+        , runTest "TagToEnum" def{hdlSim=False}
+        , runTest "TestIndex" def{hdlSim=False}
+        , runTest "Time" def
+        , runTest "TwoFunctions" def{hdlSim=False}
         ]
-        , clashTestGroup "ShouldFail"
-          [ runFailingTest ("tests" </> "shouldfail") [VHDL] [] "RecursiveBoxed" (Just "Callgraph after normalisation contains following recursive components")
-          , runFailingTest ("tests" </> "shouldfail") [VHDL] [] "RecursiveDatatype" (Just "Not in normal form: no Letrec")
-          , runFailingTest ("tests" </> "shouldfail" </> "InvalidPrimitive") [VHDL] ["-itests/shouldfail/InvalidPrimitive"] "InvalidPrimitive" (Just "InvalidPrimitive.json")
-          -- Disabled, due to it eating gigabytes of memory:
-          -- , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursivePoly" (Just "??")
-          ]
       , clashTestGroup "BitVector"
-        [ runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "Box"              (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "BoxGrow"          (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "CLZ"              (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "RePack"           ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ReduceZero"       (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ReduceOne"        (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "ExtendingNumZero" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild ["-fconstraint-solver-iterations=15"] "GenericBitPack"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "BitVector") defBuild [] "AppendZero"       (["","testBench"],"testBench",True)
+        [ runTest "Box" def
+        , runTest "BoxGrow" def
+        , runTest "CLZ" def
+        , runTest "RePack" def{hdlSim=False}
+        , runTest "ReduceZero" def
+        , runTest "ReduceOne" def
+        , runTest "ExtendingNumZero" def
+        , runTest "GenericBitPack" def{clashFlags=["-fconstraint-solver-iterations=15"]}
+        , runTest "AppendZero" def
         ]
       , clashTestGroup "BlackBox"
         [ outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "TemplateFunction"   "main"
         , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "BlackBoxFunction"   "main"
-        , runTest    ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   []    "BlackBoxFunctionHO" (["","testBench"],"testBench",True)
+        , runTest "BlackBoxFunctionHO" def{hdlTargets=[VHDL]}
         , outputTest ("tests" </> "shouldwork" </> "Signal")   defBuild [] [] "BlockRamLazy"       "main"
         , runFailingTest ("tests" </> "shouldfail" </> "BlackBox") [VHDL] [] "WrongReference" (Just "Function WrongReference.myMultiply was annotated with an inline primitive for WrongReference.myMultiplyX. These names should be the same.")
         ]
       , clashTestGroup "BoxedFunctions"
-        [ runTest ("tests" </> "shouldwork" </> "BoxedFunctions") defBuild [] "DeadRecursiveBoxed" ([""],"topEntity",False)
+        [ runTest "DeadRecursiveBoxed" def{hdlSim=False}
         ]
       , clashTestGroup "CSignal"
-        [ runTest ("tests" </> "shouldwork" </> "CSignal") defBuild [] "CBlockRamTest" ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "CSignal") defBuild [] "MAC"           ([""],"topEntity",False)
+        [ runTest "CBlockRamTest" def{hdlSim=False}
+        , runTest "MAC" def{hdlSim=False}
         ]
 #ifdef COSIM
       , clashTestGroup "CoSim"
-        [ runTest ("tests" </> "shouldwork" </> "CoSim") [Verilog] [] "Multiply" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CoSim") [Verilog] [] "Register" (["","testBench"],"testBench",True)
+        [ runTest "Multiply" def{hdlTargets=[Verilog]}
+        , runTest "Register" def{hdlTargets=[Verilog]}
         ]
 #endif
       , clashTestGroup "CustomReprs"
-        [ runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "RotateC")       defBuild [] "RotateC"                (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "RotateC")       defBuild [] "ReprCompact"            (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "RotateC")       defBuild [] "ReprCompactScrambled"   (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "RotateC")       defBuild [] "ReprLastBitConstructor" (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "RotateC")       [VHDL]   [] "ReprStrangeMasks"       (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "RotateC")       defBuild [] "ReprWide"               (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "RotateC")       defBuild [] "RotateCScrambled"       (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "RotateCNested") defBuild [] "RotateCNested"          (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "Rotate")        defBuild [] "Rotate"                 (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "Deriving")      defBuild [] "BitPackDerivation"      (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "Indexed")       defBuild [] "Indexed"                (["", "testBench"],"testBench",True)
+        [ clashTestGroup "RotateC"
+          [ runTest "RotateC" def
+          , runTest "ReprCompact" def
+          , runTest "ReprCompactScrambled"   def
+          , runTest "ReprLastBitConstructor" def
+          , runTest "ReprStrangeMasks" def{hdlTargets=[VHDL]}
+          , runTest "ReprWide" def
+          , runTest "RotateCScrambled" def
+          ]
+        , clashTestGroup "RotateCNested" [ runTest "RotateCNested" def ]
+        , clashTestGroup "Rotate" [ runTest "Rotate" def ]
+        , clashTestGroup "Deriving" [ runTest "BitPackDerivation" def ]
+        , clashTestGroup "Indexed" [ runTest "Indexed" def ]
 
-        , runTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "ZeroWidth" ([""],"topEntity",False)
-        , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully1" (Just "Unexpected projection of zero-width type")
-        , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully2" (Just "Unexpected projection of zero-width type")
-        , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully3" (Just "Unexpected projection of zero-width type")
+        , clashTestGroup "ZeroWidth"
+          [ runTest "ZeroWidth" def{hdlSim=False}
+          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully1" (Just "Unexpected projection of zero-width type")
+          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully2" (Just "Unexpected projection of zero-width type")
+          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully3" (Just "Unexpected projection of zero-width type")
+          ]
         ]
       , clashTestGroup "DDR"
-        [ runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRinGA" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRinGS" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRinUA" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRinUS" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRoutUA" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRoutUS" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRoutGA" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DDR") defBuild [] "DDRoutGS" (["","testBench"],"testBench",True)
+        [ runTest "DDRinGA" def
+        , runTest "DDRinGS" def
+        , runTest "DDRinUA" def
+        , runTest "DDRinUS" def
+        , runTest "DDRoutUA" def
+        , runTest "DDRoutUS" def
+        , runTest "DDRoutGA" def
+        , runTest "DDRoutGS" def
         ]
       , clashTestGroup "DSignal"
-        [ runTest ("tests" </> "shouldwork" </> "DSignal") defBuild [] "DelayedFold" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DSignal") defBuild [] "DelayI"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "DSignal") defBuild [] "DelayN"      (["","testBench"],"testBench",True)
+        [ runTest "DelayedFold" def
+        , runTest "DelayI" def
+        , runTest "DelayN" def
         ]
       , clashTestGroup "Feedback"
-        [ runTest ("tests" </> "shouldwork" </> "Feedback") defBuild [] "Fib" (["","testBench"],"testBench",True)
+        [ runTest "Fib" def
 #ifdef CLASH_MULTIPLE_HIDDEN
-        , runTest ("tests" </> "shouldwork" </> "Feedback") defBuild [] "MutuallyRecursive" (["","testBench"],"testBench",True)
+        , runTest "MutuallyRecursive" def
 #endif
         ]
       , clashTestGroup "Fixed"
-        [ runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "Mixer"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "SFixedTest" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "SatWrap"    ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Fixed") defBuild [] "ZeroInt"    (["","testBench"],"testBench",True)
+        [ runTest "Mixer" def
+        , runTest "SFixedTest" def
+        , runTest "SatWrap" def{hdlSim=False}
+        , runTest "ZeroInt" def
         ]
       , clashTestGroup "Floating"
-        [ runTest ("tests" </> "shouldwork" </> "Floating") defBuild ["-fclash-float-support"] "FloatPack" ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Floating") defBuild ["-fclash-float-support"] "FloatConstFolding" (["","testBench"],"testBench",True)
+        [ runTest "FloatPack" def{hdlSim=False, clashFlags=["-fclash-float-support"]}
+        , runTest "FloatConstFolding" def{clashFlags=["-fclash-float-support"]}
         ]
       , clashTestGroup "GADTs"
-        [ runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Constrained"          (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Head"                 (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "HeadM"                (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "MonomorphicTopEntity" (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Record"               (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "Tail"                 (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "TailM"                (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "GADTs") defBuild [] "TailOfTail"           (["", "testBench"],"testBench",True)
+        [ runTest "Constrained" def
+        , runTest "Head" def
+        , runTest "HeadM" def
+        , runTest "MonomorphicTopEntity" def
+        , runTest "Record" def
+        , runTest "Tail" def
+        , runTest "TailM" def
+        , runTest "TailOfTail" def
         ]
       , clashTestGroup "HOPrim"
-        [ runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "HOIdx"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "HOImap"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Map"       (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Map2"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "TestMap"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "Transpose" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "HOPrim") defBuild [] "VecFun"    (["","testBench"],"testBench",True)
+        [ runTest "HOIdx" def
+        , runTest "HOImap" def
+        , runTest "Map" def
+        , runTest "Map2" def
+        , runTest "TestMap" def
+        , runTest "Transpose" def
+        , runTest "VecFun" def
       ]
       , clashTestGroup "Numbers"
-        [ runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "BitInteger"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Bounds"       (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "DivideByZero" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"] "ExpWithGhcCF"        (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"] "ExpWithClashCF"        (["","testBench"],"testBench",True)
+        [ runTest "BitInteger" def
+        , runTest "Bounds" def
+        , runTest "DivideByZero" def
+        , runTest "ExpWithGhcCF" def{clashFlags=["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"]}
+        , runTest "ExpWithClashCF" def{clashFlags=["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"]}
         , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] ["-itests/shouldwork/Numbers"] "ExpWithClashCF"  "main"
-        , runTest ("tests" </> "shouldwork" </> "Numbers") [VHDL] [] "HalfAsBlackboxArg" ([""],"topEntity",False)
+        , runTest "HalfAsBlackboxArg" def{hdlTargets=[VHDL], hdlSim=False}
         -- TODO: re-enable for Verilog
-        , runTest ("tests" </> "shouldwork" </> "Numbers") (defBuild \\ [Verilog]) ["-itests/shouldwork/Numbers"] "NumConstantFoldingTB_1"        (["","testBench"],"testBench",True)
+        , runTest "NumConstantFoldingTB_1" def{clashFlags=["-itests/shouldwork/Numbers"]}
         , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding_1"  "main"
-        , runTest ("tests" </> "shouldwork" </> "Numbers") (defBuild \\ [Verilog]) ["-itests/shouldwork/Numbers"] "NumConstantFoldingTB_2"        (["","testBench"],"testBench",True)
+        , runTest "NumConstantFoldingTB_2" def{clashFlags=["-itests/shouldwork/Numbers"]}
         , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding_2"  "main"
 #if MIN_VERSION_base(4,12,0)
         -- Naturals are broken on GHC <= 8.4. See https://github.com/clash-lang/clash-compiler/pull/473
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Naturals"     (["","testBench"],"testBench",True)
+        , runTest "Naturals" def
 #endif
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "NegativeLits" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize"       (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize2"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Resize3"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SatMult"      ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] "ShiftRotate"         (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SignedProjectionTB"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "SignedZero"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Signum"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "Strict"       (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Numbers") defBuild [] "UnsignedZero" (["","testBench"],"testBench",True)
+        , runTest "NegativeLits" def
+        , runTest "Resize" def
+        , runTest "Resize2" def
+        , runTest "Resize3" def
+        , runTest "SatMult" def{hdlSim=False}
+        , runTest "ShiftRotate" def{clashFlags=["-itests/shouldwork/Numbers"]}
+        , runTest "SignedProjectionTB" def
+        , runTest "SignedZero" def
+        , runTest "Signum" def
+        , runTest "Strict" def
+        , runTest "UnsignedZero" def
         ]
       , clashTestGroup "Polymorphism"
-        [ runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "ExistentialBoxed"  ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "FunctionInstances" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "GADTExistential"   ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Polymorphism") defBuild [] "LocalPoly"         ([""],"topEntity",False)
+        [ runTest "ExistentialBoxed" def{hdlSim=False}
+        , runTest "FunctionInstances" def
+        , runTest "GADTExistential" def{hdlSim=False}
+        , runTest "LocalPoly" def{hdlSim=False}
         ]
       , clashTestGroup "PrimitiveGuards"
         [ runFailingTest ("tests" </> "shouldfail" </> "PrimitiveGuards") defBuild [] "HasBlackBox" (Just "No BlackBox definition for 'HasBlackBox.primitive' even though this value was annotated with 'HasBlackBox'.")
@@ -248,129 +267,136 @@ runClashTest =
         ]
 
       , clashTestGroup "PrimitiveReductions"
-        [ runTest ("tests" </> "shouldwork" </> "PrimitiveReductions") defBuild [] "Lambda"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "PrimitiveReductions") defBuild [] "ReplaceInt" (["","testBench"],"testBench",True)
+        [ runTest "Lambda" def
+        , runTest "ReplaceInt" def
         ]
       , clashTestGroup "RTree"
-        [ runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TFold"       ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TRepeat"  (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TRepeat2"  (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "RTree") defBuild [] "TZip"        ([""],"topEntity",False)
+        [ runTest "TFold" def{hdlSim=False}
+        , runTest "TRepeat" def
+        , runTest "TRepeat2" def
+        , runTest "TZip" def{hdlSim=False}
       ]
       , clashTestGroup "Signal"
-        [ runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "AlwaysHigh"      ([""],"topEntity",False)
+        [ runTest "AlwaysHigh" def{hdlSim=False}
         , outputTest ("tests" </> "shouldwork" </> "Signal") defBuild [] [] "BlockRamLazy"    "main"
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamFile"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRam0"        (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRam1"        (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "BlockRamTest"    ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Compression"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "DelayedReset"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "NoCPR"           (["example"],"example",False)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Oversample"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Ram"             (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "RegisterAR"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "RegisterSR"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "RegisterAE"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "RegisterSE"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "ResetGen"        (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "ResetLow"        (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "Rom"             (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "RomFile"         (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal") defBuild [] "SigP"            ([""],"topEntity",False)
+        , runTest "BlockRamFile" def
+        , runTest "BlockRam0" def
+        , runTest "BlockRam1" def
+        , runTest "BlockRamTest" def{hdlSim=False}
+        , runTest "Compression" def
+        , runTest "DelayedReset" def
+        , runTest "NoCPR" def{
+            entities=Entities ["example"]
+          , topEntity=TopEntity "example"
+          , hdlSim=False
+          }
+        , runTest "Oversample" def
+        , runTest "Ram" def
+        , runTest "RegisterAR" def
+        , runTest "RegisterSR" def
+        , runTest "RegisterAE" def
+        , runTest "RegisterSE" def
+        , runTest "ResetGen" def
+        , runTest "ResetLow" def
+        , runTest "Rom" def
+        , runTest "RomFile" def
+        , runTest "SigP" def{hdlSim=False}
 
-        , runTest ("tests" </> "shouldwork" </> "Signal" </> "BiSignal") defBuild [] "Counter" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal" </> "BiSignal") defBuild [] "CounterHalfTuple" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Signal" </> "BiSignal") defBuild [] "CounterHalfTupleRev" (["","testBench"],"testBench",True)
+        , clashTestGroup "BiSignal"
+          [ runTest "Counter" def
+          , runTest "CounterHalfTuple" def
+          , runTest "CounterHalfTupleRev" def
+          ]
 
         , runFailingTest ("tests" </> "shouldfail" </> "Signal") defBuild [] "MAC" (Just "Couldn't instantiate blackbox for Clash.Signal.Internal.register#")
         ]
       , clashTestGroup "SynthesisAttributes"
         [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] [] "Simple"  "main"
         , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] [] "Product" "main"
-        , runTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] "Product" (["", "testBench"],"testBench",True)
+        , runTest "Product" def
         , clashTestGroup "ShouldFail" [
             runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInArgs"   (Just "Attempted to split Product into a number of HDL ports.")
           , runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInResult" (Just "Attempted to split Product into a number of HDL ports.")
           ]
         ]
       , clashTestGroup "Testbench"
-        [ runTest ("tests" </> "shouldwork" </> "Testbench") defBuild ["-fclash-inline-limit=0"] "TB" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Testbench") defBuild [] "SyncTB"                    (["","testBench"],"testBench",True)
+        [ runTest "TB" def{clashFlags=["-fclash-inline-limit=0"]}
+        , runTest "SyncTB" def
         ]
       , clashTestGroup "Types"
-        [ runTest ("tests" </> "shouldwork" </> "Types") defBuild [] "TypeFamilyReduction" ([""],"topEntity",False)
+        [ runTest "TypeFamilyReduction" def{hdlSim=False}
         ]
       , clashTestGroup "TopEntity"
         -- VHDL tests disabled for now: I can't figure out how to generate a static name whilst retaining the ability to actually test..
-        [ runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNames" (["","PortNames_topEntity","PortNames_testBench"],"PortNames_testBench",True)
+        [ runTest "PortNames" def{hdlTargets=[Verilog],entities=Entities ["", "PortNames_topEntity", "PortNames_testBench"], topEntity=TopEntity "PortNames_testBench"}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNames" "main"
-        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortProducts" (["","PortProducts_topEntity","PortProducts_testBench"],"PortProducts_testBench",True)
+        , runTest "PortProducts" def{hdlTargets=[Verilog],entities=Entities ["", "PortProducts_topEntity", "PortProducts_testBench"], topEntity=TopEntity "PortProducts_testBench"}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortProducts" "main"
-        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortProductsSum" (["","PortProductsSum_topEntity","PortProductsSum_testBench"],"PortProductsSum_testBench",True)
+        , runTest "PortProductsSum" def{hdlTargets=[Verilog],entities=Entities ["", "PortProductsSum_topEntity", "PortProductsSum_testBench"], topEntity=TopEntity "PortProductsSum_testBench"}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortProductsSum" "main"
-        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithUnit" (["","PortNamesWithUnit_topEntity","PortNamesWithUnit_testBench"],"PortNamesWithUnit_testBench",True)
+        , runTest "PortNamesWithUnit" def{hdlTargets=[Verilog],entities=Entities ["", "PortNamesWithUnit_topEntity", "PortNamesWithUnit_testBench"], topEntity=TopEntity "PortNamesWithUnit_testBench"}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithUnit" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithSingletonVector" "main"
-        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithVector" (["","PortNamesWithVector_topEntity","PortNamesWithVector_testBench"],"PortNamesWithVector_testBench",True)
+        , runTest "PortNamesWithVector" def{hdlTargets=[Verilog],entities=Entities ["", "PortNamesWithVector_topEntity", "PortNamesWithVector_testBench"], topEntity=TopEntity "PortNamesWithVector_testBench"}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithVector" "main"
-        , runTest ("tests" </> "shouldwork" </> "TopEntity")    [Verilog] [] "PortNamesWithRTree" (["","PortNamesWithRTree_topEntity","PortNamesWithRTree_testBench"],"PortNamesWithRTree_testBench",True)
+        , runTest "PortNamesWithRTree" def{hdlTargets=[Verilog],entities=Entities ["", "PortNamesWithRTree_topEntity", "PortNamesWithRTree_testBench"], topEntity=TopEntity "PortNamesWithRTree_testBench"}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithRTree" "main"
-        , runTest ("tests" </> "shouldwork" </> "TopEntity")    defBuild [] "TopEntHOArg" (["f","g"],"f",False)
+        , runTest "TopEntHOArg" def{entities=Entities ["f", "g"], topEntity=TopEntity "f", hdlSim=False}
         ]
-      , clashTestGroup "Void"
-        [ runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "Imap"                         (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithUnitVector"            (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithTupleWithUnitLeft"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithTupleWithUnitRight"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithTripleWithUnitMiddle"  (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithUnitSP"                (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Unit") defBuild [] "ZipWithUnitSP2"               (["","testBench"],"testBench",True)
+      , clashTestGroup "Unit"
+        [ runTest "Imap" def
+        , runTest "ZipWithUnitVector" def
+        , runTest "ZipWithTupleWithUnitLeft" def
+        , runTest "ZipWithTupleWithUnitRight" def
+        , runTest "ZipWithTripleWithUnitMiddle" def
+        , runTest "ZipWithUnitSP" def
+        , runTest "ZipWithUnitSP2" def
         ]
       , clashTestGroup "Vector"
-        [ runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Concat"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DFold"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DFold2"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "DTFold"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "EnumTypes"  ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FindIndex"  (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FirOddSize" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Fold"       (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FoldlFuns"  ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Foldr"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "FoldrEmpty" (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "HOClock"    ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "HOCon"      ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "HOPrim"     ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "IndexInt"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Indices"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Minimum"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "MovingAvg"  ([""],"topEntity", False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "PatHOCon"   ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Scatter"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Split"      ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "ToList"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "Unconcat"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VACC"       ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VEmpty"     (["", "testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VIndex"     ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VIndicesI"  (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VFold"      (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VMapAccum"  ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VMerge"     (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VReplace"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VReverse"   (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VRotate"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VScan"      ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VSelect"    (["","testBench"],"testBench",True)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VZip"       ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VecConst"   ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "VecOfSum"   ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") defBuild [] "T452"       ([""],"topEntity",False)
-        , runTest ("tests" </> "shouldwork" </> "Vector") [VHDL]   [] "T895"       ([""],"topEntity",False)
-        ]
-      ]
-    ]
+        [ runTest "Concat" def
+        , runTest "DFold" def
+        , runTest "DFold2" def
+        , runTest "DTFold" def
+        , runTest "EnumTypes" def{hdlSim=False}
+        , runTest "FindIndex" def
+        , runTest "FirOddSize" def
+        , runTest "Fold" def
+        , runTest "FoldlFuns" def{hdlSim=False}
+        , runTest "Foldr" def
+        , runTest "FoldrEmpty" def
+        , runTest "HOClock" def{hdlSim=False}
+        , runTest "HOCon" def{hdlSim=False}
+        , runTest "HOPrim" def{hdlSim=False}
+        , runTest "IndexInt" def
+        , runTest "Indices" def
+        , runTest "Minimum" def
+        , runTest "MovingAvg" def{hdlSim=False}
+        , runTest "PatHOCon" def{hdlSim=False}
+        , runTest "Scatter" def
+        , runTest "Split" def{hdlSim=False}
+        , runTest "ToList" def
+        , runTest "Unconcat" def
+        , runTest "VACC" def{hdlSim=False}
+        , runTest "VEmpty" def
+        , runTest "VIndex" def{hdlSim=False}
+        , runTest "VIndicesI" def
+        , runTest "VFold" def
+        , runTest "VMapAccum" def{hdlSim=False}
+        , runTest "VMerge" def
+        , runTest "VReplace" def
+        , runTest "VReverse" def
+        , runTest "VRotate" def
+        , runTest "VScan" def{hdlSim=False}
+        , runTest "VSelect" def
+        , runTest "VZip" def{hdlSim=False}
+        , runTest "VecConst" def{hdlSim=False}
+        , runTest "VecOfSum" def{hdlSim=False}
+        , runTest "T452" def{hdlSim=False}
+        , runTest "T895" def{hdlSim=False,hdlTargets=[VHDL]}
+        ] -- end Vector
+      ] -- end shouldwork
+    ] -- end tests
+  ] -- end .
 
 main :: IO ()
 main = do

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -77,11 +77,11 @@ runClashTest = defaultMain $ clashTestRoot
       , runFailingTest ("tests" </> "shouldfail") [VHDL] [] "RecursiveDatatype" (Just "Not in normal form: no Letrec")
       , runFailingTest ("tests" </> "shouldfail" </> "InvalidPrimitive") [VHDL] ["-itests/shouldfail/InvalidPrimitive"] "InvalidPrimitive" (Just "InvalidPrimitive.json")
       -- Disabled, due to it eating gigabytes of memory:
-      -- , runFailingTest ("tests" </> "shouldfail") defBuild [] "RecursivePoly" (Just "??")
+      -- , runFailingTest ("tests" </> "shouldfail") allTargets [] "RecursivePoly" (Just "??")
       ]
     , clashTestGroup "shouldwork"
       [ clashTestGroup "AutoReg"
-        [ outputTest ("tests" </> "shouldwork" </> "AutoReg") defBuild [] [] "AutoReg" "main"
+        [ outputTest ("tests" </> "shouldwork" </> "AutoReg") allTargets [] [] "AutoReg" "main"
         ]
       , clashTestGroup "Basic"
         [ -- TODO: Enable AES test on SystemVerilog. See issue #569.
@@ -101,7 +101,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "MultipleHidden" def
 #endif
         , runTest "NameInstance" def{hdlSim=False}
-        , outputTest ("tests" </> "shouldwork" </> "Basic") defBuild [] [] "NameInstance" "main"
+        , outputTest ("tests" </> "shouldwork" </> "Basic") allTargets [] [] "NameInstance" "main"
         , runTest "NameOverlap" def{
             entities=Entities ["nameoverlap"]
           , topEntity=TopEntity "nameoverlap"
@@ -137,7 +137,7 @@ runClashTest = defaultMain $ clashTestRoot
         [ outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "TemplateFunction"   "main"
         , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "BlackBoxFunction"   "main"
         , runTest "BlackBoxFunctionHO" def{hdlTargets=[VHDL]}
-        , outputTest ("tests" </> "shouldwork" </> "Signal")   defBuild [] [] "BlockRamLazy"       "main"
+        , outputTest ("tests" </> "shouldwork" </> "Signal")   allTargets [] [] "BlockRamLazy"       "main"
         , runFailingTest ("tests" </> "shouldfail" </> "BlackBox") [VHDL] [] "WrongReference" (Just "Function WrongReference.myMultiply was annotated with an inline primitive for WrongReference.myMultiplyX. These names should be the same.")
         ]
       , clashTestGroup "BoxedFunctions"
@@ -170,9 +170,9 @@ runClashTest = defaultMain $ clashTestRoot
 
         , clashTestGroup "ZeroWidth"
           [ runTest "ZeroWidth" def{hdlSim=False}
-          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully1" (Just "Unexpected projection of zero-width type")
-          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully2" (Just "Unexpected projection of zero-width type")
-          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") defBuild [] "FailGracefully3" (Just "Unexpected projection of zero-width type")
+          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") allTargets [] "FailGracefully1" (Just "Unexpected projection of zero-width type")
+          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") allTargets [] "FailGracefully2" (Just "Unexpected projection of zero-width type")
+          , runFailingTest ("tests" </> "shouldwork" </> "CustomReprs" </> "ZeroWidth") allTargets [] "FailGracefully3" (Just "Unexpected projection of zero-width type")
           ]
         ]
       , clashTestGroup "DDR"
@@ -231,13 +231,13 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "DivideByZero" def
         , runTest "ExpWithGhcCF" def{clashFlags=["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"]}
         , runTest "ExpWithClashCF" def{clashFlags=["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"]}
-        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-itests/shouldwork/Numbers"] ["-itests/shouldwork/Numbers"] "ExpWithClashCF"  "main"
+        , outputTest ("tests" </> "shouldwork" </> "Numbers") allTargets ["-itests/shouldwork/Numbers"] ["-itests/shouldwork/Numbers"] "ExpWithClashCF"  "main"
         , runTest "HalfAsBlackboxArg" def{hdlTargets=[VHDL], hdlSim=False}
         -- TODO: re-enable for Verilog
         , runTest "NumConstantFoldingTB_1" def{clashFlags=["-itests/shouldwork/Numbers"]}
-        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding_1"  "main"
+        , outputTest ("tests" </> "shouldwork" </> "Numbers") allTargets ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding_1"  "main"
         , runTest "NumConstantFoldingTB_2" def{clashFlags=["-itests/shouldwork/Numbers"]}
-        , outputTest ("tests" </> "shouldwork" </> "Numbers") defBuild ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding_2"  "main"
+        , outputTest ("tests" </> "shouldwork" </> "Numbers") allTargets ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding_2"  "main"
 #if MIN_VERSION_base(4,12,0)
         -- Naturals are broken on GHC <= 8.4. See https://github.com/clash-lang/clash-compiler/pull/473
         , runTest "Naturals" def
@@ -261,8 +261,8 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "LocalPoly" def{hdlSim=False}
         ]
       , clashTestGroup "PrimitiveGuards"
-        [ runFailingTest ("tests" </> "shouldfail" </> "PrimitiveGuards") defBuild [] "HasBlackBox" (Just "No BlackBox definition for 'HasBlackBox.primitive' even though this value was annotated with 'HasBlackBox'.")
-        , runFailingTest ("tests" </> "shouldfail" </> "PrimitiveGuards") defBuild [] "DontTranslate" (Just "Clash was forced to translate 'DontTranslate.primitive', but this value was marked with DontTranslate. Did you forget to include a blackbox for one of the constructs using this?")
+        [ runFailingTest ("tests" </> "shouldfail" </> "PrimitiveGuards") allTargets [] "HasBlackBox" (Just "No BlackBox definition for 'HasBlackBox.primitive' even though this value was annotated with 'HasBlackBox'.")
+        , runFailingTest ("tests" </> "shouldfail" </> "PrimitiveGuards") allTargets [] "DontTranslate" (Just "Clash was forced to translate 'DontTranslate.primitive', but this value was marked with DontTranslate. Did you forget to include a blackbox for one of the constructs using this?")
         , runWarningTest ("tests" </> "shouldwork" </> "PrimitiveGuards") [VHDL] [] "WarnAlways" (Just "You shouldn't use 'primitive'!")
         ]
 
@@ -278,7 +278,7 @@ runClashTest = defaultMain $ clashTestRoot
       ]
       , clashTestGroup "Signal"
         [ runTest "AlwaysHigh" def{hdlSim=False}
-        , outputTest ("tests" </> "shouldwork" </> "Signal") defBuild [] [] "BlockRamLazy"    "main"
+        , outputTest ("tests" </> "shouldwork" </> "Signal") allTargets [] [] "BlockRamLazy"    "main"
         , runTest "BlockRamFile" def
         , runTest "BlockRam0" def
         , runTest "BlockRam1" def
@@ -308,15 +308,15 @@ runClashTest = defaultMain $ clashTestRoot
           , runTest "CounterHalfTupleRev" def
           ]
 
-        , runFailingTest ("tests" </> "shouldfail" </> "Signal") defBuild [] "MAC" (Just "Couldn't instantiate blackbox for Clash.Signal.Internal.register#")
+        , runFailingTest ("tests" </> "shouldfail" </> "Signal") allTargets [] "MAC" (Just "Couldn't instantiate blackbox for Clash.Signal.Internal.register#")
         ]
       , clashTestGroup "SynthesisAttributes"
-        [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] [] "Simple"  "main"
-        , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") defBuild [] [] "Product" "main"
+        [ outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") allTargets [] [] "Simple"  "main"
+        , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") allTargets [] [] "Product" "main"
         , runTest "Product" def
         , clashTestGroup "ShouldFail" [
-            runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInArgs"   (Just "Attempted to split Product into a number of HDL ports.")
-          , runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") defBuild [] "ProductInResult" (Just "Attempted to split Product into a number of HDL ports.")
+            runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") allTargets [] "ProductInArgs"   (Just "Attempted to split Product into a number of HDL ports.")
+          , runFailingTest ("tests" </> "shouldfail" </> "SynthesisAttributes") allTargets [] "ProductInResult" (Just "Attempted to split Product into a number of HDL ports.")
           ]
         ]
       , clashTestGroup "Testbench"

--- a/testsuite/Test/Tasty/Clash.hs
+++ b/testsuite/Test/Tasty/Clash.hs
@@ -65,18 +65,14 @@ data TestOptions =
     }
 
 
-defBuild :: [BuildTarget]
-#ifdef DISABLE_SV_TESTS
-defBuild = [VHDL, Verilog]
-#else
-defBuild = [VHDL, Verilog, SystemVerilog]
-#endif
+allTargets :: [BuildTarget]
+allTargets = [VHDL, Verilog, SystemVerilog]
 
 instance Default TestOptions where
   def =
     TestOptions
       { hdlSim=True
-      , hdlTargets=defBuild
+      , hdlTargets=allTargets
       , clashFlags=[]
       , entities=AutoEntities
       , topEntity=AutoTopEntity

--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -16,12 +16,6 @@ build-type:          Simple
 -- extra-source-files:
 cabal-version:       >=1.10
 
-flag disable-sv-tests
-   description:
-     Don't run systemverilog tests
-   default: False
-   manual: True
-
 flag cosim
    description:
      Run the co-simulation tests
@@ -64,7 +58,5 @@ executable clash-testsuite
 
   -- hs-source-dirs:
   default-language:    Haskell2010
-  if flag(disable-sv-tests)
-    cpp-options:       -DDISABLE_SV_TESTS
   if flag(cosim)
     cpp-options:       -DCOSIM

--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -37,6 +37,7 @@ executable clash-testsuite
                        OverloadedStrings
                        ViewPatterns
   build-depends:       base               >=4.10     && <5,
+                       data-default       >=0.7      && <0.8,
                        deepseq            >=1.4      && <1.5,
                        directory          >=1.2      && <1.4,
                        filepath           >=1.4      && <1.5,


### PR DESCRIPTION
"Special" tests remain verbose for now. We probably need to merge
'runTest'/'outputTest'/'runFailingTest' by adding more options to
"TestOptions".