### PR TITLE
Add 'RenderVoid' option to blackboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * New internal features:
   * [#821](https://github.com/clash-lang/clash-compiler/pull/821): Add `DebugTry`: print name of all tried transformations, even if they didn't succeed
   * [#856](https://github.com/clash-lang/clash-compiler/pull/856): Add `-fclash-debug-transformations`: only print debug info for specific transformations
+  * [#911](https://github.com/clash-lang/clash-compiler/pull/911): Add 'RenderVoid' option to blackboxes
 
 * Fixes issues:
   * [#810](https://github.com/clash-lang/clash-compiler/issues/810): Verilog backend now correctly specifies type of `BitVector 1`

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -199,7 +199,7 @@ checkPrimitive :: CompiledPrimMap -> GHC.CoreBndr -> C2C ()
 checkPrimitive primMap v = do
   nm <- qualifiedNameString (GHC.varName v)
   case HashMap.lookup nm primMap of
-    Just (extractPrim -> Just (BlackBox _ _ _ _ _ _ _ _ inc r ri templ)) -> do
+    Just (extractPrim -> Just (BlackBox _ _ _ _ _ _ _ _ _ inc r ri templ)) -> do
       let
         info = GHC.idInfo v
         inline = GHC.inlinePragmaSpec $ GHC.inlinePragInfo info

--- a/clash-lib/prims/systemverilog/Clash_Signal_BiSignal.json
+++ b/clash-lib/prims/systemverilog/Clash_Signal_BiSignal.json
@@ -1,6 +1,7 @@
 [ { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.writeToBiSignal#",
       "kind" : "Declaration",
+      "renderVoid": "RenderVoid",
       "type" :
 "writeToBiSignal#
   :: HasCallStack                   -- ARG[0]

--- a/clash-lib/prims/verilog/Clash_Signal_BiSignal.json
+++ b/clash-lib/prims/verilog/Clash_Signal_BiSignal.json
@@ -1,6 +1,7 @@
 [ { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.writeToBiSignal#",
       "kind" : "Declaration",
+      "renderVoid": "RenderVoid",
       "type" :
 "writeToBiSignal#
   :: HasCallStack                   -- ARG[0]

--- a/clash-lib/prims/vhdl/Clash_Signal_BiSignal.json
+++ b/clash-lib/prims/vhdl/Clash_Signal_BiSignal.json
@@ -1,6 +1,7 @@
 [ { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.writeToBiSignal#",
       "kind" : "Declaration",
+      "renderVoid": "RenderVoid",
       "type" :
 "writeToBiSignal#
   :: HasCallStack                   -- ARG[0]

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -415,14 +415,15 @@ compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf bbGenName source
     go args Nothing = do
       loadImportAndInterpret idirs args topDir qualMod funcName "BlackBoxFunction"
 
-compilePrimitive idirs pkgDbs topDir (BlackBox pNm wf tkind () oReg libM imps fPlural incs rM riM templ) = do
+compilePrimitive idirs pkgDbs topDir
+  (BlackBox pNm wf rVoid tkind () oReg libM imps fPlural incs rM riM templ) = do
   libM'  <- mapM parseTempl libM
   imps'  <- mapM parseTempl imps
   incs'  <- mapM (traverse parseBB) incs
   templ' <- parseBB templ
   rM'    <- traverse parseBB rM
   riM'   <- traverse parseBB riM
-  return (BlackBox pNm wf tkind () oReg libM' imps' fPlural incs' rM' riM' templ')
+  return (BlackBox pNm wf rVoid tkind () oReg libM' imps' fPlural incs' rM' riM' templ')
  where
   iArgs = concatMap (("-package-db":) . (:[])) pkgDbs
 

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -881,15 +881,20 @@ mkDcApplication dstHType bndr dc args = do
       Signed _
         | dcNm == "GHC.Integer.Type.S#"
         -> pure (head argExprsFiltered)
+        -- ByteArray# are non-translatable / void, except when they're literals
         | dcNm == "GHC.Integer.Type.Jp#"
-        -> pure (head argExprsFiltered)
+        , HW.Literal Nothing (NumLit _) <- head argExprs
+        -> pure (head argExprs)
         | dcNm == "GHC.Integer.Type.Jn#"
-        , HW.Literal Nothing (NumLit i) <- head argExprsFiltered
+        -- ByteArray# are non-translatable / void, except when they're literals
+        , HW.Literal Nothing (NumLit i) <- head argExprs
         -> pure (HW.Literal Nothing (NumLit (negate i)))
       Unsigned _
         | dcNm == "GHC.Natural.NatS#"
         -> pure (head argExprsFiltered)
         | dcNm == "GHC.Natural.NatJ#"
-        -> pure (head argExprsFiltered)
+        -- ByteArray# are non-translatable / void, except when they're literals
+        , HW.Literal Nothing (NumLit _) <- head argExprs
+        -> pure (head argExprs)
       _ ->
         error $ $(curLoc) ++ "mkDcApplication undefined for: " ++ show (dstHType,dc,args,argHWTys)

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -25,9 +25,11 @@ module Clash.Netlist.BlackBox.Types
  , Element(..)
  , Decl(..)
  , HdlSyn(..)
+ , RenderVoid(..)
  ) where
 
 import                Control.DeepSeq            (NFData)
+import                Data.Aeson                 (FromJSON)
 import                Data.Binary                (Binary)
 import                Data.Hashable              (Hashable)
 import                Data.Text.Lazy             (Text)
@@ -40,6 +42,15 @@ import {-# SOURCE #-} Clash.Netlist.Types
   (BlackBox, NetlistMonad)
 
 import qualified      Clash.Signal.Internal      as Signal
+
+-- | Whether this primitive should be rendered when its result type is void.
+-- Defaults to 'NoRenderVoid'.
+data RenderVoid
+  = RenderVoid
+  -- ^ Render blackbox, even if result type is void
+  | NoRenderVoid
+  -- ^ Don't render blackbox result type is void. Default for all blackboxes.
+  deriving (Show, Generic, NFData, Binary, Hashable, FromJSON)
 
 data TemplateKind
   = TDecl
@@ -55,12 +66,13 @@ data BlackBoxMeta =
                , bbImports :: [BlackBoxTemplate]
                , bbFunctionPlurality :: [(Int, Int)]
                , bbIncludes :: [((S.Text, S.Text), BlackBox)]
+               , bbRenderVoid :: RenderVoid
                }
 
 -- | Use this value in your blackbox template function if you do want to
 -- accept the defaults as documented in @Clash.Primitives.Types.BlackBox@.
 emptyBlackBoxMeta :: BlackBoxMeta
-emptyBlackBoxMeta = BlackBoxMeta False TExpr [] [] [] []
+emptyBlackBoxMeta = BlackBoxMeta False TExpr [] [] [] [] NoRenderVoid
 
 -- | A BlackBox function generates a blackbox template, given the inputs and
 -- result type of the function it should provide a blackbox for. This is useful

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -331,6 +331,8 @@ data Expr
       !Bool                    -- FIELD Wrap in paretheses?
   | ConvBV     (Maybe Identifier) HWType Bool Expr
   | IfThenElse Expr Expr Expr
+  -- | Do nothing
+  | Noop
   deriving Show
 
 -- | Literals used in an expression

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -106,12 +106,6 @@ isVoid _       = False
 isFilteredVoid :: FilteredHWType -> Bool
 isFilteredVoid = isVoid . stripFiltered
 
-isBiSignalOut :: HWType -> Bool
-isBiSignalOut (Void (Just (BiDirectional Out _))) = True
-isBiSignalOut (Vector n ty) | n /= 0              = isBiSignalOut ty
-isBiSignalOut (RTree _ ty)                        = isBiSignalOut ty
-isBiSignalOut _                                   = False
-
 mkIdentifier :: IdType -> Identifier -> NetlistMonad Identifier
 mkIdentifier typ nm = Lens.use mkIdentifierFn <*> pure typ <*> pure nm
 

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -97,6 +97,10 @@ stripFiltered (FilteredHWType hwty _filtered) = hwty
 flattenFiltered :: FilteredHWType -> [[Bool]]
 flattenFiltered (FilteredHWType _hwty filtered) = map (map fst) filtered
 
+isVoidMaybe :: Bool -> Maybe HWType -> Bool
+isVoidMaybe dflt Nothing = dflt
+isVoidMaybe _dflt (Just t) = isVoid t
+
 -- | Determines if type is a zero-width construct ("void")
 isVoid :: HWType -> Bool
 isVoid Void {} = True

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -751,7 +751,7 @@ removeUnusedExpr :: HasCallStack => NormRewrite
 removeUnusedExpr _ e@(collectArgsTicks -> (p@(Prim nm pInfo),args,ticks)) = do
   bbM <- HashMap.lookup nm <$> Lens.use (extra.primitives)
   case bbM of
-    Just (extractPrim ->  Just (BlackBox pNm _ _ _ _ _ _ _ inc r ri templ)) -> do
+    Just (extractPrim ->  Just (BlackBox pNm _ _ _ _ _ _ _ _ inc r ri templ)) -> do
       let usedArgs | isFromInt pNm
                    = [0,1,2]
                    | nm `elem` ["Clash.Annotations.BitRepresentation.Deriving.dontApplyInHDL"

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -39,7 +39,7 @@ import {-# SOURCE #-} Clash.Netlist.Types
 import           Clash.Annotations.Primitive  (PrimitiveGuard)
 import           Clash.Core.Term (WorkInfo (..))
 import           Clash.Netlist.BlackBox.Types
-  (BlackBoxFunction, BlackBoxTemplate, TemplateKind (..))
+  (BlackBoxFunction, BlackBoxTemplate, TemplateKind (..), RenderVoid(..))
 import           Control.Applicative          ((<|>))
 import           Control.DeepSeq              (NFData)
 import           Data.Aeson
@@ -142,6 +142,9 @@ data Primitive a b c d
     -- ^ Name of the primitive
   , workInfo  :: WorkInfo
     -- ^ Whether the primitive does any work, i.e. takes chip area
+  , renderVoid :: RenderVoid
+    -- ^ Whether this primitive should be rendered when its result type is
+    -- void. Defaults to 'NoRenderVoid'.
   , kind      :: TemplateKind
     -- ^ Whether this results in an expression or a declaration
   , warning  :: c
@@ -226,6 +229,7 @@ instance FromJSON UnresolvedPrimitive where
           "BlackBox"  ->
             BlackBox <$> conVal .: "name"
                      <*> (conVal .:? "workInfo" >>= maybe (pure Nothing) parseWorkInfo) .!= WorkVariable
+                     <*> conVal .:? "renderVoid" .!= NoRenderVoid
                      <*> (conVal .: "kind" >>= parseTemplateKind)
                      <*> conVal .:? "warning"
                      <*> conVal .:? "outputReg" .!= False

--- a/clash-lib/src/Clash/Primitives/Util.hs
+++ b/clash-lib/src/Clash/Primitives/Util.hs
@@ -96,7 +96,7 @@ resolvePrimitive' _metaPath (Primitive name wf primType) =
   return (name, HasBlackBox (Primitive name wf primType))
 resolvePrimitive' metaPath BlackBox{template=t, includes=i, resultName=r, resultInit=ri, ..} = do
   let resolveSourceM = traverse (traverse (resolveTemplateSource metaPath))
-  bb <- BlackBox name workInfo kind () outputReg libraries imports functionPlurality
+  bb <- BlackBox name workInfo renderVoid kind () outputReg libraries imports functionPlurality
           <$> mapM (traverse resolveSourceM) i
           <*> traverse resolveSourceM r
           <*> traverse resolveSourceM ri

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -218,6 +218,11 @@ traceIf True  msg = trace msg
 traceIf False _   = id
 {-# INLINE traceIf #-}
 
+-- | A version of 'concatMap' that works with a monadic predicate.
+concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
+concatMapM f as = concat <$> sequence (map f as)
+{-# INLINE concatMapM #-}
+
 -- | Monadic version of 'Data.List.partition'
 partitionM :: Monad m
            => (a -> m Bool)

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -493,3 +493,9 @@ unwantedLanguageExtensions =
   , LangExt.Strict
   , LangExt.StrictData
   ]
+
+filterOnFst :: (a -> Bool) -> [(a, b)] -> [b]
+filterOnFst f xs = map snd (filter (f . fst) xs)
+
+filterOnSnd :: (b -> Bool) -> [(a, b)] -> [a]
+filterOnSnd f xs = map fst (filter (f . snd) xs)

--- a/tests/shouldwork/BlackBox/ZeroWidth.hs
+++ b/tests/shouldwork/BlackBox/ZeroWidth.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE BangPatterns #-}
+
+module ZeroWidth where
+
+import qualified Prelude                      as P
+import           Control.Monad                (forM_)
+import           Clash.Annotations.Primitive
+import           Clash.Prelude
+import           GHC.Exts
+import           Data.String.Interpolate      (i)
+import           Data.String.Interpolate.Util (unindent)
+import           Data.List                    (isInfixOf)
+import           System.Environment           (getArgs)
+import           System.FilePath              ((</>), takeDirectory)
+
+
+luckyNumber, question, answer :: String
+luckyNumber = "Your lucky number is 3552664958674928."
+question = "What lies on the bottom of the ocean and twitches?"
+answer = "A nervous wreck."
+
+
+-- | Inserts given comment in HDL. Returns "nothing".
+comment :: String -> ()
+comment !_s = ()
+{-# NOINLINE comment #-}
+{-# ANN comment (InlinePrimitive VHDL $ unindent [i|
+  [ { "BlackBox" :
+      { "name"      : "ZeroWidth.comment"
+      , "kind"      : "Declaration"
+      , "renderVoid": "RenderVoid"
+      , "template"  : "~NAME[0]"
+      }
+    }
+  ] |]
+  ) #-}
+
+implicitComment :: Int -> ()
+implicitComment n =
+  case n of
+    5 -> ()
+    _ ->
+      comment question
+{-# NOINLINE implicitComment #-}
+
+topEntity :: Int -> (Int, (), ())
+topEntity a = (succ a, comment luckyNumber, implicitComment a)
+
+mainHDL :: String -> String -> IO ()
+mainHDL topFile implFile = do
+  [topDir] <- getArgs
+  contentTopEntity <- readFile (takeDirectory topDir </> topFile)
+  contentImplicitComment <- readFile (takeDirectory topDir </> implFile)
+
+  if luckyNumber `isInfixOf` contentTopEntity then
+    pure ()
+  else
+    error $ "Expected:\n\n" P.++ luckyNumber
+       P.++ "\n\nBut did not find it in:\n\n" P.++ contentTopEntity
+
+  if question `isInfixOf` contentImplicitComment then
+    pure ()
+  else
+    error $ "Expected:\n\n" P.++ question
+       P.++ "\n\nBut did not find it in:\n\n" P.++ contentImplicitComment
+
+mainSystemVerilog, mainVerilog, mainVHDL :: IO ()
+mainSystemVerilog = error "NYI"
+mainVerilog       = error "NYI"
+mainVHDL          = mainHDL "topentity.vhdl" "implicitcomment.vhdl"

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -138,6 +138,7 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "BlackBoxFunction"   "main"
         , runTest "BlackBoxFunctionHO" def{hdlTargets=[VHDL]}
         , outputTest ("tests" </> "shouldwork" </> "Signal")   allTargets [] [] "BlockRamLazy"       "main"
+        , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "ZeroWidth"          "main"
         , runFailingTest ("tests" </> "shouldfail" </> "BlackBox") [VHDL] [] "WrongReference" (Just "Function WrongReference.myMultiply was annotated with an inline primitive for WrongReference.myMultiplyX. These names should be the same.")
         ]
       , clashTestGroup "BoxedFunctions"


### PR DESCRIPTION
    Add 'RenderVoid' option to blackboxes
    
    Void data (e.g., `Index 1`, `BitVector 0`, `()`) results in zero-width
    vectors in HDL. HDL tools handle these constructs poorly. To work around
    that 01843d3f1907111c460536ef3e37ccb679d74135 added void-filtering to
    Clash. As a consequence, any functions solely generating a void
    construct aren't rendered at all. Often, this is okay: functions
    yielding voids are generally the result of a generalization and don't
    perform any actually work when instantiated with a void. _Sometimes_
    though, we would like to generate them:
    
     * In the case of `BiSignal`s, one would like to completely remove any
       `BiSignalOut`s from the HDL, as the corresponding `BiSignalIn` will
       already be converted to an `inout` wire. We'd still like to render
       all the blackboxes yielding a `BiSignalOut` though.
    
     * (SystemVerilog) Assertions don't carry any "out" signals. They
       construct a comment instructing the simulator / verification tool to
       check some property. Clash simulation can't support this though:
       functions without outputs simply do not exist. In this case, we'd
       like to mark an "assertion result" as void, so it would get filtered
       in HDL. Similar to the previous use case, we'ld like the comments
       to be rendered still. See #864 for more information.
    
     * Some `IO ()` actions as described in #815 must result in HDL. Like
       the previous two features, `IO ()` would get filtered though.
    
    This commit allows blackboxes to specify whether they would like to be
    rendered even if their result is void. Note that any blackboxes
    specifying this must make sure that they do not assign anything to
    their result - as this is zero bits, Clash won't generate any signal
    declarations for it.
    
    As a happy coincidence, this removes the need for special support for
    BiSignalOut in the compiler.
