### PR TITLE
Add 'WorkerWrapper' to unwanted optimizations list

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -583,6 +583,7 @@ wantedOptimizationFlags df =
                , Opt_Loopification -- STG pass, don't care
                , Opt_CprAnal -- The worker/wrapper introduced by CPR breaks Clash, see [NOTE: CPR breaks Clash]
                , Opt_FullLaziness -- increases sharing, but seems to result in worse circuits (in both area and propagation delay)
+               , Opt_WorkerWrapper -- can cause data constructions of Clocks/Resets to be exposed
                ]
 
     -- Coercions between Integer and Clash' numeric primitives cause Clash to


### PR DESCRIPTION
The I2C test in our testsuite would trip after some (seemingly
unrelated) internal API changes, after GHC decided to perform a worker
wrapper transformation on a function taking a Clock argument. This
transformation caused Clash to see projections/DC applications of the
Clock type.