### PR TITLE
Conditionally stop deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@
       `HiddenClockResetEnable` constraint is supported.
     * Data/type family support is best effort.
   * Added `Bundle ((f :*: g) a)` instance
-  * Added `NFDataX CUShort` instance`
+  * Added `NFDataX CUShort` instance
   * Clash's internal type family solver now recognizes `AppendSymbol` and `CmpSymbol`
   * Added `Clash.Magic.suffixNameFromNat`: can be used in cases where `suffixName` is too slow
   * Added `Clash.Class.AutoReg`. Improves the chances of synthesis tools inferring clock-gated registers, when used. See [#873](https://github.com/clash-lang/clash-compiler/pull/873).
   * `Clash.Magic.suffixNameP`, `Clash.Magic.suffixNameFromNatP`: enable prefixing of name suffixes
+  * Added `Clash.Magic.noDeDup`: can be used to instruct Clash to /not/ share a function between multiple branches
 
 * New internal features:
   * [#821](https://github.com/clash-lang/clash-compiler/pull/821): Add `DebugTry`: print name of all tried transformations, even if they didn't succeed

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -347,6 +347,9 @@ coreToTerm primMap unlocs = term
         go "Clash.Magic.setName" args
           | [Type nmTy,_aTy,f] <- args
           = C.Tick <$> (C.NameMod C.SetName <$> coreToType nmTy) <*> term f
+        go "Clash.Magic.noDeDup" args
+          | [_aTy,f] <- args
+          = C.Tick C.NoDeDup <$> term f
 
         go _ _ = term' e
     term' (Var x)                 = var x

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -234,6 +234,7 @@ instance PrettyPrec TickInfo where
   pprPrec prec (NameMod SuffixName t) = ("<suffixName>" <>) <$> pprPrec prec t
   pprPrec prec (NameMod SuffixNameP t) = ("<suffixNameP>" <>) <$> pprPrec prec t
   pprPrec prec (NameMod SetName t)    = ("<setName>" <>) <$> pprPrec prec t
+  pprPrec _    NoDeDup                = pure "<noDeDup>"
 
 instance PrettyPrec SrcSpan where
   pprPrec _ sp = return ("<src>"<>pretty (GHC.showSDocUnsafe (GHC.ppr sp)))

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -488,6 +488,7 @@ substTm doc subst = go where
 
   goTick t@(SrcSpan _)  = t
   goTick (NameMod m ty) = NameMod m (substTy subst ty)
+  goTick t@NoDeDup      = t
 
 -- | Find the substitution for an 'Id' in the 'Subst'
 lookupIdSubst

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -71,6 +71,9 @@ data TickInfo
   | NameMod !NameMod !Type
   -- ^ Modifier for naming module instantiations and registers, are added by
   -- the user by using the functions @Clash.Magic.[prefixName,suffixName,setName]@
+  | NoDeDup
+  -- ^ Do not deduplicate, i.e. /keep/, an expression inside a case-alternative;
+  -- do not try to share expressions between multiple branches.
   deriving (Eq,Show,Generic,NFData,Hashable,Binary)
 
 -- | Tag to indicate which instance/register name modifier was used

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -1881,6 +1881,8 @@ withTicks ticks0 k = do
  where
   go decls [] = k (reverse decls)
 
+  go decls (NoDeDup:ticks) = go decls ticks
+
   go decls (SrcSpan sp:ticks) =
     go (TickDecl (Text.pack (showSDocUnsafe (ppr sp))):decls) ticks
 

--- a/examples/Sprockell.hs
+++ b/examples/Sprockell.hs
@@ -186,12 +186,12 @@ alu opCode (x, y) = (z, cnd)
             Neg     -> \x y -> -x
             Add     -> (+)          -- goes without saying
             Sub     -> (-)
-            Mul     -> (*)
+            Mul     -> noDeDup (*)
             Equal   -> (tobit.).(==)    -- test for equality; result 0 or 1
             NEq     -> (tobit.).(/=)    -- test for inequality
             Gt      -> (tobit.).(>)
             Lt      -> (tobit.).(<)
-            And     -> (*)
+            And     -> noDeDup (*)
             Or      -> \x y -> 0
             Not     -> \x y -> 1-x
             NoOp    -> \x y -> 0        -- result will always be 0

--- a/tests/shouldwork/Netlist/NoDeDup.hs
+++ b/tests/shouldwork/Netlist/NoDeDup.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module NoDeDup where
+
+import Prelude as P
+
+import Clash.Magic
+import Clash.Prelude
+import Clash.Netlist.Types
+
+import Test.Tasty.Clash
+import Test.Tasty.Clash.NetlistTest
+
+data ABCD = A | B | C | D
+
+twice :: Int -> Int
+twice a = 2 * a
+{-# NOINLINE twice #-}
+
+-- | 'f' should have one call to twice in the netlist
+f :: Int -> ABCD -> Int
+f n abcd =
+  case abcd of
+    A -> twice (6 + n)
+    B -> 5 + n
+    C -> n - 3
+    D -> twice (3 + n)
+{-# NOINLINE f #-}
+
+-- | 'g' should have two calls to twice in the netlist
+g :: Int -> ABCD -> Int
+g n abcd =
+  case abcd of
+    A -> noDeDup (twice (6 + n))
+    B -> 5 + n
+    C -> n - 3
+    D -> noDeDup (twice (3 + n))
+{-# NOINLINE g #-}
+
+topEntity :: Int -> ABCD -> Int
+topEntity n abcd = (f n abcd) - (g n abcd)
+
+testPath :: FilePath
+testPath = "tests/shouldwork/Netlist/NoDeDup.hs"
+
+isTwiceInst (InstDecl Entity Nothing "twice" _ _ _) = True
+isTwiceInst _ = False
+
+assertNumTwiceInsts :: Component -> IO ()
+assertNumTwiceInsts (Component nm inps outs ds) =
+  case nm of
+    "f" | nTwiceInsts == 1 -> pure ()
+        | otherwise ->
+            error ( "Found " <> show nTwiceInsts <> " instances of twice in f. "
+                 <> "Expected 1.")
+    "g" | nTwiceInsts == 2 -> pure ()
+        | otherwise ->
+            error ( "Found " <> show nTwiceInsts <> " instances of twice in g. "
+                 <> "Expected 2.")
+    "twice" -> pure ()
+    "topentity" -> pure ()
+    _ -> error ("Unexpected component: " <> show nm)
+ where
+  twiceInsts = filter isTwiceInst ds
+  nTwiceInsts = P.length twiceInsts
+
+getComponent :: (a, b, c, d) -> d
+getComponent (_, _, _, x) = x
+
+mainVHDL :: IO ()
+mainVHDL = do
+  netlist <- runToNetlistStage SVHDL [] testPath
+  mapM_ (assertNumTwiceInsts . getComponent) netlist

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -39,6 +39,7 @@ runClashTest :: IO ()
 runClashTest = defaultMain $ clashTestRoot
   [ clashTestGroup "netlist"
     [ netlistTest ("tests" </> "shouldwork" </> "Netlist") allTargets [] "Identity" "main"
+    , netlistTest ("tests" </> "shouldwork" </> "Netlist") [VHDL] [] "NoDeDup" "main"
     ]
   , clashTestGroup "examples"
     [ runTest "ALU" def{hdlSim=False}


### PR DESCRIPTION
Normally Clash converts

```haskell
case x of
  A -> f 3 y
  B -> f x x
  C -> h x
```

to

```haskell
let f_arg0 = case x of {A -> 3; _ -> x}
    f_arg1 = case x of {A -> y; _ -> x}
    f_out  = f f_arg0 f_arg1
in  case x of
      A -> f_out
      B -> f_out
      C -> h x
```

i.e. it deduplicates functions (and certain operators) between
case-alternatives to save on area. This comes at the cost of
multiplexers on the arguments of the deduplicated function
(or operator), which add to the propagation delay for the entire
case-expression.

So sometimes we don't want Clash to do the deduplication, i.e.
it adds to the critical path. In that case we can now specifically
tell Clash not to deduplicate:

```haskell
case x of
  A -> noDeDup f 3 y
  B -> f x y
  C -> h x
```

where the application of `f` in the A-alternative is now
explicitly not deduplicated, and the `f` in the B-alternative
is the only remaining application of `f` it also will not be
deduplicated.

If the C-alternative also had an application of `f`, then the
applications of `f` in the B- and C-alternatives would have
been deduplicated; i.e. there would have been two applications
of `f` in total.