### PR TITLE
Fix type of (:<), add COMPLETE pragmas. Fixes #867.

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -321,6 +321,7 @@ test-suite unittests
       clash-prelude,
 
       ghc-typelits-knownnat,
+      ghc-typelits-natnormalise,
 
       base,
       hint          >= 0.7      && < 0.10,
@@ -338,6 +339,7 @@ test-suite unittests
                  Clash.Tests.Signal
                  Clash.Tests.NFDataX
                  Clash.Tests.TopEntityGeneration
+                 Clash.Tests.Vector
 
 
 benchmark benchmark-clash-prelude

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright  :  (C) 2014-2016, University of Twente,
+Copyright  :  (C) 2013-2016, University of Twente,
                   2017     , Myrtle Software Ltd
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
@@ -262,6 +262,8 @@ cCons = mkConstr tVec "Cons" [] Prefix
 instance NFData a => NFData (Vec n a) where
   rnf = foldl (\() -> rnf) ()
 
+{-# COMPLETE (:>)       #-}
+{-# COMPLETE Nil, (:>)  #-}
 -- | Add an element to the head of a vector.
 --
 -- >>> 3 :> 4 :> 5 :> Nil
@@ -297,6 +299,8 @@ pattern x :> xs = Cons x xs
 
 infixr 5 :>
 
+{-# COMPLETE (:<)       #-}
+{-# COMPLETE Nil, (:<)  #-}
 -- | Add an element to the tail of a vector.
 --
 -- >>> (3 :> 4 :> 5 :> Nil) :< 1
@@ -326,16 +330,17 @@ pattern (:<)
   :: forall m a
    . ()
   => forall n
-   . (m ~ n)
-  => Vec n a -> a -> Vec (m + 1) a
+   . ((n + 1) ~ m)
+  => Vec n a -> a -> Vec m a
 pattern xs :< x <- (snocPattern -> Cons x xs)
   where
     xs :< x = xs ++ singleton x
 
 infixl 5 :<
 
-snocPattern :: Vec (n + 1) a -> Vec (n + 1) a
-snocPattern xs  = Cons (last xs) (init xs)
+snocPattern :: Vec n a -> Vec n a
+snocPattern Nil         = Nil
+snocPattern xs@(_ :> _) = last xs :> init xs
 {-# INLINE snocPattern #-}
 
 

--- a/clash-prelude/tests/Clash/Tests/Vector.hs
+++ b/clash-prelude/tests/Clash/Tests/Vector.hs
@@ -1,0 +1,118 @@
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
+
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE TypeOperators    #-}
+
+module Clash.Tests.Vector where
+
+import           Data.List (isInfixOf)
+import           Language.Haskell.Interpreter (OptionVal((:=)))
+import qualified Language.Haskell.Interpreter as Hint
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Clash.Prelude
+import qualified Clash.Sized.Vector as Vec
+
+typeCheck
+  :: ([Hint.GhcError] -> Assertion)
+  -> (String -> Assertion)
+  -> String
+  -> Assertion
+typeCheck fErr fTy expr = do
+  result <- Hint.runInterpreter $ do
+    Hint.reset
+    Hint.set [Hint.languageExtensions := langExts]
+    Hint.setImports ["Clash.Prelude"]
+
+    mapM_ Hint.runStmt [test0s, test1s]
+    Hint.typeChecksWithDetails expr
+
+  case result of
+    Left err -> assertFailure $ "Failed to run interpreter: " <> show err
+    Right x  -> either fErr fTy x
+ where
+  langExts =
+    [ Hint.DataKinds
+    , Hint.GADTs
+    , Hint.TypeOperators
+    ]
+
+assertType :: String -> String -> Assertion
+assertType ty = typeCheck fErr fTy
+ where
+  fErr es = assertFailure
+    $ "Expression failed to typecheck: " <> show es
+
+  fTy = assertEqual "assertType" ty
+
+assertError :: String -> String -> Assertion
+assertError expected = typeCheck fErr fTy
+ where
+  fErr es
+    | any containsErr es = return ()
+    | otherwise          = assertFailure
+        $ "Expression failed with unexpected error: " <> show es
+   where
+    containsErr e = expected `isInfixOf` show (Hint.errMsg e)
+
+  fTy ty = assertFailure
+    $ "Supposedly invalid expression type checked as: " <> show ty
+
+test0s :: String
+test0s = "let test0 = undefined :: Vec n a -> Vec n a"
+
+test1s :: String
+test1s = mconcat
+  [ "let test1 :: Vec n a -> Vec (n + 1) a;"
+  , "test1 = undefined"
+  ]
+
+tests :: TestTree
+tests = testGroup "Vector"
+  [ testCase "test0" $ assertType "Vec n a -> Vec n a" "test0"
+  , testCase "test1" $ assertType "Int"
+      "let x :: Int; (x :> _) = test1 (Nil :: Vec 0 Int) in x"
+
+  , testGroup "Untouchable GADT Patterns" 
+    [ testCase "Cons" $ assertError "is untouchable"
+        "let f x@(Cons _ _) = x in f undefined"
+    
+    , testCase "(:>)" $ assertError "is untouchable"
+        "let f x@(_ :> _) = x in f undefined"
+
+    , testCase "(:<)" $ assertError "is untouchable"
+        "let f x@(_ :< _) = x in f undefined"
+    ]
+
+  , testGroup "Pattern Synonym Examples"
+    [ testCase "middleL/R" $ middleL vec  @?= middleR vec
+    , testCase "issueEx1"  $ issueEx1 vec @?= vec
+    , testCase "issueEx2"  $ issueEx2 vec @?= Vec.length vec /= 0
+    ]
+  ]
+ where
+  vec :: Vec 10 Int
+  vec = $(listToVecTH [(1 :: Int)..10])
+
+-- Functions below should survive recompilation
+
+middleL :: Vec (n + 2) a -> Vec n a
+middleL ((_ :> xs) :< _) = xs
+
+middleR :: Vec (n + 2) a -> Vec n a
+middleR (_ :> (xs :< _)) = xs
+
+issueEx1 :: (KnownNat n) => Vec n a -> Vec n a
+issueEx1 Nil         = Nil
+issueEx1 xs@(_ :> _) = f xs
+ where
+  f :: (1 <= n, KnownNat n) => Vec n a -> Vec n a
+  f = id
+
+issueEx2 :: Vec n a -> Bool
+issueEx2 Nil      = False
+issueEx2 (_ :< _) = True
+

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -9,6 +9,7 @@ import qualified Clash.Tests.DerivingDataRepr
 import qualified Clash.Tests.Signal
 import qualified Clash.Tests.NFDataX
 import qualified Clash.Tests.TopEntityGeneration
+import qualified Clash.Tests.Vector
 
 tests :: TestTree
 tests = testGroup "Unittests"
@@ -19,6 +20,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.Signal.tests
   , Clash.Tests.NFDataX.tests
   , Clash.Tests.TopEntityGeneration.tests
+  , Clash.Tests.Vector.tests
   ]
 
 main :: IO ()


### PR DESCRIPTION
The previous changes in this issue did not in practice work as
expected in all cases, as it gave some type errors for correct
definitions using (:<), and gave warnings that functions using
the pattern synonyms did not cover all cases. These have been
amended now, and the issue should be solved.