### PR TITLE
Remove global trace map in `Clash.Signal.Trace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   * Added `Clash.Class.AutoReg`. Improves the chances of synthesis tools inferring clock-gated registers, when used. See [#873](https://github.com/clash-lang/clash-compiler/pull/873).
   * `Clash.Magic.suffixNameP`, `Clash.Magic.suffixNameFromNatP`: enable prefixing of name suffixes
   * Added `Clash.Magic.noDeDup`: can be used to instruct Clash to /not/ share a function between multiple branches
+  * Added `Clash.Annotations.Primitive.idBlackBoxTH`: can be used to easily create blackboxes that simply forward one of its arguments.
 
 * New internal features:
   * [#821](https://github.com/clash-lang/clash-compiler/pull/821): Add `DebugTry`: print name of all tried transformations, even if they didn't succeed

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -584,6 +584,7 @@ wantedOptimizationFlags df =
                , Opt_Loopification -- STG pass, don't care
                , Opt_CprAnal -- The worker/wrapper introduced by CPR breaks Clash, see [NOTE: CPR breaks Clash]
                , Opt_FullLaziness -- increases sharing, but seems to result in worse circuits (in both area and propagation delay)
+               , Opt_WorkerWrapper -- can cause data constructions of Clocks/Resets to be exposed
                ]
 
     -- Coercions between Integer and Clash' numeric primitives cause Clash to

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -265,6 +265,7 @@ Library
                       containers                >= 0.4.0   && < 0.7,
                       data-binary-ieee754       >= 0.4.4   && < 0.6,
                       data-default-class        >= 0.1.2   && < 0.2,
+                      data-default              >= 0.7     && < 0.8,
                       integer-gmp               >= 0.5.1.0 && < 1.1,
                       deepseq                   >= 1.4.1.0 && < 1.5,
                       ghc-prim                  >= 0.5.1.0 && < 0.6,

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -266,7 +266,9 @@ Library
                       data-binary-ieee754       >= 0.4.4   && < 0.6,
                       data-default-class        >= 0.1.2   && < 0.2,
                       data-default              >= 0.7     && < 0.8,
+                      entropy                   >= 0.4     && < 0.5,
                       integer-gmp               >= 0.5.1.0 && < 1.1,
+                      interpolate               >= 0.2.0    && < 1.0,
                       deepseq                   >= 1.4.1.0 && < 1.5,
                       ghc-prim                  >= 0.5.1.0 && < 0.6,
                       ghc-typelits-extra        >= 0.3.1   && < 0.4,
@@ -288,6 +290,7 @@ Library
                       time                      >= 1.8     && < 1.10,
                       transformers              >= 0.5.2.0 && < 0.6,
                       type-errors               >= 0.2.0.0 && < 0.3,
+                      unordered-containers      >= 0.2.10   && < 0.3,
                       vector                    >= 0.11    && < 1.0
 
 test-suite doctests
@@ -328,7 +331,8 @@ test-suite unittests
       tasty         >= 1.2      && < 1.3,
       tasty-hunit,
       tasty-quickcheck,
-      template-haskell
+      template-haskell,
+      text
 
   Other-Modules:
                  Clash.Tests.AutoReg
@@ -337,6 +341,7 @@ test-suite unittests
                  Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes
                  Clash.Tests.Signal
+                 Clash.Tests.Signal.Trace
                  Clash.Tests.NFDataX
                  Clash.Tests.TopEntityGeneration
 

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -56,10 +56,8 @@ module Clash.Signal.Internal
   , mergeSignalMeta#
   , mergeSignalMetas#
   , metaNameMap
-  , metaNameMap1
   , meta#
   , toStream#
-  , getRandomMetaId
     -- * Domains
   , Domain
   , KnownDomain(..)
@@ -156,7 +154,6 @@ where
 
 import           Clash.Annotations.Primitive (hasBlackBox)
 import           Control.Applicative        (liftA2, liftA3)
-import           Control.Arrow              (second)
 import           Control.DeepSeq            (NFData)
 import           Data.Binary                (Binary, decode)
 import           Data.ByteString.Lazy       (fromStrict)
@@ -709,22 +706,9 @@ getRandomMetaId = MetaId <$> decode <$> fromStrict <$> getEntropy 32
 -- | Remove meta ids from a meta hashmap, leaving only a mapping from meta names
 -- to their values.
 metaNameMap
-  :: (HashSet MetaId -> HashMap MetaId (MetaName, a))
-  -> HashMap MetaName [a]
-metaNameMap fm =
-  let m = fm HashSet.empty in
-  HashMap.fromListWith (<>) (map (second pure) (HashMap.elems m))
-
--- | Same as 'metaNameMap', but assumes meta names in given meta map correspond
--- to only a single value. If it doesn't, 'metaNameMap1' returns a list of meta
--- names violating this property.
-metaNameMap1
-  :: (HashSet MetaId -> HashMap MetaId (MetaName, a))
-  -> Either [MetaName] (HashMap MetaName a)
-metaNameMap1 (metaNameMap -> m) =
-  case filter (\(_, v) -> length v > 1) (HashMap.toList m) of
-    [] -> Right (HashMap.map head m)
-    dups -> Left (map fst dups)
+  :: (HashSet MetaId -> HashMap MetaName a)
+  -> HashMap MetaName a
+metaNameMap fm = fm HashSet.empty
 
 {-
 Note [The why and how of "SignalMeta"]

--- a/clash-prelude/tests/Clash/Tests/Signal/Trace.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal/Trace.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Tests.Signal.Trace where
+
+import           Prelude
+import           Clash.Prelude          hiding (take,drop)
+import           Clash.Signal.Trace     (dumpToList)
+import qualified Data.Text              as Text
+import           Data.Text              (Text)
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+dump :: Signal dom a -> Int -> Text -> [Int]
+dump s n nm =
+  case take n <$> dumpToList s nm of
+    Left err -> error (Text.unpack err)
+    Right ints -> ints
+
+dumpS :: Text -> [Int]
+dumpS = dump simpleTrace 5
+
+dumpR :: Text -> [Int]
+dumpR = dump recursiveTrace 10
+
+-- | Simple (non-recursive) adder, where the inputs are delayed by a register
+simpleTrace :: Signal System Int
+simpleTrace = withClockResetEnable clockGen resetGen enableGen $
+  delayedAdd
+    (fromListWithReset 2 [3, 4, 5])
+    (fromListWithReset 20 [30, 40, 50])
+ where
+  delayedAdd a b =
+    let
+      a' = traceSignal "a'" (register 1 a)
+      b' = traceSignal "b'" (register 10 b)
+    in
+      traceSignal "c" (a' + b')
+
+-- | Recursively defined  counting circuit
+recursiveTrace :: Signal System Int
+recursiveTrace = withClockResetEnable clockGen resetGen enableGen c
+ where
+  c :: HiddenClockResetEnable dom => Signal dom Int
+  c =
+    let
+      a = traceSignal "a" $ mealy (\(!s) i -> (s+i, s)) 0 b
+      b = traceSignal "b" $ mealy (\(!s) i -> (s+i, s)) 8 a
+    in
+      a
+
+tests :: TestTree
+tests = testGroup "Signal.Trace"
+  [ testGroup "Simple"
+    [ -- Simple, non-recursive test case
+      testCase "a'" $ dumpS "a'" @?= [1,1,3,4,5]
+    , testCase "b'" $ dumpS "b'" @?= [10,10,30,40,50]
+    , testCase "c"  $ dumpS "c" @?= [11,11,33,44,55]
+    ]
+  , testGroup "Rec"
+    [ -- Recursive test case, to test for <<loop>>
+      testCase "a" $ dumpR "a" @?= [0,0,8,16,32,64,128,256,512,1024]
+    , testCase "b" $ dumpR "b" @?= [8,8,8,16,32,64,128,256,512,1024]
+    ]
+  ]
+

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -7,6 +7,7 @@ import qualified Clash.Tests.BitPack
 import qualified Clash.Tests.BitVector
 import qualified Clash.Tests.DerivingDataRepr
 import qualified Clash.Tests.Signal
+import qualified Clash.Tests.Signal.Trace
 import qualified Clash.Tests.NFDataX
 import qualified Clash.Tests.TopEntityGeneration
 
@@ -17,6 +18,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.BitVector.tests
   , Clash.Tests.DerivingDataRepr.tests
   , Clash.Tests.Signal.tests
+  , Clash.Tests.Signal.Trace.tests
   , Clash.Tests.NFDataX.tests
   , Clash.Tests.TopEntityGeneration.tests
   ]


### PR DESCRIPTION
This fixes most of the weird behavior of `traceSignal`. We can reuse this infrastructure for assertions and validation in the future.

```
Note [The why and how of "SignalMeta"]
--------------------------------------------------------------
For various features, most notably traces (see "Clash.Signal.Trace") and
assertions (see "Clash.Validation"), we'd like access to some data structure
created inside a design. For example, a user might want to trace a signal
for debugging purposes. At first glance, we've got three basic design options:

  1. Make the user propagate the trace all the way to their top-level function
  2. Use 'unsafePerformIO' to print every value to stdout
  3. Use 'unsafePerformIO' to store the trace in a global map

All three of these options leave a lot to be desired. We either ask too much of
the user (1) or we introduce all the dragons that come with 'unsafePerformIO'
(2, 3).

"SignalMeta" tries to solve these problems by redefining "Signal" to not just
be a stream of values (~ `a :- Signal a`), but a product of meta information and
the stream. 'traceSignal' can now store its trace in the signal's metadata. Any
time two signals are combined, the combinator should make sure the metadata from
both signals is propagated in the combined one. Ignoring blackboxes for now, the
only function combining two signals is '<*>' from the "Applicative" instance of
"Signal". So the next question is, what should the implementation of the
function merging the two metadatas look like? The most obvious implementation
(assuming SignalMeta carries some hashmap) would be:

@
  mergeMeta :: SignalMeta -> SignalMeta -> SignalMeta
  mergeMeta (SignalMeta f1) (SignalMeta f2) = SignalMeta (HashMap.union f1 f2)
@

This simple implementation doesn't really work though. In a feedback loop 'f1'
and 'f2' might (indirectly) be the result of @HashMap.union f1 f2@. Using it
therefore sets off an infinite loop.

We'd like to break the infinite loop triggered by the naive version of
'mergeMeta' written earlier. Instead of adding data to the map directly, we
store a function instead. This function takes a set of _seen_ identifiers. Every
merge-point ('mergeMeta') will generate a unique id and return the aforementioned
function with that id in scope. The function will check whether it has seen it's
own merge-point before. If it hasn't, it will add itself to the set of seen ids
and merge the incoming metadatas. If its own id _is_ in there, it can assume all
the metadata it would add is already in the metadata the caller collected so
far. It can therefore break the loop and simply return an empty map.
```

------------------------------------

Concerning performance: if you don't use the signal metadata, GHC can garbage collect it all, as any functions recurse over _streams_, not signals.

------------------------------------

@christiaanb Concerning `Add 'WorkerWrapper' to unwanted optimizations list`: the PR currently still need it. The I2C testbench fails as soon as we add "SignalMeta" to "Signal", even if "SignalMeta" itself is a data type with a single constructor with zero fields. The behavior is only triggered when using `-O2`. GHC then produces:

```
I2C.ByteMaster.$w$smealy43532 before normalization:

[..]

    λ(ww8286623314361987328 :: Clash.Promoted.Symbol.SSymbol8214565720323789525
                                 "System") ->
    λ(w8286623314361987321 :: Clash.Signal.Internal.Reset8214565720323789571
                                "System") ->
    λ(w18286623314361987322 :: Clash.Signal.Internal.Enable8214565720323789562
                                 "System") ->
    λ(w28286623314361987323 :: I2C.ByteMaster.ByteMasterS8214565720324019851
                           -> i8286623314361987318
                           -> GHC.Tuple.(,)3746994889972252676
                                I2C.ByteMaster.ByteMasterS8214565720324019851
                                o8286623314361987319) ->
    λ(w38286623314361987324 :: I2C.ByteMaster.ByteMasterS8214565720324019851) ->
    λ(w48286623314361987325 :: Clash.Signal.Internal.Signal8214565720323789592
                                 "System"
                                 i8286623314361987318) ->
```

the weird thing is that it's then only used to reconstruct the clock later on..

```
          (Clash.Signal.Internal.register# @"System"
             @I2C.ByteMaster.ByteMasterS8214565720324019851
             Clash.Signal.Internal.$fKnownDomain"System"8214565720323878380[GlobalId]
             I2C.ByteMaster.$fNFDataXByteMasterS8214565720324020842[GlobalId]
             (Clash.Signal.Internal.Clock8214565720323878019
                @"System"
                ww8286623314361987328[LocalId])
```

I don't understand why this is useful, or why it's triggered. 