### PR TITLE
Prefixing suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   * Clash's internal type family solver now recognizes `AppendSymbol` and `CmpSymbol`
   * Added `Clash.Magic.suffixNameFromNat`: can be used in cases where `suffixName` is too slow
   * Added `Clash.Class.AutoReg`. Improves the chances of synthesis tools inferring clock-gated registers, when used. See [#873](https://github.com/clash-lang/clash-compiler/pull/873).
+  * `Clash.Magic.suffixNameP`, `Clash.Magic.suffixNameFromNatP`: enable prefixing of name suffixes
 
 * New internal features:
   * [#821](https://github.com/clash-lang/clash-compiler/pull/821): Add `DebugTry`: print name of all tried transformations, even if they didn't succeed

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -338,6 +338,12 @@ coreToTerm primMap unlocs = term
         go "Clash.Magic.suffixNameFromNat" args
           | [Type nmTy,_aTy,f] <- args
           = C.Tick <$> (C.NameMod C.SuffixName <$> coreToType nmTy) <*> term f
+        go "Clash.Magic.suffixNameP" args
+          | [Type nmTy,_aTy,f] <- args
+          = C.Tick <$> (C.NameMod C.SuffixNameP <$> coreToType nmTy) <*> term f
+        go "Clash.Magic.suffixNameFromNatP" args
+          | [Type nmTy,_aTy,f] <- args
+          = C.Tick <$> (C.NameMod C.SuffixNameP <$> coreToType nmTy) <*> term f
         go "Clash.Magic.setName" args
           | [Type nmTy,_aTy,f] <- args
           = C.Tick <$> (C.NameMod C.SetName <$> coreToType nmTy) <*> term f

--- a/clash-lib/prims/common/Clash_Magic.json
+++ b/clash-lib/prims/common/Clash_Magic.json
@@ -14,6 +14,16 @@
     }
   }
 , { "Primitive" :
+    { "name"      : "Clash.Magic.suffixNameP"
+    , "primType"  : "Function"
+    }
+  }
+, { "Primitive" :
+    { "name"      : "Clash.Magic.suffixNameFromNatP"
+    , "primType"  : "Function"
+    }
+  }
+, { "Primitive" :
     { "name"      : "Clash.Magic.setName"
     , "primType"  : "Function"
     }

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -232,6 +232,7 @@ instance PrettyPrec TickInfo where
   pprPrec prec (SrcSpan sp)   = pprPrec prec sp
   pprPrec prec (NameMod PrefixName t) = ("<prefixName>" <>) <$> pprPrec prec t
   pprPrec prec (NameMod SuffixName t) = ("<suffixName>" <>) <$> pprPrec prec t
+  pprPrec prec (NameMod SuffixNameP t) = ("<suffixNameP>" <>) <$> pprPrec prec t
   pprPrec prec (NameMod SetName t)    = ("<setName>" <>) <$> pprPrec prec t
 
 instance PrettyPrec SrcSpan where

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -79,6 +79,8 @@ data NameMod
   -- ^ @Clash.Magic.prefixName@
   | SuffixName
   -- ^ @Clash.Magic.suffixName@
+  | SuffixNameP
+  -- ^ @Clash.Magic.suffixNameP@
   | SetName
   -- ^ @Clash.Magic.setName@
   deriving (Eq,Show,Generic,NFData,Hashable,Binary)

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -1896,6 +1896,9 @@ withTicks ticks0 k = do
   modName SuffixName (Text.pack -> s2) env@(NetlistEnv {_suffixName = s1})
     | Text.null s1 = env {_suffixName = s2}
     | otherwise    = env {_suffixName = s2 <> "_" <> s1}
+  modName SuffixNameP (Text.pack -> s2) env@(NetlistEnv {_suffixName = s1})
+    | Text.null s1 = env {_suffixName = s2}
+    | otherwise    = env {_suffixName = s1 <> "_" <> s2}
   modName SetName (Text.pack -> s) env = env {_setName = Just s}
 
 -- | Add the pre- and suffix names in the current environment to the given

--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -176,7 +176,7 @@ instance (KnownNat n, AutoReg a) => AutoReg (Vec n a) where
     bundle $ smap go (lazyV initVal) <*> unbundle xs
    where
     go :: forall (i :: Nat). SNat i -> a  -> Signal dom a -> Signal dom a
-    go SNat = suffixNameFromNat @i . autoReg clk rst en
+    go SNat = suffixNameFromNatP @i . autoReg clk rst en
 
 instance (KnownNat d, AutoReg a) => AutoReg (RTree d a) where
   autoReg clk rst en initVal xs =
@@ -250,8 +250,8 @@ instance (AutoReg a, AutoReg b, ..) => AutoReg (Product a b ..) where
       field1 = (\(MkProduct _ x ...) -> x) <$> input
       ...
       MkProduct initVal0 initVal1 ... = initVal
-      sig0 = suffixName @"getA" autoReg clk rst en initVal0 field0
-      sig1 = suffixName @"getB" autoReg clk rst en initVal1 field1
+      sig0 = suffixNameP @"getA" autoReg clk rst en initVal0 field0
+      sig1 = suffixNameP @"getB" autoReg clk rst en initVal1 field1
       ...
 -}
 deriveAutoRegProduct :: DatatypeInfo -> ConstructorInfo -> DecsQ
@@ -313,7 +313,7 @@ deriveAutoRegProduct tyInfo conInfo = go (constructorName conInfo) fieldInfos
         nameMe = case nameM of
           Nothing -> [| id |]
           Just nm -> let nmSym = litT $ strTyLit (nameBase nm)
-                     in [| suffixName @($nmSym) |]
+                     in [| suffixNameP @($nmSym) |]
 
     partDecls <- concat <$> (sequence $ zipWith4 genAutoRegDecl
                                                  (varP <$> sigs)

--- a/clash-prelude/src/Clash/Magic.hs
+++ b/clash-prelude/src/Clash/Magic.hs
@@ -34,6 +34,52 @@ suffixNameFromNat
 suffixNameFromNat = id
 {-# NOINLINE suffixNameFromNat #-}
 
+-- | Suffix instance and register names with the given 'Symbol', but add it
+-- in front of other suffixes.
+--
+-- When you write
+--
+-- @
+-- suffixName \@\"A\" (suffixName \@\"B\" f))
+-- @
+--
+-- you get register and instance names inside /f/ with the suffix: "_B_A"
+--
+-- However, if you want them in the other order you can write:
+--
+-- @
+-- suffixNameP \@\"A\" (suffixName \@\"B\" f))
+-- @
+--
+-- so that names inside /f/ will have the suffix "_A_B"
+suffixNameP
+  :: forall (name :: Symbol) a . a -> name ::: a
+suffixNameP = id
+{-# NOINLINE suffixNameP #-}
+
+-- | Suffix instance and register names with the given 'Nat', but add it in
+-- front of other suffixes.
+--
+-- When you write
+--
+-- @
+-- suffixNameNat \@1 (suffixName \@\"B\" f))
+-- @
+--
+-- you get register and instance names inside /f/ with the suffix: "_B_1"
+--
+-- However, if you want them in the other order you can write:
+--
+-- @
+-- suffixNameNatP \@1 (suffixName \@\"B\" f))
+-- @
+--
+-- so that names inside /f/ will have the suffix "_1_B"
+suffixNameFromNatP
+  :: forall (name :: Nat) a . a -> name ::: a
+suffixNameFromNatP = id
+{-# NOINLINE suffixNameFromNatP #-}
+
 -- | Name the instance or register with the given 'Symbol', instead of using
 -- an auto-generated name. Pre- and suffixes annotated with 'prefixName' and
 -- 'suffixName' will be added to both instances and registers named with


### PR DESCRIPTION
When you write

```
suffixName @"A" (suffixName "B" f))
```

you get names inside `f` with the suffix: "_B_A"

if you want them in the other order you now have:

```
suffixNameP @"A" (suffixName "B" f))
```

where names inside `f` will now have the suffix "_A_B"

This is also the behaviour that we want in the AutoReg instances