### PR TITLE
Fix Integral blackboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   * [#871](https://github.com/clash-lang/clash-compiler/issues/871): RTree Bundle instance is now properly lazy
   * [#895](https://github.com/clash-lang/clash-compiler/issues/895): VHDL type error when generating `Maybe (Vec 2 (Signed 8), Index 1)`
   * [#880](https://github.com/clash-lang/clash-compiler/issues/880): Custom bit representations can now be used on product types too
+  * [#934](https://github.com/clash-lang/clash-compiler/pull/934): Fix Integral blackboxes
 
 * Fixes without issue reports:
   * Fix bug in `rnfX` defined for `Down` ([baef30e](https://github.com/clash-lang/clash-compiler/commit/baef30eae03dc02ba847ffbb8fae7f365c5287c2))

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
@@ -1,15 +1,27 @@
 [ { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.div#"
     , "kind"      : "Declaration"
-    , "type"      : "div# :: KnownNat n => Signed n -> Signed n -> Signed n"
+    , "type"      : "div# :: Signed n -> Signed n -> Signed n"
     , "template"  :
 "// divSigned begin
-// divide (rounds towards zero)
-~SIGD[~GENSYM[quot_res][0]][1];
-assign ~SYM[0] = ~VAR[dividend][1] / ~VAR[divider][2];
+logic ~GENSYM[resultPos][1];
+logic ~GENSYM[dividerNeg][2];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
 
-// round toward minus infinity
-assign ~RESULT = (~VAR[dividend][1][~LIT[0]-1] == ~VAR[divider][2][~LIT[0]-1]) ? ~SYM[0] : ~SYM[0] - ~LIT[0]'sd1;
+assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
+assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
+assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
+assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
+
+assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
+                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
+                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
+
+assign ~SYM[6] = ~SYM[3] / ~SYM[5];
+assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // divSigned end"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.json
@@ -38,7 +38,7 @@ assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 // modulo
 assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 (~VAR[dividend][0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
+                 (~SYM[0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modSigned end"
     }
   }

--- a/clash-lib/prims/systemverilog/GHC_Classes.json
+++ b/clash-lib/prims/systemverilog/GHC_Classes.json
@@ -38,7 +38,7 @@ assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 // modulo
 assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
+                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInt# end"
     }
   }

--- a/clash-lib/prims/systemverilog/GHC_Classes.json
+++ b/clash-lib/prims/systemverilog/GHC_Classes.json
@@ -4,12 +4,24 @@
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "template"  :
 "// divInt# begin
-// divide (rounds towards zero)
-~SIGD[~GENSYM[quot_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
+logic ~GENSYM[resultPos][1];
+logic ~GENSYM[dividerNeg][2];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
 
-// round toward minus infinity
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
+assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
+assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
+assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
+
+assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
+                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
+                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
+
+assign ~SYM[6] = ~SYM[3] / ~SYM[5];
+assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // divInt# end"
     }
   }

--- a/clash-lib/prims/systemverilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/systemverilog/GHC_Integer_Type.json
@@ -38,7 +38,7 @@ assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 // modulo
 assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
+                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInteger end"
     }
   }

--- a/clash-lib/prims/systemverilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/systemverilog/GHC_Integer_Type.json
@@ -42,4 +42,56 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
 // modInteger end"
     }
   }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.divModInteger"
+    , "kind"      : "Declaration"
+    , "type"      : "divModInteger :: Integer -> Integer -> (# Integer, Integer #)"
+    , "template"  :
+"// divModInteger begin
+logic ~GENSYM[resultPos][1];
+logic ~GENSYM[dividerNeg][2];
+logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];
+logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];
+logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];
+logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];
+logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];
+
+assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];
+assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;
+assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension
+assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension
+
+assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
+                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)
+                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));
+
+assign ~SYM[6] = ~SYM[3] / ~SYM[5];
+assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);
+
+logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[rem_res][8];
+logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[mod_res][9];
+assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];
+assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?
+                 ~SYM[8] :
+                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);
+
+assign ~RESULT = {~SYM[7],~SYM[9]};
+// divModInteger end"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.quotRemInteger"
+    , "kind"      : "Declaration"
+    , "type"      : "quotRemInteger :: Integer -> Integer -> (# Integer, Integer #)"
+    , "template"  :
+"// quotRemInteger begin
+~SIGD[~GENSYM[quot_res][0]][0];
+~SIGD[~GENSYM[rem_res][1]][0];
+assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+assign ~SYM[1] = ~ARG[0] % ~ARG[1];
+
+assign ~RESULT = {~SYM[0],~SYM[1]};
+// quotRemInteger end"
+    }
+  }
 ]

--- a/clash-lib/prims/systemverilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/systemverilog/GHC_Integer_Type.json
@@ -4,12 +4,24 @@
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "template"  :
 "// divInteger begin
-// divide (rounds towards zero)
-~SIGD[~GENSYM[quot_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
+logic ~GENSYM[resultPos][1];
+logic ~GENSYM[dividerNeg][2];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
+logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
 
-// round toward minus infinity
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
+assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
+assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
+assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
+
+assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
+                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
+                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
+
+assign ~SYM[6] = ~SYM[3] / ~SYM[5];
+assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // divInteger end"
     }
   }

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
@@ -32,13 +32,13 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "template"  :
 "// modSigned begin
 // remainder
-~SIGD[~GENSYM[rem_res][0]][0];
+wire ~SIGD[~GENSYM[rem_res][0]][0];
 assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 
 // modulo
 assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 (~VAR[dividend][0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
+                 (~SYM[0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modSigned end"
     }
   }

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.json
@@ -4,12 +4,24 @@
     , "type"      : "div# :: Signed n -> Signed n -> Signed n"
     , "template"  :
 "// divSigned begin
-// divide (rounds towards zero)
-wire ~SIGD[~GENSYM[quot_res][0]][1];
-assign ~SYM[0] = ~VAR[dividend][1] / ~VAR[divider][2];
+wire ~GENSYM[resultPos][1];
+wire ~GENSYM[dividerNeg][2];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
 
-// round toward minus infinity
-assign ~RESULT = (~VAR[dividend][1][~LIT[0]-1] == ~VAR[divider][2][~LIT[0]-1]) ? ~SYM[0] : ~SYM[0] - ~LIT[0]'sd1;
+assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
+assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
+assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
+assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
+
+assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
+                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
+                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
+
+assign ~SYM[6] = ~SYM[3] / ~SYM[5];
+assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // divSigned end"
     }
   }

--- a/clash-lib/prims/verilog/GHC_Classes.json
+++ b/clash-lib/prims/verilog/GHC_Classes.json
@@ -4,12 +4,24 @@
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "template"  :
 "// divInt# begin
-// divide (rounds towards zero)
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
+wire ~GENSYM[resultPos][1];
+wire ~GENSYM[dividerNeg][2];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
 
-// round toward minus infinity
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
+assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
+assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
+assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
+
+assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
+                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
+                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
+
+assign ~SYM[6] = ~SYM[3] / ~SYM[5];
+assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // divInt# end"
     }
   }

--- a/clash-lib/prims/verilog/GHC_Classes.json
+++ b/clash-lib/prims/verilog/GHC_Classes.json
@@ -38,7 +38,7 @@ assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 // modulo
 assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
+                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInt# end"
     }
   }

--- a/clash-lib/prims/verilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/verilog/GHC_Integer_Type.json
@@ -38,7 +38,7 @@ assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
 // modulo
 assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
                  ~SYM[0] :
-                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
+                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInteger end"
     }
   }

--- a/clash-lib/prims/verilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/verilog/GHC_Integer_Type.json
@@ -42,4 +42,58 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
 // modInteger end"
     }
   }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.divModInteger"
+    , "kind"      : "Declaration"
+    , "type"      : "divModInteger :: Integer -> Integer -> (# Integer, Integer #)"
+    , "template"  :
+"// divModInteger begin
+wire ~GENSYM[resultPos][1];
+wire ~GENSYM[dividerNeg][2];
+wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];
+wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];
+wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];
+wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];
+wire signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];
+
+assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];
+assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;
+assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension
+assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension
+
+assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
+                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)
+                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));
+
+assign ~SYM[6] = ~SYM[3] / ~SYM[5];
+assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);
+
+wire ~SIGD[~GENSYM[rem_res][8]][0];
+wire ~SIGD[~GENSYM[mod_res][9]][0];
+assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];
+
+// modulo
+assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?
+                 ~SYM[8] :
+                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);
+
+assign ~RESULT = {~SYM[7],~SYM[9]};
+// divModInteger end"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.quotRemInteger"
+    , "kind"      : "Declaration"
+    , "type"      : "quotRemInteger :: Integer -> Integer -> (# Integer, Integer #)"
+    , "template"  :
+"// quotRemInteger begin
+wire ~SIGD[~GENSYM[quot_res][0]][0];
+wire ~SIGD[~GENSYM[rem_res][1]][0];
+assign ~SYM[0] = ~ARG[0] / ~ARG[1];
+assign ~SYM[1] = ~ARG[0] % ~ARG[1];
+
+assign ~RESULT = {~SYM[0],~SYM[1]};
+// quotRemInteger end"
+    }
+  }
 ]

--- a/clash-lib/prims/verilog/GHC_Integer_Type.json
+++ b/clash-lib/prims/verilog/GHC_Integer_Type.json
@@ -4,12 +4,24 @@
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "template"  :
 "// divInteger begin
-// divide (rounds towards zero)
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
+wire ~GENSYM[resultPos][1];
+wire ~GENSYM[dividerNeg][2];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
+wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
 
-// round toward minus infinity
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
+assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
+assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
+assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
+assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
+
+assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
+                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
+                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
+
+assign ~SYM[6] = ~SYM[3] / ~SYM[5];
+assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // divInteger end"
     }
   }

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.json
@@ -146,11 +146,18 @@
     , "template"  :
 "-- divSigned begin
 ~GENSYM[divSigned][0] : block
-  signal ~GENSYM[quot_res][3] : ~TYP[0];
+  signal ~GENSYM[resultPos][1] : boolean;
+  signal ~GENSYM[dividerNeg][2] : boolean;
+  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);
+  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);
 begin
-  ~SYM[3] <= ~ARG[0] / ~ARG[1];
-  ~RESULT <= ~SYM[3] - to_signed(1,~SIZE[~TYPO]) when ~VAR[dividend][0](~VAR[dividend][0]'high) = not (~VAR[divider][1](~VAR[divider][1]'high)) else
-             ~SYM[3];
+  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
+  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
+  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
+             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
+             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
 -- divSigned end"
     }

--- a/clash-lib/prims/vhdl/GHC_Classes.json
+++ b/clash-lib/prims/vhdl/GHC_Classes.json
@@ -38,15 +38,22 @@
     , "kind"      : "Declaration"
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "template"  :
-"-- divInt begin
+"-- divInt# begin
 ~GENSYM[divInt][0] : block
-  signal ~GENSYM[quot_res][1] : ~TYP[1];
+  signal ~GENSYM[resultPos][1] : boolean;
+  signal ~GENSYM[dividerNeg][2] : boolean;
+  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);
+  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);
 begin
-  ~SYM[1] <= ~ARG[0] / ~ARG[1];
-  ~RESULT <= ~SYM[1] - 1 when ((~ARG[0] = abs ~ARG[0]) /= (~ARG[1] = abs ~ARG[1])) else
-             ~SYM[1];
+  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
+  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
+  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
+             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
+             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
--- divInt end"
+-- divInt# end"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.json
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.json
@@ -42,11 +42,18 @@
     , "template"   :
 "-- divInteger begin
 ~GENSYM[divInteger][0] : block
-  signal ~GENSYM[quot_res][1] : ~TYP[1];
+  signal ~GENSYM[resultPos][1] : boolean;
+  signal ~GENSYM[dividerNeg][2] : boolean;
+  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);
+  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);
 begin
-  ~SYM[1] <= ~ARG[0] / ~ARG[1];
-  ~RESULT <= ~SYM[1] - 1 when ((~ARG[0] = abs ~ARG[0]) /= (~ARG[1] = abs ~ARG[1])) else
-             ~SYM[1];
+  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
+  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
+  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
+             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
+             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
 -- divInteger end"
     }

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.json
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.json
@@ -66,6 +66,38 @@ end block;
     }
   }
 , { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.divModInteger"
+    , "kind"      : "Declaration"
+    , "type"      : "divModInteger :: Integer -> Integer -> (# Integer, Integer #)"
+    , "template"  :
+"-- divModInteger begin
+~GENSYM[divModInteger][0] : block
+  signal ~GENSYM[resultPos][1] : boolean;
+  signal ~GENSYM[dividerNeg][2] : boolean;
+  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYP[0]] downto 0);
+  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYP[0]] downto 0);
+  signal ~GENSYM[div_res][5] : signed(~SIZE[~TYP[0]]-1 downto 0);
+begin
+  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
+  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
+  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1)   when ~SYM[1] else
+             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) - 1)   when ~SYM[2] else
+             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) + 1);
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~SYM[5] <= signed(~SYM[4](~SIZE[~TYP[0]]-1 downto 0));
+  ~RESULT <= (~SYM[5], ~VAR[dividend][0] mod ~VAR[divider][1]);
+end block;
+-- divModInteger end"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.quotRemInteger"
+    , "kind"      : "Expression"
+    , "type"      : "quotRemInteger :: Integer -> Integer -> (# Integer, Integer #)"
+    , "template"  : "(~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "GHC.Integer.Type.remInteger"
     , "kind"      : "Expression"
     , "type"      : "remInteger :: Integer -> Integer -> Integer"

--- a/tests/shouldwork/Numbers/Integral.hs
+++ b/tests/shouldwork/Numbers/Integral.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE DeriveLift            #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE ViewPatterns          #-}
+
+
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+module Integral where
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import Data.Int
+import Data.Word
+
+test :: forall a. Integral a => Integer -> Integer -> _
+test (fromInteger -> x) (fromInteger -> y) =
+  ( quot @a x y
+  , rem @a x y
+  , div @a x y
+  , mod @a x y
+  , quotRem @a x y
+  , divMod @a x y
+  )
+
+topEntity :: (Integer, Integer) -> _
+topEntity (x,y) =
+  ( test @Integer x y
+  , test @Int x y
+  , test @Int8 x y
+  , test @Int16 x y
+  , test @Int32 x y
+  , test @Int64 x y
+  , test @Word x y
+  , test @Word8 x y
+  , test @Word16 x y
+  , test @Word32 x y
+  , test @Word64 x y
+  , test @(Signed 8) x y
+  , test @(Unsigned 8) x y
+  , test @(BitVector 8) x y
+  , test @(Index 128) (abs x) (abs y)
+  )
+{-# NOINLINE topEntity #-}
+
+inputs :: Vec _ (Integer,Integer)
+inputs =
+  $(let range = [1,2,4,8,9,127,-1,-2,-3,-8,-9,-127] :: [Integer]
+    in listToVecTH [(a,b) | a <- range, b <- range, b /= 0])
+
+-- Lift for 8-15 tuples
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h)
+      => Lift (a,b,c,d,e,f,g,h)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i)
+      => Lift (a,b,c,d,e,f,g,h,i)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j)
+      => Lift (a,b,c,d,e,f,g,h,i,j)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k,l)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m, Lift n)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
+deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m, Lift n, Lift o)
+      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)

--- a/tests/shouldwork/Numbers/IntegralTB.hs
+++ b/tests/shouldwork/Numbers/IntegralTB.hs
@@ -1,0 +1,20 @@
+module IntegralTB where
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import qualified Integral
+
+instance ShowX Ordering
+
+expected = $(lift $ map Integral.topEntity $ Integral.inputs)
+
+topEntity = Integral.topEntity
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst Integral.inputs
+    expectedOutput = outputVerifier' clk rst expected
+    done           = expectedOutput (Integral.topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -238,6 +238,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "ExpWithClashCF" def{clashFlags=["-itests/shouldwork/Numbers", "-fconstraint-solver-iterations=15"]}
         , outputTest ("tests" </> "shouldwork" </> "Numbers") allTargets ["-itests/shouldwork/Numbers"] ["-itests/shouldwork/Numbers"] "ExpWithClashCF"  "main"
         , runTest "HalfAsBlackboxArg" def{hdlTargets=[VHDL], hdlSim=False}
+        , runTest "IntegralTB" def{clashFlags=["-itests/shouldwork/Numbers"]}
         -- TODO: re-enable for Verilog
         , runTest "NumConstantFoldingTB_1" def{clashFlags=["-itests/shouldwork/Numbers"]}
         , outputTest ("tests" </> "shouldwork" </> "Numbers") allTargets ["-fconstraint-solver-iterations=15"] ["-itests/shouldwork/Numbers"] "NumConstantFolding_1"  "main"


### PR DESCRIPTION
Because we weren't actively testing the HDL support for the Integral class methods(`div`,`mod`,`rem`,`quot`,...), it wasn't great.

  * `divModInteger` and `quotRemInteger` were missing #792
  * some blackboxes didn't produces valid HDL
  * the results of `div` on signed numbers were sometimes off by one
  * the results of `mod` on signed numbers were sometimes off by one divisor

This is now all fixed.