### PR TITLE
Fix running clash-testsuite locally

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,6 +16,10 @@ packages:
 -- displays to you (as the second update will be a no-op)
 index-state: 2019-10-29T08:01:38Z
 
+-- For some reason the `clash-testsuite` executable fails to run without
+-- this, as it cannot find the related library...
+tests: True
+
 package clash-ghc
   executable-dynamic: True
 


### PR DESCRIPTION
Apparently `clash-testsuite` needs to be built with tests enabled
in order to run tests (as otherwise it complains about the library
modules being in a hidden package). This commit enables tests by
default for `clash-testsuite` so the testsuite can run locally
without problems again.