### PR TITLE
Error on warnings in clash-cores

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -19,6 +19,10 @@ package clash-cosim
   ghc-options: -Werror
   documentation: True
   tests: True
+package clash-cores
+  ghc-options: -Werror
+  documentation: True
+  tests: True
 
 package clash-testsuite
   ghc-options: -Werror

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -42,5 +42,5 @@ if [[ ${tag_version} != "" && ${version} != ${tag_version} ]]; then
 fi
 
 # Run actual tests
-cabal new-test clash-cosim clash-prelude clash-lib
+cabal new-test clash-cores clash-cosim clash-prelude clash-lib
 cabal new-run -- clash-testsuite -j$THREADS --hide-successes -p "/.VHDL./ || /.Verilog./"

--- a/clash-cores/src/Clash/Cores/SPI.hs
+++ b/clash-cores/src/Clash/Cores/SPI.hs
@@ -67,16 +67,10 @@ idleOnLow SPIMode0 = True
 idleOnLow SPIMode1 = True
 idleOnLow _        = False
 
-idleOnHigh :: SPIMode -> Bool
-idleOnHigh = not . idleOnLow
-
 sampleOnRising :: SPIMode -> Bool
 sampleOnRising SPIMode0 = True
 sampleOnRising SPIMode3 = True
 sampleOnRising _        = False
-
-sampleOnFalling :: SPIMode -> Bool
-sampleOnFalling = not . sampleOnRising
 
 sampleOnLeading :: SPIMode -> Bool
 sampleOnLeading SPIMode0 = True

--- a/clash-cores/test/Test/Cores/Internal/SampleSPI.hs
+++ b/clash-cores/test/Test/Cores/Internal/SampleSPI.hs
@@ -72,15 +72,15 @@ sampleCycling genM genS divHalf wait mVals sVals mode latch duration =
   slaveIn = genS clk rst sVals sAck
 
   (misoZ, sAck, sOut) =
-    exposeSpecificClockResetEnable spiSlaveLatticeSBIO clk rst enableGen
-      mode latch sclk mosi miso ss slaveIn
+    withClockResetEnable clk rst enableGen
+      (spiSlaveLatticeSBIO mode latch sclk mosi miso ss slaveIn)
 
   miso = veryUnsafeToBiSignalIn misoZ
   masterIn = genM clk rst mVals mAck bp
 
   (sclk, mosi, ss, bp, mAck, mOut) =
-    exposeSpecificClockResetEnable spiMaster clk rst enableGen
-      mode divHalf wait masterIn (readFromBiSignal miso)
+    withClockResetEnable clk rst enableGen
+      (spiMaster mode divHalf wait masterIn (readFromBiSignal miso))
 
   clk = systemClockGen
   rst = systemResetGen

--- a/clash-cores/test/Test/Cores/SPI/MultiSlave.hs
+++ b/clash-cores/test/Test/Cores/SPI/MultiSlave.hs
@@ -61,16 +61,16 @@ testMasterMultiSlave divHalf wait mVal sVal mode latch duration =
  where
   slaveIn = pure sVal
   (misoZ0, _, slaveOut0) =
-    exposeSpecificClockResetEnable spiSlaveLatticeSBIO
-      clk rst enableGen mode latch sclk mosi miso ss0 slaveIn
+    withClockResetEnable clk rst enableGen
+      (spiSlaveLatticeSBIO mode latch sclk mosi miso ss0 slaveIn)
 
   (misoZ1, _, slaveOut1) =
-    exposeSpecificClockResetEnable spiSlaveLatticeSBIO
-      clk rst enableGen mode latch sclk mosi miso ss1 slaveIn
+    withClockResetEnable clk rst enableGen
+      (spiSlaveLatticeSBIO mode latch sclk mosi miso ss1 slaveIn)
 
   (misoZ2, _, slaveOut2) =
-    exposeSpecificClockResetEnable spiSlaveLatticeSBIO
-      clk rst enableGen mode latch sclk mosi miso ss2 slaveIn
+    withClockResetEnable clk rst enableGen
+      (spiSlaveLatticeSBIO mode latch sclk mosi miso ss2 slaveIn)
 
   miso = veryUnsafeToBiSignalIn
          (mergeBiSignalOuts (misoZ2 :> misoZ1 :> misoZ0 :> Nil))
@@ -80,8 +80,8 @@ testMasterMultiSlave divHalf wait mVal sVal mode latch duration =
   (ss2 :> ss1 :> ss0 :> Nil) = slaveAddressRotate @3 clk rst (ss,bp)
 
   (sclk, mosi, ss, bp, masterAck, masterOut) =
-    exposeSpecificClockResetEnable spiMaster
-      clk rst enableGen mode divHalf wait masterIn (readFromBiSignal miso)
+    withClockResetEnable clk rst enableGen
+      (spiMaster mode divHalf wait masterIn (readFromBiSignal miso))
 
   clk = systemClockGen
   rst = systemResetGen

--- a/clash-prelude/src/Clash/Class/HasDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain.hs
@@ -1,6 +1,11 @@
 module Clash.Class.HasDomain
   ( WithSpecificDomain
   , WithSingleDomain
+
+  , HasDomain
+  , TryDomain
+  , TryDomainResult(..)
+  , DomEq
   ) where
 
 -- Compilation is split across modules to maximize GHC parallelism

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -96,6 +96,7 @@ topEntity clk rst = readFromBiSignal bus'
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
+{-# LANGUAGE UndecidableInstances   #-}
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif
@@ -118,6 +119,7 @@ import           Data.Kind                  (Type)
 import           Data.List                  (intercalate)
 import           Data.Maybe                 (fromMaybe,fromJust,isJust)
 
+import           Clash.Class.HasDomain
 import           Clash.Class.BitPack        (BitPack (..))
 import           Clash.Sized.BitVector      (BitVector)
 import qualified Clash.Sized.Vector         as V
@@ -166,6 +168,9 @@ data BiSignalIn (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
 -- the signals may write at a single time step.
 newtype BiSignalOut (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
   = BiSignalOut [Signal dom (Maybe (BitVector n))]
+
+type instance HasDomain dom1 (BiSignalOut ds dom2 n) = DomEq dom1 dom2
+type instance TryDomain t (BiSignalOut ds dom n) = 'Found dom
 
 #if MIN_VERSION_base(4,11,0)
 instance Semigroup (BiSignalOut defaultState dom n) where


### PR DESCRIPTION
@alex-mckenna If we enable warning checking on the CI for clash-cores, it fails due to unused binders. Did you intend to export these, or should we remove them?