### PR TITLE
Update README with all installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,51 @@ Features of Clash:
 
 **IRC**: [freenode#clash-lang](https://webchat.freenode.net/#clash-lang)
 
-# Using Clash from source
+# Installing Clash
+
+## Installing via Snap
+
+Clash is released as a binary package on snapcraft. Snap is supported on all
+major Linux distributions. Visit [Clash’s snapcraft page](https://snapcraft.io/clash),
+scroll down, and choose your distribution for installation instructions. To
+install the latest stable version, use:
+
+```bash
+snap install clash
+```
+
+To install the latest development version of Clash, run:
+
+```bash
+snap install clash --edge
+```
+
+This version is updated every 24 hours.
+
+## Installing via Source (Linux / MacOS)
+
+Install the [latest nix](https://nixos.org/nix/download.html) and run:
+
+```bash
+curl -s -L https://github.com/clash-lang/clash-compiler/archive/1.0.tar.gz | tar xz
+nix-shell clash-compiler-1.0/shell.nix
+```
+
+See the [releases page](https://github.com/clash-lang/clash-compiler/releases)
+for all available versions of the compiler.
+
+## Installing via Source (Windows)
+
+  1. Install [GHC Platform](https://www.haskell.org/platform/windows.html). Make sure to install Stack along with it.
+  2. Download the source code of [Clash 1.0](https://github.com/clash-lang/clash-compiler/archive/1.0.tar.gz)
+  3. Unpack the archive
+  4. Use cd to navigate to the unpacked directory
+  5. Run `stack build clash-ghc`. **This will take a while.**
+
+See the [releases page](https://github.com/clash-lang/clash-compiler/releases)
+for all available versions of the compiler.
+
+## Installing via Source (HEAD)
 Clone Clash from github using `git` and enter the cloned directory:
 
 ```bash
@@ -42,7 +86,7 @@ cd clash-compiler
 
 Use one of the build tools below to get Clash up and running.
 
-## Cabal
+### Cabal
 Install Cabal >= 2.4 and GHC >= 8.4. Even though GHC 8.6 is supported, we currently recommend running 8.4 as the former contains some known bugs concerning documentation generation. If you're using Ubuntu, add [HVR's PPA](https://launchpad.net/~hvr/+archive/ubuntu/ghc) and install them using APT:
 
 ```bash
@@ -56,7 +100,7 @@ Add `/opt/ghc/bin` [to your PATH](https://askubuntu.com/questions/60218/how-to-a
 cabal new-run --write-ghc-environment-files=always -- clash
 ```
 
-## Stack
+### Stack
 
 You can use [Stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/) to build and run Clash too:
 
@@ -64,7 +108,7 @@ You can use [Stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/
 stack run -- clash
 ```
 
-## Nix
+### Nix
 
 Or [use Nix](https://nixos.org/nix/download.html) to get a shell with the `clash` and `clashi` binaries on your PATH:
 


### PR DESCRIPTION
The README now contains installation instructions for users wanting
to install using `snap`, or from a stable release on the GitHub page.
Existing instructions now clearly show that they are for building
a development version from HEAD.