### PR TITLE
Remove :> pattern, rename Cons to :>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * `Clash.Magic.suffixNameP`, `Clash.Magic.suffixNameFromNatP`: enable prefixing of name suffixes
   * Added `Clash.Magic.noDeDup`: can be used to instruct Clash to /not/ share a function between multiple branches
   * A `BitPack a` constraint now implies a `KnownNat (BitSize a)` constraint, so you won't have to add it manually anymore. See [#942](https://github.com/clash-lang/clash-compiler/pull/942).
+  * `Vec`'s `Cons` is gone in favor of `:>`. You can now use the actual constructor instead of a pattern to do pattern matches! See [#943](https://github.com/clash-lang/clash-compiler/pull/943).
 
 * New internal features:
   * [#918](https://github.com/clash-lang/clash-compiler/pull/935): Add X-Optimization to normalization passes

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -3685,7 +3685,7 @@ mkIndexLit' (rTy,nTy,kn) = mkIndexLit rTy nTy kn
 -- | Create a vector of supplied elements
 mkVecCons
   :: DataCon
-  -- ^ The Cons (:>) constructor
+  -- ^ The (:>) constructor
   -> Type
   -- ^ Element type
   -> Integer

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -544,7 +544,7 @@ termSize (Case subj _ alts) = sum (subjSz:altSzs)
 
 -- | Create a vector of supplied elements
 mkVec :: DataCon -- ^ The Nil constructor
-      -> DataCon -- ^ The Cons (:>) constructor
+      -> DataCon -- ^ The (:>) constructor
       -> Type    -- ^ Element type
       -> Integer -- ^ Length of the vector
       -> [Term]  -- ^ Elements to put in the vector
@@ -571,7 +571,7 @@ mkVec nilCon consCon resTy = go
                                                      ,(LitTy (NumTy (n-1)))])
 
 -- | Append elements to the supplied vector
-appendToVec :: DataCon -- ^ The Cons (:>) constructor
+appendToVec :: DataCon -- ^ The (:>) constructor
             -> Type    -- ^ Element type
             -> Term    -- ^ The vector to append the elements to
             -> Integer -- ^ Length of the vector
@@ -601,7 +601,7 @@ extractElems
   -> InScopeSet
   -- ^ (Superset of) in scope variables
   -> DataCon
-  -- ^ The Cons (:>) constructor
+  -- ^ The (:>) constructor
   -> Type
   -- ^ The element type
   -> Char

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -865,10 +865,10 @@ mkDcApplication dstHType bndr dc args = do
       Vector 0 _ -> return (HW.DataCon dstHType VecAppend [])
       Vector 1 _ -> case argExprsFiltered of
                       [e] -> return (HW.DataCon dstHType VecAppend [e])
-                      _ -> error $ $(curLoc) ++ "Unexpected number of arguments for `Cons`: " ++ showPpr args
+                      _ -> error $ $(curLoc) ++ "Unexpected number of arguments for `:>`: " ++ showPpr args
       Vector _ _ -> case argExprsFiltered of
                       [e1,e2] -> return (HW.DataCon dstHType VecAppend [e1,e2])
-                      _ -> error $ $(curLoc) ++ "Unexpected number of arguments for `Cons`: " ++ showPpr args
+                      _ -> error $ $(curLoc) ++ "Unexpected number of arguments for `:>`: " ++ showPpr args
       RTree 0 _ -> case argExprsFiltered of
                       [e] -> return (HW.DataCon dstHType RTreeAppend [e])
                       _ -> error $ $(curLoc) ++ "Unexpected number of arguments for `LR`: " ++ showPpr args

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -311,7 +311,7 @@ reduceTraverse (TransformContext is0 ctx) n aTy fTy bTy dict fun arg = do
 -- > (:>) <$> x0 <*> ((:>) <$> x1 <*> pure Nil)
 mkTravVec :: TyConName -- ^ Vec tcon
           -> DataCon   -- ^ Nil con
-          -> DataCon   -- ^ Cons con
+          -> DataCon   -- ^ :> con
           -> Term      -- ^ 'pure' term
           -> Term      -- ^ '<*>' term
           -> Term      -- ^ 'fmap' term

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -293,8 +293,8 @@ caseElemNonReachable _ e = return e
 -- existential should be. For example, consider Vec:
 --
 --    data Vec :: Nat -> Type -> Type where
---      Nil       :: Vec 0 a
---      Cons x xs :: a -> Vec n a -> Vec (n + 1) a
+--      Nil  :: Vec 0 a
+--      (:>) :: a -> Vec n a -> Vec (n + 1) a
 --
 -- Thus, 'null' (annotated with existentials) could look like:
 --
@@ -302,7 +302,7 @@ caseElemNonReachable _ e = return e
 --    null v =
 --      case v of
 --        Nil  {n ~ 0}                                     -> True
---        Cons {n1:Nat} {n~n1+1} (x :: a) (xs :: Vec n1 a) -> False
+--        (:>) {n1:Nat} {n~n1+1} (x :: a) (xs :: Vec n1 a) -> False
 --
 -- When it's applied to a vector of length 5, this becomes:
 --
@@ -310,7 +310,7 @@ caseElemNonReachable _ e = return e
 --    null v =
 --      case v of
 --        Nil  {5 ~ 0}                                     -> True
---        Cons {n1:Nat} {5~n1+1} (x :: a) (xs :: Vec n1 a) -> False
+--        (:>) {n1:Nat} {5~n1+1} (x :: a) (xs :: Vec n1 a) -> False
 --
 -- This function solves 'n1' and replaces every occurrence with its solution. A
 -- very limited number of solutions are currently recognized: only adds (such
@@ -800,9 +800,9 @@ removeUnusedExpr _ e@(Case _ _ [(DataPat _ [] xs,altExpr)]) =
      else return e
 
 -- Replace any expression that creates a Vector of size 0 within the application
--- of the Cons constructor, by the Nil constructor.
+-- of the (:>) constructor, by the Nil constructor.
 removeUnusedExpr _ e@(collectArgsTicks -> (Data dc, [_,Right aTy,Right nTy,_,Left a,Left nil],ticks))
-  | nameOcc (dcName dc) == "Clash.Sized.Vector.Cons"
+  | nameOcc (dcName dc) == "Clash.Sized.Vector.:>"
   = do
     tcm <- Lens.view tcCache
     case runExcept (tyNatSize tcm nTy) of
@@ -2470,7 +2470,7 @@ xOptimizeMany _ _ _ [] =
 mkFieldSelector
   :: MonadUnique m
   => InScopeSet
-  -> Id 
+  -> Id
   -- ^ subject id
   -> DataCon
   -> [TyVar]

--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -17,7 +17,7 @@
 {-# LANGUAGE ViewPatterns         #-}
 
 #if __GLASGOW_HASKELL__ < 806
-{-# OPTIONS_GHC -Wwarn=unused-pattern-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-pattern-binds #-}
 #endif
 
 module Clash.Class.AutoReg.Internal

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -38,7 +38,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 module Clash.Sized.Vector
   ( -- * 'Vec'tor data type
-    Vec(Nil,(:>),(:<))
+    Vec(Nil,(:>),Cons,(:<))
     -- * Accessors
     -- ** Length information
   , length, lengthS
@@ -275,6 +275,46 @@ cCons = mkConstr tVec ":>" [] Prefix
 instance NFData a => NFData (Vec n a) where
   rnf = foldl (\() -> rnf) ()
 
+
+{-# COMPLETE Nil, (:>)  #-}
+-- | Add an element to the head of a vector.
+--
+-- >>> 3 :> 4 :> 5 :> Nil
+-- <3,4,5>
+-- >>> let x = 3 :> 4 :> 5 :> Nil
+-- >>> :t x
+-- x :: Num b => Vec 3 b
+--
+-- Can be used as a pattern:
+--
+-- >>> :set -Wno-incomplete-patterns
+-- >>> let f :: Num a => Vec (n + 2) a -> a; f (x :> y :> _) = x + y
+-- >>> :t f
+-- f :: Num a => Vec (n + 2) a -> a
+-- >>> f (3 :> 4 :> 5 :> 6 :> 7 :> Nil)
+-- 7
+--
+-- Also in conjunctions with (':<'):
+--
+-- >>> let g :: Num a => Vec (n + 4) a -> a; g (a :> b :> (_ :< y :< x)) = a + b +  x + y
+-- >>> :t g
+-- g :: Num a => Vec (n + 4) a -> a
+-- >>> g (1 :> 2 :> 3 :> 4 :> 5 :> Nil)
+-- 12
+--
+-- N.B.: Deprecated! Use (:>)
+pattern Cons
+  :: forall m a
+   . ()
+  => forall n
+   . ((n + 1) ~ m)
+  => a -> Vec n a -> Vec m a
+pattern Cons x xs = x :> xs
+{-# DEPRECATED Cons "Cons will be removed in Clash 1.4. Use :> instead." #-}
+
+infixr 5 `Cons`
+
+
 {-# COMPLETE Nil, (:<)  #-}
 -- | Add an element to the tail of a vector.
 --
@@ -282,7 +322,7 @@ instance NFData a => NFData (Vec n a) where
 -- <3,4,5,1>
 -- >>> let x = (3 :> 4 :> 5 :> Nil) :< 1
 -- >>> :t x
--- x :: Num b => Vec 4 b
+-- x :: Num a => Vec 4 a
 --
 -- Can be used as a pattern:
 --

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -32,9 +32,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
 
-#if __GLASGOW_HASKELL__ <= 804
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns -fno-warn-redundant-constraints #-}
-#endif
 
 {-# OPTIONS_HADDOCK show-extensions #-}
 
@@ -213,7 +211,6 @@ data Vec :: Nat -> Type -> Type where
   (:>) :: a -> Vec n a -> Vec (n + 1) a
 
 infixr 5 :>
-{-# COMPLETE (:>) #-}
 
 -- | In many cases, this Generic instance only allows generic
 -- functions/instances over vectors of at least size 1, due to the
@@ -278,7 +275,6 @@ cCons = mkConstr tVec ":>" [] Prefix
 instance NFData a => NFData (Vec n a) where
   rnf = foldl (\() -> rnf) ()
 
-{-# COMPLETE (:<)       #-}
 {-# COMPLETE Nil, (:<)  #-}
 -- | Add an element to the tail of a vector.
 --

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -32,13 +32,15 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
 
+#if __GLASGOW_HASKELL__ <= 804
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns -fno-warn-redundant-constraints #-}
+#endif
 
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Sized.Vector
   ( -- * 'Vec'tor data type
-    Vec(Nil,(:>),(:<),Cons)
+    Vec(Nil,(:>),(:<))
     -- * Accessors
     -- ** Length information
   , length, lengthS
@@ -119,7 +121,7 @@ import Data.Proxy                 (Proxy (..))
 import Data.Singletons.Prelude    (TyFun,Apply,type (@@))
 import GHC.TypeLits               (CmpNat, KnownNat, Nat, type (+), type (-), type (*),
                                    type (^), type (<=), natVal)
-import GHC.Base                   (Int(I#),Int#,isTrue#)
+import GHC.Base                   (Int(I#), Int#, isTrue#, liftA2)
 import GHC.Generics               hiding (Fixity (..))
 import GHC.Prim                   ((==#),(<#),(-#))
 import Language.Haskell.TH        (ExpQ)
@@ -208,9 +210,10 @@ let populationCount' :: (KnownNat k, KnownNat (2^k)) => BitVector (2^k) -> Index
 --   ending at @'length' - 1@.
 data Vec :: Nat -> Type -> Type where
   Nil  :: Vec 0 a
-  Cons :: a -> Vec n a -> Vec (n + 1) a
+  (:>) :: a -> Vec n a -> Vec (n + 1) a
 
-infixr 5 `Cons`
+infixr 5 :>
+{-# COMPLETE (:>) #-}
 
 -- | In many cases, this Generic instance only allows generic
 -- functions/instances over vectors of at least size 1, due to the
@@ -223,7 +226,7 @@ instance KnownNat n => Generic (Vec n a) where
   type Rep (Vec n a) =
     D1 ('MetaData "Vec" "Clash.Data.Vector" "clash-prelude" 'False)
       (C1 ('MetaCons "Nil" 'PrefixI 'False) U1 :+:
-       C1 ('MetaCons "Cons" 'PrefixI 'False)
+       C1 ('MetaCons ":>" 'PrefixI 'False)
         (S1 ('MetaSel 'Nothing
                 'NoSourceUnpackedness
                 'NoSourceStrictness
@@ -234,22 +237,23 @@ instance KnownNat n => Generic (Vec n a) where
                 'NoSourceStrictness
                 'DecidedLazy)
             (Rec0 (Vec (n-1) a))))
-  from Nil         = M1 (L1 (M1 U1))
-  from (Cons x xs) = M1 (R1 (M1 (M1 (K1 x) :*: M1 (K1 xs))))
+  from Nil       = M1 (L1 (M1 U1))
+  from (x :> xs) = M1 (R1 (M1 (M1 (K1 x) :*: M1 (K1 xs))))
   to (M1 g) = case compareSNat (SNat @n) (SNat @0) of
     SNatLE -> case leZero @n of
       Sub Dict -> Nil
     SNatGT -> case g of
-      R1 (M1 (M1 (K1 p) :*: M1 (K1 q))) -> Cons p q
+      R1 (M1 (M1 (K1 p) :*: M1 (K1 q))) -> p :> q
+      L1 _ -> error "Generic (Vec n a): not reachable"
 
 instance (KnownNat n, Typeable a, Data a) => Data (Vec n a) where
   gunfold k z _ = case compareSNat (SNat @n) (SNat @0) of
     SNatLE -> case leZero @n of
       Sub Dict -> z Nil
-    SNatGT -> k (k (z @(a -> Vec (n-1) a -> Vec n a) Cons))
-  toConstr Nil        = cNil
-  toConstr (Cons _ _) = cCons
-  dataTypeOf _        = tVec
+    SNatGT -> k (k (z @(a -> Vec (n-1) a -> Vec n a) (:>)))
+  toConstr Nil = cNil
+  toConstr (_ :> _) = cCons
+  dataTypeOf _ = tVec
 
   gfoldl
     :: (forall d b. Data d => c (d -> b) -> d -> c b)
@@ -269,47 +273,10 @@ cNil :: Constr
 cNil = mkConstr tVec "Nil" [] Prefix
 
 cCons :: Constr
-cCons = mkConstr tVec "Cons" [] Prefix
+cCons = mkConstr tVec ":>" [] Prefix
 
 instance NFData a => NFData (Vec n a) where
   rnf = foldl (\() -> rnf) ()
-
-{-# COMPLETE (:>)       #-}
-{-# COMPLETE Nil, (:>)  #-}
--- | Add an element to the head of a vector.
---
--- >>> 3 :> 4 :> 5 :> Nil
--- <3,4,5>
--- >>> let x = 3 :> 4 :> 5 :> Nil
--- >>> :t x
--- x :: Num a => Vec 3 a
---
--- Can be used as a pattern:
---
--- >>> :set -Wno-incomplete-patterns
--- >>> let f :: Num a => Vec (n + 2) a -> a; f (x :> y :> _) = x + y
--- >>> :t f
--- f :: Num a => Vec (n + 2) a -> a
--- >>> f (3 :> 4 :> 5 :> 6 :> 7 :> Nil)
--- 7
---
--- Also in conjunctions with (':<'):
---
--- >>> let g :: Num a => Vec (n + 4) a -> a; g (a :> b :> (_ :< y :< x)) = a + b +  x + y
--- >>> :t g
--- g :: Num a => Vec (n + 4) a -> a
--- >>> g (1 :> 2 :> 3 :> 4 :> 5 :> Nil)
--- 12
---
-pattern (:>)
-  :: forall m a
-   . ()
-  => forall n
-   . ((n + 1) ~ m)
-  => a -> Vec n a -> Vec m a
-pattern x :> xs = Cons x xs
-
-infixr 5 :>
 
 {-# COMPLETE (:<)       #-}
 {-# COMPLETE Nil, (:<)  #-}
@@ -319,7 +286,7 @@ infixr 5 :>
 -- <3,4,5,1>
 -- >>> let x = (3 :> 4 :> 5 :> Nil) :< 1
 -- >>> :t x
--- x :: Num a => Vec 4 a
+-- x :: Num b => Vec 4 b
 --
 -- Can be used as a pattern:
 --
@@ -344,7 +311,7 @@ pattern (:<)
   => forall n
    . ((n + 1) ~ m)
   => Vec n a -> a -> Vec m a
-pattern xs :< x <- (snocPattern -> Cons x xs)
+pattern xs :< x <- (snocPattern -> x :> xs)
   where
     xs :< x = xs ++ singleton x
 
@@ -375,8 +342,8 @@ instance ShowX a => ShowX (Vec n a) where
           punc (x :> xs)  = \s -> showsX x (',':punc xs s)
 
 instance (KnownNat n, Eq a) => Eq (Vec n a) where
-  (==) Nil _            = True
-  (==) v1@(Cons _ _) v2 = fold (&&) (zipWith (==) v1 v2)
+  (==) Nil _ = True
+  (==) v1@(_ :> _) v2 = fold (&&) (zipWith (==) v1 v2)
 
 instance (KnownNat n, Ord a) => Ord (Vec n a) where
   compare x y = foldr f EQ $ zipWith compare x y
@@ -411,7 +378,7 @@ instance (KnownNat n, 1 <= n) => Traversable (Vec n) where
 {-# NOINLINE traverse# #-}
 traverse# :: forall a f b n . Applicative f => (a -> f b) -> Vec n a -> f (Vec n b)
 traverse# _ Nil       = pure Nil
-traverse# f (x :> xs) = Cons <$> f x <*> traverse# f xs
+traverse# f (x :> xs) = liftA2 (:>) (f x) (traverse# f xs)
 
 instance (Default a, KnownNat n) => Default (Vec n a) where
   def = repeat def
@@ -1380,7 +1347,7 @@ replace i y xs = replace_int xs (fromEnum i) y
 -- <interactive>:...
 --     • Couldn't match type ‘4 + n0’ with ‘2’
 --       Expected type: Vec (4 + n0) a
---         Actual type: Vec 2 a
+--         Actual type: Vec (1 + 1) a
 --       The type variable ‘n0’ is ambiguous
 --     • In the second argument of ‘take’, namely ‘(1 :> 2 :> Nil)’
 --       In the expression: take d4 (1 :> 2 :> Nil)
@@ -1577,7 +1544,7 @@ transpose = traverse# id
 --
 -- >>> let xs = (1:>2:>3:>4:>5:>6:>Nil)
 -- >>> :t xs
--- xs :: Num a => Vec 6 a
+-- xs :: Num b => Vec 6 b
 -- >>> :t stencil1d d2 sum xs
 -- stencil1d d2 sum xs :: Num b => Vec 5 b
 -- >>> stencil1d d2 sum xs
@@ -1599,7 +1566,7 @@ stencil1d stX f xs = map f (windows1d stX xs)
 --
 -- >>> let xss = ((1:>2:>3:>4:>Nil):>(5:>6:>7:>8:>Nil):>(9:>10:>11:>12:>Nil):>(13:>14:>15:>16:>Nil):>Nil)
 -- >>> :t xss
--- xss :: Num a => Vec 4 (Vec 4 a)
+-- xss :: Num b => Vec 4 (Vec 4 b)
 -- >>> :t stencil2d d2 d2 (sum . map sum) xss
 -- stencil2d d2 d2 (sum . map sum) xss :: Num b => Vec 3 (Vec 3 b)
 -- >>> stencil2d d2 d2 (sum . map sum) xss
@@ -1618,7 +1585,7 @@ stencil2d stY stX f xss = (map.map) f (windows2d stY stX xss)
 --
 -- >>> let xs = (1:>2:>3:>4:>5:>6:>Nil)
 -- >>> :t xs
--- xs :: Num a => Vec 6 a
+-- xs :: Num b => Vec 6 b
 -- >>> :t windows1d d2 xs
 -- windows1d d2 xs :: Num a => Vec 5 (Vec 2 a)
 -- >>> windows1d d2 xs
@@ -1640,7 +1607,7 @@ windows1d stX xs = map (take stX) (rotations xs)
 --
 -- >>> let xss = ((1:>2:>3:>4:>Nil):>(5:>6:>7:>8:>Nil):>(9:>10:>11:>12:>Nil):>(13:>14:>15:>16:>Nil):>Nil)
 -- >>> :t xss
--- xss :: Num a => Vec 4 (Vec 4 a)
+-- xss :: Num b => Vec 4 (Vec 4 b)
 -- >>> :t windows2d d2 d2 xss
 -- windows2d d2 d2 xss :: Num a => Vec 3 (Vec 3 (Vec 2 (Vec 2 a)))
 -- >>> windows2d d2 d2 xss
@@ -1957,7 +1924,7 @@ lazyV = lazyV' (repeat ())
 -- While the type of (':>') is:
 --
 -- >>> :t (:>)
--- (:>) :: a -> Vec n a -> Vec (n + 1) a
+-- (:>) :: b -> Vec n b -> Vec (n + 1) b
 --
 -- We thus need a @fold@ function that can handle the growing vector type:
 -- 'dfold'. Compared to 'foldr', 'dfold' takes an extra parameter, called the

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -2106,8 +2106,8 @@ Here is a list of Haskell features for which the Clash compiler has only
 
         @
         mapV :: (a -> b) -> Vec n a -> Vec n b
-        mapV _ Nil         = Nil
-        mapV f (Cons x xs) = Cons (f x) (mapV f xs)
+        mapV _ Nil = Nil
+        mapV f (x :> xs) = f x :> mapV f xs
 
         topEntity :: Vec 4 Int -> Vec 4 Int
         topEntity = mapV (+1)

--- a/clash-prelude/tests/Clash/Tests/Vector.hs
+++ b/clash-prelude/tests/Clash/Tests/Vector.hs
@@ -103,9 +103,11 @@ tests = testGroup "Vector"
 
 middleL :: Vec (n + 2) a -> Vec n a
 middleL ((_ :> xs) :< _) = xs
+middleL _ = error "middleL: unreachable"
 
 middleR :: Vec (n + 2) a -> Vec n a
 middleR (_ :> (xs :< _)) = xs
+middleR _ = error "middleR: unreachable"
 
 issueEx1 :: (KnownNat n) => Vec n a -> Vec n a
 issueEx1 Nil         = Nil

--- a/clash-prelude/tests/Clash/Tests/Vector.hs
+++ b/clash-prelude/tests/Clash/Tests/Vector.hs
@@ -1,9 +1,14 @@
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
 
+{-# LANGUAGE CPP              #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE TemplateHaskell  #-}
 {-# LANGUAGE TypeFamilies     #-}
 {-# LANGUAGE TypeOperators    #-}
+
+#if __GLASGOW_HASKELL__ <= 804
+{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
+#endif
 
 module Clash.Tests.Vector where
 
@@ -76,11 +81,8 @@ tests = testGroup "Vector"
   , testCase "test1" $ assertType "Int"
       "let x :: Int; (x :> _) = test1 (Nil :: Vec 0 Int) in x"
 
-  , testGroup "Untouchable GADT Patterns" 
-    [ testCase "Cons" $ assertError "is untouchable"
-        "let f x@(Cons _ _) = x in f undefined"
-    
-    , testCase "(:>)" $ assertError "is untouchable"
+  , testGroup "Untouchable GADT Patterns"
+    [ testCase "(:>)" $ assertError "is untouchable"
         "let f x@(_ :> _) = x in f undefined"
 
     , testCase "(:<)" $ assertError "is untouchable"

--- a/tests/shouldwork/GADTs/Head.hs
+++ b/tests/shouldwork/GADTs/Head.hs
@@ -4,7 +4,7 @@ import Clash.Prelude
 import Clash.Explicit.Testbench
 
 head' :: Vec (n+1) (Signed 16) -> Signed 16
-head' (Cons x xs) = x
+head' (x :> xs) = x
 {-# NOINLINE head' #-}
 
 topEntity :: Vec 3 (Signed 16) -> Signed 16

--- a/tests/shouldwork/GADTs/HeadM.hs
+++ b/tests/shouldwork/GADTs/HeadM.hs
@@ -4,7 +4,7 @@ import Clash.Prelude
 import Clash.Explicit.Testbench
 
 head' :: Vec 3 (Signed 16) -> Signed 16
-head' (Cons x xs) = x
+head' (x :> xs) = x
 {-# NOINLINE head' #-}
 
 topEntity :: Vec 3 (Signed 16) -> Signed 16

--- a/tests/shouldwork/GADTs/Tail.hs
+++ b/tests/shouldwork/GADTs/Tail.hs
@@ -4,7 +4,7 @@ import Clash.Prelude
 import Clash.Explicit.Testbench
 
 tail' :: Vec (n+1) (Signed 16) -> Vec n (Signed 16)
-tail' (Cons x xs) = xs
+tail' (x :> xs) = xs
 {-# NOINLINE tail' #-}
 
 topEntity :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)

--- a/tests/shouldwork/GADTs/TailM.hs
+++ b/tests/shouldwork/GADTs/TailM.hs
@@ -4,7 +4,7 @@ import Clash.Prelude
 import Clash.Explicit.Testbench
 
 tail' :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)
-tail' (Cons x xs) = xs
+tail' (x :> xs) = xs
 {-# NOINLINE tail' #-}
 
 topEntity :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)

--- a/tests/shouldwork/GADTs/TailOfTail.hs
+++ b/tests/shouldwork/GADTs/TailOfTail.hs
@@ -4,7 +4,7 @@ import Clash.Prelude
 import Clash.Explicit.Testbench
 
 tailOfTail :: Vec (n+2) (Signed 16) -> Vec n (Signed 16)
-tailOfTail (Cons _ (Cons _ xs)) = xs
+tailOfTail (_ :> (_ :> xs)) = xs
 {-# NOINLINE tailOfTail #-}
 
 topEntity :: Vec 4 (Signed 16) -> Vec 2 (Signed 16)

--- a/tests/shouldwork/Numbers/HalfAsBlackboxArg.hs
+++ b/tests/shouldwork/Numbers/HalfAsBlackboxArg.hs
@@ -9,7 +9,7 @@ g :: KnownNat n => Vec n Half -> Half
 g v =
   case v of
     Nil -> Half 5
-    Cons a as -> a
+    a :> as -> a
 
 topEntity =
   ( g (replicate d3 (Half 7))


### PR DESCRIPTION
This solves the performance penalty induced by the pattern. We have
supported GADT pattern matching for a while now, so this shouldn't
affect synthesizability.