### PR TITLE
Profile Memory use on PortNamesWithRTree Test

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -32,13 +32,12 @@ where
 
 -- External Modules
 import           Control.Lens                ((^.), (%~), (&), (%=))
-import           Control.Monad.RWS.Lazy      (RWS)
-import qualified Control.Monad.RWS.Lazy      as RWS
+import           Control.Monad.RWS.Strict    (RWS)
+import qualified Control.Monad.RWS.Strict    as RWS
 import qualified Data.ByteString.Char8       as Char8
 import           Data.Hashable               (Hashable (..))
-import           Data.HashMap.Lazy           (HashMap)
-import qualified Data.HashMap.Lazy           as HashMap
-import qualified Data.HashMap.Strict         as HSM
+import           Data.HashMap.Strict         (HashMap)
+import qualified Data.HashMap.Strict         as HashMap
 import           Data.Maybe                  (catMaybes,fromMaybe,listToMaybe)
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
@@ -131,7 +130,7 @@ data GHC2CoreState
 makeLenses ''GHC2CoreState
 
 emptyGHC2CoreState :: GHC2CoreState
-emptyGHC2CoreState = GHC2CoreState C.emptyUniqMap HSM.empty
+emptyGHC2CoreState = GHC2CoreState C.emptyUniqMap HashMap.empty
 
 newtype SrcSpanRB = SrcSpanRB {unSrcSpanRB :: SrcSpan}
 

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -17,7 +17,7 @@ import           Control.DeepSeq         (deepseq)
 import           Control.Lens            ((%~),(&),view,_1)
 import           Control.Monad           (unless)
 import qualified Control.Monad.State     as State
-import qualified Control.Monad.RWS.Lazy  as RWS
+import qualified Control.Monad.RWS.Strict as RWS
 import           Data.Coerce             (coerce)
 import           Data.Either             (partitionEithers, lefts, rights)
 import           Data.IntMap.Strict      (IntMap)

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -46,7 +46,7 @@ module Clash.XException
 where
 
 import           Clash.CPP           (maxTupleSize)
-import           Clash.XException.TH (mkNFDataXTupleInstances)
+import           Clash.XException.TH
 import           Control.Exception   (Exception, catch, evaluate, throw)
 import           Control.DeepSeq     (NFData, rnf)
 import           Data.Complex        (Complex)
@@ -278,29 +278,6 @@ genericShowsPrecX :: (Generic a, GShowX (Rep a)) => Int -> a -> ShowS
 genericShowsPrecX n = gshowsPrecX Pref n . from
 
 instance ShowX ()
-instance (ShowX a, ShowX b) => ShowX (a,b)
-instance (ShowX a, ShowX b, ShowX c) => ShowX (a,b,c)
-instance (ShowX a, ShowX b, ShowX c, ShowX d) => ShowX (a,b,c,d)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e) => ShowX (a,b,c,d,e)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f) => ShowX (a,b,c,d,e,f)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g) => ShowX (a,b,c,d,e,f,g)
-
--- Show is defined up to 12-tuples, but GHC.Generics only has Generic instances
--- up to 7-tuples, hence we need these orphan instances.
-deriving instance Generic ((,,,,,,,) a b c d e f g h)
-deriving instance Generic ((,,,,,,,,) a b c d e f g h i)
-deriving instance Generic ((,,,,,,,,,) a b c d e f g h i j)
-deriving instance Generic ((,,,,,,,,,,) a b c d e f g h i j k)
-deriving instance Generic ((,,,,,,,,,,,) a b c d e f g h i j k l)
-
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h) => ShowX (a,b,c,d,e,f,g,h)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i) => ShowX (a,b,c,d,e,f,g,h,i)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i, ShowX j)
-  => ShowX (a,b,c,d,e,f,g,h,i,j)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i, ShowX j, ShowX k)
-  => ShowX (a,b,c,d,e,f,g,h,i,j,k)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i, ShowX j, ShowX k, ShowX l)
-  => ShowX (a,b,c,d,e,f,g,h,i,j,k,l)
 
 instance {-# OVERLAPPABLE #-} ShowX a => ShowX [a] where
   showsPrecX _ = showListX
@@ -842,4 +819,5 @@ instance NFDataX c => GDeepErrorX (K1 i c) where
 instance GDeepErrorX (f :+: g) where
   gDeepErrorX = errorX
 
+mkShowXTupleInstances [2..maxTupleSize]
 mkNFDataXTupleInstances [2..maxTupleSize]


### PR DESCRIPTION
Profiling the memory usage of the test `PortNamesWithRTree` led to the discoveries that

  * some parts of GHC2Core were not as strict as they should have been
  * The instances of `ShowX` for tuples up to the max size use a lot of memory (compared to using `TemplateHaskell` to generate the instances)

Dealing with these has reduced the memory footprint of running this test by a reasonable amount, which is good for helping prevent CI slowdown / tests being killed due to using too much memory.