### PR TITLE
Make tuples in tests fit within MAX_TUPLE_SIZE

### DIFF
--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -285,16 +285,13 @@ instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e) => ShowX (a,b,c,d,e)
 instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f) => ShowX (a,b,c,d,e,f)
 instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g) => ShowX (a,b,c,d,e,f,g)
 
--- Show is defined up to 15-tuples, but GHC.Generics only has Generic instances
+-- Show is defined up to 12-tuples, but GHC.Generics only has Generic instances
 -- up to 7-tuples, hence we need these orphan instances.
 deriving instance Generic ((,,,,,,,) a b c d e f g h)
 deriving instance Generic ((,,,,,,,,) a b c d e f g h i)
 deriving instance Generic ((,,,,,,,,,) a b c d e f g h i j)
 deriving instance Generic ((,,,,,,,,,,) a b c d e f g h i j k)
 deriving instance Generic ((,,,,,,,,,,,) a b c d e f g h i j k l)
-deriving instance Generic ((,,,,,,,,,,,,) a b c d e f g h i j k l m)
-deriving instance Generic ((,,,,,,,,,,,,,) a b c d e f g h i j k l m n)
-deriving instance Generic ((,,,,,,,,,,,,,,) a b c d e f g h i j k l m n o)
 
 instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h) => ShowX (a,b,c,d,e,f,g,h)
 instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i) => ShowX (a,b,c,d,e,f,g,h,i)
@@ -304,15 +301,6 @@ instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h
   => ShowX (a,b,c,d,e,f,g,h,i,j,k)
 instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i, ShowX j, ShowX k, ShowX l)
   => ShowX (a,b,c,d,e,f,g,h,i,j,k,l)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i, ShowX j, ShowX k, ShowX l
-         ,ShowX m)
-  => ShowX (a,b,c,d,e,f,g,h,i,j,k,l,m)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i, ShowX j, ShowX k, ShowX l
-         ,ShowX m, ShowX n)
-  => ShowX (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
-instance (ShowX a, ShowX b, ShowX c, ShowX d, ShowX e, ShowX f, ShowX g, ShowX h, ShowX i, ShowX j, ShowX k, ShowX l
-         ,ShowX m, ShowX n, ShowX o)
-  => ShowX (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
 
 instance {-# OVERLAPPABLE #-} ShowX a => ShowX [a] where
   showsPrecX _ = showListX

--- a/tests/shouldwork/Numbers/Integral.hs
+++ b/tests/shouldwork/Numbers/Integral.hs
@@ -26,21 +26,24 @@ test (fromInteger -> x) (fromInteger -> y) =
 
 topEntity :: (Integer, Integer) -> _
 topEntity (x,y) =
-  ( test @Integer x y
-  , test @Int x y
-  , test @Int8 x y
-  , test @Int16 x y
-  , test @Int32 x y
-  , test @Int64 x y
-  , test @Word x y
-  , test @Word8 x y
-  , test @Word16 x y
-  , test @Word32 x y
-  , test @Word64 x y
-  , test @(Signed 8) x y
-  , test @(Unsigned 8) x y
-  , test @(BitVector 8) x y
-  , test @(Index 128) (abs x) (abs y)
+  ( ( test @Integer x y
+    , test @Int x y
+    , test @Int8 x y
+    , test @Int16 x y
+    , test @Int32 x y
+    , test @Int64 x y
+    )
+  , ( test @Word x y
+    , test @Word8 x y
+    , test @Word16 x y
+    , test @Word32 x y
+    , test @Word64 x y
+    )
+  , ( test @(Signed 8) x y
+    , test @(Unsigned 8) x y
+    , test @(BitVector 8) x y
+    , test @(Index 128) (abs x) (abs y)
+    )
   )
 {-# NOINLINE topEntity #-}
 
@@ -60,9 +63,4 @@ deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift 
       => Lift (a,b,c,d,e,f,g,h,i,j,k)
 deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l)
       => Lift (a,b,c,d,e,f,g,h,i,j,k,l)
-deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m)
-      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m)
-deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m, Lift n)
-      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
-deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m, Lift n, Lift o)
-      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
+

--- a/tests/shouldwork/Numbers/NumConstantFolding_2.hs
+++ b/tests/shouldwork/Numbers/NumConstantFolding_2.hs
@@ -200,21 +200,24 @@ bvSpecific = (r1,r2,r3,r4)
     r4 = (lit 22007 :: BitVector 16) ! 0
 
 fromIntegralConversions
-  = ( convertTo @Integer
-    , convertTo @Int
-    , convertTo @Int8
-    , convertTo @Int16
-    , convertTo @Int32
-    , convertTo @Int64
-    , convertTo @Word
-    , convertTo @Word8
-    , convertTo @Word16
-    , convertTo @Word32
-    , convertTo @Word64
-    , convertTo @(Signed 16)
-    , convertTo @(Unsigned 16)
-    , convertTo @(BitVector 16)
-    , convertTo @(Index 30000)
+  = ( ( convertTo @Integer
+      , convertTo @Int
+      , convertTo @Int8
+      , convertTo @Int16
+      , convertTo @Int32
+      , convertTo @Int64
+      )
+    , ( convertTo @Word
+      , convertTo @Word8
+      , convertTo @Word16
+      , convertTo @Word32
+      , convertTo @Word64
+      )
+    , ( convertTo @(Signed 16)
+      , convertTo @(Unsigned 16)
+      , convertTo @(BitVector 16)
+      , convertTo @(Index 30000)
+      )
     )
     where
       convertTo :: forall b. Num b => _
@@ -294,11 +297,6 @@ deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift 
       => Lift (a,b,c,d,e,f,g,h,i,j,k)
 deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l)
       => Lift (a,b,c,d,e,f,g,h,i,j,k,l)
-deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m)
-      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m)
-deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m, Lift n)
-      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
-deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l, Lift m, Lift n, Lift o)
-      => Lift (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
+
 deriving instance Lift Ordering
 


### PR DESCRIPTION
The tuples in the numbers tests now fit within MAX_TUPLE_SIZE.
Currently this makes one test fail in iverilog (IntegralTB), which
should be examined further.