### PR TITLE
Add "Clash.Core.TermLiteral"

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -171,6 +171,8 @@ Library
                       Clash.Core.Pretty
                       Clash.Core.Subst
                       Clash.Core.Term
+                      Clash.Core.TermLiteral
+                      Clash.Core.TermLiteral.TH
                       Clash.Core.TyCon
                       Clash.Core.Type
                       Clash.Core.TysPrim

--- a/clash-lib/src/Clash/Core/TermLiteral.hs
+++ b/clash-lib/src/Clash/Core/TermLiteral.hs
@@ -1,0 +1,97 @@
+{-|
+Copyright   :  (C) 2019, Myrtle Software Ltd
+License     :  BSD2 (see the file LICENSE)
+Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+
+Tools to convert a 'Term' into its "real" representation
+-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE ViewPatterns          #-}
+
+module Clash.Core.TermLiteral
+  ( TermLiteral
+  , termToData
+  , termToDataError
+  , uncheckedTermToData
+  ) where
+
+import qualified Data.Text                       as Text
+import           Data.Text                       (Text)
+import           Data.Bifunctor                  (bimap)
+import           Data.Either                     (lefts)
+import           GHC.Natural
+import           GHC.Stack
+
+import           Clash.Core.Term                 (Term(Literal), collectArgs)
+import           Clash.Core.Literal
+import           Clash.Core.Pretty               (showPpr)
+
+import           Clash.Core.TermLiteral.TH
+
+-- | Tools to deal with literals encoded as a "Term".
+class TermLiteral a where
+  -- | Convert 'Term' to the constant it represents. Will return an error if
+  -- (one of the subterms) fail to translate.
+  termToData
+    :: HasCallStack
+    => Term
+    -- ^ Term to convert
+    -> Either Term a
+    -- ^ 'Left' indicates a failure, containing the (sub)term that failed to
+    -- translate. 'Right' indicates a success.
+
+instance TermLiteral Term where
+  termToData = pure
+
+instance TermLiteral String where
+  termToData (collectArgs -> (_, [Left (Literal (StringLiteral s))])) = Right s
+  termToData t = Left t
+
+instance TermLiteral Text where
+  termToData t = Text.pack <$> termToData t
+
+instance TermLiteral Int where
+  termToData (collectArgs -> (_, [Left (Literal (IntLiteral n))])) =
+    Right (fromInteger n)
+  termToData t = Left t
+
+instance TermLiteral Integer where
+  termToData (collectArgs -> (_, [Left (Literal (IntegerLiteral n))])) = Right n
+  termToData t = Left t
+
+instance TermLiteral Char where
+  termToData (collectArgs -> (_, [Left (Literal (CharLiteral c))])) = Right c
+  termToData t = Left t
+
+instance TermLiteral Natural where
+  termToData (collectArgs -> (_, [Left (Literal (NaturalLiteral n))])) =
+    Right (fromInteger n)
+  termToData t = Left t
+
+instance (TermLiteral a, TermLiteral b) => TermLiteral (a, b) where
+  termToData (collectArgs -> (_, lefts -> [a, b])) = do
+    a' <- termToData a
+    b' <- termToData b
+    pure (a', b')
+  termToData t = Left t
+
+instance TermLiteral a => TermLiteral (Maybe a) where
+  termToData = $(deriveTermToData ''Maybe)
+
+instance TermLiteral Bool where
+  termToData = $(deriveTermToData ''Bool)
+
+-- | Same as 'termToData', but returns printable error message if it couldn't
+-- translate a term.
+termToDataError :: TermLiteral a => Term -> Either String a
+termToDataError term = bimap err id (termToData term)
+ where
+  err failedTerm =
+    "Failed to translate term to literal. Term that failed to translate:\n\n"
+    ++ showPpr failedTerm ++ "\n\nIn the full term:\n\n" ++ showPpr term
+
+-- | Same as 'termToData', but errors hard if it can't translate a given term
+-- to data.
+uncheckedTermToData :: TermLiteral a => Term -> a
+uncheckedTermToData = either error id . termToDataError

--- a/clash-lib/src/Clash/Core/TermLiteral/TH.hs
+++ b/clash-lib/src/Clash/Core/TermLiteral/TH.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE ViewPatterns          #-}
+
+module Clash.Core.TermLiteral.TH
+  (  deriveTermToData
+  ) where
+
+import           Data.Either
+import qualified Data.Text                       as Text
+import           Language.Haskell.TH.Syntax
+
+import           Clash.Core.DataCon
+import           Clash.Core.Term                 (collectArgs, Term(Data))
+import           Clash.Core.Name                 (nameOcc)
+
+-- Workaround for a strange GHC bug, where it complains about Subst only
+-- existing as a boot file:
+--
+-- module Clash.Core.Subst cannot be linked; it is only available as a boot module
+import Clash.Core.Subst ()
+
+dcName' :: DataCon -> String
+dcName' = Text.unpack . nameOcc . dcName
+
+termToDataName :: Name
+termToDataName = mkName "Clash.Core.TermLiteral.termToData"
+
+deriveTermToData :: Name -> Q Exp
+deriveTermToData typName = do
+  TyConI (DataD _ _ _ _ constrs _) <- reify typName
+  pure (deriveTermToData1 (map toConstr' constrs))
+ where
+  toConstr' (NormalC cName fields) = (cName, length fields)
+  toConstr' c = error $ "Unexpected constructor: " ++ show c
+
+deriveTermToData1 :: [(Name, Int)] -> Exp
+deriveTermToData1 constrs =
+  LamE
+    [pat]
+    (if null args then theCase else LetE args theCase)
+ where
+  nArgs = maximum (map snd constrs)
+
+  args :: [Dec]
+  args = zipWith (\n nm -> ValD (VarP nm) (NormalB (arg n)) []) [0..] argNames
+  arg n = UInfixE (VarE argsName) (VarE '(!!)) (LitE (IntegerL n))
+
+  -- case nm of {"ConstrOne" -> ConstOne <$> termToData arg0; "ConstrTwo" -> ...}
+  theCase :: Exp
+  theCase =
+    CaseE
+      (VarE nameName)
+      (map match constrs ++ [emptyMatch])
+
+  emptyMatch = Match WildP (NormalB (ConE 'Left `AppE` VarE termName)) []
+
+  match :: (Name, Int) -> Match
+  match (cName, nFields) =
+    Match (LitP (StringL (show cName))) (NormalB (mkCall cName nFields)) []
+
+  mkCall :: Name -> Int -> Exp
+  mkCall cName 0  = ConE 'Right `AppE` ConE cName
+  mkCall cName 1 =
+    UInfixE
+      (ConE cName)
+      (VarE '(<$>))
+      (VarE termToDataName `AppE` VarE (head argNames))
+  mkCall cName nFields =
+    foldl
+      (\e aName ->
+        UInfixE
+          e
+          (VarE '(<*>))
+          (VarE termToDataName `AppE` VarE aName))
+      (mkCall cName 1)
+      (take (nFields-1) (tail argNames))
+
+  -- term@(collectArgs -> (Data (dcName' -> nm), args))
+  pat :: Pat
+  pat =
+    AsP
+      termName
+      (ViewP
+        (VarE 'collectArgs)
+        (TupP [ ConP 'Data [ViewP (VarE 'dcName') (VarP nameName)]
+              , ViewP
+                 (VarE 'lefts)
+                 (if nArgs == 0 then WildP else VarP argsName)]))
+
+  termName = mkName "term"
+  argsName = mkName "args"
+  argNames = [mkName ("arg" ++ show n) | n <- [0..nArgs-1]]
+  nameName = mkName "nm"
+


### PR DESCRIPTION
This feature is needed for https://github.com/clash-lang/clash-compiler/pull/864, but might come in handy in other places too.

In the future we might want to add:

* Template Haskell to generate tuple instances.
* `dataToTerm`