### PR TITLE
Hide X-Optimization Behind a Flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
   * `Vec`'s `Cons` is gone in favor of `:>`. You can now use the actual constructor instead of a pattern to do pattern matches! See [#943](https://github.com/clash-lang/clash-compiler/pull/943).
 
 * New internal features:
-  * [#918](https://github.com/clash-lang/clash-compiler/pull/935): Add X-Optimization to normalization passes
+  * [#918](https://github.com/clash-lang/clash-compiler/pull/935): Add X-Optimization to normalization passes (-fclash-aggressive-x-optimization)
   * [#821](https://github.com/clash-lang/clash-compiler/pull/821): Add `DebugTry`: print name of all tried transformations, even if they didn't succeed
   * [#856](https://github.com/clash-lang/clash-compiler/pull/856): Add `-fclash-debug-transformations`: only print debug info for specific transformations
   * [#911](https://github.com/clash-lang/clash-compiler/pull/911): Add 'RenderVoid' option to blackboxes

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -84,6 +84,7 @@ flagsClash r = [
   , defFlag "fclash-no-escaped-identifiers"      $ NoArg (liftEwM (setNoEscapedIds r))
   , defFlag "fclash-compile-ultra"               $ NoArg (liftEwM (setUltra r))
   , defFlag "fclash-force-undefined"             $ OptIntSuffix (setUndefined r)
+  , defFlag "fclash-aggressive-x-optimization"   $ NoArg (liftEwM (setAggressiveXOpt r))
   ]
 
 -- | Print deprecated flag warning
@@ -209,3 +210,7 @@ setUndefined _ (Just x) | x < 0 || x > 1 =
            " not in range [0,1]")
 setUndefined r iM =
   liftEwM (modifyIORef r (\c -> c {opt_forceUndefined = Just iM}))
+
+setAggressiveXOpt :: IORef ClashOpts -> IO ()
+setAggressiveXOpt r = modifyIORef r (\c -> c { opt_aggressiveXOpt = True })
+

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -89,6 +89,10 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            -- * /Just (Just x)/: replace undefined's by /x/ in
                            -- the HDL
                            , opt_checkIDir   :: Bool
+                           , opt_aggressiveXOpt :: Bool
+                           -- ^ Enable aggressive X optimization, which may
+                           -- remove undefineds from generated HDL by replaced
+                           -- with defined alternatives.
                            }
 
 
@@ -117,6 +121,7 @@ defClashOpts
   , opt_ultra               = False
   , opt_forceUndefined      = Nothing
   , opt_checkIDir           = True
+  , opt_aggressiveXOpt      = False
   }
 
 -- | Information about the generated HDL between (sub)runs of the compiler

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -117,6 +117,7 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcs
     rwEnv     = RewriteEnv
                   (opt_dbgLevel opts)
                   (opt_dbgTransformations opts)
+                  (opt_aggressiveXOpt opts)
                   typeTrans
                   tcm
                   tupTcm

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -90,6 +90,7 @@ data RewriteEnv
   { _dbgLevel       :: DebugLevel
   -- ^ Level at which we print debugging messages
   , _dbgTransformations :: Set.Set String
+  , _aggressiveXOpt :: Bool
   -- ^ Transformations to print debugging info for
   , _typeTranslator :: CustomReprs
                     -> TyConMap

--- a/tests/shouldwork/Netlist/Identity.hs
+++ b/tests/shouldwork/Netlist/Identity.hs
@@ -30,16 +30,16 @@ getComponent (_, _, _, x) = x
 
 mainVHDL :: IO ()
 mainVHDL = do
-  netlist <- runToNetlistStage SVHDL [] testPath
+  netlist <- runToNetlistStage SVHDL id testPath
   mapM_ (assertAssignsInOut . getComponent) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
-  netlist <- runToNetlistStage SVerilog [] testPath
+  netlist <- runToNetlistStage SVerilog id testPath
   mapM_ (assertAssignsInOut . getComponent) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  netlist <- runToNetlistStage SSystemVerilog [] testPath
+  netlist <- runToNetlistStage SSystemVerilog id testPath
   mapM_ (assertAssignsInOut . getComponent) netlist
 

--- a/tests/shouldwork/Netlist/NoDeDup.hs
+++ b/tests/shouldwork/Netlist/NoDeDup.hs
@@ -70,5 +70,5 @@ getComponent (_, _, _, x) = x
 
 mainVHDL :: IO ()
 mainVHDL = do
-  netlist <- runToNetlistStage SVHDL [] testPath
+  netlist <- runToNetlistStage SVHDL id testPath
   mapM_ (assertNumTwiceInsts . getComponent) netlist

--- a/tests/shouldwork/XOptimization/ManyDefined.hs
+++ b/tests/shouldwork/XOptimization/ManyDefined.hs
@@ -5,6 +5,7 @@ import           Test.Tasty.Clash
 import           Test.Tasty.Clash.NetlistTest
 
 import           Clash.Prelude
+import           Clash.Driver.Types
 import           Clash.Netlist.Types
 
 data MaybeIntBool
@@ -38,18 +39,21 @@ testPath = "tests/shouldwork/XOptimization/ManyDefined.hs"
 getComponent :: (a, b, c, d) -> d
 getComponent (_, _, _, x) = x
 
+enableXOpt :: ClashOpts -> ClashOpts
+enableXOpt c = c { opt_aggressiveXOpt = True }
+
 mainVHDL :: IO ()
 mainVHDL = do
-  netlist <- runToNetlistStage SVHDL [] testPath
+  netlist <- runToNetlistStage SVHDL enableXOpt testPath
   mapM_ (assertOneAltPerDefined . getComponent) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
-  netlist <- runToNetlistStage SVerilog [] testPath
+  netlist <- runToNetlistStage SVerilog enableXOpt testPath
   mapM_ (assertOneAltPerDefined . getComponent) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  netlist <- runToNetlistStage SSystemVerilog [] testPath
+  netlist <- runToNetlistStage SSystemVerilog enableXOpt testPath
   mapM_ (assertOneAltPerDefined . getComponent) netlist
 

--- a/tests/shouldwork/XOptimization/OneDefinedDataPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedDataPat.hs
@@ -1,6 +1,7 @@
 module OneDefinedDataPat where
 
 import Clash.Prelude
+import Clash.Driver.Types
 import Clash.Netlist.Types
 
 import Test.Tasty.Clash
@@ -27,18 +28,21 @@ testPath = "tests/shouldwork/XOptimization/OneDefinedDataPat.hs"
 getComponent :: (a, b, c, d) -> d
 getComponent (_, _, _, x) = x
 
+enableXOpt :: ClashOpts -> ClashOpts
+enableXOpt c = c { opt_aggressiveXOpt = True }
+
 mainVHDL :: IO ()
 mainVHDL = do
-  netlist <- runToNetlistStage SVHDL [] testPath
+  netlist <- runToNetlistStage SVHDL enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
-  netlist <- runToNetlistStage SVerilog [] testPath
+  netlist <- runToNetlistStage SVerilog enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  netlist <- runToNetlistStage SSystemVerilog [] testPath
+  netlist <- runToNetlistStage SSystemVerilog enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 

--- a/tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs
@@ -1,6 +1,7 @@
 module OneDefinedDefaultPat where
 
 import Clash.Prelude
+import Clash.Driver.Types
 import Clash.Netlist.Types
 
 import Test.Tasty.Clash
@@ -27,18 +28,21 @@ testPath = "tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs"
 getComponent :: (a, b, c, d) -> d
 getComponent (_, _, _, x) = x
 
+enableXOpt :: ClashOpts -> ClashOpts
+enableXOpt c = c { opt_aggressiveXOpt = True }
+
 mainVHDL :: IO ()
 mainVHDL = do
-  netlist <- runToNetlistStage SVHDL [] testPath
+  netlist <- runToNetlistStage SVHDL enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
-  netlist <- runToNetlistStage SVerilog [] testPath
+  netlist <- runToNetlistStage SVerilog enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  netlist <- runToNetlistStage SSystemVerilog [] testPath
+  netlist <- runToNetlistStage SSystemVerilog enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 

--- a/tests/shouldwork/XOptimization/OneDefinedLitPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedLitPat.hs
@@ -1,6 +1,7 @@
 module OneDefinedLitPat where
 
 import Clash.Prelude
+import Clash.Driver.Types
 import Clash.Netlist.Types
 
 import Test.Tasty.Clash
@@ -27,18 +28,21 @@ testPath = "tests/shouldwork/XOptimization/OneDefinedLitPat.hs"
 getComponent :: (a, b, c, d) -> d
 getComponent (_, _, _, x) = x
 
+enableXOpt :: ClashOpts -> ClashOpts
+enableXOpt c = c { opt_aggressiveXOpt = True }
+
 mainVHDL :: IO ()
 mainVHDL = do
-  netlist <- runToNetlistStage SVHDL [] testPath
+  netlist <- runToNetlistStage SVHDL enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
-  netlist <- runToNetlistStage SVerilog [] testPath
+  netlist <- runToNetlistStage SVerilog enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  netlist <- runToNetlistStage SSystemVerilog [] testPath
+  netlist <- runToNetlistStage SSystemVerilog enableXOpt testPath
   mapM_ (assertNoMux . getComponent) netlist
 


### PR DESCRIPTION
The X-optimization feature previously added is now only enabled
when -faggressive-x-optimization is set. As a result, the testsuite
now takes a function to modify the clash options before running
instead of a list of extra include dirs.