### PR TITLE
Respect setName for functions with Synthesize. Closes #952

### DIFF
--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -1368,7 +1368,9 @@ mkTopUnWrapper topEntity annM man dstId args tickDecls = do
       result = ("result",snd dstId)
 
   instLabel0 <- extendIdentifier Basic topName ("_" `Text.append` fst dstId)
-  instLabel1 <- mkUniqueIdentifier Basic instLabel0
+  instLabel1 <- fromMaybe instLabel0 <$> Lens.view setName
+  instLabel2 <- affixName instLabel1
+  instLabel3 <- mkUniqueIdentifier Basic instLabel2
   topOutputM <- mkTopOutput topM (zip outNames outTys) (head oPortSupply) result
 
   let
@@ -1377,7 +1379,7 @@ mkTopUnWrapper topEntity annM man dstId args tickDecls = do
         Entity
         (Just topName)
         topName
-        instLabel1
+        instLabel3
         []
         ( map (\(p,i,t) -> (Identifier p Nothing,In, t,Identifier i Nothing)) (concat iports) ++
           map (\(p,o,t) -> (Identifier p Nothing,Out,t,Identifier o Nothing)) oports)

--- a/tests/shouldwork/Basic/SetName.hs
+++ b/tests/shouldwork/Basic/SetName.hs
@@ -1,0 +1,42 @@
+module SetName where
+
+import Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+
+f :: Int -> Int -> Int
+f a b = g a b * g b a
+{-# ANN f (Synthesize
+    { t_name   = "f"
+    , t_inputs = [PortName "f_x", PortName "f_y"]
+    , t_output = PortName "result"
+    }) #-}
+
+g :: Int -> Int -> Int
+g = setName @"foo" h
+
+h :: Int -> Int -> Int
+h x y = if signum (x - y) == 1 then x else y
+{-# ANN h (Synthesize
+    { t_name   = "h"
+    , t_inputs = [PortName "x", PortName "y"]
+    , t_output = PortName "diff"
+    }) #-} 
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                   , "\n\nIn:\n\n", haystack ]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content  <- readFile (takeDirectory topDir </> "f" </> "f.vhdl")
+
+  assertIn "foo" content
+  assertIn "foo_0" content
+

--- a/tests/shouldwork/TopEntity/InlinedAnnotations.hs
+++ b/tests/shouldwork/TopEntity/InlinedAnnotations.hs
@@ -1,0 +1,24 @@
+module InlinedAnnotations where
+
+import           Clash.Prelude
+import qualified Clash.Explicit.Testbench as E
+
+f :: Int -> Int -> Int
+f a b = g a b * g b a
+{-# ANN f (Synthesize
+    { t_name   = "f"
+    , t_inputs = [PortName "f_x", PortName "f_y"]
+    , t_output = PortName "result"
+    }) #-}
+
+g :: Int -> Int -> Int
+g = setName @"foo" h
+
+h :: Int -> Int -> Int
+h x y = if signum (x - y) == 1 then x else y
+{-# ANN h (Synthesize
+    { t_name   = "h"
+    , t_inputs = [PortName "x", PortName "y"]
+    , t_output = PortName "diff"
+    }) #-}
+

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -106,6 +106,7 @@ runClashTest = defaultMain $ clashTestRoot
 #endif
         , runTest "NameInstance" def{hdlSim=False}
         , outputTest ("tests" </> "shouldwork" </> "Basic") allTargets [] [] "NameInstance" "main"
+        , outputTest ("tests" </> "shouldwork" </> "Basic") [VHDL] [] [] "SetName" "main"
         , runTest "NameOverlap" def{
             entities=Entities ["nameoverlap"]
           , topEntity=TopEntity "nameoverlap"


### PR DESCRIPTION
Functions with a synthesize annotation now respect setName, insetad
of returning HDL using the original name of the synthesized
component.