### PR TITLE
Show `-fclash-*` Options in `clash --show-options`

### DIFF
--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -160,7 +160,7 @@ defaultMain = flip withArgs $ do
                    ShowSupportedExtensions   -> showSupportedExtensions
                    ShowVersion               -> showVersion
                    ShowNumVersion            -> putStrLn cProjectVersion
-                   ShowOptions isInteractive -> showOptions isInteractive
+                   ShowOptions isInteractive -> showOptions isInteractive r
         Right postStartupMode ->
             -- start our GHC session
             GHC.runGhc (Just libDir) $ do
@@ -838,12 +838,13 @@ showVersion = putStrLn $ concat [ "Clash, version "
                                 , ")"
                                 ]
 
-showOptions :: Bool -> IO ()
-showOptions isInteractive = putStr (unlines availableOptions)
+showOptions :: Bool -> IORef ClashOpts -> IO ()
+showOptions isInteractive = putStr . unlines . availableOptions
     where
-      availableOptions = concat [
-        flagsForCompletion isInteractive,
-        map ('-':) (getFlagNames mode_flags)
+      availableOptions opts = concat
+        [ flagsForCompletion isInteractive
+        , map ('-':) (getFlagNames mode_flags)
+        , map ('-':) (getFlagNames (flagsClash opts))
         ]
       getFlagNames opts         = map flagName opts
 

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -151,7 +151,7 @@ defaultMain = flip withArgs $ do
                    ShowSupportedExtensions   -> showSupportedExtensions
                    ShowVersion               -> showVersion
                    ShowNumVersion            -> putStrLn cProjectVersion
-                   ShowOptions isInteractive -> showOptions isInteractive
+                   ShowOptions isInteractive -> showOptions isInteractive r
         Right postStartupMode ->
             -- start our GHC session
             GHC.runGhc (Just libDir) $ do
@@ -832,12 +832,13 @@ showVersion = putStrLn $ concat [ "Clash, version "
                                 , ")"
                                 ]
 
-showOptions :: Bool -> IO ()
-showOptions isInteractive = putStr (unlines availableOptions)
+showOptions :: Bool -> IORef ClashOpts -> IO ()
+showOptions isInteractive = putStr . unlines . availableOptions
     where
-      availableOptions = concat [
-        flagsForCompletion isInteractive,
-        map ('-':) (getFlagNames mode_flags)
+      availableOptions opts = concat
+        [ flagsForCompletion isInteractive
+        , map ('-':) (getFlagNames mode_flags)
+        , map ('-':) (getFlagNames (flagsClash opts))
         ]
       getFlagNames opts         = map flagName opts
 

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -147,7 +147,7 @@ defaultMain = flip withArgs $ do
                  ShowSupportedExtensions   -> showSupportedExtensions
                  ShowVersion               -> showVersion
                  ShowNumVersion            -> putStrLn cProjectVersion
-                 ShowOptions isInteractive -> showOptions isInteractive
+                 ShowOptions isInteractive -> showOptions isInteractive r
       Right postStartupMode ->
           -- start our GHC session
           GHC.runGhc (Just libDir) $ do
@@ -844,12 +844,13 @@ showVersion = putStrLn $ concat [ "Clash, version "
                                 , ")"
                                 ]
 
-showOptions :: Bool -> IO ()
-showOptions isInteractive = putStr (unlines availableOptions)
+showOptions :: Bool -> IORef ClashOpts -> IO ()
+showOptions isInteractive = putStr . unlines . availableOptions
     where
-      availableOptions = concat [
-        flagsForCompletion isInteractive,
-        map ('-':) (getFlagNames mode_flags)
+      availableOptions opts = concat
+        [ flagsForCompletion isInteractive
+        , map ('-':) (getFlagNames mode_flags)
+        , map ('-':) (getFlagNames (flagsClash opts))
         ]
       getFlagNames opts         = map flagName opts
 

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -11,6 +11,7 @@
 
 module Clash.GHC.ClashFlags
   ( parseClashFlags
+  , flagsClash
   )
 where
 


### PR DESCRIPTION
When calling clash with the --show-options flag, it now prints
all options, including common clash options which were previously
not being shown.

~It remains to be seen how to document all the flags which are
added by clash (instead of GHC).~

EDIT: Flag reference is a separate issue, see #987 