### PR TITLE
Use default extensions in our packages

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -183,6 +183,27 @@ exceptions =
   :> West :> Middle :> Nil
 ```
 
+### Language pragmas
+Place LANGUAGE pragmas right after a module's documentation. Do not align the `#-}`s. `Safe`, `Unsafe`, or in some way "special" language pragmas should follow the normal ones separated by a single blank line. Pragmas should be ordered alphabetically. Example:
+
+```haskell
+{-|
+  .. docs ..
+-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+#if __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
+
+{-# LANGUAGE Safe #-}
+```
+
+
 ### Pragmas
 
 Put pragmas immediately following the function they apply to. Example:

--- a/benchmark/profiling/prepare/instances/SerialiseInstances.hs
+++ b/benchmark/profiling/prepare/instances/SerialiseInstances.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans    #-}
-{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE StandaloneDeriving #-}
 module SerialiseInstances where
 

--- a/clash-cores/src/Clash/Cores/LatticeSemi/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/Blackboxes/IO.hs
@@ -6,7 +6,7 @@
   HDL generation functionality for LATTICE ICE IO primitives.
 -}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Clash.Cores.LatticeSemi.Blackboxes.IO (sbioTF) where
 

--- a/clash-cores/src/Clash/Cores/LatticeSemi/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/IO.hs
@@ -7,13 +7,13 @@
   <http://www.latticesemi.com/~/media/LatticeSemi/Documents/TechnicalBriefs/SBTICETechnologyLibrary201504.pdf LATTICE ICE Technology Library>,
   referred to as LITL.
 -}
-{-# LANGUAGE BinaryLiterals      #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Clash.Cores.LatticeSemi.IO
   ( sbio

--- a/clash-cores/test/Test/Cores/Internal/SampleSPI.hs
+++ b/clash-cores/test/Test/Cores/Internal/SampleSPI.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Test.Cores.Internal.SampleSPI
   ( SPISamples(..)

--- a/clash-cosim/Setup.hs
+++ b/clash-cosim/Setup.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE CPP #-}
 
 import Control.Exception (IOException, SomeException, try, throwIO, catch)
 import Control.Monad     (unless)

--- a/clash-cosim/src/Clash/CoSim.hs
+++ b/clash-cosim/src/Clash/CoSim.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-|
 Module      : Clash.CoSim.CoSim

--- a/clash-cosim/src/Clash/CoSim/CoSimInstances.hs
+++ b/clash-cosim/src/Clash/CoSim/CoSimInstances.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ViewPatterns #-}
 
 {-|
 Module      : Clash.CoSim.CoSimInstances

--- a/clash-cosim/src/Clash/CoSim/CodeGeneration.hs
+++ b/clash-cosim/src/Clash/CoSim/CodeGeneration.hs
@@ -1,8 +1,8 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE CPP #-}
 
 {-|
 Module      : Clash.CoSim.CodeGeneration

--- a/clash-cosim/src/Clash/CoSim/Simulator.hs
+++ b/clash-cosim/src/Clash/CoSim/Simulator.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -5,7 +6,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE CPP #-}
 
 {-|
 Module      : Clash.CoSim.Simulator

--- a/clash-cosim/src/Clash/CoSim/Types.hs
+++ b/clash-cosim/src/Clash/CoSim/Types.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 {-|

--- a/clash-cosim/tests/CoSimTest.hs
+++ b/clash-cosim/tests/CoSimTest.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}

--- a/clash-cosim/tests/test.hs
+++ b/clash-cosim/tests/test.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
 
 import Clash.Prelude
 import Clash.Prelude.Testbench

--- a/clash-dev
+++ b/clash-dev
@@ -3,6 +3,10 @@ GHC_VERSION=$(ghc --numeric-version)
 GHC_MAJOR_VERSION=$(echo ${GHC_VERSION} | tr -d '.' | head -c2)
 GHC_BIN_SRC=$(ls -d clash-ghc/src-bin-${GHC_MAJOR_VERSION}*)
 
+if [ ${GHC_MAJOR_VERSION} != 84 ]; then
+  XNoStarIsType="-XNoStarIsType"
+fi
+
 ghci \
   -fobject-code \
   -iclash-ghc/src-bin-common/ \
@@ -10,4 +14,9 @@ ghci \
   -iclash-lib/src \
   -iclash-ghc/src-ghc \
   -Wall -DTOOL_VERSION_ghc=\"${GHC_VERSION}\" \
+  -XBangPatterns -XBinaryLiterals -XDataKinds -XDefaultSignatures \
+  -XDeriveDataTypeable -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric \
+  -XDeriveLift -XDeriveTraversable -XDerivingStrategies -XInstanceSigs \
+  -XKindSignatures ${XNoStarIsType} -XScopedTypeVariables -XStandaloneDeriving \
+  -XTupleSections -XTypeApplications -XTypeOperators -XViewPatterns \
   Clash.hs

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -84,7 +84,33 @@ executable clashi
   extra-libraries:    pthread
   default-language:   Haskell2010
 
+common common-options
+  default-language:   Haskell2010
+  default-extensions: BangPatterns
+                      BinaryLiterals
+                      DataKinds
+                      DefaultSignatures
+                      DeriveDataTypeable
+                      DeriveFoldable
+                      DeriveFunctor
+                      DeriveGeneric
+                      DeriveLift
+                      DeriveTraversable
+                      DerivingStrategies
+                      InstanceSigs
+                      KindSignatures
+                      ScopedTypeVariables
+                      StandaloneDeriving
+                      TupleSections
+                      TypeApplications
+                      TypeOperators
+                      ViewPatterns
+
+  if impl(ghc >= 8.6)
+      default-extensions: NoStarIsType
+
 library
+  import:             common-options
   HS-Source-Dirs:     src-ghc, src-bin-common
   if impl(ghc >= 8.7.0)
     HS-Source-Dirs: src-bin-881
@@ -93,24 +119,13 @@ library
   elif impl(ghc >= 8.4.1)
     HS-Source-Dirs: src-bin-841
 
-  default-language:   Haskell2010
   GHC-Options:        -Wall -fno-warn-name-shadowing
   CPP-Options:        -DGHCI
-  default-extensions: ForeignFunctionInterface
-                      UnboxedTuples
-                      FlexibleInstances
-                      MagicHash
-                      CPP
-                      PatternGuards
-                      NondecreasingIndentation
 
   other-extensions:   FlexibleContexts
                       OverloadedStrings
                       RecordWildCards
-                      ScopedTypeVariables
                       TemplateHaskell
-                      TupleSections
-                      ViewPatterns
 
   Build-Depends:      array                     >= 0.4      && < 0.6,
                       base                      >= 4.10     && < 5,

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
@@ -6,8 +5,6 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS -fno-cse #-}
 -- -fno-cse is needed for GLOBAL_VAR's to behave properly

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI/Info.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI/Info.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI/Info.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI/Monad.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI/Monad.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE CPP, FlexibleInstances, UnboxedTuples, MagicHash #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
 {-# OPTIONS_GHC -fno-cse -fno-warn-orphans #-}
 -- -fno-cse is needed for GLOBAL_VAR's to behave properly
 

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI/Tags.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI/Tags.hs
@@ -7,6 +7,7 @@
 -----------------------------------------------------------------------------
 
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+
 module Clash.GHCi.UI.Tags (
   createCTagsWithLineNumbersCmd,
   createCTagsWithRegExesCmd,

--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP, NondecreasingIndentation, ScopedTypeVariables, TupleSections #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NondecreasingIndentation #-}
+
 {-# OPTIONS -fno-warn-incomplete-patterns -optc-DNON_POSIX_SOURCE #-}
 
 -----------------------------------------------------------------------------

--- a/clash-ghc/src-bin-861/Clash/GHCi/Leak.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/Leak.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE RecordWildCards, LambdaCase #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Clash.GHCi.Leak
   ( LeakIndicators
   , getLeakIndicators

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
@@ -6,8 +5,6 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS -fno-cse #-}
 -- -fno-cse is needed for GLOBAL_VAR's to behave properly

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI/Info.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI/Info.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI/Info.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI/Monad.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI/Monad.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE CPP, FlexibleInstances, UnboxedTuples, MagicHash #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
 {-# OPTIONS_GHC -fno-cse -fno-warn-orphans #-}
 -- -fno-cse is needed for GLOBAL_VAR's to behave properly
 

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI/Tags.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI/Tags.hs
@@ -7,6 +7,7 @@
 -----------------------------------------------------------------------------
 
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+
 module Clash.GHCi.UI.Tags (
   createCTagsWithLineNumbersCmd,
   createCTagsWithRegExesCmd,

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP, NondecreasingIndentation, ScopedTypeVariables, TupleSections #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NondecreasingIndentation #-}
+
 {-# OPTIONS -fno-warn-incomplete-patterns -optc-DNON_POSIX_SOURCE #-}
 
 -----------------------------------------------------------------------------

--- a/clash-ghc/src-bin-881/Clash/GHCi/Leak.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/Leak.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE RecordWildCards, LambdaCase #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Clash.GHCi.Leak
   ( LeakIndicators
   , getLeakIndicators

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
@@ -6,9 +5,6 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS -fno-cse #-}
 -- -fno-cse is needed for GLOBAL_VAR's to behave properly

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI/Info.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI/Info.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI/Info.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI/Info.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- | Get information on modules, expressions, and identifiers
 module Clash.GHCi.UI.Info

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI/Monad.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI/Monad.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP, FlexibleInstances #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+
 {-# OPTIONS_GHC -fno-cse -fno-warn-orphans #-}
 -- -fno-cse is needed for GLOBAL_VAR's to behave properly
 

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI/Tags.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI/Tags.hs
@@ -7,6 +7,7 @@
 -----------------------------------------------------------------------------
 
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+
 module Clash.GHCi.UI.Tags (
   createCTagsWithLineNumbersCmd,
   createCTagsWithRegExesCmd,

--- a/clash-ghc/src-bin-881/Clash/GHCi/Util.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/Util.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE MagicHash, UnboxedTuples #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
 
 -- | Utilities for GHCi.
 module Clash.GHCi.Util where

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE CPP, NondecreasingIndentation, ScopedTypeVariables, TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NondecreasingIndentation #-}
+
 {-# OPTIONS -fno-warn-incomplete-patterns -optc-DNON_POSIX_SOURCE #-}
 
 -----------------------------------------------------------------------------

--- a/clash-ghc/src-bin-common/Clash/GHCi/Common.hs
+++ b/clash-ghc/src-bin-common/Clash/GHCi/Common.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP        #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Clash.GHCi.Common

--- a/clash-ghc/src-ghc/Batch.hs
+++ b/clash-ghc/src-ghc/Batch.hs
@@ -5,6 +5,7 @@
 
   Entry point for the @clash@ executable.
 -}
+
 module Main
   ( main -- :: IO ()
   ) where

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -5,8 +5,8 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP           #-}
-{-# LANGUAGE LambdaCase    #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Clash.GHC.ClashFlags
   ( parseClashFlags

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -7,7 +7,6 @@
 
 {-# LANGUAGE CPP           #-}
 {-# LANGUAGE LambdaCase    #-}
-{-# LANGUAGE TupleSections #-}
 
 module Clash.GHC.ClashFlags
   ( parseClashFlags

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -6,17 +6,12 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE KindSignatures    #-}
 {-# LANGUAGE MagicHash         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE UnboxedTuples     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.GHC.Evaluator where
 

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -6,12 +6,12 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE MagicHash         #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE UnboxedTuples     #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UnboxedTuples #-}
 
 module Clash.GHC.Evaluator where
 

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -6,10 +6,10 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP              #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -10,8 +10,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell  #-}
-{-# LANGUAGE TupleSections    #-}
-{-# LANGUAGE ViewPatterns     #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -5,7 +5,7 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.GHC.GenerateBindings

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -7,7 +7,6 @@
 
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.GHC.GenerateBindings
   (generateBindings)

--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -7,10 +7,7 @@
 
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Clash.GHC.LoadInterfaceFiles
   ( loadExternalExprs

--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -5,9 +5,9 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.GHC.LoadInterfaceFiles
   ( loadExternalExprs

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -6,10 +6,10 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.GHC.LoadModules
   ( loadModules

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -9,9 +9,7 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 module Clash.GHC.LoadModules
   ( loadModules

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -7,8 +7,6 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.GHC.NetlistTypes
   (ghcTypeToHWType)

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -6,7 +6,7 @@
 -}
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.GHC.NetlistTypes
   (ghcTypeToHWType)

--- a/clash-ghc/src-ghc/Clash/GHC/Util.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Util.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 module Clash.GHC.Util where
 
 import ErrUtils           (mkPlainErrMsg)

--- a/clash-ghc/src-ghc/Interactive.hs
+++ b/clash-ghc/src-ghc/Interactive.hs
@@ -5,6 +5,7 @@
 
   Entry point for the @clashi@ executable.
 -}
+
 module Main
   ( main -- :: IO ()
   ) where

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -90,30 +90,50 @@ flag unittests
   default: True
   manual: True
 
+common common-options
+  default-language:   Haskell2010
+  default-extensions: BangPatterns
+                      BinaryLiterals
+                      DataKinds
+                      DefaultSignatures
+                      DeriveDataTypeable
+                      DeriveFoldable
+                      DeriveFunctor
+                      DeriveGeneric
+                      DeriveLift
+                      DeriveTraversable
+                      DerivingStrategies
+                      InstanceSigs
+                      KindSignatures
+                      ScopedTypeVariables
+                      StandaloneDeriving
+                      TupleSections
+                      TypeApplications
+                      TypeOperators
+                      ViewPatterns
+
+  if impl(ghc >= 8.6)
+      default-extensions: NoStarIsType
+
+
 Library
+  import:             common-options
   HS-Source-Dirs:     src
 
-  default-language:   Haskell2010
   ghc-options:        -Wall
   CPP-Options:        -DCABAL
 
   other-extensions:   CPP
                       DeriveAnyClass
-                      DeriveGeneric
-                      DeriveFoldable
-                      DeriveFunctor
                       FlexibleContexts
                       FlexibleInstances
                       GeneralizedNewtypeDeriving
                       LambdaCase
                       MultiParamTypeClasses
                       OverloadedStrings
-                      Rank2Types
+                      RankNTypes
                       RecordWildCards
-                      ScopedTypeVariables
                       TemplateHaskell
-                      TupleSections
-                      ViewPatterns
 
   Build-depends:      aeson                   >= 0.6.2.0  && < 1.5,
                       ansi-terminal           >= 0.8.0.0  && < 0.10,
@@ -238,6 +258,7 @@ Library
     cpp-options:      -DHISTORY
 
 test-suite unittests
+  import:           common-options
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   main-is:          unittests.hs

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -7,12 +7,12 @@
   Generate SystemVerilog for assorted Netlist datatypes
 -}
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE MultiWayIf        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecursiveDo       #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Backend.SystemVerilog (SystemVerilogState) where
 

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -13,8 +13,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecursiveDo       #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Backend.SystemVerilog (SystemVerilogState) where
 

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -12,11 +12,8 @@
 {-# LANGUAGE MultiWayIf          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecursiveDo         #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 module Clash.Backend.VHDL (VHDLState) where
 

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -7,13 +7,13 @@
   Generate VHDL for assorted Netlist datatypes
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE MultiWayIf          #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecursiveDo         #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Backend.VHDL (VHDLState) where
 

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -14,8 +14,6 @@
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE RecursiveDo       #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Backend.Verilog
   ( VerilogState

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -7,13 +7,13 @@
   Generate Verilog for assorted Netlist datatypes
 -}
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE MultiWayIf        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE RecursiveDo       #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Backend.Verilog
   ( VerilogState

--- a/clash-lib/src/Clash/Core/DataCon.hs
+++ b/clash-lib/src/Clash/Core/DataCon.hs
@@ -9,7 +9,6 @@
 
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}

--- a/clash-lib/src/Clash/Core/DataCon.hs
+++ b/clash-lib/src/Clash/Core/DataCon.hs
@@ -7,11 +7,11 @@
   Data Constructors in CoreHW
 -}
 
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Core.DataCon
   ( DataCon (..)

--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -10,12 +10,10 @@
 
 -}
 
-{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE MagicHash         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Core.Evaluator where
 

--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -10,10 +10,10 @@
 
 -}
 
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE MagicHash         #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Core.Evaluator where
 

--- a/clash-lib/src/Clash/Core/FreeVars.hs
+++ b/clash-lib/src/Clash/Core/FreeVars.hs
@@ -6,8 +6,8 @@
   Free variable calculations
 -}
 
-{-# LANGUAGE LambdaCase   #-}
-{-# LANGUAGE RankNTypes   #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Clash.Core.FreeVars
   (-- * Free variable calculation

--- a/clash-lib/src/Clash/Core/FreeVars.hs
+++ b/clash-lib/src/Clash/Core/FreeVars.hs
@@ -8,7 +8,6 @@
 
 {-# LANGUAGE LambdaCase   #-}
 {-# LANGUAGE RankNTypes   #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Clash.Core.FreeVars
   (-- * Free variable calculation

--- a/clash-lib/src/Clash/Core/Literal.hs
+++ b/clash-lib/src/Clash/Core/Literal.hs
@@ -8,8 +8,8 @@
   Term Literal
 -}
 
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Clash.Core.Literal

--- a/clash-lib/src/Clash/Core/Literal.hs
+++ b/clash-lib/src/Clash/Core/Literal.hs
@@ -9,7 +9,6 @@
 -}
 
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 

--- a/clash-lib/src/Clash/Core/Name.hs
+++ b/clash-lib/src/Clash/Core/Name.hs
@@ -7,7 +7,6 @@
 -}
 
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}

--- a/clash-lib/src/Clash/Core/Name.hs
+++ b/clash-lib/src/Clash/Core/Name.hs
@@ -6,11 +6,11 @@
   Names
 -}
 
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Core.Name
   ( module Clash.Core.Name

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE ViewPatterns      #-}
 {-# LANGUAGE LambdaCase        #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -9,8 +9,8 @@
 
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE LambdaCase #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -8,9 +8,9 @@
 -}
 
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE LambdaCase #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -7,8 +7,8 @@
   Capture-free substitution function for CoreHW
 -}
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -8,13 +8,10 @@
 -}
 
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE ViewPatterns          #-}
 
 module Clash.Core.Term
   ( Term (..)

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -7,11 +7,11 @@
   Term representation in the CoreHW language: System F + LetRec + Case
 -}
 
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Core.Term
   ( Term (..)

--- a/clash-lib/src/Clash/Core/TermLiteral.hs
+++ b/clash-lib/src/Clash/Core/TermLiteral.hs
@@ -5,8 +5,8 @@ Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 Tools to convert a 'Term' into its "real" representation
 -}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Core.TermLiteral
   ( TermLiteral

--- a/clash-lib/src/Clash/Core/TermLiteral.hs
+++ b/clash-lib/src/Clash/Core/TermLiteral.hs
@@ -7,7 +7,6 @@ Tools to convert a 'Term' into its "real" representation
 -}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE ViewPatterns          #-}
 
 module Clash.Core.TermLiteral
   ( TermLiteral

--- a/clash-lib/src/Clash/Core/TermLiteral/TH.hs
+++ b/clash-lib/src/Clash/Core/TermLiteral/TH.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskellQuotes #-}
-{-# LANGUAGE ViewPatterns          #-}
 
 module Clash.Core.TermLiteral.TH
   (  deriveTermToData

--- a/clash-lib/src/Clash/Core/TyCon.hs
+++ b/clash-lib/src/Clash/Core/TyCon.hs
@@ -6,9 +6,9 @@
   Type Constructors in CoreHW
 -}
 
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Clash.Core.TyCon

--- a/clash-lib/src/Clash/Core/TyCon.hs
+++ b/clash-lib/src/Clash/Core/TyCon.hs
@@ -8,7 +8,6 @@
 
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -8,14 +8,14 @@
   Types in CoreHW
 -}
 
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MagicHash             #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Core.Type
   ( Type (..)

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -10,14 +10,12 @@
 
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE ViewPatterns          #-}
 
 module Clash.Core.Type
   ( Type (..)

--- a/clash-lib/src/Clash/Core/TysPrim.hs
+++ b/clash-lib/src/Clash/Core/TysPrim.hs
@@ -7,7 +7,7 @@
   Builtin Type and Kind definitions
 -}
 
-{-# LANGUAGE CPP               #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Core.TysPrim

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -6,12 +6,10 @@
   Smart constructor and destructor functions for CoreHW
 -}
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Core.Util where
 

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -8,8 +8,6 @@
 -}
 
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE ExplicitForAll        #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RankNTypes            #-}

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -7,10 +7,10 @@
   Variables in CoreHW
 -}
 
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Clash.Core.Var
   ( Attr' (..)

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE TypeSynonymInstances       #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 module Clash.Core.VarEnv
   ( -- * Environment with variables as keys

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -9,8 +9,6 @@
 -}
 
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE ScopedTypeVariables      #-}
-{-# LANGUAGE TupleSections            #-}
 
 module Clash.Driver where
 

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -8,12 +8,12 @@
   Create Netlists out of normalized CoreHW Terms
 -}
 
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE MagicHash         #-}
-{-# LANGUAGE MultiWayIf        #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Netlist where
 

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -14,8 +14,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Netlist where
 

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -12,8 +12,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Netlist.BlackBox where
 

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -8,10 +8,10 @@
   Functions to create BlackBox Contexts and fill in BlackBox templates
 -}
 
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Netlist.BlackBox where
 

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -9,8 +9,6 @@
 
 {-# LANGUAGE CPP            #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
-
 -- since GHC 8.6 we can haddock individual contructor fields \o/
 #if __GLASGOW_HASKELL__ >= 806
 #define FIELD ^

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -7,7 +7,7 @@
   Types used in BlackBox modules
 -}
 
-{-# LANGUAGE CPP            #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 -- since GHC 8.6 we can haddock individual contructor fields \o/
 #if __GLASGOW_HASKELL__ >= 806

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -13,9 +13,7 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 module Clash.Netlist.BlackBox.Util where
 

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -8,12 +8,12 @@
   in templates
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Netlist.BlackBox.Util where
 

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -8,7 +8,6 @@
 
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Netlist.Id
   ( IdType (..)

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -6,7 +6,7 @@
   Transform/format a Netlist Identifier so that it is acceptable as a HDL identifier
 -}
 
-{-# LANGUAGE CPP               #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Netlist.Id

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -8,14 +8,14 @@
   Type and instance definitions for Netlist modules
 -}
 
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE PatternSynonyms            #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- since GHC 8.6 we can haddock individual contructor fields \o/
 #if __GLASGOW_HASKELL__ >= 806

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -10,16 +10,12 @@
 
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE DeriveLift                 #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
 
 -- since GHC 8.6 we can haddock individual contructor fields \o/
 #if __GLASGOW_HASKELL__ >= 806

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -17,8 +17,6 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 module Clash.Netlist.Util where
 

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -8,15 +8,15 @@
   Utilities for converting Core Type/Term to Netlist datatypes
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 #if !MIN_VERSION_ghc(8,8,0)
 {-# LANGUAGE MonadFailDesugaring #-}
 #endif
-{-# LANGUAGE MultiWayIf          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Netlist.Util where
 

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -8,9 +8,9 @@
   Turn CoreHW terms into normalized CoreHW Terms
 -}
 
-{-# LANGUAGE CPP               #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -10,10 +10,7 @@
 
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE ViewPatterns      #-}
-{-# LANGUAGE BangPatterns      #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -26,13 +26,9 @@
   >       C -> h x
 -}
 
-{-# LANGUAGE DeriveFoldable    #-}
-{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecursiveDo       #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Normalize.DEC
   (collectGlobals

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -27,8 +27,8 @@
 -}
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecursiveDo       #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Normalize.DEC
   (collectGlobals

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -33,7 +33,6 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Normalize.PrimitiveReductions where
 

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -30,9 +30,9 @@
     * Clash.Sized.Vector.transpose
 -}
 
-{-# LANGUAGE CPP               #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Normalize.PrimitiveReductions where
 

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -8,13 +8,13 @@
   Transformations of the Normalization process
 -}
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE MagicHash         #-}
-{-# LANGUAGE MultiWayIf        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Normalize.Transformations
   ( appProp

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -8,7 +8,6 @@
   Transformations of the Normalization process
 -}
 
-{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
@@ -16,8 +15,6 @@
 {-# LANGUAGE MultiWayIf        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Normalize.Transformations
   ( appProp

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -7,7 +7,7 @@
   Types used in Normalize modules
 -}
 
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Normalize.Types where
 

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -6,9 +6,9 @@
   Utility functions used by the normalisation transformations
 -}
 
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Clash.Normalize.Util
  ( ConstantSpecInfo(..)

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -6,11 +6,9 @@
   Utility functions used by the normalisation transformations
 -}
 
-{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Normalize.Util
  ( ConstantSpecInfo(..)

--- a/clash-lib/src/Clash/Primitives/GHC/Int.hs
+++ b/clash-lib/src/Clash/Primitives/GHC/Int.hs
@@ -7,7 +7,6 @@
 -}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Primitives.GHC.Int (intTF) where
 

--- a/clash-lib/src/Clash/Primitives/GHC/Int.hs
+++ b/clash-lib/src/Clash/Primitives/GHC/Int.hs
@@ -5,7 +5,7 @@
 
   Blackbox generation for GHC.Int.IntX# data constructors. (System)Verilog only!
 -}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Primitives.GHC.Int (intTF) where

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -7,7 +7,6 @@
 -}
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Primitives.Intel.ClockGen where
 

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE QuasiQuotes         #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Primitives.Sized.Vector where
 

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 module Clash.Primitives.Sized.Vector where
 

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -9,15 +9,10 @@
 -}
 
 {-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveFoldable    #-}
-{-# LANGUAGE DeriveFunctor     #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Primitives.Types
   ( TemplateSource(..)

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -8,10 +8,10 @@
   Type and instance definitions for Primitive
 -}
 
-{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Primitives.Types

--- a/clash-lib/src/Clash/Primitives/Util.hs
+++ b/clash-lib/src/Clash/Primitives/Util.hs
@@ -11,7 +11,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TupleSections     #-}
 
 module Clash.Primitives.Util
   ( generatePrimMap

--- a/clash-lib/src/Clash/Primitives/Util.hs
+++ b/clash-lib/src/Clash/Primitives/Util.hs
@@ -8,9 +8,9 @@
   Utility functions to generate Primitives
 -}
 
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Clash.Primitives.Util
   ( generatePrimMap

--- a/clash-lib/src/Clash/Rewrite/Combinators.hs
+++ b/clash-lib/src/Clash/Rewrite/Combinators.hs
@@ -6,10 +6,6 @@
   Rewriting combinators and traversals
 -}
 
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE ViewPatterns        #-}
-
 module Clash.Rewrite.Combinators
   ( allR
   , (!->)

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -9,11 +9,11 @@
 -}
 
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Rewrite.Types where
 

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -14,7 +14,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
 
 module Clash.Rewrite.Types where
 

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -8,12 +8,12 @@
   Type and instance definitions for Rewrite modules
 -}
 
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 module Clash.Rewrite.Types where
 

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -9,11 +9,11 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -8,13 +8,13 @@
   Utilities for rewriting: e.g. inlining, specialisation, etc.
 -}
 
-{-# LANGUAGE CPP                      #-}
-{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE OverloadedStrings        #-}
-{-# LANGUAGE RankNTypes               #-}
-{-# LANGUAGE FlexibleContexts         #-}
-{-# LANGUAGE TemplateHaskell          #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -8,15 +8,13 @@
   Utilities for rewriting: e.g. inlining, specialisation, etc.
 -}
 
-{-# LANGUAGE BangPatterns             #-}
 {-# LANGUAGE CPP                      #-}
 {-# LANGUAGE LambdaCase               #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE OverloadedStrings        #-}
-{-# LANGUAGE Rank2Types               #-}
+{-# LANGUAGE RankNTypes               #-}
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE TemplateHaskell          #-}
-{-# LANGUAGE ViewPatterns             #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Unique
   ( -- * Unique

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -10,8 +10,7 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE MagicHash            #-}
 {-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE Rank2Types           #-}
-{-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE RankNTypes           #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -6,11 +6,11 @@
   Assortment of utility function used in the Clash library
 -}
 
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE MagicHash            #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/clash-lib/src/Clash/Util/Graph.hs
+++ b/clash-lib/src/Clash/Util/Graph.hs
@@ -5,6 +5,7 @@
 
   Collection of utilities
 -}
+
 module Clash.Util.Graph (topSort, reverseTopSort) where
 
 import           Data.Tuple            (swap)

--- a/clash-lib/src/Data/Text/Prettyprint/Doc/Extra.hs
+++ b/clash-lib/src/Data/Text/Prettyprint/Doc/Extra.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/clash-lib/src/GHC/BasicTypes/Extra.hs
+++ b/clash-lib/src/GHC/BasicTypes/Extra.hs
@@ -4,9 +4,6 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE StandaloneDeriving #-}
-
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module GHC.BasicTypes.Extra where

--- a/clash-lib/src/GHC/SrcLoc/Extra.hs
+++ b/clash-lib/src/GHC/SrcLoc/Extra.hs
@@ -5,8 +5,6 @@
 -}
 
 {-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell    #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/clash-lib/src/GHC/SrcLoc/Extra.hs
+++ b/clash-lib/src/GHC/SrcLoc/Extra.hs
@@ -4,8 +4,8 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -111,10 +111,36 @@ flag benchmarks
   default: True
   manual: True
 
+common common-options
+  default-language:   Haskell2010
+  default-extensions: BangPatterns
+                      BinaryLiterals
+                      DataKinds
+                      DefaultSignatures
+                      DeriveDataTypeable
+                      DeriveFoldable
+                      DeriveFunctor
+                      DeriveGeneric
+                      DeriveLift
+                      DeriveTraversable
+                      DerivingStrategies
+                      InstanceSigs
+                      KindSignatures
+                      MagicHash
+                      ScopedTypeVariables
+                      StandaloneDeriving
+                      TupleSections
+                      TypeApplications
+                      TypeOperators
+                      ViewPatterns
+
+  if impl(ghc >= 8.6)
+      default-extensions: NoStarIsType
+
 Library
+  import:             common-options
   HS-Source-Dirs:     src
 
-  default-language:   Haskell2010
   ghc-options:        -Wall -fexpose-all-unfoldings -fno-worker-wrapper
   CPP-Options:        -DCABAL
 
@@ -245,32 +271,17 @@ Library
                       Paths_clash_prelude
 
   other-extensions:   CPP
-                      BangPatterns
                       ConstraintKinds
-                      DataKinds
-                      DefaultSignatures
-                      DeriveDataTypeable
-                      DeriveTraversable
-                      DeriveLift
                       FlexibleContexts
                       FlexibleInstances
                       GADTs
                       GeneralizedNewtypeDeriving
-                      InstanceSigs
-                      KindSignatures
-                      MagicHash
                       MultiParamTypeClasses
                       PatternSynonyms
-                      Rank2Types
-                      ScopedTypeVariables
-                      StandaloneDeriving
+                      RankNTypes
                       TemplateHaskell
-                      TupleSections
-                      TypeApplications
                       TypeFamilies
-                      TypeOperators
                       UndecidableInstances
-                      ViewPatterns
 
   Build-depends:      array                     >= 0.5.1.0 && < 0.6,
                       base                      >= 4.10    && < 5,
@@ -324,8 +335,8 @@ test-suite doctests
       doctest >= 0.16.1
 
 test-suite unittests
+  import:           common-options
   type:             exitcode-stdio-1.0
-  default-language: Haskell2010
   main-is:          unittests.hs
   ghc-options:      -Wall
   hs-source-dirs:   tests

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
@@ -8,9 +8,9 @@ bit representation for a data type. See @DataReprAnn@ for documentation.
 
 -}
 
-{-# LANGUAGE RankNTypes         #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
@@ -8,9 +8,6 @@ bit representation for a data type. See @DataReprAnn@ for documentation.
 
 -}
 
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell    #-}

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -14,19 +14,12 @@ This module contains:
 
 -}
 {-# LANGUAGE CPP                #-}
-{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE MagicHash          #-}
 {-# LANGUAGE MultiWayIf         #-}
 {-# LANGUAGE QuasiQuotes        #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell    #-}
-{-# LANGUAGE ViewPatterns       #-}
-
 -- See: https://ghc.haskell.org/trac/ghc/ticket/14959. TODO: Consider putting
 -- the offending function (bitsToInteger') in a separate module.
 {-# OPTIONS_GHC -O0 #-}

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -13,13 +13,13 @@ This module contains:
     e.g. one-hot, for a data type.
 
 -}
-{-# LANGUAGE CPP                #-}
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE MultiWayIf         #-}
-{-# LANGUAGE QuasiQuotes        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TemplateHaskell #-}
 -- See: https://ghc.haskell.org/trac/ghc/ticket/14959. TODO: Consider putting
 -- the offending function (bitsToInteger') in a separate module.
 {-# OPTIONS_GHC -O0 #-}

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -6,12 +6,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE TemplateHaskell    #-}
-{-# LANGUAGE TypeApplications   #-}
 
 module Clash.Annotations.BitRepresentation.Internal
   ( buildCustomReprs

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -4,11 +4,11 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                #-}
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RankNTypes         #-}
-{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Annotations.BitRepresentation.Internal
   ( buildCustomReprs

--- a/clash-prelude/src/Clash/Annotations/Primitive.hs
+++ b/clash-prelude/src/Clash/Annotations/Primitive.hs
@@ -9,10 +9,6 @@ templates.
 -}
 
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveDataTypeable    #-}
-{-# LANGUAGE DeriveFunctor         #-}
-{-# LANGUAGE DeriveTraversable     #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 

--- a/clash-prelude/src/Clash/Annotations/Primitive.hs
+++ b/clash-prelude/src/Clash/Annotations/Primitive.hs
@@ -8,8 +8,8 @@ indicated directory. For distribution of new packages with primitive HDL
 templates.
 -}
 
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
+++ b/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
@@ -9,9 +9,7 @@
   (<https://github.com/clash-lang/clash-compiler/issues>).
 -}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE PolyKinds     #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE Safe #-}
 
 module Clash.Annotations.SynthesisAttributes

--- a/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
+++ b/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
@@ -9,7 +9,7 @@
   (<https://github.com/clash-lang/clash-compiler/issues>).
 -}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE PolyKinds     #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE Safe #-}
 
 module Clash.Annotations.SynthesisAttributes

--- a/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
+++ b/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
@@ -10,6 +10,7 @@
 -}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE PolyKinds #-}
+
 {-# LANGUAGE Safe #-}
 
 module Clash.Annotations.SynthesisAttributes

--- a/clash-prelude/src/Clash/Annotations/TH.hs
+++ b/clash-prelude/src/Clash/Annotations/TH.hs
@@ -47,21 +47,13 @@ makeTopEntity 'topEntity
 -- Required to 'makeBaseFunctor' of 'Language.Haskell.TH.Syntax.Type'
 
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveFoldable      #-}
-{-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE DeriveLift          #-}
-{-# LANGUAGE DeriveTraversable   #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE PolyKinds           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 module Clash.Annotations.TH
   ( -- * To create a Synthesize annotation pragma

--- a/clash-prelude/src/Clash/Annotations/TH.hs
+++ b/clash-prelude/src/Clash/Annotations/TH.hs
@@ -46,14 +46,14 @@ makeTopEntity 'topEntity
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- Required to 'makeBaseFunctor' of 'Language.Haskell.TH.Syntax.Type'
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE PatternSynonyms     #-}
-{-# LANGUAGE PolyKinds           #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Annotations.TH
   ( -- * To create a Synthesize annotation pragma

--- a/clash-prelude/src/Clash/Annotations/TopEntity.hs
+++ b/clash-prelude/src/Clash/Annotations/TopEntity.hs
@@ -197,10 +197,6 @@ g = ...
 
 -}
 
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DeriveLift         #-}
-
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/CPP.hs
+++ b/clash-prelude/src/Clash/CPP.hs
@@ -5,6 +5,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE CPP #-}
+
 {-# OPTIONS_HADDOCK hide #-}
 
 #ifndef MAX_TUPLE_SIZE

--- a/clash-prelude/src/Clash/Class/AutoReg.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg.hs
@@ -3,6 +3,7 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
+
 module Clash.Class.AutoReg
   ( AutoReg (autoReg)
   , deriveAutoReg

--- a/clash-prelude/src/Clash/Class/AutoReg/Instances.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Instances.hs
@@ -3,7 +3,7 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -4,18 +4,11 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 {-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE InstanceSigs         #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-} -- needed for constraint on the Fixed instance
-{-# LANGUAGE ViewPatterns         #-}
-
 #if __GLASGOW_HASKELL__ < 806
 {-# OPTIONS_GHC -Wwarn=unused-pattern-binds #-}
 #endif

--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -3,11 +3,11 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-} -- needed for constraint on the Fixed instance
 #if __GLASGOW_HASKELL__ < 806
 {-# OPTIONS_GHC -Wwarn=unused-pattern-binds #-}

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -8,9 +8,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -8,9 +8,10 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+
+{-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -5,10 +5,10 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -6,18 +6,10 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DefaultSignatures    #-}
 {-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE MagicHash            #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns         #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}

--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -3,7 +3,7 @@ Copyright  :  (C) 2019, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Class.BitPack.Internal (deriveBitPackTuples) where

--- a/clash-prelude/src/Clash/Class/Exp.hs
+++ b/clash-prelude/src/Clash/Class/Exp.hs
@@ -4,8 +4,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP           #-}
-{-# LANGUAGE TypeFamilies  #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 

--- a/clash-prelude/src/Clash/Class/Exp.hs
+++ b/clash-prelude/src/Clash/Class/Exp.hs
@@ -5,14 +5,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE CPP           #-}
-{-# LANGUAGE DataKinds     #-}
-{-# LANGUAGE MagicHash     #-}
 {-# LANGUAGE TypeFamilies  #-}
-{-# LANGUAGE TypeOperators #-}
-
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType  #-}
-#endif
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 

--- a/clash-prelude/src/Clash/Class/HasDomain/CodeGen.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/CodeGen.hs
@@ -4,8 +4,6 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE ViewPatterns #-}
-
 module Clash.Class.HasDomain.CodeGen
   ( mkTryDomainTuples
   , mkHasDomainTuples

--- a/clash-prelude/src/Clash/Class/HasDomain/Common.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/Common.hs
@@ -4,10 +4,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE PolyKinds          #-}
 {-# LANGUAGE TypeFamilies       #-}
-{-# LANGUAGE TypeOperators      #-}
 
 module Clash.Class.HasDomain.Common
   ( Unlines

--- a/clash-prelude/src/Clash/Class/HasDomain/Common.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/Common.hs
@@ -4,8 +4,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE PolyKinds          #-}
-{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Class.HasDomain.Common
   ( Unlines

--- a/clash-prelude/src/Clash/Class/HasDomain/HasSingleDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/HasSingleDomain.hs
@@ -4,10 +4,10 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/clash-prelude/src/Clash/Class/HasDomain/HasSingleDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/HasSingleDomain.hs
@@ -4,12 +4,12 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 #if __GLASGOW_HASKELL__ < 806

--- a/clash-prelude/src/Clash/Class/HasDomain/HasSingleDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/HasSingleDomain.hs
@@ -7,12 +7,11 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif

--- a/clash-prelude/src/Clash/Class/HasDomain/HasSpecificDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/HasSpecificDomain.hs
@@ -4,14 +4,14 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}

--- a/clash-prelude/src/Clash/Class/HasDomain/HasSpecificDomain.hs
+++ b/clash-prelude/src/Clash/Class/HasDomain/HasSpecificDomain.hs
@@ -6,14 +6,13 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
+
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif

--- a/clash-prelude/src/Clash/Class/Num.hs
+++ b/clash-prelude/src/Clash/Class/Num.hs
@@ -5,7 +5,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE Safe #-}
 

--- a/clash-prelude/src/Clash/Class/Num.hs
+++ b/clash-prelude/src/Clash/Class/Num.hs
@@ -4,7 +4,6 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
 

--- a/clash-prelude/src/Clash/Class/Parity.hs
+++ b/clash-prelude/src/Clash/Class/Parity.hs
@@ -4,8 +4,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}

--- a/clash-prelude/src/Clash/Class/Parity.hs
+++ b/clash-prelude/src/Clash/Class/Parity.hs
@@ -5,11 +5,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DefaultSignatures    #-}
 {-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE MagicHash            #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}

--- a/clash-prelude/src/Clash/Class/Resize.hs
+++ b/clash-prelude/src/Clash/Class/Resize.hs
@@ -4,10 +4,6 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds      #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE TypeOperators  #-}
-
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
@@ -15,10 +11,11 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 module Clash.Class.Resize where
 
+import Data.Kind (Type)
 import GHC.TypeLits (Nat, KnownNat, type (+))
 
 -- | Coerce a value to be represented by a different number of bits
-class Resize (f :: Nat -> *) where
+class Resize (f :: Nat -> Type) where
   -- | A sign-preserving resize operation
   --
   -- * For signed datatypes: Increasing the size of the number replicates the

--- a/clash-prelude/src/Clash/Clocks.hs
+++ b/clash-prelude/src/Clash/Clocks.hs
@@ -7,9 +7,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Generic clock related utilities.
 -}
 
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Clocks (Clocks, clocks) where
 

--- a/clash-prelude/src/Clash/Clocks.hs
+++ b/clash-prelude/src/Clash/Clocks.hs
@@ -7,13 +7,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Generic clock related utilities.
 -}
 
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE InstanceSigs        #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Clash.Clocks (Clocks, clocks) where
 

--- a/clash-prelude/src/Clash/Clocks/Deriving.hs
+++ b/clash-prelude/src/Clash/Clocks/Deriving.hs
@@ -5,8 +5,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Clash.Clocks.Deriving (deriveClocksInstances) where
 

--- a/clash-prelude/src/Clash/Clocks/Deriving.hs
+++ b/clash-prelude/src/Clash/Clocks/Deriving.hs
@@ -5,8 +5,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Clocks.Deriving (deriveClocksInstances) where
 

--- a/clash-prelude/src/Clash/Clocks/Deriving.hs
+++ b/clash-prelude/src/Clash/Clocks/Deriving.hs
@@ -7,7 +7,6 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Clocks.Deriving (deriveClocksInstances) where
 

--- a/clash-prelude/src/Clash/Examples.hs
+++ b/clash-prelude/src/Clash/Examples.hs
@@ -5,9 +5,14 @@ Copyright : © 2015-2016, Christiaan Baaij,
 Licence   : Creative Commons 4.0 (CC BY 4.0) (https://creativecommons.org/licenses/by/4.0/)
 -}
 
-{-# LANGUAGE NoImplicitPrelude, CPP, TemplateHaskell, DataKinds, BinaryLiterals,
-             FlexibleContexts, GADTs, TypeOperators, TypeApplications,
-             RecordWildCards, DeriveGeneric, DeriveAnyClass #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
@@ -548,6 +553,7 @@ crc enable ld dIn = s
 {- $uart
 @
 {\-\# LANGUAGE RecordWildCards \#-\}
+
 module UART (uart) where
 
 import Clash.Prelude

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -374,7 +374,7 @@ This concludes the short introduction to using 'blockRam'.
 
 -}
 
-{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -19,6 +19,7 @@ codes:
 
 @
 {\-\# LANGUAGE RecordWildCards, TupleSections, DeriveAnyClass \#-\}
+
 module CPU where
 
 import Clash.Explicit.Prelude
@@ -373,15 +374,7 @@ This concludes the short introduction to using 'blockRam'.
 
 -}
 
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -375,6 +375,7 @@ This concludes the short introduction to using 'blockRam'.
 -}
 
 {-# LANGUAGE GADTs #-}
+
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -71,14 +71,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 
 -}
 
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -72,6 +72,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 -}
 
 {-# LANGUAGE GADTs #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -71,7 +71,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 
 -}
 
-{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -18,9 +18,9 @@ to dedicated hardware resources use the functions from "Clash.Intel.DDR"
 or "Clash.Xilinx.DDR".
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Explicit.DDR
   ( ddrIn

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -19,17 +19,8 @@ or "Clash.Xilinx.DDR".
 -}
 
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE ViewPatterns        #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#endif
 
 module Clash.Explicit.DDR
   ( ddrIn

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -10,6 +10,7 @@ defined in "Clash.Prelude".
 -}
 
 {-# LANGUAGE NoImplicitPrelude #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -9,10 +9,7 @@ This module defines the explicitly clocked counterparts of the functions
 defined in "Clash.Prelude".
 -}
 
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TypeOperators     #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -13,6 +13,7 @@ defined in "Clash.Prelude".
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -11,12 +11,8 @@ This module defines the explicitly clocked counterparts of the functions
 defined in "Clash.Prelude".
 -}
 
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -11,8 +11,8 @@ This module defines the explicitly clocked counterparts of the functions
 defined in "Clash.Prelude".
 -}
 
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -8,9 +8,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 RAM primitives with a combinational read port.
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Trustworthy #-}
 
 -- See: https://github.com/clash-lang/clash-compiler/commit/721fcfa9198925661cd836668705f817bddaae3c

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -10,8 +10,9 @@ RAM primitives with a combinational read port.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
+
+{-# LANGUAGE Trustworthy #-}
 
 -- See: https://github.com/clash-lang/clash-compiler/commit/721fcfa9198925661cd836668705f817bddaae3c
 -- as to why we need this.

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -8,16 +8,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 RAM primitives with a combinational read port.
 -}
 
-{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 -- See: https://github.com/clash-lang/clash-compiler/commit/721fcfa9198925661cd836668705f817bddaae3c

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -10,8 +10,8 @@ RAM primitives with a combinational read port.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- See: https://github.com/clash-lang/clash-compiler/commit/721fcfa9198925661cd836668705f817bddaae3c
 -- as to why we need this.

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -10,6 +10,7 @@ ROMs
 
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
+
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -8,13 +8,8 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 ROMs
 -}
 
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE MagicHash           #-}
 {-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -8,8 +8,8 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 ROMs
 -}
 
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -70,6 +70,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -69,7 +69,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 @
 -}
 
-{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -69,13 +69,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 @
 -}
 
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -129,11 +129,11 @@ can potentially introduce situations prone to meta-stability:
 
 -}
 
-{-# LANGUAGE ExplicitNamespaces    #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -134,6 +134,7 @@ can potentially introduce situations prone to meta-stability:
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -129,18 +129,11 @@ can potentially introduce situations prone to meta-stability:
 
 -}
 
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ExplicitNamespaces    #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE ViewPatterns          #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -10,8 +10,8 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -9,7 +9,6 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -6,18 +6,14 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#else
+{-# LANGUAGE Trustworthy #-}
+
+#if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif
 

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -9,8 +9,8 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 #if __GLASGOW_HASKELL__ < 806

--- a/clash-prelude/src/Clash/Explicit/SimIO.hs
+++ b/clash-prelude/src/Clash/Explicit/SimIO.hs
@@ -6,8 +6,8 @@
   I\/O actions that are translatable to HDL
 -}
 
-{-# LANGUAGE DataKinds, GADTs, TypeApplications #-}
 {-# LANGUAGE BangPatterns, MagicHash, TypeOperators, ScopedTypeVariables, FlexibleContexts #-}
+{-# LANGUAGE DataKinds, GADTs, TypeApplications #-}
 
 module Clash.Explicit.SimIO
   ( -- * I\/O environment for simulation

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -8,9 +8,9 @@ Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Synchronizer circuits for safe clock domain crossings
 -}
 
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE Safe                  #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -9,8 +9,8 @@ Synchronizer circuits for safe clock domain crossings
 -}
 
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -9,8 +9,9 @@ Synchronizer circuits for safe clock domain crossings
 -}
 
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE TypeFamilies #-}
+
+{-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -9,11 +9,7 @@ Synchronizer circuits for safe clock domain crossings
 -}
 
 {-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE Safe                  #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -6,13 +6,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -6,7 +6,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -7,6 +7,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE TypeFamilies #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Hidden.hs
+++ b/clash-prelude/src/Clash/Hidden.hs
@@ -8,14 +8,9 @@ Hidden arguments
 
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE ConstraintKinds        #-}
-{-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE KindSignatures         #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE Rank2Types             #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
-{-# LANGUAGE TypeApplications       #-}
-
+{-# LANGUAGE RankNTypes             #-}
 {-# LANGUAGE Trustworthy #-}
 
 module Clash.Hidden

--- a/clash-prelude/src/Clash/Hidden.hs
+++ b/clash-prelude/src/Clash/Hidden.hs
@@ -11,6 +11,7 @@ Hidden arguments
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+
 {-# LANGUAGE Trustworthy #-}
 
 module Clash.Hidden

--- a/clash-prelude/src/Clash/Hidden.hs
+++ b/clash-prelude/src/Clash/Hidden.hs
@@ -6,11 +6,11 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Hidden arguments
 -}
 
-{-# LANGUAGE AllowAmbiguousTypes    #-}
-{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Trustworthy #-}
 
 module Clash.Hidden

--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -7,7 +7,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Intel (Altera) FPGAs
 -}
 
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Clash.Intel.ClockGen
   ( altpll

--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -7,10 +7,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Intel (Altera) FPGAs
 -}
 
-{-# LANGUAGE BangPatterns      #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE ExplicitForAll    #-}
 
 module Clash.Intel.ClockGen
   ( altpll

--- a/clash-prelude/src/Clash/Intel/DDR.hs
+++ b/clash-prelude/src/Clash/Intel/DDR.hs
@@ -13,9 +13,9 @@ see ALTDDIO userguide for the specifics:
 <https://www.altera.com/content/dam/altera-www/global/en_US/pdfs/literature/ug/ug_altddio.pdf>
 -}
 
-{-# LANGUAGE CPP              #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Intel.DDR
   ( altddioIn

--- a/clash-prelude/src/Clash/Intel/DDR.hs
+++ b/clash-prelude/src/Clash/Intel/DDR.hs
@@ -14,14 +14,8 @@ see ALTDDIO userguide for the specifics:
 -}
 
 {-# LANGUAGE CPP              #-}
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash        #-}
 {-# LANGUAGE TypeFamilies     #-}
-{-# LANGUAGE TypeOperators    #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#endif
 
 module Clash.Intel.DDR
   ( altddioIn

--- a/clash-prelude/src/Clash/Magic.hs
+++ b/clash-prelude/src/Clash/Magic.hs
@@ -6,11 +6,6 @@
 Control module instance, and register, names in generated HDL code.
 -}
 
-{-# LANGUAGE DataKinds      #-}
-{-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE TypeOperators  #-}
-
 module Clash.Magic where
 
 import Clash.NamedTypes ((:::))

--- a/clash-prelude/src/Clash/NamedTypes.hs
+++ b/clash-prelude/src/Clash/NamedTypes.hs
@@ -34,6 +34,7 @@ fifo @System
 -}
 
 {-# LANGUAGE PolyKinds #-}
+
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/NamedTypes.hs
+++ b/clash-prelude/src/Clash/NamedTypes.hs
@@ -34,8 +34,6 @@ fifo @System
 -}
 
 {-# LANGUAGE PolyKinds     #-}
-{-# LANGUAGE TypeOperators #-}
-
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/NamedTypes.hs
+++ b/clash-prelude/src/Clash/NamedTypes.hs
@@ -33,7 +33,7 @@ fifo @System
 
 -}
 
-{-# LANGUAGE PolyKinds     #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -36,6 +36,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -33,12 +33,9 @@
 -}
 
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE MonoLocalBinds    #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TypeOperators     #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -32,9 +32,9 @@
   Some circuit examples can be found in "Clash.Examples".
 -}
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE MonoLocalBinds    #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE Unsafe #-}
 

--- a/clash-prelude/src/Clash/Prelude/BitIndex.hs
+++ b/clash-prelude/src/Clash/Prelude/BitIndex.hs
@@ -4,10 +4,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash        #-}
-{-# LANGUAGE TypeOperators    #-}
 {-# LANGUAGE TypeFamilies     #-}
 
 {-# LANGUAGE Trustworthy #-}

--- a/clash-prelude/src/Clash/Prelude/BitIndex.hs
+++ b/clash-prelude/src/Clash/Prelude/BitIndex.hs
@@ -5,7 +5,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Prelude/BitReduction.hs
+++ b/clash-prelude/src/Clash/Prelude/BitReduction.hs
@@ -5,8 +5,6 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash        #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/BitReduction.hs
+++ b/clash-prelude/src/Clash/Prelude/BitReduction.hs
@@ -5,6 +5,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
+
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -373,8 +373,8 @@ This concludes the short introduction to using 'blockRam'.
 
 -}
 
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -19,6 +19,7 @@ codes:
 
 @
 {\-\# LANGUAGE RecordWildCards, TupleSections, DeriveAnyClass, TypeApplications \#-\}
+
 module CPU where
 
 import Clash.Prelude
@@ -372,12 +373,8 @@ This concludes the short introduction to using 'blockRam'.
 
 -}
 
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -375,6 +375,7 @@ This concludes the short introduction to using 'blockRam'.
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
@@ -67,6 +67,7 @@ __>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
@@ -65,15 +65,8 @@ __>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 
 -}
 
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
@@ -65,8 +65,8 @@ __>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 
 -}
 
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -8,9 +8,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Self-synchronizing circuits based on data-flow principles.
 -}
 
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -8,14 +8,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Self-synchronizing circuits based on data-flow principles.
 -}
 
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -10,8 +10,9 @@ Self-synchronizing circuits based on data-flow principles.
 
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE TypeFamilies #-}
+
+{-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -10,8 +10,8 @@ Self-synchronizing circuits based on data-flow principles.
 
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}

--- a/clash-prelude/src/Clash/Prelude/RAM.hs
+++ b/clash-prelude/src/Clash/Prelude/RAM.hs
@@ -8,9 +8,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 RAM primitives with a combinational read port.
 -}
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/RAM.hs
+++ b/clash-prelude/src/Clash/Prelude/RAM.hs
@@ -10,8 +10,8 @@ RAM primitives with a combinational read port.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}
 

--- a/clash-prelude/src/Clash/Prelude/RAM.hs
+++ b/clash-prelude/src/Clash/Prelude/RAM.hs
@@ -10,8 +10,9 @@ RAM primitives with a combinational read port.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE TypeFamilies #-}
+
+{-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}
 

--- a/clash-prelude/src/Clash/Prelude/RAM.hs
+++ b/clash-prelude/src/Clash/Prelude/RAM.hs
@@ -8,16 +8,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 RAM primitives with a combinational read port.
 -}
 
-{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -9,7 +9,7 @@ ROMs
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes       #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -8,12 +8,8 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 ROMs
 -}
 
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash        #-}
 {-# LANGUAGE RankNTypes       #-}
-{-# LANGUAGE TypeOperators    #-}
-
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -10,6 +10,7 @@ ROMs
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -63,7 +63,7 @@ __>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 @
 -}
 
-{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -63,13 +63,7 @@ __>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 @
 -}
 
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -64,6 +64,7 @@ __>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -31,6 +31,7 @@
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -29,11 +29,8 @@
   Some circuit examples can be found in "Clash.Examples".
 -}
 
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE TypeOperators       #-}
-
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -29,8 +29,8 @@
   Some circuit examples can be found in "Clash.Examples".
 -}
 
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/Prelude/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Prelude/Synchronizer.hs
@@ -6,8 +6,6 @@ Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Synchronizer circuits for safe clock domain crossings
 -}
 
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
 
 module Clash.Prelude.Synchronizer

--- a/clash-prelude/src/Clash/Prelude/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Prelude/Synchronizer.hs
@@ -6,7 +6,7 @@ Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Synchronizer circuits for safe clock domain crossings
 -}
 
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Prelude.Synchronizer
   ( -- * Bit-synchronizers

--- a/clash-prelude/src/Clash/Prelude/Testbench.hs
+++ b/clash-prelude/src/Clash/Prelude/Testbench.hs
@@ -6,8 +6,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/Testbench.hs
+++ b/clash-prelude/src/Clash/Prelude/Testbench.hs
@@ -6,11 +6,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/Testbench.hs
+++ b/clash-prelude/src/Clash/Prelude/Testbench.hs
@@ -8,6 +8,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -8,8 +8,8 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -6,10 +6,10 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -7,18 +7,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE RankNTypes          #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#endif
 
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Promoted/Nat/Literals.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat/Literals.hs
@@ -20,8 +20,6 @@ You can generate more 'SNat' literals using 'decLiteralsD' from "Clash.Promoted.
 
 {-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DataKinds       #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_HADDOCK show-extensions, prune #-}

--- a/clash-prelude/src/Clash/Promoted/Nat/Literals.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat/Literals.hs
@@ -20,6 +20,7 @@ You can generate more 'SNat' literals using 'decLiteralsD' from "Clash.Promoted.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
+
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_HADDOCK show-extensions, prune #-}

--- a/clash-prelude/src/Clash/Promoted/Nat/Literals.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat/Literals.hs
@@ -18,7 +18,7 @@ d1024 = SNat :: SNat 1024
 You can generate more 'SNat' literals using 'decLiteralsD' from "Clash.Promoted.Nat.TH"
 -}
 
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Promoted/Symbol.hs
+++ b/clash-prelude/src/Clash/Promoted/Symbol.hs
@@ -4,7 +4,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Promoted/Symbol.hs
+++ b/clash-prelude/src/Clash/Promoted/Symbol.hs
@@ -4,9 +4,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -68,20 +68,11 @@ Check out 'IntelSystem' and 'XilinxSystem' too!
 
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ExplicitNamespaces    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeOperators         #-}
-#if __GLASGOW_HASKELL__ < 806
-{-# LANGUAGE TypeInType #-}
-#endif
 
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -66,8 +66,8 @@ never create a clock that goes any faster!
 Check out 'IntelSystem' and 'XilinxSystem' too!
 -}
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -66,13 +66,13 @@ never create a clock that goes any faster!
 Check out 'IntelSystem' and 'XilinxSystem' too!
 -}
 
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE ExplicitNamespaces    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -83,14 +83,14 @@ topEntity clk rst = readFromBiSignal bus'
 @
 -}
 
-{-# LANGUAGE CPP                    #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
-{-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE RankNTypes             #-}
-{-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -84,19 +84,14 @@ topEntity clk rst = readFromBiSignal bus'
 -}
 
 {-# LANGUAGE CPP                    #-}
-{-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE InstanceSigs           #-}
-{-# LANGUAGE KindSignatures         #-}
-{-# LANGUAGE MagicHash              #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE RankNTypes             #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
+
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif

--- a/clash-prelude/src/Clash/Signal/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle.hs
@@ -9,14 +9,10 @@ The Product/Signal isomorphism
 -}
 
 {-# LANGUAGE CPP                    #-}
-{-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE DefaultSignatures      #-}
-{-# LANGUAGE KindSignatures         #-}
-{-# LANGUAGE MagicHash              #-}
 {-# LANGUAGE TemplateHaskell        #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
-{-# LANGUAGE TypeOperators          #-}
+
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif

--- a/clash-prelude/src/Clash/Signal/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle.hs
@@ -8,9 +8,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 The Product/Signal isomorphism
 -}
 
-{-# LANGUAGE CPP                    #-}
-{-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 
 #if __GLASGOW_HASKELL__ < 806

--- a/clash-prelude/src/Clash/Signal/Bundle/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Signal.Bundle.Internal where

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -6,20 +6,18 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE KindSignatures       #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+#if __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
 #endif
 
 {-# LANGUAGE Safe #-}
 
-{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
 
 module Clash.Signal.Delayed
   ( -- * Delay-annotated synchronous signals

--- a/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
@@ -6,15 +6,12 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 {-# LANGUAGE CPP                    #-}
-{-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE DefaultSignatures      #-}
 {-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE KindSignatures         #-}
 {-# LANGUAGE NoImplicitPrelude      #-}
 {-# LANGUAGE PolyKinds              #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
-{-# LANGUAGE TypeOperators          #-}
+
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif

--- a/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
@@ -5,11 +5,11 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
-{-# LANGUAGE CPP                    #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE NoImplicitPrelude      #-}
-{-# LANGUAGE PolyKinds              #-}
-{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 
 #if __GLASGOW_HASKELL__ < 806

--- a/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
@@ -5,11 +5,11 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}

--- a/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
@@ -6,16 +6,11 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveLift                 #-}
-{-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
+
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -6,15 +6,15 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE ConstraintKinds        #-}
-{-# LANGUAGE CPP                    #-}
-{-# LANGUAGE DeriveAnyClass         #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
-{-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE StandaloneDeriving     #-}
-{-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -8,24 +8,14 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# LANGUAGE ConstraintKinds        #-}
 {-# LANGUAGE CPP                    #-}
-{-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE DeriveAnyClass         #-}
-{-# LANGUAGE DeriveDataTypeable     #-}
-{-# LANGUAGE DeriveGeneric          #-}
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE MagicHash              #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE StandaloneDeriving     #-}
 {-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE TypeOperators          #-}
-{-# LANGUAGE ViewPatterns           #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#endif
+
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif

--- a/clash-prelude/src/Clash/Signal/Internal/Ambiguous.hs
+++ b/clash-prelude/src/Clash/Signal/Internal/Ambiguous.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE RankNTypes             #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
-{-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
 
 module Clash.Signal.Internal.Ambiguous

--- a/clash-prelude/src/Clash/Signal/Internal/Ambiguous.hs
+++ b/clash-prelude/src/Clash/Signal/Internal/Ambiguous.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE AllowAmbiguousTypes    #-}
-{-# LANGUAGE RankNTypes             #-}
-{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Signal.Internal.Ambiguous
   ( knownVDomain

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -44,10 +44,10 @@ main = do
       writeFile "mainCounter.vcd" contents
 @
 -}
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -45,16 +45,9 @@ main = do
 @
 -}
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE MagicHash           #-}
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}

--- a/clash-prelude/src/Clash/Sized/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/BitVector.hs
@@ -4,8 +4,6 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE MagicHash #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -24,17 +24,11 @@ BEWARE: rounding by truncation introduces a sign bias!
 -}
 
 {-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
@@ -77,6 +71,7 @@ import Data.Bits                  (Bits (..), FiniteBits)
 import Data.Data                  (Data)
 import Data.Default.Class         (Default (..))
 import Data.Either                (isLeft)
+import Data.Kind                  (Type)
 import Text.Read                  (Read(..))
 import Data.List                  (find)
 import Data.Maybe                 (fromJust)
@@ -123,7 +118,7 @@ import Clash.XException
 --
 -- The 'Num' operators for this type saturate to 'maxBound' on overflow and
 -- 'minBound' on underflow, and use truncation as the rounding method.
-newtype Fixed (rep :: Nat -> *) (int :: Nat) (frac :: Nat) =
+newtype Fixed (rep :: Nat -> Type) (int :: Nat) (frac :: Nat) =
   Fixed { unFixed :: rep (int + frac) }
 
 deriving instance NFData (rep (int + frac)) => NFData (Fixed rep int frac)

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -23,14 +23,14 @@ BEWARE: rounding by truncation introduces a sign bias!
 * Truncation for negative numbers effectively results in: round towards -infinity.
 -}
 
-{-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# LANGUAGE Trustworthy #-}
 

--- a/clash-prelude/src/Clash/Sized/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Index.hs
@@ -4,10 +4,6 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds     #-}
-{-# LANGUAGE MagicHash     #-}
-{-# LANGUAGE TypeOperators #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Extra.Solver -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -11,6 +11,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -6,11 +6,11 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -6,21 +6,11 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
-{-# LANGUAGE ViewPatterns               #-}
-
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs-boot
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs-boot
@@ -4,8 +4,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds       #-}
-{-# LANGUAGE KindSignatures  #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RoleAnnotations #-}
 module Clash.Sized.Internal.BitVector where
 

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs-boot
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs-boot
@@ -11,9 +11,10 @@ module Clash.Sized.Internal.BitVector where
 
 import GHC.TypeLits (KnownNat,Nat)
 import GHC.Stack    (HasCallStack)
+import Data.Kind    (Type)
 
 type role BitVector phantom
-data BitVector :: Nat -> *
+data BitVector :: Nat -> Type
 data Bit
 
 undefError :: (HasCallStack, KnownNat n) => String -> [BitVector n] -> a

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -5,25 +5,13 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveDataTypeable    #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE MagicHash             #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#endif
 
 {-# LANGUAGE Unsafe #-}
 

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -5,13 +5,13 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# LANGUAGE Unsafe #-}
 

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs-boot
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs-boot
@@ -4,9 +4,9 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds       #-}
-{-# LANGUAGE KindSignatures  #-}
-{-# LANGUAGE MagicHash       #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE RoleAnnotations #-}
 module Clash.Sized.Internal.Index where
 

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs-boot
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs-boot
@@ -10,10 +10,11 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE RoleAnnotations #-}
 module Clash.Sized.Internal.Index where
 
+import Data.Kind (Type)
 import GHC.TypeLits (KnownNat, Nat)
 
 type role Index phantom
-data Index :: Nat -> *
+data Index :: Nat -> Type
 
 instance KnownNat n => Num (Index n)
 toInteger# :: Index n -> Integer

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -5,11 +5,11 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# LANGUAGE Unsafe #-}
 

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -5,18 +5,10 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
 {-# LANGUAGE Unsafe #-}

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -5,11 +5,11 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# LANGUAGE Unsafe #-}
 

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -5,17 +5,10 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
 {-# LANGUAGE Unsafe #-}

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -5,23 +5,12 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE GADTs                #-}
-{-# LANGUAGE InstanceSigs         #-}
-{-# LANGUAGE KindSignatures       #-}
 {-# LANGUAGE PatternSynonyms      #-}
 {-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TupleSections        #-}
-{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns         #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#endif
 
 {-# LANGUAGE Trustworthy #-}
 
@@ -92,7 +81,8 @@ import Clash.XException
 >>> :set -fplugin GHC.TypeLits.Normalise
 >>> :set -XUndecidableInstances
 >>> import Clash.Prelude
->>> data IIndex (f :: TyFun Nat *) :: *
+>>> import Data.Kind
+>>> data IIndex (f :: TyFun Nat Type) :: Type
 >>> type instance Apply IIndex l = Index ((2^l)+1)
 >>> :{
 let populationCount' :: (KnownNat k, KnownNat (2^k)) => BitVector (2^k) -> Index ((2^k)+1)

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -4,12 +4,12 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE PatternSynonyms      #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# LANGUAGE Trustworthy #-}

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -5,27 +5,14 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE BangPatterns         #-}
 {-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GADTs                #-}
-{-# LANGUAGE InstanceSigs         #-}
-{-# LANGUAGE KindSignatures       #-}
-{-# LANGUAGE MagicHash            #-}
 {-# LANGUAGE PatternSynonyms      #-}
-{-# LANGUAGE Rank2Types           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TupleSections        #-}
-{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns         #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#endif
 
 {-# LANGUAGE Trustworthy #-}
 
@@ -157,6 +144,7 @@ import Clash.XException
 >>> :set -XTypeApplications
 >>> :set -fplugin GHC.TypeLits.Normalise
 >>> import Clash.Prelude
+>>> import Data.Kind
 >>> let compareSwapL a b = if a < b then (a,b) else (b,a)
 >>> :{
 let sortV xs = map fst sorted :< (snd (last sorted))
@@ -182,13 +170,13 @@ let sortV_flip xs = map fst sorted :< (snd (last sorted))
         sorted = zipWith (flip compareSwapL) rights lefts
 :}
 
->>> data Append (m :: Nat) (a :: *) (f :: TyFun Nat *) :: *
+>>> data Append (m :: Nat) (a :: Type) (f :: TyFun Nat Type) :: Type
 >>> type instance Apply (Append m a) l = Vec (l + m) a
 >>> let append' xs ys = dfold (Proxy :: Proxy (Append m a)) (const (:>)) ys xs
 >>> let compareSwap a b = if a > b then (a,b) else (b,a)
 >>> let insert y xs     = let (y',xs') = mapAccumL compareSwap y xs in xs' :< y'
 >>> let insertionSort   = vfold (const insert)
->>> data IIndex (f :: TyFun Nat *) :: *
+>>> data IIndex (f :: TyFun Nat Type) :: Type
 >>> :set -XUndecidableInstances
 >>> type instance Apply IIndex l = Index ((2^l)+1)
 >>> :{

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -5,13 +5,13 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE PatternSynonyms      #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# LANGUAGE Trustworthy #-}

--- a/clash-prelude/src/Clash/Sized/Vector.hs-boot
+++ b/clash-prelude/src/Clash/Sized/Vector.hs-boot
@@ -11,11 +11,12 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE TypeOperators   #-}
 module Clash.Sized.Vector where
 
+import Data.Kind (Type)
 import GHC.TypeLits  (KnownNat, Nat, type (<=))
 import {-# SOURCE #-} Clash.Sized.Internal.BitVector (BitVector, Bit)
 
 type role Vec nominal representational
-data Vec :: Nat -> * -> *
+data Vec :: Nat -> Type -> Type
 
 instance (KnownNat n, 1 <= n) => Foldable (Vec n)
 

--- a/clash-prelude/src/Clash/Sized/Vector.hs-boot
+++ b/clash-prelude/src/Clash/Sized/Vector.hs-boot
@@ -4,11 +4,11 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds       #-}
-{-# LANGUAGE GADTs           #-}
-{-# LANGUAGE KindSignatures  #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RoleAnnotations #-}
-{-# LANGUAGE TypeOperators   #-}
+{-# LANGUAGE TypeOperators #-}
 module Clash.Sized.Vector where
 
 import Data.Kind (Type)

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -5,7 +5,8 @@ Copyright : © 2014-2016, Christiaan Baaij,
 Licence   : Creative Commons 4.0 (CC BY 4.0) (https://creativecommons.org/licenses/by/4.0/)
 -}
 
-{-# LANGUAGE NoImplicitPrelude, MagicHash #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 module Clash.Tutorial (
@@ -2409,6 +2410,7 @@ Blinker circuit in Clash 0.99:
 
 @
 {\-\# LANGUAGE NoMonoLocalBinds \#-\}
+
 module Blinker where
 
 import Clash.Prelude

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -16,19 +16,13 @@ CallStack (from HasCallStack):
 -}
 
 {-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DefaultSignatures     #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE EmptyCase             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeOperators         #-}
-
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -23,6 +23,7 @@ CallStack (from HasCallStack):
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -15,14 +15,14 @@ CallStack (from HasCallStack):
 "(X,4)"
 -}
 
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE EmptyCase             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/clash-prelude/src/Clash/XException/TH.hs
+++ b/clash-prelude/src/Clash/XException/TH.hs
@@ -4,7 +4,6 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE ViewPatterns          #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 module Clash.XException.TH

--- a/clash-prelude/src/Clash/Xilinx/ClockGen.hs
+++ b/clash-prelude/src/Clash/Xilinx/ClockGen.hs
@@ -7,7 +7,7 @@ PLL and other clock-related components for Xilinx FPGAs
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE GADTs #-}
 
 module Clash.Xilinx.ClockGen where
 

--- a/clash-prelude/src/Clash/Xilinx/ClockGen.hs
+++ b/clash-prelude/src/Clash/Xilinx/ClockGen.hs
@@ -6,11 +6,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Xilinx FPGAs
 -}
 
-{-# LANGUAGE BangPatterns     #-}
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ExplicitForAll   #-}
 {-# LANGUAGE GADTs            #-}
+
 module Clash.Xilinx.ClockGen where
 
 import Clash.Annotations.Primitive    (hasBlackBox)

--- a/clash-prelude/src/Clash/Xilinx/DDR.hs
+++ b/clash-prelude/src/Clash/Xilinx/DDR.hs
@@ -14,9 +14,9 @@ For more information about the Xilinx DDR primitives see:
   <https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_3/ug953-vivado-7series-libraries.pdf>
 -}
 
-{-# LANGUAGE CPP              #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Xilinx.DDR
   ( iddr

--- a/clash-prelude/src/Clash/Xilinx/DDR.hs
+++ b/clash-prelude/src/Clash/Xilinx/DDR.hs
@@ -15,14 +15,8 @@ For more information about the Xilinx DDR primitives see:
 -}
 
 {-# LANGUAGE CPP              #-}
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash        #-}
 {-# LANGUAGE TypeFamilies     #-}
-{-# LANGUAGE TypeOperators    #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE NoStarIsType #-}
-#endif
 
 module Clash.Xilinx.DDR
   ( iddr

--- a/clash-prelude/src/Language/Haskell/TH/Compat.hs
+++ b/clash-prelude/src/Language/Haskell/TH/Compat.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 module Language.Haskell.TH.Compat where
 import           Language.Haskell.TH
 

--- a/clash-prelude/tests/Clash/Tests/AutoReg.hs
+++ b/clash-prelude/tests/Clash/Tests/AutoReg.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Clash.Tests.AutoReg where
 

--- a/clash-prelude/tests/Clash/Tests/BitPack.hs
+++ b/clash-prelude/tests/Clash/Tests/BitPack.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP            #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
-{-# LANGUAGE MagicHash      #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
 

--- a/clash-prelude/tests/Clash/Tests/BitPack.hs
+++ b/clash-prelude/tests/Clash/Tests/BitPack.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP            #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/tests/Clash/Tests/BitVector.hs
+++ b/clash-prelude/tests/Clash/Tests/BitVector.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE BinaryLiterals  #-}
-{-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE LambdaCase      #-}
-{-# LANGUAGE ViewPatterns    #-}
 
 module Clash.Tests.BitVector where
 

--- a/clash-prelude/tests/Clash/Tests/BitVector.hs
+++ b/clash-prelude/tests/Clash/Tests/BitVector.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Tests.BitVector where
 

--- a/clash-prelude/tests/Clash/Tests/BitVector.hs
+++ b/clash-prelude/tests/Clash/Tests/BitVector.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Clash.Tests.BitVector where
 

--- a/clash-prelude/tests/Clash/Tests/DerivingDataRepr.hs
+++ b/clash-prelude/tests/Clash/Tests/DerivingDataRepr.hs
@@ -1,10 +1,7 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BinaryLiterals #-}
 
 module Clash.Tests.DerivingDataRepr where
 

--- a/clash-prelude/tests/Clash/Tests/DerivingDataReprTypes.hs
+++ b/clash-prelude/tests/Clash/Tests/DerivingDataReprTypes.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Clash.Tests.DerivingDataReprTypes where

--- a/clash-prelude/tests/Clash/Tests/NFDataX.hs
+++ b/clash-prelude/tests/Clash/Tests/NFDataX.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE CPP              #-}
-{-# LANGUAGE DeriveAnyClass   #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 module Clash.Tests.NFDataX where
 

--- a/clash-prelude/tests/Clash/Tests/NFDataX.hs
+++ b/clash-prelude/tests/Clash/Tests/NFDataX.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE CPP              #-}
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE DeriveAnyClass   #-}
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE MagicHash        #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Clash.Tests.NFDataX where
 

--- a/clash-prelude/tests/Clash/Tests/Signal.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal.hs
@@ -4,10 +4,10 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                       #-}
-{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 

--- a/clash-prelude/tests/Clash/Tests/Signal.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal.hs
@@ -5,10 +5,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE CPP                       #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE RankNTypes                #-}
 
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 

--- a/clash-prelude/tests/Clash/Tests/TopEntityGeneration.hs
+++ b/clash-prelude/tests/Clash/Tests/TopEntityGeneration.hs
@@ -1,10 +1,10 @@
 {-# OPTIONS_GHC -Wwarn #-}
 
-{-# LANGUAGE CPP              #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs            #-}
-{-# LANGUAGE TemplateHaskell  #-}
-{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.Tests.TopEntityGeneration where
 

--- a/clash-prelude/tests/Clash/Tests/TopEntityGeneration.hs
+++ b/clash-prelude/tests/Clash/Tests/TopEntityGeneration.hs
@@ -1,14 +1,10 @@
 {-# OPTIONS_GHC -Wwarn #-}
 
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TemplateHaskell  #-}
-{-# LANGUAGE TypeOperators    #-}
-{-# LANGUAGE TypeFamilies     #-}
-{-# LANGUAGE GADTs            #-}
-
 {-# LANGUAGE CPP              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeFamilies     #-}
 
 module Clash.Tests.TopEntityGeneration where
 

--- a/clash-prelude/tests/doctests.hs
+++ b/clash-prelude/tests/doctests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 module Main where
 
 import Test.DocTest (doctest)
@@ -10,8 +11,31 @@ main = doctest (docTestOpts ++ ["-isrc","src/Clash/Prelude.hs"
 
 docTestOpts :: [String]
 docTestOpts =
-#if __GLASGOW_HASKELL__ >= 802
-  ["-fdiagnostics-color=never"]
-#else
-  []
+#if __GLASGOW_HASKELL__ >= 806
+  "-XNoStarIsType" :
 #endif
+#if __GLASGOW_HASKELL__ <= 804
+  "-XTypeInType" :
+#endif
+  -- TODO: Figure out a way to auto-sync this with clash-prelude.cabal
+  [ "-XBangPatterns"
+  , "-XBinaryLiterals"
+  , "-XDataKinds"
+  , "-XDefaultSignatures"
+  , "-XDeriveDataTypeable"
+  , "-XDeriveFoldable"
+  , "-XDeriveFunctor"
+  , "-XDeriveGeneric"
+  , "-XDeriveLift"
+  , "-XDeriveTraversable"
+  , "-XDerivingStrategies"
+  , "-XInstanceSigs"
+  , "-XKindSignatures"
+  , "-XMagicHash"
+  , "-XScopedTypeVariables"
+  , "-XStandaloneDeriving"
+  , "-XTupleSections"
+  , "-XTypeApplications"
+  , "-XTypeOperators"
+  , "-XViewPatterns"
+  ]

--- a/docs/examples/Overdrive.hs
+++ b/docs/examples/Overdrive.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE FunctionalDependencies     #-}
-{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE NoMonomorphismRestriction  #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Overdrive
   ( circuit
   , testBench

--- a/examples/CHIP8.hs
+++ b/examples/CHIP8.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards #-}
 module CHIP8 where
 
 -- Thanks to Dr. Gergő Érdi:

--- a/tests/shouldfail/BlackBox/WrongReference.hs
+++ b/tests/shouldfail/BlackBox/WrongReference.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module WrongReference where
 

--- a/tests/shouldfail/BlackBox/WrongReference.hs
+++ b/tests/shouldfail/BlackBox/WrongReference.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 
 module WrongReference where
 

--- a/tests/shouldwork/AutoReg/AutoReg.hs
+++ b/tests/shouldwork/AutoReg/AutoReg.hs
@@ -3,9 +3,9 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
-{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}

--- a/tests/shouldwork/Basic/Parameters.hs
+++ b/tests/shouldwork/Basic/Parameters.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Parameters where
 

--- a/tests/shouldwork/Basic/PopCount.hs
+++ b/tests/shouldwork/Basic/PopCount.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PartialTypeSignatures           #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 module PopCount where

--- a/tests/shouldwork/BitVector/GenericBitPack.hs
+++ b/tests/shouldwork/BitVector/GenericBitPack.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module GenericBitPack where

--- a/tests/shouldwork/BitVector/GenericBitPackTypes.hs
+++ b/tests/shouldwork/BitVector/GenericBitPackTypes.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module GenericBitPackTypes where

--- a/tests/shouldwork/BlackBox/BlackBoxFunction.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunction.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module BlackBoxFunction where
 

--- a/tests/shouldwork/BlackBox/BlackBoxFunction.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunction.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 
 module BlackBoxFunction where
 

--- a/tests/shouldwork/BlackBox/BlackBoxFunctionHO.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunctionHO.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module BlackBoxFunctionHO where
 

--- a/tests/shouldwork/BlackBox/BlackBoxFunctionHO.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunctionHO.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE ViewPatterns      #-}
-{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeOperators #-}
 
 module BlackBoxFunctionHO where
 

--- a/tests/shouldwork/BlackBox/TemplateFunction.hs
+++ b/tests/shouldwork/BlackBox/TemplateFunction.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 
 module TemplateFunction where
 

--- a/tests/shouldwork/BlackBox/TemplateFunction.hs
+++ b/tests/shouldwork/BlackBox/TemplateFunction.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module TemplateFunction where
 

--- a/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
+++ b/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Indexed where
 

--- a/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
+++ b/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Indexed where
 

--- a/tests/shouldwork/CustomReprs/RotateC/ReprCompact.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprCompact.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module ReprCompact
   ( testBench

--- a/tests/shouldwork/CustomReprs/RotateC/ReprCompactScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprCompactScrambled.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module ReprCompactScrambled
   ( testBench

--- a/tests/shouldwork/CustomReprs/RotateC/ReprLastBitConstructor.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprLastBitConstructor.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module ReprLastBitConstructor
   ( topEntity

--- a/tests/shouldwork/CustomReprs/RotateC/ReprStrangeMasks.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprStrangeMasks.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module ReprStrangeMasks
   ( topEntity

--- a/tests/shouldwork/CustomReprs/RotateC/ReprWide.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprWide.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module ReprWide
   ( topEntity

--- a/tests/shouldwork/GADTs/Record.hs
+++ b/tests/shouldwork/GADTs/Record.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE FlexibleInstances #-}
 
 module Record where
 

--- a/tests/shouldwork/Netlist/NoDeDup.hs
+++ b/tests/shouldwork/Netlist/NoDeDup.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module NoDeDup where
 

--- a/tests/shouldwork/Numbers/Exp.hs
+++ b/tests/shouldwork/Numbers/Exp.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}

--- a/tests/shouldwork/Numbers/Integral.hs
+++ b/tests/shouldwork/Numbers/Integral.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE DeriveLift            #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ViewPatterns #-}
 
 
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}

--- a/tests/shouldwork/Numbers/NumConstantFolding_1.hs
+++ b/tests/shouldwork/Numbers/NumConstantFolding_1.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 

--- a/tests/shouldwork/Numbers/NumConstantFolding_2.hs
+++ b/tests/shouldwork/Numbers/NumConstantFolding_2.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 

--- a/tests/shouldwork/Numbers/SignedProjection.hs
+++ b/tests/shouldwork/Numbers/SignedProjection.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 

--- a/tests/shouldwork/PrimitiveGuards/WarnAlways.hs
+++ b/tests/shouldwork/PrimitiveGuards/WarnAlways.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 
 module WarnAlways where
 

--- a/tests/shouldwork/PrimitiveGuards/WarnAlways.hs
+++ b/tests/shouldwork/PrimitiveGuards/WarnAlways.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module WarnAlways where
 

--- a/tests/shouldwork/Shadowing/T990.hs
+++ b/tests/shouldwork/Shadowing/T990.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Arrows #-}
+{-# LANGUAGE RankNTypes #-}
 
 module T990 (topEntity, testBench) where
 

--- a/tests/shouldwork/Signal/NoCPR.hs
+++ b/tests/shouldwork/Signal/NoCPR.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE DataKinds #-}
 
 module NoCPR where
 

--- a/testsuite/src/Test/Tasty/Clash.hs
+++ b/testsuite/src/Test/Tasty/Clash.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DataKinds          #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE KindSignatures     #-}
-{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Tasty.Clash where
 

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE CPP                    #-}
-{-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE KindSignatures         #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
-{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 
 #include "MachDeps.h"
 


### PR DESCRIPTION
As a follow-up of https://github.com/clash-lang/clash-compiler/issues/969

* Accidentally fixes newline consistency issues too, thanks to an over-zealous regex.
* Removes alignment on `#-}`, adds it to the style guide
* Orders LANGUAGE pragmas (mostly)