### PR TITLE
Make evaluation of `&&` and `||` lazy in both arguments

### DIFF
--- a/tests/shouldwork/XOptimization/Conjunction.hs
+++ b/tests/shouldwork/XOptimization/Conjunction.hs
@@ -1,0 +1,50 @@
+{-# OPTIONS_GHC -fno-strictness #-}
+module Conjunction where
+
+import qualified Prelude as P
+import Prelude ((++))
+
+import Clash.Prelude hiding (assert, (++))
+import Clash.Annotations.SynthesisAttributes
+
+import Data.String (IsString)
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+f x y = x && y
+{-# NOINLINE f #-}
+
+topEntity (x :: Bool) = f (let y :: Bool = y in y) True
+
+--------------- Actual tests for generated HDL -------------------
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | needle `isInfixOf` haystack = P.error $ P.concat [ "Did not Expect:\n\n  "
+                                                     , needle
+                                                     , "\n\nIn:\n\n"
+                                                     , haystack ]
+  | otherwise                   = return ()
+
+-- VHDL test
+mainVHDL :: IO ()
+mainVHDL = do
+  [topFile] <- getArgs
+  content <- readFile topFile
+
+  assertNotIn "true" content
+
+-- Verilog test
+mainVerilog :: IO ()
+mainVerilog = do
+  [topFile] <- getArgs
+  content <- readFile topFile
+
+  assertNotIn "1'b1" content
+
+-- SystemVerilog test
+mainSystemVerilog :: IO ()
+mainSystemVerilog = mainVerilog

--- a/tests/shouldwork/XOptimization/Disjunction.hs
+++ b/tests/shouldwork/XOptimization/Disjunction.hs
@@ -1,0 +1,50 @@
+{-# OPTIONS_GHC -fno-strictness #-}
+module Disjunction where
+
+import qualified Prelude as P
+import Prelude ((++))
+
+import Clash.Prelude hiding (assert, (++))
+import Clash.Annotations.SynthesisAttributes
+
+import Data.String (IsString)
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+f x y = x || y
+{-# NOINLINE f #-}
+
+topEntity (x :: Bool) = f (let y :: Bool = y in y) False
+
+--------------- Actual tests for generated HDL -------------------
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | needle `isInfixOf` haystack = P.error $ P.concat [ "Did not Expect:\n\n  "
+                                                     , needle
+                                                     , "\n\nIn:\n\n"
+                                                     , haystack ]
+  | otherwise                   = return ()
+
+-- VHDL test
+mainVHDL :: IO ()
+mainVHDL = do
+  [topFile] <- getArgs
+  content <- readFile topFile
+
+  assertNotIn "false" content
+
+-- Verilog test
+mainVerilog :: IO ()
+mainVerilog = do
+  [topFile] <- getArgs
+  content <- readFile topFile
+
+  assertNotIn "1'b0" content
+
+-- SystemVerilog test
+mainSystemVerilog :: IO ()
+mainSystemVerilog = mainVerilog

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -404,7 +404,9 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T895" def{hdlSim=False,hdlTargets=[VHDL]}
         ] -- end vector
       , clashTestGroup "XOptimization"
-        [ netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedDataPat" "main"
+        [ outputTest  ("tests" </> "shouldwork" </> "XOptimization") allTargets [] [] "Conjunction"  "main"
+        , outputTest  ("tests" </> "shouldwork" </> "XOptimization") allTargets [] [] "Disjunction"  "main"
+        , netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedDataPat" "main"
         , netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedLitPat" "main"
         , netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedDefaultPat" "main"
         , netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "ManyDefined" "main"


### PR DESCRIPTION
We now implement:

```haskell
x && True  --> x
x && False --> False
x || True  --> True
x || False --> x
```

Even when `x` evaluates to _|_, i.e. it is lazier than the
Haskell definitions of `&&` and `||` which are strict in
their first argument.

We also implement:

```haskell
True  && x --> x
False && x --> False
True  || x --> True
False || x --> x
```