### PR TITLE
Build clash-cores with nix

### DIFF
--- a/clash-cores/default.nix
+++ b/clash-cores/default.nix
@@ -1,0 +1,6 @@
+{ nixpkgs ? import ../nix/nixpkgs.nix {} }:
+
+with nixpkgs.pkgs;
+with gitignore;
+
+haskellPackages.callCabal2nix "clash-cores" (gitignoreSource ./.) {}

--- a/default.nix
+++ b/default.nix
@@ -2,4 +2,4 @@
 
 with nixpkgs.pkgs.haskellPackages;
 
-{ inherit clash-ghc clash-lib clash-prelude; }
+{ inherit clash-ghc clash-lib clash-prelude clash-cores; }

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -19,6 +19,7 @@ let
         clash-lib = import ../clash-lib { inherit nixpkgs; };
         clash-ghc = import ../clash-ghc { inherit nixpkgs; };
         clash-prelude = import ../clash-prelude { inherit nixpkgs; };
+        clash-cores = import ../clash-cores { inherit nixpkgs; };
       };
     };
   };


### PR DESCRIPTION
I wanted to play with clash on lattice board.
I've noticed that there are some primitives already in the repo. To use them more easily I've added nix expressions to have them in the overlay.

Hopefully they might be useful.