### PR TITLE
Use `reg` instead of `wire` when appropiate in `foldBBF`

### DIFF
--- a/tests/shouldwork/BlackBox/T919.hs
+++ b/tests/shouldwork/BlackBox/T919.hs
@@ -1,0 +1,48 @@
+module T919 where
+
+import Clash.Prelude
+
+type U8  = BitVector 8
+type U16 = BitVector 16
+type U32 = BitVector 32
+type U64 = BitVector 64
+
+data SearchTarget = None |
+                    S16 U16 | S32 U32
+  deriving (Generic, Eq, Show, ShowX, NFDataX)
+type SearchState = (SearchTarget, BitVector 24, BitVector 32, Bool)
+type SearchResult = BitVector 32
+
+searchT
+  :: SearchState
+  -> (Maybe U64)
+  -> (Maybe SearchResult)
+
+searchT (S32 t, buff, offset, first) (Just x) = m
+ where
+  m = fmap collate
+    $ fold (<|>)
+    $ imap match
+    $ take d2
+    $ id @(Vec 8 (Vec 4 U8))
+    $ windows1d d4 $ bitCoerce @_ @(Vec _ U8)
+    $ x ++# buff
+  match i v = Just i
+  collate i = resize (pack i)
+
+searchT (S16 t, buff, offset, first) (Just x) = m
+ where
+  m = fmap collate
+    $ fold (<|>)
+    $ imap match
+    $ take d2
+    $ id @(Vec 8 (Vec 2 U8))
+    $ windows1d d2 $ bitCoerce @_ @(Vec _ U8)
+    $ x ++# slice d23 d16 buff
+  match i v = Just i
+  collate i = resize (pack i)
+
+searchT _ _ = Nothing
+
+
+topEntity = searchT

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -146,6 +146,7 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "Signal")   allTargets [] [] "BlockRamLazy"       "main"
         , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "ZeroWidth"          "main"
         , runFailingTest ("tests" </> "shouldfail" </> "BlackBox") [VHDL] [] "WrongReference" (Just "Function WrongReference.myMultiply was annotated with an inline primitive for WrongReference.myMultiplyX. These names should be the same.")
+        , runTest "T919" def{hdlSim=False}
         ]
       , clashTestGroup "BoxedFunctions"
         [ runTest "DeadRecursiveBoxed" def{hdlSim=False}


### PR DESCRIPTION
Fixes #919