### PR TITLE
Don't inline registers with non-constant clock and reset

### DIFF
--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -531,12 +531,14 @@ isWorkFreeIsh e = do
         (Prim _ pInfo, args) -> case primWorkInfo pInfo of
           WorkAlways     -> pure False -- Things like clock or reset generator always
                                        -- perform work
+          WorkVariable   -> pure (all isConstantArg args)
           _              -> allM isWorkFreeIshArg args
         (Lam _ _, _)     -> pure (not (hasLocalFreeVars e))
         (Literal _,_)    -> pure True
         _                -> pure False
  where
   isWorkFreeIshArg = either isWorkFreeIsh (pure . const True)
+  isConstantArg    = either isConstant (const True)
 
 inlineOrLiftBinders
   :: (LetBinding -> RewriteMonad extra Bool)


### PR DESCRIPTION
While working on #996 I noticed that master was duplicating
registers. This was because `isWorkFreeIsh` didn't respect the
`WorkVariable` workinfo, which states that a primive performs
work if any of its arguments are non-constants. Now it does.