### PR TITLE
Preparation for Partial Evaluator

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -53,7 +53,7 @@ doHDL b src = do
   putStrLn $ "Loading dependencies took " ++ prepStartDiff
 
   generateHDL (buildCustomReprs reprs) bindingsMap (Just b) primMap tcm tupTcm
-    (ghcTypeToHWType WORD_SIZE_IN_BITS True) reduceConstant topEntities
+    (ghcTypeToHWType WORD_SIZE_IN_BITS True) primEvaluator topEntities
     defClashOpts{opt_cachehdl = False, opt_dbgLevel = DebugSilent}
     (startTime,prepTime)
 

--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -9,7 +9,7 @@ import           Clash.Core.TyCon
 import           Clash.Core.Var
 import           Clash.Driver
 import           Clash.Driver.Types
-import           Clash.GHC.Evaluator          (reduceConstant)
+import           Clash.GHC.Evaluator
 import           Clash.Primitives.Types
 
 import           Criterion.Main
@@ -45,7 +45,7 @@ benchFile idirs src =
     \ ~((bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity),supplyN) -> do
       bench ("normalization of " ++ src)
             (nf (normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans
-                                 reduceConstant topEntityNames
+                                 primEvaluator topEntityNames
                                  (opts idirs) supplyN :: _ -> BindingMap) topEntity)
 
 setupEnv

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -14,7 +14,7 @@ import Clash.Core.Type
 import Clash.Core.Var
 import Clash.Driver
 import Clash.Driver.Types
-import Clash.GHC.Evaluator (reduceConstant)
+import Clash.GHC.Evaluator
 import Clash.GHC.GenerateBindings
 import Clash.GHC.NetlistTypes
 import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
@@ -88,6 +88,6 @@ runNormalisationStage idirs src = do
     runInputStage idirs src
   let opts1 = opts idirs
       transformedBindings =
-        normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans reduceConstant
+        normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans primEvaluator
           topEntityNames opts1 supplyN topEntity
   return (transformedBindings,topEntities,primMap,tcm,reprs,topEntity)

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -4,7 +4,7 @@ import           Clash.Core.TyCon
 import           Clash.Core.Var
 import           Clash.Driver
 import           Clash.Driver.Types
-import           Clash.GHC.Evaluator          (reduceConstant)
+import           Clash.GHC.Evaluator
 
 import qualified Control.Concurrent.Supply    as Supply
 import           Control.DeepSeq              (deepseq)
@@ -37,7 +37,7 @@ benchFile idirs src = do
   let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity) = env
       primMap' = fmap (fmap unremoveBBfunc) primMap
       res :: BindingMap
-      res = normalizeEntity reprs bindingsMap primMap' tcm tupTcm typeTrans reduceConstant
+      res = normalizeEntity reprs bindingsMap primMap' tcm tupTcm typeTrans primEvaluator 
                    topEntityNames (opts idirs) supplyN topEntity
   res `deepseq` putStrLn ".. done\n"
 

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -2010,7 +2010,7 @@ makeHDL backend optsRef srcs = do
                   tcm
                   tupTcm
                   (ghcTypeToHWType iw fp)
-                  reduceConstant
+                  primEvaluator
                   topEntities
                   opts2
                   (startTime,prepTime)

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -2059,7 +2059,7 @@ makeHDL backend optsRef srcs = do
                   tcm
                   tupTcm
                   (ghcTypeToHWType iw fp)
-                  reduceConstant
+                  primEvaluator
                   topEntities
                   opts2
                   (startTime,prepTime)

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -2151,7 +2151,7 @@ makeHDL backend optsRef srcs = do
                   tcm
                   tupTcm
                   (ghcTypeToHWType iw fp)
-                  reduceConstant
+                  primEvaluator
                   topEntities
                   opts2
                   (startTime,prepTime)

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -381,7 +381,7 @@ coreToTerm primMap unlocs = term
         x' <- coreToIdSP sp x
         return (x',b')
 
-    term' (Case _ _ ty [])  = C.TyApp (C.Prim (pack "EmptyCase") (C.PrimInfo C.undefinedTy C.WorkNever))
+    term' (Case _ _ ty [])  = C.TyApp (C.Prim (C.PrimInfo (pack "EmptyCase") C.undefinedTy C.WorkNever))
                                 <$> coreToType ty
     term' (Case e b ty alts) = do
      let usesBndr = any ( not . isEmptyVarSet . exprSomeFreeVars (== b))
@@ -409,9 +409,9 @@ coreToTerm primMap unlocs = term
     term' (Tick (SourceNote rsp _) e) =
       C.Tick (C.SrcSpan (RealSrcSpan rsp)) <$> addUsefull (RealSrcSpan rsp) (term e)
     term' (Tick _ e)        = term e
-    term' (Type t)          = C.TyApp (C.Prim (pack "_TY_") (C.PrimInfo C.undefinedTy C.WorkNever)) <$>
+    term' (Type t)          = C.TyApp (C.Prim (C.PrimInfo (pack "_TY_") C.undefinedTy C.WorkNever)) <$>
                                 coreToType t
-    term' (Coercion co)     = C.TyApp (C.Prim (pack "_CO_") (C.PrimInfo C.undefinedTy C.WorkNever)) <$>
+    term' (Coercion co)     = C.TyApp (C.Prim (C.PrimInfo (pack "_CO_") C.undefinedTy C.WorkNever)) <$>
                                 coreToType (coercionType co)
 
 
@@ -428,7 +428,7 @@ coreToTerm primMap unlocs = term
         xType  <- coreToType (varType x)
         case isDataConId_maybe x of
           Just dc -> case lookupPrim xNameS of
-            Just p  -> return $ C.Prim xNameS (C.PrimInfo xType (maybe C.WorkVariable workInfo p))
+            Just p  -> return $ C.Prim (C.PrimInfo xNameS xType (maybe C.WorkVariable workInfo p))
             Nothing -> if isDataConWrapId x && not (isNewTyCon (dataConTyCon dc))
               then let xInfo = idInfo x
                        unfolding = unfoldingInfo xInfo
@@ -460,20 +460,20 @@ coreToTerm primMap unlocs = term
               -> return (nameModTerm C.SuffixName xType)
               | f == pack "Clash.Magic.setName"
               -> return (nameModTerm C.SetName xType)
-              | otherwise                                    -> return (C.Prim xNameS (C.PrimInfo xType wi))
+              | otherwise                                    -> return (C.Prim (C.PrimInfo xNameS xType wi))
             Just (Just (BlackBox {workInfo = wi})) ->
-              return $ C.Prim xNameS (C.PrimInfo xType wi)
+              return $ C.Prim (C.PrimInfo xNameS xType wi)
             Just (Just (BlackBoxHaskell {workInfo = wi})) ->
-              return $ C.Prim xNameS (C.PrimInfo xType wi)
+              return $ C.Prim (C.PrimInfo xNameS xType wi)
             Just Nothing ->
               -- Was guarded by "DontTranslate". We don't know yet if Clash will
               -- actually use it later on, so we don't err here.
-              return $ C.Prim xNameS (C.PrimInfo xType C.WorkVariable)
+              return $ C.Prim (C.PrimInfo xNameS xType C.WorkVariable)
             Nothing
               | x `elem` unlocs
-              -> return (C.Prim xNameS (C.PrimInfo xType C.WorkVariable))
+              -> return (C.Prim (C.PrimInfo xNameS xType C.WorkVariable))
               | pack "$cshow" `isInfixOf` xNameS
-              -> return (C.Prim xNameS (C.PrimInfo xType C.WorkVariable))
+              -> return (C.Prim (C.PrimInfo xNameS xType C.WorkVariable))
               | otherwise
               -> C.Var <$> coreToId x
 
@@ -1147,7 +1147,7 @@ runRWTerm (C.ForAllTy rTV (C.ForAllTy oTV funTy)) =
   C.TyLam rTV (
   C.TyLam oTV (
   C.Lam   fId (
-  (C.App (C.Var fId) (C.Prim rwNm (C.PrimInfo rwTy C.WorkNever))))))
+  (C.App (C.Var fId) (C.Prim (C.PrimInfo rwNm rwTy C.WorkNever))))))
   where
     (C.FunTy fTy _)  = C.tyView funTy
     (C.FunTy rwTy _) = C.tyView fTy

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -187,6 +187,7 @@ Library
 
                       Clash.Core.DataCon
                       Clash.Core.Evaluator
+                      Clash.Core.Evaluator.Types
                       Clash.Core.FreeVars
                       Clash.Core.Literal
                       Clash.Core.Name

--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -27,7 +27,6 @@ import           Data.List
 import           Data.IntMap                             (IntMap)
 import qualified Data.Primitive.ByteArray                as BA
 import qualified Data.Vector.Primitive                   as PV
-import           Data.Text                               (Text)
 import qualified Data.Text as Text
 import           Data.Text.Prettyprint.Doc
 import           Debug.Trace
@@ -68,7 +67,7 @@ data StackFrame
   | GUpdate Id
   | Apply  Id
   | Instantiate Type
-  | PrimApply  Text PrimInfo [Type] [Value] [Term]
+  | PrimApply  PrimInfo [Type] [Value] [Term]
   | Scrutinise Type [Alt]
   | Tickish TickInfo
   deriving Show
@@ -78,11 +77,11 @@ instance ClashPretty StackFrame where
   clashPretty (GUpdate i) = hsep ["GUpdate", fromPpr i]
   clashPretty (Apply i) = hsep ["Apply", fromPpr i]
   clashPretty (Instantiate t) = hsep ["Instantiate", fromPpr t]
-  clashPretty (PrimApply a b c d e) = do
-    hsep ["PrimApply", fromPretty a, "::", fromPpr (primType b),
-          "; type args=", fromPpr c,
-          "; val args=", fromPpr (map valToTerm d),
-          "term args=", fromPpr e]
+  clashPretty (PrimApply p tys vs ts) =
+    hsep ["PrimApply", fromPretty (primName p), "::", fromPpr (primType p),
+          "; type args=", fromPpr tys,
+          "; val args=", fromPpr (map valToTerm vs),
+          "term args=", fromPpr ts]
   clashPretty (Scrutinise a b) =
     hsep ["Scrutinise ", fromPpr a,
           fromPpr (Case (Literal (CharLiteral '_')) a b)]
@@ -105,7 +104,7 @@ data Value
   -- ^ Data constructors
   | Lit Literal
   -- ^ Literals
-  | PrimVal  Text PrimInfo [Type] [Value]
+  | PrimVal  PrimInfo [Type] [Value]
   -- ^ Clash's number types are represented by their "fromInteger#" primitive
   -- function. So some primitives are values.
   | Suspend Term
@@ -121,7 +120,6 @@ type PrimEvaluator =
   TyConMap -> -- Type constructors
   Heap ->
   Stack ->
-  Text -> -- Name of the primitive
   PrimInfo -> -- Type of the primitive
   [Type] -> -- Type arguments of the primitive
   [Value] -> -- Value arguments of the primitive
@@ -179,11 +177,11 @@ isScrut _ = False
 unwindStack :: State -> Maybe State
 unwindStack s@(_,[],_) = Just s
 unwindStack (h@(Heap gh gbl h' ids is),(kf:k'),e) = case kf of
-  PrimApply nm ty tys vs tms ->
+  PrimApply p tys vs tms ->
     unwindStack
       (h,k'
       ,foldl' App
-              (foldl' App (foldl' TyApp (Prim nm ty) tys) (map valToTerm vs))
+              (foldl' App (foldl' TyApp (Prim p) tys) (map valToTerm vs))
               (e:tms))
   Instantiate ty ->
     unwindStack (h,k',TyApp e ty)
@@ -258,7 +256,8 @@ step eval tcm (h, k, e) = case e of
                    (h2,e')  = mkAbstr (h,e) tys'
                in  step eval tcm (h2,k,e')
          GT -> error "Overapplied DC"
-    | (Prim nm pInfo,args,_ticks) <- collectArgsTicks e
+    | (Prim pInfo,args,_ticks) <- collectArgsTicks e
+    , let nm = primName pInfo
     , let ty = primType pInfo
     , (tys,_) <- splitFunForallTy ty
     -> case compare (length args) (length tys) of
@@ -280,10 +279,10 @@ step eval tcm (h, k, e) = case e of
                   [a0,a1 ] | nm `elem` ["GHC.Classes.&&","GHC.Classes.||"] ->
                     let (h0,i) = newLetBinding tcm h  a0
                         (h1,j) = newLetBinding tcm h0 a1
-                    in  eval (isScrut k) tcm h1 k nm pInfo []
+                    in  eval (isScrut k) tcm h1 k pInfo []
                              [Suspend (Var i),Suspend (Var j)]
                   (e':es) ->
-                    Just (h,PrimApply nm pInfo (rights args) [] es:k,e')
+                    Just (h,PrimApply pInfo (rights args) [] es:k,e')
                   _ -> error "internal error"
          LT -> let (tys',_) = splitFunForallTy (termType tcm e)
                    (h2,e') = mkAbstr (h,e) tys'
@@ -299,29 +298,30 @@ step eval tcm (h, k, e) = case e of
                    (h2,e') = mkAbstr (h,e) tys'
                in  step eval tcm (h2,k,e')
          GT -> error "Overapplied DC"
-    | (Prim nm pInfo,args,_ticks) <- collectArgsTicks e
+    | (Prim pInfo,args,_ticks) <- collectArgsTicks e
+    , let nm = primName pInfo
     , let ty' = primType pInfo
     , (tys,_) <- splitFunForallTy ty'
     -> case compare (length args) (length tys) of
          EQ -> case lefts args of
               [] | nm `elem` ["Clash.Transformations.removedArg"]
                  -- The above primitives are actually values, and not operations.
-                 -> unwind eval tcm h k (PrimVal nm pInfo (rights args) [])
+                 -> unwind eval tcm h k (PrimVal pInfo (rights args) [])
                  | otherwise
-                 -> eval (isScrut k) tcm h k nm pInfo (rights args) []
-              (e':es) -> Just (h,PrimApply nm pInfo (rights args) [] es:k,e')
+                 -> eval (isScrut k) tcm h k pInfo (rights args) []
+              (e':es) -> Just (h,PrimApply pInfo (rights args) [] es:k,e')
          LT -> let (tys',_) = splitFunForallTy (termType tcm e)
                    (h2,e') = mkAbstr (h,e) tys'
                in  step eval tcm (h2,k,e')
          GT -> Just (h,Instantiate ty:k,e1)
   (Data dc) -> unwind eval tcm h k (DC dc [])
-  (Prim nm pInfo)
-    | nm `elem` ["GHC.Prim.realWorld#"]
-    -> unwind eval tcm h k (PrimVal nm pInfo [] [])
+  (Prim pInfo)
+    | primName pInfo == "GHC.Prim.realWorld#"
+    -> unwind eval tcm h k (PrimVal pInfo [] [])
     | otherwise
     , let ty' = primType pInfo
     -> case fst (splitFunForallTy ty')  of
-        []  -> eval (isScrut k) tcm h k nm pInfo [] []
+        []  -> eval (isScrut k) tcm h k pInfo [] []
         tys -> let (h2,e') = mkAbstr (h,e) tys
                in  step eval tcm (h2,k,e')
   (App e1 e2)  -> let (h2,id_) = newLetBinding tcm h e2
@@ -403,7 +403,7 @@ unwind eval tcm h k v = do
     GUpdate x                    -> return (gupdate h k' x v)
     Apply x                      -> return (apply  h k' v x)
     Instantiate ty               -> return (instantiate h k' v ty)
-    PrimApply nm ty tys vals tms -> primop eval tcm h k' nm ty tys vals v tms
+    PrimApply ty tys vals tms    -> primop eval tcm h k' ty tys vals v tms
     Scrutinise _ alts            -> return (scrutinise h k' v alts)
     -- Adding back the Tick constructor will make the evaluator loop
     Tickish _                    -> return (h,k',valToTerm v)
@@ -428,7 +428,7 @@ valToTerm v = case v of
   DC dc pxs            -> foldl' (\e a -> either (App e) (TyApp e) a)
                                  (Data dc) pxs
   Lit l                -> Literal l
-  PrimVal nm ty tys vs -> foldl' App (foldl' TyApp (Prim nm ty) tys)
+  PrimVal ty tys vs    -> foldl' App (foldl' TyApp (Prim ty) tys)
                                  (map valToTerm vs)
   Suspend e            -> e
 
@@ -487,8 +487,6 @@ primop
   -> TyConMap
   -> Heap
   -> Stack
-  -> Text
-  -- ^ Name of the primitive
   -> PrimInfo
   -- ^ Type of the primitive
   -> [Type]
@@ -500,51 +498,51 @@ primop
   -> [Term]
   -- ^ The remaining terms which must be evaluated to a value
   -> Maybe State
-primop eval tcm h k nm ty tys vs v []
-  | nm `elem` ["Clash.Sized.Internal.Index.fromInteger#"
-              ,"GHC.CString.unpackCString#"
-              ,"Clash.Transformations.removedArg"
-              ,"GHC.Prim.MutableByteArray#"
-              ]
+primop eval tcm h k ty tys vs v []
+  | primName ty `elem` [ "Clash.Sized.Internal.Index.fromInteger#"
+                       , "GHC.CString.unpackCString#"
+                       , "Clash.Transformations.removedArg"
+                       , "GHC.Prim.MutableByteArray#"
+                       ]
               -- The above primitives are actually values, and not operations.
-  = unwind eval tcm h k (PrimVal nm ty tys (vs ++ [v]))
-  | nm == "Clash.Sized.Internal.BitVector.fromInteger#"
+  = unwind eval tcm h k (PrimVal ty tys (vs ++ [v]))
+  | primName ty == "Clash.Sized.Internal.BitVector.fromInteger#"
   = case (vs,v) of
     ([naturalLiteral -> Just n,mask], integerLiteral -> Just i) ->
-      unwind eval tcm h k (PrimVal nm ty tys [Lit (NaturalLiteral n)
+      unwind eval tcm h k (PrimVal ty tys [Lit (NaturalLiteral n)
                                              ,mask
                                              ,Lit (IntegerLiteral (wrapUnsigned n i))])
     _ -> error ($(curLoc) ++ "Internal error"  ++ show (vs,v))
-  | nm == "Clash.Sized.Internal.BitVector.fromInteger##"
+  | primName ty == "Clash.Sized.Internal.BitVector.fromInteger##"
   = case (vs,v) of
     ([mask], integerLiteral -> Just i) ->
-      unwind eval tcm h k (PrimVal nm ty tys [mask
+      unwind eval tcm h k (PrimVal ty tys [mask
                                              ,Lit (IntegerLiteral (wrapUnsigned 1 i))])
     _ -> error ($(curLoc) ++ "Internal error"  ++ show (vs,v))
-  | nm == "Clash.Sized.Internal.Signed.fromInteger#"
+  | primName ty == "Clash.Sized.Internal.Signed.fromInteger#"
   = case (vs,v) of
     ([naturalLiteral -> Just n],integerLiteral -> Just i) ->
-      unwind eval tcm h k (PrimVal nm ty tys [Lit (NaturalLiteral n)
+      unwind eval tcm h k (PrimVal ty tys [Lit (NaturalLiteral n)
                                              ,Lit (IntegerLiteral (wrapSigned n i))])
     _ -> error ($(curLoc) ++ "Internal error"  ++ show (vs,v))
-  | nm == "Clash.Sized.Internal.Unsigned.fromInteger#"
+  | primName ty == "Clash.Sized.Internal.Unsigned.fromInteger#"
   = case (vs,v) of
     ([naturalLiteral -> Just n],integerLiteral -> Just i) ->
-      unwind eval tcm h k (PrimVal nm ty tys [Lit (NaturalLiteral n)
+      unwind eval tcm h k (PrimVal ty tys [Lit (NaturalLiteral n)
                                              ,Lit (IntegerLiteral (wrapUnsigned n i))])
     _ -> error ($(curLoc) ++ "Internal error"  ++ show (vs,v))
-  | otherwise = eval (isScrut k) tcm h k nm ty tys (vs ++ [v])
-primop eval tcm h0 k nm ty tys vs v [e]
-  | nm `elem` [ "Clash.Sized.Vector.lazyV"
-              , "Clash.Sized.Vector.replicate"
-              , "Clash.Sized.Vector.replace_int"
-              , "GHC.Classes.&&"
-              , "GHC.Classes.||"
-              ]
+  | otherwise = eval (isScrut k) tcm h k ty tys (vs ++ [v])
+primop eval tcm h0 k ty tys vs v [e]
+  | primName ty `elem` [ "Clash.Sized.Vector.lazyV"
+                       , "Clash.Sized.Vector.replicate"
+                       , "Clash.Sized.Vector.replace_int"
+                       , "GHC.Classes.&&"
+                       , "GHC.Classes.||"
+                       ]
   = let (h1,i) = newLetBinding tcm h0 e
-    in  eval (isScrut k) tcm h1 k nm ty tys (vs ++ [v,Suspend (Var i)])
-primop _ _ h k nm ty tys vs v (e:es) =
-  Just (h,PrimApply nm ty tys (vs ++ [v]) es:k,e)
+    in  eval (isScrut k) tcm h1 k ty tys (vs ++ [v,Suspend (Var i)])
+primop _ _ h k ty tys vs v (e:es) =
+  Just (h,PrimApply ty tys (vs ++ [v]) es:k,e)
 
 -- | Evaluate a case-expression
 scrutinise :: Heap -> Stack -> Value -> [Alt] -> State
@@ -604,7 +602,7 @@ scrutinise h k (DC dc xs) alts
               [altE | (DefaultPat,altE) <- alts ]
   = (h,k,altE)
 
-scrutinise h k v@(PrimVal nm _ _ vs) alts
+scrutinise h k v@(PrimVal p _ vs) alts
   | any (\case {(LitPat {},_) -> True; _ -> False}) alts
   = case alts of
       ((DefaultPat,altE):alts1) -> (h,k,go altE alts1)
@@ -615,7 +613,7 @@ scrutinise h k v@(PrimVal nm _ _ vs) alts
   go _   ((LitPat l1,altE):_) | l1 == l = altE
   go def (_:alts1) = go def alts1
 
-  l = case nm of
+  l = case primName p of
         "Clash.Sized.Internal.BitVector.fromInteger#"
           | [_,Lit (IntegerLiteral 0),Lit l0] <- vs -> l0
         "Clash.Sized.Internal.Index.fromInteger#"

--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -17,21 +17,21 @@
 
 module Clash.Core.Evaluator where
 
+import           Prelude                                 hiding (lookup)
+
 import           Control.Concurrent.Supply               (Supply, freshId)
-import           Control.Lens                            (view, _4)
-import           Data.Bits                               (shiftL)
 import           Data.Either                             (lefts,rights)
-import           Data.List
-  (foldl',mapAccumL,uncons)
-import           Data.IntMap                             (IntMap)
+import           Data.List                               (foldl',mapAccumL)
+import           Data.Maybe                              (fromMaybe)
 import qualified Data.Primitive.ByteArray                as BA
-import qualified Data.Vector.Primitive                   as PV
 import qualified Data.Text as Text
-import           Data.Text.Prettyprint.Doc
+import qualified Data.Vector.Primitive                   as PV
 import           Debug.Trace
 import           GHC.Integer.GMP.Internals
   (Integer (..), BigNat (..))
+
 import           Clash.Core.DataCon
+import           Clash.Core.Evaluator.Types
 import           Clash.Core.FreeVars
 import           Clash.Core.Literal
 import           Clash.Core.Name
@@ -44,235 +44,159 @@ import           Clash.Core.Util
 import           Clash.Core.Var
 import           Clash.Core.VarEnv
 import           Clash.Driver.Types                      (BindingMap)
-import           Prelude                                 hiding (lookup)
+import           Clash.Pretty
 import           Clash.Unique
 import           Clash.Util                              (curLoc)
-import           Clash.Pretty
 
--- | The heap
-data Heap = Heap GlobalHeap GPureHeap PureHeap Supply InScopeSet
-
-type PureHeap = VarEnv Term
-newtype GPureHeap = GPureHeap { unGPureHeap :: PureHeap }
-
--- | Global heap
-type GlobalHeap = (IntMap Term, Int)
-
--- | The stack
-type Stack = [StackFrame]
-
-data StackFrame
-  = Update Id
-  | GUpdate Id
-  | Apply  Id
-  | Instantiate Type
-  | PrimApply  PrimInfo [Type] [Value] [Term]
-  | Scrutinise Type [Alt]
-  | Tickish TickInfo
-  deriving Show
-
-instance ClashPretty StackFrame where
-  clashPretty (Update i) = hsep ["Update", fromPpr i]
-  clashPretty (GUpdate i) = hsep ["GUpdate", fromPpr i]
-  clashPretty (Apply i) = hsep ["Apply", fromPpr i]
-  clashPretty (Instantiate t) = hsep ["Instantiate", fromPpr t]
-  clashPretty (PrimApply p tys vs ts) =
-    hsep ["PrimApply", fromPretty (primName p), "::", fromPpr (primType p),
-          "; type args=", fromPpr tys,
-          "; val args=", fromPpr (map valToTerm vs),
-          "term args=", fromPpr ts]
-  clashPretty (Scrutinise a b) =
-    hsep ["Scrutinise ", fromPpr a,
-          fromPpr (Case (Literal (CharLiteral '_')) a b)]
-  clashPretty (Tickish sp) =
-    hsep ["Tick", fromPpr sp]
-
-mkTickish
-  :: Stack
-  -> [TickInfo]
-  -> Stack
-mkTickish s sps = map Tickish sps ++ s
-
--- Values
-data Value
-  = Lambda Id Term
-  -- ^ Functions
-  | TyLambda TyVar Term
-  -- ^ Type abstractions
-  | DC DataCon [Either Term Type]
-  -- ^ Data constructors
-  | Lit Literal
-  -- ^ Literals
-  | PrimVal  PrimInfo [Type] [Value]
-  -- ^ Clash's number types are represented by their "fromInteger#" primitive
-  -- function. So some primitives are values.
-  | Suspend Term
-  -- ^ Used by lazy primitives
-  deriving Show
-
--- | State of the evaluator
-type State = (Heap, Stack, Term)
-
--- | Function that can evaluator primitives, i.e., perform delta-reduction
-type PrimEvaluator =
-  Bool -> -- Force special primitives? See [Note: forcing special primitives]
-  TyConMap -> -- Type constructors
-  Heap ->
-  Stack ->
-  PrimInfo -> -- Type of the primitive
-  [Type] -> -- Type arguments of the primitive
-  [Value] -> -- Value arguments of the primitive
-  Maybe State -- Delta-reduction can get stuck, so Nothing is an option
-
--- | Evaluate to WHNF starting with an empty Heap and Stack
 whnf'
-  :: PrimEvaluator
+  :: PrimStep
+  -> PrimUnwind
   -> BindingMap
   -> TyConMap
-  -> GlobalHeap
+  -> PrimHeap
   -> Supply
   -> InScopeSet
   -> Bool
   -> Term
-  -> (GlobalHeap, PureHeap, Term)
-whnf' eval gbl0 tcm gh ids is isSubj e
-  = case whnf eval tcm isSubj (Heap gh gbl1 emptyVarEnv ids is,[],e) of
-      (Heap gh' _ ph' _ _,_,e') -> (gh',ph',e')
+  -> (PrimHeap, PureHeap, Term)
+whnf' eval fu bm tcm ph ids is isSubj e =
+  toResult $ whnf tcm isSubj m
  where
-  gbl1 = GPureHeap (mapVarEnv (view _4) gbl0)
+  toResult x = (mHeapPrim x, mHeapLocal x, mTerm x)
+
+  m  = Machine eval fu ph gh emptyVarEnv [] ids is e
+  gh = mapVarEnv (\(_, _, _, x) -> x) bm
 
 -- | Evaluate to WHNF given an existing Heap and Stack
 whnf
-  :: PrimEvaluator
-  -> TyConMap
+  :: TyConMap
   -> Bool
-  -> State
-  -> State
-whnf eval tcm isSubj (h,k,e) =
-    if isSubj
-       then go (h,Scrutinise ty []:k,e) -- See [Note: empty case expressions]
-       else go (h,k,e)
+  -> Machine
+  -> Machine
+whnf tcm isSubj m
+  | isSubj =
+      -- See [Note: empty case expressions]
+      let ty = termType tcm (mTerm m)
+       in go (stackPush (Scrutinise ty []) m)
+  | otherwise = go m
   where
-    ty = termType tcm e
-
-    go s@(h',k',e') = case step e' eval tcm h' k' of
+    go s = case step s tcm of
       Just s' -> go s'
-      Nothing
-        | Just e'' <- unwindStack s
-        -> e''
-        | otherwise
-        -> error $ showDoc $ ppr e
-
--- | Are we in a context where special primitives must be forced.
---
--- See [Note: forcing special primitives]
-isScrut :: Stack -> Bool
-isScrut (Scrutinise {}:_) = True
-isScrut (PrimApply {} :_) = True
-isScrut (Tickish {}:k) = isScrut k
-isScrut _ = False
+      Nothing -> fromMaybe (error . showDoc . ppr $ mTerm m) (unwindStack s)
 
 -- | Completely unwind the stack to get back the complete term
-unwindStack :: State -> Maybe State
-unwindStack s@(_,[],_) = Just s
-unwindStack (h@(Heap gh gbl h' ids is),(kf:k'),e) = case kf of
-  PrimApply p tys vs tms ->
-    unwindStack
-      (h,k'
-      ,foldl' App
-              (foldl' App (foldl' TyApp (Prim p) tys) (map valToTerm vs))
-              (e:tms))
-  Instantiate ty ->
-    unwindStack (h,k',TyApp e ty)
-  Apply id_ -> do
-    case lookupVarEnv id_ h' of
-      Just e' -> unwindStack (h,k',App e e')
-      Nothing -> error $ unlines
-                       $ [ "Clash.Core.Evaluator.unwindStack:"
-                         , "Stack:"
-                         ] ++
-                         [ "  "++ showDoc (clashPretty frame) | frame <- kf:k'] ++
-                         [ ""
-                         , "Expression:"
-                         , showPpr e
-                         , ""
-                         , "Heap:"
-                         , showDoc (clashPretty h')
-                         ]
-  Scrutinise _ [] ->
-    unwindStack (h,k',e)
-  Scrutinise ty alts ->
-    unwindStack (h,k',Case e ty alts)
-  Update x ->
-    unwindStack (Heap gh gbl (extendVarEnv x e h') ids is,k',e)
-  GUpdate _ ->
-    unwindStack (h,k',e)
-  Tickish sp ->
-    unwindStack (h,k',Tick sp e)
+unwindStack :: Machine -> Maybe Machine
+unwindStack m
+  | stackNull m = Just m
+  | otherwise = do
+      (m', kf) <- stackPop m
 
-{- [Note: forcing special primitives]
-Clash uses the `whnf` function in two places (for now):
+      case kf of
+        PrimApply p tys vs tms ->
+          let term = foldl' App
+                       (foldl' App
+                         (foldl' TyApp (Prim p) tys)
+                         (fmap valToTerm vs))
+                       (mTerm m' : tms)
+           in unwindStack (setTerm term m')
 
-  1. The case-of-known-constructor transformation
-  2. The reduceConstant transformation
+        Instantiate ty ->
+          let term = TyApp (getTerm m') ty
+           in unwindStack (setTerm term m')
 
-The first transformation is needed to reach the required normal form. The
-second transformation is more of cleanup transformation, so non-essential.
+        Apply n ->
+          case heapLookup LocalId n m' of
+            Just e ->
+              let term = App (getTerm m') e
+               in unwindStack (setTerm term m')
 
-Normally, `whnf` would force the evaluation of all primitives, which is needed
-in the `case-of-known-constructor` transformation. However, there are some
-primitives which we want to leave unevaluated in the `reduceConstant`
-transformation. Such primitives are:
+            Nothing -> error $ unlines $
+              [ "Clash.Core.Evaluator.unwindStack:"
+              , "Stack:"
+              ] <>
+              [ "  " <> showDoc (clashPretty frame) | frame <- mStack m] <>
+              [ ""
+              , "Expression:"
+              , showPpr (mTerm m)
+              , ""
+              , "Heap:"
+              , showDoc (clashPretty $ mHeapLocal m)
+              ]
 
-  - Primitives such as `Clash.Sized.Vector.transpose`, `Clash.Sized.Vector.map`,
-    etc. that do not reduce to an expression in normal form. Where the
-    `reduceConstant` transformation is supposed to be normal-form preserving.
-  - Primitives such as `GHC.Int.I8#`, `GHC.Word.W32#`, etc. which seem like
-    wrappers around a 64-bit literal, but actually perform truncation to the
-    desired bit-size.
+        Scrutinise _ [] ->
+          unwindStack m'
 
-This is why the Primitive Evaluator gets a flag telling whether it should
-evaluate these special primitives.
--}
+        Scrutinise ty alts ->
+          let term = Case (getTerm m') ty alts
+           in unwindStack (setTerm term m')
+
+        Update LocalId x ->
+          unwindStack (heapInsert LocalId x (mTerm m') m')
+
+        Update GlobalId _ ->
+          unwindStack m'
+
+        Tickish sp ->
+          let term = Tick sp (getTerm m')
+           in unwindStack (setTerm term m')
 
 -- | A single step in the partial evaluator. The result is the new heap and
 -- stack, and the next expression to be reduced.
 --
-type Step = PrimEvaluator -> TyConMap -> Heap -> Stack -> Maybe State
+type Step = Machine -> TyConMap -> Maybe Machine
 
 stepVar :: Id -> Step
-stepVar i _ _ h k = force h k i
+stepVar i m _
+  | Just e <- heapLookup LocalId i m
+  = go LocalId e
+
+  | Just e <- heapLookup GlobalId i m
+  , isGlobalId i
+  = go GlobalId e
+
+  | otherwise
+  = Nothing
+ where
+  go s e =
+    let term = deShadowTerm (mScopeNames m) (tickExpr e)
+     in Just . setTerm term . stackPush (Update s i) $ heapDelete s i m
+
+  -- Removing the heap-bound value on a force ensures we do not get stuck on
+  -- expressions such as: "let x = x in x"
+  tickExpr = Tick (NameMod PrefixName (LitTy . SymTy $ toStr i))
+  unQualName = snd . Text.breakOnEnd "."
+  toStr = Text.unpack . unQualName . flip Text.snoc '_' . nameOcc . varName
 
 stepData :: DataCon -> Step
-stepData dc f tcm h k = unwind f tcm h k (DC dc [])
+stepData dc m tcm = unwind tcm m (DC dc [])
 
 stepLiteral :: Literal -> Step
-stepLiteral l f tcm h k = unwind f tcm h k (Lit l)
+stepLiteral l m tcm = unwind tcm m (Lit l)
 
 stepPrim :: PrimInfo -> Step
-stepPrim pInfo f tcm h k
+stepPrim pInfo m tcm
   | primName pInfo == "GHC.Prim.realWorld#" =
-      unwind f tcm h k (PrimVal pInfo [] [])
+      unwind tcm m (PrimVal pInfo [] [])
 
   | otherwise =
       case fst $ splitFunForallTy (primType pInfo) of
-        []  -> f (isScrut k) tcm h k pInfo [] []
-        tys -> newBinder tys (Prim pInfo) f tcm h k
+        []  -> mPrimStep m tcm (forcePrims m) pInfo [] [] m
+        tys -> newBinder tys (Prim pInfo) m tcm
 
 stepLam :: Id -> Term -> Step
-stepLam x e f tcm h k = unwind f tcm h k (Lambda x e)
+stepLam x e m tcm = unwind tcm m (Lambda x e)
 
 stepTyLam :: TyVar -> Term -> Step
-stepTyLam x e f tcm h k = unwind f tcm h k (TyLambda x e)
+stepTyLam x e m tcm = unwind tcm m (TyLambda x e)
 
 stepApp :: Term -> Term -> Step
-stepApp x y f tcm h k =
+stepApp x y m tcm =
   case term of
     Data dc ->
       let tys = fst $ splitFunForallTy (dcType dc)
        in case compare (length args) (length tys) of
-            EQ -> unwind f tcm h k (DC dc args)
-            LT -> newBinder tys' (App x y) f tcm h k
+            EQ -> unwind tcm m (DC dc args)
+            LT -> newBinder tys' (App x y) m tcm
             GT -> error "Overapplied DC"
 
     Prim p ->
@@ -294,34 +218,34 @@ stepApp x y f tcm h k =
               -- rule lazier than the actual Haskel implementations which
               -- are strict in the first argument and lazy in the second.
               [a0, a1] | primName p `elem` ["GHC.Classes.&&","GHC.Classes.||"] ->
-                    let (h0,i) = newLetBinding tcm h  a0
-                        (h1,j) = newLetBinding tcm h0 a1
-                    in  f (isScrut k) tcm h1 k p [] [Suspend (Var i), Suspend (Var j)]
+                    let (m0,i) = newLetBinding tcm m  a0
+                        (m1,j) = newLetBinding tcm m0 a1
+                    in  mPrimStep m tcm (forcePrims m) p [] [Suspend (Var i), Suspend (Var j)] m1
 
               (e':es) ->
-                    Just (h, PrimApply p (rights args) [] es:k, e')
+                Just . setTerm e' $ stackPush (PrimApply p (rights args) [] es) m
 
               _ -> error "internal error"
        
-            LT -> newBinder tys' (App x y) f tcm h k
+            LT -> newBinder tys' (App x y) m tcm
 
-            GT -> let (h0, n) = newLetBinding tcm h y
-                   in Just (h0, Apply n : k, x)
+            GT -> let (m0, n) = newLetBinding tcm m y
+                   in Just . setTerm x $ stackPush (Apply n) m0
 
-    _ -> let (h0, n) = newLetBinding tcm h y
-          in Just (h0, Apply n : k, x)
+    _ -> let (m0, n) = newLetBinding tcm m y
+          in Just . setTerm x $ stackPush (Apply n) m0
  where
   (term, args, _) = collectArgsTicks (App x y)
   tys' = fst . splitFunForallTy . termType tcm $ App x y
 
 stepTyApp :: Term -> Type -> Step
-stepTyApp x ty f tcm h k =
+stepTyApp x ty m tcm =
   case term of
     Data dc ->
       let tys = fst $ splitFunForallTy (dcType dc)
        in case compare (length args) (length tys) of
-            EQ -> unwind f tcm h k (DC dc args)
-            LT -> newBinder tys' (TyApp x ty) f tcm h k
+            EQ -> unwind tcm m (DC dc args)
+            LT -> newBinder tys' (TyApp x ty) m tcm
             GT -> error "Overapplied DC"
 
     Prim p ->
@@ -329,277 +253,151 @@ stepTyApp x ty f tcm h k =
        in case compare (length args) (length tys) of
             EQ -> case lefts args of
                     [] | primName p == "Clash.Transformations.removedArg" ->
-                            unwind f tcm h k (PrimVal p (rights args) [])
+                            unwind tcm m (PrimVal p (rights args) [])
 
                        | otherwise ->
-                            f (isScrut k) tcm h k p (rights args) []
+                            mPrimStep m tcm (forcePrims m) p (rights args) [] m
 
-                    (e':es) -> Just (h, PrimApply p (rights args) [] es : k, e')
+                    (e':es) ->
+                      Just . setTerm e' $ stackPush (PrimApply p (rights args) [] es) m
 
-            LT -> newBinder tys' (TyApp x ty) f tcm h k
-            GT -> Just (h, Instantiate ty : k, x)
+            LT -> newBinder tys' (TyApp x ty) m tcm
+            GT -> Just . setTerm x $ stackPush (Instantiate ty) m
 
-    _ -> Just (h, Instantiate ty : k, x)
+    _ -> Just . setTerm x $ stackPush (Instantiate ty) m
  where
   (term, args, _) = collectArgsTicks (TyApp x ty)
   tys' = fst . splitFunForallTy . termType tcm $ TyApp x ty
 
 stepLetRec :: [LetBinding] -> Term -> Step
-stepLetRec bs x _ _ h k = Just (allocate h k bs x)
+stepLetRec bs x m _ = Just (allocate bs x m)
 
 stepCase :: Term -> Type -> [Alt] -> Step
-stepCase scrut ty alts _ _ h k = Just (h, Scrutinise ty alts : k, scrut)
+stepCase scrut ty alts m _ =
+  Just . setTerm scrut $ stackPush (Scrutinise ty alts) m
 
 -- TODO Support stepwise evaluation of casts.
 --
 stepCast :: Term -> Type -> Type -> Step
-stepCast _ _ _ _ _ _ _ =
+stepCast _ _ _ _ _ =
   flip trace Nothing $ unlines
     [ "WARNING: " <> $(curLoc) <> "Clash can't symbolically evaluate casts"
     , "Please file an issue at https://github.com/clash-lang/clash-compiler/issues"
     ] 
 
 stepTick :: TickInfo -> Term -> Step
-stepTick tick x _ _ h k = Just (h, Tickish tick : k, x)
+stepTick tick x m _ =
+  Just . setTerm x $ stackPush (Tickish tick) m
 
 -- | Small-step operational semantics.
-step :: Term -> Step
-step (Var i) = stepVar i
-step (Data dc) = stepData dc
-step (Literal l) = stepLiteral l
-step (Prim p) = stepPrim p
-step (Lam v x) = stepLam v x
-step (TyLam v x) = stepTyLam v x
-step (App x y) = stepApp x y
-step (TyApp x ty) = stepTyApp x ty
-step (Letrec bs x) = stepLetRec bs x
-step (Case scrut ty alts) = stepCase scrut ty alts
-step (Cast x a b) = stepCast x a b
-step (Tick t x) = stepTick t x
+--
+step :: Step
+step m = case mTerm m of
+  Var i -> stepVar i m
+  Data dc -> stepData dc m
+  Literal l -> stepLiteral l m
+  Prim p -> stepPrim p m
+  Lam v x -> stepLam v x m
+  TyLam v x -> stepTyLam v x m
+  App x y -> stepApp x y m
+  TyApp x ty -> stepTyApp x ty m
+  Letrec bs x -> stepLetRec bs x m
+  Case s ty as -> stepCase s ty as m
+  Cast x a b -> stepCast x a b m
+  Tick t x -> stepTick t x m
 
 -- | Take a list of types or type variables and create a lambda / type lambda
 -- for each one around the given term.
 --
 newBinder :: [Either TyVar Type] -> Term -> Step
-newBinder tys x f tcm h k =
-  let (h', x') = mkAbstr (h, x) tys
-   in step x' f tcm h' k
+newBinder tys x m tcm =
+  let (s', iss', x') = mkAbstr (mSupply m, mScopeNames m, x) tys
+      m' = m { mSupply = s', mScopeNames = iss', mTerm = x' }
+   in step m' tcm
  where
-  mkAbstr
-    :: (Heap,Term)
-    -> [Either TyVar Type]
-    -> (Heap,Term)
   mkAbstr = foldr go
     where
-      go (Left tv)  (h',e')          =
-        (h',TyLam tv (TyApp e' (VarTy tv)))
-      go (Right ty) (Heap gh gbl h' ids is,e') =
-        let ((ids',_), n) = mkUniqSystemId (ids,is) ("x",ty)
-        in  (Heap gh gbl h' ids' is,Lam n (App e' (Var n)))
+      go (Left tv) (s', iss', e') =
+        (s', iss', TyLam tv (TyApp e' (VarTy tv)))
+
+      go (Right ty) (s', iss', e') =
+        let ((s'', _), n) = mkUniqSystemId (s', iss') ("x", ty)
+        in  (s'', iss' ,Lam n (App e' (Var n)))
 
 newLetBinding
   :: TyConMap
-  -> Heap
+  -> Machine
   -> Term
-  -> (Heap,Id)
-newLetBinding tcm h@(Heap gh gbl h' ids is0) e
+  -> (Machine, Id)
+newLetBinding tcm m e
   | Var v <- e
-  , Just _ <- lookupVarEnv v h'
-  = (h, v)
-  | otherwise
-  = (Heap gh gbl (extendVarEnv id_ e h') ids' is1,id_)
-  where
-    ty = termType tcm e
-    ((ids',is1),id_) = mkUniqSystemId (ids,is0) ("x",ty)
+  , heapContains LocalId v m
+  = (m, v)
 
--- | Force the evaluation of a variable.
-force :: Heap -> Stack -> Id -> Maybe State
-force (Heap gh g@(GPureHeap gbl) h ids is) k x' = case lookupVarEnv x' h of
-    Nothing -> case lookupVarEnv x' gbl of
-      Just e | isGlobalId x'
-        -> let e' = tickExpr e
-            in Just ( Heap gh (GPureHeap (delVarEnv gbl x')) h ids is
-                , GUpdate x':k
-                , deShadowTerm is e'
-                )
-      _ -> Nothing
-    Just e -> let e' = tickExpr e
-               in Just (Heap gh g (delVarEnv h x') ids is,Update x':k,e')
-    -- Removing the heap-bound value on a force ensures we do not get stuck on
-    -- expressions such as: "let x = x in x"
+  | otherwise
+  = let m' = heapInsert LocalId id_ e m
+     in (m' { mSupply = ids', mScopeNames = is1 }, id_)
  where
-  tickExpr = Tick (NameMod PrefixName (LitTy . SymTy $ toStr x'))
-  unQualName = snd . Text.breakOnEnd "."
-  toStr = Text.unpack . unQualName . flip Text.snoc '_' . nameOcc . varName
+  ty = termType tcm e
+  ((ids', is1), id_) = mkUniqSystemId (mSupply m, mScopeNames m) ("x", ty)
 
 -- | Unwind the stack by 1
 unwind
-  :: PrimEvaluator
-  -> TyConMap
-  -> Heap -> Stack -> Value -> Maybe State
-unwind eval tcm h k v = do
-  (kf,k') <- uncons k
-  case kf of
-    Update x                     -> return (update h k' x v)
-    GUpdate x                    -> return (gupdate h k' x v)
-    Apply x                      -> return (apply  h k' v x)
-    Instantiate ty               -> return (instantiate h k' v ty)
-    PrimApply ty tys vals tms    -> primop eval tcm h k' ty tys vals v tms
-    Scrutinise _ alts            -> return (scrutinise h k' v alts)
-    -- Adding back the Tick constructor will make the evaluator loop
-    Tickish _                    -> return (h,k',valToTerm v)
+  :: TyConMap
+  -> Machine
+  -> Value
+  -> Maybe Machine
+unwind tcm m v = do
+  (m', kf) <- stackPop m
+  go kf m'
+ where
+  go (Update s x)             = return . update s x v
+  go (Apply x)                = return . apply v x
+  go (Instantiate ty)         = return . instantiate v ty
+  go (PrimApply p tys vs tms) = mPrimUnwind m tcm p tys vs v tms
+  go (Scrutinise _ as)        = return . scrutinise v as
+  go (Tickish _)              = return . setTerm (valToTerm v)
 
 -- | Update the Heap with the evaluated term
-update :: Heap -> Stack -> Id -> Value -> State
-update (Heap gh gbl h ids is) k x v = (Heap gh gbl (extendVarEnv x v' h) ids is,k,v')
-  where
-    v' = valToTerm v
-
--- | Update the Globals with the evaluated term
-gupdate :: Heap -> Stack -> Id -> Value -> State
-gupdate (Heap gh (GPureHeap gbl) h ids is) k x v =
-  (Heap gh (GPureHeap (extendVarEnv x v' gbl)) h ids is,k,v')
- where
-  v' = valToTerm v
-
-valToTerm :: Value -> Term
-valToTerm v = case v of
-  Lambda x e           -> Lam x e
-  TyLambda x e         -> TyLam x e
-  DC dc pxs            -> foldl' (\e a -> either (App e) (TyApp e) a)
-                                 (Data dc) pxs
-  Lit l                -> Literal l
-  PrimVal ty tys vs    -> foldl' App (foldl' TyApp (Prim ty) tys)
-                                 (map valToTerm vs)
-  Suspend e            -> e
-
-toVar :: Id -> Term
-toVar x = Var x
-
-toType :: TyVar -> Type
-toType x = VarTy x
+update :: IdScope -> Id -> Value -> Machine -> Machine
+update s x (valToTerm -> term) =
+  setTerm term . heapInsert s x term
 
 -- | Apply a value to a function
-apply :: Heap -> Stack -> Value -> Id -> State
-apply h@(Heap _ _ _ _ is0) k (Lambda x' e) x = (h,k,substTm "Evaluator.apply" subst e)
+apply :: Value -> Id -> Machine -> Machine
+apply (Lambda x' e) x m =
+  setTerm (substTm "Evaluator.apply" subst e) m
  where
   subst  = extendIdSubst subst0 x' (Var x)
-  subst0 = mkSubst (extendInScopeSet is0 x)
-apply _ _ _ _ = error "not a lambda"
+  subst0 = mkSubst $ extendInScopeSet (mScopeNames m) x
+
+apply _ _ _ = error "Evaluator.apply: Not a lambda"
 
 -- | Instantiate a type-abstraction
-instantiate :: Heap -> Stack -> Value -> Type -> State
-instantiate h k (TyLambda x e) ty = (h,k,substTm "Evaluator.instantiate" subst e)
+instantiate :: Value -> Type -> Machine -> Machine
+instantiate (TyLambda x e) ty =
+  setTerm (substTm "Evaluator.instantiate" subst e)
  where
   subst  = extendTvSubst subst0 x ty
-  subst0 = mkSubst is0
-  is0    = mkInScopeSet (localFVsOfTerms [e] `unionUniqSet` tyFVsOfTypes [ty])
-instantiate _ _ _ _ = error "not a ty lambda"
+  subst0 = mkSubst iss0
+  iss0   = mkInScopeSet (localFVsOfTerms [e] `unionUniqSet` tyFVsOfTypes [ty])
 
-naturalLiteral :: Value -> Maybe Integer
-naturalLiteral v =
-  case v of
-    Lit (NaturalLiteral i) -> Just i
-    DC dc [Left (Literal (WordLiteral i))]
-      | dcTag dc == 1
-      -> Just i
-    DC dc [Left (Literal (ByteArrayLiteral (PV.Vector _ _ (BA.ByteArray ba))))]
-      | dcTag dc == 2
-      -> Just (Jp# (BN# ba))
-    _ -> Nothing
-
-integerLiteral :: Value -> Maybe Integer
-integerLiteral v =
-  case v of
-    Lit (IntegerLiteral i) -> Just i
-    DC dc [Left (Literal (IntLiteral i))]
-      | dcTag dc == 1
-      -> Just i
-    DC dc [Left (Literal (ByteArrayLiteral (PV.Vector _ _ (BA.ByteArray ba))))]
-      | dcTag dc == 2
-      -> Just (Jp# (BN# ba))
-      | dcTag dc == 3
-      -> Just (Jn# (BN# ba))
-    _ -> Nothing
-
--- | Evaluation of primitive operations.
--- TODO This should really be in Clash.GHC.Evaluator -- the evaluator in
--- clash-lib should NEVER refer to GHC primitives.
-primop
-  :: PrimEvaluator
-  -> TyConMap
-  -> Heap
-  -> Stack
-  -> PrimInfo
-  -- ^ Type of the primitive
-  -> [Type]
-  -- ^ Applied types
-  -> [Value]
-  -- ^ Applied values
-  -> Value
-  -- ^ The current value
-  -> [Term]
-  -- ^ The remaining terms which must be evaluated to a value
-  -> Maybe State
-primop eval tcm h k ty tys vs v []
-  | primName ty `elem` [ "Clash.Sized.Internal.Index.fromInteger#"
-                       , "GHC.CString.unpackCString#"
-                       , "Clash.Transformations.removedArg"
-                       , "GHC.Prim.MutableByteArray#"
-                       ]
-              -- The above primitives are actually values, and not operations.
-  = unwind eval tcm h k (PrimVal ty tys (vs ++ [v]))
-  | primName ty == "Clash.Sized.Internal.BitVector.fromInteger#"
-  = case (vs,v) of
-    ([naturalLiteral -> Just n,mask], integerLiteral -> Just i) ->
-      unwind eval tcm h k (PrimVal ty tys [Lit (NaturalLiteral n)
-                                             ,mask
-                                             ,Lit (IntegerLiteral (wrapUnsigned n i))])
-    _ -> error ($(curLoc) ++ "Internal error"  ++ show (vs,v))
-  | primName ty == "Clash.Sized.Internal.BitVector.fromInteger##"
-  = case (vs,v) of
-    ([mask], integerLiteral -> Just i) ->
-      unwind eval tcm h k (PrimVal ty tys [mask
-                                             ,Lit (IntegerLiteral (wrapUnsigned 1 i))])
-    _ -> error ($(curLoc) ++ "Internal error"  ++ show (vs,v))
-  | primName ty == "Clash.Sized.Internal.Signed.fromInteger#"
-  = case (vs,v) of
-    ([naturalLiteral -> Just n],integerLiteral -> Just i) ->
-      unwind eval tcm h k (PrimVal ty tys [Lit (NaturalLiteral n)
-                                             ,Lit (IntegerLiteral (wrapSigned n i))])
-    _ -> error ($(curLoc) ++ "Internal error"  ++ show (vs,v))
-  | primName ty == "Clash.Sized.Internal.Unsigned.fromInteger#"
-  = case (vs,v) of
-    ([naturalLiteral -> Just n],integerLiteral -> Just i) ->
-      unwind eval tcm h k (PrimVal ty tys [Lit (NaturalLiteral n)
-                                             ,Lit (IntegerLiteral (wrapUnsigned n i))])
-    _ -> error ($(curLoc) ++ "Internal error"  ++ show (vs,v))
-  | otherwise = eval (isScrut k) tcm h k ty tys (vs ++ [v])
-primop eval tcm h0 k ty tys vs v [e]
-  | primName ty `elem` [ "Clash.Sized.Vector.lazyV"
-                       , "Clash.Sized.Vector.replicate"
-                       , "Clash.Sized.Vector.replace_int"
-                       , "GHC.Classes.&&"
-                       , "GHC.Classes.||"
-                       ]
-  = let (h1,i) = newLetBinding tcm h0 e
-    in  eval (isScrut k) tcm h1 k ty tys (vs ++ [v,Suspend (Var i)])
-primop _ _ h k ty tys vs v (e:es) =
-  Just (h,PrimApply ty tys (vs ++ [v]) es:k,e)
+instantiate _ _ = error "Evaluator.instantiate: Not a tylambda"
 
 -- | Evaluate a case-expression
-scrutinise :: Heap -> Stack -> Value -> [Alt] -> State
-scrutinise h k v [] = (h,k,valToTerm v)
+scrutinise :: Value -> [Alt] -> Machine -> Machine
+scrutinise v [] m = setTerm (valToTerm v) m
 -- [Note: empty case expressions]
 --
 -- Clash does not have empty case-expressions; instead, empty case-expressions
 -- are used to indicate that the `whnf` function was called the context of a
 -- case-expression, which means certain special primitives must be forced.
 -- See also [Note: forcing special primitives]
-scrutinise h k (Lit l) alts = case alts of
-  (DefaultPat,altE):alts1 -> (h,k,go altE alts1)
-  _ -> (h,k,go (error ("scrutinise: no match " ++
-          showPpr (Case (valToTerm (Lit l)) (ConstTy Arrow) alts))) alts)
+scrutinise (Lit l) alts m = case alts of
+  (DefaultPat, altE):alts1 -> setTerm (go altE alts1) m
+  _ -> let term = go (error $ "Evaluator.scrutinise: no match "
+                    <> showPpr (Case (valToTerm (Lit l)) (ConstTy Arrow) alts)) alts
+        in setTerm term m
  where
   go def [] = def
   go _ ((LitPat l1,altE):_) | l1 == l = altE
@@ -639,18 +437,19 @@ scrutinise h k (Lit l) alts = case alts of
       in  substTm "Evaluator.scrutinise" subst1 altE
   go def (_:alts1) = go def alts1
 
-scrutinise h k (DC dc xs) alts
+scrutinise (DC dc xs) alts m
   | altE:_ <- [substAlt altDc tvs pxs xs altE
               | (DataPat altDc tvs pxs,altE) <- alts, altDc == dc ] ++
               [altE | (DefaultPat,altE) <- alts ]
-  = (h,k,altE)
+  = setTerm altE m
 
-scrutinise h k v@(PrimVal p _ vs) alts
+scrutinise v@(PrimVal p _ vs) alts m
   | any (\case {(LitPat {},_) -> True; _ -> False}) alts
   = case alts of
-      ((DefaultPat,altE):alts1) -> (h,k,go altE alts1)
-      _ -> (h,k,go (error ("scrutinise: no match " ++
-                showPpr (Case (valToTerm v) (ConstTy Arrow) alts))) alts)
+      ((DefaultPat,altE):alts1) -> setTerm (go altE alts1) m
+      _ -> let term = go (error $ "Evaluator.scrutinise: no match "
+                        <> showPpr (Case (valToTerm v) (ConstTy Arrow) alts)) alts
+            in setTerm term m
  where
   go def [] = def
   go _   ((LitPat l1,altE):_) | l1 == l = altE
@@ -667,7 +466,7 @@ scrutinise h k v@(PrimVal p _ vs) alts
           | [_,Lit l0] <- vs -> l0
         _ -> error ("scrutinise: " ++ showPpr (Case (valToTerm v) (ConstTy Arrow) alts))
 
-scrutinise _ _ v alts = error ("scrutinise: " ++ showPpr (Case (valToTerm v) (ConstTy Arrow) alts))
+scrutinise v alts _ = error ("scrutinise: " ++ showPpr (Case (valToTerm v) (ConstTy Arrow) alts))
 
 substAlt :: DataCon -> [TyVar] -> [Id] -> [Either Term Type] -> Term -> Term
 substAlt dc tvs xs args e = substTm "Evaluator.substAlt" subst e
@@ -681,19 +480,23 @@ substAlt dc tvs xs args e = substTm "Evaluator.substAlt" subst e
   subst0     = mkSubst (mkInScopeSet inScope)
 
 -- | Allocate let-bindings on the heap
-allocate :: Heap -> Stack -> [LetBinding] -> Term -> State
-allocate (Heap gh gbl h ids is0) k xes e =
-  (Heap gh gbl (h `extendVarEnvList` xes') ids' isN,k,e')
+allocate :: [LetBinding] -> Term -> Machine -> Machine
+allocate xes e m =
+  m { mHeapLocal = extendVarEnvList (mHeapLocal m) xes'
+    , mSupply = ids'
+    , mScopeNames = isN
+    , mTerm = e'
+    }
  where
-  xNms     = map fst xes
-  is1      = extendInScopeSetList is0 xNms
-  (ids',s) = mapAccumL (letSubst h) ids xNms
-  (nms,s') = unzip s
-  isN      = extendInScopeSetList is1 nms
-  subst    = extendIdSubstList subst0 s'
-  subst0   = mkSubst (foldl' extendInScopeSet is1 nms)
-  xes'     = zip nms (map (substTm "Evaluator.allocate0" subst . snd) xes)
-  e'       = substTm "Evaluator.allocate1" subst e
+  xNms      = fmap fst xes
+  is1       = extendInScopeSetList (mScopeNames m) xNms
+  (ids', s) = mapAccumL (letSubst (mHeapLocal m)) (mSupply m) xNms
+  (nms, s') = unzip s
+  isN       = extendInScopeSetList is1 nms
+  subst     = extendIdSubstList subst0 s'
+  subst0    = mkSubst (foldl' extendInScopeSet is1 nms)
+  xes'      = zip nms (fmap (substTm "Evaluator.allocate0" subst . snd) xes)
+  e'        = substTm "Evaluator.allocate1" subst e
 
 -- | Create a unique name and substitution for a let-binder
 letSubst
@@ -702,26 +505,13 @@ letSubst
   -> Id
   -> (Supply, (Id, (Id, Term)))
 letSubst h acc id0 =
-  let (acc',id1) = uniqueInHeap h acc id0
+  let (acc',id1) = mkUniqueHeapId h acc id0
   in  (acc',(id1,(id0,Var id1)))
  where
-  -- | Create a name that's unique in the heap
-  uniqueInHeap :: PureHeap -> Supply -> Id -> (Supply, Id)
-  uniqueInHeap h' ids x =
-    maybe (ids', x') (const $ uniqueInHeap h' ids' x) (lookupVarEnv x' h')
+  mkUniqueHeapId :: PureHeap -> Supply -> Id -> (Supply, Id)
+  mkUniqueHeapId h' ids x =
+    maybe (ids', x') (const $ mkUniqueHeapId h' ids' x) (lookupVarEnv x' h')
    where
     (i,ids') = freshId ids
     x'       = modifyVarName (`setUnique` i) x
 
-wrapUnsigned :: Integer -> Integer -> Integer
-wrapUnsigned n i = i `mod` sz
- where
-  sz = 1 `shiftL` fromInteger n
-
-wrapSigned :: Integer -> Integer -> Integer
-wrapSigned n i = if mask == 0 then 0 else res
- where
-  mask = 1 `shiftL` fromInteger (n - 1)
-  res  = case divMod i mask of
-           (s,i1) | even s    -> i1
-                  | otherwise -> i1 - mask

--- a/clash-lib/src/Clash/Core/Evaluator/Types.hs
+++ b/clash-lib/src/Clash/Core/Evaluator/Types.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+  Copyright     : (C) 2020, QBayLogic B.V.
+  License       : BSD2 (see the file LICENSE)
+  Maintainer    : Christiaan Baaij <christiaan.baaij@gmail.com>
+
+  Types for the Partial Evaluator
+-}
+module Clash.Core.Evaluator.Types where
+
+import Control.Concurrent.Supply (Supply)
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap (insert, lookup)
+import Data.List (foldl')
+import Data.Maybe (isJust)
+import Data.Text.Prettyprint.Doc (hsep)
+
+import Clash.Core.DataCon (DataCon)
+import Clash.Core.Literal (Literal(CharLiteral))
+import Clash.Core.Pretty (fromPpr)
+import Clash.Core.Term (Term(..), PrimInfo(..), TickInfo, Alt)
+import Clash.Core.TyCon (TyConMap)
+import Clash.Core.Type (Type)
+import Clash.Core.Var (Id, IdScope(..), TyVar)
+import Clash.Core.VarEnv
+import Clash.Pretty (ClashPretty(..), fromPretty)
+
+{- [Note: forcing special primitives]
+Clash uses the `whnf` function in two places (for now):
+
+  1. The case-of-known-constructor transformation
+  2. The reduceConstant transformation
+
+The first transformation is needed to reach the required normal form. The
+second transformation is more of cleanup transformation, so non-essential.
+
+Normally, `whnf` would force the evaluation of all primitives, which is needed
+in the `case-of-known-constructor` transformation. However, there are some
+primitives which we want to leave unevaluated in the `reduceConstant`
+transformation. Such primitives are:
+
+  - Primitives such as `Clash.Sized.Vector.transpose`, `Clash.Sized.Vector.map`,
+    etc. that do not reduce to an expression in normal form. Where the
+    `reduceConstant` transformation is supposed to be normal-form preserving.
+  - Primitives such as `GHC.Int.I8#`, `GHC.Word.W32#`, etc. which seem like
+    wrappers around a 64-bit literal, but actually perform truncation to the
+    desired bit-size.
+
+This is why the Primitive Evaluator gets a flag telling whether it should
+evaluate these special primitives.
+-}
+
+type PrimStep
+  =  TyConMap
+  -> Bool
+  -> PrimInfo
+  -> [Type]
+  -> [Value]
+  -> Machine
+  -> Maybe Machine
+
+type PrimUnwind
+  =  TyConMap
+  -> PrimInfo
+  -> [Type]
+  -> [Value]
+  -> Value
+  -> [Term]
+  -> Machine
+  -> Maybe Machine
+
+type PrimEvaluator = (PrimStep, PrimUnwind)
+
+data Machine = Machine
+  { mPrimStep   :: PrimStep
+  , mPrimUnwind :: PrimUnwind
+  , mHeapPrim   :: PrimHeap
+  , mHeapGlobal :: PureHeap
+  , mHeapLocal  :: PureHeap
+  , mStack      :: Stack
+  , mSupply     :: Supply
+  , mScopeNames :: InScopeSet
+  , mTerm       :: Term
+  }
+
+instance Show Machine where
+  show (Machine _ _ ph gh lh s _ _ x) =
+    unlines
+      [ "Machine:"
+      , ""
+      , "Heap (Prim):"
+      , show ph
+      , ""
+      , "Heap (Globals):"
+      , show gh
+      , ""
+      , "Heap (Locals):"
+      , show lh
+      , ""
+      , "Stack:"
+      , show (fmap clashPretty s)
+      , ""
+      , "Term:"
+      , show x
+      ]
+
+type PrimHeap = (IntMap Term, Int)
+type PureHeap = VarEnv Term
+
+type Stack = [StackFrame]
+
+data StackFrame
+  = Update IdScope Id
+  | Apply  Id
+  | Instantiate Type
+  | PrimApply  PrimInfo [Type] [Value] [Term]
+  | Scrutinise Type [Alt]
+  | Tickish TickInfo
+  deriving Show
+
+instance ClashPretty StackFrame where
+  clashPretty (Update GlobalId i) = hsep ["Update(Global)", fromPpr i]
+  clashPretty (Update LocalId i)  = hsep ["Update(Local)", fromPpr i]
+  clashPretty (Apply i) = hsep ["Apply", fromPpr i]
+  clashPretty (Instantiate t) = hsep ["Instantiate", fromPpr t]
+  clashPretty (PrimApply p tys vs ts) =
+    hsep ["PrimApply", fromPretty (primName p), "::", fromPpr (primType p),
+          "; type args=", fromPpr tys,
+          "; val args=", fromPpr (map valToTerm vs),
+          "term args=", fromPpr ts]
+  clashPretty (Scrutinise a b) =
+    hsep ["Scrutinise ", fromPpr a,
+          fromPpr (Case (Literal (CharLiteral '_')) a b)]
+  clashPretty (Tickish sp) =
+    hsep ["Tick", fromPpr sp]
+
+-- Values
+data Value
+  = Lambda Id Term
+  -- ^ Functions
+  | TyLambda TyVar Term
+  -- ^ Type abstractions
+  | DC DataCon [Either Term Type]
+  -- ^ Data constructors
+  | Lit Literal
+  -- ^ Literals
+  | PrimVal  PrimInfo [Type] [Value]
+  -- ^ Clash's number types are represented by their "fromInteger#" primitive
+  -- function. So some primitives are values.
+  | Suspend Term
+  -- ^ Used by lazy primitives
+  | TickValue TickInfo Value
+  -- ^ Preserve ticks from Terms in Values
+  | CastValue Value Type Type
+  -- ^ Preserve casts from Terms in Values
+  deriving Show
+
+valToTerm :: Value -> Term
+valToTerm v = case v of
+  Lambda x e           -> Lam x e
+  TyLambda x e         -> TyLam x e
+  DC dc pxs            -> foldl' (\e a -> either (App e) (TyApp e) a)
+                                 (Data dc) pxs
+  Lit l                -> Literal l
+  PrimVal ty tys vs    -> foldl' App (foldl' TyApp (Prim ty) tys)
+                                 (map valToTerm vs)
+  Suspend e            -> e
+  TickValue t x        -> Tick t (valToTerm x)
+  CastValue x t1 t2    -> Cast (valToTerm x) t1 t2
+
+-- Collect all the ticks from a value, exposing the ticked value.
+--
+collectValueTicks
+  :: Value
+  -> (Value, [TickInfo])
+collectValueTicks = go []
+ where
+  go ticks (TickValue t v) = go (t:ticks) v
+  go ticks v = (v, ticks)
+
+-- | Are we in a context where special primitives must be forced.
+--
+-- See [Note: forcing special primitives]
+forcePrims :: Machine -> Bool
+forcePrims = go . mStack
+ where
+  go (Scrutinise{}:_) = True
+  go (PrimApply{}:_)  = True
+  go (Tickish{}:xs)   = go xs
+  go _                = False
+
+primCount :: Machine -> Int
+primCount = snd . mHeapPrim
+
+primLookup :: Int -> Machine -> Maybe Term
+primLookup i = IntMap.lookup i . fst . mHeapPrim
+
+primInsert :: Int -> Term -> Machine -> Machine
+primInsert i x m =
+  let (gh, c) = mHeapPrim m
+   in m { mHeapPrim = (IntMap.insert i x gh, c + 1) }
+
+primUpdate :: Int -> Term -> Machine -> Machine
+primUpdate i x m =
+  let (gh, c) = mHeapPrim m
+   in m { mHeapPrim = (IntMap.insert i x gh, c) }
+
+heapLookup :: IdScope -> Id -> Machine -> Maybe Term
+heapLookup GlobalId i m =
+  lookupVarEnv i $ mHeapGlobal m
+heapLookup LocalId i m =
+  lookupVarEnv i $ mHeapLocal m
+
+heapContains :: IdScope -> Id -> Machine -> Bool
+heapContains scope i = isJust . heapLookup scope i
+
+heapInsert :: IdScope -> Id -> Term -> Machine -> Machine
+heapInsert GlobalId i x m =
+  m { mHeapGlobal = extendVarEnv i x (mHeapGlobal m) }
+heapInsert LocalId i x m =
+  m { mHeapLocal = extendVarEnv i x (mHeapLocal m) }
+
+heapDelete :: IdScope -> Id -> Machine -> Machine
+heapDelete GlobalId i m =
+  m { mHeapGlobal = delVarEnv (mHeapGlobal m) i }
+heapDelete LocalId i m =
+  m { mHeapLocal = delVarEnv (mHeapLocal m) i }
+
+stackPush :: StackFrame -> Machine -> Machine
+stackPush f m = m { mStack = f : mStack m }
+
+stackPop :: Machine -> Maybe (Machine, StackFrame)
+stackPop m = case mStack m of
+  [] -> Nothing
+  (x:xs) -> Just (m { mStack = xs }, x)
+
+stackClear :: Machine -> Machine
+stackClear m = m { mStack = [] }
+
+stackNull :: Machine -> Bool
+stackNull = null . mStack
+
+getTerm :: Machine -> Term
+getTerm = mTerm
+
+setTerm :: Term -> Machine -> Machine
+setTerm x m = m { mTerm = x }
+

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -43,7 +43,7 @@ import Clash.Core.DataCon               (DataCon (..))
 import Clash.Core.Literal               (Literal (..))
 import Clash.Core.Name                  (Name (..))
 import Clash.Core.Term
-  (Pat (..), Term (..), TickInfo (..), NameMod (..), CoreContext (..), primArg)
+  (Pat (..), Term (..), TickInfo (..), NameMod (..), CoreContext (..), primArg, PrimInfo(primName))
 import Clash.Core.TyCon                 (TyCon (..), TyConName, isTupleTyConLike)
 import Clash.Core.Type                  (ConstTy (..), Kind, LitTy (..),
                                          Type (..), TypeView (..), tyView)
@@ -211,7 +211,7 @@ instance PrettyPrec Term where
       pure (v <> brackets s)
     Data dc         -> pprPrec prec dc
     Literal l       -> pprPrec prec l
-    Prim nm _       -> pprPrecPrim prec nm
+    Prim p          -> pprPrecPrim prec (primName p)
     Lam  v e1       -> annotate (AnnContext $ LamBody v) <$>
                          pprPrecLam prec [v] e1
     TyLam tv e1     -> annotate (AnnContext $ TyLamBody tv) <$>

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -51,12 +51,13 @@ where
 import           Data.Coerce               (coerce)
 import           Data.Text.Prettyprint.Doc
 import qualified Data.List                 as List
+import           Data.Ord                  (comparing)
 
 import           Clash.Core.FreeVars
   (noFreeVarsOfType, localFVsOfTerms, tyFVsOfTypes)
 import           Clash.Core.Pretty         (ppr, fromPpr)
 import           Clash.Core.Term
-  (LetBinding, Pat (..), Term (..), TickInfo (..))
+  (LetBinding, Pat (..), Term (..), TickInfo (..), PrimInfo(primName))
 import           Clash.Core.Type           (Type (..))
 import           Clash.Core.VarEnv
 import           Clash.Core.Var            (Id, Var (..), TyVar, isGlobalId)
@@ -733,7 +734,7 @@ acmpTerm' inScope = go (mkRnEnv inScope)
   go env (Var id1) (Var id2)   = compare (rnOccLId env id1) (rnOccRId env id2)
   go _   (Data dc1) (Data dc2) = compare dc1 dc2
   go _   (Literal l1) (Literal l2) = compare l1 l2
-  go _   (Prim p1 _) (Prim p2 _) = compare p1 p2
+  go _   (Prim p1) (Prim p2) = comparing primName p1 p2
   go env (Lam b1 e1) (Lam b2 e2) =
     acmpType' env (varType b1) (varType b2) `thenCompare`
     go (rnTmBndr env b1 b2) e1 e2

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -53,7 +53,7 @@ data Term
   = Var     !Id                             -- ^ Variable reference
   | Data    !DataCon                        -- ^ Datatype constructor
   | Literal !Literal                        -- ^ Literal
-  | Prim    !Text !PrimInfo                 -- ^ Primitive
+  | Prim    !PrimInfo                       -- ^ Primitive
   | Lam     !Id Term                        -- ^ Term-abstraction
   | TyLam   !TyVar Term                     -- ^ Type-abstraction
   | App     !Term !Term                     -- ^ Application
@@ -90,12 +90,11 @@ data NameMod
   -- ^ @Clash.Magic.setName@
   deriving (Eq,Show,Generic,NFData,Hashable,Binary)
 
-data PrimInfo
-  = PrimInfo
-  { primType     :: !Type
+data PrimInfo = PrimInfo
+  { primName     :: !Text
+  , primType     :: !Type
   , primWorkInfo :: !WorkInfo
-  }
-  deriving (Show,Generic,NFData,Hashable,Binary)
+  } deriving (Show,Generic,NFData,Hashable,Binary)
 
 data WorkInfo
   = WorkConstant
@@ -232,8 +231,8 @@ primArg
   -- ^ If @Term@ was a primitive: (name of primitive, #type args, #term args)
 primArg (collectArgs -> t) =
   case t of
-    (Prim nm _, args) ->
-      Just (nm, length (rights args), length (lefts args))
+    (Prim p, args) ->
+      Just (primName p, length (rights args), length (lefts args))
     _ ->
       Nothing
 
@@ -254,7 +253,7 @@ walkTerm f = catMaybes . DList.toList . go
     Var _ -> mempty
     Data _ -> mempty
     Literal _ -> mempty
-    Prim _ _ -> mempty
+    Prim _ -> mempty
     Lam _ t1 -> go t1
     TyLam _ t1 -> go t1
     App t1 t2 -> go t1 <> go t2
@@ -275,7 +274,7 @@ collectTermIds = concat . walkTerm (Just . go)
   go (Case _ _ alts) = concatMap (pat . fst) alts
   go (Data _) = []
   go (Literal _) = []
-  go (Prim _ _) = []
+  go (Prim _) = []
   go (TyLam _ _) = []
   go (App _ _) = []
   go (TyApp _ _) = []

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -278,7 +278,7 @@ termType m e = case e of
   Var t          -> varType t
   Data dc        -> dcType dc
   Literal l      -> literalType l
-  Prim _ t       -> primType t
+  Prim t         -> primType t
   Lam v e'       -> mkFunTy (varType v) (termType m e')
   TyLam tv e'    -> ForAllTy tv (termType m e')
   App _ _        -> case collectArgs e of
@@ -899,13 +899,13 @@ dataConInstArgTys (MkData { dcArgTys, dcUnivTyVars, dcExtTyVars }) inst_tys =
 primCo
   :: Type
   -> Term
-primCo ty = Prim "_CO_" (PrimInfo ty WorkNever)
+primCo ty = Prim (PrimInfo "_CO_" ty WorkNever)
 
 -- | Make an undefined term
 undefinedTm
   :: Type
   -> Term
-undefinedTm = TyApp (Prim "Clash.Transformations.undefined" (PrimInfo undefinedTy WorkNever))
+undefinedTm = TyApp (Prim (PrimInfo "Clash.Transformations.undefined" undefinedTy WorkNever))
 
 substArgTys
   :: DataCon

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -64,7 +64,7 @@ import           Clash.Annotations.BitRepresentation.Internal
 import           Clash.Annotations.TopEntity      (TopEntity (..))
 import           Clash.Annotations.TopEntity.Extra ()
 import           Clash.Backend
-import           Clash.Core.Evaluator             (PrimEvaluator)
+import           Clash.Core.Evaluator.Types       (PrimStep, PrimUnwind)
 import           Clash.Core.Name                  (Name (..))
 import           Clash.Core.Term                  (Term)
 import           Clash.Core.Type                  (Type)
@@ -107,7 +107,7 @@ generateHDL
   -> (CustomReprs -> TyConMap -> Type ->
       State HWMap (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
-  -> PrimEvaluator
+  -> (PrimStep, PrimUnwind)
   -- ^ Hardcoded evaluator (delta-reduction)
   -> [( Id
       , Maybe TopEntity
@@ -680,7 +680,7 @@ normalizeEntity
   -> (CustomReprs -> TyConMap -> Type ->
       State HWMap (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
-  -> PrimEvaluator
+  -> (PrimStep, PrimUnwind)
   -- ^ Hardcoded evaluator (delta-reduction)
   -> [Id]
   -- ^ TopEntities

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -55,7 +55,7 @@ import           Clash.Core.Literal               (Literal (..))
 import           Clash.Core.Name                  (Name(..))
 import           Clash.Core.Pretty                (showPpr)
 import           Clash.Core.Term
-  (Alt, Pat (..), Term (..), TickInfo (..), collectArgs, collectArgsTicks, collectTicks)
+  (Alt, Pat (..), Term (..), TickInfo (..), PrimInfo(primName), collectArgs, collectArgsTicks, collectTicks)
 import qualified Clash.Core.Term                  as Core
 import           Clash.Core.Type
   (Type (..), coreView1, splitFunTys, splitCoreFunForallTy)
@@ -297,11 +297,11 @@ mkNetDecl (id_,tm) = preserveVarEnv $ do
       case iteAlts scrutHTy alts0 of
         Just _ | ite -> return Wire
         _ -> return Reg
-    termToWireOrReg (collectArgs -> (Prim nm' _,_)) = do
-      bbM <- HashMap.lookup nm' <$> Lens.use primitives
+    termToWireOrReg (collectArgs -> (Prim p,_)) = do
+      bbM <- HashMap.lookup (primName p) <$> Lens.use primitives
       case bbM of
         Just (extractPrim -> Just BlackBox {..}) | outputReg -> return Reg
-        _ | nm' == "Clash.Explicit.SimIO.mealyIO" -> return Reg
+        _ | primName p == "Clash.Explicit.SimIO.mealyIO" -> return Reg
         _ -> return Wire
     termToWireOrReg _ = return Wire
 
@@ -313,7 +313,7 @@ mkNetDecl (id_,tm) = preserveVarEnv $ do
     getResInit
       :: (Id,Term) -> NetlistMonad (Maybe Expr)
     getResInit (i,collectArgsTicks -> (k,args,ticks)) = case k of
-      Prim pNm _ -> extractPrimWarnOrFail pNm >>= go pNm
+      Prim p -> extractPrimWarnOrFail (primName p) >>= go (primName p)
       _ -> return Nothing
      where
       go pNm (BlackBox {resultInit = Just nmD}) = withTicks ticks $ \_ -> do
@@ -688,7 +688,7 @@ mkExpr bbEasD declType bndr app =
   let hwTyA = head hwTys
   case appF of
     Data dc -> mkDcApplication hwTys bndr dc tmArgs
-    Prim nm pinfo -> mkPrimitive False bbEasD bndr (nm,pinfo) args tickDecls
+    Prim pInfo -> mkPrimitive False bbEasD bndr pInfo args tickDecls
     Var f
       | null tmArgs ->
           if isVoid hwTyA then

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -186,7 +186,7 @@ prepareBlackBox _pNm templ bbCtx =
 isLiteral :: Term -> Bool
 isLiteral e = case collectArgs e of
   (Data _, args)   -> all (either isLiteral (const True)) args
-  (Prim _ _, args) -> all (either isLiteral (const True)) args
+  (Prim _, args) -> all (either isLiteral (const True)) args
   (C.Literal _,_)  -> True
   _                -> False
 
@@ -205,9 +205,9 @@ mkArgument bndr e = do
     let eTyMsg = "(" ++ showPpr e ++ " :: " ++ showPpr ty ++ ")"
     ((e',t,l),d) <- case hwTyM of
       Nothing
-        | (Prim nm _,_) <- collectArgs e
-        , nm == "Clash.Transformations.removedArg"
-        -> return ((Identifier nm Nothing, Void Nothing, False),[])
+        | (Prim p,_) <- collectArgs e
+        , primName p == "Clash.Transformations.removedArg"
+        -> return ((Identifier (primName p) Nothing, Void Nothing, False),[])
         | otherwise
         -> return ((error ($(curLoc) ++ "Forced to evaluate untranslatable type: " ++ eTyMsg), Void Nothing, False), [])
       Just hwTy -> case collectArgsTicks e of
@@ -228,8 +228,8 @@ mkArgument bndr e = do
           return ((N.Literal (Just (Unsigned 64,64)) (N.NumLit i),hwTy,True),[])
         (C.Literal (NaturalLiteral n), [],_) ->
           return ((N.Literal (Just (Unsigned iw,iw)) (N.NumLit n),hwTy,True),[])
-        (Prim f pinfo,args,ticks) -> withTicks ticks $ \tickDecls -> do
-          (e',d) <- mkPrimitive True False (NetlistId bndr ty) (f,pinfo) args tickDecls
+        (Prim pinfo,args,ticks) -> withTicks ticks $ \tickDecls -> do
+          (e',d) <- mkPrimitive True False (NetlistId bndr ty) pinfo args tickDecls
           case e' of
             (Identifier _ _) -> return ((e',hwTy,False), d)
             _                -> return ((e',hwTy,isLiteral e), d)
@@ -311,15 +311,15 @@ mkPrimitive
   -- ^ Treat BlackBox expression as declaration
   -> NetlistId
   -- ^ Id to assign the result to
-  -> (TextS.Text, PrimInfo)
-  -- ^ Name and info of primitive
+  -> PrimInfo
+  -- ^ Primitive info
   -> [Either Term Type]
   -- ^ Arguments
   -> [Declaration]
   -- ^ Tick declarations
   -> NetlistMonad (Expr,[Declaration])
-mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
-  go =<< extractPrimWarnOrFail nm
+mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
+  go =<< extractPrimWarnOrFail (primName pInfo)
   where
     ty = head (netlistTypes dst)
 
@@ -329,7 +329,7 @@ mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
     go =
       \case
         P.BlackBoxHaskell bbName wf funcName (_fHash, func) -> do
-          bbFunRes <- func bbEasD nm args ty
+          bbFunRes <- func bbEasD (primName pInfo) args ty
           case bbFunRes of
             Left err -> do
               -- Blackbox template function returned an error:
@@ -353,7 +353,7 @@ mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
               resM <- resBndr1 True dst
               case resM of
                 Just (dst',dstNm,dstDecl) -> do
-                  (bbCtx,ctxDcls)   <- mkBlackBoxContext nm dst' args
+                  (bbCtx,ctxDcls)   <- mkBlackBoxContext (primName pInfo) dst' args
                   (templ,templDecl) <- prepareBlackBox pNm tempD bbCtx
                   let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                            (includes p) templ bbCtx
@@ -362,7 +362,7 @@ mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
                 -- Render declarations as a Noop when requested
                 Nothing | RenderVoid <- renderVoid p -> do
                   let dst1 = mkLocalId ty (mkUnsafeSystemName "__VOID_TDECL_NOOP__" 0)
-                  (bbCtx,ctxDcls) <- mkBlackBoxContext nm dst1 args
+                  (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) dst1 args
                   (templ,templDecl) <- prepareBlackBox pNm tempD bbCtx
                   let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                            (includes p) templ bbCtx
@@ -378,7 +378,7 @@ mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
                   resM <- resBndr1 True dst
                   case resM of
                     Just (dst',dstNm,dstDecl) -> do
-                      (bbCtx,ctxDcls)     <- mkBlackBoxContext nm dst' args
+                      (bbCtx,ctxDcls)     <- mkBlackBoxContext (primName pInfo) dst' args
                       (bbTempl,templDecl) <- prepareBlackBox pNm tempE bbCtx
                       let tmpAssgn = Assignment dstNm
                                         (BlackBoxE pNm (libraries p) (imports p)
@@ -389,7 +389,7 @@ mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
                     -- Render expression as a Noop when requested
                     Nothing | RenderVoid <- renderVoid p -> do
                       let dst1 = mkLocalId ty (mkUnsafeSystemName "__VOID_TEXPRD_NOOP__" 0)
-                      (bbCtx,ctxDcls) <- mkBlackBoxContext nm dst1 args
+                      (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) dst1 args
                       (templ,templDecl) <- prepareBlackBox pNm tempE bbCtx
                       let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                                (includes p) templ bbCtx
@@ -401,9 +401,9 @@ mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
                   resM <- resBndr1 False dst
                   case resM of
                     Just (dst',_,_) -> do
-                      (bbCtx,ctxDcls)      <- mkBlackBoxContext nm dst' args
+                      (bbCtx,ctxDcls)      <- mkBlackBoxContext (primName pInfo) dst' args
                       (bbTempl,templDecl0) <- prepareBlackBox pNm tempE bbCtx
-                      let templDecl1 = case nm of
+                      let templDecl1 = case primName pInfo of
                             "Clash.Sized.Internal.BitVector.fromInteger#"
                               | [N.Literal _ (NumLit _), N.Literal _ _, N.Literal _ _] <- extractLiterals bbCtx -> []
                             "Clash.Sized.Internal.BitVector.fromInteger##"
@@ -419,7 +419,7 @@ mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
                     -- Render expression as a Noop when requested
                     Nothing | RenderVoid <- renderVoid p -> do
                       let dst1 = mkLocalId ty (mkUnsafeSystemName "__VOID_TEXPRE_NOOP__" 0)
-                      (bbCtx,ctxDcls) <- mkBlackBoxContext nm dst1 args
+                      (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) dst1 args
                       (templ,templDecl) <- prepareBlackBox pNm tempE bbCtx
                       let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                                (includes p) templ bbCtx
@@ -577,7 +577,7 @@ mkPrimitive bbEParen bbEasD dst (nm,pinfo) args tickDecls =
               -- TODO: check that it's okay to use `mkUnsafeInternalName`
               let nm3 = mkUnsafeSystemName nm2 0
                   id_ = mkLocalId ty nm3
-              idDeclM <- mkNetDecl (id_,mkApps (Prim nm pinfo) args)
+              idDeclM <- mkNetDecl (id_,mkApps (Prim pInfo) args)
               case idDeclM of
                 Nothing     -> return Nothing
                 Just idDecl -> return (Just ([id_],[nm2],[idDecl]))
@@ -763,8 +763,8 @@ collectBindIO dst (m:Lam x q@(Lam _ e):_) = do
         _ -> error "internal error"
     _ -> case e of
       Letrec {} -> error "internal error"
-      (collectArgs -> (Prim nm _,args))
-        | nm == "Clash.Explicit.SimIO.bindSimIO#" -> do
+      (collectArgs -> (Prim p,args))
+        | primName p == "Clash.Explicit.SimIO.bindSimIO#" -> do
             (expr,ds1) <- collectBindIO dst (lefts args)
             return (expr, ds0 ++ ds1)
       _ -> do
@@ -793,11 +793,11 @@ collectBindIO _ es = error ("internal error:\n" ++ showPpr es)
 -- | Collect the sequential declarations for 'appIO'
 collectAppIO :: NetlistId -> [Term] -> [Term] -> NetlistMonad (Expr,[Declaration])
 collectAppIO dst (fun1:arg1:_) rest = case collectArgs fun1 of
-  (Prim "Clash.Explicit.SimIO.fmapSimIO#" _,(lefts -> (fun0:arg0:_))) -> do
+  (Prim (PrimInfo "Clash.Explicit.SimIO.fmapSimIO#" _ _),(lefts -> (fun0:arg0:_))) -> do
     tcm <- Lens.use tcCache
     let argN = map (Left . unSimIO tcm) (arg0:arg1:rest)
     mkExpr False Sequential dst (mkApps fun0 argN)
-  (Prim "Clash.Explicit.SimIO.apSimIO#" _,(lefts -> args)) -> do
+  (Prim (PrimInfo "Clash.Explicit.SimIO.apSimIO#" _ _),(lefts -> args)) -> do
     collectAppIO dst args (arg1:rest)
   _ -> error ("internal error:\n" ++ showPpr (fun1:arg1:rest))
 
@@ -817,8 +817,7 @@ unSimIO tcm arg =
   let argTy = termType tcm arg
   in  case tyView argTy of
         TyConApp _ [tcArg] ->
-          mkApps (Prim "Clash.Explicit.SimIO.unSimIO#"
-                       (PrimInfo (mkFunTy argTy tcArg) WorkNever))
+          mkApps (Prim (PrimInfo "Clash.Explicit.SimIO.unSimIO#" (mkFunTy argTy tcArg) WorkNever))
                  [Left arg]
         _ -> error ("internal error:\n" ++ showPpr arg)
 
@@ -847,11 +846,11 @@ mkFunInput resId e =
   -- TODO: generates strings that are later parsed/interpreted again. Silly!
   (bbCtx,dcls) <- mkBlackBoxContext "__INTERNAL__" resId args
   templ <- case appE of
-            Prim nm _ -> do
-              bb  <- extractPrimWarnOrFail nm
+            Prim p -> do
+              bb  <- extractPrimWarnOrFail (primName p)
               case bb of
                 P.BlackBox {..} ->
-                  pure (Left (kind,outputReg,libraries,imports,includes,nm,template))
+                  pure (Left (kind,outputReg,libraries,imports,includes,primName p,template))
                 P.Primitive pn _ pt ->
                   error $ $(curLoc) ++ "Unexpected blackbox type: "
                                     ++ "Primitive " ++ show pn

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -68,7 +68,7 @@ import           Clash.Core.Subst
    extendInScopeIdList, mkSubst, substTm)
 import           Clash.Core.Term
   (Alt, LetBinding, Pat (..), Term (..), TickInfo (..), NameMod (..),
-   collectArgsTicks, collectTicks)
+   collectArgsTicks, collectTicks, PrimInfo(primName))
 import           Clash.Core.TyCon
   (TyConName, TyConMap, tyConDataCons)
 import           Clash.Core.Type         (Type (..), TypeView (..),
@@ -732,7 +732,7 @@ setBinderName
   -- ^ The binding
   -> NetlistMonad ((Id, Subst, [(Id,Term)]),Id)
 setBinderName subst res resRead m@(resN,_,_) (i,collectArgsTicks -> (k,args,ticks)) = case k of
-  Prim nm _ -> extractPrimWarnOrFail nm >>= go nm
+  Prim p -> let nm = primName p in extractPrimWarnOrFail nm >>= go nm
   _ -> goDef
  where
   go nm (BlackBox {resultName = Just (BBTemplate nmD)}) = withTicks ticks $ \_ -> do

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -41,7 +41,7 @@ import           SrcLoc                           (SrcSpan,noSrcSpan)
 
 import           Clash.Annotations.BitRepresentation.Internal
   (CustomReprs)
-import           Clash.Core.Evaluator             (PrimEvaluator)
+import           Clash.Core.Evaluator.Types       (PrimStep, PrimUnwind)
 import           Clash.Core.FreeVars
   (freeLocalIds, globalIds, globalIdOccursIn, localIdDoesNotOccurIn)
 import           Clash.Core.Name (nameOcc) -- TODO
@@ -96,7 +96,7 @@ runNormalization
   -- ^ TyCon cache
   -> IntMap TyConName
   -- ^ Tuple TyCon cache
-  -> PrimEvaluator
+  -> (PrimStep, PrimUnwind)
   -- ^ Hardcoded evaluator (delta-reduction)
   -> CompiledPrimMap
   -- ^ Primitive Definitions

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -139,12 +139,12 @@ collectGlobals' inScope substitution seen e@(collectArgsTicks -> (fun, args@(_:_
   | not eIsconstant = do
     tcm <- Lens.view tcCache
     bndrs <- Lens.use bindings
-    primEval <- Lens.view evaluator
+    (primEval, primUnwind) <- Lens.view evaluator
     gh <- Lens.use globalHeap
     ids <- Lens.use uniqSupply
     let (ids1,ids2) = splitSupply ids
     uniqSupply Lens..= ids2
-    let eval = (Lens.view Lens._3) . whnf' primEval bndrs tcm gh ids1 inScope False
+    let eval = (Lens.view Lens._3) . whnf' primEval primUnwind bndrs tcm gh ids1 inScope False
         eTy  = termType tcm e
     untran <- isUntranslatableType False eTy
     case untran of

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -450,10 +450,10 @@ interestingToLift inScope _ e@(Var v) _ ticks =
   if NoDeDup `notElem` ticks && (isGlobalId v ||  v `elemInScopeSet` inScope)
      then pure (Just e)
      else pure Nothing
-interestingToLift inScope eval e@(Prim nm pInfo) args ticks
+interestingToLift inScope eval e@(Prim pInfo) args ticks
   | NoDeDup `notElem` ticks = do
   let anyArgNotConstant = any (not . isConstant) lArgs
-  case List.lookup nm interestingPrims of
+  case List.lookup (primName pInfo) interestingPrims of
     Just t | t || anyArgNotConstant -> pure (Just e)
     _ | DeDup `elem` ticks -> pure (Just e)
     _ -> do
@@ -512,12 +512,12 @@ interestingToLift inScope eval e@(Prim nm pInfo) args ticks
     termIsPow2 e' = case eval e' of
       Literal (IntegerLiteral n) -> isPow2 n
       a -> case collectArgs a of
-        (Prim nm' _,[Right _,Left _,Left (Literal (IntegerLiteral n))])
-          | isFromInteger nm' -> isPow2 n
-        (Prim nm' _,[Right _,Left _,Left _,Left (Literal (IntegerLiteral n))])
-          | nm' == "Clash.Sized.Internal.BitVector.fromInteger#"  -> isPow2 n
-        (Prim nm' _,[Right _,       Left _,Left (Literal (IntegerLiteral n))])
-          | nm' == "Clash.Sized.Internal.BitVector.fromInteger##" -> isPow2 n
+        (Prim p,[Right _,Left _,Left (Literal (IntegerLiteral n))])
+          | isFromInteger (primName p) -> isPow2 n
+        (Prim p,[Right _,Left _,Left _,Left (Literal (IntegerLiteral n))])
+          | primName p == "Clash.Sized.Internal.BitVector.fromInteger#"  -> isPow2 n
+        (Prim p,[Right _,       Left _,Left (Literal (IntegerLiteral n))])
+          | primName p == "Clash.Sized.Internal.BitVector.fromInteger##" -> isPow2 n
 
         _ -> False
 

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -212,8 +212,7 @@ reduceImap (TransformContext is0 ctx) n argElTy resElTy fun arg = do
                                                (mkTyConApp idxTcNm
                                                            [VarTy nTv])
                                                [integerPrimTy,integerPrimTy])
-            idxFromInteger   = Prim "Clash.Sized.Internal.Index.fromInteger#"
-                                    (PrimInfo idxFromIntegerTy WorkNever)
+            idxFromInteger   = Prim (PrimInfo "Clash.Sized.Internal.Index.fromInteger#" idxFromIntegerTy WorkNever)
             idxs             = map (App (App (TyApp idxFromInteger (LitTy (NumTy n)))
                                              (Literal (IntegerLiteral (toInteger n))))
                                    . Literal . IntegerLiteral . toInteger) [0..(n-1)]
@@ -778,8 +777,7 @@ reduceReplace_int is0 n aTy vTy v i newA = do
     -> Type
     -> Term
   eqIntPrim intTy boolTy =
-    Prim "Clash.Transformations.eqInt"
-         (PrimInfo (mkFunTy intTy (mkFunTy intTy boolTy)) WorkVariable)
+    Prim (PrimInfo "Clash.Transformations.eqInt" (mkFunTy intTy (mkFunTy intTy boolTy)) WorkVariable)
 
   go tcm (coreView1 tcm -> Just ty') = go tcm ty'
   go tcm (tyView -> TyConApp vecTcNm _)
@@ -879,8 +877,7 @@ reduceIndex_int is0 n aTy v i = do
     -> Type
     -> Term
   eqIntPrim intTy boolTy =
-    Prim "Clash.Transformations.eqInt"
-         (PrimInfo (mkFunTy intTy (mkFunTy intTy boolTy)) WorkVariable)
+    Prim (PrimInfo "Clash.Transformations.eqInt" (mkFunTy intTy (mkFunTy intTy boolTy)) WorkVariable)
 
   go tcm (coreView1 tcm -> Just ty') = go tcm ty'
   go tcm (tyView -> TyConApp vecTcNm _)

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -296,17 +296,17 @@ constantSpecInfo ctx e = do
   -- primitive's workinfo.
   if isClockOrReset tcm (termType tcm e) then
     case collectArgs e of
-      (Prim "Clash.Transformations.removedArg" _, _) ->
-        pure (constantCsr e)
-      _ -> do
-        bindCsr ctx e
+      (Prim p, _) 
+        | primName p == "Clash.Transformations.removedArg" ->
+          pure (constantCsr e)
+      _ -> bindCsr ctx e
   else
     case collectArgsTicks e of
       (dc@(Data _), args, ticks) ->
         mergeCsrs ctx ticks e (mkApps dc) args
 
       -- TODO: Work with prim's WorkInfo?
-      (prim@(Prim _ _), args, ticks) -> do
+      (prim@(Prim _), args, ticks) -> do
         csr <- mergeCsrs ctx ticks e (mkApps prim) args
         if null (csrNewBindings csr) then
           pure csr
@@ -466,7 +466,7 @@ removedTm
   :: Type
   -> Term
 removedTm =
-  TyApp (Prim "Clash.Transformations.removedArg" (PrimInfo undefinedTy WorkNever))
+  TyApp (Prim (PrimInfo "Clash.Transformations.removedArg" undefinedTy WorkNever))
 
 -- | A tick to prefix an inlined expression with it's original name.
 -- For example, given

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -35,7 +35,7 @@ import Data.Monoid                           (Any)
 import qualified Data.Set                    as Set
 import GHC.Generics
 
-import Clash.Core.Evaluator      (GlobalHeap, PrimEvaluator)
+import Clash.Core.Evaluator.Types      (PrimHeap, PrimStep, PrimUnwind)
 import Clash.Core.Term           (Term, Context)
 import Clash.Core.Type           (Type)
 import Clash.Core.TyCon          (TyConName, TyConMap)
@@ -75,7 +75,7 @@ data RewriteState extra
   -- ^ Function which is currently normalized
   , _nameCounter      :: {-# UNPACK #-} !Int
   -- ^ Used for 'Fresh'
-  , _globalHeap       :: GlobalHeap
+  , _globalHeap       :: PrimHeap
   -- ^ Used as a heap for compile-time evaluation of primitives that live in I/O
   , _extra            :: !extra
   -- ^ Additional state
@@ -100,7 +100,7 @@ data RewriteEnv
   -- ^ TyCon cache
   , _tupleTcCache   :: IntMap TyConName
   -- ^ Tuple TyCon cache
-  , _evaluator      :: PrimEvaluator
+  , _evaluator      :: (PrimStep, PrimUnwind)
   -- ^ Hardcoded evaluator (delta-reduction)}
   , _topEntities    :: VarSet
   -- ^ Functions that are considered TopEntities

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -32,7 +32,7 @@ import           Clash.Core.Type
 import           Clash.Core.Var
 import           Clash.Driver as Driver
 import           Clash.Driver.Types
-import           Clash.GHC.Evaluator (reduceConstant)
+import           Clash.GHC.Evaluator
 import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.Netlist
@@ -99,7 +99,7 @@ runToNetlistStage target f src = do
   supplyN <- Supply.newSupply
 
   let transformedBindings = normalizeEntity reprs bm pm tcm tupTcm typeTrans
-          reduceConstant teNames opts supplyN te
+          primEvaluator teNames opts supplyN te
 
   fmap (force . fst) $ netlistFrom (transformedBindings, tcm, tes, pm, reprs, te)
  where


### PR DESCRIPTION
Putting up for review now because the tidying in prep of changing the partial evaluator ended up being more involved than I was expecting. In short

  * the primitive evaluator is no longer so tightly coupled to the generic evaluator. Some coupling still remains, but only in `scrutinise`

  * the evaluator now has more descriptive type names and definitions. This makes it easier to skim a definition and understand how it relates to evaluation

A new PR will be created for the actual feature, and the issue will remain open.