### PR TITLE
Don't build clash-cosim with stack

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,3 @@ packages:
 - clash-lib
 - clash-ghc
 # - testsuite # still uses cabal new-build internally
-
-extra-deps:
-- ./clash-cosim


### PR DESCRIPTION
clash-cosim cannot be build on windows, and since stack is the recommended install path for windows, we should not try to build it.