### PR TITLE
Literals of Fixed saturate correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Closed
   * [#960](https://github.com/clash-lang/clash-compiler/issues/626): Blackbox Error Caused by Simple map
   * [#1012](https://github.com/clash-lang/clash-compiler/issues/1012): Case-let doesn't look through ticks
   * [#430](https://github.com/clash-lang/clash-compiler/issues/430): Issue warning when not compiled with `executable-dynamic: True`
+  * [#374](https://github.com/clash-lang/clash-compiler/issues/1012): Clash.Sized.Fixed: fromInteger and fromRational don't saturate correctly
 
 * Fixes without issue reports:
   * Fix bug in `rnfX` defined for `Down` ([baef30e](https://github.com/clash-lang/clash-compiler/commit/baef30eae03dc02ba847ffbb8fae7f365c5287c2))


### PR DESCRIPTION
Needs `-XNegativeLiterals` to fully saturate to `minBound`, because without that extension `-42` is desugared to `negate (fromInteger 42)`, and `-42.0` is desugared to `negate (fromRational (42 % 1))`. Which means it's first saturated to the upper bound and then negated.

Fixes #374