### PR TITLE
Generate qsys files for altpll and alterapll

### DIFF
--- a/clash-lib/prims/common/Clash_Intel_ClockGen.json
+++ b/clash-lib/prims/common/Clash_Intel_ClockGen.json
@@ -2,6 +2,12 @@
     { "name"      : "Clash.Intel.ClockGen.altpll"
     , "workInfo"  : "Always"
     , "kind"      : "Declaration"
+    , "includes"  : [ {"extension": "qsys"
+                      ,"name": "altpll"
+                      ,"format": "Haskell"
+                      ,"templateFunction": "Clash.Primitives.Intel.ClockGen.altpllQsysTF"
+                      }
+                    ]
     , "format"    : "Haskell"
     , "templateFunction" : "Clash.Primitives.Intel.ClockGen.altpllTF"
     }
@@ -10,6 +16,12 @@
     { "name"      : "Clash.Intel.ClockGen.alteraPll"
     , "workInfo"  : "Always"
     , "kind"      : "Declaration"
+    , "includes"  : [ {"extension": "qsys"
+                      ,"name": "altera_pll"
+                      ,"format": "Haskell"
+                      ,"templateFunction": "Clash.Primitives.Intel.ClockGen.alteraPllQsysTF"
+                      }
+                    ]
     , "format"    : "Haskell"
     , "templateFunction" : "Clash.Primitives.Intel.ClockGen.alteraPllTF"
     }

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -54,16 +54,10 @@ import           Clash.Netlist.Types             (BlackBoxContext (..),
                                                   Modifier (..),
                                                   Declaration(BlackBoxD))
 import qualified Clash.Netlist.Types             as N
-import           Clash.Netlist.Util              (typeSize, isVoid)
+import           Clash.Netlist.Util              (typeSize, isVoid, stripVoid)
 import           Clash.Signal.Internal
   (ResetKind(..), ResetPolarity(..), InitBehavior(..))
 import           Clash.Util
-
--- | Strip as many "Void" layers as possible. Might still return a Void if the
--- void doesn't contain a hwtype.
-stripVoid :: HWType -> HWType
-stripVoid (Void (Just e)) = stripVoid e
-stripVoid e = e
 
 inputHole :: Element -> Maybe Int
 inputHole = \case

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -7,6 +7,8 @@
 -}
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Clash.Primitives.Intel.ClockGen where
 
@@ -14,10 +16,12 @@ import Clash.Backend
 import Clash.Netlist.BlackBox.Util
 import Clash.Netlist.Id
 import Clash.Netlist.Types
+import Clash.Netlist.Util hiding (mkUniqueIdentifier)
 
 import Control.Monad.State
 
 import Data.Semigroup.Monad
+import qualified Data.String.Interpolate.IsString as I
 import Data.Text.Prettyprint.Doc.Extra
 
 import qualified Data.Text as TextS
@@ -25,9 +29,20 @@ import qualified Data.Text as TextS
 altpllTF :: TemplateFunction
 altpllTF = TemplateFunction used valid altpllTemplate
  where
-  used         = [0,1,2]
+  used         = [0..4]
   valid bbCtx
-    | [(nm,_,_),_,_] <- bbInputs bbCtx
+    | [_,_,(nm,_,_),_,_] <- bbInputs bbCtx
+    , Just _ <- exprToString nm
+    , (Identifier _ Nothing,Product {}) <- bbResult bbCtx
+    = True
+  valid _ = False
+
+altpllQsysTF :: TemplateFunction
+altpllQsysTF = TemplateFunction used valid altpllQsysTemplate
+ where
+  used = [0..4]
+  valid bbCtx
+    | [_,_,(nm,_,_),_,_] <- bbInputs bbCtx
     , Just _ <- exprToString nm
     , (Identifier _ Nothing,Product {}) <- bbResult bbCtx
     = True
@@ -36,11 +51,20 @@ altpllTF = TemplateFunction used valid altpllTemplate
 alteraPllTF :: TemplateFunction
 alteraPllTF = TemplateFunction used valid alteraPllTemplate
  where
-  used         = [1,2,3]
+  used         = [1..20]
   valid bbCtx
-    | [_,(nm,_,_),_,_] <- bbInputs bbCtx
+    | ((nm,_,_):_) <- drop 3 (bbInputs bbCtx)
     , Just _ <- exprToString nm
-    , (Identifier _ Nothing,Product {}) <- bbResult bbCtx
+    = True
+  valid _ = False
+
+alteraPllQsysTF :: TemplateFunction
+alteraPllQsysTF = TemplateFunction used valid alteraPllQsysTemplate
+ where
+  used  = [1..20]
+  valid bbCtx
+    | ((nm,_,_):_) <- drop 3 (bbInputs bbCtx)
+    , Just _ <- exprToString nm
     = True
   valid _ = False
 
@@ -52,8 +76,8 @@ alteraPllTemplate bbCtx = do
  let mkId = mkUniqueIdentifier Basic
  locked <- mkId "locked"
  pllLock <- mkId "pllLock"
- alteraPll <- mkId "alteraPll"
- alteraPll_inst <- mkId "alterPll_inst"
+ alteraPll <- mkId "altera_pll_block"
+ alteraPll_inst <- mkId instname0
 
  clocks <- traverse (mkUniqueIdentifier Extended)
                     [TextS.pack ("pllOut" ++ show n) | n <- [0..length tys - 1]]
@@ -77,10 +101,11 @@ alteraPllTemplate bbCtx = do
    ]
   ]
  where
-  [_,(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = bbInputs bbCtx
-  (Identifier result Nothing,resTy@(Product _ _ (tail -> tys))) = bbResult bbCtx
+  (Identifier result Nothing,resTy@(Product _ _ (init -> tys))) = bbResult bbCtx
+  [(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = drop 3 (bbInputs bbCtx)
   Just nm' = exprToString nm
-  compName = TextS.pack nm'
+  instname0 = TextS.pack nm'
+  compName = head (bbQsysIncName bbCtx)
 
 altpllTemplate
   :: Backend s
@@ -91,14 +116,14 @@ altpllTemplate bbCtx = do
  pllOut <- mkId "pllOut"
  locked <- mkId "locked"
  pllLock <- mkId "pllLock"
- alteraPll <- mkId "altpll"
- alteraPll_inst <- mkId "altpll_inst"
+ alteraPll <- mkId "altpll_block"
+ alteraPll_inst <- mkId instname0
  getMon $ blockDecl alteraPll
   [ NetDecl Nothing locked  Bit
   , NetDecl' Nothing Reg pllLock (Right Bool) Nothing
   , NetDecl Nothing pllOut clkOutTy
   , InstDecl Comp Nothing compName alteraPll_inst []
-      [(Identifier "inclk0" Nothing,In,clkTy,clk)
+      [(Identifier "clk" Nothing,In,clkTy,clk)
       ,(Identifier "areset" Nothing,In,rstTy,rst)
       ,(Identifier "c0" Nothing,Out,clkOutTy,Identifier pllOut Nothing)
       ,(Identifier "locked" Nothing,Out,Bit,Identifier locked Nothing)]
@@ -111,8 +136,94 @@ altpllTemplate bbCtx = do
 
   ]
  where
-  [(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = bbInputs bbCtx
+  [_,_,(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = bbInputs bbCtx
   (Identifier result Nothing,resTy@(Product _ _ [clkOutTy,_])) = bbResult bbCtx
   Just nm' = exprToString nm
-  compName = TextS.pack nm'
+  instname0 = TextS.pack nm'
+  compName = head (bbQsysIncName bbCtx)
 
+
+altpllQsysTemplate
+  :: Backend s
+  => BlackBoxContext
+  -> State s Doc
+altpllQsysTemplate bbCtx = pure bbText
+ where
+  ((_,stripVoid -> kdIn,_):(_,stripVoid -> kdOut,_):_) = bbInputs bbCtx
+  KnownDomain _ clkInPeriod _ _ _ _ = kdIn
+  KnownDomain _ clkOutPeriod _ _ _ _ = kdOut
+  clkOutFreq :: Double
+  clkOutFreq = (1.0 / (fromInteger clkOutPeriod * 1.0e-12)) / 1e6
+  clklcm = lcm clkInPeriod clkOutPeriod
+  clkmult = clklcm `quot` clkOutPeriod
+  clkdiv = clklcm `quot` clkInPeriod
+  -- Note [QSys file templates]
+  -- This QSys file template was derived from a "full" QSys system with a single
+  -- "altpll" IP. Module parameters were then stripped on a trial-and-error
+  -- basis to get a template that has the minimal number of parameters, but
+  -- still has the desired, working, configuration.
+  bbText = [I.i|<?xml version="1.0" encoding="UTF-8"?>
+<system name="$${FILENAME}">
+  <module
+    name="altpll0"
+    kind="altpll"
+    enabled="1"
+    autoexport="1">
+  <parameter name="AVALON_USE_SEPARATE_SYSCLK" value="NO" />
+  <parameter name="BANDWIDTH" value="" />
+  <parameter name="BANDWIDTH_TYPE" value="AUTO" />
+  <parameter name="CLK0_DIVIDE_BY" value="#{clkdiv}" />
+  <parameter name="CLK0_DUTY_CYCLE" value="50" />
+  <parameter name="CLK0_MULTIPLY_BY" value="#{clkmult}" />
+  <parameter name="CLK0_PHASE_SHIFT" value="0" />
+  <parameter name="COMPENSATE_CLOCK" value="CLK0" />
+  <parameter name="INCLK0_INPUT_FREQUENCY" value="#{clkInPeriod}" />
+  <parameter name="OPERATION_MODE" value="NORMAL" />
+  <parameter name="PLL_TYPE" value="AUTO" />
+  <parameter name="PORT_ARESET" value="PORT_USED" />
+  <parameter name="PORT_INCLK0" value="PORT_USED" />
+  <parameter name="PORT_LOCKED" value="PORT_USED" />
+  <parameter name="PORT_clk0" value="PORT_USED" />
+  <parameter name="HIDDEN_IS_FIRST_EDIT" value="0" />
+  <parameter name="HIDDEN_PRIVATES">PT#EFF_OUTPUT_FREQ_VALUE0 #{clkOutFreq}</parameter>
+  </module>
+</system>|]
+
+alteraPllQsysTemplate
+  :: Backend s
+  => BlackBoxContext
+  -> State s Doc
+alteraPllQsysTemplate bbCtx = pure bbText
+ where
+  (_:(_,stripVoid -> kdIn,_):(_,stripVoid -> kdOutsProd,_):_) = bbInputs bbCtx
+  kdOuts = case kdOutsProd of
+    Product _ _ ps -> ps
+    KnownDomain {} -> [kdOutsProd]
+    _ -> error "internal error: not a Product or KnownDomain"
+
+  cklFreq (KnownDomain _ p _ _ _ _)
+    = (1.0 / (fromInteger p * 1.0e-12 :: Double)) / 1e6
+  cklFreq _ = error "internal error: not a KnownDomain"
+
+  clkOuts = TextS.unlines
+    [[I.i|<parameter name="gui_output_clock_frequency#{n}" value="#{f}"/>|]
+    | (n,f) <- zip [(0 :: Word)..] (map cklFreq kdOuts)
+    ]
+
+  -- See Note [QSys file templates] on how this qsys template was derived.
+  bbText = [I.i|<?xml version="1.0" encoding="UTF-8"?>
+<system name="$${FILENAME}">
+ <module
+    name="pll_0"
+    kind="altera_pll"
+    enabled="1"
+    autoexport="1">
+  <parameter name="gui_feedback_clock" value="Global Clock" />
+  <parameter name="gui_number_of_clocks" value="#{length kdOuts}" />
+  <parameter name="gui_operation_mode" value="direct" />
+  #{clkOuts}
+  <parameter name="gui_pll_mode" value="Integer-N PLL" />
+  <parameter name="gui_reference_clock_frequency" value="#{cklFreq kdIn}" />
+  <parameter name="gui_use_locked" value="true" />
+ </module>
+</system>|]

--- a/clash-prelude/src/Clash/Clocks.hs
+++ b/clash-prelude/src/Clash/Clocks.hs
@@ -7,18 +7,25 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 Generic clock related utilities.
 -}
 
+{-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 
-module Clash.Clocks (Clocks, clocks) where
+module Clash.Clocks (Clocks(..)) where
+
+import Data.Kind (Constraint)
 
 import Clash.Signal.Internal
 import Clash.Clocks.Deriving (deriveClocksInstances)
 
 class Clocks t where
+  type ClocksCxt t :: Constraint
+
   clocks
-    :: Clock domIn
+    :: (KnownDomain domIn, ClocksCxt t)
+    => Clock domIn
     -> Reset domIn
     -> t
 

--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -14,13 +14,15 @@ module Clash.Intel.ClockGen
   , alteraPll
   ) where
 
-import Clash.Clocks           (clocks, Clocks)
+import Clash.Clocks           (Clocks (..))
 import Clash.Promoted.Symbol  (SSymbol)
 import Clash.Signal.Internal
-  (Signal, Clock, Reset)
+  (Signal, Clock, Reset, KnownDomain (..))
 
 
 -- | A clock source that corresponds to the Intel/Quartus \"ALTPLL\" component
+-- (Arria GX, Arria II, Stratix IV, Stratix III, Stratix II, Stratix,
+--  Cyclone 10 LP, Cyclone IV, Cyclone III, Cyclone II, Cyclone)
 -- with settings to provide a stable 'Clock' from a single free-running input
 --
 -- Only works when configured with:
@@ -38,11 +40,11 @@ import Clash.Signal.Internal
 -- @
 altpll
   :: forall domOut domIn name
-   . SSymbol name
-  -- ^ Name of the component, must correspond to the name entered in the QSys
-  -- dialog.
+   . (KnownDomain domIn, KnownDomain domOut)
+  => SSymbol name
+  -- ^ Name of the component instance.
   --
-  -- For example, when you entered \"altPLL50\", instantiate as follows:
+  -- Instantiate as follows:
   --
   -- > SSymbol @"altPLL50"
   -> Clock domIn
@@ -51,12 +53,12 @@ altpll
   -- ^ Reset for the PLL
   -> (Clock domOut, Signal domOut Bool)
   -- ^ (Stable PLL clock, PLL lock)
-altpll !_ = clocks
+altpll !_ = knownDomain @domIn `seq` knownDomain @domOut `seq` clocks
 {-# NOINLINE altpll #-}
 
 -- | A clock source that corresponds to the Intel/Quartus \"Altera PLL\"
--- component with settings to provide a stable 'Clock' from a single
--- free-running input
+-- component (Arria V, Stratix V, Cyclone V) with settings to provide a stable
+-- 'Clock' from a single free-running input
 --
 -- Only works when configured with:
 --
@@ -80,12 +82,11 @@ altpll !_ = clocks
 --
 -- respectively.
 alteraPll
-  :: Clocks t
+  :: (Clocks t, KnownDomain domIn, ClocksCxt t)
   => SSymbol name
-  -- ^ Name of the component, must correspond to the name entered in the QSys
-  -- dialog.
+  -- ^ Name of the component instance.
   --
-  -- For example, when you entered \"alteraPLL50\", instantiate as follows:
+  -- Instantiate as follows:
   --
   -- > SSymbol @"alteraPLL50"
   -> Clock domIn


### PR DESCRIPTION
Fixes #545

Todo:

- [x] Infer speeds of incoming and outgoing clocks
- [x] Calculate the PLL divide/muliply settings from said speeds
- [x] Implement qsys generation for `alterapll`
- [x] Support size 3+ Constraint Tuples (only size 2 is supported so far)