### PR TITLE
Use TypeInType in Clash.Signal for GHC 8.4

### DIFF
--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -76,6 +76,10 @@ Check out 'IntelSystem' and 'XilinxSystem' too!
 
 {-# LANGUAGE Trustworthy #-}
 
+#if __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
+
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 


### PR DESCRIPTION
Makes sure we can compile with GHC 8.4.4 and `-f-multiple-hidden`.