### PR TITLE
Don't produce empty letrecs in inlineCleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@
   * [#990](https://github.com/clash-lang/clash-compiler/issues/990): Internal shadowing bug results in incorrect HDL
   * [#945](https://github.com/clash-lang/clash-compiler/issues/945): Rewrite rules for Vec Applicative Functor
   * [#919](https://github.com/clash-lang/clash-compiler/issues/919): Clash generating invalid Verilog after Vec operations #919
-Closed
   * [#996](https://github.com/clash-lang/clash-compiler/issues/996): Ambiguous clock when using `ClearOnReset` and `resetGen` together
   * [#701](https://github.com/clash-lang/clash-compiler/issues/701): Unexpected behaviour with the `Synthesize` annotation
   * [#694](https://github.com/clash-lang/clash-compiler/issues/694): Custom bit representation error only with VHDL
@@ -82,6 +81,7 @@ Closed
   * [#374](https://github.com/clash-lang/clash-compiler/issues/1012): Clash.Sized.Fixed: fromInteger and fromRational don't saturate correctly
   * [#836](https://github.com/clash-lang/clash-compiler/issues/836): Generate warning when `toInteger` blackbox drops MSBs
   * [#1019](https://github.com/clash-lang/clash-compiler/issues/1019): Clash breaks on constants defined in terms of `GHC.Natural.gcdNatural`
+  * [#1025](https://github.com/clash-lang/clash-compiler/issues/1025): `inlineCleanup`will not produce empty letrecs anymore
 
 * Fixes without issue reports:
   * Fix bug in `rnfX` defined for `Down` ([baef30e](https://github.com/clash-lang/clash-compiler/commit/baef30eae03dc02ba847ffbb8fae7f365c5287c2))

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -2297,8 +2297,10 @@ inlineCleanup (TransformContext is0 _) (Letrec binds body) = do
       bodyFVs       = Lens.foldMapOf freeLocalIds unitVarSet body
       (il,keep)     = List.partition (isInteresting allOccs prims bodyFVs) binds
       keep'         = inlineBndrs is1 keep il
-  if null il then return  (Letrec binds body)
-             else changed (Letrec keep' body)
+
+  if | null il -> return  (Letrec binds body)
+     | null keep' -> changed body
+     | otherwise -> changed (Letrec keep' body)
   where
     -- Determine whether a let-binding is interesting to inline
     isInteresting


### PR DESCRIPTION
Fixes #1025.