### PR TITLE
Check for EOL whitespace on CI

### DIFF
--- a/.ci/build_sdist.sh
+++ b/.ci/build_sdist.sh
@@ -21,7 +21,7 @@ SDIST=$(grep "Wrote tarball sdist to" -A 1 sdist.log | tail -n 1)
 # Extract location of documentation tarball
 DDIST=$(grep "Documentation tarball created:" -A 1 haddock.log | tail -n 1)
 
-# Copy 
+# Copy
 cd -
 cp $SDIST $(basename $SDIST)  # Example: clash-prelude-0.9999.tar.gz
 cp $DDIST $(basename $DDIST)  # Example: clash-prelude-0.9999-docs.tar.gz

--- a/.ci/publish_sdist.sh
+++ b/.ci/publish_sdist.sh
@@ -14,8 +14,8 @@ if [[ "$HACKAGE_RELEASE" == "yes" ]]; then
     cabal upload --publish --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST}
 elif [[ "$HACKAGE_RELEASE" == "no" ]]; then
     # Upload as release candidate
-    cabal upload --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST} 
-    cabal upload --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST} 
+    cabal upload --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST}
+    cabal upload --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST}
 else
     echo "Unrecognized \$HACAKGE_RELEASE: $HACAKGE_RELEASE"
     exit 1;

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-set -xeo pipefail
+set -xo pipefail
+
+egrep ' $' -n -r . --include=*.{hs,hs-boot,sh} --exclude-dir=dist-newstyle
+if [[ $? == 0 ]]; then
+    echo "EOL whitespace detected. See ^"
+    exit 1;
+fi
+
+set -e
 
 # Create a ghc environment file needed for the doctests
 # On cabal>=2.4.1.0 and ghc<8.4.4 this isn't done automaticly

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -37,7 +37,7 @@ benchFile idirs src = do
   let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity) = env
       primMap' = fmap (fmap unremoveBBfunc) primMap
       res :: BindingMap
-      res = normalizeEntity reprs bindingsMap primMap' tcm tupTcm typeTrans primEvaluator 
+      res = normalizeEntity reprs bindingsMap primMap' tcm tupTcm typeTrans primEvaluator
                    topEntityNames (opts idirs) supplyN topEntity
   res `deepseq` putStrLn ".. done\n"
 

--- a/bindist/linux/snap/mkBinDist.sh
+++ b/bindist/linux/snap/mkBinDist.sh
@@ -5,7 +5,7 @@ set -x
 # Path to thhe nix file containing the derivation we want to package
 NIXFILE=$(dirname $0)/bindist.nix
 
-# "drv" will be set to the path inside /nix/store which contains the resulting 
+# "drv" will be set to the path inside /nix/store which contains the resulting
 # the derivation
 drv=$(nix-build $NIXFILE)
 
@@ -17,7 +17,7 @@ tmpdir=$(mktemp -d)
 trap "rm -rf $tmpdir" EXIT
 cd $tmpdir
 
-# create symlinks inside target's /bin to every executable in the derivation 
+# create symlinks inside target's /bin to every executable in the derivation
 # (non-transitively)
 mkdir -p bin
 for binary in $(find ${drv}/bin); do

--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -226,7 +226,7 @@ stepApp x y m tcm =
                 Just . setTerm e' $ stackPush (PrimApply p (rights args) [] es) m
 
               _ -> error "internal error"
-       
+
             LT -> newBinder tys' (App x y) m tcm
 
             GT -> let (m0, n) = newLetBinding tcm m y
@@ -283,7 +283,7 @@ stepCast _ _ _ _ _ =
   flip trace Nothing $ unlines
     [ "WARNING: " <> $(curLoc) <> "Clash can't symbolically evaluate casts"
     , "Please file an issue at https://github.com/clash-lang/clash-compiler/issues"
-    ] 
+    ]
 
 stepTick :: TickInfo -> Term -> Step
 stepTick tick x m _ =

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -2582,7 +2582,7 @@ xOptimizeMany _ _ _ [] =
 mkFieldSelector
   :: MonadUnique m
   => InScopeSet
-  -> Id 
+  -> Id
   -- ^ subject id
   -> DataCon
   -> [TyVar]

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -296,7 +296,7 @@ constantSpecInfo ctx e = do
   -- primitive's workinfo.
   if isClockOrReset tcm (termType tcm e) then
     case collectArgs e of
-      (Prim p, _) 
+      (Prim p, _)
         | primName p == "Clash.Transformations.removedArg" ->
           pure (constantCsr e)
       _ -> bindCsr ctx e

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation.hs
@@ -103,8 +103,8 @@ liftQ = (>>= TH.lift)
 -- underlying @Color@ field of @Just@ by passing /[0b11]/ to ConstrRepr. This
 -- indicates that the first field is encoded in the first and second bit of the
 -- whole datatype (0b11).
--- 
--- __NB__: BitPack for a custom encoding can be derived using 
+--
+-- __NB__: BitPack for a custom encoding can be derived using
 -- 'Clash.Annotations.BitRepresentation.Deriving.deriveBitPack'.
 data DataReprAnn =
   DataReprAnn

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -407,7 +407,7 @@ dumpVCD## (offset, cycles) traceMap now
   format 1 label (0,1)   = ['1', label, '\n']
   format 1 label (1,_)   = ['x', label, '\n']
   format 1 label (mask,val) =
-    error $ "Can't format 1 bit wide value for " ++ show label ++ ": value " ++ show val ++ " and mask " ++ show mask 
+    error $ "Can't format 1 bit wide value for " ++ show label ++ ": value " ++ show val ++ " and mask " ++ show mask
   format n label (mask,val) =
     "b" ++ map digit (reverse [0..n-1]) ++ " " ++ [label]
     where

--- a/tests/shouldwork/Basic/NameInlining.hs
+++ b/tests/shouldwork/Basic/NameInlining.hs
@@ -36,20 +36,20 @@ mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
   content  <- readFile (takeDirectory topDir </> "f" </> "f.vhdl")
-  
+
   assertIn "g_foo" content
 
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
   content  <- readFile (takeDirectory topDir </> "f" </> "f.v")
-  
+
   assertIn "g_foo" content
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   [topDir] <- getArgs
   content  <- readFile (takeDirectory topDir </> "f" </> "f.sv")
-  
+
   assertIn "g_foo" content
 

--- a/tests/shouldwork/Basic/SetName.hs
+++ b/tests/shouldwork/Basic/SetName.hs
@@ -24,7 +24,7 @@ h x y = if signum (x - y) == 1 then x else y
     { t_name   = "h"
     , t_inputs = [PortName "x", PortName "y"]
     , t_output = PortName "diff"
-    }) #-} 
+    }) #-}
 
 assertIn :: String -> String -> IO ()
 assertIn needle haystack


### PR DESCRIPTION
Small QOL improvement: My editor autofixes EOL whitespace issues if it detects them in a file it's saving, making me accidentally commit "useless" whitespace fixes. I've seen this happening to other people too, so I've added a check to the CI.