### PR TITLE
Add 'usedArguments' to 'BlackBoxHaskell'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
   * [#884](https://github.com/clash-lang/clash-compiler/pull/884): Teach reduceTypeFamily about AppendSymbol and CmpSymbol
   * [#784](https://github.com/clash-lang/clash-compiler/pull/784): Print whether `Id` is global or local in ppr output
   * [#781](https://github.com/clash-lang/clash-compiler/pull/781): Use naming contexts in register names
+  * [#1061](https://github.com/clash-lang/clash-compiler/pull/1061): Add 'usedArguments' to BlackBoxHaskell blackboxes
 
 * Fixes issues:
   * [#974](https://github.com/clash-lang/clash-compiler/issues/974): Fix indirect shadowing in `reduceNonRepPrim`

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -58,7 +58,7 @@ import           Clash.GHC.GHC2Core
   (C2C, GHC2CoreState, tyConMap, coreToId, coreToName, coreToTerm,
    makeAllTyCons, qualifiedNameString, emptyGHC2CoreState)
 import           Clash.GHC.LoadModules   (ghcLibDir, loadModules)
-import           Clash.Netlist.BlackBox.Util (usedArguments)
+import           Clash.Netlist.BlackBox.Util (getUsedArguments)
 import           Clash.Netlist.Types     (TopEntityT(..))
 import           Clash.Primitives.Types
   (Primitive (..), CompiledPrimMap)
@@ -212,10 +212,10 @@ checkPrimitive primMap v = do
         warnIf cond msg = traceIf cond ("\n"++loc++"Warning: "++msg) return ()
       qName <- Text.unpack <$> qualifiedNameString (GHC.varName v)
       let primStr = "primitive " ++ qName ++ " "
-      let usedArgs = concat [ maybe [] usedArguments r
-                            , maybe [] usedArguments ri
-                            , usedArguments templ
-                            , concatMap (usedArguments . snd) inc
+      let usedArgs = concat [ maybe [] getUsedArguments r
+                            , maybe [] getUsedArguments ri
+                            , getUsedArguments templ
+                            , concatMap (getUsedArguments . snd) inc
                             ]
 
       let warnArgs [] = return ()

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -511,14 +511,14 @@ compilePrimitive
   -> ResolvedPrimitive
   -- ^ Primitive to compile
   -> IO CompiledPrimitive
-compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf bbGenName source) = do
+compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf usedArgs bbGenName source) = do
   let interpreterArgs = concatMap (("-package-db":) . (:[])) pkgDbs
   -- Compile a blackbox template function or fetch it from an already compiled file.
   r <- go interpreterArgs source
   processHintError
     (show bbGenName)
     bbName
-    (\bbFunc -> BlackBoxHaskell bbName wf bbGenName (hash source, bbFunc))
+    (\bbFunc -> BlackBoxHaskell bbName wf usedArgs bbGenName (hash source, bbFunc))
     r
   where
     qualMod = intercalate "." modNames

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -328,7 +328,7 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
       -> NetlistMonad (Expr, [Declaration])
     go =
       \case
-        P.BlackBoxHaskell bbName wf funcName (_fHash, func) -> do
+        P.BlackBoxHaskell bbName wf _usedArgs funcName (_fHash, func) -> do
           bbFunRes <- func bbEasD (primName pInfo) args ty
           case bbFunRes of
             Left err -> do
@@ -855,7 +855,7 @@ mkFunInput resId e =
                   error $ $(curLoc) ++ "Unexpected blackbox type: "
                                     ++ "Primitive " ++ show pn
                                     ++ " " ++ show pt
-                P.BlackBoxHaskell pName _workInfo fName (_, func) -> do
+                P.BlackBoxHaskell pName _workInfo _usedArgs fName (_, func) -> do
                   -- Determine result type of this blackbox. If it's not a
                   -- function, simply use its term type.
                   let

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -99,7 +99,7 @@ type BlackBoxTemplate = [Element]
 --  - Clash.Netlist.BlackBox.Types.renderElem
 --  - Clash.Netlist.BlackBox.Types.renderTag
 --  - Clash.Netlist.BlackBox.Types.setSym
---  - Clash.Netlist.BlackBox.Types.usedArguments
+--  - Clash.Netlist.BlackBox.Types.getUsedArguments
 --  - Clash.Netlist.BlackBox.Types.usedVariables
 --  - Clash.Netlist.BlackBox.Types.verifyBlackBoxContext
 --  - Clash.Netlist.BlackBox.Types.walkElement

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -1009,9 +1009,9 @@ usedVariables (BlackBoxE _ _ _ _ t bb _) = nub (sList ++ sList')
     sList' = concatMap (walkElement matchVar) t'
 
 -- | Collect arguments (e.g., ~ARG, ~LIT) used in this blackbox
-usedArguments :: N.BlackBox -> [Int]
-usedArguments (N.BBFunction _nm _hsh (N.TemplateFunction k _ _)) = k
-usedArguments (N.BBTemplate t) = nub (concatMap (walkElement matchArg) t)
+getUsedArguments :: N.BlackBox -> [Int]
+getUsedArguments (N.BBFunction _nm _hsh (N.TemplateFunction k _ _)) = k
+getUsedArguments (N.BBTemplate t) = nub (concatMap (walkElement matchArg) t)
   where
     matchArg =
       \case

--- a/clash-lib/src/Clash/Primitives/Util.hs
+++ b/clash-lib/src/Clash/Primitives/Util.hs
@@ -103,8 +103,9 @@ resolvePrimitive' metaPath BlackBox{template=t, includes=i, resultName=r, result
   case warning of
     Just w  -> pure (name, WarnNonSynthesizable (TS.unpack w) bb)
     Nothing -> pure (name, HasBlackBox bb)
-resolvePrimitive' metaPath (BlackBoxHaskell bbName wf funcName t) =
-  (bbName,) . HasBlackBox . BlackBoxHaskell bbName wf funcName <$> (mapM (resolveTemplateSource metaPath) t)
+resolvePrimitive' metaPath (BlackBoxHaskell bbName wf usedArgs funcName t) =
+  (bbName,) . HasBlackBox . BlackBoxHaskell bbName wf usedArgs funcName <$>
+    (mapM (resolveTemplateSource metaPath) t)
 
 -- | Interprets contents of json file as list of @Primitive@s. Throws
 -- exception if it fails.


### PR DESCRIPTION
This allows 'BlackBoxHaskell' blackboxes to indicate what arguments they
use and have 'removeUnusedExpr' subsequently remove any unused ones.