### PR TITLE
Deshadow in `caseLet` and `nonRepANF`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
   * Render numbers inside gensym [#809](https://github.com/clash-lang/clash-compiler/pull/809)
   * Don't overwrite existing binders when specializing [#790](https://github.com/clash-lang/clash-compiler/pull/790)
   * Deshadow in 'caseCase' [#1067](https://github.com/clash-lang/clash-compiler/pull/1067)
+  * Deshadow in 'caseLet' and 'nonRepANF' [#1071](https://github.com/clash-lang/clash-compiler/pull/1071)
 
 * Deprecations & removals:
   * Removed support for GHC 8.2 ([#842](https://github.com/clash-lang/clash-compiler/pull/842))

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -44,6 +44,7 @@ module Clash.Core.Subst
   , deShadowTerm
   , deShadowAlt
   , freshenTm
+  , deshadowLetExpr
     -- * Alpha equivalence
   , aeqType
   , aeqTerm
@@ -621,6 +622,23 @@ deShadowAlt ::
   (Pat, Term) ->
   (Pat, Term)
 deShadowAlt is = substAlt "deShadowAlt" (mkSubst is)
+
+-- | Ensure that non of the let-bindings of a let-expression shadow w.r.t the
+-- in-scope set
+deshadowLetExpr
+  :: HasCallStack
+  => InScopeSet
+  -- ^ Current InScopeSet
+  -> [LetBinding]
+  -- ^ Bindings of the let-expression
+  -> Term
+  -- ^ The body of the let-expression
+  -> ([LetBinding],Term)
+  -- ^ Deshadowed let-bindings, where let-bound expressions and the let-body
+  -- properly reference the renamed variables
+deshadowLetExpr is bs e =
+  case substBind "deshadowLetBindings" (mkSubst is) bs of
+    (s1,bs1) -> (bs1, substTm "deShadowLetBody" s1 e)
 
 -- | A much stronger variant of `deShadowTerm` that ensures that all bound
 -- variables are unique.


### PR DESCRIPTION
They had the potential to accidentally capture free variables