### PR TITLE
Use 'Type' instead of 'Term' in 'splitTopAnn'

### DIFF
--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -159,6 +159,7 @@ splitTopAnn tcm sp e t@Synthesize{t_inputs} =
   tctx = TransformContext emptyInScopeSet []
 
   prependName :: String -> PortName -> PortName
+  prependName "" pn = pn
   prependName p (PortProduct nm ps) = PortProduct (p ++ "_" ++ nm) ps
   prependName p (PortName nm) = PortName (p ++ "_" ++ nm)
 

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -2478,7 +2478,7 @@ flattenLet (TransformContext is0 _) letrec@(Letrec _ _) = do
 
 flattenLet _ e = return e
 
--- | Worker function of 'separateArguments'. It's reused in "Clash.Driver".
+-- | Worker function of 'separateArguments'.
 separateLambda
   :: TyConMap
   -> TransformContext
@@ -2486,9 +2486,8 @@ separateLambda
   -- ^ Lambda binder
   -> Term
   -- ^ Lambda body
-  -> Maybe (Term, Int)
-  -- ^ If lambda is split up, this function returns a Just containing the new
-  -- term plus the number of binders the single lambda binder was split up into.
+  -> Maybe Term
+  -- ^ If lambda is split up, this function returns a Just containing the new term
 separateLambda tcm ctx@(TransformContext is0 _) b eb0 =
   case shouldSplit tcm (varType b) of
     Just (dc,argTys@(_:_:_)) ->
@@ -2499,7 +2498,7 @@ separateLambda tcm ctx@(TransformContext is0 _) b eb0 =
         subst = extendIdSubst (mkSubst is1) b (mkApps dc (map (Left . Var) bs1))
         eb1 = substTm "separateArguments" subst eb0
       in
-        Just (mkLams eb1 bs1, length bs1)
+        Just (mkLams eb1 bs1)
     _ ->
       Nothing
  where
@@ -2524,7 +2523,7 @@ separateArguments :: HasCallStack => NormRewrite
 separateArguments ctx e0@(Lam b eb) = do
   tcm <- Lens.view tcCache
   case separateLambda tcm ctx b eb of
-    Just (e1, _n) -> changed e1
+    Just e1 -> changed e1
     Nothing -> return e0
 
 separateArguments (TransformContext is0 _) e@(collectArgsTicks -> (Var g, args, ticks))

--- a/tests/shouldwork/TopEntity/T1072.hs
+++ b/tests/shouldwork/TopEntity/T1072.hs
@@ -1,0 +1,55 @@
+module T1072 where
+
+import Clash.Explicit.Prelude
+import Data.List
+import System.Environment
+import System.FilePath
+import qualified Prelude as P
+
+topEntity2
+  :: (Clock System, Reset System)
+  -> (Enable System, Signal System Int)
+  -> Signal System Int
+topEntity2 (clk, rst) (en, a) = register clk rst en 0 a
+{-# NOINLINE topEntity2 #-}
+
+{-# ANN topEntity
+  (Synthesize
+    { t_name   = "top"
+    , t_inputs = [ PortProduct "" [ PortName "theClock", PortName "theReset"]
+                 , PortProduct "" [PortName "theEnable", PortName "theA" ] ]
+    , t_output = PortName "theResult" }
+  )#-}
+topEntity = topEntity2
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+-- VHDL test
+main :: FilePath -> IO ()
+main topFile = do
+  content <- readFile topFile
+
+  assertIn " theClock" content
+  assertIn " theReset" content
+  assertIn " theEnable" content
+  assertIn " theA" content
+  assertIn " theResult" content
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topFile] <- getArgs
+  main (replaceFileName topFile "top/top.vhdl")
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topFile] <- getArgs
+  main (replaceFileName topFile "top/top.v")
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  [topFile] <- getArgs
+  main (replaceFileName topFile "top/top.sv")

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -385,6 +385,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T701" def {hdlSim=False,entities=Entities ["mynot", ""]}
         , runTest "T1033" def {hdlSim=False,entities=Entities ["top", ""], topEntity=TopEntity "top"}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1033" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1072" "main"
         ]
       , clashTestGroup "Unit"
         [ runTest "Imap" def


### PR DESCRIPTION
'splitTopAnn' is used on pre-normalized topentities. This means
'etaExpansionTL' has not run yet. The logic in 'separateLambda' relies
on this however so 'splitTopAnn' breaks. Instead, 'splitTopAnn' should
use type information to calculate new port names.