### PR TITLE
Change Binding from a type synonym

### DIFF
--- a/clash-lib/src/Clash/Core/Evaluator.hs
+++ b/clash-lib/src/Clash/Core/Evaluator.hs
@@ -43,7 +43,7 @@ import           Clash.Core.Type
 import           Clash.Core.Util
 import           Clash.Core.Var
 import           Clash.Core.VarEnv
-import           Clash.Driver.Types                      (BindingMap)
+import           Clash.Driver.Types                      (BindingMap, Binding(..))
 import           Clash.Pretty
 import           Clash.Unique
 import           Clash.Util                              (curLoc)
@@ -65,7 +65,7 @@ whnf' eval fu bm tcm ph ids is isSubj e =
   toResult x = (mHeapPrim x, mHeapLocal x, mTerm x)
 
   m  = Machine eval fu ph gh emptyVarEnv [] ids is e
-  gh = mapVarEnv (\(_, _, _, x) -> x) bm
+  gh = mapVarEnv bindingTerm bm
 
 -- | Evaluate to WHNF given an existing Heap and Stack
 whnf

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -17,7 +17,7 @@ module Clash.Driver where
 import qualified Control.Concurrent.Supply        as Supply
 import           Control.DeepSeq
 import           Control.Exception                (tryJust, bracket, throw)
-import           Control.Lens                     (view, (^.), _4)
+import           Control.Lens                     (view, _4)
 import           Control.Monad                    (guard, when, unless, foldM)
 import           Control.Monad.Catch              (MonadMask)
 import           Control.Monad.IO.Class           (MonadIO)
@@ -172,7 +172,7 @@ splitTopEntityT
   -> TopEntityT
 splitTopEntityT tcm bindingsMap tt@(TopEntityT id_ (Just t@(Synthesize {})) _) =
   case lookupVarEnv id_ bindingsMap of
-    Just (_id, sp, _, _) ->
+    Just (Binding _id sp _ _) ->
       tt{topAnnotation=Just (splitTopAnn tcm sp (varType id_) t)}
     Nothing ->
       error "Internal error in 'splitTopEntityT'. Please report as a bug."
@@ -750,7 +750,7 @@ callGraphBindings
   -- ^ Root of the call graph
   -> [Term]
 callGraphBindings bindingsMap tm =
-  map ((^. _4) . (bindingsMap `lookupUniqMap'`)) (keysUniqMap cg)
+  map (bindingTerm . (bindingsMap `lookupUniqMap'`)) (keysUniqMap cg)
   where
     cg = callGraph bindingsMap tm
 

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -18,25 +18,31 @@ module Clash.Driver.Types where
 -- For Int/Word size
 #include "MachDeps.h"
 
-import           GHC.Generics
+import           Control.DeepSeq                (NFData)
+import           Data.Binary                    (Binary)
 import           Data.Hashable
-
-import           BasicTypes                     (InlineSpec)
 import qualified Data.Set                       as Set
 import           Data.Text                      (Text)
+import           GHC.Generics                   (Generic)
+
+import           BasicTypes                     (InlineSpec)
 import           SrcLoc                         (SrcSpan)
 import           Util                           (OverridingBool(..))
 
 import           Clash.Core.Term                (Term)
 import           Clash.Core.Var                 (Id)
 import           Clash.Core.VarEnv              (VarEnv)
-
 import           Clash.Netlist.BlackBox.Types   (HdlSyn (..))
 
 
 -- A function binder in the global environment.
 --
-type Binding = (Id, SrcSpan, InlineSpec, Term)
+data Binding = Binding
+  { bindingId :: Id
+  , bindingLoc :: SrcSpan
+  , bindingSpec :: InlineSpec
+  , bindingTerm :: Term
+  } deriving (Binary, Generic, NFData, Show)
 
 -- | Global function binders
 --


### PR DESCRIPTION
Use of the `Binding` type (representing a single binding from a
`BindingMap`) is often quite obtuse, as it was a synonym for a
4-tuple. This commit changes it to a type, making it clearer at
use-sites what the data actually represents.