### PR TITLE
Use Data.Sequence instead of Data.Vector for RAMs

### DIFF
--- a/clash-prelude/benchmarks/BenchRAM.hs
+++ b/clash-prelude/benchmarks/BenchRAM.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE MagicHash, TypeApplications #-}
+module BenchRAM where
+
+import Criterion (Benchmark, env, bench, nf)
+
+import Clash.Explicit.BlockRam
+import Clash.Explicit.RAM
+import Clash.Explicit.ROM
+import Clash.Explicit.Signal
+import Clash.Prelude.ROM
+import Clash.Promoted.Nat.Literals
+import qualified Clash.Sized.Vector as V
+
+asyncRamBench :: Benchmark
+asyncRamBench = env setup $ \m ->
+  bench "asyncRam#" $
+  nf (take 98 . drop 2 . simulate_lazy
+        (\rw -> let (r,w) = unbundle rw
+                in  asyncRam# @System
+                      clockGen
+                      clockGen
+                      enableGen
+                      d1024
+                      r
+                      (pure True)
+                      w
+                      w
+                   )) m
+  where
+    setup   = pure (zip [556,557..856] [557,558..857])
+
+asyncRomBench :: Benchmark
+asyncRomBench = env setup $ \m ->
+  bench "asyncRom#" $
+  nf (take 98 . drop 2 . fmap (asyncRom# ramInit)) m
+  where
+    ramInit = V.replicate d1024 (1 :: Int)
+    setup   = pure ([557,558..857])
+
+blockRamBench :: Benchmark
+blockRamBench = env setup $ \m ->
+  bench "blockRam# (100% writes)" $
+  nf (take 98 . drop 2 . simulate_lazy
+        (\w -> blockRam# @System
+                    clockGen
+                    enableGen
+                    ramInit
+                    w
+                    (pure True)
+                    w
+                    w
+                   )) m
+  where
+    ramInit = V.replicate d1024 (1 :: Int)
+    setup   = pure ([557,558..857])
+
+blockRamROBench :: Benchmark
+blockRamROBench = env setup $ \m ->
+  bench "blockRam# (0% writes)" $
+  nf (take 98 . drop 2 . simulate_lazy
+        (\w -> blockRam# @System
+                    clockGen
+                    enableGen
+                    ramInit
+                    w
+                    (pure False)
+                    w
+                    w
+                   )) m
+  where
+    ramInit = V.replicate d1024 (1 :: Int)
+    setup   = pure ([557,558..857])
+
+romBench :: Benchmark
+romBench = env setup $ \m ->
+  bench "rom#" $
+  nf (take 98 . drop 2 . simulate_lazy
+        (\r -> rom# @System
+                    clockGen
+                    enableGen
+                    ramInit
+                    r
+                   )) m
+  where
+    ramInit = V.replicate d1024 (1 :: Int)
+    setup   = pure ([557,558..857])

--- a/clash-prelude/benchmarks/benchmark-main.hs
+++ b/clash-prelude/benchmarks/benchmark-main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Criterion.Main
 
+import qualified BenchRAM       as RAM
 import qualified BenchBitVector as BV
 import qualified BenchFixed     as F
 import qualified BenchSigned    as S
@@ -10,7 +11,14 @@ main :: IO ()
 main =
   defaultMain
   [
-    bgroup "BitVector"
+    bgroup "RAMs"
+        [ RAM.asyncRamBench
+        , RAM.asyncRomBench
+        , RAM.blockRamBench
+        , RAM.blockRamROBench
+        , RAM.romBench
+        ]
+  , bgroup "BitVector"
         [ BV.addBench
         , BV.negateBench
         , BV.subBench

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -386,4 +386,5 @@ benchmark benchmark-clash-prelude
 
   Other-Modules:    BenchBitVector
                     BenchFixed
+                    BenchRAM
                     BenchSigned


### PR DESCRIPTION
1. Data.Vector has `O(n)` update and `O(1)` indexing
2. Data.Sequence `O(log(min(i,n-i))` update and indexing

Given that RAMs will, on average, see as many writes as reads; Data.Sequence seems asymptotically better. This is what the benchmarks say:

Data.Vector:
```
benchmarking RAMs/asyncRam#
time                 86.89 μs   (86.64 μs .. 87.23 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 87.55 μs   (87.07 μs .. 88.39 μs)
std dev              2.057 μs   (1.328 μs .. 3.267 μs)
variance introduced by outliers: 20% (moderately inflated)

benchmarking RAMs/blockRam# (100% writes)
time                 99.86 μs   (99.30 μs .. 100.5 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 99.79 μs   (99.46 μs .. 100.3 μs)
std dev              1.362 μs   (857.3 ns .. 2.070 μs)

benchmarking RAMs/blockRam# (0% writes)
time                 25.77 μs   (25.64 μs .. 25.91 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 25.85 μs   (25.75 μs .. 26.01 μs)
std dev              402.1 ns   (256.0 ns .. 691.0 ns)
variance introduced by outliers: 12% (moderately inflated)
```

Data.Sequence:
```
benchmarking RAMs/asyncRam#
time                 34.94 μs   (34.58 μs .. 35.32 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 35.24 μs   (35.07 μs .. 35.51 μs)
std dev              731.6 ns   (521.7 ns .. 1.239 μs)
variance introduced by outliers: 18% (moderately inflated)

benchmarking RAMs/blockRam# (100% writes)
time                 47.83 μs   (47.39 μs .. 48.29 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 47.09 μs   (46.83 μs .. 47.44 μs)
std dev              985.5 ns   (802.2 ns .. 1.250 μs)
variance introduced by outliers: 17% (moderately inflated)

benchmarking RAMs/blockRam# (0% writes)
time                 28.74 μs   (28.32 μs .. 29.28 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 28.52 μs   (28.33 μs .. 28.86 μs)
std dev              854.1 ns   (565.6 ns .. 1.394 μs)
variance introduced by outliers: 32% (moderately inflated)
```

i.e. Data.Sequence seems like an overall win