### PR TITLE
CSE: inverse topological sort of letbindings and traverse once

### DIFF
--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -29,6 +29,7 @@ import Data.IntMap.Strict           (IntMap)
 defaultTests :: [FilePath]
 defaultTests =
   [ "examples/FIR.hs"
+  , "examples/Reducer.hs"
   , "examples/Queens.hs"
   , "benchmark/tests/BundleMapRepeat.hs"
   , "benchmark/tests/PipelinesViaFolds.hs"

--- a/benchmark/tests/PipelinesViaFolds.hs
+++ b/benchmark/tests/PipelinesViaFolds.hs
@@ -10,10 +10,10 @@ topEntity = pipeline
   where
     pipeline :: Signal System Word32 -> Signal System Word32
     -- slow normalisation, 32s
-    pipeline = foldr (\x acc -> stage x . acc) id $ iterate d32 (+1) 1
+    -- pipeline = foldr (\x acc -> stage x . acc) id $ iterate d32 (+1) 1
 
     -- slow normalisation, killed after 60s
-    -- pipeline = foldr (.) id $ map stage $ iterate d32 (+1) 1
+    pipeline = foldr (.) id $ map stage $ iterate d32 (+1) 1
 
     -- fast normalisation, 1s
     -- pipeline =


### PR DESCRIPTION
* ~Reintroduces `fgl` dependency in order to deal with recursive
  let-bindings in `inverseTopSortLetBindings`. Is also faster
  than our hand-rolled `Clash.Util.Graph.topSort`.~
  Uses `Data.Graph` from `containers` to determine inverse topological sort

* Gives a 20%-30% speed improvement in total normalization time.
  More pronounced in larger examples. Also left breadcrumps in
  comments for further potential speed improvements of CSE pass.

Previous fix-point CSE:
```
benchmarking normalization of examples/Reducer.hs
time                 5.429 s    (5.293 s .. 5.533 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.411 s    (5.391 s .. 5.437 s)
std dev              26.28 ms   (9.948 ms .. 36.29 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 1.846 s    (1.681 s .. 1.969 s)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 1.820 s    (1.765 s .. 1.841 s)
std dev              37.73 ms   (5.735 ms .. 48.06 ms)
variance introduced by outliers: 19% (moderately inflated)
```

New topsort CSE:
```
benchmarking normalization of examples/Reducer.hs
time                 4.314 s    (4.102 s .. 4.485 s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 4.365 s    (4.327 s .. 4.385 s)
std dev              37.25 ms   (23.84 ms .. 44.57 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 1.277 s    (1.266 s .. 1.295 s)
                     1.000 R²   (NaN R² .. 1.000 R²)
mean                 1.239 s    (1.198 s .. 1.254 s)
std dev              27.64 ms   (2.830 ms .. 34.60 ms)
variance introduced by outliers: 19% (moderately inflated)
```