### PR TITLE
CaseCon: 0-bit subject check only for variable references

### DIFF
--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -996,6 +996,7 @@ whnfRW isSubj ctx@(TransformContext is0 _) e rw = do
     (!gh1,ph,v) -> do
       globalHeap Lens..= gh1
       bindPureHeap tcm ph rw ctx v
+{-# SCC whnfRW #-}
 
 -- | Binds variables on the PureHeap over the result of the rewrite
 --


### PR DESCRIPTION
Other transformations will eventually reduce it to a either a
variable reference; or something on which `caseCon` can also
fire: Data, Literal, Prim

Doing the 0-bit check on the type of the subject only when the
subject is a variable refence can give a 15% speed improvement
on Case-heavy code, such as Reducer:

Before:
```
benchmarking normalization of examples/Reducer.hs
time                 5.146 s    (5.043 s .. 5.226 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.037 s    (4.918 s .. 5.082 s)
std dev              81.05 ms   (12.78 ms .. 103.7 ms)
variance introduced by outliers: 19% (moderately inflated)
```

After:
```
benchmarking normalization of examples/Reducer.hs
time                 4.332 s    (3.674 s .. 4.768 s)
                     0.997 R²   (0.995 R² .. NaN R²)
mean                 4.458 s    (4.342 s .. 4.555 s)
std dev              121.3 ms   (95.91 ms .. 140.4 ms)
variance introduced by outliers: 19% (moderately inflated)
```