### PR TITLE
Only cache transformed work-free top-level up to a certain size

### DIFF
--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -33,6 +33,7 @@ defaultTests =
   , "examples/Queens.hs"
   , "benchmark/tests/BundleMapRepeat.hs"
   , "benchmark/tests/PipelinesViaFolds.hs"
+  , "tests/shouldwork/Basic/AES.hs"
   ]
 
 typeTrans :: (CustomReprs -> TyConMap -> Type ->

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -84,6 +84,7 @@ flagsClash r = [
   , defFlag "fclash-compile-ultra"               $ NoArg (liftEwM (setUltra r))
   , defFlag "fclash-force-undefined"             $ OptIntSuffix (setUndefined r)
   , defFlag "fclash-aggressive-x-optimization"   $ NoArg (liftEwM (setAggressiveXOpt r))
+  , defFlag "fclash-inline-workfree-limit"       $ IntSuffix (liftEwM . setInlineWFLimit r)
   ]
 
 -- | Print deprecated flag warning
@@ -118,6 +119,12 @@ setInlineConstantLimit
   -> Int
   -> IO ()
 setInlineConstantLimit r n = modifyIORef r (\c -> c {opt_inlineConstantLimit = toEnum n})
+
+setInlineWFLimit
+  :: IORef ClashOpts
+  -> Int
+  -> IO ()
+setInlineWFLimit r n = modifyIORef r (\c -> c {opt_inlineWFCacheLimit = toEnum n})
 
 setSpecLimit :: IORef ClashOpts
              -> Int

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -110,6 +110,9 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            -- ^ Enable aggressive X optimization, which may
                            -- remove undefineds from generated HDL by replaced
                            -- with defined alternatives.
+                           , opt_inlineWFCacheLimit :: Word
+                           -- ^ At what size do we cache normalized work-free
+                           -- top-level binders.
                            }
 
 instance Hashable ClashOpts where
@@ -138,7 +141,8 @@ instance Hashable ClashOpts where
     opt_ultra `hashWithSalt`
     opt_forceUndefined `hashWithSalt`
     opt_checkIDir `hashWithSalt`
-    opt_aggressiveXOpt
+    opt_aggressiveXOpt `hashWithSalt`
+    opt_inlineWFCacheLimit
    where
     hashOverridingBool :: Int -> OverridingBool -> Int
     hashOverridingBool s1 Auto = hashWithSalt s1 (0 :: Int)
@@ -176,6 +180,7 @@ defClashOpts
   , opt_forceUndefined      = Nothing
   , opt_checkIDir           = True
   , opt_aggressiveXOpt      = False
+  , opt_inlineWFCacheLimit  = 10 -- TODO: find "optimal" value
   }
 
 -- | Information about the generated HDL between (sub)runs of the compiler

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -144,6 +144,7 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcs
                   rcsMap
                   (opt_newInlineStrat opts)
                   (opt_ultra opts)
+                  (opt_inlineWFCacheLimit opts)
 
 
 normalize

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -68,6 +68,8 @@ data NormalizeState
   -- ^ High-effort normalization session, trading performance improvement for
   -- potentially much longer compile times. Follows the 'Clash.Driver.opt_ultra'
   -- flag.
+  , _inlineWFCacheLimit :: !Word
+  -- ^ At what size do we cache normalized work-free top-level binders.
   }
 
 makeLenses ''NormalizeState


### PR DESCRIPTION
And don't apply the full set of normalization transformations on them, only "local" (i.e. not touch other global binders) constant propagation.

This can decrease normalization time on certain tests up to 10 times, such as AES.hs

before:
```
benchmarking normalization of tests/shouldwork/Basic/AES.hs
time                 6.516 s    (6.483 s .. 6.553 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.493 s    (6.477 s .. 6.505 s)
std dev              15.76 ms   (7.314 ms .. 20.13 ms)
variance introduced by outliers: 19% (moderately inflated)
```

after:
```
benchmarking normalization of tests/shouldwork/Basic/AES.hs
time                 542.5 ms   (504.8 ms .. 591.1 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 526.8 ms   (517.7 ms .. 534.7 ms)
std dev              9.958 ms   (4.435 ms .. 13.13 ms)
variance introduced by outliers: 19% (moderately inflated)
```