### PR TITLE
Add "Clash.Signal.Bundle.TaggedUnit"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   * Add `Clash.Magic.deDup`: instruct Clash to force sharing an operator between multiple branches of a case-expression
   * `InlinePrimitive` can now support multiple backends simultaneously [#425](https://github.com/clash-lang/clash-compiler/issues/425)
   * Add `Clash.XException.hwSeqX`: render declarations of an argument, but don't assign it to a result signal
+  * Add `Clash.Signal.Bundle.TaggedUnit`: allows users to emulate the pre-1.0 behavior of "Bundle ()". See [#1096](https://github.com/clash-lang/clash-compiler/pull/1096)
 
 * New features (Compiler):
   * [#961](https://github.com/clash-lang/clash-compiler/pull/961): Show `-fclash-*` Options in `clash --show-options`

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -230,6 +230,8 @@ module Clash.Explicit.Signal
   , (.&&.), (.||.)
     -- * Product/Signal isomorphism
   , Bundle(..)
+  , TaggedUnit
+  , TaggedUnit'(..)
     -- * Simulation functions (not synthesizable)
   , simulate
   , simulateB
@@ -270,7 +272,8 @@ import           GHC.TypeLits                   (type (+), type (<=))
 import           Clash.Annotations.Primitive    (hasBlackBox)
 import           Clash.Class.Num                (satSucc, SaturationMode(SatBound))
 import           Clash.Promoted.Nat             (SNat(..), snatToNum)
-import           Clash.Signal.Bundle            (Bundle (..), vecBundle#)
+import           Clash.Signal.Bundle
+  (Bundle (..), TaggedUnit, TaggedUnit'(..), vecBundle#)
 import           Clash.Signal.BiSignal
 import           Clash.Signal.Internal
 import           Clash.Signal.Internal.Ambiguous

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -212,6 +212,8 @@ module Clash.Signal
   , (.&&.), (.||.)
     -- * Product/Signal isomorphism
   , Bundle(..)
+  , TaggedUnit
+  , TaggedUnit'(..)
     -- * Simulation functions (not synthesizable)
   , simulate
   , simulateB
@@ -266,7 +268,7 @@ import qualified Clash.Explicit.Signal as S
 import           Clash.Hidden
 import           Clash.Promoted.Nat    (SNat (..), snatToNum)
 import           Clash.Promoted.Symbol (SSymbol (..))
-import           Clash.Signal.Bundle   (Bundle (..))
+import           Clash.Signal.Bundle   (Bundle (..), TaggedUnit, TaggedUnit'(..))
 import           Clash.Signal.BiSignal --(BisignalIn, BisignalOut, )
 import           Clash.Signal.Internal hiding
   (sample, sample_lazy, sampleN, sampleN_lazy, simulate, simulate_lazy, testFor)

--- a/clash-prelude/src/Clash/Signal/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle.hs
@@ -171,7 +171,7 @@ instance Bundle ((f :*: g) a) where
     getL (l :*: _) = l
     getR (_ :*: r) = r
 
--- | Internal data type, see "TaggedUnit".
+-- | See "TaggedUnit".
 data TaggedUnit' (dom :: k) = TaggedUnit
 
 -- | Helper type to emulate the "old" behavior of Bundle's unit instance. I.e.,


### PR DESCRIPTION
Helper type to emulate the "old" behavior of Bundle's unit instance. I.e.,
the instance for `Bundle ()` used to be defined as:

```haskell
class Bundle () where
  bundle   :: () -> Signal domain ()
  unbundle :: Signal domain () -> ()
```

In order to have sensible type inference, the `Bundle` class specifies that
the argument type of 'bundle' should uniquely identify the result type, and
vice versa for `unbundle`. The type signatures in the snippet above don't
though, as `()` doesn't uniquely map to a specific domain. In other words,
'domain' should occur in both the argument and result of both functions.

`TaggedUnit` fixes this by carrying the domain in its type. Use `taggedUnit`
to construct a `TaggedUnit`. The actual constructor is hidden to hide some
implementation details. If you need to pattern match on it use `seq` or
BangPatterns.