### PR TITLE
reduceNonRepPrim: postpone call to shouldReduce

### DIFF
--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -398,6 +398,18 @@ anyM p (x:xs) = do
   else
     anyM p xs
 
+-- | short-circuiting monadic version of 'or'
+orM
+  :: (Monad m)
+  => [m Bool]
+  -> m Bool
+orM [] = pure False
+orM (x:xs) = do
+  p <- x
+  if p then
+    pure True
+  else
+    orM xs
 
 -- | Get the package id of the type of a value
 -- >>> pkgIdFromTypeable (undefined :: TopEntity)


### PR DESCRIPTION
and use short-circuiting monadic predicate checkers. This can speed up normalization by 30% in some tests:

before:
```
benchmarking normalization of tests/shouldwork/Basic/AES.hs
time                 542.5 ms   (504.8 ms .. 591.1 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 526.8 ms   (517.7 ms .. 534.7 ms)
std dev              9.958 ms   (4.435 ms .. 13.13 ms)
variance introduced by outliers: 19% (moderately inflated)
```

after:
```
benchmarking normalization of tests/shouldwork/Basic/AES.hs
time                 387.7 ms   (362.7 ms .. 444.8 ms)
                     0.997 R²   (0.995 R² .. 1.000 R²)
mean                 368.8 ms   (363.7 ms .. 378.8 ms)
std dev              10.04 ms   (190.7 μs .. 11.74 ms)
variance introduced by outliers: 19% (moderately inflated)
```