### PR TITLE
Add "Clash.Signal.Bundle.TaggedEmptyTuple"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   * Add `Clash.Magic.deDup`: instruct Clash to force sharing an operator between multiple branches of a case-expression
   * `InlinePrimitive` can now support multiple backends simultaneously [#425](https://github.com/clash-lang/clash-compiler/issues/425)
   * Add `Clash.XException.hwSeqX`: render declarations of an argument, but don't assign it to a result signal
+  * Add `Clash.Signal.Bundle.TaggedEmptyTuple`: allows users to emulate the pre-1.0 behavior of "Bundle ()". See [#1100](https://github.com/clash-lang/clash-compiler/pull/1100)
 
 * New features (Compiler):
   * [#961](https://github.com/clash-lang/clash-compiler/pull/961): Show `-fclash-*` Options in `clash --show-options`

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -230,6 +230,8 @@ module Clash.Explicit.Signal
   , (.&&.), (.||.)
     -- * Product/Signal isomorphism
   , Bundle(..)
+  , EmptyTuple(..)
+  , TaggedEmptyTuple(..)
     -- * Simulation functions (not synthesizable)
   , simulate
   , simulateB
@@ -270,7 +272,8 @@ import           GHC.TypeLits                   (type (+), type (<=))
 import           Clash.Annotations.Primitive    (hasBlackBox)
 import           Clash.Class.Num                (satSucc, SaturationMode(SatBound))
 import           Clash.Promoted.Nat             (SNat(..), snatToNum)
-import           Clash.Signal.Bundle            (Bundle (..), vecBundle#)
+import           Clash.Signal.Bundle
+  (Bundle (..), EmptyTuple(..), TaggedEmptyTuple(..), vecBundle#)
 import           Clash.Signal.BiSignal
 import           Clash.Signal.Internal
 import           Clash.Signal.Internal.Ambiguous

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -212,6 +212,8 @@ module Clash.Signal
   , (.&&.), (.||.)
     -- * Product/Signal isomorphism
   , Bundle(..)
+  , EmptyTuple(..)
+  , TaggedEmptyTuple(..)
     -- * Simulation functions (not synthesizable)
   , simulate
   , simulateB
@@ -266,7 +268,8 @@ import qualified Clash.Explicit.Signal as S
 import           Clash.Hidden
 import           Clash.Promoted.Nat    (SNat (..), snatToNum)
 import           Clash.Promoted.Symbol (SSymbol (..))
-import           Clash.Signal.Bundle   (Bundle (..))
+import           Clash.Signal.Bundle
+  (Bundle (..), EmptyTuple(..), TaggedEmptyTuple(..))
 import           Clash.Signal.BiSignal --(BisignalIn, BisignalOut, )
 import           Clash.Signal.Internal hiding
   (sample, sample_lazy, sampleN, sampleN_lazy, simulate, simulate_lazy, testFor)

--- a/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
@@ -17,10 +17,9 @@
 #endif
 
 module Clash.Signal.Delayed.Bundle (
-  Bundle,
-  Unbundled,
-  bundle,
-  unbundle,
+    Bundle(..)
+  -- ** Tools to emulate pre Clash 1.0 @Bundle ()@ instance
+  , TaggedEmptyTuple
   ) where
 
 import           Control.Applicative           (liftA2)
@@ -219,3 +218,17 @@ instance KnownNat d => Bundle (RTree d a) where
   type Unbundled t delay (RTree d a) = RTree d (DSignal t delay a)
   bundle   = sequenceA
   unbundle = sequenceA . fmap lazyT
+
+-- | Same as "Clash.Signal.Bundle.TaggedEmptyTuple", but adapted for "DSignal".
+data TaggedEmptyTuple (dom :: Domain) (d :: Nat) = TaggedEmptyTuple
+
+-- | See https://github.com/clash-lang/clash-compiler/pull/539/commits/94b0bff5770aa4961e04ddce2515130df3fc7863
+-- and documentation for "TaggedEmptyTuple".
+instance Bundle B.EmptyTuple where
+  type Unbundled dom d B.EmptyTuple = TaggedEmptyTuple dom d
+
+  bundle :: TaggedEmptyTuple dom d -> DSignal dom d B.EmptyTuple
+  bundle TaggedEmptyTuple = pure B.EmptyTuple
+
+  unbundle :: DSignal dom d B.EmptyTuple -> TaggedEmptyTuple dom d
+  unbundle s = seq s TaggedEmptyTuple


### PR DESCRIPTION
Helper type to emulate the "old" behavior of Bundle's unit instance. I.e.,
the instance for `Bundle ()` used to be defined as:

    class Bundle () where
      bundle   :: () -> Signal domain ()
      unbundle :: Signal domain () -> ()

In order to have sensible type inference, the "Bundle" class specifies that
the argument type of 'bundle' should uniquely identify the result type, and
vice versa for 'unbundle'. The type signatures in the snippet above don't
though, as `()` doesn't uniquely map to a specific domain. In other words,
'domain' should occur in both the argument and result of both functions.

"TaggedEmptyTuple" tackles this by carrying the domain in its type. The
'bundle' and 'unbundle' instance now looks like:

    class Bundle EmptyTuple where
      bundle   :: TaggedEmptyTuple domain -> Signal domain EmptyTuple
      unbundle :: Signal domain EmptyTuple -> TaggedEmptyTuple domain

`domain` is now mentioned both the argument and result for both 'bundle' and
'unbundle'.