### PR TITLE
Add 'bundle' and 'unbundle' primitives 

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -351,6 +351,14 @@ coreToTerm primMap unlocs = term
         go "Clash.Magic.noDeDup" args
           | [_aTy,f] <- args
           = C.Tick C.NoDeDup <$> term f
+        go nm args
+          | "Clash.Signal.Bundle.unbundle" `Text.isPrefixOf` nm
+          , "#" `Text.isSuffixOf` nm
+          = term (last args)
+        go nm args
+          | "Clash.Signal.Bundle.bundle" `Text.isPrefixOf` nm
+          , "#" `Text.isSuffixOf` nm
+          = term (last args)
 
         go _ _ = term' e
     term' (Var x)                 = var x

--- a/clash-prelude/src/Clash/Annotations/Primitive.hs
+++ b/clash-prelude/src/Clash/Annotations/Primitive.hs
@@ -150,7 +150,7 @@ data HDL
   = SystemVerilog
   | Verilog
   | VHDL
-  deriving (Eq, Show, Read, Data, Generic, NFData, Hashable)
+  deriving (Eq, Show, Read, Data, Generic, NFData, Hashable, Enum, Bounded)
 
 -- | The 'Primitive' constructor instructs the clash compiler to look for primitive
 -- HDL templates in the indicated directory. 'InlinePrimitive' is equivalent but

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -418,7 +418,7 @@ import           Clash.Sized.Index      (Index)
 import           Clash.Sized.Vector     (Vec, replicate, toList, iterateI)
 import qualified Clash.Sized.Vector     as CV
 import           Clash.XException
-  (maybeIsX, seqX, NFDataX, deepErrorX, defaultSeqX, errorX)
+  (maybeIsX, seqX, NFDataX, deepErrorX, defaultSeqX, fromJustX)
 
 {- $setup
 >>> import Clash.Explicit.Prelude as C
@@ -685,10 +685,6 @@ prog2 = -- 0 := 4
 :}
 
 -}
-
-fromJustX :: HasCallStack => Maybe a -> a
-fromJustX Nothing  = errorX "fromJustX: Nothing"
-fromJustX (Just x) = x
 
 -- | Create a blockRAM with space for @n@ elements
 --

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -93,7 +93,7 @@ module Clash.Explicit.BlockRam.File
 where
 
 import Data.Char             (digitToInt)
-import Data.Maybe            (fromJust, isJust, listToMaybe)
+import Data.Maybe            (isJust, listToMaybe)
 import qualified Data.Sequence as Seq
 import GHC.Stack             (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits          (KnownNat)
@@ -106,7 +106,7 @@ import Clash.Signal.Internal
   (Clock(..), Signal (..), Enable, KnownDomain, fromEnable, (.&&.))
 import Clash.Signal.Bundle   (unbundle)
 import Clash.Sized.Unsigned  (Unsigned)
-import Clash.XException      (errorX, maybeIsX, seqX)
+import Clash.XException      (errorX, maybeIsX, seqX, fromJustX)
 
 
 -- | Create a blockRAM with space for 2^@n@ elements
@@ -199,7 +199,7 @@ blockRamFile
   -- clock cycle
 blockRamFile = \clk gen sz file rd wrM ->
   let en       = isJust <$> wrM
-      (wr,din) = unbundle (fromJust <$> wrM)
+      (wr,din) = unbundle (fromJustX <$> wrM)
   in  withFrozenCallStack
       (blockRamFile# clk gen sz file (fromEnum <$> rd) en (fromEnum <$> wr) din)
 {-# INLINE blockRamFile #-}

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -119,7 +119,6 @@ module Clash.Explicit.Prelude
   , module Data.Default.Class
     -- ** Exceptions
   , module Clash.XException
-  , undefined
     -- ** Named types
   , module Clash.NamedTypes
     -- ** Magic

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -90,7 +90,6 @@ module Clash.Explicit.Prelude.Safe
   , module Data.Bits
       -- ** Exceptions
   , module Clash.XException
-  , undefined
     -- ** Named types
   , module Clash.NamedTypes
     -- ** Haskell Prelude
@@ -102,7 +101,6 @@ where
 import Control.Applicative
 import Data.Bits
 import GHC.Generics (Generic, Generic1)
-import GHC.Stack
 import GHC.TypeLits
 import GHC.TypeLits.Extra
 import Clash.HaskellPrelude
@@ -250,5 +248,3 @@ oscillate clk rst en begin SNat =
       else (s+1, i)     -- hold current output
 {-# INLINEABLE oscillate #-}
 
-undefined :: HasCallStack => a
-undefined = errorX "undefined"

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -29,7 +29,7 @@ module Clash.Explicit.RAM
   )
 where
 
-import Data.Maybe            (fromJust, isJust)
+import Data.Maybe            (isJust)
 import GHC.Stack             (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits          (KnownNat)
 import qualified Data.Sequence as Seq
@@ -39,7 +39,7 @@ import Clash.Explicit.Signal
 import Clash.Promoted.Nat    (SNat (..), snatToNum, pow2SNat)
 import Clash.Signal.Internal (Clock (..), Signal (..), Enable, fromEnable)
 import Clash.Sized.Unsigned  (Unsigned)
-import Clash.XException      (errorX, maybeIsX)
+import Clash.XException      (errorX, maybeIsX, fromJustX)
 
 -- | Create a RAM with space for 2^@n@ elements
 --
@@ -103,7 +103,7 @@ asyncRam
    -- ^ Value of the @RAM@ at address @r@
 asyncRam = \wclk rclk gen sz rd wrM ->
   let en       = isJust <$> wrM
-      (wr,din) = unbundle (fromJust <$> wrM)
+      (wr,din) = unbundle (fromJustX <$> wrM)
   in  withFrozenCallStack
       (asyncRam# wclk rclk gen sz (fromEnum <$> rd) en (fromEnum <$> wr) din)
 {-# INLINE asyncRam #-}

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -266,7 +266,7 @@ module Clash.Explicit.Signal
   )
 where
 
-import           Data.Maybe                     (isJust, fromJust)
+import           Data.Maybe                     (isJust)
 import           GHC.TypeLits                   (type (+), type (<=))
 
 import           Clash.Annotations.Primitive    (hasBlackBox)
@@ -280,7 +280,7 @@ import           Clash.Signal.Internal.Ambiguous
   (knownVDomain, clockPeriod, activeEdge, resetKind, initBehavior, resetPolarity)
 import           Clash.Sized.Index              (Index)
 import qualified Clash.Sized.Vector
-import           Clash.XException               (NFDataX, deepErrorX)
+import           Clash.XException               (NFDataX, deepErrorX, fromJustX)
 
 {- $setup
 >>> :set -XDataKinds -XTypeApplications -XFlexibleInstances -XMultiParamTypeClasses -XTypeFamilies
@@ -612,7 +612,7 @@ delayMaybe
   -> Signal dom (Maybe a)
   -> Signal dom a
 delayMaybe clk gen dflt i =
-  delayEn clk gen dflt (isJust <$> i) (fromJust <$> i)
+  delayEn clk gen dflt (isJust <$> i) (fromJustX <$> i)
 {-# INLINE delayMaybe #-}
 
 -- | Version of 'delay' that only updates when its third argument is asserted.
@@ -697,7 +697,7 @@ regMaybe
   -> Signal dom (Maybe a)
   -> Signal dom a
 regMaybe clk rst en initial iM =
-  register clk rst (enable en (fmap isJust iM)) initial (fmap fromJust iM)
+  register clk rst (enable en (fmap isJust iM)) initial (fmap fromJustX iM)
 {-# INLINE regMaybe #-}
 
 -- | Version of 'register' that only updates its content when its fourth

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -145,7 +145,6 @@ module Clash.Prelude
   , module Data.Default.Class
     -- ** Exceptions
   , module Clash.XException
-  , undefined
     -- ** Named types
   , module Clash.NamedTypes
     -- ** Hidden arguments

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -106,7 +106,6 @@ module Clash.Prelude.Safe
   , module Data.Bits
       -- ** Exceptions
   , module Clash.XException
-  , E.undefined
     -- ** Named types
   , module Clash.NamedTypes
     -- ** Hidden arguments

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -112,7 +112,7 @@ module Clash.Signal.BiSignal (
 
 import           Data.Kind                  (Type)
 import           Data.List                  (intercalate)
-import           Data.Maybe                 (fromMaybe,fromJust,isJust)
+import           Data.Maybe                 (fromMaybe,isJust)
 
 import           Clash.Class.HasDomain
 import           Clash.Class.BitPack        (BitPack (..))
@@ -120,7 +120,7 @@ import           Clash.Sized.BitVector      (BitVector)
 import qualified Clash.Sized.Vector         as V
 import           Clash.Sized.Vector         (Vec)
 import           Clash.Signal.Internal      (Signal(..), Domain, head#, tail#)
-import           Clash.XException           (errorX)
+import           Clash.XException           (errorX, fromJustX)
 
 import           GHC.TypeLits               (KnownNat, Nat)
 import           GHC.Stack                  (HasCallStack)
@@ -249,7 +249,7 @@ writeToBiSignal input writes =
     input
     (fmap pack <$> writes)
     (isJust <$> writes)
-    (pack . fromJust <$> writes)
+    (pack . fromJustX <$> writes)
 {-# INLINE writeToBiSignal #-}
 
 -- | Converts the 'out' part of a BiSignal to an 'in' part. In simulation it

--- a/clash-prelude/src/Clash/Signal/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle.hs
@@ -19,6 +19,7 @@ The Product/Signal isomorphism
 
 {-# LANGUAGE Trustworthy #-}
 
+--{-# OPTIONS_GHC -ddump-splices #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Signal.Bundle

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -74,7 +74,6 @@ import Data.Either                (isLeft)
 import Data.Kind                  (Type)
 import Text.Read                  (Read(..))
 import Data.List                  (find)
-import Data.Maybe                 (fromJust)
 import Data.Proxy                 (Proxy (..))
 import Data.Ratio                 ((%), denominator, numerator)
 import Data.Typeable              (Typeable, TypeRep, typeRep)
@@ -97,7 +96,7 @@ import Clash.Sized.BitVector      (BitVector, (++#))
 import Clash.Sized.Signed         (Signed)
 import Clash.Sized.Unsigned       (Unsigned)
 import Clash.XException
-  (ShowX (..), NFDataX (..), isX, errorX, showsPrecXWith)
+  (ShowX (..), NFDataX (..), isX, errorX, showsPrecXWith, fromJustX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -255,7 +254,7 @@ instance ( size ~ (int + frac), KnownNat frac, Integral (rep size)
          ) => Show (Fixed rep int frac) where
   show f@(Fixed fRep) =
       i ++ "." ++ (uncurry pad . second (show . numerator) .
-                   fromJust . find ((==1) . denominator . snd) .
+                   fromJustX . find ((==1) . denominator . snd) .
                    iterate (succ *** (*10)) . (,) 0 $ (nom % denom))
     where
       pad n str = replicate (n - length str) '0' ++ str

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -21,6 +21,7 @@ CallStack (from HasCallStack):
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -30,7 +31,7 @@ CallStack (from HasCallStack):
 
 module Clash.XException
   ( -- * 'X': An exception for uninitialized values
-    XException(..), errorX, isX, hasX, maybeIsX, maybeHasX
+    XException(..), errorX, isX, hasX, maybeIsX, maybeHasX, fromJustX, undefined
     -- * Printing 'X' exceptions as \"X\"
   , ShowX (..), showsX, printX, showsPrecXWith
     -- * Strict evaluation
@@ -39,6 +40,8 @@ module Clash.XException
   , NFDataX (rnfX, deepErrorX, hasUndefined, ensureSpine)
   )
 where
+
+import           Prelude             hiding (undefined)
 
 import           Clash.Annotations.Primitive (hasBlackBox)
 import           Clash.CPP           (maxTupleSize)
@@ -836,3 +839,12 @@ instance GDeepErrorX (f :+: g) where
 
 mkShowXTupleInstances [2..maxTupleSize]
 mkNFDataXTupleInstances [2..maxTupleSize]
+
+undefined :: HasCallStack => a
+undefined = errorX "undefined"
+
+-- | Same as "Data.Maybe.fromJust", but returns a bottom/undefined value that
+-- other Clash constructs are aware of.
+fromJustX :: HasCallStack => Maybe a -> a
+fromJustX Nothing = errorX "isJustX: Nothing"
+fromJustX (Just a) = a

--- a/repld
+++ b/repld
@@ -36,7 +36,7 @@ elif [[ $1 == "l" || $1 == "lib" || $1 == "clash-lib" ]]; then
   target="cabal new-repl clash-lib"
   watch="clash-prelude clash-lib/clash-lib.cabal"
 elif [[ $1 == "g" || $1 == "ghc" || $1 == "clash-ghc" ]]; then
-  target="cabal new-repl clash-ghc --repl-options=-fobject-code"
+  target="cabal new-repl clash-ghc --repl-options=-fobject-code --repl-options=-fforce-recomp"
   watch="clash-prelude clash-lib clash-ghc/clash-ghc.cabal"
 elif [[ $1 == "dev" || $1 == "clash-dev" ]]; then
   target="./clash-dev"

--- a/tests/shouldwork/Signal/T1102A.hs
+++ b/tests/shouldwork/Signal/T1102A.hs
@@ -1,0 +1,27 @@
+module T1102A where
+
+import Clash.Prelude
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+{-# ANN topEntity Synthesize {t_name = "top", t_inputs = [PortName "x"], t_output = PortName "y"} #-}
+topEntity
+  :: (Signal System Int, Signal System Int)
+  -> Signal System (Int, Int)
+topEntity = bundle
+{-# NOINLINE topEntity #-}
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (takeDirectory topDir </> "top/top.vhdl")
+  assertIn "y <= x" content
+

--- a/tests/shouldwork/Signal/T1102B.hs
+++ b/tests/shouldwork/Signal/T1102B.hs
@@ -1,0 +1,26 @@
+module T1102B where
+
+import Clash.Prelude
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+
+{-# ANN topEntity Synthesize {t_name = "top", t_inputs = [PortName "x"], t_output = PortName "y"} #-}
+topEntity
+  :: Signal System (Int, Int, Int, Int, Int)
+  -> Signal System (Int, Int, Int, Int, Int)
+topEntity = bundle . unbundle
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (takeDirectory topDir </> "top/top.vhdl")
+  assertIn "y <= x" content

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -338,6 +338,8 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "Rom" def
         , runTest "RomFile" def
         , runTest "SigP" def{hdlSim=False}
+        , outputTest ("tests" </> "shouldwork" </> "Signal") [VHDL] [] [] "T1102A" "main"
+        , outputTest ("tests" </> "shouldwork" </> "Signal") [VHDL] [] [] "T1102B" "main"
 
         , clashTestGroup "BiSignal"
           [ runTest "Counter" def


### PR DESCRIPTION
Eliminates the need for netlist to construct/deconstruct vectors when using bundle/unbundle. This cuts down HDL noise. For example:

```haskell
module Test where

import Clash.Prelude

{-# ANN topEntity Synthesize {t_name = "top", t_inputs = [PortName "x"], t_output = PortName "y"} #-}
topEntity
  :: Signal System (Int, Int, Int, Int, Int)
  -> Signal System (Int, Int, Int, Int, Int)
topEntity = bundle . unbundle
```

would yield:

```haskell
entity top is
  port(x : in top_types.tup5;
       y : out top_types.tup5);
end;

architecture structural of top is
  signal a5 : signed(63 downto 0);
  signal a6 : signed(63 downto 0);
  signal a7 : signed(63 downto 0);
  signal a8 : signed(63 downto 0);
  signal a9 : signed(63 downto 0);

begin
  y <= ( tup5_sel0_signed_0 => a5
       , tup5_sel1_signed_1 => a6
       , tup5_sel2_signed_2 => a7
       , tup5_sel3_signed_3 => a8
       , tup5_sel4_signed_4 => a9 );

  a5 <= x.tup5_sel0_signed_0;

  a6 <= x.tup5_sel1_signed_1;

  a7 <= x.tup5_sel2_signed_2;

  a8 <= x.tup5_sel3_signed_3;

  a9 <= x.tup5_sel4_signed_4;


end;
```

now yields:

```vhdl
entity top is
  port(x : in top_types.tup5;
       y : out top_types.tup5);
end;

architecture structural of top is


begin
  y <= x;


end;
```