### PR TITLE
Minimize substitutions inside inlineCleanup

### DIFF
--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -13,6 +13,7 @@ module Clash.Core.VarEnv
     -- ** Indexing
   , lookupVarEnv
   , lookupVarEnv'
+  , lookupVarEnvDirectly
     -- ** Construction
   , emptyVarEnv
   , unitVarEnv
@@ -29,6 +30,8 @@ module Clash.Core.VarEnv
     -- *** Mapping
   , mapVarEnv
   , mapMaybeVarEnv
+    -- ** Folding
+  , foldlWithUniqueVarEnv'
     -- ** Working with predicates
     -- *** Searching
   , elemVarEnv
@@ -126,6 +129,13 @@ lookupVarEnv
   -> Maybe a
 lookupVarEnv = lookupUniqMap
 
+-- | Lookup a value based on the unique of a variable
+lookupVarEnvDirectly
+  :: Unique
+  -> VarEnv a
+  -> Maybe a
+lookupVarEnvDirectly = lookupUniqMap
+
 -- | Lookup a value based on the variable
 --
 -- Errors out when the variable is not present
@@ -218,6 +228,15 @@ mapMaybeVarEnv
   -> VarEnv a
   -> VarEnv b
 mapMaybeVarEnv = mapMaybeUniqMap
+
+-- | Strict left-fold over an environment using both the unique of the
+-- the variable and the value
+foldlWithUniqueVarEnv'
+  :: (a -> Unique -> b -> a)
+  -> a
+  -> VarEnv b
+  -> a
+foldlWithUniqueVarEnv' = foldlWithUnique'
 
 -- | Extract the elements
 eltsVarEnv

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -39,6 +39,7 @@ module Clash.Unique
   , elemUniqMapDirectly
     -- ** Folding
   , foldrWithUnique
+  , foldlWithUnique'
     -- ** Conversions
     -- *** Lists
   , eltsUniqMap
@@ -301,6 +302,14 @@ foldrWithUnique
   -> UniqMap a
   -> b
 foldrWithUnique f s (UniqMap m) = IntMap.foldrWithKey f s m
+
+-- | Strict left-fold over a map using both the key and the value
+foldlWithUnique'
+  :: (a -> Unique -> b -> a)
+  -> a
+  -> UniqMap b
+  -> a
+foldlWithUnique' f s (UniqMap m) = IntMap.foldlWithKey' f s m
 
 -- | Set of things that have a 'Unique'
 --


### PR DESCRIPTION
before:
```
benchmarking normalization of examples/Reducer.hs
time                 2.280 s    (2.156 s .. 2.463 s)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 2.268 s    (2.242 s .. 2.283 s)
std dev              25.00 ms   (6.513 ms .. 33.26 ms)
variance introduced by outliers: 19% (moderately inflated)
```

after:
```
benchmarking normalization of examples/Reducer.hs
time                 1.002 s    (969.5 ms .. 1.025 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.019 s    (1.007 s .. 1.023 s)
std dev              8.327 ms   (49.15 μs .. 10.22 ms)
variance introduced by outliers: 19% (moderately inflated)
```