### PR TITLE
inlineOrLiftNonRep: share let-body FV count

### DIFF
--- a/clash-lib/src/Clash/Core/FreeVars.hs
+++ b/clash-lib/src/Clash/Core/FreeVars.hs
@@ -28,6 +28,7 @@ module Clash.Core.FreeVars
   , localIdDoesNotOccurIn
   , localIdsDoNotOccurIn
   , localVarsDoNotOccurIn
+  , countFreeOccurances
   -- * Internal
   , typeFreeVars'
   , termFreeVars'
@@ -45,7 +46,8 @@ import Clash.Core.Term                  (Pat (..), Term (..), TickInfo (..))
 import Clash.Core.Type                  (Type (..))
 import Clash.Core.Var
   (Id, IdScope (..), TyVar, Var (..), isLocalId)
-import Clash.Core.VarEnv                (VarSet, unitVarSet)
+import Clash.Core.VarEnv
+  (VarEnv, VarSet, emptyVarEnv, unionVarEnvWith, unitVarSet, unitVarEnv)
 
 -- | Gives the free type-variables in a Type, implemented as a 'Fold'
 --
@@ -326,3 +328,11 @@ localFVsOfTerms
 localFVsOfTerms = foldMap go
  where
   go = Lens.foldMapOf freeLocalVars unitVarSet
+
+-- | Get the free variables of an expression and count the number of occurrences
+countFreeOccurances
+  :: Term
+  -> VarEnv Int
+countFreeOccurances =
+  Lens.foldMapByOf freeLocalIds (unionVarEnvWith (+)) emptyVarEnv
+                   (`unitVarEnv` (1 :: Int))


### PR DESCRIPTION
before:
```
benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 1.066 s    (1.052 s .. 1.093 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.065 s    (1.057 s .. 1.070 s)
std dev              8.007 ms   (2.932 ms .. 10.99 ms)
variance introduced by outliers: 19% (moderately inflated)
```

after:
```
benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 966.0 ms   (923.8 ms .. 986.9 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 973.8 ms   (967.6 ms .. 977.4 ms)
std dev              6.027 ms   (1.990 ms .. 8.113 ms)
variance introduced by outliers: 19% (moderately inflated)
```