### PR TITLE
deadCode: use VarEnv to track used binders

### DIFF
--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -54,6 +54,7 @@ module Clash.Core.VarEnv
     -- ** Conversions
     -- *** Lists
   , mkVarSet
+  , eltsVarSet
     -- * In-scope sets
   , InScopeSet
     -- ** Accessors
@@ -330,6 +331,11 @@ mkVarSet
   :: [Var a]
   -> VarSet
 mkVarSet xs = mkUniqSet (coerce xs)
+
+eltsVarSet
+  :: VarSet
+  -> [Var Any]
+eltsVarSet = eltsUniqSet
 
 -- * InScopeSet
 


### PR DESCRIPTION
before
```
benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 966.0 ms   (923.8 ms .. 986.9 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 973.8 ms   (967.6 ms .. 977.4 ms)
std dev              6.027 ms   (1.990 ms .. 8.113 ms)
variance introduced by outliers: 19% (moderately inflated)
```

after
```
benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 919.1 ms   (866.9 ms .. 1.000 s)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 917.2 ms   (896.0 ms .. 937.6 ms)
std dev              22.71 ms   (13.53 ms .. 32.07 ms)
variance introduced by outliers: 19% (moderately inflated)
```