### PR TITLE
Refactor `inlineOrLiftBinders`

### DIFF
--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -160,14 +160,14 @@ inlineOrLiftNonRep ctx eLet@(Letrec _ body) =
                                    <*> pure ty)
     nonRepTest _ = return False
 
-    inlineTest :: Term -> (Id, Term) -> RewriteMonad extra Bool
-    inlineTest e (id_, e') = pure $
+    inlineTest :: Term -> (Id, Term) -> Bool
+    inlineTest e (id_, e') =
       -- We do __NOT__ inline:
       not $ or
         [ -- 1. recursive let-binders
-          id_ `localIdOccursIn` e'
+          -- id_ `localIdOccursIn` e' -- <= already checked in inlineOrLiftBinders
           -- 2. join points (which are not void-wrappers)
-        , isJoinPointIn id_ e && not (isVoidWrapper e')
+          isJoinPointIn id_ e && not (isVoidWrapper e')
           -- 3. binders that are used more than once in the body, because
           --    it makes CSE a whole lot more difficult.
           --


### PR DESCRIPTION
* LiftOrInline test no longer monadic (not needed)
* `substituteBinders` performs fewer `substTm` calls, but still
  does the same amount of substitution

before:
```
benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 919.1 ms   (866.9 ms .. 1.000 s)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 917.2 ms   (896.0 ms .. 937.6 ms)
std dev              22.71 ms   (13.53 ms .. 32.07 ms)
variance introduced by outliers: 19% (moderately inflated)
```

after:
```
benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 878.9 ms   (758.0 ms .. 1.021 s)
                     0.997 R²   (0.989 R² .. 1.000 R²)
mean                 875.8 ms   (852.2 ms .. 895.7 ms)
std dev              24.47 ms   (10.76 ms .. 33.48 ms)
variance introduced by outliers: 19% (moderately inflated)
```