### PR TITLE
Refactor `inlineOrLiftBinders`

### DIFF
--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -160,14 +160,14 @@ inlineOrLiftNonRep ctx eLet@(Letrec _ body) =
                                    <*> pure ty)
     nonRepTest _ = return False
 
-    inlineTest :: Term -> (Id, Term) -> RewriteMonad extra Bool
-    inlineTest e (id_, e') = pure $
+    inlineTest :: Term -> (Id, Term) -> Bool
+    inlineTest e (id_, e') =
       -- We do __NOT__ inline:
       not $ or
         [ -- 1. recursive let-binders
-          id_ `localIdOccursIn` e'
+          -- id_ `localIdOccursIn` e' -- <= already checked in inlineOrLiftBinders
           -- 2. join points (which are not void-wrappers)
-        , isJoinPointIn id_ e && not (isVoidWrapper e')
+          isJoinPointIn id_ e && not (isVoidWrapper e')
           -- 3. binders that are used more than once in the body, because
           --    it makes CSE a whole lot more difficult.
           --


### PR DESCRIPTION
* LiftOrInline test no longer monadic (not needed)
* `substituteBinders` performs fewer `substTm` calls, but still
  does the same amount of substitution

before:
```
benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 724.2 ms   (683.6 ms .. 750.1 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 711.9 ms   (702.4 ms .. 717.1 ms)
std dev              9.126 ms   (1.802 ms .. 11.97 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of examples/Reducer.hs
time                 763.0 ms   (621.8 ms .. 927.8 ms)
                     0.995 R²   (0.981 R² .. 1.000 R²)
mean                 759.5 ms   (720.6 ms .. 801.2 ms)
std dev              45.28 ms   (22.51 ms .. 63.66 ms)
variance introduced by outliers: 19% (moderately inflated)
```

after:
```
benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 715.4 ms   (677.1 ms .. NaN s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 714.2 ms   (710.5 ms .. 720.5 ms)
std dev              6.163 ms   (463.1 μs .. 8.007 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of examples/Reducer.hs
time                 691.2 ms   (649.2 ms .. NaN s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 676.9 ms   (661.8 ms .. 685.8 ms)
std dev              15.05 ms   (5.252 ms .. 20.46 ms)
variance introduced by outliers: 19% (moderately inflated)
```