### PR TITLE
Lift recursive group

### DIFF
--- a/tests/shouldfail/LiftRecursiveGroup.hs
+++ b/tests/shouldfail/LiftRecursiveGroup.hs
@@ -1,0 +1,9 @@
+module LiftRecursiveGroup where
+
+import Clash.Prelude
+
+topEntity x y z
+  = let g p q k v = k (p + q) * v
+        h = ((3 :: Integer) *) . (g x y f)
+        f = ((4 :: Integer) *) . (g x y h)
+    in  f (h z) + h (f z)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -163,6 +163,10 @@ runClashTest = defaultMain $ clashTestRoot
           , expectClashFail=Just (def, "Unexpected projection of zero-width type")
           }
         ]
+      , runTest "LiftRecursiveGroup" def{
+          hdlTargets=[VHDL]
+        , expectClashFail=Just (def,"Callgraph after normalization contains following recursive components:")
+        }
       , runTest "Poly" def{
           hdlTargets=[VHDL]
         , expectClashFail=Just (def, "Clash can only normalize monomorphic functions, but this is polymorphic:")


### PR DESCRIPTION
In order to deal with a set of "to-lift" let-binders that form a recursive group, e.g.

```haskell
topEntity x y z
  = let g p q k v = k (p + q) * v
        h = ((3 :: Integer) *) . (g x y f)
        f = ((4 :: Integer) *) . (g x y h)
    in  f (h z) + h (f z)
```

The above definition remains recursive after normalization, at the global level, but it contains no self-recursive let-bindings. The previous implementation of the algorith would result in a normalized set of expressions with self-recursive, non-representable, let-bindings; which is not allowed.
