### PR TITLE
Make rom simulation faster

### DIFF
--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -104,16 +104,16 @@ rom#
   -- ^ Read address @rd@
   -> Signal dom a
   -- ^ The value of the ROM at address @rd@ from the previous clock cycle
-rom# _ en content rd =
+rom# _ en content =
   go
     (withFrozenCallStack (deepErrorX "rom: initial value undefined"))
     (fromEnable en)
-    ((arr !) <$> rd)
  where
   szI = length content
   arr = listArray (0,szI-1) (toList content)
 
-  go o (e :- es) as@(~(x :- xs)) =
+  go o (e :- es) rd@(~(r :- rs)) =
+    let o1 = if e then arr ! r else o
     -- See [Note: register strictness annotations]
-    o `seqX` o :- (as `seq` if e then go x es xs else go o es xs)
+    in  o `seqX` o :- (rd `seq` go o1 es rs)
 {-# NOINLINE rom# #-}

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -88,7 +88,7 @@ asyncRom#
   -- ^ Read address @rd@
   -> a
   -- ^ The value of the ROM at address @rd@
-asyncRom# content rd = arr ! rd
+asyncRom# content = \rd -> arr ! rd
   where
     szI = length content
     arr = listArray (0,szI-1) (toList content)


### PR DESCRIPTION
before:
```
benchmarking RAMs/asyncRom#
time                 677.1 μs   (675.6 μs .. 679.0 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 676.2 μs   (675.8 μs .. 677.0 μs)
std dev              1.809 μs   (869.3 ns .. 2.976 μs)

benchmarking RAMs/rom#
time                 10.30 μs   (10.28 μs .. 10.31 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.29 μs   (10.28 μs .. 10.30 μs)
std dev              28.54 ns   (18.45 ns .. 43.55 ns)
```

after:
```
benchmarking RAMs/asyncRom#
time                 1.720 μs   (1.719 μs .. 1.721 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.719 μs   (1.719 μs .. 1.720 μs)
std dev              2.431 ns   (1.673 ns .. 3.641 ns)

benchmarking RAMs/rom#
time                 3.210 μs   (3.203 μs .. 3.219 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.208 μs   (3.202 μs .. 3.226 μs)
std dev              28.64 ns   (12.48 ns .. 59.03 ns)
```