### PR TITLE
Rename 'Var' to 'ToVar'

### DIFF
--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -82,7 +82,7 @@ pTagE =  Result True       <$  string "~ERESULT"
      <|> Const             <$> (string "~CONST" *> brackets' natural')
      <|> Lit               <$> (string "~LIT" *> brackets' natural')
      <|> Name              <$> (string "~NAME" *> brackets' natural')
-     <|> Var               <$> try (string "~VAR" *> brackets' pSigD) <*> brackets' natural'
+     <|> ToVar             <$> try (string "~VAR" *> brackets' pSigD) <*> brackets' natural'
      <|> (Sym Text.empty)  <$> (string "~SYM" *> brackets' natural')
      <|> Typ Nothing       <$  string "~TYPO"
      <|> (Typ . Just)      <$> try (string "~TYP" *> brackets' natural')

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -121,7 +121,7 @@ data Element
   -- ^ Like Arg, but input hole must be a literal
   | Name !Int
   -- ^ Name hole
-  | Var [Element] !Int
+  | ToVar [Element] !Int
   -- ^ Like Arg but only insert variable reference (creating an assignment
   -- elsewhere if necessary).
   | Sym !Text !Int


### PR DESCRIPTION
Multiple things are called 'Var', which makes it difficult to find
where this particular 'Var' is used.