### PR TITLE
Remove block indention in (System)Verilog

### DIFF
--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -157,10 +157,10 @@ instance Backend SystemVerilogState where
   blockDecl _ ds  = do
     decs <- decls ds
     if isEmpty decs
-      then indent 2 (insts ds)
+      then insts ds
       else
         pure decs <> line <>
-        indent 2 (insts ds)
+        insts ds
   unextend = return rmSlash
   addIncludes inc = includes %= (inc++)
   addLibraries libs = libraries %= (libs ++)

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -158,10 +158,10 @@ instance Backend VerilogState where
   blockDecl _ ds  = do
     decs <- decls ds
     if isEmpty decs
-      then indent 2 (insts ds)
+      then insts ds
       else
         pure decs <> line <>
-        indent 2 (insts ds)
+        insts ds
   unextend = return rmSlash
   addIncludes inc = includes %= (inc++)
   addLibraries libs = libraries %= (libs ++)


### PR DESCRIPTION
There's no concept of a "block" in these HDLs anyway. Indentation
therefore results in weird looking code.