### PR TITLE
Don't export *SpecificClock when multiple-hidden is disabled

### DIFF
--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -158,9 +158,11 @@ module Clash.Signal
   , HiddenClock
   , hideClock
   , exposeClock
-  , exposeSpecificClock
   , withClock
+#ifdef CLASH_MULTIPLE_HIDDEN
+  , exposeSpecificClock
   , withSpecificClock
+#endif
   , hasClock
     -- ** Hidden reset
   , HiddenReset


### PR DESCRIPTION
They should have been hidden just like the rest of the `*Specific*`
functions