### PR TITLE
Add fast Unsigned->Word conversions

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -2294,6 +2294,43 @@ reduceConstant tcm isSubj pInfo tys args mach = case primName pInfo of
            val = i .&. bitsKeep
     in reduce (mkUnsignedLit ty mTy km val)
 
+-- Conversions
+  "Clash.Sized.Internal.Unsigned.unsignedToWord"
+    | isSubj
+    , [a] <- unsignedLiterals' args
+    -> let b = Unsigned.unsignedToWord (U (fromInteger a))
+           (_,tyView -> TyConApp wordTcNm []) = splitFunForallTy ty
+           (Just wordTc) = lookupUniqMap wordTcNm tcm
+           [wordDc] = tyConDataCons wordTc
+       in  reduce (mkApps (Data wordDc) [Left (Literal (WordLiteral (toInteger b)))])
+
+  "Clash.Sized.Internal.Unsigned.unsigned8toWord8"
+    | isSubj
+    , [a] <- unsignedLiterals' args
+    -> let b = Unsigned.unsigned8toWord8 (U (fromInteger a))
+           (_,tyView -> TyConApp wordTcNm []) = splitFunForallTy ty
+           (Just wordTc) = lookupUniqMap wordTcNm tcm
+           [wordDc] = tyConDataCons wordTc
+       in  reduce (mkApps (Data wordDc) [Left (Literal (WordLiteral (toInteger b)))])
+
+  "Clash.Sized.Internal.Unsigned.unsigned16toWord16"
+    | isSubj
+    , [a] <- unsignedLiterals' args
+    -> let b = Unsigned.unsigned16toWord16 (U (fromInteger a))
+           (_,tyView -> TyConApp wordTcNm []) = splitFunForallTy ty
+           (Just wordTc) = lookupUniqMap wordTcNm tcm
+           [wordDc] = tyConDataCons wordTc
+       in  reduce (mkApps (Data wordDc) [Left (Literal (WordLiteral (toInteger b)))])
+
+  "Clash.Sized.Internal.Unsigned.unsigned32toWord32"
+    | isSubj
+    , [a] <- unsignedLiterals' args
+    -> let b = Unsigned.unsigned32toWord32 (U (fromInteger a))
+           (_,tyView -> TyConApp wordTcNm []) = splitFunForallTy ty
+           (Just wordTc) = lookupUniqMap wordTcNm tcm
+           [wordDc] = tyConDataCons wordTc
+       in  reduce (mkApps (Data wordDc) [Left (Literal (WordLiteral (toInteger b)))])
+
   "Clash.Annotations.BitRepresentation.Deriving.dontApplyInHDL"
     | isSubj
     , f : a : _ <- args

--- a/clash-lib/prims/common/Clash_Sized_Internal_Unsigned.json
+++ b/clash-lib/prims/common/Clash_Sized_Internal_Unsigned.json
@@ -19,4 +19,28 @@
     , "template"  : "~ARG[0] / ~ARG[1]"
     }
   }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.unsignedToWord"
+    , "kind"      : "Expression"
+    , "template"  : "~ARG[0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.unsigned8toWord8"
+    , "kind"      : "Expression"
+    , "template"  : "~ARG[0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.unsigned16toWord16"
+    , "kind"      : "Expression"
+    , "template"  : "~ARG[0]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.unsigned32toWord32"
+    , "kind"      : "Expression"
+    , "template"  : "~ARG[0]"
+    }
+  }
 ]

--- a/clash-prelude/benchmarks/BenchUnsigned.hs
+++ b/clash-prelude/benchmarks/BenchUnsigned.hs
@@ -10,6 +10,7 @@
 module BenchUnsigned (unsignedBench) where
 
 import Data.Bits
+import Data.Word
 import Clash.Class.Num
 import Clash.Class.BitPack
 import Clash.Sized.BitVector
@@ -47,6 +48,10 @@ unsignedBench = bgroup "Unsigned"
   , orBenchL
   , complementBench
   , complementBenchL
+  , unsigned8toWord8Bench
+  , unsigned16toWord16Bench
+  , unsigned32toWord32Bench
+  , unsignedToWordBench
   ]
 
 smallValueI :: Integer
@@ -60,6 +65,18 @@ smallValue1 = $(lift (2^(16::Int)-10 :: Unsigned WORD_SIZE_IN_BITS))
 smallValue2 :: Unsigned WORD_SIZE_IN_BITS
 smallValue2 = $(lift (2^(16::Int)-100 :: Unsigned WORD_SIZE_IN_BITS))
 {-# INLINE smallValue2 #-}
+
+smallValueW8 :: Unsigned 8
+smallValueW8 = $(lift (2^(4::Int)-10 :: Unsigned 8))
+{-# INLINE smallValueW8 #-}
+
+smallValueW16 :: Unsigned 16
+smallValueW16 = $(lift (2^(8::Int)-10 :: Unsigned 16))
+{-# INLINE smallValueW16 #-}
+
+smallValueW32 :: Unsigned 32
+smallValueW32 = $(lift (2^(16::Int)-10 :: Unsigned 32))
+{-# INLINE smallValueW32 #-}
 
 smallValueBV :: BitVector WORD_SIZE_IN_BITS
 smallValueBV = $(lift (2^(16::Int)-10 :: BitVector WORD_SIZE_IN_BITS))
@@ -224,3 +241,27 @@ complementBenchL = env setup $ \m ->
   bench "complement 3*WORD_SIZE_IN_BITS" $ nf complement m
   where
     setup = return largeValue1
+
+unsigned8toWord8Bench :: Benchmark
+unsigned8toWord8Bench = env setup $ \m ->
+  bench "unsigned8toWord8 WORD_SIZE_IN_BITS" $ nf (bitCoerce :: Unsigned 8 -> Word8) m
+  where
+    setup = return smallValueW8
+
+unsigned16toWord16Bench :: Benchmark
+unsigned16toWord16Bench = env setup $ \m ->
+  bench "unsigned16toWord16 WORD_SIZE_IN_BITS" $ nf (bitCoerce :: Unsigned 16 -> Word16) m
+  where
+    setup = return smallValueW16
+
+unsigned32toWord32Bench :: Benchmark
+unsigned32toWord32Bench = env setup $ \m ->
+  bench "unsigned32toWord32 WORD_SIZE_IN_BITS" $ nf (bitCoerce :: Unsigned 32 -> Word32) m
+  where
+    setup = return smallValueW32
+
+unsignedToWordBench :: Benchmark
+unsignedToWordBench = env setup $ \m ->
+  bench "unsignedToWord WORD_SIZE_IN_BITS" $ nf (bitCoerce :: Unsigned WORD_SIZE_IN_BITS -> Word) m
+  where
+    setup = return smallValue1

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -134,7 +134,7 @@ packXWith f x =
                                 (\(XException _) -> return undefined#))
 {-# NOINLINE packXWith #-}
 
-{-# INLINE bitCoerce #-}
+{-# INLINE[1] bitCoerce #-}
 -- | Coerce a value from one type to another through its bit representation.
 --
 -- >>> pack (-5 :: Signed 6)


### PR DESCRIPTION
Usefull when Clash simulation needs to interact with the outside world; i.e. for `Unsigned 8 -> Ptr Word8`

before:
```
benchmarking Unsigned/unsigned8toWord8 WORD_SIZE_IN_BITS
time                 21.89 ns   (21.77 ns .. 22.05 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 21.96 ns   (21.81 ns .. 22.38 ns)
std dev              806.7 ps   (185.9 ps .. 1.658 ns)
variance introduced by outliers: 59% (severely inflated)

benchmarking Unsigned/unsigned16toWord16 WORD_SIZE_IN_BITS
time                 22.48 ns   (22.30 ns .. 22.77 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 22.54 ns   (22.37 ns .. 23.04 ns)
std dev              914.9 ps   (351.0 ps .. 1.801 ns)
variance introduced by outliers: 64% (severely inflated)

benchmarking Unsigned/unsigned32toWord32 WORD_SIZE_IN_BITS
time                 22.45 ns   (22.44 ns .. 22.47 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 22.48 ns   (22.45 ns .. 22.56 ns)
std dev              139.2 ps   (43.39 ps .. 279.7 ps)

benchmarking Unsigned/unsignedToWord WORD_SIZE_IN_BITS
time                 21.93 ns   (21.87 ns .. 22.03 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 21.89 ns   (21.86 ns .. 21.96 ns)
std dev              143.9 ps   (42.29 ps .. 275.4 ps)
```

after:
```
benchmarking Unsigned/unsigned8toWord8 WORD_SIZE_IN_BITS
time                 4.559 ns   (4.558 ns .. 4.562 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.565 ns   (4.561 ns .. 4.573 ns)
std dev              17.88 ps   (10.75 ps .. 32.04 ps)

benchmarking Unsigned/unsigned16toWord16 WORD_SIZE_IN_BITS
time                 4.783 ns   (4.781 ns .. 4.785 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.783 ns   (4.782 ns .. 4.784 ns)
std dev              4.618 ps   (3.615 ps .. 6.532 ps)

benchmarking Unsigned/unsigned32toWord32 WORD_SIZE_IN_BITS
time                 5.086 ns   (5.085 ns .. 5.088 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.087 ns   (5.085 ns .. 5.091 ns)
std dev              7.924 ps   (4.884 ps .. 14.50 ps)

benchmarking Unsigned/unsignedToWord WORD_SIZE_IN_BITS
time                 4.667 ns   (4.664 ns .. 4.671 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.675 ns   (4.666 ns .. 4.713 ns)
std dev              57.20 ps   (6.486 ps .. 120.4 ps)
variance introduced by outliers: 15% (moderately inflated)
```