### PR TITLE
Single-dc, single field types cannot have a PortProduct annotation

### DIFF
--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -630,10 +630,12 @@ filterVoidPorts
   -> PortName
 filterVoidPorts _hwty (PortName s) =
   PortName s
-filterVoidPorts (FilteredHWType _hwty [filtered]) (PortProduct s ps) =
-  PortProduct s [filterVoidPorts f p | (p, (void, f)) <- zip ps filtered, not void]
+filterVoidPorts (FilteredHWType _hwty [filtered]) (PortProduct s ps)
+  | length filtered > 1
+  = PortProduct s [filterVoidPorts f p | (p, (void, f)) <- zip ps filtered, not void]
 filterVoidPorts (FilteredHWType _hwty fs) (PortProduct s ps)
   | length (filter (not.fst) (concat fs)) == 1
+  , length fs > 1
   , length ps == 2
   = PortProduct s ps
 filterVoidPorts filtered pp@(PortProduct _s _ps) =

--- a/tests/shouldfail/TopEntity/T1063.hs
+++ b/tests/shouldfail/TopEntity/T1063.hs
@@ -1,0 +1,9 @@
+module T1063 where
+
+import Clash.Prelude
+
+{-# ANN topEntity (defSyn "top")
+  {t_inputs = [PortProduct "wrong" [PortName "one", PortName "two"]]}
+  #-}
+topEntity :: Int -> Int
+topEntity = id

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -148,6 +148,10 @@ runClashTest = defaultMain $ clashTestRoot
             hdlTargets=[VHDL]
           , expectClashFail=Just (def, "PortProduct \"wrong\" []")
           }
+        , runTest "T1063" def{
+            hdlTargets=[VHDL]
+          , expectClashFail=Just (def, "Ports were annotated as product, but type wasn't one")
+          }
         ]
       , clashTestGroup "Verification"
         [ let n = 9 in -- GHDL only has VERY basic PSL support


### PR DESCRIPTION
@christiaanb: Changes the logic in 'filterVoidPorts' to stop recognizing these "wrapper" types as one-products

Fixes #1063