### PR TITLE
CI: Prevent OOM with -f-large-tuples

### DIFF
--- a/.ci/nix_build.sh
+++ b/.ci/nix_build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -xeo pipefail
+
+sed -z -i 's/-- large-tuples\n  default: True/default: False/' clash-prelude/clash-prelude.cabal || true
+nix-build

--- a/.ci/stack_build.sh
+++ b/.ci/stack_build.sh
@@ -5,4 +5,4 @@ apt update
 apt install wget -y
 wget -q https://get.haskellstack.org/ -O stack_install.sh
 sh stack_install.sh
-stack build -j${THREADS}
+stack build -j${THREADS} --flag clash-prelude:-large-tuples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,16 +57,19 @@ aliases:
     run:
       name: Setup binaries (such as git)
       command: |
-        nix-env -i git findutils gnugrep coreutils openssh
-
         # Circle CI needs git/ssh in /usr/bin
-        ln -s $(find /nix -type f -name git | grep libexec | head -n1) /usr/bin
-        ln -s $(find /nix -type f -name ssh | grep openssh | head -n1) /usr/bin
+        nix-env -i git findutils gnugrep gnused coreutils openssh bash-4.4-p23
+
+        #                               bin         nix pkg        multiple may exist
+        ln -s $(find /nix -type f -name git  | grep libexec      | head -n1) /usr/bin
+        ln -s $(find /nix -type f -name ssh  | grep openssh      | head -n1) /usr/bin
+        ln -s $(find /nix -type f -name sed  | grep gnused       | head -n1) /usr/bin
+        ln -s $(find /nix -type f -name bash | grep bash-4.4-p23 | head -n1) /bin
 
   - &nix_build
     run:
       name: Build dependencies and Clash itself with Nix
-      command: nix-build
+      command: .ci/nix_build.sh
 
   - &stack_build
     run:

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -72,6 +72,10 @@ flag large-tuples
     increases compile times for `clash-prelude` and therefore mostly impacts the
     Clash developers themselves. Hence its default is set to disabled on
     development versions and enabled on releases.
+  -- I have no idea to pass cabal flags to nix, so the comment below,
+  -- "-- large-tuples", is there to enable a call to 'sed' that replaces
+  -- True with False. This is done to prevent OOM on CircleCI.
+  -- large-tuples
   default: False
   manual: True
 


### PR DESCRIPTION
Not super useful on master as it's already the default. Note that `-flarge-tuples` will still be tested by our GitLab runners, just not for the nix and stack builds.