### PR TITLE
Faster vec (un)pack

### DIFF
--- a/clash-prelude/benchmarks/BenchVector.hs
+++ b/clash-prelude/benchmarks/BenchVector.hs
@@ -20,11 +20,16 @@ import Prelude                     hiding (replicate)
 vectorBench :: Benchmark
 vectorBench = bgroup "Vector"
   [ vectorPackBench
+  , vectorUnpackBench
   ]
 
 smallValue1 :: Vec 8 (BitVector 24)
 smallValue1 = $(lift (replicate d8 (2^(16::Int)-10 :: BitVector 24)))
 {-# INLINE smallValue1 #-}
+
+smallValue2 :: BitVector 192
+smallValue2 = $(lift (maxBound :: BitVector 192))
+{-# INLINE smallValue2 #-}
 
 vectorPackBench :: Benchmark
 vectorPackBench = env setup $ \m ->
@@ -32,3 +37,10 @@ vectorPackBench = env setup $ \m ->
   nf (pack :: Vec 8 (BitVector 24) -> BitVector 192) m
   where
     setup = return smallValue1
+
+vectorUnpackBench :: Benchmark
+vectorUnpackBench = env setup $ \m ->
+  bench "unpack" $
+  nf (unpack :: BitVector 192 -> Vec 8 (BitVector 24)) m
+  where
+    setup = return smallValue2

--- a/clash-prelude/benchmarks/BenchVector.hs
+++ b/clash-prelude/benchmarks/BenchVector.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE CPP, DataKinds, MagicHash, TypeOperators, TemplateHaskell #-}
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE NoStarIsType #-}
+#endif
+
+{-# OPTIONS_GHC -ddump-simpl -ddump-splices -ddump-to-file #-}
+
+#define WORD_SIZE_IN_BITS 64
+
+module BenchVector (vectorBench) where
+
+import Clash.Class.BitPack
+import Clash.Promoted.Nat.Literals
+import Clash.Sized.BitVector
+import Clash.Sized.Vector
+import Criterion                   (Benchmark, env, bench, nf, bgroup)
+import Language.Haskell.TH.Syntax  (lift)
+import Prelude                     hiding (replicate)
+
+vectorBench :: Benchmark
+vectorBench = bgroup "Vector"
+  [ vectorPackBench
+  ]
+
+smallValue1 :: Vec 8 (BitVector 24)
+smallValue1 = $(lift (replicate d8 (2^(16::Int)-10 :: BitVector 24)))
+{-# INLINE smallValue1 #-}
+
+vectorPackBench :: Benchmark
+vectorPackBench = env setup $ \m ->
+  bench "pack" $
+  nf (pack :: Vec 8 (BitVector 24) -> BitVector 192) m
+  where
+    setup = return smallValue1

--- a/clash-prelude/benchmarks/benchmark-main.hs
+++ b/clash-prelude/benchmarks/benchmark-main.hs
@@ -7,6 +7,7 @@ import BenchBitVector
 import BenchFixed
 import BenchSigned
 import BenchUnsigned
+import BenchVector
 
 main :: IO ()
 main =
@@ -16,4 +17,5 @@ main =
   , fixedBench
   , signedBench
   , unsignedBench
+  , vectorBench
   ]

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -424,3 +424,4 @@ benchmark benchmark-clash-prelude
                     BenchRAM
                     BenchSigned
                     BenchUnsigned
+                    BenchVector

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -786,17 +786,14 @@ split#
    . KnownNat n
   => BitVector (m + n)
   -> (BitVector m, BitVector n)
-split# (BV m i) = (BV lMask l, BV rMask r)
-  where
-    n     = fromInteger (natVal (Proxy @n))
-    mask  = 1 `shiftL` n
-    -- The code below is faster than:
-    -- > (l,r) = i `divMod` mask
-    r     = i `mod` mask
-    rMask = m `mod` mask
-    l     = i `shiftR` n
-    lMask = m `shiftR` n
-
+split# (BV m i) =
+  let n     = fromInteger (natVal (Proxy @n))
+      mask  = maskMod (natVal (Proxy @n))
+      r     = mask i
+      rMask = mask m
+      l     = i `shiftR` n
+      lMask = m `shiftR` n
+  in  (BV lMask l, BV rMask r)
 
 and#, or#, xor# :: forall n . KnownNat n => BitVector n -> BitVector n -> BitVector n
 {-# NOINLINE and# #-}

--- a/clash-prelude/tests/Clash/Tests/BitPack.hs
+++ b/clash-prelude/tests/Clash/Tests/BitPack.hs
@@ -9,6 +9,8 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Clash.Class.BitPack
+import Clash.Sized.Vector
+import Clash.Sized.Signed
 
 import GHC.Generics (Generic)
 
@@ -44,6 +46,7 @@ tests =
         , testCase "SP2" (rtt (P 10))
         , testCase "Rec1" (rtt (Rec1 10))
         , testCase "Rec2" (rtt (Rec2 10 30))
+        , testCase "Vec" (rtt ((1 :: Signed 6) :> 2 :> (-5) :> 4 :> Nil))
         ]
     ]
 


### PR DESCRIPTION
Before:
```
benchmarking Vector/pack
time                 662.0 ns   (660.4 ns .. 663.4 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 659.9 ns   (658.5 ns .. 661.4 ns)
std dev              4.740 ns   (4.109 ns .. 5.578 ns)

benchmarking Vector/unpack
time                 1.197 μs   (1.196 μs .. 1.200 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.197 μs   (1.196 μs .. 1.201 μs)
std dev              6.806 ns   (2.929 ns .. 12.70 ns)

benchmarking BitVector/split# WORD_SIZE_IN_BITS
time                 52.77 ns   (52.58 ns .. 53.07 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 52.71 ns   (52.63 ns .. 52.83 ns)
std dev              312.5 ps   (209.9 ps .. 502.4 ps)

benchmarking BitVector/split# (3*WORD_SIZE_IN_BITS)
time                 61.04 ns   (60.98 ns .. 61.15 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 61.08 ns   (61.04 ns .. 61.18 ns)
std dev              219.1 ps   (132.5 ps .. 351.4 ps)
```
after:
```
benchmarking Vector/pack
time                 491.6 ns   (490.5 ns .. 492.9 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 491.6 ns   (490.9 ns .. 492.8 ns)
std dev              2.963 ns   (2.181 ns .. 3.994 ns)

benchmarking Vector/unpack
time                 796.2 ns   (795.5 ns .. 797.0 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 796.5 ns   (795.9 ns .. 797.5 ns)
std dev              2.521 ns   (1.787 ns .. 3.911 ns)

benchmarking BitVector/split# WORD_SIZE_IN_BITS
time                 39.09 ns   (39.08 ns .. 39.10 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 39.15 ns   (39.12 ns .. 39.22 ns)
std dev              134.2 ps   (70.88 ps .. 252.6 ps)

benchmarking BitVector/split# (3*WORD_SIZE_IN_BITS)
time                 59.10 ns   (59.09 ns .. 59.12 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 59.12 ns   (59.11 ns .. 59.15 ns)
std dev              68.60 ps   (45.69 ps .. 118.2 ps)
```