### PR TITLE
autoDelay: autoReg without the reset

### DIFF
--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -62,11 +62,12 @@ import           Clash.Netlist.Util
 import           Clash.Normalize.Strategy
 import           Clash.Normalize.Transformations
   (appPropFast, bindConstantVar, caseCon, flattenLet, reduceConst, topLet,
-   reduceNonRepPrim, removeUnusedExpr)
+   reduceNonRepPrim, removeUnusedExpr, deadCode)
 import           Clash.Normalize.Types
 import           Clash.Normalize.Util
 import           Clash.Primitives.Types           (CompiledPrimMap)
-import           Clash.Rewrite.Combinators        ((>->),(!->),repeatR,topdownR)
+import           Clash.Rewrite.Combinators
+  ((>->),(!->),repeatR,topdownR,bottomupR)
 import           Clash.Rewrite.Types
   (RewriteEnv (..), RewriteState (..), bindings, dbgLevel, extra,
    tcCache, topEntities)
@@ -393,6 +394,7 @@ flattenCallTree (CBranch (nm,(Binding nm' sp inl tm)) used) = do
                  apply "reduceNonRepPrim" reduceNonRepPrim >->
                  apply "removeUnusedExpr" removeUnusedExpr >->
                  apply "flattenLet" flattenLet)) !->
+      bottomupR (apply "deadcode" deadCode) >->
       topdownSucR (apply "topLet" topLet)
 
     goCheap c@(CLeaf   (nm2,(Binding _ _ inl2 e)))

--- a/clash-prelude/src/Clash/Class/AutoReg.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg.hs
@@ -5,7 +5,7 @@
 -}
 
 module Clash.Class.AutoReg
-  ( AutoReg (autoReg)
+  ( AutoReg (autoReg, autoDelay)
   , deriveAutoReg
   ) where
 

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -133,7 +133,7 @@ module Clash.Prelude
     -- ** Type classes
     -- *** Clash
   -- , module Clash.Class.AutoReg
-  , autoReg, deriveAutoReg
+  , autoReg, autoDelay, deriveAutoReg
   , module Clash.Class.BitPack
   , module Clash.Class.Exp
   , module Clash.Class.Num
@@ -272,3 +272,11 @@ autoReg
   -> Signal dom a
   -> Signal dom a
 autoReg = hideClockResetEnable E.autoReg
+
+-- | Implicit version of 'Clash.Class.AutoReg.autoDelay'
+autoDelay
+  :: (HasCallStack, HiddenClockEnable dom, AutoReg a)
+  => a
+  -> Signal dom a
+  -> Signal dom a
+autoDelay = hideClockEnable E.autoDelay

--- a/tests/shouldwork/AutoReg/AutoReg.hs
+++ b/tests/shouldwork/AutoReg/AutoReg.hs
@@ -91,15 +91,31 @@ expectedRegCount = sum
   , 1   -- Bool
   , 2   -- Tup2
   , 3   -- Tup3
-  , 2   -- Maybe Bool
-  , 3   -- Maybe (Maybe Bool)
+  , 1   -- Maybe Bool
+  , 1   -- Maybe (Maybe Bool)
   , 2   -- OtherPair Int8 Int16
   , 2   -- Concrete
   , 2   -- InfixDataCon Bool Bool
   , 1   -- ((),Bool)
   , 2   -- Vec 2 Bool
-  , 2*2 -- Vec 2 (Maybe Bool)
-  , 1+2*2 -- Maybe (Vec 2 (Maybe Bool))
+  , 2*1 -- Vec 2 (Maybe Bool)
+  , 1   -- Maybe (Vec 2 (Maybe Bool))
+  ]
+
+expectedDelayCount = sum
+  [ 0   -- Unsigned
+  , 0   -- Bool
+  , 0   -- Tup2
+  , 0   -- Tup3
+  , 1   -- Maybe Bool
+  , 2   -- Maybe (Maybe Bool)
+  , 0   -- OtherPair Int8 Int16
+  , 0   -- Concrete
+  , 0   -- InfixDataCon Bool Bool
+  , 0   -- ((),Bool)
+  , 0   -- Vec 2 Bool
+  , 2*1 -- Vec 2 (Maybe Bool)
+  , 2*2 -- Maybe (Vec 2 (Maybe Bool))
   ]
 
 countLinesContaining :: String -> String -> Int
@@ -110,6 +126,13 @@ mainHDL topFile = do
   [topDir] <- getArgs
   content <- readFile (takeDirectory topDir </> topFile)
   let regCount = countLinesContaining "register begin" content
+      delayCount = countLinesContaining "delay begin" content
+  when (expectedDelayCount /= delayCount)
+    (error $ unlines
+      [ ""
+      , "Error: Found " <> show delayCount <> " delays in " <> topFile
+      , "But expected " <> show expectedDelayCount
+      ])
   when (expectedRegCount /= regCount)
     (error $ unlines
       [ ""


### PR DESCRIPTION
Mostly so that we don't generate reset ports for the field bits of a `Maybe a` when the reset value is `Nothing`. Although the field bits would subsequently be reset to undefined, there's not guarantee that logic synthesis actually removes the reset port on the register, it's free to leave it in and reset to whatever it wants.

With autoDelay, we are explicit in the fact that we don't want a reset port.