### PR TITLE
mergify: don't fail silently when cherry-picking fails

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,5 +5,6 @@ pull_request_rules:
       - label=backport 1.2
     actions:
       backport:
+        ignore_conflicts: True
         branches:
           - "1.2"


### PR DESCRIPTION
Flag documentation from https://doc.mergify.io/actions.html:

    Whether to create the pull requests even if they are
    conflicts when cherry-picking the commits.