### PR TITLE
CI: test that the index-state is new enough

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -4,6 +4,11 @@ set -xeo pipefail
 # TODO: make sdist work on all, it currently fails for clash-cosim
 cabal new-sdist clash-prelude clash-lib clash-ghc
 
+# test that we can create a build plan with the index-state in cabal.project
+mv cabal.project.local cabal.project.local.disabled
+cabal new-build --dry-run all > /dev/null || (echo Maybe the index-state should be updated?; false)
+mv cabal.project.local.disabled cabal.project.local
+
 cabal new-build all
 
 # Build with installed constraints for packages in global-db

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ packages:
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2020-03-09T08:01:04Z
+index-state: 2020-03-09T11:53:12Z
 
 -- For some reason the `clash-testsuite` executable fails to run without
 -- this, as it cannot find the related library...


### PR DESCRIPTION
This should make the CI fail, because the current `index-state` doesn't contain `ghc-typelits-natnormalise-0.7.2`.

After it failed I'll add a commit to update the index-state and fix it.