### PR TITLE
Fix makeTopEntity for #1182 and add netlist tests

### DIFF
--- a/clash-prelude/src/Clash/Annotations/TH.hs
+++ b/clash-prelude/src/Clash/Annotations/TH.hs
@@ -253,9 +253,10 @@ typeTreeToPorts (AppTF (AppT (ConT split) (LitT (StrTyLit name)), _) (_,c))
   -- - We only have no names from children: use split name as PortName
   -- - We have children reporting names: use split name as name to PortProduct
   = c >>= \case
-    Complete [] -> return $ Complete [PortName name]
-    Complete xs -> return $ Complete [PortProduct name xs]
-    x           -> return x
+    Complete []  -> return $ Complete [PortName name]
+    Complete [PortName n2] -> return $ Complete [PortName (name ++ "_" ++ n2)]
+    Complete xs  -> return $ Complete [PortProduct name xs]
+    x            -> return x
 
 typeTreeToPorts (ConTF name) = do
   -- Only attempt to resolve a subtree for names we haven't seen before

--- a/clash-prelude/tests/Clash/Tests/TopEntityGeneration.hs
+++ b/clash-prelude/tests/Clash/Tests/TopEntityGeneration.hs
@@ -138,10 +138,10 @@ expectedTopEntity4 =
   Synthesize "topEntity4"
     [ PortName "gadt"
     , PortName "s"
-    , PortProduct "cfiii" [PortName "s"]
-    , PortProduct "cfbii" [PortName "s"]
-    , PortProduct "ofiii" [PortName "s"]
-    , PortProduct "ofbii" [PortName "s"]
+    , PortName "cfiii_s"
+    , PortName "cfbii_s"
+    , PortName "ofiii_s"
+    , PortName "ofbii_s"
     , PortProduct "" [PortName "xiii", PortName "xiii2"]
     , PortName "xbii"
     ]
@@ -209,7 +209,7 @@ expectedTopEntity8 =
  Synthesize "topEntity8"
     [ PortProduct "" [PortName "clk", PortName "rst", PortName "en"]
     , PortProduct "pair" [PortName "left", PortName "right"]
-    , PortProduct "pair" [PortProduct "left" [PortName "s"], PortProduct "right" [PortName "s"]]
+    , PortProduct "pair" [PortName "left_s", PortName "right_s"]
     ]
     (PortName "out")
 
@@ -261,7 +261,7 @@ topEntityFailure7 = undefined
 #endif
 
 topEntityFailure8
-  :: "int"     ::: Signal System (Passthrough Int Simple )
+  :: "int"     ::: Signal System (Passthrough Int Simple)
   -> "out"     ::: Signal System Bool
 topEntityFailure8 = undefined
 

--- a/tests/shouldwork/TopEntity/PortGeneration.hs
+++ b/tests/shouldwork/TopEntity/PortGeneration.hs
@@ -1,0 +1,200 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module PortNames where
+
+import qualified Prelude as P
+
+import Clash.Prelude
+import Clash.Annotations.TH
+
+type Pair a = ("left" ::: a, "right" ::: a)
+
+data Unnamed = Unnamed Int
+data Simple = Simple ("simple1" ::: Int) ("simple2" ::: Bool)
+data Named
+  = Named
+  { name1 :: "named1" ::: BitVector 3
+  , name2 :: "named2" ::: BitVector 5
+  }
+data Embedded
+  = Embedded
+  { name3 :: "embedded1" ::: Simple
+  , name4 :: "embedded2" ::: Bool
+  }
+data OneSide
+  = OneSide
+  { name5 :: "embedded1" ::: Simple
+  , name6 :: Bool
+  }
+newtype Single = Single ("s" ::: Int)
+
+data Gadt x where
+  Gadt :: ("gadt" ::: Int) -> Gadt Int
+
+type family CF x y z where
+  CF Int Int Int = ("cfiii" ::: Single)
+  CF Bool Int Int = ("cfbii" ::: Single)
+type family OF x y z
+type instance OF Int Int Int = ("ofiii" ::: Single)
+type instance OF Bool Int Int = ("ofbii" ::: Single)
+
+data family X x y z
+data instance X Int Int Int = X1 ("xiii" ::: Int) ("xiii2" ::: Bool)
+newtype instance X Bool Int Int = X2 ("xbii" ::: Int)
+
+data Impossible = L ("left" ::: Int) | R ("right" ::: Bool)
+
+data FailureTy1 = TwoF1 ("one" ::: Int) Int
+data SuccessTy = TwoS ("one" ::: Int) Single
+
+data Passthrough a b = Passthrough a b
+
+topEntity1 :: "in1" ::: Signal System Int
+           -> "in2" ::: Signal System Bool
+           -> "out" ::: Signal System Int
+topEntity1 = undefined
+makeTopEntity 'topEntity1
+
+expectedTopEntity1 :: TopEntity
+expectedTopEntity1 =
+ Synthesize "topEntity1"
+    [PortName "in1", PortName "in2"]
+    (PortName "out")
+
+topEntity2 :: "int"      ::: Signal System Int
+           -> "tuple"    ::: ( "tup1" ::: Signal System (BitVector 7)
+                             , "tup2" ::: Signal System (BitVector 9))
+           -> "simple"   ::: Signal System Simple
+           -> "named"    ::: Signal System Named
+           -> "embedded" ::: Signal System Embedded
+           -> "out"      ::: Signal System Bool
+topEntity2 = undefined
+makeTopEntity 'topEntity2
+
+expectedTopEntity2 :: TopEntity
+expectedTopEntity2 =
+  Synthesize "topEntity2"
+    [ PortName "int"
+    , PortProduct "tuple" [PortName "tup1",PortName "tup2"]
+    , PortProduct "simple" [PortName "simple1",PortName "simple2"]
+    , PortProduct "named" [PortName "named1",PortName "named2"]
+    , PortProduct "embedded"
+      [ PortProduct "embedded1"
+        [ PortName "simple1"
+        , PortName "simple2"]
+      , PortName "embedded2"]
+    ]
+    (PortName "out")
+
+topEntity3 :: "clk" ::: Clock System
+           -> "rst" ::: Reset System
+           -> "en"  ::: Enable System
+           -> "tup1" ::: Signal System (Int, Bool)
+           -> "tup2" ::: (Signal System Int, Signal System Bool)
+           -> "tup3" ::: Signal System ("int":::Int, "bool":::Bool)
+           -> "tup4" ::: ("int":::Signal System Int, "bool":::Signal System Bool)
+           -> "custom" ::: Signal System Named
+           -> "outTup" ::: Signal System ("outint":::Int, "outbool":::Bool)
+topEntity3 = undefined
+makeTopEntity 'topEntity3
+
+expectedTopEntity3 :: TopEntity
+expectedTopEntity3 =
+  Synthesize "topEntity3"
+    [ PortName "clk"
+    , PortName "rst"
+    , PortName "en"
+    , PortName "tup1"
+    , PortName "tup2"
+    , PortProduct "tup3" [PortName "int",PortName "bool"]
+    , PortProduct "tup4" [PortName "int",PortName "bool"]
+    , PortProduct "custom" [PortName "named1",PortName "named2"]
+    ]
+    (PortProduct "outTup" [PortName "outint",PortName "outbool"])
+
+topEntity4 :: Signal System (Gadt Int)
+           -> Signal System Single
+           -> Signal System (CF Int Int Int)
+           -> Signal System (CF Bool Int Int)
+           -> Signal System (OF Int Int Int)
+           -> Signal System (OF Bool Int Int)
+           -> Signal System (X Int Int Int)
+           -> Signal System (X Bool Int Int)
+           -> Signal System Single
+topEntity4 = undefined
+makeTopEntity 'topEntity4
+
+expectedTopEntity4 :: TopEntity
+expectedTopEntity4 =
+  Synthesize "topEntity4"
+    [ PortName "gadt"
+    , PortName "s"
+    , PortProduct "cfiii" [PortName "s"]
+    , PortProduct "cfbii" [PortName "s"]
+    , PortProduct "ofiii" [PortName "s"]
+    , PortProduct "ofbii" [PortName "s"]
+    , PortProduct "" [PortName "xiii", PortName "xiii2"]
+    , PortName "xbii"
+    ]
+    (PortName "s")
+
+topEntity5 :: "in1" ::: Signal System SuccessTy
+           -> "ab"     ::: Signal System (Passthrough (Passthrough Simple Simple) Simple)
+           -> "out" ::: Signal System Int
+topEntity5 = undefined
+makeTopEntity 'topEntity5
+
+expectedTopEntity5 :: TopEntity
+expectedTopEntity5 =
+ Synthesize "topEntity5"
+    [ PortProduct "in1" [PortName "one", PortName "s"]
+    , PortProduct "ab" [PortProduct "" [PortProduct "" [PortName "simple1",PortName "simple2"]
+                                       ,PortProduct "" [PortName "simple1",PortName "simple2"]]
+                       ,PortProduct "" [PortName "simple1",PortName "simple2"]]
+    ]
+    (PortName "out")
+
+expectedTopEntity6 :: TopEntity
+expectedTopEntity6 =
+ Synthesize "topEntity6"
+    [ PortProduct "" [ PortName "clk", PortName "rst", PortName "en"]
+    , PortProduct "in1" [PortName "one", PortName "s"]]
+    (PortName "out")
+
+
+topEntity7 :: (HiddenClockResetEnable System)
+           => "in1" ::: Signal System (Vec 3 Int)
+           -> "in2" ::: Signal System (Vec 3 Simple)
+           -> "passthrough" ::: Signal System (Passthrough Single Single)
+           -> "out" ::: Signal System Int
+topEntity7 = undefined
+makeTopEntity 'topEntity7
+
+expectedTopEntity7 :: TopEntity
+expectedTopEntity7 =
+ Synthesize "topEntity7"
+    [ PortProduct "" [PortName "clk", PortName "rst", PortName "en"]
+    , PortName "in1"
+    , PortName "in2"
+    , PortProduct "passthrough" [PortName "s", PortName "s"]
+    ]
+    (PortName "out")
+
+topEntity8 :: (HiddenClockResetEnable System)
+           => "pair" ::: Signal System (Pair Bool)
+           -> "pair" ::: Signal System (Pair Single)
+           -> "out" ::: Signal System Int
+topEntity8 = undefined
+makeTopEntity 'topEntity8
+
+expectedTopEntity8 :: TopEntity
+expectedTopEntity8 =
+ Synthesize "topEntity8"
+    [ PortProduct "" [PortName "clk", PortName "rst", PortName "en"]
+    , PortProduct "pair" [PortName "left", PortName "right"]
+    , PortProduct "pair" [PortProduct "left" [PortName "s"], PortProduct "right" [PortName "s"]]
+    ]
+    (PortName "out")

--- a/tests/shouldwork/TopEntity/PortGeneration.hs
+++ b/tests/shouldwork/TopEntity/PortGeneration.hs
@@ -58,12 +58,6 @@ topEntity1 :: "in1" ::: Signal System Int
 topEntity1 = undefined
 makeTopEntity 'topEntity1
 
-expectedTopEntity1 :: TopEntity
-expectedTopEntity1 =
- Synthesize "topEntity1"
-    [PortName "in1", PortName "in2"]
-    (PortName "out")
-
 topEntity2 :: "int"      ::: Signal System Int
            -> "tuple"    ::: ( "tup1" ::: Signal System (BitVector 7)
                              , "tup2" ::: Signal System (BitVector 9))
@@ -73,21 +67,6 @@ topEntity2 :: "int"      ::: Signal System Int
            -> "out"      ::: Signal System Bool
 topEntity2 = undefined
 makeTopEntity 'topEntity2
-
-expectedTopEntity2 :: TopEntity
-expectedTopEntity2 =
-  Synthesize "topEntity2"
-    [ PortName "int"
-    , PortProduct "tuple" [PortName "tup1",PortName "tup2"]
-    , PortProduct "simple" [PortName "simple1",PortName "simple2"]
-    , PortProduct "named" [PortName "named1",PortName "named2"]
-    , PortProduct "embedded"
-      [ PortProduct "embedded1"
-        [ PortName "simple1"
-        , PortName "simple2"]
-      , PortName "embedded2"]
-    ]
-    (PortName "out")
 
 topEntity3 :: "clk" ::: Clock System
            -> "rst" ::: Reset System
@@ -101,20 +80,6 @@ topEntity3 :: "clk" ::: Clock System
 topEntity3 = undefined
 makeTopEntity 'topEntity3
 
-expectedTopEntity3 :: TopEntity
-expectedTopEntity3 =
-  Synthesize "topEntity3"
-    [ PortName "clk"
-    , PortName "rst"
-    , PortName "en"
-    , PortName "tup1"
-    , PortName "tup2"
-    , PortProduct "tup3" [PortName "int",PortName "bool"]
-    , PortProduct "tup4" [PortName "int",PortName "bool"]
-    , PortProduct "custom" [PortName "named1",PortName "named2"]
-    ]
-    (PortProduct "outTup" [PortName "outint",PortName "outbool"])
-
 topEntity4 :: Signal System (Gadt Int)
            -> Signal System Single
            -> Signal System (CF Int Int Int)
@@ -127,43 +92,11 @@ topEntity4 :: Signal System (Gadt Int)
 topEntity4 = undefined
 makeTopEntity 'topEntity4
 
-expectedTopEntity4 :: TopEntity
-expectedTopEntity4 =
-  Synthesize "topEntity4"
-    [ PortName "gadt"
-    , PortName "s"
-    , PortProduct "cfiii" [PortName "s"]
-    , PortProduct "cfbii" [PortName "s"]
-    , PortProduct "ofiii" [PortName "s"]
-    , PortProduct "ofbii" [PortName "s"]
-    , PortProduct "" [PortName "xiii", PortName "xiii2"]
-    , PortName "xbii"
-    ]
-    (PortName "s")
-
 topEntity5 :: "in1" ::: Signal System SuccessTy
            -> "ab"     ::: Signal System (Passthrough (Passthrough Simple Simple) Simple)
            -> "out" ::: Signal System Int
 topEntity5 = undefined
 makeTopEntity 'topEntity5
-
-expectedTopEntity5 :: TopEntity
-expectedTopEntity5 =
- Synthesize "topEntity5"
-    [ PortProduct "in1" [PortName "one", PortName "s"]
-    , PortProduct "ab" [PortProduct "" [PortProduct "" [PortName "simple1",PortName "simple2"]
-                                       ,PortProduct "" [PortName "simple1",PortName "simple2"]]
-                       ,PortProduct "" [PortName "simple1",PortName "simple2"]]
-    ]
-    (PortName "out")
-
-expectedTopEntity6 :: TopEntity
-expectedTopEntity6 =
- Synthesize "topEntity6"
-    [ PortProduct "" [ PortName "clk", PortName "rst", PortName "en"]
-    , PortProduct "in1" [PortName "one", PortName "s"]]
-    (PortName "out")
-
 
 topEntity7 :: (HiddenClockResetEnable System)
            => "in1" ::: Signal System (Vec 3 Int)
@@ -173,28 +106,9 @@ topEntity7 :: (HiddenClockResetEnable System)
 topEntity7 = undefined
 makeTopEntity 'topEntity7
 
-expectedTopEntity7 :: TopEntity
-expectedTopEntity7 =
- Synthesize "topEntity7"
-    [ PortProduct "" [PortName "clk", PortName "rst", PortName "en"]
-    , PortName "in1"
-    , PortName "in2"
-    , PortProduct "passthrough" [PortName "s", PortName "s"]
-    ]
-    (PortName "out")
-
 topEntity8 :: (HiddenClockResetEnable System)
            => "pair" ::: Signal System (Pair Bool)
            -> "pair" ::: Signal System (Pair Single)
            -> "out" ::: Signal System Int
 topEntity8 = undefined
 makeTopEntity 'topEntity8
-
-expectedTopEntity8 :: TopEntity
-expectedTopEntity8 =
- Synthesize "topEntity8"
-    [ PortProduct "" [PortName "clk", PortName "rst", PortName "en"]
-    , PortProduct "pair" [PortName "left", PortName "right"]
-    , PortProduct "pair" [PortProduct "left" [PortName "s"], PortProduct "right" [PortName "s"]]
-    ]
-    (PortName "out")

--- a/tests/shouldwork/TopEntity/PortGeneration.hs
+++ b/tests/shouldwork/TopEntity/PortGeneration.hs
@@ -112,3 +112,14 @@ topEntity8 :: (HiddenClockResetEnable System)
            -> "out" ::: Signal System Int
 topEntity8 = undefined
 makeTopEntity 'topEntity8
+
+-- Only check for successful Clash compilation, not content
+
+mainVHDL :: IO ()
+mainVHDL = pure ()
+
+mainVerilog :: IO ()
+mainVerilog = pure ()
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = pure ()

--- a/tests/shouldwork/TopEntity/T1182A.hs
+++ b/tests/shouldwork/TopEntity/T1182A.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module PortNames where
+
+import qualified Prelude as P
+
+import Clash.Prelude
+import Clash.Netlist.Types
+import Clash.Annotations.TH
+
+import Clash.Class.HasDomain
+
+import Test.Tasty.Clash
+import Test.Tasty.Clash.NetlistTest
+
+import qualified Data.Text as T
+
+data SevenSegment dom (n :: Nat) = SevenSegment
+    { anodes :: "AN" ::: Signal dom (Vec n Bool) }
+
+type instance TryDomain t (SevenSegment dom n) = Found dom
+
+topEntity
+    :: "CLK" ::: Clock System
+    -> "SS" ::: SevenSegment System 8
+topEntity clk = withClockResetEnable clk resetGen enableGen $
+    SevenSegment{ anodes = pure $ repeat False }
+makeTopEntity 'topEntity
+
+testPath :: FilePath
+testPath = "tests/shouldwork/TopEntity/T1182A.hs"
+
+assertInputs :: Component -> IO ()
+assertInputs (Component _ [(clk,Clock _)] [(Wire,(ssan,Vector 8 Bool),Nothing)] ds)
+  | clk == T.pack "CLK"
+  && ssan == T.pack "SS_AN"
+  = pure ()
+assertInputs c = error $ "Component mismatch: " P.++ show c
+
+getComponent :: (a, b, c, d) -> d
+getComponent (_, _, _, x) = x
+
+mainVHDL :: IO ()
+mainVHDL = do
+  netlist <- runToNetlistStage SVHDL id testPath
+  mapM_ (assertInputs . getComponent) netlist
+
+mainVerilog :: IO ()
+mainVerilog = do
+  netlist <- runToNetlistStage SVerilog id testPath
+  mapM_ (assertInputs . getComponent) netlist
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  netlist <- runToNetlistStage SSystemVerilog id testPath
+  mapM_ (assertInputs . getComponent) netlist
+

--- a/tests/shouldwork/TopEntity/T1182B.hs
+++ b/tests/shouldwork/TopEntity/T1182B.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module PortNames where
+
+import qualified Prelude as P
+
+import Clash.Prelude
+import Clash.Netlist.Types
+import Clash.Annotations.TH
+
+import Clash.Class.HasDomain
+
+import Test.Tasty.Clash
+import Test.Tasty.Clash.NetlistTest
+
+import qualified Data.Text as T
+
+data SevenSegment dom (n :: Nat) = SevenSegment
+    { anodes :: "AN" ::: Signal dom (Vec n Bool)
+    , segments :: "SEG" ::: Signal dom (Vec 7 Bool)
+    , dp :: "DP" ::: Signal dom Bool
+    }
+
+type instance TryDomain t (SevenSegment dom n) = Found dom
+
+topEntity
+    :: "CLK" ::: Clock System
+    -> "SS" ::: SevenSegment System 8
+topEntity clk = withClockResetEnable clk resetGen enableGen $
+    SevenSegment{ anodes = pure $ repeat False, segments = pure $ repeat False, dp = pure False }
+makeTopEntity 'topEntity
+
+testPath :: FilePath
+testPath = "tests/shouldwork/TopEntity/T1182B.hs"
+
+assertInputs :: Component -> IO ()
+assertInputs (Component _ [(clk,Clock _)]
+  [ (Wire,(ssan,Vector 8 Bool),Nothing)
+  , (Wire,(ssseg,Vector 7 Bool),Nothing)
+  , (Wire,(ssdp,Bool),Nothing)
+  ] ds)
+  | clk == T.pack "CLK"
+  && ssan == T.pack "SS_AN"
+  && ssseg == T.pack "SS_SEG"
+  && ssdp == T.pack "SS_DP"
+  = pure ()
+assertInputs c = error $ "Component mismatch: " P.++ show c
+
+getComponent :: (a, b, c, d) -> d
+getComponent (_, _, _, x) = x
+
+mainVHDL :: IO ()
+mainVHDL = do
+  netlist <- runToNetlistStage SVHDL id testPath
+  mapM_ (assertInputs . getComponent) netlist
+
+mainVerilog :: IO ()
+mainVerilog = do
+  netlist <- runToNetlistStage SVerilog id testPath
+  mapM_ (assertInputs . getComponent) netlist
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  netlist <- runToNetlistStage SSystemVerilog id testPath
+  mapM_ (assertInputs . getComponent) netlist
+

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -506,7 +506,7 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithVector" "main"
         , runTest "PortNamesWithRTree" def{hdlTargets=[Verilog],entities=Entities [["", "PortNamesWithRTree_topEntity", "PortNamesWithRTree_testBench"]], topEntities=TopEntities ["PortNamesWithRTree_testBench"]}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithRTree" "main"
-        , runTest  "PortGeneration" def{hdlTargets=[VHDL],hdlSim=False}
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "PortGeneration" "main"
         , netlistTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] "T1182A" "main"
         , netlistTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] "T1182B" "main"
         , runTest "TopEntHOArg" def{entities=Entities [["f", "g"]], topEntities=TopEntities ["f"], hdlSim=False}

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -506,6 +506,9 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithVector" "main"
         , runTest "PortNamesWithRTree" def{hdlTargets=[Verilog],entities=Entities [["", "PortNamesWithRTree_topEntity", "PortNamesWithRTree_testBench"]], topEntities=TopEntities ["PortNamesWithRTree_testBench"]}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithRTree" "main"
+        , runTest  "PortGeneration" def{hdlTargets=[VHDL],hdlSim=False}
+        , netlistTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] "T1182A" "main"
+        , netlistTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] "T1182B" "main"
         , runTest "TopEntHOArg" def{entities=Entities [["f", "g"]], topEntities=TopEntities ["f"], hdlSim=False}
         , runTest "T701" def {hdlSim=False,entities=Entities [["mynot", ""]]}
         , runTest "T1033" def {hdlSim=False,entities=Entities [["top", ""]], topEntities=TopEntities ["top"]}


### PR DESCRIPTION
This squashes PortProducts with a single child, as per Clash. Additionally adds 

- `tests/shouldwork/TopEntity/PortGeneration.hs`: The unit tests from `tests/Clash/Tests/TopEntityGeneration.hs` but makes sure they pass through Clash.
- `tests/shouldwork/TopEntity/T1182{A,B}.hs`: Netlist tests for #1182

I can back port this to 1.2, shall I just cherry pick the commit ontop of the 1.2 tag?