### PR TITLE
Switch around Vector.fold arguments

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ packages:
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2020-03-09T11:53:12Z
+index-state: 2020-03-11T09:14:18Z
 
 -- For some reason the `clash-testsuite` executable fails to run without
 -- this, as it cannot find the related library...

--- a/changelog/2020-03-10T13:26:52+01:00_vector_fold_arguments_switched.md
+++ b/changelog/2020-03-10T13:26:52+01:00_vector_fold_arguments_switched.md
@@ -1,0 +1,1 @@
+CHANGED: Type arguments of `Clash.Sized.Vector.fold` swapped: before `forall a n . (a -> a -> a) -> Vec (n+1) a -> a`, after `forall n a . (a -> a -> a) -> Vec (n+1) a`. This makes it easier to use `fold` in a `1 <= n` context so you can "simply" do `fold @(n-1)`

--- a/clash-cosim/clash-cosim.cabal
+++ b/clash-cosim/clash-cosim.cabal
@@ -72,7 +72,7 @@ Library
   Build-Depends:    base                      >= 4.10    && < 5,
                     clash-prelude             >= 0.99,
                     deepseq                   >= 1.4.0,
-                    ghc-typelits-extra        >= 0.2.1   && < 0.4,
+                    ghc-typelits-extra        >= 0.2.1   && < 0.5,
                     ghc-typelits-knownnat     >= 0.2.2   && < 0.8,
                     ghc-typelits-natnormalise >= 0.4.2   && < 0.8,
                     neat-interpolation        >= 0.3.0,

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -148,7 +148,7 @@ library
                       clash-lib                 == 1.3.0,
                       clash-prelude             == 1.3.0,
                       concurrent-supply         >= 0.1.7    && < 0.2,
-                      ghc-typelits-extra        >= 0.3.2    && < 0.4,
+                      ghc-typelits-extra        >= 0.3.2    && < 0.5,
                       ghc-typelits-knownnat     >= 0.6      && < 0.8,
                       ghc-typelits-natnormalise >= 0.6      && < 0.8,
                       deepseq                   >= 1.3.0.2  && < 1.5,

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -3032,7 +3032,7 @@ reduceConstant tcm isSubj pInfo tys args mach = case primName pInfo of
                      ]
   "Clash.Sized.Vector.fold" -- :: (a -> a -> a) -> Vec (n + 1) a -> a
     | isSubj
-    , aTy : nTy : _ <- tys
+    , nTy : aTy :  _ <- tys
     , f : vs : _ <- args
     , DC _ vArgs <- vs
     , Right n <- runExcept (tyNatSize tcm nTy)
@@ -3071,14 +3071,14 @@ reduceConstant tcm isSubj pInfo tys args mach = case primName pInfo of
               in  reduceWHNF $
                   mkApps (valToTerm f)
                          [Left (mkApps (Prim pInfo)
-                                       [Right aTy
-                                       ,Right m'ty
+                                       [Right m'ty
+                                       ,Right aTy
                                        ,Left (valToTerm f)
                                        ,Left (Case splitAtCall mVecTy [asAlt])
                                        ])
                          ,Left (mkApps (Prim pInfo)
-                                       [Right aTy
-                                       ,Right n1m'ty
+                                       [Right n1m'ty
+                                       ,Right aTy
                                        ,Left  (valToTerm f)
                                        ,Left  (Case splitAtCall n1mVecTy [bsAlt])
                                        ])

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -2108,7 +2108,7 @@ reduceNonRepPrim c@(TransformContext is0 ctx) e@(App _ _) | (Prim p, args, ticks
             in  (`mkTicks` ticks) <$> reduceTraverse c n aTy fTy bTy dict fun arg
           _ -> return e
       "Clash.Sized.Vector.fold" | argLen == 4 -> do
-        let [aTy,nTy] = Either.rights args
+        let [nTy,aTy] = Either.rights args
         case runExcept (tyNatSize tcm nTy) of
           Right n -> do
             shouldReduce1 <- orM [ pure (ultra || n == 0)

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -64,7 +64,7 @@ foldBBF _isD _primName args _resTy = do
   pure (Right (meta tcm, bb))
  where
   bb = BBFunction "Clash.Primitives.Sized.Vector.foldTF" 0 foldTF
-  [_, vecLengthMinusOne] = rights args
+  [vecLengthMinusOne, _] = rights args
   vecLength tcm =
     case coreView tcm vecLengthMinusOne of
       (LitTy (NumTy n)) -> n + 1

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -323,7 +323,7 @@ Library
                       integer-gmp               >= 0.5.1.0 && < 1.1,
                       deepseq                   >= 1.4.1.0 && < 1.5,
                       ghc-prim                  >= 0.5.1.0 && < 0.6,
-                      ghc-typelits-extra        >= 0.3.3   && < 0.4,
+                      ghc-typelits-extra        >= 0.4     && < 0.5,
                       ghc-typelits-knownnat     >= 0.7.2   && < 0.8,
                       ghc-typelits-natnormalise >= 0.7.2   && < 0.8,
                       hashable                  >= 1.2.1.0  && < 1.4,

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -1010,7 +1010,7 @@ foldl1 f xs = foldl f (head xs) (tail xs)
 -- \"'fold' @f xs@\" corresponds to the following circuit layout:
 --
 -- <<doc/fold.svg>>
-fold :: (a -> a -> a) -> Vec (n + 1) a -> a
+fold :: forall n a . (a -> a -> a) -> Vec (n + 1) a -> a
 fold f vs = fold' (toList vs)
   where
     fold' [x] = x

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": null,
         "owner": "clash-lang",
         "repo": "ghc-typelits-extra",
-        "rev": "4260319fc9242bac504b74d6e1b9592ae53a3609",
-        "sha256": "1gmvh3gv8zysgfi4xwhiz0xw5hn8wqpdi5dziqsj7knrh69fvp5d",
+        "rev": "487ea1c54c75e49ae56f1f3ced5aabfb1337ac1e",
+        "sha256": "0dabhh3lkl24h2f30smnzyr3bqr7wnj050sk2asx8b30f3aswlbs",
         "type": "tarball",
-        "url": "https://github.com/clash-lang/ghc-typelits-extra/archive/4260319fc9242bac504b74d6e1b9592ae53a3609.tar.gz",
+        "url": "https://github.com/clash-lang/ghc-typelits-extra/archive/487ea1c54c75e49ae56f1f3ced5aabfb1337ac1e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ghc-typelits-natnormalise": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,3 +11,4 @@ extra-deps:
 - ./clash-cosim
 - concurrent-supply-0.1.8@sha256:9373f4868ad28936a7b93781b214ef4afdeacf377ef4ac729583073491c9f9fb,1627
 - ghc-typelits-natnormalise-0.7.2@sha256:0fc48a3744aa25e5e53a054a8bb1fe6410752e497f446d75db9bd67bb258d05e,3495
+- ghc-typelits-extra-0.4@sha256:e1ba4ebf14cb7025dd940380dfb15db444f7e8bced7e30bdad6e1707f0af7622,4813


### PR DESCRIPTION
This makes it easer to use `fold` in a `1 <= n` context so you can "simply" do `fold @(n-1)`. The plugins won't be able to do this automatically because we end up with constraints:

```
[G] 1 <= m
[W] (n + 1) ~ m
```

where there's simply no strategy to discharge that `[W] (n+1) ~ m` in a deterministic and sound way.