### PR TITLE
Handle 'Letrec' in 'mkArgument'

### DIFF
--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -239,6 +239,9 @@ mkArgument bndr e = do
         (Case scrut ty' [alt],[],_) -> do
           (projection,decls) <- mkProjection False (NetlistId bndr ty) scrut ty' alt
           return ((projection,hwTy,False),decls)
+        (Letrec _bnds _term, [], _ticks) -> do
+          (exprN, letDecls) <- mkExpr False Concurrent (NetlistId bndr ty) e
+          return ((exprN,hwTy,False),letDecls)
         _ ->
           return ((Identifier (error ($(curLoc) ++ "Forced to evaluate unexpected function argument: " ++ eTyMsg)) Nothing
                   ,hwTy,False),[])

--- a/tests/shouldwork/Issues/T1187.hs
+++ b/tests/shouldwork/Issues/T1187.hs
@@ -1,0 +1,45 @@
+module T1187 where
+
+-- See https://github.com/clash-lang/clash-compiler/issues/1187
+-- I couldn't reduce the test case any further :(
+
+import T1187.Keypad (inputKeypad)
+import T1187.SerialTx (serialTx)
+import Clash.Prelude
+
+type Digit = Index 10
+
+topEntity
+    :: Clock System
+    -> Signal System Bit
+    -> Signal System (Vec 4 Bool)
+    -> ( Signal System Bit
+      , Signal System (Vec 4 Bool)
+      )
+topEntity clk = withClockResetEnable clk resetGen enableGen board
+  where
+    board rx rows = (tx, cols)
+      where
+        digits = logic @4 cmd
+
+        (tx, ack) = serialTx @8 (SNat @9600) (fmap bitCoerce <$> serialDisplay ack digits)
+        cmd = (const Nothing =<<) <$> (serialRx @8 (SNat @9600) rx)
+
+        (cols, _) = inputKeypad (repeat $ repeat (0 :: Int))  rows
+
+serialDisplay
+    :: forall n dom. (KnownNat n, HiddenClockResetEnable dom)
+    => Signal dom Bool
+    -> Signal dom (Vec n (Maybe Digit))
+    -> Signal dom (Maybe (Unsigned 8))
+serialDisplay _ack _digits = pure Nothing
+
+logic
+    :: forall n dom. (KnownNat n, HiddenClockResetEnable dom)
+    => Signal dom (Maybe ())
+    -> Signal dom (Vec n (Maybe Digit))
+logic = const $ pure $ repeat Nothing
+
+serialRx :: forall n rate dom. SNat rate -> Signal dom Bit -> Signal dom (Maybe (Vec n Bit))
+serialRx _rate = undefined
+

--- a/tests/shouldwork/Issues/T1187/Clock.hs
+++ b/tests/shouldwork/Issues/T1187/Clock.hs
@@ -1,0 +1,16 @@
+module T1187.Clock
+    ( HzToPeriod
+    , Milliseconds
+    , ClockDivider
+    ) where
+
+import Clash.Prelude
+
+type HzToPeriod (rate :: Nat) = (Seconds 1 + rate - 1) `Div` rate
+
+type Seconds (s :: Nat) = Milliseconds (1000 * s)
+type Milliseconds (ms :: Nat) = Microseconds (1000 * ms)
+type Microseconds (us :: Nat) = Nanoseconds (1000 * us)
+type Nanoseconds (ns :: Nat) = 1000 * ns
+
+type ClockDivider dom ps = ps `Div` DomainPeriod dom

--- a/tests/shouldwork/Issues/T1187/Keypad.hs
+++ b/tests/shouldwork/Issues/T1187/Keypad.hs
@@ -1,0 +1,56 @@
+module T1187.Keypad (inputKeypad) where
+
+import Clash.Prelude
+import T1187.Utils (debounce, roundRobin, moreIdx, (.==))
+import T1187.Clock (Milliseconds, ClockDivider)
+import Control.Monad (mplus)
+
+type Matrix rows cols a = Vec rows (Vec cols a)
+
+type KeyStates rows cols = Matrix rows cols Bool
+
+data KeyEvent
+    = Pressed
+    | Released
+    deriving (Show, Eq, Generic, NFDataX)
+
+type KeyEvents rows cols = Matrix rows cols (Maybe KeyEvent)
+
+scanKeypad
+    :: (KnownNat rows, KnownNat cols, HiddenClockResetEnable dom)
+    => Signal dom (Vec rows Bool)
+    -> (Signal dom (Vec cols Bool), Signal dom (KeyStates rows cols))
+scanKeypad rows = (cols, transpose <$> bundle state)
+  where
+    (cols, currentCol) = roundRobin nextCol
+    nextCol = riseEvery (SNat @1000)
+
+    state = map colState indicesI
+      where
+        colState thisCol = regEn (repeat False) (stable .&&. currentCol .== thisCol) $ rows
+
+        stable = cnt .== maxBound
+        cnt = register (0 :: Index 10) $ mux nextCol 0 (moreIdx <$> cnt)
+
+keypadEvents
+    :: (KnownNat rows, KnownNat cols, HiddenClockResetEnable dom)
+    => Signal dom (KeyStates rows cols)
+    -> Signal dom (KeyEvents rows cols)
+keypadEvents states = zipWith (zipWith undefined) <$> states <*> states
+
+pressedKeys :: Matrix rows cols a -> KeyEvents rows cols  -> Matrix rows cols (Maybe a)
+pressedKeys = zipWith (zipWith undefined)
+
+firstJust2D :: Matrix rows cols (Maybe a) -> Maybe a
+firstJust2D = foldl (foldl mplus) Nothing
+
+inputKeypad
+    :: (KnownNat rows, KnownNat cols, HiddenClockResetEnable dom, KnownNat (ClockDivider dom (Milliseconds 5)))
+    => Matrix rows cols a
+    -> Signal dom (Vec rows Bool)
+    -> (Signal dom (Vec cols Bool), Signal dom (Maybe a))
+inputKeypad keymap rows = (cols, pressedKey)
+  where
+    (cols, keyState) = scanKeypad rows
+    events = keypadEvents . debounce (SNat @(Milliseconds 5)) (repeat . repeat $ False) $ keyState
+    pressedKey = firstJust2D . pressedKeys keymap <$> events

--- a/tests/shouldwork/Issues/T1187/SerialTx.hs
+++ b/tests/shouldwork/Issues/T1187/SerialTx.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+module T1187.SerialTx
+    ( serialTx
+    , serialTxDyn
+    , fifo
+    ) where
+
+import Clash.Prelude
+import T1187.Utils (mealyStateB)
+import T1187.Clock
+
+import Control.Monad.State
+
+import Data.Word
+
+
+txStep :: Word32 -> Maybe (Vec n Bit) -> State Int (Bit, Bool)
+txStep _bitDuration _input = undefined
+
+serialTxDyn
+    :: (KnownNat n, HiddenClockResetEnable dom)
+    => Signal dom Word32
+    -> Signal dom (Maybe (Vec n Bit))
+    -> (Signal dom Bit, Signal dom Bool)
+serialTxDyn bitDuration input = mealyStateB (uncurry txStep) 0 (bitDuration, input)
+
+serialTx
+    :: forall n rate dom. (KnownNat n, KnownNat (ClockDivider dom (HzToPeriod rate)), HiddenClockResetEnable dom)
+    => SNat rate
+    -> Signal dom (Maybe (Vec n Bit))
+    -> (Signal dom Bit, Signal dom Bool)
+serialTx _rate = serialTxDyn $ pure . fromIntegral . natVal $ SNat @(ClockDivider dom (HzToPeriod rate))
+
+fifo
+    :: forall a dom. (NFDataX a, HiddenClockResetEnable dom)
+    => Signal dom (Maybe a) -> Signal dom Bool -> Signal dom (Maybe a)
+fifo _input _outReady = undefined

--- a/tests/shouldwork/Issues/T1187/Utils.hs
+++ b/tests/shouldwork/Issues/T1187/Utils.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module T1187.Utils
+    ( (.==)
+
+    , debounce
+
+    , roundRobin
+
+    , succIdx, moreIdx
+
+    , mealyStateB
+    ) where
+
+import Clash.Prelude
+import Data.Maybe (fromMaybe)
+import Control.Monad.State
+import T1187.Clock
+
+unchanged :: (HiddenClockResetEnable dom, Eq a, NFDataX a) => a -> Signal dom a -> Signal dom Bool
+unchanged x0 x = x .==. register x0 x
+
+debounce
+    :: forall ps a dom. (Eq a, NFDataX a, HiddenClockResetEnable dom, KnownNat (ClockDivider dom ps))
+    => SNat ps -> a -> Signal dom a -> Signal dom a
+debounce _ initial this = regEn initial stable this
+  where
+    counter = register (0 :: Index (ClockDivider dom ps)) counter'
+    counter' = mux (unchanged initial this) counter 0
+    stable = counter' .==. pure maxBound
+
+roundRobin
+    :: forall n dom. (KnownNat n, HiddenClockResetEnable dom)
+    => Signal dom Bool
+    -> (Signal dom (Vec n Bool), Signal dom (Index n))
+roundRobin _next = undefined
+
+infix 4 .==
+(.==) :: (Eq a, Functor f) => f a -> a -> f Bool
+fx .== y = (== y) <$> fx
+
+moreIdx :: (Eq a, Enum a, Bounded a) => a -> a
+moreIdx = fromMaybe maxBound . succIdx
+
+succIdx :: (Eq a, Enum a, Bounded a) => a -> Maybe a
+succIdx x | x == maxBound = Nothing
+          | otherwise = Just $ succ x
+
+mealyState
+   :: (HiddenClockResetEnable dom, NFDataX s)
+   => (i -> State s o) -> s -> (Signal dom i -> Signal dom o)
+mealyState f = mealy step
+  where
+    step s x = let (y, s') = runState (f x) s in (s', y)
+
+mealyStateB
+    :: (HiddenClockResetEnable dom, NFDataX s, Bundle i, Bundle o)
+    => (i -> State s o) -> s -> (Unbundled dom i -> Unbundled dom o)
+mealyStateB f s0 = unbundle . mealyState f s0 . bundle

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -374,6 +374,9 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "Transpose" def
         , runTest "VecFun" def
       ]
+      , clashTestGroup "Issues"
+        [ runTest "T1187" def{hdlSim=False, hdlTargets=[Verilog]}
+        ]
       , clashTestGroup "Naming"
         [ runTest "T967a" def{hdlSim=False}
         , runTest "T967b" def{hdlSim=False}


### PR DESCRIPTION
Prevents errors such as #1187. I'd like a smaller testcase, but I've long crossed the point of diminishing returns..