### PR TITLE
`Exp.(^)` result is at least 1 bit

### DIFF
--- a/changelog/2020-03-11T09:40:36+01:00_exp_1_bit
+++ b/changelog/2020-03-11T09:40:36+01:00_exp_1_bit
@@ -1,0 +1,1 @@
+FIXED: result of `Clash.Class.Exp.(^)` is at least 1 bit in order to deal with `x^0`.


### PR DESCRIPTION
Fixes #1201