### PR TITLE
 Add '-main-is' support 

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -53,7 +53,7 @@ doHDL b src = do
   putStrLn $ "Loading dependencies took " ++ prepStartDiff
 
   generateHDL (buildCustomReprs reprs) bindingsMap (Just b) primMap tcm tupTcm
-    (ghcTypeToHWType WORD_SIZE_IN_BITS True) primEvaluator topEntities
+    (ghcTypeToHWType WORD_SIZE_IN_BITS True) primEvaluator topEntities Nothing
     defClashOpts{opt_cachehdl = False, opt_dbgLevel = DebugSilent}
     (startTime,prepTime)
 

--- a/changelog/2020-03-11T12:29:55+01:00_Add_main-is_support
+++ b/changelog/2020-03-11T12:29:55+01:00_Add_main-is_support
@@ -1,0 +1,1 @@
+ADDED: Clash now repects '-main-is' when used with '--vhdl', '--verilog', or '--systemverilog'

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -1998,6 +1998,8 @@ makeHDL backend optsRef srcs = do
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
+                let getMain = getMainTopEntity src bindingsMap topEntities
+                mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
@@ -2013,6 +2015,7 @@ makeHDL backend optsRef srcs = do
                   (ghcTypeToHWType iw fp)
                   primEvaluator
                   topEntities
+                  mainTopEntity
                   opts2
                   (startTime,prepTime)
 

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -2047,6 +2047,8 @@ makeHDL backend optsRef srcs = do
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
+                let getMain = getMainTopEntity src bindingsMap topEntities
+                mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
@@ -2062,6 +2064,7 @@ makeHDL backend optsRef srcs = do
                   (ghcTypeToHWType iw fp)
                   primEvaluator
                   topEntities
+                  mainTopEntity
                   opts2
                   (startTime,prepTime)
 

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -2139,6 +2139,9 @@ makeHDL backend optsRef srcs = do
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
+
+                let getMain = getMainTopEntity src bindingsMap topEntities
+                mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
@@ -2154,6 +2157,7 @@ makeHDL backend optsRef srcs = do
                   (ghcTypeToHWType iw fp)
                   primEvaluator
                   topEntities
+                  mainTopEntity
                   opts2
                   (startTime,prepTime)
 

--- a/clash-ghc/src-bin-common/Clash/GHCi/Common.hs
+++ b/clash-ghc/src-bin-common/Clash/GHCi/Common.hs
@@ -1,15 +1,19 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Clash.GHCi.Common
   ( checkImportDirs
   , checkMonoLocalBinds
   , checkMonoLocalBindsMod
   , checkClashDynamic
+  , getMainTopEntity
   ) where
 
 -- Clash
-import           Clash.Driver.Types     (ClashOpts (..))
+import           Clash.Driver.Types     (ClashOpts (..), BindingMap)
+import           Clash.Netlist.Types    (TopEntityT(..))
 
 -- The GHC interface
 import qualified DynFlags
@@ -20,12 +24,57 @@ import qualified Data.IntSet            as IntSet -- ghc82
 #endif
 import qualified GHC                    (DynFlags, ModSummary (..), Module (..),
                                          extensionFlags, moduleNameString)
+import           Clash.Core.Name        (nameOcc)
+import           Clash.Core.Var         (varName)
+import           Clash.Normalize.Util   (collectCallGraphUniques, callGraph)
+import qualified Clash.Util.Interpolate as I
+import           Clash.Util             (ClashException(..), HasCallStack, noSrcSpan)
+import           Clash.Unique           (getUnique)
+import           Control.Exception      (throw)
+import           Data.List              (isSuffixOf)
+import qualified Data.Text              as Text
+import qualified Data.HashSet           as HashSet
 import qualified GHC.LanguageExtensions as LangExt (Extension (..))
 import           Panic                  (GhcException (..), throwGhcException)
 
 import           Control.Monad          (forM_, unless, when)
 import           System.Directory       (doesDirectoryExist)
 import           System.IO              (hPutStrLn, stderr)
+
+getMainTopEntity
+  :: HasCallStack
+  => String
+  -- ^ Module name
+  -> BindingMap
+  -- ^ Map of global binders
+  -> [TopEntityT]
+  -- ^ List of top entities loaded by LoadModules
+  -> String
+  -- ^ string passed with -main-is
+  -> IO (TopEntityT, [TopEntityT])
+  -- ^ Throws exception if -main-is was set, but no such top entity was found.
+  -- Otherwise, returns main top entity and all top entities (transitively) used
+  -- in the main top entity.
+getMainTopEntity modName bindingMap topEnts nm =
+  case filter isNm topEnts of
+    [] -> throw $ ClashException noSrcSpan [I.i|
+      Could not find top entity called #{show nm} in #{show modName}
+    |] Nothing
+    [t] ->
+      let
+        closure0 = collectCallGraphUniques (callGraph bindingMap (topId t))
+        closure1 = HashSet.delete (getUnique (topId t)) closure0
+      in
+        pure (t, filter ((`HashSet.member` closure1) . getUnique . topId) topEnts)
+    ts ->
+      error $ [I.i|
+        Internal error: multiple top entities called #{nm} (#{map topId ts})
+        found in #{modName}.
+      |]
+ where
+  isNm (TopEntityT{topId}) =
+    let topIdNm = Text.unpack (nameOcc (varName topId)) in
+    topIdNm == nm || ('.':nm) `isSuffixOf` topIdNm
 
 -- | Checks whether MonoLocalBinds language extension is enabled or not in
 -- modules.

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -330,6 +330,11 @@ loadModules useColor hdl modName dflagsM idirs = do
   startTime <- Clock.getCurrentTime
   GHC.runGhc (Just libDir) $ do
     setupGhc useColor dflagsM idirs
+    -- TODO: We currently load the transitive closure of _all_ bindings found
+    -- TODO: in the top module. This is wasteful if one or more binders don't
+    -- TODO: contribute to any top entities. This effect is worsened when using
+    -- TODO: -main-is, which only synthesizes a single top entity (and all its
+    -- TODO: dependencies).
     (rootIds, modFamInstEnvs, rootModule, LoadedBinders{..}, allBinders) <-
       -- We need to try and load external modules first, because we can't
       -- recover from errors in 'loadLocalModule'.
@@ -368,8 +373,9 @@ loadModules useColor hdl modName dflagsM idirs = do
     benchAnn   <- findTestBenchAnnotations rootIds
     reprs'     <- findCustomReprAnnotations
     primGuards <- findPrimitiveGuardAnnotations allBinderIds
-    let varNameString = OccName.occNameString . Name.nameOccName . Var.varName
-        topEntities = filter ((== "topEntity") . varNameString) rootIds
+    let topEntityNames = catMaybes [Just "topEntity", GHC.mainFunIs =<< dflagsM]
+        varNameString = OccName.occNameString . Name.nameOccName . Var.varName
+        topEntities = filter ((`elem` topEntityNames) . varNameString) rootIds
         benches     = filter ((== "testBench") . varNameString) rootIds
         mergeBench (x,y) = (x,y,lookup x benchAnn)
         allSyn'     = map mergeBench allSyn

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -225,14 +225,18 @@ generateHDL
   -> (PrimStep, PrimUnwind)
   -- ^ Hardcoded evaluator (delta-reduction)
   -> [TopEntityT]
-  -- ^ Topentities and associated testbench
+  -- ^ All topentities and associated testbench
+  -> Maybe (TopEntityT, [TopEntityT])
+  -- ^ Main top entity to compile. If Nothing, all top entities in previous
+  -- argument will be compiled.
   -> ClashOpts
   -- ^ Debug information level for the normalization process
   -> (Clock.UTCTime,Clock.UTCTime)
   -> IO ()
 generateHDL reprs bindingsMap hdlState primMap tcm tupTcm typeTrans eval
-  topEntities0 opts (startTime,prepTime) =
-    go prepTime HashMap.empty (sortTop bindingsMap topEntities2)
+  topEntities0 mainTopEntity opts (startTime,prepTime) =
+    let todo = maybe topEntities2 (uncurry (:)) mainTopEntity in
+    go prepTime HashMap.empty (sortTop bindingsMap todo)
  where
   topEntities1 = map (splitTopEntityT tcm bindingsMap) topEntities0
   -- Remove forall's used in type equality constraints

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -20,6 +20,7 @@ module Clash.Normalize.Util
  , isRecursiveBndr
  , isClosed
  , callGraph
+ , collectCallGraphUniques
  , classifyFunction
  , isCheapFunction
  , isNonRecursiveGlobalVar
@@ -40,6 +41,7 @@ import           Data.Either             (lefts)
 import qualified Data.List               as List
 import qualified Data.Map                as Map
 import qualified Data.HashMap.Strict     as HashMapS
+import qualified Data.HashSet            as HashSet
 import           Data.Text               (Text)
 import qualified Data.Text as Text
 
@@ -343,6 +345,13 @@ constantSpecInfo ctx e = do
 -- | A call graph counts the number of occurrences that a functions 'g' is used
 -- in 'f'.
 type CallGraph = VarEnv (VarEnv Word)
+
+-- | Collect all binders mentioned in CallGraph into a HashSet
+collectCallGraphUniques :: CallGraph -> HashSet.HashSet Unique
+collectCallGraphUniques cg = HashSet.fromList (us0 ++ us1)
+ where
+  us0 = keysUniqMap cg
+  us1 = concatMap keysUniqMap (eltsUniqMap cg)
 
 -- | Create a call graph for a set of global binders, given a root
 callGraph

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -10,8 +10,8 @@ if [[ -z $(command -v python3) ]]; then
 fi
 
 echo "$SCRIPT: Building HTML"
-python3 -msphinx -M html . _build
+/usr/bin/env python3 -msphinx -M html . _build
 
 echo "$SCRIPT: Building LaTeX"
-python3 -msphinx -M latexpdf . _build
+/usr/bin/env python3 -msphinx -M latexpdf . _build
 

--- a/docs/developing-hardware/flags.rst
+++ b/docs/developing-hardware/flags.rst
@@ -190,3 +190,7 @@ Clash Compiler Flags
 
   **Default:** False
 
+-main-is
+  When using one of ``--vhdl``, ``--verilog``, or ``--systemverilog``, this
+  flag refers to synthesis target. For example, running Clash with
+  ``clash My.Module -main-is top --vhdl`` would synthesize ``My.Module.top``.

--- a/repld
+++ b/repld
@@ -26,6 +26,8 @@
 
 set -e
 
+GHC=${GHC:-ghc}
+
 inotifywait --help | grep -e "^inotifywait"
 ghcid --version
 
@@ -67,7 +69,7 @@ while true; do
     sed -i '/clash-ghc/d' .ghc.environment.x86_64-linux-*
   fi
 
-  ghcid -c "${target}" ${restart_cmd} ${@:2}
+  ghcid -c "${target} -w ${GHC}" ${restart_cmd} ${@:2}
 
   inotifywait -e modify,create,delete -r ${watch}
   if [[ $? == 130 ]]; then

--- a/tests/shouldwork/TopEntity/Multiple.hs
+++ b/tests/shouldwork/TopEntity/Multiple.hs
@@ -1,0 +1,63 @@
+module Multiple where
+
+import Prelude
+import Clash.Prelude (defSyn)
+import System.Environment (getArgs)
+import System.FilePath (splitFileName)
+import System.Directory (listDirectory)
+import Data.List (sort)
+
+import Debug.Trace
+
+topEntity1 :: Int
+topEntity1 = 11111111
+{-# ANN topEntity1 (defSyn "topentity1") #-}
+{-# NOINLINE topEntity1 #-}
+
+topEntity2 :: Int
+topEntity2 = topEntity1
+{-# ANN topEntity2 (defSyn "topentity2") #-}
+{-# NOINLINE topEntity2 #-}
+
+topEntity3 :: Int
+topEntity3 = topEntity2
+{-# NOINLINE topEntity3 #-}
+
+-- | Make sure topEntity2 is not compiled when -main-is topEntity1
+main1SystemVerilog :: IO ()
+main1SystemVerilog = do
+  [(dir, _fname)] <- map splitFileName <$> getArgs
+  files <- listDirectory dir
+  if files == ["topentity1"] then
+    pure ()
+  else
+    error ("Unexpected files / directories: " ++ show files)
+
+-- | Make sure topEntity1 is not compiled when -main-is topEntity2 and
+-- -fclash-single-main is enabled. TODO: Implement this feature.
+main2Verilog :: IO ()
+main2Verilog = do
+  args <- getArgs
+  putStrLn (show args)
+  [(dir, _fname)] <- map splitFileName <$> getArgs
+  files <- listDirectory dir
+  if files == ["topentity2"] then
+    pure ()
+  else
+    error ("Unexpected files / directories: " ++ show files)
+
+-- | Check whether we can compile a binder that doesn't have a synthesize
+-- annotation _and_ isn't called 'topEntity' using -main-is.
+main3VHDL :: IO ()
+main3VHDL = do
+  [(dir, _fname)] <- map splitFileName <$> getArgs
+  files <- listDirectory dir
+  if sort files == sort [ "multiple_types.vhdl"
+                        , "topentity1"
+                        , "topentity2"
+                        , "topentity3.manifest"
+                        , "topentity3.vhdl"
+                        ] then
+    pure ()
+  else
+    error ("Unexpected files / directories: " ++ show (sort files))

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -518,6 +518,8 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1033" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1072" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1074" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [SystemVerilog] ["-main-is", "topEntity1"] [] "Multiple" "main1"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [VHDL] ["-main-is", "topEntity3"] [] "Multiple" "main3"
         , runTest "T1139" def{hdlSim=False}
         ]
       , clashTestGroup "Unit"


### PR DESCRIPTION
```
-main-is
  When using one of ``--vhdl``, ``--verilog``, or ``--systemverilog``, this
  flag refers to synthesis target. For example, running Clash with
  ``clash My.Module -main-is top --vhdl`` would synthesize ``My.Module.top``.
  Note that this will make Clash NOT compile any other binders with Synthesize
  annotations.
```