### PR TITLE
Verilog: allow non-contiguous field bit-patterns

### DIFF
--- a/clash-lib/src/Data/Semigroup/Monad/Extra.hs
+++ b/clash-lib/src/Data/Semigroup/Monad/Extra.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Data.Semigroup.Monad.Extra
@@ -6,8 +10,13 @@ module Data.Semigroup.Monad.Extra
 where
 
 import Control.Monad.Fix
+import Control.Monad.State
 import Data.Semigroup.Monad
 
 instance MonadFix f => MonadFix (Mon f) where
   mfix f = Mon (mfix (getMon . f))
 
+instance MonadState s m => MonadState s (Mon m) where
+  get = Mon get
+  put = Mon . put
+  state = Mon . state

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -310,7 +310,7 @@ runClashTest = defaultMain $ clashTestRoot
           , runTest "ReprCompact" def
           , runTest "ReprCompactScrambled"   def
           , runTest "ReprLastBitConstructor" def
-          , runTest "ReprStrangeMasks" def{hdlTargets=[VHDL]}
+          , runTest "ReprStrangeMasks" def{hdlTargets=[VHDL,Verilog]}
           , runTest "ReprWide" def
           , runTest "RotateCScrambled" def
           ]

--- a/testsuite/src/Test/Tasty/Clash.hs
+++ b/testsuite/src/Test/Tasty/Clash.hs
@@ -420,7 +420,7 @@ iverilog path modName subdirs entName =
       workDir = testDirectory path </> "verilog" </> modName
       test = testProgram testName "iverilog" args GlobStar PrintStdErr False (Just workDir)
       testName = "iverilog (" ++ entName ++ ")"
-      args = ("-g2":"-s":entName:"-o":noConflict entName subdirs:[workDir </> subdir </> "*.v" | subdir <- subdirs])
+      args = concat  [["-I",workDir </> subdir] | subdir <- subdirs] ++ ("-g2":"-s":entName:"-o":noConflict entName subdirs:[workDir </> subdir </> "*.v" | subdir <- subdirs])
 
 noConflict :: String -> [String] -> String
 noConflict nm seen


### PR DESCRIPTION
The front-end already supported it, but so far only the VHDL back-end did. This brings the Verilog back-end up to par. NB. The SystemVerilog back-end still does not support non-contiguous field bit patterns.
