### PR TITLE
Use Microstache instead of Mustache

### DIFF
--- a/clash-shake/clash-shake.cabal
+++ b/clash-shake/clash-shake.cabal
@@ -61,7 +61,8 @@ Library
                       containers >= 0.5.11.0  && < 0.7,
                       directory >= 1.3 && < 1.4,
                       mtl >= 2.2 && < 2.3,
-                      mustache >= 2.3 && < 2.4,
+                      aeson >= 1.4 && < 1.5,
+                      microstache >= 1.0 && < 1.2,
                       shake >= 0.18 && < 0.19,
                       text >= 1.2 && < 1.3,
                       unordered-containers >= 0.2.3.3 && < 0.3


### PR DESCRIPTION
Switch over to Microstache, which is already a transitive dependency of Clash (via Criterion).

Note that [Microstache has no TH API](https://github.com/phadej/microstache/issues/18) and I am waiting to hear back from the maintainer if he'd be happy accepting a patch to add it back in. I think a "real" production version of `clash-shake` should include its templates compiled in instead of relying on fragile external files.