### PR TITLE
Hackage releases based on ghc-8.6.5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ hackage-sdist:
   extends: .tests
   interruptible: false
   variables:
-    GHC: ghc-8.8.2
+    GHC: ghc-8.6.5
   script:
     - export GHC="${GHC:-$CI_JOB_NAME}"
     - export THREADS=$(nproc)
@@ -110,7 +110,7 @@ hackage-sdist:
   cache:
     key: hackage
   variables:
-    GHC: ghc-8.8.2
+    GHC: ghc-8.6.5
   script:
     - export GHC="${GHC:-$CI_JOB_NAME}"
     - export THREADS=$(nproc)


### PR DESCRIPTION
Hackage is still on 8.6.5, so basing our hackage releases, and corresponding haddock docs, on any later release results in 404s when following links to external packages (such as base-4.13).

Until hackage upgrades to GHC 8.8 or later, we should make sure we base our generated haddock on packages included with GHC 8.6.5