### PR TITLE
Only use cabal 2.4 for ghc 8.4.*

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -5,11 +5,11 @@ apt-get update -q
 
 if [[ "$GHC" = ghc-head ]]; then
   CABAL="cabal-install-head"
-elif [[ "$GHC" = ghc-8.8.* ]]; then
-  CABAL="cabal-install-3.0"
-else
-  # GHC <= 8.6
+elif [[ "$GHC" = ghc-8.4.* ]]; then
   CABAL="cabal-install-2.4"
+else
+  # GHC >= 8.6
+  CABAL="cabal-install-3.0"
 fi
 
 apt-get install -yq $CABAL $GHC


### PR DESCRIPTION
Allows CI to publish releases with GHC 8.4