### PR TITLE
Ensure the register# primitive is inlined

### DIFF
--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -282,6 +282,8 @@ import           Clash.Sized.Index              (Index)
 import qualified Clash.Sized.Vector
 import           Clash.XException               (NFDataX, deepErrorX, fromJustX)
 
+import GHC.Magic (inline)
+
 {- $setup
 >>> :set -XDataKinds -XTypeApplications -XFlexibleInstances -XMultiParamTypeClasses -XTypeFamilies
 >>> :set -fno-warn-deprecations
@@ -661,8 +663,8 @@ register
   -- will also be the initial value.
   -> Signal dom a
   -> Signal dom a
-register clk rst gen initial i =
-  register# clk rst gen initial initial i
+register clk rst gen initial =
+  register# clk rst gen (inline initial) (inline initial)
 {-# INLINE register #-}
 
 -- | Version of 'register' that only updates its content when its fourth

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -1380,13 +1380,11 @@ register
   -- 'register' outputs the reset value when the reset value is active
   -> Signal dom a
   -> Signal dom a
-register i s =
+register =
   E.register
     (fromLabel @(HiddenClockName dom))
     (fromLabel @(HiddenResetName dom))
     (fromLabel @(HiddenEnableName dom))
-    i
-    s
 {-# INLINE register #-}
 infixr 3 `register`
 


### PR DESCRIPTION
But use `GHC.Magic.inline` to make sure it doesn't want to share the value for powerup and reset.

~Fixes #1240~

Sadly, it only fixes the example in #1240, but not the general case. e.g. changing the example to:
```haskell
topEntity = register @System (iterate d10 not True)
```
still results in failure