### PR TITLE
`funSubst` works for all applications

### DIFF
--- a/changelog/2020-03-24T13:08:40+01:00_fix1242
+++ b/changelog/2020-03-24T13:08:40+01:00_fix1242
@@ -1,0 +1,1 @@
+FIXED: [#1242](https://github.com/clash-lang/clash-compiler/issues/1242) Synthesizing BitPack instances for type with phantom parameter fails

--- a/tests/shouldwork/Basic/T1242.hs
+++ b/tests/shouldwork/Basic/T1242.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+module T1242 where
+
+import           Clash.Prelude
+import           Control.DeepSeq   (NFData)
+import           GHC.Generics      (Generic)
+
+data RepKind = AppRep | WireRep
+  deriving (Generic, Show, Eq, NFData, NFDataX)
+
+newtype U16 (t :: RepKind) = U16 (Unsigned 16)
+
+deriving instance Generic (U16 a)
+deriving instance Eq (U16 a)
+deriving instance Show (U16 a)
+deriving instance NFData (U16 a)
+deriving instance NFDataX (U16 a)
+deriving instance BitPack (U16 'AppRep)
+
+class WireApp w a where
+    toWire :: a -> w
+    toApp :: w -> a
+
+instance WireApp (U16 'WireRep) (U16 'AppRep) where
+    toWire v = case v of U16 x -> U16 x
+    toApp v = case v of U16 x -> U16 x
+
+instance (BitPack (t 'AppRep), WireApp (t 'WireRep)  (t 'AppRep)) => BitPack (t 'WireRep) where
+  type BitSize (t 'WireRep) = BitSize (t 'AppRep)
+  pack x = bv
+    where
+        bv :: BitVector (BitSize (t 'WireRep))
+        bv = pack app
+        app :: t 'AppRep
+        app = toApp $ x
+  unpack x = toWire app
+    where
+        app :: t 'AppRep
+        app = unpack x
+
+data Record
+  = Record
+  { f1 :: U16 'WireRep
+  , f2 :: U16 'WireRep
+  } deriving (Generic, NFData, Show, Eq, BitPack, NFDataX)
+
+topEntity :: Signal System Bool -> Signal System Bool
+topEntity _ = pure (unpack 0 == Record (U16 0) (U16 0))

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -266,6 +266,7 @@ runClashTest = defaultMain $ clashTestRoot
           , topEntities=TopEntities ["top1"]
           }
         , runTest "T1012" def{hdlSim=False}
+        , runTest "T1242" def{hdlSim=False}
         , runTest "TagToEnum" def{hdlSim=False}
         , runTest "TestIndex" def{hdlSim=False}
         , runTest "Time" def


### PR DESCRIPTION
Before, `funSubst`, the heart of our type-family resolution engine, could only deal with `a -> b` and `F a b` on both the matching side and argument side. Now it works on all applications, including things of the form `f a`.

Fixes #1242