### PR TITLE
Don't `unsafeCoerce` from `Any @Nat` in `toBNat`

### DIFF
--- a/changelog/2020-03-31T13:49:40+02:00_no_any_tobnat
+++ b/changelog/2020-03-31T13:49:40+02:00_no_any_tobnat
@@ -1,0 +1,1 @@
+FIXED: Synthesis of `fromBNat (toBNat d5)` failed due to `unsafeCoerce` coercing from `Any`

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -386,11 +386,11 @@ showBNat = go []
 toBNat :: SNat n -> BNat n
 toBNat s@SNat = toBNat' (snatToInteger s)
   where
-    toBNat' :: Integer -> BNat m
+    toBNat' :: forall m . Integer -> BNat m
     toBNat' 0 = unsafeCoerce BT
     toBNat' n = case n `divMod` 2 of
-      (n',1) -> unsafeCoerce (B1 (toBNat' n'))
-      (n',_) -> unsafeCoerce (B0 (toBNat' n'))
+      (n',1) -> unsafeCoerce (B1 (toBNat' @(Div (m-1) 2) n'))
+      (n',_) -> unsafeCoerce (B0 (toBNat' @(Div m 2) n'))
 
 -- | Convert a base-2 encoded natural number to its singleton representation
 --


### PR DESCRIPTION
This can lead to synthesis issues:

```
Clash.Netlist(278): Clash.Core.Util(322): Cannot reduce to an integer:
    GHC.Types.Any[3674937295934325098]
      GHC.Types.Nat[3674937295934325064]
```