### PR TITLE
Add CoreTest to testsuite

### DIFF
--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -42,8 +42,8 @@ clashTestGroup testName testTrees =
 runClashTest :: IO ()
 runClashTest = defaultMain $ clashTestRoot
   [ clashTestGroup "netlist"
-    [ netlistTest ("tests" </> "shouldwork" </> "Netlist") allTargets [] "Identity" "main"
-    , netlistTest ("tests" </> "shouldwork" </> "Netlist") [VHDL] [] "NoDeDup" "main"
+    [ clashLibTest ("tests" </> "shouldwork" </> "Netlist") allTargets [] "Identity" "main"
+    , clashLibTest ("tests" </> "shouldwork" </> "Netlist") [VHDL] [] "NoDeDup" "main"
     ]
   , clashTestGroup "examples"
     [ runTest "ALU" def{hdlSim=False}
@@ -382,7 +382,7 @@ runClashTest = defaultMain $ clashTestRoot
         [ runTest "T967a" def{hdlSim=False}
         , runTest "T967b" def{hdlSim=False}
         , runTest "T967c" def{hdlSim=False}
-        , netlistTest ("tests" </> "shouldwork" </> "Naming") allTargets [] "T1041" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "Naming") allTargets [] "T1041" "main"
         ]
       , clashTestGroup "Numbers"
         [ runTest "BitInteger" def
@@ -511,8 +511,8 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "PortNamesWithRTree" def{hdlTargets=[Verilog],entities=Entities [["", "PortNamesWithRTree_topEntity", "PortNamesWithRTree_testBench"]], topEntities=TopEntities ["PortNamesWithRTree_testBench"]}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithRTree" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "PortGeneration" "main"
-        , netlistTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] "T1182A" "main"
-        , netlistTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] "T1182B" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] "T1182A" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] "T1182B" "main"
         , runTest "TopEntHOArg" def{entities=Entities [["f", "g"]], topEntities=TopEntities ["f"], hdlSim=False}
         , runTest "T701" def {hdlSim=False,entities=Entities [["mynot", ""]]}
         , runTest "T1033" def {hdlSim=False,entities=Entities [["top", ""]], topEntities=TopEntities ["top"]}
@@ -577,10 +577,10 @@ runClashTest = defaultMain $ clashTestRoot
       , clashTestGroup "XOptimization"
         [ outputTest  ("tests" </> "shouldwork" </> "XOptimization") allTargets [] [] "Conjunction"  "main"
         , outputTest  ("tests" </> "shouldwork" </> "XOptimization") allTargets [] [] "Disjunction"  "main"
-        , netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedDataPat" "main"
-        , netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedLitPat" "main"
-        , netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedDefaultPat" "main"
-        , netlistTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "ManyDefined" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedDataPat" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedLitPat" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "OneDefinedDefaultPat" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "XOptimization") allTargets [] "ManyDefined" "main"
         ]
       ] -- end shouldwork
     ] -- end tests

--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -64,6 +64,7 @@ library
 
   exposed-modules:
     Test.Tasty.Clash
+    Test.Tasty.Clash.CoreTest
     Test.Tasty.Clash.NetlistTest
     Test.Tasty.Program
 

--- a/testsuite/src/Test/Tasty/Clash.hs
+++ b/testsuite/src/Test/Tasty/Clash.hs
@@ -724,7 +724,7 @@ outputTest env targets extraClashArgs extraGhcArgs modName funcName path =
   testGroup testName
     [outputTest' env target extraClashArgs extraGhcArgs modName funcName path' | target <- targets]
 
-netlistTest'
+clashLibTest'
   :: FilePath
   -- ^ Work directory
   -> BuildTarget
@@ -740,7 +740,7 @@ netlistTest'
   -- item in the list will be the root node, while the first one will be the
   -- one closest to the test.
   -> TestTree
-netlistTest' env target extraGhcArgs modName funcName path =
+clashLibTest' env target extraGhcArgs modName funcName path =
   withResource acquire tastyRelease (const seqTests)
     where
       path' = show target:path
@@ -754,7 +754,7 @@ netlistTest' env target extraGhcArgs modName funcName path =
              , "runghc"
              ]
              ++ langExts ++
-             [ "-DNETLISTTEST"
+             [ "-DCLASHLIBTEST"
              , "--ghc-arg=-package"
              , "--ghc-arg=clash-testsuite"
              , "--ghc-arg=-main-is"
@@ -770,7 +770,7 @@ netlistTest' env target extraGhcArgs modName funcName path =
         [ ("runghc", testProgram "runghc" "cabal" args NoGlob PrintStdErr False Nothing)
         ]
 
-netlistTest
+clashLibTest
   :: FilePath
   -- ^ Work directory
   -> [BuildTarget]
@@ -786,9 +786,9 @@ netlistTest
   -- item in the list will be the root node, while the first one will be the
   -- one closest to the test.
   -> TestTree
-netlistTest env targets extraGhcArgs modName funcName path =
-  let testName = modName ++ " [netlist test]" in
+clashLibTest env targets extraGhcArgs modName funcName path =
+  let testName = modName ++ " [clash-lib test]" in
   let path' = testName : path in
   testGroup testName
-    [netlistTest' env target extraGhcArgs modName funcName path' | target <- targets]
+    [clashLibTest' env target extraGhcArgs modName funcName path' | target <- targets]
 

--- a/testsuite/src/Test/Tasty/Clash/CoreTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/CoreTest.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+
+#include "MachDeps.h"
+
+module Test.Tasty.Clash.CoreTest
+  ( runToCoreStage
+  ) where
+
+import Clash.Backend
+import Clash.Backend.SystemVerilog
+import Clash.Backend.Verilog
+import Clash.Backend.VHDL
+import Clash.Core.TyCon
+import Clash.Driver.Types
+import Clash.GHC.GenerateBindings
+import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
+
+import Util
+
+import Test.Tasty.Clash
+
+type family TargetToState (target :: BuildTarget) where
+  TargetToState 'SystemVerilog = SystemVerilogState
+  TargetToState 'VHDL          = VHDLState
+  TargetToState 'Verilog       = VerilogState
+
+mkClashOpts :: ClashOpts
+mkClashOpts = defClashOpts
+  { opt_cachehdl     = False
+  , opt_errorExtra   = True
+  , opt_floatSupport = True
+  }
+
+mkBackend
+  :: (Backend (TargetToState target))
+  => SBuildTarget target
+  -> TargetToState target
+mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True Nothing
+
+-- Run clash as far as having access to core for all bindings. This is used
+-- to test operations on core, such as transformations and evaluation.
+--
+-- TODO This is somewhat of a hack. Ideally, Clash.Driver would provide a means
+-- to run the compiler up to a given stage. There are currently numerous
+-- problems standing in the way of this however.
+--
+runToCoreStage
+  :: (Backend (TargetToState target))
+  => SBuildTarget target
+  -> (ClashOpts -> ClashOpts)
+  -> FilePath
+  -> IO (BindingMap, TyConMap)
+runToCoreStage target f src = do
+  pds <- primDirs backend
+  (bm, tcm, _, _, _, _) <- generateBindings
+    Auto pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
+
+  return (bm, tcm)
+ where
+  backend = mkBackend target
+  opts = f mkClashOpts
+


### PR DESCRIPTION
Similar to netlist tests added in ee5d000, core tests are now
available. These run the clash-ghc frontend as far as generating
bindings for top level definitions, giving access to the bindings
map and the TyConMap.

Core tests allow tests to be defined which inspect the result of
operating on Clash's core IR. This makes it easier to define tests
that inspect the behaviour of the partial evaluator, or
transformations in the normalizer.