### PR TITLE
Infix use of `defaultSeqX` and `deepSeqX` righ-assoc

### DIFF
--- a/changelog/2020-04-13T17:44:01+02:00_fix1256
+++ b/changelog/2020-04-13T17:44:01+02:00_fix1256
@@ -1,0 +1,2 @@
+FIXED: Memory leak in register primitives [#1256](https://github.com/clash-lang/clash-compiler/issues/1256)
+CHANGED: Infix use of `deepseqX` is now right-associative

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -89,6 +89,7 @@ instance Exception XException
 defaultSeqX :: NFDataX a => a -> b -> b
 defaultSeqX = if fSuperStrict then deepseqX else seqX
 {-# INLINE defaultSeqX #-}
+infixr 0 `defaultSeqX`
 
 -- | Like 'error', but throwing an 'XException' instead of an 'ErrorCall'
 --
@@ -453,6 +454,7 @@ forceX x = x `deepseqX` x
 deepseqX :: NFDataX a => a -> b -> b
 deepseqX a b = rnfX a `seq` b
 {-# NOINLINE deepseqX #-}
+infixr 0 `deepseqX`
 
 -- | Reduce to weak head normal form
 --


### PR DESCRIPTION
In the register and delay primitive we were writing:

```
q `defaultSeqX` q :- rest
```

which was parsed as:

```
(q `defaultSeqX` q) :- rest
```

because of the missing fixity declaration, our intention was the following however: !!!

```
q `defaultSeqX` (q :- rest)
```

so that the currunt value in the register was forced to WHNF (or NF) whenever the tail of the Signal was requested in order to prevent space-leaks. Without the fixity declaration on `defaultSeqX`, this space-leak prevention was of course not happening! And we were leaking space as demonstrated by
https://github.com/clash-lang/clash-compiler/issues/1256

Fixes #1256