### PR TITLE
Fold identifier logic into 'Clash.Netlist.Id'. Fix #1230 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ result*
 
 # Sphinx output
 _build/
+
+# Python env
+docs/env

--- a/Clash.hs
+++ b/Clash.hs
@@ -17,6 +17,7 @@ import Clash.Backend.SystemVerilog
 import Clash.Backend.VHDL
 import Clash.Backend.Verilog
 import Clash.Netlist.BlackBox.Types
+import Clash.Netlist.Types (PreserveCase(..))
 import Clash.Annotations.BitRepresentation.Internal (buildCustomReprs)
 import Clash.Util
 
@@ -28,17 +29,17 @@ import Util (OverridingBool(..))
 genSystemVerilog
   :: String
   -> IO ()
-genSystemVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True False Nothing (AggressiveXOptBB False) :: SystemVerilogState)
+genSystemVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False) :: SystemVerilogState)
 
 genVHDL
   :: String
   -> IO ()
-genVHDL = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True False Nothing (AggressiveXOptBB False):: VHDLState)
+genVHDL = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False):: VHDLState)
 
 genVerilog
   :: String
   -> IO ()
-genVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True False Nothing (AggressiveXOptBB False):: VerilogState)
+genVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False):: VerilogState)
 
 doHDL
   :: HasCallStack

--- a/Clash.hs
+++ b/Clash.hs
@@ -28,17 +28,17 @@ import Util (OverridingBool(..))
 genSystemVerilog
   :: String
   -> IO ()
-genSystemVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True Nothing (AggressiveXOptBB False) :: SystemVerilogState)
+genSystemVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True False Nothing (AggressiveXOptBB False) :: SystemVerilogState)
 
 genVHDL
   :: String
   -> IO ()
-genVHDL = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True Nothing (AggressiveXOptBB False):: VHDLState)
+genVHDL = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True False Nothing (AggressiveXOptBB False):: VHDLState)
 
 genVerilog
   :: String
   -> IO ()
-genVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True Nothing (AggressiveXOptBB False):: VerilogState)
+genVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True False Nothing (AggressiveXOptBB False):: VerilogState)
 
 doHDL
   :: HasCallStack

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -62,7 +62,7 @@ hdl :: HDL
 hdl = VHDL
 
 backend :: VHDLState
-backend = initBackend WORD_SIZE_IN_BITS HDLSYN True Nothing (AggressiveXOptBB False)
+backend = initBackend WORD_SIZE_IN_BITS HDLSYN True False Nothing (AggressiveXOptBB False)
 
 runInputStage
   :: [FilePath]

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -24,7 +24,8 @@ import Clash.GHC.Evaluator
 import Clash.GHC.GenerateBindings
 import Clash.GHC.NetlistTypes
 import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
-import Clash.Netlist.Types          (HWMap, FilteredHWType, TopEntityT, topId)
+import Clash.Netlist.Types
+  (PreserveCase(..), HWMap, FilteredHWType, TopEntityT, topId)
 import Clash.Primitives.Types
 
 import Util (OverridingBool(..))
@@ -62,7 +63,7 @@ hdl :: HDL
 hdl = VHDL
 
 backend :: VHDLState
-backend = initBackend WORD_SIZE_IN_BITS HDLSYN True False Nothing (AggressiveXOptBB False)
+backend = initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False)
 
 runInputStage
   :: [FilePath]

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -5,6 +5,7 @@
 
 module BenchmarkCommon where
 
+import Clash.Annotations.Primitive (HDL(VHDL))
 import Clash.Annotations.BitRepresentation.Internal (CustomReprs, buildCustomReprs)
 import Clash.Backend
 import Clash.Backend.VHDL
@@ -56,6 +57,9 @@ opts idirs =
     , opt_importPaths=idirs
     , opt_specLimit=40 -- For "PipelinesViaFolds"
     }
+
+hdl :: HDL
+hdl = VHDL
 
 backend :: VHDLState
 backend = initBackend WORD_SIZE_IN_BITS HDLSYN True Nothing (AggressiveXOptBB False)

--- a/benchmark/profiling/run/profile-netlist-run.hs
+++ b/benchmark/profiling/run/profile-netlist-run.hs
@@ -43,7 +43,7 @@ benchFile idirs src = do
       topEntityS = Text.unpack (nameOcc (varName topEntity))
       modName    = takeWhile (/= '.') topEntityS
       hdlState'  = setModName (Text.pack modName) backend
-      (compNames, seen) = genTopNames Nothing True False hdl topEntities
+      (compNames, seen) = genTopNames Nothing True PreserveCase hdl topEntities
       topEntityMap = mkVarEnv (zip (map topId topEntities) topEntities)
       prefixM    = Nothing
       ite        = ifThenElseExpr hdlState'

--- a/benchmark/profiling/run/profile-netlist-run.hs
+++ b/benchmark/profiling/run/profile-netlist-run.hs
@@ -43,7 +43,7 @@ benchFile idirs src = do
       topEntityS = Text.unpack (nameOcc (varName topEntity))
       modName    = takeWhile (/= '.') topEntityS
       hdlState'  = setModName (Text.pack modName) backend
-      (compNames, seen) = genTopNames Nothing True hdl topEntities
+      (compNames, seen) = genTopNames Nothing True False hdl topEntities
       topEntityMap = mkVarEnv (zip (map topId topEntities) topEntities)
       prefixM    = Nothing
       ite        = ifThenElseExpr hdlState'

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -19,7 +19,7 @@ import           GHC.Stack
   (HasCallStack, prettyCallStack, callStack)
 
 import           Clash.Backend
-import           Clash.Netlist.Id
+import qualified Clash.Netlist.Id as Id
 import           Clash.Netlist.Types
 
 pinConfigLiteral
@@ -51,14 +51,15 @@ sbioTemplate
   => BlackBoxContext
   -> State s Doc
 sbioTemplate bbCtx = do
-  let mkId = mkUniqueIdentifier Basic
-      compName = "SB_IO"  -- Hardcoded for now
+  let compName = Id.unsafeMake "SB_IO"  -- Hardcoded for now
 
-  sbio <- mkId "sbio"
-  sbio_inst <- mkId "sbio_inst"
+  sbio <- Id.makeBasic "sbio"
+  sbio_inst <- Id.makeBasic "sbio_inst"
 
-  dIn0 <- mkId "dIn0"
-  dIn1 <- mkId "dIn1"
+  dIn0 <- Id.makeBasic "dIn0"
+  dIn1 <- Id.makeBasic "dIn1"
+
+  let u = Id.unsafeMake
 
   let
     resultTuple =
@@ -73,22 +74,22 @@ sbioTemplate bbCtx = do
     [ NetDecl Nothing dIn0 Bit
     , NetDecl Nothing dIn1 Bit
     , InstDecl Comp Nothing [] compName sbio_inst
-      [ (Identifier "PIN_TYPE" Nothing, BitVector 6, pinConfig)
+      [ (Identifier (u "PIN_TYPE") Nothing, BitVector 6, pinConfig)
       ]
       [ -- NOTE: Direction is set to 'In', but will be rendered as inout due to
         -- its the type packackagePinTy
-        (Identifier "PACKAGE_PIN" Nothing, In, packagePinTy, packagePin)
-      , (Identifier "LATCH_INPUT_VALUE" Nothing, In, Bit, latchInput)
+        (Identifier (u "PACKAGE_PIN") Nothing, In, packagePinTy, packagePin)
+      , (Identifier (u "LATCH_INPUT_VALUE") Nothing, In, Bit, latchInput)
       -- TODO: If clock is constantly enabled, docs recommend  not connecting
       -- TODO: CLOCK_ENABLE at all.
-      , (Identifier "CLOCK_ENABLE" Nothing, In, Bool, en)
-      , (Identifier "INPUT_CLK" Nothing, In, clkTy, clk)
-      , (Identifier "OUTPUT_CLK" Nothing, In, clkTy, clk)
-      , (Identifier "OUTPUT_ENABLE" Nothing, In, Bool, outputEnable)
-      , (Identifier "D_OUT_0" Nothing, In, Bit, dOut0)
-      , (Identifier "D_OUT_1" Nothing, In, Bit, dOut1)
-      , (Identifier "D_IN_0" Nothing, Out, Bit, Identifier dIn0 Nothing)
-      , (Identifier "D_IN_1" Nothing, Out, Bit, Identifier dIn1 Nothing)
+      , (Identifier (u "CLOCK_ENABLE") Nothing, In, Bool, en)
+      , (Identifier (u "INPUT_CLK") Nothing, In, clkTy, clk)
+      , (Identifier (u "OUTPUT_CLK") Nothing, In, clkTy, clk)
+      , (Identifier (u "OUTPUT_ENABLE") Nothing, In, Bool, outputEnable)
+      , (Identifier (u "D_OUT_0") Nothing, In, Bit, dOut0)
+      , (Identifier (u "D_OUT_1") Nothing, In, Bit, dOut1)
+      , (Identifier (u "D_IN_0") Nothing, Out, Bit, Identifier dIn0 Nothing)
+      , (Identifier (u "D_IN_1") Nothing, Out, Bit, Identifier dIn1 Nothing)
       ]
     , Assignment result resultTuple
     ]

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -21,6 +21,7 @@ import           GHC.Stack
 import           Clash.Backend
 import qualified Clash.Netlist.Id as Id
 import           Clash.Netlist.Types
+import           Clash.Netlist.Util (instPort)
 
 pinConfigLiteral
   :: HasCallStack
@@ -59,8 +60,6 @@ sbioTemplate bbCtx = do
   dIn0 <- Id.makeBasic "dIn0"
   dIn1 <- Id.makeBasic "dIn1"
 
-  let u = Id.unsafeMake
-
   let
     resultTuple =
       DataCon
@@ -74,22 +73,22 @@ sbioTemplate bbCtx = do
     [ NetDecl Nothing dIn0 Bit
     , NetDecl Nothing dIn1 Bit
     , InstDecl Comp Nothing [] compName sbio_inst
-      [ (Identifier (u "PIN_TYPE") Nothing, BitVector 6, pinConfig)
+      [ (instPort "PIN_TYPE", BitVector 6, pinConfig)
       ]
       [ -- NOTE: Direction is set to 'In', but will be rendered as inout due to
         -- its the type packackagePinTy
-        (Identifier (u "PACKAGE_PIN") Nothing, In, packagePinTy, packagePin)
-      , (Identifier (u "LATCH_INPUT_VALUE") Nothing, In, Bit, latchInput)
+        (instPort "PACKAGE_PIN", In, packagePinTy, packagePin)
+      , (instPort "LATCH_INPUT_VALUE", In, Bit, latchInput)
       -- TODO: If clock is constantly enabled, docs recommend  not connecting
       -- TODO: CLOCK_ENABLE at all.
-      , (Identifier (u "CLOCK_ENABLE") Nothing, In, Bool, en)
-      , (Identifier (u "INPUT_CLK") Nothing, In, clkTy, clk)
-      , (Identifier (u "OUTPUT_CLK") Nothing, In, clkTy, clk)
-      , (Identifier (u "OUTPUT_ENABLE") Nothing, In, Bool, outputEnable)
-      , (Identifier (u "D_OUT_0") Nothing, In, Bit, dOut0)
-      , (Identifier (u "D_OUT_1") Nothing, In, Bit, dOut1)
-      , (Identifier (u "D_IN_0") Nothing, Out, Bit, Identifier dIn0 Nothing)
-      , (Identifier (u "D_IN_1") Nothing, Out, Bit, Identifier dIn1 Nothing)
+      , (instPort "CLOCK_ENABLE", In, Bool, en)
+      , (instPort "INPUT_CLK", In, clkTy, clk)
+      , (instPort "OUTPUT_CLK", In, clkTy, clk)
+      , (instPort "OUTPUT_ENABLE", In, Bool, outputEnable)
+      , (instPort "D_OUT_0", In, Bit, dOut0)
+      , (instPort "D_OUT_1", In, Bit, dOut1)
+      , (instPort "D_IN_0", Out, Bit, Identifier dIn0 Nothing)
+      , (instPort "D_IN_1", Out, Bit, Identifier dIn1 Nothing)
       ]
     , Assignment result resultTuple
     ]

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -2146,7 +2146,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2187,7 +2187,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
         -> IORef ClashOpts
         -> [FilePath]
         -> m ()
@@ -2201,6 +2201,7 @@ makeHDL backend optsRef srcs = do
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
                   esc    = opt_escapedIds opts1
+                  lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
                   xOptBB = opt_aggressiveXOptBB opts1
                   hdl    = Clash.Backend.hdlKind backend'
@@ -2215,7 +2216,7 @@ makeHDL backend optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc frcUdf (coerce xOptBB)
+                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB)
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -163,6 +163,7 @@ import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.GHCi.Common
 import           Clash.Netlist.BlackBox.Types (HdlSyn)
+import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
@@ -2146,7 +2147,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2187,7 +2188,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
         -> IORef ClashOpts
         -> [FilePath]
         -> m ()

--- a/clash-ghc/src-bin-8.10/Clash/Main.hs
+++ b/clash-ghc/src-bin-8.10/Clash/Main.hs
@@ -100,6 +100,7 @@ import           Clash.Driver.Types
   (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
+import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir, setWantedLanguageExtensions)
 import           Clash.GHC.Util (handleClashException)
@@ -1002,7 +1003,7 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs

--- a/clash-ghc/src-bin-8.10/Clash/Main.hs
+++ b/clash-ghc/src-bin-8.10/Clash/Main.hs
@@ -1002,7 +1002,7 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -1927,7 +1927,7 @@ exceptT = ExceptT . pure
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts
   -> [FilePath]
   -> InputT GHCi ()
@@ -1969,7 +1969,7 @@ makeHDL' backend opts lst = go =<< case lst of
 makeHDL
   :: GHC.GhcMonad m
   => Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts
   -> [FilePath]
   -> m ()
@@ -1983,6 +1983,7 @@ makeHDL backend optsRef srcs = do
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
                   esc    = opt_escapedIds opts1
+                  lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
                   xOptBB = opt_aggressiveXOptBB opts1
                   hdl    = Clash.Backend.hdlKind backend'
@@ -1997,7 +1998,7 @@ makeHDL backend optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc frcUdf (coerce xOptBB)
+                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB)
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs
@@ -2036,13 +2037,13 @@ makeHDL backend optsRef srcs = do
                   (startTime,prepTime)
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -152,6 +152,7 @@ import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.GHCi.Common
 import           Clash.Netlist.BlackBox.Types (HdlSyn)
+import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
@@ -1927,7 +1928,7 @@ exceptT = ExceptT . pure
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts
   -> [FilePath]
   -> InputT GHCi ()
@@ -1969,7 +1970,7 @@ makeHDL' backend opts lst = go =<< case lst of
 makeHDL
   :: GHC.GhcMonad m
   => Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts
   -> [FilePath]
   -> m ()
@@ -2037,13 +2038,13 @@ makeHDL backend optsRef srcs = do
                   (startTime,prepTime)
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -95,6 +95,7 @@ import           Clash.Backend.Verilog (VerilogState)
 import           Clash.Driver.Types (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
+import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir, setWantedLanguageExtensions)
 import           Clash.GHC.Util (handleClashException)
@@ -979,7 +980,7 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts
   -> [(String,Maybe Phase)]
   -> Ghc ()
@@ -987,13 +988,13 @@ makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs
 
 makeVHDL :: IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
 
 makeVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
 
 makeSystemVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-841/Clash/Main.hs
+++ b/clash-ghc/src-bin-841/Clash/Main.hs
@@ -979,19 +979,21 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
-  -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
+  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  -> IORef ClashOpts
+  -> [(String,Maybe Phase)]
+  -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs
 
 makeVHDL :: IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
 
 makeVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
 
 makeSystemVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -1977,7 +1977,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2018,7 +2018,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
         -> IORef ClashOpts
         -> [FilePath]
         -> m ()
@@ -2032,6 +2032,7 @@ makeHDL backend optsRef srcs = do
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
                   esc    = opt_escapedIds opts1
+                  lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
                   xOptBB = opt_aggressiveXOptBB opts1
                   hdl    = Clash.Backend.hdlKind backend'
@@ -2046,7 +2047,7 @@ makeHDL backend optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc frcUdf (coerce xOptBB)
+                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB)
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs
@@ -2085,13 +2086,13 @@ makeHDL backend optsRef srcs = do
                   (startTime,prepTime)
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -158,6 +158,7 @@ import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.GHCi.Common
 import           Clash.Netlist.BlackBox.Types (HdlSyn)
+import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
@@ -1977,7 +1978,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2018,7 +2019,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
         -> IORef ClashOpts
         -> [FilePath]
         -> m ()
@@ -2086,13 +2087,13 @@ makeHDL backend optsRef srcs = do
                   (startTime,prepTime)
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -971,19 +971,19 @@ abiHash strs = do
 -----------------------------------------------------------------------------
 -- HDL Generation
 
-makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
          -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs
 
 makeVHDL :: IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
 
 makeVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
 
 makeSystemVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -98,6 +98,7 @@ import           Clash.Driver.Types
   (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
+import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir, setWantedLanguageExtensions)
 import           Clash.GHC.Util (handleClashException)
@@ -971,19 +972,19 @@ abiHash strs = do
 -----------------------------------------------------------------------------
 -- HDL Generation
 
-makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
          -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs
 
 makeVHDL :: IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
 
 makeVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
 
 makeSystemVerilog ::  IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -160,6 +160,7 @@ import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.GHCi.Common
 import           Clash.Netlist.BlackBox.Types (HdlSyn)
+import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
@@ -2068,7 +2069,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2109,7 +2110,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
         -> IORef ClashOpts
         -> [FilePath]
         -> m ()

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -2068,7 +2068,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2109,7 +2109,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
         -> IORef ClashOpts
         -> [FilePath]
         -> m ()
@@ -2123,6 +2123,7 @@ makeHDL backend optsRef srcs = do
                   syn    = opt_hdlSyn opts1
                   color  = opt_color opts1
                   esc    = opt_escapedIds opts1
+                  lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
                   xOptBB = opt_aggressiveXOptBB opts1
                   hdl    = Clash.Backend.hdlKind backend'
@@ -2137,7 +2138,7 @@ makeHDL backend optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc frcUdf (coerce xOptBB)
+                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB)
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -980,7 +980,7 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -95,6 +95,7 @@ import           Clash.Driver.Types
   (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
 import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
+import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir, setWantedLanguageExtensions)
 import           Clash.GHC.Util (handleClashException)
@@ -980,7 +981,7 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> Bool -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
   -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend r srcs = makeHDL backend r $ fmap fst srcs

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -24,6 +24,7 @@ import           Data.IORef
 import           Data.List                      (dropWhileEnd)
 import           Data.List.Split                (splitOn)
 import qualified Data.Set                       as Set
+import qualified Data.Text                      as Text
 import           Text.Read                      (readMaybe)
 
 import           Clash.Driver.Types
@@ -215,7 +216,8 @@ setComponentPrefix
   :: IORef ClashOpts
   -> String
   -> IO ()
-setComponentPrefix r s = modifyIORef r (\c -> c {opt_componentPrefix = Just s})
+setComponentPrefix r s =
+  modifyIORef r (\c -> c {opt_componentPrefix = Just (Text.pack s)})
 
 setOldInlineStrategy :: IORef ClashOpts -> IO ()
 setOldInlineStrategy r = modifyIORef r (\c -> c {opt_newInlineStrat = False})

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -29,6 +29,7 @@ import           Text.Read                      (readMaybe)
 
 import           Clash.Driver.Types
 import           Clash.Netlist.BlackBox.Types   (HdlSyn (..))
+import           Clash.Netlist.Types            (PreserveCase (ToLower))
 
 parseClashFlags :: IORef ClashOpts -> [Located String]
                 -> IO ([Located String]
@@ -227,7 +228,7 @@ setNoEscapedIds :: IORef ClashOpts -> IO ()
 setNoEscapedIds r = modifyIORef r (\c -> c {opt_escapedIds = False})
 
 setLowerCaseBasicIds :: IORef ClashOpts -> IO ()
-setLowerCaseBasicIds r = modifyIORef r (\c -> c {opt_lowerCaseBasicIds = True})
+setLowerCaseBasicIds r = modifyIORef r (\c -> c {opt_lowerCaseBasicIds = ToLower})
 
 setUltra :: IORef ClashOpts -> IO ()
 setUltra r = modifyIORef r (\c -> c {opt_ultra = True})

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -85,6 +85,7 @@ flagsClash r = [
   , defFlag "fclash-component-prefix"            $ SepArg (liftEwM . setComponentPrefix r)
   , defFlag "fclash-old-inline-strategy"         $ NoArg (liftEwM (setOldInlineStrategy r))
   , defFlag "fclash-no-escaped-identifiers"      $ NoArg (liftEwM (setNoEscapedIds r))
+  , defFlag "fclash-lower-case-basic-identifiers"$ NoArg (liftEwM (setLowerCaseBasicIds r))
   , defFlag "fclash-compile-ultra"               $ NoArg (liftEwM (setUltra r))
   , defFlag "fclash-force-undefined"             $ OptIntSuffix (setUndefined r)
   , defFlag "fclash-aggressive-x-optimization"   $ NoArg (liftEwM (setAggressiveXOpt r))
@@ -224,6 +225,9 @@ setOldInlineStrategy r = modifyIORef r (\c -> c {opt_newInlineStrat = False})
 
 setNoEscapedIds :: IORef ClashOpts -> IO ()
 setNoEscapedIds r = modifyIORef r (\c -> c {opt_escapedIds = False})
+
+setLowerCaseBasicIds :: IORef ClashOpts -> IO ()
+setLowerCaseBasicIds r = modifyIORef r (\c -> c {opt_lowerCaseBasicIds = True})
 
 setUltra :: IORef ClashOpts -> IO ()
 setUltra r = modifyIORef r (\c -> c {opt_ultra = True})

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -235,6 +235,7 @@ Library
                       Clash.Netlist.BlackBox.Util
                       Clash.Netlist.Id
                       Clash.Netlist.Id.Common
+                      Clash.Netlist.Id.Internal
                       Clash.Netlist.Id.SystemVerilog
                       Clash.Netlist.Id.Verilog
                       Clash.Netlist.Id.VHDL
@@ -339,4 +340,3 @@ test-suite unittests
 
   if flag(experimental-evaluator)
     cpp-options:      -DEXPERIMENTAL_EVALUATOR
-

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -234,6 +234,10 @@ Library
                       Clash.Netlist.BlackBox.Types
                       Clash.Netlist.BlackBox.Util
                       Clash.Netlist.Id
+                      Clash.Netlist.Id.Common
+                      Clash.Netlist.Id.SystemVerilog
+                      Clash.Netlist.Id.Verilog
+                      Clash.Netlist.Id.VHDL
                       Clash.Netlist.Types
                       Clash.Netlist.Util
 
@@ -271,6 +275,7 @@ Library
                       Data.Text.Prettyprint.Doc.Extra
 
   Other-Modules:      Clash.Annotations.TopEntity.Extra
+                      Control.Applicative.Extra
                       Data.Aeson.Extra
                       Data.List.Extra
                       Data.Primitive.ByteArray.Extra
@@ -294,7 +299,7 @@ test-suite unittests
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   main-is:          unittests.hs
-  ghc-options:      -Wall -Wcompat
+  ghc-options:      -Wall -Wcompat -threaded -with-rtsopts=-N
   hs-source-dirs:   tests
 
   if !flag(unittests)
@@ -307,6 +312,7 @@ test-suite unittests
       ghc-typelits-knownnat,
 
       base,
+      bytestring,
       containers,
       concurrent-supply,
       data-default,
@@ -314,8 +320,10 @@ test-suite unittests
       haskell-src-exts,
       ghc,
       lens,
+      quickcheck-text,
       tasty         >= 1.2      && < 1.4,
       tasty-hunit,
+      tasty-quickcheck,
       template-haskell,
       text,
       transformers,
@@ -323,6 +331,7 @@ test-suite unittests
 
   Other-Modules: Clash.Tests.Core.FreeVars
                  Clash.Tests.Core.Subst
+                 Clash.Tests.Netlist.Id
                  Clash.Tests.Util.Interpolate
                  Clash.Tests.Normalize.Transformations
 

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -63,7 +63,7 @@ class HasIdentifierSet state => Backend state where
     :: Int
     -> HdlSyn
     -> Bool
-    -> Bool
+    -> PreserveCase
     -> Maybe (Maybe Int)
     -> AggressiveXOptBB
     -> state

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -10,7 +10,6 @@
 
 module Clash.Backend where
 
-import qualified  Control.Lens              as Lens
 import Data.HashSet                         (HashSet)
 import Data.Semigroup.Monad                 (Mon (..))
 import Data.Text                            (Text)
@@ -132,13 +131,3 @@ class HasIdentifierSet state => Backend state where
   ifThenElseExpr :: state -> Bool
   -- | Whether -fclash-aggressive-x-optimization-blackboxes was set
   aggressiveXOptBB :: State state AggressiveXOptBB
-
-preserveSeen
-  :: Backend s
-  => Mon (State s) a
-  -> Mon (State s) a
-preserveSeen m = do
-  s <- Mon (Lens.use identifierSet)
-  a <- m
-  Mon (identifierSet Lens..= s)
-  return a

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -63,6 +63,7 @@ class HasIdentifierSet state => Backend state where
     :: Int
     -> HdlSyn
     -> Bool
+    -> Bool
     -> Maybe (Maybe Int)
     -> AggressiveXOptBB
     -> state

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -10,14 +10,9 @@
 
 module Clash.Backend where
 
-import Control.Lens                         (Lens')
 import qualified  Control.Lens              as Lens
-import Data.HashMap.Strict                  (HashMap)
-import qualified Data.HashMap.Strict        as HashMap
 import Data.HashSet                         (HashSet)
-import Data.Maybe                           (fromMaybe)
 import Data.Semigroup.Monad                 (Mon (..))
-import qualified Data.Text                  as T
 import Data.Text                            (Text)
 import qualified Data.Text.Lazy             as LT
 import Control.Monad.State                  (State)
@@ -25,7 +20,6 @@ import Data.Text.Prettyprint.Doc.Extra      (Doc)
 
 import SrcLoc (SrcSpan)
 
-import Clash.Netlist.Id
 import {-# SOURCE #-} Clash.Netlist.Types
 import Clash.Netlist.BlackBox.Types
 
@@ -52,7 +46,7 @@ clashVer = Data.Version.showVersion Paths_clash_lib.version
 clashVer = "development"
 #endif
 
-type ModName = Identifier
+type ModName = Text
 
 -- | Is a type used for internal or external use
 data Usage
@@ -64,7 +58,7 @@ data Usage
 -- | Is '-fclash-aggresive-x-optimization-blackbox' set?
 newtype AggressiveXOptBB = AggressiveXOptBB Bool
 
-class Backend state where
+class HasIdentifierSet state => Backend state where
   -- | Initial state for state monad
   initBackend
     :: Int
@@ -91,9 +85,9 @@ class Backend state where
   extractTypes     :: state -> HashSet HWType
 
   -- | Generate HDL for a Netlist component
-  genHDL           :: Identifier -> SrcSpan -> HashMap Identifier Word -> Component -> Mon (State state) ((String, Doc),[(String,Doc)])
+  genHDL           :: ModName -> SrcSpan -> IdentifierSet -> Component -> Mon (State state) ((String, Doc),[(String,Doc)])
   -- | Generate a HDL package containing type definitions for the given HWTypes
-  mkTyPackage      :: Identifier -> [HWType] -> Mon (State state) [(String, Doc)]
+  mkTyPackage      :: ModName -> [HWType] -> Mon (State state) [(String, Doc)]
   -- | Convert a Netlist HWType to a target HDL type
   hdlType          :: Usage -> HWType -> Mon (State state) Doc
   -- | Convert a Netlist HWType to an HDL error value for that type
@@ -120,10 +114,6 @@ class Backend state where
   fromBV           :: HWType -> LT.Text -> Mon (State state) Doc
   -- | Synthesis tool we're generating HDL for
   hdlSyn           :: State state HdlSyn
-  -- | mkIdentifier
-  mkIdentifier     :: State state (IdType -> Identifier -> Identifier)
-  -- | mkIdentifier
-  extendIdentifier :: State state (IdType -> Identifier -> Identifier -> Identifier)
   -- | setModName
   setModName       :: ModName -> state -> state
   -- | setSrcSpan
@@ -131,9 +121,7 @@ class Backend state where
   -- | getSrcSpan
   getSrcSpan       :: State state SrcSpan
   -- | Block of declarations
-  blockDecl        :: Text -> [Declaration] -> Mon (State state) Doc
-  -- | unextend/unescape identifier
-  unextend         :: State state (Identifier -> Identifier)
+  blockDecl        :: Identifier -> [Declaration] -> Mon (State state) Doc
   addIncludes      :: [(String, Doc)] -> State state ()
   addLibraries     :: [LT.Text] -> State state ()
   addImports       :: [LT.Text] -> State state ()
@@ -141,54 +129,16 @@ class Backend state where
   getDataFiles     :: State state [(String,FilePath)]
   addMemoryDataFile  :: (String,String) -> State state ()
   getMemoryDataFiles :: State state [(String,String)]
-  seenIdentifiers  :: Lens' state (HashMap Identifier Word)
   ifThenElseExpr :: state -> Bool
   -- | Whether -fclash-aggressive-x-optimization-blackboxes was set
   aggressiveXOptBB :: State state AggressiveXOptBB
-
--- | Replace a normal HDL template placeholder with an unescaped/unextended
--- template placeholder.
---
--- Needed when the the place-holder is filled with an escaped/extended identifier
--- inside an escaped/extended identifier and we want to strip the escape
--- /extension markers. Otherwise we end up with illegal identifiers.
-escapeTemplate :: Identifier -> Identifier
-escapeTemplate "~RESULT" = "~ERESULT"
-escapeTemplate t = fromMaybe t $ do
-  t1 <- T.stripPrefix "~ARG[" t
-  n  <- T.stripSuffix "]" t1
-  pure (T.concat ["~EARG[",n,"]"])
-
-mkUniqueIdentifier
-  :: Backend s
-  => IdType
-  -> Identifier
-  -> State s Identifier
-mkUniqueIdentifier typ nm = do
-  mkId     <- mkIdentifier
-  extendId <- extendIdentifier
-  seen     <- Lens.use seenIdentifiers
-  let i = mkId typ nm
-  case HashMap.lookup i seen of
-    Just n -> go extendId n seen i
-    Nothing -> do
-     seenIdentifiers Lens.%= (HashMap.insert i 0)
-     return i
- where
-  go extendId n seen i = do
-    let i' = extendId typ i (T.pack ('_':show n))
-    case HashMap.lookup i' seen of
-       Just _ -> go extendId (n+1) seen i
-       Nothing -> do
-        seenIdentifiers Lens.%= (HashMap.insert i' (n+1))
-        return i'
 
 preserveSeen
   :: Backend s
   => Mon (State s) a
   -> Mon (State s) a
 preserveSeen m = do
-  s <- Mon (Lens.use seenIdentifiers)
+  s <- Mon (Lens.use identifierSet)
   a <- m
-  Mon (seenIdentifiers Lens..= s)
+  Mon (identifierSet Lens..= s)
   return a

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -1248,13 +1248,13 @@ toSLV t e = case t of
   RTree _ _ -> braces (verilogTypeMark t <> "_to_lv" <> parens (expr_ False e))
   _ -> expr_ False e
 
-fromSLV :: HWType -> TextS.Text -> Int -> Int -> SystemVerilogM Doc
+fromSLV :: HWType -> IdentifierText -> Int -> Int -> SystemVerilogM Doc
 fromSLV t@(Vector _ _) id_ start end = verilogTypeMark t <> "_from_lv" <> parens (pretty id_ <> brackets (int start <> colon <> int end))
 fromSLV t@(RTree _ _) id_ start end = verilogTypeMark t <> "_from_lv" <> parens (pretty id_ <> brackets (int start <> colon <> int end))
 fromSLV (Signed _) id_ start end = "$signed" <> parens (pretty id_ <> brackets (int start <> colon <> int end))
 fromSLV _ id_ start end = pretty id_ <> brackets (int start <> colon <> int end)
 
-simpleFromSLV :: HWType -> TextS.Text -> SystemVerilogM Doc
+simpleFromSLV :: HWType -> IdentifierText -> SystemVerilogM Doc
 simpleFromSLV t@(Vector _ _) id_ = verilogTypeMark t <> "_from_lv" <> parens (pretty id_)
 simpleFromSLV t@(RTree _ _) id_ = verilogTypeMark t <> "_from_lv" <> parens (pretty id_)
 simpleFromSLV (Signed _) id_ = "$signed" <> parens (pretty id_)

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -93,12 +93,12 @@ instance HasIdentifierSet SystemVerilogState where
   identifierSet = idSeen
 
 instance Backend SystemVerilogState where
-  initBackend w hdlsyn_ esc undefVal xOpt = SystemVerilogState {
+  initBackend w hdlsyn_ esc lw undefVal xOpt = SystemVerilogState {
       _tyCache=HashSet.empty
     , _nameCache=HashMap.empty
     , _genDepth=0
     , _modNm=""
-    , _idSeen=Id.emptyIdentifierSet esc SystemVerilog
+    , _idSeen=Id.emptyIdentifierSet esc lw SystemVerilog
     , _oports=[]
     , _srcSpan=noSrcSpan
     , _includes=[]

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -293,13 +293,12 @@ genVHDL
   -> Component
   -> VHDLM ((String, Doc), [(String, Doc)])
 genVHDL nm sp seen c = do
-    -- Don't have type names conflict with component names
-    Mon $ idSeen .= seen
-
-    -- Don't have type names conflict with type names generated in previous
-    -- genVHDL
-    typNames <- use nameCache
-    mapM_ Id.addRaw (HashMapS.elems typNames)
+    -- Don't have type names conflict with module names or with previously
+    -- generated type names.
+    --
+    -- TODO: Collect all type names up front, to prevent relatively costly union.
+    -- TODO: Investigate whether type names / signal names collide in the first place
+    Mon $ idSeen %= Id.union seen
 
     Mon $ setSrcSpan sp
     v <- vhdl

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -32,7 +32,7 @@ import qualified Data.HashSet                         as HashSet
 import           Data.List
   (mapAccumL, nub, nubBy, intersperse, group, sort)
 import           Data.List.Extra                      ((<:>), equalLength, zipEqual)
-import           Data.Maybe                           (catMaybes,fromMaybe,mapMaybe)
+import           Data.Maybe                           (catMaybes,mapMaybe)
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Monoid                          hiding (Sum, Product)
 #endif
@@ -59,9 +59,9 @@ import           Clash.Debug                          (traceIf)
 import           Clash.Netlist.BlackBox.Types         (HdlSyn (..))
 import           Clash.Netlist.BlackBox.Util
   (extractLiterals, renderBlackBox, renderFilePath)
-import           Clash.Netlist.Id                     (IdType (..), mkBasicId')
+import qualified Clash.Netlist.Id                     as Id
 import           Clash.Netlist.Types                  hiding (_intWidth, intWidth)
-import           Clash.Netlist.Util                   hiding (mkIdentifier)
+import           Clash.Netlist.Util
 import           Clash.Util
   (SrcSpan, noSrcSpan, clogBase, curLoc, first, makeCached, on, indexNote)
 import           Clash.Util.Graph                     (reverseTopSort)
@@ -71,14 +71,12 @@ import           Clash.Backend.Verilog (Range (..), continueWithRange)
 -- | State for the 'Clash.Netlist.VHDL.VHDLM' monad:
 data VHDLState =
   VHDLState
-  { _tyCache   :: (HashSet HWType)
+  { _tyCache   :: HashSet HWType
   -- ^ Previously encountered HWTypes
-  , _tySeen    :: HashMap Identifier Word
-  -- ^ Generated product types
   , _nameCache :: (HashMap (HWType, Bool) TextS.Text)
   -- ^ Cache for type names. Bool indicates whether this name includes length
   -- information in its first "part". See `tyName'` for more information.
-  , _modNm     :: Identifier
+  , _modNm     :: ModName
   , _srcSpan   :: SrcSpan
   , _libraries :: [T.Text]
   , _packages  :: [T.Text]
@@ -88,21 +86,40 @@ data VHDLState =
   , _memoryDataFiles:: [(String,String)]
   -- ^ Files to be stored: (filename, contents). These files are generated
   -- during the execution of 'genNetlist'.
-  , _idSeen    :: HashMapS.HashMap Identifier Word
+  , _idSeen    :: IdentifierSet
   , _intWidth  :: Int
   -- ^ Int/Word/Integer bit-width
   , _hdlsyn    :: HdlSyn
   -- ^ For which HDL synthesis tool are we generating VHDL
-  , _extendedIds :: Bool
   , _undefValue :: Maybe (Maybe Int)
+  , _productFieldNameCache :: HashMap (Maybe [TextS.Text], [HWType]) [TextS.Text]
+  -- ^ Caches output of 'productFieldNames'.
   , _aggressiveXOptBB_ :: AggressiveXOptBB
   }
 
 makeLenses ''VHDLState
 
+instance HasIdentifierSet VHDLState where
+  identifierSet = idSeen
+
 instance Backend VHDLState where
-  initBackend     = VHDLState HashSet.empty HashMap.empty HashMap.empty ""
-                              noSrcSpan [] [] [] [] [] HashMapS.empty
+  initBackend w hdlsyn_ esc undefVal xOpt = VHDLState
+    { _tyCache=mempty
+    , _nameCache=mempty
+    , _modNm=""
+    , _srcSpan=noSrcSpan
+    , _libraries=[]
+    , _packages=[]
+    , _includes=[]
+    , _dataFiles=[]
+    , _memoryDataFiles=[]
+    , _idSeen=Id.emptyIdentifierSet esc VHDL
+    , _intWidth=w
+    , _hdlsyn=hdlsyn_
+    , _undefValue=undefVal
+    , _productFieldNameCache=mempty
+    , _aggressiveXOptBB_=xOpt
+    }
   hdlKind         = const VHDL
   primDirs        = const $ do root <- primsRoot
                                return [ root System.FilePath.</> "common"
@@ -136,46 +153,21 @@ instance Backend VHDLState where
     | isBV t = pretty id_
     | otherwise = do
       nm <- Mon $ use modNm
-      seen <- use seenIdentifiers
+      -- TODO: restore hack
+--      seen <- use seenIdentifiers
       -- This is a bit hacky, as id_ is just a rendered expression.
       -- But if it's a bare identifier that we've seen before,
       -- then this identifier has a defined type and we can skip the explicit type qualification.
-      let e | T.toStrict id_ `HashMapS.member` seen = pretty id_
-            | otherwise = hdlTypeMark t <> squote <> parens (pretty id_)
-      pretty (TextS.toLower nm) <> "_types.toSLV" <> parens e
+--      let e | T.toStrict id_ `HashMapS.member` seen = pretty id_
+--            | otherwise =
+      let e = hdlTypeMark t <> squote <> parens (pretty id_)
+      pretty nm <> "_types.toSLV" <> parens e
   fromBV t id_
     | isBV t = pretty id_
     | otherwise = do
       nm <- Mon $ use modNm
-      qualTyName t <> "'" <> parens (pretty (TextS.toLower nm) <> "_types.fromSLV" <> parens (pretty id_))
+      qualTyName t <> "'" <> parens (pretty nm <> "_types.fromSLV" <> parens (pretty id_))
   hdlSyn          = use hdlsyn
-  mkIdentifier    = do
-      allowExtended <- use extendedIds
-      return (go allowExtended)
-    where
-      go _ Basic nm =
-        case (stripTrailingUnderscore . filterReserved) (TextS.toLower (mkBasicId' VHDL True nm)) of
-          nm' | TextS.null nm' -> "clash_internal"
-              | otherwise -> nm'
-      go esc Extended (rmSlash -> nm) = case go esc Basic nm of
-        nm' | esc && nm /= nm' -> TextS.concat ["\\",nm,"\\"]
-            | otherwise -> nm'
-  extendIdentifier = do
-      allowExtended <- use extendedIds
-      return (go allowExtended)
-    where
-      go _ Basic nm ext =
-        case (stripTrailingUnderscore . filterReserved) (TextS.toLower (mkBasicId' VHDL True (nm `TextS.append` ext))) of
-          nm' | TextS.null nm' -> "clash_internal"
-              | otherwise -> nm'
-      go esc Extended ((rmSlash . escapeTemplate) -> nm) ext =
-        let nmExt = nm `TextS.append` ext
-        in  case go esc Basic nm ext of
-              nm' | esc && nm' /= nmExt -> case TextS.isPrefixOf "c$" nmExt of
-                      True -> TextS.concat ["\\",nmExt,"\\"]
-                      _    -> TextS.concat ["\\c$",nmExt,"\\"]
-                  | otherwise -> nm'
-
   setModName nm s = s {_modNm = nm}
   setSrcSpan      = (srcSpan .=)
   getSrcSpan      = use srcSpan
@@ -196,7 +188,6 @@ instance Backend VHDLState where
               ("begin" <> line <>
                 insts ds) <> line <>
             "end block" <> semi
-  unextend = return rmSlash
   addIncludes inc = includes %= (inc++)
   addLibraries libs = libraries %= (libs ++)
   addImports imps = packages %= (imps ++)
@@ -208,14 +199,8 @@ instance Backend VHDLState where
   getDataFiles = use dataFiles
   addMemoryDataFile f = memoryDataFiles %= (f:)
   getMemoryDataFiles = use memoryDataFiles
-  seenIdentifiers = idSeen
   ifThenElseExpr _ = False
   aggressiveXOptBB = use aggressiveXOptBB_
-
-rmSlash :: Identifier -> Identifier
-rmSlash nm = fromMaybe nm $ do
-  nm1 <- TextS.stripPrefix "\\" nm
-  pure (TextS.filter (not . (== '\\')) nm1)
 
 type VHDLM a = Mon (State VHDLState) a
 
@@ -223,80 +208,6 @@ type VHDLM a = Mon (State VHDLState) a
 isBV :: HWType -> Bool
 isBV (normaliseType -> BitVector _) = True
 isBV _ = False
-
--- | Time units: are added to 'reservedWords' as simulators trip over signals
--- named after them.
-timeUnits :: [Identifier]
-timeUnits = ["fs", "ps", "ns", "us", "ms", "sec", "min", "hr"]
-
--- | Identifiers which are imported from the following:
---
--- use IEEE.STD_LOGIC_1164.ALL;
--- use IEEE.NUMERIC_STD.ALL;
--- use IEEE.MATH_REAL.ALL;
--- use std.textio.all;
---
--- Clash should not use these identifiers, as it can lead to errors when
--- interfacing with an EDA tool.
---
--- See https://github.com/clash-lang/clash-compiler/issues/1439.
---
-importedNames :: [Identifier]
-importedNames =
-  [ -- ieee.std_logic_1164.all
-    "std_ulogic", "std_ulogic_vector", "resolved", "std_logic", "std_logic_vector"
-  , "x01", "x01z", "ux01", "ux01z", "to_bit", "to_bitvector", "to_stdulogic"
-  , "to_stdlogicvector", "to_stdulogicvector", "to_01", "to_x01", "to_x01z"
-  , "to_ux01", "rising_edge", "falling_edge", "is_x"
-    -- ieee.numeric_std.all
-  , "unresolved_unsigned", "unresolved_signed", "u_unsigned", "u_signed"
-  , "unsigned", "signed", "find_leftmost", "find_rightmost", "minimum"
-  , "maximum", "shift_left", "shift_right", "rotate_left", "rotate_right"
-  , "resize", "to_integer", "to_unsigned", "to_signed", "std_match"
-    -- ieee.math_real.all
-  , "math_e", "math_1_over_e", "math_pi", "math_2_pi", "math_1_over_pi"
-  , "math_pi_over_2", "math_pi_over_3", "path_pi_over_4", "path_3_pi_over_2"
-  , "math_log_of_2", "math_log_of_10", "math_log10_of_e", "math_sqrt_2"
-  , "math_1_over_sqrt_2", "math_sqrt_pi", "math_deg_to_rad", "math_rad_to_deg"
-  , "sign", "ceil", "floor", "round", "trunc", "realmax", "realmin", "uniform"
-  , "sqrt", "cbrt", "exp", "log", "log2", "log10", "sin", "cos", "tan", "arcsin"
-  , "arccos", "arctan", "sinh", "cosh", "tanh", "arcsinh", "arccosh", "arctanh"
-    -- std.textio.all
-  , "line", "text", "side", "width", "justify", "input", "output", "readline"
-  , "read", "sread", "string_read", "bread", "binary_read", "oread", "octal_read"
-  , "hread", "hex_read", "writeline", "tee", "write", "swrite", "string_write"
-  , "bwrite", "binary_write", "owrite", "octal_write", "hwrite", "hex_write"
-  ]
-
--- List of reserved VHDL-2008 keywords
--- + used internal names: toslv, fromslv, tagtoenum, datatotag
--- + used IEEE library names: integer, boolean, std_logic, std_logic_vector,
---   signed, unsigned, to_integer, to_signed, to_unsigned, string
-reservedWords :: [Identifier]
-reservedWords = ["abs","access","after","alias","all","and","architecture"
-  ,"array","assert","assume","assume_guarantee","attribute","begin","block"
-  ,"body","buffer","bus","case","component","configuration","constant","context"
-  ,"cover","default","disconnect","downto","else","elsif","end","entity","exit"
-  ,"fairness","file","for","force","function","generate","generic","group"
-  ,"guarded","if","impure","in","inertial","inout","is","label","library"
-  ,"linkage","literal","loop","map","mod","nand","new","next","nor","not","null"
-  ,"of","on","open","or","others","out","package","parameter","port","postponed"
-  ,"procedure","process","property","protected","pure","range","record"
-  ,"register","reject","release","rem","report","restrict","restrict_guarantee"
-  ,"return","rol","ror","select","sequence","severity","signal","shared","sla"
-  ,"sll","sra","srl","strong","subtype","then","to","transport","type"
-  ,"unaffected","units","until","use","variable","vmode","vprop","vunit","wait"
-  ,"when","while","with","xnor","xor","toslv","fromslv","tagtoenum","datatotag"
-  ,"integer", "boolean", "std_logic", "std_logic_vector", "signed", "unsigned"
-  ,"to_integer", "to_signed", "to_unsigned", "string","log"] ++ timeUnits ++ importedNames
-
-filterReserved :: Identifier -> Identifier
-filterReserved s = if s `elem` reservedWords
-  then s `TextS.append` "_r"
-  else s
-
-stripTrailingUnderscore :: Identifier -> Identifier
-stripTrailingUnderscore = TextS.dropWhileEnd (== '_')
 
 -- | Generate unique (partial) names for product fields. Example:
 --
@@ -320,13 +231,11 @@ productFieldNames labels0 fields = do
   return names
  where
   hName
-    :: Maybe Identifier
+    :: Maybe TextS.Text
     -> HWType
-    -> VHDLM Identifier
-  hName Nothing field  =
-    tyName' False field
-  hName (Just label) _field = do
-    Mon (mkIdentifier <*> pure Basic <*> pure label)
+    -> VHDLM TextS.Text
+  hName Nothing field = tyName' False field
+  hName (Just label) _field = Id.toText <$> Id.makeBasic label
 
   name'
     :: HashMap TextS.Text Int
@@ -357,8 +266,11 @@ productFieldName
   -- ^ Index of field
   -> VHDLM Doc
 productFieldName labels fields fieldIndex = do
-  -- TODO: cache
-  names <- productFieldNames labels fields
+  names <-
+    makeCached
+      (labels, fields)
+      productFieldNameCache
+      (productFieldNames labels fields)
   return (PP.pretty (names !! fieldIndex))
 
 selectProductField
@@ -374,17 +286,27 @@ selectProductField fieldLabels fieldTypes fieldIndex =
   "_sel" <> int fieldIndex <> "_" <> productFieldName fieldLabels fieldTypes fieldIndex
 
 -- | Generate VHDL for a Netlist component
-genVHDL :: Identifier -> SrcSpan -> HashMapS.HashMap Identifier Word -> Component -> VHDLM ((String,Doc),[(String,Doc)])
-genVHDL nm sp seen c = preserveSeen $ do
-    Mon $ idSeen .= seen
+genVHDL
+  :: ModName
+  -> SrcSpan
+  -> IdentifierSet
+  -> Component
+  -> VHDLM ((String, Doc), [(String, Doc)])
+genVHDL nm sp seen c = do
     -- Don't have type names conflict with component names
-    Mon $ tySeen %= HashMap.unionWith max seen
+    Mon $ idSeen .= seen
+
+    -- Don't have type names conflict with type names generated in previous
+    -- genVHDL
+    typNames <- use nameCache
+    mapM_ Id.addRaw (HashMapS.elems typNames)
+
     Mon $ setSrcSpan sp
     v <- vhdl
     i <- Mon $ use includes
     Mon $ libraries .= []
     Mon $ packages  .= []
-    return ((TextS.unpack cName,v),i)
+    return ((TextS.unpack (Id.toText cName), v), i)
   where
     cName   = componentName c
     vhdl    = do
@@ -397,23 +319,20 @@ genVHDL nm sp seen c = preserveSeen $ do
        pure arch)
 
 -- | Generate a VHDL package containing type definitions for the given HWTypes
-mkTyPackage_ :: Identifier
-             -> [HWType]
-             -> VHDLM [(String,Doc)]
+mkTyPackage_ :: TextS.Text -> [HWType] -> VHDLM [(String,Doc)]
 mkTyPackage_ modName (map filterTransparent -> hwtys) = do
     { syn <- Mon hdlSyn
-    ; mkId <- Mon (mkIdentifier <*> pure Basic)
     ; let usedTys     = concatMap mkUsedTys hwtys
     ; let normTys0    = nub (map mkVecZ (hwtys ++ usedTys))
     ; let sortedTys0  = topSortHWTys normTys0
           packageDec  = vcat $ mapM tyDec (nubBy eqTypM sortedTys0)
           (funDecs,funBodies) = unzip . mapMaybe (funDec syn) $ nubBy eqTypM (map normaliseType sortedTys0)
 
-    ; (:[]) <$> (TextS.unpack $ mkId (modName `TextS.append` "_types"),) <$>
+    ; (:[]) <$> (TextS.unpack (modName `TextS.append` "_types"),) <$>
       "library IEEE;" <> line <>
       "use IEEE.STD_LOGIC_1164.ALL;" <> line <>
       "use IEEE.NUMERIC_STD.ALL;" <> line <> line <>
-      "package" <+> pretty (mkId (modName `TextS.append` "_types")) <+> "is" <> line <>
+      "package" <+> pretty (modName `TextS.append` "_types") <+> "is" <> line <>
          indent 2 ( packageDec <> line <>
                     vcat (sequence funDecs)
                   ) <> line <>
@@ -424,9 +343,8 @@ mkTyPackage_ modName (map filterTransparent -> hwtys) = do
     packageBodyDec funBodies = case funBodies of
       [] -> emptyDoc
       _  -> do
-        { mkId <- Mon (mkIdentifier <*> pure Basic)
-        ; line <> line <>
-         "package" <+> "body" <+> pretty (mkId (modName `TextS.append` "_types")) <+> "is" <> line <>
+        { line <> line <>
+         "package" <+> "body" <+> pretty (modName `TextS.append` "_types") <+> "is" <> line <>
            indent 2 (vcat (sequence funBodies)) <> line <>
          "end" <> semi
         }
@@ -812,9 +730,8 @@ funDec syn t@(RTree _ elTy) = Just
 
 funDec _ _ = Nothing
 
-tyImports :: Identifier -> VHDLM Doc
+tyImports :: TextS.Text -> VHDLM Doc
 tyImports nm = do
-  mkId <- Mon (mkIdentifier <*> pure Basic)
   libs <- Mon $ use libraries
   packs <- Mon $ use packages
   punctuate' semi $ sequence
@@ -824,20 +741,20 @@ tyImports nm = do
      , "use IEEE.MATH_REAL.ALL"
      , "use std.textio.all"
      , "use work.all"
-     , "use work." <> pretty (mkId (nm `TextS.append` "_types")) <> ".all"
+     , "use work." <> pretty (nm `TextS.append` "_types") <> ".all"
      ] ++ (map (("library" <+>) . pretty) (nub libs))
        ++ (map (("use" <+>) . pretty) (nub packs)))
 
 
 -- TODO: Way too much happening on a single line
 port :: Num t
-     => TextS.Text
+     => Identifier
      -> HWType
      -> VHDLM Doc
      -> Int
      -> Maybe Expr
      -> VHDLM (Doc, t)
-port elName hwType portDirection fillToN iEM =
+port (Id.toText -> elName) hwType portDirection fillToN iEM =
   (,fromIntegral $ TextS.length elName) <$>
   (encodingNote hwType <> fill fillToN (pretty elName) <+> colon <+> direction
    <+> sizedQualTyName hwType <> iE)
@@ -944,13 +861,15 @@ attrTypes = foldl attrType HashMap.empty
 attrMap
   :: forall t
    . t ~ HashMap T.Text (T.Text, [(TextS.Text, T.Text)])
-  => [(TextS.Text, Attr')]
+  => [(Identifier, Attr')]
   -> t
-attrMap attrs = foldl go empty' attrs
+attrMap attrs0 = foldl go empty' attrs1
  where
+  attrs1 = map (first Id.toText) attrs0
+
   empty' = HashMap.fromList
            [(k, (types HashMap.! k, [])) | k <- HashMap.keys types]
-  types = attrTypes (map snd attrs)
+  types = attrTypes (map snd attrs1)
 
   go :: t -> (TextS.Text, Attr') -> t
   go map' attr = HashMap.adjust
@@ -967,7 +886,7 @@ attrMap attrs = foldl go empty' attrs
 
 renderAttrs
   :: TextS.Text
-  -> [(TextS.Text, Attr')]
+  -> [(Identifier, Attr')]
   -> VHDLM Doc
 renderAttrs what (attrMap -> attrs) =
   vcat $ sequence $ intersperse " " $ map renderAttrGroup (assocs attrs)
@@ -1047,7 +966,7 @@ qualTyName (filterTransparent -> hwty) = case hwty of
   -- Custom types:
   _ -> do
     modName <- Mon (use modNm)
-    pretty (TextS.toLower modName) <> "_types." <> tyName hwty
+    pretty modName <> "_types." <> tyName hwty
 
 -- | Generates a unique name for a given type. This action will cache its
 -- results, thus returning the same answer for the same @HWType@ argument.
@@ -1221,31 +1140,16 @@ filterTransparent hwty = case hwty of
 
 -- | Create a unique type name for user defined types
 userTyName
-  :: Identifier
+  :: TextS.Text
   -- ^ Default name
-  -> Identifier
+  -> TextS.Text
   -- ^ Identifier stored in @hwTy@
   -> HWType
   -- ^ Type to give a (unique) name
   -> StateT VHDLState Identity TextS.Text
 userTyName dflt nm0 hwTy = do
   tyCache %= HashSet.insert hwTy
-  seen <- use tySeen
-  mkId <- mkIdentifier <*> pure Basic
-  let nm1 = (mkId . last . TextS.splitOn ".") nm0
-      nm2 = if TextS.null nm1 then dflt else nm1
-      (nm3,count) = case HashMap.lookup nm2 seen of
-                      Just cnt -> go mkId seen cnt nm2
-                      Nothing  -> (nm2,0)
-  tySeen %= HashMap.insert nm3 count
-  return nm3
-  where
-    go mkId seen count nm0' =
-      let nm1' = nm0' `TextS.append` TextS.pack ('_':show count) in
-      case HashMap.lookup nm1' seen of
-        Just _  -> go mkId seen (count+1) nm0'
-        Nothing -> (nm1',count+1)
-
+  Id.toText <$> Id.makeBasicOr (last (TextS.splitOn "." nm0)) dflt
 
 -- | Convert a Netlist HWType to an error VHDL value for that type
 sizedQualTyNameErrValue :: HWType -> VHDLM Doc
@@ -1306,7 +1210,7 @@ decls ds = do
       _  -> vcat (pure dsDoc)
 
 decl :: Int ->  Declaration -> VHDLM (Maybe (Doc,Int))
-decl l (NetDecl' noteM _ id_ ty iEM) = Just <$> (,fromIntegral (TextS.length id_)) <$>
+decl l (NetDecl' noteM _ id_ ty iEM) = Just <$> (,fromIntegral (TextS.length (Id.toText id_))) <$>
   maybe id addNote noteM ("signal" <+> fill l (pretty id_) <+> colon <+> either pretty sizedQualTyName ty <> iE <> semi)
   where
     addNote n = mappend ("--" <+> pretty n <> line)
@@ -1324,7 +1228,7 @@ decl _ (InstDecl Comp _ attrs nm _ gens pms) = fmap (Just . (,0)) $ do
     <> attrs'
   }
  where
-    formalLength (Identifier i _) = fromIntegral (TextS.length i)
+    formalLength (Identifier i _) = fromIntegral (TextS.length (Id.toText i))
     formalLength _                = 0
 
     portDir In  = "in"
@@ -1400,7 +1304,12 @@ insts (d:ds) = do
     _ -> insts ds
 
 -- | Helper function for inst_, handling CustomSP and CustomSum
-inst_' :: TextS.Text -> Expr -> HWType -> [(Maybe Literal, Expr)] -> VHDLM (Maybe Doc)
+inst_'
+  :: Identifier
+  -> Expr
+  -> HWType
+  -> [(Maybe Literal, Expr)]
+  -> VHDLM (Maybe Doc)
 inst_' id_ scrut scrutTy es = fmap Just $
   (pretty id_ <+> larrow <+> align (vcat (conds esNub) <> semi))
     where
@@ -1466,7 +1375,7 @@ inst_ (InstDecl entOrComp libM _ nm lbl gens pms) = do
     pms' = do
       rec (p,ls) <- fmap unzip $ sequence [ (,formalLength i) <$> fill (maximum ls) (expr_ False i) <+> "=>" <+> expr_ False e | (i,_,_,e) <- pms]
       nest 2 $ "port map" <> line <> tupled (pure p)
-    formalLength (Identifier i _) = fromIntegral (TextS.length i)
+    formalLength (Identifier i _) = fromIntegral (TextS.length (Id.toText i))
     formalLength _                = 0
     entOrComp' = case entOrComp of { Entity -> " entity"; Comp -> " component"; Empty -> ""}
 
@@ -1817,19 +1726,19 @@ bit_char Z = char 'Z'
 toSLV :: HasCallStack => HWType -> Expr -> VHDLM Doc
 toSLV Bool         e = do
   nm <- Mon $ use modNm
-  pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)
+  pretty nm <> "_types.toSLV" <> parens (expr_ False e)
 toSLV Bit          e = do
   nm <- Mon $ use modNm
-  pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)
+  pretty nm <> "_types.toSLV" <> parens (expr_ False e)
 toSLV (Clock {})    e = do
   nm <- Mon $ use modNm
-  pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)
+  pretty nm <> "_types.toSLV" <> parens (expr_ False e)
 toSLV (Reset {})    e = do
   nm <- Mon $ use modNm
   pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)
 toSLV (Enable _)    e = do
   nm <- Mon $ use modNm
-  pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)
+  pretty nm <> "_types.toSLV" <> parens (expr_ False e)
 toSLV (BitVector _) e = expr_ True e
 toSLV (Signed _)   e = "std_logic_vector" <> parens (expr_ False e)
 toSLV (Unsigned _) e = "std_logic_vector" <> parens (expr_ False e)
@@ -1845,7 +1754,7 @@ toSLV t@(Product _ labels tys) (Identifier id_ Nothing) = do
     encloseSep lparen rparen " & " (zipWithM toSLV tys selIds')
   where
     tName    = tyName t
-    selNames = map (fmap (T.toStrict . renderOneLine) ) [pretty id_ <> dot <> tName <> selectProductField labels tys i | i <- [0..(length tys)-1]]
+    selNames = map (fmap (Id.unsafeMake . T.toStrict . renderOneLine) ) [pretty id_ <> dot <> tName <> selectProductField labels tys i | i <- [0..(length tys)-1]]
     selIds   = map (fmap (\n -> Identifier n Nothing)) selNames
 toSLV (Product _ _ tys) (DataCon _ _ es) | equalLength tys es =
   -- Need equalLenght for code seen in ZipWithUnitVector
@@ -1856,7 +1765,7 @@ toSLV (CustomProduct _ _ _ _ _) e = do
   expr_ False e
 toSLV t@(Product _ _ _) e = do
   nm <- Mon $ use modNm
-  pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (qualTyName t <> "'" <> parens (expr_ False e))
+  pretty nm <> "_types.toSLV" <> parens (qualTyName t <> "'" <> parens (expr_ False e))
 toSLV (SP _ _) e       = expr_ False e
 toSLV (CustomSP _ _ _ _) e =
   -- Custom representations are represented as bitvectors in HDL, so we don't
@@ -1870,17 +1779,17 @@ toSLV (Vector n elTy) (Identifier id_ Nothing) = do
         Vivado -> mapM (expr_ False) selIds'
         _ -> mapM (toSLV elTy) selIds'))
   where
-    selNames = map (fmap (T.toStrict . renderOneLine) ) $ [pretty id_ <> parens (int i) | i <- [0 .. (n-1)]]
+    selNames = map (fmap (Id.unsafeMake . T.toStrict . renderOneLine) ) $ [pretty id_ <> parens (int i) | i <- [0 .. (n-1)]]
     selIds   = map (fmap (`Identifier` Nothing)) selNames
 -- Don't split up newtype wrappers, or void-filtered types
 toSLV (Vector _ _) e@(DataCon _ (DC (Void Nothing, -1)) _) = do
   nm <- Mon $ use modNm
-  pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)
+  pretty nm <> "_types.toSLV" <> parens (expr_ False e)
 toSLV (Vector n elTy) (DataCon _ _ es) =
   "std_logic_vector'" <> (parens $ vcat $ punctuate " & " (zipWithM toSLV [elTy,Vector (n-1) elTy] es))
 toSLV (Vector _ _) e = do
   nm <- Mon $ use modNm
-  pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)
+  pretty nm <> "_types.toSLV" <> parens (expr_ False e)
 toSLV (RTree _ _) e = do
   nm <- Mon (use modNm)
   pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (expr_ False e)

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -103,7 +103,7 @@ instance HasIdentifierSet VHDLState where
   identifierSet = idSeen
 
 instance Backend VHDLState where
-  initBackend w hdlsyn_ esc undefVal xOpt = VHDLState
+  initBackend w hdlsyn_ esc lw undefVal xOpt = VHDLState
     { _tyCache=mempty
     , _nameCache=mempty
     , _modNm=""
@@ -113,7 +113,7 @@ instance Backend VHDLState where
     , _includes=[]
     , _dataFiles=[]
     , _memoryDataFiles=[]
-    , _idSeen=Id.emptyIdentifierSet esc VHDL
+    , _idSeen=Id.emptyIdentifierSet esc lw VHDL
     , _intWidth=w
     , _hdlsyn=hdlsyn_
     , _undefValue=undefVal

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -187,13 +187,12 @@ genVerilog
   -> Component
   -> VerilogM ((String, Doc), [(String, Doc)])
 genVerilog sp seen c = do
-  -- Don't have type names conflict with component names
-    Mon $ idSeen .= seen
-
-    -- Don't have type names conflict with type names generated in previous
-    -- genVHDL
-    constrNames <- HashMap.elems <$> use customConstrs
-    mapM_ (Id.addRaw . Id.toText) constrNames
+    -- Don't have type names conflict with module names or with previously
+    -- generated type names.
+    --
+    -- TODO: Collect all type names up front, to prevent relatively costly union.
+    -- TODO: Investigate whether type names / signal names collide in the first place
+    Mon $ idSeen %= Id.union seen
 
     Mon (setSrcSpan sp)
     v    <- commentHeader <> line <> timescale <> line <> module_ c

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -485,7 +485,7 @@ inst_ (CondAssignment id_ _ scrut scrutTy es) = fmap Just $
               "endcase") <> line <>
     "end"
   where
-    conds :: TextS.Text -> [(Maybe Literal,Expr)] -> VerilogM [Doc]
+    conds :: IdentifierText -> [(Maybe Literal,Expr)] -> VerilogM [Doc]
     conds _ []                = return []
     conds i [(_,e)]           = ("default" <+> colon <+> stringS i <+> equals <+> expr_ False e) <:> return []
     conds i ((Nothing,e):_)   = ("default" <+> colon <+> stringS i <+> equals <+> expr_ False e) <:> return []

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -102,9 +102,9 @@ instance HasIdentifierSet VerilogState where
   identifierSet = idSeen
 
 instance Backend VerilogState where
-  initBackend iw hdlsyn_ esc undefVal xOpt = VerilogState
+  initBackend iw hdlsyn_ esc lw undefVal xOpt = VerilogState
     { _genDepth=0
-    , _idSeen=Id.emptyIdentifierSet esc Verilog
+    , _idSeen=Id.emptyIdentifierSet esc lw Verilog
     , _srcSpan=noSrcSpan
     , _includes=[]
     , _imports=HashSet.empty

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -145,7 +145,8 @@ lookupVarEnvDirectly = lookupUniqMap
 --
 -- Errors out when the variable is not present
 lookupVarEnv'
-  :: VarEnv a
+  :: HasCallStack
+  => VarEnv a
   -> Var b
   -> a
 lookupVarEnv' = lookupUniqMap'

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -107,7 +107,7 @@ import           Clash.Netlist.BlackBox.Parser    (runParse)
 import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate, BlackBoxFunction)
 import qualified Clash.Netlist.Id                 as Id
 import           Clash.Netlist.Types
-  (BlackBox (..), Component (..), FilteredHWType, HWMap, SomeBackend (..),
+  (IdentifierText, BlackBox (..), Component (..), FilteredHWType, HWMap, SomeBackend (..),
    TopEntityT(..), TemplateFunction, findClocks)
 import           Clash.Normalize                  (checkNonRecursive, cleanupGraph,
                                                    normalize, runNormalization)
@@ -759,7 +759,7 @@ createHDL
   :: Backend backend
   => backend
   -- ^ Backend
-  -> Data.Text.Text
+  -> IdentifierText
   -- ^ Module hierarchy root
   -> Id.IdentifierSet
   -- ^ Component names
@@ -769,7 +769,7 @@ createHDL
   -- ^ Known domains to configurations
   -> Maybe Component
   -- ^ Top component
-  -> (Data.Text.Text, Either Manifest Manifest)
+  -> (IdentifierText, Either Manifest Manifest)
   -- ^ Name of the manifest file
   -- + Either:
   --   * Left manifest:  Only write/update the hashes of the @manifest@

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -288,33 +288,33 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
   putStrLn $ "Clash: Compiling " ++ topEntityS
 
   -- Some initial setup
-  let modName1 = Data.Text.pack (takeWhile (/= '.') topEntityS)
+  let modName1 = takeWhile (/= '.') topEntityS
       topNm = lookupVarEnv' compNames topEntity
-      (modName, prefixM) = case topPrefixM of
-        Just p
-          | not (Data.Text.null p) -> case annM of
+      (modNameS, fmap Data.Text.pack -> prefixM) = case topPrefixM of
+        Just (Data.Text.unpack -> p)
+          | not (null p) -> case annM of
             -- Prefix top names with 'p', prefix other with 'p_tname'
             Just ann ->
-              let nm = p <> "_" <> Data.Text.pack (t_name ann) in
+              let nm = p <> "_" <> t_name ann in
               (nm, Just nm)
             -- Prefix top names with 'p', prefix other with 'p'
             _ -> (p <> "_" <> modName1, Just p)
           | Just ann <- annM -> case hdl of
               -- Prefix other with 't_name'
-              VHDL -> (Data.Text.pack (t_name ann), Just modName)
-              _    -> (Data.Text.pack (t_name ann), Nothing)
+              VHDL -> (t_name ann, Just modNameS)
+              _    -> (t_name ann, Nothing)
         _ -> case annM of
           Just ann -> case hdlKind (undefined :: backend) of
-            VHDL -> (Data.Text.pack (t_name ann), Nothing)
+            VHDL -> (t_name ann, Nothing)
             -- Prefix other with 't_name'
-            _ -> (Data.Text.pack (t_name ann), Just modName)
+            _ -> (t_name ann, Just modNameS)
           _ -> (modName1, Nothing)
-      modNameS  = Data.Text.unpack modName
+      modNameT  = Data.Text.pack modNameS
       iw        = opt_intWidth opts
       hdlsyn    = opt_hdlSyn opts
       forceUnd  = opt_forceUndefined opts
       xOpt      = coerce (opt_aggressiveXOptBB opts)
-      hdlState' = setModName modName
+      hdlState' = setModName modNameT
                 $ fromMaybe (initBackend iw hdlsyn escpIds forceUnd xOpt :: backend) hdlState
       hdlDir    = fromMaybe "." (opt_hdlDir opts) </>
                         Clash.Backend.name hdlState' </>
@@ -454,7 +454,7 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
 
       -- 3. Generate topEntity wrapper
       let (hdlDocs, manifest', dfiles, mfiles) =
-             createHDL hdlState' modName seen2 netlist domainConfs (Just topComponent) (topNmT, Right manifest)
+             createHDL hdlState' modNameT seen2 netlist domainConfs (Just topComponent) (topNmT, Right manifest)
       mapM_ (writeHDL dir) hdlDocs
       copyDataFiles (opt_importPaths opts) dir dfiles
       writeMemoryDataFiles dir mfiles

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -262,11 +262,12 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
      in go prepTime initIs HashMap.empty deps tes
  where
   todo = maybe topEntities2 (uncurry (:)) mainTopEntity
-  (compNames, initIs) = genTopNames topPrefixM escpIds hdl todo
+  (compNames, initIs) = genTopNames topPrefixM escpIds lwIds hdl todo
   topEntityMap = mkVarEnv (zip (map topId todo) todo)
   topPrefixM = opt_componentPrefix opts
   hdl = hdlFromBackend (Proxy @backend)
   escpIds = opt_escapedIds opts
+  lwIds = opt_lowerCaseBasicIds opts
 
   topEntities1 = map (splitTopEntityT tcm bindingsMap) topEntities0
   -- Remove forall's used in type equality constraints
@@ -315,7 +316,7 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
       forceUnd  = opt_forceUndefined opts
       xOpt      = coerce (opt_aggressiveXOptBB opts)
       hdlState' = setModName modNameT
-                $ fromMaybe (initBackend iw hdlsyn escpIds forceUnd xOpt :: backend) hdlState
+                $ fromMaybe (initBackend iw hdlsyn escpIds lwIds forceUnd xOpt :: backend) hdlState
       hdlDir    = fromMaybe "." (opt_hdlDir opts) </>
                         Clash.Backend.name hdlState' </>
                         takeWhile (/= '.') topEntityS

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -173,6 +173,9 @@ data ClashOpts = ClashOpts
   --
   --  * http://vhdl.renerta.com/mobile/source/vhd00037.htm
   --  * http://verilog.renerta.com/source/vrg00018.htm
+  , opt_lowerCaseBasicIds :: Bool
+  -- ^ Force all generated basic identifiers to lowercase. Among others, this
+  -- affects module and file names.
   , opt_ultra :: Bool
   -- ^ Perform a high-effort compile, trading improved performance for
   -- potentially much longer compile times.
@@ -227,6 +230,7 @@ instance Hashable ClashOpts where
     opt_componentPrefix `hashWithSalt`
     opt_newInlineStrat `hashWithSalt`
     opt_escapedIds `hashWithSalt`
+    opt_lowerCaseBasicIds `hashWithSalt`
     opt_ultra `hashWithSalt`
     opt_forceUndefined `hashWithSalt`
     opt_checkIDir `hashWithSalt`
@@ -270,6 +274,7 @@ defClashOpts
   , opt_componentPrefix     = Nothing
   , opt_newInlineStrat      = True
   , opt_escapedIds          = True
+  , opt_lowerCaseBasicIds   = False
   , opt_ultra               = False
   , opt_forceUndefined      = Nothing
   , opt_checkIDir           = True

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -163,7 +163,7 @@ data ClashOpts = ClashOpts
   -- not supported, use vendor primitives instead.
   , opt_importPaths :: [FilePath]
   -- ^ Paths where Clash should look for modules
-  , opt_componentPrefix :: Maybe String
+  , opt_componentPrefix :: Maybe Text
   -- ^ Prefix components with given string
   , opt_newInlineStrat :: Bool
   -- ^ Use new inline strategy. Functions marked NOINLINE will get their own

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -39,6 +39,7 @@ import           Clash.Core.Term                (Term)
 import           Clash.Core.Var                 (Id)
 import           Clash.Core.VarEnv              (VarEnv)
 import           Clash.Netlist.BlackBox.Types   (HdlSyn (..))
+import {-# SOURCE #-} Clash.Netlist.Types       (PreserveCase(..))
 
 data IsPrim
   = IsPrim
@@ -173,7 +174,7 @@ data ClashOpts = ClashOpts
   --
   --  * http://vhdl.renerta.com/mobile/source/vhd00037.htm
   --  * http://verilog.renerta.com/source/vrg00018.htm
-  , opt_lowerCaseBasicIds :: Bool
+  , opt_lowerCaseBasicIds :: PreserveCase
   -- ^ Force all generated basic identifiers to lowercase. Among others, this
   -- affects module and file names.
   , opt_ultra :: Bool
@@ -274,7 +275,7 @@ defClashOpts
   , opt_componentPrefix     = Nothing
   , opt_newInlineStrat      = True
   , opt_escapedIds          = True
-  , opt_lowerCaseBasicIds   = False
+  , opt_lowerCaseBasicIds   = PreserveCase
   , opt_ultra               = False
   , opt_forceUndefined      = Nothing
   , opt_checkIDir           = True

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -20,17 +20,16 @@
 module Clash.Netlist where
 
 import           Control.Exception                (throw)
-import           Control.Lens                     ((.=))
+import           Control.Lens                     ((.=), (<~))
 import qualified Control.Lens                     as Lens
-import           Control.Monad                    (join)
 import           Control.Monad.Extra              (concatMapM)
 import           Control.Monad.IO.Class           (liftIO)
 import           Control.Monad.Reader             (runReaderT)
-import           Control.Monad.State.Strict       (State, runStateT)
+import           Control.Monad.State.Strict       (State, runStateT, runState)
 import           Data.Binary.IEEE754              (floatToWord, doubleToWord)
 import           Data.Char                        (ord)
 import           Data.Either                      (partitionEithers, rights)
-import           Data.HashMap.Strict              (HashMap)
+import           Data.Foldable                    (foldlM)
 import qualified Data.HashMap.Strict              as HashMapS
 import qualified Data.HashMap.Lazy                as HashMap
 import           Data.List                        (elemIndex, partition, sortOn)
@@ -47,12 +46,11 @@ import           Text.Read                        (readMaybe)
 import           Outputable                       (ppr, showSDocUnsafe)
 import           SrcLoc                           (isGoodSrcSpan)
 
-import           Clash.Annotations.Primitive      (extractPrim)
+import           Clash.Annotations.Primitive      (extractPrim, HDL)
 import           Clash.Annotations.BitRepresentation.ClashLib
   (coreToType')
 import           Clash.Annotations.BitRepresentation.Internal
   (CustomReprs, DataRepr'(..), ConstrRepr'(..), getDataRepr, getConstrRepr)
-import           Clash.Annotations.TopEntity      (TopEntity (..))
 import           Clash.Core.DataCon               (DataCon (..))
 import           Clash.Core.Literal               (Literal (..))
 import           Clash.Core.Name                  (Name(..))
@@ -70,10 +68,10 @@ import           Clash.Core.Util                  (splitShouldSplit)
 import           Clash.Core.Var                   (Id, Var (..), isGlobalId)
 import           Clash.Core.VarEnv
   (VarEnv, emptyInScopeSet, emptyVarEnv, extendVarEnv, lookupVarEnv,
-   lookupVarEnv', mkVarEnv)
+   lookupVarEnv')
 import           Clash.Driver.Types               (BindingMap, Binding(..), ClashOpts (..))
 import           Clash.Netlist.BlackBox
-import           Clash.Netlist.Id
+import qualified Clash.Netlist.Id                 as Id
 import           Clash.Netlist.Types              as HW
 import           Clash.Netlist.Util
 import           Clash.Primitives.Types           as P
@@ -91,8 +89,10 @@ genNetlist
   -- ^ Custom bit representations for certain types
   -> BindingMap
   -- ^ Global binders
-  -> [TopEntityT]
-  -- ^ All the TopEntities
+  -> VarEnv TopEntityT
+  -- ^ TopEntity annotations
+  -> VarEnv Identifier
+  -- ^ Top entity names
   -> CompiledPrimMap
   -- ^ Primitive definitions
   -> TyConMap
@@ -102,33 +102,24 @@ genNetlist
   -- ^ Hardcoded Type -> HWType translator
   -> Int
   -- ^ Int/Word/Integer bit-width
-  -> (IdType -> Identifier -> Identifier)
-  -- ^ valid identifiers
-  -> (IdType -> Identifier -> Identifier -> Identifier)
-  -- ^ extend valid identifiers
   -> Bool
   -- ^ Whether the backend supports ifThenElse expressions
   -> SomeBackend
   -- ^ The current HDL backend
-  -> HashMap Identifier Word
+  -> IdentifierSet
   -- ^ Seen components
   -> FilePath
   -- ^ HDL dir
-  -> ComponentPrefix
+  -> Maybe StrictText.Text
   -- ^ Component name prefix
   -> Id
   -- ^ Name of the @topEntity@
-  -> IO (VarEnv ([Bool],SrcSpan,HashMap Identifier Word,Component),HashMap Identifier Word)
-genNetlist isTb opts reprs globals tops primMap tcm typeTrans iw mkId extId ite be seen env prefixM topEntity = do
-  (_,s) <- runNetlistMonad isTb opts reprs globals topEntityMap
-             primMap tcm typeTrans iw mkId extId ite be seen env prefixM $
-             genComponent topEntity
-  return ( _components s
-         , _seenComps s
-         )
-  where
-    topEntityMap :: VarEnv TopEntityT
-    topEntityMap = mkVarEnv (zip (map topId tops) tops)
+  -> IO (Component, VarEnv ([Bool],SrcSpan,IdentifierSet,Component), IdentifierSet)
+genNetlist isTb opts reprs globals tops topNames primMap tcm typeTrans iw ite be seen env prefixM topEntity = do
+  ((_wereVoids, _sp, _is, topComponent), s) <-
+    runNetlistMonad isTb opts reprs globals tops topNames primMap tcm typeTrans
+                    iw ite be seen env prefixM $ genComponent topEntity
+  return (topComponent, _components s, _seenIds s)
 
 -- | Run a NetlistMonad action in a given environment
 runNetlistMonad
@@ -142,6 +133,8 @@ runNetlistMonad
   -- ^ Global binders
   -> VarEnv TopEntityT
   -- ^ TopEntity annotations
+  -> VarEnv Identifier
+  -- ^ Top entity names
   -> CompiledPrimMap
   -- ^ Primitive Definitions
   -> TyConMap
@@ -151,58 +144,110 @@ runNetlistMonad
   -- ^ Hardcode Type -> HWType translator
   -> Int
   -- ^ Int/Word/Integer bit-width
-  -> (IdType -> Identifier -> Identifier)
-  -- ^ valid identifiers
-  -> (IdType -> Identifier -> Identifier -> Identifier)
-  -- ^ extend valid identifiers
   -> Bool
   -- ^ Whether the backend supports ifThenElse expressions
   -> SomeBackend
   -- ^ The current HDL backend
-  -> HashMap Identifier Word
+  -> IdentifierSet
   -- ^ Seen components
   -> FilePath
   -- ^ HDL dir
-  -> ComponentPrefix
+  -> Maybe StrictText.Text
   -- ^ Component name prefix
   -> NetlistMonad a
   -- ^ Action to run
   -> IO (a, NetlistState)
-runNetlistMonad isTb opts reprs s tops p tcm typeTrans iw mkId extId ite be seenIds_ env prefixM
+runNetlistMonad isTb opts reprs s tops topNames p tcm typeTrans iw ite be seenIds0 env prefixM
   = flip runReaderT (NetlistEnv "" "" Nothing)
   . flip runStateT s'
   . runNetlist
   where
     s' =
       NetlistState
-        s 0 emptyVarEnv p typeTrans tcm (StrictText.empty,noSrcSpan) iw mkId
-        extId HashMapS.empty seenIds' Set.empty names tops env 0 prefixM reprs opts isTb ite be
-        HashMapS.empty
+        { _bindings=s
+        , _components=emptyVarEnv
+        , _primitives=p
+        , _typeTranslator=typeTrans
+        , _tcCache=tcm
+        , _curCompNm=(error "genComponent should have set _curCompNm", noSrcSpan)
+        , _intWidth=iw
+        , _seenIds=seenIds1
+        , _seenComps=seenIds1
+        , _seenPrimitives=Set.empty
+        , _componentNames=componentNames_
+        , _topEntityAnns=tops
+        , _hdlDir=env
+        , _curBBlvl=0
+        , _customReprs=reprs
+        , _clashOpts=opts
+        , _isTestBench=isTb
+        , _backEndITE=ite
+        , _backend=be
+        , _htyCache=HashMapS.empty
+        }
 
-    (seenIds',names) = genNames (opt_newInlineStrat opts) mkId prefixM seenIds_
-                                emptyVarEnv s
+    (componentNames_, seenIds1) =
+      genNames (opt_newInlineStrat opts) prefixM seenIds0 topNames s
 
-genNames :: Bool
-         -> (IdType -> Identifier -> Identifier)
-         -> ComponentPrefix
-         -> HashMap Identifier Word
-         -> VarEnv Identifier
-         -> BindingMap
-         -> (HashMap Identifier Word, VarEnv Identifier)
-genNames newInlineStrat mkId prefixM s0 m0 = foldr go (s0,m0)
-  where
-    go b (s,m) =
-      let nm' = genComponentName newInlineStrat s mkId prefixM (bindingId b)
-          s'  = HashMapS.insert nm' 0 s
-          m'  = extendVarEnv (bindingId b) nm' m
-      in (s', m')
+-- | Generate names for all binders in "BindingMap", execpt for the ones already
+-- present in given identifier varenv.
+genNames
+  :: Bool
+  -- ^ New inline strategy enabled?
+  -> Maybe StrictText.Text
+  -- ^ Prefix
+  -> IdentifierSet
+  -- ^ Identifier set to extend
+  -> VarEnv Identifier
+  -- ^ Pre-generated names
+  -> BindingMap
+  -> (VarEnv Identifier, IdentifierSet)
+genNames newInlineStrat prefixM is env bndrs =
+  runState (foldlM go env bndrs) is
+ where
+  go env_ (bindingId -> id_) =
+    case lookupVarEnv id_ env_ of
+      Just _ -> pure env_
+      Nothing -> do
+        nm <- Id.makeBasic (genComponentName newInlineStrat prefixM id_)
+        pure (extendVarEnv id_ nm env_)
+
+-- | Generate names for top entities. Should be executed at the very start of
+-- the synthesis process and shared between all passes.
+genTopNames
+  :: Maybe StrictText.Text
+  -- ^ Prefix
+  -> Bool
+  -- ^ Allow escaped identifiers?
+  -> HDL
+  -- ^ HDL to generate identifiers for
+  -> [TopEntityT]
+  -> (VarEnv Identifier, IdentifierSet)
+genTopNames prefixM esc hdl tops =
+  -- TODO: Report error if fixed top entities have conflicting names
+  flip runState (Id.emptyIdentifierSet esc hdl) $ do
+    env0 <- foldlM goFixed emptyVarEnv fixedTops
+    env1 <- foldlM goNonFixed env0 (nonFixedTops ++ tests)
+    pure env1
+ where
+  fixedTops = [(topId, ann) | TopEntityT{topId, topAnnotation=Just ann} <- tops]
+  nonFixedTops = [topId | TopEntityT{topId, topAnnotation=Nothing} <- tops]
+  tests = [testId | TopEntityT{associatedTestbench=Just testId} <- tops]
+
+  goFixed env (topId, ann) = do
+    topNm <- genTopName prefixM ann
+    pure (extendVarEnv topId topNm env)
+
+  goNonFixed env id_ = do
+    topNm <- Id.makeBasic (genComponentName True prefixM id_)
+    pure (extendVarEnv id_ topNm env)
 
 -- | Generate a component for a given function (caching)
 genComponent
   :: HasCallStack
   => Id
   -- ^ Name of the function
-  -> NetlistMonad ([Bool],SrcSpan,HashMap Identifier Word,Component)
+  -> NetlistMonad ([Bool],SrcSpan,IdentifierSet,Component)
 genComponent compName = do
   compExprM <- lookupVarEnv compName <$> Lens.use bindings
   case compExprM of
@@ -219,33 +264,29 @@ genComponentT
   -- ^ Name of the function
   -> Term
   -- ^ Corresponding term
-  -> NetlistMonad ([Bool],SrcSpan,HashMap Identifier Word,Component)
-genComponentT compName componentExpr = do
-  varCount .= 0
-  componentName1 <- (`lookupVarEnv'` compName) <$> Lens.use componentNames
-  topEntMM <- fmap topAnnotation . lookupVarEnv compName <$> Lens.use topEntityAnns
-  prefixM <- Lens.use componentPrefix
-  let componentName2 = case (componentPrefixTop prefixM, join topEntMM) of
-                         (Just p, Just ann) -> p `StrictText.append` StrictText.pack ('_':t_name ann)
-                         (_,Just ann) -> StrictText.pack (t_name ann)
-                         _ -> componentName1
-  sp <- (bindingLoc . (`lookupVarEnv'` compName)) <$> Lens.use bindings
-  curCompNm .= (componentName2,sp)
-
+  -> NetlistMonad ([Bool],SrcSpan,IdentifierSet,Component)
+genComponentT compName0 componentExpr = do
   tcm <- Lens.use tcCache
+  compName1 <- (`lookupVarEnv'` compName0) <$> Lens.use componentNames
+  sp <- (bindingLoc . (`lookupVarEnv'` compName0)) <$> Lens.use bindings
+  curCompNm .= (compName1, sp)
 
-  -- HACK: Determine resulttype of this function by looking at its definition
-  -- in topEntityAnns, instead of looking at its last binder (which obscures
-  -- any attributes [see: Clash.Annotations.SynthesisAttributes]).
-  topEntityTypeM <- lookupVarEnv compName <$> Lens.use topEntityAnns
-  let topEntityTypeM' = snd . splitCoreFunForallTy tcm . varType . topId <$> topEntityTypeM
+  topEntityTM <- lookupVarEnv compName0 <$> Lens.use topEntityAnns
+  let topAnnMM = topAnnotation <$> topEntityTM
+      topVarTypeM = snd . splitCoreFunForallTy tcm . varType . topId <$> topEntityTM
 
-  seenIds .= HashMapS.empty
+  seenIds <~ Lens.use seenComps
   (wereVoids,compInps,argWrappers,compOutps,resUnwrappers,binders,resultM) <-
     case splitNormalized tcm componentExpr of
       Right (args, binds, res) -> do
-        let varType'   = fromMaybe (varType res) topEntityTypeM'
-        mkUniqueNormalized emptyInScopeSet topEntMM ((args, binds, res{varType=varType'}))
+        let varType1 = fromMaybe (varType res) topVarTypeM
+        mkUniqueNormalized
+          emptyInScopeSet
+          topAnnMM
+          -- HACK: Determine resulttype of this function by looking at its definition
+          -- instead of looking at its last binder (which obscures any attributes
+          -- [see: Clash.Annotations.SynthesisAttributes]).
+          ((args, binds, res{varType=varType1}))
       Left err ->
         throw (ClashException sp ($curLoc ++ err) Nothing)
 
@@ -262,7 +303,7 @@ genComponentT compName componentExpr = do
                        in  (map (Wire,,Nothing) compOutps
                            ,NetDecl' n rw res (Right resTy) Nothing:tail resUnwrappers
                            )
-          component      = Component componentName2 compInps compOutps'
+          component      = Component compName1 compInps compOutps'
                              (netDecls ++ argWrappers ++ decls ++ resUnwrappers')
       ids <- Lens.use seenIds
       return (wereVoids, sp, ids, component)
@@ -270,7 +311,7 @@ genComponentT compName componentExpr = do
     -- when the TopEntity has an empty result. We just create an empty component
     -- in this case.
     Nothing -> do
-      let component = Component componentName2 compInps [] (netDecls ++ argWrappers ++ decls)
+      let component = Component compName1 compInps [] (netDecls ++ argWrappers ++ decls)
       ids <- Lens.use seenIds
       return (wereVoids, sp, ids, component)
 
@@ -466,7 +507,7 @@ mkSelection declType bndr scrut altTy alts0 tickDecls = do
   tcm <- Lens.use tcCache
   let scrutTy = termType tcm scrut
   scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-  scrutId  <- extendIdentifier Extended dstId "_selection"
+  scrutId  <- Id.suffix dstId "selection"
   (_,sp) <- Lens.use curCompNm
   ite <- Lens.use backEndITE
   altHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) altTy
@@ -479,8 +520,8 @@ mkSelection declType bndr scrut altTy alts0 tickDecls = do
         SP {} -> first (mkScrutExpr sp scrutHTy (fst (last alts0))) <$>
                    mkExpr True declType (NetlistId scrutId scrutTy) scrut
         _ -> mkExpr False declType (NetlistId scrutId scrutTy) scrut
-      altTId <- extendIdentifier Extended dstId "_sel_alt_t"
-      altFId <- extendIdentifier Extended dstId "_sel_alt_f"
+      altTId <- Id.suffix dstId "sel_alt_t"
+      altFId <- Id.suffix dstId "sel_alt_f"
       (altTExpr,altTDecls) <- mkExpr False declType (NetlistId altTId altTy) altT
       (altFExpr,altFDecls) <- mkExpr False declType (NetlistId altFId altTy) altF
       -- This logic (and the same logic a few lines below) is faulty in the
@@ -521,9 +562,7 @@ mkSelection declType bndr scrut altTy alts0 tickDecls = do
  where
   mkCondExpr :: HWType -> (Pat,Term) -> NetlistMonad ((Maybe HW.Literal,Expr),[Declaration])
   mkCondExpr scrutHTy (pat,alt) = do
-    altId <- extendIdentifier Extended
-               (netlistId1 id id2identifier bndr)
-               "_sel_alt"
+    altId <- Id.suffix (netlistId1 id id2identifier bndr) "sel_alt"
     (altExpr,altDecls) <- mkExpr False declType (NetlistId altId altTy) alt
     (,altDecls) <$> case pat of
       DefaultPat           -> return (Nothing,altExpr)
@@ -620,6 +659,8 @@ mkFunApp dstId fun args tickDecls = do
       , length fArgTys1 == length args
       -> do
         let annM = topAnnotation topEntity
+        topNameI <- lookupVarEnv' <$> Lens.use componentNames <*> pure fun
+        let topName = StrictText.unpack (Id.toText topNameI)
         argHWTys <- mapM (unsafeCoreTypeToHWTypeM' $(curLoc)) fArgTys1
         (argExprs, concat -> argDecls) <- unzip <$>
           mapM (\(e,t) -> mkExpr False Concurrent (NetlistId dstId t) e)
@@ -632,13 +673,8 @@ mkFunApp dstId fun args tickDecls = do
 
         dstHWty  <- unsafeCoreTypeToHWTypeM' $(curLoc) fResTy
         env  <- Lens.use hdlDir
-        mkId <- Lens.use mkIdentifierFn
-        prefixM <- Lens.use componentPrefix
-        newInlineStrat <- opt_newInlineStrat <$> Lens.use clashOpts
-        let topName = StrictText.unpack
-                      (genTopComponentName newInlineStrat mkId prefixM annM fun)
-            modName = takeWhile (/= '.')
-                                (StrictText.unpack (nameOcc (varName fun)))
+        let modName = takeWhile (/= '.') (StrictText.unpack (nameOcc (varName fun)))
+
         manFile <- case annM of
           Just _  -> return (env </> ".." </> modName </> topName </> topName <.> "manifest")
           Nothing -> return (env </> topName <.> "manifest")
@@ -680,10 +716,10 @@ mkFunApp dstId fun args tickDecls = do
                   outpAssign    = case compOutp of
                     Nothing -> []
                     Just (id_,hwtype) -> [(Identifier id_ Nothing,Out,hwtype,Identifier dstId Nothing)]
-              instLabel0 <- extendIdentifier Basic compName (StrictText.pack "_" `StrictText.append` dstId)
+              let instLabel0 = StrictText.concat [Id.toText compName, "_", Id.toText dstId]
               instLabel1 <- fromMaybe instLabel0 <$> Lens.view setName
               instLabel2 <- affixName instLabel1
-              instLabel3 <- mkUniqueIdentifier Basic instLabel2
+              instLabel3 <- Id.makeBasic instLabel2
               let instDecl = InstDecl Entity Nothing [] compName instLabel3 [] (outpAssign ++ inpAssigns)
               return (argDecls ++ argDecls' ++ tickDecls ++ [instDecl])
             else error [I.i|
@@ -708,7 +744,7 @@ mkFunApp dstId fun args tickDecls = do
       case args of
         [] ->
           -- TODO: Figure out what to do with zero-width constructs
-          return [Assignment dstId (Identifier (nameOcc $ varName fun) Nothing)]
+          return [Assignment dstId (Identifier (id2identifier fun) Nothing)]
         _ -> error [I.i|
           Netlist generation encountered a local function. This should not
           happen. Function:
@@ -737,14 +773,11 @@ toSimpleVar :: Identifier
             -> NetlistMonad (Expr,[Declaration])
 toSimpleVar _ (e@(Identifier _ Nothing),_) = return (e,[])
 toSimpleVar dstId (e,ty) = do
-  argNm <- extendIdentifier Extended
-             dstId
-             "_fun_arg"
-  argNm' <- mkUniqueIdentifier Extended argNm
+  argNm <- Id.suffix dstId "fun_arg"
   hTy <- unsafeCoreTypeToHWTypeM' $(curLoc) ty
-  let argDecl         = NetDecl Nothing argNm' hTy
-      argAssn         = Assignment argNm' e
-  return (Identifier argNm' Nothing,[argDecl,argAssn])
+  let argDecl         = NetDecl Nothing argNm hTy
+      argAssn         = Assignment argNm e
+  return (Identifier argNm Nothing,[argDecl,argAssn])
 
 -- | Generate an expression for a term occurring on the RHS of a let-binder
 mkExpr :: HasCallStack
@@ -788,20 +821,18 @@ mkExpr bbEasD declType bndr app =
           if isVoid hwTyA then
             return (Noop, [])
           else
-            return (Identifier (nameOcc $ varName f) Nothing, [])
+            return (Identifier (id2identifier f) Nothing, [])
       | not (null tyArgs) ->
           throw (ClashException sp ($(curLoc) ++ "Not in normal form: "
             ++ "Var-application with Type arguments:\n\n" ++ showPpr app) Nothing)
       | otherwise -> do
-          argNm0 <- extendIdentifier Extended (netlistId1 id id2identifier bndr)
-                                     "_fun_arg"
-          argNm1 <- mkUniqueIdentifier Extended argNm0
-          decls  <- mkFunApp argNm1 f tmArgs tickDecls
+          argNm <- Id.suffix (netlistId1 id id2identifier bndr) "fun_arg"
+          decls  <- mkFunApp argNm f tmArgs tickDecls
           if isVoid hwTyA then
             return (Noop, decls)
           else
-            return ( Identifier argNm1 Nothing
-                   , NetDecl' Nothing Wire argNm1 (Right hwTyA) Nothing:decls)
+            return ( Identifier argNm Nothing
+                   , NetDecl' Nothing Wire argNm (Right hwTyA) Nothing:decls)
     Case scrut ty' [alt] -> mkProjection bbEasD bndr scrut ty' alt
     Case scrut tyA alts -> do
       tcm <- Lens.use tcCache
@@ -811,15 +842,14 @@ mkExpr bbEasD declType bndr app =
       let wr = case iteAlts scrutHTy alts of
                  Just _ | ite -> Wire
                  _ -> Reg
-      argNm0 <- extendIdentifier Extended (netlistId1 id id2identifier bndr) "_sel_arg"
-      argNm1 <- mkUniqueIdentifier Extended argNm0
-      decls  <- mkSelection declType (NetlistId argNm1 (netlistTypes1 bndr))
+      argNm <- Id.suffix (netlistId1 id id2identifier bndr) "sel_arg"
+      decls  <- mkSelection declType (NetlistId argNm (netlistTypes1 bndr))
                             scrut tyA alts tickDecls
       if isVoid hwTyA then
         return (Noop, decls)
       else
-        return ( Identifier argNm1 Nothing
-               , NetDecl' Nothing wr argNm1 (Right hwTyA) Nothing:decls)
+        return ( Identifier argNm Nothing
+               , NetDecl' Nothing wr argNm (Right hwTyA) Nothing:decls)
     Letrec binders body -> do
       netDecls <- concatMapM mkNetDecl binders
       decls    <- concatMapM (uncurry mkDeclarations) binders
@@ -857,8 +887,8 @@ mkProjection mkDec bndr scrut altTy alt@(pat,v) = do
   scrutRendered <- do
     scrutNm <-
       netlistId1
-        return
-        (\b -> extendIdentifier Extended (id2identifier b) "_projection")
+        Id.next
+        (\b -> Id.suffix (id2identifier b) "projection")
         bndr
     (scrutExpr,newDecls) <- mkExpr False Concurrent (NetlistId scrutNm scrutTy) scrut
     case scrutExpr of
@@ -871,15 +901,14 @@ mkProjection mkDec bndr scrut altTy alt@(pat,v) = do
         -- TODO: seems useless?
         pure (Left newDecls)
       _ -> do
-        scrutNm' <- mkUniqueIdentifier Extended scrutNm
-        let scrutDecl = NetDecl Nothing scrutNm' sHwTy
-            scrutAssn = Assignment scrutNm' scrutExpr
-        pure (Right (scrutNm', Nothing, newDecls ++ [scrutDecl, scrutAssn]))
+        let scrutDecl = NetDecl Nothing scrutNm sHwTy
+            scrutAssn = Assignment scrutNm scrutExpr
+        pure (Right (scrutNm, Nothing, newDecls ++ [scrutDecl, scrutAssn]))
 
   case scrutRendered of
     Left newDecls -> pure (Noop, newDecls)
     Right (selId, modM, decls) -> do
-      let altVarId = nameOcc (varName varTm)
+      let altVarId = id2identifier varTm
       modifier <- case pat of
         DataPat dc exts tms -> do
           let
@@ -909,7 +938,7 @@ mkProjection mkDec bndr scrut altTy alt@(pat,v) = do
       let extractExpr = Identifier (maybe altVarId (const selId) modifier) modifier
       case bndr of
         NetlistId scrutNm _ | mkDec -> do
-          scrutNm' <- mkUniqueIdentifier Extended scrutNm
+          scrutNm' <- Id.next scrutNm
           let scrutDecl = NetDecl Nothing scrutNm' vHwTy
               scrutAssn = Assignment scrutNm' extractExpr
           return (Identifier scrutNm' Nothing,scrutDecl:scrutAssn:decls)
@@ -938,7 +967,7 @@ mkDcApplication [dstHType] bndr dc args = do
   let dcNm = nameOcc (dcName dc)
   tcm <- Lens.use tcCache
   let argTys = map (termType tcm) args
-  argNm <- netlistId1 return (\b -> extendIdentifier Extended (nameOcc (varName b)) "_dc_arg") bndr
+  argNm <- netlistId1 return (\b -> Id.suffix (id2identifier b) "_dc_arg") bndr
   argHWTys <- mapM coreTypeToHWTypeM' argTys
 
   (argExprs, concat -> argDecls) <- unzip <$>

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -218,7 +218,7 @@ genTopNames
   -- ^ Prefix
   -> Bool
   -- ^ Allow escaped identifiers?
-  -> Bool
+  -> PreserveCase
   -- ^ Lower case basic ids?
   -> HDL
   -- ^ HDL to generate identifiers for

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -188,7 +188,7 @@ runNetlistMonad isTb opts reprs s tops p tcm typeTrans iw
         , _htyCache=HashMapS.empty
         }
 
--- | Generate names for all binders in "BindingMap", execpt for the ones already
+-- | Generate names for all binders in "BindingMap", except for the ones already
 -- present in given identifier varenv.
 genNames
   :: Bool
@@ -218,13 +218,15 @@ genTopNames
   -- ^ Prefix
   -> Bool
   -- ^ Allow escaped identifiers?
+  -> Bool
+  -- ^ Lower case basic ids?
   -> HDL
   -- ^ HDL to generate identifiers for
   -> [TopEntityT]
   -> (VarEnv Identifier, IdentifierSet)
-genTopNames prefixM esc hdl tops =
+genTopNames prefixM esc lw hdl tops =
   -- TODO: Report error if fixed top entities have conflicting names
-  flip runState (Id.emptyIdentifierSet esc hdl) $ do
+  flip runState (Id.emptyIdentifierSet esc lw hdl) $ do
     env0 <- foldlM goFixed emptyVarEnv fixedTops
     env1 <- foldlM goNonFixed env0 (nonFixedTops ++ tests)
     pure env1

--- a/clash-lib/src/Clash/Netlist.hs-boot
+++ b/clash-lib/src/Clash/Netlist.hs-boot
@@ -16,20 +16,19 @@ module Clash.Netlist
   ,mkFunApp
   ) where
 
-import Data.HashMap.Strict  (HashMap)
 import Clash.Core.DataCon   (DataCon)
 import Clash.Core.Term      (Alt,LetBinding,Term)
 import Clash.Core.Type      (Type)
 import Clash.Core.Var       (Id)
 import Clash.Netlist.Types  (Expr, HWType, Identifier, NetlistMonad, Component,
-                             Declaration, NetlistId, DeclarationType)
+                             Declaration, NetlistId, DeclarationType, IdentifierSet)
 import SrcLoc               (SrcSpan)
 
 import GHC.Stack (HasCallStack)
 
 genComponent :: HasCallStack
              => Id
-             -> NetlistMonad ([Bool],SrcSpan,HashMap Identifier Word,Component)
+             -> NetlistMonad ([Bool],SrcSpan,IdentifierSet,Component)
 
 mkExpr :: HasCallStack
        => Bool

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -10,15 +10,16 @@
 -}
 
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE QuasiQuotes #-}
 
 module Clash.Netlist.BlackBox where
 
 import           Control.Exception             (throw)
-import           Control.Lens                  ((<<%=),(%=))
+import           Control.Lens                  ((%=))
 import qualified Control.Lens                  as Lens
 import           Control.Monad                 (when, replicateM, zipWithM)
 import           Control.Monad.Extra           (concatMapM)
@@ -57,6 +58,7 @@ import           Clash.Core.FreeVars           (freeIds)
 import           Clash.Core.Literal            as L (Literal (..))
 import           Clash.Core.Name
   (Name (..), mkUnsafeSystemName)
+import qualified Clash.Netlist.Id              as Id
 import           Clash.Core.Pretty             (showPpr)
 import           Clash.Core.Subst              (extendIdSubst, mkSubst, substTm)
 import           Clash.Core.Term               as C
@@ -81,7 +83,6 @@ import           Clash.Driver.Types
   (opt_primWarn, opt_color, ClashOpts)
 import           Clash.Netlist.BlackBox.Types  as B
 import           Clash.Netlist.BlackBox.Util   as B
-import           Clash.Netlist.Id              (IdType (..))
 import           Clash.Netlist.Types           as N
 import           Clash.Netlist.Util            as N
 import           Clash.Primitives.Types        as P
@@ -123,7 +124,7 @@ mkBlackBoxContext
 mkBlackBoxContext bbName resIds args@(lefts -> termArgs) = do
     -- Make context inputs
     let
-      resNms = map (nameOcc . varName) resIds
+      resNms = map id2identifier resIds
       resNm = fromMaybe (error "mkBlackBoxContext: head") (listToMaybe resNms)
     resTys <- mapM (unsafeCoreTypeToHWTypeM' $(curLoc) . V.varType) resIds
     (imps,impDecls) <- unzip <$> zipWithM (mkArgument bbName resNm) [0..] termArgs
@@ -141,7 +142,7 @@ mkBlackBoxContext bbName resIds args@(lefts -> termArgs) = do
 
     -- Set "context name" to value set by `Clash.Magic.setName`, default to the
     -- name of the closest binder
-    ctxName1 <- fromMaybe resNms . fmap pure <$> Lens.view setName
+    ctxName1 <- fromMaybe (map Id.toText resNms) . fmap pure <$> Lens.view setName
     -- Update "context name" with prefixes and suffixes set by
     -- `Clash.Magic.prefixName` and `Clash.Magic.suffixName`
     ctxName2 <- mapM affixName ctxName1
@@ -182,7 +183,7 @@ prepareBlackBox _pNm templ bbCtx =
     Nothing -> do
       (t2,decls) <-
         onBlackBox
-          (fmap (first BBTemplate) . setSym mkUniqueIdentifier bbCtx)
+          (fmap (first BBTemplate) . setSym bbCtx)
           (\bbName bbHash bbFunc -> pure (BBFunction bbName bbHash bbFunc, []))
           templ
       return (t2,decls)
@@ -223,11 +224,12 @@ mkArgument bbName bndr nArg e = do
       Nothing
         | (Prim p,_) <- collectArgs e
         , primName p == "Clash.Transformations.removedArg"
-        -> return ((Identifier (primName p) Nothing, Void Nothing, False),[])
+        -> return ((Identifier (Id.unsafeMake "Clash.Transformations.removedArg") Nothing, Void Nothing, False), [])
         | otherwise
         -> return ((error ($(curLoc) ++ "Forced to evaluate untranslatable type: " ++ eTyMsg), Void Nothing, False), [])
       Just hwTy -> case collectArgsTicks e of
-        (C.Var v,[],_) -> return ((Identifier (nameOcc (varName v)) Nothing,hwTy,False),[])
+        (C.Var v,[],_) ->
+          return ((Identifier (id2identifier v) Nothing,hwTy,False),[])
         (C.Literal (IntegerLiteral i),[],_) ->
           return ((N.Literal (Just (Signed iw,iw)) (N.NumLit i),hwTy,True),[])
         (C.Literal (IntLiteral i), [],_) ->
@@ -436,7 +438,7 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                       return (Noop, ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
 
                     -- Otherwise don't render them
-                    Nothing -> return (Identifier "__VOID_TEXPRD__" Nothing,[])
+                    Nothing -> return (Identifier (Id.unsafeMake "__VOID_TEXPRD__") Nothing,[])
                 else do
                   resM <- resBndr1 False dst
                   case resM of
@@ -467,7 +469,7 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                       return (Noop, ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
 
                     -- Otherwise don't render them
-                    Nothing -> return (Identifier "__VOID__" Nothing,[])
+                    Nothing -> return (Identifier (Id.unsafeMake "__VOID__") Nothing,[])
         P.Primitive pNm _ _
           | pNm == "GHC.Prim.tagToEnum#" -> do
               hwTy <- N.unsafeCoreTypeToHWTypeM' $(curLoc) ty
@@ -482,12 +484,12 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   tcm     <- Lens.use tcCache
                   let scrutTy = termType tcm scrut
                   (scrutExpr,scrutDecls) <-
-                    mkExpr False Concurrent (NetlistId "c$tte_rhs" scrutTy) scrut
+                    mkExpr False Concurrent (NetlistId (Id.unsafeMake "c$tte_rhs") scrutTy) scrut
                   case scrutExpr of
                     Identifier id_ Nothing -> return (DataTag hwTy (Left id_),scrutDecls)
                     _ -> do
                       scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-                      tmpRhs <- mkUniqueIdentifier Extended "c$tte_rhs"
+                      tmpRhs <- Id.make "c$tte_rhs"
                       let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                           netAssignRhs = Assignment tmpRhs scrutExpr
                       return (DataTag hwTy (Left tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
@@ -501,11 +503,11 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                 let scrutTy = termType tcm scrut
                 scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
                 (scrutExpr,scrutDecls) <-
-                  mkExpr False Concurrent (NetlistId "c$dtt_rhs" scrutTy) scrut
+                  mkExpr False Concurrent (NetlistId (Id.unsafeMake "c$dtt_rhs") scrutTy) scrut
                 case scrutExpr of
                   Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
                   _ -> do
-                    tmpRhs  <- mkUniqueIdentifier Extended "c$dtt_rhs"
+                    tmpRhs <- Id.make "c$dtt_rhs"
                     let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
                         netAssignRhs = Assignment tmpRhs scrutExpr
                     return (DataTag scrutHTy (Right tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
@@ -609,14 +611,13 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
           NetlistId dstL _ -> case mkDec of
             False -> do
               -- TODO: check that it's okay to use `mkUnsafeSystemName`
-              let nm' = mkUnsafeSystemName dstL 0
+              let nm' = mkUnsafeSystemName (Id.toText dstL) 0
                   id_ = mkLocalId ty nm'
               return (Just ([id_],[dstL],[]))
             True -> do
-              nm1 <- extendIdentifier Extended dstL "_res"
-              nm2 <- mkUniqueIdentifier Extended nm1
+              nm2 <- Id.suffix dstL "res"
               -- TODO: check that it's okay to use `mkUnsafeInternalName`
-              let nm3 = mkUnsafeSystemName nm2 0
+              let nm3 = mkUnsafeSystemName (Id.toText nm2) 0
                   id_ = mkLocalId ty nm3
               idDeclM <- mkNetDecl (id_, mkApps (Prim pInfo) args)
               case idDeclM of
@@ -630,8 +631,10 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   Multi primitive should only appear on the RHS of a
                   let-binding. Please report this as a bug.
                 |]
-          CoreId dstR -> return (Just ([dstR],[nameOcc . varName $ dstR],[]))
-          MultiId ids -> return (Just (ids,map (nameOcc . varName) ids,[]))
+          CoreId dstR ->
+            return (Just ([dstR], [Id.unsafeMake . nameOcc . varName $ dstR], []))
+          MultiId ids ->
+            return (Just (ids, map (Id.unsafeMake . nameOcc . varName) ids, []))
 
     -- Like resBndr, but fails on MultiId
     resBndr1
@@ -771,7 +774,7 @@ collectMealy dstNm dst tcm (kd:clk:mealyFun:mealyInit:mealyIn:_) = do
                    KnownDomain _ _ Falling _ _ _ -> Rising
                    _ -> error "internal error"
       (clkExpr,clkDecls) <-
-        mkExpr False Concurrent (NetlistId "__MEALY_CLK__" (termType tcm clk)) clk
+        mkExpr False Concurrent (NetlistId (Id.unsafeMake "__MEALY_CLK__") (termType tcm clk)) clk
 
       -- collect the declarations related to the input
       let netDeclsInp1 = netDeclsInp ++ inpDeclsMisc
@@ -943,9 +946,9 @@ mkFunInput resId e =
                 -- be completely transparent.
                 Just (_resHTy, areVoids@[countEq False -> 1]) -> do
                   let nonVoidArgI = fromJust (elemIndex False (head areVoids))
-                  let arg = TextS.concat ["~ARG[", showt nonVoidArgI, "]"]
-                  let assign = Assignment "~RESULT" (Identifier arg Nothing)
-                  return (Right (("", tickDecls ++ [assign]), Wire))
+                  let arg = Id.unsafeMake (TextS.concat ["~ARG[", showt nonVoidArgI, "]"])
+                  let assign = Assignment (Id.unsafeMake "~RESULT") (Identifier arg Nothing)
+                  return (Right ((Id.unsafeMake "", tickDecls ++ [assign]), Wire))
 
                 -- Because we filter void constructs, the argument indices and
                 -- the field indices don't necessarily correspond anymore. We
@@ -956,10 +959,11 @@ mkFunInput resId e =
                   let
                       dcI       = dcTag dc - 1
                       areVoids1 = indexNote ($(curLoc) ++ "No areVoids with index: " ++ show dcI) areVoids0 dcI
-                      dcInps    = [Identifier (TextS.pack ("~ARG[" ++ show x ++ "]")) Nothing | x <- originalIndices areVoids1]
+                      mkArg i   = Id.unsafeMake ("~ARG[" <> showt i <> "]")
+                      dcInps    = [Identifier (mkArg x) Nothing | x <- originalIndices areVoids1]
                       dcApp     = DataCon resHTy (DC (resHTy,dcI)) dcInps
-                      dcAss     = Assignment "~RESULT" dcApp
-                  return (Right (("",tickDecls ++ [dcAss]),Wire))
+                      dcAss     = Assignment (Id.unsafeMake "~RESULT") dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
 
                 -- CustomSP the same as SP, but with a user-defined bit
                 -- level representation
@@ -967,41 +971,44 @@ mkFunInput resId e =
                   let
                       dcI       = dcTag dc - 1
                       areVoids1 = indexNote ($(curLoc) ++ "No areVoids with index: " ++ show dcI) areVoids0 dcI
-                      dcInps    = [Identifier (TextS.pack ("~ARG[" ++ show x ++ "]")) Nothing | x <- originalIndices areVoids1]
+                      mkArg i   = Id.unsafeMake ("~ARG[" <> showt i <> "]")
+                      dcInps    = [Identifier (mkArg x) Nothing | x <- originalIndices areVoids1]
                       dcApp     = DataCon resHTy (DC (resHTy,dcI)) dcInps
-                      dcAss     = Assignment "~RESULT" dcApp
-                  return (Right (("",tickDecls ++ [dcAss]),Wire))
+                      dcAss     = Assignment (Id.unsafeMake "~RESULT") dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
 
                 -- Like SP, we have to retrieve the index BEFORE filtering voids
                 Just (resHTy@(Product _ _ _), areVoids0) -> do
                   let areVoids1 = head areVoids0
-                      dcInps    = [ Identifier (TextS.pack ("~ARG[" ++ show x ++ "]")) Nothing | x <- originalIndices areVoids1]
+                      mkArg i    = Id.unsafeMake ("~ARG[" <> showt i <> "]")
+                      dcInps    = [ Identifier (mkArg x) Nothing | x <- originalIndices areVoids1]
                       dcApp     = DataCon resHTy (DC (resHTy,0)) dcInps
-                      dcAss     = Assignment "~RESULT" dcApp
-                  return (Right (("",tickDecls ++ [dcAss]),Wire))
+                      dcAss     = Assignment (Id.unsafeMake "~RESULT") dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
 
                 -- Vectors never have defined areVoids (or all set to False), as
                 -- it would be converted to Void otherwise. We can therefore
                 -- safely ignore it:
                 Just (resHTy@(Vector _ _), _areVoids) -> do
-                  let dcInps = [ Identifier (TextS.pack ("~ARG[" ++ show x ++ "]")) Nothing | x <- [(1::Int)..2] ]
+                  let mkArg i = Id.unsafeMake ("~ARG[" <> showt i <> "]")
+                      dcInps = [ Identifier (mkArg x) Nothing | x <- [(1::Int)..2] ]
                       dcApp  = DataCon resHTy (DC (resHTy,1)) dcInps
-                      dcAss  = Assignment "~RESULT" dcApp
-                  return (Right (("",tickDecls ++ [dcAss]),Wire))
+                      dcAss  = Assignment (Id.unsafeMake "~RESULT") dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
 
                 -- Sum types OR a Sum type after filtering empty types:
                 Just (resHTy@(Sum _ _), _areVoids) -> do
                   let dcI   = dcTag dc - 1
                       dcApp = DataCon resHTy (DC (resHTy,dcI)) []
-                      dcAss = Assignment "~RESULT" dcApp
-                  return (Right (("",tickDecls ++ [dcAss]),Wire))
+                      dcAss = Assignment (Id.unsafeMake "~RESULT") dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
 
                 -- Same as Sum, but with user defined bit level representation
                 Just (resHTy@(CustomSum {}), _areVoids) -> do
                   let dcI   = dcTag dc - 1
                       dcApp = DataCon resHTy (DC (resHTy,dcI)) []
-                      dcAss = Assignment "~RESULT" dcApp
-                  return (Right (("",tickDecls ++ [dcAss]),Wire))
+                      dcAss = Assignment (Id.unsafeMake "~RESULT") dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
 
                 Just (Void {}, _areVoids) ->
                   return (error $ $(curLoc) ++ "Encountered Void in mkFunInput."
@@ -1021,17 +1028,16 @@ mkFunInput resId e =
                         preserveVarEnv $ genComponent fun
 
                       let inpAssign (i, t) e' = (Identifier i Nothing, In, t, e')
-                          inpVar i            = TextS.pack ("~VAR[arg" ++ show i ++ "][" ++ show i ++ "]")
+                          inpVar i            = Id.unsafeMake ("~VAR[arg" <> showt i <> "][" <> showt i <> "]")
                           inpVars             = [Identifier (inpVar i)  Nothing | i <- originalIndices wereVoids]
                           inpAssigns          = zipWith inpAssign compInps inpVars
                           outpAssign          = ( Identifier (fst compOutp) Nothing
                                                 , Out
                                                 , snd compOutp
-                                                , Identifier "~RESULT" Nothing )
-                      i <- varCount <<%= (+1)
-                      let instLabel     = TextS.concat [compName,TextS.pack ("_" ++ show i)]
-                          instDecl      = InstDecl Entity Nothing [] compName instLabel [] (outpAssign:inpAssigns)
-                      return (Right (("",tickDecls ++ [instDecl]),Wire))
+                                                , Identifier (Id.unsafeMake "~RESULT") Nothing )
+                      instLabel <- Id.next compName
+                      let instDecl      = InstDecl Entity Nothing [] compName instLabel [] (outpAssign:inpAssigns)
+                      return (Right ((Id.unsafeMake "",tickDecls ++ [instDecl]),Wire))
                     Nothing -> error $ $(curLoc) ++ "Cannot make function input for: " ++ showPpr e
             C.Lam {} -> do
               let is0 = mkInScopeSet (Lens.foldMapOf freeIds unitVarSet appE)
@@ -1045,20 +1051,21 @@ mkFunInput resId e =
     Left (TDecl,oreg,libs,imps,inc,_,templ') -> do
       (l',templDecl)
         <- onBlackBox
-            (fmap (first BBTemplate) . setSym mkUniqueIdentifier bbCtx)
+            (fmap (first BBTemplate) . setSym bbCtx)
             (\bbName bbHash bbFunc -> pure $ (BBFunction bbName bbHash bbFunc, []))
             templ'
       return ((Left l',if oreg then Reg else Wire,libs,imps,inc,bbCtx),dcls ++ templDecl)
     Left (TExpr,_,libs,imps,inc,nm,templ') -> do
       onBlackBox
         (\t -> do t' <- getMon (prettyBlackBox t)
-                  let assn = Assignment "~RESULT" (Identifier (Text.toStrict t') Nothing)
-                  return ((Right ("",[assn]),Wire,libs,imps,inc,bbCtx),dcls))
+                  let t'' = Id.unsafeMake (Text.toStrict t')
+                      assn = Assignment (Id.unsafeMake "~RESULT") (Identifier t'' Nothing)
+                  return ((Right (Id.unsafeMake "",[assn]),Wire,libs,imps,inc,bbCtx),dcls))
         (\bbName bbHash (TemplateFunction k g _) -> do
           let f' bbCtx' = do
-                let assn = Assignment "~RESULT"
+                let assn = Assignment (Id.unsafeMake "~RESULT")
                             (BlackBoxE nm libs imps inc templ' bbCtx' False)
-                p <- getMon (Backend.blockDecl "" [assn])
+                p <- getMon (Backend.blockDecl (Id.unsafeMake "") [assn])
                 return p
           return ((Left (BBFunction bbName bbHash (TemplateFunction k g f'))
                   ,Wire
@@ -1075,24 +1082,29 @@ mkFunInput resId e =
       return ((Right decl,wr,[],[],[],bbCtx),dcls)
   where
     goExpr app@(collectArgsTicks -> (C.Var fun,args@(_:_),ticks)) = do
+      tcm <- Lens.use tcCache
+      resTy <- unsafeCoreTypeToHWTypeM' $(curLoc) (termType tcm app)
       let (tmArgs,tyArgs) = partitionEithers args
       if null tyArgs
         then
           withTicks ticks $ \tickDecls -> do
-            appDecls <- mkFunApp "~RESULT" fun tmArgs tickDecls
-            nm <- mkUniqueIdentifier Basic "block"
-            return (Right ((nm,appDecls),Wire))
+            resNm <- Id.make "result"
+            appDecls <- mkFunApp resNm fun tmArgs tickDecls
+            let assn = [ Assignment (Id.unsafeMake "~RESULT") (Identifier resNm Nothing)
+                       , NetDecl Nothing resNm resTy ]
+            nm <- Id.makeBasic "block"
+            return (Right ((nm,assn++appDecls),Wire))
         else do
           (_,sp) <- Lens.use curCompNm
           throw (ClashException sp ($(curLoc) ++ "Not in normal form: Var-application with Type arguments:\n\n" ++ showPpr app) Nothing)
     goExpr e' = do
       tcm <- Lens.use tcCache
       let eType = termType tcm e'
-      (appExpr,appDecls) <- mkExpr False Concurrent (NetlistId "c$bb_res" eType) e'
-      let assn = Assignment "~RESULT" appExpr
+      (appExpr,appDecls) <- mkExpr False Concurrent (NetlistId (Id.unsafeMake "c$bb_res") eType) e'
+      let assn = Assignment (Id.unsafeMake "~RESULT") appExpr
       nm <- if null appDecls
-               then return ""
-               else mkUniqueIdentifier Basic "block"
+               then return (Id.unsafeMake "")
+               else Id.makeBasic "block"
       return (Right ((nm,appDecls ++ [assn]),Wire))
 
     go is0 n (Lam id_ e') = do
@@ -1106,32 +1118,30 @@ mkFunInput resId e =
       go is1 (n+(1::Int)) e''
 
     go _ _ (C.Var v) = do
-      let assn = Assignment "~RESULT" (Identifier (nameOcc (varName v)) Nothing)
-      return (Right (("",[assn]),Wire))
+      let assn = Assignment (Id.unsafeMake "~RESULT") (Identifier (id2identifier v) Nothing)
+      return (Right ((Id.unsafeMake "",[assn]),Wire))
 
     go _ _ (Case scrut ty [alt]) = do
       tcm <- Lens.use tcCache
       let sTy = termType tcm scrut
-      (projection,decls) <- mkProjection False (NetlistId "c$bb_res" sTy) scrut ty alt
-      let assn = Assignment "~RESULT" projection
+      (projection,decls) <- mkProjection False (NetlistId (Id.unsafeMake "c$bb_res") sTy) scrut ty alt
+      let assn = Assignment (Id.unsafeMake "~RESULT") projection
       nm <- if null decls
-               then return ""
-               else mkUniqueIdentifier Basic "projection"
+               then return (Id.unsafeMake "")
+               else Id.makeBasic "projection"
       return (Right ((nm,decls ++ [assn]),Wire))
 
     go _ _ (Case scrut ty alts@(_:_:_)) = do
-      -- TODO: check that it's okay to use `mkUnsafeSystemName`
-      let resId'  = resId {varName = mkUnsafeSystemName "~RESULT" 0}
-      selectionDecls <- mkSelection Concurrent (CoreId resId') scrut ty alts []
-      nm <- mkUniqueIdentifier Basic "selection"
-      tcm <- Lens.use tcCache
-      let scrutTy = termType tcm scrut
-      scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-      ite <- Lens.use backEndITE
-      let wr = case iteAlts scrutHTy alts of
-                 Just _ | ite -> Wire
-                 _ -> Reg
-      return (Right ((nm,selectionDecls),wr))
+      resNm <- Id.make "result"
+      -- It's safe to use 'mkUnsafeSystemName' here: only the name, not the
+      -- unique, will be used
+      let resId'  = NetlistId resNm ty
+      selectionDecls <- mkSelection Concurrent resId' scrut ty alts []
+      resTy <- unsafeCoreTypeToHWTypeM' $(curLoc) ty
+      let assn = [ NetDecl Nothing resNm resTy
+                 , Assignment (Id.unsafeMake "~RESULT") (Identifier resNm Nothing) ]
+      nm <- Id.makeBasic "selection"
+      return (Right ((nm,assn++selectionDecls),Wire))
 
     go is0 _ e'@(Letrec {}) = do
       tcm <- Lens.use tcCache
@@ -1142,17 +1152,18 @@ mkFunInput resId e =
       case resultM of
         Just result -> do
           -- TODO: figure out what to do with multires blackboxes here
-          let binders' = map (\(id_,tm) -> (goR result id_,tm)) binders
-          netDecls <- concatMapM mkNetDecl $ filter ((/= result) . fst) binders
-          decls    <- concat <$> mapM (uncurry mkDeclarations) binders'
-          [NetDecl' _ rw _ _ _] <- mkNetDecl . head $ filter ((==result) . fst) binders
-          nm <- mkUniqueIdentifier Basic "fun"
-          return (Right ((nm,netDecls ++ decls),rw))
-        Nothing -> return (Right (("",[]),Wire))
-      where
-        -- TODO: check that it's okay to use `mkUnsafeSystemName`
-        goR r id_ | id_ == r  = id_ {varName = mkUnsafeSystemName "~RESULT" 0}
-                  | otherwise = id_
+          netDecls <- concatMapM mkNetDecl $ binders
+          decls    <- concatMapM (uncurry mkDeclarations) binders
+          nm <- Id.makeBasic "fun"
+          let resultId = id2identifier result
+          -- TODO: Due to reasons lost in the mists of time, #1265 creates an
+          -- assignement here, whereas it previously wouldn't. With the PR in
+          -- tests break when reverting to the old behavior. In some cases this
+          -- creates "useless" assignments. We should investigate whether we can
+          -- get the old behavior back.
+          let resDecl = Assignment (Id.unsafeMake "~RESULT") (Identifier resultId Nothing)
+          return (Right ((nm,resDecl:netDecls ++ decls),Wire))
+        Nothing -> return (Right ((Id.unsafeMake "",[]),Wire))
 
     go is0 n (Tick _ e') = go is0 n e'
 

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -74,11 +74,9 @@ pInput = symbol "~INPUT" *> symbol "<=" *> ((,) <$> (pBlackBoxE <* symbol "~") <
 
 -- | Parse an Expression element
 pTagE :: Parser Element
-pTagE =  Result True       <$  string "~ERESULT"
-     <|> Result False      <$  string "~RESULT"
+pTagE =  Result            <$  string "~RESULT"
      <|> ArgGen            <$> (string "~ARGN" *> brackets' natural') <*> brackets' natural'
-     <|> Arg True          <$> (string "~EARG" *> brackets' natural')
-     <|> Arg False         <$> (string "~ARG" *> brackets' natural')
+     <|> Arg               <$> (string "~ARG" *> brackets' natural')
      <|> Const             <$> (string "~CONST" *> brackets' natural')
      <|> Lit               <$> (string "~LIT" *> brackets' natural')
      <|> Name              <$> (string "~NAME" *> brackets' natural')

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -110,10 +110,10 @@ data Element
   -- ^ Dumps given text without processing in HDL
   | Component !Decl
   -- ^ Component instantiation hole
-  | Result !Bool
-  -- ^ Output hole; @Bool@ asserts escape marker stripping
-  | Arg !Bool !Int
-  -- ^ Input hole; @Bool@ asserts escape marker stripping
+  | Result
+  -- ^ Output hole;
+  | Arg !Int
+  -- ^ Input hole
   | ArgGen !Int !Int
   -- ^ Like Arg, but its first argument is the scoping level. For use in
   -- in generated code only.

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -157,8 +157,8 @@ setSym bbCtx l = do
 
     setSym'
       :: Element
-      -> StateT ( IntMap.IntMap Data.Text.Text
-                , IntMap.IntMap (Data.Text.Text, [N.Declaration]))
+      -> StateT ( IntMap.IntMap N.IdentifierText
+                , IntMap.IntMap (N.IdentifierText, [N.Declaration]))
                 m
                 Element
     setSym' e = case e of
@@ -1001,7 +1001,7 @@ walkElement f el = maybeToList (f el) ++ walked
 
 -- | Determine variables used in an expression. Used for VHDL sensitivity list.
 -- Also see: https://github.com/clash-lang/clash-compiler/issues/365
-usedVariables :: Expr -> [Data.Text.Text]
+usedVariables :: Expr -> [N.IdentifierText]
 usedVariables Noop              = []
 usedVariables (Identifier i _)  = [Id.toText i]
 usedVariables (DataCon _ _ es)  = concatMap usedVariables es

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -46,16 +46,14 @@ import           Text.Printf
 import           Text.Read                       (readEither)
 import           Text.Trifecta.Result            hiding (Err)
 
-import           Clash.Backend                   (Backend (..), Usage (..), mkUniqueIdentifier)
-import qualified Clash.Backend                   as Backend
+import           Clash.Backend
+  (Backend (..), Usage (..), AggressiveXOptBB(..))
 import           Clash.Netlist.BlackBox.Parser
 import           Clash.Netlist.BlackBox.Types
-import           Clash.Netlist.Id                (IdType (..))
-import           Clash.Netlist.Types             (BlackBoxContext (..),
-                                                  Expr (..), HWType (..),
-                                                  Identifier, Literal (..),
-                                                  Modifier (..),
-                                                  Declaration(BlackBoxD))
+import           Clash.Netlist.Types
+  (BlackBoxContext (..), Expr (..), HWType (..), Literal (..), Modifier (..),
+   Declaration(BlackBoxD))
+import qualified Clash.Netlist.Id                as Id
 import qualified Clash.Netlist.Types             as N
 import           Clash.Netlist.Util              (typeSize, isVoid, stripVoid)
 import           Clash.Signal.Internal
@@ -65,7 +63,7 @@ import qualified Clash.Util.Interpolate          as I
 
 inputHole :: Element -> Maybe Int
 inputHole = \case
-  Arg _ n       -> pure n
+  Arg n         -> pure n
   Lit n         -> pure n
   Const n       -> pure n
   Name n        -> pure n
@@ -147,12 +145,11 @@ extractLiterals = map (\case (e,_,_) -> e)
 -- counter for every newly encountered symbol.
 setSym
   :: forall m
-   . Monad m
-  => (IdType -> Identifier -> m Identifier)
-  -> BlackBoxContext
+   . Id.IdentifierSetMonad m
+  => BlackBoxContext
   -> BlackBoxTemplate
   -> m (BlackBoxTemplate,[N.Declaration])
-setSym mkUniqueIdentifierM bbCtx l = do
+setSym bbCtx l = do
     (a,(_,decls)) <- runStateT (mapM setSym' l) (IntMap.empty,IntMap.empty)
     return (a,concatMap snd (IntMap.elems decls))
   where
@@ -160,33 +157,34 @@ setSym mkUniqueIdentifierM bbCtx l = do
 
     setSym'
       :: Element
-      -> StateT ( IntMap.IntMap Identifier
-                , IntMap.IntMap (Identifier,[N.Declaration]))
+      -> StateT ( IntMap.IntMap Data.Text.Text
+                , IntMap.IntMap (Data.Text.Text, [N.Declaration]))
                 m
                 Element
     setSym' e = case e of
       ToVar nm i | i < length (bbInputs bbCtx) -> case bbInputs bbCtx !! i of
-        (Identifier nm' Nothing,_,_) ->
-          return (ToVar [Text (Text.fromStrict nm')] i)
+        (Identifier nm0 Nothing,_,_) ->
+          return (ToVar [Text (Id.toLazyText nm0)] i)
 
         (e',hwTy,_) -> do
           varM <- IntMap.lookup i <$> use _2
           case varM of
             Nothing -> do
-              nm' <- lift (mkUniqueIdentifierM Extended (Text.toStrict (concatT (Text "c$":nm))))
+              nm' <- lift (Id.make (Text.toStrict (concatT (Text "c$":nm))))
               let decls = case typeSize hwTy of
                     0 -> []
                     _ -> [N.NetDecl Nothing nm' hwTy
                          ,N.Assignment nm' e'
                          ]
-              _2 %= (IntMap.insert i (nm',decls))
+              _2 %= (IntMap.insert i (Id.toText nm',decls))
+              return (ToVar [Text (Id.toLazyText nm')] i)
+            Just (nm',_) ->
               return (ToVar [Text (Text.fromStrict nm')] i)
-            Just (nm',_) -> return (ToVar [Text (Text.fromStrict nm')] i)
       Sym _ i -> do
         symM <- IntMap.lookup i <$> use _1
         case symM of
           Nothing -> do
-            t <- lift (mkUniqueIdentifierM Extended "c$n")
+            t <- Id.toText <$> lift (Id.make "c$n")
             _1 %= (IntMap.insert i t)
             return (Sym (Text.fromStrict t) i)
           Just t -> return (Sym (Text.fromStrict t) i)
@@ -194,7 +192,7 @@ setSym mkUniqueIdentifierM bbCtx l = do
         symM <- IntMap.lookup i <$> use _1
         case symM of
           Nothing -> do
-            t' <- lift (mkUniqueIdentifierM Basic (Text.toStrict (concatT t)))
+            t' <- Id.toText <$> lift (Id.makeBasic (Text.toStrict (concatT t)))
             _1 %= (IntMap.insert i t')
             return (GenSym [Text (Text.fromStrict t')] i)
           Just _ ->
@@ -226,12 +224,12 @@ setSym mkUniqueIdentifierM bbCtx l = do
               error $ $(curLoc) ++  "Could not convert ~LIT[" ++ show i ++ "]"
                    ++ " to string:" ++ msg ++ "\n\nError occured while "
                    ++ "processing blackbox for " ++ bbnm
-        Result _ | [(Identifier t _, _)] <- bbResults bbCtx -> Text.fromStrict t
-        CompName -> Text.fromStrict (bbCompName bbCtx)
+        Result | [(Identifier t _, _)] <- bbResults bbCtx -> Id.toLazyText t
+        CompName -> Id.toLazyText (bbCompName bbCtx)
         CtxName ->
           case bbCtxName bbCtx of
             Just nm -> Text.fromStrict nm
-            _ | [(Identifier t _, _)] <- bbResults bbCtx -> Text.fromStrict t
+            _ | [(Identifier t _, _)] <- bbResults bbCtx -> Id.toLazyText t
             _ -> error $ $(curLoc) ++ "Internal error when processing blackbox "
                       ++ "for " ++ bbnm
         _ -> error $ $(curLoc) ++ "Unexpected element in GENSYM when processing "
@@ -343,7 +341,7 @@ renderElem b (Component (Decl n subN (l:ls))) = do
       Left t ->
         return t
       Right (nm0,ds) -> do
-        nm1 <- mkUniqueIdentifier Basic nm0
+        nm1 <- Id.next nm0
         block <- getMon (blockDecl nm1 ds)
         return (render block)
 
@@ -352,13 +350,13 @@ renderElem b (Component (Decl n subN (l:ls))) = do
       N.BBFunction {} ->
         return templ1
       N.BBTemplate templ2 -> do
-        (templ3, templDecls) <- setSym Backend.mkUniqueIdentifier b' templ2
+        (templ3, templDecls) <- setSym b' templ2
         case templDecls of
           [] ->
             return (N.BBTemplate templ3)
           _ -> do
-            nm1 <- Backend.mkUniqueIdentifier Basic "bb"
-            nm2 <- Backend.mkUniqueIdentifier Basic "bb"
+            nm1 <- Id.toText <$> Id.makeBasic "bb"
+            nm2 <- Id.makeBasic "bb"
             let bbD = BlackBoxD nm1 libs imps inc (N.BBTemplate templ3) b'
             block <- getMon (blockDecl nm2 (templDecls ++ [bbD]))
             return (render block)
@@ -413,6 +411,7 @@ renderElem b (IF c t f) = do
   let c' = check (coerce xOpt) iw syn c
   if c' > 0 then renderTemplate b t else renderTemplate b f
   where
+    check :: Bool -> Int -> HdlSyn -> Element -> Int
     check xOpt iw syn c' = case c' of
       (Size e)   -> typeSize (lineToType b [e])
       (Length e) -> case lineToType b [e] of
@@ -524,9 +523,10 @@ parseFail t = case runParse t of
   Success templ -> templ
 
 idToExpr
-  :: (Text,HWType)
-  -> (Expr,HWType,Bool)
-idToExpr (t,ty) = (Identifier (Text.toStrict t) Nothing,ty,False)
+  :: (Text, HWType)
+  -> (Expr, HWType, Bool)
+idToExpr (t, ty) =
+  (Identifier (Id.unsafeMake (Text.toStrict t)) Nothing, ty, False)
 
 bbResult :: HasCallStack => String -> BlackBoxContext -> (Expr, HWType)
 bbResult _s (bbResults -> [r]) = r
@@ -569,13 +569,11 @@ renderTag :: Backend backend
           -> Element
           -> State backend Text
 renderTag _ (Text t)        = return t
-renderTag b (Result esc)    = do
-  escape <- if esc then unextend else pure id
-  fmap (Text.fromStrict . escape . Text.toStrict . renderOneLine) . getMon . expr False . fst $ bbResult "~RESULT" b
-renderTag b (Arg esc n)  = do
+renderTag b (Result)    = do
+  fmap renderOneLine . getMon . expr False . fst $ bbResult "~RESULT" b
+renderTag b (Arg n)  = do
   let (e,_,_) = bbInputs b !! n
-  escape <- if esc then unextend else pure id
-  (Text.fromStrict . escape . Text.toStrict . renderOneLine) <$> getMon (expr False e)
+  renderOneLine <$> getMon (expr False e)
 
 renderTag b (Const n)  = do
   let (e,_,_) = bbInputs b !! n
@@ -727,12 +725,12 @@ renderTag b (Template filenameL sourceL) = case file of
           source   <- elementsToText b sourceL
           return (Text.unpack filename, Text.unpack source)
 
-renderTag b CompName = pure (Text.fromStrict (bbCompName b))
+renderTag b CompName = pure (Id.toLazyText (bbCompName b))
 
 renderTag b CtxName = case bbCtxName b of
   Just nm -> return (Text.fromStrict nm)
   _ | Identifier t _ <- fst (bbResult "~CTXNAME" b)
-    -> return (Text.fromStrict t)
+    -> return (Id.toLazyText t)
   _ -> error "internal error"
 
 
@@ -808,8 +806,8 @@ prettyElem (Component (Decl i 0 args)) = do
       <> line <> string "~INST")
 prettyElem (Component (Decl {})) =
   error $ $(curLoc) ++ "prettyElem can't (yet) render ~INST when subfuncion /= 0!"
-prettyElem (Result b) = if b then return "~ERESULT" else return "~RESULT"
-prettyElem (Arg b i) = renderOneLine <$> (if b then string "~EARG" else string "~ARG" <> brackets (int i))
+prettyElem Result = return "~RESULT"
+prettyElem (Arg i) = renderOneLine <$> ("~ARG" <> brackets (int i))
 prettyElem (Lit i) = renderOneLine <$> (string "~LIT" <> brackets (int i))
 prettyElem (Const i) = renderOneLine <$> (string "~CONST" <> brackets (int i))
 prettyElem (Name i) = renderOneLine <$> (string "~NAME" <> brackets (int i))
@@ -960,8 +958,8 @@ walkElement f el = maybeToList (f el) ++ walked
         GenSym es _ -> concatMap go es
         DevNull es -> concatMap go es
         Text _ -> []
-        Result _ -> []
-        Arg _ _ -> []
+        Result -> []
+        Arg _ -> []
         ArgGen _ _ -> []
         Const _ -> []
         Lit _ -> []
@@ -1003,17 +1001,17 @@ walkElement f el = maybeToList (f el) ++ walked
 
 -- | Determine variables used in an expression. Used for VHDL sensitivity list.
 -- Also see: https://github.com/clash-lang/clash-compiler/issues/365
-usedVariables :: Expr -> [Identifier]
+usedVariables :: Expr -> [Data.Text.Text]
 usedVariables Noop              = []
-usedVariables (Identifier i _)  = [i]
+usedVariables (Identifier i _)  = [Id.toText i]
 usedVariables (DataCon _ _ es)  = concatMap usedVariables es
-usedVariables (DataTag _ e')    = [either id id e']
+usedVariables (DataTag _ e')    = [Id.toText (either id id e')]
 usedVariables (Literal {})      = []
 usedVariables (ConvBV _ _ _ e') = usedVariables e'
 usedVariables (IfThenElse e1 e2 e3) = concatMap usedVariables [e1,e2,e3]
 usedVariables (BlackBoxE _ _ _ _ t bb _) = nub (sList ++ sList')
   where
-    matchArg (Arg _ i) = Just i
+    matchArg (Arg i) = Just i
     matchArg _         = Nothing
 
     matchVar (ToVar [Text v] _) = Just (Text.toStrict v)
@@ -1031,7 +1029,7 @@ getUsedArguments (N.BBTemplate t) = nub (concatMap (walkElement matchArg) t)
   where
     matchArg =
       \case
-        Arg _ i -> Just i
+        Arg i -> Just i
         Component (Decl i _ _) -> Just i
         Const i -> Just i
         IsLit i -> Just i
@@ -1072,7 +1070,7 @@ getUsedArguments (N.BBTemplate t) = nub (concatMap (walkElement matchArg) t)
         MaxIndex _ -> Nothing
         OutputWireReg _ -> Nothing
         Repeat _ _ -> Nothing
-        Result _ -> Nothing
+        Result -> Nothing
         Sel _ _ -> Nothing
         SigD _ _ -> Nothing
         Size _ -> Nothing

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -1,7 +1,7 @@
 {-|
-  Copyright  :  (C) 2012-2016, University of Twente
+  Copyright  :  (C) 2020, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Transform/format a Netlist Identifier so that it is acceptable as a HDL identifier
 -}
@@ -14,8 +14,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
-
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Clash.Netlist.Id
   ( -- * Utilities to use IdentifierSet
@@ -57,34 +55,18 @@ module Clash.Netlist.Id
 where
 
 import           Clash.Annotations.Primitive (HDL (..))
-import           Clash.Core.Name (nameOcc)
-import           Clash.Core.Var (Id, varName)
+import           Clash.Core.Var (Id)
 import {-# SOURCE #-} Clash.Netlist.Types
   (HasIdentifierSet(..), IdentifierSet(..), Identifier(..), IdentifierType(..),
-   IdentifierSetMonad(identifierSetM), FreshCache)
-import           Control.Arrow (second)
-import qualified Data.Char as Char
-import           Data.Function (on)
+   IdentifierSetMonad(identifierSetM))
+import qualified Data.HashSet as HashSet
 import qualified Data.List as List
-import qualified Data.Text as Text
 import           Data.Text (Text)
 import qualified Data.Text.Lazy as LT
-import qualified Data.Maybe as Maybe
-import           Data.Hashable (Hashable(..))
-import           Text.Read (readMaybe)
-import           TextShow (showt)
 import           GHC.Stack (HasCallStack)
 
-import qualified Data.IntMap as IntMap
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.HashSet as HashSet
-
-import qualified Data.Text.Prettyprint.Doc as PP
-
-import qualified Clash.Netlist.Id.SystemVerilog as SystemVerilog
-import qualified Clash.Netlist.Id.Verilog as Verilog
 import qualified Clash.Netlist.Id.VHDL as VHDL
-import qualified Clash.Netlist.Id.Common as Common
+import           Clash.Netlist.Id.Internal
 
 -- | Identifier set without identifiers
 emptyIdentifierSet
@@ -125,136 +107,6 @@ makeSet esc lw hdl ids = IdentifierSet esc lw hdl fresh store
 toList :: IdentifierSet -> [Identifier]
 toList (IdentifierSet _ _ _ _ idStore) = HashSet.toList idStore
 
--- | Return identifier with highest extension for given identifier. See
--- 'is_freshCache' for more information.
---
--- For example, if the FreshCache contains "foo_12_25" and the given identifier
--- is "foo_12_13" this function would return "Just 25". In this case, "foo_12_26"
--- is guaranteed to be a fresh identifier.
-lookupFreshCache# :: FreshCache -> Identifier -> Maybe Word
-lookupFreshCache# fresh0 id0 = do
-  fresh1 <- HashMap.lookup (i_baseNameCaseFold id0) fresh0
-  IntMap.lookup (length (i_extensionsRev id0)) fresh1
-
--- | Add new identifier to FreshCache, see 'is_freshCache' for more information.
-updateFreshCache# :: HasCallStack => FreshCache -> Identifier -> FreshCache
-updateFreshCache# _fresh (RawIdentifier _s Nothing) =
-  error "Internal error: updateFreshCache# called with unsafely made identifier"
-updateFreshCache# fresh (RawIdentifier _s (Just id_)) =
-  updateFreshCache# fresh id_
-updateFreshCache# fresh id_ =
-  go0 (go1 (max (Maybe.fromMaybe 0 (Maybe.listToMaybe exts))))
- where
-  go0 f = HashMap.alter (Just . f . Maybe.fromMaybe mempty) base fresh
-  go1 f = IntMap.alter (Just . f . Maybe.fromMaybe 0) (length exts)
-
-  exts = i_extensionsRev id_
-  base = i_baseNameCaseFold id_
-
--- | Adds identifier at verbatim if its basename hasn't been used before.
--- Otherwise it will return the first free identifier.
-mkUnique#
-  :: HasCallStack
-  => IdentifierSet
-  -> Identifier
-  -> (IdentifierSet, Identifier)
-mkUnique# _is0 (RawIdentifier {}) =
-  error "Internal error: mkUnique# cannot be used on RawIdentifiers"
-mkUnique# is0 id_@(i_extensionsRev -> []) = deepen# is0 id_
-mkUnique# is id0 = (is{is_freshCache=freshCache, is_store=isStore}, id1)
- where
-  freshCache = updateFreshCache# (is_freshCache is) id1
-  isStore = HashSet.insert id1 (is_store is)
-  id1 = case lookupFreshCache# (is_freshCache is) id0 of
-    Just currentMax ->
-      id0{i_extensionsRev=currentMax+1 : tail (i_extensionsRev id0)}
-    Nothing ->
-      -- Identifier doesn't exist in set yet, so just return it.
-      id0
-
--- | Non-monadic, internal version of 'addRaw'
-addRaw# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
-addRaw# is0 id0 = second (RawIdentifier id0 . Just) (make# is0 (unextend id0))
- where
-  unextend = case is_hdl is0 of
-    VHDL -> VHDL.unextend
-    Verilog -> Verilog.unextend
-    SystemVerilog -> SystemVerilog.unextend
-
--- | Non-monadic, internal version of 'make'
-make# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
-make# is0@(IdentifierSet esc lw hdl fresh0 ids0) (Common.prettyName -> id0) =
-  if id1 `HashSet.member` ids0 then
-    -- Ideally we'd like to continue with the id from the HashSet so all the old
-    -- strings can be garbage collected, but I haven't found an efficient way of
-    -- doing so. I also doubt that this case will get hit often..
-    deepen# is0 id1
-  else
-    (is0{is_freshCache=fresh1, is_store=ids1}, id1)
- where
-  ids1 = HashSet.insert id1 ids0
-  fresh1 = updateFreshCache# fresh0 id1
-  id1 = make## (is_hdl is0) (if esc then id0 else toBasicId# hdl lw id0)
-
--- | Non-monadic, internal version of 'makeBasic'
-makeBasic# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
-makeBasic# is0 = make# is0 . toBasicId# (is_hdl is0) (is_lowerCaseBasicIds is0)
-
--- | Non-monadic, internal version of 'makeBasicOr'
-makeBasicOr# :: IdentifierSet -> Text -> Text -> (IdentifierSet, Identifier)
-makeBasicOr# is0 hint altHint = make# is0 id1
- where
-  id0 = toBasicId# (is_hdl is0) (is_lowerCaseBasicIds is0) hint
-  id1 = if Text.null id0
-        then toBasicId# (is_hdl is0) (is_lowerCaseBasicIds is0) altHint
-        else id0
-
--- | Non-monadic, internal version of 'next'
-next# :: IdentifierSet -> Identifier ->  (IdentifierSet, Identifier)
-next# is0 (RawIdentifier t Nothing) = uncurry next# (make# is0 t)
-next# is0 (RawIdentifier _ (Just id_)) = next# is0 id_
-next# is0 id_@(i_extensionsRev -> []) = deepen# is0 id_
-next# is0 id_ = mkUnique# is0 id_
-
--- | Non-monadic, internal version of 'nextN'
-nextN# :: Int -> IdentifierSet -> Identifier ->  (IdentifierSet, [Identifier])
-nextN# n is0 id0 = List.mapAccumL (\is1 _n -> next# is1 id0) is0 [1..n]
--- TODO: ^ More efficient implementation.
-
--- | Non-monadic, internal version of 'deepenN'
-deepenN# :: Int -> IdentifierSet -> Identifier ->  (IdentifierSet, [Identifier])
-deepenN# n is0 id0 = List.mapAccumL (\is1 _n -> deepen# is1 id0) is0 [1..n]
--- TODO: ^ More efficient implementation.
-
--- | Non-monadic, internal version of 'deepen'
-deepen# :: IdentifierSet -> Identifier ->  (IdentifierSet, Identifier)
-deepen# is0 (RawIdentifier t Nothing) = uncurry deepen# (make# is0 t)
-deepen# is0 (RawIdentifier _ (Just id_)) = deepen# is0 id_
-deepen# is0 id_ = mkUnique# is0 (id_{i_extensionsRev=0:i_extensionsRev id_})
-
--- | Non-monadic, internal version of 'suffix'
-suffix# :: IdentifierSet -> Identifier -> Text -> (IdentifierSet, Identifier)
-suffix# is0 (RawIdentifier t Nothing) suffix_ = (uncurry suffix# (make# is0 t)) suffix_
-suffix# is0 (RawIdentifier _ (Just id_)) suffix_ = suffix# is0 id_ suffix_
-suffix# is0 id0 suffix_ = make# is0 (i_baseName id0 <> "_" <> suffix_)
-
--- | Non-monadic, internal version of 'prefix'
-prefix# :: IdentifierSet -> Identifier -> Text -> (IdentifierSet, Identifier)
-prefix# is0 (RawIdentifier t Nothing) prefix_ = (uncurry prefix# (make# is0 t)) prefix_
-prefix# is0 (RawIdentifier _ (Just id_)) prefix_ = prefix# is0 id_ prefix_
-prefix# is0 id0 prefix_ = make# is0 (prefix_ <> "_" <> i_baseName id0)
-
-toText# :: Identifier -> Text
-toText# (RawIdentifier t _) = t
-toText# (UniqueIdentifier{..}) =
-  case i_hdl of
-    VHDL -> VHDL.toText i_idType basicId
-    Verilog -> Verilog.toText i_idType basicId
-    SystemVerilog -> SystemVerilog.toText i_idType basicId
- where
-  exts = map showt (reverse i_extensionsRev)
-  basicId = Text.intercalate "_" (i_baseName : exts)
-
 -- | Convert an identifier to string. Use 'unmake' if you need the
 -- "IdentifierType" too.
 toText :: Identifier -> Text
@@ -264,11 +116,6 @@ toText = toText#
 -- "IdentifierType" too.
 toLazyText :: Identifier -> LT.Text
 toLazyText = LT.fromStrict . toText
-
--- | Convert a Clash Core Id to an identifier. Makes sure returned identifier
--- is unique.
-fromCoreId# :: IdentifierSet -> Id -> (IdentifierSet, Identifier)
-fromCoreId# is0 id0 = make# is0 (nameOcc (varName id0))
 
 -- | Helper function to define pure Id functions in terms of a IdentifierSetMonad
 withIdentifierSetM
@@ -360,89 +207,3 @@ prefix id0 prefix_ = withIdentifierSetM (\is id1 -> prefix# is id1 prefix_) id0
 -- is unique.
 fromCoreId :: IdentifierSetMonad m => Id -> m Identifier
 fromCoreId = withIdentifierSetM fromCoreId#
-
-instance PP.Pretty Identifier where
-  pretty = PP.pretty . toText
-
-instance Hashable Identifier where
-  hashWithSalt salt = hashWithSalt salt . hash
-  hash = uncurry hash# . eqTup#
-
-instance Eq Identifier where
-  i1 == i2 = eqTup# i1 == eqTup# i2
-  i1 /= i2 = eqTup# i1 /= eqTup# i2
-
-instance Ord Identifier where
-  compare = compare `on` eqTup#
-
-eqTup# :: Identifier -> ((Text, Bool), [Word])
-eqTup# (RawIdentifier t _id) = ((t, True), [])
-eqTup# id_ = ((i_baseNameCaseFold id_, False), i_extensionsRev id_)
-
-hash# :: Hashable a => a -> [Word] -> Int
-hash# a extensions =
-  -- 'hash' has an identity around zero, e.g. `hash (0, 2) == 2`. Because a lot
-  -- of zeros can be expected, extensions are fuzzed in order to keep efficient
-  -- `HashMap`s.
-  let fuzz fuzzFactor ext = fuzzFactor * fuzzFactor * ext in
-  hash (a, List.foldl' fuzz 2 extensions)
-
--- | Is given string a valid basic identifier in given HDL?
-isBasic# :: HDL -> Text -> Bool
-isBasic# VHDL = VHDL.parseBasic
-isBasic# Verilog = Verilog.parseBasic
-isBasic# SystemVerilog = SystemVerilog.parseBasic
-
--- | Is given string a valid extended identifier in given HDL?
-isExtended# :: HDL -> Text -> Bool
-isExtended# VHDL = VHDL.parseExtended
-isExtended# Verilog = Verilog.parseExtended
-isExtended# SystemVerilog = SystemVerilog.parseExtended
-
--- | Convert given string to ASCII. Retains all printable ASCII. All other
--- characters are thrown out.
-toPrintableAscii# :: Text -> Text
-toPrintableAscii# = Text.filter (\c -> Char.isPrint c && Char.isAscii c)
-
--- | Split identifiers such as "foo_1_2" into ("foo", [2, 1]).
-parseIdentifier# :: Text -> (Text, [Word])
-parseIdentifier# t =
-  let (tsRev, extsRev) = go (List.reverse (Text.splitOn "_" t)) in
-  (Text.intercalate "_" (List.reverse tsRev), extsRev)
- where
-  go :: [Text] -> ([Text], [Word])
-  go [] = go ["clash", "internal"]
-  go (i:is) = case readMaybe @Word (Text.unpack i) of
-    Just w -> second (w:) (go is)
-    Nothing -> (i:is, [])
-
-make## :: HDL -> Text -> Identifier
-make## hdl =
-    go
-  . Text.strip
-  . Text.replace "\\" ""
-  . toPrintableAscii#
- where
-  go s | Text.null s = go "clash_internal"
-       | otherwise =
-          let
-            (baseName, extensions) = parseIdentifier# s
-            idType = if isBasic# hdl s then Basic else Extended
-
-            -- VHDL is a case insensitive language, so we convert the given
-            -- text to lowercase. Note that 'baseNameCaseFold' is used in the
-            -- Eq for Identifier.
-            baseNameCaseFold = case hdl of
-              VHDL -> Text.toCaseFold baseName
-              _ -> baseName
-          in
-            UniqueIdentifier baseName baseNameCaseFold extensions idType hdl
-
-toBasicId# :: HDL -> Bool -> Text -> Text
-toBasicId# hdl lw id0 =
-  case hdl of
-    VHDL -> VHDL.toBasic id1
-    Verilog -> Verilog.toBasic id1
-    SystemVerilog -> SystemVerilog.toBasic id1
- where
-  id1 = if lw then Text.toLower id0 else id0

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -7,111 +7,414 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Clash.Netlist.Id
-  ( IdType (..)
-  , mkBasicId'
-  , stripDollarPrefixes
+  ( -- * Utilities to use IdentifierSet
+    IdentifierSet
+  , IdentifierSetMonad(..)
+  , HasIdentifierSet(..)
+  , emptyIdentifierSet
+  , makeSet
+
+    -- * Unsafe creation and extracting identifiers
+  , Identifier
+  , IdentifierType (..)
+  , unsafeMake
+  , toText
+  , toLazyText
+  , toList
+  , union
+
+    -- * Creating and extending identifiers
+  , make
+  , makeBasic
+  , makeBasicOr
+  , makeAs
+  , addRaw
+  , deepen
+  , deepenN
+  , next
+  , nextN
+  , prefix
+  , suffix
+  , fromCoreId
+
+  -- * Misc. and internals
+  , VHDL.stripDollarPrefixes
+  , toBasicId#
+  , isBasic#
+  , isExtended#
   )
 where
 
-import Clash.Annotations.Primitive (HDL (..))
-import Data.Char (isAsciiLower,isAsciiUpper,isDigit)
-import Data.Text as Text
+import           Clash.Annotations.Primitive (HDL (..))
+import           Clash.Core.Name (nameOcc)
+import           Clash.Core.Var (Id, varName)
+import {-# SOURCE #-} Clash.Netlist.Types
+  (HasIdentifierSet(..), IdentifierSet(..), Identifier(..), IdentifierType(..),
+   IdentifierSetMonad(identifierSetM), FreshCache)
+import           Control.Arrow (second)
+import qualified Data.Char as Char
+import           Data.Function (on)
+import qualified Data.List as List
+import qualified Data.Text as Text
+import           Data.Text (Text)
+import qualified Data.Text.Lazy as LT
+import qualified Data.Maybe as Maybe
+import           Data.Hashable (Hashable(..))
+import           Text.Read (readMaybe)
+import           TextShow (showt)
+import           GHC.Stack (HasCallStack)
 
-data IdType = Basic | Extended
+import qualified Data.IntMap as IntMap
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.HashSet as HashSet
 
-mkBasicId'
-  :: HDL
-  -> Bool
+import qualified Data.Text.Prettyprint.Doc as PP
+
+import qualified Clash.Netlist.Id.SystemVerilog as SystemVerilog
+import qualified Clash.Netlist.Id.Verilog as Verilog
+import qualified Clash.Netlist.Id.VHDL as VHDL
+import qualified Clash.Netlist.Id.Common as Common
+
+-- | Identifier set without identifiers
+emptyIdentifierSet
+  :: Bool
+  -- ^ Allow escaped identifiers?
+  -> HDL
+  -- ^ HDL to generate names for
+  -> IdentifierSet
+emptyIdentifierSet esc hdl = makeSet esc hdl []
+
+-- | Union of two identifier sets. Errors if given sets have been made with
+-- different options enabled.
+union :: HasCallStack => IdentifierSet -> IdentifierSet -> IdentifierSet
+union is1@(IdentifierSet esc1 hdl1 _ _) is2@(IdentifierSet esc2 hdl2 _ _)
+  | esc1 /= esc2 = error $ "Internal error: esc1 /= esc2, " <> show (esc1, esc2)
+  | hdl1 /= hdl2 = error $ "Internal error: hdl1 /= hdl2, " <> show (hdl1, hdl2)
+  | otherwise = makeSet esc1 hdl1 (toList is1 ++ toList is2)
+
+-- | Make a identifier set filled with given identifiers
+makeSet
+  :: Bool
+  -- ^ Allow escaped identifiers?
+  -> HDL
+  -- ^ HDL to generate names for
+  -> [Identifier]
+  -- ^ Identifiers to add to set
+  -> IdentifierSet
+makeSet esc hdl ids = IdentifierSet esc hdl fresh store
+ where
+  fresh = List.foldl' updateFreshCache# mempty ids
+  store = HashSet.fromList ids
+
+toList :: IdentifierSet -> [Identifier]
+toList (IdentifierSet _ _ _ idStore) = HashSet.toList idStore
+
+lookupFreshCache# :: FreshCache -> Identifier -> Maybe Word
+lookupFreshCache# fresh0 id0 = do
+  fresh1 <- HashMap.lookup (i_baseNameCaseFold id0) fresh0
+  IntMap.lookup (length (i_extensionsRev id0)) fresh1
+
+updateFreshCache# :: HasCallStack => FreshCache -> Identifier -> FreshCache
+updateFreshCache# _fresh (RawIdentifier _s Nothing) =
+  error "Internal error: updateFreshCache# called with unsafely made identifier"
+updateFreshCache# fresh (RawIdentifier _s (Just id_)) =
+  updateFreshCache# fresh id_
+updateFreshCache# fresh id_ =
+  go0 (go1 (max (Maybe.fromMaybe 0 (Maybe.listToMaybe exts))))
+ where
+  go0 f = HashMap.alter (Just . f . Maybe.fromMaybe mempty) base fresh
+  go1 f = IntMap.alter (Just . f . Maybe.fromMaybe 0) (length exts)
+
+  exts = i_extensionsRev id_
+  base = i_baseNameCaseFold id_
+
+-- | Adds identifier at verbatim if its basename hasn't been used before.
+-- Otherwise it will return the first free identifier.
+mkUnique#
+  :: HasCallStack
+  => IdentifierSet
+  -> Identifier
+  -> (IdentifierSet, Identifier)
+mkUnique# _is0 (RawIdentifier {}) =
+  error "Internal error: mkUnique# cannot be used on RawIdentifiers"
+mkUnique# is0 id_@(i_extensionsRev -> []) = deepen# is0 id_
+mkUnique# is id0 = (is{is_freshCache=freshCache, is_store=isStore}, id1)
+ where
+  freshCache = updateFreshCache# (is_freshCache is) id1
+  isStore = HashSet.insert id1 (is_store is)
+  id1 = case lookupFreshCache# (is_freshCache is) id0 of
+    Just currentMax ->
+      id0{i_extensionsRev=currentMax+1 : tail (i_extensionsRev id0)}
+    Nothing ->
+      -- Identifier doesn't exist in set yet, so just return it.
+      id0
+
+addRaw# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
+addRaw# is0 id0 = second (RawIdentifier id0 . Just) (make# is0 (unextend id0))
+ where
+  unextend = case is_hdl is0 of
+    VHDL -> VHDL.unextend
+    Verilog -> Verilog.unextend
+    SystemVerilog -> SystemVerilog.unextend
+
+make# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
+make# is0@(IdentifierSet esc hdl fresh0 ids0) (Common.prettyName -> id0) =
+  if id1 `HashSet.member` ids0 then
+    -- Ideally we'd like to continue with the id from the HashSet so all the old
+    -- strings can be garbage collected, but I haven't found an efficient way of
+    -- doing so. I also doubt that this case will get hit often..
+    deepen# is0 id1
+  else
+    (is0{is_freshCache=fresh1, is_store=ids1}, id1)
+ where
+  ids1 = HashSet.insert id1 ids0
+  fresh1 = updateFreshCache# fresh0 id1
+  id1 = make## (is_hdl is0) (if esc then id0 else toBasicId# hdl id0)
+
+makeBasic# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
+makeBasic# is0 = make# is0 . toBasicId# (is_hdl is0)
+
+makeBasicOr# :: IdentifierSet -> Text -> Text -> (IdentifierSet, Identifier)
+makeBasicOr# is0 hint altHint = make# is0 id1
+ where
+  id0 = toBasicId# (is_hdl is0) hint
+  id1 = if Text.null id0 then toBasicId# (is_hdl is0) altHint else id0
+
+next# :: IdentifierSet -> Identifier ->  (IdentifierSet, Identifier)
+next# is0 (RawIdentifier t Nothing) = uncurry next# (make# is0 t)
+next# is0 (RawIdentifier _ (Just id_)) = next# is0 id_
+next# is0 id_@(i_extensionsRev -> []) = deepen# is0 id_
+next# is0 id_ = mkUnique# is0 id_
+
+nextN# :: Int -> IdentifierSet -> Identifier ->  (IdentifierSet, [Identifier])
+nextN# n is0 id0 = List.mapAccumL (\is1 _n -> next# is1 id0) is0 [1..n]
+-- TODO: ^ More efficient implementation.
+
+deepenN# :: Int -> IdentifierSet -> Identifier ->  (IdentifierSet, [Identifier])
+deepenN# n is0 id0 = List.mapAccumL (\is1 _n -> deepen# is1 id0) is0 [1..n]
+-- TODO: ^ More efficient implementation.
+
+deepen# :: IdentifierSet -> Identifier ->  (IdentifierSet, Identifier)
+deepen# is0 (RawIdentifier t Nothing) = uncurry deepen# (make# is0 t)
+deepen# is0 (RawIdentifier _ (Just id_)) = deepen# is0 id_
+deepen# is0 id_ = mkUnique# is0 (id_{i_extensionsRev=0:i_extensionsRev id_})
+
+suffix# :: IdentifierSet -> Identifier -> Text -> (IdentifierSet, Identifier)
+suffix# is0 (RawIdentifier t Nothing) suffix_ = (uncurry suffix# (make# is0 t)) suffix_
+suffix# is0 (RawIdentifier _ (Just id_)) suffix_ = suffix# is0 id_ suffix_
+suffix# is0 id0 suffix_ = make# is0 (i_baseName id0 <> "_" <> suffix_)
+
+prefix# :: IdentifierSet -> Identifier -> Text -> (IdentifierSet, Identifier)
+prefix# is0 (RawIdentifier t Nothing) prefix_ = (uncurry prefix# (make# is0 t)) prefix_
+prefix# is0 (RawIdentifier _ (Just id_)) prefix_ = prefix# is0 id_ prefix_
+prefix# is0 id0 prefix_ = make# is0 (prefix_ <> "_" <> i_baseName id0)
+
+toText# :: Identifier -> Text
+toText# (RawIdentifier t _) = t
+toText# (UniqueIdentifier{..}) =
+  case i_hdl of
+    VHDL -> VHDL.toText i_idType basicId
+    Verilog -> Verilog.toText i_idType basicId
+    SystemVerilog -> SystemVerilog.toText i_idType basicId
+ where
+  exts = map showt (reverse i_extensionsRev)
+  basicId = Text.intercalate "_" (i_baseName : exts)
+
+-- | Convert an identifier to string. Use 'unmake' if you need the
+-- "IdentifierType" too.
+toText :: Identifier -> Text
+toText = toText#
+
+-- | Convert an identifier to string. Use 'unmake' if you need the
+-- "IdentifierType" too.
+toLazyText :: Identifier -> LT.Text
+toLazyText = LT.fromStrict . toText
+
+-- | Convert a Clash Core Id to an identifier. Makes sure returned identifier
+-- is unique.
+fromCoreId# :: IdentifierSet -> Id -> (IdentifierSet, Identifier)
+fromCoreId# is0 id0 = make# is0 (nameOcc (varName id0))
+
+-- | Helper function to define pure Id functions in terms of a IdentifierSetMonad
+withIdentifierSetM
+  :: IdentifierSetMonad m
+  => (IdentifierSet -> a -> (IdentifierSet, b))
+  -> a
+  -> m b
+withIdentifierSetM f a = do
+  is0 <- identifierSetM id
+  let (is1, b) = f is0 a
+  _ <- identifierSetM (const is1)
+  pure b
+
+-- | Like 'addRaw', 'unsafeMake' creates an identifier that will be spliced
+-- at verbatim in the HDL. As opposed to 'addRaw', the resulting Identifier
+-- might be generated at a later point as it is NOT added to an IdentifierSet.
+unsafeMake :: Text -> Identifier
+unsafeMake t = RawIdentifier t Nothing
+
+-- | Add a string as is to an IdentifierSet. Should only be used for identifiers
+-- that should be spliced at verbatim in HDL, such as port names. It's sanitized
+-- version will still be added to the identifier set, to prevent freshly
+-- generated variables clashing with the raw one.
+addRaw :: IdentifierSetMonad m => Text -> m Identifier
+addRaw = withIdentifierSetM addRaw#
+
+-- | Make unique identifier based on given string
+make :: IdentifierSetMonad m => Text -> m Identifier
+make = withIdentifierSetM make#
+
+-- | Make unique basic identifier based on given string
+makeBasic :: IdentifierSetMonad m => Text -> m Identifier
+makeBasic = withIdentifierSetM makeBasic#
+
+-- | Make unique basic identifier based on given string. If given string can't
+-- be converted to a basic identifier (i.e., it would yield an empty string) the
+-- alternative name is used.
+makeBasicOr
+  :: IdentifierSetMonad m
+  => Text
+  -- ^ Name hint
   -> Text
-  -> Text
-mkBasicId' hdl tupEncode = stripMultiscore hdl . stripLeading hdl . zEncode hdl tupEncode
-  where
-    stripLeading VHDL = Text.dropWhile (`elem` ('_':['0'..'9']))
-    stripLeading _    = Text.dropWhile (`elem` ('$':['0'..'9']))
-    stripMultiscore VHDL
-      = Text.concat
-      . Prelude.map (\cs -> case Text.head cs of
-                              '_' -> "_"
-                              _   -> cs
-                    )
-      . Text.group
-    stripMultiscore _ = id
+  -- ^ If name hint can't be converted to a sensible basic id, use this instead
+  -> m Identifier
+makeBasicOr hint altHint =
+  withIdentifierSetM
+    (\is0 -> uncurry (makeBasicOr# is0))
+    (hint, altHint)
 
-stripDollarPrefixes :: Text -> Text
-stripDollarPrefixes = stripWorkerPrefix . stripSpecPrefix . stripConPrefix
-                    . stripWorkerPrefix . stripDictFunPrefix
-  where
-    stripDictFunPrefix t = case Text.stripPrefix "$f" t of
-                             Just k  -> takeWhileEnd (/= '_') k
-                             Nothing -> t
+-- | Make unique identifier. Uses 'makeBasic' if first argument is 'Basic'
+makeAs :: IdentifierSetMonad m => IdentifierType -> Text -> m Identifier
+makeAs Basic = makeBasic
+makeAs Extended = make
 
-    stripWorkerPrefix t = case Text.stripPrefix "$w" t of
-                              Just k  -> k
-                              Nothing -> t
+-- | Given identifier "foo_1_2" return "foo_1_3". If "foo_1_3" is already a
+-- member of the given set, return "foo_1_4" instead, etc. Identifier returned
+-- is guaranteed to be unique.
+next :: IdentifierSetMonad m => Identifier -> m Identifier
+next = withIdentifierSetM next#
 
-    stripConPrefix t = case Text.stripPrefix "$c" t of
-                         Just k  -> k
-                         Nothing -> t
+-- | Same as 'nextM', but returns N fresh identifiers
+nextN :: IdentifierSetMonad m => Int -> Identifier -> m [Identifier]
+nextN n = withIdentifierSetM (nextN# n)
 
-    stripSpecPrefix t = case Text.stripPrefix "$s" t of
-                          Just k -> k
-                          Nothing -> t -- snd (Text.breakOnEnd "$s" t)
+-- | Given identifier "foo_1_2" return "foo_1_2_0". If "foo_1_2_0" is already a
+-- member of the given set, return "foo_1_2_1" instead, etc. Identifier returned
+-- is guaranteed to be unique.
+deepen :: IdentifierSetMonad m => Identifier -> m Identifier
+deepen = withIdentifierSetM deepen#
 
+-- | Same as 'deepenM', but returns N fresh identifiers. For example, given
+-- "foo_23" is would return "foo_23_0", "foo_23_1", ...
+deepenN :: IdentifierSetMonad m => Int -> Identifier -> m [Identifier]
+deepenN n = withIdentifierSetM (deepenN# n)
 
-type UserString    = Text -- As the user typed it
-type EncodedString = Text -- Encoded form
+-- | Given identifier "foo_1_2" and a suffix "bar", return an identifier called
+-- "foo_bar". Identifier returned is guaranteed to be unique according to the
+-- rules of 'nextIdentifier'.
+suffix :: IdentifierSetMonad m => Identifier -> Text -> m Identifier
+suffix id0 suffix_ = withIdentifierSetM (\is id1 -> suffix# is id1 suffix_) id0
 
-zEncode :: HDL -> Bool -> UserString -> EncodedString
-zEncode hdl False cs = go (uncons cs)
-  where
-    go Nothing         = empty
-    go (Just (c,cs'))  = append (encodeDigitCh hdl c) (go' $ uncons cs')
-    go' Nothing        = empty
-    go' (Just (c,cs')) = append (encodeCh hdl c) (go' $ uncons cs')
+-- | Given identifier "foo_1_2" and a prefix "bar", return an identifier called
+-- "bar_foo". Identifier returned is guaranteed to be unique according to the
+-- rules of 'nextIdentifier'.
+prefix :: IdentifierSetMonad m => Identifier -> Text -> m Identifier
+prefix id0 prefix_ = withIdentifierSetM (\is id1 -> prefix# is id1 prefix_) id0
 
-zEncode hdl True cs = case maybeTuple cs of
-                    Just (n,cs') -> append n (go' (uncons cs'))
-                    Nothing      -> go (uncons cs)
-  where
-    go Nothing         = empty
-    go (Just (c,cs'))  = append (encodeDigitCh hdl c) (go' $ uncons cs')
-    go' Nothing        = empty
-    go' (Just (c,cs')) = case maybeTuple (cons c cs') of
-                           Just (n,cs2) -> append n (go' $ uncons cs2)
-                           Nothing      -> append (encodeCh hdl c) (go' $ uncons cs')
+-- | Convert a Clash Core Id to an identifier. Makes sure returned identifier
+-- is unique.
+fromCoreId :: IdentifierSetMonad m => Id -> m Identifier
+fromCoreId = withIdentifierSetM fromCoreId#
 
-encodeDigitCh :: HDL -> Char -> EncodedString
-encodeDigitCh _   c | isDigit c = Text.empty -- encodeAsUnicodeChar c
-encodeDigitCh hdl c             = encodeCh hdl c
+instance PP.Pretty Identifier where
+  pretty = PP.pretty . toText
 
-encodeCh :: HDL -> Char -> EncodedString
-encodeCh hdl c | unencodedChar hdl c = singleton c     -- Common case first
-               | otherwise           = Text.empty
+instance Hashable Identifier where
+  hashWithSalt salt = hashWithSalt salt . hash
+  hash = uncurry hash# . eqTup#
 
-unencodedChar :: HDL -> Char -> Bool   -- True for chars that don't need encoding
-unencodedChar hdl c  =
-  or [ isAsciiLower c
-     , isAsciiUpper c
-     , isDigit c
-     , if hdl == VHDL then c == '_' else c `elem` ['_','$']
-     ]
+instance Eq Identifier where
+  i1 == i2 = eqTup# i1 == eqTup# i2
+  i1 /= i2 = eqTup# i1 /= eqTup# i2
 
-maybeTuple :: UserString -> Maybe (EncodedString,UserString)
-maybeTuple "(# #)" = Just ("Unit",empty)
-maybeTuple "()"    = Just ("Unit",empty)
-maybeTuple (uncons -> Just ('(',uncons -> Just ('#',cs))) =
-  case countCommas 0 cs of
-    (n,uncons -> Just ('#',uncons -> Just (')',cs'))) -> Just (pack ("Tup" ++ show (n+1)),cs')
-    _ -> Nothing
-maybeTuple (uncons -> Just ('(',cs)) =
-  case countCommas 0 cs of
-    (n,uncons -> Just (')',cs')) -> Just (pack ("Tup" ++ show (n+1)),cs')
-    _ -> Nothing
-maybeTuple _  = Nothing
+instance Ord Identifier where
+  compare = compare `on` eqTup#
 
-countCommas :: Int -> UserString -> (Int,UserString)
-countCommas n (uncons -> Just (',',cs)) = countCommas (n+1) cs
-countCommas n cs                        = (n,cs)
+eqTup# :: Identifier -> ((Text, Bool), [Word])
+eqTup# (RawIdentifier t _id) = ((t, True), [])
+eqTup# id_ = ((i_baseNameCaseFold id_, False), i_extensionsRev id_)
+
+hash# :: Hashable a => a -> [Word] -> Int
+hash# a extensions =
+  -- 'hash' has an identity around zero, e.g. `hash (0, 2) == 2`. Because a lot
+  -- of zeros can be expected, extensions are fuzzed in order to keep efficient
+  -- `HashMap`s.
+  let fuzz fuzzFactor ext = fuzzFactor * fuzzFactor * ext in
+  hash (a, List.foldl' fuzz 2 extensions)
+
+-- | Is given string a valid basic identifier in given HDL?
+isBasic# :: HDL -> Text -> Bool
+isBasic# VHDL = VHDL.parseBasic
+isBasic# Verilog = Verilog.parseBasic
+isBasic# SystemVerilog = SystemVerilog.parseBasic
+
+-- | Is given string a valid extended identifier in given HDL?
+isExtended# :: HDL -> Text -> Bool
+isExtended# VHDL = VHDL.parseExtended
+isExtended# Verilog = Verilog.parseExtended
+isExtended# SystemVerilog = SystemVerilog.parseExtended
+
+-- | Convert given string to ASCII. Retains all printable ASCII. All other
+-- characters are thrown out.
+toPrintableAscii# :: Text -> Text
+toPrintableAscii# = Text.filter (\c -> Char.isPrint c && Char.isAscii c)
+
+-- | Split identifiers such as "foo_1_2" into ("foo", [2, 1]).
+parseIdentifier# :: Text -> (Text, [Word])
+parseIdentifier# t =
+  let (tsRev, extsRev) = go (List.reverse (Text.splitOn "_" t)) in
+  (Text.intercalate "_" (List.reverse tsRev), extsRev)
+ where
+  go :: [Text] -> ([Text], [Word])
+  go [] = go ["clash", "internal"]
+  go (i:is) = case readMaybe @Word (Text.unpack i) of
+    Just w -> second (w:) (go is)
+    Nothing -> (i:is, [])
+
+make## :: HDL -> Text -> Identifier
+make## hdl =
+    go
+  . Text.strip
+  . Text.replace "\\" ""
+  . toPrintableAscii#
+ where
+  go s | Text.null s = go "clash_internal"
+       | otherwise =
+          let
+            (baseName, extensions) = parseIdentifier# s
+            idType = if isBasic# hdl s then Basic else Extended
+
+            -- VHDL is a case insensitive language, so we convert the given
+            -- text to lowercase. Note that 'baseNameCaseFold' is used in the
+            -- Eq for Identifier.
+            baseNameCaseFold = case hdl of
+              VHDL -> Text.toCaseFold baseName
+              _ -> baseName
+          in
+            UniqueIdentifier baseName baseNameCaseFold extensions idType hdl
+
+toBasicId# :: HDL -> Text -> Text
+toBasicId# VHDL          = VHDL.toBasic
+toBasicId# Verilog       = Verilog.toBasic
+toBasicId# SystemVerilog = SystemVerilog.toBasic

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -60,6 +60,8 @@ import {-# SOURCE #-} Clash.Netlist.Types
   (HasIdentifierSet(..), IdentifierSet(..), Identifier(..), IdentifierType(..),
    IdentifierSetMonad(identifierSetM))
 import qualified Data.HashSet as HashSet
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.IntMap.Strict as IntMap
 import qualified Data.List as List
 import           Data.Text (Text)
 import qualified Data.Text.Lazy as LT
@@ -82,11 +84,14 @@ emptyIdentifierSet esc lw hdl = makeSet esc lw hdl []
 -- | Union of two identifier sets. Errors if given sets have been made with
 -- different options enabled.
 union :: HasCallStack => IdentifierSet -> IdentifierSet -> IdentifierSet
-union is1@(IdentifierSet esc1 lw1 hdl1 _ _) is2@(IdentifierSet esc2 lw2 hdl2 _ _)
-  | esc1 /= esc2 = error $ "Internal error: esc1 /= esc2, " <> show (esc1, esc2)
-  | hdl1 /= hdl2 = error $ "Internal error: hdl1 /= hdl2, " <> show (hdl1, hdl2)
-  | lw1 /= lw2 = error $ "Internal error: lw1 /= lw2 , " <> show (lw1, lw2)
-  | otherwise = makeSet esc1 lw1 hdl1 (toList is1 ++ toList is2)
+union (IdentifierSet escL lwL hdlL freshL idsL) (IdentifierSet escR lwR hdlR freshR idsR)
+  | escL /= escR = error $ "Internal error: escL /= escR, " <> show (escL, escR)
+  | hdlL /= hdlR = error $ "Internal error: hdlL /= hdlR, " <> show (hdlL, hdlR)
+  | lwL /= lwR = error $ "Internal error: lwL /= lwR , " <> show (lwL, lwR)
+  | otherwise = IdentifierSet escR lwR hdlR fresh ids
+ where
+  fresh = HashMap.unionWith (IntMap.unionWith max) freshL freshR
+  ids = HashSet.union idsL idsR
 
 -- | Make a identifier set filled with given identifiers
 makeSet

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -57,8 +57,8 @@ where
 import           Clash.Annotations.Primitive (HDL (..))
 import           Clash.Core.Var (Id)
 import {-# SOURCE #-} Clash.Netlist.Types
-  (HasIdentifierSet(..), IdentifierSet(..), Identifier(..), IdentifierType(..),
-   IdentifierSetMonad(identifierSetM))
+  (PreserveCase(..), HasIdentifierSet(..), IdentifierSet(..), Identifier(..),
+   IdentifierType(..), IdentifierSetMonad(identifierSetM))
 import qualified Data.HashSet as HashSet
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.IntMap.Strict as IntMap
@@ -74,12 +74,12 @@ import           Clash.Netlist.Id.Internal
 emptyIdentifierSet
   :: Bool
   -- ^ Allow escaped identifiers?
-  -> Bool
+  -> PreserveCase
   -- ^ Should all basic identifiers be lower case?
   -> HDL
   -- ^ HDL to generate names for
   -> IdentifierSet
-emptyIdentifierSet esc lw hdl = makeSet esc lw hdl []
+emptyIdentifierSet esc lw hdl = makeSet esc lw hdl mempty
 
 -- | Union of two identifier sets. Errors if given sets have been made with
 -- different options enabled.
@@ -97,17 +97,16 @@ union (IdentifierSet escL lwL hdlL freshL idsL) (IdentifierSet escR lwR hdlR fre
 makeSet
   :: Bool
   -- ^ Allow escaped identifiers?
-  -> Bool
+  -> PreserveCase
   -- ^ Should all basic identifiers be lower case?
   -> HDL
   -- ^ HDL to generate names for
-  -> [Identifier]
+  -> HashSet.HashSet Identifier
   -- ^ Identifiers to add to set
   -> IdentifierSet
-makeSet esc lw hdl ids = IdentifierSet esc lw hdl fresh store
+makeSet esc lw hdl ids = IdentifierSet esc lw hdl fresh ids
  where
   fresh = List.foldl' updateFreshCache# mempty ids
-  store = HashSet.fromList ids
 
 toList :: IdentifierSet -> [Identifier]
 toList (IdentifierSet _ _ _ _ idStore) = HashSet.toList idStore

--- a/clash-lib/src/Clash/Netlist/Id.hs-boot
+++ b/clash-lib/src/Clash/Netlist/Id.hs-boot
@@ -1,0 +1,6 @@
+module Clash.Netlist.Id where
+
+import {-# SOURCE #-} Clash.Netlist.Types (Identifier)
+import Data.Text (Text)
+
+toText :: Identifier -> Text

--- a/clash-lib/src/Clash/Netlist/Id/Common.hs
+++ b/clash-lib/src/Clash/Netlist/Id/Common.hs
@@ -1,3 +1,8 @@
+{-|
+  Copyright  :  (C) 2020, QBayLogic B.V.
+  License    :  BSD2 (see the file LICENSE)
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com
+-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Netlist.Id.Common where
@@ -101,4 +106,3 @@ parseTuple t0 = do
   t4 <- parseMaybeSingle (=='#') t3
   t5 <- parseSingle (==')') t4
   pure (n+1, t5)
-

--- a/clash-lib/src/Clash/Netlist/Id/Common.hs
+++ b/clash-lib/src/Clash/Netlist/Id/Common.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Netlist.Id.Common where
+
+import           Control.Arrow (first)
+import           Control.Applicative ((<|>))
+import           Control.Applicative.Extra (orEmpty)
+import           Data.Maybe (fromMaybe)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Char as Char
+import           TextShow (showt)
+
+parseWhiteSpace :: Text -> Maybe Text
+parseWhiteSpace = parseSingle isWhiteSpace
+
+isWhiteSpace :: Char -> Bool
+isWhiteSpace c = c `elem` [' ', '\n', '\t']
+
+parsePrintable :: Text -> Maybe Text
+parsePrintable = parseSingle (\c -> Char.isPrint c && Char.isAscii c)
+
+parseSingle :: (Char -> Bool) -> Text -> Maybe Text
+parseSingle predicate s = do
+  (l, ls) <- Text.uncons s
+  orEmpty (predicate l) ls
+
+parseMaybeSingle :: (Char -> Bool) -> Text -> Maybe Text
+parseMaybeSingle predicate s = Just (fromMaybe s (parseSingle predicate s))
+
+parseLetter :: Text -> Maybe Text
+parseLetter = parseSingle (\c -> Char.isAscii c && Char.isLetter c)
+
+parseDigit :: Text -> Maybe Text
+parseDigit = parseSingle Char.isDigit
+
+parseLetterOrDigit :: Text -> Maybe Text
+parseLetterOrDigit s = parseLetter s <|> parseDigit s
+
+parseUnderscore :: Text -> Maybe Text
+parseUnderscore = parseSingle (=='_')
+
+parseDollar :: Text -> Maybe Text
+parseDollar = parseSingle (=='$')
+
+parseTab :: Text -> Maybe Text
+parseTab = parseSingle (=='\t')
+
+parseBackslash :: Text -> Maybe Text
+parseBackslash = parseSingle (=='\\')
+
+failNonEmpty :: Text -> Maybe Text
+failNonEmpty s | Text.null s = Just Text.empty
+               | otherwise = Nothing
+
+repeatParseN :: (Text -> Maybe Text) -> Text -> Maybe (Int, Text)
+repeatParseN parser = go 0
+ where
+  go n s0 =
+    case parser s0 of
+      Just s1 -> go (n+1) s1
+      Nothing -> Just (n, s0)
+
+repeatParse :: (Text -> Maybe Text) -> Text -> Maybe Text
+repeatParse parser s0 = snd <$> repeatParseN parser s0
+
+-- | Encodes tuples as "TupN" and removes all characters not matching a
+-- predicate.
+zEncode
+  :: (Char -> Bool)
+  -- ^ Characters to keep
+  -> Text
+  -> Text
+zEncode keep s =
+  let go = zEncode keep in
+  case maybeTuple s of
+    Just (tupName, rest) ->
+      tupName <> go rest
+    Nothing ->
+      case Text.uncons s of
+        Just (c, rest) ->
+          if keep c then
+            Text.cons c (go rest)
+          else
+            go rest
+        Nothing -> s
+
+prettyName :: Text -> Text
+prettyName t = maybe t (uncurry (<>)) (maybeTuple t)
+
+maybeTuple :: Text -> Maybe (Text, Text)
+maybeTuple "(# #)" = Just ("Unit", "")
+maybeTuple "()" = Just ("Unit", "")
+maybeTuple t = first (\n -> "Tup" <> showt n) <$> parseTuple t
+
+parseTuple :: Text -> Maybe (Int, Text)
+parseTuple t0 = do
+  t1 <- parseSingle (=='(') t0
+  t2 <- parseMaybeSingle (=='#') t1
+  (n, t3) <- repeatParseN (parseSingle (== ',')) t2
+  t4 <- parseMaybeSingle (=='#') t3
+  t5 <- parseSingle (==')') t4
+  pure (n+1, t5)
+

--- a/clash-lib/src/Clash/Netlist/Id/Internal.hs
+++ b/clash-lib/src/Clash/Netlist/Id/Internal.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Clash.Netlist.Id.Internal where
+
+import           Clash.Annotations.Primitive (HDL (..))
+import           Clash.Core.Name (Name(nameOcc))
+import           Clash.Core.Var (Id, varName)
+import {-# SOURCE #-} Clash.Netlist.Types
+  (IdentifierSet(..), Identifier(..), FreshCache, IdentifierType(..))
+import           Control.Arrow (second)
+import qualified Data.Char as Char
+import qualified Data.List as List
+import qualified Data.Text.Prettyprint.Doc as PP
+import qualified Data.Text as Text
+import           Data.Text (Text)
+import qualified Data.Maybe as Maybe
+import           Text.Read (readMaybe)
+import           TextShow (showt)
+import           GHC.Stack (HasCallStack)
+
+import qualified Data.IntMap as IntMap
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.HashSet as HashSet
+
+import qualified Clash.Netlist.Id.SystemVerilog as SystemVerilog
+import qualified Clash.Netlist.Id.Verilog as Verilog
+import qualified Clash.Netlist.Id.VHDL as VHDL
+import qualified Clash.Netlist.Id.Common as Common
+
+-- | Return identifier with highest extension for given identifier. See
+-- 'is_freshCache' for more information.
+--
+-- For example, if the FreshCache contains "foo_12_25" and the given identifier
+-- is "foo_12_13" this function would return "Just 25". In this case, "foo_12_26"
+-- is guaranteed to be a fresh identifier.
+lookupFreshCache# :: FreshCache -> Identifier -> Maybe Word
+lookupFreshCache# fresh0 id0 = do
+  fresh1 <- HashMap.lookup (i_baseNameCaseFold id0) fresh0
+  IntMap.lookup (length (i_extensionsRev id0)) fresh1
+
+-- | Add new identifier to FreshCache, see 'is_freshCache' for more information.
+updateFreshCache# :: HasCallStack => FreshCache -> Identifier -> FreshCache
+updateFreshCache# _fresh (RawIdentifier _s Nothing) =
+  error "Internal error: updateFreshCache# called with unsafely made identifier"
+updateFreshCache# fresh (RawIdentifier _s (Just id_)) =
+  updateFreshCache# fresh id_
+updateFreshCache# fresh id_ =
+  go0 (go1 (max (Maybe.fromMaybe 0 (Maybe.listToMaybe exts))))
+ where
+  go0 f = HashMap.alter (Just . f . Maybe.fromMaybe mempty) base fresh
+  go1 f = IntMap.alter (Just . f . Maybe.fromMaybe 0) (length exts)
+
+  exts = i_extensionsRev id_
+  base = i_baseNameCaseFold id_
+
+-- | Adds identifier at verbatim if its basename hasn't been used before.
+-- Otherwise it will return the first free identifier.
+mkUnique#
+  :: HasCallStack
+  => IdentifierSet
+  -> Identifier
+  -> (IdentifierSet, Identifier)
+mkUnique# _is0 (RawIdentifier {}) =
+  error "Internal error: mkUnique# cannot be used on RawIdentifiers"
+mkUnique# is0 id_@(i_extensionsRev -> []) = deepen# is0 id_
+mkUnique# is id0 = (is{is_freshCache=freshCache, is_store=isStore}, id1)
+ where
+  freshCache = updateFreshCache# (is_freshCache is) id1
+  isStore = HashSet.insert id1 (is_store is)
+  id1 = case lookupFreshCache# (is_freshCache is) id0 of
+    Just currentMax ->
+      id0{i_extensionsRev=currentMax+1 : tail (i_extensionsRev id0)}
+    Nothing ->
+      -- Identifier doesn't exist in set yet, so just return it.
+      id0
+
+-- | Non-monadic, internal version of 'addRaw'
+addRaw# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
+addRaw# is0 id0 = second (RawIdentifier id0 . Just) (make# is0 (unextend id0))
+ where
+  unextend = case is_hdl is0 of
+    VHDL -> VHDL.unextend
+    Verilog -> Verilog.unextend
+    SystemVerilog -> SystemVerilog.unextend
+
+-- | Non-monadic, internal version of 'make'
+make# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
+make# is0@(IdentifierSet esc lw hdl fresh0 ids0) (Common.prettyName -> id0) =
+  if id1 `HashSet.member` ids0 then
+    -- Ideally we'd like to continue with the id from the HashSet so all the old
+    -- strings can be garbage collected, but I haven't found an efficient way of
+    -- doing so. I also doubt that this case will get hit often..
+    deepen# is0 id1
+  else
+    (is0{is_freshCache=fresh1, is_store=ids1}, id1)
+ where
+  ids1 = HashSet.insert id1 ids0
+  fresh1 = updateFreshCache# fresh0 id1
+  id1 = make## (is_hdl is0) (if esc then id0 else toBasicId# hdl lw id0)
+
+-- | Non-monadic, internal version of 'makeBasic'
+makeBasic# :: IdentifierSet -> Text -> (IdentifierSet, Identifier)
+makeBasic# is0 = make# is0 . toBasicId# (is_hdl is0) (is_lowerCaseBasicIds is0)
+
+-- | Non-monadic, internal version of 'makeBasicOr'
+makeBasicOr# :: IdentifierSet -> Text -> Text -> (IdentifierSet, Identifier)
+makeBasicOr# is0 hint altHint = make# is0 id1
+ where
+  id0 = toBasicId# (is_hdl is0) (is_lowerCaseBasicIds is0) hint
+  id1 = if Text.null id0
+        then toBasicId# (is_hdl is0) (is_lowerCaseBasicIds is0) altHint
+        else id0
+
+-- | Non-monadic, internal version of 'next'
+next# :: IdentifierSet -> Identifier ->  (IdentifierSet, Identifier)
+next# is0 (RawIdentifier t Nothing) = uncurry next# (make# is0 t)
+next# is0 (RawIdentifier _ (Just id_)) = next# is0 id_
+next# is0 id_@(i_extensionsRev -> []) = deepen# is0 id_
+next# is0 id_ = mkUnique# is0 id_
+
+-- | Non-monadic, internal version of 'nextN'
+nextN# :: Int -> IdentifierSet -> Identifier ->  (IdentifierSet, [Identifier])
+nextN# n is0 id0 = List.mapAccumL (\is1 _n -> next# is1 id0) is0 [1..n]
+-- TODO: ^ More efficient implementation.
+
+-- | Non-monadic, internal version of 'deepenN'
+deepenN# :: Int -> IdentifierSet -> Identifier ->  (IdentifierSet, [Identifier])
+deepenN# n is0 id0 = List.mapAccumL (\is1 _n -> deepen# is1 id0) is0 [1..n]
+-- TODO: ^ More efficient implementation.
+
+-- | Non-monadic, internal version of 'deepen'
+deepen# :: IdentifierSet -> Identifier ->  (IdentifierSet, Identifier)
+deepen# is0 (RawIdentifier t Nothing) = uncurry deepen# (make# is0 t)
+deepen# is0 (RawIdentifier _ (Just id_)) = deepen# is0 id_
+deepen# is0 id_ = mkUnique# is0 (id_{i_extensionsRev=0:i_extensionsRev id_})
+
+-- | Non-monadic, internal version of 'suffix'
+suffix# :: IdentifierSet -> Identifier -> Text -> (IdentifierSet, Identifier)
+suffix# is0 (RawIdentifier t Nothing) suffix_ = (uncurry suffix# (make# is0 t)) suffix_
+suffix# is0 (RawIdentifier _ (Just id_)) suffix_ = suffix# is0 id_ suffix_
+suffix# is0 id0 suffix_ = make# is0 (i_baseName id0 <> "_" <> suffix_)
+
+-- | Non-monadic, internal version of 'prefix'
+prefix# :: IdentifierSet -> Identifier -> Text -> (IdentifierSet, Identifier)
+prefix# is0 (RawIdentifier t Nothing) prefix_ = (uncurry prefix# (make# is0 t)) prefix_
+prefix# is0 (RawIdentifier _ (Just id_)) prefix_ = prefix# is0 id_ prefix_
+prefix# is0 id0 prefix_ = make# is0 (prefix_ <> "_" <> i_baseName id0)
+
+toText# :: Identifier -> Text
+toText# (RawIdentifier t _) = t
+toText# (UniqueIdentifier{..}) =
+  case i_hdl of
+    VHDL -> VHDL.toText i_idType basicId
+    Verilog -> Verilog.toText i_idType basicId
+    SystemVerilog -> SystemVerilog.toText i_idType basicId
+ where
+  exts = map showt (reverse i_extensionsRev)
+  basicId = Text.intercalate "_" (i_baseName : exts)
+
+-- | Is given string a valid basic identifier in given HDL?
+isBasic# :: HDL -> Text -> Bool
+isBasic# VHDL = VHDL.parseBasic
+isBasic# Verilog = Verilog.parseBasic
+isBasic# SystemVerilog = SystemVerilog.parseBasic
+
+-- | Is given string a valid extended identifier in given HDL?
+isExtended# :: HDL -> Text -> Bool
+isExtended# VHDL = VHDL.parseExtended
+isExtended# Verilog = Verilog.parseExtended
+isExtended# SystemVerilog = SystemVerilog.parseExtended
+
+-- | Convert given string to ASCII. Retains all printable ASCII. All other
+-- characters are thrown out.
+toPrintableAscii# :: Text -> Text
+toPrintableAscii# = Text.filter (\c -> Char.isPrint c && Char.isAscii c)
+
+-- | Split identifiers such as "foo_1_2" into ("foo", [2, 1]).
+parseIdentifier# :: Text -> (Text, [Word])
+parseIdentifier# t =
+  let (tsRev, extsRev) = go (List.reverse (Text.splitOn "_" t)) in
+  (Text.intercalate "_" (List.reverse tsRev), extsRev)
+ where
+  go :: [Text] -> ([Text], [Word])
+  go [] = go ["clash", "internal"]
+  go (i:is) = case readMaybe @Word (Text.unpack i) of
+    Just w -> second (w:) (go is)
+    Nothing -> (i:is, [])
+
+make## :: HDL -> Text -> Identifier
+make## hdl =
+    go
+  . Text.strip
+  . Text.replace "\\" ""
+  . toPrintableAscii#
+ where
+  go s | Text.null s = go "clash_internal"
+       | otherwise =
+          let
+            (baseName, extensions) = parseIdentifier# s
+            idType = if isBasic# hdl s then Basic else Extended
+
+            -- VHDL is a case insensitive language, so we convert the given
+            -- text to lowercase. Note that 'baseNameCaseFold' is used in the
+            -- Eq for Identifier.
+            baseNameCaseFold = case hdl of
+              VHDL -> Text.toCaseFold baseName
+              _ -> baseName
+          in
+            UniqueIdentifier baseName baseNameCaseFold extensions idType hdl
+
+toBasicId# :: HDL -> Bool -> Text -> Text
+toBasicId# hdl lw id0 =
+  case hdl of
+    VHDL -> VHDL.toBasic id1
+    Verilog -> Verilog.toBasic id1
+    SystemVerilog -> SystemVerilog.toBasic id1
+ where
+  id1 = if lw then Text.toLower id0 else id0
+
+-- | Convert a Clash Core Id to an identifier. Makes sure returned identifier
+-- is unique.
+fromCoreId# :: IdentifierSet -> Id -> (IdentifierSet, Identifier)
+fromCoreId# is0 id0 = make# is0 (nameOcc (varName id0))
+
+instance PP.Pretty Identifier where
+  pretty = PP.pretty . toText#

--- a/clash-lib/src/Clash/Netlist/Id/Internal.hs
+++ b/clash-lib/src/Clash/Netlist/Id/Internal.hs
@@ -10,7 +10,8 @@ import           Clash.Annotations.Primitive (HDL (..))
 import           Clash.Core.Name (Name(nameOcc))
 import           Clash.Core.Var (Id, varName)
 import {-# SOURCE #-} Clash.Netlist.Types
-  (IdentifierSet(..), Identifier(..), FreshCache, IdentifierType(..))
+  (PreserveCase(..), IdentifierSet(..), Identifier(..), FreshCache,
+   IdentifierType(..))
 import           Control.Arrow (second)
 import qualified Data.Char as Char
 import qualified Data.List as List
@@ -212,14 +213,14 @@ make## hdl =
           in
             UniqueIdentifier baseName baseNameCaseFold extensions idType hdl
 
-toBasicId# :: HDL -> Bool -> Text -> Text
+toBasicId# :: HDL -> PreserveCase -> Text -> Text
 toBasicId# hdl lw id0 =
   case hdl of
     VHDL -> VHDL.toBasic id1
     Verilog -> Verilog.toBasic id1
     SystemVerilog -> SystemVerilog.toBasic id1
  where
-  id1 = if lw then Text.toLower id0 else id0
+  id1 = case lw of {PreserveCase -> id0; ToLower -> Text.toLower id0}
 
 -- | Convert a Clash Core Id to an identifier. Makes sure returned identifier
 -- is unique.

--- a/clash-lib/src/Clash/Netlist/Id/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Netlist/Id/SystemVerilog.hs
@@ -1,3 +1,8 @@
+{-|
+  Copyright  :  (C) 2020, QBayLogic B.V.
+  License    :  BSD2 (see the file LICENSE)
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com
+-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Netlist.Id.SystemVerilog where

--- a/clash-lib/src/Clash/Netlist/Id/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Netlist/Id/SystemVerilog.hs
@@ -47,16 +47,17 @@ keywords = HashSet.fromList
   ,"var","vectored","virtual","void","wait","wait_order","wand","weak","weak0"
   ,"weak1","while","wildcard","wire","with","within","wor","xnor","xor"]
 
+isKeyword :: Text -> Bool
+isKeyword t = HashSet.member (Text.toLower t) keywords
+
 parseBasic :: Text -> Bool
-parseBasic id0 =
-  Verilog.parseBasic' id0 && not (HashSet.member (Text.toLower id0) keywords)
+parseBasic id0 = Verilog.parseBasic' id0 && not (isKeyword id0)
 
 parseExtended :: Text -> Bool
 parseExtended = Verilog.parseExtended
 
 toBasic :: Text -> Text
-toBasic (Verilog.toBasic' -> t) =
-  if HashSet.member (Text.toLower t) keywords then "r_" <> t else t
+toBasic (Verilog.toBasic' -> t) = if isKeyword t then "r_" <> t else t
 
 unextend :: Text -> Text
 unextend = Verilog.unextend

--- a/clash-lib/src/Clash/Netlist/Id/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Netlist/Id/SystemVerilog.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Netlist.Id.SystemVerilog where
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import qualified Clash.Netlist.Id.Verilog as Verilog
+
+import           Clash.Netlist.Types (IdentifierType)
+
+-- List of reserved SystemVerilog-2012 keywords
+keywords :: HashSet Text
+keywords = HashSet.fromList
+  ["accept_on","alias","always","always_comb","always_ff"
+  ,"always_latch","and","assert","assign","assume","automatic","before","begin"
+  ,"bind","bins","binsof","bit","break","buf","bufif0","bufif1","byte","case"
+  ,"casex","casez","cell","chandle","checker","class","clocking","cmos","config"
+  ,"const","constraint","context","continue","cover","covergroup","coverpoint"
+  ,"cross","deassign","default","defparam","design","disable","dist","do","edge"
+  ,"else","end","endcase","endchecker","endclass","endclocking","endconfig"
+  ,"endfunction","endgenerate","endgroup","endinterface","endmodule","endpackage"
+  ,"endprimitive","endprogram","endproperty","endspecify","endsequence"
+  ,"endtable","endtask","enum","event","eventually","expect","export","extends"
+  ,"extern","final","first_match","for","force","foreach","forever","fork"
+  ,"forkjoin","function","generate","genvar","global","highz0","highz1","if"
+  ,"iff","ifnone","ignore_bins","illegal_bins","implements","implies","import"
+  ,"incdir","include","initial","inout","input","inside","instance","int"
+  ,"integer","interconnect","interface","intersect","join","join_any"
+  ,"join_none","large","let","liblist","library","local","localparam","logic"
+  ,"longint","macromodule","matches","medium","modport","module","nand"
+  ,"negedge","nettype","new","nexttime","nmos","nor","noshowcancelled","not"
+  ,"notif0","notif1","null","or","output","package","packed","parameter","pmos"
+  ,"posedge","primitive","priority","program","property","protected","pull0"
+  ,"pull1","pulldown","pullup","pulsestyle_ondetect","pulsestyle_onevent"
+  ,"pure","rand","randc","randcase","randsequence","rcmos","real","realtime"
+  ,"ref","reg","reject_on","release","repeat","restrict","return","rnmos"
+  ,"rpmos","rtran","rtranif0","rtranif1","s_always","s_eventually","s_nexttime"
+  ,"s_until","s_until_with","scalared","sequence","shortint","shortreal"
+  ,"showcancelled","signed","small","soft","solve","specify","specparam"
+  ,"static","string","strong","strong0","strong1","struct","super","supply0"
+  ,"supply1","sync_accept_on","sync_reject_on","table","tagged","task","this"
+  ,"throughout","time","timeprecision","timeunit","tran","tranif0","tranif1"
+  ,"tri","tri0","tri1","triand","trior","trireg","type","typedef","union"
+  ,"unique","unique0","unsigned","until","until_with","untyped","use","uwire"
+  ,"var","vectored","virtual","void","wait","wait_order","wand","weak","weak0"
+  ,"weak1","while","wildcard","wire","with","within","wor","xnor","xor"]
+
+parseBasic :: Text -> Bool
+parseBasic id0 =
+  Verilog.parseBasic' id0 && not (HashSet.member (Text.toLower id0) keywords)
+
+parseExtended :: Text -> Bool
+parseExtended = Verilog.parseExtended
+
+toBasic :: Text -> Text
+toBasic (Verilog.toBasic' -> t) =
+  if HashSet.member (Text.toLower t) keywords then "r_" <> t else t
+
+unextend :: Text -> Text
+unextend = Verilog.unextend
+
+toText :: IdentifierType -> Text -> Text
+toText = Verilog.toText

--- a/clash-lib/src/Clash/Netlist/Id/VHDL.hs
+++ b/clash-lib/src/Clash/Netlist/Id/VHDL.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Clash.Netlist.Id.VHDL where
+
+import Clash.Netlist.Id.Common
+
+import           Control.Applicative ((<|>))
+import qualified Data.Char as Char
+import qualified Data.Text as Text
+import           Data.Text (Text)
+import           Data.Maybe (isJust, fromMaybe)
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+
+import           Clash.Netlist.Types (IdentifierType(..))
+
+-- | Time units: are added to 'reservedWords' as simulators trip over signals
+-- named after them.
+timeUnits :: [Text]
+timeUnits = ["fs", "ps", "ns", "us", "ms", "sec", "min", "hr"]
+
+-- List of reserved VHDL-2008 keywords
+-- + used internal names: toslv, fromslv, tagtoenum, datatotag
+-- + used IEEE library names: integer, boolean, std_logic, std_logic_vector,
+--   signed, unsigned, to_integer, to_signed, to_unsigned, string
+keywords :: HashSet Text
+keywords = HashSet.fromList $
+  ["abs","access","after","alias","all","and","architecture"
+  ,"array","assert","assume","assume_guarantee","attribute","begin","block"
+  ,"body","buffer","bus","case","component","configuration","constant","context"
+  ,"cover","default","disconnect","downto","else","elsif","end","entity","exit"
+  ,"fairness","file","for","force","function","generate","generic","group"
+  ,"guarded","if","impure","in","inertial","inout","is","label","library"
+  ,"linkage","literal","loop","map","mod","nand","new","next","nor","not","null"
+  ,"of","on","open","or","others","out","package","parameter","port","postponed"
+  ,"procedure","process","property","protected","pure","range","record"
+  ,"register","reject","release","rem","report","restrict","restrict_guarantee"
+  ,"return","rol","ror","select","sequence","severity","signal","shared","sla"
+  ,"sll","sra","srl","strong","subtype","then","to","transport","type"
+  ,"unaffected","units","until","use","variable","vmode","vprop","vunit","wait"
+  ,"when","while","with","xnor","xor","toslv","fromslv","tagtoenum","datatotag"
+  ,"integer", "boolean", "std_logic", "std_logic_vector", "signed", "unsigned"
+  ,"to_integer", "to_signed", "to_unsigned", "string","log"] <> timeUnits
+
+parseBasic :: Text -> Bool
+parseBasic id0 =
+  parseBasic' id0 && not (HashSet.member (Text.toLower id0) keywords)
+
+parseBasic' :: Text -> Bool
+parseBasic' id0 = isJust $ do
+  id1 <- parseLetter id0
+  id2 <- repeatParse parseGroup id1
+  failNonEmpty id2
+ where
+  parseGroup s0 = do
+    s1 <- parseUnderscore s0 <|> Just s0
+    s2 <- parseLetterOrDigit s1
+    repeatParse parseLetterOrDigit s2
+
+parseExtended :: Text -> Bool
+parseExtended id0 = isJust $ do
+  id1 <- parseBackslash id0
+  id2 <- parse id1
+  id3 <- parseBackslash id2
+  failNonEmpty id3
+ where
+  parse s0 =
+    case parseBackslash s0 of
+      Just s1 -> parseBackslash s1 >>= repeatParse parse
+      Nothing -> parsePrintable s0 >>= repeatParse parse
+
+toBasic :: Text -> Text
+toBasic =
+    replaceKeywords
+  . stripMultiscore
+  . Text.dropWhileEnd (=='_')
+  . Text.dropWhile (\c -> c == '_' || Char.isDigit c)
+  . zEncode isBasicChar
+  . stripDollarPrefixes
+--  . Text.toLower
+ where
+  replaceKeywords i
+    | HashSet.member (Text.toLower i) keywords = "r_" <> i
+    | otherwise = i
+
+  stripMultiscore =
+      Text.concat
+    . Prelude.map (\cs -> case Text.head cs of {'_' -> "_"; _ -> cs})
+    . Text.group
+
+isBasicChar :: Char -> Bool
+isBasicChar c = or
+  [ Char.isAsciiLower c
+  , Char.isAsciiUpper c
+  , Char.isDigit c
+  , c == '_'
+  ]
+
+stripDollarPrefixes :: Text -> Text
+stripDollarPrefixes = stripWorkerPrefix . stripSpecPrefix . stripConPrefix
+                    . stripWorkerPrefix . stripDictFunPrefix
+  where
+    stripDictFunPrefix t =
+      maybe t (Text.takeWhileEnd (/='_')) (Text.stripPrefix "$f" t)
+    stripWorkerPrefix t = fromMaybe t (Text.stripPrefix "$w" t)
+    stripConPrefix t = fromMaybe t (Text.stripPrefix "$c" t)
+    stripSpecPrefix t = fromMaybe t (Text.stripPrefix "$s" t)
+
+unextend :: Text -> Text
+unextend =
+     Text.strip
+   . (\t -> fromMaybe t (Text.stripPrefix "\\" t))
+   . (\t -> fromMaybe t (Text.stripSuffix "\\" t))
+   . Text.strip
+
+toText :: IdentifierType -> Text -> Text
+toText Basic t = t
+toText Extended t = "\\" <> t <> "\\"

--- a/clash-lib/src/Clash/Netlist/Id/VHDL.hs
+++ b/clash-lib/src/Clash/Netlist/Id/VHDL.hs
@@ -1,3 +1,8 @@
+{-|
+  Copyright  :  (C) 2020, QBayLogic B.V.
+  License    :  BSD2 (see the file LICENSE)
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com
+-}
 {-# LANGUAGE OverloadedStrings #-}
 module Clash.Netlist.Id.VHDL where
 

--- a/clash-lib/src/Clash/Netlist/Id/VHDL.hs
+++ b/clash-lib/src/Clash/Netlist/Id/VHDL.hs
@@ -13,6 +13,45 @@ import qualified Data.HashSet as HashSet
 
 import           Clash.Netlist.Types (IdentifierType(..))
 
+-- | Identifiers which are imported from the following:
+--
+-- use IEEE.STD_LOGIC_1164.ALL;
+-- use IEEE.NUMERIC_STD.ALL;
+-- use IEEE.MATH_REAL.ALL;
+-- use std.textio.all;
+--
+-- Clash should not use these identifiers, as it can lead to errors when
+-- interfacing with an EDA tool.
+--
+-- See https://github.com/clash-lang/clash-compiler/issues/1439.
+--
+importedNames :: [Text]
+importedNames =
+  [ -- ieee.std_logic_1164.all
+    "std_ulogic", "std_ulogic_vector", "resolved", "std_logic", "std_logic_vector"
+  , "x01", "x01z", "ux01", "ux01z", "to_bit", "to_bitvector", "to_stdulogic"
+  , "to_stdlogicvector", "to_stdulogicvector", "to_01", "to_x01", "to_x01z"
+  , "to_ux01", "rising_edge", "falling_edge", "is_x"
+    -- ieee.numeric_std.all
+  , "unresolved_unsigned", "unresolved_signed", "u_unsigned", "u_signed"
+  , "unsigned", "signed", "find_leftmost", "find_rightmost", "minimum"
+  , "maximum", "shift_left", "shift_right", "rotate_left", "rotate_right"
+  , "resize", "to_integer", "to_unsigned", "to_signed", "std_match"
+    -- ieee.math_real.all
+  , "math_e", "math_1_over_e", "math_pi", "math_2_pi", "math_1_over_pi"
+  , "math_pi_over_2", "math_pi_over_3", "path_pi_over_4", "path_3_pi_over_2"
+  , "math_log_of_2", "math_log_of_10", "math_log10_of_e", "math_sqrt_2"
+  , "math_1_over_sqrt_2", "math_sqrt_pi", "math_deg_to_rad", "math_rad_to_deg"
+  , "sign", "ceil", "floor", "round", "trunc", "realmax", "realmin", "uniform"
+  , "sqrt", "cbrt", "exp", "log", "log2", "log10", "sin", "cos", "tan", "arcsin"
+  , "arccos", "arctan", "sinh", "cosh", "tanh", "arcsinh", "arccosh", "arctanh"
+    -- std.textio.all
+  , "line", "text", "side", "width", "justify", "input", "output", "readline"
+  , "read", "sread", "string_read", "bread", "binary_read", "oread", "octal_read"
+  , "hread", "hex_read", "writeline", "tee", "write", "swrite", "string_write"
+  , "bwrite", "binary_write", "owrite", "octal_write", "hwrite", "hex_write"
+  ]
+
 -- | Time units: are added to 'reservedWords' as simulators trip over signals
 -- named after them.
 timeUnits :: [Text]
@@ -39,7 +78,7 @@ keywords = HashSet.fromList $
   ,"unaffected","units","until","use","variable","vmode","vprop","vunit","wait"
   ,"when","while","with","xnor","xor","toslv","fromslv","tagtoenum","datatotag"
   ,"integer", "boolean", "std_logic", "std_logic_vector", "signed", "unsigned"
-  ,"to_integer", "to_signed", "to_unsigned", "string","log"] <> timeUnits
+  ,"to_integer", "to_signed", "to_unsigned", "string","log"] <> timeUnits <> importedNames
 
 isKeyword :: Text -> Bool
 isKeyword t = HashSet.member (Text.toLower t) keywords

--- a/clash-lib/src/Clash/Netlist/Id/VHDL.hs
+++ b/clash-lib/src/Clash/Netlist/Id/VHDL.hs
@@ -41,9 +41,11 @@ keywords = HashSet.fromList $
   ,"integer", "boolean", "std_logic", "std_logic_vector", "signed", "unsigned"
   ,"to_integer", "to_signed", "to_unsigned", "string","log"] <> timeUnits
 
+isKeyword :: Text -> Bool
+isKeyword t = HashSet.member (Text.toLower t) keywords
+
 parseBasic :: Text -> Bool
-parseBasic id0 =
-  parseBasic' id0 && not (HashSet.member (Text.toLower id0) keywords)
+parseBasic id0 = parseBasic' id0 && not (isKeyword id0)
 
 parseBasic' :: Text -> Bool
 parseBasic' id0 = isJust $ do
@@ -79,7 +81,7 @@ toBasic =
 --  . Text.toLower
  where
   replaceKeywords i
-    | HashSet.member (Text.toLower i) keywords = "r_" <> i
+    | isKeyword i = "r_" <> i
     | otherwise = i
 
   stripMultiscore =

--- a/clash-lib/src/Clash/Netlist/Id/Verilog.hs
+++ b/clash-lib/src/Clash/Netlist/Id/Verilog.hs
@@ -33,9 +33,11 @@ keywords = HashSet.fromList
   ,"tri0","tri1","triand","trior","trireg","unsigned","use","uwire","vectored"
   ,"wait","wand","weak0","weak1","while","wire","wor","xnor","xor"]
 
+isKeyword :: Text -> Bool
+isKeyword t = HashSet.member (Text.toLower t) keywords
+
 parseBasic :: Text -> Bool
-parseBasic id0 =
-  parseBasic' id0 && not (HashSet.member (Text.toLower id0) keywords)
+parseBasic id0 = parseBasic' id0 && not (isKeyword id0)
 
 parseBasic' :: Text -> Bool
 parseBasic' id0 = isJust $ do

--- a/clash-lib/src/Clash/Netlist/Id/Verilog.hs
+++ b/clash-lib/src/Clash/Netlist/Id/Verilog.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Netlist.Id.Verilog where
+
+import           Control.Applicative ((<|>))
+import qualified Data.Char as Char
+import           Data.Maybe (isJust, fromMaybe)
+import qualified Data.Text as Text
+import           Data.Text (Text)
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+
+import           Clash.Netlist.Id.Common
+import           Clash.Netlist.Types (IdentifierType(..))
+
+-- List of reserved Verilog-2005 keywords
+keywords :: HashSet Text
+keywords = HashSet.fromList
+  ["always","and","assign","automatic","begin","buf","bufif0"
+  ,"bufif1","case","casex","casez","cell","cmos","config","deassign","default"
+  ,"defparam","design","disable","edge","else","end","endcase","endconfig"
+  ,"endfunction","endgenerate","endmodule","endprimitive","endspecify"
+  ,"endtable","endtask","event","for","force","forever","fork","function"
+  ,"generate","genvar","highz0","highz1","if","ifnone","incdir","include"
+  ,"initial","inout","input","instance","integer","join","large","liblist"
+  ,"library","localparam","macromodule","medium","module","nand","negedge"
+  ,"nmos","nor","noshowcancelled","not","notif0","notif1","or","output"
+  ,"parameter","pmos","posedge","primitive","pull0","pull1","pulldown","pullup"
+  ,"pulsestyle_onevent","pulsestyle_ondetect","rcmos","real","realtime","reg"
+  ,"release","repeat","rnmos","rpmos","rtran","rtranif0","rtranif1","scalared"
+  ,"showcancelled","signed","small","specify","specparam","strong0","strong1"
+  ,"supply0","supply1","table","task","time","tran","tranif0","tranif1","tri"
+  ,"tri0","tri1","triand","trior","trireg","unsigned","use","uwire","vectored"
+  ,"wait","wand","weak0","weak1","while","wire","wor","xnor","xor"]
+
+parseBasic :: Text -> Bool
+parseBasic id0 =
+  parseBasic' id0 && not (HashSet.member (Text.toLower id0) keywords)
+
+parseBasic' :: Text -> Bool
+parseBasic' id0 = isJust $ do
+  id1 <- parseUnderscore id0 <|> parseLetter id0
+  id2 <- repeatParse parseAllowedChars id1
+  failNonEmpty id2
+ where
+  parseAllowedChars s =
+        parseLetterOrDigit s
+    <|> parseUnderscore s
+    <|> parseDollar s
+
+parseExtended :: Text -> Bool
+parseExtended id0 =
+  isJust ((parse id0 >>= failNonEmpty) >> parseEnd id0)
+ where
+  -- Extended identifier must start with backslash, followed by printable chars
+  parse s = parseBackslash s >>= repeatParse parsePrintable
+
+  -- Extended identifier must end in exactly one whitespace
+  parseEnd :: Text -> Maybe Text
+  parseEnd s =
+    case Text.unpack (Text.takeEnd 2 s) of
+      [c0, c1] | not (isWhiteSpace c0) && isWhiteSpace c1 -> Just ""
+      _ -> Nothing
+
+toBasic' :: Text -> Text
+toBasic' (zEncode isBasicChar -> t) =
+  case Text.uncons t of
+    Just (c, _) | Char.isDigit c || c == '$' -> Text.cons '_' t
+    _ -> t
+
+toBasic :: Text -> Text
+toBasic (toBasic' -> t) =
+  if HashSet.member (Text.toLower t) keywords then "r_" <> t else t
+
+isBasicChar :: Char -> Bool
+isBasicChar c = or
+  [ Char.isAsciiLower c
+  , Char.isAsciiUpper c
+  , Char.isDigit c
+  , c == '_'
+  , c == '$'
+  ]
+
+unextend :: Text -> Text
+unextend =
+     Text.strip
+   . (\t -> fromMaybe t (Text.stripPrefix "\\" t))
+   . Text.strip
+
+toText :: IdentifierType -> Text -> Text
+toText Basic t = t
+toText Extended t = "\\" <> t <> " "
+

--- a/clash-lib/src/Clash/Netlist/Id/Verilog.hs
+++ b/clash-lib/src/Clash/Netlist/Id/Verilog.hs
@@ -1,3 +1,8 @@
+{-|
+  Copyright  :  (C) 2020, QBayLogic B.V.
+  License    :  BSD2 (see the file LICENSE)
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com
+-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Netlist.Id.Verilog where
@@ -92,4 +97,3 @@ unextend =
 toText :: IdentifierType -> Text -> Text
 toText Basic t = t
 toText Extended t = "\\" <> t <> " "
-

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -428,7 +428,7 @@ data Declaration
   -- | Instantiation of another component:
   | InstDecl
       EntityOrComponent                  -- FIELD Whether it's an entity or a component
-      (Maybe Comment)                    -- FIELD Comment to add to the generated code
+      (Maybe Text)                       -- FIELD Library instance is defined in
       [Attr']                            -- FIELD Attributes to add to the generated code
       !Identifier                        -- FIELD The component's (or entity's) name
       !Identifier                        -- FIELD Instance label

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -23,7 +23,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
--- since GHC 8.6 we can haddock individual contructor fields \o/
+-- since GHC 8.6 we can haddock individual constructor fields \o/
 #if __GLASGOW_HASKELL__ >= 806
 #define FIELD ^
 #endif
@@ -125,6 +125,7 @@ newtype NetlistMonad a =
 
 type HWMap = HashMap Type (Either String FilteredHWType)
 
+-- | See 'is_freshCache'
 type FreshCache = HashMap Text (IntMap Word)
 
 type IdentifierText = Text

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -92,6 +92,30 @@ data TopEntityT = TopEntityT
   -- ^ (Maybe) a test bench associated with the topentity
   } deriving (Generic, Show)
 
+-- | Same as "TopEntity", but with all port names that end up in HDL specified
+data ExpandedTopEntity a = ExpandedTopEntity
+  { et_inputs :: [Maybe (ExpandedPortName a)]
+  -- ^ Inputs with fully expanded port names. /Nothing/ if port is void.
+  , et_output :: Maybe (ExpandedPortName a)
+  -- ^ Output with fully expanded port names. /Nothing/ if port is void or
+  -- BiDirectionalOut.
+  } deriving (Show, Functor, Foldable, Traversable)
+
+-- | See "ExpandedTopEntity"
+data ExpandedPortName a
+  -- | Same as "PortName", but fully expanded
+  = ExpandedPortName HWType a
+
+  -- | Same as "PortProduct", but fully expanded
+  | ExpandedPortProduct
+      Text
+      -- FIELD Name hint. Can be used to create intermediate signal names.
+      HWType
+      -- FIELD Type of product
+      [ExpandedPortName a]
+      -- FIELD Product fields
+  deriving (Show, Functor, Foldable, Traversable)
+
 -- | Monad that caches generated components (StateT) and remembers hidden inputs
 -- of components that are being generated (WriterT)
 newtype NetlistMonad a =

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -373,6 +373,8 @@ data FilteredHWType =
   FilteredHWType HWType [[(IsVoid, FilteredHWType)]]
     deriving (Eq, Show)
 
+type DomainName = Text
+
 -- | Representable hardware types
 data HWType
   = Void (Maybe HWType)
@@ -406,12 +408,12 @@ data HWType
   -- populated when using records.
   | SP !Text [(Text, [HWType])]
   -- ^ Sum-of-Product type: Name and Constructor names + field types
-  | Clock !Text
-  -- ^ Clock type corresponding to domain /Identifier/
-  | Reset !Text
-  -- ^ Reset type corresponding to domain /Identifier/
-  | Enable !Text
-  -- ^ Enable type corresponding to domain /Identifier/
+  | Clock !DomainName
+  -- ^ Clock type corresponding to domain /DomainName/
+  | Reset !DomainName
+  -- ^ Reset type corresponding to domain /DomainName/
+  | Enable !DomainName
+  -- ^ Enable type corresponding to domain /DomainName/
   | BiDirectional !PortDirection !HWType
   -- ^ Tagging type indicating a bidirectional (inout) port
   | CustomSP !Text !DataRepr' !Size [(ConstrRepr', Text, [HWType])]
@@ -425,7 +427,7 @@ data HWType
   -- info, see: Clash.Annotations.BitRepresentations.
   | Annotated [Attr'] !HWType
   -- ^ Annotated with HDL attributes
-  | KnownDomain !Text !Integer !ActiveEdge !ResetKind !InitBehavior !ResetPolarity
+  | KnownDomain !DomainName !Integer !ActiveEdge !ResetKind !InitBehavior !ResetPolarity
   -- ^ Domain name, period, active edge, reset kind, initial value behavior
   | FileType
   -- ^ File type for simulation-level I/O
@@ -473,11 +475,11 @@ data Declaration
 
   -- | Signal declaration
   | NetDecl'
-      (Maybe Comment)            -- FIELD Note; will be inserted as a comment in target hdl
-      WireOrReg                  -- FIELD Wire or register
-      !Identifier                -- FIELD Name of signal
-      (Either Text HWType)       -- FIELD Pointer to type of signal or type of signal
-      (Maybe Expr)               -- FIELD Initial value
+      (Maybe Comment)                -- FIELD Note; will be inserted as a comment in target hdl
+      WireOrReg                      -- FIELD Wire or register
+      !Identifier                    -- FIELD Name of signal
+      (Either IdentifierText HWType) -- FIELD Pointer to type of signal or type of signal
+      (Maybe Expr)                   -- FIELD Initial value
       -- ^ Signal declaration
   | TickDecl Comment
   -- ^ HDL tick corresponding to a Core tick
@@ -618,14 +620,14 @@ data BlackBoxContext
   --   , Whether the result should be /reg/ or a /wire/ (Verilog only)
   --   , Partial Blackbox Context
   --   )
-  , bbQsysIncName :: [Text]
+  , bbQsysIncName :: [IdentifierText]
   , bbLevel :: Int
   -- ^ The scoping level this context is associated with, ensures that
   -- @~ARGN[k][n]@ holes are only filled with values from this context if @k@
   -- is equal to the scoping level of this context.
   , bbCompName :: Identifier
   -- ^ The component the BlackBox is instantiated in
-  , bbCtxName :: Maybe Text
+  , bbCtxName :: Maybe IdentifierText
   -- ^ The "context name", name set by `Clash.Magic.setName`, defaults to the
   -- name of the closest binder
   }

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -133,6 +133,13 @@ type FreshCache = HashMap Text (IntMap Word)
 
 type IdentifierText = Text
 
+-- | Whether to preserve casing in ids or converted everything to
+--  lowercase. Influenced by '-fclash-lower-case-basic-identifiers'
+data PreserveCase
+  = PreserveCase
+  | ToLower
+  deriving (Show, Generic, NFData, Eq, Binary, Hashable)
+
 -- See: http://vhdl.renerta.com/mobile/source/vhd00037.htm
 --      http://www.verilog.renerta.com/source/vrg00018.htm
 data IdentifierType
@@ -153,7 +160,7 @@ data IdentifierSet
       is_allowEscaped :: !Bool
       -- ^ Allow escaped ids? If set to False, "make" will always behave like
       -- "makeBasic".
-    , is_lowerCaseBasicIds :: !Bool
+    , is_lowerCaseBasicIds :: !PreserveCase
       -- ^ Force all generated basic identifiers to lowercase.
     , is_hdl :: !HDL
       -- ^ HDL to generate fresh identifiers for

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -150,6 +150,8 @@ data IdentifierSet
       is_allowEscaped :: !Bool
       -- ^ Allow escaped ids? If set to False, "make" will always behave like
       -- "makeBasic".
+    , is_lowerCaseBasicIds :: !Bool
+      -- ^ Force all generated basic identifiers to lowercase.
     , is_hdl :: !HDL
       -- ^ HDL to generate fresh identifiers for
     , is_freshCache :: !FreshCache

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -11,12 +11,17 @@
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 -- since GHC 8.6 we can haddock individual contructor fields \o/
 #if __GLASGOW_HASKELL__ >= 806
@@ -30,29 +35,34 @@ module Clash.Netlist.Types
 where
 
 import Control.DeepSeq
+import qualified Control.Lens               as Lens
+import Control.Lens                         (Lens', (.=))
 #if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail                   (MonadFail)
 #endif
 import Control.Monad.Reader                 (ReaderT, MonadReader)
-import Control.Monad.State                  as Lazy (State)
-import Control.Monad.State.Strict           as Strict
-  (State,MonadIO, MonadState, StateT)
+import qualified Control.Monad.State        as Lazy (State)
+import qualified Control.Monad.State.Strict as Strict
+  (State, MonadIO, MonadState, StateT)
 import Data.Bits                            (testBit)
 import Data.Binary                          (Binary(..))
 import Data.Hashable                        (Hashable)
 import Data.HashMap.Strict                  (HashMap)
+import Data.HashSet                         (HashSet)
 import Data.IntMap                          (IntMap, empty)
 import Data.Maybe                           (mapMaybe)
 import qualified Data.Set                   as Set
-import Data.Text                            (Text, pack)
+import Data.Text                            (Text)
 import Data.Typeable                        (Typeable)
 import Data.Text.Prettyprint.Doc.Extra      (Doc)
+import Data.Semigroup.Monad                 (Mon(..))
 import GHC.Generics                         (Generic)
 import Language.Haskell.TH.Syntax           (Lift)
 
 import SrcLoc                               (SrcSpan)
 
 import Clash.Annotations.BitRepresentation  (FieldAnn)
+import Clash.Annotations.Primitive          (HDL(..))
 import Clash.Annotations.TopEntity          (TopEntity)
 import Clash.Backend                        (Backend)
 import Clash.Core.Type                      (Type)
@@ -61,7 +71,6 @@ import Clash.Core.TyCon                     (TyConMap)
 import Clash.Core.VarEnv                    (VarEnv)
 import Clash.Driver.Types                   (BindingMap, ClashOpts)
 import Clash.Netlist.BlackBox.Types         (BlackBoxTemplate)
-import Clash.Netlist.Id                     (IdType)
 import Clash.Primitives.Types               (CompiledPrimMap)
 import Clash.Signal.Internal
   (ResetPolarity, ActiveEdge, ResetKind, InitBehavior)
@@ -69,6 +78,8 @@ import Clash.Util                           (HasCallStack, makeLenses)
 
 import Clash.Annotations.BitRepresentation.Internal
   (CustomReprs, DataRepr', ConstrRepr')
+
+import {-# SOURCE #-} qualified Clash.Netlist.Id as Id
 
 -- | Structure describing a top entity: it's id, its port annotations, and
 -- associated testbench.
@@ -84,20 +95,118 @@ data TopEntityT = TopEntityT
 -- | Monad that caches generated components (StateT) and remembers hidden inputs
 -- of components that are being generated (WriterT)
 newtype NetlistMonad a =
-  NetlistMonad { runNetlist :: StateT NetlistState (ReaderT NetlistEnv IO) a }
+  NetlistMonad { runNetlist :: Strict.StateT NetlistState (ReaderT NetlistEnv IO) a }
   deriving newtype (Functor, Monad, Applicative, MonadReader NetlistEnv,
-                    MonadState NetlistState, MonadIO, MonadFail)
+                    Strict.MonadState NetlistState, Strict.MonadIO, MonadFail)
 
 type HWMap = HashMap Type (Either String FilteredHWType)
+
+type FreshCache = HashMap Text (IntMap Word)
+
+type IdentifierText = Text
+
+-- See: http://vhdl.renerta.com/mobile/source/vhd00037.htm
+--      http://www.verilog.renerta.com/source/vrg00018.htm
+data IdentifierType
+  = Basic
+  -- ^ A basic identifier: does not have to be escaped in order to be a valid
+  -- identifier in HDL.
+  | Extended
+  -- ^ An extended identifier: has to be escaped, wrapped, or otherwise
+  -- postprocessed before writhing it to HDL.
+  deriving (Show, Generic, NFData, Eq)
+
+-- | A collection of unique identifiers. Allows for fast fresh identifier
+-- generation.
+--
+-- __NB__: use the functions in Clash.Netlist.Id. Don't use the constructor directly.
+data IdentifierSet
+  = IdentifierSet {
+      is_allowEscaped :: !Bool
+      -- ^ Allow escaped ids? If set to False, "make" will always behave like
+      -- "makeBasic".
+    , is_hdl :: !HDL
+      -- ^ HDL to generate fresh identifiers for
+    , is_freshCache :: !FreshCache
+      -- ^ Maps an 'i_baseNameCaseFold' to a map mapping the number of
+      -- extensions (in 'i_extensionsRev') to the maximum word at that
+      -- basename/level. For example, if a set would contain the identifiers:
+      --
+      --   [foo, foo_1, foo_2, bar_5, bar_7_8]
+      --
+      -- the map would look like:
+      --
+      --   [(foo, [(0, 0), (1, 2)]), (bar, [(1, 5), (2, 8)])]
+      --
+      -- This mapping makes sure we can quickly generate fresh identifiers. For
+      -- example, generating a new id for "foo_1" would be a matter of looking
+      -- up the base name in this map, concluding that the maximum identifier
+      -- with this basename and this number of extensions is "foo_2",
+      -- subsequently generating "foo_3".
+      --
+      -- Note that an identifier with no extensions is also stored in this map
+      -- for practical purposes, but the maximum ext is invalid.
+    , is_store :: !(HashSet Identifier)
+      -- ^ Identifier store
+    } deriving (Generic, NFData, Show)
+
+-- | HDL identifier. Consists of a base name and a number of extensions. An
+-- identifier with a base name of "foo" and a list of extensions [1, 2] will be
+-- rendered as "foo_1_2".
+--
+-- Note: The Eq instance of "Identifier" is case insensitive! E.g., two
+-- identifiers with base names 'fooBar' and 'FoObAR' are considered the same.
+-- However, identifiers are stored case preserving. This means Clash won't
+-- generate two identifiers with differing case, but it will try to keep
+-- capitalization.
+--
+-- The goal of this data structure is to greatly simplify how Clash deals with
+-- identifiers internally. Any Identifier should be trivially printable to any
+-- HDL.
+--
+-- __NB__: use the functions in Clash.Netlist.Id. Don't use these constructors
+-- directly.
+data Identifier
+  -- | Unparsed identifier. Used for things such as port names, which should
+  -- appear in the HDL exactly as the user specified.
+  = RawIdentifier
+      !Text
+      -- FIELD An identifier exactly as given by the user
+      (Maybe Identifier)
+      -- FIELD Parsed version of raw identifier. Will not be populated if this
+      -- identifier was created with an unsafe function.
+
+  -- | Parsed and sanitized identifier. See various fields for more information
+  -- on its invariants.
+  | UniqueIdentifier {
+      i_baseName :: !Text
+    -- ^ Base name of identifier. 'make' makes sure this field:
+    --
+    --    * does not end in '_num' where 'num' is a digit.
+    --    * is solely made up of printable ASCII characters
+    --    * has no leading or trailing whitespace
+    --
+    , i_baseNameCaseFold :: !Text
+    -- ^ Same as 'i_baseName', but can be used for equality testing that doesn't
+    -- depend on capitalization.
+    , i_extensionsRev :: [Word]
+    -- ^ Extensions applied to base identifier. E.g., an identifier with a base
+    -- name of 'foo' and an extension of [6, 5] would render as 'foo_5_6'. Note
+    -- that extensions are stored in reverse order for easier manipulation.
+    , i_idType :: !IdentifierType
+    -- ^ See "IdentifierType".
+    , i_hdl :: !HDL
+    -- ^ HDL this identifier is generated for.
+    } deriving (Show, Generic, NFData)
 
 -- | Environment of the NetlistMonad
 data NetlistEnv
   = NetlistEnv
-  { _prefixName  :: Identifier
+  { _prefixName  :: Text
   -- ^ Prefix for instance/register names
-  , _suffixName :: Identifier
+  , _suffixName :: Text
   -- ^ Postfix for instance/register names
-  , _setName     :: Maybe Identifier
+  , _setName :: Maybe Text
   -- ^ (Maybe) user given instance/register name
   }
 
@@ -106,9 +215,7 @@ data NetlistState
   = NetlistState
   { _bindings       :: BindingMap
   -- ^ Global binders
-  , _varCount       :: !Int
-  -- ^ Number of signal declarations
-  , _components     :: VarEnv ([Bool],SrcSpan,HashMap Identifier Word,Component)
+  , _components     :: VarEnv ([Bool],SrcSpan,IdentifierSet,Component)
   -- ^ Cached components
   , _primitives     :: CompiledPrimMap
   -- ^ Primitive Definitions
@@ -119,20 +226,38 @@ data NetlistState
   -- ^ TyCon cache
   , _curCompNm      :: !(Identifier,SrcSpan)
   , _intWidth       :: Int
-  , _mkIdentifierFn :: IdType -> Identifier -> Identifier
-  , _extendIdentifierFn :: IdType -> Identifier -> Identifier -> Identifier
-  , _seenIds        :: HashMap Identifier Word
-  , _seenComps      :: HashMap Identifier Word
+  , _seenIds        :: IdentifierSet
+  -- ^ All names currently in scope.
+  , _seenComps      :: IdentifierSet
+  -- ^ Components (to be) generated during this netlist run. This is always a
+  -- subset of 'seenIds'. Reason d'etre: we currently generate components in a
+  -- top down manner. E.g. given:
+  --
+  --   - A
+  --   -- B
+  --   -- C
+  --
+  -- we would generate component 'A' first. Before trying to generate 'B' and
+  -- 'C'. 'A' might introduce a number of signal declarations. The names of these
+  -- signals can't clash with the name of component 'B', hence we need to pick a
+  -- name for B unique w.r.t. all these signal names. If we would postpone
+  -- generating a unqiue name for 'B' til _after_ generating all the signal
+  -- names, the signal names would get all the "nice" names. E.g., a signal
+  -- would be called "foo", thereby forcing the component 'B' to be called
+  -- "foo_1". Ideally, we'd use the "nice" names for components, and the "ugly"
+  -- names for signals. To achieve this, we generate all the component names
+  -- up front and subsequently store them in '_seenComps'.
   , _seenPrimitives :: Set.Set Text
   -- ^ Keeps track of invocations of ´mkPrimitive´. It is currently used to
   -- filter duplicate warning invocations for dubious blackbox instantiations,
   -- see GitHub pull request #286.
   , _componentNames :: VarEnv Identifier
+  -- ^ Names of components (to be) generated during this netlist run. Includes
+  -- top entity names.
   , _topEntityAnns  :: VarEnv TopEntityT
   , _hdlDir         :: FilePath
   , _curBBlvl       :: Int
   -- ^ The current scoping level assigned to black box contexts
-  , _componentPrefix :: ComponentPrefix
   , _customReprs    :: CustomReprs
   , _clashOpts      :: ClashOpts
   -- ^ Settings Clash was called with
@@ -147,16 +272,15 @@ data NetlistState
 
 data ComponentPrefix
   = ComponentPrefix
-  { componentPrefixTop :: Maybe Identifier   -- ^ Prefix for top-level components
-  , componentPrefixOther :: Maybe Identifier -- ^ Prefix for all other components
+  { componentPrefixTop :: Maybe Text
+    -- ^ Prefix for top-level components
+  , componentPrefixOther :: Maybe Text
+    -- ^ Prefix for all other components
   } deriving Show
 
 -- | Existentially quantified backend
 data SomeBackend where
   SomeBackend :: Backend backend => backend -> SomeBackend
-
--- | Signal reference
-type Identifier = Text
 
 type Comment = Text
 
@@ -177,11 +301,11 @@ instance NFData Component where
 
 -- | Find the name and domain name of each clock argument of a component.
 --
-findClocks :: Component -> [(Identifier, Identifier)]
+findClocks :: Component -> [(Text, Text)]
 findClocks (Component _ is _ _) =
   mapMaybe isClock is
  where
-  isClock (i, Clock d) = Just (i, d)
+  isClock (i, Clock d) = Just (Id.toText i, d)
   isClock (i, Annotated _ t) = isClock (i,t)
   isClock _ = Nothing
 
@@ -223,33 +347,33 @@ data HWType
   -- ^ Vector type
   | RTree !Size !HWType
   -- ^ RTree type
-  | Sum !Identifier [Identifier]
+  | Sum !Text [Text]
   -- ^ Sum type: Name and Constructor names
-  | Product !Identifier (Maybe [Text]) [HWType]
+  | Product !Text (Maybe [Text]) [HWType]
   -- ^ Product type: Name, field names, and field types. Field names will be
   -- populated when using records.
-  | SP !Identifier [(Identifier,[HWType])]
+  | SP !Text [(Text, [HWType])]
   -- ^ Sum-of-Product type: Name and Constructor names + field types
-  | Clock !Identifier
+  | Clock !Text
   -- ^ Clock type corresponding to domain /Identifier/
-  | Reset !Identifier
+  | Reset !Text
   -- ^ Reset type corresponding to domain /Identifier/
-  | Enable !Identifier
+  | Enable !Text
   -- ^ Enable type corresponding to domain /Identifier/
   | BiDirectional !PortDirection !HWType
   -- ^ Tagging type indicating a bidirectional (inout) port
-  | CustomSP !Identifier !DataRepr' !Size [(ConstrRepr', Identifier, [HWType])]
+  | CustomSP !Text !DataRepr' !Size [(ConstrRepr', Text, [HWType])]
   -- ^ Same as Sum-Of-Product, but with a user specified bit representation. For
   -- more info, see: Clash.Annotations.BitRepresentations.
-  | CustomSum !Identifier !DataRepr' !Size [(ConstrRepr', Identifier)]
+  | CustomSum !Text !DataRepr' !Size [(ConstrRepr', Text)]
   -- ^ Same as Sum, but with a user specified bit representation. For more info,
   -- see: Clash.Annotations.BitRepresentations.
-  | CustomProduct !Identifier !DataRepr' !Size (Maybe [Text]) [(FieldAnn, HWType)]
+  | CustomProduct !Text !DataRepr' !Size (Maybe [Text]) [(FieldAnn, HWType)]
   -- ^ Same as Product, but with a user specified bit representation. For more
   -- info, see: Clash.Annotations.BitRepresentations.
   | Annotated [Attr'] !HWType
   -- ^ Annotated with HDL attributes
-  | KnownDomain !Identifier !Integer !ActiveEdge !ResetKind !InitBehavior !ResetPolarity
+  | KnownDomain !Text !Integer !ActiveEdge !ResetKind !InitBehavior !ResetPolarity
   -- ^ Domain name, period, active edge, reset kind, initial value behavior
   | FileType
   -- ^ File type for simulation-level I/O
@@ -300,7 +424,7 @@ data Declaration
       (Maybe Comment)            -- FIELD Note; will be inserted as a comment in target hdl
       WireOrReg                  -- FIELD Wire or register
       !Identifier                -- FIELD Name of signal
-      (Either Identifier HWType) -- FIELD Pointer to type of signal or type of signal
+      (Either Text HWType)       -- FIELD Pointer to type of signal or type of signal
       (Maybe Expr)               -- FIELD Initial value
       -- ^ Signal declaration
   | TickDecl Comment
@@ -383,7 +507,7 @@ data Expr
       [((Text,Text),BlackBox)] -- FIELD Intel/Quartus only: create a @.qsys@ file from given template.
       !BlackBox                -- FIELD Template tokens
       !BlackBoxContext         -- FIELD Context in which tokens should be rendered
-      !Bool                    -- FIELD Wrap in paretheses?
+      !Bool                    -- FIELD Wrap in parentheses?
   | ConvBV     (Maybe Identifier) HWType Bool Expr
   | IfThenElse Expr Expr Expr
   -- | Do nothing
@@ -442,14 +566,14 @@ data BlackBoxContext
   --   , Whether the result should be /reg/ or a /wire/ (Verilog only)
   --   , Partial Blackbox Context
   --   )
-  , bbQsysIncName :: [Identifier]
+  , bbQsysIncName :: [Text]
   , bbLevel :: Int
   -- ^ The scoping level this context is associated with, ensures that
   -- @~ARGN[k][n]@ holes are only filled with values from this context if @k@
   -- is equal to the scoping level of this context.
   , bbCompName :: Identifier
   -- ^ The component the BlackBox is instantiated in
-  , bbCtxName :: Maybe Identifier
+  , bbCtxName :: Maybe Text
   -- ^ The "context name", name set by `Clash.Magic.setName`, defaults to the
   -- name of the closest binder
   }
@@ -466,8 +590,12 @@ data BlackBox
 data TemplateFunction where
   TemplateFunction
     :: [Int]
+    -- FIELD Used arguments
     -> (BlackBoxContext -> Bool)
+    -- FIELD Validation function. Should return 'False' if function can't render
+    -- given a certain context.
     -> (forall s . Backend s => BlackBoxContext -> Lazy.State s Doc)
+    -- FIELD Render function
     -> TemplateFunction
 
 instance Show BlackBox where
@@ -549,17 +677,53 @@ data DeclarationType
   | Sequential
 
 emptyBBContext :: Text -> BlackBoxContext
-emptyBBContext n
+emptyBBContext name
   = Context
-  { bbName        = n
+  { bbName        = name
   , bbResults     = []
   , bbInputs      = []
   , bbFunctions   = empty
   , bbQsysIncName = []
   , bbLevel       = (-1)
-  , bbCompName    = pack "__NOCOMPNAME__"
+  , bbCompName    = UniqueIdentifier "__NOCOMPNAME__" "__NOCOMPNAME__" [] Basic VHDL
   , bbCtxName     = Nothing
   }
 
 makeLenses ''NetlistEnv
 makeLenses ''NetlistState
+
+-- | Structures that hold an 'IdentifierSet'
+class HasIdentifierSet s where
+  identifierSet :: Lens' s IdentifierSet
+
+instance HasIdentifierSet IdentifierSet where
+  identifierSet = ($)
+
+-- | An "IdentifierSetMonad" supports unique name generation for Clash Netlist
+class Monad m => IdentifierSetMonad m where
+  identifierSetM :: (IdentifierSet -> IdentifierSet) -> m IdentifierSet
+
+instance IdentifierSetMonad NetlistMonad where
+  identifierSetM f = do
+    is0 <- Lens.use seenIds
+    let is1 = f is0
+    seenIds .= is1
+    pure is1
+  {-# INLINE identifierSetM #-}
+
+instance HasIdentifierSet s => IdentifierSetMonad (Strict.State s) where
+  identifierSetM f = do
+    is0 <- Lens.use identifierSet
+    identifierSet .= f is0
+    Lens.use identifierSet
+  {-# INLINE identifierSetM #-}
+
+instance HasIdentifierSet s => IdentifierSetMonad (Lazy.State s) where
+  identifierSetM f = do
+    is0 <- Lens.use identifierSet
+    identifierSet .= f is0
+    Lens.use identifierSet
+  {-# INLINE identifierSetM #-}
+
+instance IdentifierSetMonad m => IdentifierSetMonad (Mon m) where
+  identifierSetM = Mon . identifierSetM

--- a/clash-lib/src/Clash/Netlist/Types.hs-boot
+++ b/clash-lib/src/Clash/Netlist/Types.hs-boot
@@ -9,6 +9,7 @@
 module Clash.Netlist.Types where
 
 import Control.Lens (Lens')
+import Data.Hashable
 
 data IdentifierType
 data Identifier
@@ -27,3 +28,5 @@ class HasIdentifierSet s where
 
 type role NetlistMonad nominal
 data NetlistMonad a
+data PreserveCase = PreserveCase | ToLower
+instance Hashable PreserveCase

--- a/clash-lib/src/Clash/Netlist/Types.hs-boot
+++ b/clash-lib/src/Clash/Netlist/Types.hs-boot
@@ -8,15 +8,22 @@
 
 module Clash.Netlist.Types where
 
-import Data.Text (Text)
+import Control.Lens (Lens')
 
-type Identifier = Text
-
+data IdentifierType
+data Identifier
+data IdentifierSet
 data HWType
 data Declaration
 data Component
 data Expr
 data BlackBox
+
+class Monad m => IdentifierSetMonad m where
+  identifierSetM :: (IdentifierSet -> IdentifierSet) -> m IdentifierSet
+
+class HasIdentifierSet s where
+  identifierSet :: Lens' s IdentifierSet
 
 type role NetlistMonad nominal
 data NetlistMonad a

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -112,6 +112,23 @@ hmFindWithDefault = HashMap.findWithDefault
 hmFindWithDefault = HashMap.lookupDefault
 #endif
 
+-- | Generate a simple port_name expression. See:
+--
+--   https://www.hdlworks.com/hdl_corner/vhdl_ref/VHDLContents/PortMap.htm
+--
+-- This function will simply make the left part of a single port map, e.g. "Rst"
+-- in:
+--
+--  Rst => Reset
+--
+-- If you need more complex constructions, e.g.
+--
+--  Q(3 downto 1)
+--
+-- you can build an Expr manually.
+instPort :: Text -> Expr
+instPort pn = Identifier (Id.unsafeMake pn) Nothing
+
 -- | Throw away information indicating which constructor fields were filtered
 -- due to being void.
 stripFiltered :: FilteredHWType -> HWType

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -1233,8 +1233,8 @@ mkOutput epp@(ExpandedPortProduct p hwty ps) = do
     Assignment i (Identifier p_ (Just (Indexed (hwty_, con, n))))
 
 mkTopCompDecl
-  :: Maybe Comment
-  -- ^ Comment to add to the generated code
+  :: Maybe Text
+  -- ^ Library entity is defined in
   -> [Attr']
   -- ^ Attributes to add to generate code
   -> Identifier
@@ -1248,8 +1248,8 @@ mkTopCompDecl
   -> [(Identifier, Identifier, HWType)]
   -- ^ Output port assignments
   -> Declaration
-mkTopCompDecl comment attrs name instName params inputs outputs =
-  InstDecl Entity comment attrs name instName params ports
+mkTopCompDecl lib attrs name instName params inputs outputs =
+  InstDecl Entity lib attrs name instName params ports
  where
   ports = map (toPort In) inputs ++ map (toPort Out) outputs
   toExpr id_ = Identifier id_ Nothing

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -1582,7 +1582,7 @@ throwAnnotatedSplitError loc typ = do
 mkTopOutput
   :: Maybe Identifier
   -- ^ (maybe) Name of the _TopEntity_
-  -> [(Identifier, Text)]
+  -> [(Identifier, IdentifierText)]
   -- ^ /Rendered/ output port names and types
   -> Maybe PortName
   -- ^ (maybe) The @PortName@ of a _TopEntity_ annotation for this output
@@ -1604,7 +1604,7 @@ mkTopOutput'
   :: HasCallStack
   => Maybe Identifier
   -- ^ (maybe) Name of the _TopEntity_
-  -> [(Identifier, Text)]
+  -> [(Identifier, IdentifierText)]
   -- ^ /Rendered/ output port names and types
   -> Maybe PortName
   -- ^ (maybe) The @PortName@ of a _TopEntity_ annotation for this output
@@ -1622,7 +1622,7 @@ mkTopOutput' topM outps pM = case pM of
     -- No @PortName@
     go
       :: HasCallStack
-      => [(Identifier, Text)]
+      => [(Identifier, IdentifierText)]
       -> (Identifier, HWType)
       -> NetlistMonad ( [(Identifier, Text)]
                       , ( [(Identifier,Identifier,HWType)]
@@ -1674,9 +1674,9 @@ mkTopOutput' topM outps pM = case pM of
     -- With a @PortName@
     go'
       :: PortName
-      -> [(Identifier, Text)]
+      -> [(Identifier, IdentifierText)]
       -> (Identifier, HWType)
-      -> NetlistMonad ( [(Identifier, Text)]
+      -> NetlistMonad ( [(Identifier, IdentifierText)]
                       , ( [(Identifier,Identifier,HWType)]
                         , [Declaration]
                         , Either Identifier (Identifier,HWType)

--- a/clash-lib/src/Clash/Primitives/GHC/Int.hs
+++ b/clash-lib/src/Clash/Primitives/GHC/Int.hs
@@ -51,10 +51,10 @@ intTF' False [Left (Literal (getIntLit -> Just n))] intSize =
 intTF' True [Left (Literal (getIntLit -> Just n))] intSize =
   -- Literal as declaration:
   ( emptyBlackBoxMeta
-  , BBTemplate (assign (Result False) [signedLiteral intSize n]))
+  , BBTemplate (assign Result [signedLiteral intSize n]))
 
 intTF' _isDecl _args _intSize =
   -- Not a literal. We need an assignment as Verilog does not support truncating
   -- arbitrary expression.
   ( emptyBlackBoxMeta {bbKind = TDecl }
-  , BBTemplate (assign (Result False) (signed (Arg False 0))))
+  , BBTemplate (assign Result (signed (Arg 0))))

--- a/clash-lib/src/Clash/Primitives/GHC/Word.hs
+++ b/clash-lib/src/Clash/Primitives/GHC/Word.hs
@@ -40,10 +40,10 @@ wordTF' False [Left (Literal (WordLiteral n))] wordSize =
 wordTF' True [Left (Literal (WordLiteral n))] wordSize =
   -- Literal as declaration:
   ( emptyBlackBoxMeta
-  , BBTemplate (assign (Result False) [unsignedLiteral wordSize n]))
+  , BBTemplate (assign Result [unsignedLiteral wordSize n]))
 
 wordTF' _isDecl _args _wordSize =
   -- Not a literal. We need an assignment as Verilog does not support truncating
   -- arbitrary expression.
   ( emptyBlackBoxMeta {bbKind = TDecl }
-  , BBTemplate (assign (Result False) (unsigned (Arg False 0))))
+  , BBTemplate (assign Result (unsigned (Arg 0))))

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -86,17 +86,17 @@ alteraPllTemplate bbCtx = do
   -- TODO: bbQsysIncName into account when generating fresh ids
  let compName = Id.unsafeMake (head (bbQsysIncName bbCtx))
 
- let outclkPorts = map (\n -> toPort ("outclk_" <> showt n)) [(0 :: Int)..length clocks-1]
+ let outclkPorts = map (\n -> instPort ("outclk_" <> showt n)) [(0 :: Int)..length clocks-1]
 
  getMon $ blockDecl alteraPll $ concat
   [[ NetDecl Nothing locked  rstTy
    , NetDecl' Nothing Reg pllLock (Right Bool) Nothing]
   ,[ NetDecl Nothing clkNm ty | (clkNm,ty) <- zip clocks tys]
   ,[ InstDecl Comp Nothing [] compName alteraPll_inst [] $ concat
-      [ [ (toPort "refclk", In, clkTy, clk)
-        , (toPort "rst", In, rstTy, rst)]
+      [ [ (instPort "refclk", In, clkTy, clk)
+        , (instPort "rst", In, rstTy, rst)]
       , [ (p, Out, ty, Identifier k Nothing) | (k, ty, p) <- zip3 clocks tys outclkPorts ]
-      , [(toPort "locked", Out, rstTy, Identifier locked Nothing)]]
+      , [(instPort "locked", Out, rstTy, Identifier locked Nothing)]]
    , CondAssignment pllLock Bool (Identifier locked Nothing) rstTy
       [(Just (BitLit H),Literal Nothing (BoolLit True))
       ,(Nothing        ,Literal Nothing (BoolLit False))]
@@ -111,9 +111,6 @@ alteraPllTemplate bbCtx = do
   [(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = drop 3 (bbInputs bbCtx)
   Just nm' = exprToString nm
   instname0 = TextS.pack nm'
-
-  -- unsafeMake is safe here: it's just port names predefined by the PLL IP
-  toPort p = Identifier (Id.unsafeMake p) Nothing
 
 altpllTemplate
   :: Backend s
@@ -135,10 +132,10 @@ altpllTemplate bbCtx = do
   , NetDecl' Nothing Reg pllLock (Right Bool) Nothing
   , NetDecl Nothing pllOut clkOutTy
   , InstDecl Comp Nothing [] compName alteraPll_inst []
-      [ (toPort "clk", In, clkTy, clk)
-      , (toPort "areset", In, rstTy, rst)
-      , (toPort "c0", Out, clkOutTy, Identifier pllOut Nothing)
-      , (toPort "locked", Out, Bit, Identifier locked Nothing)]
+      [ (instPort "clk", In, clkTy, clk)
+      , (instPort "areset", In, rstTy, rst)
+      , (instPort "c0", Out, clkOutTy, Identifier pllOut Nothing)
+      , (instPort "locked", Out, Bit, Identifier locked Nothing)]
   , CondAssignment pllLock Bool (Identifier locked Nothing) rstTy
       [(Just (BitLit H),Literal Nothing (BoolLit True))
       ,(Nothing        ,Literal Nothing (BoolLit False))]
@@ -152,10 +149,6 @@ altpllTemplate bbCtx = do
   [(Identifier result Nothing,resTy@(Product _ _ [clkOutTy,_]))] = bbResults bbCtx
   Just nm' = exprToString nm
   instname0 = TextS.pack nm'
-
-  -- unsafeMake is safe here: it's just port names predefined by the PLL IP
-  toPort p = Identifier (Id.unsafeMake p) Nothing
-
 
 altpllQsysTemplate
   :: Backend s

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -14,15 +14,16 @@ module Clash.Primitives.Intel.ClockGen where
 
 import Clash.Backend
 import Clash.Netlist.BlackBox.Util
-import Clash.Netlist.Id
+import qualified Clash.Netlist.Id as Id
 import Clash.Netlist.Types
-import Clash.Netlist.Util hiding (mkUniqueIdentifier)
+import Clash.Netlist.Util
 
 import Control.Monad.State
 
 import Data.Semigroup.Monad
 import qualified Data.String.Interpolate.IsString as I
 import Data.Text.Prettyprint.Doc.Extra
+import TextShow (showt)
 
 import qualified Data.Text as TextS
 
@@ -69,28 +70,33 @@ alteraPllQsysTF = TemplateFunction used valid alteraPllQsysTemplate
   valid _ = False
 
 alteraPllTemplate
-  :: Backend s
+  :: forall s
+   . Backend s
   => BlackBoxContext
   -> State s Doc
 alteraPllTemplate bbCtx = do
- let mkId = mkUniqueIdentifier Basic
- locked <- mkId "locked"
- pllLock <- mkId "pllLock"
- alteraPll <- mkId "altera_pll_block"
- alteraPll_inst <- mkId instname0
+ locked <- Id.makeBasic "locked"
+ pllLock <- Id.makeBasic "pllLock"
+ alteraPll <- Id.makeBasic "altera_pll_block"
+ alteraPll_inst <- Id.makeBasic instname0
 
- clocks <- traverse (mkUniqueIdentifier Extended)
-                    [TextS.pack ("pllOut" ++ show n) | n <- [0..length tys - 1]]
+ clocks <- Id.nextN (length tys - 1) =<< Id.make "pllOut"
+
+  -- TODO: unsafeMake is dubious here: I don't think we take names in
+  -- TODO: bbQsysIncName into account when generating fresh ids
+ let compName = Id.unsafeMake (head (bbQsysIncName bbCtx))
+
+ let outclkPorts = map (\n -> toPort ("outclk_" <> showt n)) [(0 :: Int)..length clocks-1]
+
  getMon $ blockDecl alteraPll $ concat
   [[ NetDecl Nothing locked  rstTy
    , NetDecl' Nothing Reg pllLock (Right Bool) Nothing]
   ,[ NetDecl Nothing clkNm ty | (clkNm,ty) <- zip clocks tys]
   ,[ InstDecl Comp Nothing [] compName alteraPll_inst [] $ concat
-      [[(Identifier "refclk" Nothing,In,clkTy,clk)
-       ,(Identifier "rst" Nothing,In,rstTy,rst)]
-      ,[(Identifier (TextS.pack ("outclk_" ++ show n)) Nothing,Out,ty,Identifier k Nothing)
-       |(k,ty,n) <- zip3 clocks tys [(0 :: Int)..]  ]
-      ,[(Identifier "locked" Nothing,Out,rstTy,Identifier locked Nothing)]]
+      [ [ (toPort "refclk", In, clkTy, clk)
+        , (toPort "rst", In, rstTy, rst)]
+      , [ (p, Out, ty, Identifier k Nothing) | (k, ty, p) <- zip3 clocks tys outclkPorts ]
+      , [(toPort "locked", Out, rstTy, Identifier locked Nothing)]]
    , CondAssignment pllLock Bool (Identifier locked Nothing) rstTy
       [(Just (BitLit H),Literal Nothing (BoolLit True))
       ,(Nothing        ,Literal Nothing (BoolLit False))]
@@ -105,28 +111,34 @@ alteraPllTemplate bbCtx = do
   [(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = drop 3 (bbInputs bbCtx)
   Just nm' = exprToString nm
   instname0 = TextS.pack nm'
-  compName = head (bbQsysIncName bbCtx)
+
+  -- unsafeMake is safe here: it's just port names predefined by the PLL IP
+  toPort p = Identifier (Id.unsafeMake p) Nothing
 
 altpllTemplate
   :: Backend s
   => BlackBoxContext
   -> State s Doc
 altpllTemplate bbCtx = do
- let mkId = mkUniqueIdentifier Basic
- pllOut <- mkId "pllOut"
- locked <- mkId "locked"
- pllLock <- mkId "pllLock"
- alteraPll <- mkId "altpll_block"
- alteraPll_inst <- mkId instname0
+ pllOut <- Id.make "pllOut"
+ locked <- Id.make "locked"
+ pllLock <- Id.make "pllLock"
+ alteraPll <- Id.make "altpll_block"
+ alteraPll_inst <- Id.make instname0
+
+ -- TODO: unsafeMake is dubious here: I don't think we take names in
+ -- TODO: bbQsysIncName into account when generating fresh ids
+ let compName = Id.unsafeMake (head (bbQsysIncName bbCtx))
+
  getMon $ blockDecl alteraPll
   [ NetDecl Nothing locked  Bit
   , NetDecl' Nothing Reg pllLock (Right Bool) Nothing
   , NetDecl Nothing pllOut clkOutTy
   , InstDecl Comp Nothing [] compName alteraPll_inst []
-      [(Identifier "clk" Nothing,In,clkTy,clk)
-      ,(Identifier "areset" Nothing,In,rstTy,rst)
-      ,(Identifier "c0" Nothing,Out,clkOutTy,Identifier pllOut Nothing)
-      ,(Identifier "locked" Nothing,Out,Bit,Identifier locked Nothing)]
+      [ (toPort "clk", In, clkTy, clk)
+      , (toPort "areset", In, rstTy, rst)
+      , (toPort "c0", Out, clkOutTy, Identifier pllOut Nothing)
+      , (toPort "locked", Out, Bit, Identifier locked Nothing)]
   , CondAssignment pllLock Bool (Identifier locked Nothing) rstTy
       [(Just (BitLit H),Literal Nothing (BoolLit True))
       ,(Nothing        ,Literal Nothing (BoolLit False))]
@@ -140,7 +152,9 @@ altpllTemplate bbCtx = do
   [(Identifier result Nothing,resTy@(Product _ _ [clkOutTy,_]))] = bbResults bbCtx
   Just nm' = exprToString nm
   instname0 = TextS.pack nm'
-  compName = head (bbQsysIncName bbCtx)
+
+  -- unsafeMake is safe here: it's just port names predefined by the PLL IP
+  toPort p = Identifier (Id.unsafeMake p) Nothing
 
 
 altpllQsysTemplate

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -12,6 +12,7 @@
 
 module Clash.Primitives.Sized.Vector where
 
+import           Control.Monad                      (replicateM)
 import           Control.Monad.State                (State, zipWithM)
 import qualified Control.Lens                       as Lens
 import           Data.Either                        (rights)
@@ -19,8 +20,6 @@ import qualified Data.IntMap                        as IntMap
 import           Data.List.Extra                    (iterateNM)
 import           Data.Maybe                         (fromMaybe)
 import           Data.Semigroup.Monad               (getMon)
-import qualified Data.Text                          as Text
-import qualified Data.Text.Lazy                     as LText
 import           Data.Text.Lazy                     (pack)
 import           Data.Text.Prettyprint.Doc.Extra
   (Doc, string, renderLazy, layoutPretty, LayoutOptions(..),
@@ -28,9 +27,10 @@ import           Data.Text.Prettyprint.Doc.Extra
 import           Text.Trifecta.Result               (Result(Success))
 import qualified Data.String.Interpolate            as I
 import qualified Data.String.Interpolate.Util       as I
+import           TextShow                           (showt)
 
 import           Clash.Backend
-  (Backend, hdlTypeErrValue, expr, mkUniqueIdentifier, blockDecl)
+  (Backend, hdlTypeErrValue, expr, blockDecl)
 import           Clash.Core.Type
   (Type(LitTy), LitTy(NumTy), coreView)
 import           Clash.Netlist.BlackBox             (isLiteral)
@@ -45,7 +45,7 @@ import           Clash.Netlist.Types
    BlackBox(BBTemplate, BBFunction), TemplateFunction(..), WireOrReg(Wire),
    Modifier(Indexed, Nested), bbInputs, bbResults, emptyBBContext, tcCache,
    bbFunctions)
-import           Clash.Netlist.Id                   (IdType(Basic))
+import qualified Clash.Netlist.Id                   as Id
 import           Clash.Netlist.Util                 (typeSize)
 import qualified Clash.Primitives.DSL               as Prim
 import           Clash.Primitives.DSL
@@ -136,9 +136,10 @@ foldTF = TemplateFunction [] (const True) foldTF'
 foldTF' :: forall s . (HasCallStack, Backend s) => BlackBoxContext -> State s Doc
 foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
   -- Create an id for every element in the vector
-  vecIds <- mapM (\i -> mkId ("acc_0_" <> show i)) [0..n-1]
+  baseId <- Id.make "acc_0"
+  vecIds <- replicateM n (Id.next baseId)
 
-  vecId <- mkId "vec"
+  vecId <- Id.make "vec"
   let vecDecl = sigDecl vecType Wire vecId
       vecAssign = Assignment vecId vec
       elemAssigns = zipWith Assignment vecIds (map (iIndex vecId) [0..])
@@ -160,7 +161,7 @@ foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
       resultAssign = Assignment resultId (Identifier result Nothing)
 
   callDecls <- zipWithM callDecl [0..] fCalls
-  foldNm <- mkId "fold"
+  foldNm <- Id.make "fold"
 
   getMon $ blockDecl foldNm $
     resultAssign :
@@ -171,9 +172,6 @@ foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
     callDecls
 
  where
-  mkId :: String -> State s Identifier
-  mkId = mkUniqueIdentifier Basic . Text.pack
-
   callDecl :: Int -> FCall -> State s Declaration
   callDecl fSubPos (FCall a b r) = do
     rendered0 <- string =<< (renderElem bbCtx call <*> pure 0)
@@ -189,9 +187,9 @@ foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
    where
     call  = Component (Decl fPos fSubPos (resEl:aEl:[bEl]))
     elTyp = [TypElem (Typ (Just vecPos))]
-    resEl = ([Text (LText.fromStrict r)], elTyp)
-    aEl   = ([Text (LText.fromStrict a)], elTyp)
-    bEl   = ([Text (LText.fromStrict b)], elTyp)
+    resEl = ([Text (Id.toLazyText r)], elTyp)
+    aEl   = ([Text (Id.toLazyText a)], elTyp)
+    bEl   = ([Text (Id.toLazyText b)], elTyp)
 
   -- Argument no. of function
   fPos = 0
@@ -222,7 +220,7 @@ foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
     -> [Identifier]
     -> State s ([FCall], [Identifier])
   mkLevel (!lvl, !offset) (a:b:rest) = do
-    c <- mkId ("acc_" <> show lvl <> "_" <> show offset)
+    c <- Id.makeBasic ("acc_" <> showt lvl <> "_" <> showt offset)
     (calls, results) <- mkLevel (lvl, offset+1) rest
     pure (FCall a b c:calls, c:results)
   mkLevel _lvl rest =

--- a/clash-lib/src/Control/Applicative/Extra.hs
+++ b/clash-lib/src/Control/Applicative/Extra.hs
@@ -1,0 +1,18 @@
+{-|
+  Copyright   :  (C) 2020, QBayLogic B.V.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+module Control.Applicative.Extra
+  ( orEmpty
+  , emptyIf
+  ) where
+
+import Control.Applicative (Alternative, empty)
+
+orEmpty :: Alternative f => Bool -> a -> f a
+orEmpty b a = if b then pure a else empty
+
+emptyIf :: Alternative f => a -> Bool -> f a
+emptyIf a b = if b then empty else pure a

--- a/clash-lib/tests/Clash/Tests/Netlist/Id.hs
+++ b/clash-lib/tests/Clash/Tests/Netlist/Id.hs
@@ -1,0 +1,213 @@
+{-|
+Copyright  :  (C) 2019, QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MagicHash #-}
+
+module Clash.Tests.Netlist.Id (
+    module Clash.Tests.Netlist.Id
+  ) where
+
+import qualified Clash.Netlist.Types as Id
+import qualified Clash.Netlist.Id as Id
+
+import Clash.Annotations.Primitive
+import Control.Monad.Trans.State.Lazy
+import qualified Data.ByteString as BS
+import Data.Coerce
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+import qualified Data.Text as Text
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import Test.QuickCheck.Utf8
+
+newtype NonEmptyText = NonEmptyText Text deriving (Show)
+newtype ArbitraryText = ArbitraryText Text deriving (Show)
+newtype ArbitraryAsciiText = ArbitraryAsciiText Text deriving (Show)
+
+instance Arbitrary ArbitraryAsciiText where
+  arbitrary = coerce (decodeUtf8 . BS.concat <$> listOf oneByte)
+  shrink = coerce shrinkValidUtf8
+
+instance Arbitrary ArbitraryText where
+  arbitrary = coerce genValidUtf8
+  shrink = coerce shrinkValidUtf8
+
+instance Arbitrary NonEmptyText where
+  arbitrary = coerce genValidUtf81
+  shrink = coerce shrinkValidUtf81
+
+eval :: Bool -> HDL -> State Id.IdentifierSet a -> a
+eval esc hdl a = evalState a (Id.emptyIdentifierSet esc hdl)
+
+eval' :: State Id.IdentifierSet a -> a
+eval' = eval True VHDL
+
+roundTrip :: Bool -> HDL -> Text -> Text
+roundTrip esc hdl = Id.toText . eval esc hdl . Id.make
+
+roundTrip' :: Text -> Text
+roundTrip' = roundTrip True VHDL
+
+roundTripTest :: Text -> TestTree
+roundTripTest t =
+  testCase (Text.unpack ("roundTrip: " <> t)) (t @=? roundTrip' t)
+
+-- | Raw identifiers should always come up the same after 'Id.toText'
+rawToIdProperty :: NonEmptyText -> Property
+rawToIdProperty t = coerce t === Id.toText (eval' (Id.addRaw (coerce t)))
+
+xor :: Bool -> Bool -> Bool
+xor True True = False
+xor True False = True
+xor False True = True
+xor False False = False
+
+tests :: TestTree
+tests =
+  testGroup
+    "Clash.Tests.Netlist.Id"
+    [ testCase "roundTrip: empty id" ("clash_internal" @=? roundTrip' "")
+
+    -- Round trip tests tess whether a "make -> to text" roundtrip ~ id
+    , roundTripTest "foo_bar"
+    , roundTripTest "foo_1"
+    , roundTripTest "foo_1_2"
+    , roundTripTest "foo_1_2_ab"
+    , roundTripTest "foo_1_ab_2"
+
+    , testGroup "no collisions (one id)" $ flip map [minBound..maxBound] $ \hdl ->
+        testProperty (show hdl) $ \id0 -> eval True hdl $ do
+          id0t <- Id.toText <$> Id.make (coerce @ArbitraryAsciiText id0)
+          id1t <- Id.toText <$> Id.make (coerce @ArbitraryAsciiText id0)
+          pure (id0t /= id1t)
+
+    , testGroup "no collisions (two ids)" $ flip map [minBound..maxBound] $ \hdl ->
+        testProperty (show hdl) $ \id0 id1 -> eval True hdl $ do
+          id0t <- Id.toText <$> Id.make (coerce @ArbitraryAsciiText id0)
+          id1t <- Id.toText <$> Id.make (coerce @ArbitraryAsciiText id1)
+          pure (id0t /= id1t)
+
+    , testGroup "make0" $ eval' $ do
+        id0 <- Id.toText <$> Id.make "foo"
+        id1 <- Id.toText <$> Id.make "foo"
+        id2 <- Id.toText <$> Id.make "foo_0"
+        id3 <- Id.toText <$> Id.make "foo"
+        id4 <- Id.toText <$> Id.make "foo_0"
+        pure [ testCase "id0 == foo"     $ id0 @?= "foo"
+             , testCase "id1 == foo_0"   $ id1 @?= "foo_0"
+             , testCase "id2 == foo_0_0" $ id2 @?= "foo_0_0"
+             , testCase "id3 == foo_0_1" $ id3 @?= "foo_1"
+             , testCase "id4 == foo_0_0" $ id4 @?= "foo_0_1"
+             ]
+
+    , testGroup "make1" $ eval' $ do
+        id0 <- Id.toText <$> Id.make "foo"
+        id1 <- Id.toText <$> Id.make "foo_37"
+        id2 <- Id.toText <$> Id.make "foo"
+        id3 <- Id.toText <$> Id.make "foo_3"
+        pure [ testCase "id0 == foo"    $ id0 @?= "foo"
+             , testCase "id1 == foo_37" $ id1 @?= "foo_37"
+             , testCase "id2 == foo_38" $ id2 @?= "foo_38"
+             , testCase "id3 == foo_3"  $ id3 @?= "foo_3"
+             ]
+
+    -- Some tools/hdls are case insensitive, so we should make sure we are too
+    , testGroup "case sensitivity" $ eval' $ do
+        id0 <- Id.toText <$> Id.make "foobar"
+        id1 <- Id.toText <$> Id.make "fOoBAr"
+        pure [ testCase "id0 == foobar"   $ id0 @?= "foobar"
+             , testCase "id1 == fOoBAr_0" $ id1 @?= "fOoBAr_0"
+             ]
+
+    -- An identifier made with 'mkBasic' should pass the 'isBasic' test
+    , testGroup "mkBasic" $ concat $ flip map [minBound..maxBound] $ \hdl ->
+      [ testProperty (show hdl <> " (ascii)")
+          (Id.isBasic# hdl . roundTrip False hdl . coerce @ArbitraryAsciiText)
+      , testProperty (show hdl <> " (UTF8)")
+          (Id.isBasic# hdl . roundTrip False hdl . coerce @ArbitraryText)
+      ]
+
+      -- We expect a processed identifier to be either a valid basic xor
+      -- extended identifier. Anything "in between" is an error.
+    , testGroup "Basic XOR Extended" $ flip map [minBound..maxBound] $ \hdl ->
+        testProperty (show hdl) $ \id0 ->
+          let id1 = roundTrip True hdl (coerce @ArbitraryText id0) in
+          Id.isBasic# hdl id1 `xor` Id.isExtended# hdl id1
+
+    , testCase "keyword (use => \\use\\)" ("\\use\\" @=? roundTrip' "use")
+    , testCase "keyword (else => \\else\\)" ("\\else\\" @=? roundTrip' "else")
+    , testCase "keyword (record => \\record\\)" ("\\record\\" @=? roundTrip' "record")
+    , testCase "keyword (configuration => \\configuration\\)" ("\\configuration\\" @=? roundTrip' "configuration")
+    , testCase "keyword (cOnFiGUrAtiON => \\cOnFiGUrAtiON\\)" ("\\cOnFiGUrAtiON\\" @=? roundTrip' "cOnFiGUrAtiON")
+    , testCase "Verilog keyword in VHDL (always => always)" ("always" @=? roundTrip' "always")
+
+    , testGroup "extended identifiers"
+      [ testCase "(1) foo bar => \\foo bar\\" $ "\\foo bar\\" @=? roundTrip' "foo bar"
+      , testCase "(2) foo bar => \\foo bar\\" $ 9 @=? Text.length (roundTrip' "foo bar")
+
+      , testCase "foo\\bar => foobar" $ "foobar" @=? roundTrip' "foo\\bar"
+      , testCase "\\foobar\\ => foobar" $ "foobar" @=? roundTrip' "\\foobar\\"
+
+      -- This behavior makes sense, but it results in ugly identifiers, so
+      -- backslashes are stripped
+      -- , testCase "foo\\bar => \\foo\\\\bar\\" $ "\\foo\\\\bar\\" @=? roundTrip' "foo\\bar"
+      -- , testCase "\\foobar\\ => \\\\\\foobar\\\\\\" $ "\\\\\\foobar\\\\\\" @=? roundTrip' "\\foobar\\"
+      ]
+
+    , testGroup "pretty names"
+      [ testCase "(# #) => Unit" $ "Unit" @=? roundTrip' "(# #)"
+      , testCase "() => Unit" $ "Unit" @=? roundTrip' "()"
+      , testCase "(,,) => Tup3" $ "Tup3" @=? roundTrip' "(,,)"
+      , testCase "(#,,,,#) => Tup5" $ "Tup5" @=? roundTrip' "(,,,,)"
+      ]
+
+    , testGroup "pretty names (force basic)"
+      [ testCase "(# #) => Unit" $ "Unit" @=? roundTrip False VHDL "(# #)"
+      , testCase "() => Unit" $ "Unit" @=? roundTrip False VHDL "()"
+      , testCase "(,,) => Tup3" $ "Tup3" @=? roundTrip False VHDL "(,,)"
+      , testCase "(#,,,,#) => Tup5" $ "Tup5" @=? roundTrip False VHDL "(,,,,)"
+      ]
+
+    , testGroup "disallow escaped identifiers"
+      [ testCase "foo bar => foobar" $ "foobar" @=? roundTrip False VHDL "foo bar"
+      , testCase "foo\\bar => foobar" $ "foobar" @=? roundTrip False VHDL "foo\\bar"
+      ]
+
+      -- Raw identifiers are a bit weird: they're passed in by users and should
+      -- be spliced into the HDL at verbatim. Clash shouldn't generate collisions
+      -- though.
+    , testGroup "raw identifiers"
+      [ testProperty "id" rawToIdProperty
+      , testGroup "Verilog: \\foo bar␣" $ eval True Verilog $ do
+          id0 <- Id.toText <$> Id.addRaw "\\foo bar "
+          id1 <- Id.toText <$> Id.make "foo bar"
+          pure [ testCase "id0 == \\foo bar " $ id0 @?= "\\foo bar "
+               , testCase "id1 == \\foo bar_0 " $ id1 @?= "\\foo bar_0 "
+               ]
+      , testGroup "Verilog: \\foo bar␣␣" $ eval True Verilog $ do
+          id0 <- Id.toText <$> Id.addRaw "\\foo bar  "
+          id1 <- Id.toText <$> Id.make "foo bar"
+          pure [ testCase "id0 == \\foo bar  " $ id0 @?= "\\foo bar  "
+               , testCase "id1 == \\foo bar_0 " $ id1 @?= "\\foo bar_0 "
+               ]
+      , testGroup "VHDL: \\foo bar\\" $ eval True VHDL $ do
+          id0 <- Id.toText <$> Id.addRaw "\\foo bar\\"
+          id1 <- Id.toText <$> Id.make "foo bar"
+          pure [ testCase "id0 == \\foo bar\\" $ id0 @?= "\\foo bar\\"
+               , testCase "id1 == \\foo bar_0\\ " $ id1 @?= "\\foo bar_0\\"
+               ]
+      , testGroup "VHDL: \\foo bar \\" $ eval True VHDL $ do
+          id0 <- Id.toText <$> Id.addRaw "\\foo bar \\"
+          id1 <- Id.toText <$> Id.make "foo bar"
+          -- While 'id1' could strictly be \foo bar\, it's probably best to be
+          -- whitespace insensitive.
+          pure [ testCase "id0 == \\foo bar \\" $ id0 @?= "\\foo bar \\"
+               , testCase "id1 == \\foo bar_0\\ " $ id1 @?= "\\foo bar_0\\"
+               ]
+      ]
+    ]

--- a/clash-lib/tests/Clash/Tests/Netlist/Id.hs
+++ b/clash-lib/tests/Clash/Tests/Netlist/Id.hs
@@ -42,7 +42,7 @@ instance Arbitrary NonEmptyText where
   shrink = coerce shrinkValidUtf81
 
 eval :: Bool -> HDL -> State Id.IdentifierSet a -> a
-eval esc hdl a = evalState a (Id.emptyIdentifierSet esc hdl)
+eval esc hdl a = evalState a (Id.emptyIdentifierSet esc False hdl)
 
 eval' :: State Id.IdentifierSet a -> a
 eval' = eval True VHDL

--- a/clash-lib/tests/Clash/Tests/Netlist/Id.hs
+++ b/clash-lib/tests/Clash/Tests/Netlist/Id.hs
@@ -42,7 +42,7 @@ instance Arbitrary NonEmptyText where
   shrink = coerce shrinkValidUtf81
 
 eval :: Bool -> HDL -> State Id.IdentifierSet a -> a
-eval esc hdl a = evalState a (Id.emptyIdentifierSet esc False hdl)
+eval esc hdl a = evalState a (Id.emptyIdentifierSet esc Id.PreserveCase hdl)
 
 eval' :: State Id.IdentifierSet a -> a
 eval' = eval True VHDL

--- a/clash-lib/tests/unittests.hs
+++ b/clash-lib/tests/unittests.hs
@@ -1,19 +1,31 @@
 module Main where
 
 import Test.Tasty
+import Test.Tasty.QuickCheck
 
 import qualified Clash.Tests.Core.FreeVars
 import qualified Clash.Tests.Core.Subst
+import qualified Clash.Tests.Netlist.Id
 import qualified Clash.Tests.Util.Interpolate
 import qualified Clash.Tests.Normalize.Transformations
+
+-- AFAIK there's no good way to override the default, so we just detect the
+-- default value and change it.
+setDefaultQuickCheckTests :: QuickCheckTests -> QuickCheckTests
+setDefaultQuickCheckTests (QuickCheckTests 100) = 10000
+setDefaultQuickCheckTests opt = opt
 
 tests :: TestTree
 tests = testGroup "Unittests"
   [ Clash.Tests.Core.FreeVars.tests
   , Clash.Tests.Core.Subst.tests
   , Clash.Tests.Util.Interpolate.tests
+  , Clash.Tests.Netlist.Id.tests
   , Clash.Tests.Normalize.Transformations.tests
   ]
 
 main :: IO ()
-main = defaultMain tests
+main =
+    defaultMain
+  $ adjustOption setDefaultQuickCheckTests
+  $ tests

--- a/docs/developing-hardware/flags.rst
+++ b/docs/developing-hardware/flags.rst
@@ -188,10 +188,17 @@ Clash Compiler Flags
 
 -fclash-no-escaped-identifiers
   Disable extended identifiers, as used in some HDLs like VHDL to allow more
-  flexibility with names. Clash will only generate normal idenfiers if this
+  flexibility with names. Clash will only generate basic identifiers if this
   is used.
 
   **Default:** Escaped identifiers are allowed
+
+-fclash-lower-case-basic-identifiers
+  Clash will only generate lower case basic identifiers if this is used. This
+  affects places where the various HDLs only allow basic identifiers to be used,
+  most notably module and file names.
+
+  **Default:** Disabled
 
 -fclash-compile-ultra
   Aggressively run the normalizer, potentially gaining much better runtime

--- a/tests/shouldwork/AutoReg/AutoReg.hs
+++ b/tests/shouldwork/AutoReg/AutoReg.hs
@@ -120,4 +120,4 @@ mainHDL topFile = do
 mainSystemVerilog, mainVerilog, mainVHDL :: IO ()
 mainSystemVerilog = mainHDL "topEntity.sv"
 mainVerilog       = mainHDL "topEntity.v"
-mainVHDL          = mainHDL "topentity.vhdl"
+mainVHDL          = mainHDL "topEntity.vhdl"

--- a/tests/shouldwork/Basic/NameInstance.hs
+++ b/tests/shouldwork/Basic/NameInstance.hs
@@ -36,5 +36,5 @@ mainVerilog = do
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "topentity.vhdl")
+  content <- readFile (takeDirectory topDir </> "topEntity.vhdl")
   assertIn "before_foo_after" content

--- a/tests/shouldwork/Basic/Parameters.hs
+++ b/tests/shouldwork/Basic/Parameters.hs
@@ -14,8 +14,8 @@ import Data.Text.Prettyprint.Doc.Extra (Doc)
 import System.Environment (getArgs)
 import System.FilePath ((</>))
 
-import Clash.Backend (mkUniqueIdentifier, blockDecl)
-import Clash.Netlist.Id (IdType(Basic))
+import Clash.Backend (blockDecl)
+import qualified Clash.Netlist.Id as Id
 import Clash.Netlist.Types
 import Clash.Netlist.Util (typeSize)
 
@@ -39,13 +39,20 @@ myAddTemplate
 myAddTemplate bbCtx = do
   let [_, (xExp, xTy, _), (yExp, yTy, _)] = bbInputs bbCtx
       [(resExp, resTy)] = bbResults bbCtx
-  getMon $ blockDecl "my_add_block"
-    [ InstDecl Comp Nothing [] "my_add" "my_add_inst"
-        [ (Identifier "size" Nothing, Integer, Literal Nothing (NumLit . fromIntegral $ typeSize xTy))
+  sizeId <- Id.make "size"
+  let xId = Id.unsafeMake "x"
+  let yId = Id.unsafeMake "y"
+  let resultId = Id.unsafeMake "result"
+  blockId <- Id.make "my_add_block"
+  myAddInstId <- Id.make "my_add_inst"
+  let myAddId = Id.unsafeMake "my_add"
+  getMon $ blockDecl blockId
+    [ InstDecl Comp Nothing [] myAddId myAddInstId
+        [ (Identifier sizeId Nothing, Integer, Literal Nothing (NumLit . fromIntegral $ typeSize xTy))
         ]
-        [ (Identifier "x" Nothing, In, xTy, xExp)
-        , (Identifier "y" Nothing, In, yTy, yExp)
-        , (Identifier "result" Nothing, Out, resTy, resExp)
+        [ (Identifier xId Nothing, In, xTy, xExp)
+        , (Identifier yId Nothing, In, yTy, yExp)
+        , (Identifier resultId Nothing, Out, resTy, resExp)
         ]
     ]
 

--- a/tests/shouldwork/BlackBox/BlackBoxFunctionHO.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunctionHO.hs
@@ -21,7 +21,7 @@ myMultiplyTF isD primName args ty = pure $
   Right ( emptyBlackBoxMeta
         , BBTemplate
            [ Text "resize("
-           , Arg False 0, Text " * ", Arg False 1
+           , Arg 0, Text " * ", Arg 1
            , Text ",64)"
            ]
         )

--- a/tests/shouldwork/BlackBox/TemplateFunction.hs
+++ b/tests/shouldwork/BlackBox/TemplateFunction.hs
@@ -12,8 +12,8 @@ import Data.Text.Prettyprint.Doc.Extra (Doc)
 import System.Environment (getArgs)
 import System.FilePath ((</>))
 
-import Clash.Backend (mkUniqueIdentifier, blockDecl)
-import Clash.Netlist.Id (IdType(Basic))
+import Clash.Backend (blockDecl)
+import qualified Clash.Netlist.Id as Id
 import Clash.Netlist.Types
 
 import Clash.Prelude
@@ -31,8 +31,8 @@ myMultiplyTemplate
   => BlackBoxContext
   -> State s Doc
 myMultiplyTemplate bbCtx = do
-  x <- mkUniqueIdentifier Basic "x123456"
-  y <- mkUniqueIdentifier Basic "y123456"
+  x <- Id.make "x123456"
+  y <- Id.make "y123456"
   getMon $ blockDecl x [NetDecl Nothing y Bool]
 
 

--- a/tests/shouldwork/BlackBox/ZeroWidth.hs
+++ b/tests/shouldwork/BlackBox/ZeroWidth.hs
@@ -67,4 +67,4 @@ mainHDL topFile implFile = do
 mainSystemVerilog, mainVerilog, mainVHDL :: IO ()
 mainSystemVerilog = error "NYI"
 mainVerilog       = error "NYI"
-mainVHDL          = mainHDL "topentity.vhdl" "implicitcomment.vhdl"
+mainVHDL          = mainHDL "topEntity.vhdl" "implicitComment.vhdl"

--- a/tests/shouldwork/Issues/T1171.hs
+++ b/tests/shouldwork/Issues/T1171.hs
@@ -41,7 +41,7 @@ mainVHDL = do
   [topDir] <- getArgs
   content  <- readFile (takeDirectory topDir </> "f" </> "f.vhdl")
 
-  assertIn "en  : in f_types.en_system;" content
+  assertIn "en  : in f_types.en_System;" content
 
 mainVerilog :: IO ()
 mainVerilog = do
@@ -56,4 +56,3 @@ mainSystemVerilog = do
   content  <- readFile (takeDirectory topDir </> "f" </> "f.sv")
 
   assertIn "input logic en  // enable" content
-

--- a/tests/shouldwork/Issues/T1439.hs
+++ b/tests/shouldwork/Issues/T1439.hs
@@ -9,6 +9,7 @@ module T1439 where
 import Clash.Prelude
 import Clash.Sized.Internal.BitVector
 import Clash.Netlist.Types
+import qualified Clash.Netlist.Id as Id
 
 import Test.Tasty.Clash
 import Test.Tasty.Clash.NetlistTest
@@ -47,7 +48,7 @@ testPath = "tests/shouldwork/Issues/T1439.hs"
 
 noRotateRight :: Component -> IO ()
 noRotateRight (Component nm _ _ _)
-  | nm == "rotate_right" = error ("No component should be called rotate_right")
+  | Id.toText nm == "rotate_right" = error ("No component should be called rotate_right")
   | otherwise = pure ()
 
 getComponent :: (a, b, c, d) -> d
@@ -57,4 +58,3 @@ mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
   mapM_ (noRotateRight . getComponent) netlist
-

--- a/tests/shouldwork/Issues/T1506B.hs
+++ b/tests/shouldwork/Issues/T1506B.hs
@@ -37,4 +37,4 @@ mainHDL topFile = do
 mainSystemVerilog, mainVerilog, mainVHDL :: IO ()
 mainSystemVerilog = mainHDL "topEntity_0.sv"
 mainVerilog       = mainHDL "topEntity_0.v"
-mainVHDL          = mainHDL "topentity_0.vhdl"
+mainVHDL          = mainHDL "topEntity_0.vhdl"

--- a/tests/shouldwork/Naming/NameHint.hs
+++ b/tests/shouldwork/Naming/NameHint.hs
@@ -5,6 +5,7 @@ module NameHint where
 
 import Clash.Prelude
 import Clash.Netlist.Types
+import qualified Clash.Netlist.Id as Id
 
 import Prelude as P
 import Data.Text (isInfixOf)
@@ -38,7 +39,7 @@ assertOneDecl (Component _ _ _ ds) =
       error $ "Expected one declaration of a signal named "
            <> "\"someSignalName\", got " <> show (P.length is)
  where
-  isSigDecl (NetDecl' _ _ i@(isInfixOf "someSignalName" -> True) _ _) = [i]
+  isSigDecl (NetDecl' _ _ i@(isInfixOf "someSignalName" . Id.toText -> True) _ _) = [i]
   isSigDecl _ = []
 
   isSigAssignment i (Assignment _ (Identifier i' _)) = i == i'
@@ -56,4 +57,3 @@ mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog id testPath
   mapM_ (assertOneDecl . getComponent) netlist
-

--- a/tests/shouldwork/Naming/T1041.hs
+++ b/tests/shouldwork/Naming/T1041.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module T1041 where
 
@@ -7,6 +8,7 @@ import Prelude as P
 
 import Clash.Prelude
 import Clash.Netlist.Types
+import qualified Clash.Netlist.Id as Id
 
 import Test.Tasty.Clash
 import Test.Tasty.Clash.NetlistTest
@@ -69,8 +71,8 @@ assertOneVGA (Component _ _ _ ds)
   -- Multiple cases as mkUniqueIdentifier Basic
   -- in VHDL changes names to be lowercase.
   --
-  isVGADecl (NetDecl' _ Wire "vga" _ _) = True
-  isVGADecl (NetDecl' _ Wire "VGA" _ _) = True
+  isVGADecl (NetDecl' _ Wire (Id.toText -> "vga") _ _) = True
+  isVGADecl (NetDecl' _ Wire (Id.toText -> "VGA") _ _) = True
   isVGADecl _ = False
 
 getComponent :: (a, b, c, d) -> d

--- a/tests/shouldwork/Netlist/Identity.hs
+++ b/tests/shouldwork/Netlist/Identity.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE QuasiQuotes #-}
 module Identity where
 
 import Prelude as P
 
 import Clash.Prelude
 import Clash.Netlist.Types
+import qualified Clash.Util.Interpolate as I
+import qualified Clash.Netlist.Id as Id
 
 import Test.Tasty.Clash
 import Test.Tasty.Clash.NetlistTest
@@ -18,8 +21,20 @@ assertAssignsInOut :: Component -> IO ()
 assertAssignsInOut (Component _ [i] [o] ds) =
   case ds of
     [Assignment oName (Identifier iName Nothing)]
-      | iName == fst i && oName == fst ((\(_,x,_) -> x) o) -> return ()
-      | otherwise -> P.error "Incorrect input/output names"
+      | Id.toText iName == Id.toText (fst i)
+      , Id.toText oName == Id.toText (fst ((\(_,x,_) -> x) o))
+      -> return ()
+      | otherwise -> P.error [I.i|
+          Incorrect input/output names:
+
+           oName: #{oName}
+
+           o: #{o}
+
+           iName: #{iName}
+
+           i: #{i}
+        |]
 
     _ -> P.error "Identity circuit performs more than just one assignment"
 

--- a/tests/shouldwork/Netlist/NoDeDup.hs
+++ b/tests/shouldwork/Netlist/NoDeDup.hs
@@ -8,6 +8,7 @@ import Prelude as P
 import Clash.Magic
 import Clash.Prelude
 import Clash.Netlist.Types
+import qualified Clash.Netlist.Id as Id
 
 import Test.Tasty.Clash
 import Test.Tasty.Clash.NetlistTest
@@ -44,12 +45,12 @@ topEntity n abcd = (f n abcd) - (g n abcd)
 testPath :: FilePath
 testPath = "tests/shouldwork/Netlist/NoDeDup.hs"
 
-isTwiceInst (InstDecl Entity Nothing [] "twice" _ _ _) = True
+isTwiceInst (InstDecl Entity Nothing [] (Id.toText -> "twice") _ _ _) = True
 isTwiceInst _ = False
 
 assertNumTwiceInsts :: Component -> IO ()
 assertNumTwiceInsts (Component nm inps outs ds) =
-  case nm of
+  case Id.toText nm of
     "f" | nTwiceInsts == 1 -> pure ()
         | otherwise ->
             error ( "Found " <> show nTwiceInsts <> " instances of twice in f. "
@@ -59,7 +60,7 @@ assertNumTwiceInsts (Component nm inps outs ds) =
             error ( "Found " <> show nTwiceInsts <> " instances of twice in g. "
                  <> "Expected 2.")
     "twice" -> pure ()
-    "topentity" -> pure ()
+    "topEntity" -> pure ()
     _ -> error ("Unexpected component: " <> show nm)
  where
   twiceInsts = filter isTwiceInst ds

--- a/tests/shouldwork/SynthesisAttributes/InstDeclAnnotations.hs
+++ b/tests/shouldwork/SynthesisAttributes/InstDeclAnnotations.hs
@@ -5,7 +5,7 @@ module InstDeclAnnotations where
 import           Clash.Annotations.Primitive     (HDL (..), Primitive (..))
 import           Clash.Backend
 import           Clash.Core.Var                  (Attr' (..))
-import           Clash.Netlist.Id
+import qualified Clash.Netlist.Id                as Id
 import           Clash.Netlist.Types
 import           Clash.Prelude
 import           Control.Monad.State
@@ -32,10 +32,10 @@ myTemplate
   => BlackBoxContext
   -> State s Doc
 myTemplate bbCtx = do
-  blkName  <- mkUniqueIdentifier Basic "blkName"
-  compInst <- mkUniqueIdentifier Basic "test_inst"
+  blkName  <- Id.makeBasic "blkName"
+  compInst <- Id.makeBasic "test_inst"
+  compName <- Id.makeBasic "TEST"
   let
-    compName = "TEST"
     attrs =
       [ IntegerAttr' "my_int_attr"    7
       , StringAttr'  "my_string_attr" "Hello World!"
@@ -97,4 +97,3 @@ mainVerilog = do
 
 -- Verilog and SystemVerilog should share annotation syntax
 mainSystemVerilog = mainVerilog
-

--- a/tests/shouldwork/TopEntity/Multiple.hs
+++ b/tests/shouldwork/TopEntity/Multiple.hs
@@ -52,11 +52,11 @@ main3VHDL :: IO ()
 main3VHDL = do
   [(dir, _fname)] <- map splitFileName <$> getArgs
   files <- listDirectory dir
-  if sort files == sort [ "multiple_types.vhdl"
+  if sort files == sort [ "Multiple_types.vhdl"
                         , "topentity1"
                         , "topentity2"
-                        , "topentity3.manifest"
-                        , "topentity3.vhdl"
+                        , "topEntity3.manifest"
+                        , "topEntity3.vhdl"
                         ] then
     pure ()
   else

--- a/tests/shouldwork/TopEntity/T1182A.hs
+++ b/tests/shouldwork/TopEntity/T1182A.hs
@@ -9,6 +9,7 @@ import qualified Prelude as P
 
 import Clash.Prelude
 import Clash.Netlist.Types
+import qualified Clash.Netlist.Id as Id
 import Clash.Annotations.TH
 
 import Clash.Class.HasDomain
@@ -35,8 +36,8 @@ testPath = "tests/shouldwork/TopEntity/T1182A.hs"
 
 assertInputs :: Component -> IO ()
 assertInputs (Component _ [(clk,Clock _)] [(Wire,(ssan,Vector 8 Bool),Nothing)] ds)
-  | clk == T.pack "CLK"
-  && ssan == T.pack "SS_AN"
+  | Id.toText clk == T.pack "CLK"
+  , Id.toText ssan == T.pack "SS_AN"
   = pure ()
 assertInputs c = error $ "Component mismatch: " P.++ show c
 

--- a/tests/shouldwork/TopEntity/T1182B.hs
+++ b/tests/shouldwork/TopEntity/T1182B.hs
@@ -9,6 +9,7 @@ import qualified Prelude as P
 
 import Clash.Prelude
 import Clash.Netlist.Types
+import qualified Clash.Netlist.Id as Id
 import Clash.Annotations.TH
 
 import Clash.Class.HasDomain
@@ -42,10 +43,10 @@ assertInputs (Component _ [(clk,Clock _)]
   , (Wire,(ssseg,Vector 7 Bool),Nothing)
   , (Wire,(ssdp,Bool),Nothing)
   ] ds)
-  | clk == T.pack "CLK"
-  && ssan == T.pack "SS_AN"
-  && ssseg == T.pack "SS_SEG"
-  && ssdp == T.pack "SS_DP"
+  | Id.toText clk == T.pack "CLK"
+  , Id.toText ssan == T.pack "SS_AN"
+  , Id.toText ssseg == T.pack "SS_SEG"
+  , Id.toText ssdp == T.pack "SS_DP"
   = pure ()
 assertInputs c = error $ "Component mismatch: " P.++ show c
 

--- a/tests/shouldwork/Vector/IterateCF.hs
+++ b/tests/shouldwork/Vector/IterateCF.hs
@@ -32,7 +32,7 @@ assertNotIn needle haystack
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "topentity.vhdl")
+  content  <- readFile (takeDirectory topDir </> "topEntity.vhdl")
 
   assertNotIn "255" content
   assertNotIn "256" content

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -164,11 +164,11 @@ runClashTest = defaultMain $ clashTestRoot
       , clashTestGroup "SynthesisAttributes"
         [ runTest "ProductInArgs" def{
             hdlTargets=[VHDL]
-          , expectClashFail=Just (def, "Attempted to split Product into a number of HDL ports.")
+          , expectClashFail=Just (def, "Cannot use attribute annotations on product types of top entities")
           }
         , runTest "ProductInResult" def{
             hdlTargets=[VHDL]
-          , expectClashFail=Just (def, "Attempted to split Product into a number of HDL ports.")
+          , expectClashFail=Just (def, "Cannot use attribute annotations on product types of top entities")
           }
         ]
       , clashTestGroup "TopEntity"
@@ -178,7 +178,7 @@ runClashTest = defaultMain $ clashTestRoot
           }
         , runTest "T1063" def{
             hdlTargets=[VHDL]
-          , expectClashFail=Just (def, "Ports were annotated as product, but type wasn't one")
+          , expectClashFail=Just (def, "Saw a PortProduct in a Synthesize annotation")
           }
         ]
       , clashTestGroup "Verification"

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -4,6 +4,7 @@ module Main (main) where
 
 import qualified Clash.Util.Interpolate    as I
 
+import           Clash.Annotations.Primitive (HDL(..))
 import           Control.Exception         (finally)
 import qualified Data.Text                 as Text
 import           Data.Default              (def)

--- a/testsuite/src/Test/Tasty/Clash.hs
+++ b/testsuite/src/Test/Tasty/Clash.hs
@@ -7,6 +7,7 @@
 
 module Test.Tasty.Clash where
 
+import           Clash.Annotations.Primitive (HDL(..))
 import           Data.Char                 (toLower)
 import           Data.Default              (Default, def)
 import qualified Data.List                 as List
@@ -28,16 +29,15 @@ import Test.Tasty.Program
   , PrintOutput (PrintStdErr, PrintNeither), GlobArgs(..)
   , ExpectOutput(..))
 
-data BuildTarget
-  = VHDL
-  | SystemVerilog
-  | Verilog
-  deriving (Eq, Ord, Show)
-
-data SBuildTarget (target :: BuildTarget) where
+data SBuildTarget (target :: HDL) where
   SVHDL          :: SBuildTarget 'VHDL
   SVerilog       :: SBuildTarget 'Verilog
   SSystemVerilog :: SBuildTarget 'SystemVerilog
+
+buildTargetToHdl :: SBuildTarget target -> HDL
+buildTargetToHdl SVHDL = VHDL
+buildTargetToHdl SVerilog = Verilog
+buildTargetToHdl SSystemVerilog = SystemVerilog
 
 data Entities
   = AutoEntities
@@ -92,7 +92,7 @@ data TestOptions =
     , expectClashFail :: Maybe (TestExitCode, T.Text)
     -- ^ Expect Clash to fail: Nothing if Clash is expected to compile without
     -- errors, or Just (part of) the error message Clash is expected to throw.
-    , hdlTargets :: [BuildTarget]
+    , hdlTargets :: [HDL]
     -- ^ Run tests for these targets
     , clashFlags :: [String]
     -- ^ Extra flags to pass to Clash
@@ -105,7 +105,7 @@ data TestOptions =
     -- ^ Whether an empty stderr means test failure when running VVP
     }
 
-allTargets :: [BuildTarget]
+allTargets :: [HDL]
 allTargets = [VHDL, Verilog, SystemVerilog]
 
 instance Default TestOptions where
@@ -209,7 +209,7 @@ createDirs path subdirs =
 -- | Generate command to run clash to compile a file and place the resulting
 -- hdl files in a specific directory
 clashCmd
-  :: BuildTarget
+  :: HDL
   -- ^ Build target
   -> FilePath
   -- ^ Source directory
@@ -245,7 +245,7 @@ clashCmd target sourceDir extraArgs modName oDir =
 clashHDL
   :: Maybe (TestExitCode, T.Text)
   -- ^ Expect failure / test exit code. See "TestOptions".
-  -> BuildTarget
+  -> HDL
   -- ^ Build target
   -> FilePath
   -- ^ Source directory
@@ -316,23 +316,21 @@ ghdlLibrary entName path modName lib =
                , ("--work=" ++ workName)
                , ("--workdir=" ++ relWorkdir)
                , ("--std=93")
-               , (workDir </> lib' </> "*.vhdl")
+               , (workDir </> lib </> "*.vhdl")
                ]
-
-        lib' = map toLower lib
 
         -- Special case for FIR?
         workName =
-          case lib' of
+          case lib of
             [] ->
               case modName of
-                "FIR" -> "test_topentity"
-                _     -> "topentity"
+                "FIR" -> "test_topEntity"
+                _     -> "topEntity"
             k ->
               k
 
         relWorkdir =
-          case lib' of
+          case lib of
             [] -> "."
             k -> k
 
@@ -348,11 +346,10 @@ ghdlImport
 ghdlImport entName path modName subdirs =
   (testName, test)
     where
-      subdirs' = (map.map) toLower subdirs
       testName = "GHDL (import " ++ entName ++ ")"
       test = testProgram testName "ghdl" args GlobStar PrintStdErr False (Just workDir)
       workDir = testDirectory path </> "vhdl" </> modName
-      args = "-i":"--workdir=work":"--std=93":[workDir </> subdir </> "*.vhdl" | subdir <- subdirs']
+      args = "-i":"--workdir=work":"--std=93":[workDir </> subdir </> "*.vhdl" | subdir <- subdirs]
 
 ghdlMake
   :: [TestName]
@@ -374,8 +371,8 @@ ghdlMake path modName subdirs libs entName =
                -- Enable flags when running newer versions of the (GCC) linker.
                -- , ["-Wl,-no-pie"]
                   , ["--workdir=work"]
-                  , map (\l -> "-P" ++ emptyToDot (map toLower l)) libs
-                  , ["-o", map toLower (noConflict entName subdirs) ]
+                  , map (\l -> "-P" ++ emptyToDot l) libs
+                  , ["-o", map toLower (noConflict entName subdirs)]
                   , [entName] ]
     testName = "GHDL (make " ++ entName ++ ")"
     test = testProgram testName "ghdl" args NoGlob PrintStdErr False (Just workDir)
@@ -528,7 +525,7 @@ runTest1
   :: String
   -> TestOptions
   -> [String]
-  -> BuildTarget
+  -> HDL
   -> TestTree
 runTest1 modName testOptions@TestOptions{..} path VHDL =
   withResource acquire tastyRelease (const seqTests)
@@ -650,7 +647,7 @@ runTest modName testOptions path =
 outputTest'
   :: FilePath
   -- ^ Work directory
-  -> BuildTarget
+  -> HDL
   -- ^ Build target
   -> [String]
   -- ^ Extra Clash arguments
@@ -671,7 +668,7 @@ outputTest' env target extraClashArgs extraGhcArgs modName funcName path =
       path' = show target:path
       acquire = tastyAcquire path' [modDir]
 
-      modDir = (map (toLower) (show target)) </> modName
+      modDir = show target </> modName
 
       args = [ "new-exec"
              , "--write-ghc-environment-files=never"
@@ -694,7 +691,7 @@ outputTest' env target extraClashArgs extraGhcArgs modName funcName path =
       topFile =
         case target of
           VHDL ->
-            "vhdl" </> modName </> "topentity.vhdl"
+            "vhdl" </> modName </> "topEntity.vhdl"
           Verilog ->
             "verilog" </> modName </> "topEntity.v"
           SystemVerilog ->
@@ -710,7 +707,7 @@ outputTest' env target extraClashArgs extraGhcArgs modName funcName path =
 outputTest
   :: FilePath
   -- ^ Work directory
-  -> [BuildTarget]
+  -> [HDL]
   -- ^ Build targets
   -> [String]
   -- ^ Extra clash arguments
@@ -734,7 +731,7 @@ outputTest env targets extraClashArgs extraGhcArgs modName funcName path =
 clashLibTest'
   :: FilePath
   -- ^ Work directory
-  -> BuildTarget
+  -> HDL
   -- ^ Build target
   -> [String]
   -- ^ Extra GHC arguments
@@ -753,7 +750,7 @@ clashLibTest' env target extraGhcArgs modName funcName path =
       path' = show target:path
       acquire = tastyAcquire path' [modDir]
 
-      modDir = (map (toLower) (show target)) </> modName
+      modDir = show target </> modName
 
       args = [ "new-exec"
              , "--write-ghc-environment-files=never"
@@ -782,7 +779,7 @@ clashLibTest' env target extraGhcArgs modName funcName path =
 clashLibTest
   :: FilePath
   -- ^ Work directory
-  -> [BuildTarget]
+  -> [HDL]
   -- ^ Build targets
   -> [String]
   -- ^ Extra GHC arguments

--- a/testsuite/src/Test/Tasty/Clash/CoreTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/CoreTest.hs
@@ -14,6 +14,7 @@ module Test.Tasty.Clash.CoreTest
 import Control.Concurrent.Supply
 import qualified Data.List as List (find)
 
+import Clash.Annotations.Primitive (HDL(..))
 import Clash.Backend
 import Clash.Backend.SystemVerilog
 import Clash.Backend.Verilog
@@ -34,7 +35,7 @@ import Util
 
 import Test.Tasty.Clash
 
-type family TargetToState (target :: BuildTarget) where
+type family TargetToState (target :: HDL) where
   TargetToState 'SystemVerilog = SystemVerilogState
   TargetToState 'VHDL          = VHDLState
   TargetToState 'Verilog       = VerilogState

--- a/testsuite/src/Test/Tasty/Clash/CoreTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/CoreTest.hs
@@ -51,7 +51,7 @@ mkBackend
   :: (Backend (TargetToState target))
   => SBuildTarget target
   -> TargetToState target
-mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True Nothing (AggressiveXOptBB False)
+mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True False Nothing (AggressiveXOptBB False)
 
 -- Run clash as far as having access to core for all bindings. This is used
 -- to test operations on core, such as transformations and evaluation.

--- a/testsuite/src/Test/Tasty/Clash/CoreTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/CoreTest.hs
@@ -27,6 +27,7 @@ import Clash.Core.Var
 import Clash.Core.VarEnv
 import Clash.Driver.Types
 import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
+import Clash.Netlist.Types (PreserveCase(..))
 
 import Clash.GHC.GenerateBindings
 import Clash.GHC.PartialEval
@@ -51,7 +52,7 @@ mkBackend
   :: (Backend (TargetToState target))
   => SBuildTarget target
   -> TargetToState target
-mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True False Nothing (AggressiveXOptBB False)
+mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True PreserveCase Nothing (AggressiveXOptBB False)
 
 -- Run clash as far as having access to core for all bindings. This is used
 -- to test operations on core, such as transformations and evaluation.

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -82,7 +82,7 @@ type family TargetToState (target :: HDL) where
 mkBackend
   :: (Backend (TargetToState target))
   => SBuildTarget target -> TargetToState target
-mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True False Nothing (AggressiveXOptBB False)
+mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True PreserveCase Nothing (AggressiveXOptBB False)
 
 runToNetlistStage
   :: (Backend (TargetToState target))
@@ -98,7 +98,7 @@ runToNetlistStage target f src = do
   (bm, tcm, tupTcm, tes, pm, rs, _)
     <- generateBindings Auto pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
 
-  let (compNames, initIs) = genTopNames Nothing True False hdl tes
+  let (compNames, initIs) = genTopNames Nothing True PreserveCase hdl tes
       teNames = fmap topId tes
       te      = topId (P.head tes)
       reprs   = buildCustomReprs rs

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -21,6 +21,7 @@ module Test.Tasty.Clash.NetlistTest
 import qualified Prelude as P
 import           Clash.Prelude
 
+import           Clash.Annotations.Primitive (HDL(..))
 import           Clash.Annotations.BitRepresentation.Internal
 import           Clash.Backend as Backend
 import           Clash.Backend.SystemVerilog
@@ -43,6 +44,7 @@ import           Clash.GHC.Evaluator
 import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.Netlist
+import qualified Clash.Netlist.Id as Id
 import           Clash.Netlist.BlackBox.Types (HdlSyn(Other))
 import           Clash.Netlist.Types hiding (backend, hdlDir)
 import           Clash.Util
@@ -52,9 +54,6 @@ import           Util
 import qualified Control.Concurrent.Supply as Supply
 import           Control.DeepSeq (force)
 import           Control.Monad.State.Strict (State)
-import qualified Control.Monad.State as State
-import           Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HashMap
 import           Data.Maybe
 import qualified Data.Text as Text
 import           System.FilePath ((</>))
@@ -75,7 +74,7 @@ mkClashOpts = defClashOpts
   , opt_floatSupport = True
   }
 
-type family TargetToState (target :: BuildTarget) where
+type family TargetToState (target :: HDL) where
   TargetToState 'VHDL          = VHDLState
   TargetToState 'Verilog       = VerilogState
   TargetToState 'SystemVerilog = SystemVerilogState
@@ -93,15 +92,17 @@ runToNetlistStage
   -- ^ Function to modify the default clash options
   -> FilePath
   -- ^ Module to load
-  -> IO [([Bool], SrcSpan, HashMap Identifier Word, Component)]
+  -> IO [([Bool], SrcSpan, Id.IdentifierSet, Component)]
 runToNetlistStage target f src = do
   pds <- primDirs backend
   (bm, tcm, tupTcm, tes, pm, rs, _)
     <- generateBindings Auto pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
 
-  let teNames = fmap topId tes
+  let (compNames, initIs) = genTopNames Nothing True hdl tes
+      teNames = fmap topId tes
       te      = topId (P.head tes)
       reprs   = buildCustomReprs rs
+      tes2    = mkVarEnv (P.zip (P.map topId tes) tes)
 
   supplyN <- Supply.newSupply
 
@@ -113,24 +114,21 @@ runToNetlistStage target f src = do
 #endif
           teNames opts supplyN te
 
-  fmap (force . eltsVarEnv . fst) $ netlistFrom (transformedBindings, tcm, tes, pm, reprs, te)
+  fmap (\(_,x,_) -> force (eltsVarEnv x)) $ netlistFrom (transformedBindings, tcm, tes2, compNames, pm, reprs, te, initIs)
  where
   backend = mkBackend target
   opts = f mkClashOpts
+  hdl = buildTargetToHdl target
 
-  netlistFrom (bm, tcm, tes, pm, rs, te) =
-    genNetlist False opts rs bm tes pm tcm typeTrans
-      iw mkId1 extId ite (SomeBackend hdlSt) seen hdlDir prefixM te
+  netlistFrom (bm, tcm, tes, compNames, pm, rs, te, seen) =
+    genNetlist False opts rs bm tes compNames pm tcm typeTrans
+      iw ite (SomeBackend hdlSt) seen hdlDir Nothing te
    where
     iw      = opt_intWidth opts
     teS     = Text.unpack . nameOcc $ varName te
     modN    = takeWhile (/= '.') teS
     hdlSt   = setModName (Text.pack modN) backend
-    mkId1   = State.evalState mkIdentifier hdlSt
-    extId   = State.evalState extendIdentifier hdlSt
-    prefixM = ComponentPrefix Nothing Nothing
     ite     = ifThenElseExpr hdlSt
-    seen    = HashMap.empty
     hdlDir  = fromMaybe "." (opt_hdlDir opts)
       </> Backend.name hdlSt
       </> takeWhile (/= '.') teS

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -82,7 +82,7 @@ type family TargetToState (target :: HDL) where
 mkBackend
   :: (Backend (TargetToState target))
   => SBuildTarget target -> TargetToState target
-mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True Nothing (AggressiveXOptBB False)
+mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True False Nothing (AggressiveXOptBB False)
 
 runToNetlistStage
   :: (Backend (TargetToState target))
@@ -98,7 +98,7 @@ runToNetlistStage target f src = do
   (bm, tcm, tupTcm, tes, pm, rs, _)
     <- generateBindings Auto pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
 
-  let (compNames, initIs) = genTopNames Nothing True hdl tes
+  let (compNames, initIs) = genTopNames Nothing True False hdl tes
       teNames = fmap topId tes
       te      = topId (P.head tes)
       reprs   = buildCustomReprs rs


### PR DESCRIPTION
```
    Fold identifier logic into 'Clash.Netlist.Id'. Fix #1230
    
    This megacommit moves all identifier (uniqueness) logic to a single
    module "Clash.Netlist.Id". "Identifier" is no longer a type alias for
    Text, but a data type allowing cheap new unique identifier generation.
    
    It fixes a number of (unreported) bugs:
    
     * #1230: Clash no longer produces "name conflicts" between basic and
       extended identifiers. I.e., \x\ and x are now considered the same
       variable in VHDL (likewise for other HDLs). Although the VHDL spec
       considers them distinct variables, some HDL tools - like Quartus -
       don't.
    
     * Capitalization of Haskell names are now preserved in VHDL. Note that
       VHDL is a case insensitive languages, so there are measures in place
       to prevent Clash from generating both Foo and fOO. This used to be
       handled by promoting every capitalized identifier to an extended one,
       and wasn't handled for basic ones.
    
     * Names generated for testbenches can no longer cause collisions with
       previously generated entities.
    
     * Names generated for components can no longer cause collisions with
       user specified top entity names.
    
     * For (System)Verilog, variables can no longer cause collisions with
       (to be) generated entity names.
    
     * HO blackboxes can no longer cause collisions with identifiers
       declared in their surrounding architecture block.

```

--------------------------------------------

TODO:
 - [x] Fully expand top entity annotations (even if they don't exist!) _before_ running `mkInput`, `mkOutput`, `mkTopInput`, `mkTopOutput`. This will remove half of the (duplicated) code base for these functions, and will solve the test failure in `PortNamesWithVector`.
 - [x] Check docs for legacy comments
 - [x] Change misleading documentation/type of second ~~NetDecl~~ InstDecl field
 - [x] Think about whether I'm happy with the "abuse" of the IdentifierSet in the VHDL/SystemVerilog backend
 - [x] ~~Change `make#`, `deepen#`, etc. to work on lenses, allowing for a cheap way of using multiple identifiersets in a single monadic context. Would probably solve previous TODO.~~ meh
 - [x] Add tests for (unreported) issues
 - [x] ~~Test on production codebase~~
 - [x] Check whether use of `Id.unsafeMake` usage is actually safe
 - [x] Current code doesn't clean up between components, therefore generating more and more "ugly" identifier names as it goes on 
 - [x] Rebase on master
 - [x] In cases where this PR drops `Identifier` in favor of `Text`, it should be replaced by `IdentifierText` instead. (Unless it's really not an identifier)
 - [x] Add `Id.toLText`
 - [x] Remove `Clash.Primitives.DSL.newName` (it's the same as `Id.makeBasic`)