### PR TITLE
Add NFDataX instances for `Data.Monoid.{First,Last}`.

### DIFF
--- a/changelog/2020-04-20T09:38:52+02:00_Add_NFDataX_instances_for_Data_Monoid_First_Last
+++ b/changelog/2020-04-20T09:38:52+02:00_Add_NFDataX_instances_for_Data_Monoid_First_Last
@@ -1,0 +1,1 @@
+ADDED: Added NFDataX instances for `Data.Monoid.{First,Last}`

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -55,6 +55,7 @@ import           Data.Int            (Int8, Int16, Int32, Int64)
 import           Data.Ord            (Down (Down))
 import           Data.Ratio          (Ratio, numerator, denominator)
 import qualified Data.Semigroup      as SG
+import qualified Data.Monoid         as M
 import           Data.Sequence       (Seq(Empty, (:<|)))
 import           Data.Word           (Word8, Word16, Word32, Word64)
 import           Foreign.C.Types     (CUShort)
@@ -813,6 +814,8 @@ instance NFDataX a => NFDataX (SG.Min a)
 instance NFDataX a => NFDataX (SG.Option a)
 instance NFDataX a => NFDataX (SG.Product a)
 instance NFDataX a => NFDataX (SG.Sum a)
+instance NFDataX a => NFDataX (M.First a)
+instance NFDataX a => NFDataX (M.Last a)
 
 class GDeepErrorX f where
   gDeepErrorX :: HasCallStack => String -> f a


### PR DESCRIPTION
[There are good reasons to keep using these](https://old.reddit.com/r/haskell/comments/g3glwn/migration_path_for_last_c/) instead of their `Data.Semigroup` counterparts. Also, there are currently [efforts underway to stop the deprecation process for these types](https://mail.haskell.org/pipermail/libraries/2020-April/030357.html).