### PR TITLE
Bump to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
 # Changelog for the Clash project
 
-## 1.3.0
-See `changelog/README.md`
+## 1.2.1 *April 23rd 2020*
+* Changed:
+ * Treat `Signed 0`, `Unsigned 0`, `Index 1`, `BitVector 0` as unit. In effect this means that 'minBound' and 'maxBound' return 0, whereas previously they might crash [#1183](https://github.com/clash-lang/clash-compiler/issues/1183)
+ * Infix use of `deepseqX` is now right-associative
 
-* New features (API):
-  * Added basic support for writing PSL/SVA assertions in `Clash.Verification`
-* New features (Compiler):
-  * No new features yet!
-* Fixes issues:
-  * No fixes yet!
-* Fixes without issue reports:
-  *  Use `ByteArray` instead of `Vector Word8` in the `ByteArrayLiteral` type. See [#1151](https://github.com/clash-lang/clash-compiler/pull/1151)
+* Added:
+  * Add 'natToInteger', 'natToNatural', and 'natToNum'. Similar to 'snatTo*', but works solely on a type argument instead of an SNat.
+  * `Clash.Sized.Vector.unfoldr` and `Clash.Sized.Vector.unfoldrI` to construct vectors from a seed value
+  * Added NFDataX instances for `Data.Monoid.{First,Last}`
+
+* Fixed:
+ * The Verilog backend can now deal with non-contiguous ranges in custom bit-representations.
+ * Synthesizing BitPack instances for type with phantom parameter fails [#1242](https://github.com/clash-lang/clash-compiler/issues/1242)
+ * Synthesis of `fromBNat (toBNat d5)` failed due to `unsafeCoerce` coercing from `Any`
+ * Memory leak in register primitives [#1256](https://github.com/clash-lang/clash-compiler/issues/1256)
+ * Illegal VHDL slice when projecting nested SOP type [#1254](https://github.com/clash-lang/clash-compiler/issues/1254)
+ * Vivado VHDL code path (`-fclash-hdlsyn Vivado`) generates illegal VHDL [#1264](https://github.com/clash-lang/clash-compiler/issues/1264)
 
 ## 1.2.0 *March 5th 2020*
 As promised when releasing 1.0, we've tried our best to keep the API stable. We

--- a/bindist/linux/snap/snap/snapcraft.yaml
+++ b/bindist/linux/snap/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: clash
-version: '1.2.0'
+version: '1.2.1'
 summary: 'Clash: from Haskell to hardware'
 description: |
   Clash is a functional hardware description language that borrows both its

--- a/changelog/2020-03-06T10:08:00+01:00_Move_to_CHANGELOG_files.md
+++ b/changelog/2020-03-06T10:08:00+01:00_Move_to_CHANGELOG_files.md
@@ -1,1 +1,0 @@
-Inspired by [Solving Gitlab's CHANGELOG crisis](https://about.gitlab.com/blog/2018/07/03/solving-gitlabs-changelog-conflict-crisis/) we now use a file per change.

--- a/changelog/2020-03-11T08:57:16+01:00_Add_natToInteger_natToNatural_natToNum
+++ b/changelog/2020-03-11T08:57:16+01:00_Add_natToInteger_natToNatural_natToNum
@@ -1,1 +1,0 @@
-ADDED:  Add 'natToInteger', 'natToNatural', and 'natToNum'. Similar to 'snatTo*', but works solely on a type argument instead of an SNat.

--- a/changelog/2020-03-11T09:00:54+01:00_Treat_Signed_0_as_unit
+++ b/changelog/2020-03-11T09:00:54+01:00_Treat_Signed_0_as_unit
@@ -1,1 +1,0 @@
-CHANGED: Treat `Signed 0`, `Unsigned 0`, `Index 1`, `BitVector 0` as unit. In effect this means that 'minBound' and 'maxBound' return 0, whereas previously they might crash. https://github.com/clash-lang/clash-compiler/issues/1183

--- a/changelog/2020-03-12T17:10:38+01:00_verilog_non_contiguous_fields
+++ b/changelog/2020-03-12T17:10:38+01:00_verilog_non_contiguous_fields
@@ -1,1 +1,0 @@
-FIXED: The Verilog backend can now deal with non-contiguous ranges in custom bit-representations.

--- a/changelog/2020-03-19T11:30:00+01:00_unfoldr
+++ b/changelog/2020-03-19T11:30:00+01:00_unfoldr
@@ -1,1 +1,0 @@
-ADDED: `Clash.Sized.Vector.unfoldr` and `Clash.Sized.Vector.unfoldrI` to construct vectors from a seed value

--- a/changelog/2020-03-24T13:08:40+01:00_fix1242
+++ b/changelog/2020-03-24T13:08:40+01:00_fix1242
@@ -1,1 +1,0 @@
-FIXED: [#1242](https://github.com/clash-lang/clash-compiler/issues/1242) Synthesizing BitPack instances for type with phantom parameter fails

--- a/changelog/2020-03-31T13:49:40+02:00_no_any_tobnat
+++ b/changelog/2020-03-31T13:49:40+02:00_no_any_tobnat
@@ -1,1 +1,0 @@
-FIXED: Synthesis of `fromBNat (toBNat d5)` failed due to `unsafeCoerce` coercing from `Any`

--- a/changelog/2020-04-13T17:44:01+02:00_fix1256
+++ b/changelog/2020-04-13T17:44:01+02:00_fix1256
@@ -1,2 +1,0 @@
-FIXED: Memory leak in register primitives [#1256](https://github.com/clash-lang/clash-compiler/issues/1256)
-CHANGED: Infix use of `deepseqX` is now right-associative

--- a/changelog/2020-04-17T09:30:39+02:00_fix1254
+++ b/changelog/2020-04-17T09:30:39+02:00_fix1254
@@ -1,1 +1,0 @@
-FIXED: Illegal VHDL slice when projecting nested SOP type [#1254](https://github.com/clash-lang/clash-compiler/issues/1254)

--- a/changelog/2020-04-17T12:03:14+02:00_fix1264
+++ b/changelog/2020-04-17T12:03:14+02:00_fix1264
@@ -1,1 +1,0 @@
-FIXED: Vivado VHDL code path (`-fclash-hdlsyn Vivado`) generates illegal VHDL [#1264](https://github.com/clash-lang/clash-compiler/issues/1264)

--- a/changelog/2020-04-20T09:38:52+02:00_Add_NFDataX_instances_for_Data_Monoid_First_Last
+++ b/changelog/2020-04-20T09:38:52+02:00_Add_NFDataX_instances_for_Data_Monoid_First_Last
@@ -1,1 +1,0 @@
-ADDED: Added NFDataX instances for `Data.Monoid.{First,Last}`

--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.2
 
 name:                clash-cores
-version:             1.2.0
+version:             1.2.1
 synopsis:            A collection of IP cores for Clash
 description:         A collection of IP cores for Clash
 bug-reports:         https://github.com/clash-lang/clash-cores/issues

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -1,6 +1,6 @@
 Cabal-version:        2.2
 Name:                 clash-ghc
-Version:              1.2.0
+Version:              1.2.1
 Synopsis:             CAES Language for Synchronous Hardware
 Description:
   Clash is a functional hardware description language that borrows both its
@@ -145,8 +145,8 @@ library
                       transformers              >= 0.5.2.0  && < 0.6,
                       unordered-containers      >= 0.2.1.0  && < 0.3,
 
-                      clash-lib                 == 1.2.0,
-                      clash-prelude             == 1.2.0,
+                      clash-lib                 == 1.2.1,
+                      clash-prelude             == 1.2.1,
                       concurrent-supply         >= 0.1.7    && < 0.2,
                       ghc-typelits-extra        >= 0.3.2    && < 0.4,
                       ghc-typelits-knownnat     >= 0.6      && < 0.8,

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -1,6 +1,6 @@
 Cabal-version:        2.2
 Name:                 clash-lib
-Version:              1.2.0
+Version:              1.2.1
 Synopsis:             CAES Language for Synchronous Hardware - As a Library
 Description:
   Clash is a functional hardware description language that borrows both its
@@ -141,7 +141,7 @@ Library
                       base                    >= 4.11     && < 5,
                       binary                  >= 0.8.5    && < 0.11,
                       bytestring              >= 0.10.0.2 && < 0.11,
-                      clash-prelude           == 1.2.0,
+                      clash-prelude           == 1.2.1,
                       concurrent-supply       >= 0.1.7    && < 0.2,
                       containers              >= 0.5.0.0  && < 0.7,
                       data-binary-ieee754     >= 0.4.4    && < 0.6,

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -1,6 +1,6 @@
 Cabal-version:        2.2
 Name:                 clash-prelude
-Version:              1.2.0
+Version:              1.2.1
 Synopsis:             CAES Language for Synchronous Hardware - Prelude library
 Description:
   Clash is a functional hardware description language that borrows both its

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ master_doc = 'index'
 project = 'Clash'
 copyright = '2017-2019, The Clash Developers'
 author = 'The Clash Developers'
-version = '1.2.0'
+version = '1.2.1'
 release = version
 
 # Syntax highlighting


### PR DESCRIPTION
Merge after https://github.com/clash-lang/clash-compiler/pull/1273 and https://github.com/clash-lang/clash-compiler/pull/1272. Make sure to forwardport ` Update CHANGELOG.md in preparation of 1.2.1 `.