### PR TITLE
[snap] Install and expose cabal binary

### DIFF
--- a/bindist/linux/snap/bindist.nix
+++ b/bindist/linux/snap/bindist.nix
@@ -6,6 +6,8 @@ buildEnv {
   name = "clash-compiler-bindist";
   paths = [
     bash
+    pkgs.binutils
+    pkgs.haskellPackages.cabal-install
     (pkgs.haskellPackages.ghcWithPackages (p: with p; [clash-prelude clash-lib]))
     pkgs.haskellPackages.clash-ghc
   ];

--- a/bindist/linux/snap/snap/snapcraft.yaml
+++ b/bindist/linux/snap/snap/snapcraft.yaml
@@ -24,6 +24,10 @@ apps:
     command: bin/clashi
     plugs: [home]
 
+  cabal:
+    command: bin/cabal
+    plugs: [home]
+
 layout:
   /usr/nix:
     bind: $SNAP/usr/nix


### PR DESCRIPTION
Over at https://github.com/clash-lang/clash-compiler/issues/1291 Luka Rahne asked how to deal with Haskell dependencies when using the Clash snap package. The answer is not clear-cut for the current snap package, so this PR makes the snap carry and expose cabal too. This makes using Haskell dependencies relatively straight-forward thanks to ghc-environment files:

```bash
clash.cabal new-build --write-ghc-environment-files=always
clash Clash.Test --vhdl
```