### PR TITLE
Re-index in (Un)Signed fromSLV conversion

### DIFF
--- a/changelog/2020-04-28T10_19_48+02_00_fix1292
+++ b/changelog/2020-04-28T10_19_48+02_00_fix1292
@@ -1,0 +1,1 @@
+FIXED: Missing re-indexing in (Un)Signed fromSLV conversion [#1292](https://github.com/clash-lang/clash-compiler/issues/1292)

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -601,8 +601,9 @@ funDec _ (Signed _) = Just
       indent 2 ("return" <+> "std_logic_vector" <> parens ("s") <> semi) <> line <>
     "end" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "signed" <+> "is" <> line <>
+      indent 2 ("alias islv : std_logic_vector(0 to slv'length - 1) is slv;") <> line <>
     "begin" <> line <>
-      indent 2 ("return" <+> "signed" <> parens ("slv") <> semi) <> line <>
+      indent 2 ("return" <+> "signed" <> parens ("islv") <> semi) <> line <>
     "end" <> semi
   )
 
@@ -614,8 +615,9 @@ funDec _ (Unsigned _) = Just
       indent 2 ("return" <+> "std_logic_vector" <> parens ("u") <> semi) <> line <>
     "end" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "unsigned" <+> "is"  <> line <>
+      indent 2 "alias islv : std_logic_vector(0 to slv'length - 1) is slv;" <> line <>
     "begin" <> line <>
-      indent 2 ("return" <+> "unsigned" <> parens ("slv") <> semi) <> line <>
+      indent 2 ("return" <+> "unsigned" <> parens ("islv") <> semi) <> line <>
     "end" <> semi
 
   )

--- a/tests/shouldwork/Basic/T1292.hs
+++ b/tests/shouldwork/Basic/T1292.hs
@@ -1,0 +1,17 @@
+module T1292 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity :: Maybe (Index 16, Unsigned 4) -> Index 16
+topEntity (Just (a,_)) = a
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (Just (2,0):>Nil)
+    expectedOutput = outputVerifier' clk rst (2:>Nil)
+    done           = expectedOutput (fmap topEntity testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -268,6 +268,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1012" def{hdlSim=False}
         , runTest "T1242" def{hdlSim=False}
         , runTest "T1254" def{hdlTargets=[VHDL],hdlSim=False}
+        , runTest "T1292" def{hdlTargets=[VHDL]}
         , runTest "TagToEnum" def{hdlSim=False}
         , runTest "TestIndex" def{hdlSim=False}
         , runTest "Time" def


### PR DESCRIPTION
Fixes #1292
This error only showed up during *simulation* in ModelSim.
GHDL simulation and Quartus synthesis never raised any issues,
and also "did the right thing".