### PR TITLE
Fix clash-dev with ghc-8.10

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -13,9 +13,13 @@ set -e
 # On cabal>=2.4.1.0 and ghc<8.4.4 this isn't done automaticly
 cabal --write-ghc-environment-files=always new-build all
 
-# Check that clash-dev compiles
-sed "s/^ghci/ghc -fno-code/" clash-dev > clash-dev-test
-sh clash-dev-test
+# Check that clash-dev works
+echo "" > clash-dev.result
+echo 'genVHDL "./examples/FIR.hs" >> writeFile "clash-dev.result" "success"' | ./clash-dev
+if [[ "$(cat clash-dev.result)" != "success" ]]; then
+  echo "clash-dev test failed"
+  exit 1
+fi
 
 # Check whether version numbers in snap / clash-{prelude,lib,ghc} are the same
 cabal_files="clash-prelude/clash-prelude.cabal clash-lib/clash-lib.cabal clash-ghc/clash-ghc.cabal clash-cores/clash-cores.cabal"

--- a/Clash.hs
+++ b/Clash.hs
@@ -2,6 +2,8 @@
 
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
+module Main where
+
 #include "MachDeps.h"
 #define HDLSYN Other
 

--- a/clash-dev
+++ b/clash-dev
@@ -1,7 +1,6 @@
 #!/bin/sh
 GHC_VERSION=$(ghc --numeric-version)
 GHC_MAJOR_VERSION=$(echo ${GHC_VERSION} | tr -d '.' | head -c2)
-GHC_BIN_SRC=$(ls -d clash-ghc/src-bin-${GHC_MAJOR_VERSION}*)
 
 if [ ${GHC_MAJOR_VERSION} != 84 ]; then
   XNoStarIsType="-XNoStarIsType"
@@ -10,7 +9,6 @@ fi
 ghci \
   -fobject-code \
   -iclash-ghc/src-bin-common/ \
-  -i${GHC_BIN_SRC} \
   -iclash-lib/src \
   -iclash-ghc/src-ghc \
   -Wall -Wcompat -DTOOL_VERSION_ghc=\"${GHC_VERSION}\" \


### PR DESCRIPTION
Files without an explicit module declaration are treated differently by ghci-8.10.1,
only their main function is accessible.
Add a `module Main where` to Clash.hs so everything is exported.

Also improve the clash-dev test in .ci/test.sh to detect such issues.
And drop `-iclash-ghc/src-bin-...`, Clash.hs doesn't need it and it was causing warnings.