### PR TITLE
Backport snap release logic

### DIFF
--- a/.ci/snap_bindist.sh
+++ b/.ci/snap_bindist.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+# TODO: Clean up nix-store after building
+
+THREADS=$(nproc)
+export THREADS
+export XZ_DEFAULTS="-T ${THREADS} -3"
+ROOT=$(pwd)
+export ROOT
+
+# Restore cache (gitlab ci's method is too slow for big caches)
+tar xf usr_nix.tar.xz -C / || true
+
+# Build binary distribution
+# TODO: Remove need for ksh in mkBinDist.sh
+apt update
+apt install ksh -y
+cd bindist/linux/snap
+./mkBinDist.sh |& tee $ROOT/nix_build.log | (egrep -i '^(building|copying)' || true)
+
+# Create cache
+tar cJf $ROOT/usr_nix.tar.xz /usr/nix

--- a/.ci/snap_publish.sh
+++ b/.ci/snap_publish.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+SNAPCRAFT_BUILD_ENVIRONMENT_CPU=$(nproc)
+export SNAPCRAFT_BUILD_ENVIRONMENT_CPU
+SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY=16G
+export SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY
+
+# Prevent running if we've already published this revision
+apt update
+apt install git -y
+touch snap-last-run-hash
+if [ "$(cat snap-last-run-hash)" == "$(git rev-parse HEAD)-${RELEASE_CHANNEL}" ]; then
+  echo "Already built and published $(git rev-parse HEAD) on ${RELEASE_CHANNEL}. Nothing to do!";
+  exit 0;
+fi
+
+git rev-parse HEAD > snap-last-run-hash
+echo "-${RELEASE_CHANNEL}" >> snap-last-run-hash
+cd bindist/linux/snap || exit
+echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > snapcraft.login
+snapcraft login --with snapcraft.login
+snapcraft
+snapcraft push ./*.snap --release ${RELEASE_CHANNEL}

--- a/.ci/snap_publish.sh
+++ b/.ci/snap_publish.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 SNAPCRAFT_BUILD_ENVIRONMENT_CPU=$(nproc)
 export SNAPCRAFT_BUILD_ENVIRONMENT_CPU
 SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY=16G
@@ -12,10 +14,19 @@ if [ "$(cat snap-last-run-hash)" == "$(git rev-parse HEAD)-${RELEASE_CHANNEL}" ]
   echo "Already built and published $(git rev-parse HEAD) on ${RELEASE_CHANNEL}. Nothing to do!";
   exit 0;
 fi
-
 git rev-parse HEAD > snap-last-run-hash
 echo "-${RELEASE_CHANNEL}" >> snap-last-run-hash
+
 cd bindist/linux/snap || exit
+
+# Make sure devel is in snap/snapcraft.yaml before replacing it with 'stable'
+# (if applicable). sed doesn't fail if it doesn't replace anything.
+grep devel snap/snapcraft.yaml
+if [[ ${RELEASE_CHANNEL} == "stable" || ${RELEASE_CHANNEL} == "beta" ]]; then
+  # The Snap Store only allows grade=stable for stable snaps
+  sed -i s/devel/stable/ snap/snapcraft.yaml
+fi
+
 echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > snapcraft.login
 snapcraft login --with snapcraft.login
 snapcraft

--- a/.ci/snap_publish.sh
+++ b/.ci/snap_publish.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+set -x
 
 SNAPCRAFT_BUILD_ENVIRONMENT_CPU=$(nproc)
 export SNAPCRAFT_BUILD_ENVIRONMENT_CPU
@@ -18,11 +19,13 @@ apt install git -y
 # go into Snap's 'edge' channel, otherwise it's a pre-release dot-version
 # (i.e., latest released version + fixes accumulated in release branch) thus
 # beta.
-branch_name=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
-if [[ ${branch_name} == "master" && ${RELEASE_CHANNEL} == "beta_or_edge" ]]; then
-  RELEASE_CHANNEL="edge"
-else
-  RELEASE_CHANNEL="beta"
+branch_name=${CI_COMMIT_REF_SLUG}
+if [[ ${RELEASE_CHANNEL} == "beta_or_edge" ]]; then
+  if [[ ${branch_name} == "master" ]]; then
+    RELEASE_CHANNEL="edge"
+  else
+    RELEASE_CHANNEL="beta"
+  fi
 fi
 
 # Prevent running if we've already published this revision
@@ -46,6 +49,7 @@ if [[ ${RELEASE_CHANNEL} == "stable" || ${RELEASE_CHANNEL} == "beta" ]]; then
   sed -i s/devel/stable/ snap/snapcraft.yaml
 fi
 
+set +x
 echo "$SNAPCRAFT_LOGIN_FILE" | base64 --decode --ignore-garbage > snapcraft.login
 snapcraft login --with snapcraft.login
 snapcraft

--- a/.ci/snap_publish.sh
+++ b/.ci/snap_publish.sh
@@ -46,7 +46,7 @@ if [[ ${RELEASE_CHANNEL} == "stable" || ${RELEASE_CHANNEL} == "beta" ]]; then
   sed -i s/devel/stable/ snap/snapcraft.yaml
 fi
 
-echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > snapcraft.login
+echo "$SNAPCRAFT_LOGIN_FILE" | base64 --decode --ignore-garbage > snapcraft.login
 snapcraft login --with snapcraft.login
 snapcraft
 snapcraft push ./*.snap --release ${RELEASE_CHANNEL}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,10 +197,10 @@ snap-bindist:
   script:
     - .ci/snap_publish.sh
 
-snap-beta:
+snap-beta-or-edge:
   extends: .snap
   variables:
-    RELEASE_CHANNEL: beta
+    RELEASE_CHANNEL: beta_or_edge
   only:
     - schedules
     - triggers

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,7 +186,7 @@ snap-bindist:
   image: snapcore/snapcraft
   stage: publish
   cache:
-    key: snap-last-run-hash
+    key: snap-last-run-hash-$CI_COMMIT_REF_SLUG
     paths:
       - snap-last-run-hash
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,15 +173,7 @@ snap-bindist:
       - bindist/linux/snap/clash-snap-bindist.tar.xz
     expire_in: 1 week
   script:
-    # TODO: Clean up nix-store after building
-    - export THREADS=$(nproc)
-    - export XZ_DEFAULTS="-T ${THREADS} -3"
-    - export ROOT=$(pwd)
-    - tar xf usr_nix.tar.xz -C / || true
-    - apt update
-    - apt install ksh -y  # TODO: Remove need for ksh in mkBinDist.sh
-    - cd bindist/linux/snap && ./mkBinDist.sh |& tee $ROOT/nix_build.log | (egrep -i '^(building|copying)' || true)
-    - tar cJf $ROOT/usr_nix.tar.xz /usr/nix
+    - .ci/snap_bindist.sh
 
   # Run every night, when explicitly triggered, or when tagged (release)
   only:
@@ -203,23 +195,7 @@ snap-bindist:
       - bindist/linux/snap/*.snap
     expire_in: 1 week
   script:
-    - export SNAPCRAFT_BUILD_ENVIRONMENT_CPU=$(nproc)
-    - export SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY=16G
-    - apt update
-    - apt install git -y
-    - touch snap-last-run-hash
-    - |
-      if [ "$(cat snap-last-run-hash)" == "$(git rev-parse HEAD)-${RELEASE_CHANNEL}" ]; then
-        echo "Already built and published $(git rev-parse HEAD) on ${RELEASE_CHANNEL}. Nothing to do!";
-        exit 0;
-      fi
-    - git rev-parse HEAD > snap-last-run-hash
-    - echo "-${RELEASE_CHANNEL}" >> snap-last-run-hash
-    - cd bindist/linux/snap
-    - echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > snapcraft.login
-    - snapcraft login --with snapcraft.login
-    - snapcraft
-    - snapcraft push *.snap --release ${RELEASE_CHANNEL}
+    - .ci/snap_publish.sh
 
 snap-beta:
   extends: .snap


### PR DESCRIPTION
During the 1.2.0 release I discovered some issues with the snap release logic and fixed that through a number of pull requests. I forgot to backport them to 1.2, which [caused publishing 1.2.1 on snapcraft.io to fail](https://gitlab.com/clash-lang/clash-compiler/-/jobs/524507410). This PR backports the changes. I'll manually release 1.2.1 on snapcraft.