### PR TITLE
Add '-fclash-debug-transformations-{from,limit}'

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -63,6 +63,8 @@ flagsClash :: IORef ClashOpts -> [Flag IO]
 flagsClash r = [
     defFlag "fclash-debug"                       $ SepArg (setDebugLevel r)
   , defFlag "fclash-debug-transformations"       $ SepArg (setDebugTransformations r)
+  , defFlag "fclash-debug-transformations-from"  $ OptIntSuffix (setDebugTransformationsFrom r)
+  , defFlag "fclash-debug-transformations-limit" $ OptIntSuffix (setDebugTransformationsLimit r)
   , defFlag "fclash-hdldir"                      $ SepArg (setHdlDir r)
   , defFlag "fclash-hdlsyn"                      $ SepArg (setHdlSyn r)
   , defFlag "fclash-nocache"                     $ NoArg (deprecated "nocache" "no-cache" setNoCache r)
@@ -137,6 +139,16 @@ setDebugTransformations r s =
  where
   transformations = Set.fromList (filter (not . null) (map trim (splitOn "," s)))
   trim = dropWhileEnd isSpace . dropWhile isSpace
+
+setDebugTransformationsFrom :: IORef ClashOpts -> Maybe Int -> EwM IO ()
+setDebugTransformationsFrom r (Just n) =
+  liftEwM (modifyIORef r (\c -> c {opt_dbgTransformationsFrom = n}))
+setDebugTransformationsFrom _r Nothing = pure ()
+
+setDebugTransformationsLimit :: IORef ClashOpts -> Maybe Int -> EwM IO ()
+setDebugTransformationsLimit r (Just n) =
+  liftEwM (modifyIORef r (\c -> c {opt_dbgTransformationsLimit = n}))
+setDebugTransformationsLimit _r Nothing = pure ()
 
 setDebugLevel :: IORef ClashOpts
               -> String

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -73,6 +73,13 @@ data ClashOpts = ClashOpts { opt_inlineLimit :: Int
                            , opt_inlineConstantLimit :: Word
                            , opt_dbgLevel    :: DebugLevel
                            , opt_dbgTransformations :: Set.Set String
+                           , opt_dbgTransformationsFrom :: Int
+                           -- ^ Only output debug information from (applied)
+                           -- transformation n
+                           , opt_dbgTransformationsLimit :: Int
+                           -- ^ Only output debug information for n (applied)
+                           -- transformations. If this limit is exceeded, Clash
+                           -- will stop normalizing.
                            , opt_cachehdl    :: Bool
                            , opt_cleanhdl    :: Bool
                            , opt_primWarn    :: Bool
@@ -124,6 +131,8 @@ instance Hashable ClashOpts where
     opt_inlineConstantLimit `hashWithSalt`
     opt_dbgLevel `hashSet`
     opt_dbgTransformations `hashWithSalt`
+    opt_dbgTransformationsFrom `hashWithSalt`
+    opt_dbgTransformationsLimit `hashWithSalt`
     opt_cachehdl `hashWithSalt`
     opt_cleanhdl `hashWithSalt`
     opt_primWarn `hashWithSalt`
@@ -159,6 +168,8 @@ defClashOpts
   = ClashOpts
   { opt_dbgLevel            = DebugNone
   , opt_dbgTransformations  = Set.empty
+  , opt_dbgTransformationsFrom = 0
+  , opt_dbgTransformationsLimit = maxBound
   , opt_inlineLimit         = 20
   , opt_specLimit           = 20
   , opt_inlineFunctionLimit = 15

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -119,6 +119,8 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcs
     rwEnv     = RewriteEnv
                   (opt_dbgLevel opts)
                   (opt_dbgTransformations opts)
+                  (opt_dbgTransformationsFrom opts)
+                  (opt_dbgTransformationsLimit opts)
                   (opt_aggressiveXOpt opts)
                   typeTrans
                   tcm

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -89,6 +89,11 @@ data RewriteEnv
   { _dbgLevel       :: DebugLevel
   -- ^ Level at which we print debugging messages
   , _dbgTransformations :: Set.Set String
+  -- ^ See ClashOpts.dbgTransformations
+  , _dbgTransformationsFrom :: Int
+  -- ^ See ClashOpts.opt_dbgTransformationsFrom
+  , _dbgTransformationsLimit :: Int
+  -- ^ See ClashOpts.opt_dbgTransformationsLimit
   , _aggressiveXOpt :: Bool
   -- ^ Transformations to print debugging info for
   , _typeTranslator :: CustomReprs

--- a/docs/developing-hardware/flags.rst
+++ b/docs/developing-hardware/flags.rst
@@ -43,6 +43,24 @@ Clash Compiler Flags
 
   **Default:** []
 
+-fclash-debug-transformations-from
+  Only print debug output from applied transformation ``n`` and onwards.
+
+  .. code-block:: bash
+
+    clash -fclash-debug-transformations-from=21570
+
+  **Default:** 0
+
+-fclash-debug-transformations-limit
+  Only print debug output for ``n`` applied transformations.
+
+  .. code-block:: bash
+
+    clash -fclash-debug-transformations-limit=12
+
+  **Default:** MAX_INT
+
 -fclash-hdldir
   Specify the directory that generated HDL is written into. Generated code
   is still put into a directory named according to the output language within


### PR DESCRIPTION
Clash now emits transformation numbers when running in debug mode. For
example, running with -fclash-debug DebugName could output:

    caseCase {0}
    caseCon {1}
    bindOrLiftNonRep {2}
    [..]

Running with -fclash-debug-transformations-from=1 would omit the first
debug line. Running with -fclash-debug-transformations-limit=2 would
only print the first two and stop Clash after that. These flags can be
combined to get only a slice of transactions.

Useful when a "cheap" debug level (e.g., DebugName) identified a number
of troublesome transformations, while running with an "expensive" debug
level (e.g., DebugApplied) would produce massive logs.

--------------------------------------

Note: purposely didn't add a changelog entry, as this isn't really a user feature nor bug.