### PR TITLE
Cleanup unused let-bindings in bindPureHeap. Fix #1320

### DIFF
--- a/changelog/2020-05-11T16_51_33+02_00_fix_1320
+++ b/changelog/2020-05-11T16_51_33+02_00_fix_1320
@@ -1,0 +1,1 @@
+FIXES: Certain case-expressions throw the Clash compiler into an infinite loop [#1320](https://github.com/clash-lang/clash-compiler/issues/1320)

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -37,9 +37,12 @@ import           Data.Bifunctor              (bimap)
 import           Data.Coerce                 (coerce)
 import           Data.Functor.Const          (Const (..))
 import           Data.List                   (group, partition, sort)
+import qualified Data.List                   as List
+import qualified Data.List.Extra             as List
 import           Data.List.Extra             (allM, partitionM)
 import qualified Data.Map                    as Map
-import           Data.Maybe                  (catMaybes,isJust,mapMaybe)
+import           Data.Maybe
+  (catMaybes, isJust, mapMaybe, fromMaybe)
 import qualified Data.Monoid                 as Monoid
 import qualified Data.Set                    as Set
 import qualified Data.Set.Lens               as Lens
@@ -61,7 +64,7 @@ import           Clash.Core.DataCon          (dcExtTyVars)
 import           Clash.Core.Evaluator.Types  (PureHeap, whnf')
 import           Clash.Core.FreeVars
   (freeLocalVars, hasLocalFreeVars, localIdDoesNotOccurIn, localIdOccursIn,
-   typeFreeVars, termFreeVars')
+   typeFreeVars, termFreeVars', freeLocalIds)
 import           Clash.Core.Name
 import           Clash.Core.Pretty           (showPpr)
 import           Clash.Core.Subst
@@ -80,7 +83,8 @@ import           Clash.Core.Var
   (Id, IdScope (..), TyVar, Var (..), isLocalId, mkGlobalId, mkLocalId, mkTyVar)
 import           Clash.Core.VarEnv
   (InScopeSet, VarEnv, elemVarSet, extendInScopeSetList, mkInScopeSet,
-   uniqAway, uniqAway', mapVarEnv)
+   uniqAway, uniqAway', mapVarEnv, eltsVarEnv, unitVarSet, emptyVarEnv,
+   mkVarEnv, eltsVarSet, elemVarEnv, lookupVarEnv, extendVarEnv)
 import           Clash.Debug (traceIf)
 import           Clash.Driver.Types
   (DebugLevel (..), BindingMap, Binding(..))
@@ -1118,7 +1122,7 @@ bindPureHeap
 bindPureHeap tcm heap rw (TransformContext is0 hist) e = do
   (e1, Monoid.getAny -> hasChanged) <- Writer.listen $ rw ctx e
   if hasChanged && not (null bndrs)
-    then return $ Letrec bndrs e1
+    then return $ fromMaybe (Letrec bndrs e1) (removeUnusedBinders bndrs e1)
     else return e1
   where
     bndrs = map toLetBinding $ toListUniqMap heap
@@ -1131,3 +1135,33 @@ bindPureHeap tcm heap rw (TransformContext is0 hist) e = do
       where
         ty = termType tcm term
         nm = mkLocalId ty (mkUnsafeSystemName "x" uniq) -- See [Note: Name re-creation]
+
+-- | Remove unused binders in given let-binding. Returns /Nothing/ if no unused
+-- binders were found.
+removeUnusedBinders
+  :: [LetBinding]
+  -> Term
+  -> Maybe Term
+removeUnusedBinders binds body =
+  case eltsVarEnv used of
+    [] -> Just body
+    qqL | not (List.equalLength qqL binds)
+        -> Just (Letrec qqL body)
+        | otherwise
+        -> Nothing
+ where
+  bodyFVs = Lens.foldMapOf freeLocalIds unitVarSet body
+  used = List.foldl' collectUsed emptyVarEnv (eltsVarSet bodyFVs)
+  bindsEnv = mkVarEnv (map (\(x,e0) -> (x,(x,e0))) binds)
+
+  collectUsed env v =
+    if v `elemVarEnv` env then
+      env
+    else
+      case lookupVarEnv v bindsEnv of
+        Just (x,e0) ->
+          let eFVs = Lens.foldMapOf freeLocalIds unitVarSet e0
+          in  List.foldl' collectUsed
+                          (extendVarEnv x (x,e0) env)
+                          (eltsVarSet eFVs)
+        Nothing -> env


### PR DESCRIPTION
Has no measurable effect on performance. Before:

```
benchmarking normalization of examples/FIR.hs
time                 34.50 ms   (33.73 ms .. 35.90 ms)
                     0.997 R²   (0.993 R² .. 1.000 R²)
mean                 34.03 ms   (33.85 ms .. 34.93 ms)
std dev              636.2 μs   (132.1 μs .. 1.293 ms)

benchmarking normalization of examples/Reducer.hs
time                 708.5 ms   (682.9 ms .. 739.2 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 721.6 ms   (714.8 ms .. 728.1 ms)
std dev              8.124 ms   (516.8 μs .. 9.930 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of examples/Queens.hs
time                 16.42 ms   (16.41 ms .. 16.43 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 16.43 ms   (16.43 ms .. 16.44 ms)
std dev              16.21 μs   (13.15 μs .. 20.86 μs)

benchmarking normalization of benchmark/tests/BundleMapRepeat.hs
time                 23.81 ms   (22.19 ms .. 25.28 ms)
                     0.980 R²   (0.958 R² .. 0.993 R²)
mean                 23.03 ms   (22.45 ms .. 24.04 ms)
std dev              1.620 ms   (901.1 μs .. 2.333 ms)
variance introduced by outliers: 29% (moderately inflated)

benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 1.136 s    (1.100 s .. NaN s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.122 s    (1.108 s .. 1.130 s)
std dev              13.55 ms   (1.035 ms .. 17.09 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of tests/shouldwork/Basic/AES.hs
time                 317.0 ms   (307.1 ms .. 351.8 ms)
                     0.995 R²   (0.983 R² .. 1.000 R²)
mean                 312.5 ms   (308.0 ms .. 325.6 ms)
std dev              9.770 ms   (117.0 μs .. 12.09 ms)
variance introduced by outliers: 16% (moderately inflated)
```

after

```
benchmarking normalization of examples/FIR.hs
time                 34.96 ms   (34.21 ms .. 36.43 ms)
                     0.997 R²   (0.994 R² .. 1.000 R²)
mean                 34.47 ms   (34.30 ms .. 34.97 ms)
std dev              632.4 μs   (123.1 μs .. 1.131 ms)

benchmarking normalization of examples/Reducer.hs
time                 716.3 ms   (698.6 ms .. 730.6 ms)
                     1.000 R²   (NaN R² .. 1.000 R²)
mean                 727.9 ms   (721.6 ms .. 733.3 ms)
std dev              6.972 ms   (5.981 ms .. 7.826 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of examples/Queens.hs
time                 16.78 ms   (16.67 ms .. 16.92 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 16.76 ms   (16.70 ms .. 16.86 ms)
std dev              169.0 μs   (108.0 μs .. 241.7 μs)

benchmarking normalization of benchmark/tests/BundleMapRepeat.hs
time                 22.86 ms   (21.89 ms .. 24.42 ms)
                     0.982 R²   (0.960 R² .. 1.000 R²)
mean                 22.62 ms   (22.16 ms .. 23.57 ms)
std dev              1.507 ms   (775.7 μs .. 2.400 ms)
variance introduced by outliers: 28% (moderately inflated)

benchmarking normalization of benchmark/tests/PipelinesViaFolds.hs
time                 1.138 s    (1.106 s .. 1.163 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.123 s    (1.110 s .. 1.130 s)
std dev              12.08 ms   (915.4 μs .. 15.23 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of tests/shouldwork/Basic/AES.hs
time                 322.9 ms   (301.7 ms .. 360.2 ms)
                     0.994 R²   (0.968 R² .. 1.000 R²)
mean                 319.4 ms   (314.6 ms .. 332.8 ms)
std dev              10.09 ms   (316.6 μs .. 12.76 ms)
variance introduced by outliers: 16% (moderately inflated)

```