### PR TITLE
Detect terminal size and use it in showDoc

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -170,6 +170,7 @@ Library
                       reducers                >= 3.12.2   && < 4.0,
                       template-haskell        >= 2.8.0.0  && < 2.17,
                       temporary               >= 1.2.1    && < 1.4,
+                      terminal-size           >= 0.3      && < 0.4,
                       text                    >= 1.2.2    && < 1.3,
                       text-show               >= 3.7      && < 3.9,
                       time                    >= 1.4.0.1  && < 1.11,

--- a/clash-lib/src/Clash/Pretty.hs
+++ b/clash-lib/src/Clash/Pretty.hs
@@ -1,10 +1,37 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Clash.Pretty where
 
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.String
+import Data.Maybe (fromMaybe)
+import qualified System.Console.Terminal.Size as Terminal
+import System.Environment (lookupEnv)
+import System.IO.Unsafe (unsafePerformIO)
+import Text.Read (readMaybe)
+import qualified Clash.Util.Interpolate as I
+import GHC.Stack (HasCallStack)
+
+unsafeLookupEnvWord :: HasCallStack => String -> Word -> Word
+unsafeLookupEnvWord key dflt =
+  case unsafePerformIO (lookupEnv key) of
+    Nothing -> dflt
+    Just w -> flip fromMaybe (readMaybe w) $ error [I.i|
+      'unsafeLookupEnvWord' tried to lookup #{key} in the environment. It found
+      it, but couldn't interpret it to as a Word (positive Int). Found:
+
+        #{w}
+    |]
+
+defaultPprWidth :: Int
+defaultPprWidth =
+  let dflt = max 80 (maybe 80 Terminal.width (unsafePerformIO Terminal.size)) in
+  fromIntegral (unsafeLookupEnvWord "CLASH_PPR_WIDTH" dflt)
 
 showDoc :: Doc ann -> String
-showDoc = renderString . layoutPretty (LayoutOptions (AvailablePerLine 80 0.6))
+showDoc =
+  let layoutOpts = LayoutOptions (AvailablePerLine defaultPprWidth 0.6) in
+  renderString . layoutPretty layoutOpts
 
 removeAnnotations :: Doc ann -> Doc ()
 removeAnnotations = reAnnotate $ const ()

--- a/testsuite/src/Test/Tasty/Clash.hs
+++ b/testsuite/src/Test/Tasty/Clash.hs
@@ -759,6 +759,8 @@ clashLibTest' env target extraGhcArgs modName funcName path =
              , "--ghc-arg=clash-testsuite"
              , "--ghc-arg=-main-is"
              , "--ghc-arg=" ++ modName ++ "." ++ funcName ++ show target
+             , "--ghc-arg=-outputdir"
+             , "--ghc-arg=" <> env </> show target
              ] ++ map ("--ghc-arg="++) extraGhcArgs ++
              [ env </> modName <.> "hs"
              ]


### PR DESCRIPTION
Before this patch debugging output would limit itself to 80 chars. This
makes reading logs much harder than it should be. In the current logic:

  1. The environment var CLASH_PPR_WIDTH takes precedence over
     everything. If it's set to 10 chars, this will be obeyed.

  2. If CLASH_PPR_WIDTH is not set, the terminal width will be probed.
     If terminal width can't be detected or if the returned size is
     smaller than 80 chars, a limit of 80 chars will be used.