### PR TITLE
DEC: skip recursive groups of let-bindings (backport 1.2)

### DIFF
--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -581,3 +581,15 @@ inverseTopSortLetBindings (Letrec bndrs0 res) =
 
 inverseTopSortLetBindings e = e
 {-# SCC inverseTopSortLetBindings #-}
+
+-- | Group let-bindings into cyclic groups and acyclic individual bindings
+sccLetBindings
+  :: HasCallStack
+  => [LetBinding]
+  -> [Graph.SCC LetBinding]
+sccLetBindings =
+  Graph.stronglyConnComp .
+  (map (\(i,e) -> let fvs = fmap varUniq
+                            (Set.elems (Lens.setOf freeLocalIds e) )
+                  in  ((i,e),varUniq i,fvs)))
+{-# SCC sccLetBindings #-}


### PR DESCRIPTION
Solves issue where DEC introduced combinational loops
"in the wild"; i.e. no small unit test exists.