### PR TITLE
Do not disable the monomorphism restriction

### DIFF
--- a/changelog/2020-05-28T16_27_54+02_00_no_disable_monomorphism
+++ b/changelog/2020-05-28T16_27_54+02_00_no_disable_monomorphism
@@ -1,0 +1,4 @@
+CHANGED: Clash no longer disables the monomorphism restriction.
+See https://github.com/clash-lang/clash-compiler/issues/1270, and mentioned issues, as to why.
+This can cause, among other things, certain eta-reduced descriptions of sequential circuits to no longer type-check.
+See https://github.com/clash-lang/clash-compiler/pull/1349 for code hints on what kind of changes to make to your own code in case it no longer type-checks due to this change.

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -689,8 +689,11 @@ setWantedLanguageExtensions :: GHC.DynFlags -> GHC.DynFlags
 setWantedLanguageExtensions df =
    foldl' DynFlags.gopt_set
     (foldl' DynFlags.xopt_unset
-      (foldl' DynFlags.xopt_set df wantedLanguageExtensions) unwantedLanguageExtensions)
-      wantedOptimizations
+      (foldl' DynFlags.xopt_set
+        (DynFlags.wopt_set df DynFlags.Opt_WarnMonomorphism)
+        wantedLanguageExtensions)
+      unwantedLanguageExtensions)
+    wantedOptimizations
  where
   wantedOptimizations =
     [ Opt_CSE -- CSE

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1848,8 +1848,8 @@ recToLetRec (TransformContext is0 []) e = do
     eqArg _ v1 v2@(stripTicks -> Var {})
       = v1 == v2
     eqArg tcm v1 v2@(collectArgs . stripTicks -> (Data _, args'))
-      | let t1 = termType tcm v1
-      , let t2 = termType tcm v2
+      | let t1 = normalizeType tcm (termType tcm v1)
+      , let t2 = normalizeType tcm (termType tcm v2)
       , t1 == t2
       = if isClassConstraint t1 then
           -- Class constraints are equal if their types are equal, so we can

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -254,7 +254,7 @@ applyDebug lvl _transformations _fromLimit name exprOld hasChanged exprNew =
                      , "substitution."
                      ])
 
-    traceIf (lvl >= DebugApplied && (not (beforeTy `aeqType` afterTy)))
+    traceIf (lvl >= DebugApplied && (not (normalizeType tcm beforeTy `aeqType` normalizeType tcm afterTy)))
             ( concat [ $(curLoc)
                      , "Error when applying rewrite ", name
                      , " to:\n" , before

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -301,11 +301,9 @@ wantedLanguageExtensions =
 unwantedLanguageExtensions :: [LangExt.Extension]
 unwantedLanguageExtensions =
   [ LangExt.ImplicitPrelude
-  , LangExt.MonomorphismRestriction
 #if MIN_VERSION_ghc(8,6,0)
   , LangExt.StarIsType
 #endif
   , LangExt.Strict
   , LangExt.StrictData
   ]
-

--- a/examples/CHIP8.hs
+++ b/examples/CHIP8.hs
@@ -18,11 +18,11 @@ topEntity
     -> Enable System
     -> ( Signal System Bit
        )
-topEntity = exposeClockResetEnable output
-  where
-    cpuIn = pure CPUIn{ cpuInMem = 0x00 }
+topEntity = exposeClockResetEnable $ let
+    cpuIn  = pure CPUIn{ cpuInMem = 0x00 } :: Signal System CPUIn
     cpuOut = mealyState (runCPU defaultOut cpu) initState cpuIn
     output = boolToBit . (== 0x00) . cpuOutMemAddr <$> cpuOut
+ in output
 
 mealyState
   :: ( HiddenClockResetEnable tag

--- a/tests/shouldwork/Basic/NameOverlap.hs
+++ b/tests/shouldwork/Basic/NameOverlap.hs
@@ -18,7 +18,8 @@ topEntity
     -> Reset System
     -> Enable System
     -> Signal System Bit
-topEntity = exposeClockResetEnable board
-  where
+topEntity = exposeClockResetEnable $ let
     board = boolToBit <$> led
+    led :: Signal System Bool
     led = register True $ complement <$> led
+  in board

--- a/tests/shouldwork/BitVector/ExtendingNumZero.hs
+++ b/tests/shouldwork/BitVector/ExtendingNumZero.hs
@@ -28,9 +28,10 @@ topEntity clk rst =
 testBench :: Signal System Bool
 testBench = done
   where
-    n              = 22
+    n              = 22 :: BitVector 17
+    n1             = 22 :: BitVector 16
     expectedOutput = outputVerifier' clk rst ((n, n, n, -n, 0, 0) :> Nil)
-    done           = expectedOutput (topEntity clk rst (pure n))
+    done           = expectedOutput (topEntity clk rst (pure n1))
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
 {-# NOINLINE testBench #-}

--- a/tests/shouldwork/BitVector/UnpackUndefined.hs
+++ b/tests/shouldwork/BitVector/UnpackUndefined.hs
@@ -4,4 +4,4 @@ import Clash.Sized.Internal.BitVector
 
 -- https://github.com/clash-lang/clash-compiler/issues/804
 state = unpack undefined#    :: Vec 3 Bit
-topEntity = register @System state
+topEntity a = register @System state a

--- a/tests/shouldwork/CustomReprs/Deriving/BitPackDerivation.hs
+++ b/tests/shouldwork/CustomReprs/Deriving/BitPackDerivation.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module BitPackDerivation where
 
 import Clash.Prelude
@@ -32,6 +34,7 @@ testBench
   :: Signal System Bool
 testBench = done'
   where
+    testInput :: _ => _
     testInput = stimuliGenerator $ Toy
                                 :> Maintenance
                                 :> Freight (2, 3)
@@ -45,6 +48,7 @@ testBench = done'
                                             :> ($$(bLit "00101011") :: BitVector 8)
                                             :> ($$(bLit "000101..") :: BitVector 8)
                                             :> Nil
+    done :: _ => _
     done  = expectedOutput (topEntity testInput)
     done' =
       withClockResetEnable

--- a/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
+++ b/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
@@ -6,7 +6,7 @@ module Indexed where
 import Type
 import Clash.Annotations.BitRepresentation.Deriving
 import Clash.Prelude
-import Clash.Prelude.Testbench
+import Clash.Explicit.Testbench
 
 deriveDefaultAnnotation [t| WithVector |]
 
@@ -21,24 +21,20 @@ topEntity = fmap topEntity'
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool
-testBench = done'
+testBench = done
   where
-    testInput = stimuliGenerator $ MkTB True
+    testInput = stimuliGenerator clk rst $ MkTB True
                                 :> MkTB False
                                 :> MkTA (True :> False :> Nil) 2
                                 :> MkTA (True :> True :> Nil) 2
                                 :> Nil
 
-    expectedOutput = outputVerifier' $ True
+    expectedOutput = outputVerifier' clk rst $ True
                                    :> False
                                    :> False
                                    :> True
                                    :> Nil
 
-    done  = expectedOutput (topEntity testInput)
-    done' =
-      withClockResetEnable
-        (tbSystemClockGen (not <$> done'))
-        systemResetGen
-        enableGen
-        done
+    done = expectedOutput (topEntity testInput)
+    clk  = tbSystemClockGen (not <$> done)
+    rst  = systemResetGen

--- a/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
+++ b/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
 module Rotate where
 
 import Clash.Prelude.Testbench
@@ -77,18 +80,20 @@ topEntity = fmap f
 testBench :: Signal System Bool
 testBench = done'
   where
+    testInput :: _ => _
     testInput = stimuliGenerator $ Nothing
                                :> (Just Red)
                                :> (Just Green)
                                :> (Just Blue)
                                :> Nil
 
-    expectedOutput = outputVerifier' $ Red
+    expectedOutput a = outputVerifier' (Red
                                    :> Green
                                    :> Blue
                                    :> Red
-                                   :> Nil
+                                   :> Nil) a
 
+    done :: _ => _
     done  = expectedOutput (topEntity testInput)
     done' =
       withClockResetEnable

--- a/tests/shouldwork/CustomReprs/RotateC/ReprCompact.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprCompact.hs
@@ -50,5 +50,5 @@ import Clash.Annotations.BitRepresentation
         [0b11] -- Masks
     ]) #-}
 
-topEntity = RotateC.topEntity
+topEntity a = RotateC.topEntity a
 testBench = RotateC.testBench

--- a/tests/shouldwork/CustomReprs/RotateC/ReprCompactScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprCompactScrambled.hs
@@ -50,6 +50,5 @@ import Clash.Annotations.BitRepresentation
         [0b11] -- Masks
     ]) #-}
 
-
-topEntity = RotateC.topEntity
+topEntity a = RotateC.topEntity a
 testBench = RotateC.testBench

--- a/tests/shouldwork/CustomReprs/RotateC/ReprLastBitConstructor.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprLastBitConstructor.hs
@@ -28,5 +28,5 @@ import Clash.Annotations.BitRepresentation
         [0b110] -- Masks
     ]) #-}
 
-topEntity = RotateC.topEntity
+topEntity a = RotateC.topEntity a
 testBench = RotateC.testBench

--- a/tests/shouldwork/CustomReprs/RotateC/ReprStrangeMasks.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprStrangeMasks.hs
@@ -49,6 +49,5 @@ import Clash.Annotations.BitRepresentation
         [0b01010] -- Masks
     ]) #-}
 
-
-topEntity = RotateC.topEntity
+topEntity a = RotateC.topEntity a
 testBench = RotateC.testBench

--- a/tests/shouldwork/CustomReprs/RotateC/ReprWide.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprWide.hs
@@ -33,5 +33,5 @@ import Clash.Annotations.BitRepresentation
         []
     ]) #-}
 
-topEntity = RotateC.topEntity
+topEntity a = RotateC.topEntity a
 testBench = RotateC.testBench

--- a/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module RotateC where
 
 import Clash.Prelude.Testbench
@@ -44,18 +46,20 @@ topEntity = fmap f
 testBench :: Signal System Bool
 testBench = done'
   where
+    testInput :: _ => _
     testInput = stimuliGenerator $ NothingC
                                :> (JustC Red)
                                :> (JustC Green)
                                :> (JustC Blue)
                                :> Nil
 
-    expectedOutput = outputVerifier' $ Red
+    expectedOutput a = outputVerifier' (Red
                                    :> Green
                                    :> Blue
                                    :> Red
-                                   :> Nil
+                                   :> Nil) a
 
+    done :: _ => _
     done = expectedOutput (topEntity testInput)
     done' =
       withClockResetEnable

--- a/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
 module RotateCScrambled
   ( topEntity
   , testBench
@@ -88,18 +91,20 @@ topEntity = fmap f
 testBench :: Signal System Bool
 testBench = done'
   where
+    testInput :: _ => _
     testInput = stimuliGenerator $ NothingC
                                :> (JustC Red)
                                :> (JustC Green)
                                :> (JustC Blue)
                                :> Nil
 
-    expectedOutput = outputVerifier' $ Blue
+    expectedOutput a = outputVerifier' (Blue
                                    :> Green
                                    :> Blue
                                    :> Red
-                                   :> Nil
+                                   :> Nil) a
 
+    done :: _ => _
     done  = expectedOutput (topEntity testInput)
     done' =
       withClockResetEnable

--- a/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
+++ b/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
 module RotateCNested where
 
 import Clash.Prelude.Testbench
@@ -82,6 +85,7 @@ topEntity = fmap f
 testBench :: Signal System Bool
 testBench = done'
   where
+    testInput :: _ => _
     testInput = stimuliGenerator $ Nothing
                                :> Just (NothingC)
                                :> Just (JustC Red)
@@ -89,6 +93,7 @@ testBench = done'
                                :> Just (JustC Blue)
                                :> Nil
 
+    expectedOutput :: _ => _
     expectedOutput = outputVerifier' $ Red
                                    :> Blue
                                    :> Green
@@ -96,6 +101,7 @@ testBench = done'
                                    :> Red
                                    :> Nil
 
+    done :: _ => _
     done  = expectedOutput (topEntity testInput)
     done' =
       withClockResetEnable

--- a/tests/shouldwork/Floating/FloatConstFolding.hs
+++ b/tests/shouldwork/Floating/FloatConstFolding.hs
@@ -55,11 +55,14 @@ operations
   . (/ f)
   . recip
 
+twiddle :: Floating a => a -> a
 twiddle = (+ 1e-5) -- prevent any optimiser from doing: asin . sin <=> id
 
+pi_noinline :: Floating a => a
 pi_noinline = pi
 {-# NOINLINE pi_noinline #-}
 
+a,b,c,d,e,f :: Floating a => a
 a = 1.0
 b = a + pi_noinline
 c = b + pi_noinline
@@ -67,6 +70,7 @@ d = c + pi_noinline
 e = d + pi_noinline
 f = e + pi_noinline
 
+expectedOutput :: Vec 1 (Float, Double, Signed 8, Signed 9)
 expectedOutput = (unpack 0x3F45628A, unpack 0x3FED4161686C9EEE, 1, 1) :> Nil
 
 testBench :: Signal System Bool

--- a/tests/shouldwork/Naming/T967b.hs
+++ b/tests/shouldwork/Naming/T967b.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module T967b where
 
 import Clash.Prelude
 
+topEntity :: SystemClockResetEnable => Signal System Bool
 topEntity = setName @"myRegister" (delay @System True topEntity)

--- a/tests/shouldwork/Numbers/SignedZero.hs
+++ b/tests/shouldwork/Numbers/SignedZero.hs
@@ -28,9 +28,10 @@ topEntity clk rst =
 testBench :: Signal System Bool
 testBench = done
   where
-    n              = 22
+    n              = 22 :: Signed 17
+    n1             = 22 :: Signed 16
     expectedOutput = outputVerifier' clk rst ((n, n, n, -n, 0, 0) :> Nil)
-    done           = expectedOutput (topEntity clk rst (pure n))
+    done           = expectedOutput (topEntity clk rst (pure n1))
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
 {-# NOINLINE testBench #-}

--- a/tests/shouldwork/Numbers/UnsignedZero.hs
+++ b/tests/shouldwork/Numbers/UnsignedZero.hs
@@ -26,9 +26,10 @@ topEntity clk rst =
 testBench :: Signal System Bool
 testBench = done
   where
-    n              = 22
+    n              = 22 :: Unsigned 17
+    n1             = 22 :: Unsigned 16
     expectedOutput = outputVerifier' clk rst ((n, n, n, 0, 0) :> Nil)
-    done           = expectedOutput (topEntity clk rst (pure n))
+    done           = expectedOutput (topEntity clk rst (pure n1))
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
 {-# NOINLINE testBench #-}

--- a/tests/shouldwork/RTree/TRepeat2.hs
+++ b/tests/shouldwork/RTree/TRepeat2.hs
@@ -3,7 +3,7 @@ module TRepeat2 where
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
-topEntity = register @System (trepeat @2 True)
+topEntity x = register @System (trepeat @2 True) x
 {-# NOINLINE topEntity #-}
 
 testBench :: Signal System Bool

--- a/tests/shouldwork/Signal/BlockRamLazy.hs
+++ b/tests/shouldwork/Signal/BlockRamLazy.hs
@@ -9,6 +9,7 @@ topEntity :: Signal System (Unsigned 1)
 topEntity = pure 0
 
 -- Actual bug test
+bug :: SystemClockResetEnable => Signal System (Unsigned 1)
 bug = blockRamPow2 (repeat (0 :: Unsigned 1)) bug (pure Nothing)
 
 main = mapM printX $ sampleN @System 4 bug

--- a/tests/shouldwork/SynthesisAttributes/Product.hs
+++ b/tests/shouldwork/SynthesisAttributes/Product.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module Product where
 
 import qualified Prelude as P
@@ -87,17 +89,19 @@ mainSystemVerilog = do
 testBench :: Signal System Bool
 testBench = done'
   where
+    testInput :: _ => _
     testInput      = stimuliGenerator $(listToVecTH [ (1, 1) :: (Signed 9, Signed 9)
                                                     , (2, 2)
                                                     , (3, 3)
                                                     , (4, 4)
                                                     ])
 
-    expectedOutput = outputVerifier' $(listToVecTH [ (0, 0) :: (Signed 9, Signed 9)
+    expectedOutput a = outputVerifier' $(listToVecTH [ (0, 0) :: (Signed 9, Signed 9)
                                                   , (1, 1)
                                                   , (5, 5)
                                                   , (14, 14)
-                                                  ])
+                                                  ]) a
 
+    done :: _ => _
     done           = expectedOutput (topEntity testInput)
     done'          = withClockResetEnable (tbSystemClockGen (not <$> done')) systemResetGen enableGen done


### PR DESCRIPTION
Warn when it is turned off when converting Hs to HDL. Also enable -Wmonomorphism-restriction by default so you know when you might want to add a type signature to prevent unexpected monomorphism.

This commit also demonstrates the fallout of leaving the `MonomorphismRestriction` enabled by default, and can be used as a guide for fixing Clash code suffering from the same
issues once this commit lands in a released version of the compiler.

Fixes #1270
Fixes #1345