### PR TITLE
Make sure head and tail Verilog blackboxes return correctly typed values

### DIFF
--- a/changelog/2020-05-28T18_41_52+02_00_fix1351
+++ b/changelog/2020-05-28T18_41_52+02_00_fix1351
@@ -1,0 +1,1 @@
+FIXED: Fix result type of head and tail Verilog blackboxes [#1351](https://github.com/clash-lang/clash-compiler/issues/1351)

--- a/clash-lib/prims/verilog/Clash_Sized_Vector.json
+++ b/clash-lib/prims/verilog/Clash_Sized_Vector.json
@@ -3,7 +3,7 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "head :: Vec (n + 1) a -> a"
-    , "template"  : "~VAR[vec][0][~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]]"
+    , "template"  : "~FROMBV[~VAR[vec][0][\\~SIZE[~TYP[0]]-1 -: ~SIZE[~TYPO]\\]][~TYPO]"
     }
   }
 , { "BlackBox" :
@@ -19,7 +19,7 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "Vec (n + 1) a -> a"
-    , "template"  : "~VAR[vec][0][~SIZE[~TYPO]-1:0]"
+    , "template"  : "~FROMBV[~VAR[vec][0][\\~SIZE[~TYPO]-1:0\\]][~TYPO]"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -139,8 +139,12 @@ instance Backend VerilogState where
   inst            = inst_
   expr            = expr_
   iwWidth         = use intWidth
-  toBV _          = string
-  fromBV _        = string
+  toBV ty e       = case ty of
+    Signed _ -> "$unsigned" <> parens (string e)
+    _ -> string e
+  fromBV ty e     = case ty of
+    Signed _ -> "$signed" <> parens (string e)
+    _ -> string e
   hdlSyn          = use hdlsyn
   mkIdentifier    = do
       allowEscaped <- use escapedIds

--- a/tests/shouldwork/Numbers/T1351.hs
+++ b/tests/shouldwork/Numbers/T1351.hs
@@ -1,0 +1,19 @@
+module T1351 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+type F = Signed 8
+
+topEntity :: HiddenClockResetEnable System => Signal System F -> Signal System F
+topEntity i = boundedAdd <$> 0 <*> (last $ generate d1 (register 0) i)
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (-4:>Nil)
+    expectedOutput = outputVerifier' clk rst (0:>(-4):>Nil)
+    done           = expectedOutput (exposeClockResetEnable topEntity clk rst (enableGen) testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -429,6 +429,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "Signum" def
         , runTest "Strict" def
         , runTest "T1019" def{hdlSim=False}
+        , runTest "T1351" def
         , outputTest ("tests" </> "shouldwork" </> "Numbers") allTargets [] ["-itests/shouldwork/Numbers"] "UndefinedConstantFolding"  "main"
         , runTest "UnsignedZero" def
         ]


### PR DESCRIPTION
The part-selects (`var[x:y]`) always return unsigned values in Verilog.
This can create problems when we call head or tail on a vector of signed values.

This is fixed by using (and implementing) `~FROMBV` to add a cast when the result is `Signed`.

Fixes #1351