### PR TITLE
Backport synthesizable precompiled modules

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -55,7 +55,7 @@ doHDL b src = do
   putStrLn $ "Loading dependencies took " ++ prepStartDiff
 
   generateHDL (buildCustomReprs reprs) bindingsMap (Just b) primMap tcm tupTcm
-    (ghcTypeToHWType WORD_SIZE_IN_BITS True) primEvaluator topEntities
+    (ghcTypeToHWType WORD_SIZE_IN_BITS True) primEvaluator topEntities Nothing
     defClashOpts{opt_cachehdl = False, opt_dbgLevel = DebugSilent}
     (startTime,prepTime)
 

--- a/changelog/2020-03-11T12:29:55+01:00_Add_main-is_support
+++ b/changelog/2020-03-11T12:29:55+01:00_Add_main-is_support
@@ -1,0 +1,1 @@
+ADDED: Clash now repects '-main-is' when used with '--vhdl', '--verilog', or '--systemverilog'

--- a/changelog/2020-06-03T08_52_41+02_00_precompiled_modules
+++ b/changelog/2020-06-03T08_52_41+02_00_precompiled_modules
@@ -1,0 +1,1 @@
+ADDED: Clash can now load designs from precompiled modules (i.e., stored in a package database). See [#1172](https://github.com/clash-lang/clash-compiler/pull/1172)

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -2218,6 +2218,8 @@ makeHDL backend optsRef srcs = do
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
+                let getMain = getMainTopEntity src bindingsMap topEntities
+                mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
@@ -2233,6 +2235,7 @@ makeHDL backend optsRef srcs = do
                   (ghcTypeToHWType iw fp)
                   primEvaluator
                   topEntities
+                  mainTopEntity
                   opts2
                   (startTime,prepTime)
 

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -2000,6 +2000,8 @@ makeHDL backend optsRef srcs = do
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
+                let getMain = getMainTopEntity src bindingsMap topEntities
+                mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
@@ -2015,6 +2017,7 @@ makeHDL backend optsRef srcs = do
                   (ghcTypeToHWType iw fp)
                   primEvaluator
                   topEntities
+                  mainTopEntity
                   opts2
                   (startTime,prepTime)
 

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -2049,6 +2049,8 @@ makeHDL backend optsRef srcs = do
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
+                let getMain = getMainTopEntity src bindingsMap topEntities
+                mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
@@ -2064,6 +2066,7 @@ makeHDL backend optsRef srcs = do
                   (ghcTypeToHWType iw fp)
                   primEvaluator
                   topEntities
+                  mainTopEntity
                   opts2
                   (startTime,prepTime)
 

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -2140,6 +2140,9 @@ makeHDL backend optsRef srcs = do
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
                 (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
+
+                let getMain = getMainTopEntity src bindingsMap topEntities
+                mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
                 prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
@@ -2155,6 +2158,7 @@ makeHDL backend optsRef srcs = do
                   (ghcTypeToHWType iw fp)
                   primEvaluator
                   topEntities
+                  mainTopEntity
                   opts2
                   (startTime,prepTime)
 

--- a/clash-ghc/src-bin-common/Clash/GHCi/Common.hs
+++ b/clash-ghc/src-bin-common/Clash/GHCi/Common.hs
@@ -1,26 +1,75 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Clash.GHCi.Common
   ( checkImportDirs
   , checkMonoLocalBinds
   , checkMonoLocalBindsMod
   , checkClashDynamic
+  , getMainTopEntity
   ) where
 
 -- Clash
-import           Clash.Driver.Types     (ClashOpts (..))
+import           Clash.Driver.Types     (ClashOpts (..), BindingMap)
+import           Clash.Netlist.Types    (TopEntityT(..))
 
 -- The GHC interface
 import qualified DynFlags
 import qualified EnumSet                as GHC (member)
 import qualified GHC                    (DynFlags, ModSummary (..), Module (..),
                                          extensionFlags, moduleNameString)
+import           Clash.Core.Name        (nameOcc)
+import           Clash.Core.Var         (varName)
+import           Clash.Normalize.Util   (collectCallGraphUniques, callGraph)
+import qualified Clash.Util.Interpolate as I
+import           Clash.Util             (ClashException(..), HasCallStack, noSrcSpan)
+import           Clash.Unique           (getUnique)
+import           Control.Exception      (throw)
+import           Data.List              (isSuffixOf)
+import qualified Data.Text              as Text
+import qualified Data.HashSet           as HashSet
 import qualified GHC.LanguageExtensions as LangExt (Extension (..))
 import           Panic                  (GhcException (..), throwGhcException)
 
 import           Control.Monad          (forM_, unless, when)
 import           System.Directory       (doesDirectoryExist)
 import           System.IO              (hPutStrLn, stderr)
+
+getMainTopEntity
+  :: HasCallStack
+  => String
+  -- ^ Module name
+  -> BindingMap
+  -- ^ Map of global binders
+  -> [TopEntityT]
+  -- ^ List of top entities loaded by LoadModules
+  -> String
+  -- ^ string passed with -main-is
+  -> IO (TopEntityT, [TopEntityT])
+  -- ^ Throws exception if -main-is was set, but no such top entity was found.
+  -- Otherwise, returns main top entity and all top entities (transitively) used
+  -- in the main top entity.
+getMainTopEntity modName bindingMap topEnts nm =
+  case filter isNm topEnts of
+    [] -> throw $ ClashException noSrcSpan [I.i|
+      Could not find top entity called #{show nm} in #{show modName}
+    |] Nothing
+    [t] ->
+      let
+        closure0 = collectCallGraphUniques (callGraph bindingMap (topId t))
+        closure1 = HashSet.delete (getUnique (topId t)) closure0
+      in
+        pure (t, filter ((`HashSet.member` closure1) . getUnique . topId) topEnts)
+    ts ->
+      error $ [I.i|
+        Internal error: multiple top entities called #{nm} (#{map topId ts})
+        found in #{modName}.
+      |]
+ where
+  isNm (TopEntityT{topId}) =
+    let topIdNm = Text.unpack (nameOcc (varName topId)) in
+    topIdNm == nm || ('.':nm) `isSuffixOf` topIdNm
 
 -- | Checks whether MonoLocalBinds language extension is enabled or not in
 -- modules.

--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -6,6 +6,7 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -13,6 +14,9 @@ module Clash.GHC.LoadInterfaceFiles
   ( loadExternalExprs
   , loadExternalBinders
   , getUnresolvedPrimitives
+  , LoadedBinders(..)
+  , mergeLoadedBinders
+  , emptyLb
   )
 where
 
@@ -20,7 +24,6 @@ where
 import           Control.Monad.IO.Class      (MonadIO (..))
 import qualified Data.ByteString.Lazy.UTF8   as BLU
 import qualified Data.ByteString.Lazy        as BL
-import           Data.Either                 (partitionEithers)
 import           Data.List                   (elemIndex, foldl', partition)
 import qualified Data.Text                   as Text
 import           Data.Maybe                  (isJust, isNothing,
@@ -65,6 +68,38 @@ import           Clash.Primitives.Util               (decodeOrErr)
 import           Clash.GHC.GHC2Core                  (qualifiedNameString')
 import           Clash.Util                          (curLoc)
 
+-- | Data structure tracking loaded binders (and their related data)
+data LoadedBinders = LoadedBinders
+  { lbBinders :: [(CoreSyn.CoreBndr, CoreSyn.CoreExpr)]
+  -- ^ Binder + expression it's binding
+  , lbClassOps :: [(CoreSyn.CoreBndr, Int)]
+  -- ^ Type class dict projection functions
+  , lbUnlocatable :: [CoreSyn.CoreBndr]
+  -- ^ Binders with missing unfoldings
+  , lbPrims :: [Either UnresolvedPrimitive FilePath]
+  -- ^ Primitives; either an primitive data structure or a path to a directory
+  -- containing json files
+  , lbReprs :: [DataRepr']
+  -- ^ Custom data representations
+  }
+
+mergeLoadedBinders :: [LoadedBinders] -> LoadedBinders
+mergeLoadedBinders lbs =
+  LoadedBinders {
+    lbBinders=concat (map lbBinders lbs)
+  , lbClassOps=concat (map lbClassOps lbs)
+  , lbUnlocatable=concat (map lbUnlocatable lbs)
+  , lbPrims=concat (map lbPrims lbs)
+  , lbReprs=concat (map lbReprs lbs)
+  }
+
+emptyLb :: LoadedBinders
+emptyLb = LoadedBinders [] [] [] [] []
+
+collectLbBinders :: LoadedBinders -> [CoreSyn.CoreBndr]
+collectLbBinders LoadedBinders{lbBinders, lbUnlocatable, lbClassOps} =
+  concat [map fst lbBinders, lbUnlocatable, map fst lbClassOps]
+
 runIfl :: GHC.GhcMonad m => GHC.Module -> TcRnTypes.IfL a -> m a
 runIfl modName action = do
   hscEnv <- GHC.getSession
@@ -95,73 +130,48 @@ loadExternalBinders
   :: GHC.GhcMonad m
   => HDL
   -> [CoreSyn.CoreBndr]
-  -> m ( [(CoreSyn.CoreBndr,CoreSyn.CoreExpr)] -- Binders
-       , [(CoreSyn.CoreBndr,Int)]              -- Class Ops
-       , [CoreSyn.CoreBndr]                    -- Unlocatable
-       , [Either UnresolvedPrimitive FilePath]
-       , [DataRepr']
-       )
+  -> m LoadedBinders
 loadExternalBinders hdl bndrs = do
-  (locatedAndUnlocated, prims0, reprs0) <- unzip3 <$> mapM (loadExprFromIface hdl) bndrs
-  let (located0, unlocated0) = partitionEithers locatedAndUnlocated
-  (located1, classOps, unlocated1, prims1, reprs1, _seen) <-
+  loaded <- mergeLoadedBinders <$> mapM (loadExprFromIface hdl) bndrs
+  fst <$>
     loadExternalExprs'
-      hdl located0 [] unlocated0 (concat prims0) (concat reprs0)
-      (UniqSet.mkUniqSet (map fst located0)) (map snd located0)
-  pure (located1, classOps, unlocated1, prims1, reprs1)
+      hdl
+      loaded
+      (UniqSet.mkUniqSet (collectLbBinders loaded))
+      (map snd (lbBinders loaded))
 
 loadExternalExprs
   :: GHC.GhcMonad m
   => HDL
   -> UniqSet.UniqSet CoreSyn.CoreBndr
   -> [CoreSyn.CoreBind]
-  -> m ( [(CoreSyn.CoreBndr,CoreSyn.CoreExpr)] -- Binders
-       , [(CoreSyn.CoreBndr,Int)]              -- Class Ops
-       , [CoreSyn.CoreBndr]                    -- Unlocatable
-       , [Either UnresolvedPrimitive FilePath]
-       , [DataRepr']
-       )
-loadExternalExprs hdl = go [] [] [] [] []
+  -> m LoadedBinders
+loadExternalExprs hdl = go emptyLb
   where
-    go locatedExprs clsOps unlocated pFP reprs _ [] =
-      return (locatedExprs,clsOps,unlocated,pFP,reprs)
-
-    go locatedExprs clsOps unlocated pFP reprs visited (CoreSyn.NonRec _ e:bs) = do
-      (locatedExprs',clsOps',unlocated',pFP',reprs',visited') <-
-        loadExternalExprs' hdl locatedExprs clsOps unlocated pFP reprs visited [e]
-      go locatedExprs' clsOps' unlocated' pFP' reprs' visited' bs
-
-    go locatedExprs clsOps unlocated pFP reprs visited (CoreSyn.Rec bs:bs') = do
-      (locatedExprs',clsOps',unlocated',pFP',reprs',visited') <-
-        loadExternalExprs' hdl locatedExprs clsOps unlocated pFP reprs visited (map snd bs)
-      go locatedExprs' clsOps' unlocated' pFP' reprs' visited' bs'
+    go loaded _ [] =
+      return loaded
+    go loaded0 visited0 (CoreSyn.NonRec _ e:bs) = do
+      (loaded1, visited1) <- loadExternalExprs' hdl loaded0 visited0 [e]
+      go loaded1 visited1 bs
+    go loaded0 visited0 (CoreSyn.Rec bs:bs') = do
+      (loaded1, visited1) <- loadExternalExprs' hdl loaded0 visited0 (map snd bs)
+      go loaded1 visited1 bs'
 
 -- | Used by entry points: 'loadExternalExprs', 'loadExternalBinders'
 loadExternalExprs'
   :: GHC.GhcMonad m
   => HDL
-  -> [(CoreSyn.CoreBndr, CoreSyn.CoreExpr)]
-  -> [(Var.Id, Int)]
-  -> [CoreSyn.CoreBndr]
-  -> [Either UnresolvedPrimitive FilePath]
-  -> [DataRepr']
+  -> LoadedBinders
   -> UniqSet.UniqSet CoreSyn.CoreBndr
   -> [CoreSyn.CoreExpr]
-  -> m ( [(CoreSyn.CoreBndr, CoreSyn.CoreExpr)]
-       , [(Var.Id, Int)]
-       , [CoreSyn.CoreBndr]
-       , [Either UnresolvedPrimitive FilePath]
-       , [DataRepr']
-       , UniqSet.UniqSet CoreSyn.CoreBndr
-       )
-loadExternalExprs' _hdl locatedExprs clsOps unlocated pFP reprs visited [] =
-  return (locatedExprs, clsOps, unlocated, pFP, reprs, visited)
-
-loadExternalExprs' hdl locatedExprs clsOps unlocated pFP reprs visited (e:es) = do
+  -> m ( LoadedBinders, UniqSet.UniqSet CoreSyn.CoreBndr)
+loadExternalExprs' _hdl loaded visited [] =
+  return (loaded, visited)
+loadExternalExprs' hdl loaded0 visited0 (e:es) = do
   let fvs = CoreFVs.exprSomeFreeVarsList
               (\v -> Var.isId v &&
                      isNothing (Id.isDataConId_maybe v) &&
-                     not (v `UniqSet.elementOfUniqSet` visited)
+                     not (v `UniqSet.elementOfUniqSet` visited0)
               ) e
 
       (clsOps',fvs') = partition (isJust . Id.isClassOpId_maybe) fvs
@@ -174,41 +184,27 @@ loadExternalExprs' hdl locatedExprs clsOps unlocated pFP reprs visited (e:es) = 
                       (elemIndex v clsIds)
         ) clsOps'
 
-  (locatedAndUnlocated, pFP', reprs') <- unzip3 <$> mapM (loadExprFromIface hdl) fvs'
-  let (locatedExprs', unlocated') = partitionEithers locatedAndUnlocated
+  loaded1 <- mergeLoadedBinders <$> mapM (loadExprFromIface hdl) fvs'
 
-  let visited' = foldl' UniqSet.addListToUniqSet visited
-                   [ map fst locatedExprs'
-                   , unlocated'
-                   , clsOps'
-                   ]
-
-  loadExternalExprs' hdl
-      (locatedExprs'++locatedExprs)
-      (clsOps''++clsOps)
-      (unlocated'++unlocated)
-      (concat pFP'++pFP)
-      (concat reprs'++reprs)
-      visited'
-      (es ++ map snd locatedExprs')
+  loadExternalExprs'
+    hdl
+    (mergeLoadedBinders [loaded0, loaded1, emptyLb{lbClassOps=clsOps''}])
+    (foldl' UniqSet.addListToUniqSet visited0 [collectLbBinders loaded1, clsOps'])
+    (es ++ map snd (lbBinders loaded1))
 
 loadExprFromIface
   :: GHC.GhcMonad m
   => HDL
   -> CoreSyn.CoreBndr
-  -> m (Either
-          (CoreSyn.CoreBndr,CoreSyn.CoreExpr) -- Located
-          CoreSyn.CoreBndr                    -- Unlocated
-       ,[Either UnresolvedPrimitive FilePath]
-       ,[DataRepr']
-       )
+  -> m LoadedBinders
 loadExprFromIface hdl bndr = do
   let moduleM = Name.nameModule_maybe $ Var.varName bndr
   case moduleM of
     Just nameMod -> runIfl nameMod $ do
       ifaceM <- loadIface nameMod
       case ifaceM of
-        Nothing    -> return (Right bndr,[],[])
+        Nothing ->
+          return (emptyLb{lbUnlocatable=[bndr]})
         Just iface -> do
           let decls = map snd (GHC.mi_decls iface)
           let nameFun = GHC.getOccName $ Var.varName bndr
@@ -216,12 +212,16 @@ loadExprFromIface hdl bndr = do
           anns <- TcIface.tcIfaceAnnotations (GHC.mi_anns iface)
           primFPs   <- loadPrimitiveAnnotations hdl anns
           let reprs  = loadCustomReprAnnotations anns
+              lb     = emptyLb{lbPrims=primFPs, lbReprs=reprs}
           case declM of
             [namedDecl] -> do
               tyThing <- loadDecl namedDecl
-              return (loadExprFromTyThing bndr tyThing,primFPs,reprs)
-            _ -> return (Right bndr,primFPs,reprs)
-    Nothing -> return (Right bndr,[],[])
+              case loadExprFromTyThing bndr tyThing of
+                Left bndr1 -> return (lb{lbBinders=[bndr1]})
+                Right unloc -> return (lb{lbUnlocatable=[unloc]})
+            _ -> return (lb{lbUnlocatable=[bndr]})
+    Nothing ->
+      return (emptyLb{lbUnlocatable=[bndr]})
 
 
 loadCustomReprAnnotations

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -332,7 +332,9 @@ loadModules useColor hdl modName dflagsM idirs = do
   libDir <- MonadUtils.liftIO ghcLibDir
   startTime <- Clock.getCurrentTime
   GHC.runGhc (Just libDir) $ do
-    setupGhc useColor dflagsM idirs
+    -- 'mainFunIs' is set to Nothing due to issue #1304:
+    -- https://github.com/clash-lang/clash-compiler/issues/1304
+    setupGhc useColor ((\d -> d{GHC.mainFunIs=Nothing}) <$> dflagsM) idirs
     -- TODO: We currently load the transitive closure of _all_ bindings found
     -- TODO: in the top module. This is wasteful if one or more binders don't
     -- TODO: contribute to any top entities. This effect is worsened when using

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -97,7 +97,8 @@ import qualified Var
 -- Internal Modules
 import           Clash.GHC.GHC2Core                           (modNameM, qualifiedNameString')
 import           Clash.GHC.LoadInterfaceFiles
-  (loadExternalExprs, getUnresolvedPrimitives, loadExternalBinders)
+  (loadExternalExprs, getUnresolvedPrimitives, loadExternalBinders,
+   LoadedBinders(..))
 import           Clash.GHCi.Common                            (checkMonoLocalBindsMod)
 import           Clash.Util                                   (curLoc, noSrcSpan, reportTimeDiff
                                                               ,wantedLanguageExtensions, unwantedLanguageExtensions)
@@ -145,11 +146,7 @@ loadExternalModule
           ( [CoreSyn.CoreBndr]                     -- Root binders
           , FamInstEnv.FamInstEnv                  -- Local type family instances
           , GHC.ModuleName                         -- Module name
-          , [CoreSyn.CoreBndr]                     -- All binders
-          , [(CoreSyn.CoreBndr, Int)]              -- Type class projection functions
-          , [CoreSyn.CoreBndr]                     -- Unlocatable binders
-          , [Either UnresolvedPrimitive FilePath]  -- Primitives
-          , [DataRepr']                            -- Custom data representations
+          , LoadedBinders
           , [CoreSyn.CoreBind]                     -- All bindings
           ) )
 loadExternalModule hdl modName0 = Exception.gtry $ do
@@ -159,18 +156,9 @@ loadExternalModule hdl modName0 = Exception.gtry $ do
   modInfo <- fromMaybe (error errMsg) <$> (GHC.getModuleInfo foundMod)
   tyThings <- catMaybes <$> mapM GHC.lookupGlobalName (GHC.modInfoExports modInfo)
   let rootIds = [id_ | GHC.AnId id_ <- tyThings]
-  (allBinders, clsOps, unlocatable, prims, reprs) <- loadExternalBinders hdl rootIds
-  return $
-    ( rootIds
-    , FamInstEnv.emptyFamInstEnv
-    , modName1
-    , map fst allBinders
-    , clsOps
-    , unlocatable
-    , prims
-    , reprs
-    , makeRecursiveGroups allBinders
-    )
+  loaded <- loadExternalBinders hdl rootIds
+  let allBinders = makeRecursiveGroups (lbBinders loaded)
+  return (rootIds, FamInstEnv.emptyFamInstEnv, modName1, loaded, allBinders)
 
 setupGhc
   :: GHC.GhcMonad m
@@ -245,11 +233,7 @@ loadLocalModule
   -> m ( [CoreSyn.CoreBndr]                     -- Root binders
        , FamInstEnv.FamInstEnv                  -- Local type family instances
        , GHC.ModuleName                         -- Module name
-       , [CoreSyn.CoreBndr]                     -- All binders
-       , [(CoreSyn.CoreBndr, Int)]              -- Type class projection functions
-       , [CoreSyn.CoreBndr]                     -- Unlocatable binders
-       , [Either UnresolvedPrimitive FilePath]  -- Primitives
-       , [DataRepr']                            -- Custom data representations
+       , LoadedBinders
        , [CoreSyn.CoreBind]                     -- All bindings
        )
 loadLocalModule hdl modName = do
@@ -313,22 +297,14 @@ loadLocalModule hdl modName = do
   -- Because tidiedMods is in topological order, binders is also, and hence
   -- the binders belonging to the "root" module are the last binders
   let rootIds = map fst . CoreSyn.flattenBinds $ last binders
-  (externalBndrs, clsOps, unlocatable, unresolvedPrimitives0, reprs) <-
-    loadExternalExprs hdl (UniqSet.mkUniqSet binderIds) (concat binders)
+  loaded0 <- loadExternalExprs hdl (UniqSet.mkUniqSet binderIds) (concat binders)
 
   -- Find local primitive annotations
-  unresolvedPrimitives1 <- findPrimitiveAnnotations hdl binderIds
+  localPrims <- findPrimitiveAnnotations hdl binderIds
+  let loaded1 = loaded0{lbPrims=lbPrims loaded0 ++ localPrims}
 
-  pure ( rootIds
-       , modFamInstEnvs'
-       , rootModule
-       , map fst externalBndrs ++ binderIds
-       , clsOps
-       , unlocatable
-       , unresolvedPrimitives0 ++ unresolvedPrimitives1
-       , reprs
-       , concat binders ++ makeRecursiveGroups externalBndrs
-       )
+  let allBinders = concat binders ++ makeRecursiveGroups (lbBinders loaded0)
+  pure (rootIds, modFamInstEnvs', rootModule, loaded1, allBinders)
 
 loadModules
   :: OverridingBool
@@ -356,19 +332,21 @@ loadModules useColor hdl modName dflagsM idirs = do
   libDir <- MonadUtils.liftIO ghcLibDir
   startTime <- Clock.getCurrentTime
   GHC.runGhc (Just libDir) $ do
-    () <- setupGhc useColor dflagsM idirs
-    (rootIds, modFamInstEnvs, rootModule, allBinderIds, clsOps, unlocatable, unresolvedPrimitives, reprs, allBinders) <-
+    setupGhc useColor dflagsM idirs
+    (rootIds, modFamInstEnvs, rootModule, LoadedBinders{..}, allBinders) <-
       -- We need to try and load external modules first, because we can't
       -- recover from errors in 'loadLocalModule'.
       loadExternalModule hdl modName >>= \case
         Left _loadExternalErr -> loadLocalModule hdl modName
         Right res -> pure res
 
+    let allBinderIds = map fst (CoreSyn.flattenBinds allBinders)
+
     modTime <- startTime `deepseq` length allBinderIds `seq` MonadUtils.liftIO Clock.getCurrentTime
     let modStartDiff = reportTimeDiff modTime startTime
     MonadUtils.liftIO $ putStrLn $ "GHC: Parsing and optimising modules took: " ++ modStartDiff
 
-    extTime <- modTime `deepseq` length unlocatable `deepseq` MonadUtils.liftIO Clock.getCurrentTime
+    extTime <- modTime `deepseq` length lbUnlocatable `deepseq` MonadUtils.liftIO Clock.getCurrentTime
     let extModDiff = reportTimeDiff extTime modTime
     MonadUtils.liftIO $ putStrLn $ "GHC: Loading external modules from interface files took: " ++ extModDiff
 
@@ -424,12 +402,12 @@ loadModules useColor hdl modName dflagsM idirs = do
         (_, _) ->
           Panic.pgmError $ $(curLoc) ++ "Multiple 'topEntities' found."
 
-    let reprs1 = reprs ++ reprs'
+    let reprs1 = lbReprs ++ reprs'
 
     annTime <-
       extTime
         `deepseq` length topEntities'
-        `deepseq` unresolvedPrimitives
+        `deepseq` lbPrims
         `deepseq` reprs1
         `deepseq` primGuards
         `deepseq` MonadUtils.liftIO Clock.getCurrentTime
@@ -438,11 +416,11 @@ loadModules useColor hdl modName dflagsM idirs = do
     MonadUtils.liftIO $ putStrLn $ "GHC: Parsing annotations took: " ++ annExtDiff
 
     return ( allBinders
-           , clsOps
-           , unlocatable
+           , lbClassOps
+           , lbUnlocatable
            , (fst famInstEnvs, modFamInstEnvs)
            , topEntities'
-           , unresolvedPrimitives
+           , lbPrims
            , reprs1
            , primGuards
            )

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -376,9 +376,9 @@ loadModules useColor hdl modName dflagsM idirs = do
     benchAnn   <- findTestBenchAnnotations rootIds
     reprs'     <- findCustomReprAnnotations
     primGuards <- findPrimitiveGuardAnnotations allBinderIds
-    let topEntityNames = catMaybes [Just "topEntity", GHC.mainFunIs =<< dflagsM]
+    let topEntityName = fromMaybe "topEntity" (GHC.mainFunIs =<< dflagsM)
         varNameString = OccName.occNameString . Name.nameOccName . Var.varName
-        topEntities = filter ((`elem` topEntityNames) . varNameString) rootIds
+        topEntities = filter ((==topEntityName) . varNameString) rootIds
         benches     = filter ((== "testBench") . varNameString) rootIds
         mergeBench (x,y) = (x,y,lookup x benchAnn)
         allSyn'     = map mergeBench allSyn

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -387,14 +387,20 @@ loadModules useColor hdl modName dflagsM idirs = do
       case (topEntities, topSyn) of
         ([], []) ->
           let modName1 = Outputable.showSDocUnsafe (ppr rootModule) in
-          Panic.pgmError [I.i|
-            No top-level function called 'topEntity' found, nor a function with
-            a 'Synthesize' annotation in module #{modName1}. Did you forget to
-            export them?
+          if topEntityName /= "topEntity" then
+            Panic.pgmError [I.i|
+              No top-level function called '#{topEntityName}' found. Did you
+              forget to export it?
+            |]
+          else
+            Panic.pgmError [I.i|
+              No top-level function called 'topEntity' found, nor a function with
+              a 'Synthesize' annotation in module #{modName1}. Did you forget to
+              export them?
 
-            For more information on 'Synthesize' annotations, check out the
-            documentation of "Clash.Annotations.TopEntity".
-          |]
+              For more information on 'Synthesize' annotations, check out the
+              documentation of "Clash.Annotations.TopEntity".
+            |]
         ([], _) ->
           return allSyn'
         ([x], _) ->

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -225,14 +225,18 @@ generateHDL
   -> (PrimStep, PrimUnwind)
   -- ^ Hardcoded evaluator (delta-reduction)
   -> [TopEntityT]
-  -- ^ Topentities and associated testbench
+  -- ^ All topentities and associated testbench
+  -> Maybe (TopEntityT, [TopEntityT])
+  -- ^ Main top entity to compile. If Nothing, all top entities in previous
+  -- argument will be compiled.
   -> ClashOpts
   -- ^ Debug information level for the normalization process
   -> (Clock.UTCTime,Clock.UTCTime)
   -> IO ()
 generateHDL reprs bindingsMap hdlState primMap tcm tupTcm typeTrans eval
-  topEntities0 opts (startTime,prepTime) =
-    go prepTime HashMap.empty (sortTop bindingsMap topEntities2)
+  topEntities0 mainTopEntity opts (startTime,prepTime) =
+    let todo = maybe topEntities2 (uncurry (:)) mainTopEntity in
+    go prepTime HashMap.empty (sortTop bindingsMap todo)
  where
   topEntities1 = map (splitTopEntityT tcm bindingsMap) topEntities0
   -- Remove forall's used in type equality constraints

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -20,6 +20,7 @@ module Clash.Normalize.Util
  , isRecursiveBndr
  , isClosed
  , callGraph
+ , collectCallGraphUniques
  , classifyFunction
  , isCheapFunction
  , isNonRecursiveGlobalVar
@@ -41,6 +42,7 @@ import qualified Data.List               as List
 import qualified Data.List.Extra         as List
 import qualified Data.Map                as Map
 import qualified Data.HashMap.Strict     as HashMapS
+import qualified Data.HashSet            as HashSet
 import           Data.Text               (Text)
 import qualified Data.Text as Text
 
@@ -343,6 +345,13 @@ constantSpecInfo ctx e = do
 -- | A call graph counts the number of occurrences that a functions 'g' is used
 -- in 'f'.
 type CallGraph = VarEnv (VarEnv Word)
+
+-- | Collect all binders mentioned in CallGraph into a HashSet
+collectCallGraphUniques :: CallGraph -> HashSet.HashSet Unique
+collectCallGraphUniques cg = HashSet.fromList (us0 ++ us1)
+ where
+  us0 = keysUniqMap cg
+  us1 = concatMap keysUniqMap (eltsUniqMap cg)
 
 -- | Create a call graph for a set of global binders, given a root
 callGraph

--- a/docs/developing-hardware/flags.rst
+++ b/docs/developing-hardware/flags.rst
@@ -208,3 +208,7 @@ Clash Compiler Flags
 
   **Default:** False
 
+-main-is
+  When using one of ``--vhdl``, ``--verilog``, or ``--systemverilog``, this
+  flag refers to synthesis target. For example, running Clash with
+  ``clash My.Module -main-is top --vhdl`` would synthesize ``My.Module.top``.

--- a/repld
+++ b/repld
@@ -79,7 +79,7 @@ while true; do
     sed -i '/clash-ghc/d' .ghc.environment.x86_64-linux-*
   fi
 
-  ghcid -c "${target} -w ${GHC}" ${restart_cmd} ${@:2}
+  ghcid -c "${target} -w ${GHC}" ${restart_cmd} "${@:2}"
 
   inotifywait -e modify,create,delete -r ${watch}
   if [[ $? == 130 ]]; then

--- a/repld
+++ b/repld
@@ -28,6 +28,8 @@
 
 set -e
 
+GHC=${GHC:-ghc}
+
 inotifywait --help | grep -e "^inotifywait"
 ghcid --version
 
@@ -77,7 +79,7 @@ while true; do
     sed -i '/clash-ghc/d' .ghc.environment.x86_64-linux-*
   fi
 
-  ghcid -c "${target}" ${restart_cmd} ${@:2}
+  ghcid -c "${target} -w ${GHC}" ${restart_cmd} ${@:2}
 
   inotifywait -e modify,create,delete -r ${watch}
   if [[ $? == 130 ]]; then

--- a/repld
+++ b/repld
@@ -17,6 +17,8 @@
 #
 #   * `p`, `prelude`, `clash-prelude`
 #   * `l`, `lib`, `clash-lib`
+#   * `l:tests`, `lib:tests`, `clash-lib:tests`
+#   * `c`, `cores`, `clash-cores`
 #   * `g`, `ghc`, `clash-ghc`
 #   * `dev`, `clash-dev`
 #
@@ -35,6 +37,12 @@ if [[ $1 == "p" || $1 == "prelude" || $1 == "clash-prelude" ]]; then
 elif [[ $1 == "l" || $1 == "lib" || $1 == "clash-lib" ]]; then
   target="cabal new-repl clash-lib"
   watch="clash-prelude clash-lib/clash-lib.cabal"
+elif [[ $1 == "l:tests" || $1 == "lib:tests" || $1 == "clash-lib:tests" ]]; then
+  target="cabal new-repl clash-lib:unittests"
+  watch="clash-prelude clash-lib clash-cores/clash-cores.cabal"
+elif [[ $1 == "c" || $1 == "cores" || $1 == "clash-cores" ]]; then
+  target="cabal new-repl clash-cores"
+  watch="clash-prelude clash-lib clash-cores/clash-cores.cabal"
 elif [[ $1 == "g" || $1 == "ghc" || $1 == "clash-ghc" ]]; then
   target="cabal new-repl clash-ghc --repl-options=-fobject-code --repl-options=-fforce-recomp"
   watch="clash-prelude clash-lib clash-ghc/clash-ghc.cabal"
@@ -42,11 +50,13 @@ elif [[ $1 == "dev" || $1 == "clash-dev" ]]; then
   target="./clash-dev"
   watch="clash-prelude clash-lib/clash-lib.cabal clash-ghc/clash-ghc.cabal"
 else
-  echo "Unrecognized target. Use one of:"  > /dev/stderr
-  echo "  p, prelude, clash-prelude"       > /dev/stderr
-  echo "  l, lib, clash-lib"               > /dev/stderr
-  echo "  g, ghc, clash-ghc"               > /dev/stderr
-  echo "  dev, clash-dev"                  > /dev/stderr
+  echo "Unrecognized target. Use one of:"                    > /dev/stderr
+  echo "  p, prelude, clash-prelude"                         > /dev/stderr
+  echo "  l, lib, clash-lib"                                 > /dev/stderr
+  echo "  l:tests, lib:tests, clash-lib:tests"               > /dev/stderr
+  echo "  g, ghc, clash-ghc"                                 > /dev/stderr
+  echo "  c, cores, clash-cores"                             > /dev/stderr
+  echo "  dev, clash-dev"                                    > /dev/stderr
   exit 1;
 fi
 

--- a/tests/shouldwork/Basic/T1304.hs
+++ b/tests/shouldwork/Basic/T1304.hs
@@ -1,0 +1,1 @@
+topEntity = 'a'

--- a/tests/shouldwork/Basic/T1305.hs
+++ b/tests/shouldwork/Basic/T1305.hs
@@ -1,0 +1,9 @@
+module T1305 where
+
+import Clash.Prelude
+
+plus :: Signed 8 -> Signed 8 -> Signed 8
+plus a b = a + b
+
+topEntity :: Signed 8 -> Signed 8 -> Signed 8
+topEntity = plus

--- a/tests/shouldwork/TopEntity/Multiple.hs
+++ b/tests/shouldwork/TopEntity/Multiple.hs
@@ -1,0 +1,63 @@
+module Multiple where
+
+import Prelude
+import Clash.Prelude (defSyn)
+import System.Environment (getArgs)
+import System.FilePath (splitFileName)
+import System.Directory (listDirectory)
+import Data.List (sort)
+
+import Debug.Trace
+
+topEntity1 :: Int
+topEntity1 = 11111111
+{-# ANN topEntity1 (defSyn "topentity1") #-}
+{-# NOINLINE topEntity1 #-}
+
+topEntity2 :: Int
+topEntity2 = topEntity1
+{-# ANN topEntity2 (defSyn "topentity2") #-}
+{-# NOINLINE topEntity2 #-}
+
+topEntity3 :: Int
+topEntity3 = topEntity2
+{-# NOINLINE topEntity3 #-}
+
+-- | Make sure topEntity2 is not compiled when -main-is topEntity1
+main1SystemVerilog :: IO ()
+main1SystemVerilog = do
+  [(dir, _fname)] <- map splitFileName <$> getArgs
+  files <- listDirectory dir
+  if files == ["topentity1"] then
+    pure ()
+  else
+    error ("Unexpected files / directories: " ++ show files)
+
+-- | Make sure topEntity1 is not compiled when -main-is topEntity2 and
+-- -fclash-single-main is enabled. TODO: Implement this feature.
+main2Verilog :: IO ()
+main2Verilog = do
+  args <- getArgs
+  putStrLn (show args)
+  [(dir, _fname)] <- map splitFileName <$> getArgs
+  files <- listDirectory dir
+  if files == ["topentity2"] then
+    pure ()
+  else
+    error ("Unexpected files / directories: " ++ show files)
+
+-- | Check whether we can compile a binder that doesn't have a synthesize
+-- annotation _and_ isn't called 'topEntity' using -main-is.
+main3VHDL :: IO ()
+main3VHDL = do
+  [(dir, _fname)] <- map splitFileName <$> getArgs
+  files <- listDirectory dir
+  if sort files == sort [ "multiple_types.vhdl"
+                        , "topentity1"
+                        , "topentity2"
+                        , "topentity3.manifest"
+                        , "topentity3.vhdl"
+                        ] then
+    pure ()
+  else
+    error ("Unexpected files / directories: " ++ show (sort files))

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -250,6 +250,10 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1254" def{hdlTargets=[VHDL,SystemVerilog],hdlSim=False}
         , runTest "T1292" def{hdlTargets=[VHDL]}
         , runTest "T1297" def{hdlTargets=[VHDL], hdlSim=False}
+        , runTest "T1304" def{
+            hdlTargets=[VHDL]
+          , hdlLoad=False
+          }
         , runTest "T1305" def{
             hdlTargets=[VHDL]
           , hdlSim=False

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -250,6 +250,12 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1254" def{hdlTargets=[VHDL,SystemVerilog],hdlSim=False}
         , runTest "T1292" def{hdlTargets=[VHDL]}
         , runTest "T1297" def{hdlTargets=[VHDL], hdlSim=False}
+        , runTest "T1305" def{
+            hdlTargets=[VHDL]
+          , hdlSim=False
+          , clashFlags=["-main-is", "plus"]
+          , topEntities=TopEntities ["plus"]
+          }
         , runTest "T1316" def{hdlTargets=[VHDL], hdlSim=False}
         , runTest "T1322" def{hdlTargets=[VHDL]}
         , runTest "T1340" def{hdlTargets=[VHDL], hdlSim=False}

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -509,6 +509,8 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1033" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1072" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1074" "main"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [SystemVerilog] ["-main-is", "topEntity1"] [] "Multiple" "main1"
+        , outputTest ("tests" </> "shouldwork" </> "TopEntity") [VHDL] ["-main-is", "topEntity3"] [] "Multiple" "main3"
         , runTest "T1139" def{hdlSim=False}
         ]
       , clashTestGroup "Unit"

--- a/testsuite/src/Test/Tasty/Clash.hs
+++ b/testsuite/src/Test/Tasty/Clash.hs
@@ -82,6 +82,9 @@ data TestOptions =
   TestOptions
     { hdlSim :: Bool
     -- ^ Run hdl simulators (GHDL, ModelSim, etc.)
+    , hdlLoad :: Bool
+    -- ^ Load hdl into simulator (GHDL, ModelSim, etc.). Disabling this will
+    -- disable 'hdlSim' too.
     , expectSimFail :: Maybe (TestExitCode, T.Text)
     -- ^ Expect simulation to fail: Nothing if simulation is expected to run
     -- without errors, or Just (part of) the error message the simulation is
@@ -109,6 +112,7 @@ instance Default TestOptions where
   def =
     TestOptions
       { hdlSim=True
+      , hdlLoad=True
       , expectClashFail=Nothing
       , expectSimFail=Nothing
       , hdlTargets=allTargets
@@ -562,9 +566,10 @@ runTest1 modName testOptions@TestOptions{..} path VHDL =
        clashTest : concat (zipWith mkTests entNames subdirss)
 
    mkTests entName subdirs =
-     case (isJust expectClashFail, hdlSim) of
-       (True, _) -> []
-       (_, False) -> makeTests entName subdirs
+     case (isJust expectClashFail, hdlLoad, hdlSim) of
+       (True, _, _) -> []
+       (_, False, _) -> []
+       (_, _, False) -> makeTests entName subdirs
        _ -> makeTests entName subdirs ++ [simTest entName subdirs]
 
 runTest1 modName testOptions@TestOptions{..} path Verilog =
@@ -592,9 +597,10 @@ runTest1 modName testOptions@TestOptions{..} path Verilog =
       clashTest : concat (zipWith mkTests entNames subdirss)
 
    mkTests entName subdirs =
-     case (isJust expectClashFail, hdlSim) of
-       (True, _) -> []
-       (_, False) -> [makeTest entName subdirs]
+     case (isJust expectClashFail, hdlLoad, hdlSim) of
+       (True, _, _) -> []
+       (_, False, _) -> []
+       (_, _, False) -> [makeTest entName subdirs]
        _ -> [makeTest entName subdirs, simTest entName subdirs]
 
 runTest1 modName testOptions@TestOptions{..} path SystemVerilog =
@@ -620,9 +626,10 @@ runTest1 modName testOptions@TestOptions{..} path SystemVerilog =
       clashTest : concat (zipWith mkTests entNames subdirss)
 
    mkTests entName subdirs =
-     case (isJust expectClashFail, hdlSim) of
-       (True, _) -> []
-       (_, False) -> makeTest entName subdirs
+     case (isJust expectClashFail, hdlLoad, hdlSim) of
+       (True, _, _) -> []
+       (_, False, _) -> []
+       (_, _, False) -> makeTest entName subdirs
        _ -> makeTest entName subdirs ++ [simTest entName]
 
 runTest


### PR DESCRIPTION
Backports:

* https://github.com/clash-lang/clash-compiler/pull/1357
* https://github.com/clash-lang/clash-compiler/pull/1172
* https://github.com/clash-lang/clash-compiler/pull/1207

This is preparation work to release the Clash starter project with Clash 1.2.2.