### PR TITLE
Add `hie.yaml` now that `ghcide-0.2.0` has multi-cradle support

### DIFF
--- a/clash-cosim/clash-cosim.cabal
+++ b/clash-cosim/clash-cosim.cabal
@@ -107,10 +107,14 @@ test-suite test
       base >= 4 && < 5,
       clash-cosim,
       clash-prelude >= 0.99,
+      ghc-typelits-extra,
+      ghc-typelits-knownnat,
+      ghc-typelits-natnormalise,
       deepseq,
       tasty >= 1.0,
       tasty-hunit,
-      tasty-quickcheck
+      tasty-quickcheck,
+      template-haskell
   ghc-options:   -Wall -Wcompat
   if flag(pedantic)
     ghc-options: -Werror

--- a/clash-cosim/tests/CoSimTest.hs
+++ b/clash-cosim/tests/CoSimTest.hs
@@ -36,34 +36,36 @@ dotp
   => Vec (n + 1) a
   -> Vec (n + 1) a
   -> a
-dotp as bs = fold boundedPlus (zipWith boundedMult as bs)
+dotp as bs = fold boundedAdd (zipWith boundedMul as bs)
 
 fir
   :: ( Default a
      , KnownNat n
      , SaturatingNum a
+     , KnownDomain d
+     , NFDataX a
      )
-  => Clock d Source
-  -> Reset d Asynchronous
+  => Clock d
+  -> Reset d
   -> Vec (n + 1) a
   -> Signal d a
   -> Signal d a
 fir clk rst coeffs x_t = y_t
   where
     y_t = dotp coeffs <$> bundle xs
-    xs = window clk rst x_t
+    xs = window clk rst enableGen x_t
 
 topEntity
-  :: Clock System Source
-  -> Reset System Asynchronous
+  :: Clock System
+  -> Reset System
   -> Signal System (Signed 64)
   -> Signal System (Signed 64)
 topEntity clk rst s = verilog_mult s s
 
 
 testInput
-    :: Clock System Source
-    -> Reset System Asynchronous
+    :: Clock System
+    -> Reset System
     -> Signal System (Signed 64)
 testInput clk rst = stimuliGenerator clk rst (2:>3:>4:>8:>9:>10:>Nil)
 
@@ -106,7 +108,7 @@ verilog_fir x = [verilog|
 -}
 
 verilog_mult
-  :: t ~ Signed 64
+  :: (t ~ Signed 64, KnownDomain d)
   => Signal d t
   -> Signal d t
   -> Signal d t

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -68,8 +68,8 @@ import Clash.Core.DataCon                      (DataCon)
 import Clash.Core.Literal                      (Literal)
 import Clash.Core.Name                         (Name (..))
 import {-# SOURCE #-} Clash.Core.Subst         () -- instance Eq Type
-import {-# SOURCE #-} Clash.Core.Type
-import Clash.Core.Var                          (Var(Id), Id)
+import {-# SOURCE #-} Clash.Core.Type          (Type)
+import Clash.Core.Var                          (Var(Id), Id, TyVar)
 import Clash.Util                              (curLoc)
 
 -- | Term representation in the CoreHW language: System F + LetRec + Case

--- a/clash-lib/src/Clash/Core/TermLiteral/TH.hs
+++ b/clash-lib/src/Clash/Core/TermLiteral/TH.hs
@@ -2,6 +2,9 @@
 
 module Clash.Core.TermLiteral.TH
   (  deriveTermToData
+     -- Stop exporting @dcName'@  once `ghcide` stops type-checking expanded
+     -- TH splices
+  ,  dcName'
   ) where
 
 import           Data.Either

--- a/clash-lib/src/Clash/Util/Interpolate.hs
+++ b/clash-lib/src/Clash/Util/Interpolate.hs
@@ -42,7 +42,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Clash.Util.Interpolate(i) where
+-- TODO: only export the @i@ quasiquotor when `ghcide` stop type-checking
+-- exanded quasiquote splices
+module Clash.Util.Interpolate (i, format, toString) where
 
 import           Language.Haskell.Meta.Parse (parseExp)
 import           Language.Haskell.TH.Lib     (appE, varE)

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,42 @@
+cradle:
+  multi:
+    # Skip benchmark and profiling code for now
+    - path: "./benchmark"
+      config: { cradle: {none: }}
+    - path: "./clash-cores"
+      config: { cradle: {cabal: [{path: "./clash-cores/src", component: "lib:clash-cores"}
+                                ,{path: "./clash-cores/test", component: "clash-cores:unittests"}]}}
+    - path: "./clash-cosim"
+      config: { cradle: {cabal: [{path: "./clash-cosim/src", component: "lib:clash-cosim"}
+                                ,{path: "./clash-cosim/test", component: "clash-cosim:test"}]}}
+    - path: "./clash-ghc"
+      config: { cradle: {cabal: [{path: "./clash-ghc/src-ghc", component: "lib:clash-ghc"}
+                                ,{path: "./clash-ghc/src-ghc-common", component: "lib:clash-ghc"}]}}
+    # The src-bin directories are GHC version dependant, so don't load them
+    - path: "./clash-ghc/src-bin-8.10"
+      config: { cradle: {none: }}
+    - path: "./clash-ghc/src-bin-841"
+      config: { cradle: {none: }}
+    - path: "./clash-ghc/src-bin-861"
+      config: { cradle: {none: }}
+    - path: "./clash-ghc/src-bin-881"
+      config: { cradle: {none: }}
+    - path: "./clash-lib"
+      config: { cradle: {cabal: [{path: "./clash-lib/src", component: "lib:clash-lib"}
+                                ,{path: "./clash-lib/test", component: "clash-lib:unittests"} ] } }
+    # Clash prelude is broken for now because ghcide won't use -fobject-code
+    # when loading ./clash-prelude/src/Clash/Sized/Internal/Mod.hs transitively
+    # as a dependency of another module
+    - path: "./clash-prelude"
+      config: { cradle: {none: }}
+    - path: "./clash-term"
+      config: { cradle: {cabal: {component: "exe:clash-term"}}}
+    # Skip examples for now
+    - path: "./examples"
+      config: { cradle: {none: }}
+    # Skip tests for now
+    - path: "./tests"
+      config: { cradle: {none: }}
+    - path: "./testsuite"
+      config: { cradle: {cabal: [{path: "./testsuite/src", component: "lib:clash-testsuite"}
+                                ,{path: "./testsuite/Main.hs", component: "exe:clash-testsuite"}]}}

--- a/testsuite/src/Test/Tasty/Program.hs
+++ b/testsuite/src/Test/Tasty/Program.hs
@@ -32,36 +32,36 @@
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+
+  This module provides a function that tests whether a program can
+  be run successfully. For example if you have 'foo.hs' source file:
+
+  > module Foo where
+  >
+  > foo :: Int
+  > foo = 5
+
+  you can test whether GHC can compile it:
+
+  > module Main (
+  >   main
+  >  ) where
+  >
+  > import Test.Tasty
+  > import Test.Tasty.Program
+  >
+  > main :: IO ()
+  > main = defaultMain $ testGroup "Compilation with GHC" $ [
+  >     testProgram "Foo" "ghc" ["-fforce-recomp", "foo.hs"] Nothing
+  >   ]
+
+  Program's output and error streams are ignored.
 -}
 
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
-
--- | This module provides a function that tests whether a program can
--- be run successfully. For example if you have 'foo.hs' source file:
---
--- > module Foo where
--- >
--- > foo :: Int
--- > foo = 5
---
--- you can test whether GHC can compile it:
---
--- > module Main (
--- >   main
--- >  ) where
--- >
--- > import Test.Tasty
--- > import Test.Tasty.Program
--- >
--- > main :: IO ()
--- > main = defaultMain $ testGroup "Compilation with GHC" $ [
--- >     testProgram "Foo" "ghc" ["-fforce-recomp", "foo.hs"] Nothing
--- >   ]
---
--- Program's output and error streams are ignored.
 
 module Test.Tasty.Program (
    testProgram


### PR DESCRIPTION
* Also fixes the clash-cosim testsuite
* Weird issue in Term.hs which imports SOURCE Type.hs-boot which does not export TyVar, where Type.hs does export TyVar, but GHC was all fine with it. `ghcide` was very confused where TyVar was supposed to come from, so we import it from Var.hs
* ghcide seems to typecheck the expanded TH and QQ splices, which leads to errors because some identifiers aren't exported.
* clash-prelude gets a "None" cradle because of some issues where there's no way to convince ghcide to load a Mod.hs with -fobject-code (it uses UnboxedTuples) when it's a (transitive) dependency. Loading Mod.hs itself works fine. But loading Signed.hs, which depends on Mod.hs, does not work.