### PR TITLE
VHDL: automatically generate a type qualification inside ~TOBV

### DIFF
--- a/changelog/2020-06-11T16_27_46+02_00_fix1360
+++ b/changelog/2020-06-11T16_27_46+02_00_fix1360
@@ -1,0 +1,1 @@
+FIXED: VHDL: automatically generate a type qualification inside ~TOBV, fixes [#1360](https://github.com/clash-lang/clash-compiler/issues/1360)

--- a/clash-lib/prims/vhdl/Clash_Sized_RTree.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_RTree.json
@@ -3,7 +3,7 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat n -> a -> RTree d a"
-    , "template"  : "~TYPMO'(0 to (2**~LIT[0])-1 => ~IF~VIVADO~THEN~TOBV[~TYPM[1]'(~ARG[1])][~TYP[1]]~ELSE~ARG[1]~FI)"
+    , "template"  : "~TYPMO'(0 to (2**~LIT[0])-1 => ~IF~VIVADO~THEN~TOBV[~ARG[1]][~TYP[1]]~ELSE~ARG[1]~FI)"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.json
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.json
@@ -333,7 +333,7 @@ end block;
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "replicate :: SNat n -> a -> Vec n a"
-    , "template"  : "~TYPMO'(0 to ~LIT[0]-1 => ~IF ~VIVADO ~THEN ~TOBV[~TYPM[1]'(~ARG[1])][~TYP[1]] ~ELSE ~ARG[1] ~FI)"
+    , "template"  : "~TYPMO'(0 to ~LIT[0]-1 => ~IF ~VIVADO ~THEN ~TOBV[~ARG[1]][~TYP[1]] ~ELSE ~ARG[1] ~FI)"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -135,8 +135,13 @@ instance Backend VHDLState where
     | isBV t = pretty id_
     | otherwise = do
       nm <- Mon $ use modNm
-      -- TODO It would be nice to leave out the type qualification if we know id_ is a var
-      pretty (TextS.toLower nm) <> "_types.toSLV" <> parens (hdlTypeMark t <> squote <> parens (pretty id_))
+      seen <- use seenIdentifiers
+      -- This is a bit hacky, as id_ is just a rendered expression.
+      -- But if it's a bare identifier that we've seen before,
+      -- then this identifier has a defined type and we can skip the explicit type qualification.
+      let e | T.toStrict id_ `HashMapS.member` seen = pretty id_
+            | otherwise = hdlTypeMark t <> squote <> parens (pretty id_)
+      pretty (TextS.toLower nm) <> "_types.toSLV" <> parens e
   fromBV t id_
     | isBV t = pretty id_
     | otherwise = do

--- a/tests/shouldwork/Vector/T1360.hs
+++ b/tests/shouldwork/Vector/T1360.hs
@@ -1,0 +1,11 @@
+module T1360 where
+
+import Clash.Prelude
+
+data StatusA = InactiveA | ActiveA deriving (Generic,NFDataX)
+
+topEntity :: HiddenClockResetEnable System =>
+  Signal System (Vec 2 StatusA) -> Signal System (Index 2) -> Signal System (Vec 2 StatusA)
+topEntity input idx = out
+  where
+    out = replace <$> idx <*> pure InactiveA <*> input

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -618,6 +618,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "VecOfSum" def{hdlSim=False}
         , runTest "T452" def{hdlSim=False}
         , runTest "T895" def{hdlSim=False,hdlTargets=[VHDL]}
+        , runTest "T1360" def{hdlSim=False, hdlTargets=[VHDL], clashFlags=["-fclash-hdlsyn", "Vivado"]}
         ] -- end vector
       , clashTestGroup "XOptimization"
         [ outputTest  ("tests" </> "shouldwork" </> "XOptimization") allTargets [] [] "Conjunction"  "main"


### PR DESCRIPTION
This makes sure VHDL always knows which `toSLV `to call.
Fixes #1360

This also leave out `to`- and `fromSLV` calls when the type is already `std_logic_vector`.
And fixes the layout of the entity declaration `end` keyword.