### PR TITLE
Disable by-default monomorphism restriction warning

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -697,9 +697,7 @@ setWantedLanguageExtensions :: GHC.DynFlags -> GHC.DynFlags
 setWantedLanguageExtensions df =
    foldl' DynFlags.gopt_set
     (foldl' DynFlags.xopt_unset
-      (foldl' DynFlags.xopt_set
-        (DynFlags.wopt_set df DynFlags.Opt_WarnMonomorphism)
-        wantedLanguageExtensions)
+      (foldl' DynFlags.xopt_set df wantedLanguageExtensions)
       unwantedLanguageExtensions)
     wantedOptimizations
  where


### PR DESCRIPTION
In hindsight, it's mostly pointless. It warns you when a term is given a monomorphic type, where a polymorphic type would have been possible with the monomorphism restriction disabled.

However, my original reasoning behind enabling the warning by-default was to help users in case they got a type error because they used a term in a polymorphic setting but was given a monomorphic type due to the restriction. However, the warning never shows up in case a type error is given first, thus making enabling the warning by-default rather useless. In addition, it gives a lot of noise on code that actually compiles fine as is.

See also #1392