### PR TITLE
"Use" arguments in blockRamFile and rom primitive

### DIFF
--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -71,6 +71,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 
 -}
 
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 
 {-# LANGUAGE Unsafe #-}
@@ -226,7 +227,7 @@ blockRamFile#
   -- ^ Value to write (at address @w@)
   -> Signal dom (BitVector m)
   -- ^ Value of the @blockRAM@ at address @r@ from the previous clock cycle
-blockRamFile# (Clock _) ena _sz file rd wen =
+blockRamFile# (Clock _) ena !_sz file rd wen =
   go
     ramI
     (withFrozenCallStack (errorX "blockRamFile#: intial value undefined"))

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -8,6 +8,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 ROMs
 -}
 
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -104,7 +105,7 @@ rom#
   -- ^ Read address @rd@
   -> Signal dom a
   -- ^ The value of the ROM at address @rd@ from the previous clock cycle
-rom# _ en content =
+rom# !_ en content =
   go
     (withFrozenCallStack (deepErrorX "rom: initial value undefined"))
     (fromEnable en)


### PR DESCRIPTION
And by use we mean "add a bang pattern" so that the argument gets a proper demand signature; thus preventing GHC from replacing the argument by `absentArg`. Additionally silences the corresponding
Clash warning.

Fixes #1391