### PR TITLE
Generate SDC files for top entity

### DIFF
--- a/changelog/2020-06-25T15_41_51+02_00_generate_sdc_files
+++ b/changelog/2020-06-25T15_41_51+02_00_generate_sdc_files
@@ -1,0 +1,2 @@
+CHANGED: Clash now generates SDC files for each topentity with clock inputs
+See github.com/clash-lang/clash-compiler/issues/1387.

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -2,8 +2,9 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2017     , Myrtle Software Ltd,
                     2017-2018, Google Inc.
+                    2020     , QBayLogic
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Type and instance definitions for Netlist modules
 -}
@@ -41,6 +42,7 @@ import Data.Binary                          (Binary(..))
 import Data.Hashable                        (Hashable)
 import Data.HashMap.Strict                  (HashMap)
 import Data.IntMap                          (IntMap, empty)
+import Data.Maybe                           (mapMaybe)
 import qualified Data.Set                   as Set
 import Data.Text                            (Text, pack)
 import Data.Typeable                        (Typeable)
@@ -172,6 +174,15 @@ instance NFData Component where
   rnf c = case c of
     Component nm inps outps decls -> rnf nm    `seq` rnf inps `seq`
                                      rnf outps `seq` rnf decls
+
+-- | Find the name and domain name of each clock argument of a component.
+--
+findClocks :: Component -> [(Identifier, Identifier)]
+findClocks (Component _ is _ _) =
+  mapMaybe isClock is
+ where
+  isClock (i, Clock d) = Just (i, d)
+  isClock _ = Nothing
 
 -- | Size indication of a type (e.g. bit-size or number of elements)
 type Size = Int


### PR DESCRIPTION
Fixes #1387

This PR uses createHDL to generate SDC files for each component
with a clock as an input. If a component has multiple clocks as an
input, each clock will appear in the SDC file.