### PR TITLE
Use `unsigned` typemark when rendering the mask of a BitVector

### DIFF
--- a/changelog/2020-06-24T17_58_25+02_00_fix1402
+++ b/changelog/2020-06-24T17_58_25+02_00_fix1402
@@ -1,0 +1,1 @@
+FIXED: Clash renders incorrect VHDL when GHCs Worker/Wrapper transformation is enabled

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -2204,7 +2204,7 @@ renderModifier (DontCare,_) _ = do
   -- These mask projections always come last, so it's safe not to return a
   -- modified name, but an expression instead.
   traceIf True ($(curLoc) ++ "WARNING: rendering bitvector mask as dontcare") $
-    sizedQualTyNameErrValue (Signed iw)
+    sizedQualTyNameErrValue (Unsigned iw)
 renderModifier (Range r,t) doc = do
   nm <- Mon (use modNm)
   let doc1 = case r of

--- a/tests/shouldwork/Basic/T1402.hs
+++ b/tests/shouldwork/Basic/T1402.hs
@@ -1,7 +1,8 @@
-{-# OPTIONS_GHC -O #-}
+{-# OPTIONS_GHC -fno-worker-wrapper #-}
 module T1402 where
 
 import Clash.Prelude
+import Clash.Explicit.Testbench
 
 topEntity :: Maybe (BitVector 128) -> BitVector 128 -> (BitVector 128,Bool)
 topEntity q y = case q of
@@ -12,3 +13,16 @@ f :: Bool -> BitVector 128 ->  (BitVector 128, Bool)
 f t x = case x of
   1 -> (x,t)
   _ -> (x,t)
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput1 = stimuliGenerator clk rst $(listToVecTH
+        [Just (maxBound :: (BitVector 128))])
+    testInput2 = stimuliGenerator clk rst $(listToVecTH
+        [maxBound :: (BitVector 128)])
+    expectedOutput = outputVerifier' clk rst $(listToVecTH
+        [(maxBound :: (BitVector 128), True)])
+    done           = expectedOutput (topEntity <$> testInput1 <*> testInput2)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/tests/shouldwork/Basic/T1402.hs
+++ b/tests/shouldwork/Basic/T1402.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -O #-}
+module T1402 where
+
+import Clash.Prelude
+
+topEntity :: Maybe (BitVector 128) -> BitVector 128 -> (BitVector 128,Bool)
+topEntity q y = case q of
+  Just b -> f True b
+  _      -> f False y
+
+f :: Bool -> BitVector 128 ->  (BitVector 128, Bool)
+f t x = case x of
+  1 -> (x,t)
+  _ -> (x,t)

--- a/tests/shouldwork/Basic/T1402b.hs
+++ b/tests/shouldwork/Basic/T1402b.hs
@@ -1,0 +1,8 @@
+module T1402b where
+
+import Clash.Prelude
+import Clash.Sized.Internal.BitVector
+import GHC.Natural
+
+topEntity :: BitVector 128 -> Natural
+topEntity = unsafeMask

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -305,7 +305,8 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1354A" def{hdlTargets=[VHDL], hdlSim=False}
 #endif
         , runTest "T1354B" def{hdlTargets=[VHDL], hdlSim=False}
-        , runTest "T1402" def{hdlTargets=[VHDL], hdlSim=False}
+        , runTest "T1402" def{clashFlags=["-O"]}
+        , runTest "T1402b" def{hdlTargets=[VHDL], hdlSim=False}
         , runTest "TagToEnum" def{hdlSim=False}
         , runTest "TestIndex" def{hdlSim=False}
         , runTest "Time" def

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -305,6 +305,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1354A" def{hdlTargets=[VHDL], hdlSim=False}
 #endif
         , runTest "T1354B" def{hdlTargets=[VHDL], hdlSim=False}
+        , runTest "T1402" def{hdlTargets=[VHDL], hdlSim=False}
         , runTest "TagToEnum" def{hdlSim=False}
         , runTest "TestIndex" def{hdlSim=False}
         , runTest "Time" def


### PR DESCRIPTION
Fixes #1402 