### PR TITLE
Build with primitive-0.7.1.0

### DIFF
--- a/clash-lib/src/Data/Primitive/ByteArray/Extra.hs
+++ b/clash-lib/src/Data/Primitive/ByteArray/Extra.hs
@@ -1,15 +1,20 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Data.Primitive.ByteArray.Extra where
 
+#if !MIN_VERSION_primitive(0,7,1)
 import Control.DeepSeq (NFData(..))
+#endif
 import Data.Binary (Binary(..))
 import Data.Hashable (Hashable(..))
 import Data.Primitive.ByteArray (ByteArray)
 import GHC.Exts (IsList(..))
 
+#if !MIN_VERSION_primitive(0,7,1)
 instance NFData ByteArray where
   rnf x = x `seq` ()
+#endif
 
 instance Binary ByteArray where
   get = fmap fromList get


### PR DESCRIPTION
Released on 2020-06-25, it comes with an NFData ByteArray instance that overlaps with our orphan instance.