### PR TITLE
CI upgrades

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -9,7 +9,7 @@ mv cabal.project.local cabal.project.local.disabled
 cabal new-build --dry-run all > /dev/null || (echo Maybe the index-state should be updated?; false)
 mv cabal.project.local.disabled cabal.project.local
 
-if [ "$RUN_BUILD_ALL" = "yes" ]; then
+if [[ "$RUN_BUILD_ALL" = "yes" ]]; then
   # Build with installed constraints for packages in global-db
   echo cabal new-build $(ghc-pkg list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh
 
@@ -17,9 +17,9 @@ if [ "$RUN_BUILD_ALL" = "yes" ]; then
   cabal new-build all
 fi
 
-if [ "$RUN_HADDOCK" = "yes" ]; then
+if [[ "$RUN_HADDOCK" = "yes" ]]; then
   # Check that documentation was generated successfully
-  if [ "$GHC" = "ghc-8.6.2" ]; then
+  if [[ "$GHC" = "ghc-8.6.2" ]]; then
     haddock_pkgs="clash-lib clash-cosim"
   else
     haddock_pkgs="clash-lib clash-cosim clash-prelude"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xeo pipefail
+set -xueo pipefail
 
 # TODO: make sdist work on all, it currently fails for clash-cosim
 cabal new-sdist clash-prelude clash-lib clash-ghc

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -9,21 +9,23 @@ mv cabal.project.local cabal.project.local.disabled
 cabal new-build --dry-run all > /dev/null || (echo Maybe the index-state should be updated?; false)
 mv cabal.project.local.disabled cabal.project.local
 
-cabal new-build all
+if [ "$RUN_BUILD_ALL" = "yes" ]; then
+  # Build with installed constraints for packages in global-db
+  echo cabal new-build $(ghc-pkg list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh
 
-# Build with installed constraints for packages in global-db
-echo cabal new-build $(ghc-pkg list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh
-
-# Check that documentation was generated succesfully
-if [ "$GHC" = "ghc-8.6.2" ]; then
-  haddock_pkgs="clash-lib clash-cosim"
-else
-  haddock_pkgs="clash-lib clash-cosim clash-prelude"
+  # Build with default constraints
+  cabal new-build all
 fi
 
-for pkg in ${haddock_pkgs}; do
-  if [ ! -e dist-newstyle/build/*/ghc-*/${pkg}-*/doc/html/${pkg}/index.html ]; then
-    echo "Haddock generation failed for package ${pkg}"
-    exit 1
+if [ "$RUN_HADDOCK" = "yes" ]; then
+  # Check that documentation was generated successfully
+  if [ "$GHC" = "ghc-8.6.2" ]; then
+    haddock_pkgs="clash-lib clash-cosim"
+  else
+    haddock_pkgs="clash-lib clash-cosim clash-prelude"
   fi
-done
+
+  for pkg in ${haddock_pkgs}; do
+    cabal new-haddock ${pkg}
+  done
+fi

--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -7,22 +7,18 @@ package *
 
 package clash-lib
   ghc-options: -Werror
-  documentation: True
   tests: True
   flags: +debug
 package clash-prelude
   ghc-options: -Werror
-  documentation: True
   flags: +doctests
   tests: True
   benchmarks: True
 package clash-cosim
   ghc-options: -Werror
-  documentation: True
   tests: True
 package clash-cores
   ghc-options: -Werror
-  documentation: True
   tests: True
 
 package clash-testsuite

--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -44,13 +44,13 @@ WORKDIR /
 RUN apt-get remove -y $DEPS_IVERILOG \
  && rm -Rf ghdl-0.36 iverilog-10_3 \
  && apt-get autoremove -y --purge \
- && apt-get clean \
- && rm /etc/apt/apt.conf.d/docker-clean \
- && apt-get install -y --download-only \
+ && apt-get install -y \
       cabal-install-2.4 \
       cabal-install-3.0 \
       cabal-install-3.2 \
       ghc-8.4.4 \
       ghc-8.6.5 \
       ghc-8.8.3 \
-      ghc-8.10.1
+      ghc-8.10.1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -2,9 +2,8 @@ hackage-sdist:
   extends: .tests
   interruptible: false
   variables:
-    GHC: ghc-8.10.1
+    GHC: 8.10.1
   script:
-    - export GHC="${GHC:-$CI_JOB_NAME}"
     - export THREADS=$(nproc)
     - export CABAL_JOBS=$(nproc)
     - .ci/setup.sh
@@ -27,9 +26,8 @@ hackage-sdist:
   cache:
     key: hackage
   variables:
-    GHC: ghc-8.10.1
+    GHC: 8.10.1
   script:
-    - export GHC="${GHC:-$CI_JOB_NAME}"
     - export THREADS=$(nproc)
     - export CABAL_JOBS=$(nproc)
     - .ci/setup.sh

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -1,0 +1,88 @@
+hackage-sdist:
+  extends: .tests
+  interruptible: false
+  variables:
+    GHC: ghc-8.10.1
+  script:
+    - export GHC="${GHC:-$CI_JOB_NAME}"
+    - export THREADS=$(nproc)
+    - export CABAL_JOBS=$(nproc)
+    - .ci/setup.sh
+    - .ci/build_sdist.sh clash-prelude
+    - .ci/build_sdist.sh clash-lib
+    - .ci/build_sdist.sh clash-ghc
+  artifacts:
+    paths:
+      - clash-*.tar.gz  # clash-{prelude,lib,ghc}-$version{-docs,}.tar.gz
+    expire_in: 1 week
+  rules:
+    - if: '$CI_COMMIT_TAG != null' # tags
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+
+.hackage:
+  extends: .tests
+  interruptible: false
+  stage: publish
+  cache:
+    key: hackage
+  variables:
+    GHC: ghc-8.10.1
+  script:
+    - export GHC="${GHC:-$CI_JOB_NAME}"
+    - export THREADS=$(nproc)
+    - export CABAL_JOBS=$(nproc)
+    - .ci/setup.sh
+    - .ci/publish_sdist.sh clash-prelude
+    - .ci/publish_sdist.sh clash-lib
+    - .ci/publish_sdist.sh clash-ghc
+
+# Create a binary distribution using nix, and store it in a tarball. A special
+# nix distribution is used that has its store installed on /usr/nix/store,
+# instead of the default /nix. This is used to work around a know limitation
+# of snap layouts. As of August 2019 the snapcraft docs mention:
+#
+#  > Layouts cannot currently create new top-level files or directories.
+#  >
+#  >  - https://snapcraft.io/docs/snap-layouts
+#
+# If this limitation is ever annulled, we can use a "proper" nix distribution.
+snap-bindist:
+  image: clashlang/nixbuntu:2.3.3
+  stage: build
+  cache:
+    key: usr-nix-$CI_JOB_NAME
+    paths:
+      # GitLab CI uses zip as a cache archive. For some reason, nix can't
+      # handle this (wrong permissions, missing symlinks?), so we pre-tar it.
+      - usr_nix.tar.xz
+  artifacts:
+    when: always
+    paths:
+      - nix_build.log
+      - bindist/linux/snap/clash-snap-bindist.tar.xz
+    expire_in: 1 week
+  script:
+    - .ci/snap_bindist.sh
+
+  # Run every night, when explicitly triggered, or when tagged (release)
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+    - if: '$CI_COMMIT_TAG != null' # tags
+
+# Use binary distribution built in `snap-bindist` to build a snap pacakge.
+.snap:
+  image: snapcore/snapcraft
+  stage: publish
+  cache:
+    key: snap-last-run-hash-$CI_COMMIT_REF_SLUG
+    paths:
+      - snap-last-run-hash
+  artifacts:
+    when: always
+    paths:
+      - bindist/linux/snap/*.snap
+    expire_in: 1 week
+  script:
+    - .ci/snap_publish.sh

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -69,6 +69,12 @@ snap-bindist:
     - if: $CI_PIPELINE_SOURCE == "trigger"
     - if: '$CI_COMMIT_TAG != null' # tags
 
+  # Building the nix distribution crucially depends on the cache being
+  # available, so we limit it to a single machine to make sure the cache is
+  # shared.
+  tags:
+    - diepenheim
+
 # Use binary distribution built in `snap-bindist` to build a snap pacakge.
 .snap:
   image: snapcore/snapcraft

--- a/.ci/gitlab/tests.yml
+++ b/.ci/gitlab/tests.yml
@@ -1,0 +1,40 @@
+.tests:
+  image: clashlang/clash-ci:2020-04-15
+  stage: build
+  timeout: 2 hours
+  variables:
+    GIT_SUBMODULE_STRATEGY: recursive
+    TERM: xterm-color
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+  cache:
+    key: cabal-store-$CI_JOB_NAME
+    paths:
+      - cabal-store/
+  script:
+    - unset SNAPCRAFT_LOGIN_FILE
+    - unset HACKAGE_PASSWORD
+    # Use either ${GHC} or if that's not set, try to detect GHC version by analyzing
+    # $CI_JOB_NAME.
+    - export GHC="${GHC:-$(echo $CI_JOB_NAME | egrep -o 'ghc-[0-9]+.[0-9]+.[0-9]+')}"
+    - export THREADS=$(nproc)
+    - export CABAL_JOBS=$(nproc)
+    - export
+    - .ci/setup.sh
+    - .ci/build.sh
+    - .ci/test.sh
+
+.tests-interruptible:
+  extends: .tests
+  interruptible: true
+  rules:
+    - if: '$CI_COMMIT_BRANCH != "master"'
+
+.tests-non-interruptible:
+  extends: .tests
+  interruptible: true
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'

--- a/.ci/gitlab/tests.yml
+++ b/.ci/gitlab/tests.yml
@@ -3,6 +3,7 @@
   stage: build
   timeout: 2 hours
   variables:
+    MULTIPLE_HIDDEN: "no"
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   retry:

--- a/.ci/gitlab/tests.yml
+++ b/.ci/gitlab/tests.yml
@@ -53,9 +53,13 @@
     RUN_BUILD_ALL: "no"
   rules:
     - if: '$CI_COMMIT_BRANCH != "master"'
+  tags:
+    - local
 
 .tests-non-interruptible:
   extends: .tests
   interruptible: true
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
+  tags:
+    - local

--- a/.ci/gitlab/tests.yml
+++ b/.ci/gitlab/tests.yml
@@ -6,6 +6,12 @@
     MULTIPLE_HIDDEN: "no"
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
+
+    RUN_HADDOCK: "yes"
+    RUN_LIBTESTS: "yes"
+    RUN_CLASHDEV: "yes"
+    RUN_TESTSUITE: "yes"
+    RUN_BUILD_ALL: "yes"
   retry:
     max: 2
     when:
@@ -20,7 +26,7 @@
     - unset HACKAGE_PASSWORD
     # Use either ${GHC} or if that's not set, try to detect GHC version by analyzing
     # $CI_JOB_NAME.
-    - export GHC="${GHC:-$(echo $CI_JOB_NAME | egrep -o 'ghc-[0-9]+.[0-9]+.[0-9]+')}"
+    - export GHC=ghc-"${GHC:-$(echo $CI_JOB_NAME | egrep -o '[0-9]+.[0-9]+.[0-9]+')}"
     - export THREADS=$(nproc)
     - export CABAL_JOBS=$(nproc)
     - export
@@ -31,6 +37,19 @@
 .tests-interruptible:
   extends: .tests
   interruptible: true
+  variables:
+    RUN_TESTSUITE: "no"
+  rules:
+    - if: '$CI_COMMIT_BRANCH != "master"'
+
+.testsuite-interruptible:
+  extends: .tests
+  interruptible: true
+  variables:
+    RUN_HADDOCK: "no"
+    RUN_LIBTESTS: "no"
+    RUN_CLASHDEV: "no"
+    RUN_BUILD_ALL: "no"
   rules:
     - if: '$CI_COMMIT_BRANCH != "master"'
 

--- a/.ci/gitlab/tests.yml
+++ b/.ci/gitlab/tests.yml
@@ -21,6 +21,7 @@
     key: cabal-store-$CI_JOB_NAME
     paths:
       - cabal-store/
+      - cabal-packages/
   script:
     - unset SNAPCRAFT_LOGIN_FILE
     - unset HACKAGE_PASSWORD

--- a/.ci/gitlab/tests.yml
+++ b/.ci/gitlab/tests.yml
@@ -1,5 +1,5 @@
 .tests:
-  image: clashlang/clash-ci:2020-04-15
+  image: clashlang/clash-ci:2020-06-29
   stage: build
   timeout: 2 hours
   variables:

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -xeo pipefail
 
-apt-get update -q
-
 if [[ "$GHC" = ghc-head ]]; then
-  CABAL="cabal-install-head"
+  CABAL="cabal-head"
 elif [[ "$GHC" = ghc-8.4.* ]]; then
-  CABAL="cabal-install-2.4"
+  CABAL="cabal-2.4"
 elif [[ "$GHC" = ghc-8.6.* || "$GHC" = ghc-8.8.* ]]; then
-  CABAL="cabal-install-3.0"
+  CABAL="cabal-3.0"
 else
   # GHC >= 8.10
-  CABAL="cabal-install-3.2"
+  CABAL="cabal-3.2"
 fi
 
-apt-get install -yq $CABAL $GHC
+update-alternatives --set opt-ghc /opt/ghc/bin/${GHC}
+update-alternatives --set opt-cabal /opt/cabal/bin/${CABAL}
+
 cabal --version
 ghc --version
 cp .ci/cabal.project.local .

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
-set -xeou pipefail
+set -xou pipefail
+
+egrep ' $' -n -r . --include=*.{hs,hs-boot,sh} --exclude-dir=dist-newstyle
+if [[ $? == 0 ]]; then
+    echo "EOL whitespace detected. See ^"
+    exit 1;
+fi
+
+set -e
+
+# Check whether version numbers in snap / clash-{prelude,lib,ghc} are the same
+cabal_files="clash-prelude/clash-prelude.cabal clash-lib/clash-lib.cabal clash-ghc/clash-ghc.cabal clash-cores/clash-cores.cabal"
+snapcraft_file="bindist/linux/snap/snap/snapcraft.yaml"
+versions=$(grep "^[vV]ersion" $cabal_files $snapcraft_file | grep -Eo '[0-9]+(\.[0-9]+)+')
+
+if [[ $(echo $versions | tr ' ' '\n' | wc -l) == 5 ]]; then
+    if [[ $(echo $versions | tr ' ' '\n' | uniq | wc -l) != 1 ]]; then
+        echo "Expected all distributions to have the same version number. Found: $versions"
+        exit 1;
+    fi
+else
+    echo "Expected to find version number in all distributions. Found: $versions";
+    exit 1;
+fi
 
 # Here to test whether all these variables are set
 echo "RUN_HADDOCK=${RUN_HADDOCK}"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -xeou pipefail
 
+# Here to test whether all these variables are set
+echo "RUN_HADDOCK=${RUN_HADDOCK}"
+echo "RUN_LIBTESTS=${RUN_LIBTESTS}"
+echo "RUN_TESTSUITE=${RUN_TESTSUITE}"
+echo "RUN_CLASHDEV=${RUN_CLASHDEV}"
+echo "RUN_BUILD_ALL=${RUN_BUILD_ALL}"
+
+apt-get update -q
+
 if [[ "$GHC" = ghc-head ]]; then
   CABAL="cabal-head"
 elif [[ "$GHC" = ghc-8.4.* ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -49,13 +49,17 @@ fi
 
 cat cabal.project.local
 
+cabal user-config init
+sed -i "s/-- ghc-options:/ghc-options: -j$THREADS/g" ${HOME}/.cabal/config
+sed -i "s/^[- ]*jobs:.*/jobs: $CABAL_JOBS/g" ${HOME}/.cabal/config
+echo "store-dir: ${PWD}/cabal-store" >> ${HOME}/.cabal/config
+sed -i "/remote-repo-cache:.*/d" ${HOME}/.cabal/config
+echo "remote-repo-cache: ${PWD}/cabal-packages" >> ${HOME}/.cabal/config
+cat ${HOME}/.cabal/config
+
 # run new-update first to generate the cabal config file that we can then modify
 # retry 5 times, as hackage servers are not perfectly reliable
 NEXT_WAIT_TIME=0
 until cabal new-update || [ $NEXT_WAIT_TIME -eq 5 ]; do
    sleep $(( NEXT_WAIT_TIME++ ))
 done
-
-sed -i "s/-- ghc-options:/ghc-options: -j$THREADS/g" ${HOME}/.cabal/config
-sed -i "s/^[- ]*jobs:.*/jobs: $CABAL_JOBS/g" ${HOME}/.cabal/config
-echo "store-dir: ${PWD}/cabal-store" >> ${HOME}/.cabal/config

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xeo pipefail
+set -xeou pipefail
 
 if [[ "$GHC" = ghc-head ]]; then
   CABAL="cabal-head"

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,7 +2,7 @@
 set -xou pipefail
 
 # Check that clash-dev works
-if [ "$RUN_CLASHDEV" = "yes" ]; then
+if [[ "$RUN_CLASHDEV" = "yes" ]]; then
   cabal --write-ghc-environment-files=always new-build clash-prelude
   echo "" > clash-dev.result
   echo 'genVHDL "./examples/FIR.hs" >> writeFile "clash-dev.result" "success"' | ./clash-dev
@@ -31,7 +31,7 @@ if [[ ${tag_version} != "" && ${version} != ${tag_version} ]]; then
 fi
 
 # Run unittests, doctests
-if [ "$RUN_LIBTESTS" = "yes" ]; then
+if [[ "$RUN_LIBTESTS" = "yes" ]]; then
   # Create a ghc environment file needed for the doctests
   # On cabal>=2.4.1.0 and ghc<8.4.4 this isn't done automatically
   cabal --write-ghc-environment-files=always new-build all
@@ -39,6 +39,6 @@ if [ "$RUN_LIBTESTS" = "yes" ]; then
 fi
 
 # Run HDL generation / simulation
-if [ "$RUN_TESTSUITE" = "yes" ]; then
+if [[ "$RUN_TESTSUITE" = "yes" ]]; then
   cabal new-run -- clash-testsuite -j$THREADS --hide-successes -p "/.VHDL./ || /.Verilog./"
 fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -9,16 +9,14 @@ fi
 
 set -e
 
-# Create a ghc environment file needed for the doctests
-# On cabal>=2.4.1.0 and ghc<8.4.4 this isn't done automatically
-cabal --write-ghc-environment-files=always new-build all
-
 # Check that clash-dev works
-echo "" > clash-dev.result
-echo 'genVHDL "./examples/FIR.hs" >> writeFile "clash-dev.result" "success"' | ./clash-dev
-if [[ "$(cat clash-dev.result)" != "success" ]]; then
-  echo "clash-dev test failed"
-  exit 1
+if [ "$RUN_CLASHDEV" = "yes" ]; then
+  echo "" > clash-dev.result
+  echo 'genVHDL "./examples/FIR.hs" >> writeFile "clash-dev.result" "success"' | ./clash-dev
+  if [[ "$(cat clash-dev.result)" != "success" ]]; then
+    echo "clash-dev test failed"
+    exit 1
+  fi
 fi
 
 # Check whether version numbers in snap / clash-{prelude,lib,ghc} are the same
@@ -54,6 +52,15 @@ if [[ ${tag_version} != "" && ${version} != ${tag_version} ]]; then
     fi
 fi
 
-# Run actual tests
-cabal new-test clash-cores clash-cosim clash-prelude clash-lib
-cabal new-run -- clash-testsuite -j$THREADS --hide-successes -p "/.VHDL./ || /.Verilog./"
+# Run unittests, doctests
+if [ "$RUN_LIBTESTS" = "yes" ]; then
+  # Create a ghc environment file needed for the doctests
+  # On cabal>=2.4.1.0 and ghc<8.4.4 this isn't done automatically
+  cabal --write-ghc-environment-files=always new-build all
+  cabal new-test clash-cores clash-cosim clash-prelude clash-lib
+fi
+
+# Run HDL generation / simulation
+if [ "$RUN_TESTSUITE" = "yes" ]; then
+  cabal new-run -- clash-testsuite -j$THREADS --hide-successes -p "/.VHDL./ || /.Verilog./"
+fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xo pipefail
+set -xou pipefail
 
 egrep ' $' -n -r . --include=*.{hs,hs-boot,sh} --exclude-dir=dist-newstyle
 if [[ $? == 0 ]]; then
@@ -38,6 +38,7 @@ fi
 
 # You'd think comparing v${version} with ${CI_COMMIT_TAG} would do the
 # trick, but no..
+CI_COMMIT_TAG=${CI_COMMIT_TAG:-}
 version=$(echo $versions | tr ' ' '\n' | head -n 1)
 tag_version=${CI_COMMIT_TAG:1:${#CI_COMMIT_TAG}-1}  # Strip first character (v0.99 -> 0.99)
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -11,6 +11,7 @@ set -e
 
 # Check that clash-dev works
 if [ "$RUN_CLASHDEV" = "yes" ]; then
+  cabal --write-ghc-environment-files=always new-build clash-prelude
   echo "" > clash-dev.result
   echo 'genVHDL "./examples/FIR.hs" >> writeFile "clash-dev.result" "success"' | ./clash-dev
   if [[ "$(cat clash-dev.result)" != "success" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -10,7 +10,7 @@ fi
 set -e
 
 # Create a ghc environment file needed for the doctests
-# On cabal>=2.4.1.0 and ghc<8.4.4 this isn't done automaticly
+# On cabal>=2.4.1.0 and ghc<8.4.4 this isn't done automatically
 cabal --write-ghc-environment-files=always new-build all
 
 # Check that clash-dev works

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -xou pipefail
 
-egrep ' $' -n -r . --include=*.{hs,hs-boot,sh} --exclude-dir=dist-newstyle
-if [[ $? == 0 ]]; then
-    echo "EOL whitespace detected. See ^"
-    exit 1;
-fi
-
-set -e
-
 # Check that clash-dev works
 if [ "$RUN_CLASHDEV" = "yes" ]; then
   cabal --write-ghc-environment-files=always new-build clash-prelude
@@ -18,21 +10,6 @@ if [ "$RUN_CLASHDEV" = "yes" ]; then
     echo "clash-dev test failed"
     exit 1
   fi
-fi
-
-# Check whether version numbers in snap / clash-{prelude,lib,ghc} are the same
-cabal_files="clash-prelude/clash-prelude.cabal clash-lib/clash-lib.cabal clash-ghc/clash-ghc.cabal clash-cores/clash-cores.cabal"
-snapcraft_file="bindist/linux/snap/snap/snapcraft.yaml"
-versions=$(grep "^[vV]ersion" $cabal_files $snapcraft_file | grep -Eo '[0-9]+(\.[0-9]+)+')
-
-if [[ $(echo $versions | tr ' ' '\n' | wc -l) == 5 ]]; then
-    if [[ $(echo $versions | tr ' ' '\n' | uniq | wc -l) != 1 ]]; then
-        echo "Expected all distributions to have the same version number. Found: $versions"
-        exit 1;
-    fi
-else
-    echo "Expected to find version number in all distributions. Found: $versions";
-    exit 1;
 fi
 
 # You'd think comparing v${version} with ${CI_COMMIT_TAG} would do the

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ aliases:
     THREADS: 1
     CABAL_JOBS: 1
 
+    RUN_HADDOCK: "yes"
+    RUN_LIBTESTS: "yes"
+    RUN_CLASHDEV: "yes"
+    RUN_TESTSUITE: "yes"
+    RUN_BUILD_ALL: "yes"
   - &submodules
     run:
       name: "Checkout submodules"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,8 +35,8 @@ stages:
 .tests-interruptible:
   extends: .tests
   interruptible: true
-  except:
-    - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH != "master"'
 
 # Test jobs:
 ghc-8.4.4:
@@ -61,22 +61,22 @@ ghc-8.6.5-singular-hidden:
 # Same as test jobs, but non-interruptable
 ghc-8.4.4-master:
   extends: .tests
-  only:
-    - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
 #ghc-8.6.5:
 #  extends: .tests
 ghc-8.8.3-master:
   extends: .tests
-  only:
-    - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
 ghc-8.10.1-master:
   extends: .tests
-  only:
-    - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
 ghc-8.6.5-singular-hidden-master:
   extends: .tests
-  only:
-    - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
   variables:
     MULTIPLE_HIDDEN: "no"
 #ghc-head-master:
@@ -105,10 +105,10 @@ hackage-sdist:
     paths:
       - clash-*.tar.gz  # clash-{prelude,lib,ghc}-$version{-docs,}.tar.gz
     expire_in: 1 week
-  only:
-    - tags
-    - schedules
-    - triggers
+  rules:
+    - if: '$CI_COMMIT_TAG != null' # tags
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "trigger"
 
 .hackage:
   extends: .tests
@@ -134,9 +134,9 @@ hackage-release-candidate:
   variables:
     HACKAGE_RELEASE: "no"
 
-  only:
-    - schedules
-    - triggers
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "trigger"
 
 # Release new version of Clash to Hackage
 hackage-release:
@@ -145,8 +145,8 @@ hackage-release:
   variables:
     HACKAGE_RELEASE: "yes"
 
-  only:
-    - tags
+  rules:
+    - if: '$CI_COMMIT_TAG != null' # tags
 
 # Create a binary distribution using nix, and store it in a tarball. A special
 # nix distribution is used that has its store installed on /usr/nix/store,
@@ -177,10 +177,10 @@ snap-bindist:
     - .ci/snap_bindist.sh
 
   # Run every night, when explicitly triggered, or when tagged (release)
-  only:
-    - schedules
-    - triggers
-    - tags
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+    - if: '$CI_COMMIT_TAG != null' # tags
 
 # Use binary distribution built in `snap-bindist` to build a snap pacakge.
 .snap:
@@ -202,13 +202,13 @@ snap-beta-or-edge:
   extends: .snap
   variables:
     RELEASE_CHANNEL: beta_or_edge
-  only:
-    - schedules
-    - triggers
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "trigger"
 
 snap-stable:
   extends: .snap
   variables:
     RELEASE_CHANNEL: stable
-  only:
-    - tags
+  rules:
+    - if: '$CI_COMMIT_TAG != null' # tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,48 +1,15 @@
+include:
+  - '/.ci/gitlab/publish.yml'
+  - '/.ci/gitlab/tests.yml'
+
 stages:
   - build
   # TODO: add test stage to prevent cache throwouts if test failed?
   - publish
 
-.tests:
-  image: clashlang/clash-ci:2020-04-15
-  stage: build
-  timeout: 2 hours
-  variables:
-    GIT_SUBMODULE_STRATEGY: recursive
-    TERM: xterm-color
-  retry:
-    max: 2
-    when:
-      - runner_system_failure
-      - stuck_or_timeout_failure
-  cache:
-    key: cabal-store-$CI_JOB_NAME
-    paths:
-      - cabal-store/
-  script:
-    - unset SNAPCRAFT_LOGIN_FILE
-    - unset HACKAGE_PASSWORD
-    # Use either ${GHC} or if that's not set, try to detect GHC version by analyzing
-    # $CI_JOB_NAME.
-    - export GHC="${GHC:-$(echo $CI_JOB_NAME | egrep -o 'ghc-[0-9]+.[0-9]+.[0-9]+')}"
-    - export THREADS=$(nproc)
-    - export CABAL_JOBS=$(nproc)
-    - export
-    - .ci/setup.sh
-    - .ci/build.sh
-    - .ci/test.sh
-
-.tests-interruptible:
-  extends: .tests
-  interruptible: true
-  rules:
-    - if: '$CI_COMMIT_BRANCH != "master"'
-
 # Test jobs:
 ghc-8.4.4:
   extends: .tests-interruptible
-#ghc-8.6.5:
-#  extends: .tests
 ghc-8.8.3:
   extends: .tests-interruptible
 ghc-8.10.1:
@@ -51,81 +18,19 @@ ghc-8.6.5-singular-hidden:
   extends: .tests-interruptible
   variables:
     MULTIPLE_HIDDEN: "no"
-#ghc-head:
-#  # extends: .tests-interruptible
-#  stage: build
-#  allow_failure: true
-#  script:
-#    TODO test with HEAD
 
-# Same as test jobs, but non-interruptable
+# Tests on master. These are marked non-interruptible so we can receive e-mails
+# on failed jobs, without receiving false negatives.
 ghc-8.4.4-master:
-  extends: .tests
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "master"'
-#ghc-8.6.5:
-#  extends: .tests
+  extends: .tests-non-interruptible
 ghc-8.8.3-master:
-  extends: .tests
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "master"'
+  extends: .tests-non-interruptible
 ghc-8.10.1-master:
-  extends: .tests
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "master"'
+  extends: .tests-non-interruptible
 ghc-8.6.5-singular-hidden-master:
-  extends: .tests
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "master"'
+  extends: .tests-non-interruptible
   variables:
     MULTIPLE_HIDDEN: "no"
-#ghc-head-master:
-#  # extends: .tests-non-interruptible
-#  only:
-#    - master
-#  stage: build
-#  allow_failure: true
-#  script:
-#    TODO test with HEAD
-
-hackage-sdist:
-  extends: .tests
-  interruptible: false
-  variables:
-    GHC: ghc-8.10.1
-  script:
-    - export GHC="${GHC:-$CI_JOB_NAME}"
-    - export THREADS=$(nproc)
-    - export CABAL_JOBS=$(nproc)
-    - .ci/setup.sh
-    - .ci/build_sdist.sh clash-prelude
-    - .ci/build_sdist.sh clash-lib
-    - .ci/build_sdist.sh clash-ghc
-  artifacts:
-    paths:
-      - clash-*.tar.gz  # clash-{prelude,lib,ghc}-$version{-docs,}.tar.gz
-    expire_in: 1 week
-  rules:
-    - if: '$CI_COMMIT_TAG != null' # tags
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_PIPELINE_SOURCE == "trigger"
-
-.hackage:
-  extends: .tests
-  interruptible: false
-  stage: publish
-  cache:
-    key: hackage
-  variables:
-    GHC: ghc-8.10.1
-  script:
-    - export GHC="${GHC:-$CI_JOB_NAME}"
-    - export THREADS=$(nproc)
-    - export CABAL_JOBS=$(nproc)
-    - .ci/setup.sh
-    - .ci/publish_sdist.sh clash-prelude
-    - .ci/publish_sdist.sh clash-lib
-    - .ci/publish_sdist.sh clash-ghc
 
 # "Publish" a release candidate
 hackage-release-candidate:
@@ -148,56 +53,7 @@ hackage-release:
   rules:
     - if: '$CI_COMMIT_TAG != null' # tags
 
-# Create a binary distribution using nix, and store it in a tarball. A special
-# nix distribution is used that has its store installed on /usr/nix/store,
-# instead of the default /nix. This is used to work around a know limitation
-# of snap layouts. As of August 2019 the snapcraft docs mention:
-#
-#  > Layouts cannot currently create new top-level files or directories.
-#  >
-#  >  - https://snapcraft.io/docs/snap-layouts
-#
-# If this limitation is ever annulled, we can use a "proper" nix distribution.
-snap-bindist:
-  image: clashlang/nixbuntu:2.3.3
-  stage: build
-  cache:
-    key: usr-nix-$CI_JOB_NAME
-    paths:
-      # GitLab CI uses zip as a cache archive. For some reason, nix can't
-      # handle this (wrong permissions, missing symlinks?), so we pre-tar it.
-      - usr_nix.tar.xz
-  artifacts:
-    when: always
-    paths:
-      - nix_build.log
-      - bindist/linux/snap/clash-snap-bindist.tar.xz
-    expire_in: 1 week
-  script:
-    - .ci/snap_bindist.sh
-
-  # Run every night, when explicitly triggered, or when tagged (release)
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_PIPELINE_SOURCE == "trigger"
-    - if: '$CI_COMMIT_TAG != null' # tags
-
-# Use binary distribution built in `snap-bindist` to build a snap pacakge.
-.snap:
-  image: snapcore/snapcraft
-  stage: publish
-  cache:
-    key: snap-last-run-hash-$CI_COMMIT_REF_SLUG
-    paths:
-      - snap-last-run-hash
-  artifacts:
-    when: always
-    paths:
-      - bindist/linux/snap/*.snap
-    expire_in: 1 week
-  script:
-    - .ci/snap_publish.sh
-
+# Publish a release candidate (beta/edge) to snapcraft.io/clash
 snap-beta-or-edge:
   extends: .snap
   variables:
@@ -206,6 +62,7 @@ snap-beta-or-edge:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "trigger"
 
+# Publish a new version to stable channel on snapcraft.io/clash
 snap-stable:
   extends: .snap
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,15 +7,29 @@ stages:
   # TODO: add test stage to prevent cache throwouts if test failed?
   - publish
 
-# Test jobs:
-ghc-8.4.4:
+# Haddock, doctests, unittests, clash-dev testing. These are single threaded
+# tests and therefore suitable for public runners.
+tests-8.4.4:
   extends: .tests-interruptible
-ghc-8.8.3:
+tests-8.8.3:
   extends: .tests-interruptible
-ghc-8.10.1:
+tests-8.10.1:
   extends: .tests-interruptible
-ghc-8.6.5-singular-hidden:
+tests-8.6.5-singular-hidden:
   extends: .tests-interruptible
+  variables:
+    MULTIPLE_HIDDEN: "no"
+
+# Testsuite (HDL generation and simulation). Highly parallel and memory
+# intensive, should only picked up by beefy (local) runners.
+testsuite-8.4.4:
+  extends: .testsuite-interruptible
+testsuite-8.8.3:
+  extends: .testsuite-interruptible
+testsuite-8.10.1:
+  extends: .testsuite-interruptible
+testsuite-8.6.5-singular-hidden:
+  extends: .testsuite-interruptible
   variables:
     MULTIPLE_HIDDEN: "no"
 


### PR DESCRIPTION
This PR streamlines our GitLab CI infrastructure somewhat:

* `only`/`except` are deprecated keywords, so I've replaced them with `rules`
* all CI scripts now fail on undefined variables
* GHC and Cabal are now selected using `update-alternatives`, instead of using `apt`. This allows us to preinstall all ghcs and cabals.
* Hackage cache (typically `~/.cabal/packages`) is now cached. Prevents fetching the whole index from Hackage every time.
* `.gitlab-ci.yml` is split up into multiple files. The main one now only defines what jobs to run, instead of how to run them.
* Tests are split into two: unittests+doctests+build tests+clashdev+haddock tests and the testsuite. The testsuite is marked with the tag `local`, such that it will only run our own runners. All other ones can run on public runners. (We'd need to backport this to 1.2 in order to enable public runners and make our runners not run tagless jobs.) This allows us to use as much as the free resources GitLab offers us.

All in all, this makes jobs run in <=25 minutes even on a fully clogged diepenheim.