### PR TITLE
Basic Termination Analysis and Fuel

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -77,6 +77,7 @@ flagsClash r = [
   , defFlag "fclash-inline-limit"                $ IntSuffix (liftEwM . setInlineLimit r)
   , defFlag "fclash-inline-function-limit"       $ IntSuffix (liftEwM . setInlineFunctionLimit r)
   , defFlag "fclash-inline-constant-limit"       $ IntSuffix (liftEwM . setInlineConstantLimit r)
+  , defFlag "fclash-evaluator-fuel-limit"        $ IntSuffix (liftEwM . setEvaluatorFuelLimit r)
   , defFlag "fclash-intwidth"                    $ IntSuffix (setIntWidth r)
   , defFlag "fclash-error-extra"                 $ NoArg (liftEwM (setErrorExtra r))
   , defFlag "fclash-float-support"               $ NoArg (liftEwM (setFloatSupport r))
@@ -122,6 +123,12 @@ setInlineConstantLimit
   -> Int
   -> IO ()
 setInlineConstantLimit r n = modifyIORef r (\c -> c {opt_inlineConstantLimit = toEnum n})
+
+setEvaluatorFuelLimit
+  :: IORef ClashOpts
+  -> Int
+  -> IO ()
+setEvaluatorFuelLimit r n = modifyIORef r (\c -> c {opt_evaluatorFuelLimit = toEnum n})
 
 setInlineWFLimit
   :: IORef ClashOpts

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -151,6 +151,11 @@ generateBindings useColor primDirs importDirs dbs hdl modName dflagsM = do
          , domainConfs
          )
 
+-- TODO This function should be changed to provide the information that
+-- Clash.Core.Termination.mkRecInfo provides. To achieve this, it should also
+-- be changed to no longer flatten recursive groups (see the documentation for
+-- mkRecInfo for an explanation of these).
+--
 mkBindings
   :: CompiledPrimMap
   -> [GHC.CoreBind]

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -143,6 +143,7 @@ Library
 
   Build-depends:      aeson                   >= 0.6.2.0  && < 1.5,
                       ansi-terminal           >= 0.8.0.0  && < 0.11,
+                      array,
                       attoparsec              >= 0.10.4.0 && < 0.14,
                       base                    >= 4.11     && < 5,
                       binary                  >= 0.8.5    && < 0.11,
@@ -209,6 +210,7 @@ Library
                       Clash.Core.TermInfo
                       Clash.Core.TermLiteral
                       Clash.Core.TermLiteral.TH
+                      Clash.Core.Termination
                       Clash.Core.TyCon
                       Clash.Core.Type
                       Clash.Core.TysPrim

--- a/clash-lib/src/Clash/Core/Termination.hs
+++ b/clash-lib/src/Clash/Core/Termination.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Clash.Core.Termination
+  ( RecInfo
+  , mkRecInfo
+  , isRecursive
+  , recursiveGroup
+  ) where
+
+import Control.Lens.Fold
+import Data.Graph (SCC(..))
+import qualified Data.Graph as Graph
+import qualified Data.List as List
+
+import Clash.Core.FreeVars
+import Clash.Core.Var
+import Clash.Core.VarEnv
+import Clash.Driver.Types
+
+-- Quick lookup for whether a binding is recursive or non-recursive. If a
+-- binding is non-recursive, we can assume that it terminates and skip
+-- analysing it.
+--
+data RecInfo = RecInfo
+  { recBindings    :: [VarSet]
+    -- ^ Recursive bindings, organized into groups of strongly connected
+    -- components.
+  , nonRecBindings :: VarSet
+    -- ^ Non-recursive bindings
+  }
+
+instance Show RecInfo where
+  show (RecInfo rs ns) =
+    "recursive groups:\n" <> show (fmap eltsVarSet rs)
+      <> "\n\nnon-recursive:\n" <> show (eltsVarSet ns)
+
+instance Semigroup RecInfo where
+  {-# INLINE (<>) #-}
+  RecInfo rX nX <> RecInfo rY nY =
+    RecInfo (rX <> rY) (nX <> nY)
+
+instance Monoid RecInfo where
+  {-# INLINE mempty #-}
+  mempty = RecInfo mempty mempty
+
+  {-# INLINE mappend #-}
+  mappend = (<>)
+
+-- | Given a map of top-level bindings, identify which terms are recursive and
+-- organize them into groups of mutually recursive bindings. For example,
+-- calling mkRecInfo on a BindingMap with the definitions
+--
+--   f []     = []
+--   f (x:xs) = g x : h xs
+--
+--   g x = x + 1
+--
+--   h []     = []
+--   h (x:xs) = x : f xs
+--
+--   i []     = []
+--   i (x:xs) = x * 2 : i xs
+--
+-- would identify [f, g] and [i] as recursive groups, and g as non-recursive.
+--
+mkRecInfo :: BindingMap -> RecInfo
+mkRecInfo =
+  mconcat . fmap asInfo . dependencies
+ where
+  -- Convert a SCC to RecInfo
+  asInfo = \case
+    AcyclicSCC x -> RecInfo [] (unitVarSet $ bindingId x)
+    CyclicSCC xs -> RecInfo [mkVarSet $ fmap bindingId xs] emptyVarSet
+
+  -- Get the SCCs of the dependency graph of free variables.
+  dependencies =
+    Graph.stronglyConnComp . eltsVarEnv . fmap go
+   where
+    go x = let fvs = bindingTerm x ^.. freeIds
+            in (x, bindingId x, fvs)
+
+-- | Check if a global binder is recursive. To be conservative, binders which
+-- are not included in the RecInfo are assumed to be recursive.
+--
+isRecursive :: Id -> RecInfo -> Bool
+isRecursive i
+  | isGlobalId i = not . elemVarSet i . nonRecBindings
+  | otherwise = error ("isRecursive: " <> show i <> " is not a global Id")
+
+-- | Return the recursive group that a global binder belongs to. If the
+-- binder is non-recursive or not included in the RecInfo, Nothing is returned.
+--
+recursiveGroup :: Id -> RecInfo -> Maybe VarSet
+recursiveGroup i = List.find (elemVarSet i) . recBindings
+

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -94,6 +94,11 @@ data ClashOpts = ClashOpts
   -- always inlined. A value of 0 inlines all constants.
   --
   -- Command line flag: -fclash-inline-constant-limit
+  , opt_evaluatorFuelLimit :: Word
+  -- ^ Set the threshold for maximum unfolding depth in the evaluator. A value
+  -- of zero means no potentially non-terminating binding is unfolded.
+  --
+  -- Command line flag: -fclash-evaluator-fuel-limit
   , opt_dbgLevel :: DebugLevel
   -- ^ Set the debugging mode for the compiler, exposing additional output. See
   -- "DebugLevel" for the available options.
@@ -184,6 +189,7 @@ instance Hashable ClashOpts where
     opt_specLimit `hashWithSalt`
     opt_inlineFunctionLimit `hashWithSalt`
     opt_inlineConstantLimit `hashWithSalt`
+    opt_evaluatorFuelLimit `hashWithSalt`
     opt_dbgLevel `hashSet`
     opt_dbgTransformations `hashWithSalt`
     opt_dbgTransformationsFrom `hashWithSalt`
@@ -230,6 +236,7 @@ defClashOpts
   , opt_specLimit           = 20
   , opt_inlineFunctionLimit = 15
   , opt_inlineConstantLimit = 0
+  , opt_evaluatorFuelLimit  = 20
   , opt_cachehdl            = True
   , opt_cleanhdl            = True
   , opt_primWarn            = True

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -50,6 +50,7 @@ import           Clash.Core.Subst
   (extendGblSubstList, mkSubst, substTm)
 import           Clash.Core.Term                  (Term (..), collectArgsTicks
                                                   ,mkApps, mkTicks)
+import           Clash.Core.Termination           (mkRecInfo)
 import           Clash.Core.Type                  (Type, splitCoreFunForallTy)
 import           Clash.Core.TyCon
   (TyConMap, TyConName)
@@ -132,6 +133,8 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcs
                   eval
                   (mkVarSet topEnts)
                   reprs
+                  (mkRecInfo globals)
+                  (opt_evaluatorFuelLimit opts)
 
     rwState   = RewriteState
                   0

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -79,7 +79,6 @@ import Clash.Core.VarEnv
   (InScopeSet, elemInScopeSet, extendInScopeSetList, notElemInScopeSet, unionInScope)
 import Clash.Normalize.Types (NormalizeState)
 import Clash.Rewrite.Types
-  (RewriteMonad, bindings, evaluator, globalHeap, tcCache, tupleTcCache, uniqSupply)
 import Clash.Rewrite.Util    (mkInternalVar, mkSelectorCase,
                               isUntranslatableType, isConstant)
 import Clash.Unique          (lookupUniqMap)
@@ -158,7 +157,10 @@ collectGlobals' is0 substitution seen e@(collectArgsTicks -> (fun, args@(_:_), t
     let (ids1,ids2) = splitSupply ids
     uniqSupply Lens..= ids2
 #if EXPERIMENTAL_EVALUATOR
-    let env = mkGlobalEnv bndrs gh tcm is0 ids1
+    ri <- Lens.view recInfo
+    fuel <- Lens.view fuelLimit
+
+    let env = mkGlobalEnv bndrs ri fuel gh tcm is0 ids1
     let eval = asTerm . fst . runEval env . evaluateNf evaluate
 #else
     let eval = (Lens.view Lens._3) . whnf' evaluate bndrs tcm gh ids1 is0 False

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -42,6 +42,7 @@ import Clash.Core.Evaluator.Types            (Evaluator, PrimHeap)
 #endif
 
 import Clash.Core.Term           (Term, Context)
+import Clash.Core.Termination    (RecInfo)
 import Clash.Core.Type           (Type)
 import Clash.Core.TyCon          (TyConName, TyConMap)
 import Clash.Core.Var            (Id)
@@ -122,6 +123,10 @@ data RewriteEnv
   -- ^ Functions that are considered TopEntities
   , _customReprs    :: CustomReprs
   -- ^ Custom bit representations
+  , _recInfo        :: RecInfo
+  -- ^ Information about recursive global bindings
+  , _fuelLimit      :: Word
+  -- ^ Maximum amount of fuel for the evaluator
   }
 
 makeLenses ''RewriteEnv

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -1132,7 +1132,10 @@ whnfRW _isSubj ctx@(TransformContext is0 _) e rw = do
   gh <- Lens.use globalHeap
 
 #if EXPERIMENTAL_EVALUATOR
-  case runEval (mkGlobalEnv bndrs gh tcm is0 ids1) (evaluateNf eval e) of
+  ri <- Lens.view recInfo
+  fuel <- Lens.view fuelLimit
+
+  case runEval (mkGlobalEnv bndrs ri fuel gh tcm is0 ids1) (evaluateNf eval e) of
     (!e', !env') -> do
       globalHeap Lens..= genvPrimsIO env'
       rw ctx (asTerm e')

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -71,6 +71,8 @@ instance Default RewriteEnv where
     , _evaluator=error "_evaluator: NYI"
     , _topEntities=emptyVarSet
     , _customReprs=buildCustomReprs []
+    , _recInfo=mempty
+    , _fuelLimit=10
     }
 
 instance Default extra => Default (RewriteState extra) where

--- a/docs/developing-hardware/flags.rst
+++ b/docs/developing-hardware/flags.rst
@@ -143,6 +143,12 @@ Clash Compiler Flags
 
   **Default:** 0
 
+-fclash-evaluator-fuel-limit
+  Set the threshold for unfolding potentially non-terminating bindings in the
+  evaluator. A value of 0 only unfolds terminating bindings.
+
+  **Default:** 20
+
 -fclash-intwidth
   Set the bit width for the ``Int/Word/Integer`` types. The only allowed values
   are 32 or 64.

--- a/testsuite/src/Test/Tasty/Clash/CoreTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/CoreTest.hs
@@ -20,6 +20,7 @@ import Clash.Backend.Verilog
 import Clash.Backend.VHDL
 import Clash.Core.Evaluator.Models
 import Clash.Core.Name
+import Clash.Core.Termination
 import Clash.Core.TyCon
 import Clash.Core.Var
 import Clash.Core.VarEnv
@@ -81,10 +82,11 @@ findBinding
 findBinding nm (bm, tcm, ids) =
   case List.find byName (eltsVarEnv bm) of
     Just bd ->
-      let env = mkGlobalEnv bm (mempty, 0) tcm emptyInScopeSet ids
+      let env = mkGlobalEnv bm ri 20 (mempty, 0) tcm emptyInScopeSet ids
        in fst . runEval env $ evaluateNf ghcEvaluator (bindingTerm bd)
 
     Nothing -> error ("Not in binding map: " <> show nm)
  where
+  ri = mkRecInfo bm
   byName b = nm == nameOcc (varName $ bindingId b)
 


### PR DESCRIPTION
The partial evaluator now performs incredibly limited termination
analysis, by taking into consideration whether a global binding is
non-recursive when determining whether to inline. This means that
any non-recursive binding can always be unfolded.

This commit also introduces fuel as a way to limit the number of
times a potentially non-terminating function can be unfolded, with
global bindings being ignored if there is no fuel available.