### PR TITLE
Minor fixes for `Clash.Annotations.SynthesisAttributes.Annotated`

### DIFF
--- a/changelog/2020-07-05T21_11_29+02_00_annotated_fixes
+++ b/changelog/2020-07-05T21_11_29+02_00_annotated_fixes
@@ -1,0 +1,1 @@
+FIXED: Minor faults in generated HDL when using annotations from `Clash.Annotations.SynthesisAttributes`

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -977,6 +977,7 @@ appendSize baseType sizedType = case sizedType of
   Unsigned n  -> baseType <> parens (int (n-1) <+> "downto 0")
   Vector n _  -> baseType <> parens ("0 to" <+> int (n-1))
   RTree d _   -> baseType <> parens ("0 to" <+> int ((2^d)-1))
+  Annotated _ elTy -> appendSize baseType elTy
   _           -> baseType
 
 -- | Same as @qualTyName@, but instantiate generic types with their size.
@@ -1857,6 +1858,7 @@ encodingNote :: HWType -> VHDLM Doc
 encodingNote (Clock _)  = "-- clock" <> line
 encodingNote (Reset _)  = "-- reset" <> line
 encodingNote (Enable _) = "-- enable" <> line
+encodingNote (Annotated _ t) = encodingNote t
 encodingNote _          = emptyDoc
 
 tupledSemi :: Applicative f => f [Doc] -> f Doc

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -960,7 +960,7 @@ assocs m = zip keys (map (m HashMap.!) keys)
 
 -- | Convert single attribute to VHDL syntax
 renderAttr :: Attr' -> T.Text
-renderAttr (StringAttr'  _key value) = T.pack $ show value
+renderAttr (StringAttr'  _key value) = T.replace "\\\"" "\"\"" $ T.pack $ show value
 renderAttr (IntegerAttr' _key value) = T.pack $ show value
 renderAttr (BoolAttr'    _key True ) = T.pack $ "true"
 renderAttr (BoolAttr'    _key False) = T.pack $ "false"

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -334,6 +334,7 @@ verilogType t = case t of
   Bit      -> emptyDoc
   Bool     -> emptyDoc
   FileType -> emptyDoc
+  Annotated _ ty -> verilogType ty
   _        -> brackets (int (typeSize t -1) <> colon <> int 0)
 
 sigDecl :: VerilogM Doc -> HWType -> VerilogM Doc
@@ -1213,4 +1214,5 @@ encodingNote :: Applicative m => HWType -> m Doc
 encodingNote (Clock _) = string " // clock"
 encodingNote (Reset _) = string " // reset"
 encodingNote (Enable _) = string " // enable"
+encodingNote (Annotated _ t) = encodingNote t
 encodingNote _         = emptyDoc

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -182,6 +182,7 @@ findClocks (Component _ is _ _) =
   mapMaybe isClock is
  where
   isClock (i, Clock d) = Just (i, d)
+  isClock (i, Annotated _ t) = isClock (i,t)
   isClock _ = Nothing
 
 -- | Size indication of a type (e.g. bit-size or number of elements)

--- a/examples/Blinker.hs
+++ b/examples/Blinker.hs
@@ -2,6 +2,7 @@ module Blinker where
 
 import Clash.Prelude
 import Clash.Intel.ClockGen
+import Clash.Annotations.SynthesisAttributes
 
 data LedMode
   = Rotate
@@ -27,12 +28,20 @@ createDomain vSystem{vName="Dom50", vPeriod=50000}
     }) #-}
 topEntity
   :: Clock Input
+      `Annotate` 'StringAttr "chip_pin" "R8"
+      `Annotate` 'StringAttr "altera_attribute" "-name IO_STANDARD \"3.3-V LVTTL\""
   -- ^ Incoming clock
   -> Signal Input Bool
+      `Annotate` 'StringAttr "chip_pin" "J15"
+      `Annotate` 'StringAttr "altera_attribute" "-name IO_STANDARD \"3.3-V LVTTL\""
   -- ^ Reset signal, straight from KEY0
   -> Signal Dom50 Bit
+      `Annotate` 'StringAttr "chip_pin" "E1"
+      `Annotate` 'StringAttr "altera_attribute" "-name IO_STANDARD \"3.3-V LVTTL\""
   -- ^ Mode choice, straight from KEY1. See 'LedMode'.
   -> Signal Dom50 (BitVector 8)
+      `Annotate` 'StringAttr "chip_pin" "L3, B1, F3, D1, A11, B13, A13, A15"
+      `Annotate` 'StringAttr "altera_attribute" "-name IO_STANDARD \"3.3-V LVTTL\""
   -- ^ Output containing 8 bits, corresponding to 8 LEDs
 topEntity clk20 rstBtn modeBtn =
   exposeClockResetEnable


### PR DESCRIPTION
* Escape `"` with `"` in VHDL string attributes
* Look through `Annotated` in `appendSize` and `encodingNote`
* Look through `Annotated` to find clocks for SDC file