### PR TITLE
Add `PrintfArg` instance (going via `Integer`) for sized integral types

### DIFF
--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -73,6 +73,7 @@ import Data.Data                  (Data)
 import Data.Default.Class         (Default (..))
 import Data.Proxy                 (Proxy (..))
 import Text.Read                  (Read (..), ReadPrec)
+import Text.Printf                (PrintfArg (..))
 import Language.Haskell.TH        (TypeQ, appT, conT, litT, numTyLit, sigE)
 import Language.Haskell.TH.Syntax (Lift(..))
 #if MIN_VERSION_template_haskell(2,16,0)
@@ -360,6 +361,9 @@ quot#,rem# :: Index n -> Index n -> Index n
 {-# NOINLINE toInteger# #-}
 toInteger# :: Index n -> Integer
 toInteger# (I n) = n
+
+instance KnownNat n => PrintfArg (Index n) where
+  formatArg = formatArg . toInteger
 
 instance (KnownNat n, 1 <= n) => Parity (Index n) where
   even = even . pack

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -87,6 +87,7 @@ import Data.Data                      (Data)
 import Data.Default.Class             (Default (..))
 import Data.Proxy                     (Proxy (..))
 import Text.Read                      (Read (..), ReadPrec)
+import Text.Printf                    (PrintfArg (..))
 import GHC.Generics                   (Generic)
 import GHC.Natural                    (naturalFromInteger)
 #if MIN_VERSION_base(4,12,0)
@@ -418,6 +419,9 @@ mod# (S a) (S b) = S (a `mod` b)
 {-# NOINLINE toInteger# #-}
 toInteger# :: Signed n -> Integer
 toInteger# (S n) = n
+
+instance KnownNat n => PrintfArg (Signed n) where
+  formatArg = formatArg . toInteger
 
 instance KnownNat n => Parity (Signed n) where
   even = even . pack

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -85,6 +85,7 @@ import Data.Data                      (Data)
 import Data.Default.Class             (Default (..))
 import Data.Proxy                     (Proxy (..))
 import Text.Read                      (Read (..), ReadPrec)
+import Text.Printf                    (PrintfArg (..))
 import GHC.Exts                       (narrow8Word#, narrow16Word#, narrow32Word#)
 import GHC.Generics                   (Generic)
 import GHC.Integer.GMP.Internals      (bigNatToWord)
@@ -348,6 +349,9 @@ rem# (U i) (U j) = U (i `rem` j)
 {-# NOINLINE toInteger# #-}
 toInteger# :: Unsigned n -> Integer
 toInteger# (U i) = naturalToInteger i
+
+instance KnownNat n => PrintfArg (Unsigned n) where
+  formatArg = formatArg . toInteger
 
 instance KnownNat n => Parity (Unsigned n) where
   even = even . pack


### PR DESCRIPTION
This is useful for simulation, especially with hexadecimal formats like `"%04x"` to print a 0-padded 4-hex-digit value.