### PR TITLE
Prevent name clashes with VHDL imports

### DIFF
--- a/changelog/2020-07-10T13_02_57+02_00_fix_imported_name_clashes
+++ b/changelog/2020-07-10T13_02_57+02_00_fix_imported_name_clashes
@@ -1,0 +1,10 @@
+FIXED: Clash no longer uses component names that clash with identifiers imported from
+
+  * IEEE.STD_LOGIC_1164.all
+  * IEEE.NUMERIC_STD.all
+  * IEEE.MATH_REAL.all
+  * std.textio.all
+
+when generating VHDL.
+See https://github.com/clash-lang/clash-compiler/issues/1439.
+

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -227,6 +227,45 @@ isBV _ = False
 timeUnits :: [Identifier]
 timeUnits = ["fs", "ps", "ns", "us", "ms", "sec", "min", "hr"]
 
+-- | Identifiers which are imported from the following:
+--
+-- use IEEE.STD_LOGIC_1164.ALL;
+-- use IEEE.NUMERIC_STD.ALL;
+-- use IEEE.MATH_REAL.ALL;
+-- use std.textio.all;
+--
+-- Clash should not use these identifiers, as it can lead to errors when
+-- interfacing with an EDA tool.
+--
+-- See https://github.com/clash-lang/clash-compiler/issues/1439.
+--
+importedNames :: [Identifier]
+importedNames =
+  [ -- ieee.std_logic_1164.all
+    "std_ulogic", "std_ulogic_vector", "resolved", "std_logic", "std_logic_vector"
+  , "x01", "x01z", "ux01", "ux01z", "to_bit", "to_bitvector", "to_stdulogic"
+  , "to_stdlogicvector", "to_stdulogicvector", "to_01", "to_x01", "to_x01z"
+  , "to_ux01", "rising_edge", "falling_edge", "is_x"
+    -- ieee.numeric_std.all
+  , "unresolved_unsigned", "unresolved_signed", "u_unsigned", "u_signed"
+  , "unsigned", "signed", "find_leftmost", "find_rightmost", "minimum"
+  , "maximum", "shift_left", "shift_right", "rotate_left", "rotate_right"
+  , "resize", "to_integer", "to_unsigned", "to_signed", "std_match"
+    -- ieee.math_real.all
+  , "math_e", "math_1_over_e", "math_pi", "math_2_pi", "math_1_over_pi"
+  , "math_pi_over_2", "math_pi_over_3", "path_pi_over_4", "path_3_pi_over_2"
+  , "math_log_of_2", "math_log_of_10", "math_log10_of_e", "math_sqrt_2"
+  , "math_1_over_sqrt_2", "math_sqrt_pi", "math_deg_to_rad", "math_rad_to_deg"
+  , "sign", "ceil", "floor", "round", "trunc", "realmax", "realmin", "uniform"
+  , "sqrt", "cbrt", "exp", "log", "log2", "log10", "sin", "cos", "tan", "arcsin"
+  , "arccos", "arctan", "sinh", "cosh", "tanh", "arcsinh", "arccosh", "arctanh"
+    -- std.textio.all
+  , "line", "text", "side", "width", "justify", "input", "output", "readline"
+  , "read", "sread", "string_read", "bread", "binary_read", "oread", "octal_read"
+  , "hread", "hex_read", "writeline", "tee", "write", "swrite", "string_write"
+  , "bwrite", "binary_write", "owrite", "octal_write", "hwrite", "hex_write"
+  ]
+
 -- List of reserved VHDL-2008 keywords
 -- + used internal names: toslv, fromslv, tagtoenum, datatotag
 -- + used IEEE library names: integer, boolean, std_logic, std_logic_vector,
@@ -247,7 +286,7 @@ reservedWords = ["abs","access","after","alias","all","and","architecture"
   ,"unaffected","units","until","use","variable","vmode","vprop","vunit","wait"
   ,"when","while","with","xnor","xor","toslv","fromslv","tagtoenum","datatotag"
   ,"integer", "boolean", "std_logic", "std_logic_vector", "signed", "unsigned"
-  ,"to_integer", "to_signed", "to_unsigned", "string","log"] ++ timeUnits
+  ,"to_integer", "to_signed", "to_unsigned", "string","log"] ++ timeUnits ++ importedNames
 
 filterReserved :: Identifier -> Identifier
 filterReserved s = if s `elem` reservedWords

--- a/tests/shouldwork/Issues/T1439.hs
+++ b/tests/shouldwork/Issues/T1439.hs
@@ -1,0 +1,60 @@
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module T1439 where
+
+import Clash.Prelude
+import Clash.Sized.Internal.BitVector
+import Clash.Netlist.Types
+
+import Test.Tasty.Clash
+import Test.Tasty.Clash.NetlistTest
+
+topEntity :: BitVector 32 -> BitVector 32
+topEntity = rotate_right True
+
+rotate_right
+    :: forall n . (KnownNat n, 1 <= n)
+    => Bool
+    -- ^ Client request
+    -> BitVector n
+    -- ^ Object of shift operation
+    -> BitVector n
+    -- ^ Result.
+rotate_right bv =
+  leToPlus @1 @n (rotate_right' bv)
+{-# NOINLINE rotate_right #-}
+
+rotate_right'
+    :: forall n . (KnownNat n)
+    => Bool
+    -- ^ Client request
+    -> BitVector (n+1)
+    -- ^ Object of shift in operation
+    -> BitVector (n+1)
+    -- ^ Result.
+rotate_right' bool bv
+    | bool      = pack b ++# (fst $ split# bv)
+    | otherwise = bv
+    where b = lsb bv
+{-# NOINLINE rotate_right' #-}
+
+testPath :: FilePath
+testPath = "tests/shouldwork/Issues/T1439.hs"
+
+noRotateRight :: Component -> IO ()
+noRotateRight (Component nm _ _ _)
+  | nm == "rotate_right" = error ("No component should be called rotate_right")
+  | otherwise = pure ()
+
+getComponent :: (a, b, c, d) -> d
+getComponent (_, _, _, x) = x
+
+mainVHDL :: IO ()
+mainVHDL = do
+  netlist <- runToNetlistStage SVHDL id testPath
+  mapM_ (noRotateRight . getComponent) netlist
+

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -454,6 +454,7 @@ runClashTest = defaultMain $ clashTestRoot
            in NEEDS_PRIMS(runTest "T1187" _opts)
         , clashLibTest ("tests" </> "shouldwork" </> "Issues") [VHDL] [] "T1388" "main"
         , outputTest ("tests" </> "shouldwork" </> "Issues") allTargets [] [] "T1171" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "Issues") [VHDL] [] "T1439" "main"
         ]
       , clashTestGroup "Naming"
         [ runTest "T967a" def{hdlSim=False}


### PR DESCRIPTION
When generating VHDL, clash no longer generates component names
which clash with identifiers from imported modules.