### PR TITLE
Fix starter project tests

### DIFF
--- a/clash-starters/clash-example-project/src/Example/Project.hs
+++ b/clash-starters/clash-example-project/src/Example/Project.hs
@@ -1,4 +1,4 @@
-module Example.Project (topEntity) where
+module Example.Project (topEntity, plus) where
 
 import Clash.Prelude
 


### PR DESCRIPTION
When running the instructions to test the starter project (using
cabal), it would error out because `plus` was not exported from the
library module.