### PR TITLE
Add benchmarking to CI

### DIFF
--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,0 +1,42 @@
+.benchmark:
+  image: clashlang/clash-ci:2020-06-29
+  stage: build
+  timeout: 2 hours
+  variables:
+    MULTIPLE_HIDDEN: "no"
+    GIT_SUBMODULE_STRATEGY: recursive
+    TERM: xterm-color
+
+    # setup.sh checks whether these variables exist so it can fail early
+    RUN_HADDOCK: "no"
+    RUN_LIBTESTS: "no"
+    RUN_CLASHDEV: "no"
+    RUN_TESTSUITE: "no"
+    RUN_BUILD_ALL: "no"
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+  cache:
+    key: cabal-store-$CI_JOB_NAME
+    paths:
+      - cabal-store/
+      - cabal-packages/
+  script:
+    - unset SNAPCRAFT_LOGIN_FILE
+    - unset HACKAGE_PASSWORD
+    # Use either ${GHC} or if that's not set, try to detect GHC version by analyzing
+    # $CI_JOB_NAME.
+    - export GHC=ghc-"${GHC_VERSION:-$(echo $CI_JOB_NAME | egrep -o '[0-9]+.[0-9]+.[0-9]+')}"
+    - export THREADS=2
+    - export CABAL_JOBS=2
+    - export
+    - .ci/setup.sh
+    - cabal new-run --write-ghc-environment-files=always benchmark -- --csv benchmark.csv
+  tags:
+    - benchmarks
+  artifacts:
+    paths:
+      - benchmark.csv
+    expire_in: 1 week

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 include:
   - '/.ci/gitlab/publish.yml'
+  - '/.ci/gitlab/benchmark.yml'
   - '/.ci/gitlab/tests.yml'
 
 stages:
@@ -45,6 +46,10 @@ ghc-8.6.5-singular-hidden-master:
   extends: .tests-non-interruptible
   variables:
     MULTIPLE_HIDDEN: "no"
+
+# Run benchmarks for isclashfastyet.com
+benchmark-8.8.3:
+  extends: .benchmark
 
 # "Publish" a release candidate
 hackage-release-candidate:


### PR DESCRIPTION
Publishes results as GitLab CI artificats

-------------------------

The plan is to push the benchmark results to https://github.com/clash-lang/clash-benchmark-results, but I haven't found a safe way of doing so (read: without exposing secrets to random people). Maybe by running a nightly job pointed to master, gathering and pushing these results?