### PR TITLE
Store seen PrimInfo in HashMap for lookup

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -49,12 +49,12 @@ doHDL
 doHDL b src = do
   startTime <- Clock.getCurrentTime
   pd      <- primDirs b
-  (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <- generateBindings Auto pd ["."] [] (hdlKind b) src Nothing
+  (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs,primInfos) <- generateBindings Auto pd ["."] [] (hdlKind b) src Nothing
   prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` reprs `deepseq` Clock.getCurrentTime
   let prepStartDiff = reportTimeDiff prepTime startTime
   putStrLn $ "Loading dependencies took " ++ prepStartDiff
 
-  generateHDL (buildCustomReprs reprs) domainConfs bindingsMap (Just b) primMap tcm tupTcm
+  generateHDL (buildCustomReprs reprs) domainConfs primInfos bindingsMap (Just b) primMap tcm tupTcm
     (ghcTypeToHWType WORD_SIZE_IN_BITS True) evaluator topEntities Nothing
     defClashOpts{opt_cachehdl = False, opt_dbgLevel = DebugSilent}
     (startTime,prepTime)

--- a/benchmark/clash-benchmark.cabal
+++ b/benchmark/clash-benchmark.cabal
@@ -25,6 +25,7 @@ library
                        containers           >= 0.5.4.0  && < 0.7,
                        ghc                  >= 8.4.0    && < 8.11,
                        mtl                  >= 2.1.2    && < 2.3,
+                       text,
                        unordered-containers >= 0.2.3.3  && < 0.3,
 
                        clash-ghc,
@@ -45,6 +46,7 @@ executable clash-benchmark-normalization
                        deepseq              >= 1.4      && < 1.5,
                        directory            >= 1.3.0.0  && < 1.4,
                        filepath             >= 1.4      && < 1.5,
+                       text,
                        unordered-containers,
 
                        clash-benchmark,

--- a/benchmark/profiling/prepare/profile-normalization-prepare.hs
+++ b/benchmark/profiling/prepare/profile-normalization-prepare.hs
@@ -24,7 +24,7 @@ prepareFile idirs fIn = do
   putStrLn $ "Preparing: " ++ fIn
   let fOut = fIn ++ ".bin"
   inp <- runInputStage idirs fIn
-  let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity) = inp
+  let (bindingsMap,tcm,tupTcm,_topEntities,_primInfos,primMap,reprs,topEntityNames,topEntity) = inp
       inp' = (bindingsMap,tcm,tupTcm,_topEntities, fmap (fmap removeBBfunc) primMap, reprs,topEntityNames,topEntity)
   putStrLn $ "Serialising to : " ++ fOut
   B.writeFile fOut $ encode inp'

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -2222,7 +2222,7 @@ makeHDL backend optsRef srcs = do
               forM_ srcs $ \src -> do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <-
+                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs,primInfos) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
 
                 let getMain = getMainTopEntity src bindingsMap topEntities
@@ -2235,6 +2235,7 @@ makeHDL backend optsRef srcs = do
                 Clash.Driver.generateHDL
                   (buildCustomReprs reprs)
                   domainConfs
+                  primInfos
                   bindingsMap
                   (Just backend')
                   primMap

--- a/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-841/Clash/GHCi/UI.hs
@@ -2004,7 +2004,7 @@ makeHDL backend optsRef srcs = do
               forM_ srcs $ \src -> do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <-
+                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs,primInfos) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
                 let getMain = getMainTopEntity src bindingsMap topEntities
                 mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
@@ -2016,6 +2016,7 @@ makeHDL backend optsRef srcs = do
                 Clash.Driver.generateHDL
                   (buildCustomReprs reprs)
                   domainConfs
+                  primInfos
                   bindingsMap
                   (Just backend')
                   primMap

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -2053,7 +2053,7 @@ makeHDL backend optsRef srcs = do
               forM_ srcs $ \src -> do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <-
+                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs,primInfos) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
                 let getMain = getMainTopEntity src bindingsMap topEntities
                 mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
@@ -2065,6 +2065,7 @@ makeHDL backend optsRef srcs = do
                 Clash.Driver.generateHDL
                   (buildCustomReprs reprs)
                   domainConfs
+                  primInfos
                   bindingsMap
                   (Just backend')
                   primMap

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -2144,7 +2144,7 @@ makeHDL backend optsRef srcs = do
               forM_ srcs $ \src -> do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <-
+                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs,primInfos) <-
                   generateBindings color primDirs idirs dbs hdl src (Just dflags)
 
                 let getMain = getMainTopEntity src bindingsMap topEntities
@@ -2157,6 +2157,7 @@ makeHDL backend optsRef srcs = do
                 Clash.Driver.generateHDL
                   (buildCustomReprs reprs)
                   domainConfs
+                  primInfos
                   bindingsMap
                   (Just backend')
                   primMap

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -22,6 +22,7 @@ import           Control.Monad                    (when)
 import           Control.Monad.State.Strict       (State)
 import           Data.Default                     (def)
 import           Data.Either                      (lefts,partitionEithers)
+import           Data.HashMap.Strict              (HashMap)
 import qualified Data.IntMap                      as IntMap
 import           Data.IntMap.Strict               (IntMap)
 import           Data.List
@@ -30,6 +31,7 @@ import qualified Data.Map                         as Map
 import qualified Data.Maybe                       as Maybe
 import qualified Data.Set                         as Set
 import qualified Data.Set.Lens                    as Lens
+import           Data.Text                        (Text)
 import           Data.Text.Prettyprint.Doc        (vcat)
 
 import           BasicTypes                       (InlineSpec (..))
@@ -49,7 +51,7 @@ import           Clash.Core.Pretty                (PrettyOptions(..), showPpr, s
 import           Clash.Core.Subst
   (extendGblSubstList, mkSubst, substTm)
 import           Clash.Core.Term                  (Term (..), collectArgsTicks
-                                                  ,mkApps, mkTicks)
+                                                  ,mkApps, mkTicks,PrimInfo)
 import           Clash.Core.Termination           (mkRecInfo)
 import           Clash.Core.Type                  (Type, splitCoreFunForallTy)
 import           Clash.Core.TyCon
@@ -97,6 +99,8 @@ runNormalization
   -- ^ Level of debug messages to print
   -> Supply
   -- ^ UniqueSupply
+  -> HashMap Text PrimInfo
+  -- ^ Primitives used in design
   -> BindingMap
   -- ^ Global Binders
   -> (CustomReprs -> TyConMap -> Type ->
@@ -118,7 +122,7 @@ runNormalization
   -> NormalizeSession a
   -- ^ NormalizeSession to run
   -> a
-runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcsMap topEnts
+runNormalization opts supply primInfos globals typeTrans reprs tcm tupTcm eval primMap rcsMap topEnts
   = runRewriteSession rwEnv rwState
   where
     rwEnv     = RewriteEnv
@@ -134,6 +138,7 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm eval primMap rcs
                   (mkVarSet topEnts)
                   reprs
                   (mkRecInfo globals)
+                  primInfos
                   (opt_evaluatorFuelLimit opts)
 
     rwState   = RewriteState

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -158,9 +158,10 @@ collectGlobals' is0 substitution seen e@(collectArgsTicks -> (fun, args@(_:_), t
     uniqSupply Lens..= ids2
 #if EXPERIMENTAL_EVALUATOR
     ri <- Lens.view recInfo
+    pis <- Lens.view primInfos
     fuel <- Lens.view fuelLimit
 
-    let env = mkGlobalEnv bndrs ri fuel gh tcm is0 ids1
+    let env = mkGlobalEnv bndrs ri pis fuel gh tcm is0 ids1
     let eval = asTerm . fst . runEval env . evaluateNf evaluate
 #else
     let eval = (Lens.view Lens._3) . whnf' evaluate bndrs tcm gh ids1 is0 False

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -29,10 +29,12 @@ import Control.Monad.State                   (MonadState (..))
 import Control.Monad.State.Strict            (State)
 import Control.Monad.Writer                  (MonadWriter (..))
 import Data.Binary                           (Binary)
+import Data.HashMap.Strict                   (HashMap)
 import Data.Hashable                         (Hashable)
 import Data.IntMap.Strict                    (IntMap)
 import Data.Monoid                           (Any)
 import qualified Data.Set                    as Set
+import Data.Text                             (Text)
 import GHC.Generics
 
 #if EXPERIMENTAL_EVALUATOR
@@ -41,7 +43,7 @@ import Clash.Core.Evaluator.Models           (Evaluator, GlobalIO)
 import Clash.Core.Evaluator.Types            (Evaluator, PrimHeap)
 #endif
 
-import Clash.Core.Term           (Term, Context)
+import Clash.Core.Term           (Term, PrimInfo, Context)
 import Clash.Core.Termination    (RecInfo)
 import Clash.Core.Type           (Type)
 import Clash.Core.TyCon          (TyConName, TyConMap)
@@ -125,6 +127,8 @@ data RewriteEnv
   -- ^ Custom bit representations
   , _recInfo        :: RecInfo
   -- ^ Information about recursive global bindings
+  , _primInfos      :: HashMap Text PrimInfo
+  -- ^ Information about primitives in the design
   , _fuelLimit      :: Word
   -- ^ Maximum amount of fuel for the evaluator
   }

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -1133,9 +1133,10 @@ whnfRW _isSubj ctx@(TransformContext is0 _) e rw = do
 
 #if EXPERIMENTAL_EVALUATOR
   ri <- Lens.view recInfo
+  pis <- Lens.view primInfos
   fuel <- Lens.view fuelLimit
 
-  case runEval (mkGlobalEnv bndrs ri fuel gh tcm is0 ids1) (evaluateNf eval e) of
+  case runEval (mkGlobalEnv bndrs ri pis fuel gh tcm is0 ids1) (evaluateNf eval e) of
     (!e', !env') -> do
       globalHeap Lens..= genvPrimsIO env'
       rw ctx (asTerm e')

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -72,6 +72,7 @@ instance Default RewriteEnv where
     , _topEntities=emptyVarSet
     , _customReprs=buildCustomReprs []
     , _recInfo=mempty
+    , _primInfos=mempty
     , _fuelLimit=10
     }
 

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -95,7 +95,7 @@ runToNetlistStage
   -> IO [([Bool], SrcSpan, HashMap Identifier Word, Component)]
 runToNetlistStage target f src = do
   pds <- primDirs backend
-  (bm, tcm, tupTcm, tes, pm, rs, _)
+  (bm, tcm, tupTcm, tes, pm, rs, _, ps)
     <- generateBindings Auto pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
 
   let teNames = fmap topId tes
@@ -104,7 +104,7 @@ runToNetlistStage target f src = do
 
   supplyN <- Supply.newSupply
 
-  let transformedBindings = normalizeEntity reprs bm pm tcm tupTcm typeTrans
+  let transformedBindings = normalizeEntity reprs bm ps pm tcm tupTcm typeTrans
 #if EXPERIMENTAL_EVALUATOR
           ghcEvaluator
 #else


### PR DESCRIPTION
When translating from GHC core to Clash core, any PrimInfo which is
constructed is stored in a map indexed by the name of the primitive.
This can be used later in the evaluator to lookup PrimInfo rather
than creating it ad-hoc where it is needed. The benefits being:

  * no chance to construct a primitive with the wrong type / workinfo
  * more succinct code in the evaluator when building prims