### PR TITLE
Allows aeson-1.5.* and dlist-1.0.*

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -141,7 +141,7 @@ Library
                       RecordWildCards
                       TemplateHaskell
 
-  Build-depends:      aeson                   >= 0.6.2.0  && < 1.5,
+  Build-depends:      aeson                   >= 0.6.2.0  && < 1.6,
                       ansi-terminal           >= 0.8.0.0  && < 0.11,
                       array,
                       attoparsec              >= 0.10.4.0 && < 0.14,
@@ -154,7 +154,7 @@ Library
                       data-binary-ieee754     >= 0.4.4    && < 0.6,
                       data-default            >= 0.7      && < 0.8,
                       deepseq                 >= 1.3.0.2  && < 1.5,
-                      dlist                   >= 0.8      && < 0.9,
+                      dlist                   >= 0.8      && < 1.1,
                       directory               >= 1.2.0.1  && < 1.4,
                       errors                  >= 1.4.2    && < 2.4,
                       exceptions              >= 0.8.3    && < 0.11.0,


### PR DESCRIPTION
I've verified that this compiles and passes tests locally for `clash-lib`.