### PR TITLE
Convert XException to ErrorCall

### DIFF
--- a/changelog/2020-07-28T14_24_22+02_00_x_to_error
+++ b/changelog/2020-07-28T14_24_22+02_00_x_to_error
@@ -1,0 +1,1 @@
+FEATURE: Added `xToErrorCtx`, to make it easier to track the origin of `XException` where `pack` would hide them [#1461](https://github.com/clash-lang/clash-compiler/pull/1461)

--- a/clash-lib/prims/common/Clash_XException.json
+++ b/clash-lib/prims/common/Clash_XException.json
@@ -30,4 +30,9 @@
      , "template"  : "~DEVNULL[~VAR[x][0]]~ARG[1]"
      }
   }
+, { "Primitive" :
+    { "name"      : "Clash.XException.xToErrorCtx"
+    , "primType"  : "Function"
+    }
+  }
 ]

--- a/tests/shouldwork/Basic/XToError.hs
+++ b/tests/shouldwork/Basic/XToError.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE ViewPatterns #-}
+module XToError where
+
+import Clash.Prelude
+
+topEntity :: Bit -> BitVector 8 -> BitVector 8
+topEntity (xToError -> a) (xToError -> b) = slice d7 d0 (pack a ++# b)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -334,6 +334,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1402b" def{hdlTargets=[VHDL], hdlSim=False}
         , runTest "TagToEnum" def{hdlSim=False}
         , runTest "TwoFunctions" def{hdlSim=False}
+        , runTest "XToError" def{hdlSim=False}
         ]
       , clashTestGroup "BitVector"
         [ NEEDS_PRIMS_GHC(runTest "Box" def)


### PR DESCRIPTION
To make it easier to report `XException` when `pack` would normally hide them.