### PR TITLE
Preprocess JSON files to be compatible with aeson-1.5

### DIFF
--- a/changelog/2020-07-27T19_25_21+02_00_relax_aeson_dlist_versions
+++ b/changelog/2020-07-27T19_25_21+02_00_relax_aeson_dlist_versions
@@ -1,0 +1,1 @@
+CHANGED: Relaxed upper bound versions of `aeson` and `dlist`, in preparation for the new Stack LTS.

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -154,7 +154,7 @@ Library
                       data-binary-ieee754     >= 0.4.4    && < 0.6,
                       data-default            >= 0.7      && < 0.8,
                       deepseq                 >= 1.3.0.2  && < 1.5,
-                      dlist                   >= 0.8      && < 0.9,
+                      dlist                   >= 0.8      && < 1.1,
                       directory               >= 1.2.0.1  && < 1.4,
                       errors                  >= 1.4.2    && < 2.4,
                       exceptions              >= 0.8.3    && < 0.11.0,

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -141,7 +141,7 @@ Library
                       RecordWildCards
                       TemplateHaskell
 
-  Build-depends:      aeson                   >= 0.6.2.0  && < 1.5,
+  Build-depends:      aeson                   >= 0.6.2.0  && < 1.6,
                       ansi-terminal           >= 0.8.0.0  && < 0.11,
                       array,
                       attoparsec              >= 0.10.4.0 && < 0.14,
@@ -183,6 +183,7 @@ Library
                       time                    >= 1.4.0.1  && < 1.11,
                       transformers            >= 0.5.2.0  && < 0.6,
                       trifecta                >= 1.7.1.1  && < 2.2,
+                      utf8-string             >= 1.0.1    && < 1.1,
                       vector                  >= 0.11     && < 1.0,
                       vector-binary-instances >= 0.2.3.5  && < 0.3,
                       unordered-containers    >= 0.2.3.3  && < 0.3

--- a/clash-lib/src/Data/Aeson/Extra.hs
+++ b/clash-lib/src/Data/Aeson/Extra.hs
@@ -4,13 +4,22 @@
   Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Data.Aeson.Extra where
 
 import           Control.Exception    (throw)
+import qualified Data.IntMap          as IntMap
+import           Data.IntMap          (IntMap)
 import qualified Data.Ix              as Ix
 import qualified Data.Text            as T
 import           Data.Text            (Text,pack,unpack)
-import           Data.List            (intercalate)
+import qualified Data.Text.Lazy       as LT
+import qualified Data.Text.Lazy.Encoding as LT
+import           Data.Text.Encoding.Error (UnicodeException(..))
+import           Data.List            (intercalate, groupBy)
+import           Data.Tuple.Extra     (second)
 import           Data.Aeson           (FromJSON, Result (..), fromJSON, json)
 import           Data.Attoparsec.Lazy (Result (..), parse)
 import           Data.ByteString.Lazy (ByteString)
@@ -18,33 +27,99 @@ import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Char8 as BSChar
 import           System.FilePath      ()
 
+import qualified Clash.Util.Interpolate as I
 import           Clash.Util           (ClashException(..))
 import           SrcLoc               (mkGeneralSrcSpan)
 import           FastString           (mkFastString)
 import           GHC.Stack            (HasCallStack)
 
--- Quick and dirty way of replacing fake escapes in naively converted bytestring
-replaceCommonEscapes :: Text -> Text
-replaceCommonEscapes = ( T.replace (pack "\\n") (pack "\n") ) .
-                       ( T.replace (pack "\\\\") (pack "\\") ) .
-                       ( T.replace (pack "\\\"") (pack "\"") )
+-- | See 'toSpecNewlines'. A line map maps "virtual" lines to a range of
+-- "real" lines. E.g., a map of {0: (0, 3), 1: (4, 5)} would mean that line
+-- 0 in the virtual JSON (i.e., the one with newlines replaced) file map to
+-- lines 0 up to and including 3 in the original user-supplied one.
+type LineMap = IntMap (Int, Int)
 
-genLineErr' :: [Text] -> (Int, Int) -> Int -> Text
-genLineErr' allLines range errorLineN = T.unlines [ T.concat [ if i == errorLineN then pack ">> " else  pack "   "
-                                                             , pack $ show i
-                                                             , pack ". "
-                                                             , allLines !! i
-                                                             ] | i <- Ix.range range]
+-- | Aeson versions <1.5.0 accept unescaped newlines in JSON strings. This is in
+-- violation of RFC 7159. Aeson 1.5.0 fixes this bug. Unfortunately, "Clash
+-- JSON" files rely on the old behavior. This function replaces newlines (in
+-- stings) with their escaped variants.
+toSpecNewlines
+  :: ByteString
+  -> Either UnicodeException (LineMap, ByteString)
+toSpecNewlines bs = do
+ s0 <- LT.unpack <$> LT.decodeUtf8' bs
+ Right ( toLineMap (go2 0 False s0)
+       , LT.encodeUtf8 (LT.pack (go False s0)))
+ where
+  -- replace newlines with escaped ones
+  go :: Bool -> String -> String
+  go _ [] = []
+  go True ('\n':rest) = '\\' : 'n' : go True rest
+  go True ('\r':rest) = '\\' : 'r' : go True rest
+  go True ('\t':rest) = '\\' : 't' : go True rest
+  go inString ('\\':r:rest) = '\\' : r : go inString rest
+  go inString ('"':rest) = '"' : go (not inString) rest
+  go inString (r:rest) = r : go inString rest
+
+  -- Calculate real:virtual mapping
+  go2
+    -- virtual line counter.
+    :: Int
+    -- Processing a JSON string?
+    -> Bool
+    -- String left to process
+    -> String
+    -- Virtual line numbers. [0, 1, 1, 2, 2, ..] would mean:
+    --
+    --  real | virtual
+    --  --------------
+    --     0 |       0
+    --     1 |       1
+    --     2 |       1
+    --     3 |       2
+    --     4 |       2
+    --   ... |     ...
+    --
+    -> [Int]
+  go2 n _        [] = [n]
+  go2 n True     ('\n':rest) = n : go2 n True rest
+  go2 n False    ('\n':rest) = n : go2 (succ n) False rest
+  go2 n inString ('\\':_:rest) = go2 n inString rest
+  go2 n inString ('"':rest) = go2 n (not inString) rest
+  go2 n inString (_:rest) = go2 n inString rest
+
+  toLineMap :: [Int] -> LineMap
+  toLineMap virtuals =
+      IntMap.fromList
+    $ map (second (\reals -> (minimum reals, maximum reals)))
+    $ map (\(unzip -> (virts, reals)) -> (head virts, reals))
+    $ groupBy (\a b -> fst a == fst b)
+    $ zip virtuals [(0::Int)..]
+
+genLineErr' :: [Text] -> (Int, Int) -> [Int] -> Text
+genLineErr' allLines range errorLines =
+  T.unlines [ T.concat [ if elem i errorLines then pack ">> " else  pack "   "
+            , pack $ show (i + 1)
+            , pack ". "
+            , allLines !! i
+            ] | i <- Ix.range range]
 
 -- | Pretty print part of json file related to error
-genLineErr :: ByteString -> ByteString -> Text
-genLineErr full part = genLineErr' allLines interval errorLineN
+genLineErr :: LineMap -> ByteString -> ByteString -> ByteString -> Text
+genLineErr lineMap fullOrig full part =
+    genLineErr' allLinesOrig interval [errorLineMin..errorLineMax]
   where
-    -- Determine interval, and pass to helper function
-    nLastLines = 1 + (length $ T.lines $ replaceCommonEscapes $ pack $ show part)
-    errorLineN = length allLines - nLastLines + 1
-    allLines   = T.lines $ replaceCommonEscapes $ pack $ show full
-    interval   = (max 0 (errorLineN - 5), min (max 0 $ length allLines - 1) (errorLineN + 5))
+    -- Determine error line in "virtual" json file
+    nLastLines = 1 + (length $ LT.lines $ LT.decodeUtf8 part)
+    errorLineN = min (length allLines - 1) (length allLines - nLastLines + 1)
+    allLines   = T.lines $ LT.toStrict $ LT.decodeUtf8 full
+
+    -- Convert to error lines in actual json file, and calculate interval
+    -- to display to user.
+    allLinesOrig = T.lines $ LT.toStrict $ LT.decodeUtf8 fullOrig
+    (errorLineMin, errorLineMax) = lineMap IntMap.! errorLineN
+    interval = ( max 0 (errorLineMin - 5)
+               , min (max 0 $ length allLinesOrig - 1) (errorLineMax + 5) )
 
 -- | Parse a ByteString according to the given JSON template. Throws exception
 -- if it fails.
@@ -55,31 +130,43 @@ decodeOrErr
   -> ByteString
   -- ^ Bytestring to parse
   -> a
-decodeOrErr path contents =
-  case parse json contents of
-    Done leftover v ->
-      case fromJSON v of
-        Success _ | BS.any notWhitespace leftover ->
-          clashError ("After parsing " ++  show path
-                 ++ ", found unparsed trailing garbage:\n"
-                 ++ BSChar.unpack leftover)
-        Success a ->
-          a
-        Error msg ->
-          clashError
-            ( "Could not deduce valid scheme for json in "
-           ++ show path ++ ". Error was: \n\n" ++ msg )
+decodeOrErr path contents0 =
+  case toSpecNewlines contents0 of
+    Left (DecodeError err _) -> clashError [I.i|
+      Failed to decode JSON file as UTF8:
 
-    -- JSON parse error:
-    Fail bytes cntxs msg ->
-      clashError
-        ( "Could not read or parse json in " ++ show path ++ ". "
-       ++ (if null cntxs then "" else "Context was:\n  " ++ intercalate "\n  " cntxs)
-       ++ "\n\nError reported by Attoparsec was:\n  "
-       ++ msg
-       ++ "\n\nApproximate location of error:\n\n"
-       -- HACK: Replace with proper parser/fail logic in future. Or don't. It's not important.
-       ++ (unpack $ genLineErr contents bytes) )
+        #{path}
+
+      Decoder reported:
+
+        #{err}
+    |]
+    Left _ -> error "unreachable"
+    Right (!lineMap, !contents1) ->
+      case parse json contents1 of
+        Done leftover v ->
+          case fromJSON v of
+            Success _ | BS.any notWhitespace leftover ->
+              clashError ("After parsing " ++  show path
+                     ++ ", found unparsed trailing garbage:\n"
+                     ++ BSChar.unpack leftover)
+            Success a ->
+              a
+            Error msg ->
+              clashError
+                ( "Could not deduce valid scheme for json in "
+               ++ show path ++ ". Error was: \n\n" ++ msg )
+
+        -- JSON parse error:
+        Fail bytes cntxs msg ->
+          clashError
+            ( "Could not read or parse json in " ++ show path ++ ". "
+           ++ (if null cntxs then "" else "Context was:\n  " ++ intercalate "\n  " cntxs)
+           ++ "\n\nError reported by Attoparsec was:\n  "
+           ++ msg
+           ++ "\n\nApproximate location of error:\n\n"
+           -- HACK: Replace with proper parser/fail logic in future. Or don't. It's not important.
+           ++ (unpack $ genLineErr lineMap contents0 contents1 bytes) )
   where
     loc = mkGeneralSrcSpan $ mkFastString path
     clashError msg = throw $ ClashException loc msg Nothing

--- a/clash-lib/src/Data/Aeson/Extra.hs
+++ b/clash-lib/src/Data/Aeson/Extra.hs
@@ -18,8 +18,9 @@ import           Data.Text            (Text,pack,unpack)
 import qualified Data.Text.Lazy       as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import           Data.Text.Encoding.Error (UnicodeException(..))
-import           Data.List            (intercalate, groupBy)
-import           Data.Tuple.Extra     (second)
+import           Data.List            (intercalate)
+import           Data.List.Extra      (groupOn)
+import           Data.Tuple.Extra     (second, first)
 import           Data.Aeson           (FromJSON, Result (..), fromJSON, json)
 import           Data.Attoparsec.Lazy (Result (..), parse)
 import           Data.ByteString.Lazy (ByteString)
@@ -92,8 +93,8 @@ toSpecNewlines bs = do
   toLineMap virtuals =
       IntMap.fromList
     $ map (second (\reals -> (minimum reals, maximum reals)))
-    $ map (\(unzip -> (virts, reals)) -> (head virts, reals))
-    $ groupBy (\a b -> fst a == fst b)
+    $ map (first head . unzip)
+    $ groupOn fst
     $ zip virtuals [(0::Int)..]
 
 genLineErr' :: [Text] -> (Int, Int) -> [Int] -> Text

--- a/clash-lib/src/Data/List/Extra.hs
+++ b/clash-lib/src/Data/List/Extra.hs
@@ -1,16 +1,30 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
 
-module Data.List.Extra where
+module Data.List.Extra
+  ( partitionM
+  , mapAccumLM
+  , iterateNM
+  , (<:>)
+  , indexMaybe
+  , splitAtList
+  , equalLength
+  , countEq
+  , zipEqual
+
+  -- * From Control.Monad.Extra
+  , anyM
+  , allM
+  , orM
+
+  -- * From "extra"
+  , module NeilsExtra
+  ) where
+
+import "extra" Data.List.Extra as NeilsExtra
+import "extra" Control.Monad.Extra (anyM, allM, orM, partitionM)
 
 import Control.Applicative (liftA2)
-
--- | Monadic version of 'Data.List.partition'
-partitionM :: (Monad m) => (a -> m Bool) -> [a] -> m ([a], [a])
-partitionM _ []     = return ([], [])
-partitionM p (x:xs) = do
-  test      <- p x
-  (ys, ys') <- partitionM p xs
-  return $ if test then (x:ys, ys') else (ys, x:ys')
 
 -- | Monadic version of 'Data.List.mapAccumL'
 mapAccumLM
@@ -91,40 +105,3 @@ zipEqual [] [] = []
 zipEqual (a:as) (b:bs) = (a,b) : zipEqual as bs
 zipEqual _ _ = error "zipEqual"
 #endif
-
--- | Short-circuiting monadic version of 'any'
-anyM
-  :: (Monad m)
-  => (a -> m Bool)
-  -> [a]
-  -> m Bool
-anyM _ []     = return False
-anyM p (x:xs) = do
-  q <- p x
-  if q then
-    return True
-  else
-    anyM p xs
-
-allM :: (Monad m) => (a -> m Bool) -> [a] -> m Bool
-allM _ [] = return True
-allM p (x:xs) = do
-  q <- p x
-  if q then
-    allM p xs
-  else
-    return False
-
--- | short-circuiting monadic version of 'or'
-orM
-  :: (Monad m)
-  => [m Bool]
-  -> m Bool
-orM [] = pure False
-orM (x:xs) = do
-  p <- x
-  if p then
-    pure True
-  else
-    orM xs
-


### PR DESCRIPTION
Aeson versions <1.5 accept unescaped newline characters in JSON strings.
For example, it would accept this non-RFC7159-compliant JSON:

    { "a": "foo
            bar" }

The primitive definitions in `clash-lib/prims/` (ab)use this fact. Aeson
1.5 fixed this oversight though, hence Clash breaking on this version.
This patch preprocesss the JSON files such that they're standards-
compliant.