### PR TITLE
Fully normalize type families in `normalizeType`.

### DIFF
--- a/changelog/2020-08-07T16_33_09+02_00_normalize_types.md
+++ b/changelog/2020-08-07T16_33_09+02_00_normalize_types.md
@@ -1,0 +1,4 @@
+Fixed: #1469
+The normalizeType function now fully normalizes types which require calls to
+reduceTypeFamily.
+

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -646,7 +646,14 @@ normalizeType tcMap = go
              let args' = map go args
                  ty' = mkTyConApp tcNm args'
              in case reduceTypeFamily tcMap ty' of
-               Just ty'' -> ty''
+               -- TODO Instead of recursing here, reduceTypeFamily should
+               -- ensure that if the result is a reducible type family it is
+               -- also reduced. This would reduce traversals over a type.
+               --
+               -- It may be a good idea to keep reduceTypeFamily only reducing
+               -- one family, and definiing reduceTypeFamilies to reduce all
+               -- it encounters in one traversal.
+               Just ty'' -> go ty''
                Nothing  -> ty'
     FunTy ty1 ty2 -> mkFunTy (go ty1) (go ty2)
     OtherType (ForAllTy tyvar ty')


### PR DESCRIPTION
Normalize type did not recurse on the result of reducing a type
family, meaning if a type family reduced to another type family it
would not be normalized.

Closes #1469 