### PR TITLE
Fix SNat logarithm primitives

### DIFF
--- a/changelog/2020-08-11T15_28_24+02_00_fix-snat-log-prims.md
+++ b/changelog/2020-08-11T15_28_24+02_00_fix-snat-log-prims.md
@@ -1,0 +1,3 @@
+FIXED: flogBaseSNat, clogBaseSNat and logBaseSNat primitives are now implemented correctly.
+Previously these primitives would be left unevaluated causing issues like #1473.
+

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -1434,7 +1434,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
                                 , Left (Literal (NaturalLiteral c))]
 
   "Clash.Promoted.Nat.flogBaseSNat"
-    | [_,_,Right a, Right b] <- map (runExcept . tyNatSize tcm) tys
+    | [Right a, Right b] <- map (runExcept . tyNatSize tcm) tys
     , Just c <- flogBase a b
     , let c' = toInteger c
     -> let (_,tyView -> TyConApp snatTcNm _) = splitFunForallTy ty
@@ -1445,7 +1445,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
                                 , Left (Literal (NaturalLiteral c'))]
 
   "Clash.Promoted.Nat.clogBaseSNat"
-    | [_,_,Right a, Right b] <- map (runExcept . tyNatSize tcm) tys
+    | [Right a, Right b] <- map (runExcept . tyNatSize tcm) tys
     , Just c <- clogBase a b
     , let c' = toInteger c
     -> let (_,tyView -> TyConApp snatTcNm _) = splitFunForallTy ty
@@ -1454,9 +1454,11 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
        in  reduce $
            mkApps (Data snatDc) [ Right (LitTy (NumTy c'))
                                 , Left (Literal (NaturalLiteral c'))]
+    | otherwise
+    -> error ("clogBaseSNat: args = " <> show args <> ", tys = " <> show tys)
 
   "Clash.Promoted.Nat.logBaseSNat"
-    | [_,Right a, Right b] <- map (runExcept . tyNatSize tcm) tys
+    | [Right a, Right b] <- map (runExcept . tyNatSize tcm) tys
     , Just c <- flogBase a b
     , let c' = toInteger c
     -> let (_,tyView -> TyConApp snatTcNm _) = splitFunForallTy ty

--- a/clash-lib/prims/common/GHC_Natural.json
+++ b/clash-lib/prims/common/GHC_Natural.json
@@ -7,6 +7,14 @@
     }
   },
   {
+    "Primitive": {
+      "name": "GHC.Natural.naturalToInteger",
+      "workInfo": "Never",
+      "primType": "Function",
+      "warning": "GHC.Natural.naturalToInteger: No blackbox available without size inference for Natural and Integer"
+    }
+  },
+  {
     "BlackBox": {
       "name": "GHC.Natural.underflowError",
       "workInfo" : "Constant",

--- a/tests/shouldwork/Numbers/NaturalToInteger.hs
+++ b/tests/shouldwork/Numbers/NaturalToInteger.hs
@@ -1,0 +1,8 @@
+module NaturalToInteger where
+
+import Clash.Prelude
+import GHC.Natural
+
+topEntity :: Natural
+topEntity = snatToNum $ clogBaseSNat d2 d1024
+

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -485,6 +485,7 @@ runClashTest = defaultMain $ clashTestRoot
 #if MIN_VERSION_base(4,12,0)
         -- Naturals are broken on GHC <= 8.4. See https://github.com/clash-lang/clash-compiler/pull/473
         , NEEDS_PRIMS_GHC(runTest "Naturals" def)
+        , NEEDS_PRIMS_GHC(runTest "NaturalToInteger" def{hdlSim=False})
 #endif
         , NEEDS_PRIMS_GHC(runTest "NegativeLits" def)
         , NEEDS_PRIMS_GHC(runTest "Resize" def)


### PR DESCRIPTION
~The naturalToInteger function has an implementation in the evaluator but was not listed as a blackbox in the Json primitives.~

The real cause of the issue: the logarithm primitives on SNat were assuming the wrong number of type arguments, leading to these prims not being reduced.