### PR TITLE
Add `instance Ix` for `Unsigned` and `Signed`.

### DIFF
--- a/changelog/2020-08-20T19_07_14+08_00_ix_instances
+++ b/changelog/2020-08-20T19_07_14+08_00_ix_instances
@@ -1,0 +1,1 @@
+FEATURE: Added `Data.Ix.Ix` instances for `Signed` and `Unsigned` [#1481](https://github.com/clash-lang/clash-compiler/pull/1481)

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -87,7 +87,7 @@ import Data.Data                      (Data)
 import Data.Default.Class             (Default (..))
 import Data.Proxy                     (Proxy (..))
 import Text.Read                      (Read (..), ReadPrec)
-import Text.Printf                    (PrintfArg (..))
+import Text.Printf                    (PrintfArg (..), printf)
 import GHC.Generics                   (Generic)
 import GHC.Natural                    (naturalFromInteger)
 #if MIN_VERSION_base(4,12,0)
@@ -98,7 +98,7 @@ import Clash.Sized.Internal.Mod       (naturalToInteger)
 
 import GHC.TypeLits                   (KnownNat, Nat, type (+), natVal)
 import GHC.TypeLits.Extra             (Max)
-import GHC.Arr                        (Ix(..), indexError)
+import Data.Ix                        (Ix(..))
 import Language.Haskell.TH            (TypeQ, appT, conT, litT, numTyLit, sigE)
 import Language.Haskell.TH.Syntax     (Lift(..))
 #if MIN_VERSION_template_haskell(2,16,0)
@@ -691,7 +691,7 @@ instance KnownNat n => Ixed (Signed n) where
 
 instance (KnownNat n) => Ix (Signed n) where
   range (a, b) = [a..b]
-  index ab@(a, _b) x
+  index ab@(a, b) x
     | inRange ab x = fromIntegral $ x - a
-    | otherwise = indexError ab x ("Signed " <> show (natVal (Proxy @n)))
+    | otherwise = error $ printf "Index %d out of bounds (%d, %d) ab" x a b
   inRange (a, b) x = a <= x && x <= b

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -85,7 +85,7 @@ import Data.Data                      (Data)
 import Data.Default.Class             (Default (..))
 import Data.Proxy                     (Proxy (..))
 import Text.Read                      (Read (..), ReadPrec)
-import Text.Printf                    (PrintfArg (..))
+import Text.Printf                    (PrintfArg (..), printf)
 import GHC.Exts                       (narrow8Word#, narrow16Word#, narrow32Word#)
 import GHC.Generics                   (Generic)
 import GHC.Integer.GMP.Internals      (bigNatToWord)
@@ -96,7 +96,7 @@ import GHC.Natural                    (naturalToInteger)
 import GHC.TypeLits                   (KnownNat, Nat, type (+), natVal)
 import GHC.TypeLits.Extra             (Max)
 import GHC.Word                       (Word (..), Word8 (..), Word16 (..), Word32 (..))
-import GHC.Arr                        (Ix(..), indexError)
+import Data.Ix                        (Ix(..))
 import Language.Haskell.TH            (TypeQ, appT, conT, litT, numTyLit, sigE)
 import Language.Haskell.TH.Syntax     (Lift(..))
 #if MIN_VERSION_template_haskell(2,16,0)
@@ -522,9 +522,9 @@ instance KnownNat n => Ixed (Unsigned n) where
 
 instance (KnownNat n) => Ix (Unsigned n) where
   range (a, b) = [a..b]
-  index ab@(a, _b) x
+  index ab@(a, b) x
     | inRange ab x = fromIntegral $ x - a
-    | otherwise = indexError ab x ("Unsigned " <> show (natVal (Proxy @n)))
+    | otherwise = error $ printf "Index %d out of bounds (%d, %d) ab" x a b
   inRange (a, b) x = a <= x && x <= b
 
 unsignedToWord :: Unsigned WORD_SIZE_IN_BITS -> Word


### PR DESCRIPTION
This allows using `Signed n` and `Unsigned n` as `Data.Array` indices,
for example in test benches that simulate memory.