### PR TITLE
Add `nameHint` to `Clash.Magic`

### DIFF
--- a/changelog/2020-08-23T19_14_45+02_00_add_nameHint
+++ b/changelog/2020-08-23T19_14_45+02_00_add_nameHint
@@ -1,0 +1,1 @@
+FEATURE: Added `nameHint` to allow explicitly naming terms, e.g. `Signal`s.

--- a/clash-lib/prims/commonverilog/Clash_Magic.json
+++ b/clash-lib/prims/commonverilog/Clash_Magic.json
@@ -1,0 +1,13 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Magic.nameHint"
+    , "kind" : "Declaration"
+    , "type" :
+"nameHint
+  :: SSymbol sym  -- ARG[0]
+  -> a            -- ARG[1]
+  -> a"
+    , "resultName" : { "template" : "~NAME[0]" }
+    , "template" : "assign ~RESULT = ~ARG[1];"
+    }
+  }
+]

--- a/clash-lib/prims/vhdl/Clash_Magic.json
+++ b/clash-lib/prims/vhdl/Clash_Magic.json
@@ -1,0 +1,13 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Magic.nameHint"
+    , "kind" : "Declaration"
+    , "type" :
+"nameHint
+  :: SSymbol sym  -- ARG[0]
+  -> a            -- ARG[1]
+  -> a"
+    , "resultName" : { "template" : "~NAME[0]" }
+    , "template" : "~RESULT <= ~ARG[1];"
+    }
+  }
+]

--- a/clash-prelude/src/Clash/Magic.hs
+++ b/clash-prelude/src/Clash/Magic.hs
@@ -3,7 +3,17 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
-Control module instance, and register, names in generated HDL code.
+Control naming and deduplication in the generated HDL code. Explicitly nameable
+things include:
+
+* Component (VHDL) / module ((System)Verilog) instances
+
+* Registers
+
+* Terms
+
+Refer to "Clash.Annotations.TopEntity" for controlling naming of entities
+(VHDL) / modules ((System)Verilog) and their ports.
 -}
 
 module Clash.Magic
@@ -15,14 +25,17 @@ module Clash.Magic
   , suffixNameFromNat
   , suffixNameFromNatP
   , setName
+  , nameHint
 
   -- ** Functions to control Clash's (de)duplication mechanisms
   , deDup
   , noDeDup
   ) where
 
-import Clash.NamedTypes ((:::))
-import GHC.TypeLits     (Nat,Symbol)
+import Clash.NamedTypes            ((:::))
+import GHC.TypeLits                (Nat,Symbol)
+import Clash.Promoted.Symbol       (SSymbol)
+import Clash.Annotations.Primitive (hasBlackBox)
 
 -- | Prefix instance and register names with the given 'Symbol'
 prefixName
@@ -96,6 +109,26 @@ setName
   :: forall (name :: Symbol) a . a -> name ::: a
 setName = id
 {-# NOINLINE setName #-}
+
+-- | Name a given term, such as one of type 'Clash.Signal.Signal', using the
+-- given 'SSymbol'. Results in a declaration with the name used as the
+-- identifier in the generated HDL code.
+--
+-- Example usage:
+--
+-- @
+-- nameHint (SSymbol @"identifier") term
+-- @
+--
+-- __NB__: The given name should be considered a hint as it may be expanded,
+-- e.g. if it collides with existing identifiers.
+nameHint
+  :: SSymbol sym
+  -- ^ A hint for a name
+  -> a -> a
+nameHint = seq
+{-# NOINLINE nameHint #-}
+{-# ANN nameHint hasBlackBox #-}
 
 -- | Force deduplication, i.e. share a function or operator between multiple
 -- branches.

--- a/tests/shouldwork/Naming/NameHint.hs
+++ b/tests/shouldwork/Naming/NameHint.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module NameHint where
+
+import Clash.Prelude
+import Clash.Netlist.Types
+
+import Prelude as P
+import Data.Text (isInfixOf)
+
+import Test.Tasty.Clash
+import Test.Tasty.Clash.NetlistTest
+
+import Debug.Trace
+
+topEntity
+  :: Signal System Bool
+  -> Signal System Bool
+topEntity = liftA $ nameHint (SSymbol @"someSignalName")
+
+testPath :: FilePath
+testPath = "tests/shouldwork/Naming/NameHint.hs"
+
+-- | Assert that a signal named "someSignalName", optionally expanded, is
+-- declared once and used in an assignment once.
+assertOneDecl :: Component -> IO ()
+assertOneDecl (Component _ _ _ ds) =
+  case P.concatMap isSigDecl ds of
+    [i] ->
+      case P.length (filter (isSigAssignment i) ds) of
+        1 ->
+          pure ()
+        n ->
+          error $ "Expected one assignment of a signal named "
+                  <> "\"someSignalName\", got " <> show n
+    is ->
+      error $ "Expected one declaration of a signal named "
+           <> "\"someSignalName\", got " <> show (P.length is)
+ where
+  isSigDecl (NetDecl' _ _ i@(isInfixOf "someSignalName" -> True) _ _) = [i]
+  isSigDecl _ = []
+
+  isSigAssignment i (Assignment _ (Identifier i' _)) = i == i'
+  isSigAssignment _ _ = False
+
+getComponent :: (a, b, c, d) -> d
+getComponent (_, _, _, x) = x
+
+mainVHDL :: IO ()
+mainVHDL = do
+  netlist <- runToNetlistStage SVHDL id testPath
+  mapM_ (assertOneDecl . getComponent) netlist
+
+mainVerilog :: IO ()
+mainVerilog = do
+  netlist <- runToNetlistStage SVerilog id testPath
+  mapM_ (assertOneDecl . getComponent) netlist
+

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -463,6 +463,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T967b" def{hdlSim=False}
         , runTest "T967c" def{hdlSim=False}
         , NEEDS_PRIMS_GHC(clashLibTest ("tests" </> "shouldwork" </> "Naming") allTargets [] "T1041" "main")
+        , clashLibTest ("tests" </> "shouldwork" </> "Naming") [VHDL,Verilog] [] "NameHint" "main"
         ]
       , clashTestGroup "Numbers"
         [ NEEDS_PRIMS_GHC(runTest "BitInteger" def)


### PR DESCRIPTION
Gives a hint for how to name e.g. a `Signal` in the generated HDL.

My use case is the Vivado integrated logic analyzer GUI. It uses the signal names used in the ILA's port map in VHDL as probe names, so it is nice to be able to give these signals sensible identifiers.

Code is courtesy of @christiaanb.

Should something like this have a test?