### PR TITLE
Allow clash-term to patch Ticks

### DIFF
--- a/clash-term/Main.hs
+++ b/clash-term/Main.hs
@@ -120,6 +120,10 @@ instance Diff Term where
           Case (go t) ty alts
         (Cast t ty ty', CastBody) ->
           Cast (go t) ty ty'
+        (Tick ti x, TickC ti') ->
+          if ti == ti'
+            then Tick ti (go x)
+            else error $ "Ctx.Tick: different ticks " ++ show (ti, ti')
         _ -> error "patch: context does not agree with term"
     where
       go :: Term -> Term


### PR DESCRIPTION
The patch function in clash-term previously did not allow ticks
to be patched (despite clash-lib defining a tick context `TickC`).
A pattern for this has been added to clash-term.

Closes #1487.