### PR TITLE
Deprecate 'Clash.Prelude.DataFlow'

### DIFF
--- a/changelog/2020-08-25T13_42_55+02_00_deprecated_dataflow
+++ b/changelog/2020-08-25T13_42_55+02_00_deprecated_dataflow
@@ -1,0 +1,1 @@
+DEPRECATED: 'Clash.Prelude.DataFlow' is now deprecated, see [PR 1490](https://github.com/clash-lang/clash-compiler/pull/1490).

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -74,8 +74,6 @@ module Clash.Explicit.Prelude
     -- ** Synchronous signals
   , module Clash.Explicit.Signal
   , module Clash.Explicit.Signal.Delayed
-    -- ** DataFlow interface
-  , module Clash.Prelude.DataFlow
     -- ** Datatypes
     -- *** Bit vectors
   , module Clash.Sized.BitVector
@@ -158,7 +156,6 @@ import Clash.Explicit.Signal.Delayed
 import Clash.Explicit.Testbench
 import Clash.Prelude.BitIndex
 import Clash.Prelude.BitReduction
-import Clash.Prelude.DataFlow
 import Clash.Prelude.ROM.File       (asyncRomFile, asyncRomFilePow2)
 import Clash.Promoted.Nat
 import Clash.Promoted.Nat.TH

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -50,8 +50,6 @@ module Clash.Explicit.Prelude.Safe
     -- ** Synchronous signals
   , module Clash.Explicit.Signal
   , module Clash.Explicit.Signal.Delayed
-    -- ** DataFlow interface
-  , module Clash.Prelude.DataFlow
     -- ** Datatypes
     -- *** Bit vectors
   , module Clash.Sized.BitVector
@@ -123,7 +121,6 @@ import Clash.Explicit.Synchronizer
   (dualFlipFlopSynchronizer, asyncFIFOSynchronizer)
 import Clash.Prelude.BitIndex
 import Clash.Prelude.BitReduction
-import Clash.Prelude.DataFlow
 import Clash.Prelude.ROM             (asyncRom, asyncRomPow2)
 import Clash.Promoted.Nat
 import Clash.Promoted.Nat.TH

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -98,8 +98,6 @@ module Clash.Prelude
     -- ** Synchronous signals
   , module Clash.Signal
   , module Clash.Signal.Delayed
-    -- ** DataFlow interface
-  , module Clash.Prelude.DataFlow
     -- ** Datatypes
     -- *** Bit vectors
   , module Clash.Sized.BitVector
@@ -181,7 +179,6 @@ import           Clash.Prelude.BitIndex
 import           Clash.Prelude.BitReduction
 import           Clash.Prelude.BlockRam
 import           Clash.Prelude.BlockRam.File
-import           Clash.Prelude.DataFlow
 import           Clash.Prelude.ROM.File
 import           Clash.Prelude.Safe
 #ifdef CLASH_MULTIPLE_HIDDEN

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -18,7 +18,7 @@ Self-synchronizing circuits based on data-flow principles.
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
-module Clash.Prelude.DataFlow
+module Clash.Prelude.DataFlow {-# DEPRECATED "Module will be removed in future versions of clash-prelude." #-}
   ( -- * Data types
     DataFlow (..)
     -- * Creating DataFlow circuits

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -66,8 +66,6 @@ module Clash.Prelude.Safe
     -- ** Synchronous signals
   , module Clash.Signal
   , module Clash.Signal.Delayed
-    -- ** DataFlow interface
-  , module Clash.Prelude.DataFlow
     -- ** Datatypes
     -- *** Bit vectors
   , module Clash.Sized.BitVector
@@ -138,7 +136,6 @@ import           Clash.Prelude.Mealy         (mealy, mealyB, (<^>))
 import           Clash.Prelude.Moore         (moore, mooreB)
 import           Clash.Prelude.RAM           (asyncRam,asyncRamPow2)
 import           Clash.Prelude.ROM           (asyncRom,asyncRomPow2,rom,romPow2)
-import           Clash.Prelude.DataFlow
 import           Clash.Promoted.Nat
 import           Clash.Promoted.Nat.TH
 import           Clash.Promoted.Nat.Literals


### PR DESCRIPTION
Current API makes it impossible to use for designs on multiple domains.
We should probably design something closer to cchalmers's circuit as
defined over at github.com/cchalmers/circuit-notation.

Deprecating due to namespace clashes for users designing dataflow
libraries that are better suited for real world designs.