### PR TITLE
Add checked versions of 'resize', 'truncateB', and 'fromIntegral'

### DIFF
--- a/changelog/2020-08-27T16_45_36+02_00_added_checked_functions
+++ b/changelog/2020-08-27T16_45_36+02_00_added_checked_functions
@@ -1,0 +1,11 @@
+ADDED: Checked versions of 'resize', 'truncateB', and 'fromIntegral'
+
+Depending on the type 'resize', 'truncateB', and 'fromIntegral' either
+yield an XException or silently perform wrap-around if its argument does
+not fit in the resulting type's bounds. The added functions check the
+bound condition and fail with an error call if the condition is
+violated. They do not affect HDL generation.
+
+Useful in cases where runtime behavior should ensure that an out of
+bound or wrap around should not occur and users want their code to fail
+hard if this invariant is ever violated.

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -382,6 +382,7 @@ test-suite unittests
       ghc-typelits-knownnat,
 
       base,
+      deepseq,
       hint          >= 0.7      && < 0.10,
       quickcheck-classes-base >= 0.6 && < 1.0,
       tasty         >= 1.2      && < 1.4,
@@ -399,6 +400,7 @@ test-suite unittests
                  Clash.Tests.Signed
                  Clash.Tests.SizedNum
                  Clash.Tests.NFDataX
+                 Clash.Tests.Resize
                  Clash.Tests.TopEntityGeneration
                  Clash.Tests.Unsigned
 

--- a/clash-prelude/src/Clash/Class/Resize.hs
+++ b/clash-prelude/src/Clash/Class/Resize.hs
@@ -1,7 +1,8 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente
+                  2020,      Myrtle Software Ltd
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE Safe #-}
@@ -9,9 +10,18 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
-module Clash.Class.Resize where
+module Clash.Class.Resize
+ ( Resize(..)
+
+ -- * Resize helpers
+ , checkedResize
+ , checkedFromIntegral
+ , checkedTruncateB
+ ) where
 
 import Data.Kind (Type)
+import Data.Proxy (Proxy(Proxy))
+import GHC.Stack (HasCallStack)
 import GHC.TypeLits (Nat, KnownNat, type (+))
 
 -- | Coerce a value to be represented by a different number of bits
@@ -37,3 +47,66 @@ class Resize (f :: Nat -> Type) where
   signExtend = resize
   -- | Remove bits from the MSB
   truncateB :: KnownNat a => f (a + b) -> f a
+
+-- | Helper function of 'checkedFromIntegral', 'checkedResize' and 'checkedTruncateB'
+checkIntegral ::
+  forall a b.
+  HasCallStack =>
+  (Integral a, Integral b, Bounded b) =>
+  Proxy b ->
+  a -> ()
+checkIntegral Proxy v =
+  if toInteger v > toInteger (maxBound @b)
+  || toInteger v < toInteger (minBound @b) then
+    error $ "Given integral " <> show (toInteger v) <> " is out of bounds for" <>
+            " target type. Bounds of target type are: [" <>
+            show (toInteger (minBound @b)) <> ".." <>
+            show (toInteger (maxBound @b)) <> "]."
+  else
+    ()
+
+-- | Like 'fromIntegral', but errors if /a/ is out of bounds for /b/. Useful when
+-- you "know" /a/ can't be out of bounds, but would like to have your assumptions
+-- checked.
+--
+-- __N.B.__: Check only affects simulation. I.e., no checks will be inserted
+-- into the generated HDL
+checkedFromIntegral ::
+  forall a b.
+  HasCallStack =>
+  (Integral a, Integral b, Bounded b) =>
+  a -> b
+checkedFromIntegral v =
+  checkIntegral (Proxy @b) v `seq` fromIntegral v
+
+-- | Like 'resize', but errors if /f a/ is out of bounds for /f b/. Useful when
+-- you "know" /f a/ can't be out of bounds, but would like to have your
+-- assumptions checked.
+--
+-- __N.B.__: Check only affects simulation. I.e., no checks will be inserted
+-- into the generated HDL
+checkedResize ::
+  forall a b f.
+  ( HasCallStack
+  , Resize f
+  , KnownNat a, Integral (f a)
+  , KnownNat b, Integral (f b), Bounded (f b) ) =>
+  f a -> f b
+checkedResize v =
+  checkIntegral (Proxy @(f b)) v `seq` resize v
+
+-- | Like 'truncateB', but errors if /f (a + b)/ is out of bounds for /f a/. Useful
+-- when you "know" /f (a + b)/ can't be out of bounds, but would like to have your
+-- assumptions checked.
+--
+-- __N.B.__: Check only affects simulation. I.e., no checks will be inserted
+-- into the generated HDL
+checkedTruncateB ::
+  forall a b f.
+  ( HasCallStack
+  , Resize f
+  , KnownNat b, Integral (f (a + b))
+  , KnownNat a, Integral (f a), Bounded (f a) ) =>
+  f (a + b) -> f a
+checkedTruncateB v =
+  checkIntegral (Proxy @(f a)) v `seq` truncateB v

--- a/clash-prelude/tests/Clash/Tests/Resize.hs
+++ b/clash-prelude/tests/Clash/Tests/Resize.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.Tests.Resize (tests) where
+
+import Control.DeepSeq (NFData)
+import Control.Exception (SomeException, try, evaluate)
+import Clash.XException (XException)
+import Data.Either (isLeft)
+import Data.Proxy (Proxy(Proxy))
+import GHC.TypeNats (KnownNat, type (<=))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck
+
+import qualified Clash.Class.Resize as Resize
+import Clash.Sized.Index
+
+-- | Anything that's in bounds should not cause an error
+indexProp ::
+  forall a b.
+  ((a <= b), KnownNat a, KnownNat b) =>
+  Proxy b -> Index a -> Bool
+indexProp Proxy v =
+  Resize.resize v == Resize.checkedResize @a @b v
+
+-- | Anything that's out of bounds should cause an error
+indexFailProp ::
+  forall a b.
+  ((b <= a), KnownNat a, KnownNat b) =>
+  Proxy b -> Index a -> Property
+indexFailProp Proxy v =
+  let checked = Resize.checkedResize @a @b v in
+  if toInteger v > toInteger (maxBound @(Index b)) then
+    expectExceptionNoX checked
+  else
+    discard
+
+-- | Succeed if evaluating leads to a non-XException Exception
+expectExceptionNoX :: (Show a, NFData a) => a -> Property
+expectExceptionNoX a0 = ioProperty $ do
+  a1 <- try @SomeException (try @XException (evaluate a0))
+  pure $
+    counterexample
+      ("Expected non-XException Exception, got: " <> show a1)
+      (isLeft a1)
+
+tests :: TestTree
+tests = testGroup "Resize"
+  [ testGroup "checkedResize"
+    [ testProperty "indexProp @17 @19" (indexProp @17 @19 Proxy)
+    , testProperty "indexProp @19 @19" (indexProp @19 @19 Proxy)
+    , testProperty "indexFailProp @37 @7" (indexFailProp @37 @7 Proxy)
+    ]
+  ]

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -9,6 +9,7 @@ import qualified Clash.Tests.DerivingDataRepr
 import qualified Clash.Tests.Signal
 import qualified Clash.Tests.Signed
 import qualified Clash.Tests.NFDataX
+import qualified Clash.Tests.Resize
 import qualified Clash.Tests.TopEntityGeneration
 import qualified Clash.Tests.Unsigned
 
@@ -23,6 +24,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.NFDataX.tests
   , Clash.Tests.TopEntityGeneration.tests
   , Clash.Tests.Unsigned.tests
+  , Clash.Tests.Resize.tests
   ]
 
 main :: IO ()

--- a/repld
+++ b/repld
@@ -36,12 +36,15 @@ ghcid --version
 if [[ $1 == "p" || $1 == "prelude" || $1 == "clash-prelude" ]]; then
   target="cabal new-repl clash-prelude --repl-options=-fobject-code --repl-options=-fforce-recomp"
   watch="clash-prelude/clash-prelude.cabal"
+elif [[ $1 == "p:tests" || $1 == "prelude:tests" || $1 == "clash-prelude:tests" ]]; then
+  target="cabal new-repl clash-prelude:unittests"
+  watch="clash-prelude/src clash-prelude/clash-prelude.cabal"
 elif [[ $1 == "l" || $1 == "lib" || $1 == "clash-lib" ]]; then
   target="cabal new-repl clash-lib"
   watch="clash-prelude clash-lib/clash-lib.cabal"
 elif [[ $1 == "l:tests" || $1 == "lib:tests" || $1 == "clash-lib:tests" ]]; then
   target="cabal new-repl clash-lib:unittests"
-  watch="clash-prelude clash-lib clash-cores/clash-cores.cabal"
+  watch="clash-prelude clash-lib/src clash-lib/clash-lib.cabal clash-cores/clash-cores.cabal"
 elif [[ $1 == "c" || $1 == "cores" || $1 == "clash-cores" ]]; then
   target="cabal new-repl clash-cores"
   watch="clash-prelude clash-lib clash-cores/clash-cores.cabal"


### PR DESCRIPTION
Depending on the type 'resize', 'truncateB', and 'fromIntegral' either
yield an XException or silently perform wrap-around if its argument does
not fit in the resulting type's bounds. The added functions check the
bound condition and fail with an error call if the condition is
violated. They do not affect HDL generation.

Useful in cases where runtime behavior should ensure that and out of
bound or wrap around should not occur and users want their code to fail
hard if this invariant is ever violated.