### PR TITLE
Fix satSucc/satPred for small instances

### DIFF
--- a/changelog/2020-09-08T16_28_54+02_00_fix_satsucc_satpred_small_instances
+++ b/changelog/2020-09-08T16_28_54+02_00_fix_satsucc_satpred_small_instances
@@ -1,0 +1,5 @@
+FIXED: Make `satSucc`, `satPred` work correctly for small instances.
+`satSucc` and `satPred` are moved to the class `SaturatingNum`. The default
+methods assure existing code keeps working. For types where small instances
+cannot express the number 1, i.e., `Index`, `Signed` and `Fixed`, an
+alternative implementation assures correct behavior nonetheless.

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -380,12 +380,16 @@ test-suite unittests
       clash-prelude,
 
       ghc-typelits-knownnat,
+      ghc-typelits-natnormalise,
+      ghc-typelits-extra,
 
       base,
       deepseq,
+      hedgehog,
       hint          >= 0.7      && < 0.10,
       quickcheck-classes-base >= 0.6 && < 1.0,
       tasty         >= 1.2      && < 1.4,
+      tasty-hedgehog,
       tasty-hunit,
       tasty-quickcheck,
       template-haskell
@@ -396,11 +400,12 @@ test-suite unittests
                  Clash.Tests.BitVector
                  Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes
+                 Clash.Tests.Fixed
+                 Clash.Tests.NFDataX
+                 Clash.Tests.Resize
                  Clash.Tests.Signal
                  Clash.Tests.Signed
                  Clash.Tests.SizedNum
-                 Clash.Tests.NFDataX
-                 Clash.Tests.Resize
                  Clash.Tests.TopEntityGeneration
                  Clash.Tests.Unsigned
 

--- a/clash-prelude/src/Clash/Class/Num.hs
+++ b/clash-prelude/src/Clash/Class/Num.hs
@@ -52,7 +52,7 @@ data SaturationMode
   | SatSymmetric -- ^ Become 'maxBound' on overflow, and (@'minBound' + 1@) on
                  -- underflow for signed numbers, and 'minBound' for unsigned
                  -- numbers.
-  deriving Eq
+  deriving (Show, Eq, Enum, Bounded)
 
 -- | 'Num' operators in which overflow and underflow behavior can be specified
 -- using 'SaturationMode'.

--- a/clash-prelude/src/Clash/Class/Num.hs
+++ b/clash-prelude/src/Clash/Class/Num.hs
@@ -20,8 +20,6 @@ module Clash.Class.Num
   , boundedAdd
   , boundedSub
   , boundedMul
-  , satSucc
-  , satPred
   )
 where
 
@@ -65,16 +63,16 @@ class (Bounded a, Num a) => SaturatingNum a where
   satSub  :: SaturationMode -> a -> a -> a
   -- | Multiplication with parameterizable over- and underflow behavior
   satMul :: SaturationMode -> a -> a -> a
-
--- | Get successor of (or in other words, add 1 to) given number
-satSucc :: SaturatingNum a => SaturationMode -> a -> a
-satSucc s n = satAdd s n 1
-{-# INLINE satSucc #-}
-
--- | Get predecessor of (or in other words, subtract 1 from) given number
-satPred :: SaturatingNum a => SaturationMode -> a -> a
-satPred s n = satSub s n 1
-{-# INLINE satPred #-}
+  -- | Get successor of (or in other words, add 1 to) given number
+  satSucc :: SaturationMode -> a -> a
+  -- Default method suitable for types that can represent the number 1
+  satSucc s n = satAdd s n 1
+  {-# INLINE satSucc #-}
+  -- | Get predecessor of (or in other words, subtract 1 from) given number
+  satPred :: SaturationMode -> a -> a
+  -- Default method suitable for types that can represent the number 1
+  satPred s n = satSub s n 1
+  {-# INLINE satPred #-}
 
 -- | Addition that clips to 'maxBound' on overflow, and 'minBound' on underflow
 boundedAdd :: SaturatingNum a => a -> a -> a

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -339,6 +339,18 @@ instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
           , z > m -> maxBound#
         z -> resize# z
 
+  satSucc satMode !a =
+    case natToInteger @n of
+      1 -> fromInteger# 0
+      _ -> satAdd satMode a $ fromInteger# 1
+  {-# INLINE satSucc #-}
+
+  satPred satMode !a =
+    case natToInteger @n of
+      1 -> fromInteger# 0
+      _ -> satSub satMode a $ fromInteger# 1
+  {-# INLINE satPred #-}
+
 instance KnownNat n => Real (Index n) where
   toRational = toRational . toInteger#
 

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -662,6 +662,11 @@ instance KnownNat n => SaturatingNum (Signed n) where
             0 -> maxBound#
             _ -> minBoundSym#
 
+  satSucc satMode a = satSub satMode a $ fromInteger# (-1)
+  {-# INLINE satSucc #-}
+  satPred satMode a = satAdd satMode a $ fromInteger# (-1)
+  {-# INLINE satPred #-}
+
 minBoundSym# :: KnownNat n => Signed n
 minBoundSym# = minBound# +# fromInteger# 1
 

--- a/clash-prelude/tests/Clash/Tests/Fixed.hs
+++ b/clash-prelude/tests/Clash/Tests/Fixed.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
+
+module Clash.Tests.Fixed (tests) where
+
+import Test.Tasty
+import Test.Tasty.Hedgehog
+
+import Clash.Class.Num
+import Clash.Sized.Fixed (SFixed, UFixed)
+
+import GHC.TypeLits (KnownNat)
+
+import Hedgehog
+import qualified Hedgehog.Range as Range
+import qualified Hedgehog.Gen as Gen
+
+-- Saturate a number to be within certain bounds according to SaturationMode.
+saturate
+  :: RealFrac a
+  => a  -- minBound
+  -> a  -- maxBound
+  -> a  -- repInt: the repetition interval of wrapping behaviour.
+  -> SaturationMode
+  -> a -> a
+saturate minB _ repInt SatWrap x =
+  let offs = x - minB
+      offsW = minB + (offs - repInt * fromIntegral (floor @_ @Integer
+                (offs / repInt)))
+  in offsW
+saturate minB maxB _ SatBound x
+  | x < minB  = minB
+  | x > maxB  = maxB
+  | otherwise = x
+saturate minB maxB _ SatZero x
+  | x < minB  = 0
+  | x > maxB  = 0
+  | otherwise = x
+saturate minB maxB _ SatSymmetric x
+  | x < minB  = if minB < 0 then (-maxB) else minB
+  | x > maxB  = maxB
+  | otherwise = x
+
+-- Saturate to bounds of type b.
+--
+-- It assumes the following values for the repetition interval:
+--   - 2*(-minBound) when minBound < 0
+--   - floor maxBound + 1 otherwise
+-- This is correct for at least:
+-- - Unsigned: maxBound @(Unsigned 4) == 15, behaves as modulo 16
+-- - Signed: minBound @(Signed 4) == -8, behaves as shifted modulo 16
+-- - UFixed: maxBound @(UFixed 4 2) == 15.75, behaves as modulo 16
+-- - SFixed: minBound @(SFixed 4 m) == -8.0, behaves as shifted modulo 16
+saturateToBounded
+  :: forall b
+   . (Bounded b, Real b)
+  => SaturationMode
+  -> Rational
+  -> Rational
+saturateToBounded satMode x =
+  let repInt = if (minBound @b) < 0
+               then 2 * negate (toRational (minBound @b))
+               else 1 + toRational (floor @_ @Integer $ toRational $
+                                      maxBound @b)
+  in saturate (toRational (minBound @b)) (toRational (maxBound @b)) repInt
+       satMode x
+
+
+satSuccProperty
+  :: forall a
+   . (SaturatingNum a, Real a, Show a)
+  => Gen a
+  -> Property
+satSuccProperty genA = property $ do
+  satMode <- forAll Gen.enumBounded
+  a <- forAll genA
+  toRational (satSucc satMode a) === (saturateToBounded @a satMode)
+                                        (toRational a + 1)
+
+satPredProperty
+  :: forall a
+   . (SaturatingNum a, Real a, Show a)
+  => Gen a
+  -> Property
+satPredProperty genA = property $ do
+  satMode <- forAll Gen.enumBounded
+  a <- forAll genA
+  toRational (satPred satMode a) === (saturateToBounded @a satMode)
+                                        (toRational a - 1)
+
+saturatingNumLaws
+  :: (SaturatingNum a, Real a, Show a)
+  => Gen a
+  -> [TestTree]
+saturatingNumLaws genA =
+  [ testProperty "satSucc" $ satSuccProperty genA
+  , testProperty "satPred" $ satPredProperty genA
+  ]
+
+testSaturationLaws
+  :: (SaturatingNum a, Real a, Show a)
+  => String
+  -> Gen a
+  -> TestTree
+testSaturationLaws typeName genA = testGroup typeName (saturatingNumLaws genA)
+
+-- | Generates a bounded fractional with a bias towards extreme values:
+--
+--     10%: uniform [minBound, minBound + 1]
+--     10%: uniform [maxBound - 1, maxBound]
+--      5%: 0.0
+--     75%: uniform [minBound, maxBound]
+--
+genBoundedFractional :: forall a. (Real a, Fractional a, Bounded a) => Gen a
+genBoundedFractional = Gen.frequency
+  [ (10,   fmap (fromRational . toRational)
+         $ Gen.double
+         $ fmap fromRational
+         $ Range.linearFrac
+             (toRational (minBound @a))
+             (toRational (minBound @a) + 1))
+  , (10,   fmap (fromRational . toRational)
+         $ Gen.double
+         $ fmap fromRational
+         $ Range.linearFrac
+             (toRational (maxBound @a) - 1)
+             (toRational (maxBound @a)))
+  , (5,  pure 0.0)
+  , (75,   fmap (fromRational . toRational)
+         $ Gen.double
+         $ fmap fromRational
+         $ Range.linearFrac
+             (toRational (minBound @a))
+             (toRational (maxBound @a))) ]
+
+genSFixed :: forall a b. (KnownNat a, KnownNat b) => Gen (SFixed a b)
+genSFixed = genBoundedFractional
+
+genUFixed :: forall a b. (KnownNat a, KnownNat b) => Gen (UFixed a b)
+genUFixed = genBoundedFractional
+
+tests :: TestTree
+tests = testGroup "SaturatingNum"
+  [ testSaturationLaws "SFixed 0 0" (genSFixed @0 @0)
+  , testSaturationLaws "SFixed 0 1" (genSFixed @0 @1)
+  , testSaturationLaws "SFixed 1 0" (genSFixed @1 @0)
+  , testSaturationLaws "SFixed 1 1" (genSFixed @1 @1)
+  , testSaturationLaws "SFixed 1 2" (genSFixed @1 @2)
+  , testSaturationLaws "SFixed 2 1" (genSFixed @2 @1)
+  , testSaturationLaws "SFixed 2 2" (genSFixed @2 @2)
+  , testSaturationLaws "SFixed 128 128" (genSFixed @128 @128)
+
+  , testSaturationLaws "UFixed 0 0" (genUFixed @0 @0)
+  , testSaturationLaws "UFixed 0 1" (genUFixed @0 @1)
+  , testSaturationLaws "UFixed 1 0" (genUFixed @1 @0)
+  , testSaturationLaws "UFixed 1 1" (genUFixed @1 @1)
+  , testSaturationLaws "UFixed 1 2" (genUFixed @1 @2)
+  , testSaturationLaws "UFixed 2 1" (genUFixed @2 @1)
+  , testSaturationLaws "UFixed 2 2" (genUFixed @2 @2)
+  , testSaturationLaws "UFixed 128 128" (genUFixed @128 @128)
+  ]

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -6,10 +6,11 @@ import qualified Clash.Tests.AutoReg
 import qualified Clash.Tests.BitPack
 import qualified Clash.Tests.BitVector
 import qualified Clash.Tests.DerivingDataRepr
-import qualified Clash.Tests.Signal
-import qualified Clash.Tests.Signed
+import qualified Clash.Tests.Fixed
 import qualified Clash.Tests.NFDataX
 import qualified Clash.Tests.Resize
+import qualified Clash.Tests.Signal
+import qualified Clash.Tests.Signed
 import qualified Clash.Tests.TopEntityGeneration
 import qualified Clash.Tests.Unsigned
 
@@ -19,12 +20,13 @@ tests = testGroup "Unittests"
   , Clash.Tests.BitPack.tests
   , Clash.Tests.BitVector.tests
   , Clash.Tests.DerivingDataRepr.tests
+  , Clash.Tests.Fixed.tests
+  , Clash.Tests.NFDataX.tests
+  , Clash.Tests.Resize.tests
   , Clash.Tests.Signal.tests
   , Clash.Tests.Signed.tests
-  , Clash.Tests.NFDataX.tests
   , Clash.Tests.TopEntityGeneration.tests
   , Clash.Tests.Unsigned.tests
-  , Clash.Tests.Resize.tests
   ]
 
 main :: IO ()


### PR DESCRIPTION
The previous definition of `satSucc`/`satPred` only worked for types that can represent the number 1. But, e.g., `Index 1` and `Signed 1` cannot.

So `satSucc` and `satPred` are moved to the `SaturatingNum` class, but with their current implementation as the default method, such that existing code will keep working. For types where small instances of the type cannot represent 1, a new definition is provided that takes care of the issue.

A unit test for Fixed was added. The definitions `saturateToBounded` and `satSuccPropList` (in `Clash.Tests.Fixed`) work for `Unsigned`, `Signed` and `Fixed`. They could be factored out to some common module, but they are needlessly complicated for integer types.