### PR TITLE
Add Enum, SaturationNum law tests

### DIFF
--- a/changelog/2020-09-02T10_07_09+02_00_enum_laws
+++ b/changelog/2020-09-02T10_07_09+02_00_enum_laws
@@ -1,0 +1,1 @@
+CHANGED / FIXED: `Signed`, `Unsigned`, `SFixed`, and `UFixed` now correctly implement the `Enum` law specifying that the predecessor of `minBound` and the successor of `maxBound` should result in an error.

--- a/changelog/2020-09-02T10_10_00+02_00_resize_bug
+++ b/changelog/2020-09-02T10_10_00+02_00_resize_bug
@@ -1,0 +1,1 @@
+Fixed: Resizes to `Signed 0` (e.g., `resize @(Signed n) @(Signed 0)`) don't throw an error anymore

--- a/changelog/2020-09-02T10_11_31+02_00_satMul_index_bug
+++ b/changelog/2020-09-02T10_11_31+02_00_satMul_index_bug
@@ -1,0 +1,1 @@
+Fixed: `satMul` now correctly handles arguments of type `Index 2`

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -385,7 +385,7 @@ test-suite unittests
 
       base,
       deepseq,
-      hedgehog,
+      hedgehog      >= 1.0.3    && < 1.1,
       hint          >= 0.7      && < 0.10,
       quickcheck-classes-base >= 0.6 && < 1.0,
       tasty         >= 1.2      && < 1.4,

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -409,6 +409,10 @@ test-suite unittests
                  Clash.Tests.TopEntityGeneration
                  Clash.Tests.Unsigned
 
+                 Clash.Tests.Laws.Enum
+
+                 Test.Tasty.HUnit.Extra
+                 Test.QuickCheck.Extra
 
 benchmark benchmark-clash-prelude
   type:             exitcode-stdio-1.0

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -410,6 +410,7 @@ test-suite unittests
                  Clash.Tests.Unsigned
 
                  Clash.Tests.Laws.Enum
+                 Clash.Tests.Laws.SaturatingNum
 
                  Test.Tasty.HUnit.Extra
                  Test.QuickCheck.Extra

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -951,7 +951,7 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
   satPred satMode f@(Fixed fRep) =
     let sh       = natToNum @frac
         symBound = if isSigned fRep
-                   then Fixed $ succ minBound
+                   then Fixed $ minBound + 1
                    else minBound
     in case natVal (Proxy @int) of
          0 -> case satMode of

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -322,6 +322,7 @@ instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
   satMul SatWrap !a !b =
     case natToInteger @n of
       1 -> fromInteger# 0
+      2 -> case a of {0 -> 0; _ -> b}
       _ -> leToPlusKN @1 @n $
         case times# a b of
           z -> let m = fromInteger# (natToInteger @n)

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -563,8 +563,10 @@ instance Resize Signed where
 
 {-# NOINLINE resize# #-}
 resize# :: forall m n . (KnownNat n, KnownNat m) => Signed n -> Signed m
-resize# s@(S i) | n' <= m'  = extended
-                | otherwise = truncated
+resize# s@(S i)
+  | natToNatural @m == 0 = S 0
+  | n' <= m'  = extended
+  | otherwise = truncated
   where
     n  = fromInteger (natVal s)
     n' = shiftL 1 n

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -237,8 +237,22 @@ le# (S n) (S m) = n <= m
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
 -- 'enumFromThenTo', are not synthesizable.
 instance KnownNat n => Enum (Signed n) where
-  succ           = (+# fromInteger# 1)
-  pred           = (-# fromInteger# 1)
+  succ n
+    | n == maxBound =
+        error $ "'succ' was called on (" <> show @(Signed n) maxBound <> " :: "
+             <> "Signed " <> show (natToNatural @n) <> ") and caused an "
+             <> "overflow. Use 'satSucc' and specify a SaturationMode if you "
+             <> "need other behavior."
+    | otherwise = n +# fromInteger# 1
+
+  pred n
+    | n == minBound =
+        error $ "'pred' was called on (" <> show @(Signed n) maxBound <> " :: "
+             <> "Signed " <> show (natToNatural @n) <> ") and caused an "
+             <> "underflow. Use 'satPred' and specify a SaturationMode if you "
+             <> "need other behavior."
+    | otherwise = n -# fromInteger# 1
+
   toEnum         = fromInteger# . toInteger
   fromEnum       = fromEnum . toInteger#
   enumFrom       = enumFrom#

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -113,7 +113,7 @@ import Clash.Class.Parity             (Parity (..))
 import Clash.Class.Resize             (Resize (..))
 import Clash.Prelude.BitIndex         ((!), msb, replaceBit, split)
 import Clash.Prelude.BitReduction     (reduceOr)
-import Clash.Promoted.Nat             (natToNum)
+import Clash.Promoted.Nat             (natToNum, natToNatural)
 import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
 import Clash.Sized.Internal.Mod
@@ -229,8 +229,22 @@ le# (U n) (U m) = n <= m
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
 -- 'enumFromThenTo', are not synthesizable.
 instance KnownNat n => Enum (Unsigned n) where
-  succ           = (+# fromInteger# 1)
-  pred           = (-# fromInteger# 1)
+  succ n
+    | n == maxBound =
+        error $ "'succ' was called on (" <> show @(Unsigned n) maxBound <> " :: "
+             <> "Unsigned " <> show (natToNatural @n) <> ") and caused an "
+             <> "overflow. Use 'satSucc' and specify a SaturationMode if you "
+             <> "need other behavior."
+    | otherwise = n +# fromInteger# 1
+
+  pred n
+    | n == minBound =
+        error $ "'pred' was called on (" <> show @(Unsigned n) maxBound <> " :: "
+             <> "Unsigned " <> show (natToNatural @n) <> ") and caused an "
+             <> "underflow. Use 'satPred' and specify a SaturationMode if you "
+             <> "need other behavior."
+    | otherwise = n -# fromInteger# 1
+
   toEnum         = fromInteger# . toInteger
   fromEnum       = fromEnum . toInteger#
   enumFrom       = enumFrom#

--- a/clash-prelude/tests/Clash/Tests/Laws/Enum.hs
+++ b/clash-prelude/tests/Clash/Tests/Laws/Enum.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Clash.Tests.Laws.Enum (tests) where
+
+import Control.DeepSeq (NFData)
+import Data.Proxy
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Clash.Sized.Index (Index)
+import Clash.Sized.Signed (Signed)
+import Clash.Sized.Fixed (SFixed, UFixed)
+import Clash.Sized.Unsigned (Unsigned)
+
+import Test.Tasty.HUnit.Extra
+
+succMaxBoundLaw ::
+  forall a .
+  (NFData a, Show a, Enum a, Bounded a) =>
+  Proxy a ->
+  Assertion
+succMaxBoundLaw Proxy = expectException (succ @a maxBound)
+
+predMinBoundLaw ::
+  forall a .
+  (NFData a, Show a, Enum a, Bounded a) =>
+  Proxy a ->
+  Assertion
+predMinBoundLaw Proxy = expectException (pred @a minBound)
+
+enumLaws ::
+  (NFData a, Show a, Enum a, Bounded a) =>
+  Proxy a ->
+  [TestTree]
+enumLaws proxy =
+  [ testCase "succ maxBound ~ _|_" (succMaxBoundLaw proxy)
+  , testCase "pred minBound ~ _|_" (predMinBoundLaw proxy)
+  ]
+
+testEnumLaws ::
+  (NFData a, Show a, Enum a, Bounded a) =>
+  String ->
+  Proxy a ->
+  TestTree
+testEnumLaws typeName proxy = testGroup typeName (enumLaws proxy)
+
+tests :: TestTree
+tests = testGroup "Enum"
+  [ testEnumLaws "Index 1" (Proxy @(Index 1))
+  , testEnumLaws "Index 2" (Proxy @(Index 2))
+  , testEnumLaws "Index 128" (Proxy @(Index 128))
+
+  , testEnumLaws "Unsigned 0" (Proxy @(Unsigned 0))
+  , testEnumLaws "Unsigned 1" (Proxy @(Unsigned 1))
+  , testEnumLaws "Unsigned 32" (Proxy @(Unsigned 32))
+  , testEnumLaws "Unsigned 127" (Proxy @(Unsigned 127))
+  , testEnumLaws "Unsigned 128" (Proxy @(Unsigned 128))
+
+  , testEnumLaws "Signed 0" (Proxy @(Signed 0))
+  , testEnumLaws "Signed 1" (Proxy @(Signed 1))
+  , testEnumLaws "Signed 32" (Proxy @(Signed 32))
+  , testEnumLaws "Signed 127" (Proxy @(Signed 127))
+  , testEnumLaws "Signed 128" (Proxy @(Signed 128))
+
+  -- TODO: SFixed and UFixed are partial for
+  --
+  --         succ (maxBound-1, maxBound]
+  --         pred [minBound, minBound+1)
+  --
+  -- Tests only test minBound/maxBound though.
+  --
+  , testEnumLaws "SFixed 0 0" (Proxy @(SFixed 0 0))
+  , testEnumLaws "SFixed 0 1" (Proxy @(SFixed 0 1))
+  , testEnumLaws "SFixed 1 0" (Proxy @(SFixed 1 0))
+  , testEnumLaws "SFixed 1 1" (Proxy @(SFixed 1 1))
+  , testEnumLaws "SFixed 1 2" (Proxy @(SFixed 1 2))
+  , testEnumLaws "SFixed 2 1" (Proxy @(SFixed 2 1))
+  , testEnumLaws "SFixed 2 2" (Proxy @(SFixed 2 2))
+  , testEnumLaws "SFixed 128 128" (Proxy @(SFixed 128 128))
+
+  , testEnumLaws "UFixed 0 0" (Proxy @(UFixed 0 0))
+  , testEnumLaws "UFixed 0 1" (Proxy @(UFixed 0 1))
+  , testEnumLaws "UFixed 1 0" (Proxy @(UFixed 1 0))
+  , testEnumLaws "UFixed 1 1" (Proxy @(UFixed 1 1))
+  , testEnumLaws "UFixed 1 2" (Proxy @(UFixed 1 2))
+  , testEnumLaws "UFixed 2 1" (Proxy @(UFixed 2 1))
+  , testEnumLaws "UFixed 2 2" (Proxy @(UFixed 2 2))
+  , testEnumLaws "UFixed 128 128" (Proxy @(UFixed 128 128))
+  ]

--- a/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
+++ b/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
@@ -173,7 +173,7 @@ tests = testGroup "SaturatingNum"
   , testSaturationLaws True "Signed 127" (genSigned @127)
   , testSaturationLaws True "Signed 128" (genSigned @128)
 
-  -- , testSaturationLaws False "SFixed 0 0" (genSFixed @0 @0)
+  , testSaturationLaws False "SFixed 0 0" (genSFixed @0 @0)
   , testSaturationLaws False "SFixed 0 1" (genSFixed @0 @1)
   , testSaturationLaws False "SFixed 1 0" (genSFixed @1 @0)
   , testSaturationLaws False "SFixed 1 1" (genSFixed @1 @1)

--- a/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
+++ b/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE RankNTypes #-}
+
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
+
+module Clash.Tests.Laws.SaturatingNum (tests) where
+
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.HUnit
+
+import Clash.Class.Num
+import Clash.Sized.Index (Index)
+import Clash.Sized.Signed (Signed)
+import Clash.Sized.Fixed (SFixed, UFixed)
+import Clash.Sized.Unsigned (Unsigned)
+
+import Control.DeepSeq (NFData)
+import GHC.TypeLits (KnownNat)
+
+import Hedgehog
+import qualified Hedgehog.Range as Range
+import qualified Hedgehog.Gen as Gen
+
+type TestWrap = Bool
+
+type SaturationLaw a =
+  (Ord a, Show a, Eq a, SaturatingNum a) =>
+  Gen a ->
+  Assertion
+
+isTotal ::
+  forall a.
+  (NFData a, Show a, Eq a) =>
+  (SaturationMode -> a -> a -> a) ->
+  Gen a ->
+  Property
+isTotal f genA = property $ do
+  satMode <- forAll Gen.enumBounded
+  a <- forAll genA
+  b <- forAll genA
+  _ <- evalNF (f satMode a b)
+  pure ()
+
+satWrapOverflowLaw :: forall a. SaturationLaw a
+satWrapOverflowLaw _ = satSucc @a SatWrap maxBound @?= minBound
+
+satWrapUnderflowLaw :: forall a. SaturationLaw a
+satWrapUnderflowLaw _ = satPred @a SatWrap minBound @?= maxBound
+
+satBoundOverflowLaw :: forall a. SaturationLaw a
+satBoundOverflowLaw _ = satSucc @a SatBound maxBound @?= maxBound
+
+satBoundUnderflowLaw :: forall a. SaturationLaw a
+satBoundUnderflowLaw _ = satPred @a SatBound minBound @?= minBound
+
+satZeroOverflowLaw :: forall a. SaturationLaw a
+satZeroOverflowLaw _ = satSucc @a SatZero maxBound @?= 0
+
+satZeroUnderflowLaw :: forall a. SaturationLaw a
+satZeroUnderflowLaw _ = satPred @a SatZero minBound @?= 0
+
+satSymmetricOverflow :: forall a. SaturationLaw a
+satSymmetricOverflow _ = satSucc @a SatSymmetric maxBound @?= maxBound
+
+satSymmetricUnderflow :: forall a. SaturationLaw a
+satSymmetricUnderflow _ =
+  if minBound @a < 0 then
+    -- Signed number
+    satPred @a SatSymmetric minBound @?= satSucc SatWrap minBound
+  else
+    -- Unsigned number (or zero-width)
+    satPred @a SatSymmetric minBound @?= minBound
+
+saturatingNumLaws ::
+  (NFData a, Ord a, Show a, Eq a, SaturatingNum a) =>
+  TestWrap ->
+  Gen a ->
+  [TestTree]
+saturatingNumLaws testWrap genA =
+  (if testWrap then
+    [ testCase "SatWrap: Wrap around on overflow" (satWrapOverflowLaw genA)
+    , testCase "SatWrap: Wrap around on underflow" (satWrapUnderflowLaw genA) ]
+  else
+    []) <>
+  [ testCase "SatBound: Become maxBound on overflow" (satBoundOverflowLaw genA)
+  , testCase "SatBound: Become minBound on underflow" (satBoundUnderflowLaw genA)
+
+  , testCase "SatZero: Become 0 on overflow" (satZeroOverflowLaw genA)
+  , testCase "SatZero: Become 0 on underflow" (satZeroUnderflowLaw genA)
+
+  , testCase "SatSymmetric: Become maxBound on overflow" (satSymmetricOverflow genA)
+  , testCase "SatSymmetric: Become minBound or minBound+1 on underflow" (satSymmetricUnderflow genA)
+
+  , testProperty "satAddTotal" (isTotal satAdd genA)
+  , testProperty "satSubTotal" (isTotal satSub genA)
+  , testProperty "satMulTotal" (isTotal satMul genA)
+  ]
+
+testSaturationLaws ::
+  (NFData a, Ord a, Show a, Eq a, SaturatingNum a) =>
+  TestWrap ->
+  String ->
+  Gen a ->
+  TestTree
+testSaturationLaws testWrap typeName genA =
+  testGroup typeName (saturatingNumLaws testWrap genA)
+
+-- | Generates a bounded integral with a bias towards extreme values:
+--
+--      5%: minBound
+--      5%: maxBound
+--      5%: 0
+--     85%: uniform [minBound, maxBound]
+--
+genBoundedIntegral :: (Integral a, Bounded a) => Gen a
+genBoundedIntegral = Gen.frequency
+  [ (5,  pure minBound)
+  , (5,  pure maxBound)
+  , (5,  pure 0)
+  , (85, Gen.integral (Range.linear minBound maxBound)) ]
+
+genIndex :: forall n. KnownNat n => Gen (Index n)
+genIndex = genBoundedIntegral
+
+genUnsigned :: forall n. KnownNat n => Gen (Unsigned n)
+genUnsigned = genBoundedIntegral
+
+genSigned :: forall n. KnownNat n => Gen (Signed n)
+genSigned = genBoundedIntegral
+
+-- | Generates a bounded fractional with a bias towards extreme values:
+--
+--      5%: minBound
+--      5%: maxBound
+--      5%: 0.0
+--     85%: uniform [minBound, maxBound]
+--
+genBoundedFractional :: forall a. (Real a, Fractional a, Bounded a) => Gen a
+genBoundedFractional = Gen.frequency
+  [ (5,  pure minBound)
+  , (5,  pure maxBound)
+  , (5,  pure 0.0)
+  , (85,   fmap (fromRational . toRational)
+         $ Gen.double
+         $ fmap fromRational
+         $ Range.linearFrac
+             (toRational (minBound @a))
+             (toRational (maxBound @a))) ]
+
+genSFixed :: forall a b. (KnownNat a, KnownNat b) => Gen (SFixed a b)
+genSFixed = genBoundedFractional
+
+genUFixed :: forall a b. (KnownNat a, KnownNat b) => Gen (UFixed a b)
+genUFixed = genBoundedFractional
+
+tests :: TestTree
+tests = testGroup "SaturatingNum"
+  [ testSaturationLaws True "Index 1" (genIndex @1)
+  , testSaturationLaws True "Index 2" (genIndex @2)
+  , testSaturationLaws True "Index 128" (genIndex @128)
+
+  , testSaturationLaws True "Unsigned 0" (genUnsigned @0)
+  , testSaturationLaws True "Unsigned 1" (genUnsigned @1)
+  , testSaturationLaws True "Unsigned 32" (genUnsigned @32)
+  , testSaturationLaws True "Unsigned 127" (genUnsigned @127)
+  , testSaturationLaws True "Unsigned 128" (genUnsigned @128)
+
+  , testSaturationLaws True "Signed 0" (genSigned @0)
+  , testSaturationLaws True "Signed 1" (genSigned @1)
+  , testSaturationLaws True "Signed 32" (genSigned @32)
+  , testSaturationLaws True "Signed 127" (genSigned @127)
+  , testSaturationLaws True "Signed 128" (genSigned @128)
+
+  -- , testSaturationLaws False "SFixed 0 0" (genSFixed @0 @0)
+  , testSaturationLaws False "SFixed 0 1" (genSFixed @0 @1)
+  , testSaturationLaws False "SFixed 1 0" (genSFixed @1 @0)
+  , testSaturationLaws False "SFixed 1 1" (genSFixed @1 @1)
+  , testSaturationLaws False "SFixed 1 2" (genSFixed @1 @2)
+  , testSaturationLaws False "SFixed 2 1" (genSFixed @2 @1)
+  , testSaturationLaws False "SFixed 2 2" (genSFixed @2 @2)
+  , testSaturationLaws False "SFixed 128 128" (genSFixed @128 @128)
+
+  , testSaturationLaws False "UFixed 0 0" (genUFixed @0 @0)
+  , testSaturationLaws False "UFixed 0 1" (genUFixed @0 @1)
+  , testSaturationLaws False "UFixed 1 0" (genUFixed @1 @0)
+  , testSaturationLaws False "UFixed 1 1" (genUFixed @1 @1)
+  , testSaturationLaws False "UFixed 1 2" (genUFixed @1 @2)
+  , testSaturationLaws False "UFixed 2 1" (genUFixed @2 @1)
+  , testSaturationLaws False "UFixed 2 2" (genUFixed @2 @2)
+  , testSaturationLaws False "UFixed 128 128" (genUFixed @128 @128)
+  ]

--- a/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
+++ b/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
@@ -81,7 +81,9 @@ saturatingNumLaws ::
 saturatingNumLaws testWrap genA =
   (if testWrap then
     [ testCase "SatWrap: Wrap around on overflow" (satWrapOverflowLaw genA)
-    , testCase "SatWrap: Wrap around on underflow" (satWrapUnderflowLaw genA) ]
+    , testCase "SatWrap: Wrap around on underflow" (satWrapUnderflowLaw genA)
+    , testCase "SatSymmetric: Become maxBound on overflow" (satSymmetricOverflow genA)
+    , testCase "SatSymmetric: Become minBound or minBound+1 on underflow" (satSymmetricUnderflow genA) ]
   else
     []) <>
   [ testCase "SatBound: Become maxBound on overflow" (satBoundOverflowLaw genA)
@@ -89,9 +91,6 @@ saturatingNumLaws testWrap genA =
 
   , testCase "SatZero: Become 0 on overflow" (satZeroOverflowLaw genA)
   , testCase "SatZero: Become 0 on underflow" (satZeroUnderflowLaw genA)
-
-  , testCase "SatSymmetric: Become maxBound on overflow" (satSymmetricOverflow genA)
-  , testCase "SatSymmetric: Become minBound or minBound+1 on underflow" (satSymmetricUnderflow genA)
 
   , testProperty "satAddTotal" (isTotal satAdd genA)
   , testProperty "satSubTotal" (isTotal satSub genA)

--- a/clash-prelude/tests/Test/QuickCheck/Extra.hs
+++ b/clash-prelude/tests/Test/QuickCheck/Extra.hs
@@ -1,0 +1,39 @@
+module Test.QuickCheck.Extra
+  ( expectException
+  , expectXException
+  , expectExceptionNoX
+  ) where
+
+import Test.Tasty.QuickCheck
+import Control.DeepSeq (NFData)
+import Control.Exception (SomeException, try, evaluate)
+import Data.Either (isLeft)
+
+import Clash.XException (XException)
+
+-- | Succeed if evaluating leads to an XException
+expectXException :: (Show a, NFData a) => a -> Property
+expectXException a0 = ioProperty $ do
+  a1 <- try @XException (evaluate a0)
+  pure $
+    counterexample
+      ("Expected Exception, got: " <> show a1)
+      (isLeft a1)
+
+-- | Succeed if evaluating leads to an Exception
+expectException :: (Show a, NFData a) => a -> Property
+expectException a0 = ioProperty $ do
+  a1 <- try @SomeException (evaluate a0)
+  pure $
+    counterexample
+      ("Expected Exception, got: " <> show a1)
+      (isLeft a1)
+
+-- | Succeed if evaluating leads to a non-XException Exception
+expectExceptionNoX :: (Show a, NFData a) => a -> Property
+expectExceptionNoX a0 = ioProperty $ do
+  a1 <- try @SomeException (try @XException (evaluate a0))
+  pure $
+    counterexample
+      ("Expected non-XException Exception, got: " <> show a1)
+      (isLeft a1)

--- a/clash-prelude/tests/Test/Tasty/HUnit/Extra.hs
+++ b/clash-prelude/tests/Test/Tasty/HUnit/Extra.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Test.Tasty.HUnit.Extra
+  ( expectException
+  , expectXException
+  , expectExceptionNoX
+  ) where
+
+import Control.DeepSeq (NFData)
+import Control.Exception (SomeException, try, evaluate)
+import Test.Tasty.HUnit
+
+import Clash.XException (XException)
+
+-- | Succeed if evaluating leads to an XException
+expectXException :: (Show a, NFData a) => a -> Assertion
+expectXException a0 =
+  try @XException (evaluate a0) >>= \case
+    Left _ -> pure ()
+    Right a -> assertFailure ("Expected Exception, got: " <> show a)
+
+-- | Succeed if evaluating leads to an Exception
+expectException :: (Show a, NFData a) => a -> Assertion
+expectException a0 =
+  try @SomeException (evaluate a0) >>= \case
+    Left _ -> pure ()
+    Right a -> assertFailure ("Expected Exception, got: " <> show a)
+
+-- | Succeed if evaluating leads to a non-XException Exception
+expectExceptionNoX :: (Show a, NFData a) => a -> Assertion
+expectExceptionNoX a0 =
+  try @SomeException (try @XException (evaluate a0)) >>= \case
+    Left _ -> pure ()
+    Right a -> assertFailure ("Expected Exception, got: " <> show a)

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -15,6 +15,7 @@ import qualified Clash.Tests.TopEntityGeneration
 import qualified Clash.Tests.Unsigned
 
 import qualified Clash.Tests.Laws.Enum
+import qualified Clash.Tests.Laws.SaturatingNum
 
 tests :: TestTree
 tests = testGroup "Unittests"
@@ -31,6 +32,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.Unsigned.tests
   , testGroup "Laws"
     [ Clash.Tests.Laws.Enum.tests
+    , Clash.Tests.Laws.SaturatingNum.tests
     ]
   ]
 

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -14,6 +14,8 @@ import qualified Clash.Tests.Signed
 import qualified Clash.Tests.TopEntityGeneration
 import qualified Clash.Tests.Unsigned
 
+import qualified Clash.Tests.Laws.Enum
+
 tests :: TestTree
 tests = testGroup "Unittests"
   [ Clash.Tests.AutoReg.tests
@@ -27,6 +29,9 @@ tests = testGroup "Unittests"
   , Clash.Tests.Signed.tests
   , Clash.Tests.TopEntityGeneration.tests
   , Clash.Tests.Unsigned.tests
+  , testGroup "Laws"
+    [ Clash.Tests.Laws.Enum.tests
+    ]
   ]
 
 main :: IO ()

--- a/repld
+++ b/repld
@@ -16,6 +16,7 @@
 # Shortcuts exist for all supported libraries:
 #
 #   * `p`, `prelude`, `clash-prelude`
+#   * `p:tests`, `prelude:tests`, `clash-prelude:tests`
 #   * `l`, `lib`, `clash-lib`
 #   * `l:tests`, `lib:tests`, `clash-lib:tests`
 #   * `c`, `cores`, `clash-cores`
@@ -57,6 +58,7 @@ elif [[ $1 == "dev" || $1 == "clash-dev" ]]; then
 else
   echo "Unrecognized target. Use one of:"                    > /dev/stderr
   echo "  p, prelude, clash-prelude"                         > /dev/stderr
+  echo "  p:tests, prelude:tests, clash-prelude:tests"       > /dev/stderr
   echo "  l, lib, clash-lib"                                 > /dev/stderr
   echo "  l:tests, lib:tests, clash-lib:tests"               > /dev/stderr
   echo "  g, ghc, clash-ghc"                                 > /dev/stderr


### PR DESCRIPTION
..and a bunch of fixes discovered by the tests.

The commented tests in `clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs` should be fixed in https://github.com/clash-lang/clash-compiler/pull/1492. There's still some discussion on whether the tests actually make sense for `SFixed` / `UFixed`. But I'll leave that to @DigitalBrains1  :).