### PR TITLE
Add '-fno-worker-wrapper' as a ghc-option in clash-cores.cabal

### DIFF
--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -79,6 +79,7 @@ library
 
   ghc-options:
     -fexpose-all-unfoldings
+    -fno-worker-wrapper
 
   build-depends:
     clash-lib,


### PR DESCRIPTION
Prevents GHC from creating a worker wrapper for primitives.