### PR TITLE
added ECP5 vendor configured SPI slave core

### DIFF
--- a/changelog/2020-09-02T15_54_37+02_00_ECP5_spiSlave
+++ b/changelog/2020-09-02T15_54_37+02_00_ECP5_spiSlave
@@ -1,0 +1,4 @@
+* New features (API):
+  * [#1498](https://github.com/clash-lang/clash-compiler/pull/1498): added a `HasBiSignalDefault` constraint to Clash.Signal.BiSignal, `pullUpMode` gives access to the pull-up mode, cortesy of @christiaanb
+* Clash-cores:
+  * [#1498](https://github.com/clash-lang/clash-compiler/pull/1498): moved ICE40 primitives to Clash.Cores.LatticeSemi.ICE40 and added an ECP5 bidirectional buffer primitive with tri-state in Clash.Cores.LatticeSemi.ECP5; when using SPI core on ECP5 FPGAs, use `Clash.Cores.SPI.spiSlaveLatticeBB`

--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -66,6 +66,7 @@ common basic-config
     ghc-typelits-natnormalise >= 0.6,
     ghc-typelits-extra        >= 0.3.2,
     ghc-typelits-knownnat     >= 0.6,
+    interpolate               >= 0.2,
     QuickCheck
 
 library
@@ -74,8 +75,10 @@ library
 
   exposed-modules:
     Clash.Cores.SPI
-    Clash.Cores.LatticeSemi.IO
-    Clash.Cores.LatticeSemi.Blackboxes.IO
+    Clash.Cores.LatticeSemi.ICE40.IO
+    Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO
+    Clash.Cores.LatticeSemi.ECP5.IO
+    Clash.Cores.LatticeSemi.ECP5.Blackboxes.IO
 
   ghc-options:
     -fexpose-all-unfoldings

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
@@ -1,0 +1,71 @@
+{-|
+  Copyright   :  (C) 2020, Foamspace corp
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  hcab14@gmail.com
+
+  LATTICE ECP5 IO primitives. Implementations are documented in the
+  <http://www.latticesemi.com/-/media/LatticeSemi/Documents/ApplicationNotes/EH/FPGA-TN-02032-1-2-ECP5-ECP5G-sysIO-Usage-Guide.ashx?document_id=50464>.
+-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Clash.Cores.LatticeSemi.ECP5.Blackboxes.IO (bbTF) where
+
+import           Clash.Backend
+import           Clash.Netlist.BlackBox.Util
+import           Clash.Netlist.Id
+import           Clash.Netlist.Types
+import           Control.Monad.State             (State())
+import           Data.Semigroup.Monad            (getMon)
+import           Data.Text as TextS
+import           Data.Text.Prettyprint.Doc.Extra
+import           Prelude
+
+-- | Generates HDL for ECP5 bidirectional buffer BB
+--   FPGA TN 02032 sysIO
+--     BB buf7 (.I(Q_out7), .T(Q_tri7), .O(buf_Data7), .B(Data[7]));
+bbTF :: TemplateFunction
+bbTF = TemplateFunction used valid bbTemplate
+ where
+  used = [3..6]
+  valid = const True
+
+bbTemplate
+  :: Backend s
+  => BlackBoxContext
+  -> State s Doc
+bbTemplate bbCtx = do
+  let mkId = mkUniqueIdentifier Basic
+
+  bb      <- mkId "bb"
+  bb_inst <- mkId "bb_inst"
+  dIn     <- mkId "dIn"
+
+  getMon $ blockDecl bb $
+    [ NetDecl Nothing dIn Bit
+    , InstDecl Comp Nothing [] compName bb_inst
+      [
+      ]
+      [ -- NOTE: Direction is set to 'In', but will be rendered as inout due to
+        -- its type packagePinTy
+        (Identifier "B" Nothing, In, packagePinTy, packagePin)
+      , (Identifier "T" Nothing, In,  Bool, outputEnable)
+      , (Identifier "I" Nothing, In,  Bit, dOut)
+      , (Identifier "O" Nothing, Out, Bit, Identifier dIn Nothing)
+      ]
+    , Assignment result (Identifier dIn Nothing)
+    ]
+ where
+  [  _HasCallStack
+   , _HasBiSignalDefault
+   , _KnownDomain
+   , (intrinsicName, String, _)
+   , (packagePin, packagePinTy, _)
+   , (dOut, Bit, _)
+   , (outputEnable, Bool, _)
+   ] = bbInputs bbCtx
+
+  Just compName' = exprToString intrinsicName
+  compName = TextS.pack compName'
+
+  (Identifier result Nothing,_) = bbResult bbCtx

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright   :  (C) 2020, Foamspace corp
+  Copyright   :  (C) 2020, Foamspace corp & Christoph Mayer
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  hcab14@gmail.com
 

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright   :  (C) 2020, Foamspace corp
+  Copyright   :  (C) 2020, Foamspace corp & Christoph Mayer
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  hcab14@gmail.com
 

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
@@ -1,0 +1,90 @@
+{-|
+  Copyright   :  (C) 2020, Foamspace corp
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  hcab14@gmail.com
+
+  LATTICE ECP5 IO primitives. Implementations are documented in the
+  <http://www.latticesemi.com/-/media/LatticeSemi/Documents/ApplicationNotes/EH/FPGA-TN-02032-1-2-ECP5-ECP5G-sysIO-Usage-Guide.ashx?document_id=50464>.
+-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE BangPatterns #-}
+
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Clash.Cores.LatticeSemi.ECP5.IO
+  ( bidirectionalBuffer
+  ) where
+
+import           Clash.Annotations.Primitive  (Primitive(..), HDL(..), hasBlackBox)
+import           Clash.Prelude
+import           Clash.Signal.BiSignal
+import           Data.String.Interpolate      (i)
+import           Data.String.Interpolate.Util (unindent)
+import           GHC.Stack                    (HasCallStack())
+
+-- | BB primitive
+bidirectionalBuffer
+  :: forall ds dom
+   . ( HasCallStack
+     , HasBiSignalDefault ds
+     , KnownDomain dom
+     )
+  => Enable dom
+  -- ^ output enable
+  -> BiSignalIn ds dom 1
+  -- ^ PKG_PIN output BiSignal
+  -> Signal dom Bit
+  -- ^ output bit
+  -> ( BiSignalOut ds dom 1
+     -- ^ PKG_PIN input BiSignal
+     , Signal dom Bit
+     -- ^ input bit
+     )
+bidirectionalBuffer en pkgPinOut output = (pkgPinIn, dIn)
+  where
+    (pkgPinIn,dIn) = -- the BB primitve has an active low enable signal
+      bbECP5 intrinsicName pkgPinOut output invertedEnable
+    invertedEnable = not <$> fromEnable en
+    intrinsicName = case (pullUpMode pkgPinOut) of
+                      SFloating -> "BB"
+                      SPullUp   -> "BBPU"
+                      SPullDown -> "BBPD"
+-- {-# NOINLINE bidirectionalBuffer #-}
+
+bbECP5
+  :: forall ds dom
+   . ( HasCallStack
+     , HasBiSignalDefault ds
+     , KnownDomain dom
+     )
+  => String
+  -> BiSignalIn ds dom 1
+  -> Signal dom Bit
+  -> Signal dom Bool
+  -> ( BiSignalOut ds dom 1
+     , Signal dom Bit
+     )
+bbECP5 _intrinsicName pkgPinIn output notOutputEnable
+  = (pkgPinOut, dIn)
+   where
+     dIn :: Signal dom Bit
+     dIn = readFromBiSignal pkgPinIn
+     pkgPinOut = writeToBiSignal pkgPinIn (toMaybe . not <$> notOutputEnable <*> output)
+
+     toMaybe :: Bool -> a -> Maybe a
+     toMaybe True a  = Just a
+     toMaybe False _ = Nothing
+{-# NOINLINE bbECP5 #-}
+{-# ANN bbECP5 hasBlackBox #-}
+{-# ANN bbECP5 (InlinePrimitive [VHDL,Verilog,SystemVerilog] $ unindent [i|
+   [ { "BlackBox" :
+        { "name" : "Clash.Cores.LatticeSemi.ECP5.IO.bbECP5",
+          "kind" : "Declaration",
+          "format": "Haskell",
+          "templateFunction": "Clash.Cores.LatticeSemi.ECP5.Blackboxes.IO.bbTF"
+        }
+     }
+   ]
+   |]) #-}

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
@@ -37,10 +37,8 @@ bidirectionalBuffer
   -- ^ PKG_PIN output BiSignal
   -> Signal dom Bit
   -- ^ output bit
-  -> ( BiSignalOut ds dom 1
-     -- ^ PKG_PIN input BiSignal
-     , Signal dom Bit
-     -- ^ input bit
+  -> ( BiSignalOut ds dom 1 -- PKG_PIN input BiSignal
+     , Signal dom Bit       -- input bit
      )
 bidirectionalBuffer en pkgPinOut output = (pkgPinIn, dIn)
   where

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Clash.Cores.LatticeSemi.Blackboxes.IO (sbioTF) where
+module Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO (sbioTF) where
 
 import           Prelude
 

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
@@ -7,15 +7,13 @@
   <http://www.latticesemi.com/~/media/LatticeSemi/Documents/TechnicalBriefs/SBTICETechnologyLibrary201504.pdf LATTICE ICE Technology Library>,
   referred to as LITL.
 -}
-{-# LANGUAGE BinaryLiterals #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
 
-module Clash.Cores.LatticeSemi.IO
+module Clash.Cores.LatticeSemi.ICE40.IO
   ( sbio
   , spiConfig
   , PinOutputConfig(..)
@@ -23,10 +21,13 @@ module Clash.Cores.LatticeSemi.IO
   ) where
 
 import           Data.Functor                 ((<&>))
-import           GHC.Stack
+import           GHC.Stack                    (HasCallStack())
 
-import           Clash.Annotations.Primitive  (Primitive(..), HDL(..))
+import           Clash.Annotations.Primitive  (Primitive(..), HDL(..), hasBlackBox)
 import           Clash.Prelude
+
+import           Data.String.Interpolate      (i)
+import           Data.String.Interpolate.Util (unindent)
 
 toMaybe :: Bool -> a -> Maybe a
 toMaybe True a = Just a
@@ -199,7 +200,7 @@ sbio pinConf pkgPinIn latchInput dOut_0 _dOut_1 outputEnable0 =
   clockLessLatchErr =
     "Either LATCH_INPUT_VALUE was asserted or pin type was set to one of " <>
     "INPUT_REGISTERED_LATCH or PIN_INPUT_LATCH. This is currently not " <>
-    "supported by this 'Clash.Cores.LatticeSemi.IO.sbio', due to CLash not " <>
+    "supported by this 'Clash.Cores.LatticeSemi.ICE40.IO.sbio', due to CLash not " <>
     "supporting clockless latches."
 
   latch_dIn_0 =
@@ -230,4 +231,14 @@ sbio pinConf pkgPinIn latchInput dOut_0 _dOut_1 outputEnable0 =
       pkgPinIn
       (toMaybe <$> outputEnable1 <*> pkgPinWriteInput)
 {-# NOINLINE sbio #-}
-{-# ANN sbio (InlinePrimitive [VHDL,Verilog,SystemVerilog] "[ { \"BlackBox\" : { \"name\" : \"Clash.Cores.LatticeSemi.IO.sbio\", \"kind\": \"Declaration\", \"format\": \"Haskell\", \"templateFunction\": \"Clash.Cores.LatticeSemi.Blackboxes.IO.sbioTF\"}} ]") #-}
+{-# ANN sbio hasBlackBox #-}
+{-# ANN sbio (InlinePrimitive [VHDL,Verilog,SystemVerilog] $ unindent [i|
+   [ { "BlackBox" :
+        { "name" : "Clash.Cores.LatticeSemi.ICE40.IO.sbio",
+          "kind" : "Declaration",
+          "format": "Haskell",
+          "templateFunction": "Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO.sbioTF"
+        }
+     }
+   ]
+   |]) #-}

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -110,6 +110,8 @@ module Clash.Signal.BiSignal (
     BiSignalIn()
   , BiSignalOut()
   , BiSignalDefault(..)
+  , SBiSignalDefault(..)
+  , HasBiSignalDefault(..)
   , mergeBiSignalOuts
   , readFromBiSignal
   , writeToBiSignal
@@ -158,6 +160,20 @@ instance Given (SBiSignalDefault 'PullDown) where
 
 instance Given (SBiSignalDefault 'Floating) where
   given = SFloating
+
+-- | Type class for 'BiSignalDefault':
+--   can be used as a constraint and for obtaining the pull-up mode
+class HasBiSignalDefault (ds :: BiSignalDefault) where
+  pullUpMode :: BiSignalIn ds dom n -> SBiSignalDefault ds
+
+instance HasBiSignalDefault 'PullUp where
+  pullUpMode _ = SPullUp
+
+instance HasBiSignalDefault 'PullDown where
+  pullUpMode _ = SPullDown
+
+instance HasBiSignalDefault 'Floating where
+  pullUpMode _ = SFloating
 
 -- | The /in/ part of an __inout__ port
 data BiSignalIn (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)


### PR DESCRIPTION
* added a `HasBiSignalDefault` constraint to Clash.Signal.BiSignal, `pullUpMode` gives access to the pull-up mode (by cortesy of @christiaanb)
* moved ICE40 primitives to `Clash.Cores.LatticeSemi.ICE40`
* added an ECP5 bidirectional buffer with tri-state primitive in `Clash.Cores.LatticeSemi.ECP5`, its pull-up mode is inferred from `BiSignalIn`, `BiSignalOut`
* added an additional SPI slave core for ECP5 FPGAs, `Clash.Cores.SPI.spiSlaveLatticeBB`
