### PR TITLE
Store whether bindings are primitive unfoldings

### DIFF
--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -211,7 +211,7 @@ splitTopEntityT
   -> TopEntityT
 splitTopEntityT tcm bindingsMap tt@(TopEntityT id_ (Just t@(Synthesize {})) _) =
   case lookupVarEnv id_ bindingsMap of
-    Just (Binding _id sp _ _) ->
+    Just (Binding _id sp _ _ _) ->
       tt{topAnnotation=Just (splitTopAnn tcm sp (varType id_) t)}
     Nothing ->
       error "Internal error in 'splitTopEntityT'. Please report as a bug."

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -40,14 +40,30 @@ import           Clash.Core.Var                 (Id)
 import           Clash.Core.VarEnv              (VarEnv)
 import           Clash.Netlist.BlackBox.Types   (HdlSyn (..))
 
+data IsPrim
+  = IsPrim
+    -- ^ The binding is the unfolding for a primitive.
+  | IsFun
+    -- ^ The binding is an ordinary function.
+  deriving (Binary, Eq, Generic, NFData, Show)
 
 -- A function binder in the global environment.
 --
 data Binding a = Binding
   { bindingId :: Id
+    -- ^ The core identifier for this binding.
   , bindingLoc :: SrcSpan
+    -- ^ The source location of this binding in the original source code.
   , bindingSpec :: InlineSpec
+    -- ^ the inline specification for this binding, in the original source code.
+  , bindingIsPrim :: IsPrim
+    -- ^ Is the binding a core term corresponding to a primitive with a known
+    -- implementation? If so, it can potentially be inlined despite being
+    -- marked as NOINLINE in source.
   , bindingTerm :: a
+    -- ^ The term representation for this binding. This is polymorphic so
+    -- alternate representations can be used if more appropriate (i.e. in the
+    -- evaluator this can be Value for evaluated bindings).
   } deriving (Binary, Functor, Generic, NFData, Show)
 
 -- | Global function binders

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -410,7 +410,7 @@ normalizeTopLvlBndr
   -> Id
   -> Binding Term
   -> NormalizeSession (Binding Term)
-normalizeTopLvlBndr isTop nm (Binding nm' sp inl tm) = makeCachedU nm (extra.normalized) $ do
+normalizeTopLvlBndr isTop nm (Binding nm' sp inl pr tm) = makeCachedU nm (extra.normalized) $ do
   tcm <- Lens.view tcCache
   let nmS = showPpr (varName nm)
   -- We deshadow the term because sometimes GHC gives us
@@ -424,7 +424,7 @@ normalizeTopLvlBndr isTop nm (Binding nm' sp inl tm) = makeCachedU nm (extra.nor
   tm3 <- rewriteExpr ("normalization",normalization) (nmS,tm2) (nm',sp)
   curFun .= old
   let ty' = termType tcm tm3
-  return (Binding nm'{varType = ty'} sp inl tm3)
+  return (Binding nm'{varType = ty'} sp inl pr tm3)
 
 -- | Turn type equality constraints into substitutions and apply them.
 --

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -93,7 +93,7 @@ import           Clash.Core.VarEnv
    mkVarEnv, eltsVarSet, elemVarEnv, lookupVarEnv, extendVarEnv)
 import           Clash.Debug
 import           Clash.Driver.Types
-  (DebugLevel (..), BindingMap, Binding(..))
+  (DebugLevel (..), BindingMap, Binding(..), IsPrim(..))
 import           Clash.Netlist.Util          (representableType)
 import           Clash.Pretty                (clashPretty, showDoc)
 import           Clash.Rewrite.Types
@@ -750,6 +750,7 @@ liftBinding (var@Id {varName = idName} ,e) = do
 #else
                                       EmptyInlineSpec
 #endif
+                                      IsFun
                                       newBody)
              -- Return the new binder
              return (var, newExpr)
@@ -799,7 +800,7 @@ addGlobalBind
   -> RewriteMonad extra ()
 addGlobalBind vNm ty sp inl body = do
   let vId = mkGlobalId ty vNm
-  (ty,body) `deepseq` bindings %= extendUniqMap vNm (Binding vId sp inl body)
+  (ty,body) `deepseq` bindings %= extendUniqMap vNm (Binding vId sp inl IsFun body)
 
 -- | Create a new name out of the given name, but with another unique. Resulting
 -- unique is guaranteed to not be in the given InScopeSet.
@@ -957,7 +958,7 @@ specialise' specMapLbl specHistLbl specLimitLbl (TransformContext is0 _) e (Var 
       -- Determine if we can specialize f
       bodyMaybe <- fmap (lookupUniqMap (varName f)) $ Lens.use bindings
       case bodyMaybe of
-        Just (Binding _ sp inl bodyTm) -> do
+        Just (Binding _ sp inl _ bodyTm) -> do
           -- Determine if we see a sequence of specialisations on a growing argument
           specHistM <- lookupUniqMap f <$> Lens.use (extra.specHistLbl)
           specLim   <- Lens.use (extra . specLimitLbl)


### PR DESCRIPTION
In the partial evaluator, it is important to be able to fallback
to the core unfolding for a primitive without an explicit rule.
However, these primitives are marked as NOINLINE in source, meaning
the evaluator will refuse to inline them.

Rather than ignoring INLINE pragmas, we track whether a binding
refers to a primitive with a known implementation. If this is true,
the evaluator can use the core unfolding. The change to the
evaluator is not made in this commit.