### PR TITLE
Fix msb for large types

### DIFF
--- a/changelog/2020-09-09T17_35_35+02_00_fix_large_msb
+++ b/changelog/2020-09-09T17_35_35+02_00_fix_large_msb
@@ -1,0 +1,4 @@
+FIXED: Fix `msb` for large types
+When invoked on types larger than 64 bits it gave the wrong result when the
+value was smaller than 64 bits. Upon casual inspection, the result would seem
+to correctly be 0, but internally the resulting Bit was malformed.

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -134,7 +134,7 @@ import Data.Typeable              (Typeable, typeOf)
 import GHC.Generics               (Generic)
 import Data.Maybe                 (fromMaybe)
 import GHC.Exts
-  (Word#, Word (W#), eqWord#, int2Word#, uncheckedShiftRL#)
+  ((>#), Word#, Word (W#), eqWord#, int2Word#, uncheckedShiftRL#)
 import qualified GHC.Exts
 import GHC.Integer.GMP.Internals  (Integer (..), bigNatToWord, shiftRBigNat)
 import GHC.Natural
@@ -736,7 +736,9 @@ msb# (BV m v)
         (msbN v)
  where
   !(S# i#) = natVal (Proxy @n)
-  msbN (NatS# w)  = W# (w `uncheckedShiftRL#` (i# GHC.Exts.-# 1#))
+  msbN (NatS# w) = case (i# ># 64#) of
+    1# -> W# 0##
+    _  -> W# (w `uncheckedShiftRL#` (i# GHC.Exts.-# 1#))
   msbN (NatJ# bn) = W# (bigNatToWord (shiftRBigNat bn (i# GHC.Exts.-# 1#)))
 
 {-# NOINLINE lsb# #-}

--- a/clash-prelude/tests/Clash/Tests/BitVector.hs
+++ b/clash-prelude/tests/Clash/Tests/BitVector.hs
@@ -1,18 +1,50 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 
-module Clash.Tests.BitVector where
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
+
+module Clash.Tests.BitVector (tests, main) where
+
+import qualified Hedgehog as H
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 import Data.Proxy
 import GHC.TypeNats (KnownNat, SomeNat (..), natVal, someNatVal)
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck
 
-import Clash.Prelude (bitPattern)
+import qualified Test.Tasty.Hedgehog as H
+import qualified Test.Tasty.QuickCheck as Q
+
+import Clash.Prelude
+  (Bit, high, low, bitPattern, type (<=), type (-), natToInteger, liftA2, msb)
 import Clash.Sized.Internal.BitVector (BitVector (..))
 
 import Clash.Tests.SizedNum
+
+-- | Generates a BitVector either with the MSB set or not, and checks whether
+-- 'msb' agrees with it.
+msbTest :: forall n. (1 <= n, KnownNat n) => H.Property
+msbTest = H.property $ do
+  (bv, b) <- H.forAll msbGen
+  b H.=== msb bv
+ where
+  msbGen :: H.Gen (BitVector n, Bit)
+  msbGen = Gen.choice
+    [ liftA2 (,) msbSetGen (Gen.constant high)
+    , liftA2 (,) msbUnsetGen (Gen.constant low) ]
+
+  msbSetGen :: H.Gen (BitVector n)
+  msbSetGen = Gen.integral (Range.linear (2^natToInteger @(n-1)) maxBound)
+
+  msbUnsetGen :: H.Gen (BitVector n)
+  msbUnsetGen = Gen.integral (Range.linear 0 (pred (2^natToInteger @(n-1))))
 
 test1 :: BitVector 8 -> Int
 test1 =
@@ -25,7 +57,7 @@ test1 =
     _                        -> 5  -- To keep exhaustiveness checker happy
 
 tests :: TestTree
-tests = localOption (QuickCheckMaxRatio 2) $ testGroup "All"
+tests = localOption (Q.QuickCheckMaxRatio 2) $ testGroup "All"
   [ testGroup
     "bitPattern"
     [ testCase "case0-0" $ test1 0b00000000 @?= 0
@@ -39,19 +71,19 @@ tests = localOption (QuickCheckMaxRatio 2) $ testGroup "All"
     , testCase "case3-2" $ test1 0b11010110 @?= 4
     ]
   , testGroup "BitVector 1" $
-      testProperty "fromInteger"
+      Q.testProperty "fromInteger"
         (fromIntegerProp (Proxy :: Proxy 1)) :
       map lawsToTest (laws1 (Proxy :: Proxy (BitVector 1)))
   , testGroup "BitVector 21" $
-      testProperty "fromInteger"
+      Q.testProperty "fromInteger"
         (fromIntegerProp (Proxy :: Proxy 21)) :
       map lawsToTest (laws (Proxy :: Proxy (BitVector 21)))
   , testGroup "BitVector 83" $
-      testProperty "fromInteger"
+      Q.testProperty "fromInteger"
         (fromIntegerProp (Proxy :: Proxy 83)) :
       map lawsToTest (laws (Proxy :: Proxy (BitVector 83)))
   , testGroup "Random BitVector"
-    [ testProperty "fromInteger" fromIntegerRandomProp ]
+    [ Q.testProperty "fromInteger" fromIntegerRandomProp ]
   , testGroup "Enum"
     [ testCase "[4,3..]" $ [4,3..] @?= [4,3,2,1,0 :: BitVector 8]
     , testCase "[4,2..]" $ [4,2..] @?= [4,2,0 :: BitVector 8]
@@ -63,14 +95,32 @@ tests = localOption (QuickCheckMaxRatio 2) $ testGroup "All"
     [ testCase "maxBound :: BitVector 0" $ maxBound @(BitVector 0) @?= 0
     , testCase "minBound :: BitVector 0" $ minBound @(BitVector 0) @?= 0
     ]
+  , testGroup "MSB"
+    [ H.testProperty "msb @(BitVector 1)" (msbTest @1)
+    , H.testProperty "msb @(BitVector 2)" (msbTest @2)
+    , H.testProperty "msb @(BitVector 3)" (msbTest @3)
+    , H.testProperty "msb @(BitVector 37)" (msbTest @37)
+    , H.testProperty "msb @(BitVector 64)" (msbTest @64)
+    , H.testProperty "msb @(BitVector 128)" (msbTest @128)
+    , H.testProperty "msb @(BitVector 129)" (msbTest @129)
+    ]
   ]
 
-fromIntegerProp :: forall m. KnownNat m => Proxy m -> Integer -> Property
-fromIntegerProp p n = unsafeToNatural m === fromInteger (n `mod` (2 ^ toInteger (natVal p)))
+fromIntegerProp :: forall m. KnownNat m => Proxy m -> Integer -> Q.Property
+fromIntegerProp p n = unsafeToNatural m Q.=== fromInteger (n `mod` (2 ^ toInteger (natVal p)))
   where
     m :: BitVector m
     m = fromInteger n
 
-fromIntegerRandomProp :: Positive Integer -> Integer -> Property
-fromIntegerRandomProp (Positive m) n = m > 1 ==> case someNatVal (fromInteger m) of
+fromIntegerRandomProp :: Q.Positive Integer -> Integer -> Q.Property
+fromIntegerRandomProp (Q.Positive m) n = m > 1 Q.==> case someNatVal (fromInteger m) of
   SomeNat p -> fromIntegerProp p n
+
+-- Run with:
+--
+--    ./repld p:tests -T Clash.Tests.BitVector.main
+--
+-- Add -W if you want to run tests in spite of warnings
+--
+main :: IO ()
+main = defaultMain tests


### PR DESCRIPTION
`msb` would misbehave when operating on smallish values in large types:
for types with more than 64 bits, it would do `uncheckedShiftRL#` with a
shift length more than 63, which gives undefined, and indeed
undesired results.