### PR TITLE
`caseCon` and the evaluator recognise `errorX` as bottom

### DIFF
--- a/changelog/2020-09-10T12_23_16+02_00_fix1507
+++ b/changelog/2020-09-10T12_23_16+02_00_fix1507
@@ -1,0 +1,1 @@
+FIXED: Can't use `undefined` as reset value for `autoReg@Maybe` [#1507](https://github.com/clash-lang/clash-compiler/issues/1507)

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -103,7 +103,8 @@ import {-# SOURCE #-} Clash.GHC.Evaluator
 
 isUndefinedPrimVal :: Value -> Bool
 isUndefinedPrimVal (PrimVal (PrimInfo{primName}) _ _) =
-  primName == "Clash.Transformations.undefined"
+  primName `elem` ["Clash.Transformations.undefined"
+                  ,"Clash.XException.errorX"]
 isUndefinedPrimVal _ = False
 
 -- | Evaluation of primitive operations.

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -610,6 +610,10 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
                                 , "EmptyCase"] ->
         let e1 = mkApps (mkTicks (Prim pInfo) ticks) [Right ty]
         in changed e1
+      (Prim pInfo,_:callStack:msg:_,_)
+        | primName pInfo == "Clash.XException.errorX"
+        -> let e1 = mkApps (Prim pInfo) [Right ty,callStack,msg]
+            in changed e1
       -- WHNF of subject is non of the above, so either a variable reference,
       -- or a primitive for which the evaluator doesn't have any evaluation
       -- rules.

--- a/tests/shouldwork/AutoReg/T1507.hs
+++ b/tests/shouldwork/AutoReg/T1507.hs
@@ -1,0 +1,9 @@
+module T1507 where
+
+import Clash.Prelude
+
+topEntity ::
+  SystemClockResetEnable =>
+  Signal System (Maybe Int) ->
+  Signal System (Maybe Int)
+topEntity = autoReg  (errorX "foo bar")

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -251,6 +251,7 @@ runClashTest = defaultMain $ clashTestRoot
     , clashTestGroup "shouldwork"
       [ clashTestGroup "AutoReg"
         [ NEEDS_PRIMS(outputTest ("tests" </> "shouldwork" </> "AutoReg") allTargets [] [] "AutoReg" "main")
+        , NEEDS_PRIMS(runTest "T1507" def{hdlSim=False})
         ]
       , clashTestGroup "Basic"
         [ NEEDS_PRIMS(runTest "AES" def{hdlSim=False})


### PR DESCRIPTION
Fixes #1507