### PR TITLE
Ensure wrappers for `delay#` and `register#` are always inlined

### DIFF
--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -563,6 +563,7 @@ enable
   -> Enable dom
 enable e0 e1 =
   toEnable (fromEnable e0 .&&. e1)
+{-# INLINE enable #-}
 
 -- | Special version of 'delay' that doesn't take enable signals of any kind.
 -- Initial value will be undefined.
@@ -572,8 +573,8 @@ dflipflop
   => Clock dom
   -> Signal dom a
   -> Signal dom a
-dflipflop clk i =
-  delay
+dflipflop = \clk i ->
+  delay#
     clk
     (toEnable (pure True))
     (deepErrorX "First value of dflipflop undefined")
@@ -616,8 +617,8 @@ delayMaybe
   -- ^ Initial value
   -> Signal dom (Maybe a)
   -> Signal dom a
-delayMaybe clk gen dflt i =
-  delayEn clk gen dflt (isJust <$> i) (fromJustX <$> i)
+delayMaybe = \clk gen dflt i ->
+  delay# clk (enable gen (isJust <$> i)) dflt (fromJustX <$> i)
 {-# INLINE delayMaybe #-}
 
 -- | Version of 'delay' that only updates when its third argument is asserted.
@@ -639,8 +640,8 @@ delayEn
   -- ^ Enable
   -> Signal dom a
   -> Signal dom a
-delayEn clk gen dflt en i =
-  delay clk (enable gen en) dflt i
+delayEn = \clk gen dflt en i ->
+  delay# clk (enable gen en) dflt i
 {-# INLINE delayEn #-}
 
 -- | \"@'register' clk rst i s@\" delays the values in 'Signal' /s/ for one
@@ -662,7 +663,7 @@ register
   -- will also be the initial value.
   -> Signal dom a
   -> Signal dom a
-register clk rst gen initial i =
+register = \clk rst gen initial i ->
   register# clk rst gen initial initial i
 {-# INLINE register #-}
 
@@ -701,8 +702,8 @@ regMaybe
   -- will also be the initial value.
   -> Signal dom (Maybe a)
   -> Signal dom a
-regMaybe clk rst en initial iM =
-  register clk rst (enable en (fmap isJust iM)) initial (fmap fromJustX iM)
+regMaybe = \clk rst en initial iM ->
+  register# clk rst (enable en (fmap isJust iM)) initial initial (fmap fromJustX iM)
 {-# INLINE regMaybe #-}
 
 -- | Version of 'register' that only updates its content when its fourth
@@ -736,8 +737,8 @@ regEn
   -- ^ Enable signal
   -> Signal dom a
   -> Signal dom a
-regEn clk rst gen initial en i =
-  register clk rst (enable gen en) initial i
+regEn = \clk rst gen initial en i ->
+  register# clk rst (enable gen en) initial initial i
 {-# INLINE regEn #-}
 
 -- * Simulation functions

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -1308,7 +1308,7 @@ delay
   -> Signal dom a
   -- ^ Signal to delay
   -> Signal dom a
-delay dflt i =
+delay = \dflt i ->
   delay#
     (fromLabel @(HiddenClockName dom))
     (fromLabel @(HiddenEnableName dom))
@@ -1331,7 +1331,7 @@ delayMaybe
   -- ^ Initial value
   -> Signal dom (Maybe a)
   -> Signal dom a
-delayMaybe dflt i =
+delayMaybe = \dflt i ->
   E.delayMaybe
     (fromLabel @(HiddenClockName dom))
     (fromLabel @(HiddenEnableName dom))
@@ -1356,7 +1356,7 @@ delayEn
   -- ^ Enable
   -> Signal dom a
   -> Signal dom a
-delayEn dflt en i =
+delayEn = \dflt en i ->
   E.delayEn
     (fromLabel @(HiddenClockName dom))
     (fromLabel @(HiddenEnableName dom))
@@ -1380,7 +1380,7 @@ register
   -- initial value.
   -> Signal dom a
   -> Signal dom a
-register i s =
+register = \i s ->
   E.register
     (fromLabel @(HiddenClockName dom))
     (fromLabel @(HiddenResetName dom))
@@ -1421,7 +1421,7 @@ regMaybe
   -- initial value.
   -> Signal dom (Maybe a)
   -> Signal dom a
-regMaybe initial iM =
+regMaybe = \initial iM ->
   E.regMaybe
     (fromLabel @(HiddenClockName dom))
     (fromLabel @(HiddenResetName dom))
@@ -1456,7 +1456,7 @@ regEn
   -> Signal dom Bool
   -> Signal dom a
   -> Signal dom a
-regEn initial en i =
+regEn = \initial en i ->
   E.regEn
     (fromLabel @(HiddenClockName dom))
     (fromLabel @(HiddenResetName dom))


### PR DESCRIPTION
I noticed that Clash was specialising `Explicit.register` too many times during a project, which meant that GHC didn't inline it. Moving formal arguments to lamda's should mean GHC always inlines the definitions of `Explicit.register` and friends.