### PR TITLE
Add a "high-speed" version of `autoReg`

### DIFF
--- a/changelog/2020-09-16T17_04_14+02_00_autoreghs
+++ b/changelog/2020-09-16T17_04_14+02_00_autoreghs
@@ -1,0 +1,1 @@
+FEATURE: Added `autoRegHS`, a "high-speed" version of `autoReg` that still turns registers of products into products of registers, but no longer uses tag bits to control the enable of the value bits, thus decreasing the logic depth in what might potentially be the critical path.


### PR DESCRIPTION
This still splits registers of products into products of registers, but it no longer uses the tag bit to control the enable lines of the registers holding the value bits. This decreases the logic depth, thus shortening the potential critical path, at the cost of power, since the fields bit can freely toggle.