### PR TITLE
Use the exact component corresponding to the topEntity

### DIFF
--- a/changelog/2020-09-28T12_23_22+02_00_fix1533
+++ b/changelog/2020-09-28T12_23_22+02_00_fix1533
@@ -1,0 +1,1 @@
+FIXED: Clash generates manifest and sdc file for the wrong function [#1533](https://github.com/clash-lang/clash-compiler/issues/1533)

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -95,7 +95,7 @@ import           Clash.Core.Util                  (shouldSplit)
 import           Clash.Core.Var
   (Id, varName, varUniq, varType)
 import           Clash.Core.VarEnv
-  (elemVarEnv, emptyVarEnv, lookupVarEnv)
+  (VarEnv, elemVarEnv, eltsVarEnv, emptyVarEnv, lookupVarEnv, lookupVarEnv')
 import           Clash.Debug                      (debugIsOn)
 import           Clash.Driver.Types
 import           Clash.Edalize.Edam
@@ -436,7 +436,7 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
       putStrLn $ "Clash: Netlist generation took " ++ normNetDiff
 
       -- 3. Generate topEntity wrapper
-      let topComponent = view _4 . head $ filter (Data.Text.isSuffixOf topNm . componentName . view _4) netlist
+      let topComponent = view _4 (lookupVarEnv' netlist topEntity)
           (hdlDocs,manifest',dfiles,mfiles) = createHDL hdlState' (Data.Text.pack modName) seen' netlist domainConfs (Just topComponent)
                                    (topNm, Right manifest)
       mapM_ (writeHDL dir) hdlDocs
@@ -746,7 +746,7 @@ createHDL
   -- ^ Module hierarchy root
   -> HashMap Identifier Word
   -- ^ Component names
-  -> [([Bool],SrcSpan,HashMap Identifier Word,Component)]
+  -> VarEnv ([Bool],SrcSpan,HashMap Identifier Word,Component)
   -- ^ List of components
   -> HashMap Data.Text.Text VDomainConfiguration
   -- ^ Known domains to configurations
@@ -762,7 +762,11 @@ createHDL
   -- + The update manifest file
   -- + The data files that need to be copied
 createHDL backend modName seen components domainConfs mtop (topName,manifestE) = flip evalState backend $ getMon $ do
-  (hdlNmDocs,incs) <- unzip <$> mapM (\(_wereVoids,sp,ids,comp) -> genHDL modName sp (HashMap.unionWith max seen ids) comp) components
+  let componentsL = eltsVarEnv components
+  (hdlNmDocs,incs) <-
+    unzip <$> mapM (\(_wereVoids,sp,ids,comp) ->
+                      genHDL modName sp (HashMap.unionWith max seen ids) comp)
+              componentsL
   hwtys <- HashSet.toList <$> extractTypes <$> Mon get
   typesPkg <- mkTyPackage modName hwtys
   dataFiles <- Mon getDataFiles
@@ -789,7 +793,7 @@ createHDL backend modName seen components domainConfs mtop (topName,manifestE) =
       let topOutNames = map (fst . (\(_,x,_) -> x)) (outputs top)
       topOutTypes <- mapM (fmap (Text.toStrict . renderOneLine) .
                            hdlType (External topName) . snd . (\(_,x,_) -> x)) (outputs top)
-      let compNames = map (componentName . view _4) components
+      let compNames = map (componentName . view _4) componentsL
       return (m { portInNames    = topInNames
                 , portInTypes    = topInTypes
                 , portOutNames   = topOutNames

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -67,7 +67,7 @@ import           Clash.Core.TyCon                 (TyConMap)
 import           Clash.Core.Util                  (splitShouldSplit)
 import           Clash.Core.Var                   (Id, Var (..), isGlobalId)
 import           Clash.Core.VarEnv
-  (VarEnv, eltsVarEnv, emptyInScopeSet, emptyVarEnv, extendVarEnv, lookupVarEnv,
+  (VarEnv, emptyInScopeSet, emptyVarEnv, extendVarEnv, lookupVarEnv,
    lookupVarEnv', mkVarEnv)
 import           Clash.Driver.Types               (BindingMap, Binding(..), ClashOpts (..))
 import           Clash.Netlist.BlackBox
@@ -116,12 +116,12 @@ genNetlist
   -- ^ Component name prefix
   -> Id
   -- ^ Name of the @topEntity@
-  -> IO ([([Bool],SrcSpan,HashMap Identifier Word,Component)],HashMap Identifier Word)
+  -> IO (VarEnv ([Bool],SrcSpan,HashMap Identifier Word,Component),HashMap Identifier Word)
 genNetlist isTb opts reprs globals tops primMap tcm typeTrans iw mkId extId ite be seen env prefixM topEntity = do
   (_,s) <- runNetlistMonad isTb opts reprs globals topEntityMap
              primMap tcm typeTrans iw mkId extId ite be seen env prefixM $
              genComponent topEntity
-  return ( eltsVarEnv $ _components s
+  return ( _components s
          , _seenComps s
          )
   where

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -30,6 +30,7 @@ import           Clash.Core.Name
 import           Clash.Core.TyCon
 import           Clash.Core.Type
 import           Clash.Core.Var
+import           Clash.Core.VarEnv
 import           Clash.Driver as Driver
 import           Clash.Driver.Types
 
@@ -112,7 +113,7 @@ runToNetlistStage target f src = do
 #endif
           teNames opts supplyN te
 
-  fmap (force . fst) $ netlistFrom (transformedBindings, tcm, tes, pm, reprs, te)
+  fmap (force . eltsVarEnv . fst) $ netlistFrom (transformedBindings, tcm, tes, pm, reprs, te)
  where
   backend = mkBackend target
   opts = f mkClashOpts


### PR DESCRIPTION
Code archeology didn't really explain why we ever used `isSuffixOf` to find the component. I think it's some relic of when we had less control over naming, or perhaps at some point we included the full hierarchy...
Regardless, I think this is the proper solution.

Fixes #1533