### PR TITLE
Add 'Clash.Primitives.DSL.{de}constructProduct'

### DIFF
--- a/changelog/2020-09-28T13_36_27+02_00_construct_deconstruct_product
+++ b/changelog/2020-09-28T13_36_27+02_00_construct_deconstruct_product
@@ -1,0 +1,1 @@
+ADDED: Added 'constructProduct' and 'deconstructProduct' in "Clash.Primitives.DSL". Like 'tuple' and 'untuple', but on arbitrary product types.


### PR DESCRIPTION
Added 'constructProduct' and 'deconstructProduct' in "Clash.Primitives.DSL". Like 'tuple' and 'untuple', but on arbitrary product types.