### PR TITLE
Grouping and binding in bitPattern

### DIFF
--- a/changelog/2020-10-04T14_58_28+02_00_bitPattern_binding
+++ b/changelog/2020-10-04T14_58_28+02_00_bitPattern_binding
@@ -1,0 +1,1 @@
+CHANGED: Added more patterns to bitPattern [#1545](https://github.com/clash-lang/clash-compiler/pull/1545)

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -1140,8 +1140,8 @@ bitPattern s = [p| ((\_x -> $preprocess) -> $tuple) |]
       | C.isAlpha c && C.isLower c =
         ( succ i
         , Nothing:b
-        , M.alter (Just . maybe [i] (i:)) c n
+        , M.alter (Just . (i:) . fromMaybe []) c n
         )
       | otherwise = error $
         "Invalid bit pattern: " ++ show c ++
-        ", expecting one of '0', '1', '.', '_', or a lower case alphabetic character"
+        ", expecting one of '0', '1', '.', '_', or a lowercase alphabetic character"

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -1091,22 +1091,28 @@ fromBits = L.foldl (\v b -> v `shiftL` 1 .|. fromIntegral b) 0
 -- pattern. The scrutinee can be any type that is an instance of the
 -- 'Num', 'Bits' and 'Eq' typeclasses.
 --
--- The bit pattern is specified by a string which contains @\'0\'@ or
--- @\'1\'@ for matching a bit, or @\'.\'@ for bits which are not matched.
+-- The bit pattern is specified by a string which contains:
+-- 
+--   * @\'0\'@ or @\'1\'@ for matching a bit
+--
+--   * @\'.\'@ for bits which are not matched (wildcard)
+--
+--   * @\'_\'@ can be used as a separator similar to the NumericUnderscores
+--   language extension
 --
 -- The following example matches a byte against two bit patterns where
 -- some bits are relevant and others are not:
 --
 -- @
 --   decode :: Unsigned 8 -> Maybe Bool
---   decode $(bitPattern "00...110") = Just True
---   decode $(bitPattern "10..0001") = Just False
+--   decode $(bitPattern "00.._.110") = Just True
+--   decode $(bitPattern "10.._0001") = Just False
 --   decode _ = Nothing
 -- @
 bitPattern :: String -> Q Pat
 bitPattern s = [p| (($mask .&.) -> $target) |]
   where
-    bs = parse <$> s
+    bs = parse <$> filter (/= '_') s
 
     mask = litE . IntegerL . fromBits $ maybe 0 (const 1) <$> bs
     target = litP . IntegerL . fromBits $ fromMaybe 0 <$> bs

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -1094,7 +1094,7 @@ fromBits = L.foldl (\v b -> v `shiftL` 1 .|. fromIntegral b) 0
 -- 'Num', 'Bits' and 'Eq' typeclasses.
 --
 -- The bit pattern is specified by a string which contains:
--- 
+--
 --   * @\'0\'@ or @\'1\'@ for matching a bit
 --
 --   * @\'.\'@ for bits which are not matched (wildcard)

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -146,7 +146,7 @@ import GHC.Prim                   (dataToTag#)
 import GHC.Stack                  (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits               (KnownNat, Nat, type (+), type (-), natVal)
 import GHC.TypeLits.Extra         (Max)
-import Language.Haskell.TH        (Q, TExp, TypeQ, appT, conT, litT, numTyLit, sigE, Lit(..), litE, Pat, litP)
+import Language.Haskell.TH        (Lit (..), Pat, Q, TExp, TypeQ, appT, conT, litE, litP, litT, mkName, numTyLit, sigE, tupE, tupP, varP)
 import Language.Haskell.TH.Syntax (Lift(..))
 #if MIN_VERSION_template_haskell(2,16,0)
 import Language.Haskell.TH.Compat
@@ -167,7 +167,9 @@ import Clash.Sized.Internal.Mod
 
 import {-# SOURCE #-} qualified Clash.Sized.Vector         as V
 import {-# SOURCE #-} qualified Clash.Sized.Internal.Index as I
+import                qualified Data.Char                  as C
 import                qualified Data.List                  as L
+import                qualified Data.Map.Strict            as M
 
 #include "MachDeps.h"
 
@@ -1100,24 +1102,46 @@ fromBits = L.foldl (\v b -> v `shiftL` 1 .|. fromIntegral b) 0
 --   * @\'_\'@ can be used as a separator similar to the NumericUnderscores
 --   language extension
 --
+--   * lowercase alphabetical characters can be used to bind some bits to variables.
+--   For example @"0aab11bb"@ will bind two variables @aa :: BitVector 2@ and
+--   @bbb :: BitVector 3@ with their values set by the corresponding bits
+--
 -- The following example matches a byte against two bit patterns where
--- some bits are relevant and others are not:
+-- some bits are relevant and others are not while binding two variables @aa@
+-- and @bb@:
 --
 -- @
 --   decode :: Unsigned 8 -> Maybe Bool
 --   decode $(bitPattern "00.._.110") = Just True
 --   decode $(bitPattern "10.._0001") = Just False
+--   decode $(bitPattern "aa.._b0b1") = Just (aa + bb > 1)
 --   decode _ = Nothing
 -- @
 bitPattern :: String -> Q Pat
-bitPattern s = [p| (($mask .&.) -> $target) |]
+bitPattern s = [p| ((\_x -> $preprocess) -> $tuple) |]
   where
-    bs = parse <$> filter (/= '_') s
+    (_, bs, M.toList -> ns) = L.foldr parse (0, [], M.empty) $ filter (/= '_') s
+
+    var c is = varP . mkName $ L.replicate (length is) c
+    bitSelect i = [e| if testBit _x $(litE $ IntegerL i) then pack# high else pack# low |]
+    varSelect is = L.foldr1 (\a b -> [e| $a ++# $b |]) (bitSelect <$> is)
 
     mask = litE . IntegerL . fromBits $ maybe 0 (const 1) <$> bs
+    maskE = [e| $mask .&. _x |]
     target = litP . IntegerL . fromBits $ fromMaybe 0 <$> bs
 
-    parse '.' = Nothing
-    parse '0' = Just 0
-    parse '1' = Just 1
-    parse c = error $ "Invalid bit pattern: " ++ show c
+    preprocess = tupE $ maskE : (varSelect . snd <$> ns)
+    tuple = tupP $ target : (uncurry var <$> ns)
+
+    parse '.' (i, b, n) = (succ i, Nothing:b, n)
+    parse '0' (i, b, n) = (succ i, Just 0:b, n)
+    parse '1' (i, b, n) = (succ i, Just 1:b, n)
+    parse c (i, b, n)
+      | C.isAlpha c && C.isLower c =
+        ( succ i
+        , Nothing:b
+        , M.alter (Just . maybe [i] (i:)) c n
+        )
+      | otherwise = error $
+        "Invalid bit pattern: " ++ show c ++
+        ", expecting one of '0', '1', '.', '_', or a lower case alphabetic character"

--- a/clash-prelude/tests/Clash/Tests/BitVector.hs
+++ b/clash-prelude/tests/Clash/Tests/BitVector.hs
@@ -49,12 +49,13 @@ msbTest = H.property $ do
 test1 :: BitVector 8 -> Int
 test1 =
   \case
-    $(bitPattern "0.......") -> 0
-    $(bitPattern "01......") -> 1
-    $(bitPattern "11....01") -> 2
-    $(bitPattern "11111110") -> 3
-    $(bitPattern "........") -> 4
-    _                        -> 5  -- To keep exhaustiveness checker happy
+    $(bitPattern "0..._....") -> 0
+    $(bitPattern "01.._....") -> 1
+    $(bitPattern "11.._..01") -> 2
+    $(bitPattern "1111_1110") -> 3
+    $(bitPattern "110a_babb") -> 4 + fromIntegral aa + fromIntegral bbb
+    $(bitPattern "...._....") -> 4
+    _                         -> 5  -- To keep exhaustiveness checker happy
 
 tests :: TestTree
 tests = localOption (Q.QuickCheckMaxRatio 2) $ testGroup "All"
@@ -68,7 +69,7 @@ tests = localOption (Q.QuickCheckMaxRatio 2) $ testGroup "All"
     , testCase "case2-1" $ test1 0b11100001 @?= 2
     , testCase "case3-0" $ test1 0b11111110 @?= 3
     , testCase "case3-1" $ test1 0b11111111 @?= 4
-    , testCase "case3-2" $ test1 0b11010110 @?= 4
+    , testCase "case3-2" $ test1 0b11010110 @?= 9
     ]
   , testGroup "BitVector 1" $
       Q.testProperty "fromInteger"


### PR DESCRIPTION
This PR extends the functionality of the `bitPattern` TH pattern function.

It adds the possibility to use `_` as a spacer in a similar fashion to the `NumericUnderscores` language extension. There is no restriction as to where this spacer can be used (which is a bit looser than the language extension which doesn't allow the spacer on either end of a number `_0011` and `64_` for example).

It also adds the possibility to bind arbitrary bits to a variable of type `BitVector n` where `n` is the number of bits bound using the same character. Examples of this mechanism have been added to the docs.
Note this feature does not allow any given bit to be bound by multiple variables.

Was there anything else you wanted for this feature @martijnbastiaan @gergoerdi ?
Should I add tests/more docs/a changelog entry?

This was pretty fun to implement ! Hopefully it'll be useful for someone :sweat_smile: 

Closes #1540