### PR TITLE
Move work free checks to Clash.Rewrite.WorkFree

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -258,6 +258,7 @@ Library
                       Clash.Rewrite.Combinators
                       Clash.Rewrite.Types
                       Clash.Rewrite.Util
+                      Clash.Rewrite.WorkFree
 
                       Clash.Unique
                       Clash.Util

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -80,7 +80,8 @@ import Clash.Core.VarEnv
 import Clash.Normalize.Types (NormalizeState)
 import Clash.Rewrite.Types
 import Clash.Rewrite.Util    (mkInternalVar, mkSelectorCase,
-                              isUntranslatableType, isConstant)
+                              isUntranslatableType)
+import Clash.Rewrite.WorkFree (isConstant)
 import Clash.Unique          (lookupUniqMap)
 import Clash.Util
 

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -13,13 +13,14 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Rewrite.Types where
 
 import Control.Concurrent.Supply             (Supply, freshId)
 import Control.DeepSeq                       (NFData)
-import Control.Lens                          (use, (.=))
+import Control.Lens                          (Lens', use, (.=))
 #if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail                    (MonadFail(fail))
 #endif
@@ -49,6 +50,7 @@ import Clash.Core.Var            (Id)
 import Clash.Core.VarEnv         (InScopeSet, VarSet, VarEnv)
 import Clash.Driver.Types        (BindingMap, DebugLevel)
 import Clash.Netlist.Types       (FilteredHWType, HWMap)
+import Clash.Rewrite.WorkFree    (isWorkFree)
 import Clash.Util
 
 import Clash.Annotations.BitRepresentation.Internal (CustomReprs)
@@ -224,3 +226,11 @@ type Transform m = TransformContext -> Term -> m Term
 
 -- | A 'Transform' action in the context of the 'RewriteMonad'
 type Rewrite extra = Transform (RewriteMonad extra)
+
+-- Moved into Clash.Rewrite.WorkFree
+{-# SPECIALIZE isWorkFree
+      :: Lens' (RewriteState extra) (VarEnv Bool)
+      -> BindingMap
+      -> Term
+      -> RewriteMonad extra Bool
+  #-}

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -18,10 +18,11 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Clash.Rewrite.Util where
+module Clash.Rewrite.Util
+  ( module Clash.Rewrite.Util
+  , module Clash.Rewrite.WorkFree
+  ) where
 
-import           Control.Monad.Extra         (andM, eitherM)
-import           Control.Monad.State.Class   (MonadState)
 import           Control.Concurrent.Supply   (splitSupply)
 import           Control.DeepSeq
 import           Control.Exception           (throw)
@@ -41,7 +42,7 @@ import           Data.Functor.Const          (Const (..))
 import           Data.List                   (group, partition, sort)
 import qualified Data.List                   as List
 import qualified Data.List.Extra             as List
-import           Data.List.Extra             (allM, partitionM)
+import           Data.List.Extra             (partitionM)
 import qualified Data.Map                    as Map
 import           Data.Maybe
 import qualified Data.Monoid                 as Monoid
@@ -70,8 +71,8 @@ import           Clash.Core.Evaluator.Types  (PureHeap, whnf')
 #endif
 
 import           Clash.Core.FreeVars
-  (freeLocalVars, hasLocalFreeVars, localIdDoesNotOccurIn, localIdOccursIn,
-   typeFreeVars, termFreeVars', freeLocalIds, globalIdOccursIn)
+  (freeLocalVars, localIdDoesNotOccurIn, localIdOccursIn,
+   typeFreeVars, termFreeVars', freeLocalIds)
 import           Clash.Core.Name
 import           Clash.Core.Pretty           (showPpr)
 import           Clash.Core.Subst
@@ -83,11 +84,11 @@ import           Clash.Core.TyCon
 import           Clash.Core.Type             (KindOrType, Type (..),
                                               TypeView (..), coreView1,
                                               normalizeType,
-                                              typeKind, tyView, isPolyFunTy)
+                                              typeKind, tyView)
 import           Clash.Core.Util
-  (dataConInstArgTysE, isClockOrReset, isEnable)
+  (dataConInstArgTysE)
 import           Clash.Core.Var
-  (Id, IdScope (..), TyVar, Var (..), isLocalId, mkGlobalId, mkLocalId, mkTyVar)
+  (Id, IdScope (..), TyVar, Var (..), mkGlobalId, mkLocalId, mkTyVar)
 import           Clash.Core.VarEnv
   (InScopeSet, VarEnv, elemVarSet, extendInScopeSetList, mkInScopeSet,
    uniqAway, uniqAway', mapVarEnv, eltsVarEnv, unitVarSet, emptyVarEnv,
@@ -98,6 +99,7 @@ import           Clash.Driver.Types
 import           Clash.Netlist.Util          (representableType)
 import           Clash.Pretty                (clashPretty, showDoc)
 import           Clash.Rewrite.Types
+import           Clash.Rewrite.WorkFree
 import           Clash.Unique
 import           Clash.Util
 import qualified Clash.Util.Interpolate as I
@@ -527,140 +529,12 @@ liftAndSubsituteBinders inScope toLift toKeep body = do
     else
       go subst2 inl
 
--- | Determines whether a global binder is work free. Errors if binder does
--- not exist.
-isWorkFreeBinder
-  :: (HasCallStack, MonadState s m)
-  => Lens' s (VarEnv Bool)
-  -> BindingMap
-  -> Id
-  -> m Bool
-isWorkFreeBinder cache bndrs bndr =
-  makeCachedU bndr cache $
-    case lookupVarEnv bndr bndrs of
-      Nothing -> error ("isWorkFreeBinder: couldn't find binder: " ++ showPpr bndr)
-      Just (bindingTerm -> t) ->
-        if bndr `globalIdOccursIn` t
-        then pure False
-        else isWorkFree cache bndrs t
-
--- | Determine whether a term does any work, i.e. adds to the size of the
--- circuit. This function requires a cache (specified as a lens) to store the
--- result for querying work info of global binders.
---
-isWorkFree
-  :: (MonadState s m)
-  => Lens' s (VarEnv Bool)
-  -> BindingMap
-  -> Term
-  -> m Bool
-isWorkFree cache bndrs (collectArgs -> (fun,args)) = case fun of
-  Var i ->
-    if | isPolyFunTy (varType i) -> pure False
-       | isLocalId i -> pure True
-       | otherwise -> andM [isWorkFreeBinder cache bndrs i, allM isWorkFreeArg args]
-  Data {} -> allM isWorkFreeArg args
-  Literal {} -> pure True
-  Prim pInfo -> case primWorkInfo pInfo of
-    -- We can ignore the arguments, because this primitive outputs a constant
-    -- regardless of its arguments
-    WorkConstant -> pure True
-    WorkNever -> allM isWorkFreeArg args
-    WorkVariable -> pure (all isConstantArg args)
-    -- Things like clock or reset generator always perform work
-    WorkAlways -> pure False
-  Lam _ e -> andM [isWorkFree cache bndrs e, allM isWorkFreeArg args]
-  TyLam _ e -> andM [isWorkFree cache bndrs e, allM isWorkFreeArg args]
-  Letrec bs e ->
-    andM [isWorkFree cache bndrs e, allM (isWorkFree cache bndrs . snd) bs, allM isWorkFreeArg args]
-  Case s _ [(_,a)] ->
-    andM [isWorkFree cache bndrs s, isWorkFree cache bndrs a, allM isWorkFreeArg args]
-  Cast e _ _ ->
-    andM [isWorkFree cache bndrs e, allM isWorkFreeArg args]
-  _ ->
-    pure False
- where
-  isWorkFreeArg e = eitherM (isWorkFree cache bndrs) (pure . const True) (pure e)
-  isConstantArg = either isConstant (const True)
-
 isFromInt :: Text -> Bool
 isFromInt nm = nm == "Clash.Sized.Internal.BitVector.fromInteger##" ||
                nm == "Clash.Sized.Internal.BitVector.fromInteger#" ||
                nm == "Clash.Sized.Internal.Index.fromInteger#" ||
                nm == "Clash.Sized.Internal.Signed.fromInteger#" ||
                nm == "Clash.Sized.Internal.Unsigned.fromInteger#"
-
--- | Determine if a term represents a constant
-isConstant :: Term -> Bool
-isConstant e = case collectArgs e of
-  (Data _, args)   -> all (either isConstant (const True)) args
-  (Prim _, args) -> all (either isConstant (const True)) args
-  (Lam _ _, _)     -> not (hasLocalFreeVars e)
-  (Literal _,_)    -> True
-  _                -> False
-
-isConstantNotClockReset
-  :: Term
-  -> RewriteMonad extra Bool
-isConstantNotClockReset e = do
-  tcm <- Lens.view tcCache
-  let eTy = termType tcm e
-  if isClockOrReset tcm eTy
-     then case collectArgs e of
-        (Prim p,_) -> return (primName p == "Clash.Transformations.removedArg")
-        _ -> return False
-     else pure (isConstant e)
-
--- TODO: Remove function after using WorkInfo in 'isWorkFreeIsh'
-isWorkFreeClockOrResetOrEnable
-  :: TyConMap
-  -> Term
-  -> Maybe Bool
-isWorkFreeClockOrResetOrEnable tcm e =
-  let eTy = termType tcm e in
-  if isClockOrReset tcm eTy || isEnable tcm eTy then
-    case collectArgs e of
-      (Prim p,_) -> Just (primName p == "Clash.Transformations.removedArg")
-      (Var _, []) -> Just True
-      (Data _, []) -> Just True -- For Enable True/False
-      (Literal _,_) -> Just True
-      _ -> Just False
-  else
-    Nothing
-
--- | A conservative version of 'isWorkFree'. Is used to determine in 'bindConstantVar'
--- to determine whether an expression can be "bound" (locally inlined). While
--- binding workfree expressions won't result in extra work for the circuit, it
--- might very well cause extra work for Clash. In fact, using 'isWorkFree' in
--- 'bindConstantVar' makes Clash two orders of magnitude slower for some of our
--- test cases.
---
--- In effect, this function is a version of 'isConstant' that also considers
--- references to clocks and resets constant. This allows us to bind
--- HiddenClock(ResetEnable) constructs, allowing Clash to constant spec
--- subconstants - most notably KnownDomain. Doing that enables Clash to
--- eliminate any case-constructs on it.
-isWorkFreeIsh
-  :: Term
-  -> RewriteMonad extra Bool
-isWorkFreeIsh e = do
-  tcm <- Lens.view tcCache
-  case isWorkFreeClockOrResetOrEnable tcm e of
-    Just b -> pure b
-    Nothing ->
-      case collectArgs e of
-        (Data _, args)   -> allM isWorkFreeIshArg args
-        (Prim pInfo, args) -> case primWorkInfo pInfo of
-          WorkAlways     -> pure False -- Things like clock or reset generator always
-                                       -- perform work
-          WorkVariable   -> pure (all isConstantArg args)
-          _              -> allM isWorkFreeIshArg args
-        (Lam _ _, _)     -> pure (not (hasLocalFreeVars e))
-        (Literal _,_)    -> pure True
-        _                -> pure False
- where
-  isWorkFreeIshArg = either isWorkFreeIsh (pure . const True)
-  isConstantArg    = either isConstant (const True)
 
 inlineOrLiftBinders
   :: (LetBinding -> RewriteMonad extra Bool)

--- a/clash-lib/src/Clash/Rewrite/WorkFree.hs
+++ b/clash-lib/src/Clash/Rewrite/WorkFree.hs
@@ -1,0 +1,167 @@
+{-|
+Copyright   : (C) 2020, QBayLogic B.V.
+License     : BSD2 (see the file LICENSE)
+Maintainer  : QBayLogic B.V. <devops@qaylogic.com>
+
+Check whether a term is work free or not. This is used by transformations /
+evaluation to check whether it is possible to perform changes without
+duplicating work in the result, e.g. inlining.
+-}
+
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Clash.Rewrite.WorkFree
+  ( isWorkFree
+  , isWorkFreeClockOrResetOrEnable
+  , isWorkFreeIsh
+  , isConstant
+  , isConstantNotClockReset
+  ) where
+
+import Control.Lens (Lens')
+import Control.Monad.Extra (allM, andM, eitherM)
+import Control.Monad.State.Class (MonadState)
+import GHC.Stack (HasCallStack)
+
+import Clash.Core.FreeVars
+import Clash.Core.Pretty (showPpr)
+import Clash.Core.Term
+import Clash.Core.TermInfo
+import Clash.Core.TyCon (TyConMap)
+import Clash.Core.Type (isPolyFunTy)
+import Clash.Core.Util
+import Clash.Core.Var (Id, Var(..), isLocalId)
+import Clash.Core.VarEnv (VarEnv, lookupVarEnv)
+import Clash.Driver.Types (BindingMap, Binding(..))
+import Clash.Util (makeCachedU)
+
+-- | Determines whether a global binder is work free. Errors if binder does
+-- not exist.
+isWorkFreeBinder
+  :: (HasCallStack, MonadState s m)
+  => Lens' s (VarEnv Bool)
+  -> BindingMap
+  -> Id
+  -> m Bool
+isWorkFreeBinder cache bndrs bndr =
+  makeCachedU bndr cache $
+    case lookupVarEnv bndr bndrs of
+      Nothing -> error ("isWorkFreeBinder: couldn't find binder: " ++ showPpr bndr)
+      Just (bindingTerm -> t) ->
+        if bndr `globalIdOccursIn` t
+        then pure False
+        else isWorkFree cache bndrs t
+
+{-# INLINABLE isWorkFree #-}
+-- | Determine whether a term does any work, i.e. adds to the size of the
+-- circuit. This function requires a cache (specified as a lens) to store the
+-- result for querying work info of global binders.
+--
+isWorkFree
+  :: (MonadState s m)
+  => Lens' s (VarEnv Bool)
+  -> BindingMap
+  -> Term
+  -> m Bool
+isWorkFree cache bndrs (collectArgs -> (fun,args)) = case fun of
+  Var i ->
+    if | isPolyFunTy (varType i) -> pure False
+       | isLocalId i -> pure True
+       | otherwise -> andM [isWorkFreeBinder cache bndrs i, allM isWorkFreeArg args]
+  Data {} -> allM isWorkFreeArg args
+  Literal {} -> pure True
+  Prim pInfo -> case primWorkInfo pInfo of
+    -- We can ignore the arguments, because this primitive outputs a constant
+    -- regardless of its arguments
+    WorkConstant -> pure True
+    WorkNever -> allM isWorkFreeArg args
+    WorkVariable -> pure (all isConstantArg args)
+    -- Things like clock or reset generator always perform work
+    WorkAlways -> pure False
+  Lam _ e -> andM [isWorkFree cache bndrs e, allM isWorkFreeArg args]
+  TyLam _ e -> andM [isWorkFree cache bndrs e, allM isWorkFreeArg args]
+  Letrec bs e ->
+    andM [isWorkFree cache bndrs e, allM (isWorkFree cache bndrs . snd) bs, allM isWorkFreeArg args]
+  Case s _ [(_,a)] ->
+    andM [isWorkFree cache bndrs s, isWorkFree cache bndrs a, allM isWorkFreeArg args]
+  Cast e _ _ ->
+    andM [isWorkFree cache bndrs e, allM isWorkFreeArg args]
+  _ ->
+    pure False
+ where
+  isWorkFreeArg e = eitherM (isWorkFree cache bndrs) (pure . const True) (pure e)
+  isConstantArg = either isConstant (const True)
+
+-- | Determine if a term represents a constant
+isConstant :: Term -> Bool
+isConstant e = case collectArgs e of
+  (Data _, args)   -> all (either isConstant (const True)) args
+  (Prim _, args) -> all (either isConstant (const True)) args
+  (Lam _ _, _)     -> not (hasLocalFreeVars e)
+  (Literal _,_)    -> True
+  _                -> False
+
+isConstantNotClockReset :: TyConMap -> Term -> Bool
+isConstantNotClockReset tcm e
+  | isClockOrReset tcm eTy =
+      case fst (collectArgs e) of
+        Prim pr -> primName pr == "Clash.Transformations.removedArg"
+        _ -> False
+
+  | otherwise = isConstant e
+ where
+  eTy = termType tcm e
+
+-- TODO: Remove function after using WorkInfo in 'isWorkFreeIsh'
+isWorkFreeClockOrResetOrEnable
+  :: TyConMap
+  -> Term
+  -> Maybe Bool
+isWorkFreeClockOrResetOrEnable tcm e =
+  let eTy = termType tcm e in
+  if isClockOrReset tcm eTy || isEnable tcm eTy then
+    case collectArgs e of
+      (Prim p,_) -> Just (primName p == "Clash.Transformations.removedArg")
+      (Var _, []) -> Just True
+      (Data _, []) -> Just True -- For Enable True/False
+      (Literal _,_) -> Just True
+      _ -> Just False
+  else
+    Nothing
+
+-- | A conservative version of 'isWorkFree'. Is used to determine in 'bindConstantVar'
+-- to determine whether an expression can be "bound" (locally inlined). While
+-- binding workfree expressions won't result in extra work for the circuit, it
+-- might very well cause extra work for Clash. In fact, using 'isWorkFree' in
+-- 'bindConstantVar' makes Clash two orders of magnitude slower for some of our
+-- test cases.
+--
+-- In effect, this function is a version of 'isConstant' that also considers
+-- references to clocks and resets constant. This allows us to bind
+-- HiddenClock(ResetEnable) constructs, allowing Clash to constant spec
+-- subconstants - most notably KnownDomain. Doing that enables Clash to
+-- eliminate any case-constructs on it.
+isWorkFreeIsh
+  :: TyConMap
+  -> Term
+  -> Bool
+isWorkFreeIsh tcm e =
+  case isWorkFreeClockOrResetOrEnable tcm e of
+    Just b -> b
+    Nothing ->
+      case collectArgs e of
+        (Data _, args)     -> all isWorkFreeIshArg args
+        (Prim pInfo, args) -> case primWorkInfo pInfo of
+          WorkAlways   -> False -- Things like clock or reset generator always
+                                       -- perform work
+          WorkVariable -> all isConstantArg args
+          _            -> all isWorkFreeIshArg args
+
+        (Lam _ _, _)       -> not (hasLocalFreeVars e)
+        (Literal _,_)      -> True
+        _                  -> False
+ where
+  isWorkFreeIshArg = either (isWorkFreeIsh tcm) (const True)
+  isConstantArg    = either isConstant (const True)


### PR DESCRIPTION
Tests for work free / work freeish now belong in a separate module.
This means they can be used in the partial evaluator branch without
introducing a circular dependency in imports.

In the process of changing isWorkFreeIsh to not use RewriteMonad
it became a pure function (as it does not cache like isWorkFree).