### PR TITLE
Make sure elemExistentials only eliminates existentinals and not other tyvars

### DIFF
--- a/changelog/2020-10-16T13_02_23+02_00_only_elemExistentials_existentinals
+++ b/changelog/2020-10-16T13_02_23+02_00_only_elemExistentials_existentinals
@@ -1,0 +1,1 @@
+FIXED: Make sure elemExistentials only works on existentials, fixes [#1536](https://github.com/clash-lang/clash-compiler/issues/1536)

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -377,6 +377,7 @@ dataConInstArgTysE is0 tcm (MkData { dcArgTys, dcExtTyVars, dcUnivTyVars }) inst
     (map (substTy subst) dcArgTys)
 
  where
+  exts = mkVarSet dcExtTyVars
   go
     :: [TyVar]
     -- ^ Existentials
@@ -386,7 +387,7 @@ dataConInstArgTysE is0 tcm (MkData { dcArgTys, dcExtTyVars, dcUnivTyVars }) inst
     -- ^ Maybe ([type of non-existential])
   go exts0 args0 =
     let eqs = catMaybes (map (typeEq tcm) args0) in
-    case solveNonAbsurds tcm eqs of
+    case solveNonAbsurds tcm exts eqs of
       [] ->
         Just args0
       sols ->

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -351,7 +351,7 @@ elemExistentials (TransformContext is0 _) (Case scrut altsTy alts0) = do
     -- Eliminate free type variables if possible
     go :: InScopeSet -> TyConMap -> (Pat, Term) -> NormalizeSession (Pat, Term)
     go is2 tcm alt@(DataPat dc exts0 xs0, term0) =
-      case solveNonAbsurds tcm (altEqs tcm alt) of
+      case solveNonAbsurds tcm (mkVarSet exts0) (altEqs tcm alt) of
         -- No equations solved:
         [] -> return alt
         -- One or more equations solved:

--- a/tests/shouldwork/GADTs/T1536.hs
+++ b/tests/shouldwork/GADTs/T1536.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses, UndecidableInstances #-} -- Needed for `TypeError` only
+
+module T1536 where
+
+import Clash.Prelude
+import GHC.Types
+
+topEntity = stepsOf mysteps
+
+step1 = Step INothing (IJust ())
+step2 = Step INothing INothing
+
+mysteps :: Steps 2 'False 'False
+mysteps = step1 `More` (One $ step2)
+
+data IMaybe (isJust :: Bool) a where
+    INothing :: IMaybe 'False a
+    IJust :: a -> IMaybe 'True a
+
+class Impossible where
+    impossible :: a
+
+type family Compat post1 pre2 :: Constraint where
+    Compat 'True 'True = (TypeError ('Text "Conflict between postamble and next preamble"), Impossible)
+    Compat post1 pre2 = ()
+
+data Step pre post where
+    Step :: IMaybe pre () -> IMaybe post () -> Step pre post
+
+data Steps (l :: Nat) pre post where
+    One :: Step pre post -> Steps 1 pre post
+    More :: (Compat post1 pre2) => Step pre1 post1 -> Steps n pre2 post2 -> Steps (1 + n) pre1 post2
+
+from :: IMaybe free m -> Maybe m
+from INothing = Nothing
+from (IJust x) = Just x
+
+stepsOf :: Steps n pre post -> Vec n (Maybe ())
+stepsOf xs0 = case go xs0 of (_pre, ys) -> ys
+
+go :: Steps n pre post -> (IMaybe pre (), Vec n (Maybe ()))
+go (One (Step pre post)) = (pre, singleton (from post))
+go (More (Step pre post) xs) = case go xs of (pre', ys) -> (pre, (combine post pre') :> ys)
+
+combine :: (Compat post1 pre2) => IMaybe post1 b -> IMaybe pre2 b -> Maybe b
+combine IJust{} IJust{} = impossible
+combine INothing post = from post
+combine pre INothing = from pre

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -441,6 +441,7 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS_GHC(runTest "TailM" def)
         , NEEDS_PRIMS_GHC(runTest "TailOfTail" def)
         , NEEDS_PRIMS_GHC(runTest "T1310" def{hdlSim=False})
+        , NEEDS_PRIMS_GHC(runTest "T1536" def{hdlSim=False})
         ]
       , clashTestGroup "HOPrim"
         [ NEEDS_PRIMS_GHC(runTest "HOIdx" def)


### PR DESCRIPTION
In #1536 clash got something like:
```
(ΛboolTv ->
  case pre'[LocalId] of
    INothing (ipv :: boolTv ~ False) ->
      ...
    IJust (co1 :: boolTv ~ True) .. ->
      ... SOMETHING_IMPOSSIBLE
) @False
```

Normally `appPropFast` should propagate the applied `False` type, so that `caseElemNonReachable` can eliminate the `IJust` alternative from the case because of its absurd constraint (`False ~ True`).  
Only before they could do that, `elemExistentials` came along and tried "solved" the type equalities locally and produce:
```
(ΛboolTv ->
  case pre'[LocalId] of
    INothing (ipv :: False ~ False) ->
      ...
    IJust (co1 :: True ~ True) .. ->
      ... SOMETHING_IMPOSSIBLE
) @False
```
Making the second alternative non-absurd.
But `elemExistentials` should only be trying to solve existential tyvars, ones that are bound by GADT patterns.
This PR adds that check.

Fixes #1536