### PR TITLE
Provide mkBlackBoxContext with the correct primName

### DIFF
--- a/changelog/2020-10-19T17_58_40+02_00_fix1524
+++ b/changelog/2020-10-19T17_58_40+02_00_fix1524
@@ -1,0 +1,1 @@
+FIXED: Uses of `fold` inside of other HO prims(map,etc..) [#1524](https://github.com/clash-lang/clash-compiler/issues/1524)

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -864,7 +864,6 @@ mkFunInput resId e =
   tcm <- Lens.use tcCache
   -- TODO: Rewrite this function to use blackbox functions. Right now it
   -- TODO: generates strings that are later parsed/interpreted again. Silly!
-  (bbCtx,dcls) <- mkBlackBoxContext "__INTERNAL__" resId args
   templ <- case appE of
             Prim p -> do
               bb  <- extractPrimWarnOrFail (primName p)
@@ -1000,6 +999,10 @@ mkFunInput resId e =
               let is0 = mkInScopeSet (Lens.foldMapOf freeIds unitVarSet appE)
               either Left (Right . first (second (tickDecls ++))) <$> go is0 0 appE
             _ -> error $ $(curLoc) ++ "Cannot make function input for: " ++ showPpr e
+  let pNm = case appE of
+              Prim p -> primName p
+              _ -> "__INTERNAL__"
+  (bbCtx,dcls) <- mkBlackBoxContext pNm resId args
   case templ of
     Left (TDecl,oreg,libs,imps,inc,_,templ') -> do
       (l',templDecl)

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -202,7 +202,7 @@ data Element
   deriving (Show, Generic, NFData, Binary, Hashable)
 
 -- | Component instantiation hole. First argument indicates which function argument
--- to instantiate. Second argument corresponds to output and input assignments,
+-- to instantiate. Third argument corresponds to output and input assignments,
 -- where the first element is the output assignment, and the subsequent elements
 -- are the consecutive input assignments.
 --

--- a/tests/shouldwork/BlackBox/T1524.hs
+++ b/tests/shouldwork/BlackBox/T1524.hs
@@ -1,0 +1,29 @@
+module T1524 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity :: Vec 2 (Vec 3 Int) -> Vec 2 Int
+topEntity = f @2 @(3-1)
+{-# NOINLINE topEntity #-}
+
+f :: Vec k (Vec (l+1) Int) -> Vec k Int
+f input = map g input
+
+g :: Vec (l+1) Int -> Int
+g = fold (+)
+
+case1 :: Vec 2 (Vec 3 Int)
+case1 = (1 :> 2 :> 3 :> Nil) :> (10 :> 20 :> 30 :> Nil) :> Nil
+case2 = (-1 :> -2 :> -3 :> Nil) :> (10 :> -20 :> 30 :> Nil) :> Nil
+
+input = case1 :> case2 :> Nil
+expected = (6 :> 60 :> Nil) :> (-6 :> 20 :> Nil) :> Nil
+
+testBench :: Signal System Bool
+testBench = done
+ where
+  done = outputVerifier' clk aclr expected (topEntity <$> inp)
+  clk  = tbSystemClockGen (not <$> done)
+  inp  = stimuliGenerator clk aclr input
+  aclr = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -356,6 +356,7 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "Signal") allTargets [] [] "BlockRamLazy" "main")
         , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "ZeroWidth"          "main"
         , NEEDS_PRIMS(runTest "T919" def{hdlSim=False})
+        , NEEDS_PRIMS(runTest "T1524" def)
         ]
       , clashTestGroup "BoxedFunctions"
         [ runTest "DeadRecursiveBoxed" def{hdlSim=False}


### PR DESCRIPTION
Fixes #1524

    map (fold f) ...

Would fail to generate the netlist because:
 1. `mkBlackBoxContext` for `fold` would be called  with `"__INTERNAL__"` as name
 2. this  would cause  `funcPlurality` to default to 1
 3. and thus not enough copies of `f` would be pre-rendered
 4. causing the rendering of `fold` to fail: "not enough functions rendered"