### PR TITLE
Non TH 'fromList' and 'unsafeFromList' for Vec.

### DIFF
--- a/changelog/2020-10-28T15_51_30+01_00_vector_fromlist.md
+++ b/changelog/2020-10-28T15_51_30+01_00_vector_fromlist.md
@@ -1,0 +1,6 @@
+ADDED: Non TH 'fromList' and 'unsafeFromList' for Vec.
+
+These functions allow Vectors to be created from a list without needing to
+use template haskell, which is not always desirable. The unsafe version of the
+function does not compare the length of the list to the desired length of the
+vector, either truncating or padding with undefined if the lengths differ.

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -168,7 +168,7 @@ import Clash.Sized.Index
 import Clash.Sized.RTree
 import Clash.Sized.Signed
 import Clash.Sized.Unsigned
-import Clash.Sized.Vector
+import Clash.Sized.Vector hiding (fromList, unsafeFromList)
 import Clash.XException
 
 {- $setup

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -132,7 +132,7 @@ import Clash.Sized.Index
 import Clash.Sized.RTree
 import Clash.Sized.Signed
 import Clash.Sized.Unsigned
-import Clash.Sized.Vector
+import Clash.Sized.Vector hiding (fromList, unsafeFromList)
 import Clash.XException
 
 {- $setup
@@ -246,4 +246,3 @@ oscillate clk rst en begin SNat =
       then (0,   not i) -- reset state and oscillate output
       else (s+1, i)     -- hold current output
 {-# INLINEABLE oscillate #-}
-

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -194,7 +194,7 @@ import           Clash.Sized.Index
 import           Clash.Sized.RTree
 import           Clash.Sized.Signed
 import           Clash.Sized.Unsigned
-import           Clash.Sized.Vector
+import           Clash.Sized.Vector hiding (fromList, unsafeFromList)
 import           Clash.Signal
 import           Clash.Signal.Delayed
 import           Clash.Signal.Trace

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -146,7 +146,7 @@ import           Clash.Sized.Index
 import           Clash.Sized.RTree
 import           Clash.Sized.Signed
 import           Clash.Sized.Unsigned
-import           Clash.Sized.Vector
+import           Clash.Sized.Vector hiding (fromList, unsafeFromList)
 import           Clash.Signal
 import           Clash.Signal.Delayed
 import           Clash.XException


### PR DESCRIPTION
These functions allow Vectors to be created from a list without needing to
use template haskell, which is not always desirable. The unsafe version of the
function does not compare the length of the list to the desired length of the
vector, either truncating or padding with undefined if the lengths differ.