### PR TITLE
Allow primitives to assign to multiple results

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,2 @@
+Please do not add opiniated settings, unless they're recommended by the
+style guide.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["haskell.haskell"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+  "cSpell.words": [
+    "NOINLINE",
+    "WHNF",
+    "fmap",
+    "frontends",
+    "inlines",
+    "scrutinee",
+    "subterms"
+  ],
+  "files.exclude": {
+    "**/*.dyn_hi": true,
+    "**/*.dyn_o": true,
+    "**/*.hi": true,
+    "**/*.o": true,
+    "**/*.o-boot": true,
+    "**/*.hi-boot": true,
+    "**/dist-newstyle": true,
+    "**/.stack-work": true,
+    "**/.ghc.environment.*": true,
+    ".clash-test-tmp": true
+  },
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "editor.rulers": [
+    80,
+    90
+  ],
+  "editor.tabSize": 2
+}

--- a/changelog/2020-11-03T11_46_46+01_00_add_multireset_primitives
+++ b/changelog/2020-11-03T11_46_46+01_00_add_multireset_primitives
@@ -1,0 +1,1 @@
+ADDED: Support for multi result primitives. Primitives can now assign their results to multiple variables. This can help to work around synthesis tools limits in some cases. See [#1560](https://github.com/clash-lang/clash-compiler/pull/1560).

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
@@ -68,4 +68,4 @@ bbTemplate bbCtx = do
   Just compName' = exprToString intrinsicName
   compName = TextS.pack compName'
 
-  (Identifier result Nothing,_) = bbResult bbCtx
+  [(Identifier result Nothing,_)] = bbResults bbCtx

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -104,4 +104,4 @@ sbioTemplate bbCtx = do
    , (outputEnable, Bool, _)
    ] = bbInputs bbCtx
 
-  (Identifier result Nothing,resTy) = bbResult bbCtx
+  [(Identifier result Nothing,resTy)] = bbResults bbCtx

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -456,4 +456,3 @@ letSubst h acc id0 =
    where
     (i,ids') = freshId ids
     x'       = modifyVarName (`setUnique` i) x
-

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -68,7 +68,7 @@ import           Clash.Core.Name
   (Name (..), NameSort (..), mkUnsafeSystemName)
 import           Clash.Core.Pretty   (showPpr)
 import           Clash.Core.Term
-  (Pat (..), PrimInfo (..), Term (..), WorkInfo (..), mkApps)
+  (IsMultiPrim (..), Pat (..), PrimInfo (..), Term (..), WorkInfo (..), mkApps)
 import           Clash.Core.TermInfo (piResultTys, applyTypeToArgs)
 import           Clash.Core.Type
   (Type (..), ConstTy (..), LitTy (..), TypeView (..), mkFunTy, mkTyConApp,
@@ -716,7 +716,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
            mbaTy = mkFunTy intPrimTy (last tyArgs)
            newE = mkApps (Data tupDc) (map Right tyArgs ++
                     [Left (Prim rwTy)
-                    ,Left (mkApps (Prim (PrimInfo "GHC.Prim.MutableByteArray#" mbaTy WorkNever))
+                    ,Left (mkApps (Prim (PrimInfo "GHC.Prim.MutableByteArray#" mbaTy WorkNever SingleResult))
                                   [Left (Literal . IntLiteral $ toInteger p)])
                     ])
        in Just . setTerm newE $ primInsert p lit mach
@@ -2980,7 +2980,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
     , Right n <- runExcept (tyNatSize tcm nTy)
     , let iLit = mkIndexLit (Either.rights tyArgs' !! 0) nTy n 0
     -> reduceWHNF $
-       mkApps (Prim (PrimInfo "Clash.Sized.Vector.imap_go" (vecImapGoTy vecTcNm indexTcNm) WorkNever))
+       mkApps (Prim (PrimInfo "Clash.Sized.Vector.imap_go" (vecImapGoTy vecTcNm indexTcNm) WorkNever SingleResult))
               [Right nTy
               ,Right nTy
               ,Right aTy
@@ -3009,7 +3009,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
                          ,Right (LitTy (NumTy (m'-1)))
                          ,Right aTy
                          ,Right bTy
-                         ,Left (mkApps (Prim (PrimInfo "Clash.Sized.Internal.Index.+#" (indexAddTy indexTcNm) WorkVariable))
+                         ,Left (mkApps (Prim (PrimInfo "Clash.Sized.Internal.Index.+#" (indexAddTy indexTcNm) WorkVariable SingleResult))
                                        [Right nTy
                                        ,Left (Literal (NaturalLiteral n'))
                                        ,Left (valToTerm n)
@@ -3118,7 +3118,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
                   n1mTy  = LitTy (NumTy n1)
                   n1m'ty = LitTy (NumTy (n1-1))
                   splitAtCall =
-                   mkApps (Prim (PrimInfo "Clash.Sized.Vector.fold_split" (foldSplitAtTy vecTcNm) WorkNever))
+                   mkApps (Prim (PrimInfo "Clash.Sized.Vector.fold_split" (foldSplitAtTy vecTcNm) WorkNever SingleResult))
                           [Right mTy
                           ,Right n1mTy
                           ,Right aTy
@@ -3900,14 +3900,14 @@ naturalToNaturalLiteral = Literal . NaturalLiteral . toInteger
 
 bConPrim :: Type -> Term
 bConPrim (tyView -> TyConApp bTcNm _)
-  = Prim (PrimInfo "Clash.Sized.Internal.BitVector.fromInteger##" funTy WorkNever)
+  = Prim (PrimInfo "Clash.Sized.Internal.BitVector.fromInteger##" funTy WorkNever SingleResult)
   where
     funTy      = foldr1 mkFunTy [wordPrimTy,integerPrimTy,mkTyConApp bTcNm []]
 bConPrim _ = error $ $(curLoc) ++ "called with incorrect type"
 
 bvConPrim :: Type -> Term
 bvConPrim (tyView -> TyConApp bvTcNm _)
-  = Prim (PrimInfo "Clash.Sized.Internal.BitVector.fromInteger#" (ForAllTy nTV funTy) WorkNever)
+  = Prim (PrimInfo "Clash.Sized.Internal.BitVector.fromInteger#" (ForAllTy nTV funTy) WorkNever SingleResult)
   where
     funTy = foldr1 mkFunTy [naturalPrimTy,naturalPrimTy,integerPrimTy,mkTyConApp bvTcNm [nVar]]
     nName = mkUnsafeSystemName "n" 0
@@ -3917,7 +3917,7 @@ bvConPrim _ = error $ $(curLoc) ++ "called with incorrect type"
 
 indexConPrim :: Type -> Term
 indexConPrim (tyView -> TyConApp indexTcNm _)
-  = Prim (PrimInfo "Clash.Sized.Internal.Index.fromInteger#" (ForAllTy nTV funTy) WorkNever)
+  = Prim (PrimInfo "Clash.Sized.Internal.Index.fromInteger#" (ForAllTy nTV funTy) WorkNever SingleResult)
   where
     funTy        = foldr1 mkFunTy [naturalPrimTy,integerPrimTy,mkTyConApp indexTcNm [nVar]]
     nName      = mkUnsafeSystemName "n" 0
@@ -3927,7 +3927,7 @@ indexConPrim _ = error $ $(curLoc) ++ "called with incorrect type"
 
 signedConPrim :: Type -> Term
 signedConPrim (tyView -> TyConApp signedTcNm _)
-  = Prim (PrimInfo "Clash.Sized.Internal.Signed.fromInteger#" (ForAllTy nTV funTy) WorkNever)
+  = Prim (PrimInfo "Clash.Sized.Internal.Signed.fromInteger#" (ForAllTy nTV funTy) WorkNever SingleResult)
   where
     funTy        = foldr1 mkFunTy [naturalPrimTy,integerPrimTy,mkTyConApp signedTcNm [nVar]]
     nName      = mkUnsafeSystemName "n" 0
@@ -3937,7 +3937,7 @@ signedConPrim _ = error $ $(curLoc) ++ "called with incorrect type"
 
 unsignedConPrim :: Type -> Term
 unsignedConPrim (tyView -> TyConApp unsignedTcNm _)
-  = Prim (PrimInfo "Clash.Sized.Internal.Unsigned.fromInteger#" (ForAllTy nTV funTy) WorkNever)
+  = Prim (PrimInfo "Clash.Sized.Internal.Unsigned.fromInteger#" (ForAllTy nTV funTy) WorkNever SingleResult)
   where
     funTy        = foldr1 mkFunTy [naturalPrimTy,integerPrimTy,mkTyConApp unsignedTcNm [nVar]]
     nName        = mkUnsafeSystemName "n" 0
@@ -4111,7 +4111,7 @@ splitAtPrim
   -- ^ Vec TyCon name
   -> Term
 splitAtPrim snatTcNm vecTcNm =
-  Prim (PrimInfo "Clash.Sized.Vector.splitAt" (splitAtTy snatTcNm vecTcNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Vector.splitAt" (splitAtTy snatTcNm vecTcNm) WorkNever SingleResult)
 
 splitAtTy
   :: TyConName
@@ -4178,7 +4178,7 @@ vecAppendPrim
   -- ^ Vec TyCon name
   -> Term
 vecAppendPrim vecNm =
-  Prim (PrimInfo "Clash.Sized.Vector.++" (vecAppendTy vecNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Vector.++" (vecAppendTy vecNm) WorkNever SingleResult)
 
 vecAppendTy
   :: TyConName
@@ -4211,7 +4211,7 @@ vecZipWithPrim
   -- ^ Vec TyCon name
   -> Term
 vecZipWithPrim vecNm =
-  Prim (PrimInfo "Clash.Sized.Vector.zipWith" (vecZipWithTy vecNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Vector.zipWith" (vecZipWithTy vecNm) WorkNever SingleResult)
 
 vecZipWithTy
   :: TyConName
@@ -4283,7 +4283,7 @@ bvAppendPrim
   -- ^ BitVector TyCon Name
   -> Term
 bvAppendPrim bvTcNm =
-  Prim (PrimInfo "Clash.Sized.Internal.BitVector.++#" (bvAppendTy bvTcNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Internal.BitVector.++#" (bvAppendTy bvTcNm) WorkNever SingleResult)
 
 bvAppendTy
   :: TyConName
@@ -4308,7 +4308,7 @@ bvSplitPrim
   -- ^ BitVector TyCon Name
   -> Term
 bvSplitPrim bvTcNm =
-  Prim (PrimInfo "Clash.Sized.Internal.BitVector.split#" (bvSplitTy bvTcNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Internal.BitVector.split#" (bvSplitTy bvTcNm) WorkNever SingleResult)
 
 bvSplitTy
   :: TyConName

--- a/clash-ghc/src-ghc/Clash/GHC/PartialEval/Eval.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/PartialEval/Eval.hs
@@ -302,7 +302,7 @@ caseCon subject ty alts = do
           match <- findBestAlt (matchData dc args) alts
           evalAlt def match
 
-        -- Neutral primtives may be clash primtives which are treated as
+        -- Neutral primitives may be clash primitives which are treated as
         -- values, like fromInteger# for various types in clash-prelude.
         VNeutral (NePrim pr args) -> do
           let def = VNeutral (NeCase forcedSubject ty alts)
@@ -312,8 +312,8 @@ caseCon subject ty alts = do
         -- We know nothing: attempt case-of-case / case-of-let.
         _ -> tryTransformCase forcedSubject ty alts
 
--- | Attempt to apply the a transformation to a case expression to expose
--- more oppoortunities for caseCon. If no transformations can be applied the
+-- | Attempt to apply a transformation to a case expression to expose more
+-- opportunities for caseCon. If no transformations can be applied the
 -- case expression can only be neutral.
 --
 tryTransformCase :: Value -> Type -> [(Pat, Value)] -> Eval Value
@@ -337,7 +337,7 @@ tryTransformCase subject ty alts =
       newCase <- caseCon innerSubject ty alts
       pure (VNeutral (NeLetrec bindings newCase))
 
-    -- There is no way to continue evalauting the case, do nothing.
+    -- There is no way to continue evaluating the case, do nothing.
     -- TODO elimExistentials here.
     _ -> pure (VNeutral (NeCase subject ty alts))
  where

--- a/clash-ghc/src-ghc/Clash/GHC/PartialEval/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/PartialEval/Primitive.hs
@@ -3,8 +3,8 @@ Copyright   : (C) 2020, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
-Evalaution of primitive operations in the partial evaluator. This is used
-by the Clash.GHC.PartialEval.Eval module to implement fully applied primtives.
+Evaluation of primitive operations in the partial evaluator. This is used
+by the Clash.GHC.PartialEval.Eval module to implement fully applied primitives.
 -}
 
 module Clash.GHC.PartialEval.Primitive
@@ -34,7 +34,7 @@ evalPrimitive _eval pr args =
 {-
 NOTE [Evaluating primitives]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When the evalutor encounters a primtive operation with all arguments applied,
+When the evaluator encounters a primitive operation with all arguments applied,
 it will attempt to evaluate it. If this is possible, the call to the primitive
 will be replaced with the result. However, it may not be possible to evaluate
 a primitive if not all arguments are statically known (i.e. if an argument is
@@ -42,7 +42,7 @@ a variable with an unknown value). In this case, a neutral primitive is
 returned instead.
 
 Some primitives do not evaluate, and are deliberately preserved in the result
-of the evaluator as netural primitives. Notable examples of this are
+of the evaluator as neutral primitives. Notable examples of this are
 
   * GHC.CString.unpackCString#
   * Clash.Sized.Internal.BitVector.fromInteger##
@@ -55,4 +55,3 @@ Some primitives may throw exceptions (such as division by zero) or need to
 perform IO (e.g. primitives on ByteArray#). These effects are supported by the
 Eval monad, see Clash.Core.PartialEval.Monad.
 -}
-

--- a/clash-lib/prims/common/Clash_Transformations.json
+++ b/clash-lib/prims/common/Clash_Transformations.json
@@ -14,4 +14,11 @@
     , "template"  : "~ERRORO"
     }
   }
+, { "BlackBox" :
+    { "name"      : "c$multiPrimSelect"
+    , "workInfo"  : "Always"
+    , "kind"      : "Expression"
+    , "template"  : "!__SHOULD NOT BE RENDERED__! ~ARG[0]~ARG[1]"
+    }
+  }
 ]

--- a/clash-lib/src/Clash/Core/PartialEval/AsTerm.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/AsTerm.hs
@@ -82,4 +82,3 @@ argsToTerms = fmap $ first asTerm
 
 altsToTerms :: (AsTerm a) => [(Pat, a)] -> [Alt]
 altsToTerms = fmap $ second asTerm
-

--- a/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
@@ -160,7 +160,7 @@ data LocalEnv = LocalEnv
   , lenvKeepLifted :: Bool
     -- ^ When evaluating, keep data constructors for boxed data types (e.g. I#)
     -- instead of converting these back to their corresponding primitive. This
-    -- is used when evalauting terms where the result is subject of a case
+    -- is used when evaluating terms where the result is subject of a case
     -- expression (see note: lifted data types).
   } deriving (Show)
 

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -163,11 +163,11 @@ patVars _ = []
 mkAbstraction :: Term -> [Either Id TyVar] -> Term
 mkAbstraction = foldr (either Lam TyLam)
 
--- | Abstract a term over a list of term variables
+-- | Abstract a term over a list of type variables
 mkTyLams :: Term -> [TyVar] -> Term
 mkTyLams tm = mkAbstraction tm . map Right
 
--- | Abstract a term over a list of type variables
+-- | Abstract a term over a list of variables
 mkLams :: Term -> [Id] -> Term
 mkLams tm = mkAbstraction tm . map Left
 

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -418,13 +418,15 @@ dataConInstArgTys (MkData { dcArgTys, dcUnivTyVars, dcExtTyVars }) inst_tys =
 primCo
   :: Type
   -> Term
-primCo ty = Prim (PrimInfo "_CO_" ty WorkNever)
+primCo ty = Prim (PrimInfo "_CO_" ty WorkNever SingleResult)
 
 -- | Make an undefined term
 undefinedTm
   :: Type
   -> Term
-undefinedTm = TyApp (Prim (PrimInfo "Clash.Transformations.undefined" undefinedTy WorkNever))
+undefinedTm =
+  let undefinedNm = "Clash.Transformations.undefined" in
+  TyApp (Prim (PrimInfo undefinedNm  undefinedTy WorkNever SingleResult))
 
 substArgTys
   :: DataCon

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -36,7 +36,7 @@ where
 import Control.DeepSeq                  (NFData (..))
 import Data.Binary                      (Binary)
 import Data.Function                    (on)
-import Data.Hashable                    (Hashable)
+import Data.Hashable                    (Hashable(hashWithSalt))
 import GHC.Generics                     (Generic)
 import Clash.Core.Name                  (Name (..))
 import {-# SOURCE #-} Clash.Core.Term   (Term, TmName)
@@ -78,13 +78,16 @@ data Var a
   , varType :: Type
   , idScope :: IdScope
   }
-  deriving (Show,Generic,NFData,Hashable,Binary)
+  deriving (Show,Generic,NFData,Binary)
 
 -- | Gets a _key_ in the DBMS sense: a value that uniquely identifies a
 -- Var. In case of a "Var" that is its unique and (if applicable) scope
 varKey :: Var a -> (Unique, Maybe IdScope)
 varKey TyVar{varUniq} = (varUniq, Nothing)
 varKey Id{varUniq,idScope} = (varUniq, Just idScope)
+
+instance Hashable (Var a) where
+  hashWithSalt salt a = hashWithSalt salt (varKey a)
 
 instance Eq (Var a) where
   (==) = (==) `on` varKey

--- a/clash-lib/src/Clash/Debug.hs
+++ b/clash-lib/src/Clash/Debug.hs
@@ -28,4 +28,3 @@ traceWith f a = trace (f a) a
 
 traceShowWith :: Show b => (a -> b) -> a -> a
 traceShowWith f a = trace (show (f a)) a
-

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -606,7 +606,7 @@ compilePrimitive
   -> ResolvedPrimitive
   -- ^ Primitive to compile
   -> IO CompiledPrimitive
-compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf usedArgs bbGenName source) = do
+compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf usedArgs multiRes bbGenName source) = do
   bbFunc <-
     -- TODO: Use cache for hint targets. Right now Hint will fire multiple times
     -- TODO: if multiple functions use the same blackbox haskell function.
@@ -623,7 +623,7 @@ compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf usedArgs bbGenNa
           id
           r
 
-  pure (BlackBoxHaskell bbName wf usedArgs bbGenName (hash source, bbFunc))
+  pure (BlackBoxHaskell bbName wf usedArgs multiRes bbGenName (hash source, bbFunc))
  where
     fullName = qualMod ++ "." ++ funcName
     qualMod = intercalate "." modNames
@@ -657,14 +657,14 @@ compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf usedArgs bbGenNa
       loadImportAndInterpret idirs args topDir qualMod funcName "BlackBoxFunction"
 
 compilePrimitive idirs pkgDbs topDir
-  (BlackBox pNm wf rVoid tkind () oReg libM imps fPlural incs rM riM templ) = do
+  (BlackBox pNm wf rVoid multiRes tkind () oReg libM imps fPlural incs rM riM templ) = do
   libM'  <- mapM parseTempl libM
   imps'  <- mapM parseTempl imps
   incs'  <- mapM (traverse parseBB) incs
   templ' <- parseBB templ
   rM'    <- traverse parseBB rM
   riM'   <- traverse parseBB riM
-  return (BlackBox pNm wf rVoid tkind () oReg libM' imps' fPlural incs' rM' riM' templ')
+  return (BlackBox pNm wf rVoid multiRes tkind () oReg libM' imps' fPlural incs' rM' riM' templ')
  where
   iArgs = concatMap (("-package-db":) . (:[])) pkgDbs
 

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -706,7 +706,7 @@ mkExpr :: HasCallStack
        => Bool -- ^ Treat BlackBox expression as declaration
        -> DeclarationType
        -- ^ Should the returned declarations be concurrent or sequential?
-       -> NetlistId -- ^ Id to assign the result to
+       -> NetlistId -- ^ Name hint for the id to (potentially) assign the result to
        -> Term -- ^ Term to convert to an expression
        -> NetlistMonad (Expr,[Declaration]) -- ^ Returned expression and a list of generate BlackBox declarations
 mkExpr _ _ _ (stripTicks -> Core.Literal l) = do
@@ -789,7 +789,7 @@ mkProjection
   :: Bool
   -- ^ Projection must bind to a simple variable
   -> NetlistId
-  -- ^ The signal to which the projection is (potentially) assigned
+  -- ^ Name hint for the signal to which the projection is (potentially) assigned
   -> Term
   -- ^ The subject/scrutinee of the projection
   -> Type
@@ -882,7 +882,7 @@ mkDcApplication
     -- ^ HWType of the LHS of the let-binder, can multiple types when we're
     -- creating a "split" product type (e.g. a tuple of a Clock and Reset)
     -> NetlistId
-    -- ^ Id to assign the result to
+    -- ^ Name hint for result id
     -> DataCon
     -- ^ Applied DataCon
     -> [Term]

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -23,6 +23,7 @@ import           Control.Exception                (throw)
 import           Control.Lens                     ((.=))
 import qualified Control.Lens                     as Lens
 import           Control.Monad                    (join)
+import           Control.Monad.Extra              (concatMapM)
 import           Control.Monad.IO.Class           (liftIO)
 import           Control.Monad.Reader             (runReaderT)
 import           Control.Monad.State.Strict       (State, runStateT)
@@ -35,7 +36,7 @@ import qualified Data.HashMap.Lazy                as HashMap
 import           Data.List                        (elemIndex, partition, sortOn)
 import           Data.List.Extra                  (zipEqual)
 import           Data.Maybe
-  (catMaybes, listToMaybe, mapMaybe, fromMaybe)
+  (listToMaybe, mapMaybe, fromMaybe)
 import qualified Data.Set                         as Set
 import           Data.Primitive.ByteArray         (ByteArray (..))
 import qualified Data.Text                        as StrictText
@@ -57,10 +58,11 @@ import           Clash.Core.Literal               (Literal (..))
 import           Clash.Core.Name                  (Name(..))
 import           Clash.Core.Pretty                (showPpr)
 import           Clash.Core.Term
-  ( Alt, Pat (..), Term (..), TickInfo (..), PrimInfo(primName), collectArgs
-  , collectArgsTicks, collectTicks, mkApps, mkTicks, stripTicks)
+  (IsMultiPrim (..), PrimInfo (..), mpi_resultTypes,  Alt, Pat (..), Term (..),
+   TickInfo (..), collectArgs, collectArgsTicks,
+   collectTicks, mkApps, mkTicks, stripTicks)
 import qualified Clash.Core.Term                  as Core
-import           Clash.Core.TermInfo              (termType)
+import           Clash.Core.TermInfo              (multiPrimInfo', splitMultiPrimArgs, termType)
 import           Clash.Core.Type
   (Type (..), coreView1, splitFunForallTy, splitCoreFunForallTy)
 import           Clash.Core.TyCon                 (TyConMap)
@@ -247,12 +249,12 @@ genComponentT compName componentExpr = do
       Left err ->
         throw (ClashException sp ($curLoc ++ err) Nothing)
 
-  netDecls <- fmap catMaybes . mapM mkNetDecl $ filter (maybe (const True) (/=) resultM . fst) binders
+  netDecls <- concatMapM mkNetDecl (filter (maybe (const True) (/=) resultM . fst) binders)
   decls    <- concat <$> mapM (uncurry mkDeclarations) binders
 
   case resultM of
     Just result -> do
-      Just (NetDecl' _ rw _ _ rIM) <- mkNetDecl . head $ filter ((==result) . fst) binders
+      [NetDecl' _ rw _ _ rIM] <- mkNetDecl . head $ filter ((==result) . fst) binders
 
       let (compOutps',resUnwrappers') = case compOutps of
             [oport] -> ([(rw,oport,rIM)],resUnwrappers)
@@ -272,23 +274,55 @@ genComponentT compName componentExpr = do
       ids <- Lens.use seenIds
       return (wereVoids, sp, ids, component)
 
-mkNetDecl :: (Id, Term) -> NetlistMonad (Maybe Declaration)
+mkNetDecl :: (Id, Term) -> NetlistMonad [Declaration]
 mkNetDecl (id_,tm) = preserveVarEnv $ do
-  let typ             = varType id_
-  hwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) typ
-  wr   <- termToWireOrReg tm
-  rIM  <- getResInit (id_,tm)
-  if isVoid hwTy
-     then return Nothing
-     else return . Just $ NetDecl' (addSrcNote sp)
-             wr
-             (id2identifier id_)
-             (Right hwTy)
-             rIM
+  hwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) (varType id_)
+
+  if | not (shouldRenderDecl hwTy tm) -> return []
+     | (Prim pInfo@PrimInfo{primMultiResult=MultiResult}, args) <- collectArgs tm ->
+          multiDecls pInfo args
+     | otherwise -> pure <$> singleDecl hwTy
 
   where
-    nm = varName id_
-    sp = case tm of {Tick (SrcSpan s) _ -> s; _ -> nameLoc nm}
+    multiDecls pInfo args0 = do
+      tcm <- Lens.use tcCache
+      resInits0 <- getResInits (id_, tm)
+      let
+        resInits1 = map Just resInits0 <> repeat Nothing
+        mpInfo = multiPrimInfo' tcm pInfo
+        (_, res) = splitMultiPrimArgs mpInfo args0
+        netdecl i typ resInit =
+          -- TODO: Dehardcode Wire. Would entail changing 'outputReg' to a
+          -- list.
+          NetDecl' srcNote Wire (id2identifier i) (Right typ) resInit
+
+      hwTys <- mapM (unsafeCoreTypeToHWTypeM' $(curLoc)) (mpi_resultTypes mpInfo)
+      pure (zipWith3 netdecl res hwTys resInits1)
+
+
+    singleDecl hwTy = do
+      wr <- termToWireOrReg tm
+      rIM <- listToMaybe <$> getResInits (id_, tm)
+      return (NetDecl' srcNote wr (id2identifier id_) (Right hwTy) rIM)
+
+    addSrcNote loc
+      | isGoodSrcSpan loc = Just (StrictText.pack (showSDocUnsafe (ppr loc)))
+      | otherwise = Nothing
+
+    srcNote = addSrcNote $ case tm of
+      Tick (SrcSpan s) _ -> s
+      _ -> nameLoc (varName id_)
+
+    isMultiPrimSelect :: Term -> Bool
+    isMultiPrimSelect t = case collectArgs t of
+      (Prim (primName -> "c$multiPrimSelect"), _) -> True
+      _ -> False
+
+    shouldRenderDecl :: HWType -> Term -> Bool
+    shouldRenderDecl ty t
+      | isVoid ty = False
+      | isMultiPrimSelect t = False
+      | otherwise = True
 
     termToWireOrReg :: Term -> NetlistMonad WireOrReg
     termToWireOrReg (stripTicks -> Case scrut _ alts0@(_:_:_)) = do
@@ -307,31 +341,42 @@ mkNetDecl (id_,tm) = preserveVarEnv $ do
         _ -> return Wire
     termToWireOrReg _ = return Wire
 
-    addSrcNote loc = if isGoodSrcSpan loc
-                        then Just (StrictText.pack (showSDocUnsafe (ppr loc)))
-                        else Nothing
-
     -- Set the initialization value of a signal when a primitive wants to set it
-    getResInit
-      :: (Id,Term) -> NetlistMonad (Maybe Expr)
-    getResInit (i,collectArgsTicks -> (k,args,ticks)) = case k of
-      Prim p -> extractPrimWarnOrFail (primName p) >>= go (primName p)
-      _ -> return Nothing
+    getResInits :: (Id, Term) -> NetlistMonad [Expr]
+    getResInits (i,collectArgsTicks -> (k,args0,ticks)) = case k of
+      Prim p -> extractPrimWarnOrFail (primName p) >>= go p
+      _ -> return []
      where
-      go pNm (BlackBox {resultInit = Just nmD}) = withTicks ticks $ \_ -> do
-        (bbCtx,_) <- mkBlackBoxContext pNm i args
-        (bbTempl,templDecl) <- prepareBlackBox pNm nmD bbCtx
+      go pInfo (BlackBox {resultInits=nmDs, multiResult=True}) = withTicks ticks $ \_ -> do
+        tcm <- Lens.use tcCache
+        let (args1, res) = splitMultiPrimArgs (multiPrimInfo' tcm pInfo) args0
+        (bbCtx, _) <- mkBlackBoxContext (primName pInfo) res args1
+        mapM (go' (primName pInfo) bbCtx) nmDs
+      go pInfo (BlackBox {resultInits=nmDs}) = withTicks ticks $ \_ -> do
+        (bbCtx, _) <- mkBlackBoxContext (primName pInfo) [i] args0
+        mapM (go' (primName pInfo) bbCtx) nmDs
+      go _ _ = pure []
+
+      go' pNm bbCtx nmD = do
+        (bbTempl, templDecl) <- prepareBlackBox pNm nmD bbCtx
         case templDecl of
-          [] -> return (Just (BlackBoxE pNm [] [] [] bbTempl bbCtx False))
+          [] ->
+            return (BlackBoxE pNm [] [] [] bbTempl bbCtx False)
           _  -> do
             (_,sloc) <- Lens.use curCompNm
-            throw (ClashException sloc
-                    (unwords [ $(curLoc)
-                             , "signal initialization requires declarations:\n"
-                             , show templDecl
-                             ])
-                    Nothing)
-      go _ _ = return Nothing
+            throw (ClashException sloc [I.i|
+              Initial values cannot produce declarations, but saw:
+
+                #{templDecl}
+
+              after rendering initial values for blackbox:
+
+                #{pNm}
+
+              Given template:
+
+                #{nmD}
+            |] Nothing)
 
 -- | Generate a list of concurrent Declarations for a let-binder, return an
 -- empty list if the bound expression is represented by 0 bits
@@ -395,7 +440,7 @@ mkDeclarations' declType bndr app = do
               Noop ->
                 -- Rendered expression rendered a "noop" - a list of
                 -- declarations without a result. Used for things like
-                -- mealy IO / inline assertions.
+                -- mealy IO / inline assertions / multi result primitives.
                 []
               _ ->
                 -- Turn returned expression into declaration by assigning
@@ -776,8 +821,8 @@ mkExpr bbEasD declType bndr app =
         return ( Identifier argNm1 Nothing
                , NetDecl' Nothing wr argNm1 (Right hwTyA) Nothing:decls)
     Letrec binders body -> do
-      netDecls <- fmap catMaybes $ mapM mkNetDecl binders
-      decls    <- concat <$> mapM (uncurry mkDeclarations) binders
+      netDecls <- concatMapM mkNetDecl binders
+      decls    <- concatMapM (uncurry mkDeclarations) binders
       (bodyE,bodyDecls) <- mkExpr bbEasD declType bndr (mkApps (mkTicks body ticks) args)
       return (bodyE,netDecls ++ decls ++ bodyDecls)
     _ -> throw (ClashException sp ($(curLoc) ++ "Not in normal form: application of a Lambda-expression\n\n" ++ showPpr app) Nothing)

--- a/clash-lib/src/Clash/Netlist.hs-boot
+++ b/clash-lib/src/Clash/Netlist.hs-boot
@@ -62,7 +62,7 @@ mkSelection
   -> [Declaration]
   -> NetlistMonad [Declaration]
 
-mkNetDecl :: LetBinding -> NetlistMonad (Maybe Declaration)
+mkNetDecl :: LetBinding -> NetlistMonad [Declaration]
 
 mkDeclarations :: HasCallStack => Id -> Term -> NetlistMonad [Declaration]
 mkDeclarations' :: HasCallStack => DeclarationType -> Id -> Term -> NetlistMonad [Declaration]

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
@@ -20,6 +21,7 @@ import           Control.Exception             (throw)
 import           Control.Lens                  ((<<%=),(%=))
 import qualified Control.Lens                  as Lens
 import           Control.Monad                 (when, replicateM, zipWithM)
+import           Control.Monad.Extra           (concatMapM)
 import           Control.Monad.IO.Class        (liftIO)
 import           Data.Char                     (ord)
 import           Data.Either                   (lefts, partitionEithers)
@@ -27,7 +29,7 @@ import qualified Data.HashMap.Lazy             as HashMap
 import qualified Data.IntMap                   as IntMap
 import           Data.List                     (elemIndex, partition)
 import           Data.List.Extra               (countEq, mapAccumLM)
-import           Data.Maybe                    (catMaybes, fromJust, fromMaybe)
+import           Data.Maybe                    (listToMaybe, fromJust, fromMaybe)
 import           Data.Semigroup.Monad
 import qualified Data.Set                      as Set
 import           Data.Text.Lazy                (fromStrict)
@@ -58,10 +60,11 @@ import           Clash.Core.Name
 import           Clash.Core.Pretty             (showPpr)
 import           Clash.Core.Subst              (extendIdSubst, mkSubst, substTm)
 import           Clash.Core.Term               as C
-  (PrimInfo (..), Term (..), WorkInfo (..), collectArgs, collectArgsTicks, collectBndrs, mkApps)
+  (IsMultiPrim (..), PrimInfo (..), Term (..), WorkInfo (..), collectArgs,
+   collectArgsTicks, collectBndrs, mkApps)
 import           Clash.Core.TermInfo
 import           Clash.Core.Type               as C
-  (Type (..), ConstTy (..), TypeView (..), mkFunTy, splitFunTys, splitFunTy, tyView)
+  (Type (..), ConstTy (..), TypeView (..), mkFunTy, splitFunTys, tyView)
 import           Clash.Core.TyCon              as C (TyConMap, tyConDataCons)
 import           Clash.Core.Util
   (inverseTopSortLetBindings, splitShouldSplit)
@@ -109,42 +112,45 @@ warn opts msg = do
 
 -- | Generate the context for a BlackBox instantiation.
 mkBlackBoxContext
-  :: TextS.Text
+  :: HasCallStack
+  => TextS.Text
   -- ^ Blackbox function name
-  -> Id
-  -- ^ Identifier binding the primitive/blackbox application
+  -> [Id]
+  -- ^ Identifiers binding the primitive/blackbox application
   -> [Either Term Type]
   -- ^ Arguments of the primitive/blackbox application
   -> NetlistMonad (BlackBoxContext,[Declaration])
-mkBlackBoxContext bbName resId args@(lefts -> termArgs) = do
+mkBlackBoxContext bbName resIds args@(lefts -> termArgs) = do
     -- Make context inputs
-    let resNm = nameOcc (varName resId)
-    resTy <- unsafeCoreTypeToHWTypeM' $(curLoc) (V.varType resId)
+    let
+      resNms = map (nameOcc . varName) resIds
+      resNm = fromMaybe (error "mkBlackBoxContext: head") (listToMaybe resNms)
+    resTys <- mapM (unsafeCoreTypeToHWTypeM' $(curLoc) . V.varType) resIds
     (imps,impDecls) <- unzip <$> zipWithM (mkArgument bbName resNm) [0..] termArgs
     (funs,funDecls) <-
       mapAccumLM
-        (addFunction (V.varType resId))
+        (addFunction (map V.varType resIds))
         IntMap.empty
         (zip termArgs [0..])
 
     -- Make context result
-    let res = Identifier resNm Nothing
+    let ress = map (flip Identifier Nothing) resNms
 
     lvl <- Lens.use curBBlvl
     (nm,_) <- Lens.use curCompNm
 
     -- Set "context name" to value set by `Clash.Magic.setName`, default to the
     -- name of the closest binder
-    ctxName1 <- fromMaybe resNm <$> Lens.view setName
+    ctxName1 <- fromMaybe resNms . fmap pure <$> Lens.view setName
     -- Update "context name" with prefixes and suffixes set by
     -- `Clash.Magic.prefixName` and `Clash.Magic.suffixName`
-    ctxName2 <- affixName ctxName1
+    ctxName2 <- mapM affixName ctxName1
 
-    return ( Context bbName (res,resTy) imps funs [] lvl nm (Just ctxName2)
+    return ( Context bbName (zip ress resTys) imps funs [] lvl nm (listToMaybe ctxName2)
            , concat impDecls ++ concat funDecls
            )
   where
-    addFunction resTy im (arg,i) = do
+    addFunction resTys im (arg,i) = do
       tcm <- Lens.use tcCache
       if isFun tcm arg then do
         -- Only try to calculate function plurality when primitive actually
@@ -153,12 +159,12 @@ mkBlackBoxContext bbName resId args@(lefts -> termArgs) = do
         funcPlurality <-
           case extractPrim <$> prim of
             Just (Just p) ->
-              P.getFunctionPlurality p args resTy i
+              P.getFunctionPlurality p args resTys i
             _ ->
               pure 1
 
         curBBlvl Lens.+= 1
-        (fs,ds) <- unzip <$> replicateM funcPlurality (mkFunInput resId arg)
+        (fs,ds) <- unzip <$> replicateM funcPlurality (mkFunInput (head resIds) arg)
         curBBlvl Lens.-= 1
 
         let im' = IntMap.insert i fs im
@@ -342,15 +348,16 @@ mkPrimitive
 mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
   go =<< extractPrimWarnOrFail (primName pInfo)
   where
-    ty = head (netlistTypes dst)
+    tys = netlistTypes dst
+    ty = fromMaybe (error "mkPrimitive") (listToMaybe tys)
 
     go
       :: CompiledPrimitive
       -> NetlistMonad (Expr, [Declaration])
     go =
       \case
-        P.BlackBoxHaskell bbName wf _usedArgs funcName (_fHash, func) -> do
-          bbFunRes <- func bbEasD (primName pInfo) args ty
+        P.BlackBoxHaskell bbName wf _usedArgs multiResult funcName (_fHash, func) -> do
+          bbFunRes <- func bbEasD (primName pInfo) args tys
           case bbFunRes of
             Left err -> do
               -- Blackbox template function returned an error:
@@ -361,30 +368,43 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
               (_,sp) <- Lens.use curCompNm
               throw (ClashException sp err' Nothing)
             Right (BlackBoxMeta {..}, bbTemplate) ->
-              -- Blackbox template generation succesful. Rerun 'go', but this time
+              -- Blackbox template generation successful. Rerun 'go', but this time
               -- around with a 'normal' @BlackBox@
               go (P.BlackBox
-                    bbName wf bbRenderVoid bbKind () bbOutputReg bbLibrary bbImports
-                    bbFunctionPlurality bbIncludes Nothing Nothing bbTemplate)
-        p@P.BlackBox {} ->
-          case kind p of
+                    bbName wf bbRenderVoid multiResult bbKind () bbOutputReg
+                    bbLibrary bbImports bbFunctionPlurality bbIncludes
+                    bbResultNames bbResultInits bbTemplate)
+        -- See 'setupMultiResultPrim' in "Clash.Normalize.Transformations":
+        P.BlackBox {name="c$multiPrimSelect"} ->
+          pure (Noop, [])
+        p@P.BlackBox {multiResult=True, name, template} -> do
+          -- Multi result primitives assign their results to signals
+          -- provided as arguments. Hence, we ignore any declarations
+          -- from 'resBndr1'.
+          tcm <- Lens.use tcCache
+          let (args1, resArgs) = splitMultiPrimArgs (multiPrimInfo' tcm pInfo) args
+          (bbCtx, ctxDcls) <- mkBlackBoxContext (primName pInfo) resArgs args1
+          (templ, templDecl) <- prepareBlackBox name template bbCtx
+          let bbDecl = N.BlackBoxD name (libraries p) (imports p) (includes p) templ bbCtx
+          return (Noop, ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
+        p@P.BlackBox {template, name=pNm, kind} ->
+          case kind of
             TDecl -> do
-              let tempD = template p
-                  pNm = name p
               resM <- resBndr1 True dst
               case resM of
                 Just (dst',dstNm,dstDecl) -> do
-                  (bbCtx,ctxDcls)   <- mkBlackBoxContext (primName pInfo) dst' args
-                  (templ,templDecl) <- prepareBlackBox pNm tempD bbCtx
+                  (bbCtx,ctxDcls)   <- mkBlackBoxContext (primName pInfo) [dst'] args
+                  (templ,templDecl) <- prepareBlackBox pNm template bbCtx
                   let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                            (includes p) templ bbCtx
                   return (Identifier dstNm Nothing,dstDecl ++ ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
 
                 -- Render declarations as a Noop when requested
                 Nothing | RenderVoid <- renderVoid p -> do
+                  -- TODO: We should probably 'mkBlackBoxContext' to accept empty lists
                   let dst1 = mkLocalId ty (mkUnsafeSystemName "__VOID_TDECL_NOOP__" 0)
-                  (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) dst1 args
-                  (templ,templDecl) <- prepareBlackBox pNm tempD bbCtx
+                  (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) [dst1] args
+                  (templ,templDecl) <- prepareBlackBox pNm template bbCtx
                   let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                            (includes p) templ bbCtx
                   return (Noop, ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
@@ -392,15 +412,13 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                 -- Otherwise don't render them
                 Nothing -> return (Noop,[])
             TExpr -> do
-              let tempE = template p
-                  pNm = name p
               if bbEasD
                 then do
                   resM <- resBndr1 True dst
                   case resM of
                     Just (dst',dstNm,dstDecl) -> do
-                      (bbCtx,ctxDcls)     <- mkBlackBoxContext (primName pInfo) dst' args
-                      (bbTempl,templDecl) <- prepareBlackBox pNm tempE bbCtx
+                      (bbCtx,ctxDcls)     <- mkBlackBoxContext (primName pInfo) [dst'] args
+                      (bbTempl,templDecl) <- prepareBlackBox pNm template bbCtx
                       let tmpAssgn = Assignment dstNm
                                         (BlackBoxE pNm (libraries p) (imports p)
                                                    (includes p) bbTempl bbCtx
@@ -409,9 +427,10 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
 
                     -- Render expression as a Noop when requested
                     Nothing | RenderVoid <- renderVoid p -> do
+                      -- TODO: We should probably 'mkBlackBoxContext' to accept empty lists
                       let dst1 = mkLocalId ty (mkUnsafeSystemName "__VOID_TEXPRD_NOOP__" 0)
-                      (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) dst1 args
-                      (templ,templDecl) <- prepareBlackBox pNm tempE bbCtx
+                      (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) [dst1] args
+                      (templ,templDecl) <- prepareBlackBox pNm template bbCtx
                       let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                                (includes p) templ bbCtx
                       return (Noop, ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
@@ -422,8 +441,8 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   resM <- resBndr1 False dst
                   case resM of
                     Just (dst',_,_) -> do
-                      (bbCtx,ctxDcls)      <- mkBlackBoxContext (primName pInfo) dst' args
-                      (bbTempl,templDecl0) <- prepareBlackBox pNm tempE bbCtx
+                      (bbCtx,ctxDcls)      <- mkBlackBoxContext (primName pInfo) [dst'] args
+                      (bbTempl,templDecl0) <- prepareBlackBox pNm template bbCtx
                       let templDecl1 = case primName pInfo of
                             "Clash.Sized.Internal.BitVector.fromInteger#"
                               | [N.Literal _ (NumLit _), N.Literal _ _, N.Literal _ _] <- extractLiterals bbCtx -> []
@@ -439,9 +458,10 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                       return (BlackBoxE pNm (libraries p) (imports p) (includes p) bbTempl bbCtx bbEParen,ctxDcls ++ templDecl1)
                     -- Render expression as a Noop when requested
                     Nothing | RenderVoid <- renderVoid p -> do
+                      -- TODO: We should probably 'mkBlackBoxContext' to accept empty lists
                       let dst1 = mkLocalId ty (mkUnsafeSystemName "__VOID_TEXPRE_NOOP__" 0)
-                      (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) dst1 args
-                      (templ,templDecl) <- prepareBlackBox pNm tempE bbCtx
+                      (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) [dst1] args
+                      (templ,templDecl) <- prepareBlackBox pNm template bbCtx
                       let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                                (includes p) templ bbCtx
                       return (Noop, ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
@@ -581,7 +601,7 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
       -> NetlistMonad (Maybe ([Id],[Identifier],[Declaration]))
       -- Nothing when the binder would have type `Void`
     resBndr mkDec dst' = do
-      resHwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) ty
+      resHwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) (head tys)
       if isVoid resHwTy then
         pure Nothing
       else
@@ -598,10 +618,18 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
               -- TODO: check that it's okay to use `mkUnsafeInternalName`
               let nm3 = mkUnsafeSystemName nm2 0
                   id_ = mkLocalId ty nm3
-              idDeclM <- mkNetDecl (id_,mkApps (Prim pInfo) args)
+              idDeclM <- mkNetDecl (id_, mkApps (Prim pInfo) args)
               case idDeclM of
-                Nothing     -> return Nothing
-                Just idDecl -> return (Just ([id_],[nm2],[idDecl]))
+                [] -> return Nothing
+                [idDecl] -> return (Just ([id_],[nm2],[idDecl]))
+                ids -> error [I.i|
+                  Unexpected nested use of multi result primitive. Ids:
+
+                    #{show ids}
+
+                  Multi primitive should only appear on the RHS of a
+                  let-binding. Please report this as a bug.
+                |]
           CoreId dstR -> return (Just ([dstR],[nameOcc . varName $ dstR],[]))
           MultiId ids -> return (Just (ids,map (nameOcc . varName) ids,[]))
 
@@ -678,10 +706,10 @@ collectMealy dstNm dst tcm (kd:clk:mealyFun:mealyInit:mealyIn:_) = do
       --
       -- The first set is only assigned in the always block, so they must be
       -- 'reg' in Verilog terminology
-      netDeclsSeq <- fmap catMaybes (mapM mkNetDecl (sBinders ++ bindersN))
+      netDeclsSeq <- concatMapM mkNetDecl (sBinders ++ bindersN)
       -- The second set is assigned using concurrent assignment, so don't need
       -- to be 'reg'
-      netDeclsInp <- fmap catMaybes (mapM mkNetDecl iBinders)
+      netDeclsInp <- concatMapM mkNetDecl iBinders
 
       -- If the 'mealyFun' was not a let-expression with a variable reference
       -- as a body then we used the LHS of the entire 'mealyIO' expression as
@@ -776,8 +804,8 @@ collectBindIO dst (m:Lam x q@(Lam _ e):_) = do
       normE <- mkUniqueNormalized is0 Nothing (args,bs,res)
       case normE of
         (_,_,[],_,[],binders,Just result) -> do
-          ds1 <- concat <$> mapM (uncurry (mkDeclarations' Sequential)) binders
-          netDecls <- fmap catMaybes (mapM mkNetDecl binders)
+          ds1 <- concatMapM (uncurry (mkDeclarations' Sequential)) binders
+          netDecls <- concatMapM mkNetDecl binders
           let assn = Assignment (netlistId1 id id2identifier dst)
                                 (Identifier (id2identifier result) Nothing)
           return (Noop, (netDecls ++ ds0 ++ ds1 ++ [assn]))
@@ -800,12 +828,12 @@ collectBindIO dst (m:Lam x q@(Lam _ e):_) = do
       case normE of
         (_,_,[],_,[],binders,Just result) -> do
           let binders1 = tail binders ++ [(fst (head binders), C.Var result)]
-          ds1 <- concat <$> mapM (uncurry (mkDeclarations' Sequential)) binders1
-          netDecls <- fmap catMaybes (mapM mkNetDecl binders)
+          ds1 <- concatMapM (uncurry (mkDeclarations' Sequential)) binders1
+          netDecls <- concatMapM mkNetDecl binders
           return (netDecls ++ ds1)
         _ -> error "internal error"
     _ -> do
-      netDecls <- fmap catMaybes (mapM mkNetDecl [(x,m)])
+      netDecls <- concatMapM mkNetDecl [(x,m)]
       ds1 <- mkDeclarations' Sequential x m
       return (netDecls ++ ds1)
 
@@ -814,11 +842,11 @@ collectBindIO _ es = error ("internal error:\n" ++ showPpr es)
 -- | Collect the sequential declarations for 'appIO'
 collectAppIO :: NetlistId -> [Term] -> [Term] -> NetlistMonad (Expr,[Declaration])
 collectAppIO dst (fun1:arg1:_) rest = case collectArgs fun1 of
-  (Prim (PrimInfo "Clash.Explicit.SimIO.fmapSimIO#" _ _),(lefts -> (fun0:arg0:_))) -> do
+  (Prim (PrimInfo "Clash.Explicit.SimIO.fmapSimIO#" _ _ _),(lefts -> (fun0:arg0:_))) -> do
     tcm <- Lens.use tcCache
     let argN = map (Left . unSimIO tcm) (arg0:arg1:rest)
     mkExpr False Sequential dst (mkApps fun0 argN)
-  (Prim (PrimInfo "Clash.Explicit.SimIO.apSimIO#" _ _),(lefts -> args)) -> do
+  (Prim (PrimInfo "Clash.Explicit.SimIO.apSimIO#" _ _ _),(lefts -> args)) -> do
     collectAppIO dst args (arg1:rest)
   _ -> error ("internal error:\n" ++ showPpr (fun1:arg1:rest))
 
@@ -838,7 +866,11 @@ unSimIO tcm arg =
   let argTy = termType tcm arg
   in  case tyView argTy of
         TyConApp _ [tcArg] ->
-          mkApps (Prim (PrimInfo "Clash.Explicit.SimIO.unSimIO#" (mkFunTy argTy tcArg) WorkNever))
+          mkApps (Prim ( PrimInfo
+                           "Clash.Explicit.SimIO.unSimIO#"
+                           (mkFunTy argTy tcArg)
+                           WorkNever
+                           SingleResult ))
                  [Left arg]
         _ -> error ("internal error:\n" ++ showPpr arg)
 
@@ -876,17 +908,21 @@ mkFunInput resId e =
                   error $ $(curLoc) ++ "Unexpected blackbox type: "
                                     ++ "Primitive " ++ show pn
                                     ++ " " ++ show pt
-                P.BlackBoxHaskell pName _workInfo _usedArgs fName (_, func) -> do
+                P.BlackBoxHaskell{name=pName, multiResult=True} ->
+                  -- TODO: dev pointers
+                  error [I.i|
+                    Encountered multiresult primitive as a direct argument to
+                    another primitive. This should not happen.
+
+                      Encountered: #{pName}
+
+                    Please report this as an issue.
+                  |]
+                P.BlackBoxHaskell{name=pName, functionName=fName, function=(_, func)} -> do
                   -- Determine result type of this blackbox. If it's not a
                   -- function, simply use its term type.
-                  let
-                    resTy0 = termType tcm e
-                    resTy1 =
-                      case splitFunTy tcm resTy0 of
-                        Just (_, t) -> t
-                        Nothing -> resTy0
-
-                  bbhRes <- func True pName args resTy1
+                  let (_, resTy) = splitFunTys tcm (termType tcm e)
+                  bbhRes <- func True pName args [resTy]
                   case bbhRes of
                     Left err ->
                       error $ $(curLoc) ++ show fName ++ " yielded an error: "
@@ -1004,7 +1040,7 @@ mkFunInput resId e =
   let pNm = case appE of
               Prim p -> primName p
               _ -> "__INTERNAL__"
-  (bbCtx,dcls) <- mkBlackBoxContext pNm resId args
+  (bbCtx,dcls) <- mkBlackBoxContext pNm [resId] args
   case templ of
     Left (TDecl,oreg,libs,imps,inc,_,templ') -> do
       (l',templDecl)
@@ -1105,10 +1141,11 @@ mkFunInput resId e =
         Left err -> error err
       case resultM of
         Just result -> do
+          -- TODO: figure out what to do with multires blackboxes here
           let binders' = map (\(id_,tm) -> (goR result id_,tm)) binders
-          netDecls <- fmap catMaybes . mapM mkNetDecl $ filter ((/= result) . fst) binders
+          netDecls <- concatMapM mkNetDecl $ filter ((/= result) . fst) binders
           decls    <- concat <$> mapM (uncurry mkDeclarations) binders'
-          Just (NetDecl' _ rw _ _ _) <- mkNetDecl . head $ filter ((==result) . fst) binders
+          [NetDecl' _ rw _ _ _] <- mkNetDecl . head $ filter ((==result) . fst) binders
           nm <- mkUniqueIdentifier Basic "fun"
           return (Right ((nm,netDecls ++ decls),rw))
         Nothing -> return (Right (("",[]),Wire))

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -199,7 +199,8 @@ mkArgument
   :: TextS.Text
   -- ^ Blackbox function name
   -> Identifier
-  -- ^ LHS of the original let-binder
+  -- ^ LHS of the original let-binder. Is used as a name hint to generate new
+  -- names in case the argument is a declaration.
   -> Int
   -- ^ Argument n (zero-indexed). Used for error message.
   -> Term
@@ -847,7 +848,8 @@ unSimIO tcm arg =
 mkFunInput
   :: HasCallStack
   => Id
-  -- ^ Identifier binding the encompassing primitive/blackbox application
+  -- ^ Identifier binding the encompassing primitive/blackbox application. Used
+  -- as a name hint if 'mkFunInput' needs intermediate signals.
   -> Term
   -- ^ The function argument term
   -> NetlistMonad

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs-boot
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs-boot
@@ -20,10 +20,11 @@ extractPrimWarnOrFail
   -> NetlistMonad CompiledPrimitive
 
 mkBlackBoxContext
-  :: Text
+  :: HasCallStack
+  => Text
   -- ^ Blackbox function name
-  -> Id
-  -- ^ Identifier binding the primitive/blackbox application
+  -> [Id]
+  -- ^ Identifiers binding the primitive/blackbox application
   -> [Either Term Type]
   -- ^ Arguments of the primitive/blackbox application
   -> NetlistMonad (BlackBoxContext,[Declaration])

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -65,12 +65,14 @@ data BlackBoxMeta =
                , bbFunctionPlurality :: [(Int, Int)]
                , bbIncludes :: [((S.Text, S.Text), BlackBox)]
                , bbRenderVoid :: RenderVoid
+               , bbResultNames :: [BlackBox]
+               , bbResultInits :: [BlackBox]
                }
 
 -- | Use this value in your blackbox template function if you do want to
 -- accept the defaults as documented in @Clash.Primitives.Types.BlackBox@.
 emptyBlackBoxMeta :: BlackBoxMeta
-emptyBlackBoxMeta = BlackBoxMeta False TExpr [] [] [] [] NoRenderVoid
+emptyBlackBoxMeta = BlackBoxMeta False TExpr [] [] [] [] NoRenderVoid [] []
 
 -- | A BlackBox function generates a blackbox template, given the inputs and
 -- result type of the function it should provide a blackbox for. This is useful
@@ -84,8 +86,8 @@ type BlackBoxFunction
   -- ^ Name of primitive
   -> [Either Term Type]
   -- ^ Arguments
-  -> Type
-  -- ^ Result type
+  -> [Type]
+  -- ^ Result types
   -> NetlistMonad (Either String (BlackBoxMeta, BlackBox))
 
 -- | A BlackBox Template is a List of Elements

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -422,9 +422,14 @@ toBit m i = if testBit m 0
 -- | Context used to fill in the holes of a BlackBox template
 data BlackBoxContext
   = Context
-  { bbName      :: Text -- ^ Blackbox function name (for error reporting)
-  , bbResult    :: (Expr,HWType) -- ^ Result name and type
-  , bbInputs    :: [(Expr,HWType,Bool)] -- ^ Argument names, types, and whether it is a literal
+  { bbName :: Text
+  -- ^ Blackbox function name (for error reporting)
+  , bbResults :: [(Expr,HWType)]
+  -- ^ Result names and types. Will typically be a list with a single item.
+  -- Multiple result targets will be used for "multi result primitives". See
+  -- 'Clash.Normalize.Transformations.setupMultiResultPrim'.
+  , bbInputs :: [(Expr,HWType,Bool)]
+  -- ^ Argument names, types, and whether it is a literal
   , bbFunctions :: IntMap [(Either BlackBox (Identifier,[Declaration])
                           ,WireOrReg
                           ,[BlackBoxTemplate]
@@ -547,7 +552,7 @@ emptyBBContext :: Text -> BlackBoxContext
 emptyBBContext n
   = Context
   { bbName        = n
-  , bbResult      = (Identifier (pack "__EMPTY__") Nothing, Void Nothing)
+  , bbResults     = []
   , bbInputs      = []
   , bbFunctions   = empty
   , bbQsysIncName = []

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -56,7 +56,7 @@ import           Clash.Core.Name
   (nameOcc, Name(..), NameSort(User), mkUnsafeSystemName)
 import           Clash.Core.Pretty                (showPpr)
 import           Clash.Core.Term
-  (CoreContext (..), PrimInfo (..), Term (..), WorkInfo (..), Pat (..),
+  (IsMultiPrim (..), CoreContext (..), PrimInfo (..), Term (..), WorkInfo (..), Pat (..),
    collectTermIds, mkApps)
 import           Clash.Core.TermInfo
 import           Clash.Core.Type                  (LitTy (..), Type (..),
@@ -100,7 +100,7 @@ vecHeadPrim
   -> Term
 vecHeadPrim vecTcNm =
  -- head :: Vec (n+1) a -> a
-  Prim (PrimInfo "Clash.Sized.Vector.head" (vecHeadTy vecTcNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Vector.head" (vecHeadTy vecTcNm) WorkNever SingleResult)
 
 vecLastPrim
   :: TyConName
@@ -110,7 +110,7 @@ vecLastPrim vecTcNm =
   -- last :: Vec (n+1) a -> a
   -- has the same type signature as head, hence we're reusing its type
   -- definition here.
-  Prim (PrimInfo "Clash.Sized.Vector.last" (vecHeadTy vecTcNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Vector.last" (vecHeadTy vecTcNm) WorkNever SingleResult)
 
 vecHeadTy
   :: TyConName
@@ -132,7 +132,7 @@ vecTailPrim
   -> Term
 vecTailPrim vecTcNm =
   -- tail :: Vec (n + 1) a -> Vec n a
-  Prim (PrimInfo "Clash.Sized.Vector.tail" (vecTailTy vecTcNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Vector.tail" (vecTailTy vecTcNm) WorkNever SingleResult)
 
 vecInitPrim
   :: TyConName
@@ -142,7 +142,7 @@ vecInitPrim vecTcNm =
   -- init :: Vec (n + 1) a -> Vec n a
   -- has the same type signature as tail, hence we're reusing its type
   -- definition here.
-  Prim (PrimInfo "Clash.Sized.Vector.init" (vecTailTy vecTcNm) WorkNever)
+  Prim (PrimInfo "Clash.Sized.Vector.init" (vecTailTy vecTcNm) WorkNever SingleResult)
 
 vecTailTy
   :: TyConName
@@ -415,7 +415,7 @@ reduceImap (TransformContext is0 ctx) n argElTy resElTy fun arg = do
                                                (mkTyConApp idxTcNm
                                                            [VarTy nTv])
                                                [integerPrimTy,integerPrimTy])
-            idxFromInteger   = Prim (PrimInfo "Clash.Sized.Internal.Index.fromInteger#" idxFromIntegerTy WorkNever)
+            idxFromInteger   = Prim (PrimInfo "Clash.Sized.Internal.Index.fromInteger#" idxFromIntegerTy WorkNever SingleResult)
             idxs             = map (App (App (TyApp idxFromInteger (LitTy (NumTy n)))
                                              (Literal (IntegerLiteral (toInteger n))))
                                    . Literal . IntegerLiteral . toInteger) [0..(n-1)]
@@ -1041,7 +1041,11 @@ reduceReplace_int is0 n aTy vTy v i newA = do
     -> Type
     -> Term
   eqIntPrim intTy boolTy =
-    Prim (PrimInfo "Clash.Transformations.eqInt" (mkFunTy intTy (mkFunTy intTy boolTy)) WorkVariable)
+    Prim (PrimInfo
+           "Clash.Transformations.eqInt"
+           (mkFunTy intTy (mkFunTy intTy boolTy))
+           WorkVariable
+           SingleResult )
 
   go tcm (coreView1 tcm -> Just ty') = go tcm ty'
   go tcm (tyView -> TyConApp vecTcNm _)
@@ -1141,7 +1145,11 @@ reduceIndex_int is0 n aTy v i = do
     -> Type
     -> Term
   eqIntPrim intTy boolTy =
-    Prim (PrimInfo "Clash.Transformations.eqInt" (mkFunTy intTy (mkFunTy intTy boolTy)) WorkVariable)
+    Prim ( PrimInfo
+            "Clash.Transformations.eqInt"
+            (mkFunTy intTy (mkFunTy intTy boolTy))
+            WorkVariable
+            SingleResult )
 
   go tcm (coreView1 tcm -> Just ty') = go tcm ty'
   go tcm (tyView -> TyConApp vecTcNm _)

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -31,7 +31,7 @@ import Clash.Rewrite.Util
 -- | Normalisation transformation
 normalization :: NormRewrite
 normalization =
-  rmDeadcode >-> constantPropagation >-> rmUnusedExpr >-!-> anf >-!-> rmDeadcode >->
+  rmDeadcode >-> multPrim >-> constantPropagation >-> rmUnusedExpr >-!-> anf >-!-> rmDeadcode >->
   bindConst >-> letTL
 #if !EXPERIMENTAL_EVALUATOR
   >-> evalConst
@@ -40,6 +40,7 @@ normalization =
   xOptim >-> rmDeadcode >->
   cleanup >-> recLetRec >-> splitArgs
   where
+    multPrim   = topdownR (apply "setupMultiResultPrim" setupMultiResultPrim)
     anf        = topdownR (apply "nonRepANF" nonRepANF) >-> apply "ANF" makeANF >-> topdownR (apply "caseCon" caseCon)
     letTL      = topdownSucR (apply "topLet" topLet)
     recLetRec  = apply "recToLetRec" recToLetRec

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -517,7 +517,8 @@ removedTm
   :: Type
   -> Term
 removedTm =
-  TyApp (Prim (PrimInfo "Clash.Transformations.removedArg" undefinedTy WorkNever))
+  let removedNm = "Clash.Transformations.removedArg" in
+  TyApp (Prim (PrimInfo removedNm undefinedTy WorkNever SingleResult))
 
 -- | A tick to prefix an inlined expression with it's original name.
 -- For example, given

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -33,7 +33,7 @@ altpllTF = TemplateFunction used valid altpllTemplate
   valid bbCtx
     | [_,_,(nm,_,_),_,_] <- bbInputs bbCtx
     , Just _ <- exprToString nm
-    , (Identifier _ Nothing,Product {}) <- bbResult bbCtx
+    , [(Identifier _ Nothing,Product {})] <- bbResults bbCtx
     = True
   valid _ = False
 
@@ -44,7 +44,7 @@ altpllQsysTF = TemplateFunction used valid altpllQsysTemplate
   valid bbCtx
     | [_,_,(nm,_,_),_,_] <- bbInputs bbCtx
     , Just _ <- exprToString nm
-    , (Identifier _ Nothing,Product {}) <- bbResult bbCtx
+    , [(Identifier _ Nothing,Product {})] <- bbResults bbCtx
     = True
   valid _ = False
 
@@ -101,7 +101,7 @@ alteraPllTemplate bbCtx = do
    ]
   ]
  where
-  (Identifier result Nothing,resTy@(Product _ _ (init -> tys))) = bbResult bbCtx
+  [(Identifier result Nothing,resTy@(Product _ _ (init -> tys)))] = bbResults bbCtx
   [(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = drop 3 (bbInputs bbCtx)
   Just nm' = exprToString nm
   instname0 = TextS.pack nm'
@@ -137,7 +137,7 @@ altpllTemplate bbCtx = do
   ]
  where
   [_,_,(nm,_,_),(clk,clkTy,_),(rst,rstTy,_)] = bbInputs bbCtx
-  (Identifier result Nothing,resTy@(Product _ _ [clkOutTy,_])) = bbResult bbCtx
+  [(Identifier result Nothing,resTy@(Product _ _ [clkOutTy,_]))] = bbResults bbCtx
   Just nm' = exprToString nm
   instname0 = TextS.pack nm'
   compName = head (bbQsysIncName bbCtx)

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -1133,4 +1133,3 @@ removeUnusedBinders binds body =
                           (extendVarEnv x (x,e0) env)
                           (eltsVarSet eFVs)
         Nothing -> env
-

--- a/tests/shouldwork/Basic/Parameters.hs
+++ b/tests/shouldwork/Basic/Parameters.hs
@@ -38,7 +38,7 @@ myAddTemplate
   -> State s Doc
 myAddTemplate bbCtx = do
   let [_, (xExp, xTy, _), (yExp, yTy, _)] = bbInputs bbCtx
-      (resExp, resTy) = bbResult bbCtx
+      [(resExp, resTy)] = bbResults bbCtx
   getMon $ blockDecl "my_add_block"
     [ InstDecl Comp Nothing [] "my_add" "my_add_inst"
         [ (Identifier "size" Nothing, Integer, Literal Nothing (NumLit . fromIntegral $ typeSize xTy))

--- a/tests/shouldwork/BlackBox/MultiResult.hs
+++ b/tests/shouldwork/BlackBox/MultiResult.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module MultiResult where
+
+import qualified Prelude as P
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+import qualified Clash.Netlist.Types as N
+import qualified Clash.Netlist.BlackBox.Types as N
+import           Clash.Netlist.BlackBox.Types
+  (BlackBoxFunction, BlackBoxMeta (..), TemplateKind (TDecl), emptyBlackBoxMeta)
+import Clash.Primitives.DSL
+
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+-- | Ties off sh_ddr on AWS.
+tieOffShDdr :: Clock dom -> Reset dom -> Signal dom Int -> (Signal dom Int, Signal dom Int)
+tieOffShDdr !_clk !_rst !_ = (undefined, undefined)
+{-# NOINLINE tieOffShDdr #-}
+{-# ANN tieOffShDdr (blackBoxHaskell 'tieOffShDdr 'tieOffShDdrBBF def{bo_multiResult=True}) #-}
+
+tieOffShDdrBBF :: BlackBoxFunction
+tieOffShDdrBBF _isD _primName _args _ty = pure (Right (meta, bb))
+  where
+    bb = N.BBFunction (show 'tieOffShDdr) 0 tieOffShDdrTF
+    meta = emptyBlackBoxMeta
+      { bbKind = TDecl
+      , bbResultNames = [ N.BBTemplate [N.Text "foo"]
+                        , N.BBTemplate [N.Text "foo"] ]
+      }
+
+tieOffShDdrTF :: N.TemplateFunction
+tieOffShDdrTF = N.TemplateFunction [] (const True) $ \bbCtx -> do
+  let [(clk, N.Clock _), (reset, N.Reset _), (inp, inpType)] = tInputs bbCtx
+  declarationReturn bbCtx "myBlock" (pure [inp, inp])
+
+topEntity ::
+  Clock System ->
+  Reset System ->
+  Signal System Int ->
+  Signal System (Int, Int, Int)
+topEntity clk rst x = bundle (a, b, pure 5)
+ where
+  (a, b) = tieOffShDdr @System clk rst x
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (1 :> 2 :> Nil)
+    expectedOutput = outputVerifier' clk rst ((1, 1, 5) :> (2, 2, 5) :> Nil)
+    done           = expectedOutput (topEntity clk rst testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topFile] <- getArgs
+  content <- readFile topFile
+  assertIn "foo" content
+  assertIn "foo_0" content

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -356,6 +356,8 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS_GHC(runTest "BlackBoxFunctionHO" def{hdlTargets=[VHDL]})
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "Signal") allTargets [] [] "BlockRamLazy" "main")
         , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "ZeroWidth"          "main"
+        , outputTest ("tests" </> "shouldwork" </> "BlackBox") [VHDL]   [] [] "MultiResult"        "main"
+        , NEEDS_PRIMS(runTest "MultiResult" def)
         , NEEDS_PRIMS(runTest "T919" def{hdlSim=False})
         , NEEDS_PRIMS(runTest "T1524" def)
         ]


### PR DESCRIPTION
Approach:

```
-- A multi result primitive assigns its results to multiple result variables
-- instead of one. Besides producing nicer HDL it works around issues with
-- synthesis tooling described in:
--
--   https://github.com/clash-lang/clash-compiler/issues/1555
--
-- This transformation rewrites primitives indicating they can assign their
-- results to multiple signals, such that netlist can easily render it.
--
-- Example:
--
-- @
-- prim :: forall a. a -> (a, a)
-- @
--
-- will be rewritten to:
--
-- @
--   \a0 -> let
--            r  = prim @t0 a0 r0 r1     -- With 'Clash.Core.Term.MultiPrim'
--            r0 = multiPrimSelect r0 r
--            r1 = multiPrimSelect r1 r
--          in
--            (x, y)
-- @
--
-- Netlist will not render any @multiPrimSelect@ primitives. Similar to
-- primitives having a /void/ return type, /r/ is not rendered either.
--
-- This transformation is currently hardcoded to recognize tuples as return
-- types, not any product type. It will error if it sees a multi result primitive
-- with a non-tuple return type.
--
```