### PR TITLE
Set topentities as NOINLINE in generateBindings

### DIFF
--- a/changelog/2020-11-06T11_04_40+01_00_noinline_topentities
+++ b/changelog/2020-11-06T11_04_40+01_00_noinline_topentities
@@ -1,0 +1,1 @@
+CHANGED: generateBindings now sets all topentities as NOINLINE [#1568](https://github.com/clash-lang/clash-compiler/issues/1568)

--- a/tests/shouldwork/Issues/T1568.hs
+++ b/tests/shouldwork/Issues/T1568.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module T1568 where
+
+import qualified Data.List as List (find)
+
+import Clash.Prelude
+
+import Clash.Backend
+import Clash.Core.Name
+import Clash.Core.Var
+import Clash.Core.VarEnv
+import Clash.Driver.Types
+
+import BasicTypes
+
+import Test.Tasty.Clash
+import Test.Tasty.Clash.CoreTest
+
+{-# ANN f (Synthesize
+      { t_name   = "f"
+      , t_inputs = [PortName "in"]
+      , t_output = PortName "out"
+      })
+  #-}
+f :: Int -> Int
+f x = x `rem` 2
+
+topEntity :: Double -> Double
+topEntity = (*2)
+
+testPath :: FilePath
+testPath = "tests/shouldwork/Issues/T1568.hs"
+
+mainCommon
+  :: (Backend (TargetToState target))
+  => SBuildTarget target
+  -> IO ()
+mainCommon hdl = do
+  (bm, _, _) <- runToCoreStage hdl id testPath
+
+  checkTE "T1568.f" bm
+  checkTE "T1568.topEntity" bm
+ where
+  findBinding n = List.find (withName n) . eltsVarEnv
+  withName n b = nameOcc (varName (bindingId b)) == n
+
+  checkTE n bm =
+    case findBinding n bm of
+      Just b | bindingSpec b == NoInline -> pure ()
+             | otherwise -> error ("Binding is not marked NOINLINE: " <> show (bindingSpec b))
+
+      Nothing -> error ("Could not find top entity: " <> show n)
+
+mainVHDL :: IO ()
+mainVHDL = mainCommon SVHDL
+
+mainVerilog :: IO ()
+mainVerilog = mainCommon SVerilog
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = mainCommon SSystemVerilog

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -465,6 +465,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1477" def{hdlSim=False}
         , runTest "T1506A" def{hdlSim=False, clashFlags=["-fclash-aggressive-x-optimization-blackboxes"]}
         , outputTest ("tests" </> "shouldwork" </> "Issues") allTargets ["-fclash-aggressive-x-optimization-blackboxes"] ["-itests/shouldwork/Issues"] "T1506B" "main"
+        , clashLibTest ("tests" </> "shouldwork" </> "Issues") allTargets [] "T1568" "main"
         ]
       , clashTestGroup "Naming"
         [ runTest "T967a" def{hdlSim=False}


### PR DESCRIPTION
When generating bindings, any identified top entity is changed to
be NOINLINE in the bindings map. This prevents transformations /
the partial evaluator from accidentally inlining a topentity.

Ideally this should be a source plugin, as GHC may still inline
the top entity before it reaches clash.

Closes #1568 