### PR TITLE
Bumps th-abstraction upper bound

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -336,7 +336,7 @@ Library
                       reflection                >= 2       && < 2.2,
                       singletons                >= 1.0     && < 3.0,
                       template-haskell          >= 2.12.0.0 && < 2.17,
-                      th-abstraction            >= 0.2.10 && < 0.4.0,
+                      th-abstraction            >= 0.2.10 && < 0.5.0,
                       th-lift                   >= 0.7.0    && < 0.9,
                       th-orphans                >= 0.13.1   && < 1.0,
                       text                      >= 0.11.3.1 && < 1.3,


### PR DESCRIPTION
I've verified that `clash-prelude` compiles locally, and the majority of the test suite passes.

For whatever reason the doctests are failing, but I can't seem to get any readable logs out of them.