### PR TITLE
inlineWorkFree: never inline a topentity

### DIFF
--- a/changelog/2020-11-10T10_45_22+01_00_inlineWorkFree_topents.md
+++ b/changelog/2020-11-10T10_45_22+01_00_inlineWorkFree_topents.md
@@ -1,0 +1,3 @@
+FIXED: inlineWorkFree now never inlines a topentity.
+It previously only respected this invariant in one of the two cases.
+

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1081,9 +1081,11 @@ inlineWorkFree _ e@(collectArgsTicks -> (Var f,args@(_:_),ticks))
                                         (const (pure False)))
                                 args
     untranslatable <- isUntranslatableType True eTy
+    topEnts <- Lens.view topEntities
     let isSignal = isSignalType tcm eTy
     let lv = isLocalId f
-    if untranslatable || isSignal || argsHaveWork || lv
+    let isTopEnt = elemVarSet f topEnts
+    if untranslatable || isSignal || argsHaveWork || lv || isTopEnt
       then return e
       else do
         bndrs <- Lens.use bindings


### PR DESCRIPTION
The inlineWorkFree transformation was only checking if a variable
was a topEntity in one of the two cases, when it should be checking
both. This is now fixed.