### PR TITLE
Fix wrong Wire/Res assignment in Verilog

### DIFF
--- a/tests/shouldwork/Issues/T1615.hs
+++ b/tests/shouldwork/Issues/T1615.hs
@@ -1,0 +1,11 @@
+module T1615 where
+
+import Clash.Prelude
+
+data T = A | B | C
+
+f A = (8 :: Unsigned 4)
+f B = 6
+f _ = 2
+
+topEntity = map @_ @_ @2 f

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -550,6 +550,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1477" def{hdlSim=False}
         , runTest "T1506A" def{hdlSim=False, clashFlags=["-fclash-aggressive-x-optimization-blackboxes"]}
         , outputTest ("tests" </> "shouldwork" </> "Issues") allTargets ["-fclash-aggressive-x-optimization-blackboxes"] ["-itests/shouldwork/Issues"] "T1506B" "main"
+        , runTest "T1615" def{hdlSim=False, hdlTargets=[Verilog]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only


### PR DESCRIPTION
Fixes #1615

----------

No changelog for this one, as this is a regression only present in `master`.