### PR TITLE
Retain primitive warning when `HasBlackBox` annotation is present

### DIFF
--- a/changelog/2021-01-05T11_10_47+01_00_keep_prim_warning
+++ b/changelog/2021-01-05T11_10_47+01_00_keep_prim_warning
@@ -1,0 +1,1 @@
+FIXED: Primitive template warning is now retained when a `HasBlackBox` annotation is present.


### PR DESCRIPTION
A `WarnNonSynthesizable` `PrimitiveGuard` is [added by `Clash.Primitives.Util.resolvePrimitive'`](https://github.com/clash-lang/clash-compiler/blob/b0bab9c293a075975ac5cbad71db0d7345576ce5/clash-lib/src/Clash/Primitives/Util.hs#L104) whenever a primitive template has a `warning` field. In case such a primitive also has a `PrimitiveGuard` annotation, the annotation took precedence and the warning was always lost. This change makes that the warning is retained if the annotation is `HasBlackBox`; `WarnNonSynthesizable` implies `HasBlackBox` anyway.

Fixes the example mentioned in #1625. The warning is still lost when a `WarnNonSynthesizable` or `WarnAlways` annotation is present, but that's not that bad I think.