### PR TITLE
Split warnings of `PrimitiveGuard` into separate data type

### DIFF
--- a/changelog/2021-01-11T11_40_52+01_00_prim_warning_fix
+++ b/changelog/2021-01-11T11_40_52+01_00_prim_warning_fix
@@ -1,0 +1,2 @@
+CHANGED: Split warnings of `PrimitiveGuard` into separate data type.
+FIXED: Primitive template warning is now retained when a `PrimitiveGuard` annotation is present (fixes #1625).


### PR DESCRIPTION
Add a separate data type for representing warnings for `PrimitiveGuard`s so that multiple can be represented. Alternative approach to #1626.

Fixes #1625.