### PR TITLE
Teach deriveAutoReg to handle LitT's in constraints

### DIFF
--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -380,9 +380,10 @@ constraintsWantedFor clsNm [ty] = case ty of
   needRecurse :: Type -> Bool
   needRecurse (unfoldType -> (cls,tys)) =
     case tys of
-      [VarT _] -> False
-      [ConT _] -> False  -- we can just drop constraints like: "AutoReg Bool => ..."
       [AppT _ _] -> True
+      [VarT _] -> False  -- gets copied by "filter isOk" above
+      [ConT _] -> False  -- we can just drop constraints like: "AutoReg Bool => ..."
+      [LitT _] -> False  -- or "KnownNat 4 =>"
       [_] -> error ( "Error while deriveAutoReg: don't know how to handle: "
                   ++ pprint cls ++ " (" ++ pprint tys ++ ")" )
       _ -> False  -- see [NOTE: MultiParamTypeClasses]

--- a/tests/shouldwork/AutoReg/T1632.hs
+++ b/tests/shouldwork/AutoReg/T1632.hs
@@ -1,0 +1,10 @@
+module T1632 where
+import Clash.Prelude
+
+data MCause
+  = MCause (BitVector 4)
+  deriving (Generic, NFDataX)
+deriveAutoReg ''MCause
+
+topEntity :: SystemClockResetEnable => Signal System MCause -> Signal System MCause
+topEntity = autoReg (MCause 0)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -342,6 +342,8 @@ runClashTest = defaultMain $ clashTestRoot
       [ clashTestGroup "AutoReg"
         [ NEEDS_PRIMS(outputTest ("tests" </> "shouldwork" </> "AutoReg") allTargets [] [] "AutoReg" "main")
         , NEEDS_PRIMS(runTest "T1507" def{hdlSim=False})
+        , let _opts = def{hdlSim=False, hdlTargets=[VHDL]}
+           in NEEDS_PRIMS(runTest "T1632" _opts)
         ]
       , clashTestGroup "Basic"
         [ NEEDS_PRIMS(runTest "AES" def{hdlSim=False})


### PR DESCRIPTION
This allows it to drop constraints like `KnownNat 4`.

Fixes #1632