### PR TITLE
Fix `history.dat` generation

### DIFF
--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -53,7 +53,7 @@ import qualified Data.Set.Ordered.Extra      as OSet
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
 
-#ifdef EXPERIMENTAL_EVALUATOR
+#if defined(EXPERIMENTAL_EVALUATOR) || defined(HISTORY)
 import           System.IO.Unsafe            (unsafePerformIO)
 #endif
 


### PR DESCRIPTION
This seems to have slightly bit-rotten. Only a minor fix was needed.