### PR TITLE
Run clash-prelude:unittests multithreaded

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -375,7 +375,7 @@ test-suite unittests
   import:           common-options
   type:             exitcode-stdio-1.0
   main-is:          unittests.hs
-  ghc-options:      -Wall -Wcompat
+  ghc-options:      -Wall -Wcompat -threaded -with-rtsopts=-N
   hs-source-dirs:   tests
 
   if !flag(unittests)


### PR DESCRIPTION
Note that Hedgehog is not controlled by Tasty's `-j` command line option. It can be restricted with `+RTS -Nx -RTS` for some x though.