### PR TITLE
Force accumulating argument 'o' to WHNF in 'asyncRegister#'

### DIFF
--- a/changelog/2021-02-03T15_24_30+01_00_fix_register_memory_leak
+++ b/changelog/2021-02-03T15_24_30+01_00_fix_register_memory_leak
@@ -1,0 +1,1 @@
+FIXED: Fixed a memory leak in register when used on asynchronous domains. Although the memory leak has always been there, it was only triggered on asserted resets. These periods are typically short, hence unnoticable.

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -180,7 +180,7 @@ ddrOut# clk rst en i0 xs ys =
     -- That is why we drop the first value of the stream.
     let (_ :- out) = zipSig xs' ys' in out
   where
-    xs' = register# clk rst en (error "ddrOut: unreachable error") i0 xs
+    xs' = register# clk rst en (errorX "ddrOut: unreachable error") i0 xs
     ys' = register# clk rst en (deepErrorX "ddrOut: initial value undefined") i0 ys
     zipSig (a :- as) (b :- bs) = a :- b :- zipSig as bs
 {-# NOINLINE ddrOut# #-}

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -1141,7 +1141,7 @@ asyncRegister# clk (unsafeToHighPolarity -> rst) (fromEnable -> ena) initVal res
     let oR = if r then resetVal else o
         oE = if r then resetVal else (if e then x else o)
         -- [Note: register strictness annotations]
-    in  oR `defaultSeqX` oR :- (as `seq` enas `seq` go oE rs es xs)
+    in  o `defaultSeqX` oR :- (as `seq` enas `seq` go oE rs es xs)
 {-# NOINLINE asyncRegister# #-}
 {-# ANN asyncRegister# hasBlackBox #-}
 


### PR DESCRIPTION
Fixes memory leak triggered on asserted resets. This went under the
radar for a long time, as reset periods are typically very short.

Fixes #1644