### PR TITLE
Fixed enum fix

### DIFF
--- a/changelog/2021-02-01T15_17_10+01_00_fixes_for_Fixed
+++ b/changelog/2021-02-01T15_17_10+01_00_fixes_for_Fixed
@@ -1,0 +1,3 @@
+FIXED: `signum` and `RealFrac` for `Fixed` now give the correct results.
+
+CHANGED/FIXED: `Fixed` now obeys the laws for `Enum` as set out in the Haskell Report, and it is now consistent with the documentation for the `Enum` class on Hackage. As `Fixed` is also `Bounded`, the rule in the Report that `succ maxBound` and `pred minBound` should result in a runtime error is interpreted as meaning that `succ` and `pred` result in a runtime error whenever the result cannot be represented, not merely for `minBound` and `maxBound` alone.

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -409,6 +409,7 @@ test-suite unittests
                  Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes
                  Clash.Tests.Fixed
+                 Clash.Tests.FixedExhaustive
                  Clash.Tests.NFDataX
                  Clash.Tests.Reset
                  Clash.Tests.Resize
@@ -420,6 +421,8 @@ test-suite unittests
 
                  Clash.Tests.Laws.Enum
                  Clash.Tests.Laws.SaturatingNum
+
+                 Hedgehog.Extra
 
                  Test.Tasty.HUnit.Extra
                  Test.QuickCheck.Extra

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -956,7 +956,7 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
                          1 -> unpack (resize (shiftR rR sh))
                          _ -> case msb rL of
                                 0 -> maxBound
-                                _ -> succ minBound
+                                _ -> Fixed $ succ minBound
           False -> case rL of
                      0 -> unpack (resize (shiftR rR sh))
                      _ -> maxBound

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -69,6 +69,7 @@ operator that uses truncation introduces an additional error of /0.109375/:
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NegativeLiterals #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -382,7 +383,7 @@ Where 'NumSFixedC' refers to the @Constraints@ needed by the operators of
 the 'Num' class for the 'SFixed' datatype.
 
 Although the number of constraints for the @mac@ function defined earlier might
-be considered small, here is an \"this way lies madness\" example where you
+be considered small, here is a \"this way lies madness\" example where you
 really want to use constraint kinds:
 
 @
@@ -1094,10 +1095,10 @@ instance (NumFixedC rep int frac, Integral (rep (int + frac))) =>
      denom     = 1 `shiftL` nF
      nom       = toInteger fRep
 
-instance (FracFixedC rep int frac, NumFixedC rep int frac, Integral (rep (int + frac))) =>
-         RealFrac (Fixed rep int frac) where
+instance FracFixedC rep int frac => RealFrac (Fixed rep int frac) where
   properFraction f@(Fixed fRep) = (fromIntegral whole, fract)
     where
       whole = (fRep `shiftR` fracShift f) + offset
       fract = Fixed $ fRep - (whole `shiftL` fracShift f)
-      offset = if f < 0 then 1 else 0
+      frMask = fromInteger $ (1 `shiftL` fracShift f) - 1
+      offset = if f < 0 && fRep .&. frMask /= 0 then 1 else 0

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -119,7 +119,7 @@ import Text.Read                  (Read(..))
 import Data.List                  (find)
 import Data.Proxy                 (Proxy (..))
 import Data.Ratio                 ((%), denominator, numerator)
-import Data.Typeable              (Typeable, TypeRep, typeRep)
+import Data.Typeable              (Typeable, TypeRep, typeRep, typeOf)
 import GHC.TypeLits               (KnownNat, Nat, type (+), natVal)
 import GHC.TypeLits.Extra         (Max)
 import Language.Haskell.TH        (Q, appT, conT, litT, mkName,
@@ -142,7 +142,7 @@ import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
                                    boundedMul)
 import Clash.Class.Resize         (Resize (..))
 import Clash.Promoted.Nat         (SNat, natToNum, natToInteger)
-import Clash.Prelude.BitIndex     (msb, split)
+import Clash.Prelude.BitIndex     (lsb, msb, split)
 import Clash.Prelude.BitReduction (reduceAnd, reduceOr)
 import Clash.Sized.BitVector      (BitVector, (++#))
 import Clash.Sized.Signed         (Signed)
@@ -187,7 +187,6 @@ deriving instance (Typeable rep, Typeable int, Typeable frac
                   , Data (rep (int + frac))) => Data (Fixed rep int frac)
 deriving instance Eq (rep (int + frac))      => Eq (Fixed rep int frac)
 deriving instance Ord (rep (int + frac))     => Ord (Fixed rep int frac)
-deriving instance Enum (rep (int + frac))    => Enum (Fixed rep int frac)
 deriving instance Bounded (rep (int + frac)) => Bounded (Fixed rep int frac)
 deriving instance Default (rep (int + frac)) => Default (Fixed rep int frac)
 deriving instance Arbitrary (rep (int + frac)) => Arbitrary (Fixed rep int frac)
@@ -496,11 +495,10 @@ type NumFixedC rep int frac
     , BitPack (rep ((int + int) + (frac + frac)))
     , Bits    (rep ((int + int) + (frac + frac)))
     , BitPack (rep (int + frac))
-    , Enum    (rep (int + frac))
     , Bits    (rep (int + frac))
-    , Ord     (rep (int + frac))
     , Integral (rep (int + frac))
     , Resize  rep
+    , Typeable rep
     , KnownNat int
     , KnownNat frac
     )
@@ -905,6 +903,184 @@ fLitR a = Fixed (fromInteger sat)
     truncated = truncate shifted :: Integer
     shifted   = a * (2 ^ (natToInteger @frac))
 
+-- | These behave similar to 'Prelude.Float', 'Prelude.Double' and
+-- 'Prelude.Rational'. 'succ'\/'pred' add\/subtract 1. See the
+-- <https://www.haskell.org/onlinereport/haskell2010/haskellch6.html#dx13-131001 Haskell Report>
+-- for full details.
+--
+-- The rules set out there for instances of both 'Enum' and
+-- 'Bounded' are also observed. In particular, 'succ' and 'pred' result in a
+-- runtime error if the result cannot be represented. See 'satSucc' and
+-- 'satPred' for other options.
+instance NumFixedC rep int frac => Enum (Fixed rep int frac) where
+  succ f =
+    let err = error $
+             "Enum.succ{" ++ show (typeOf f) ++ "}: tried to take 'succ' of "
+          ++ show f ++ ", causing overflow. Use 'satSucc' and specify a "
+          ++ "SaturationMode if you need other behavior."
+    in case natToInteger @int of
+         0 -> err
+         _ -> if f > satPred SatBound maxBound then
+                err
+              else
+                satSucc SatWrap f
+
+
+  pred f =
+    let err = error $
+             "Enum.pred{" ++ show (typeOf f) ++ "}: tried to take 'pred' of "
+          ++ show f ++ ", causing negative overflow. Use 'satPred' and "
+          ++ "specify a SaturationMode if you need other behavior."
+    in case natToInteger @int of
+         0 -> err
+         _ -> if f < satSucc SatBound minBound then
+                err
+              else
+                satPred SatWrap f
+
+  toEnum i =
+    if res > rMax || res < rMin then
+      error $  "Enum.toEnum{"
+            ++ show (typeRep $ Proxy @(Fixed rep int frac)) ++ "}: tag ("
+            ++ show i ++ ") is outside of bounds "
+            ++ show ( minBound :: Fixed rep int frac
+                    , maxBound :: Fixed rep int frac)
+    else
+      Fixed (fromInteger res)
+     where
+      sh   = natToNum @frac
+      res  = toInteger i `shiftL` sh
+      rMax = toInteger (maxBound :: rep (int + frac))
+      rMin = toInteger (minBound :: rep (int + frac))
+
+  fromEnum f@(Fixed fRep) =
+    if res > rMax || res < rMin then
+      error $  "Enum.fromEnum{" ++ show (typeOf f) ++ "}: value ("
+            ++ show f ++ ") is outside of Int's bounds "
+            ++ show (rMin, rMax)
+    else
+      fromInteger res
+     where
+      nF     = natToNum @frac
+      frMask = fromInteger $ (1 `shiftL` nF) - 1
+      offset = if f < 0 && fRep .&. frMask /= 0 then 1 else 0
+      -- res amounts to "truncate f", but without needing all the constraints
+      -- for RealFrac.
+      res    = toInteger $ (fRep `shiftR` nF) + offset
+      rMax   = toInteger (maxBound :: Int)
+      rMin   = toInteger (minBound :: Int)
+
+  enumFrom x1 = enumFromTo x1 maxBound
+  enumFromThen (Fixed x1Rep) (Fixed x2Rep) =
+    map Fixed $ enumFromThen x1Rep x2Rep
+
+  enumFromTo x1@(Fixed x1Rep) y@(Fixed yRep)
+    | yPlusHalf < x1 = []
+    | closeToMax     = [x1]
+    | otherwise      =  map Fixed $ enumFromThenTo
+                                      x1Rep
+                                      (unFixed $ satSucc SatWrap x1)
+                                      (unFixed $ yPlusHalf)
+   where
+    closeToMax = natToInteger @int == 0 || x1 > satPred SatBound maxBound
+    nF = natToNum @frac
+    yPlusHalf | nF == 0       = y
+              | isSigned yRep = y - (Fixed $ -1 `shiftL` (nF - 1))
+              | otherwise     = y + (Fixed $ 1 `shiftL` (nF - 1))
+
+  enumFromThenTo = enumFromThenTo#
+
+-- Inspired by Enum Int from GHC.Enum in base-4.14.1.0
+--
+-- Note that if x2 /= x1, it is guaranteed that (int + frac) >= 1, because if it
+-- were zero there would only be one concrete value. This fact is relied upon in
+-- enumFromThenToUp and enumFromThenToDown, which would have undefined behavior
+-- for (int + frac) == 0.
+enumFromThenTo#
+  :: forall f rep int frac
+   . ( NumFixedC rep int frac
+     , f ~ Fixed rep int frac)
+  => f
+  -> f
+  -> f
+  -> [f]
+enumFromThenTo# x1 x2 y
+  | x2 == x1  = if y < x1 then
+                  []
+                else
+                  repeat x1
+  | x2 > x1   = enumFromThenToUp x1 x2 y
+  | otherwise = enumFromThenToDown x1 x2 y
+
+enumFromThenToUp
+  :: forall f rep int frac
+   . ( NumFixedC rep int frac
+     , f ~ Fixed rep int frac)
+  => f
+  -> f
+  -> f
+  -> [f]
+enumFromThenToUp x1 x2 y
+  | y < x1 = let y' = satAdd SatWrap y halfDelta  -- Never wraps
+             in if y' < x1 || (isMinusHalf && y' <= x1) then
+                  []
+                else
+                  [x1]
+  | y < x2 = let x2' = satSub SatWrap x2 halfDelta  -- Never wraps `
+             in if y > x2' || (not isMinusHalf && y >= x2') then
+                  [x1, x2]
+                else
+                  [x1]
+  | otherwise = let y' = satSub SatWrap y (delta `shiftR` 1) -- Does wrap
+                    go_up x
+                      | x' < x            = [x]
+                      | isHalf && x >= y' = [x]
+                      | x > y'            = [x]
+                      | otherwise          = x : go_up x'
+                     where
+                      x' = satAdd SatWrap x delta  -- Does wrap
+                in x1 : go_up x2
+ where
+   delta = satSub SatWrap x2 x1  -- Does wrap!
+   halfDelta = satSub SatWrap (x2 `shiftR` 1) (x1 `shiftR` 1)  -- Never wraps
+   isHalf = lsb delta == 1
+   isMinusHalf = lsb x2 == 0 && lsb x1 == 1
+
+enumFromThenToDown
+  :: forall f rep int frac
+   . ( NumFixedC rep int frac
+     , f ~ Fixed rep int frac)
+  => f
+  -> f
+  -> f
+  -> [f]
+enumFromThenToDown x1 x2 y
+  | y > x1 = let y' = satSub SatWrap y halfDelta  -- Never wraps
+             in if y' > x1 || (isMinusHalf && y' >= x1) then
+                  []
+                else
+                  [x1]
+  | y > x2 = let x2' = satAdd SatWrap x2 halfDelta  -- Never wraps `
+             in if y < x2' || (not isMinusHalf && y <= x2') then
+                  [x1, x2]
+                else
+                  [x1]
+  | otherwise = let y' = satAdd SatWrap y (delta `shiftR` 1)  -- Does wrap
+                    go_dn x
+                      | x' > x            = [x]
+                      | isHalf && x <= y' = [x]
+                      | x < y'            = [x]
+                      | otherwise         = x : go_dn x'
+                     where
+                      x' = satSub SatWrap x delta  -- Does wrap
+                in x1 : go_dn x2
+ where
+  delta = satSub SatWrap x1 x2  -- Does wrap!
+  halfDelta = satSub SatWrap (x1 `shiftR` 1) (x2 `shiftR` 1)  -- Never wraps
+  isHalf = lsb delta == 1
+  isMinusHalf = lsb x1 == 0 && lsb x2 == 1
+
+
 instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
   satAdd w (Fixed a) (Fixed b) = Fixed (satAdd w a b)
   satSub  w (Fixed a) (Fixed b) = Fixed (satSub w a b)
@@ -978,7 +1154,7 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
         symBound = if isSigned fRep
                    then Fixed $ minBound + 1
                    else minBound
-    in case natVal (Proxy @int) of
+    in case natToInteger @int of
          0 -> case satMode of
                 SatWrap      -> f
                 SatBound     -> minBound
@@ -1044,9 +1220,6 @@ divide (Fixed fr1) fx2@(Fixed fr2) =
 type FracFixedC rep int frac
   = ( NumFixedC rep int frac
     , DivideC   rep int frac int frac
-    , Integral  (rep (int + frac))
-    , KnownNat  int
-    , KnownNat  frac
     )
 
 -- | Constraint for the 'Fractional' instance of 'SFixed'
@@ -1087,8 +1260,7 @@ instance FracFixedC rep int frac => Fractional (Fixed rep int frac) where
       n    = numerator   r `shiftL` (2 * frac)
       d    = denominator r `shiftL` frac
 
-instance (NumFixedC rep int frac, Integral (rep (int + frac))) =>
-         Real (Fixed rep int frac) where
+instance NumFixedC rep int frac => Real (Fixed rep int frac) where
   toRational f@(Fixed fRep) = nom % denom
    where
      nF        = fracShift f

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -920,7 +920,7 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
         (rL,rR) = split res :: (BitVector int, BitVector (int + frac + frac))
     in  case isSigned a of
           True  -> let overflow = complement (reduceOr (pack (msb rR) ++# pack rL)) .|.
-                                             reduceAnd (pack (msb rR) ++# pack rL)
+                                  reduceAnd (pack (msb rR) ++# pack rL)
                    in  case overflow of
                          1 -> unpack (resize (shiftR rR sh))
                          _ -> case msb rL of
@@ -936,7 +936,7 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
         (rL,rR) = split res :: (BitVector int, BitVector (int + frac + frac))
     in  case isSigned a of
           True  -> let overflow = complement (reduceOr (pack (msb rR) ++# pack rL)) .|.
-                                             reduceAnd (pack (msb rR) ++# pack rL)
+                                  reduceAnd (pack (msb rR) ++# pack rL)
                    in  case overflow of
                          1 -> unpack (resize (shiftR rR sh))
                          _ -> 0
@@ -950,7 +950,7 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
         (rL,rR) = split res :: (BitVector int, BitVector (int + frac + frac))
     in  case isSigned a of
           True  -> let overflow = complement (reduceOr (pack (msb rR) ++# pack rL)) .|.
-                                             reduceAnd (pack (msb rR) ++# pack rL)
+                                  reduceAnd (pack (msb rR) ++# pack rL)
                    in  case overflow of
                          1 -> unpack (resize (shiftR rR sh))
                          _ -> case msb rL of

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -681,7 +681,7 @@ instance KnownNat n => SaturatingNum (Signed n) where
     let r        = times# a b
         (rL,rR)  = split r
         overflow = complement (reduceOr (BV.pack# (msb rR) ++# pack rL)) .|.
-                              reduceAnd (BV.pack# (msb rR) ++# pack rL)
+                   reduceAnd (BV.pack# (msb rR) ++# pack rL)
     in  case overflow of
           1 -> unpack# rR
           _ -> case msb rL of
@@ -691,7 +691,7 @@ instance KnownNat n => SaturatingNum (Signed n) where
     let r        = times# a b
         (rL,rR)  = split r
         overflow = complement (reduceOr (BV.pack# (msb rR) ++# pack rL)) .|.
-                              reduceAnd (BV.pack# (msb rR) ++# pack rL)
+                   reduceAnd (BV.pack# (msb rR) ++# pack rL)
     in  case overflow of
           1 -> unpack# rR
           _ -> fromInteger# 0
@@ -699,7 +699,7 @@ instance KnownNat n => SaturatingNum (Signed n) where
     let r        = times# a b
         (rL,rR)  = split r
         overflow = complement (reduceOr (BV.pack# (msb rR) ++# pack rL)) .|.
-                              reduceAnd (BV.pack# (msb rR) ++# pack rL)
+                   reduceAnd (BV.pack# (msb rR) ++# pack rL)
     in  case overflow of
           1 -> unpack# rR
           _ -> case msb rL of

--- a/clash-prelude/tests/Clash/Tests/Fixed.hs
+++ b/clash-prelude/tests/Clash/Tests/Fixed.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
@@ -7,15 +6,20 @@
 
 module Clash.Tests.Fixed (tests) where
 
+import Data.Bits (isSigned)
+import Data.Proxy (Proxy(..))
+
 import Test.Tasty
 import Test.Tasty.Hedgehog
 
 import Clash.Class.Num
-import Clash.Sized.Fixed (Fixed(..), NumFixedC, SFixed, UFixed)
+import Clash.Sized.Fixed (Fixed(..), FracFixedC, NumFixedC, SFixed, UFixed)
 
 import GHC.TypeLits (KnownNat)
 
 import Hedgehog
+import Hedgehog.Extra (throwsException)
+import Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
 import qualified Hedgehog.Range as Range
 import qualified Hedgehog.Gen as Gen
 
@@ -58,10 +62,11 @@ saturate minB maxB _ SatSymmetric x
 saturateToBounded
   :: forall b
    . (Bounded b, Real b)
-  => SaturationMode
+  => Proxy b
+  -> SaturationMode
   -> Rational
   -> Rational
-saturateToBounded satMode x =
+saturateToBounded Proxy satMode x =
   let repInt = if (minBound @b) < 0
                then 2 * negate (toRational (minBound @b))
                else 1 + toRational (floor @_ @Integer $ toRational $
@@ -78,7 +83,7 @@ satSuccProperty
 satSuccProperty genA = property $ do
   satMode <- forAll Gen.enumBounded
   a <- forAll genA
-  toRational (satSucc satMode a) === (saturateToBounded @a satMode)
+  toRational (satSucc satMode a) === (saturateToBounded (Proxy @a) satMode)
                                         (toRational a + 1)
 
 satPredProperty
@@ -89,7 +94,7 @@ satPredProperty
 satPredProperty genA = property $ do
   satMode <- forAll Gen.enumBounded
   a <- forAll genA
-  toRational (satPred satMode a) === (saturateToBounded @a satMode)
+  toRational (satPred satMode a) === (saturateToBounded (Proxy @a) satMode)
                                         (toRational a - 1)
 
 saturatingNumLaws
@@ -161,23 +166,314 @@ genBoundBiasedS = genBoundBiased
 genBoundBiasedU :: forall a b. (KnownNat a, KnownNat b) => Gen (UFixed a b)
 genBoundBiasedU = genBoundBiased
 
-tests :: TestTree
-tests = testGroup "SaturatingNum"
+saturationTests :: TestTree
+saturationTests = testGroup "SaturatingNum"
   [ testSaturationLaws "SFixed 0 0" (genBoundBiasedS @0 @0)
   , testSaturationLaws "SFixed 0 1" (genBoundBiasedS @0 @1)
   , testSaturationLaws "SFixed 1 0" (genBoundBiasedS @1 @0)
+  , testSaturationLaws "SFixed 0 2" (genBoundBiasedS @0 @2)
   , testSaturationLaws "SFixed 1 1" (genBoundBiasedS @1 @1)
+  , testSaturationLaws "SFixed 2 0" (genBoundBiasedS @2 @0)
   , testSaturationLaws "SFixed 1 2" (genBoundBiasedS @1 @2)
   , testSaturationLaws "SFixed 2 1" (genBoundBiasedS @2 @1)
   , testSaturationLaws "SFixed 2 2" (genBoundBiasedS @2 @2)
+  , testSaturationLaws "SFixed 7 7" (genBoundBiasedS @7 @7)
+  , testSaturationLaws "SFixed 121 121" (genBoundBiasedS @121 @121)
   , testSaturationLaws "SFixed 128 128" (genBoundBiasedS @128 @128)
 
   , testSaturationLaws "UFixed 0 0" (genBoundBiasedU @0 @0)
   , testSaturationLaws "UFixed 0 1" (genBoundBiasedU @0 @1)
   , testSaturationLaws "UFixed 1 0" (genBoundBiasedU @1 @0)
+  , testSaturationLaws "UFixed 0 2" (genBoundBiasedU @0 @2)
   , testSaturationLaws "UFixed 1 1" (genBoundBiasedU @1 @1)
+  , testSaturationLaws "UFixed 2 0" (genBoundBiasedU @2 @0)
   , testSaturationLaws "UFixed 1 2" (genBoundBiasedU @1 @2)
   , testSaturationLaws "UFixed 2 1" (genBoundBiasedU @2 @1)
   , testSaturationLaws "UFixed 2 2" (genBoundBiasedU @2 @2)
+  , testSaturationLaws "UFixed 7 7" (genBoundBiasedU @7 @7)
+  , testSaturationLaws "UFixed 121 121" (genBoundBiasedU @121 @121)
   , testSaturationLaws "UFixed 128 128" (genBoundBiasedU @128 @128)
   ]
+
+-- | Test pred for Fixed
+--
+-- Edges where behavior changes are picked explicitly:
+--  2 % minBound
+--  2 % highest value that causes an exception
+--  2 % minBound + 1
+--  2 % maxBound
+-- 41 % uniform [minBound, minBound + 1)
+-- 41 % uniform [minBound + 1, maxBound]
+--
+--  Note that for types with many integral bits, the two uniform ranges have
+--  vastly different sizes. The range that causes exceptions is included
+--  separately so numbers in that range will be part of a test run.
+predProperty
+  :: forall f rep int frac
+   . ( NumFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Property
+predProperty Proxy = property $ do
+  let excHi = Fixed $ satPred SatBound $ unFixed valLo
+      valLo = satSucc SatBound minBound
+  x :: f <- forAll $ Gen.frequency
+                     [ (2, pure minBound)
+                     , (2, pure excHi)
+                     , (2, pure valLo)
+                     , (2, pure maxBound)
+                     , (41, genFixed $ rangeLinearFixed excHi minBound)
+                     , (41, genFixed $ rangeLinearFixed valLo maxBound)]
+  if toRational x - 1 < toRational (minBound @f) then do
+    throwsException (pred x)
+  else do
+    toRational (pred x) === toRational x - 1
+
+-- | Test succ for Fixed
+--
+-- Edges where behaviour changes are picked explicitly:
+--  2 % minBound
+--  2 % maxBound - 1
+--  2 % lowest value that causes an exception
+--  2 % maxBound
+-- 41 % uniform (maxBound - 1, maxBound]
+-- 41 % uniform [minBound, maxBound - 1]
+--
+--  Note that for types with many integral bits, the two uniform ranges have
+--  vastly different sizes. The range that causes exceptions is included
+--  separately so numbers in that range will be part of a test run.
+succProperty
+  :: forall f rep int frac
+   . ( NumFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Property
+succProperty Proxy = property $ do
+  let valHi = satPred SatBound maxBound
+      excLo = Fixed $ satSucc SatBound $ unFixed valHi
+  x :: f <- forAll $ Gen.frequency
+                     [ (2, pure minBound)
+                     , (2, pure valHi)
+                     , (2, pure excLo)
+                     , (2, pure maxBound)
+                     , (41, genFixed $ rangeLinearFixed excLo maxBound)
+                     , (41, genFixed $ rangeLinearFixed valHi minBound)]
+  if toRational x + 1 > toRational (maxBound @f) then do
+    throwsException (succ x)
+  else do
+    toRational (succ x) === toRational x + 1
+
+-- The maximum length of lists we generate as test cases.
+--
+-- Property tests might overshoot this by a small amount, but no more than that.
+maxLength :: Num n => n
+maxLength = 1000
+
+-- Verify generated list is as expected
+--
+-- Filters those rs that cannot and therefore should not occur in fs.
+--
+-- Also asserts the length is within reasonable bounds. Property tests might
+-- overshoot `maxLength` by a small amount, but not more than that. But if some
+-- change broke our candidate number generation in the property tests, we might
+-- end up generating really long lists, which might take really long or possibly
+-- a (practically) infinite amount of time to compute. While the bug or change
+-- is probably not in the verified property itself, it still is an indication
+-- something broke or needs to be adjusted, hence unittest failure is
+-- reasonable.
+listsEqual
+  :: forall f rep int frac m
+   . ( NumFixedC rep int frac
+     , f ~ Fixed rep int frac
+     , MonadTest m
+     , HasCallStack
+     )
+  => [f]
+  -> [Rational]
+  -> m ()
+listsEqual fs rs0 = withFrozenCallStack $ do
+  let limit = 2 * maxLength
+      minVal = toRational $ minBound @f
+      maxVal = toRational $ maxBound @f
+      rs = take limit $ takeWhile (\r -> r >= minVal && r <= maxVal) rs0
+  assert (length rs < limit)
+  take limit (map toRational fs) === rs
+
+-- Round fromRational towards specific value
+--
+-- fromRational for Fixed rounds towards negative infinity.
+-- fromRationalTowards to x rounds x towards to.
+fromRationalTowards
+  :: forall rep int frac
+   . FracFixedC rep int frac
+  => Fixed rep int frac
+  -> Rational
+  -> Fixed rep int frac
+fromRationalTowards to x
+  | toRational to < x = fromRational x
+  | isSigned to       = negate $ fromRational $ negate x
+  | otherwise         = let mb = maxBound :: Fixed rep int frac
+                        in mb - fromRational (toRational mb - x)
+
+enumFromProperty
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Property
+enumFromProperty Proxy = property $ do
+  let minVal = if toRational (maxBound @f) < maxLength then
+                 minBound
+               else
+                 maxBound - maxLength
+  x1 :: f <- forAll $ genFixed $ rangeLinearFixed minVal maxBound
+  footnote $ "x1 = Fixed " ++ show (toInteger $ unFixed x1)
+  listsEqual (enumFrom x1) (enumFrom (toRational x1))
+
+enumFromThenProperty
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Property
+enumFromThenProperty Proxy = property $ do
+  x1 :: f <- forAll $ genFixed rangeLinearFixedBounded
+  footnote $ "x1 = Fixed " ++ show (toInteger $ unFixed x1)
+  approxLen <- forAll $ Gen.int $ Range.linear 0 maxLength
+  footnote $ "approxLen = " ++ show approxLen
+  let x2Range y = ( if approxLen <= 1 then
+                      y
+                    else
+                      fromRational
+                        $ toRational x1 +   (toRational y - toRational x1)
+                                          / (toRational approxLen - 1)
+                  , fromRational
+                      $ toRational x1 +   (toRational y - toRational x1)
+                                        / (toRational approxLen + 1))
+  x2 :: f <- forAll $ Gen.choice
+                      [ genFixed $ uncurry Range.constant $ x2Range minBound
+                      , genFixed $ uncurry Range.constant $ x2Range maxBound
+                      ]
+  footnote $ "x2 = Fixed " ++ show (toInteger $ unFixed x2)
+  let fs = enumFromThen x1 x2
+      rs = enumFromThen (toRational x1) (toRational x2)
+  if (x1 == x2) then do
+    take 10 (map toRational fs) === take 10 rs
+  else do
+    listsEqual fs rs
+
+enumFromToProperty
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Property
+enumFromToProperty Proxy = property $ do
+  x1 :: f <- forAll $ genFixed rangeLinearFixedBounded
+  footnote $ "x1 = Fixed " ++ show (toInteger $ unFixed x1)
+  let (minVal, maxVal) = if toRational (maxBound @f) < maxLength then
+                           (minBound, maxBound)
+                         else
+                           (x1 - maxLength, x1 + maxLength)
+  y :: f <- forAll $ genFixed $ rangeLinearFixed minVal maxVal
+  footnote $ "y = Fixed " ++ show (toInteger $ unFixed y)
+  listsEqual (enumFromTo x1 y) (enumFromTo (toRational x1) (toRational y))
+
+enumFromThenToProperty
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Property
+enumFromThenToProperty Proxy = property $ do
+  x1 :: f <- forAll $ genFixed rangeLinearFixedBounded
+  footnote $ "x1 = Fixed " ++ show (toInteger $ unFixed x1)
+  let closeToMin =
+        minBound @f +
+        fromRational ((toRational x1 - toRational (minBound @f)) / 4)
+      closeToMax =
+        maxBound @f -
+        fromRational ((toRational (maxBound @f) - toRational x1) / 4)
+  y :: f <- forAll $ Gen.frequency
+                       [ (10, genFixed $ rangeLinearFixed closeToMin minBound)
+                       , (10, genFixed $ rangeLinearFixed closeToMax maxBound)
+                       , (80, genFixed $ rangeLinearFixedBounded)]
+  footnote $ "y = Fixed " ++ show (toInteger $ unFixed y)
+  approxLen <- forAll $ Gen.int $ Range.linear 0 maxLength
+  footnote $ "approxLen = " ++ show approxLen
+  let (revBound, fwdBound) = if y < x1 then
+                               (maxBound @f, minBound @f)
+                             else
+                               (minBound, maxBound)
+      minX2 = if approxLen <= 1 then
+                y
+              else
+                fromRationalTowards y
+                  (toRational x1 +   (toRational y - toRational x1)
+                                   / (toRational approxLen - 1))
+      maxX2 = fromRationalTowards y
+                  (toRational x1 +  (toRational y - toRational x1)
+                                  / (toRational approxLen + 1))
+  x2 :: f <- forAll $ Gen.frequency
+                      [ (2, pure x1)
+                      , (2, genFixed $ rangeLinearFixed x1 revBound)
+                      , (2, genFixed $ rangeLinearFixed y fwdBound)
+                      , (94, genFixed $ Range.constant minX2 maxX2)]
+  footnote $ "x2 = Fixed " ++ show (toInteger $ unFixed x2)
+  let fs = enumFromThenTo x1 x2 y
+      rs = enumFromThenTo (toRational x1) (toRational x2) (toRational y)
+  if (x1 == x2) then do
+    take 10 (map toRational fs) === take 10 rs
+  else do
+    listsEqual fs rs
+
+enumProperties
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> [TestTree]
+enumProperties pf =
+  [ testProperty "pred" $ predProperty pf
+  , testProperty "succ" $ succProperty pf
+  , testProperty "enumFrom" $ enumFromProperty pf
+  , testProperty "enumFromThen" $ enumFromThenProperty pf
+  , testProperty "enumFromTo" $ enumFromToProperty pf
+  , testProperty "enumFromThenTo" $ enumFromThenToProperty pf
+  ]
+
+testEnumProperties
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => String
+  -> Proxy f
+  -> TestTree
+testEnumProperties typeName pf = testGroup typeName (enumProperties pf)
+
+-- Small types are tested exhaustively in Clash.Tests.FixedExhaustive
+enumTests :: TestTree
+enumTests =
+  testGroup "Enum"
+    [ testEnumProperties "SFixed 7 7" (Proxy @(SFixed 7 7))
+    , testEnumProperties "SFixed 121 121" (Proxy @(SFixed 121 121))
+    , testEnumProperties "SFixed 128 128" (Proxy @(SFixed 128 128))
+    , testEnumProperties "UFixed 7 7" (Proxy @(UFixed 7 7))
+    , testEnumProperties "UFixed 121 121" (Proxy @(UFixed 121 121))
+    , testEnumProperties "UFixed 128 128" (Proxy @(UFixed 128 128))
+    ]
+
+tests :: TestTree
+tests =
+  testGroup "Fixed"
+    [ saturationTests
+    , enumTests
+    ]

--- a/clash-prelude/tests/Clash/Tests/FixedExhaustive.hs
+++ b/clash-prelude/tests/Clash/Tests/FixedExhaustive.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE NegativeLiterals #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
+
+module Clash.Tests.FixedExhaustive (tests) where
+
+import Data.Proxy (Proxy(..))
+import Data.Typeable (typeRep)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Clash.Sized.Fixed (Fixed(..), FracFixedC, SFixed, UFixed)
+
+listsEqual
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => String
+  -> [f]
+  -> [Rational]
+  -> Assertion
+listsEqual prefix fs0 rs0 = do
+  let limit = 1000
+      minVal = toRational $ minBound @f
+      maxVal = toRational $ maxBound @f
+      fs = take limit (map toRational fs0)
+      rs = take limit $ takeWhile (\r -> r >= minVal && r <= maxVal) rs0
+  assertBool (prefix ++ "length rs > maxLength") (length rs < limit)
+  assertBool (prefix ++ show fs ++ "\n/=\n" ++ show rs) (fs == rs)
+
+forAllEnumFrom
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Assertion
+forAllEnumFrom Proxy = sequence_
+  [ listsEqual ("x1 = Fixed " ++ show (toInteger $ unFixed x1))
+               (enumFrom x1)
+               (enumFrom (toRational x1))
+  | x1 :: f <- map Fixed [minBound..]]
+
+forAllEnumFromThen
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Assertion
+forAllEnumFromThen Proxy = sequence_
+  [ let fs = enumFromThen x1 x2
+        rs = enumFromThen (toRational x1) (toRational x2)
+        prefix = unlines [ "x1 = Fixed " ++ show (toInteger $ unFixed x1)
+                         , "x2 = Fixed " ++ show (toInteger $ unFixed x2)]
+    in if (x1 == x2) then
+         listsEqual prefix (take 10 fs) (take 10 rs)
+       else
+         listsEqual prefix fs rs
+  | x1 :: f <- map Fixed [minBound..]
+  , x2 <- map Fixed [minBound..]]
+
+forAllEnumFromTo
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Assertion
+forAllEnumFromTo Proxy = sequence_
+  [ listsEqual (unlines [ "x1 = Fixed " ++ show (toInteger $ unFixed x1)
+                        , "y = Fixed " ++ show (toInteger $ unFixed y)])
+               (enumFromTo x1 y)
+               (enumFromTo (toRational x1) (toRational y))
+  | x1 :: f <- map Fixed [minBound..]
+  , y <- map Fixed [minBound..]]
+
+forAllEnumFromThenTo
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> Assertion
+forAllEnumFromThenTo Proxy = sequence_
+  [ let fs = enumFromThenTo x1 x2 y
+        rs = enumFromThenTo (toRational x1) (toRational x2) (toRational y)
+        prefix = unlines [ "x1 = Fixed " ++ show (toInteger $ unFixed x1)
+                         , "x2 = Fixed " ++ show (toInteger $ unFixed x2)
+                         , "y = Fixed " ++ show (toInteger $ unFixed y)]
+    in if (x1 == x2) then
+         listsEqual prefix (take 10 fs) (take 10 rs)
+       else
+         listsEqual prefix fs rs
+  | x1 :: f <- map Fixed [minBound..]
+  , x2 <- map Fixed [minBound..]
+  , y <- map Fixed [minBound..]]
+
+enumTests
+  :: forall f rep int frac
+   . ( FracFixedC rep int frac
+     , f ~ Fixed rep int frac
+     )
+  => Proxy f
+  -> TestTree
+enumTests pf =
+  testGroup (show $ typeRep pf)
+    [ testCase "enumFrom" $ forAllEnumFrom pf
+    , testCase "enumFromThen" $ forAllEnumFromThen pf
+    , testCase "enumFromTo" $ forAllEnumFromTo pf
+    , testCase "enumFromThenTo" $ forAllEnumFromThenTo pf ]
+
+tests :: TestTree
+tests =
+  testGroup "FixedExhaustive"
+    [ enumTests (Proxy @(SFixed 0 0))
+    , enumTests (Proxy @(SFixed 0 1))
+    , enumTests (Proxy @(SFixed 1 0))
+    , enumTests (Proxy @(SFixed 0 2))
+    , enumTests (Proxy @(SFixed 1 1))
+    , enumTests (Proxy @(SFixed 2 0))
+    , enumTests (Proxy @(SFixed 0 3))
+    , enumTests (Proxy @(SFixed 1 2))
+    , enumTests (Proxy @(SFixed 2 1))
+    , enumTests (Proxy @(SFixed 3 0))
+    , enumTests (Proxy @(SFixed 0 4))
+    , enumTests (Proxy @(SFixed 1 3))
+    , enumTests (Proxy @(SFixed 2 2))
+    , enumTests (Proxy @(SFixed 3 1))
+    , enumTests (Proxy @(SFixed 4 0))
+    , enumTests (Proxy @(UFixed 0 0))
+    , enumTests (Proxy @(UFixed 0 1))
+    , enumTests (Proxy @(UFixed 1 0))
+    , enumTests (Proxy @(UFixed 0 2))
+    , enumTests (Proxy @(UFixed 1 1))
+    , enumTests (Proxy @(UFixed 2 0))
+    , enumTests (Proxy @(UFixed 0 3))
+    , enumTests (Proxy @(UFixed 1 2))
+    , enumTests (Proxy @(UFixed 2 1))
+    , enumTests (Proxy @(UFixed 3 0))
+    , enumTests (Proxy @(UFixed 0 4))
+    , enumTests (Proxy @(UFixed 1 3))
+    , enumTests (Proxy @(UFixed 2 2))
+    , enumTests (Proxy @(UFixed 3 1))
+    , enumTests (Proxy @(UFixed 4 0))
+    ]

--- a/clash-prelude/tests/Clash/Tests/Laws/Enum.hs
+++ b/clash-prelude/tests/Clash/Tests/Laws/Enum.hs
@@ -9,7 +9,6 @@ import Test.Tasty.HUnit
 
 import Clash.Sized.Index (Index)
 import Clash.Sized.Signed (Signed)
-import Clash.Sized.Fixed (SFixed, UFixed)
 import Clash.Sized.Unsigned (Unsigned)
 
 import Test.Tasty.HUnit.Extra
@@ -62,28 +61,5 @@ tests = testGroup "Enum"
   , testEnumLaws "Signed 127" (Proxy @(Signed 127))
   , testEnumLaws "Signed 128" (Proxy @(Signed 128))
 
-  -- TODO: SFixed and UFixed are partial for
-  --
-  --         succ (maxBound-1, maxBound]
-  --         pred [minBound, minBound+1)
-  --
-  -- Tests only test minBound/maxBound though.
-  --
-  , testEnumLaws "SFixed 0 0" (Proxy @(SFixed 0 0))
-  , testEnumLaws "SFixed 0 1" (Proxy @(SFixed 0 1))
-  , testEnumLaws "SFixed 1 0" (Proxy @(SFixed 1 0))
-  , testEnumLaws "SFixed 1 1" (Proxy @(SFixed 1 1))
-  , testEnumLaws "SFixed 1 2" (Proxy @(SFixed 1 2))
-  , testEnumLaws "SFixed 2 1" (Proxy @(SFixed 2 1))
-  , testEnumLaws "SFixed 2 2" (Proxy @(SFixed 2 2))
-  , testEnumLaws "SFixed 128 128" (Proxy @(SFixed 128 128))
-
-  , testEnumLaws "UFixed 0 0" (Proxy @(UFixed 0 0))
-  , testEnumLaws "UFixed 0 1" (Proxy @(UFixed 0 1))
-  , testEnumLaws "UFixed 1 0" (Proxy @(UFixed 1 0))
-  , testEnumLaws "UFixed 1 1" (Proxy @(UFixed 1 1))
-  , testEnumLaws "UFixed 1 2" (Proxy @(UFixed 1 2))
-  , testEnumLaws "UFixed 2 1" (Proxy @(UFixed 2 1))
-  , testEnumLaws "UFixed 2 2" (Proxy @(UFixed 2 2))
-  , testEnumLaws "UFixed 128 128" (Proxy @(UFixed 128 128))
+  -- Note Fixed is tested elsewhere.
   ]

--- a/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
+++ b/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
@@ -78,21 +78,23 @@ saturatingNumLaws ::
   TestWrap ->
   Gen a ->
   [TestTree]
-saturatingNumLaws testWrap genA =
-  (if testWrap then
+saturatingNumLaws testEnum genA =
+  (if testEnum then
     [ testCase "SatWrap: Wrap around on overflow" (satWrapOverflowLaw genA)
     , testCase "SatWrap: Wrap around on underflow" (satWrapUnderflowLaw genA)
-    , testCase "SatSymmetric: Become maxBound on overflow" (satSymmetricOverflow genA)
-    , testCase "SatSymmetric: Become minBound or minBound+1 on underflow" (satSymmetricUnderflow genA) ]
+    , testCase "SatSymmetric: Become maxBound on overflow"
+               (satSymmetricOverflow genA)
+    , testCase "SatSymmetric: Become minBound or minBound+1 on underflow"
+               (satSymmetricUnderflow genA)
+    , testCase "SatBound: Become maxBound on overflow"
+               (satBoundOverflowLaw genA)
+    , testCase "SatBound: Become minBound on underflow"
+               (satBoundUnderflowLaw genA)
+    , testCase "SatZero: Become 0 on overflow" (satZeroOverflowLaw genA)
+    , testCase "SatZero: Become 0 on underflow" (satZeroUnderflowLaw genA) ]
   else
     []) <>
-  [ testCase "SatBound: Become maxBound on overflow" (satBoundOverflowLaw genA)
-  , testCase "SatBound: Become minBound on underflow" (satBoundUnderflowLaw genA)
-
-  , testCase "SatZero: Become 0 on overflow" (satZeroOverflowLaw genA)
-  , testCase "SatZero: Become 0 on underflow" (satZeroUnderflowLaw genA)
-
-  , testProperty "satAddTotal" (isTotal satAdd genA)
+  [ testProperty "satAddTotal" (isTotal satAdd genA)
   , testProperty "satSubTotal" (isTotal satSub genA)
   , testProperty "satMulTotal" (isTotal satMul genA)
   ]
@@ -103,8 +105,8 @@ testSaturationLaws ::
   String ->
   Gen a ->
   TestTree
-testSaturationLaws testWrap typeName genA =
-  testGroup typeName (saturatingNumLaws testWrap genA)
+testSaturationLaws testEnum typeName genA =
+  testGroup typeName (saturatingNumLaws testEnum genA)
 
 -- | Generates a bounded integral with a bias towards extreme values:
 --
@@ -175,18 +177,26 @@ tests = testGroup "SaturatingNum"
   , testSaturationLaws False "SFixed 0 0" (genSFixed @0 @0)
   , testSaturationLaws False "SFixed 0 1" (genSFixed @0 @1)
   , testSaturationLaws False "SFixed 1 0" (genSFixed @1 @0)
+  , testSaturationLaws False "SFixed 0 2" (genSFixed @0 @2)
   , testSaturationLaws False "SFixed 1 1" (genSFixed @1 @1)
+  , testSaturationLaws False "SFixed 2 0" (genSFixed @2 @0)
   , testSaturationLaws False "SFixed 1 2" (genSFixed @1 @2)
   , testSaturationLaws False "SFixed 2 1" (genSFixed @2 @1)
   , testSaturationLaws False "SFixed 2 2" (genSFixed @2 @2)
+  , testSaturationLaws False "SFixed 7 7" (genSFixed @7 @7)
+  , testSaturationLaws False "SFixed 121 121" (genSFixed @121 @121)
   , testSaturationLaws False "SFixed 128 128" (genSFixed @128 @128)
 
   , testSaturationLaws False "UFixed 0 0" (genUFixed @0 @0)
   , testSaturationLaws False "UFixed 0 1" (genUFixed @0 @1)
   , testSaturationLaws False "UFixed 1 0" (genUFixed @1 @0)
+  , testSaturationLaws False "UFixed 0 2" (genUFixed @0 @2)
   , testSaturationLaws False "UFixed 1 1" (genUFixed @1 @1)
+  , testSaturationLaws False "UFixed 2 0" (genUFixed @2 @0)
   , testSaturationLaws False "UFixed 1 2" (genUFixed @1 @2)
   , testSaturationLaws False "UFixed 2 1" (genUFixed @2 @1)
   , testSaturationLaws False "UFixed 2 2" (genUFixed @2 @2)
+  , testSaturationLaws False "UFixed 7 7" (genUFixed @7 @7)
+  , testSaturationLaws False "UFixed 121 121" (genUFixed @121 @121)
   , testSaturationLaws False "UFixed 128 128" (genUFixed @128 @128)
   ]

--- a/clash-prelude/tests/Hedgehog/Extra.hs
+++ b/clash-prelude/tests/Hedgehog/Extra.hs
@@ -1,0 +1,17 @@
+module Hedgehog.Extra
+  (throwsException) where
+
+import Hedgehog (failure, MonadTest, success)
+import Hedgehog.Internal.Exception (tryEvaluate)
+import Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
+
+throwsException
+  :: ( MonadTest m
+     , HasCallStack
+     )
+  => a
+  -> m ()
+throwsException x =
+  case (tryEvaluate x) of
+    Left _  -> success
+    Right _ -> withFrozenCallStack failure

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -7,6 +7,7 @@ import qualified Clash.Tests.BitPack
 import qualified Clash.Tests.BitVector
 import qualified Clash.Tests.DerivingDataRepr
 import qualified Clash.Tests.Fixed
+import qualified Clash.Tests.FixedExhaustive
 import qualified Clash.Tests.NFDataX
 import qualified Clash.Tests.Reset
 import qualified Clash.Tests.Resize
@@ -25,6 +26,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.BitVector.tests
   , Clash.Tests.DerivingDataRepr.tests
   , Clash.Tests.Fixed.tests
+  , Clash.Tests.FixedExhaustive.tests
   , Clash.Tests.NFDataX.tests
   , Clash.Tests.Reset.tests
   , Clash.Tests.Resize.tests


### PR DESCRIPTION
This PR makes the `Enum` instance of `Fixed` conform to the laws in the [Haskell Report](https://www.haskell.org/onlinereport/haskell2010/haskellch6.html#dx13-131001) as well as the doc for the [`Enum`](https://hackage.haskell.org/package/base-4.14.1.0/docs/Prelude.html#t:Enum) class on Hackage. This PR also includes some small improvements/fixes related to the `Fixed` type.

The behaviour of `Float` and `Double` described in the Report, which also matches the behaviour of `Rational`, is implemented for `Fixed`, including the rule for the ending value of arithmetic sequences.

Because `Fixed` is an instance of both `Bounded` and `Fractional`, and both the Report and the `Enum` class documentation say `succ`/`pred` add/subtract 1, the rule in the Report:
> For any type that is an instance of class Bounded as well as Enum, the following should hold:
> * The calls succ maxBound and pred minBound should result in a runtime error.

is interpreted as:
> * If the result of a call of succ or pred cannot be represented, they should result in a runtime error.

because there are more values than just `succ maxBound` and `pred minBound` that cannot be represented. I suspect the Report was written without considering something that is both `Bounded` and `Fractional`.

It should be noted that [`Data.Fixed`](https://hackage.haskell.org/package/base-4.14.1.0/docs/Data-Fixed.html) from `base` breaks the rule from the documentation (in base!) of the `Enum` class that `succ`/`pred` adds/subtracts 1, and they don't follow the extended rules for ending values of arithmetic sequences either.

A list of further comments or points of discussion:

* `Typeable` is now in `NumFixedC`, we use it to format error messages in `Enum`.
* In the unittests, Hedgehog `Size` scales the length of generated arithmetic sequences, with the largest `Size`s generating lists of up to 1000 elements. Because of how Hedgehog works, most will be shorter. Is this a good length?
* I added `Hedgehog.Extra.throwsException`, and only later discovered there was something similar at `Clash.Tests.Resize.expectExceptionNoX`. Do we harmonise this? The naming style differs: do we describe the test or the result?
* Should `throwsException` have `HasCallStack` / use `withFrozenCallStack`?
* I harmonised the tested lengths of `Fixed` over several tests. In particular, I'd like to point out that `SFixed 2 0` is the smallest type that is capable of expressing the number 1. Given that we've had issues with representing the number 1 in the past, it seems prudent to include it in our tests.
* For `Signed` and `Unsigned`, `enumFrom*` has `NOINLINE`. Do that here as well? Or is this another remnant of the never executed plans for enhanced error messages for non-synthesisable code?
* We need all of `NumFixedC` as constraint for `Enum Fixed`, this was tested. This test did reveal a redundancy: `Integral` implies both `Enum` and `Ord`, so the latter probably need not even be in `NumFixedC`.
* I based the error messages on the ones in the Haskell Prelude.
* I use `SatWrap` for speed.
* Redundant, narrower-scope tests for `Fixed` removed from `Clash.Tests.Laws.Enum`.
* `Clash.Tests.Laws.SaturatingNum` has tests for `satSucc`/`satPred`, of which only part was run for Fixed. All of them are now superfluous. The `isTotal` tests there, however, are not anywhere else yet. These tests just verify there are no runtime errors; with the infrastructure of `Clash.Tests.Fixed`, we could also verify the result.
