### PR TITLE
Remove absentError from primops which are values

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -132,7 +132,6 @@ ghcPrimUnwind tcm p tys vs v [] m
                        , "Clash.Transformations.removedArg"
                        , "GHC.Prim.MutableByteArray#"
                        , "Clash.Transformations.undefined"
-                       , "Control.Exception.Base.absentError"
                        ]
               -- The above primitives are actually values, and not operations.
   = ghcUnwind (PrimVal p tys (vs ++ [v])) m tcm


### PR DESCRIPTION
absentError was added to the lists of primitives which are
undefined and primitives which are values. These two lists should be
disjoint, as when unwinding primitives which are values are preserved
and primtives which are undefined are replaced with
Clash.Transformations.undefined.

Primitives which are values are checked before primitives which are
undefined, meaning currently absentError will be preserved in the
output from compile time eval, despite being undefined. As other GHC
error primitives are not treated as values, the correct behaviour
should be to treat it is undefined.