### PR TITLE
Allow newer, version 0.18, doctest for clash-prelude

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -367,7 +367,7 @@ test-suite doctests
   else
     build-depends:
       base,
-      doctest >= 0.9.1 && < 0.18,
+      doctest >= 0.9.1 && < 0.19,
       clash-prelude
   if impl(ghc >= 8.6)
     build-depends:


### PR DESCRIPTION
head.hackage no longer has patches for version 0.17, causing a fallback to the hackage version, which doesn't work on ghc9.
There are ghc9 patches for doctests-0.18 on head.hackage