### PR TITLE
Reign in allow newer on ghc9 CI builds

### DIFF
--- a/.ci/cabal.project.local.append-HEAD
+++ b/.ci/cabal.project.local.append-HEAD
@@ -8,7 +8,7 @@ repository head.hackage.ghc.haskell.org
        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
        7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
 
-allow-newer: *:base, *:template-haskell, *:ghc, *:stm, *:ghc-boot, *:ghc-prim, *:ghci, *:integer-gmp, *:Cabal
+allow-newer: *:base, *:Cabal, doctest:ghc, attoparsec:ghc-prim, *:template-haskell
 
 source-repository-package
     type: git

--- a/benchmark/clash-benchmark.cabal
+++ b/benchmark/clash-benchmark.cabal
@@ -23,7 +23,7 @@ library
   build-depends:       base                 >= 4.10     && < 5,
                        concurrent-supply    >= 0.1.7    && < 0.2,
                        containers           >= 0.5.4.0  && < 0.7,
-                       ghc                  >= 8.4.0    && < 8.11,
+                       ghc                  >= 8.4.0    && < 9.1,
                        mtl                  >= 2.1.2    && < 2.3,
                        unordered-containers >= 0.2.3.3  && < 0.3,
 

--- a/benchmark/profiling/prepare/clash-profiling-prepare.cabal
+++ b/benchmark/profiling/prepare/clash-profiling-prepare.cabal
@@ -32,7 +32,7 @@ executable clash-profile-normalization-prepare
                        bytestring            >= 0.10.0.2 && < 0.11,
                        directory             >= 1.3.0.0  && < 1.4,
                        filepath              >= 1.4      && < 1.5,
-                       ghc                   >= 8.4.0    && < 8.11,
+                       ghc                   >= 8.4.0    && < 9.1,
 
                        clash-lib,
                        clash-benchmark,
@@ -47,7 +47,7 @@ executable clash-profile-netlist-prepare
                        bytestring            >= 0.10.0.2 && < 0.11,
                        directory             >= 1.3.0.0  && < 1.4,
                        filepath              >= 1.4      && < 1.5,
-                       ghc                   >= 8.4.0    && < 8.11,
+                       ghc                   >= 8.4.0    && < 9.1,
 
                        clash-lib,
                        clash-benchmark,


### PR DESCRIPTION
Hopefully prevents more "forgetting to bump upper bounds on dependencies" mistakes.