### PR TITLE
hzToPeriod/periodToHz: use Ratio Natural

### DIFF
--- a/changelog/2021-02-10T17_29_11+01_00_hztoperiod_rounding
+++ b/changelog/2021-02-10T17_29_11+01_00_hztoperiod_rounding
@@ -1,0 +1,2 @@
+CHANGED: hzToPeriod now takes a `Ratio Natural` rather than a `Double`. It rounds slightly differently, leading to more intuitive results and satisfying the requested change in issue #1253. While the difference is observable in simulation, it does not affect generated circuits in a significant way.
+CHANGED: For symmetry, `periodToHz` now results in a `Ratio Natural`.

--- a/changelog/2021-02-11T14_20_26+01_00_drop_freqCalc
+++ b/changelog/2021-02-11T14_20_26+01_00_drop_freqCalc
@@ -1,0 +1,1 @@
+REMOVED: The deprecated function `freqCalc` has been removed.

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -194,7 +194,6 @@ module Clash.Explicit.Signal
   , enableGen
     -- * Clock
   , Clock
-  , freqCalc  -- DEPRECATED
   , periodToHz
   , hzToPeriod
     -- ** Synchronization primitive
@@ -357,18 +356,6 @@ systemClockGen = clockGen
 -- @
 systemResetGen ::Reset System
 systemResetGen = resetGen
-
--- | Calculate the period, in __ps__, given a frequency in __Hz__
---
--- i.e. to calculate the clock period for a circuit to run at 240 MHz we get
---
--- >>> freqCalc 240e6
--- 4167
---
--- __NB__: This function is /not/ synthesizable
-freqCalc :: Double -> Integer
-freqCalc = toInteger . hzToPeriod
-{-# DEPRECATED freqCalc "Use 'hzToPeriod' instead." #-}
 
 -- ** Synchronization primitive
 -- | The 'unsafeSynchronizer' function is a primitive that must be used to

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -156,6 +156,7 @@ import Data.Data                  (Data)
 import Data.Default.Class         (Default (..))
 import Data.Hashable              (Hashable)
 import Data.Proxy                 (Proxy(..))
+import Data.Ratio                 (Ratio)
 import Data.Type.Equality         ((:~:))
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack)
@@ -1420,24 +1421,23 @@ simulate_lazy f = sample_lazy . f . fromList_lazy
 -- i.e. to calculate the clock period for a circuit to run at 240 MHz we get
 --
 -- >>> hzToPeriod 240e6
--- 4167
+-- 4166
 --
 -- __NB__: This function is /not/ synthesizable
--- __NB__: This function is lossy. I.e., hzToPeriod . periodToHz /= id.
-hzToPeriod :: HasCallStack => Double -> Natural
-hzToPeriod freq | freq <= 0.0 = error "Frequency must be strictly positive"
-                | otherwise   = ceiling ((1.0 / freq) / 1.0e-12)
+--
+-- __NB__: This function is lossy. I.e.,  periodToHz . hzToPeriod /= id.
+hzToPeriod :: HasCallStack => Ratio Natural -> Natural
+hzToPeriod freq = floor ((1.0 / freq) / 1.0e-12)
 
 -- | Calculate the frequence in __Hz__, given the period in __ps__
 --
 -- i.e. to calculate the clock frequency of a clock with a period of 5000 ps:
 --
 -- >>> periodToHz 5000
--- 2.0e8
+-- 200000000 % 1
 --
 -- __NB__: This function is /not/ synthesizable
--- __NB__: This function is lossy. I.e., hzToPeriod . periodToHz /= id.
-periodToHz :: Natural -> Double
+periodToHz :: Natural -> Ratio Natural
 periodToHz period = 1.0 / (1.0e-12 * fromIntegral period)
 
 -- | Build an 'Automaton' from a function over 'Signal's.

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -1839,7 +1839,7 @@ We can calculate the clock periods using 'hzToPeriod':
 >>> hzToPeriod 20e6
 50000
 >>> hzToPeriod 9e6
-111112
+111111
 
 We can then create the clock and reset domains:
 


### PR DESCRIPTION
This will more often give the intuitively correct solution, per the
principle of least surprise. Actual functionality should not be affected
by the exact rounding, and thus this should not significantly change the
behaviour of existing designs.

Example:

Before this commit:

```
>>> hzToPeriod 100_000
10000001
```
After this commit:
```
>>> hzToPeriod 100_000
10000000
```

\<edit\>
We would like `hzToPeriod` to satisfy the following:

- Results should be intuitive
- Results should match a type-level equivalent as proposed in issue #1253

The former can be done with `Double`, by rounding to the nearest integer. This means that if there is an exact integer solution, we give that. Before this commit we had:

```
>>> hzToPeriod 100_000
10000001
```

instead of the intuitive result that a 100 kHz clock corresponds to a 10 µs period. The off-by-one has no significant consequences for the circuit, clocks are inherently not precise. It is just not intuitive.

But if we also want the result to match a simply expressed type-level equivalent, this is not enough, because the slight errors introduced by `Double` might cause a fractional part of 0.5 to be rounded either up or down seemingly randomly.

So the most straightforward fix is to use `Ratio Natural` and `floor`. If the result is an integral number of picoseconds, it will give that, and for roundings, it will match the behaviour of the straightforward type-level equivalent of:

```
type HzToPeriod (freq :: Nat) = 1_000_000_000_000 `Div` freq
```
\</edit\>

* ~~_Does this need a Changelog entry?_ Observable behaviour changes minutely, e.g., clock periods in generated waveforms might be a picosecond shorter or longer, two clocks might accumulate a slightly different phase relation than before. None of this affects functionality, so I'm inclined to say, no, a Changelog entry is too verbose. It's definitely subjective, though.~~
* Should we backport?