### PR TITLE
Set default GHC/Cabal version for CI jobs

### DIFF
--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -2,8 +2,6 @@ hackage-sdist:
   extends: .common
   stage: pack
   interruptible: false
-  variables:
-    GHC_VERSION: 8.10.3
   script:
     - .ci/build_sdist.sh clash-prelude
     - .ci/build_sdist.sh clash-lib
@@ -12,10 +10,6 @@ hackage-sdist:
     paths:
       - clash-*.tar.gz  # clash-{prelude,lib,ghc}-$version{-docs,}.tar.gz
     expire_in: 1 week
-  rules:
-    - if: '$CI_COMMIT_TAG != null' # tags
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_PIPELINE_SOURCE == "trigger"
 
 .hackage:
   extends: .common
@@ -23,8 +17,6 @@ hackage-sdist:
   stage: publish
   cache:
     key: hackage
-  variables:
-    GHC_VERSION: 8.10.3
   script:
     - .ci/publish_sdist.sh clash-prelude
     - .ci/publish_sdist.sh clash-lib

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,12 @@ include:
   - '/.ci/gitlab/publish.yml'
 #   - '/.ci/gitlab/benchmark.yml'
 
+# Default GHC / Cabal version. Used for generating Haddock and releasing to
+# Hackage.
+variables:
+  GHC_VERSION: 8.10.3
+  CABAL_VERSION: 3.2.0.0
+
 stages:
   - pre
   - test
@@ -58,9 +64,6 @@ haddock:
   extends: .common
   needs: []
   stage: test
-  variables:
-    GHC_VERSION: 8.10.3
-    CABAL_VERSION: 3.2.0.0
   artifacts:
     paths:
       - hadocs/*/*


### PR DESCRIPTION
Prevents failures during 'hackage-sdist':

* https://gitlab.com/clash-lang/clash-compiler/-/jobs/1022558527