### PR TITLE
Upgrade to LTS 17.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.9
+resolver: lts-17.2
 
 packages:
 - clash-prelude
@@ -9,8 +9,6 @@ packages:
 
 extra-deps:
 - ./clash-cosim
-- concurrent-supply-0.1.8@sha256:9373f4868ad28936a7b93781b214ef4afdeacf377ef4ac729583073491c9f9fb,1627
-- ghc-typelits-extra-0.4@sha256:e1ba4ebf14cb7025dd940380dfb15db444f7e8bced7e30bdad6e1707f0af7622,4813
 - arrows-0.4.4.2@sha256:a260222b766da922657e302aa7c0409451913e1e503798a47a213a61ba382460,1235
 - Stream-0.4.7.2@sha256:ed78165aa34c4e23dc53c9072f8715d414a585037f2145ea0eb2b38300354c53,1009
 - lazysmallcheck-0.6@sha256:dac7a1e4877681f1260309e863e896674dd6efc1159897b7945893e693f2a6bc,1696


### PR DESCRIPTION
I got a message this week that this blogpost:

* https://qbaylogic.com/blog/2020/11/30/clash-starter-project.html

is outdated concerning the comment:

> Note: Due to an upstream bug, these instructions are currently broken on Windows Build 2004. This is expected to be fixed with the release of GHC 8.10.3. We will update the starter project and remove this message as soon as that happens. In the meantime, consider using WSL2 to run Clash.

This prompted me to update the clash-starter project. I thought I'd apply the same change to this repo.