### PR TITLE
Do not traverse alternatives of nonRep cases

### DIFF
--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -131,7 +131,7 @@ constantPropagation =
     inlineNR :: NormRewrite
     inlineNR =
           bottomupR (apply "deadCode" deadCode)
-      >-! bottomupR (apply "inlineNonRep" inlineNonRep)
+      >-! apply "inlineNonRep" inlineNonRep
 
     specTransformations :: [(String,NormRewrite)]
     specTransformations =


### PR DESCRIPTION
More specifically: if 'inlineNonRep' successfully fires on a case's
subject, it does not traverse alternatives. The rationale is as follows:
if an inline-non-rep successfully fires in or on the subject of a case,
`caseCon` might eliminate it in the following round of
`inlineAndPropagate` or subsequent ones. If we inline in
alternatives too we risk doing too much work - as they might get
eliminated later on.

This is part of finding the root cause of #1536.