### PR TITLE
Add CLASH_PPR_TICKS flag

### DIFF
--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -84,12 +84,16 @@ data PrettyOptions = PrettyOptions
   -- ^ whether to display type information
   , displayQualifiers :: Bool
   -- ^ whether to display module qualifiers
+  , displayTicks      :: Bool
+  -- ^ whether to display ticks
   }
+
 instance Default PrettyOptions where
   def = PrettyOptions
     { displayUniques    = unsafeLookupEnvBool "CLASH_PPR_UNIQUES" True
     , displayTypes      = unsafeLookupEnvBool "CLASH_PPR_TYPES" True
     , displayQualifiers = unsafeLookupEnvBool "CLASH_PPR_QUALIFIERS" True
+    , displayTicks      = unsafeLookupEnvBool "CLASH_PPR_TICKS" True
     }
 
 -- | Annotations carried on pretty-printed code.
@@ -101,7 +105,7 @@ data ClashAnnotation
   deriving Eq
 
 -- | Specific places in the program syntax.
-data SyntaxElement = Keyword | LitS | Type | Unique | Qualifier
+data SyntaxElement = Keyword | LitS | Type | Unique | Qualifier | Ticky
   deriving (Eq, Show)
 
 -- | Clash's specialized @Doc@ type holds metadata of type @ClashAnnotation@.
@@ -130,6 +134,7 @@ class PrettyPrec p where
           if not (displayTypes opts)      && ann == AnnSyntax Type
           || not (displayUniques opts)    && ann == AnnSyntax Unique
           || not (displayQualifiers opts) && ann == AnnSyntax Qualifier
+          || not (displayTicks opts)      && ann == AnnSyntax Ticky
             then Empty
             else Annotated ann (hide d')
         d -> d
@@ -256,7 +261,7 @@ instance PrettyPrec Term where
     Tick t e'       -> do
       tDoc <- pprPrec prec t
       eDoc <- pprPrec prec e'
-      return (tDoc <> line' <> eDoc)
+      return (annotate (AnnSyntax Ticky) (tDoc <> line') <> eDoc)
 
 instance PrettyPrec TickInfo where
   pprPrec prec (SrcSpan sp)   = pprPrec prec sp

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -180,7 +180,7 @@ splitTopAnn tcm sp typ@(tyView -> FunTy {}) t@Synthesize{t_inputs} =
               to a malformed Synthesize annotation. All clocks, resets, and
               enables should be given a unique port name. Type to be split:
 
-                #{showPpr' (PrettyOptions False True False) a}
+                #{showPpr' (PrettyOptions False True False False) a}
 
               Given port annotation: #{p}. You might want to use the
               following instead: PortProduct #{show nm} []. This allows Clash to

--- a/clash-term/Main.hs
+++ b/clash-term/Main.hs
@@ -76,18 +76,20 @@ instance Diff Term where
     Type      -> RW.Type
     Unique    -> RW.Unique
     Qualifier -> RW.Qualifier
+    Ticky     -> RW.Custom "Tick"
 
   ppr' :: PrettyOptions -> Term -> ClashDoc
   ppr' = Pr.ppr'
 
   initOptions :: PrettyOptions
-  initOptions = PrettyOptions True True True
+  initOptions = PrettyOptions True True True True
 
   flagFields :: [(PrettyOptions -> Bool, PrettyOptions -> Bool -> PrettyOptions, String)]
   flagFields =
     [ (displayUniques, \opt b -> opt {displayUniques = b}, "display uniques")
     , (displayTypes, \opt b -> opt {displayTypes = b}, "display types")
     , (displayQualifiers, \opt b -> opt {displayQualifiers = b}, "display qualifiers")
+    , (displayTicks, \opt b -> opt {displayTicks = b}, "display ticks")
     ]
 
   patch :: Term -> Context -> Term -> Term


### PR DESCRIPTION
When dealing with output where a lot of inlining has occured (like PE)
ticks introduce a lot of noise. This flag means pretty printed core
need not have pesky ticks everywhere.