### PR TITLE
argCastSpec: Don't specialise prims on casted arguments 

### DIFF
--- a/clash-lib/src/Clash/Core/TermInfo.hs
+++ b/clash-lib/src/Clash/Core/TermInfo.hs
@@ -302,3 +302,8 @@ isCon _         = False
 isPrim :: Term -> Bool
 isPrim (Prim {}) = True
 isPrim _         = False
+
+-- | Is a term a cast?
+isCast :: Term -> Bool
+isCast (Cast {}) = True
+isCast _         = False

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1045,7 +1045,9 @@ letCast _ e = return e
 -- and expression where two casts are "back-to-back" after which we can
 -- eliminate them in 'eliminateCastCast'.
 argCastSpec :: HasCallStack => NormRewrite
-argCastSpec ctx e@(App _ (stripTicks -> Cast e' _ _)) = do
+argCastSpec ctx e@(App f (stripTicks -> Cast e' _ _))
+ -- Don't specialise prims, because we can't push casts into them
+ | not . isPrim . fst . collectArgs $ f = do
   bndrs <- Lens.use bindings
   isWorkFree workFreeBinders bndrs e' >>= \case
     True -> go

--- a/clash-lib/src/Clash/Normalize/Transformations.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations.hs
@@ -1046,8 +1046,13 @@ letCast _ e = return e
 -- eliminate them in 'eliminateCastCast'.
 argCastSpec :: HasCallStack => NormRewrite
 argCastSpec ctx e@(App f (stripTicks -> Cast e' _ _))
+ -- Don't specialise when the arguments are casts-of-casts, these casts-of-casts
+ -- will be eliminated by 'eliminateCastCast' during the normalization of the
+ -- "current" function. We thus prevent the unnecessary introduction of a
+ -- specialized version of 'f'.
+ | not (isCast e)
  -- Don't specialise prims, because we can't push casts into them
- | not . isPrim . fst . collectArgs $ f = do
+ , not . isPrim . fst . collectArgs $ f = do
   bndrs <- Lens.use bindings
   isWorkFree workFreeBinders bndrs e' >>= \case
     True -> go

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -920,6 +920,7 @@ specialise' specMapLbl specHistLbl specLimitLbl (TransformContext is0 _) e (Var 
           bs' -> init bs' ++ bs
         go bs _ = bs
 
+-- Specialising non Var's is used by nonRepANF
 specialise' _ _ _ _ctx _ (appE,args,ticks) (Left specArg) = do
   -- Create binders and variable references for free variables in 'specArg'
   let (specBndrs,specVars) = specArgBndrsAndVars (Left specArg)


### PR DESCRIPTION
Also make `isWorkFree` look through Casts.

Both fix #1667