### PR TITLE
Don't keep appending to history.dat

### DIFF
--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -26,6 +26,9 @@ import           Control.Lens                     (view, _4)
 import qualified Control.Monad                    as Monad
 import           Control.Monad                    (guard, when, unless, foldM)
 import           Control.Monad.Catch              (MonadMask)
+#ifdef HISTORY
+import           Control.Monad.Extra              (whenM)
+#endif
 import           Control.Monad.IO.Class           (MonadIO)
 import           Control.Monad.State              (evalState, get)
 import           Control.Monad.State.Strict       (State)
@@ -277,7 +280,10 @@ generateHDL
   -> (Clock.UTCTime,Clock.UTCTime)
   -> IO ()
 generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans eval
-  topEntities0 mainTopEntity opts (startTime,prepTime) =
+  topEntities0 mainTopEntity opts (startTime,prepTime) = do
+#ifdef HISTORY
+    whenM (Directory.doesFileExist "history.dat") (Directory.deleteFile "history.dat")
+#endif
     let (tes, deps) = sortTop bindingsMap topEntities1
      in go prepTime initIs HashMap.empty deps tes
  where


### PR DESCRIPTION
Start a new history.dat so it'll only contain the transformations of one run of clash.

This is the simplest possible fix to #1486.
But I'm tired of my disk filling up.