### PR TITLE
Create domain alias/helper only when they don't exist

### DIFF
--- a/changelog/2021-02-25T13_28_53+00_00_documentable_create_domain
+++ b/changelog/2021-02-25T13_28_53+00_00_documentable_create_domain
@@ -1,0 +1,1 @@
+FIXED: `createDomain` creates definitions without documentation [#1674] https://github.com/clash-lang/clash-compiler/issues/1674

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -543,6 +543,16 @@ isValidDomainName _ = False
 --
 -- > vSystem10 = knownVDomain @System10
 --
+-- It will also make @System10@ an instance of 'KnownDomain'.
+--
+-- If either identifier is already in scope it will not be generated a second time.
+-- Note: This can be useful for example when documenting a new domain:
+--
+-- > -- | Here is some documentation for CustomDomain
+-- > type CustomDomain = ("CustomDomain" :: Domain)
+-- >
+-- > -- | Here is some documentation for vCustomDomain
+-- > createDomain vSystem{vName="CustomDomain"}
 createDomain :: VDomainConfiguration -> Q [Dec]
 createDomain (VDomainConfiguration name period edge reset init_ polarity) =
   if isValidDomainName name then do

--- a/clash-prelude/tests/Clash/Tests/Reset.hs
+++ b/clash-prelude/tests/Clash/Tests/Reset.hs
@@ -14,7 +14,10 @@ import Test.Tasty.HUnit
 import Test.Tasty.TH
 import Clash.Explicit.Prelude
 
+-- Testing with explicit declaration of the Low type alias
+type Low = ("Low" :: Domain)
 createDomain vSystem{vName="Low", vResetPolarity=ActiveLow}
+
 createDomain vSystem{vName="NoInit", vInitBehavior=Unknown}
 
 sampleResetN :: KnownDomain dom => Int -> Reset dom -> [Bool]


### PR DESCRIPTION
fixes #1674

This makes it possible to explicitly define the type alias (or the
helper). This can be useful when writing documentation for both.

For example:

```haskell
-- | MySystem is a custom domain ...
type MySystem = ("MySystem" :: Domain)

-- | vMySystem is the domain configuration associated with `MySystem`
createDomain vSystem{vName="MySystem"}
```