### PR TITLE
Use fully qualified names in HDL output dir 

### DIFF
--- a/changelog/2021-03-04T09_21_44+01_00_use_fully_qualified_names
+++ b/changelog/2021-03-04T09_21_44+01_00_use_fully_qualified_names
@@ -1,0 +1,2 @@
+CHANGED: Each binder marked with a `Synthesize` or `TestBench` pragma will be put in its own directory under their fully qualified Haskell name. For example, two binders `foo` and `bar` in module `A` will be synthesized in `A.foo` and `A.bar`.
+CHANGED: Clash will no longer generate vhdl, verilog, or systemverilog subdirectories when using `-fclash-hdldir`.

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -150,6 +150,7 @@ library
                       Cabal,
                       containers                >= 0.5.4.0  && < 0.7,
                       directory                 >= 1.2      && < 1.4,
+                      extra                     >= 1.6      && < 1.8,
                       filepath                  >= 1.3      && < 1.5,
                       ghc                       >= 8.4.0    && < 9.1,
                       process                   >= 1.2      && < 1.7,

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -146,14 +146,13 @@ generateBindings useColor primDirs importDirs dbs hdl modName dflagsM = do
       clsMap                        = mapUniqMap (\(v,i) -> (Binding v GHC.noSrcSpan GHC.Inline IsFun (mkClassSelector inScope0 allTcCache (varType v) i))) clsVMap
       allBindings                   = bindingsMap `unionVarEnv` clsMap
       topEntities'                  =
-        (\m -> fst (RWS.evalRWS m GHC.noSrcSpan tcMap')) $ mapM (\(topEnt,annM,benchM) -> do
+        (\m -> fst (RWS.evalRWS m GHC.noSrcSpan tcMap')) $ mapM (\(topEnt,annM,isTb) -> do
           topEnt' <- coreToName GHC.varName GHC.varUnique qualifiedNameString topEnt
-          benchM' <- traverse coreToId benchM
-          return (topEnt', annM, benchM')) topEntities
+          return (topEnt', annM, isTb)) topEntities
       topEntities'' =
-        map (\(topEnt, annM, benchM) ->
+        map (\(topEnt, annM, isTb) ->
                 case lookupUniqMap topEnt allBindings of
-                  Just b -> TopEntityT (bindingId b) annM benchM
+                  Just b -> TopEntityT (bindingId b) annM isTb
                   Nothing -> error "This shouldn't happen"
             ) topEntities'
   -- Parsing / compiling primitives:

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -450,14 +450,14 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
       let seen1 = State.execState (mapM_ Id.addRaw (componentNames manifest)) seen0
       return (topTime, manifest, seen1, edamFiles')
     else do
-      -- 1. Normalise topEntity
+      -- 1. Normalize topEntity
       let transformedBindings = normalizeEntity reprs bindingsMap primMap tcm tupTcm
                                   typeTrans eval topEntityNames opts supplyN
                                   topEntity
 
       normTime <- transformedBindings `deepseq` Clock.getCurrentTime
       let prepNormDiff = reportTimeDiff normTime prevTime
-      putStrLn $ "Clash: Normalisation took " ++ prepNormDiff
+      putStrLn $ "Clash: Normalization took " ++ prepNormDiff
 
       -- 2. Generate netlist for topEntity
 

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -235,12 +235,11 @@ genTopNames prefixM esc lw hdl tops =
   -- TODO: Report error if fixed top entities have conflicting names
   flip runState (Id.emptyIdentifierSet esc lw hdl) $ do
     env0 <- foldlM goFixed emptyVarEnv fixedTops
-    env1 <- foldlM goNonFixed env0 (nonFixedTops ++ tests)
+    env1 <- foldlM goNonFixed env0 nonFixedTops
     pure env1
  where
   fixedTops = [(topId, ann) | TopEntityT{topId, topAnnotation=Just ann} <- tops]
   nonFixedTops = [topId | TopEntityT{topId, topAnnotation=Nothing} <- tops]
-  tests = [testId | TopEntityT{associatedTestbench=Just testId} <- tops]
 
   goFixed env (topId, ann) = do
     topNm <- genTopName prefixM ann

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -89,15 +89,14 @@ import Clash.Annotations.BitRepresentation.Internal
 
 import {-# SOURCE #-} qualified Clash.Netlist.Id as Id
 
--- | Structure describing a top entity: it's id, its port annotations, and
--- associated testbench.
+-- | Structure describing a top entity: it's id and its port annotations.
 data TopEntityT = TopEntityT
   { topId :: Id
   -- ^ Id of top entity
   , topAnnotation :: Maybe TopEntity
   -- ^ (Maybe) a topentity annotation
-  , associatedTestbench :: Maybe Id
-  -- ^ (Maybe) a test bench associated with the topentity
+  , topIsTestBench :: Bool
+  -- ^ Whether this entity is a test bench
   } deriving (Generic, Show)
 
 -- | Same as "TopEntity", but with all port names that end up in HDL specified

--- a/docs/developing-hardware/flags.rst
+++ b/docs/developing-hardware/flags.rst
@@ -67,17 +67,15 @@ Clash Compiler Flags
   **Default:** MAX_INT
 
 -fclash-hdldir
-  Specify the directory that generated HDL is written into. Generated code
-  is still put into a directory named according to the output language within
-  this directory. For example
+  Specify the directory that generated HDL is written into. For example
 
   .. code-block:: bash
 
     clash -fclash-hdldir build/hdl
 
-  will create a directory ``build/hdl/verilog`` if verilog is generated.
+  will create a directory ``build/hdl``
 
-  **Default:** "."
+  **Default:** Either ``vhdl``, ``verilog``, or ``systemverilog`` depending on the synthesis target.
 
 -fclash-hdlsyn
   Specify the HDL synthesis tool which will be used. Available options are

--- a/tests/shouldwork/AutoReg/AutoReg.hs
+++ b/tests/shouldwork/AutoReg/AutoReg.hs
@@ -107,7 +107,7 @@ countLinesContaining needle haystack = L.length $ L.filter (needle `L.isInfixOf`
 mainHDL :: String -> IO ()
 mainHDL topFile = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> topFile)
+  content <- readFile (topDir </> show 'topEntity </> topFile)
   let regCount = countLinesContaining "register begin" content
   when (expectedRegCount /= regCount)
     (error $ unlines

--- a/tests/shouldwork/Basic/NameInlining.hs
+++ b/tests/shouldwork/Basic/NameInlining.hs
@@ -35,21 +35,21 @@ assertIn needle haystack
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "f" </> "f.vhdl")
+  putStrLn topDir
+  content  <- readFile (topDir </> show 'f </> "f.vhdl")
 
   assertIn "g_foo" content
 
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "f" </> "f.v")
+  content  <- readFile (topDir </> show 'f </> "f.v")
 
   assertIn "g_foo" content
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "f" </> "f.sv")
+  content  <- readFile (topDir </> show 'f </> "f.sv")
 
   assertIn "g_foo" content
-

--- a/tests/shouldwork/Basic/NameInstance.hs
+++ b/tests/shouldwork/Basic/NameInstance.hs
@@ -24,17 +24,17 @@ assertIn needle haystack
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "topEntity.sv")
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
   assertIn "before_foo_after" content
 
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "topEntity.v")
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
   assertIn "before_foo_after" content
 
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "topEntity.vhdl")
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
   assertIn "before_foo_after" content

--- a/tests/shouldwork/Basic/SetName.hs
+++ b/tests/shouldwork/Basic/SetName.hs
@@ -35,8 +35,7 @@ assertIn needle haystack
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "f" </> "f.vhdl")
+  content  <- readFile (topDir </> show 'f </> "f.vhdl")
 
   assertIn "foo" content
   assertIn "foo_0" content
-

--- a/tests/shouldwork/BlackBox/BlackBoxFunction.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunction.hs
@@ -43,6 +43,6 @@ assertIn needle haystack
 
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
   assertIn "123456" content

--- a/tests/shouldwork/BlackBox/MultiResult.hs
+++ b/tests/shouldwork/BlackBox/MultiResult.hs
@@ -66,7 +66,7 @@ assertIn needle haystack
 
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
   assertIn "foo" content
   assertIn "foo_0" content

--- a/tests/shouldwork/BlackBox/TemplateFunction.hs
+++ b/tests/shouldwork/BlackBox/TemplateFunction.hs
@@ -60,6 +60,6 @@ assertIn needle haystack
 
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
   assertIn "123456" content

--- a/tests/shouldwork/BlackBox/ZeroWidth.hs
+++ b/tests/shouldwork/BlackBox/ZeroWidth.hs
@@ -49,8 +49,8 @@ topEntity a = (succ a, comment luckyNumber, implicitComment a)
 mainHDL :: String -> String -> IO ()
 mainHDL topFile implFile = do
   [topDir] <- getArgs
-  contentTopEntity <- readFile (takeDirectory topDir </> topFile)
-  contentImplicitComment <- readFile (takeDirectory topDir </> implFile)
+  contentTopEntity <- readFile (topDir </> show 'topEntity </> topFile)
+  contentImplicitComment <- readFile (topDir </> show 'topEntity </> implFile)
 
   if luckyNumber `isInfixOf` contentTopEntity then
     pure ()

--- a/tests/shouldwork/Issues/T1171.hs
+++ b/tests/shouldwork/Issues/T1171.hs
@@ -39,20 +39,20 @@ assertIn needle haystack
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "f" </> "f.vhdl")
+  content  <- readFile (topDir </> show 'f </> "f.vhdl")
 
   assertIn "en  : in f_types.en_System;" content
 
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "f" </> "f.v")
+  content  <- readFile (topDir </> show 'f </> "f.v")
 
   assertIn "input  en // enable" content
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "f" </> "f.sv")
+  content  <- readFile (topDir </> show 'f </> "f.sv")
 
   assertIn "input logic en  // enable" content

--- a/tests/shouldwork/Issues/T1506B.hs
+++ b/tests/shouldwork/Issues/T1506B.hs
@@ -22,7 +22,7 @@ countLinesContaining needle haystack = L.length $ L.filter (needle `L.isInfixOf`
 mainHDL :: String -> IO ()
 mainHDL topFile = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> topFile)
+  content <- readFile (topDir </> show 'topEntity </> topFile)
   let
     xRstCount = countLinesContaining "xRst" content
     iRstCount = countLinesContaining "iRst" content

--- a/tests/shouldwork/Signal/T1102A.hs
+++ b/tests/shouldwork/Signal/T1102A.hs
@@ -22,7 +22,7 @@ assertIn needle haystack
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "top/top.vhdl")
+  content <- readFile (topDir </> show 'topEntity </> "top.vhdl")
 
   -- TODO: Could we remove bitvector noise?
   assertIn "x_0 <= top_types.fromSLV(x);" content

--- a/tests/shouldwork/Signal/T1102B.hs
+++ b/tests/shouldwork/Signal/T1102B.hs
@@ -22,7 +22,7 @@ assertIn needle haystack
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "top/top.vhdl")
+  content <- readFile (topDir </> show 'topEntity </> "top.vhdl")
 
   -- TODO: Could we remove bitvector noise?
   assertIn "x_0 <= top_types.fromSLV(x);" content

--- a/tests/shouldwork/SynthesisAttributes/InstDeclAnnotations.hs
+++ b/tests/shouldwork/SynthesisAttributes/InstDeclAnnotations.hs
@@ -19,6 +19,7 @@ import qualified Data.Text.IO as T
 import           Data.Text.Prettyprint.Doc.Extra (Doc (..))
 import qualified Prelude as P
 import           System.Environment              (getArgs)
+import           System.FilePath                 ((</>))
 
 
 myTF :: TemplateFunction
@@ -78,8 +79,8 @@ assertIn needle haystack
 -- VHDL test
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  content <- P.readFile topFile
+  [topDir] <- getArgs
+  content <- P.readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
 
   assertIn "attribute my_int_attr : integer;" content
   assertIn "attribute my_int_attr of TEST : component is 7;" content
@@ -90,10 +91,14 @@ mainVHDL = do
 -- Verilog test
 mainVerilog :: IO ()
 mainVerilog = do
-  [topFile] <- getArgs
-  content <- P.readFile topFile
+  [topDir] <- getArgs
+  content <- P.readFile (topDir </> show 'topEntity </> "topEntity.v")
 
   assertIn "(* my_int_attr = 7, my_string_attr = \"Hello World!\" *)" content
 
 -- Verilog and SystemVerilog should share annotation syntax
-mainSystemVerilog = mainVerilog
+mainSystemVerilog = do
+  [topDir] <- getArgs
+  content <- P.readFile (topDir </> show 'topEntity </> "topEntity.sv")
+
+  assertIn "(* my_int_attr = 7, my_string_attr = \"Hello World!\" *)" content

--- a/tests/shouldwork/SynthesisAttributes/Product.hs
+++ b/tests/shouldwork/SynthesisAttributes/Product.hs
@@ -53,8 +53,8 @@ assertIn needle haystack
 -- VHDL test
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
 
   assertIn "attribute top : string;" content
   assertIn " : signal is \"input1\"" content
@@ -65,8 +65,8 @@ mainVHDL = do
 -- Verilog test
 mainVerilog :: IO ()
 mainVerilog = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
 
   assertIn "(* top = \"input1\" *) input" content
   assertIn "(* top = \"input2\" *) input" content
@@ -76,8 +76,8 @@ mainVerilog = do
 -- Verilog and SystemVerilog should share annotation syntax
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
 
   assertIn "(* top = \"input1\" *) input" content
   assertIn "(* top = \"input2\" *) input" content

--- a/tests/shouldwork/SynthesisAttributes/Simple.hs
+++ b/tests/shouldwork/SynthesisAttributes/Simple.hs
@@ -40,8 +40,8 @@ assertIn needle haystack
 -- VHDL test
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
 
   assertIn "attribute top : string;" content
   assertIn " : signal is \"input1\"" content
@@ -51,8 +51,8 @@ mainVHDL = do
 -- Verilog test
 mainVerilog :: IO ()
 mainVerilog = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
 
   assertIn "(* top = \"input1\" *) input" content
   assertIn "(* top = \"input2\" *) input" content
@@ -61,8 +61,8 @@ mainVerilog = do
 -- SystemVerilog test
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
 
   assertIn "(* top = \"input1\" *) input" content
   assertIn "(* top = \"input2\" *) input" content

--- a/tests/shouldwork/TopEntity/Multiple.hs
+++ b/tests/shouldwork/TopEntity/Multiple.hs
@@ -28,36 +28,19 @@ main1SystemVerilog :: IO ()
 main1SystemVerilog = do
   [(dir, _fname)] <- map splitFileName <$> getArgs
   files <- listDirectory dir
-  if files == ["topentity1"] then
-    pure ()
-  else
+  if any (`elem` files) [show 'topEntity2, show 'topEntity3] then
     error ("Unexpected files / directories: " ++ show files)
-
--- | Make sure topEntity1 is not compiled when -main-is topEntity2 and
--- -fclash-single-main is enabled. TODO: Implement this feature.
-main2Verilog :: IO ()
-main2Verilog = do
-  args <- getArgs
-  putStrLn (show args)
-  [(dir, _fname)] <- map splitFileName <$> getArgs
-  files <- listDirectory dir
-  if files == ["topentity2"] then
-    pure ()
   else
-    error ("Unexpected files / directories: " ++ show files)
+    pure ()
 
 -- | Check whether we can compile a binder that doesn't have a synthesize
 -- annotation _and_ isn't called 'topEntity' using -main-is.
 main3VHDL :: IO ()
 main3VHDL = do
-  [(dir, _fname)] <- map splitFileName <$> getArgs
+  [dir] <- getArgs
   files <- listDirectory dir
-  if sort files == sort [ "Multiple_types.vhdl"
-                        , "topentity1"
-                        , "topentity2"
-                        , "topEntity3.manifest"
-                        , "topEntity3.vhdl"
-                        ] then
+  let expected = [show 'topEntity1, show 'topEntity2, show 'topEntity3]
+  if all (`elem` files) expected then
     pure ()
   else
     error ("Unexpected files / directories: " ++ show (sort files))

--- a/tests/shouldwork/TopEntity/PortNames.hs
+++ b/tests/shouldwork/TopEntity/PortNames.hs
@@ -49,7 +49,7 @@ assertIn needle haystack
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "PortNames_topEntity" </> "PortNames_topEntity.v")
+  content <- readFile (topDir </> show 'topEntity </> "PortNames_topEntity.v")
 
 --  content <- readFile $ hdlDir </> "verilog/PortNames/PortNames_topEntity/PortNames_topEntity.v"
 

--- a/tests/shouldwork/TopEntity/PortNamesWithRTree.hs
+++ b/tests/shouldwork/TopEntity/PortNamesWithRTree.hs
@@ -70,7 +70,7 @@ assertNotIn needle haystack
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "PortNamesWithRTree_topEntity" </> "PortNamesWithRTree_topEntity.v")
+  content <- readFile (topDir </> show 'topEntity </> "PortNamesWithRTree_topEntity.v")
 
   assertIn    "tupje_zero" content
   assertIn    "tupje_treetje_elmje1_one" content

--- a/tests/shouldwork/TopEntity/PortNamesWithSingletonVector.hs
+++ b/tests/shouldwork/TopEntity/PortNamesWithSingletonVector.hs
@@ -43,7 +43,7 @@ assertIn needle haystack
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "PortNamesWithSingletonVector_topEntity" </> "PortNamesWithSingletonVector_topEntity.v")
+  content  <- readFile (topDir </> show 'topEntity </> "PortNamesWithSingletonVector_topEntity.v")
 
   mapM_ (`assertIn` content)
     [ "input  inp0"

--- a/tests/shouldwork/TopEntity/PortNamesWithUnit.hs
+++ b/tests/shouldwork/TopEntity/PortNamesWithUnit.hs
@@ -57,7 +57,7 @@ assertNotIn needle haystack
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "PortNamesWithUnit_topEntity" </> "PortNamesWithUnit_topEntity.v")
+  content <- readFile (topDir </> show 'topEntity </> "PortNamesWithUnit_topEntity.v")
 
   assertIn    "top_zero" content
   assertNotIn "top_sub_one" content

--- a/tests/shouldwork/TopEntity/PortNamesWithVector.hs
+++ b/tests/shouldwork/TopEntity/PortNamesWithVector.hs
@@ -70,7 +70,7 @@ assertNotIn needle haystack
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "PortNamesWithVector_topEntity" </> "PortNamesWithVector_topEntity.v")
+  content <- readFile (topDir </> show 'topEntity </> "PortNamesWithVector_topEntity.v")
 
   assertIn    "tupje_zero" content
   assertIn    "tupje_vecje_elmje1_one" content

--- a/tests/shouldwork/TopEntity/PortProducts.hs
+++ b/tests/shouldwork/TopEntity/PortProducts.hs
@@ -49,7 +49,7 @@ assertIn needle haystack
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "PortProducts_topEntity" </> "PortProducts_topEntity.v")
+  content <- readFile (topDir </> show 'topEntity </> "PortProducts_topEntity.v")
 
   assertIn "top_zero" content
   assertIn "top_sub_one" content

--- a/tests/shouldwork/TopEntity/PortProductsSum.hs
+++ b/tests/shouldwork/TopEntity/PortProductsSum.hs
@@ -49,7 +49,7 @@ assertIn needle haystack
 mainVerilog :: IO ()
 mainVerilog = do
   [topDir] <- getArgs
-  content <- readFile (takeDirectory topDir </> "PortProductsSum_topEntity" </> "PortProductsSum_topEntity.v")
+  content <- readFile (topDir </> show 'topEntity </> "PortProductsSum_topEntity.v")
 
   assertIn "top_zero" content
   assertIn "top_sub_one" content

--- a/tests/shouldwork/TopEntity/T1033.hs
+++ b/tests/shouldwork/TopEntity/T1033.hs
@@ -50,15 +50,15 @@ main topFile = do
 
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.vhdl")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.vhdl")
 
 mainVerilog :: IO ()
 mainVerilog = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.v")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.v")
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.sv")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.sv")

--- a/tests/shouldwork/TopEntity/T1072.hs
+++ b/tests/shouldwork/TopEntity/T1072.hs
@@ -41,15 +41,15 @@ main topFile = do
 
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.vhdl")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.vhdl")
 
 mainVerilog :: IO ()
 mainVerilog = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.v")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.v")
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.sv")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.sv")

--- a/tests/shouldwork/TopEntity/T1074.hs
+++ b/tests/shouldwork/TopEntity/T1074.hs
@@ -44,15 +44,15 @@ main topFile = do
 
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.vhdl")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.vhdl")
 
 mainVerilog :: IO ()
 mainVerilog = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.v")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.v")
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
-  [topFile] <- getArgs
-  main (replaceFileName topFile "top/top.sv")
+  [topDir] <- getArgs
+  main (topDir </> show 'topEntity </> "top.sv")

--- a/tests/shouldwork/Vector/IterateCF.hs
+++ b/tests/shouldwork/Vector/IterateCF.hs
@@ -32,7 +32,7 @@ assertNotIn needle haystack
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content  <- readFile (takeDirectory topDir </> "topEntity.vhdl")
+  content  <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
 
   assertNotIn "255" content
   assertNotIn "256" content

--- a/tests/shouldwork/XOptimization/Conjunction.hs
+++ b/tests/shouldwork/XOptimization/Conjunction.hs
@@ -32,19 +32,23 @@ assertNotIn needle haystack
 -- VHDL test
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
 
   assertNotIn "true" content
 
 -- Verilog test
 mainVerilog :: IO ()
 mainVerilog = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
 
   assertNotIn "1'b1" content
 
 -- SystemVerilog test
 mainSystemVerilog :: IO ()
-mainSystemVerilog = mainVerilog
+mainSystemVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
+
+  assertNotIn "1'b1" content

--- a/tests/shouldwork/XOptimization/Disjunction.hs
+++ b/tests/shouldwork/XOptimization/Disjunction.hs
@@ -32,19 +32,23 @@ assertNotIn needle haystack
 -- VHDL test
 mainVHDL :: IO ()
 mainVHDL = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
 
   assertNotIn "false" content
 
 -- Verilog test
 mainVerilog :: IO ()
 mainVerilog = do
-  [topFile] <- getArgs
-  content <- readFile topFile
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
 
   assertNotIn "1'b0" content
 
 -- SystemVerilog test
 mainSystemVerilog :: IO ()
-mainSystemVerilog = mainVerilog
+mainSystemVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
+
+  assertNotIn "1'b0" content

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -157,8 +157,7 @@ runClashTest = defaultMain $ clashTestRoot
     [ runTest "ALU" def{hdlSim=False}
     , let _opts = def { hdlSim=False
                       , hdlTargets=[VHDL]
-                      , entities=Entities [["blinker"]]
-                      , topEntities=TopEntities ["blinker"]
+                      , buildTargets=BuildSpecific ["blinker"]
                       }
        in NEEDS_PRIMS_GHC(runTest "Blinker" _opts)
     , NEEDS_PRIMS_GHC (runTest "BlockRamTest" def{hdlSim=False})
@@ -166,8 +165,7 @@ runClashTest = defaultMain $ clashTestRoot
     , NEEDS_PRIMS_GHC(runTest "CHIP8" def{hdlSim=False})
     , NEEDS_PRIMS_GHC(runTest "CochleaPlus" def{hdlSim=False})
     , let _opts = def { clashFlags=["-fclash-component-prefix", "test"]
-                      , entities=Entities [["","test_testBench"]]
-                      , topEntities=TopEntities ["test_testBench"]
+                      , buildTargets=BuildSpecific ["test_testBench"]
                       }
        in NEEDS_PRIMS(runTest "FIR" _opts)
     , NEEDS_PRIMS_GHC(runTest "Fifo" def{hdlSim=False})
@@ -182,19 +180,11 @@ runClashTest = defaultMain $ clashTestRoot
         ]
     , clashTestGroup "i2c"
         [ let _opts = def { clashFlags=["-O2","-fclash-component-prefix","test"]
-                        , entities=Entities [["test_i2c","test_bitmaster","test_bytemaster"]]
-                        , topEntities=TopEntities ["test_i2c"]
+                        , buildTargets=BuildSpecific ["test_i2c"]
                         , hdlSim=False
                         }
            in NEEDS_PRIMS_GHC(runTest "I2C" _opts)
-        , let _opts = def { entities = Entities [[ ".." </> "I2C" </> "i2c"
-                                                 , ".." </> "I2C" </> "bitmaster"
-                                                 , ".." </> "I2C" </> "bytemaster"
-                                                 , "configi2c"
-                                                 , "slave"
-                                                 , "system"
-                                                 ]]
-                          , topEntities = TopEntities ["system"]
+        , let _opts = def { buildTargets = BuildSpecific ["system"]
                           , hdlTargets = [Verilog]
                           , hdlSim = True
                           , vvpStderrEmptyFail = False
@@ -272,15 +262,13 @@ runClashTest = defaultMain $ clashTestRoot
       , clashTestGroup "Verification"
         [ let n = 9 -- GHDL only has VERY basic PSL support
               _opts = def { hdlTargets=[VHDL]
-                          , entities=Entities [["fails" ++ show i] | i <- [(1::Int)..n]]
-                          , topEntities=TopEntities ["fails" ++ show i | i <- [(1::Int)..n]]
+                          , buildTargets=BuildSpecific ["fails" <> show i | i <- [(1::Int)..n]]
                           , expectSimFail=Just (def, "psl assertion failed")
                           }
            in NEEDS_PRIMS_GHC(runTest "NonTemporalPSL" _opts)
         , let n = 13
               _opts = def { hdlTargets=[SystemVerilog]
-                          , entities=Entities [["fails" ++ show i] | i <- [(1::Int)..n]]
-                          , topEntities=TopEntities ["fails" ++ show i | i <- [(1::Int)..n]]
+                          , buildTargets=BuildSpecific ["fails" <> show i | i <- [(1::Int)..n]]
                           -- Only QuestaSim supports simulating SVA/PSL, but ModelSim does check
                           -- for syntax errors.
                           , hdlSim=False
@@ -289,8 +277,7 @@ runClashTest = defaultMain $ clashTestRoot
         , let is = [(1::Int)..13] \\ [4, 6, 7, 8, 10, 11, 12] in
           runTest "NonTemporalSVA" def{
             hdlTargets=[SystemVerilog]
-          , entities=Entities [["fails" ++ show i] | i <- is]
-          , topEntities=TopEntities ["fails" ++ show i | i <- is]
+          , buildTargets=BuildSpecific ["fails" <> show i | i <- is]
           -- Only QuestaSim supports simulating SVA/PSL, but ModelSim does check
           -- for syntax errors.
           , hdlSim=False
@@ -365,8 +352,7 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS_GHC(runTest "CountTrailingZeros" def)
         , NEEDS_PRIMS_GHC(runTest "DeepseqX" def)
         , NEEDS_PRIMS_GHC(runTest "LotOfStates" def)
-        , let _opts = def { entities = Entities [["nameoverlap"]]
-                          , topEntities = TopEntities ["nameoverlap"]
+        , let _opts = def { buildTargets = BuildSpecific ["nameoverlap"]
                           , hdlSim = False
                           }
            in NEEDS_PRIMS_GHC(runTest "NameOverlap" _opts)
@@ -383,8 +369,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "SimpleConstructor" def{hdlSim=False}
         , runTest "TyEqConstraints" def{
             hdlSim=False
-          , entities=Entities [["top1"]]
-          , topEntities=TopEntities ["top1"]
+          , buildTargets=BuildSpecific ["top1"]
           }
         , NEEDS_PRIMS(runTest "T1012" def{hdlSim=False})
         , NEEDS_PRIMS(runTest "T1240" def{hdlSim=False})
@@ -398,7 +383,7 @@ runClashTest = defaultMain $ clashTestRoot
         , let _opts = def { hdlTargets=[VHDL]
                           , hdlSim=False
                           , clashFlags=["-main-is", "plus"]
-                          , topEntities=TopEntities ["plus"]
+                          , buildTargets=BuildSpecific ["plus"]
                           }
            in NEEDS_PRIMS_GHC(runTest "T1305" _opts)
         , let _opts = def {hdlTargets = [VHDL], hdlSim = False}
@@ -652,8 +637,7 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS_GHC(runTest "BlockRamTest" def{hdlSim=False})
         , NEEDS_PRIMS_GHC(runTest "Compression" def)
         , NEEDS_PRIMS_GHC(runTest "DelayedReset" def)
-        , let _opts = def { entities=Entities [["example"]]
-                          , topEntities=TopEntities ["example"]
+        , let _opts = def { buildTargets=BuildSpecific ["example"]
                           , hdlSim=False
                           }
            in NEEDS_PRIMS_GHC(runTest "NoCPR" _opts)
@@ -680,7 +664,7 @@ runClashTest = defaultMain $ clashTestRoot
       , clashTestGroup "SimIO"
         [ let _opts = def { hdlTargets=[Verilog]
                           , vvpStderrEmptyFail=False
-                          , topEntities=TopEntities ["topEntity"]
+                          , buildTargets=BuildSpecific ["topEntity"]
                           }
            in NEEDS_PRIMS_GHC(runTest "Test00" _opts)
         ]
@@ -702,9 +686,9 @@ runClashTest = defaultMain $ clashTestRoot
         -- VHDL tests disabled for now: I can't figure out how to generate a static name whilst retaining the ability to actually test..
         [ outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "PortGeneration" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithSingletonVector" "main"
-        , runTest "TopEntHOArg" def{entities=Entities [["f", "g"]], topEntities=TopEntities ["f"], hdlSim=False}
-        , runTest "T701" def {hdlSim=False,entities=Entities [["mynot", ""]]}
-        , runTest "T1033" def {hdlSim=False,entities=Entities [["top", ""]], topEntities=TopEntities ["top"]}
+        , runTest "TopEntHOArg" def{buildTargets=BuildSpecific ["f"], hdlSim=False}
+        , runTest "T701" def {hdlSim=False}
+        , runTest "T1033" def {hdlSim=False,buildTargets=BuildSpecific ["top"]}
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1033" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1072" "main"
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") allTargets [] [] "T1074" "main"
@@ -712,38 +696,32 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "TopEntity") [VHDL] ["-main-is", "topEntity3"] [] "Multiple" "main3"
         , runTest "T1139" def{hdlSim=False}
         , let _opts = def { hdlTargets=[Verilog]
-                          , entities=Entities [["", "PortNames_topEntity", "PortNames_testBench"]]
-                          , topEntities=TopEntities ["PortNames_testBench"]
+                          , buildTargets=BuildSpecific ["PortNames_testBench"]
                           }
            in NEEDS_PRIMS_GHC(runTest "PortNames" _opts)
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNames" "main")
         , let _opts = def { hdlTargets=[Verilog]
-                          , entities=Entities [["", "PortProducts_topEntity", "PortProducts_testBench"]]
-                          , topEntities=TopEntities ["PortProducts_testBench"]
+                          , buildTargets=BuildSpecific ["PortProducts_testBench"]
                           }
            in NEEDS_PRIMS_GHC(runTest "PortProducts" _opts)
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortProducts" "main")
         , let _opts = def { hdlTargets=[Verilog]
-                          , entities=Entities [["", "PortProductsSum_topEntity", "PortProductsSum_testBench"]]
-                          , topEntities=TopEntities ["PortProductsSum_testBench"]
+                          , buildTargets=BuildSpecific ["PortProductsSum_testBench"]
                           }
            in NEEDS_PRIMS_GHC(runTest "PortProductsSum" _opts)
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortProductsSum" "main")
         , let _opts = def { hdlTargets=[Verilog]
-                          , entities=Entities [["", "PortNamesWithUnit_topEntity", "PortNamesWithUnit_testBench"]]
-                          , topEntities=TopEntities ["PortNamesWithUnit_testBench"]
+                          , buildTargets=BuildSpecific ["PortNamesWithUnit_testBench"]
                           }
            in NEEDS_PRIMS_GHC(runTest "PortNamesWithUnit" _opts)
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithUnit" "main")
         , let _opts = def { hdlTargets=[Verilog]
-                          , entities=Entities [["", "PortNamesWithVector_topEntity", "PortNamesWithVector_testBench"]]
-                          , topEntities=TopEntities ["PortNamesWithVector_testBench"]
+                          , buildTargets=BuildSpecific ["PortNamesWithVector_testBench"]
                           }
            in NEEDS_PRIMS_GHC(runTest "PortNamesWithVector" _opts)
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithVector" "main")
         , let _opts = def { hdlTargets=[Verilog]
-                          , entities=Entities [["", "PortNamesWithRTree_topEntity", "PortNamesWithRTree_testBench"]]
-                          , topEntities=TopEntities ["PortNamesWithRTree_testBench"]
+                          , buildTargets=BuildSpecific ["PortNamesWithRTree_testBench"]
                           }
            in NEEDS_PRIMS_GHC(runTest "PortNamesWithRTree" _opts)
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "TopEntity") [Verilog] [] [] "PortNamesWithRTree" "main")

--- a/testsuite/src/Test/Tasty/Program.hs
+++ b/testsuite/src/Test/Tasty/Program.hs
@@ -87,6 +87,7 @@ import qualified Data.Text    as T
 data ExpectOutput a
   = ExpectStdOut a
   | ExpectStdErr a
+  | ExpectEither a
   | ExpectNothing
   deriving Functor
 
@@ -339,9 +340,14 @@ runFailingProgram testExitCode program args stdO errOnEmptyStderr expectedCode e
           else
             case expectedStderr of
               ExpectStdErr r | not (cleanNewlines r `T.isInfixOf` cleanNewlines stderrT) ->
-                unexpectedStd "stderr" program code stderrT stdoutT r
+                unexpectedStd "stderr" program args code stderrT stdoutT r
               ExpectStdOut r | not (cleanNewlines r `T.isInfixOf` cleanNewlines stdoutT) ->
-                unexpectedStd "stdout" program code stderrT stdoutT r
+                unexpectedStd "stdout" program args code stderrT stdoutT r
+              ExpectEither r
+                |  not (cleanNewlines r `T.isInfixOf` cleanNewlines stdoutT)
+                && not (cleanNewlines r `T.isInfixOf` cleanNewlines stderrT)
+                ->
+                unexpectedStd "stdout or stderr" program args code stderrT stdoutT r
               _ ->
                 if testExitCode then
                   passed

--- a/testsuite/src/Test/Tasty/Program.hs
+++ b/testsuite/src/Test/Tasty/Program.hs
@@ -69,6 +69,8 @@ module Test.Tasty.Program (
  , PrintOutput(..)
  , GlobArgs(..)
  , ExpectOutput(..)
+ , TestProgram(..)
+ , TestFailingProgram(..)
  ) where
 
 import qualified Clash.Util.Interpolate  as I


### PR DESCRIPTION
To ease integration with external tools, Clash will now create a
separate directory for each top entity under their fully qualified name.
For example, a single module `A` containing two top entities `foo` and
`bar` will produce an HDL folder with two folders in it: `A.foo` and
`A.bar`. Fully qualified names are not influenced by top entity
annotations; instead, the Haskell name of the function is used. Files
within their respective directories will be affected by names set in
annotations.

In order to simplify implementation details, the special status of test
benches has been removed. That means they no longer have a separate code
path in `Clash.Driver` and no longer generate in a subdirectory of a top
entity. This also means that the restriction of one-test-per-topentity
has been relaxed. Top entities can now have an arbitrary number of test
benches, each showing up under their fully qualified name in the
generated HDL.

Even though test benches have no big special status anymore, Clash
still uses their existence as a hint to suppress certain blackbox
warnings. Clash continues to recognize `testBench` as a special
top-level identifier. If no annotation `TestBench` annotation is
attached, it assumes it belongs to `topEntity`.

Because our testsuite was built on many assumptions no longer valid, it
has been restructured to reflect the new situation. VHDL (GHDL) tests
now read manifest files to compile designs. Verilog and SystemVerilog
tests have been restructured in a similar manner. Users of the testsuite
now only have to indicate what entity they'd like to build/run. Other
than that nothing much has changed about the way tests are compiled and
run - making this more a documentation exercise than anything else.

Fixes #1633
Fixes #1314

-------------------

Example output:

```bash
$ stack run clash -- -iexamples/i2c -iexamples/i2c/I2Ctest --verilog -fclash-hdldir i2c_hdl I2Ctest
..
$ tree i2c_hdl
i2c_hdl/
├── I2C.BitMaster.bitMaster
│   ├── bitmaster_bitStateMachine.v
│   ├── bitmaster_busStatusCtrl_0.v
│   ├── bitmaster_busStatusCtrl.v
│   ├── bitmaster.manifest
│   ├── bitmaster.sdc
│   └── bitmaster.v
├── I2C.ByteMaster.byteMaster
│   ├── bytemaster.manifest
│   ├── bytemaster.sdc
│   └── bytemaster.v
├── I2C.i2c
│   ├── i2c.manifest
│   ├── i2c.sdc
│   └── i2c.v
├── I2Ctest.I2CConfig.config
│   ├── configi2c.manifest
│   ├── configi2c.sdc
│   └── configi2c.v
├── I2Ctest.I2CSlave.i2cSlave
│   ├── slave.manifest
│   ├── slave.sdc
│   └── slave.v
└── I2Ctest.system
    ├── system.manifest
    ├── system_system0.v
    └── system.v
```

Example output with test benches:

```$ stack run clash -- -iexamples Calculator --verilog -fclash-hdldir calculator_hdl
..
$ tree calculator_hdl/
calculator_hdl/
├── Calculator.testBench
│   ├── testBench.manifest
│   └── testBench.v
└── Calculator.topEntity
    ├── topEntity.manifest
    ├── topEntity.sdc
    └── topEntity.v

```

-------------------

TODO:
 - [x] Update docs (or rather, look for places that need updating)
 - [x] Add CHANGELOG