### PR TITLE
 Restore port types in manifest files 

### DIFF
--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -439,7 +439,7 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
         then writeEdam hdlDir (topNm, varUniq topEntity) deps edamFiles0 filesAndDigests0
         else pure (edamFiles0, filesAndDigests0)
 
-      let manifest = mkManifest opts topComponent components filesAndDigests1 topHash
+      let manifest = mkManifest hdlState' opts topComponent components filesAndDigests1 topHash
       writeManifest manifest manPath
 
       topTime <- hdlDocs `seq` Clock.getCurrentTime

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -439,7 +439,9 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
         then writeEdam hdlDir (topNm, varUniq topEntity) deps edamFiles0 filesAndDigests0
         else pure (edamFiles0, filesAndDigests0)
 
-      let manifest = mkManifest hdlState' opts topComponent components filesAndDigests1 topHash
+      let manifest = mkManifest
+                       hdlState' domainConfs opts topComponent components
+                       filesAndDigests1 topHash
       writeManifest manifest manPath
 
       topTime <- hdlDocs `seq` Clock.getCurrentTime

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -35,7 +35,7 @@ import           Clash.Backend (Backend (hdlType), Usage (External))
 import           Clash.Driver.Types
 import           Clash.Primitives.Types
 import           Clash.Core.Var (Id)
-import           Clash.Netlist.Types (TopEntityT, Component(..), HWType)
+import           Clash.Netlist.Types (TopEntityT, Component(..), HWType (Clock))
 import qualified Clash.Netlist.Types as Netlist
 import qualified Clash.Netlist.Id as Id
 import           Clash.Netlist.Util (typeSize)
@@ -55,6 +55,8 @@ data ManifestPort = ManifestPort
   -- ^ Type name (as rendered in HDL)
   , mpWidth :: Int
   -- ^ Port width in bits
+  , mpIsClock :: Bool
+  -- ^ Is this port a clock?
   } deriving (Show,Read)
 
 -- | Information about the generated HDL between (sub)runs of the compiler
@@ -104,6 +106,7 @@ mkManifestPort backend portId portType = ManifestPort{..}
  where
   mpName = Id.toText portId
   mpWidth = typeSize portType
+  mpIsClock = case portType of {Clock _ -> True; _ -> False}
   mpTypeName = flip evalState backend $ getMon $ do
      LText.toStrict . renderOneLine <$> hdlType (External mpName) portType
 

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -38,6 +38,7 @@ import           Clash.Core.Var (Id)
 import           Clash.Netlist.Types (TopEntityT, Component(..), HWType)
 import qualified Clash.Netlist.Types as Netlist
 import qualified Clash.Netlist.Id as Id
+import           Clash.Netlist.Util (typeSize)
 import           Clash.Primitives.Util (hashCompiledPrimMap)
 import           Clash.Util.Graph (callGraphBindings)
 
@@ -52,6 +53,8 @@ data ManifestPort = ManifestPort
   -- ^ Port name (as rendered in HDL)
   , mpTypeName :: Text
   -- ^ Type name (as rendered in HDL)
+  , mpWidth :: Int
+  -- ^ Port width in bits
   } deriving (Show,Read)
 
 -- | Information about the generated HDL between (sub)runs of the compiler
@@ -100,6 +103,7 @@ mkManifestPort ::
 mkManifestPort backend portId portType = ManifestPort{..}
  where
   mpName = Id.toText portId
+  mpWidth = typeSize portType
   mpTypeName = flip evalState backend $ getMon $ do
      LText.toStrict . renderOneLine <$> hdlType (External mpName) portType
 

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -452,6 +452,14 @@ data HWType
   -- ^ File type for simulation-level I/O
   deriving (Eq, Ord, Show, Generic, NFData, Hashable)
 
+hwTypeDomain :: HWType -> Maybe DomainName
+hwTypeDomain = \case
+  Clock dom -> Just dom
+  Reset dom -> Just dom
+  Enable dom -> Just dom
+  KnownDomain dom _ _ _ _ _ -> Just dom
+  _ -> Nothing
+
 -- | Extract hardware attributes from Annotated. Returns an empty list if
 -- non-Annotated given or if Annotated has an empty list of attributes.
 hwTypeAttrs :: HWType -> [Attr']

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -505,6 +505,7 @@ data VDomainConfiguration
   , vResetPolarity :: ResetPolarity
   -- ^ Corresponds to '_resetPolarity' on 'DomainConfiguration'
   }
+  deriving (Eq, Show, Read)
 
 -- | Convert 'SDomainConfiguration' to 'VDomainConfiguration'. Should be used in combination with
 -- 'createDomain' only.


### PR DESCRIPTION
See: https://github.com/gergoerdi/clash-issue-1686/pull/1#issuecomment-795198464. Sorry @gergoerdi!

Also adds some additional info:

* For clock, reset, and enable ports it now includes the synthesis domain (future work: add for all signal types too)
* Whether a port is clock
* Port width
* All domains and their properties