### PR TITLE
Fix papercuts in clash-prelude

### DIFF
--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -140,6 +140,7 @@ module Clash.Prelude
   , module Control.Applicative
   , module Data.Bits
   , module Data.Default.Class
+  , module Data.Kind
     -- ** Exceptions
   , module Clash.XException
     -- ** Named types
@@ -157,6 +158,7 @@ where
 import           Control.Applicative
 import           Data.Bits
 import           Data.Default.Class
+import           Data.Kind (Type, Constraint)
 import           GHC.Stack                   (HasCallStack)
 import           GHC.TypeLits
 import           GHC.TypeLits.Extra

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -179,7 +179,7 @@ instance (KnownNat n, 1 <= n) => BitPack (Index n) where
   unpack = unpack#
 
 -- | Safely convert an `SNat` value to an `Index`
-fromSNat :: (KnownNat m, n <= m + 1) => SNat n -> Index m
+fromSNat :: (KnownNat m, n + 1 <= m) => SNat n -> Index m
 fromSNat = snatToNum
 
 {-# NOINLINE pack# #-}

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -19,7 +19,7 @@ module Test.Tasty.Clash.NetlistTest
   ) where
 
 import qualified Prelude as P
-import           Clash.Prelude
+import           Clash.Prelude hiding (Type)
 
 import           Clash.Annotations.Primitive (HDL(..))
 import           Clash.Annotations.BitRepresentation.Internal


### PR DESCRIPTION
Fixes for recent small papercuts in clash-prelude, hopefully in
time for the 1.4 release. Fixes #1692 and #1700.