### PR TITLE
Preserve build order in Manifest files

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -282,6 +282,7 @@ Library
                       Control.Applicative.Extra
                       Data.Aeson.Extra
                       Data.List.Extra
+                      Data.Map.Ordered.Extra
                       Data.Primitive.ByteArray.Extra
                       Data.Semigroup.Monad.Extra
                       Data.Set.Ordered.Extra

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -119,6 +119,9 @@ data Manifest
     -- ^ Names of all the generated components for the @TopEntity@ (does not
     -- include the names of the components of the @TestBench@ accompanying
     -- the @TopEntity@).
+    --
+    -- This list is reverse topologically sorted. I.e., a component might depend
+    -- on any component listed before it, but not after it.
   , topComponent :: Text
     -- ^ Design entry point. This is usually the component annotated with a
     -- @TopEntity@ annotation.

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -43,9 +43,10 @@ import           Text.Read (readMaybe)
 
 import           Clash.Annotations.TopEntity.Extra ()
 import           Clash.Backend (Backend (hdlType), Usage (External))
+import           Clash.Core.Name (nameOcc)
 import           Clash.Driver.Types
 import           Clash.Primitives.Types
-import           Clash.Core.Var (Id)
+import           Clash.Core.Var (Id, varName)
 import           Clash.Netlist.Types
   (TopEntityT, Component(..), HWType (Clock), hwTypeDomain)
 import qualified Clash.Netlist.Types as Netlist
@@ -130,6 +131,9 @@ data Manifest
     -- are SHA256.
   , domains :: HashMap Text VDomainConfiguration
     -- ^ Domains encountered in design
+  , transitiveDependencies :: [Text]
+    -- ^ Dependencies of this design (fully qualified binder names). Is a
+    -- transitive closure of all dependencies.
   } deriving (Show,Read,Eq)
 
 instance ToJSON Manifest where
@@ -164,6 +168,8 @@ instance ToJSON Manifest where
             ]
           )
         | (domNm, VDomainConfiguration{..}) <- HashMap.toList domains ]
+      , "dependencies" .= Aeson.object
+        [ "transitive" .= transitiveDependencies ]
       ]
 
 instance FromJSON Manifest where
@@ -193,6 +199,7 @@ instance FromJSON Manifest where
                 pure (fName, fst (Base16.decode (Text.encodeUtf8 sha256)))
 #endif
         <*> (v .: "domains" >>= HashMap.traverseWithKey parseDomain)
+        <*> (v .: "dependencies" >>= (.: "transitive"))
    where
     parseDomain :: Text -> Aeson.Object -> Parser VDomainConfiguration
     parseDomain nm v =
@@ -254,13 +261,15 @@ mkManifest ::
   Component ->
   -- | All other entities
   [Component] ->
+  -- | Names of dependencies (transitive closure)
+  [Id] ->
   -- | Files and  their hashes
   [(FilePath, ByteString)] ->
   -- | Hash returned by 'readFreshManifest'
   Int ->
   -- | New manifest
   Manifest
-mkManifest backend domains ClashOpts{..} Component{..} components files topHash = Manifest
+mkManifest backend domains ClashOpts{..} Component{..} components deps files topHash = Manifest
   { manifestHash = topHash
   , inPorts = [mkManifestPort backend pName pType | (pName, pType) <- inputs]
   , outPorts = [mkManifestPort backend pName pType | (_, (pName, pType), _) <- outputs]
@@ -269,6 +278,7 @@ mkManifest backend domains ClashOpts{..} Component{..} components files topHash 
   , fileNames = files
   , successFlags = (opt_inlineLimit, opt_specLimit, opt_floatSupport)
   , domains = domains
+  , transitiveDependencies = map (nameOcc . varName) deps
   }
  where
   compNames = map Netlist.componentName components

--- a/clash-lib/src/Clash/Netlist.hs-boot
+++ b/clash-lib/src/Clash/Netlist.hs-boot
@@ -21,20 +21,15 @@ import Clash.Core.DataCon   (DataCon)
 import Clash.Core.Term      (Alt,LetBinding,Term)
 import Clash.Core.Type      (Type)
 import Clash.Core.Var       (Id)
-import Clash.Netlist.Types  (Expr, HWType, Identifier, NetlistMonad, Component,
-                             Declaration, NetlistId, DeclarationType, IdentifierSet)
-
-#if MIN_VERSION_ghc(9,0,0)
-import GHC.Types.SrcLoc     (SrcSpan)
-#else
-import SrcLoc               (SrcSpan)
-#endif
+import Clash.Netlist.Types
+  (Expr, HWType, Identifier, NetlistMonad, Declaration, NetlistId,
+   DeclarationType, ComponentMeta, Component)
 
 import GHC.Stack (HasCallStack)
 
 genComponent :: HasCallStack
              => Id
-             -> NetlistMonad ([Bool],SrcSpan,IdentifierSet,Component)
+             -> NetlistMonad (ComponentMeta, Component)
 
 mkExpr :: HasCallStack
        => Bool

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -52,6 +52,7 @@ import Data.HashMap.Strict                  (HashMap)
 import Data.HashSet                         (HashSet)
 import qualified Data.List                  as List
 import Data.IntMap                          (IntMap, empty)
+import Data.Map.Ordered                     (OMap)
 import Data.Maybe                           (mapMaybe)
 import qualified Data.Set                   as Set
 import Data.Text                            (Text)
@@ -82,6 +83,7 @@ import Clash.Netlist.BlackBox.Types         (BlackBoxTemplate)
 import Clash.Primitives.Types               (CompiledPrimMap)
 import Clash.Signal.Internal
   (ResetPolarity, ActiveEdge, ResetKind, InitBehavior)
+import Clash.Unique                         (Unique)
 import Clash.Util                           (makeLenses)
 
 import Clash.Annotations.BitRepresentation.Internal
@@ -281,13 +283,16 @@ data NetlistEnv
   -- ^ (Maybe) user given instance/register name
   }
 
+type ComponentMap = OMap Unique ([Bool], SrcSpan, IdentifierSet, Component)
+
 -- | State of the NetlistMonad
 data NetlistState
   = NetlistState
   { _bindings       :: BindingMap
   -- ^ Global binders
-  , _components     :: VarEnv ([Bool],SrcSpan,IdentifierSet,Component)
-  -- ^ Cached components
+  , _components     :: ComponentMap
+  -- ^ Cached components. Is an insertion ordered map to preserve a topologically
+  -- sorted component list for the manifest file.
   , _primitives     :: CompiledPrimMap
   -- ^ Primitive Definitions
   , _typeTranslator :: CustomReprs -> TyConMap -> Type

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -283,7 +283,13 @@ data NetlistEnv
   -- ^ (Maybe) user given instance/register name
   }
 
-type ComponentMap = OMap Unique ([Bool], SrcSpan, IdentifierSet, Component)
+data ComponentMeta = ComponentMeta
+  { cmWereVoids :: [Bool]
+  , cmLoc :: SrcSpan
+  , cmScope :: IdentifierSet
+  } deriving (Generic, Show, NFData)
+
+type ComponentMap = OMap Unique (ComponentMeta, Component)
 
 -- | State of the NetlistMonad
 data NetlistState

--- a/clash-lib/src/Data/Map/Ordered/Extra.hs
+++ b/clash-lib/src/Data/Map/Ordered/Extra.hs
@@ -1,0 +1,10 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Data.Map.Ordered.Extra where
+
+import Control.DeepSeq (NFData(rnf))
+import Data.Map.Ordered (OMap)
+import qualified Data.Map.Ordered as OMap
+
+instance (NFData k, NFData v) => NFData (OMap k v) where
+  rnf = rnf . OMap.assocs

--- a/clash-lib/tests/Clash/Tests/Driver/Manifest.hs
+++ b/clash-lib/tests/Clash/Tests/Driver/Manifest.hs
@@ -68,6 +68,7 @@ genManifest =
     <*> coerce @(Q.Gen ArbitraryText)   @(Q.Gen Text)   Q.arbitrary -- top name
     <*> Q.listOf ((,) <$> genString <*> genDigest) -- files
     <*> (HashMap.fromList <$> Q.listOf genDomain) -- domains
+    <*> coerce @(Q.Gen [ArbitraryText]) @(Q.Gen [Text]) Q.arbitrary -- dependencies
 
 tests :: TestTree
 tests =

--- a/tests/shouldwork/Issues/T1388.hs
+++ b/tests/shouldwork/Issues/T1388.hs
@@ -63,10 +63,7 @@ assertNoSLVInPortMap =
   goPort p = False
 
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
-  mapM_ (assertNoSLVInPortMap . getComponent) netlist
+  mapM_ (assertNoSLVInPortMap . snd) netlist

--- a/tests/shouldwork/Issues/T1439.hs
+++ b/tests/shouldwork/Issues/T1439.hs
@@ -51,10 +51,7 @@ noRotateRight (Component nm _ _ _)
   | Id.toText nm == "rotate_right" = error ("No component should be called rotate_right")
   | otherwise = pure ()
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
-  mapM_ (noRotateRight . getComponent) netlist
+  mapM_ (noRotateRight . snd) netlist

--- a/tests/shouldwork/Naming/NameHint.hs
+++ b/tests/shouldwork/Naming/NameHint.hs
@@ -45,15 +45,12 @@ assertOneDecl (Component _ _ _ ds) =
   isSigAssignment i (Assignment _ (Identifier i' _)) = i == i'
   isSigAssignment _ _ = False
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
-  mapM_ (assertOneDecl . getComponent) netlist
+  mapM_ (assertOneDecl . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog id testPath
-  mapM_ (assertOneDecl . getComponent) netlist
+  mapM_ (assertOneDecl . snd) netlist

--- a/tests/shouldwork/Naming/T1041.hs
+++ b/tests/shouldwork/Naming/T1041.hs
@@ -75,21 +75,17 @@ assertOneVGA (Component _ _ _ ds)
   isVGADecl (NetDecl' _ Wire (Id.toText -> "VGA") _ _) = True
   isVGADecl _ = False
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
-  mapM_ (assertOneVGA . getComponent) netlist
+  mapM_ (assertOneVGA . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog id testPath
-  mapM_ (assertOneVGA . getComponent) netlist
+  mapM_ (assertOneVGA . snd) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   netlist <- runToNetlistStage SSystemVerilog id testPath
-  mapM_ (assertOneVGA . getComponent) netlist
-
+  mapM_ (assertOneVGA . snd) netlist

--- a/tests/shouldwork/Netlist/Identity.hs
+++ b/tests/shouldwork/Netlist/Identity.hs
@@ -46,15 +46,14 @@ getComponent (_, _, _, x) = x
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
-  mapM_ (assertAssignsInOut . getComponent) netlist
+  mapM_ (assertAssignsInOut . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog id testPath
-  mapM_ (assertAssignsInOut . getComponent) netlist
+  mapM_ (assertAssignsInOut . snd) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   netlist <- runToNetlistStage SSystemVerilog id testPath
-  mapM_ (assertAssignsInOut . getComponent) netlist
-
+  mapM_ (assertAssignsInOut . snd) netlist

--- a/tests/shouldwork/Netlist/NoDeDup.hs
+++ b/tests/shouldwork/Netlist/NoDeDup.hs
@@ -66,10 +66,7 @@ assertNumTwiceInsts (Component nm inps outs ds) =
   twiceInsts = filter isTwiceInst ds
   nTwiceInsts = P.length twiceInsts
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
-  mapM_ (assertNumTwiceInsts . getComponent) netlist
+  mapM_ (assertNumTwiceInsts . snd) netlist

--- a/tests/shouldwork/TopEntity/T1182A.hs
+++ b/tests/shouldwork/TopEntity/T1182A.hs
@@ -41,20 +41,17 @@ assertInputs expType (N.Component _ [(clk,N.Clock _)] [(N.Wire,(ssan,actType),No
   = pure ()
 assertInputs _ c = error $ "Component mismatch: " P.++ show c
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
-  mapM_ (assertInputs (N.BitVector 8) . getComponent) netlist
+  mapM_ (assertInputs (N.BitVector 8) . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog id testPath
-  mapM_ (assertInputs (N.Vector 8 N.Bool) . getComponent) netlist
+  mapM_ (assertInputs (N.Vector 8 N.Bool) . snd) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   netlist <- runToNetlistStage SSystemVerilog id testPath
-  mapM_ (assertInputs (N.BitVector 8) . getComponent) netlist
+  mapM_ (assertInputs (N.BitVector 8) . snd) netlist

--- a/tests/shouldwork/TopEntity/T1182B.hs
+++ b/tests/shouldwork/TopEntity/T1182B.hs
@@ -52,20 +52,17 @@ assertInputs exp1 exp2 (N.Component _ [(clk, N.Clock _)]
   = pure ()
 assertInputs _ _ c = error $ "Component mismatch: " P.++ show c
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL id testPath
-  mapM_ (assertInputs (N.BitVector 8) (N.BitVector 7) . getComponent) netlist
+  mapM_ (assertInputs (N.BitVector 8) (N.BitVector 7) . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog id testPath
-  mapM_ (assertInputs (N.Vector 8 N.Bool) (N.Vector 7 N.Bool) . getComponent) netlist
+  mapM_ (assertInputs (N.Vector 8 N.Bool) (N.Vector 7 N.Bool) . snd) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   netlist <- runToNetlistStage SSystemVerilog id testPath
-  mapM_ (assertInputs (N.BitVector 8) (N.BitVector 7) . getComponent) netlist
+  mapM_ (assertInputs (N.BitVector 8) (N.BitVector 7) . snd) netlist

--- a/tests/shouldwork/XOptimization/ManyDefined.hs
+++ b/tests/shouldwork/XOptimization/ManyDefined.hs
@@ -36,24 +36,20 @@ assertOneAltPerDefined c =
 testPath :: FilePath
 testPath = "tests/shouldwork/XOptimization/ManyDefined.hs"
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 enableXOpt :: ClashOpts -> ClashOpts
 enableXOpt c = c { opt_aggressiveXOpt = True }
 
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL enableXOpt testPath
-  mapM_ (assertOneAltPerDefined . getComponent) netlist
+  mapM_ (assertOneAltPerDefined . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog enableXOpt testPath
-  mapM_ (assertOneAltPerDefined . getComponent) netlist
+  mapM_ (assertOneAltPerDefined . snd) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   netlist <- runToNetlistStage SSystemVerilog enableXOpt testPath
-  mapM_ (assertOneAltPerDefined . getComponent) netlist
-
+  mapM_ (assertOneAltPerDefined . snd) netlist

--- a/tests/shouldwork/XOptimization/OneDefinedDataPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedDataPat.hs
@@ -25,24 +25,20 @@ assertNoMux c =
 testPath :: FilePath
 testPath = "tests/shouldwork/XOptimization/OneDefinedDataPat.hs"
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 enableXOpt :: ClashOpts -> ClashOpts
 enableXOpt c = c { opt_aggressiveXOpt = True }
 
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
+  mapM_ (assertNoMux . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
+  mapM_ (assertNoMux . snd) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   netlist <- runToNetlistStage SSystemVerilog enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
-
+  mapM_ (assertNoMux . snd) netlist

--- a/tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs
@@ -25,24 +25,20 @@ assertNoMux c =
 testPath :: FilePath
 testPath = "tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs"
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 enableXOpt :: ClashOpts -> ClashOpts
 enableXOpt c = c { opt_aggressiveXOpt = True }
 
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
+  mapM_ (assertNoMux . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
+  mapM_ (assertNoMux . snd) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   netlist <- runToNetlistStage SSystemVerilog enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
-
+  mapM_ (assertNoMux . snd) netlist

--- a/tests/shouldwork/XOptimization/OneDefinedLitPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedLitPat.hs
@@ -25,24 +25,20 @@ assertNoMux c =
 testPath :: FilePath
 testPath = "tests/shouldwork/XOptimization/OneDefinedLitPat.hs"
 
-getComponent :: (a, b, c, d) -> d
-getComponent (_, _, _, x) = x
-
 enableXOpt :: ClashOpts -> ClashOpts
 enableXOpt c = c { opt_aggressiveXOpt = True }
 
 mainVHDL :: IO ()
 mainVHDL = do
   netlist <- runToNetlistStage SVHDL enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
+  mapM_ (assertNoMux . snd) netlist
 
 mainVerilog :: IO ()
 mainVerilog = do
   netlist <- runToNetlistStage SVerilog enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
+  mapM_ (assertNoMux . snd) netlist
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = do
   netlist <- runToNetlistStage SSystemVerilog enableXOpt testPath
-  mapM_ (assertNoMux . getComponent) netlist
-
+  mapM_ (assertNoMux . snd) netlist

--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -85,6 +85,7 @@ library
     mtl,
     concurrent-supply,
     unordered-containers,
+    ordered-containers,
     containers,
 
 

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -44,10 +44,8 @@ import           Clash.GHC.Evaluator
 import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.Netlist
-import qualified Clash.Netlist.Id as Id
 import           Clash.Netlist.BlackBox.Types (HdlSyn(Other))
 import           Clash.Netlist.Types hiding (backend, hdlDir)
-import           Clash.Util
 
 #if MIN_VERSION_ghc(9,0,0)
 import           GHC.Utils.Misc
@@ -97,7 +95,7 @@ runToNetlistStage
   -- ^ Function to modify the default clash options
   -> FilePath
   -- ^ Module to load
-  -> IO [([Bool], SrcSpan, Id.IdentifierSet, Component)]
+  -> IO [(ComponentMeta, Component)]
 runToNetlistStage target f src = do
   pds <- primDirs backend
   (bm, tcm, tupTcm, tes, pm, rs, _)

--- a/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/testsuite/src/Test/Tasty/Clash/NetlistTest.hs
@@ -59,6 +59,7 @@ import qualified Control.Concurrent.Supply as Supply
 import           Control.DeepSeq (force)
 import           Control.Monad.State.Strict (State)
 import           Data.Maybe
+import qualified Data.Map.Ordered as OMap
 import qualified Data.Text as Text
 import           System.FilePath ((</>))
 
@@ -118,7 +119,8 @@ runToNetlistStage target f src = do
 #endif
           teNames opts supplyN te
 
-  fmap (\(_,x,_) -> force (eltsVarEnv x)) $ netlistFrom (transformedBindings, tcm, tes2, compNames, pm, reprs, te, initIs)
+  fmap (\(_,x,_) -> force (P.map snd (OMap.assocs x))) $
+    netlistFrom (transformedBindings, tcm, tes2, compNames, pm, reprs, te, initIs)
  where
   backend = mkBackend target
   opts = f mkClashOpts


### PR DESCRIPTION
Manifest files now list files in reverse topological order. This makes
sure files can be fed to EDA tools in that order, without triggering
compilation errors.