### PR TITLE
Preliminary groundwork for GHC 9.0 compatibility

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
  && cd .. \
  && rm -rf ghdl-0.37
 
-ARG GHCUP_VERSION="0.1.12"
+ARG GHCUP_VERSION="0.1.14"
 ARG GHCUP_URL="https://downloads.haskell.org/~ghcup/${GHCUP_VERSION}/x86_64-linux-ghcup-${GHCUP_VERSION}"
 ARG GHCUP_BIN=/usr/bin/ghcup
 
@@ -38,7 +38,7 @@ RUN curl $GHCUP_URL --output $GHCUP_BIN \
  && ghcup install cabal 2.4.1.0 \
  && ghcup install cabal 3.0.0.0 \
  && ghcup install cabal 3.2.0.0 \
- && ghcup install cabal 3.4.0.0-rc4
+ && ghcup install cabal 3.4.0.0
 
 ARG ghc_version
 ENV GHC_VERSION=$ghc_version

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-02-08
+  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-03-18
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,5 +1,5 @@
 .common:
-  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-02-08
+  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-03-18
   timeout: 2 hours
   stage: build
   variables:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ aliases:
 
   - &build_default
     docker:
-      - image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-02-08
+      - image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-03-18
         # Read-only permissions
         auth:
           username: clash-lang-builder

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,9 +55,8 @@ tests-8.10:
 tests-9.0:
   extends: .common-trigger
   variables:
-    GHC_HEAD: "yes" # We need the HEAD overlay for now
     GHC_VERSION: 9.0.1
-    CABAL_VERSION: 3.4.0.0-rc4
+    CABAL_VERSION: 3.4.0.0
 
 stack-build:
   extends: .common

--- a/cabal.project
+++ b/cabal.project
@@ -11,10 +11,12 @@ packages:
   ./benchmark/profiling/run
   ./clash-term
 
+write-ghc-environment-files: always
+
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2021-02-25T05:27:39Z
+index-state: 2021-03-18T06:58:19Z
 
 -- For some reason the `clash-testsuite` executable fails to run without
 -- this, as it cannot find the related library...
@@ -43,4 +45,23 @@ optional-packages:
   ./clash-cores
 
 allow-newer:
-  brick:base
+  brick:base,
+  vector-binary-instances:base,
+  cryptohash-sha256:base
+
+source-repository-package
+  type: git
+  location: https://github.com/kcsongor/generic-lens.git
+  tag: 8e1fc7dcf444332c474fca17110d4bc554db08c8
+  subdir: generic-lens-core
+
+source-repository-package
+  type: git
+  location: https://github.com/kcsongor/generic-lens.git
+  tag: 8e1fc7dcf444332c474fca17110d4bc554db08c8
+  subdir: generic-lens
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell-hint/hint.git
+  tag: abdb192eace46ef71b7b4a2d4a67654248f8dbdb

--- a/cabal.project
+++ b/cabal.project
@@ -60,8 +60,3 @@ source-repository-package
   location: https://github.com/kcsongor/generic-lens.git
   tag: 8e1fc7dcf444332c474fca17110d4bc554db08c8
   subdir: generic-lens
-
-source-repository-package
-  type: git
-  location: https://github.com/haskell-hint/hint.git
-  tag: abdb192eace46ef71b7b4a2d4a67654248f8dbdb

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -335,7 +335,7 @@ Library
                       recursion-schemes         >= 5.1     && < 5.3,
                       QuickCheck                >= 2.7     && < 2.15,
                       reflection                >= 2       && < 2.2,
-                      singletons                >= 1.0     && < 3.0,
+                      singletons                >= 2.0     && < 3.1,
                       template-haskell          >= 2.12.0.0 && < 2.18,
                       th-abstraction            >= 0.2.10 && < 0.5.0,
                       th-lift                   >= 0.7.0    && < 0.9,

--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -49,17 +49,8 @@ import           Language.Haskell.TH.Lib
 import           Language.Haskell.TH.Ppr
 
 import           Control.Lens.Internal.TH     (conAppsT)
-
-#if MIN_VERSION_base(4,15,0)
--- | Return 'Name' contained in a 'TyVarBndr'.
-bndrName :: TyVarBndr a -> Name
-bndrName (PlainTV  n _) = n
-bndrName (KindedTV n _ _) = n
-#else
--- | Return 'Name' contained in a 'TyVarBndr'.
-bndrName :: TyVarBndr -> Name
-bndrName (PlainTV  n) = n
-bndrName (KindedTV n _) = n
+#if !(MIN_VERSION_th_abstraction(0,4,0))
+import           Control.Lens.Internal.TH     (bndrName)
 #endif
 
 -- $setup
@@ -272,7 +263,9 @@ deriveAutoRegProduct tyInfo conInfo = go (constructorName conInfo) fieldInfos
   tyNm = datatypeName tyInfo
   tyVarBndrs = datatypeVars tyInfo
 
-#if MIN_VERSION_th_abstraction(0,3,0)
+#if MIN_VERSION_th_abstraction(0,4,0)
+  toTyVar = VarT . tvName
+#elif MIN_VERSION_th_abstraction(0,3,0)
   toTyVar = VarT . bndrName
 #else
   toTyVar t = case t of

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -49,7 +49,7 @@ import Prelude                    ((.), (<$>), (<*>), id, Num(..))
 import Data.Coerce                (coerce)
 import Data.Kind                  (Type)
 import Data.Proxy                 (Proxy (..))
-import Data.Singletons.Prelude    (Apply, TyFun, type (@@))
+import Data.Singletons            (Apply, TyFun, type (@@))
 import GHC.TypeLits               (KnownNat, Nat, type (+), type (^), type (*))
 
 import Clash.Sized.Vector

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -55,7 +55,7 @@ import Data.Default.Class          (Default (..))
 import Data.Either                 (isLeft)
 import Data.Foldable               (toList)
 import Data.Kind                   (Type)
-import Data.Singletons.Prelude     (Apply, TyFun, type (@@))
+import Data.Singletons             (Apply, TyFun, type (@@))
 import Data.Proxy                  (Proxy (..))
 import GHC.TypeLits                (KnownNat, Nat, type (+), type (^), type (*))
 import Language.Haskell.TH.Syntax  (Lift(..))
@@ -85,7 +85,7 @@ import Clash.XException
 >>> :set -XUndecidableInstances
 >>> import Clash.Prelude
 >>> import Data.Kind
->>> import Data.Singletons.Prelude (Apply, TyFun)
+>>> import Data.Singletons (Apply, TyFun)
 >>> import Data.Proxy
 >>> data IIndex (f :: TyFun Nat Type) :: Type
 >>> type instance Apply IIndex l = Index ((2^l)+1)
@@ -333,7 +333,7 @@ the form of 'dtfold':
 
 @
 {\-\# LANGUAGE UndecidableInstances \#-\}
-import Data.Singletons.Prelude
+import Data.Singletons
 import Data.Proxy
 
 data IIndex (f :: 'TyFun' Nat *) :: *

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -109,7 +109,7 @@ import Data.Default.Class         (Default (..))
 import qualified Data.Foldable    as F
 import Data.Kind                  (Type)
 import Data.Proxy                 (Proxy (..))
-import Data.Singletons.Prelude    (TyFun,Apply,type (@@))
+import Data.Singletons            (TyFun,Apply,type (@@))
 import GHC.TypeLits               (CmpNat, KnownNat, Nat, type (+), type (-), type (*),
                                    type (^), type (<=), natVal)
 import GHC.Base                   (Int(I#),Int#,isTrue#)
@@ -2128,7 +2128,7 @@ lazyV = lazyV' (repeat ())
 -- now correctly define /append'/:
 --
 -- @
--- import Data.Singletons.Prelude
+-- import Data.Singletons
 -- import Data.Proxy
 --
 -- data Append (m :: Nat) (a :: *) (f :: 'TyFun' Nat *) :: *
@@ -2258,7 +2258,7 @@ the form of 'dtfold':
 
 @
 {\-\# LANGUAGE UndecidableInstances \#-\}
-import Data.Singletons.Prelude
+import Data.Singletons
 import Data.Proxy
 
 data IIndex (f :: 'TyFun' Nat *) :: *

--- a/tests/shouldwork/Basic/T1591.hs
+++ b/tests/shouldwork/Basic/T1591.hs
@@ -7,9 +7,15 @@
 module T1591 where
 
 import Clash.Prelude
-import Data.Singletons.Prelude
+
+import Data.Singletons
 import Data.Singletons.TH
 
+#if MIN_VERSION_singletons(3,0,0)
+import Prelude.Singletons
+#else
+import Data.Singletons.Prelude
+#endif
 
 $(singletons [d|
     countStates :: Nat -> Nat -> Nat

--- a/tests/shouldwork/RTree/TFold.hs
+++ b/tests/shouldwork/RTree/TFold.hs
@@ -7,9 +7,9 @@ import Data.Kind (Type)
 
 import Data.Proxy
 #if MIN_VERSION_singletons(2,4,0)
-import Data.Singletons.Prelude hiding (type (+))
+import Data.Singletons hiding (type (+))
 #else
-import Data.Singletons.Prelude
+import Data.Singletons
 #endif
 
 data IIndex (f :: TyFun Nat Type) :: Type

--- a/tests/shouldwork/Vector/DFold.hs
+++ b/tests/shouldwork/Vector/DFold.hs
@@ -4,9 +4,9 @@ module DFold where
 import Clash.Prelude
 import Clash.Explicit.Testbench
 #if MIN_VERSION_singletons(2,4,0)
-import Data.Singletons.Prelude hiding (type (+))
+import Data.Singletons hiding (type (+))
 #else
-import Data.Singletons.Prelude
+import Data.Singletons
 #endif
 import Data.Proxy
 import Data.Kind (Type)

--- a/tests/shouldwork/Vector/DTFold.hs
+++ b/tests/shouldwork/Vector/DTFold.hs
@@ -4,9 +4,9 @@ module DTFold where
 import Clash.Prelude
 import Clash.Explicit.Testbench
 #if MIN_VERSION_singletons(2,4,0)
-import Data.Singletons.Prelude hiding (type (+))
+import Data.Singletons hiding (type (+))
 #else
-import Data.Singletons.Prelude
+import Data.Singletons
 #endif
 import Data.Proxy
 import Data.Kind (Type)

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -15,11 +15,8 @@ import           System.Directory
   (createDirectoryIfMissing, removeDirectoryRecursive, getCurrentDirectory,
    doesDirectoryExist, makeAbsolute)
 import           System.Environment
-import           System.Exit
-  (exitWith, ExitCode(ExitSuccess, ExitFailure))
 import           System.FilePath           ((</>))
 import           System.Info
-import           System.Process            (readCreateProcessWithExitCode, proc)
 import           GHC.Conc                  (numCapabilities)
 import           GHC.Stack
 import           GHC.IO.Unsafe             (unsafePerformIO)
@@ -112,22 +109,10 @@ setClashEnvs :: HasCallStack => RunWith -> IO ()
 setClashEnvs Global = setEnv "GHC_ENVIRONMENT" "-"
 setClashEnvs Stack = pure ()
 setClashEnvs Cabal = do
-  -- Make sure environment variable exists
-  let cp = proc "cabal" ["--write-ghc-environment-files=always", "v2-run", "--", "clash", "--help"]
-  (exitCode, stdout, stderr) <- readCreateProcessWithExitCode cp ""
-  case exitCode of
-    ExitSuccess -> do
-      binDir <- cabalClashBinDir
-      path <- getEnv "PATH"
-      setEnv "PATH" (binDir <> ":" <> path)
-      setCabalPackagePaths
-    ExitFailure _ -> do
-      putStrLn "'cabal run clash' failed"
-      putStrLn ">>> stdout:"
-      putStrLn stdout
-      putStrLn ">>> stderr:"
-      putStrLn stderr
-      exitWith exitCode
+  binDir <- cabalClashBinDir
+  path <- getEnv "PATH"
+  setEnv "PATH" (binDir <> ":" <> path)
+  setCabalPackagePaths
 
 clashTestRoot
   :: [[TestName] -> TestTree]

--- a/testsuite/clash-testsuite.cabal
+++ b/testsuite/clash-testsuite.cabal
@@ -80,6 +80,7 @@ library
   build-depends:
     deepseq            >=1.4      && <1.5,
     concurrent-extra   >=0.7      && <0.8,
+    singletons,
     generic-lens,
     interpolate,
     mtl,
@@ -94,6 +95,18 @@ executable clash-testsuite
   main-is:             Main.hs
   ghc-options:         -threaded -with-rtsopts=-N
 
+  build-tool-depends:
+    clash-ghc:clash
+
   build-depends:
     containers,
     clash-testsuite
+
+  if impl(ghc >= 9.0.0)
+    build-depends:
+      singletons,
+      singletons-base,
+      singletons-th
+  else
+    build-depends:
+      singletons < 3.0

--- a/testsuite/src/Test/Tasty/Clash.hs
+++ b/testsuite/src/Test/Tasty/Clash.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Tasty.Clash where
 


### PR DESCRIPTION
Everything compiles with the following Stack resolver:

```
name: lts-17.5-ghc9
resolver: lts-17.5
compiler: ghc-9.0.1

packages:
  - github: kcsongor/generic-lens
    commit: 8e1fc7dcf444332c474fca17110d4bc554db08c8
    subdirs:
      - generic-lens-core
      - generic-lens

  - github: haskell-hint/hint
    commit: 6897fccb4781e6d0e3ed36b816e93a14b3b0b406
      
  - singletons-3.0
  - singletons-base-3.0
  - singletons-th-3.0

  - th-expand-syns-0.4.8.0
  - th-desugar-1.12
  - generic-deriving-1.14
  - profunctors-5.6.2
  - lens-5.0.1
  - indexed-traversable-instances-0.1
```

However, I wasn't able to test Clash itself, since at the end of the compilation, Stack fails because of https://github.com/commercialhaskell/stack/issues/5486. Unfortunately, I'm not set up to forego Stack (and it's really not a yak I am looking forward to shave)...