### PR TITLE
Fix setSlice# VHDL primitive

### DIFF
--- a/changelog/2021-03-24T10_16_52+01_00_fix1715
+++ b/changelog/2021-03-24T10_16_52+01_00_fix1715
@@ -1,0 +1,1 @@
+FIXED: Broken VHDL primitive template for setSlice# [#1715](https://github.com/clash-lang/clash-compiler/issues/1715)

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
@@ -309,11 +309,11 @@ end block; ~ELSE
            -> BitVector (m + 1 + i)"
     , "template" :
 "-- setSlice begin
-~GENSYM[setSlice][0] : process(~VAR[bv][0]~VARS[4])
-  variable ~GENSYM[ivec][1] : ~TYP[0];
+~GENSYM[setSlice][0] : process(~VAR[bv][1]~VARS[4])
+  variable ~GENSYM[ivec][1] : ~TYP[1];
 begin
-  ~SYM[1] := ~ARG[1];
-  ~SYM[1](~LIT[2] downto ~LIT[3]) := ~VAR[bv][4];
+  ~SYM[1] := ~VAR[bv][1];
+  ~SYM[1](~LIT[2] downto ~LIT[3]) := ~ARG[4];
   ~RESULT <= ~SYM[1];
 end process;
 -- setSlice end"

--- a/tests/shouldwork/Issues/T1715.hs
+++ b/tests/shouldwork/Issues/T1715.hs
@@ -1,0 +1,17 @@
+module T1715 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity :: (BitVector 16,BitVector 128) -> BitVector 128
+topEntity = uncurry (setSlice d127 d112)
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((maxBound,0):>Nil)
+    expectedOutput = outputVerifier' clk rst (340277174624079928635746076935438991360:>Nil)
+    done           = expectedOutput (fmap topEntity testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -529,6 +529,7 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "Issues") allTargets ["-fclash-aggressive-x-optimization-blackboxes"] ["-itests/shouldwork/Issues"] "T1506B" "main"
         , runTest "T1615" def{hdlSim=False, hdlTargets=[Verilog]}
         , runTest "T1663" def{hdlTargets=[VHDL], hdlSim=False}
+        , runTest "T1715" def
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only


### PR DESCRIPTION
- intermediate result was instantiated at incorrect type
- process sensitivity list incomplete

Fixes #1715