### PR TITLE
Don't check for 'devel' in snap.sh

### DIFF
--- a/.ci/snap.sh
+++ b/.ci/snap.sh
@@ -35,9 +35,6 @@ fi
 
 cd .ci/bindist/linux/snap || exit
 
-# Make sure devel is in snap/snapcraft.yaml before replacing it with 'stable'
-# (if applicable). sed doesn't fail if it doesn't replace anything.
-grep devel snap/snapcraft.yaml
 if [[ ${RELEASE_CHANNEL} == "stable" || ${RELEASE_CHANNEL} == "beta" ]]; then
   # The Snap Store only allows grade=stable for stable snaps
   sed -i s/devel/stable/ snap/snapcraft.yaml


### PR DESCRIPTION
When we dropped Nix for snaps, building and publishing a snap became one
CI job instead of two. As a consequence, 'snap.sh' is run twice in the
same session, making a (superfluous) check fail. This commit removes the
check which should mitigate the problem.

------------------------

See failure: https://gitlab.com/clash-lang/clash-compiler/-/jobs/1122657246