### PR TITLE
DEC: support functions with more then 62 arguments

### DIFF
--- a/changelog/2021-03-27T12_35_57+01_00_fix1669
+++ b/changelog/2021-03-27T12_35_57+01_00_fix1669
@@ -1,0 +1,1 @@
+FIXED: DEC transformation fails for functions applied to more than 62 arguments [#1669](https://github.com/clash-lang/clash-compiler/issues/1669)

--- a/clash-dev
+++ b/clash-dev
@@ -17,4 +17,5 @@ ghci \
   -XDeriveLift -XDeriveTraversable -XDerivingStrategies -XInstanceSigs \
   -XKindSignatures ${XNoStarIsType} -XScopedTypeVariables -XStandaloneDeriving \
   -XTupleSections -XTypeApplications -XTypeOperators -XViewPatterns \
+  -DDEBUG \
   Clash.hs

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -42,10 +42,12 @@ import qualified GHC.Core.TyCon          as GHC
 import qualified GHC.Core.Type           as GHC
 import qualified GHC.Builtin.Types       as GHC
 import qualified GHC.Utils.Misc          as GHC
+import qualified GHC.Settings.Constants  as GHC
 import qualified GHC.Types.Var           as GHC
 import qualified GHC.Types.SrcLoc        as GHC
 #else
 import qualified BasicTypes              as GHC
+import qualified Constants               as GHC
 import qualified CoreSyn                 as GHC
 import qualified Demand                  as GHC
 import qualified DynFlags                as GHC
@@ -339,12 +341,12 @@ mkTupTyCons :: GHC2CoreState -> (GHC2CoreState,IntMap TyConName)
 mkTupTyCons tcMap = (tcMap'',tupTcCache)
   where
     tupTyCons        = GHC.boolTyCon : GHC.promotedTrueDataCon : GHC.promotedFalseDataCon
-                     : map (GHC.tupleTyCon GHC.Boxed) [2..62]
+                     : map (GHC.tupleTyCon GHC.Boxed) [2..GHC.mAX_TUPLE_SIZE]
     (tcNames,tcMap',_) =
       RWS.runRWS (mapM (\tc -> coreToName GHC.tyConName GHC.tyConUnique
                                           qualifiedNameString tc) tupTyCons)
                  GHC.noSrcSpan
                  tcMap
-    tupTcCache       = IMS.fromList (zip [2..62] (drop 3 tcNames))
+    tupTcCache       = IMS.fromList (zip [2..GHC.mAX_TUPLE_SIZE] (drop 3 tcNames))
     tupHM            = listToUniqMap (zip tcNames tupTyCons)
     tcMap''          = tcMap' & tyConMap %~ (`unionUniqMap` tupHM)

--- a/clash-lib/src/Clash/Normalize/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/DEC.hs
@@ -78,7 +78,7 @@ import Clash.Core.TermInfo   (termType)
 import Clash.Core.TyCon      (tyConDataCons)
 import Clash.Core.Type       (Type, isPolyFunTy, mkTyConApp, splitFunForallTy)
 import Clash.Core.Util       (sccLetBindings)
-import Clash.Core.Var        (isGlobalId)
+import Clash.Core.Var        (isGlobalId, isLocalId)
 import Clash.Core.VarEnv
   (InScopeSet, elemInScopeSet, extendInScopeSetList, notElemInScopeSet, unionInScope)
 import Clash.Normalize.Types (NormalizeState)
@@ -437,7 +437,7 @@ areShared inScope xs@(x:_) = noFV1 && allEqual xs
     Left tm  -> getAll (Lens.foldMapOf (termFreeVars' isLocallyBound)
                                        (const (All False)) tm)
 
-  isLocallyBound v = v `notElemInScopeSet` inScope
+  isLocallyBound v = isLocalId v && v `notElemInScopeSet` inScope
 
 -- | Create a list of arguments given a map of positions to common arguments,
 -- and a list of arguments

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -753,7 +753,7 @@ mkWildValBinder is = mkInternalVar is "wild"
 -- | Make a case-decomposition that extracts a field out of a (Sum-of-)Product type
 mkSelectorCase
   :: HasCallStack
-  => (Functor m, MonadUnique m)
+  => MonadUnique m
   => String -- ^ Name of the caller of this function
   -> InScopeSet
   -> TyConMap -- ^ TyCon cache

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -352,6 +352,8 @@ Library
     Build-Depends:    ghc-bignum                >= 1.0      && < 1.1
   else
     Build-Depends:    integer-gmp               >= 1.0.1.0  && < 2.0
+  if flag(large-tuples)
+    Build-Depends:    ghc
 
 test-suite doctests
   type:             exitcode-stdio-1.0

--- a/clash-prelude/src/Clash/CPP.hs
+++ b/clash-prelude/src/Clash/CPP.hs
@@ -8,14 +8,6 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# OPTIONS_HADDOCK hide #-}
 
-#ifndef MAX_TUPLE_SIZE
-#ifdef LARGE_TUPLES
-#define MAX_TUPLE_SIZE 62
-#else
-#define MAX_TUPLE_SIZE 12
-#endif
-#endif
-
 module Clash.CPP
  ( maxTupleSize
 
@@ -23,6 +15,21 @@ module Clash.CPP
  , fSuperStrict
  , fStrictMapSignal
  ) where
+
+#ifndef MAX_TUPLE_SIZE
+#ifdef LARGE_TUPLES
+
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Settings.Constants (mAX_TUPLE_SIZE)
+#else
+import Constants (mAX_TUPLE_SIZE)
+#endif
+#define MAX_TUPLE_SIZE (fromIntegral mAX_TUPLE_SIZE)
+
+#else
+#define MAX_TUPLE_SIZE 12
+#endif
+#endif
 
 maxTupleSize :: Num a => a
 maxTupleSize = MAX_TUPLE_SIZE

--- a/tests/shouldwork/Issues/T1669_DEC.hs
+++ b/tests/shouldwork/Issues/T1669_DEC.hs
@@ -1,0 +1,27 @@
+module T1669_DEC where
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+data AB = A | B
+
+{-# NOINLINE topEntity #-}
+topEntity :: AB -> Int -> Int
+topEntity ab x = case ab of
+    A -> f 3 x 0 1 2 3 4 5 6 7 8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64
+    B -> f x x 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 0
+
+{-# NOINLINE f #-}
+f z0 z1 z2 z3 z4 z5 z6 z7 z8 z9 z10 z11 z12 z13 z14 z15 z16 z17 z18 z19 z20 z21 z22 z23 z24 z25 z26 z27 z28 z29 z30 z31 z32 z33 z34 z35 z36 z37 z38 z39 z40 z41 z42 z43 z44 z45 z46 z47 z48 z49 z50 z51 z52 z53 z54 z55 z56 z57 z58 z59 z60 z61 z62 z63 z64 z65 z66
+  = foldl (\b (a,i) -> b - a*i) 0 $ zip args ixs
+ where
+   args = z0:>z1:>z2:>z3:>z4:>z5:>z6:>z7:>z8:>z9:>z10:>z11:>z12:>z13:>z14:>z15:>z16:>z17:>z18:>z19:>z20:>z21:>z22:>z23:>z24:>z25:>z26:>z27:>z28:>z29:>z30:>z31:>z32:>z33:>z34:>z35:>z36:>z37:>z38:>z39:>z40:>z41:>z42:>z43:>z44:>z45:>z46:>z47:>z48:>z49:>z50:>z51:>z52:>z53:>z54:>z55:>z56:>z57:>z58:>z59:>z60:>z61:>z62:>z63:>z64:>z65:>z66:>Nil
+   ixs = generateI (+1) 0
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ((A,1669):>(B,42):>Nil)
+    expectedOutput = outputVerifier' clk rst (-99021 :> -93726 :> Nil)
+    done           = expectedOutput (fmap (uncurry topEntity) testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -529,6 +529,7 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest ("tests" </> "shouldwork" </> "Issues") allTargets ["-fclash-aggressive-x-optimization-blackboxes"] ["-itests/shouldwork/Issues"] "T1506B" "main"
         , runTest "T1615" def{hdlSim=False, hdlTargets=[Verilog]}
         , runTest "T1663" def{hdlTargets=[VHDL], hdlSim=False}
+        , runTest "T1669_DEC" def{hdlTargets=[VHDL]}
         , runTest "T1715" def
         , runTest "T1721" def{hdlSim=False}
         ] <>


### PR DESCRIPTION
All (non-shared) arguments to DEC'ed functions are combined into tuples,
so they can all be defined via a single case expression.
But because GHC's tuples are limited to 62 elements, this fails for functions with many arguments.

This patch uses GHC's mkChunkified to create (2-levels of) nested tuples for a maximum of 62^2=3844 arguments.

Fixes #1669