### PR TITLE
`Clash.Prelude.romFile` takes a `Enum addr => addr` address line

### DIFF
--- a/changelog/2021-03-27T12_44_20+01_00_fix407
+++ b/changelog/2021-03-27T12_44_20+01_00_fix407
@@ -1,0 +1,1 @@
+CHANGED: `Clash.Prelude.ROM.File.romFile` now takes an `Enum addr => addr` as address argument, making it actually useful. [#407](https://github.com/clash-lang/clash-compiler/issues/407)

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -269,12 +269,13 @@ romFile
      , KnownNat n
      , HiddenClock dom
      , HiddenEnable dom
+     , Enum addr
      )
   => SNat n
   -- ^ Size of the ROM
   -> FilePath
   -- ^ File describing the content of the ROM
-  -> Signal dom (Unsigned n)
+  -> Signal dom addr
   -- ^ Read address @rd@
   -> Signal dom (BitVector m)
   -- ^ The value of the ROM at address @rd@ from the previous clock cycle


### PR DESCRIPTION
Making it behave on par with `Clash.Explicit.Prelude.romFile` and thereby actually useful.

Fixes #407