### PR TITLE
Update tutorial

### DIFF
--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -223,11 +223,20 @@ For installation instructions, see <https://clash-lang.org/install/ clash-lang.o
 
 {- $working
 This tutorial can be followed best whilst having the Clash interpreter running
-at the same time. If you followed the installation instructions, you already
-know how to start the Clash compiler in interpretive mode:
+at the same time. If you followed the installation instructions based on
+<https://docs.haskellstack.org/en/stable/README/#how-to-install Stack>, you can
+start the Clash compiler in interpretive mode by:
 
 @
-clash.clashi  # When installed from source, use @clashi@
+stack exec --package clash-ghc -- clashi
+@
+
+If you followed the installation instruction based on
+<https://snapcraft.io/clash snap> (Linux only), you can start the Clash compiler
+in interpretive mode by:
+
+@
+clash.clashi
 @
 
 For those familiar with Haskell/GHC, this is indeed just @GHCi@, with three
@@ -442,7 +451,7 @@ mealy f initS = ...
 The complete sequential MAC circuit can now be specified as:
 
 @
-mac = 'mealy' macT 0
+mac inp = 'mealy' macT 0 inp
 @
 
 Where the first argument of @'mealy'@ is our @macT@ function, and the second
@@ -492,7 +501,7 @@ macT acc (x,y) = (acc',o)
     acc' = ma acc (x,y)
     o    = acc
 
-mac = 'mealy' macT 0
+mac inp = 'mealy' macT 0 inp
 
 topEntity
   :: 'Clock' 'System'

--- a/docs/getting-started/installing.rst
+++ b/docs/getting-started/installing.rst
@@ -3,118 +3,72 @@
 Installing Clash
 ================
 
+Check out `clash-lang.org/install <https://clash-lang.org/install>`__ to install
+the latest stable release of Clash, or to setup a Clash project.
 
-Installing via Snap
--------------------
+Get Clash from source
+---------------------
 
-Clash is released as a binary package on snapcraft. Snap is supported on
-all major Linux distributions. Visit `Clash’s snapcraft
-page <https://snapcraft.io/clash>`__, scroll down, and choose your
-distribution for installation instructions. To install the latest stable
-version, use:
-
-.. code:: bash
-
-   snap install clash
-
-To install the latest development version of Clash, run:
+Get the source code using
+`Git <https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F>`__ and
+enter the cloned directory:
 
 .. code:: bash
 
-   snap install clash --edge
+   git clone git@github.com:clash-lang/clash-compiler.git
 
-This version is updated every 24 hours.
+   # Alternatively, if you haven't setup SSH keys with GitHub:
+   # git clone https://github.com/clash-lang/clash-compiler.git
 
-Installing via Source (Linux / MacOS)
--------------------------------------
-
-Install the `latest nix <https://nixos.org/nix/download.html>`__ and
-run:
-
-.. code:: bash
-
-   curl -s -L https://github.com/clash-lang/clash-compiler/archive/1.2.tar.gz | tar xz
-   nix-shell clash-compiler-1.2/shell.nix
-
-See the `releases
-page <https://github.com/clash-lang/clash-compiler/releases>`__ for all
-available versions of the compiler.
-
-Installing via Source (Windows)
--------------------------------
-
-1. Install `Stack <https://get.haskellstack.org/stable/windows-x86_64-installer.exe>`__
-2. Download the source code of `Clash
-   1.2 <https://github.com/clash-lang/clash-compiler/archive/1.2.tar.gz>`__
-3. Unpack the archive
-4. Use cd to navigate to the unpacked directory
-5. Run ``stack build clash-ghc``. **This will take a while.**
-
-See the `releases
-page <https://github.com/clash-lang/clash-compiler/releases>`__ for all
-available versions of the compiler. To run clashi, execute:
-
-.. code:: bash
-
-   stack run clashi
-
-To compile a file (to VHDL) with Clash, run:
-
-
-.. code:: bash
-
-   stack run clash -- path/to/your/file.hs --vhdl
-
-Installing via Source (HEAD)
-----------------------------
-
-Clone Clash from github using ``git`` and enter the cloned directory:
-
-.. code:: bash
-
-   git clone https://github.com/clash-lang/clash-compiler.git
    cd clash-compiler
 
-Use one of the build tools below to get Clash up and running.
-
-Cabal
-~~~~~
-
-Install Cabal >= 2.4 and GHC >= 8.4. Even though GHC 8.6 is supported,
-we currently recommend running 8.4 as the former contains some known
-bugs concerning documentation generation. If you’re using Ubuntu, add
-`HVR’s PPA <https://launchpad.net/~hvr/+archive/ubuntu/ghc>`__ and
-install them using APT:
+To check out a released version, use:
 
 .. code:: bash
 
-   sudo add-apt-repository -u ppa:hvr/ghc
-   sudo apt install ghc-8.4.4 cabal-install-2.4
+   git checkout v1.2.3
 
-Add ``/opt/ghc/bin`` `to your
-PATH <https://askubuntu.com/questions/60218/how-to-add-a-directory-to-the-path>`__.
-Finally, run Clash using ``cabal``:
+To checkout a release *branch* use:
+
+.. code:: bash
+
+   git checkout 1.2
+
+Note that release branches might contain non-released patches.
+
+Cabal
+-----
+To use Cabal you need both Cabal and GHC installed on your system. For Linux and
+MacOS users we recommend using `ghcup <https://www.haskell.org/ghcup/>`__.
+Windows users are recommended to use the
+`Haskell Platform <https://www.haskell.org/platform/windows.html>`__.
+
+To run `clash` use:
 
 .. code:: bash
 
    cabal v2-run --write-ghc-environment-files=always -- clash
 
-Stack
-~~~~~
 
-You can use
-`Stack <https://docs.haskellstack.org/en/stable/install_and_upgrade/>`__
-to build and run Clash too:
+If this fails, make sure you've got an up-to-date package index:
+
+.. code:: bash
+
+   cabal update
+
+Stack
+-----
+`Install Stack <https://docs.haskellstack.org/en/stable/install_and_upgrade/`__
+and run:
 
 .. code:: bash
 
    stack run -- clash
 
 Nix
-~~~
-
-Or `use Nix <https://nixos.org/nix/download.html>`__ to get a shell with
-the ``clash`` and ``clashi`` binaries on your PATH:
+---
+Or `use Nix <https://nixos.org/nix/download.html>`__ to get a shell with the
+``clash`` and ``clashi`` binaries on your PATH:
 
 .. code:: bash
 


### PR DESCRIPTION
1. Start Clash based on new install instructions
2. eta-expand `mac` example

Fixes #1733