### PR TITLE
Improve and fix documentation

### DIFF
--- a/clash-prelude/src/Clash/Annotations/Primitive.hs
+++ b/clash-prelude/src/Clash/Annotations/Primitive.hs
@@ -241,6 +241,7 @@ data HDL
 -- nicer multiline strings.
 --
 -- @
+-- {\-\# LANGUAGE QuasiQuotes \#-\}
 -- module InlinePrimitive where
 --
 -- import           Clash.Annotations.Primitive

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -182,7 +182,7 @@ delayedI clk rst en dflt = delayed clk rst en (repeat dflt)
 -- delayN2 = 'delayN' d2
 -- @
 --
--- >>> printX $ sampleN 6 (toSignal (delayN2 (-1) enableGen systemClockGen (dfromList [1..])))
+-- >>> printX $ sampleN 6 (delayN2 (-1) enableGen systemClockGen (dfromList [1..]))
 -- [-1,-1,1,2,3,4]
 delayN
   :: forall dom a d n
@@ -214,12 +214,12 @@ delayN d dflt ena clk = coerce . go (snatToInteger d) . coerce @_ @(Signal dom a
 -- delayI2 = 'delayI'
 -- @
 --
--- >>> sampleN 6 (toSignal (delayI2 (-1) enableGen systemClockGen (dfromList [1..])))
+-- >>> sampleN 6 (delayI2 (-1) enableGen systemClockGen (dfromList [1..]))
 -- [-1,-1,1,2,3,4]
 --
 -- You can also use type application to do the same:
 --
--- >>> sampleN 6 (toSignal (delayI @2 (-1) enableGen systemClockGen (dfromList [1..])))
+-- >>> sampleN 6 (delayI @2 (-1) enableGen systemClockGen (dfromList [1..]))
 -- [-1,-1,1,2,3,4]
 delayI
   :: forall d n a dom
@@ -246,10 +246,10 @@ type instance Apply (DelayedFold dom n delay a) k = DSignal dom (n + (delay*k)) 
 -- countingSignals = repeat (dfromList [0..])
 -- @
 --
--- >>> printX $ sampleN 6 (toSignal (delayedFold  d1 (-1) (+) enableGen systemClockGen countingSignals))
+-- >>> printX $ sampleN 6 (delayedFold  d1 (-1) (+) enableGen systemClockGen countingSignals)
 -- [-1,-2,0,4,8,12]
 --
--- >>> printX $ sampleN 8 (toSignal (delayedFold d2 (-1) (*) enableGen systemClockGen countingSignals))
+-- >>> printX $ sampleN 8 (delayedFold d2 (-1) (*) enableGen systemClockGen countingSignals)
 -- [-1,-1,1,1,0,1,16,81]
 delayedFold
   :: forall dom  n delay k a

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -64,7 +64,7 @@ import           Clash.XException              (NFDataX)
 >>> let delay3 = delayed (-1 :> -1 :> -1 :> Nil)
 >>> let delay2 = delayedI :: HiddenClockResetEnable dom  => Int -> DSignal dom n Int -> DSignal dom (n + 2) Int
 >>> let delayN2 = delayN d2
->>> let delayI2 = delayI :: HiddenClockResetEnable dom  => Int -> DSignal dom n Int -> DSignal dom (n + 2) Int
+>>> let delayI2 = delayI :: (HiddenClock dom, HiddenEnable dom) => Int -> DSignal dom n Int -> DSignal dom (n + 2) Int
 >>> let countingSignals = Clash.Prelude.repeat (dfromList [0..]) :: Vec 4 (DSignal dom 0 Int)
 -}
 


### PR DESCRIPTION
- Several functions defined and documented in
`Clash.Signal.Delayed.Internal` also show up in the documentation for
`Clash.Signal.Delayed`. The former module uses explicit clocks, resets
and enables, but the latter uses hidden parameters. This can make the
documentation confusing. The confusion specifically dealt with in this
commit is that the `sampleN` from `Clash.Prelude` does not work with
`DSignal` whereas `sampleN` from `Clash.Explicit.Prelude` does. To make
the code valid for either one, an application of `toSignal` is included
in the examples. However, none of the examples for code defined in
`Clash.Explicit.Signal.Delayed` end up in confusing locations, so all
`toSignal`s there have been removed for consistenty (it was half with,
half without).

- Some examples did not typecheck, or the executed code differed from the
code in the documentation.

- The example of `InlinePrimitive` is improved by guiding the reader to
use `QuasiQuotes`.