### PR TITLE
Unroll `unconcat` in more situations than `m=0`

### DIFF
--- a/changelog/2021-04-08T17_46_59+02_00_fix1756
+++ b/changelog/2021-04-08T17_46_59+02_00_fix1756
@@ -1,0 +1,1 @@
+FIXED: `unconcat` cannot be used as initial/reset value for a `register` [#1756](https://github.com/clash-lang/clash-compiler/issues/1756)

--- a/tests/shouldwork/Issues/T1756.hs
+++ b/tests/shouldwork/Issues/T1756.hs
@@ -1,0 +1,5 @@
+module T1756 where
+
+import Clash.Prelude
+
+topEntity a = register @System (unconcat d2 (replicate d8 False)) a

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -535,6 +535,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1606A" def{hdlSim=False}
         , runTest "T1606B" def{hdlSim=False}
         , runTest "T1742" def{hdlSim=False, buildTargets=BuildSpecific ["shell"]}
+        , runTest "T1756" def{hdlSim=False}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only


### PR DESCRIPTION
Fixes #1756