### PR TITLE
Only generate up to 3-tuple instances for Haddock

### DIFF
--- a/.ci/nix_build.sh
+++ b/.ci/nix_build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -xeo pipefail
-
-sed -z -i 's/-- large-tuples\n  default: True/default: False/' clash-prelude/clash-prelude.cabal || true
-nix-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,7 @@ nix-build:
     - ln -s $(find /nix -type f -name bash | grep bash-4.4-p23 | head -n1) /bin
 
   script:
-    - .ci/nix_build.sh
+    - nix-build -j$(nproc)
 
 # Tests run on shared runners:
 haddock:

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -68,14 +68,8 @@ source-repository head
 flag large-tuples
   description:
     Generate instances for classes such as `NFDataX` and `BitPack` for tuples
-    up to and including 62 elements - the GHC imposed maximum. This greatly
-    increases compile times for `clash-prelude` and therefore mostly impacts the
-    Clash developers themselves. Hence its default is set to disabled on
-    development versions and enabled on releases.
-  -- I have no idea to pass cabal flags to nix, so the comment below,
-  -- "-- large-tuples", is there to enable a call to 'sed' that replaces
-  -- True with False. This is done to prevent OOM on CircleCI.
-  -- large-tuples
+    up to and including 62 elements - the GHC imposed maximum. Note that this
+    greatly increases compile times for `clash-prelude`.
   default: False
   manual: True
 

--- a/clash-prelude/src/Clash/CPP.hs
+++ b/clash-prelude/src/Clash/CPP.hs
@@ -27,7 +27,11 @@ import Constants (mAX_TUPLE_SIZE)
 #define MAX_TUPLE_SIZE (fromIntegral mAX_TUPLE_SIZE)
 
 #else
+#ifdef HADDOCK_ONLY
+#define MAX_TUPLE_SIZE 3
+#else
 #define MAX_TUPLE_SIZE 12
+#endif
 #endif
 #endif
 

--- a/clash-prelude/src/Clash/Class/AutoReg/Instances.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Instances.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+-- {-# OPTIONS_GHC -ddump-splices #-}
 
 module Clash.Class.AutoReg.Instances where
 
@@ -20,4 +21,8 @@ deriveAutoReg ''Complex
 deriveAutoReg ''Down
 deriveAutoReg ''Ratio
 
+-- | __N.B.__: The documentation only shows instances up to /3/-tuples. By
+-- default, instances up to and including /12/-tuples will exist. If the flag
+-- @large-tuples@ is set instances up to the GHC imposed limit will exist. The
+-- GHC imposed limit is either 62 or 64 depending on the GHC version.
 deriveAutoRegTuples [2..maxTupleSize]

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -270,6 +270,10 @@ instance BitPack () where
   pack   _ = minBound
   unpack _ = ()
 
+-- | __N.B.__: The documentation only shows instances up to /3/-tuples. By
+-- default, instances up to and including /12/-tuples will exist. If the flag
+-- @large-tuples@ is set instances up to the GHC imposed limit will exist. The
+-- GHC imposed limit is either 62 or 64 depending on the GHC version.
 instance (BitPack a, BitPack b) =>
     BitPack (a,b) where
   type BitSize (a,b) = BitSize a + BitSize b

--- a/clash-prelude/src/Clash/Class/Counter/Internal.hs
+++ b/clash-prelude/src/Clash/Class/Counter/Internal.hs
@@ -115,7 +115,13 @@ instance (Counter a, Counter b) => Counter (Either a b) where
 -- (0,1,1)
 -- >>> countSucc @T (0, 1, 1)
 -- (1,0,0)
-instance (Counter a, Counter b) => Counter (a, b) where
+--
+-- __N.B.__: The documentation only shows the instances up to /3/-tuples. By
+-- default, instances up to and including /12/-tuples will exist. If the flag
+-- @large-tuples@ is set instances up to the GHC imposed limit will exist. The
+-- GHC imposed limit is either 62 or 64 depending on the GHC version.
+instance (Counter a0, Counter a1) => Counter (a0, a1) where
+  -- a0/a1 instead of a/b to be consistent with TH generated instances
   countMin = (countMin, countMin)
   countMax = (countMax, countMax)
 

--- a/clash-prelude/src/Clash/Signal/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle.hs
@@ -142,6 +142,10 @@ instance Bundle (Fixed rep int frac)
 instance Bundle (Signed n)
 instance Bundle (Unsigned n)
 
+-- | __N.B.__: The documentation only shows instances up to /3/-tuples. By
+-- default, instances up to and including /12/-tuples will exist. If the flag
+-- @large-tuples@ is set instances up to the GHC imposed limit will exist. The
+-- GHC imposed limit is either 62 or 64 depending on the GHC version.
 deriveBundleTuples ''Bundle ''Unbundled 'bundle 'unbundle
 
 instance KnownNat n => Bundle (Vec n a) where

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -659,7 +659,16 @@ instance NFDataX a => NFDataX (M.Last a)
 instance NFDataX a => NFDataX (SG.Option a)
 #endif
 
+-- | __N.B.__: The documentation only shows instances up to /3/-tuples. By
+-- default, instances up to and including /12/-tuples will exist. If the flag
+-- @large-tuples@ is set instances up to the GHC imposed limit will exist. The
+-- GHC imposed limit is either 62 or 64 depending on the GHC version.
 mkShowXTupleInstances [2..maxTupleSize]
+
+-- | __N.B.__: The documentation only shows instances up to /3/-tuples. By
+-- default, instances up to and including /12/-tuples will exist. If the flag
+-- @large-tuples@ is set instances up to the GHC imposed limit will exist. The
+-- GHC imposed limit is either 62 or 64 depending on the GHC version.
 mkNFDataXTupleInstances [2..maxTupleSize]
 
 -- | Call to 'errorX' with default string


### PR DESCRIPTION
We currently show up to 12, which hides instance documention on all but
the widest of screens.