### PR TITLE
Use effective number of CPUs on CI, not available cores

### DIFF
--- a/.ci/bindist/linux/snap/go.sh
+++ b/.ci/bindist/linux/snap/go.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cd $(dirname $0)
 
-export SNAPCRAFT_BUILD_ENVIRONMENT_CPU=$(nproc)
+export SNAPCRAFT_BUILD_ENVIRONMENT_CPU=${THREADS:-$(nproc)}
 export SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY=8G
 
 DEBIAN_DIR=../debian

--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -42,4 +42,5 @@ RUN curl $GHCUP_URL --output $GHCUP_BIN \
 
 ARG ghc_version
 ENV GHC_VERSION=$ghc_version
-RUN ghcup install ghc ${GHC_VERSION}
+RUN ghcup install ghc ${GHC_VERSION} \
+ && ghcup set ghc ${GHC_VERSION}

--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -7,7 +7,7 @@ NAME="clash-ci-"
 DIR=$(dirname "$0")
 now=$(date +%F)
 
-GHC_VERSIONS="9.0.1 8.10.3 8.8.4 8.6.5"
+GHC_VERSIONS="9.0.1 8.10.4 8.8.4 8.6.5"
 for GHC_VERSION in $GHC_VERSIONS
 do
   docker build --build-arg ghc_version=${GHC_VERSION} -t "${REPO}/${NAME}${GHC_VERSION}:$now" "$DIR"

--- a/.ci/effective_cpus.sh
+++ b/.ci/effective_cpus.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# `nproc` doesn't account for limits set by cgroups/docker. This script tries
+# to determine the effective number of cpus we can use by inspecting the shares
+# it has been given.
+set -euo pipefail
+IFS=$'\n\t'
+
+cfs_quota_us=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+cfs_period_us=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+
+if [[ ${cfs_quota_us} == -1 ]]; then
+  # No limits set
+  nproc
+else
+  expr "${cfs_quota_us}" / "${cfs_period_us}"
+fi

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-03-18
+  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-04-14
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,5 +1,5 @@
 .common:
-  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-03-18
+  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-04-14
   timeout: 2 hours
   stage: build
   variables:
@@ -16,8 +16,8 @@
     paths:
       - cache.tar.zst
   before_script:
-    - export THREADS=$(nproc)
-    - export CABAL_JOBS=$(nproc)
+    - export THREADS=$(./.ci/effective_cpus.sh)
+    - export CABAL_JOBS=$(./.ci/effective_cpus.sh)
     - export
     - tar -xf cache.tar.zst -C / || true
     - .ci/setup.sh

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -80,6 +80,7 @@ debian-bindist-test:
       - .ci/bindist/linux/snap/*.snap
     expire_in: 1 week
   script:
+    - export THREADS=$(./.ci/effective_cpus.sh)
     - .ci/snap.sh build
     # TODO: Smoke test for snaps. Not sure how to do this on CI, as we need
     #       snapd to be running (?).

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -12,8 +12,8 @@ stages:
   before_script:
     - unset SNAPCRAFT_LOGIN_FILE
     - unset HACKAGE_PASSWORD
-    - export THREADS=$(nproc)
-    - export CABAL_JOBS=$(nproc)
+    - export THREADS=$(./.ci/effective_cpus.sh)
+    - export CABAL_JOBS=$(./.ci/effective_cpus.sh)
     - export
     - tar -xf cache.tar.zst -C / || true
     - tar -xf dist.tar.zst -C /

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ aliases:
 
   - &build_default
     docker:
-      - image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-03-18
+      - image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-04-14
         # Read-only permissions
         auth:
           username: clash-lang-builder
@@ -133,7 +133,7 @@ jobs:
   ghc-8.10:
     environment:
       <<: *env
-      GHC_VERSION: 8.10.3
+      GHC_VERSION: 8.10.4
       CABAL_VERSION: 3.2.0.0
     <<: *build_default
   ghc-8.6-singular-hidden:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ include:
 # Default GHC / Cabal version. Used for generating Haddock and releasing to
 # Hackage.
 variables:
-  GHC_VERSION: 8.10.3
+  GHC_VERSION: 8.10.4
   CABAL_VERSION: 3.2.0.0
 
 stages:
@@ -43,7 +43,7 @@ tests-8.8:
 tests-8.10:
   extends: .common-trigger
   variables:
-    GHC_VERSION: 8.10.3
+    GHC_VERSION: 8.10.4
     CABAL_VERSION: 3.2.0.0
 
 tests-9.0:
@@ -57,7 +57,7 @@ stack-build:
   needs: []
   stage: test
   variables:
-    GHC_VERSION: 8.10.3
+    GHC_VERSION: 8.10.4
     CABAL_VERSION: 3.2.0.0
   script:
     - .ci/stack_build.sh
@@ -80,7 +80,7 @@ nix-build:
     - ln -s $(find /nix -type f -name bash | grep bash-4.4-p23 | head -n1) /bin
 
   script:
-    - nix-build -j$(nproc)
+    - nix-build -j$(./.ci/effective_cpus.sh)
 
 # Tests run on shared runners:
 haddock:


### PR DESCRIPTION
Before this patch, CI would use `nproc` to determine the number of CPUs
in a Docker instance. This only works when the docker container is
pinned to certain cpus, not if it's just rate limited. This script
detects that rate limiting, allowing our GitLab runners to unpin the
runners. This would allow us to "oversell" GitLab runners, hopefully
reducing the idle time imposed by single-threaded workloads.