### PR TITLE
Add DDR support to iCE40 SB_IO

### DIFF
--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -102,6 +102,7 @@ test-suite unittests
   other-Modules:
     Test.Cores.Internal.SampleSPI
     Test.Cores.Internal.Signals
+    Test.Cores.LatticeSemi.ICE40.IO
     Test.Cores.SPI
     Test.Cores.SPI.MultiSlave
 

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
@@ -1,5 +1,6 @@
 {-|
   Copyright   :  (C) 2019, Foamspace corp
+                 (C) 2021, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -7,232 +8,300 @@
   <http://www.latticesemi.com/~/media/LatticeSemi/Documents/TechnicalBriefs/SBTICETechnologyLibrary201504.pdf LATTICE ICE Technology Library>,
   referred to as LITL.
 -}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE GADTs #-}
+
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Clash.Cores.LatticeSemi.ICE40.IO
   ( sbio
-  , spiConfig
+  , sbioDDR
   , PinOutputConfig(..)
   , PinInputConfig(..)
   ) where
 
-import           Data.Functor                 ((<&>))
-import           GHC.Stack                    (HasCallStack())
-
 import           Clash.Annotations.Primitive  (Primitive(..), HDL(..), hasBlackBox)
+import qualified Clash.Explicit.Signal as E
 import           Clash.Prelude
+import           Clash.Signal.Internal        (Signal(..))
 
 import           Data.String.Interpolate      (i)
 import           Data.String.Interpolate.Util (unindent)
-
-toMaybe :: Bool -> a -> Maybe a
-toMaybe True a = Just a
-toMaybe False _a = Nothing
-
--- | Create configuration bitvector based on pin function mnemonics. See
--- documentation on "PinInputConfig" and "PinOutputConfig" for more information.
-spiConfig
-  :: PinInputConfig
-  -> PinOutputConfig
-  -> BitVector 6
-spiConfig pic poc = pack poc ++# pack pic
+import           GHC.Stack                    (HasCallStack)
 
 -- | Input pinType  mnemonics as documented in the first table of LITL p88. Note
--- that @PIN_INPUT_DDR@ is missing. Use 'PIN_INPUT_REGISTERED' instead.
+-- that @PIN_INPUT_DDR@ is missing. Use 'PIN_INPUTRegistered' instead.
 data PinInputConfig
-  = PIN_INPUT_REGISTERED
+  = InputRegistered
   -- ^ Input data is registered in input cell. Same as @PIN_INPUT_DDR@.
-  | PIN_INPUT
+  | Input
   -- ^ Simple input pin (D_IN_0)
-  | PIN_INPUT_REGISTERED_LATCH
+  | InputRegisteredLatch
   -- ^ (Not supported by Clash simulation.) Disables internal data changes on
   -- the physical input pin by latching the value on the input register.
-  | PIN_INPUT_LATCH
+  | InputLatch
   -- ^ (Not supported by Clash simulation.) Disables internal data changes on
   -- the physical input pin by latching the value.
-  deriving (Show, Generic, BitPack)
+  deriving (Eq, Show, Generic, BitPack)
 
 -- | Output pinType  mnemonics as documented in the second table of LITL p88.
 data PinOutputConfig
-  = PIN_NO_OUTPUT
+  = NoOutput
   -- ^ Disables the output function
-  | PIN_OUTPUT
+  | Output
   -- ^ Simple output pin, (no enable)
-  | PIN_OUTPUT_TRISTATE
+  | OutputTristate
   -- ^ The output pin may be tristated using the enable
-  | PIN_OUTPUT_ENABLE_REGISTERED
+  | OutputEnableRegistered
   -- ^ The output pin may be tristated using a registered enable signal
-  | PIN_OUTPUT_REGISTERED
+  | OutputRegistered
   -- ^ (Not supported by Clash simulation.)  Output registered, (no enable)
-  | PIN_OUTPUT_REGISTERED_ENABLE
+  | OutputRegisteredEnable
   -- ^ (Not supported by Clash simulation.) Output registered with enable (enable
   -- is not registered)
-  | PIN_OUTPUT_REGISTERED_ENABLE_REGISTERED
+  | OutputRegisteredEnableRegistered
   -- ^ (Not supported by Clash simulation.) Output registered and enable
   -- registered
-  | PIN_OUTPUT_DDR
+  | OutputDDR
   -- ^ (Not supported by Clash simulation.) Output DDR data is clocked out on
   -- rising and falling clock edges
-  | PIN_OUTPUT_DDR_ENABLE
+  | OutputDDREnable
   -- ^ (Not supported by Clash simulation.) Output data is clocked out on rising
   -- and falling clock edges
-  | PIN_OUTPUT_DDR_ENABLE_REGISTERED
+  | OutputDDREnableRegistered
   -- ^ (Not supported by Clash simulation.) Output DDR data with registered
   -- enable signal
-  | PIN_OUTPUT_REGISTERED_INVERTED
+  | OutputRegisteredInverted
   --  ^ (Not supported by Clash simulation.) Output registered signal is inverted
-  | PIN_OUTPUT_REGISTERED_ENABLE_INVERTED
+  | OutputRegisteredEnableInverted
   -- ^ (Not supported by Clash simulation.) Output signal is registered and
   -- inverted (no enable function)
-  | PIN_OUTPUT_REGISTERED_ENABLE_REGISTERED_INVERTED
+  | OutputRegisteredEnableRegisteredInverted
   -- ^ (Not supported by Clash simulation.) Output signal is registered and
   -- inverted, the enable/tristate control is registered.
-  deriving (Show)
+  deriving (Eq, Show)
 
 instance BitPack PinOutputConfig where
   type BitSize PinOutputConfig = 4
   pack =
     \case
-      PIN_NO_OUTPUT -> 0b0000
-      PIN_OUTPUT -> 0b0110
-      PIN_OUTPUT_TRISTATE -> 0b1010
-      PIN_OUTPUT_ENABLE_REGISTERED -> 0b1110
-      PIN_OUTPUT_REGISTERED -> 0b0101
-      PIN_OUTPUT_REGISTERED_ENABLE -> 0b1001
-      PIN_OUTPUT_REGISTERED_ENABLE_REGISTERED -> 0b1101
-      PIN_OUTPUT_DDR -> 0b0100
-      PIN_OUTPUT_DDR_ENABLE -> 0b1000
-      PIN_OUTPUT_DDR_ENABLE_REGISTERED -> 0b1100
-      PIN_OUTPUT_REGISTERED_INVERTED -> 0b0111
-      PIN_OUTPUT_REGISTERED_ENABLE_INVERTED -> 0b1011
-      PIN_OUTPUT_REGISTERED_ENABLE_REGISTERED_INVERTED -> 0b1111
+      NoOutput -> 0b0000
+      Output -> 0b0110
+      OutputTristate -> 0b1010
+      OutputEnableRegistered -> 0b1110
+      OutputRegistered -> 0b0101
+      OutputRegisteredEnable -> 0b1001
+      OutputRegisteredEnableRegistered -> 0b1101
+      OutputDDR -> 0b0100
+      OutputDDREnable -> 0b1000
+      OutputDDREnableRegistered -> 0b1100
+      OutputRegisteredInverted -> 0b0111
+      OutputRegisteredEnableInverted -> 0b1011
+      OutputRegisteredEnableRegisteredInverted -> 0b1111
 
   unpack =
     \case
-      0b0000 -> PIN_NO_OUTPUT
-      0b0110 -> PIN_OUTPUT
-      0b1010 -> PIN_OUTPUT_TRISTATE
-      0b1110 -> PIN_OUTPUT_ENABLE_REGISTERED
-      0b0101 -> PIN_OUTPUT_REGISTERED
-      0b1001 -> PIN_OUTPUT_REGISTERED_ENABLE
-      0b1101 -> PIN_OUTPUT_REGISTERED_ENABLE_REGISTERED
+      0b0000 -> NoOutput
+      0b0110 -> Output
+      0b1010 -> OutputTristate
+      0b1110 -> OutputEnableRegistered
+      0b0101 -> OutputRegistered
+      0b1001 -> OutputRegisteredEnable
+      0b1101 -> OutputRegisteredEnableRegistered
 
-      0b0100 -> PIN_OUTPUT_DDR
-      0b1000 -> PIN_OUTPUT_DDR_ENABLE
-      0b1100 -> PIN_OUTPUT_DDR_ENABLE_REGISTERED
+      0b0100 -> OutputDDR
+      0b1000 -> OutputDDREnable
+      0b1100 -> OutputDDREnableRegistered
 
-      0b0111 -> PIN_OUTPUT_REGISTERED_INVERTED
-      0b1011 -> PIN_OUTPUT_REGISTERED_ENABLE_INVERTED
-      0b1111 -> PIN_OUTPUT_REGISTERED_ENABLE_REGISTERED_INVERTED
+      0b0111 -> OutputRegisteredInverted
+      0b1011 -> OutputRegisteredEnableInverted
+      0b1111 -> OutputRegisteredEnableRegisteredInverted
 
       b -> errorX $ "Unrecognized bit pattern in PinOutputConfig.unpack: " <> show b
 
-data OutputEnable
-  = EnableLow
-  | EnableHigh
-  | EnablePass
-  | EnableLatched
-  deriving (Show, Generic, BitPack)
-
-data OutputSelect
-  = SelectDDR0
-  | SelectDDR1
-  | SelectD0
-  | SelectLatchedInvertedD0
-  deriving (Show, Generic, BitPack)
-
-dflipflopE
+-- | ICE low-power latch
+iceGate
   :: ( HasCallStack
      , HiddenClock dom
-     , HiddenEnable dom
      , NFDataX a
      )
-  => Signal dom a
+  => Signal dom Bool
   -> Signal dom a
-dflipflopE = delay (deepErrorX "dflipflopE: undefined initial value")
+  -> Signal dom a
+iceGate latch x =
+  let qR = dflipflop q
+      q = mux latch qR x
+   in q
+
+-- | Tristate buffer
+tristate
+  :: ( HasCallStack
+     )
+  => Signal dom Bool
+  -> Signal dom a
+  -> Signal dom (Maybe a)
+tristate =
+  liftA2 (\e x -> if e then Just x else Nothing)
+
+-- Variant of Clash.Explicit.DDR.ddrIn without a reset line.
+ddrIn
+  :: forall slow fast period edge reset init polarity a
+   . ( HasCallStack
+     , KnownConfiguration slow ('DomainConfiguration slow (2 * period) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast period edge reset init polarity)
+     , HiddenClock slow
+     , HiddenEnable slow
+     , NFDataX a)
+  => Signal fast a
+  -> Signal slow (a, a)
+ddrIn =
+  let en = fromEnable (hasEnable @slow)
+      o = deepErrorX "ddrIn: undefined"
+   in go (o, o, o) en
+ where
+  go now@(o0, o1, o2) ~(e :- es) as@(~(x0 :- x1 :- xs)) =
+    let next = (o2, x0, x1)
+     in o0 `seqX` o1 `seqX` (o0, o1) :-
+       (as `seq` if e then go next es xs else go now es xs)
+
+-- Variant of Clash.Explicit.DDR.ddrOut without a reset line.
+ddrOut
+  :: forall slow fast period edge reset init polarity a
+   . ( HasCallStack
+     , KnownConfiguration slow ('DomainConfiguration slow (2 * period) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast period edge reset init polarity)
+     , HiddenClock slow
+     , HiddenEnable slow
+     , NFDataX a
+     )
+  => Signal slow a
+  -> Signal slow a
+  -> Signal fast a
+ddrOut ddr0 ddr1 =
+  let (_ :- out) = zipSignals ddr0' ddr1' in out
+ where
+  ddr0' = delay (deepErrorX "ddr0: undefined") ddr0
+  ddr1' = delay (deepErrorX "ddr1: undefined") ddr1
+
+  zipSignals (x :- xs) (y :- ys) =
+    x :- y :- zipSignals xs ys
 
 -- | SB_IO primitive as described in LITL p87.
+-- This does not support DDR configurations, see 'sbioDDR'.
 sbio
   :: forall dom
    . ( HasCallStack
-     , HiddenClock dom  -- INPUT_CLK
+     , HiddenClock dom  -- INPUT_CLK / OUTPUT_CLK
      , HiddenEnable dom -- CLK_ENABLE
      )
-  => BitVector 6
-  -- ^ Config, see 'spiConfig'
+  => PinInputConfig
+  -- ^ Pin Input (PIN_TYPE[1:0])
+  -> PinOutputConfig
+  -- ^ Pin Output (PIN_TYPE[5:2])
   -> BiSignalIn 'Floating dom 1
   -- ^ PACKAGE_PIN
   -> Signal dom Bit
   -- ^ LATCH_INPUT_VALUE
   -> Signal dom Bit
   -- ^ D_OUT_0
-  -> Signal dom Bit
-  -- ^ D_OUT_1 (Not implemented yet.)
   -> Signal dom Bool
   -- ^ OUTPUT_ENABLE
   -> ( BiSignalOut 'Floating dom 1  -- PACKAGE_PIN
      , Signal dom Bit               -- D_IN_0
-     , Signal dom Bit               -- D_IN_1
      )
-sbio pinConf pkgPinIn latchInput dOut_0 _dOut_1 outputEnable0 =
-  ( pkgPinOut
-  , dIn_0
-  , pure (errorX "d_in_1 not yet implemented")
-  )
+sbio pinIn pinOut =
+  sbioPrim (pack pinOut ++# pack pinIn)
+{-# INLINE sbio #-}
+
+sbioPrim
+  :: forall dom
+   . ( HasCallStack
+     , KnownDomain dom
+     , HiddenClock dom  -- INPUT_CLK / OUTPUT_CLK
+     , HiddenEnable dom -- CLK_ENABLE
+     )
+  => BitVector 6
+  -- ^ PIN_TYPE, see 'PinInputConfig' and 'PinOutputConfig'
+  -> BiSignalIn 'Floating dom 1
+  -- ^ PACKAGE_PIN
+  -> Signal dom Bit
+  -- ^ LATCH_INPUT_VALUE
+  -> Signal dom Bit
+  -- ^ D_OUT_0
+  -> Signal dom Bool
+  -- ^ OUTPUT_ENABLE
+  -> ( BiSignalOut 'Floating dom 1  -- PACKAGE_PIN
+     , Signal dom Bit               -- D_IN_0
+     )
+sbioPrim pinConf pkgPinIn latchInput dOut0 outputEnable =
+  (writeToBiSignal pkgPinIn pkgPinInWrite, dIn0)
  where
-  pkgPinInRead :: Signal dom Bit
-  pkgPinInRead = readFromBiSignal pkgPinIn
+  pinIn = unpack (slice d1 d0 pinConf)
+  pinOut = unpack (slice d5 d2 pinConf)
 
-  -- Combine (static) input pin configuration values with (dynamic) value
-  -- of LATCH_INPUT_VALUE
-  pinType =
-    latchInput <&> \li ->
-      unpack $
-      pack $
-        ( (li .|. (pinConf ! (1 :: Int)))
-        , (pinConf ! (0 :: Int))
-        )
+  pkgPinInRead
+      -- TODO When there is no output, we can't just echo back the value on
+      -- the BiSignal because we get an X excpetion when readFromBiSignal reads
+      -- an undefined value. However, making it always low means our assertion
+      -- is wrong. Perhaps this should be all "don't care" and the assertion
+      -- should be using Clash.Sized.Internal.BitVector.isLike?
+    | pinOut == PIN_NO_OUTPUT = pure low
+    | otherwise = readFromBiSignal @Bit pkgPinIn
 
-  clockLessLatchErr =
-    "Either LATCH_INPUT_VALUE was asserted or pin type was set to one of " <>
-    "INPUT_REGISTERED_LATCH or PIN_INPUT_LATCH. This is currently not " <>
-    "supported by this 'Clash.Cores.LatticeSemi.ICE40.IO.sbio', due to CLash not " <>
-    "supporting clockless latches."
+  dIn0 =
+    case pinIn of
+      Input ->
+        pkgPinInRead
 
-  latch_dIn_0 =
-    pinType <&>
-      \case
-        PIN_INPUT_REGISTERED -> True
-        PIN_INPUT -> False
-        PIN_INPUT_REGISTERED_LATCH -> errorX clockLessLatchErr
-        PIN_INPUT_LATCH -> errorX clockLessLatchErr
+      InputRegistered ->
+        delay (deepErrorX "dIn0: undefined") pkgPinInRead
 
-  dIn_0 =
-    mux latch_dIn_0 (dflipflopE pkgPinInRead) pkgPinInRead
+      InputLatch ->
+        iceGate (fmap bitToBool latchInput) pkgPinInRead
 
-  outputEnable1 =
-    case unpack (slice d5 d4 pinConf) of
-      EnableLow     -> pure False
-      EnableHigh    -> pure True
-      EnablePass    -> outputEnable0
-      EnableLatched -> error "OutputLatched: Not yet implemented"
+      InputRegisteredLatch ->
+        delay (deepErrorX "dIn0: undefined") $ iceGate (fmap bitToBool latchInput) pkgPinInRead
 
-  pkgPinWriteInput =
-    case unpack (slice d3 d2 pinConf) of
-      SelectD0 -> dOut_0
-      opt -> error $ "OutputSelect." <> show opt <> " not yet implemented"
+  pkgPinInWrite =
+    case pinOut of
+      NoOutput ->
+        pure (Just (unpack undefined#))
 
-  pkgPinOut =
-    writeToBiSignal
-      pkgPinIn
-      (toMaybe <$> outputEnable1 <*> pkgPinWriteInput)
-{-# NOINLINE sbio #-}
-{-# ANN sbio hasBlackBox #-}
-{-# ANN sbio (InlinePrimitive [VHDL,Verilog,SystemVerilog] $ unindent [i|
+      Output ->
+        fmap Just dOut0
+
+      OutputTristate ->
+        tristate outputEnable dOut0
+
+      OutputEnableRegistered ->
+        tristate (delay True outputEnable) dOut0
+
+      OutputRegistered ->
+        fmap Just (delay (deepErrorX "pkgPinInWrite: undefined") dOut0)
+
+      OutputRegisteredEnable ->
+        tristate outputEnable (delay (deepErrorX "pkgPinInWrite: undefined") dOut0)
+
+      OutputRegisteredEnableRegistered ->
+        tristate
+          (delay True outputEnable)
+          (delay (deepErrorX "pkgPinInWrite: undefined") dOut0)
+
+      OutputRegisteredInverted ->
+        fmap Just (delay (deepErrorX "pkgPinInWrite: undefined") (fmap complement dOut0))
+
+      OutputRegisteredEnableInverted ->
+        tristate outputEnable (delay (deepErrorX "pkgPinInWrite: undefined") (fmap complement dOut0))
+
+      OutputRegisteredEnableRegisteredInverted ->
+        tristate
+          (delay True outputEnable)
+          (delay (deepErrorX "pkgPinInWrite: undefined") (fmap complement dOut0))
+
+      _ -> error "sbio: DDR is not supported, see sbioDDR"
+
+{-# NOINLINE sbioPrim #-}
+{-# ANN sbioPrim hasBlackBox #-}
+{-# ANN sbioPrim (InlinePrimitive [VHDL,Verilog,SystemVerilog] $ unindent [i|
    [ { "BlackBox" :
         { "name" : "Clash.Cores.LatticeSemi.ICE40.IO.sbio",
           "kind" : "Declaration",
@@ -242,3 +311,97 @@ sbio pinConf pkgPinIn latchInput dOut_0 _dOut_1 outputEnable0 =
      }
    ]
    |]) #-}
+
+sbioDDR
+  :: forall slow fast period edge reset init polarity
+   . ( HasCallStack
+     , KnownDomain slow
+     , KnownConfiguration slow ('DomainConfiguration slow (2 * period) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast period edge reset init polarity)
+     , HiddenClock slow  -- INPUT_CLK / OUTPUT_CLK
+     , HiddenEnable slow -- CLK_ENABLE
+     )
+  => PinInputConfig
+  -- ^ Pin Input (PIN_TYPE[1:0])
+  -> PinOutputConfig
+  -- ^ Pin Output (PIN_TYPE[5:2])
+  -> BiSignalIn 'Floating fast 1
+  -- ^ PACKAGE_PIN
+  -> Signal slow Bit
+  -- ^ D_OUT_0
+  -> Signal slow Bit
+  -- ^ D_OUT_1
+  -> Signal slow Bool
+  -- ^ OUTPUT_ENABLE
+  -> ( BiSignalOut 'Floating fast 1  -- PACKAGE_PIN
+     , Signal slow Bit               -- D_IN_0
+     , Signal slow Bit               -- D_IN_1
+     )
+sbioDDR pinIn pinOut =
+  sbioDDRPrim (pack pinOut ++# pack pinIn)
+{-# INLINE sbioDDR #-}
+
+sbioDDRPrim
+  :: forall slow fast period edge reset init polarity
+   . ( HasCallStack
+     , KnownDomain slow
+     , KnownConfiguration slow ('DomainConfiguration slow (2 * period) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast period edge reset init polarity)
+     , HiddenClock slow  -- INPUT_CLK / OUTPUT_CLK
+     , HiddenEnable slow -- CLK_ENABLE
+     )
+  => BitVector 6
+  -- ^ PIN_TYPE, see 'PinInputConfig' and 'PinOutputConfig'
+  -> BiSignalIn 'Floating fast 1
+  -- ^ PACKAGE_PIN
+  -> Signal slow Bit
+  -- ^ D_OUT_0
+  -> Signal slow Bit
+  -- ^ D_OUT_1
+  -> Signal slow Bool
+  -- ^ OUTPUT_ENABLE
+  -> ( BiSignalOut 'Floating fast 1  -- PACKAGE_PIN
+     , Signal slow Bit               -- D_IN_0
+     , Signal slow Bit               -- D_IN_1
+     )
+sbioDDRPrim pinConf pkgPinIn dOut0 dOut1 outputEnable =
+  (writeToBiSignal pkgPinIn pkgPinInWrite, dIn0, dIn1)
+ where
+  pinIn = unpack (slice d1 d0 pinConf)
+  pinOut = unpack (slice d5 d2 pinConf)
+
+  pkgPinInRead
+      -- TODO When there is no output, we can't just echo back the value on
+      -- the BiSignal because we get an X excpetion when readFromBiSignal reads
+      -- an undefined value. However, making it always low means our assertion
+      -- is wrong. Perhaps this should be all "don't care" and the assertion
+      -- should be using Clash.Sized.Internal.BitVector.isLike?
+    | pinOut == PIN_NO_OUTPUT = pure low
+    | otherwise = readFromBiSignal @Bit pkgPinIn
+
+  (dIn0, dIn1) =
+    case pinIn of
+      -- This is really PIN_INPUT_DDR because we're in DDR mode
+      Input -> unbundle (ddrIn pkgPinInRead)
+      _ -> error "sbioDDR: Non-DDR input is not supported, see sbio"
+
+  pkgPinInWrite =
+    case pinOut of
+      NoOutput ->
+        pure (Just (unpack undefined#))
+
+      OutputDDR ->
+        fmap Just (ddrOut dOut0 dOut1)
+
+      OutputDDREnable ->
+        let en = E.veryUnsafeSynchronizer 2 1 outputEnable
+         in tristate en (ddrOut dOut0 dOut1)
+
+      OutputDDREnableRegistered ->
+        let en = E.veryUnsafeSynchronizer 2 1 (delay True outputEnable)
+         in tristate en (ddrOut dOut0 dOut1)
+
+      _ -> error "sbioDDR: Non-DDR output is not support, see sbio"
+{-# NOINLINE sbioDDRPrim #-}
+-- TODO hasBlackBox and InlinePrimitive
+

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
@@ -333,7 +333,7 @@ sbioPrim pinConf pkgPinIn latchInput dOut0 outputEnable =
 {-# ANN sbioPrim hasBlackBox #-}
 {-# ANN sbioPrim (InlinePrimitive [VHDL,Verilog,SystemVerilog] $ unindent [i|
    [ { "BlackBox" :
-        { "name" : "Clash.Cores.LatticeSemi.ICE40.IO.sbio",
+        { "name" : "Clash.Cores.LatticeSemi.ICE40.IO.sbioPrim",
           "kind" : "Declaration",
           "format": "Haskell",
           "templateFunction": "Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO.sbioTF"
@@ -428,10 +428,10 @@ sbioDDRPrim pinConf pkgPinIn dOut0 dOut1 outputEnable =
 {-# ANN sbioDDRPrim hasBlackBox #-}
 {-# ANN sbioDDRPrim (InlinePrimitive [VHDL,Verilog,SystemVerilog] $ unindent [i|
    [ { "BlackBox" :
-        { "name" : "Clash.Cores.LatticeSemi.ICE40.IO.sbio",
+        { "name" : "Clash.Cores.LatticeSemi.ICE40.IO.sbioDDRPrim",
           "kind" : "Declaration",
           "format": "Haskell",
-          "templateFunction": "Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO.sbioTF"
+          "templateFunction": "Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO.sbioDDRTF"
         }
      }
    ]

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
@@ -150,7 +150,8 @@ ddrIn
      , KnownConfiguration fast ('DomainConfiguration fast period edge reset init polarity)
      , HiddenClock slow
      , HiddenEnable slow
-     , NFDataX a)
+     , NFDataX a
+     )
   => Signal fast a
   -> Signal slow (a, a)
 ddrIn =

--- a/clash-cores/src/Clash/Cores/SPI.hs
+++ b/clash-cores/src/Clash/Cores/SPI.hs
@@ -368,7 +368,7 @@ spiSlaveLatticeSBIO mode latchSPI =
  where
   sbioX bin en dout = bout
    where
-    (bout,_,_) = sbio 0b101001 bin (pure 0) dout (pure undefined) en
+    (bout,_) = sbio Input OutputTristate bin (pure 0) dout en
 
 
 -- | SPI slave configurable SPI mode, using the BB tri-state buffer

--- a/clash-cores/test/Test/Cores/LatticeSemi/ICE40/IO.hs
+++ b/clash-cores/test/Test/Cores/LatticeSemi/ICE40/IO.hs
@@ -23,6 +23,8 @@ import Clash.XException (errorX, showX)
 
 import Clash.Cores.LatticeSemi.ICE40.IO
 
+import Debug.Trace -- TODO
+
 -- | A variant of System which runs at double speed. Used when testing DDR.
 createDomain vSystem{vName="SystemFast", vPeriod=(vPeriod vSystem `div` 2)}
 
@@ -63,8 +65,10 @@ simpleEcho =
 
     let samples = sampleSbio pinIn pinOut dOut0 dOut1 latch outEn numCycles
 
-    pure . QC.collect (pinIn, pinOut) $
-      checkDIn0 pinOut samples dIn0 .&&. checkDIn1 isDDR samples dIn1
+    pure
+      . QC.collect (pinIn, pinOut)
+      . trace (showX (show pinIn, show pinOut, dOut0, dOut1, latch, outEn, dIn0, dIn1))
+      $ checkDIn0 pinOut samples dIn0 .&&. checkDIn1 isDDR samples dIn1
 
 -- | Test that configurations which use iCEgate low power latch correctly hold
 -- the previous value when the latch is asserted.
@@ -144,8 +148,10 @@ enabledEcho =
 
     let samples = sampleSbio pinIn pinOut dOut0 dOut1 latch outEn numCycles
 
-    pure . QC.collect (pinIn, pinOut) $
-      checkDIn0 pinOut samples dIn0' .&&. checkDIn1 isDDR samples dIn1'
+    pure
+      . QC.collect (pinIn, pinOut)
+      . trace (showX (show pinIn, show pinOut, dOut0, dOut1, latch, outEn, dIn0, dIn1))
+      $ checkDIn0 pinOut samples dIn0' .&&. checkDIn1 isDDR samples dIn1'
 
 isEnableRegistered :: PinOutputConfig -> Bool
 isEnableRegistered = \case

--- a/clash-cores/test/Test/Cores/LatticeSemi/ICE40/IO.hs
+++ b/clash-cores/test/Test/Cores/LatticeSemi/ICE40/IO.hs
@@ -1,0 +1,103 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cores.LatticeSemi.ICE40.IO where
+
+import Clash.Prelude
+import Clash.Cores.LatticeSemi.ICE40.IO
+
+createDomain vSystem{vName="SystemFast", vPeriod=(vPeriod vSystem `div` 2)}
+
+tests :: TestTree
+tests = testGroup "SB_IO" []
+
+-- | A sample from an instantiated SB_IO. This contains the values of all
+-- output pins for a single clock cycle. PACKAGE_PIN is not sampled, as it
+-- having the wrong value would be reflected in the d_in_0 and d_in_1 signals.
+--
+data Sample = Sample
+  { sampledDIn0 :: Bit
+  , sampledDIn1 :: Maybe Bit
+  } deriving (Show, Generic, ShowX)
+
+sampleSbio
+  :: PinInputConfig
+  -> PinOutputConfig
+  -> [Bit]
+  -- ^ Bit sent on d_out_0
+  -> [Bit]
+  -- ^ Bit sent on d_out_1
+  -> [Bool]
+  -- ^ Latch input value
+  -> [Bool]
+  -- ^ Enable output
+  -> Int
+  -- ^ Number of samples to take
+  -> [Sample]
+sampleSbio pinIn pinOut dOut0 dOut1 latch outputEnable samples
+  | isDDRIn && isDDROut =
+      goDDR pinIn pinOut dOut0 dOut1 outputEnable samples
+
+  | not isDDRIn && not isDDROut =
+      goNonDDR pinIn pinOut dOut0 latch outputEnable samples
+
+  | otherwise =
+      error "sampleSbio: unsupported configuration."
+ where
+  isDDROut =
+    case pinOut of
+      NoOutput -> True
+      OutputDDR -> True
+      OutputDDREnable -> True
+      OutputDDREnableRegistered -> True
+      _ -> False
+
+  isDDRIn =
+    case pinIn of
+      PIN_INPUT -> isDDROut
+      _ -> False
+
+goNonDDR
+  :: PinInputConfig
+  -> PinOutputConfig
+  -> [Bit]
+  -> [Bool]
+  -> [Bool]
+  -> Int
+  -> [Sample]
+goNonDDR pinIn pinOut dOut0Vals latchVals outputEnableVals samples =
+  (\x -> Sample x Nothing) <$> sampleN @System samples dIn0
+ where
+  clk = systemClockGen
+  en = enableGen
+
+  dOut0 = fromList dOut0Vals
+  latch = fromList (fmap boolToBit latchVals)
+  outputEnable = fromList outputEnableVals
+
+  (pkgPin, dIn0) =
+    withClock clk $ withEnable en
+      (sbio pinIn pinOut (veryUnsafeToBiSignalIn pkgPin) latch dOut0 outputEnable)
+
+goDDR
+  :: PinInputConfig
+  -> PinOutputConfig
+  -> [Bit]
+  -> [Bit]
+  -> [Bool]
+  -> Int
+  -> [Sample]
+goDDR pinIn pinOut dOut0Vals dOut1Vals outputEnableVals samples =
+  (\(x, y) -> Sample x (Just y)) <$> sampleN @System samples (bundle (dIn0, dIn1))
+ where
+  clk = systemClockGen
+  en = enableGen
+
+  dOut0 = fromList dOut0Vals
+  dOut1 = fromList dOut1Vals
+  outputEnable = fromList outputEnableVals
+
+  (pkgPin, dIn0, dIn1) =
+    withSpecificClock @System clk $ withSpecificEnable @System en
+      (sbioDDR @System @SystemFast pinIn pinOut (veryUnsafeToBiSignalIn pkgPin) dOut0 dOut1 outputEnable)
+

--- a/clash-cores/test/Test/Cores/LatticeSemi/ICE40/IO.hs
+++ b/clash-cores/test/Test/Cores/LatticeSemi/ICE40/IO.hs
@@ -1,15 +1,269 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Test.Cores.LatticeSemi.ICE40.IO where
+module Test.Cores.LatticeSemi.ICE40.IO
+  ( tests
+  ) where
 
-import Clash.Prelude
+import Prelude
+
+import Data.Bits (complement)
+import Data.List (mapAccumL)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Gen, Property, (.&&.))
+import qualified Test.Tasty.QuickCheck as QC
+
+import Clash.Class.BitPack (isLike, boolToBit)
+import Clash.Signal hiding ((.&&.))
+import Clash.Sized.BitVector (Bit, low, high)
+import Clash.XException (errorX, showX)
+
 import Clash.Cores.LatticeSemi.ICE40.IO
 
+-- | A variant of System which runs at double speed. Used when testing DDR.
 createDomain vSystem{vName="SystemFast", vPeriod=(vPeriod vSystem `div` 2)}
 
 tests :: TestTree
-tests = testGroup "SB_IO" []
+tests = testGroup "SB_IO"
+  [ QC.testProperty "Simple Echo" simpleEcho
+  , QC.testProperty "Latched Echo" latchedEcho
+  , QC.testProperty "Enabled Echo" enabledEcho
+  ]
+
+-- | Test that dIn0 echoes dOut0 in simulation, with latchInput always being
+-- set to False and outputEnable always set to True.
+--
+simpleEcho :: Property
+simpleEcho =
+  QC.property $ do
+    (pinIn, pinOut) <- genConfig
+    (len, dOut0, dOut1) <- genDOut
+
+    let isDDR = isDDROut pinOut
+    let latency = uncurry (+) (configLatency pinIn pinOut)
+    let numCycles = latency + len
+
+    -- Fixed LATCH_INPUT_VALUE and OUTPUT_ENABLE
+    let latch = replicate numCycles False
+    let outEn = replicate numCycles True
+
+    -- When OUTPUT_ENABLE is behind a register, the first value is False. This
+    -- means the output in the first cycle becomes high impedence / undefined.
+    let dOut0' = if isEnableRegistered pinOut
+                   then errorX "X" : tail dOut0
+                   else dOut0
+
+    -- The values are delayed by the total latency (i.e. the total numbe of
+    -- registers along the data path).
+    let dIn0 = replicate latency (errorX "X") ++ dOut0'
+    let dIn1 = replicate latency (errorX "X") ++ dOut1
+
+    let samples = sampleSbio pinIn pinOut dOut0 dOut1 latch outEn numCycles
+
+    pure . QC.collect (pinIn, pinOut) $
+      checkDIn0 pinOut samples dIn0 .&&. checkDIn1 isDDR samples dIn1
+
+-- | Test that configurations which use iCEgate low power latch correctly hold
+-- the previous value when the latch is asserted.
+--
+latchedEcho :: Property
+latchedEcho =
+  QC.property $ do
+    (pinIn, pinOut) <- genLatchedConfig
+    (len, dOut0, dOut1) <- genDOut
+
+    let (latencyIn, latencyOut) = configLatency pinIn pinOut
+    let numCycles = latencyIn + latencyOut + len
+
+    -- Variable LATCH_INPUT_VALUE, fixed OUTPUT_ENABLE
+    latch <- QC.vector numCycles
+    let outEn = replicate numCycles True
+
+    -- When OUTPUT_ENABLE is behind a register, the first value is False. This
+    -- means the output in the first cycle becomes high impedence / undefined.
+    let dOut0' = if isEnableRegistered pinOut
+                   then errorX "X" : tail dOut0
+                   else dOut0
+
+    -- The value of the PACKAGE_PIN is delayed by the output latency (i.e. the
+    -- number of registers in the data path before the pin).
+    let pkgPin = replicate latencyOut (errorX "X") ++ dOut0'
+
+    -- The value may be latched in some cycles, which means the previous value
+    -- is held instead of taking the next value from PACKAGE_PIN.
+    let latched = snd $ mapAccumL
+                    (\x0 (x1, l) -> if l then (x0, x0) else (x1, x1))
+                    (errorX "latched: No previous value")
+                    (zip pkgPin latch)
+
+    -- The latched values are delayed by the input latency (i.e. the number of
+    -- registers in the data path after the pin).
+    let dIn0 = replicate latencyIn (errorX "X") ++ latched
+
+    -- Sampling the simulation of the hardware should produce the same result
+    -- as this list-based description of what the hardware does.
+    let samples = sampleSbio pinIn pinOut dOut0 dOut1 latch outEn numCycles
+
+    pure . QC.collect (pinIn, pinOut) $
+      checkDIn0 pinOut samples dIn0
+
+enabledEcho :: Property
+enabledEcho =
+  QC.property $ do
+    (pinIn, pinOut) <- genEnableConfig
+    (len, dOut0, dOut1) <- genDOut
+
+    let isDDR = isDDROut pinOut
+    let (latencyIn, latencyOut) = configLatency pinIn pinOut
+    let numCycles = latencyIn + latencyOut + len
+
+    -- Fixed LATCH_INPUT_VALUE, variable OUTPUT_ENABLE
+    let latch = replicate numCycles False
+    outEn <- QC.vector numCycles
+
+    -- Delay the outputs by the number of registers before PACKAGE_PIN.
+    let dOut0' = replicate latencyOut (errorX "X") ++ dOut0
+    let dOut1' = replicate latencyOut (errorX "X") ++ dOut1
+
+    -- When OUTPUT_ENABLE is behind a register, the first cycle is always False.
+    let outEn' = if isEnableRegistered pinOut then False : outEn else outEn
+
+    let nextBit x e = if e then x else errorX "X"
+
+    -- The input is the value of the output if OUTPUT_ENABLE is high, otherwise
+    -- it is high impedence (undefined).
+    let dIn0 = zipWith nextBit dOut0' outEn'
+    let dIn1 = zipWith nextBit dOut1' outEn'
+
+    -- Delay the inputs by the number of registers after PACKAGE_PIN
+    let dIn0' = replicate latencyIn (errorX "X") ++ dIn0
+    let dIn1' = replicate latencyIn (errorX "X") ++ dIn1
+
+    let samples = sampleSbio pinIn pinOut dOut0 dOut1 latch outEn numCycles
+
+    pure . QC.collect (pinIn, pinOut) $
+      checkDIn0 pinOut samples dIn0' .&&. checkDIn1 isDDR samples dIn1'
+
+isEnableRegistered :: PinOutputConfig -> Bool
+isEnableRegistered = \case
+  OutputEnableRegistered -> True
+  OutputRegisteredEnableRegistered -> True
+  OutputDDREnableRegistered -> True
+  OutputRegisteredEnableRegisteredInverted -> True
+  _ -> False
+
+checkDIn0 :: PinOutputConfig -> [Sample] -> [Bit] -> Property
+checkDIn0 pinOut samples expected =
+  let actual = dIn0Samples samples
+   in QC.counterexample
+        ("dIn0: " <> showX actual <> " `isLike` " <> showX expected)
+        (all (uncurry isLike) (zip actual expected))
+ where
+  dIn0Samples
+    | isInverted pinOut = fmap (complement . sampledDIn0)
+    | otherwise = fmap sampledDIn0
+
+  isInverted = \case
+    OutputRegisteredInverted -> True
+    OutputRegisteredEnableInverted -> True
+    OutputRegisteredEnableRegisteredInverted -> True
+    _ -> False
+
+checkDIn1 :: Bool -> [Sample] -> [Bit] -> Property
+checkDIn1 isDDR samples dOut1
+  | isDDR =
+      let expected = fmap Just dOut1
+          actual = fmap sampledDIn1 samples
+       in QC.counterexample
+            ("dIn1: " <> showX actual <> " `isLike` " <> showX expected)
+            (all (uncurry isLike) (zip actual expected))
+
+  | otherwise = QC.property True
+
+-- | Determine the number of cycles latency it takes for an input/output value
+-- to make it from/to the PACKAGE_PIN.
+--
+configLatency :: PinInputConfig -> PinOutputConfig -> (Int, Int)
+configLatency pinIn pinOut =
+  (inputLatency, outputLatency)
+ where
+  inputLatency =
+    case pinIn of
+      Input
+        | isDDROut pinOut -> 1
+        | otherwise -> 0
+
+      InputRegistered -> 1
+      InputLatch -> 0
+      InputRegisteredLatch -> 1
+
+  outputLatency =
+    case pinOut of
+      NoOutput -> 0
+      Output -> 0
+      OutputTristate -> 0
+      OutputEnableRegistered -> 0
+      _ -> 1
+
+-- Generate a pin configuration supported by the implementation.
+--
+-- TODO: If SB_IO is generalised to allow DDR input without DDR output (or
+-- vice-versa) this should be changed to something like
+--
+--   liftA2 (,) QC.arbitrary QC.arbitrary
+--
+genConfig :: Gen (PinInputConfig, PinOutputConfig)
+genConfig = do
+  pinOut <- QC.arbitrary
+  pinIn <- if isDDROut pinOut then pure Input else QC.arbitrary
+
+  pure (pinIn, pinOut)
+
+-- | Generate a pin configuration where an iCEGate low power latch is used.
+--
+genLatchedConfig :: Gen (PinInputConfig, PinOutputConfig)
+genLatchedConfig = do
+  pinOut <- QC.arbitrary `QC.suchThat` (not . isDDROut)
+  pinIn <- QC.elements [InputRegisteredLatch, InputLatch]
+
+  pure (pinIn, pinOut)
+
+-- | Generate a pin configuration where the output is tristated.
+--
+genEnableConfig :: Gen (PinInputConfig, PinOutputConfig)
+genEnableConfig = do
+  pinOut <- QC.arbitrary `QC.suchThat` isTristate
+  pinIn <- if isDDROut pinOut then pure Input else QC.arbitrary
+
+  pure (pinIn, pinOut)
+ where
+  isTristate = \case
+    NoOutput -> False
+    Output -> False
+    OutputRegistered -> False
+    OutputDDR -> False
+    OutputRegisteredInverted -> False
+    _ -> True
+
+-- | Generate some arbitrary (but equal length) inputs for the D_OUT_0 and
+-- D_OUT_1 inputs to the primitive.
+genDOut :: Gen (Int, [Bit], [Bit])
+genDOut = do
+  len <- fmap QC.getPositive QC.arbitrary
+  dOut0 <- QC.vectorOf len (QC.elements [low, high])
+  dOut1 <- QC.vectorOf len (QC.elements [low, high])
+
+  pure (len, dOut0, dOut1)
+
+isDDROut :: PinOutputConfig -> Bool
+isDDROut = \case
+  OutputDDR -> True
+  OutputDDREnable -> True
+  OutputDDREnableRegistered -> True
+  _ -> False
 
 -- | A sample from an instantiated SB_IO. This contains the values of all
 -- output pins for a single clock cycle. PACKAGE_PIN is not sampled, as it
@@ -18,7 +272,7 @@ tests = testGroup "SB_IO" []
 data Sample = Sample
   { sampledDIn0 :: Bit
   , sampledDIn1 :: Maybe Bit
-  } deriving (Show, Generic, ShowX)
+  }
 
 sampleSbio
   :: PinInputConfig
@@ -35,27 +289,22 @@ sampleSbio
   -- ^ Number of samples to take
   -> [Sample]
 sampleSbio pinIn pinOut dOut0 dOut1 latch outputEnable samples
-  | isDDRIn && isDDROut =
-      goDDR pinIn pinOut dOut0 dOut1 outputEnable samples
-
-  | not isDDRIn && not isDDROut =
+  | validNonDDR =
       goNonDDR pinIn pinOut dOut0 latch outputEnable samples
+
+  | validDDR =
+      goDDR pinIn pinOut dOut0 dOut1 outputEnable samples
 
   | otherwise =
       error "sampleSbio: unsupported configuration."
  where
-  isDDROut =
-    case pinOut of
-      NoOutput -> True
-      OutputDDR -> True
-      OutputDDREnable -> True
-      OutputDDREnableRegistered -> True
+  validDDR =
+    case pinIn of
+      Input -> isDDROut pinOut || NoOutput == pinOut
       _ -> False
 
-  isDDRIn =
-    case pinIn of
-      PIN_INPUT -> isDDROut
-      _ -> False
+  validNonDDR =
+    not (isDDROut pinOut)
 
 goNonDDR
   :: PinInputConfig

--- a/clash-cores/test/unittests.hs
+++ b/clash-cores/test/unittests.hs
@@ -10,11 +10,12 @@ module Main where
 import Prelude
 import Test.Tasty
 
+import qualified Test.Cores.LatticeSemi.ICE40.IO as IO
 import qualified Test.Cores.SPI as SPI
 import qualified Test.Cores.SPI.MultiSlave as Mul
 
 tests :: TestTree
-tests = testGroup "Unittests" [SPI.tests, Mul.tests]
+tests = testGroup "Unittests" [IO.tests, SPI.tests, Mul.tests]
 
 main :: IO ()
 main = defaultMain tests


### PR DESCRIPTION
Still TODO

  - [x] Check what to do about `ddrIn`. Does it need a blackbox?
  - [x] Check what to do for `sbioDDR` regarding `hasBlackBox` / `InlinePrimitive`
  - [x] Test the primitive's simulation in `clash-cores:unittests`
  - [ ] Test the primitive's generated HDL using iCEcube2