### PR TITLE
Make `ShowX` instances produce valid Haskell

### DIFF
--- a/changelog/2021-04-21T11_24_15+02_00_fix_1782
+++ b/changelog/2021-04-21T11_24_15+02_00_fix_1782
@@ -1,0 +1,1 @@
+CHANGED: `ShowX` and its functions now produce valid Haskell [#1782](https://github.com/clash-lang/clash-compiler/issues/1782)

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -238,7 +238,7 @@ replace it with the string "X" in the few leading outputs.
 
 @
 >>> printX $ sampleN 32 $ system2 prog systemClockGen resetGen enableGen
-[X,X,X,X,X,X,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+[undefined,undefined,undefined,undefined,undefined,undefined,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 
@@ -368,7 +368,7 @@ to conveniently filter out the undefinedness and replace it with the string "X".
 
 @
 >>> printX $ sampleN 34 $ system3 prog2 systemClockGen resetGen enableGen
-[X,0,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+[undefined,0,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -238,7 +238,7 @@ replace it with the string "X" in the few leading outputs.
 
 @
 >>> printX $ sampleN @System 32 (system2 prog)
-[X,X,X,X,X,X,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+[undefined,undefined,undefined,undefined,undefined,undefined,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 
@@ -367,7 +367,7 @@ to conveniently filter out the undefinedness and replace it with the string "X".
 
 @
 >>> printX $ sampleN @System 34 (system3 prog2)
-[X,0,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
+[undefined,0,0,0,0,0,0,4,4,4,4,4,4,4,4,6,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,2]
 
 @
 

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -12,7 +12,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 CallStack (from HasCallStack):
 ...
 >>> showX (errorX "undefined" :: Integer, 4 :: Int)
-"(X,4)"
+"(undefined,4)"
 -}
 
 {-# LANGUAGE CPP #-}
@@ -31,7 +31,7 @@ module Clash.XException
   ( -- * 'XException': An exception for uninitialized values
     XException(..), errorX, isX, hasX, maybeIsX, maybeHasX, fromJustX, undefined,
     xToErrorCtx, xToError
-    -- * Printing 'XException's as \"X\"
+    -- * Printing 'XException's as @undefined@
   , ShowX (..), showsX, printX, showsPrecXWith
     -- * Strict evaluation
   , seqX, forceX, deepseqX, rwhnfX, defaultSeqX, hwSeqX
@@ -85,7 +85,7 @@ infixr 0 `defaultSeqX`
 
 -- | Like 'error', but throwing an 'XException' instead of an 'ErrorCall'
 --
--- The 'ShowX' methods print these error-values as \"X\"; instead of error'ing
+-- The 'ShowX' methods print these error-values as @undefined@; instead of error'ing
 -- out with an exception.
 errorX :: HasCallStack => String -> a
 errorX msg = throw (XException ("X: " ++ msg ++ "\n" ++ prettyCallStack callStack))
@@ -307,14 +307,14 @@ isX a =
 {-# NOINLINE isX #-}
 
 -- | Like the 'Show' class, but values that normally throw an 'XException' are
--- converted to \"X\", instead of error'ing out with an exception.
+-- converted to @undefined@, instead of error'ing out with an exception.
 --
 -- >>> show (errorX "undefined" :: Integer, 4 :: Int)
 -- "(*** Exception: X: undefined
 -- CallStack (from HasCallStack):
 -- ...
 -- >>> showX (errorX "undefined" :: Integer, 4 :: Int)
--- "(X,4)"
+-- "(undefined,4)"
 --
 -- Can be derived using 'GHC.Generics':
 --
@@ -327,16 +327,16 @@ isX a =
 -- >   deriving (Show,Generic,ShowX)
 class ShowX a where
   -- | Like 'showsPrec', but values that normally throw an 'XException' are
-  -- converted to \"X\", instead of error'ing out with an exception.
+  -- converted to @undefined@, instead of error'ing out with an exception.
   showsPrecX :: Int -> a -> ShowS
 
   -- | Like 'show', but values that normally throw an 'XException' are
-  -- converted to \"X\", instead of error'ing out with an exception.
+  -- converted to @undefined@, instead of error'ing out with an exception.
   showX :: a -> String
   showX x = showsX x ""
 
   -- | Like 'showList', but values that normally throw an 'XException' are
-  -- converted to \"X\", instead of error'ing out with an exception.
+  -- converted to @undefined@, instead of error'ing out with an exception.
   showListX :: [a] -> ShowS
   showListX ls s = showListX__ showsX ls s
 
@@ -344,7 +344,7 @@ class ShowX a where
   showsPrecX = genericShowsPrecX
 
 -- | Like 'print', but values that normally throw an 'XException' are
--- converted to \"X\", instead of error'ing out with an exception
+-- converted to @undefined@, instead of error'ing out with an exception
 printX :: ShowX a => a -> IO ()
 printX x = putStrLn $ showX x
 

--- a/clash-prelude/src/Clash/XException/Internal.hs
+++ b/clash-prelude/src/Clash/XException/Internal.hs
@@ -12,7 +12,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 CallStack (from HasCallStack):
 ...
 >>> showX (errorX "undefined" :: Integer, 4 :: Int)
-"(X,4)"
+"(undefined,4)"
 -}
 
 {-# LANGUAGE CPP #-}
@@ -31,7 +31,7 @@ CallStack (from HasCallStack):
 
 module Clash.XException.Internal
   ( XException(..)
-    -- * Printing 'XException's as \"X\"
+    -- * Printing 'XException's as @undefined@
   , showsX, showsPrecXWith
   , showXWith
 
@@ -64,7 +64,7 @@ instance Show XException where
 instance Exception XException
 
 -- | Like 'shows', but values that normally throw an 'XException' are
--- converted to \"X\", instead of error'ing out with an exception.
+-- converted to @undefined@, instead of error'ing out with an exception.
 showsX :: ShowX a => a -> ShowS
 showsX = showsPrecX 0
 
@@ -82,15 +82,17 @@ genericShowsPrecX n = gshowsPrecX Pref n . from
 
 showXWith :: (a -> ShowS) -> a -> ShowS
 showXWith f x =
-  \s -> unsafeDupablePerformIO (catch (f <$> evaluate x <*> pure s)
-                                      (\(XException _) -> return ('X': s)))
+  unsafeDupablePerformIO $
+    catch
+      (f <$> evaluate x)
+      (\(XException _) -> return (showString "undefined"))
 
 -- | Use when you want to create a 'ShowX' instance where:
 --
 -- - There is no 'Generic' instance for your data type
 -- - The 'Generic' derived ShowX method would traverse into the (hidden)
 --   implementation details of your data type, and you just want to show the
---   entire value as \"X\".
+--   entire value as @undefined@.
 --
 -- Can be used like:
 --

--- a/clash-prelude/tests/Clash/Tests/Vector.hs
+++ b/clash-prelude/tests/Clash/Tests/Vector.hs
@@ -13,10 +13,17 @@ i :: Int -> Int
 i = id
 
 case_showXVector :: Assertion
-case_showXVector = "<1,2,X" @=? showX (1 :> i 2 :> errorX "def")
+case_showXVector = "1 :> 2 :> undefined" @=? showX (1 :> i 2 :> errorX "def")
 
 case_showX2DVector :: Assertion
-case_showX2DVector = "<<1,X,<3,5>>" @=? showX ((1 :> errorX "def") :> (3 :> i 5 :> Nil) :> Nil)
+case_showX2DVector =
+      "(1 :> undefined) :> (3 :> 5 :> Nil) :> Nil"
+  @=? showX ((1 :> errorX "def") :> (3 :> i 5 :> Nil) :> Nil)
+
+case_showX2DVectorInList :: Assertion
+case_showX2DVectorInList =
+      "[1 :> undefined,3 :> 5 :> Nil]"
+  @=? showX [(1 :> errorX "def"), (3 :> i 5 :> Nil)]
 
 case_showVector :: Assertion
 case_showVector = "1 :> 2 :> 3 :> Nil" @=? show (1 :> 2 :> i 3 :> Nil)


### PR DESCRIPTION
Fixes #1782

------------------------

Implements :grapes: from https://github.com/clash-lang/clash-compiler/issues/1777#issuecomment-823461429