### PR TITLE
Fix #1786.

### DIFF
--- a/changelog/2021-04-23T11_48_42+02_00_fix_1786
+++ b/changelog/2021-04-23T11_48_42+02_00_fix_1786
@@ -1,0 +1,1 @@
+FIXED: ~ISACTIVEENABLE in blackboxes works again, and now acts on `Signal dom Bool` in addition to `Enable dom`. Since [#1368](https://github.com/clash-lang/clash-compiler/pull/1368), enable lines were always generated even if they were known to be always enabled. Fixes [#1786](https://github.com/clash-lang/clash-compiler/issues/1786).

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -456,14 +456,23 @@ renderElem b (IF c t f) = do
 
       (IsActiveEnable n) ->
         let (e, ty, _) = bbInputs b !! n in
-        case (e, ty) of
-          (Literal Nothing (BoolLit True), Enable {})  -> 0
-          -- TODO: Emit warning? If enable signal is inferred as always False,
-          -- TODO: the component will never be enabled. This is probably not the
-          -- TODO: user's intention.
-          (Literal Nothing (BoolLit False), Enable {}) -> 1
-          (_, Bool)                                    -> 1
-          (_, Enable _)                                -> 1
+        case ty of
+          Enable _ ->
+            case e of
+              DataCon _ _ [Literal Nothing (BoolLit True)]  -> 0
+              -- TODO: Emit warning? If enable signal is inferred as always
+              -- TODO: False, the component will never be enabled. This is
+              -- TODO: probably not the user's intention.
+              DataCon _ _ [Literal Nothing (BoolLit False)] -> 1
+              _                                             -> 1
+          Bool ->
+            case e of
+              Literal Nothing (BoolLit True)  -> 0
+              -- TODO: Emit warning? If enable signal is inferred as always
+              -- TODO: False, the component will never be enabled. This is
+              -- TODO: probably not the user's intention.
+              Literal Nothing (BoolLit False) -> 1
+              _                               -> 1
           _ ->
             error $ $(curLoc) ++ "IsActiveEnable: Expected Bool, not: " ++ show ty
 

--- a/tests/shouldwork/BlackBox/T1786.hs
+++ b/tests/shouldwork/BlackBox/T1786.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE BangPatterns #-}
+module T1786 where
+
+import           Clash.Prelude
+
+import           Clash.Explicit.Testbench
+import           Clash.Annotations.Primitive
+
+import           Data.String.Interpolate.IsString (i)
+import           Data.String.Interpolate.Util     (unindent)
+
+testEnable :: Signal System Bool
+testEnable = testAlwaysEnabled enableGen
+{-# NOINLINE testEnable #-}
+
+-- Only call with always-enabled Enable if you want the model to match the HDL.
+testAlwaysEnabled
+  :: Enable System
+  -> Signal System Bool
+testAlwaysEnabled !_ = pure True
+{-# NOINLINE testAlwaysEnabled #-}
+{-# ANN testAlwaysEnabled (InlinePrimitive [VHDL] $ unindent [i|
+  [ { "BlackBox" :
+      { "name"      : "T1786.testAlwaysEnabled"
+      , "kind"      : "Expression"
+      , "template"  : "~IF ~ISACTIVEENABLE[0] ~THEN false ~ELSE true ~FI"
+      }
+    }
+  ]
+  |]) #-}
+
+testEnableTB :: Signal System Bool
+testEnableTB = done
+ where
+  done = outputVerifier' clk rst (True :> Nil) testEnable
+  clk  = tbSystemClockGen (not <$> done)
+  rst  = systemResetGen
+{-# NOINLINE testEnableTB #-}
+{-# ANN testEnableTB (TestBench 'testEnable) #-}
+
+testBool :: Signal System Bool
+testBool = testAlwaysEnabledBool (pure True)
+{-# NOINLINE testBool #-}
+
+-- Only call with always-true input if you want the model to match the HDL.
+testAlwaysEnabledBool
+  :: Signal System Bool
+  -> Signal System Bool
+testAlwaysEnabledBool !_ = pure True
+{-# NOINLINE testAlwaysEnabledBool #-}
+{-# ANN testAlwaysEnabledBool (InlinePrimitive [VHDL] $ unindent [i|
+  [ { "BlackBox" :
+      { "name"      : "T1786.testAlwaysEnabledBool"
+      , "kind"      : "Expression"
+      , "template"  : "~IF ~ISACTIVEENABLE[0] ~THEN false ~ELSE true ~FI"
+      }
+    }
+  ]
+  |]) #-}
+
+testBoolTB :: Signal System Bool
+
+testBoolTB = done
+ where
+  done = outputVerifier' clk rst (True :> Nil) testBool
+  clk  = tbSystemClockGen (not <$> done)
+  rst  = systemResetGen
+{-# NOINLINE testBoolTB #-}
+{-# ANN testBoolTB (TestBench 'testBool) #-}

--- a/testsuite/Main.hs
+++ b/testsuite/Main.hs
@@ -410,6 +410,10 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS(runTest "MultiResult" def)
         , NEEDS_PRIMS(runTest "T919" def{hdlSim=False})
         , NEEDS_PRIMS(runTest "T1524" def)
+        , runTest "T1786" def{
+            hdlTargets=[VHDL]
+          , buildTargets=BuildSpecific ["testEnableTB", "testBoolTB"]
+          }
         ]
       , clashTestGroup "BoxedFunctions"
         [ runTest "DeadRecursiveBoxed" def{hdlSim=False}


### PR DESCRIPTION
Some functionality is added: when `~ISACTIVEENABLE` is used on a signal
of type `Signal dom Bool` and it is always true, `~ISACTIVEENABLE` now
evaluates to true as well. Before this commit, it was not an error to
use `~ISACTIVEENABLE` on a `Signal dom Bool`, but it would not be
checked whether it was always true or not.