### PR TITLE
Define a pull request template for GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
+[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)
+
+Write a description of your PR here. Briefly describe the solution, taking more care with larger changes to outline the intention of the PR, or any compromises made in the final design. If there is no associated issue, it is helpful to also include the motivation for this PR.
+
+[comment]: # (Add a line of the form "Fixes: #xxxx" for each related issue closed by this pull request, where #xxxx is an issue number.)
+
+## Still TODO:
+
+  - [ ] Write a changelog entry (see changelog/README.md)
+  - [ ] Check copyright notices are up to date in edited files
+
+[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)


### PR DESCRIPTION
It is relatively common in pull requests for small auxiliary changes
like updating copyright notices to be forgotten about. Using a PR
template would make this harder to do, and allow some pointers to
be provided to new contributers about what makes a useful message.

The template is somewhat minimal, I just based it on the things I like
about the messages in @martijnbastiaan's larger PRs. I don't think it
should be so long it feels like a chore to submit.