### PR TITLE
Be more flexible getting the Ids of clk and reset in checkBBF

### DIFF
--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -26,6 +26,7 @@ module Clash.Core.Term
   , TmName
   , idToVar
   , varToId
+  , termToId
   , LetBinding
   , Pat (..)
   , patIds
@@ -387,3 +388,11 @@ idToVar tv        = error $ $(curLoc) ++ "idToVar: tyVar: " ++ show tv
 varToId :: Term -> Id
 varToId (Var i) = i
 varToId e       = error $ $(curLoc) ++ "varToId: not a var: " ++ show e
+
+-- | Make an 'Id' out of the single 'Id' mentioned in a 'Term', if there isn't
+-- exactly one 'Id' then error
+termToId :: Term -> Id
+termToId t = case collectTermIds t of
+  [] -> error $ $(curLoc) ++ "termToId: no Ids: " ++ show t
+  [i] -> i
+  _ -> error $ $(curLoc) ++ "termToId: more than one Id in term: " ++ show t

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -16,7 +16,7 @@ import           GHC.Stack                       (HasCallStack)
 import           Clash.Annotations.Primitive     (HDL(..))
 import           Clash.Backend
   (Backend, blockDecl, hdlKind)
-import           Clash.Core.Term                 (Term(Var))
+import           Clash.Core.Term                 (Term(Var), termToId)
 import           Clash.Core.TermInfo             (termType)
 import           Clash.Core.TermLiteral          (termToDataError)
 import           Clash.Util                      (indexNote)
@@ -48,8 +48,8 @@ checkBBF _isD _primName args _ty =
  where
   -- TODO: Improve error handling; currently errors don't indicate what
   -- TODO: blackbox generated them.
-  (Var (id2identifier -> clkId)) = indexNote "clk" (lefts args) 1
-  (Var (id2identifier -> _clkId)) = indexNote "rst" (lefts args) 2
+  (id2identifier -> clkId) = termToId (indexNote "clk" (lefts args) 1)
+  (id2identifier -> _clkId) = termToId (indexNote "rst" (lefts args) 2)
 
   litArgs = do
     propName <- termToDataError (indexNote "propName" (lefts args) 3)


### PR DESCRIPTION
Previously I was runnning into:
`src/Clash/Primitives/Verification.hs:51:3-65: Non-exhaustive patterns in Var (id2identifier -> clkId)`


[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

Write a description of your PR here. Briefly describe the solution, taking more care with larger changes to outline the intention of the PR, or any compromises made in the final design. If there is no associated issue, it is helpful to also include the motivation for this PR.

[comment]: # (Add a line of the form "Fixes: #xxxx" for each related issue closed by this pull request, where #xxxx is an issue number.)

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)