### PR TITLE
Document special clash primitives

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -3230,12 +3230,6 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
                     _ -> Nothing
                  _ -> Nothing
 
-  "Clash.Transformations.eqInt"
-    | [ DC _ [Left (Literal (IntLiteral i))]
-      , DC _ [Left (Literal (IntLiteral j))]
-      ] <- args
-    -> reduce (boolToBoolLiteral tcm ty (i == j))
-
 -- - specialized permutations
   "Clash.Sized.Vector.reverse" -- :: Vec n a -> Vec n a
     | isSubj

--- a/clash-ghc/src-ghc/Clash/GHC/PartialEval/Eval.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/PartialEval/Eval.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2020, QBayLogic B.V.
+Copyright   : (C) 2020-2021, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -51,6 +51,7 @@ import           Clash.Core.TysPrim (integerPrimTy)
 import qualified Clash.Core.Util as Util
 import           Clash.Core.Var
 import           Clash.Driver.Types (Binding(..), IsPrim(..))
+import qualified Clash.Normalize.Primitives as NP (undefined)
 import           Clash.Unique (lookupUniqMap')
 
 -- | Evaluate a term to WHNF.
@@ -295,7 +296,7 @@ caseCon subject ty alts = do
 
   -- If the subject is undefined, the whole expression is undefined.
   case isUndefined forcedSubject of
-    True -> eval (Util.undefinedTm ty)
+    True -> eval (TyApp (Prim NP.undefined) ty)
     False ->
       case stripValue forcedSubject of
         -- Known literal: attempt to match or throw an error.

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -239,6 +239,7 @@ Library
 
                       Clash.Normalize
                       Clash.Normalize.PrimitiveReductions
+                      Clash.Normalize.Primitives
                       Clash.Normalize.Strategy
                       Clash.Normalize.Transformations
                       Clash.Normalize.Transformations.ANF

--- a/clash-lib/prims/common/Clash_Normalize_Primitives.primitives
+++ b/clash-lib/prims/common/Clash_Normalize_Primitives.primitives
@@ -1,5 +1,5 @@
 [ { "BlackBox" :
-    { "name"      : "Clash.Transformations.removedArg"
+    { "name"      : "Clash.Normalize.Primitives.removedArg"
     , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "removedArg :: a"
@@ -7,7 +7,7 @@
     }
   }
 , { "BlackBox" :
-    { "name"      : "Clash.Transformations.undefined"
+    { "name"      : "Clash.Normalize.Primitives.undefined"
     , "workInfo"  : "Constant"
     , "kind"      : "Expression"
     , "type"      : "undefined :: forall a . a"

--- a/clash-lib/prims/commonverilog/Clash_Transformations.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Transformations.primitives
@@ -1,8 +1,0 @@
-[ { "BlackBox" :
-    { "name"      : "Clash.Transformations.eqInt"
-    , "kind"      : "Expression"
-    , "type"      : "eqInt :: Int -> Int -> Bool"
-    , "template"  : "~ARG[0] == ~ARG[1]"
-    }
-  }
-]

--- a/clash-lib/prims/vhdl/Clash_Transformations.primitives
+++ b/clash-lib/prims/vhdl/Clash_Transformations.primitives
@@ -1,8 +1,0 @@
-[ { "BlackBox" :
-    { "name"      : "Clash.Transformations.eqInt"
-    , "kind"      : "Expression"
-    , "type"      : "eqInt :: Int -> Int -> Bool"
-    , "template"  : "~ARG[0] = ~ARG[1]"
-    }
-  }
-]

--- a/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2020, QBayLogic B.V.
+Copyright   : (C) 2020-2021, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -13,6 +13,7 @@ evaluator see Clash.Core.PartialEval.
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Core.PartialEval.NormalForm
   ( Arg
@@ -33,6 +34,7 @@ import Control.Concurrent.Supply (Supply)
 import Control.Lens (Lens', lens)
 import Data.IntMap.Strict (IntMap)
 import Data.Map.Strict (Map)
+import qualified Data.Text.Extra as Text
 
 import Clash.Core.DataCon (DataCon)
 import Clash.Core.Literal
@@ -42,6 +44,7 @@ import Clash.Core.Type (Type, TyVar)
 import Clash.Core.Var (Id)
 import Clash.Core.VarEnv (VarEnv, InScopeSet)
 import Clash.Driver.Types (Binding(..))
+import qualified Clash.Normalize.Primitives as NP (undefined)
 
 type Args a
   = [Arg a]
@@ -120,7 +123,7 @@ isUndefined = \case
       , "Control.Exception.Base.patError"
       , "EmptyCase"
       , "GHC.Err.undefined"
-      , "Clash.Transformations.undefined"
+      , Text.showt 'NP.undefined
       , "Clash.XException.errorX"
       ]
 

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -1,7 +1,8 @@
 {-|
-  Copyright   :  (C) 2012-2016, University of Twente
+  Copyright   :  (C) 2012-2016, University of Twente,
+                     2021     , QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Smart constructor and destructor functions for CoreHW
 -}
@@ -426,14 +427,6 @@ primCo
   :: Type
   -> Term
 primCo ty = Prim (PrimInfo "_CO_" ty WorkNever SingleResult)
-
--- | Make an undefined term
-undefinedTm
-  :: Type
-  -> Term
-undefinedTm =
-  let undefinedNm = "Clash.Transformations.undefined" in
-  TyApp (Prim (PrimInfo undefinedNm  undefinedTy WorkNever SingleResult))
 
 substArgTys
   :: DataCon

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -2,9 +2,10 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
-                    2017     , Google Inc.
+                    2017     , Google Inc.,
+                    2021     , QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Functions to create BlackBox Contexts and fill in BlackBox templates
 -}
@@ -90,6 +91,7 @@ import           Clash.Netlist.BlackBox.Types  as B
 import           Clash.Netlist.BlackBox.Util   as B
 import           Clash.Netlist.Types           as N
 import           Clash.Netlist.Util            as N
+import           Clash.Normalize.Primitives    (removedArg)
 import           Clash.Primitives.Types        as P
 import qualified Clash.Primitives.Util         as P
 import           Clash.Signal.Internal         (ActiveEdge (..))
@@ -230,8 +232,8 @@ mkArgument bbName bndr nArg e = do
     ((e',t,l),d) <- case hwTyM of
       Nothing
         | (Prim p,_) <- collectArgs e
-        , primName p == "Clash.Transformations.removedArg"
-        -> return ((Identifier (Id.unsafeMake "Clash.Transformations.removedArg") Nothing, Void Nothing, False), [])
+        , primName p == showt 'removedArg
+        -> return ((Identifier (Id.unsafeMake (showt 'removedArg)) Nothing, Void Nothing, False), [])
         | otherwise
         -> return ((error ($(curLoc) ++ "Forced to evaluate untranslatable type: " ++ eTyMsg), Void Nothing, False), [])
       Just hwTy -> case collectArgsTicks e of

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -1,8 +1,9 @@
 {-|
   Copyright  :  (C) 2015-2016, University of Twente,
-                    2016     , Myrtle Software Ltd
+                    2016     , Myrtle Software Ltd,
+                    2021     , QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Reductions of primitives
 
@@ -79,11 +80,11 @@ import           Clash.Core.TysPrim
   (integerPrimTy, typeNatKind, liftedTypeKind)
 import           Clash.Core.Util
   (appendToVec, extractElems, extractTElems, mkRTree,
-   mkUniqInternalId, mkUniqSystemTyVar, mkVec, dataConInstArgTys,
-   primCo, undefinedTm)
+   mkUniqInternalId, mkUniqSystemTyVar, mkVec, dataConInstArgTys, primCo)
 import           Clash.Core.Var                   (Var (..), mkTyVar, mkLocalId)
 import           Clash.Core.VarEnv
   (InScopeSet, extendInScopeSetList)
+import qualified Clash.Normalize.Primitives as NP (undefined)
 import {-# SOURCE #-} Clash.Normalize.Strategy
 import           Clash.Normalize.Types
 import           Clash.Rewrite.Types
@@ -841,7 +842,7 @@ reduceLast inScope n aTy vArg = do
             (tB,_)       = head (last elems)
         uniqSupply Lens..= uniqs1
         case n of
-         0 -> changed (undefinedTm aTy)
+         0 -> changed (TyApp (Prim NP.undefined) aTy)
          _ -> changed (Letrec (init (concat elems)) (Var tB))
     go _ ty = error $ $(curLoc) ++ "reduceLast: argument does not have a vector type: " ++ showPpr ty
 
@@ -1223,7 +1224,7 @@ reduceIndex_int is0 n aTy v i = do
 
       -- Build a right-biased tree of case-expressions
       let indexed = foldr (index_intElement tcm iDc iTy)
-                              (undefinedTm aTy)
+                              (TyApp (Prim NP.undefined) aTy)
                               (zip vars [0..])
           lb      = Letrec (init elems) indexed
       uniqSupply Lens..= uniqs1

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -1089,7 +1089,7 @@ reduceReplace_int is0 n aTy vTy v i newA = do
     -> Term
   eqIntPrim intTy boolTy =
     Prim (PrimInfo
-           "Clash.Transformations.eqInt"
+           "GHC.Classes.eqInt"
            (mkFunTy intTy (mkFunTy intTy boolTy))
            WorkVariable
            SingleResult )
@@ -1193,7 +1193,7 @@ reduceIndex_int is0 n aTy v i = do
     -> Term
   eqIntPrim intTy boolTy =
     Prim ( PrimInfo
-            "Clash.Transformations.eqInt"
+            "GHC.Classes.eqInt"
             (mkFunTy intTy (mkFunTy intTy boolTy))
             WorkVariable
             SingleResult )

--- a/clash-lib/src/Clash/Normalize/Primitives.hs
+++ b/clash-lib/src/Clash/Normalize/Primitives.hs
@@ -1,0 +1,46 @@
+{-|
+Copyright   : (C) 2021, QBayLogic B.V.
+License     : BSD2 (see the file LICENSE)
+Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
+
+Special primitives created during the normalization process.
+-}
+
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Clash.Normalize.Primitives
+  ( removedArg
+  , undefined
+  ) where
+
+import Prelude hiding (undefined)
+
+import qualified Data.Text.Extra as Text
+
+import Clash.Core.Term (IsMultiPrim(..), PrimInfo(..), WorkInfo(..))
+import Clash.Core.Type (undefinedTy)
+
+-- | The removedArg primitive represents an argument which is computationally
+-- irrelevant, and has been removed from the circuit (as removing it does not
+-- change the behaviour of the circuit). Examples of such arguments are unused
+-- arguments to blackboxes, as removing them does not affect the rendered HDL.
+--
+removedArg :: PrimInfo
+removedArg = PrimInfo
+  { primName = Text.showt 'removedArg
+  , primType = undefinedTy
+  , primWorkInfo = WorkNever
+  , primMultiResult = SingleResult
+  }
+
+-- | The undefined primitive represents an undefined value that was identified
+-- during normalization. This includes undefined results to compile-time
+-- evaluation, such as division by zero.
+--
+undefined :: PrimInfo
+undefined = PrimInfo
+  { primName = Text.showt 'undefined
+  , primType = undefinedTy
+  , primWorkInfo = WorkNever
+  , primMultiResult = SingleResult
+  }

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -559,7 +559,7 @@ collectEqArgs (collectArgsTicks -> (Prim p, args, ticks))
     nm == Text.showt 'U.eq#
     = let [_,Left scrut,Left val] = args
       in Just (mkTicks scrut ticks,val)
-  | nm == "Clash.Transformations.eqInt"
+  | nm == "GHC.Classes.eqInt"
     = let [Left scrut,Left val] = args
       in  Just (mkTicks scrut ticks,val)
  where

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -62,7 +62,6 @@ import Clash.Core.Term
 import Clash.Core.TermInfo (termType)
 import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (LitTy(..), Type(..), TypeView(..), coreView1, tyView)
-import Clash.Core.Util (undefinedTm)
 import Clash.Core.Var (Var(..))
 import Clash.Core.VarEnv
   ( InScopeSet, elemVarSet, extendInScopeSet, extendInScopeSetList, mkVarSet
@@ -71,6 +70,7 @@ import Clash.Debug (traceIf)
 import Clash.Driver.Types (DebugLevel(..))
 import Clash.Netlist.Types (FilteredHWType(..), HWType(..))
 import Clash.Netlist.Util (coreTypeToHWType, representableType)
+import qualified Clash.Normalize.Primitives as NP (undefined)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Rewrite.Combinators ((>-!))
 import Clash.Rewrite.Types
@@ -203,7 +203,7 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
            -- that if there is one, and we couldn't match with any of the data
            -- patterns.
            ((DefaultPat,altE):_) -> changed altE
-           _ -> changed (undefinedTm ty)
+           _ -> changed (TyApp (Prim NP.undefined) ty)
     where
       -- Check whether the pattern matches the data constructor
       equalCon (DataPat dcPat _ _) = dcTag dc == dcTag dcPat
@@ -258,7 +258,7 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
       -- WHNF of subject is _|_, in the form of our internal _|_-values: that
       -- means the entire case-expression is _|_
       (Prim pInfo,[_],ticks)
-        | primName pInfo `elem` [ "Clash.Transformations.undefined"
+        | primName pInfo `elem` [ Text.showt 'NP.undefined
                                 , "Clash.GHC.Evaluator.undefined"
                                 , "EmptyCase"] ->
         let e1 = mkApps (mkTicks (Prim pInfo) ticks) [Right ty]

--- a/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
@@ -63,9 +63,9 @@ import Clash.Core.VarEnv
 import Clash.Netlist.BlackBox.Types ()
 import Clash.Netlist.BlackBox.Util (getUsedArguments)
 import Clash.Netlist.Util (splitNormalized)
+import Clash.Normalize.Primitives (removedArg)
 import Clash.Normalize.Transformations.Reduce (reduceBinders)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession, primitives)
-import Clash.Normalize.Util (removedTm)
 import Clash.Primitives.Types (Primitive(..), UsedArguments(..))
 import Clash.Rewrite.Types
   (TransformContext(..), bindings, curFun, extra, tcCache, workFreeBinders)
@@ -133,11 +133,11 @@ removeUnusedExpr _ e@(collectArgsTicks -> (p@(Prim pInfo),args,ticks)) = do
       args'' <- go tcm (n+1) used args'
       case tm of
         TyApp (Prim p0) _
-          | primName p0 == "Clash.Transformations.removedArg"
+          | primName p0 == Text.showt 'removedArg
           -> return (Left tm : args'')
         _ -> do
           let ty = termType tcm tm
-              p' = removedTm ty
+              p' = TyApp (Prim removedArg) ty
           if n < arity && n `notElem` used
              then changed (Left p' : args'')
              else return  (Left tm : args'')

--- a/clash-lib/src/Clash/Normalize/Transformations/Reduce.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Reduce.hs
@@ -36,8 +36,9 @@ import Clash.Core.TyCon (tyConDataCons)
 import Clash.Core.Type (TypeView(..), mkTyConApp, tyView)
 import Clash.Core.Util (mkVec, shouldSplit, tyNatSize)
 import Clash.Normalize.PrimitiveReductions
+import Clash.Normalize.Primitives (removedArg)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession, normalizeUltra)
-import Clash.Normalize.Util (removedTm, shouldReduce)
+import Clash.Normalize.Util (shouldReduce)
 import Clash.Rewrite.Types (TransformContext(..), extra, tcCache)
 import Clash.Rewrite.Util (changed, isUntranslatableType, setChanged, whnfRW)
 import Clash.Unique (lookupUniqMap)
@@ -444,7 +445,7 @@ reduceNonRepPrim c@(TransformContext is0 ctx) e@(App _ _) | (Prim p, args, ticks
                                     [Right lTy
                                     ,Right rTy
                                     ,Left  bvArg
-                                    ,Left  (removedTm rTy)
+                                    ,Left  (TyApp (Prim removedArg) rTy)
                                     ]
 
               changed (mkTicks tup ticks)
@@ -454,7 +455,7 @@ reduceNonRepPrim c@(TransformContext is0 ctx) e@(App _ _) | (Prim p, args, ticks
                   tup          = mkApps (Data tupDc)
                                     [Right lTy
                                     ,Right rTy
-                                    ,Left  (removedTm lTy)
+                                    ,Left  (TyApp (Prim removedArg) lTy)
                                     ,Left  bvArg
                                     ]
 

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -1,7 +1,8 @@
 {-|
-  Copyright  :  (C) 2012-2016, University of Twente
+  Copyright  :  (C) 2012-2016, University of Twente,
+                    2021     , QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Utility functions used by the normalisation transformations
 -}
@@ -9,6 +10,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 
 module Clash.Normalize.Util
  ( ConstantSpecInfo(..)
@@ -27,7 +29,6 @@ module Clash.Normalize.Util
  , constantSpecInfo
  , normalizeTopLvlBndr
  , rewriteExpr
- , removedTm
  , mkInlineTick
  , substWithTyEq
  , tvSubstWithTyEq
@@ -45,6 +46,7 @@ import qualified Data.HashMap.Strict     as HashMapS
 import qualified Data.HashSet            as HashSet
 import           Data.Text               (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Extra as Text
 
 #if MIN_VERSION_ghc(9,0,0)
 import           GHC.Builtin.Names       (eqTyConKey)
@@ -66,7 +68,7 @@ import           Clash.Core.Term
 import           Clash.Core.TermInfo     (isPolyFun, termType)
 import           Clash.Core.TyCon        (TyConMap)
 import           Clash.Core.Type
-  (Type(LitTy, VarTy), LitTy(SymTy), TypeView (..), tyView, undefinedTy,
+  (Type(LitTy, VarTy), LitTy(SymTy), TypeView (..), tyView,
    splitFunForallTy, splitTyConAppM, mkPolyFunTy)
 import           Clash.Core.Util
   (isClockOrReset)
@@ -76,6 +78,7 @@ import           Clash.Core.VarEnv
    lookupVarEnv, unionVarEnvWith, unitVarEnv, extendInScopeSetList)
 import           Clash.Debug             (traceIf)
 import           Clash.Driver.Types      (BindingMap, Binding(..), DebugLevel (..))
+import           Clash.Normalize.Primitives (removedArg)
 import {-# SOURCE #-} Clash.Normalize.Strategy (normalization)
 import           Clash.Normalize.Types
 import           Clash.Primitives.Util   (constantArgs)
@@ -308,7 +311,7 @@ constantSpecInfo ctx e = do
   if isClockOrReset tcm (termType tcm e) then
     case collectArgs e of
       (Prim p, _)
-        | primName p == "Clash.Transformations.removedArg" ->
+        | primName p == Text.showt 'removedArg ->
           pure (constantCsr e)
       _ -> bindCsr ctx e
   else
@@ -461,7 +464,7 @@ substWithTyEq e0 = go [] False [] e0
     , tv `elem` tvs
     = let
         subst0 = extendTvSubst (mkSubst emptyInScopeSet) tv ty
-        subst1 = extendIdSubst subst0 v (removedTm (varType v))
+        subst1 = extendIdSubst subst0 v (TyApp (Prim removedArg) (varType v))
       in go (tvs List.\\ [tv]) True (substId subst0 v : ids_) (substTm "substWithTyEq e" subst1 e)
     | otherwise = go tvs changed (v:ids_) e
   go tvs True ids_ e =
@@ -518,13 +521,6 @@ rewriteExpr (nrwS,nrw) (bndrS,expr) (nm, sp) = do
   traceIf (lvl >= DebugFinal)
     (bndrS ++ " after " ++ nrwS ++ ":\n\n" ++ after ++ "\n") $
     return rewritten
-
-removedTm
-  :: Type
-  -> Term
-removedTm =
-  let removedNm = "Clash.Transformations.removedArg" in
-  TyApp (Prim (PrimInfo removedNm undefinedTy WorkNever SingleResult))
 
 -- | A tick to prefix an inlined expression with it's original name.
 -- For example, given


### PR DESCRIPTION
This PR adds a new module `Clash.Normalize.Primitives` which contains the `PrimInfo` for primitives which are created during normalization, but do not correspond to any defined functions.

Fixes #1805

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
