### PR TITLE
Backport to 1.4: Allow hackage-sdist to run independently of other jobs

### DIFF
--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -1,5 +1,6 @@
 hackage-sdist:
   extends: .common
+  needs: []
   stage: pack
   interruptible: false
   script:


### PR DESCRIPTION
Speeds up successful CI runs