### PR TITLE
Don't render negative shift/rotate in VHDL

### DIFF
--- a/changelog/2021-05-20T14_43_21+02_00_fix_negative_shift_rotate.md
+++ b/changelog/2021-05-20T14_43_21+02_00_fix_negative_shift_rotate.md
@@ -1,0 +1,1 @@
+FIXED: Clash no longer generates calls to {shift,rotate}_{left,right} in VHDL where the count is a negative number. [#1810](https://github.com/clash-lang/clash-compiler/issues/1810).

--- a/clash-lib/prims/commonverilog/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Num_Natural.primitives
@@ -92,8 +92,15 @@ endfunction"
 , { "BlackBox" :
   { "name"      : "GHC.Num.Natural.naturalShiftL#"
   , "kind"      : "Expression"
-  , "type"      : "naturalShiftL :: Natural -> Word# -> Natural"
+  , "type"      : "naturalShiftL# :: Natural -> Word# -> Natural"
   , "template"  : "~ARG[0] <<< ~ARG[1]"
+  }
+}
+, { "BlackBox" :
+  { "name"      : "GHC.Num.Natural.naturalShiftR#"
+  , "kind"      : "Expression"
+  , "type"      : "naturalShiftR# :: Natuarl -> Word# -> Natural"
+  , "template"  : "~ARG[0] >>> ~ARG[1]"
   }
 }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
@@ -528,30 +528,50 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.shiftL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "template"  : "std_logic_vector(shift_left(unsigned(~ARG[1]),to_integer(~ARG[2])))"
+    , "template"  :
+"~RESULT <= std_logic_vector(shift_left(unsigned(~ARG[1]), to_integer(~ARG[2])))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.shiftR#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "template"  : "std_logic_vector(shift_right(unsigned(~ARG[1]),to_integer(~ARG[2])))"
+    , "template"  :
+"~RESULT <= std_logic_vector(shift_right(unsigned(~ARG[1]),to_integer(~ARG[2])))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rotateL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "template"  : "std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2])))"
+    , "template"  :
+"~RESULT <= std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2])))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rotateR#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
-    , "template"  : "std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2])))"
+    , "template"  :
+"~RESULT <= std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2])))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
@@ -205,30 +205,50 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.shiftL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => Signed n -> Int -> Signed n"
-    , "template"  : "shift_left(~ARG[1],to_integer(~ARG[2]))"
+    , "template"  :
+"~RESULT <= shift_left(~ARG[1],to_integer(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.shiftR#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => Signed n -> Int -> Signed n"
-    , "template"  : "shift_right(~ARG[1],to_integer(~ARG[2]))"
+    , "template"  :
+"~RESULT <= shift_right(~ARG[1],to_integer(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.rotateL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
-    , "template"  : "rotate_left(~ARG[1],to_integer(~ARG[2]))"
+    , "template"  :
+"~RESULT <= rotate_left(~ARG[1],to_integer(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.rotateR#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
-    , "template"  : "rotate_right(~ARG[1],to_integer(~ARG[2]))"
+    , "template"  :
+"~RESULT <= rotate_right(~ARG[1],to_integer(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
@@ -166,30 +166,50 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.shiftL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
-    , "template"  : "shift_left(~ARG[1],to_integer(~ARG[2]))"
+    , "template"  :
+"~RESULT <= shift_left(~ARG[1],to_integer(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.shiftR#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
-    , "template"  : "shift_right(~ARG[1],to_integer(~ARG[2]))"
+    , "template"  :
+"~RESULT <= shift_right(~ARG[1],to_integer(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.rotateL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
-    , "template"  : "rotate_left(~ARG[1],to_integer(~ARG[2]))"
+    , "template"  :
+"~RESULT <= rotate_left(~ARG[1],to_integer(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.rotateR#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
-    , "template"  : "rotate_right(~ARG[1],to_integer(~ARG[2]))"
+    , "template"  :
+"~RESULT <= rotate_right(~ARG[1],to_integer(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
@@ -162,16 +162,26 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.shiftRInteger"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "shiftRInteger :: Integer -> Int# -> Integer"
-    , "template"  : "shift_right(~ARG[0],to_integer(~ARG[1]))"
+    , "template"  :
+"~RESULT <= shift_right(~ARG[0], to_integer(~ARG[1]))
+    -- pragma translate_off
+    when (~ARG[1] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.shiftLInteger"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "shiftLInteger :: Integer -> Int# -> Integer"
-    , "template"  : "shift_left(~ARG[0],to_integer(~ARG[1]))"
+    , "template"  :
+"~RESULT <= shift_left(~ARG[0], to_integer(~ARG[1]))
+    -- pragma translate_off
+    when (~ARG[1] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
@@ -189,16 +189,26 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Num.Integer.integerShiftR#"
-    , "kind"      : "Expression"
-    , "type"      : "integerShiftR :: Integer -> Word# -> Integer"
-    , "template"  : "shift_right(~ARG[0],to_integer(~ARG[1]))"
+    , "kind"      : "Declaration"
+    , "type"      : "integerShiftR# :: Integer -> Word# -> Integer"
+    , "template"  :
+"~RESULT <= shift_right(~ARG[0], to_integer(~VAR[count][1](30 downto 0)))
+    -- pragma translate_off
+    when (~ARG[1] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Num.Integer.integerShiftL#"
-    , "kind"      : "Expression"
-    , "type"      : "integerShiftR :: Integer -> Word# -> Integer"
-    , "template"  : "shift_left(~ARG[0],to_integer(~ARG[1]))"
+    , "kind"      : "Declaration"
+    , "type"      : "integerShiftL# :: Integer -> Word# -> Integer"
+    , "template"  :
+"~RESULT <= shift_left(~ARG[0], to_integer(~VAR[count][1](30 downto 0)))
+    -- pragma translate_off
+    when (~ARG[1] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
@@ -78,8 +78,15 @@
 , { "BlackBox" :
   { "name"      : "GHC.Num.Natural.naturalShiftL#"
   , "kind"      : "Expression"
-  , "type"      : "naturalShiftL :: Natural -> Word# -> Natural"
+  , "type"      : "naturalShiftL# :: Natural -> Word# -> Natural"
   , "template"  : "shift_left(~ARG[0],to_integer(~ARG[1]))"
+  }
+}
+, { "BlackBox" :
+  { "name"      : "GHC.Num.Natural.naturalShiftR#"
+  , "kind"      : "Expression"
+  , "type"      : "naturalShiftR# :: Natural -> Word# -> Natural"
+  , "template"  : "shift_right(~ARG[0], to_integer(~ARG[1]))"
   }
 }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
@@ -77,16 +77,26 @@
 }
 , { "BlackBox" :
   { "name"      : "GHC.Num.Natural.naturalShiftL#"
-  , "kind"      : "Expression"
+  , "kind"      : "Declaration"
   , "type"      : "naturalShiftL# :: Natural -> Word# -> Natural"
-  , "template"  : "shift_left(~ARG[0],to_integer(~ARG[1]))"
+  , "template"  :
+"~RESULT <= shift_left(~ARG[0],to_integer(~VAR[count][1](30 downto 0)))
+    -- pragma translate_off
+    when (~ARG[1] >= to_unsigned(0, ~SIZE[~TYP[1]]-1)) else (others => 'X')
+    -- pragma translate_on
+    ;"
   }
 }
 , { "BlackBox" :
   { "name"      : "GHC.Num.Natural.naturalShiftR#"
-  , "kind"      : "Expression"
+  , "kind"      : "Declaration"
   , "type"      : "naturalShiftR# :: Natural -> Word# -> Natural"
-  , "template"  : "shift_right(~ARG[0], to_integer(~ARG[1]))"
+  , "template"  :
+"~RESULT <= shift_right(~ARG[0], to_integer(~VAR[count][1](30 downto 0)))
+    -- pragma translate_off
+    when (~ARG[1] >= to_unsigned(0, ~SIZE[~TYP[1]]-1)) else (others => 'X')
+    -- pragma translate_on
+    ;"
   }
 }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Prim.primitives
+++ b/clash-lib/prims/vhdl/GHC_Prim.primitives
@@ -163,16 +163,26 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.uncheckedIShiftL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "uncheckedIShiftL# :: Int# -> Int# -> Int#"
-    , "template"  : "shift_left(~ARG[0],to_integer(~ARG[1]))"
+    , "template"  :
+"~RESULT <= shift_left(~ARG[0],to_integer(~ARG[1]))
+    -- pragma translate_off
+    when (~ARG[1] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.uncheckedIShiftRA#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "uncheckedIShiftRA# :: Int# -> Int# -> Int#"
-    , "template"  : "shift_right(~ARG[0],to_integer(~ARG[1]))"
+    , "template"  :
+"~RESULT <= shift_right(~ARG[0],to_integer(~ARG[1]))
+    -- pragma translate_off
+    when (~ARG[1] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
@@ -233,16 +243,26 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.uncheckedShiftL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "uncheckedShiftL# :: Word# -> Int# -> Word#"
-    , "template"  : "shift_left(~ARG[0],to_integer(~ARG[1]))"
+    , "template"  :
+"~RESULT <= shift_left(~ARG[0],to_integer(~ARG[1]))
+    -- pragma translate_off
+    when (~ARG[1] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.uncheckedShiftRL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "uncheckedShiftR# :: Word# -> Int# -> Word#"
-    , "template"  : "shift_right(~ARG[0],to_integer(~ARG[1]))"
+    , "template"  :
+"~RESULT <= shift_right(~ARG[0],to_integer(~ARG[1]))
+    -- pragma translate_off
+    when (~ARG[1] >= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -353,8 +353,10 @@ instance Bits Bit where
   bitSizeMaybe _    = Just 1
   bitSize _         = 1
   isSigned _        = False
+  shift b i         = if i == 0 then b else low
   shiftL b i        = if i == 0 then b else low
   shiftR b i        = if i == 0 then b else low
+  rotate b _        = b
   rotateL b _       = b
   rotateR b _       = b
   popCount b        = if eq## b low then 0 else 1

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -575,6 +575,7 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS_GHC(runTest "Resize3" def)
         , NEEDS_PRIMS_GHC(runTest "SatMult" def{hdlSim=False})
         , NEEDS_PRIMS_GHC(runTest "ShiftRotate" def)
+        , runTest "ShiftRotateNegative" def{hdlTargets=[VHDL]}
         , NEEDS_PRIMS_GHC(runTest "SignedProjectionTB" def)
         , NEEDS_PRIMS_GHC(runTest "SignedZero" def)
         , NEEDS_PRIMS_GHC(runTest "Signum" def)

--- a/tests/shouldwork/Numbers/ShiftRotateNegative.hs
+++ b/tests/shouldwork/Numbers/ShiftRotateNegative.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE CPP #-}
+
+module ShiftRotateNegative where
+
+#if MIN_VERSION_base(4,15,0)
+import GHC.Num.Natural (Natural)
+#else
+import GHC.Natural (Natural)
+#endif
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import Clash.Sized.Internal.BitVector
+
+testBench :: Signal System Bool
+testBench = done
+ where
+  done = expectedOutput (pack . topEntity <$> testInput)
+  clk  = tbSystemClockGen (not <$> done)
+  rst  = systemResetGen
+
+  testInput =
+    stimuliGenerator clk rst $
+      (0b1111_0000_1111_0000_1111_0000_1111_0000, 1) :> Nil
+
+  expectedOutput =
+    outputVerifierBitVector' @1 clk rst (pack testOutput :> Nil)
+
+  -- Integer and Natural are stored as BitVector 64: this is how they render in
+  -- HDL, and they have no BitPack instance needed to use 'pack'.
+  testOutput
+    :: Vec 2
+         ( Int
+         , Word
+#if MIN_VERSION_base(4,15,0)
+         , BitVector 64
+         , BitVector 64
+#endif
+         , Bit
+         , BitVector 32
+         , Signed 32
+         , Unsigned 32
+         )
+  testOutput =
+    -- Exceptions when shiftL / shiftR gets a negative count.
+    ( deepErrorX "X"
+    , deepErrorX "X"
+#if MIN_VERSION_base(4,15,0)
+    , deepErrorX "X"
+    , deepErrorX "X"
+#endif
+    , 0
+    , deepErrorX "X"
+    , deepErrorX "X"
+    , deepErrorX "X"
+    ) :>
+    -- shift accepts negative counts.
+    ( 4042322160
+    , 4042322160
+#if MIN_VERSION_base(4,15,0)
+    , 4042322160
+    , 4042322160
+#endif
+    , 0
+    , 0b1111_0000_1111_0000_1111_0000_1111_0000
+    , (-252645135)
+    , 4042322160
+    ) :> Nil
+
+{-# NOINLINE topEntity #-}
+topEntity
+  :: (BitVector 32, Int)
+  -> Vec 2
+       ( Int
+       , Word
+#if MIN_VERSION_base(4,15,0)
+       , BitVector 64
+       , BitVector 64
+#endif
+       , Bit
+       , BitVector 32
+       , Signed 32
+       , Unsigned 32
+       )
+topEntity (x, i) =
+  ( f (fromIntegral x) i
+  , f (fromIntegral x) i
+#if MIN_VERSION_base(4,15,0)
+  , fromIntegral $! f (fromIntegral @_ @Integer x) i
+  , BV 0 $! f (unsafeToNatural x) i
+#endif
+  , f (x!0) i
+  , f x i
+  , f (unpack x) i
+  , f (unpack x) i
+  ) :>
+  ( g (fromIntegral x) i
+  , g (fromIntegral x) i
+#if MIN_VERSION_base(4,15,0)
+  , fromIntegral $! g (fromIntegral @_ @Integer x) i
+  , BV 0 $! g (unsafeToNatural x) i
+#endif
+  , g (x!0) i
+  , g x i
+  , g (unpack x) i
+  , g (unpack x) i
+  ) :>
+  Nil
+
+f :: (Bits a) => a -> Int -> a
+f x i = x `shiftL` (-i) `rotateL` (-i) `shiftR` (-i) `rotateR` (-i)
+
+g :: (Bits a) => a -> Int -> a
+g x i = x `shift` (-i) `rotate` (-i) `shift` i `rotate` i


### PR DESCRIPTION
This PR stops clash rendering calls to the shift and rotate functions in numeric_std with negative amounts to shift/rotate by. This should prevent errors in simulation from unexpected negative shift amounts.

Fixes #1810 

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
