### PR TITLE
clash-prelude: Fix link to Safe Haskell docs

### DIFF
--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -6,7 +6,7 @@ Copyright  :  (C) 2013-2016, University of Twente,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
-__This is the <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/safe_haskell.html Safe> API only of "Clash.Explicit.Prelude"__
+__This is the <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/exts/safe_haskell.html Safe> API only of "Clash.Explicit.Prelude"__
 
 This module defines the explicitly clocked counterparts of the functions
 defined in "Clash.Prelude".

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -6,7 +6,7 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
-  __This is the <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/safe_haskell.html Safe> API only of "Clash.Prelude"__
+  __This is the <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/exts/safe_haskell.html Safe> API only of "Clash.Prelude"__
 
   Clash is a functional hardware description language that borrows both its
   syntax and semantics from the functional programming language Haskell. The


### PR DESCRIPTION
The current link to `Safe` is dead:
- http://hackage.haskell.org/package/clash-prelude-1.4.2/docs/Clash-Prelude-Safe.html
- http://hackage.haskell.org/package/clash-prelude-1.4.2/docs/Clash-Explicit-Prelude-Safe.html