### PR TITLE
Changelog entry for removing reducers library

### DIFF
--- a/changelog/2021-06-01T09_44_12+02_00_remove_reducers.md
+++ b/changelog/2021-06-01T09_44_12+02_00_remove_reducers.md
@@ -1,0 +1,1 @@
+CHANGED: clash-lib now uses Data.Monoid.Ap instead of Data.Semigroup.Monad.Mon. This means users defining primitives with TemplateFunction will need to replace Mon/getMon with Ap/getAp.


### PR DESCRIPTION
As b8586de72e77af0b604191a031ffdea1c5856d70 is an internal change
which may affect some users (those using TemplateFunction to define
black boxes) it should have a changelog entry so it can be included
in the release notes later.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

