### PR TITLE
Add SymbiYosys to CI image

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/bin:/ro
 ARG DEPS_GHC="curl libc6-dev libgmp-dev pkg-config libnuma-dev"
 ARG DEPS_CABAL="zlib1g-dev"
 ARG DEPS_GHDL="clang gcc gnat llvm-9-dev"
+ARG DEPS_SYMBIYOSYS="tclsh git python python3 build-essential bison flex libreadline-dev gawk tcl-dev libffi-dev autoconf cmake"
 ARG DEPS_CLASH="libtinfo-dev libtinfo5"
 ARG DEPS_CLASH_COSIM="make"
 
@@ -14,6 +15,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends --no-install-suggests \
       $DEPS_GHC $DEPS_CABAL \
       $DEPS_GHDL $DEPS_IVERILOG \
+      $DEPS_SYMBIYOSYS \
       $DEPS_CLASH $DEPS_CLASH_COSIM \
       ca-certificates iverilog pixz jq zstd \
       git ssh \
@@ -28,6 +30,34 @@ RUN apt-get update \
  && make install \
  && cd .. \
  && rm -rf ghdl-0.37
+
+ARG YOSYS_VERSION="yosys-0.9"
+RUN curl -L "https://github.com/YosysHQ/yosys/archive/refs/tags/$YOSYS_VERSION.tar.gz" \
+      | tar -xz \
+ && cd yosys-$YOSYS_VERSION \
+ && make -j$(nproc) \
+ && make install \
+ && cd .. \
+ && rm -Rf yosys-$YOSYS_VERSION
+
+ARG Z3_VERSION="z3-4.8.10"
+RUN curl -L "https://github.com/Z3Prover/z3/archive/refs/tags/$Z3_VERSION.tar.gz" \
+      | tar -xz \
+ && cd z3-$Z3_VERSION \
+ && python scripts/mk_make.py \
+ && cd build \
+ && make -j$(nproc) \
+ && make install \
+ && cd ../.. \
+ && rm -Rf z3-$Z3_VERSION
+
+ARG SYMBIYOSYS_VERSION="66a458958dc93f8e12418d425e4c31848889937b"
+RUN git clone https://github.com/cliffordwolf/SymbiYosys.git SymbiYosys \
+ && cd SymbiYosys \
+ && git checkout $SYMBIYOSYS_VERSION \
+ && make install \
+ && cd .. \
+ && rm -Rf SymbiYosys
 
 ARG GHCUP_VERSION="0.1.14"
 ARG GHCUP_URL="https://downloads.haskell.org/~ghcup/${GHCUP_VERSION}/x86_64-linux-ghcup-${GHCUP_VERSION}"

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,5 +1,5 @@
 .common:
-  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-05-14
+  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-01
   timeout: 2 hours
   stage: build
   variables:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ aliases:
 
   - &build_default
     docker:
-      - image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-05-14
+      - image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-01
         # Read-only permissions
         auth:
           username: clash-lang-builder


### PR DESCRIPTION
For testing #1798, the CI image needs to include the `sby` executable,
which means the CI image needs to build Yosys + SymbiYosys + Z3.

[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

Write a description of your PR here. Briefly describe the solution, taking more care with larger changes to outline the intention of the PR, or any compromises made in the final design. If there is no associated issue, it is helpful to also include the motivation for this PR.

[comment]: # (Add a line of the form "Fixes: #xxxx" for each related issue closed by this pull request, where #xxxx is an issue number.)

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
