### PR TITLE
flattenLet nested letrec; error on unexpected change

### DIFF
--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -162,9 +162,8 @@ apply = \s rewrite ctx expr0 -> do
       isRelevantTrans = s `Set.member` dbgTranss || Set.null dbgTranss
   traceIf (isTryLvl && isRelevantTrans) ("Trying: " ++ s) (pure ())
 
-  (expr1,anyChanged) <- Writer.listen (rewrite ctx expr0)
+  (!expr1,anyChanged) <- Writer.listen (rewrite ctx expr0)
   let hasChanged = Monoid.getAny anyChanged
-      !expr2     = if hasChanged then expr1 else expr0
   Monad.when hasChanged (transformCounter += 1)
 
   -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
@@ -191,8 +190,8 @@ apply = \s rewrite ctx expr0 -> do
         else Just (dbgFrom, dbgLimit)
 
   if lvl == DebugNone
-    then return expr2
-    else applyDebug lvl dbgTranss fromLimit s expr0 hasChanged expr2
+    then return expr1
+    else applyDebug lvl dbgTranss fromLimit s expr0 hasChanged expr1
 {-# INLINE apply #-}
 
 applyDebug

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -137,6 +137,7 @@ runClashTest = defaultMain $ clashTestRoot
   [ clashTestGroup "netlist"
     [ clashLibTest ("tests" </> "shouldwork" </> "Netlist") allTargets [] "Identity" "main"
     , NEEDS_PRIMS(clashLibTest ("tests" </> "shouldwork" </> "Netlist") [VHDL] [] "NoDeDup" "main")
+    , clashLibTest ("tests" </> "shouldwork" </> "Netlist") allTargets [] "T1766" "main"
     ]
   , clashTestGroup "examples"
     [ runTest "ALU" def{hdlSim=False}

--- a/tests/shouldwork/Netlist/T1766.hs
+++ b/tests/shouldwork/Netlist/T1766.hs
@@ -1,0 +1,77 @@
+module T1766 where
+
+import qualified Prelude
+
+import Data.List (nub)
+import Data.Maybe (mapMaybe)
+
+import Clash.Class.Counter
+import Clash.Explicit.Prelude
+
+import Clash.Backend
+import Clash.Netlist.Types
+
+import Test.Tasty.Clash
+import Test.Tasty.Clash.NetlistTest
+
+brightness :: Unsigned 3 -> Unsigned 3 -> Unsigned 4
+brightness epoch led =
+  maxBound - satMul SatBound distanceToEpoch 4
+ where
+  distanceToEpoch = distance (extend epoch) (extend led)
+  distance a b = if a > b then a - b else b - a
+
+knightrider
+  :: Clock System
+  -> Reset System
+  -> Enable System
+  -> Signal System (BitVector 8)
+knightrider clk rst ena = pack <$> leds
+ where
+  leds = mealy clk rst ena modulateVec 0 (slope <$> ledPos)
+  modulateVec counter thresholds = (counter + 1, map (counter <) thresholds)
+  slope epoch = map (brightness epoch) (iterateI (+1) 0)
+
+  initial :: (Unsigned 3, Index 10)
+  initial = (0, 0)
+
+  (ledPos, delayCount) =
+      unbundle
+    $ register clk rst ena initial
+    $ fmap countSucc
+    $ bundle (ledPos, delayCount)
+
+topEntity :: Clock System -> Signal System Bool -> Signal System (BitVector 8)
+topEntity clk rstBool = knightrider clk rst enableGen
+ where
+  rst = unsafeFromLowPolarity rstBool
+
+testPath :: FilePath
+testPath = "tests/shouldwork/Netlist/T1766.hs"
+
+assertNoDuplicateSignals :: Component -> IO ()
+assertNoDuplicateSignals (Component nm inps outs ds) =
+  let names = mapMaybe netName ds
+      signals = Prelude.length names
+      unique = Prelude.length (nub names)
+   in if signals == unique
+        then pure ()
+        else error ("Signals: " <> show signals <> ", unique names: " <> show unique)
+ where
+  netName (NetDecl' _ _ i _ _) = Just i
+  netName _ = Nothing
+
+mainVHDL :: IO ()
+mainVHDL = do
+  netlist <- runToNetlistStage SVHDL id testPath
+  mapM_ (assertNoDuplicateSignals . snd) netlist
+
+mainVerilog :: IO ()
+mainVerilog = do
+  netlist <- runToNetlistStage SVerilog id testPath
+  mapM_ (assertNoDuplicateSignals . snd) netlist
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  netlist <- runToNetlistStage SSystemVerilog id testPath
+  mapM_ (assertNoDuplicateSignals . snd) netlist


### PR DESCRIPTION
The flattenLet transformation now also flattens nested letrec
expressions, by deshadowing and merging the bindings into a single
expression.

The error for when setChanged is not called was never being called,
this is now fixed so that transformations that change the core
without declaring throw an error at runtime.

Fixes: #1766 

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files