### PR TITLE
Bump Yosys version in CI

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -31,14 +31,13 @@ RUN apt-get update \
  && cd .. \
  && rm -rf ghdl-0.37
 
-ARG YOSYS_VERSION="yosys-0.9"
-RUN curl -L "https://github.com/YosysHQ/yosys/archive/refs/tags/$YOSYS_VERSION.tar.gz" \
-      | tar -xz \
- && cd yosys-$YOSYS_VERSION \
+ARG YOSYS_VERSION="8cfed1a97957e4c096d1e0a0304d978bcb27e116"
+RUN git clone https://github.com/YosysHQ/yosys.git yosys \
+ && cd yosys \
  && make -j$(nproc) \
  && make install \
  && cd .. \
- && rm -Rf yosys-$YOSYS_VERSION
+ && rm -Rf yosys
 
 ARG Z3_VERSION="z3-4.8.10"
 RUN curl -L "https://github.com/Z3Prover/z3/archive/refs/tags/$Z3_VERSION.tar.gz" \

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,5 +1,5 @@
 .common:
-  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-01
+  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-02
   timeout: 2 hours
   stage: build
   variables:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ aliases:
 
   - &build_default
     docker:
-      - image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-01
+      - image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-02
         # Read-only permissions
         auth:
           username: clash-lang-builder


### PR DESCRIPTION
The latest tagged release of Yosys is not compatible with the HEAD
commit of Symbiyosys, as it lacks a command that was added later.
Bumping yosys to a newer commit with that command should hopefully
fix CI.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
