### PR TITLE
Catch ErrorCall when using seq in blockRam#

### DIFF
--- a/changelog/2021-06-03T10_54_14+02_00_blockram_strictness.md
+++ b/changelog/2021-06-03T10_54_14+02_00_blockram_strictness.md
@@ -1,0 +1,2 @@
+FIXED: BlockRam simulation is now less strict [#1458](https://github.com/clash-lang/clash-compiler/issues/1458).
+ADDED: 'seqErrorX' for catching both XException and ErrorCall

--- a/clash-lib/prims/common/Clash_XException.primitives
+++ b/clash-lib/prims/common/Clash_XException.primitives
@@ -7,6 +7,14 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.XException.seqErrorX"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "seqErrorX :: a -> b -> b"
+    , "template"  : "~ARG[1]"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.XException.errorX"
     , "workInfo"  : "Constant"
     , "kind"      : "Expression"

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -402,6 +402,7 @@ test-suite unittests
                  Clash.Tests.AutoReg
                  Clash.Tests.BitPack
                  Clash.Tests.BitVector
+                 Clash.Tests.BlockRam
                  Clash.Tests.Counter
                  Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -1,9 +1,10 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2017, Myrtle Software Ltd,
-                  2017     , Google Inc.
+                  2017     , Google Inc.,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 BlockRAM primitives
 
@@ -422,7 +423,7 @@ import           Clash.Sized.Index      (Index)
 import           Clash.Sized.Vector     (Vec, replicate, toList, iterateI)
 import qualified Clash.Sized.Vector     as CV
 import           Clash.XException
-  (maybeIsX, seqX, NFDataX, deepErrorX, defaultSeqX, fromJustX, undefined)
+  (maybeIsX, seqErrorX, NFDataX, deepErrorX, defaultSeqX, fromJustX, undefined)
 
 {- $setup
 >>> :m -Clash.Prelude
@@ -1002,7 +1003,7 @@ blockRam# (Clock _) gen content rd wen =
   go !ram o ret@(~(re :- res)) rt@(~(r :- rs)) et@(~(e :- en)) wt@(~(w :- wr)) dt@(~(d :- din)) =
     let ram' = d `defaultSeqX` upd ram e (fromEnum w) d
         o'   = if re then ram `Seq.index` r else o
-    in  o `seqX` o :- (ret `seq` rt `seq` et `seq` wt `seq` dt `seq` go ram' o' res rs en wr din)
+    in  o `seqErrorX` o :- (ret `seq` rt `seq` et `seq` wt `seq` dt `seq` go ram' o' res rs en wr din)
 
   upd ram we waddr d = case maybeIsX we of
     Nothing -> case maybeIsX waddr of

--- a/clash-prelude/tests/Clash/Tests/BlockRam.hs
+++ b/clash-prelude/tests/Clash/Tests/BlockRam.hs
@@ -1,0 +1,29 @@
+module Clash.Tests.BlockRam (tests) where
+
+import qualified Data.List as List
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Clash.Prelude
+
+readRam
+  :: (HiddenClockResetEnable dom)
+  => Signal dom (Unsigned 4)
+  -> Signal dom (Unsigned 8)
+readRam addr = mux (register False $ addr .<. 8) ram (pure 0xff)
+  where
+    ram = blockRam1 NoClearOnReset (SNat @8) 0 addr (pure Nothing)
+
+-- If the block RAM uses the address argument too strictly, then it will
+-- attempt to access an out of bounds address when using readRam.
+--
+addrNotTooStrict :: Assertion
+addrNotTooStrict =
+  let addr = fromList [0..15]
+   in List.tail (sampleN @System 15 (readRam addr)) @?=
+        [255,0,0,0,0,0,0,0,255,255,255,255,255,255]
+
+tests :: TestTree
+tests = testGroup "BlockRam"
+  [ testCase "Address strictness" addrNotTooStrict
+  ]

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import qualified Clash.Tests.AutoReg
 import qualified Clash.Tests.BitPack
 import qualified Clash.Tests.BitVector
+import qualified Clash.Tests.BlockRam
 import qualified Clash.Tests.Counter
 import qualified Clash.Tests.DerivingDataRepr
 import qualified Clash.Tests.Fixed
@@ -26,6 +27,7 @@ tests = testGroup "Unittests"
   [ Clash.Tests.AutoReg.tests
   , Clash.Tests.BitPack.tests
   , Clash.Tests.BitVector.tests
+  , Clash.Tests.BlockRam.tests
   , Clash.Tests.Counter.tests
   , Clash.Tests.DerivingDataRepr.tests
   , Clash.Tests.Fixed.tests


### PR DESCRIPTION
When forcing the contents of block RAM, the use of Seq.index may
cause an ErrorCall to be thrown. Normal seqX cannot catch this,
so a modified seqX is defined which can catch XExceptions and
ErrorCall.

Fixes #1458 

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
