### PR TITLE
New function: memFile

### DIFF
--- a/changelog/2021-06-03T13_50_58+02_00_memFile
+++ b/changelog/2021-06-03T13_50_58+02_00_memFile
@@ -1,0 +1,1 @@
+ADDED: Added `Clash.Explicit.BlockRam.File.memFile`, a function for creating the contents of the data files this blockRAM uses. Can also be imported from `Clash.Prelude.BlockRam.File`, `Clash.Prelude.ROM.File` and `Clash.Explicit.ROM.File`.

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -1,9 +1,10 @@
 {-|
 Copyright  :  (C) 2015-2016, University of Twente,
-                  2017     , Google Inc.
-                  2019     , Myrtle Software Ltd.
+                  2017     , Google Inc.,
+                  2019     , Myrtle Software Ltd.,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 = Initializing a ROM with a data file #usingromfiles#
 
@@ -28,6 +29,12 @@ For example, a data file @memory.bin@ containing the 9-bit unsigned number
 000001011
 000001100
 000001101
+@
+
+Such a file can be produced with 'memFile':
+
+@
+writeFile "memory.bin" (memFile Nothing [7 :: Unsigned 9 .. 13])
 @
 
 We can instantiate a synchronous ROM using the content of the above file like
@@ -79,6 +86,8 @@ module Clash.Explicit.ROM.File
   ( -- * Synchronous ROM synchronized to an arbitrary clock
     romFile
   , romFilePow2
+    -- * Producing files
+  , memFile
     -- * Internal
   , romFile#
   )
@@ -88,7 +97,7 @@ import Data.Array                   (listArray,(!))
 import GHC.TypeLits                 (KnownNat)
 import System.IO.Unsafe             (unsafePerformIO)
 --
-import Clash.Explicit.BlockRam.File (initMem)
+import Clash.Explicit.BlockRam.File (initMem, memFile)
 import Clash.Promoted.Nat           (SNat (..), pow2SNat, snatToNum)
 import Clash.Sized.BitVector        (BitVector)
 import Clash.Explicit.Signal        (Clock, Enable, Signal, KnownDomain, delay)
@@ -117,8 +126,9 @@ import Clash.XException             (NFDataX(deepErrorX))
 --
 -- * See "Clash.Explicit.ROM.File#usingromfiles" for more information on how
 -- to instantiate a ROM with the contents of a data file.
--- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
--- own data files.
+-- * See 'memFile' for creating a data file with Clash.
+-- * See "Clash.Sized.Fixed#creatingdatafiles" for more ideas on how to create
+-- your own data files.
 romFilePow2
   :: forall dom  n m
    . (KnownNat m, KnownNat n, KnownDomain dom)

--- a/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
@@ -1,9 +1,10 @@
 {-|
 Copyright  :  (C) 2015-2016, University of Twente,
-                  2019     , Myrtle Software Ltd
-                  2017     , Google Inc.
+                  2019     , Myrtle Software Ltd,
+                  2017     , Google Inc.,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 = Initializing a BlockRAM with a data file #usingramfiles#
 
@@ -29,6 +30,12 @@ For example, a data file @memory.bin@ containing the 9-bit unsigned number
 000001011
 000001100
 000001101
+@
+
+Such a file can be produced with 'E.memFile':
+
+@
+writeFile "memory.bin" (memFile Nothing [7 :: Unsigned 9 .. 13])
 @
 
 We can instantiate a BlockRAM using the content of the above file like so:
@@ -80,6 +87,8 @@ module Clash.Prelude.BlockRam.File
   ( -- * BlockRAM synchronized to an arbitrary clock
     blockRamFile
   , blockRamFilePow2
+    -- * Producing files
+  , E.memFile
   )
 where
 

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -1,9 +1,10 @@
 {-|
 Copyright  :  (C) 2015-2016, University of Twente,
-                  2017     , Google Inc.
-                  2019     , Myrtle Software Ltd
+                  2017     , Google Inc.,
+                  2019     , Myrtle Software Ltd,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 = Initializing a ROM with a data file #usingromfiles#
 
@@ -28,6 +29,12 @@ For example, a data file @memory.bin@ containing the 9-bit unsigned number
 000001011
 000001100
 000001101
+@
+
+Such a file can be produced with 'memFile':
+
+@
+writeFile "memory.bin" (memFile Nothing [7 :: Unsigned 9 .. 13])
 @
 
 We can instantiate a synchronous ROM using the content of the above file like
@@ -80,6 +87,8 @@ module Clash.Prelude.ROM.File
     -- * Synchronous ROM synchronized to an arbitrary clock
   , romFile
   , romFilePow2
+    -- * Producing files
+  , memFile
     -- * Internal
   , asyncRomFile#
   )
@@ -89,7 +98,7 @@ import           Data.Array                   (listArray,(!))
 import           GHC.TypeLits                 (KnownNat)
 import           System.IO.Unsafe             (unsafePerformIO)
 
-import           Clash.Explicit.BlockRam.File (initMem)
+import           Clash.Explicit.BlockRam.File (initMem, memFile)
 import qualified Clash.Explicit.ROM.File      as E
 import           Clash.Promoted.Nat           (SNat (..), pow2SNat, snatToNum)
 import           Clash.Signal


### PR DESCRIPTION
A helper function for producing files with memory contents for such
modules as Clash.Explicit.BlockRam.File, etcetera.

I know you agreed to my initial proposal of

```haskell
showsBitPackFile
  :: BitPack a
  => a
  -> ShowS

-- used as
bla file es =
  writeFile file (foldr showsBitPackFile "" es)
```

but I changed my mind. The point of `ShowS` is that you can combine it with other datatypes that have a `Show` instance. But the memory file only contains words of a single length `n`. If people really want to put multiple datatypes into one memory, they can just `pack` it into `BitVector n`. So the function doesn't need to be combined in ways as `ShowS`, and you would in practice always invoke it as `foldr showsBitPackFile ""`, so why not incorporate that directly so people don't have to write it.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
