### PR TITLE
Look through type synonyms in SynthesisAttributes

### DIFF
--- a/changelog/2021-06-03T14_58_09+02_00_synthesis_annotation_synyonms.md
+++ b/changelog/2021-06-03T14_58_09+02_00_synthesis_annotation_synyonms.md
@@ -1,0 +1,1 @@
+FIXED: SynthesisAnnotations can now be defined in type synoynms without being excluded from the generated HDL [#1771](https://github.com/clash-lang/clash-compiler/issues/1771).

--- a/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
+++ b/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
@@ -1,7 +1,8 @@
 {-|
-  Copyright   :  (C) 2018, Google Inc.
+  Copyright   :  (C) 2018, Google Inc.,
+                     2021, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
   API for synthesis attributes (sometimes refered to as "synthesis directives",
   "pragmas", or "logic synthesis directives"). This is an experimental feature,
@@ -67,7 +68,29 @@ type Annotate (a :: Type) (attrs :: k) = a
 -- For VHDL, see:
 --     <https://www.intel.com/content/www/us/en/programmable/quartushelp/current/index.htm#hdl/vhdl/vhdl_file_dir.htm>
 --
--- Warning: This is an experimental feature, please report any unexpected or broken
+-- = Warnings
+--
+-- When using annotations, it is important that annotated arguments are not
+-- eta-reduced, as this may result in the annotation being stripped by GHC. For
+-- example
+--
+-- @
+-- f :: Signal System Bool \`Annotate\` 'StringAttr \"chip_pin\" \"C4\"
+--   -> Signal System Bool
+-- f x = id x -- Using a lambda, i.e. f = \x -> id x also works
+-- @
+--
+-- will reliably show the annotation in the generated HDL, but
+--
+-- @
+-- g :: Signal System Bool \`Annotate\` 'StringAttr \"chip_pin\" \"C4\"
+--   -> Signal System Bool
+-- g = id
+-- @
+--
+-- will not work.
+--
+-- This is an experimental feature, please report any unexpected or broken
 -- behavior to Clash's GitHub page (<https://github.com/clash-lang/clash-compiler/issues>).
 data Attr
   = BoolAttr Symbol Bool

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -660,6 +660,7 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS_GHC(outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") allTargets [] [] "Product" "main")
         ,                 outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") allTargets [] [] "InstDeclAnnotations" "main"
         , NEEDS_PRIMS_GHC(runTest "Product" def)
+        , outputTest ("tests" </> "shouldwork" </> "SynthesisAttributes") allTargets [] [] "T1771" "main"
         ]
       , clashTestGroup "Testbench"
         [ NEEDS_PRIMS_GHC(runTest "TB" def{clashFlags=["-fclash-inline-limit=0"]})

--- a/tests/shouldwork/SynthesisAttributes/T1771.hs
+++ b/tests/shouldwork/SynthesisAttributes/T1771.hs
@@ -1,0 +1,68 @@
+module T1771 where
+
+import qualified Prelude as P
+
+import qualified Data.List as List
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+import Clash.Annotations.SynthesisAttributes
+
+-- Keeping a single annotation in a type synonym should not prevent it from
+-- being rendered, or throw an error during compilation.
+type AttrSingle x = 'StringAttr "foo" x
+
+-- Keeping multiple annotations in a type synonym should not prevent them from
+-- being rendered, or throw an error during compilation.
+type AttrMulti = '[ AttrSingle "BB", 'BoolAttr "bar" 'True ]
+
+-- Hiding the Annotate synyonm in another type synonym should not prevent it
+-- from being rendered, or throw an error during compilation.
+type PinC = Annotate (BitVector 1) '[ AttrSingle "CC" ]
+
+{-# ANN topEntity (Synthesize
+      { t_name   = "topEntity"
+      , t_inputs = [PortName "pin_a", PortName "pin_b", PortName "pin_c"]
+      , t_output = PortName "res"
+      }) #-}
+topEntity
+  :: BitVector 1 `Annotate` AttrSingle "AA"
+  -> BitVector 1 `Annotate` AttrMulti
+  -> PinC
+  -> BitVector 1
+topEntity = \x y -> const const x y
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | List.isInfixOf needle haystack = pure ()
+  | otherwise = P.error $ mconcat
+      [ "Expected:\n\n  ", needle, "\n\nIn:\n\n", haystack]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
+
+  assertIn "attribute foo of pin_a : signal is \"AA\";" content
+  assertIn "attribute foo of pin_b : signal is \"BB\";" content
+  assertIn "attribute bar of pin_b : signal is true;" content
+  assertIn "attribute foo of pin_c : signal is \"CC\";" content
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
+
+  assertIn "(* foo = \"AA\" *) input [0:0] pin_a" content
+  assertIn "(* foo = \"BB\", bar = 1 *) input [0:0] pin_b" content
+  assertIn "(* foo = \"CC\" *) input [0:0] pin_c" content
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
+
+  assertIn "(* foo = \"AA\" *) input logic [0:0] pin_a" content
+  assertIn "(* foo = \"BB\", bar = 1 *) input logic [0:0] pin_b" content
+  assertIn "(* foo = \"CC\" *) input logic [0:0] pin_c" content


### PR DESCRIPTION
When extracting SynthesisAttributes from types in GHC2Core, there
were some cases where the attributes were not visible to coreToAttr
or coreToAttrs, meaning they would not be included in the
generated HDL. These cases involved type synonyms which were not
being looked though.

These functions now look through type synonyms when they fail to
find an attribute, but do find a synyonm which can be expanded.

Fixes #1771 

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
