### PR TITLE
Show inout ports correctly in clash-manifest.json

### DIFF
--- a/changelog/2021-06-04T12_15_32+02_00_manifest_inout_ports.md
+++ b/changelog/2021-06-04T12_15_32+02_00_manifest_inout_ports.md
@@ -1,0 +1,1 @@
+FIXED: Manifest files now correctly list bidirectional ports as "inout" rather than "in". [#1843](https://github.com/clash-lang/clash-compiler/issues/1843).

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -367,12 +367,13 @@ data Component
   , outputs       :: [(WireOrReg,(Identifier,HWType),Maybe Expr)] -- ^ Output ports
   , declarations  :: [Declaration] -- ^ Internal declarations
   }
-  deriving Show
+  deriving (Show, Generic, NFData)
 
-instance NFData Component where
-  rnf c = case c of
-    Component nm inps outps decls -> rnf nm    `seq` rnf inps `seq`
-                                     rnf outps `seq` rnf decls
+-- | Check if an input port is really an inout port.
+--
+isBiDirectional :: (Identifier, HWType) -> Bool
+isBiDirectional (_, BiDirectional _ _) = True
+isBiDirectional _ = False
 
 -- | Find the name and domain name of each clock argument of a component.
 --


### PR DESCRIPTION
When generating manifest files, any bidirectional ports would be
rendered as a single in port. This does not match the actual
port direction of the rendered HDL.

Fixes #1843

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
