### PR TITLE
Improved `-fclash-debug-*` flags

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -63,7 +63,7 @@ doHDL b src = do
 
   generateHDL (buildCustomReprs reprs) domainConfs bindingsMap (Just b) primMap tcm tupTcm
     (ghcTypeToHWType WORD_SIZE_IN_BITS True) evaluator topEntities Nothing
-    defClashOpts{opt_cachehdl = False, opt_dbgLevel = DebugSilent, opt_clear = True}
+    defClashOpts{opt_cachehdl = False, opt_debug = debugSilent, opt_clear = True}
     (startTime,prepTime)
 
 main :: IO ()

--- a/changelog/2021-06-08T16_16_05+02_00_improved_debug_options.md
+++ b/changelog/2021-06-08T16_16_05+02_00_improved_debug_options.md
@@ -1,0 +1,10 @@
+CHANGED: Clash now supports more expressive debug options at the command line [#1800](https://github.com/clash-lang/clash-compiler/issues/1800).
+
+With the old `DebugLevel` type for setting debug options, it was not possible to set certain debug options without implying others, i.e. counting transformations was not possible without also printing at least the final normalized core for a term. It is now possible to set options individually with new flags:
+
+  * -fclash-debug-invariants to check invariants and print warnings / errors
+  * -fclash-debug-info to choose how much information to show about individual transformations
+  * -fclash-debug-count-transformations to print a tally of each transformation applied
+
+The old -fclash-debug flag is still available for backwards compatibility, and each `DebugLevel` is now a synonym for setting these options together.
+

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -292,7 +292,7 @@ generateHDL
   -> IO ()
 generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans eval
   topEntities0 mainTopEntity opts (startTime,prepTime) = do
-    case opt_dbgRewriteHistoryFile opts of
+    case dbg_historyFile (opt_debug opts) of
       Nothing -> pure ()
       Just histFile -> whenM (Directory.doesFileExist histFile) (Directory.removeFile histFile)
     let (tes, deps) = sortTop bindingsMap topEntities1

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -371,9 +371,11 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
       -- Ignore the following settings, they don't affect the generated HDL:
 
       -- 1. Debug
-      opt_dbgLevel = DebugNone
-    , opt_dbgTransformations = Set.empty
-    , opt_dbgRewriteHistoryFile = Nothing
+      opt_debug = opt_debug
+        { dbg_invariants = False
+        , dbg_transformations = Set.empty
+        , dbg_historyFile = Nothing
+        }
 
       -- 2. Caching
     , opt_cachehdl = True

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -133,11 +133,11 @@ data ClashOpts = ClashOpts
   -- ^ List the transformations that are to be debugged.
   --
   -- Command line flag: -fclash-debug-transformations
-  , opt_dbgTransformationsFrom :: Int
+  , opt_dbgTransformationsFrom :: Word
   -- ^ Only output debug information from (applied) transformation n
   --
   -- Command line flag: -fclash-debug-transformations-from
-  , opt_dbgTransformationsLimit :: Int
+  , opt_dbgTransformationsLimit :: Word
   -- ^ Only output debug information for n (applied) transformations. If this
   -- limit is exceeded, Clash will stop normalizing.
   --

--- a/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
@@ -73,13 +73,13 @@ import Clash.Core.VarEnv
   , foldlWithUniqueVarEnv', lookupVarEnv, lookupVarEnvDirectly, mkVarEnv
   , notElemVarSet, unionVarEnv, unionVarEnvWith, unitVarSet)
 import Clash.Debug (trace, traceIf)
-import Clash.Driver.Types (Binding(..), DebugLevel(..))
+import Clash.Driver.Types (Binding(..), DebugOpts(dbg_invariants))
 import Clash.Netlist.Util (representableType)
 import Clash.Primitives.Types
   (CompiledPrimMap, Primitive(..), TemplateKind(..))
 import Clash.Rewrite.Combinators (allR)
 import Clash.Rewrite.Types
-  ( TransformContext(..), bindings, curFun, customReprs, dbgLevel, extra
+  ( TransformContext(..), bindings, curFun, customReprs, debugOpts, extra
   , tcCache, topEntities, typeTranslator)
 import Clash.Rewrite.Util
   ( changed, inlineBinders, inlineOrLiftBinders, isJoinPointIn
@@ -392,8 +392,8 @@ inlineHO _ e@(App _ _)
               limit     <- Lens.use (extra.inlineLimit)
               if (Maybe.fromMaybe 0 isInlined) > limit
                 then do
-                  lvl <- Lens.view dbgLevel
-                  traceIf (lvl > DebugNone) ($(curLoc) ++ "InlineHO: " ++ show f ++ " already inlined " ++ show limit ++ " times in:" ++ show cf) (return e)
+                  opts <- Lens.view debugOpts
+                  traceIf (dbg_invariants opts) ($(curLoc) ++ "InlineHO: " ++ show f ++ " already inlined " ++ show limit ++ " times in:" ++ show cf) (return e)
                 else do
                   bodyMaybe <- lookupVarEnv f <$> Lens.use bindings
                   case bodyMaybe of

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -79,7 +79,7 @@ data RewriteState extra
   = RewriteState
     -- TODO Given we now keep transformCounters, this should just be 'fold'
     -- over that map, otherwise the two counts could fall out of sync.
-  { _transformCounter :: {-# UNPACK #-} !Int
+  { _transformCounter :: {-# UNPACK #-} !Word
   -- ^ Total number of applied transformations
   , _transformCounters :: HashMap Text Word
   -- ^ Map that tracks how many times each transformation is applied
@@ -115,9 +115,9 @@ data RewriteEnv
   -- ^ Level at which we print debugging messages
   , _dbgTransformations :: Set.Set String
   -- ^ See ClashOpts.dbgTransformations
-  , _dbgTransformationsFrom :: Int
+  , _dbgTransformationsFrom :: Word
   -- ^ See ClashOpts.opt_dbgTransformationsFrom
-  , _dbgTransformationsLimit :: Int
+  , _dbgTransformationsLimit :: Word
   -- ^ See ClashOpts.opt_dbgTransformationsLimit
   , _dbgRewriteHistoryFile :: Maybe FilePath
   -- ^ See ClashOpts.opt_dbgRewriteHistory

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -36,7 +36,6 @@ import Data.Hashable                         (Hashable)
 import Data.HashMap.Strict                   (HashMap)
 import Data.IntMap.Strict                    (IntMap)
 import Data.Monoid                           (Any)
-import qualified Data.Set                    as Set
 import Data.Text                             (Text)
 import GHC.Generics
 
@@ -52,7 +51,7 @@ import Clash.Core.Type           (Type)
 import Clash.Core.TyCon          (TyConName, TyConMap)
 import Clash.Core.Var            (Id)
 import Clash.Core.VarEnv         (InScopeSet, VarSet, VarEnv)
-import Clash.Driver.Types        (BindingMap, DebugLevel)
+import Clash.Driver.Types        (BindingMap, DebugOpts)
 import Clash.Netlist.Types       (FilteredHWType, HWMap)
 import Clash.Rewrite.WorkFree    (isWorkFree)
 import Clash.Util
@@ -111,16 +110,8 @@ Lens.makeLenses ''RewriteState
 -- | Read-only environment of a rewriting session
 data RewriteEnv
   = RewriteEnv
-  { _dbgLevel       :: DebugLevel
-  -- ^ Level at which we print debugging messages
-  , _dbgTransformations :: Set.Set String
-  -- ^ See ClashOpts.dbgTransformations
-  , _dbgTransformationsFrom :: Word
-  -- ^ See ClashOpts.opt_dbgTransformationsFrom
-  , _dbgTransformationsLimit :: Word
-  -- ^ See ClashOpts.opt_dbgTransformationsLimit
-  , _dbgRewriteHistoryFile :: Maybe FilePath
-  -- ^ See ClashOpts.opt_dbgRewriteHistory
+  { _debugOpts      :: DebugOpts
+  -- ^ Options for debugging during rewriting
   , _aggressiveXOpt :: Bool
   -- ^ Transformations to print debugging info for
   , _typeTranslator :: CustomReprs

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -199,7 +199,7 @@ applyDebug
   -- ^ The current debugging level
   -> Set.Set String
   -- ^ Transformations to debug
-  -> Maybe (Int, Int)
+  -> Maybe (Word, Word)
   -- ^ Only print debug information for transformations [n, n+limit]. See flag
   -- documentation of "-fclash-debug-transformations-from" and
   -- "-fclash-debug-transformations-limit"

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -22,7 +22,7 @@ import qualified Clash.Core.Literal as C
 import qualified Clash.Core.Type as C
 import qualified Clash.Core.Var as C
 import Clash.Core.VarEnv (InScopeSet, emptyVarSet, emptyVarEnv, emptyInScopeSet)
-import Clash.Driver.Types (DebugLevel(DebugSilent))
+import Clash.Driver.Types (debugSilent)
 import Clash.Rewrite.Types
 import Clash.Rewrite.Util (runRewrite)
 import Clash.Normalize.Types
@@ -44,7 +44,6 @@ import qualified Language.Haskell.TH.Quote as TH
 import qualified Data.List as List
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.IntMap as IntMap
 import qualified Data.Text as Text
 
@@ -61,11 +60,7 @@ lookupTM u tm = case HashMap.lookup u tm of
 
 instance Default RewriteEnv where
   def = RewriteEnv
-    { _dbgLevel=DebugSilent
-    , _dbgTransformations=Set.empty
-    , _dbgTransformationsFrom=0
-    , _dbgTransformationsLimit=maxBound
-    , _dbgRewriteHistoryFile=Nothing
+    { _debugOpts=debugSilent
     , _aggressiveXOpt=False
     , _typeTranslator=error "_typeTranslator: NYI"
     , _tcCache=emptyUniqMap

--- a/docs/developing-hardware/flags.rst
+++ b/docs/developing-hardware/flags.rst
@@ -33,6 +33,34 @@ Clash Compiler Flags
 
   **Default:** ``DebugNone``
 
+  .. info:: This flag exists for backwards compatibility. It is now possible to
+  set debugging flags individually with `-fclash-debug-invariants`,
+  `-fclash-debug-info` and `-fclash-debug-count-transformations`.
+
+-fclash-debug-invariants
+  Check invariants while debugging and print warnings / errors which may be
+  useful, such as alterting when unexpected changes occur or when a
+  transformation introduces free variables / shadowing.
+
+-fclash-debug-info
+  Specify the information to show about individual transformations while
+  debugging. From least to most information, these are
+
+  - ``None`` to show no information
+  - ``FinalTerm`` to show the final result of normalization
+  - ``AppliedName`` to show the names of applied transformations
+  - ``AppliedTerm`` to show the result of applied transformations
+  - ``TryName`` to show the names of attempted transforamtions, as well as the
+    result of any transformations which are applied
+  - ``TryTerm`` to show the names and results of all transformations attempted
+    whether they were applied or not
+
+    **Default:** ``None``
+
+-fclash-debug-count-transformations
+  Count the transformations that are applied and print a summary at the end
+  of the normalization phase.
+
 -fclash-debug-history[=FILENAME]
   Saves all applied rewrites into ``FILENAME``,
   for later analysis with the clash-term tool.
@@ -48,8 +76,8 @@ Clash Compiler Flags
 
   **Default:** []
 
--fclash-debug-transformations-from
-  Only print debug output from applied transformation ``n`` and onwards.
+-fclash-debug-transformations-from=N
+  Only print debug output from applied transformation ``N`` and onwards.
 
   .. code-block:: bash
 
@@ -57,8 +85,8 @@ Clash Compiler Flags
 
   **Default:** 0
 
--fclash-debug-transformations-limit
-  Only print debug output for ``n`` applied transformations.
+-fclash-debug-transformations-limit=N
+  Only print debug output for ``N`` applied transformations.
 
   .. code-block:: bash
 


### PR DESCRIPTION
The old `DebugLevel` style debug options are replaced with a more granular style, where different options can be set independently. This allows things not previously possible, such as counting  transformations without having to print any normalized core.
    
The old `-fclash-debug` flag still works in the same way for backwards compatibility. Additional command line flags are now available to directly set options from the new type:
    
  * `-fclash-debug-invariants` checks for invariants and displays warnings / errors. Setting this alone is equivalent to `DebugSilent`.
  * `-fclash-debug-info` sets the amount of information to display when applying transformations. This overlaps a lot with the old `DebugLevel` type, but is named more consistently.
  * `-fclash-debug-count-transformations` counts the number of transformations applied (without showing any normalized core like `DebugCount` did)

Additionally, the debugging options are now in their own type (`DebugOpts`) which is accessed directly through the `RewriteEnv` in `apply` / `applyDebug` instead of having the individual debugging options passed as inputs to the function. This simplifies the logic slightly in these functions and avoids needing to call `applyDebug` recursively with modified values.

Fixes #1800 

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
