### PR TITLE
New: mergeEnable

### DIFF
--- a/changelog/2021-06-10T17_05_36+02_00_mergeEnable
+++ b/changelog/2021-06-10T17_05_36+02_00_mergeEnable
@@ -1,0 +1,1 @@
+ADDED: `Clash.Signal.mergeEnable`. Same functionality as `Clash.Explicit.Signal.enable`, but for hidden enables.

--- a/tests/shouldwork/Signal/MergeEnable.hs
+++ b/tests/shouldwork/Signal/MergeEnable.hs
@@ -1,0 +1,36 @@
+module MergeEnable where
+
+import Clash.Prelude
+
+import qualified Clash.Explicit.Prelude as CEP
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock System
+  -> Reset System
+  -> Enable System
+  -> Signal System Bool
+  -> Signal System (Unsigned 8)
+  -> Signal System (Unsigned 8)
+topEntity clk rst en enM =
+  let f :: HiddenClockResetEnable dom
+        => Signal dom Bool
+        -> Signal dom (Unsigned 8)
+        -> Signal dom (Unsigned 8)
+      f enM0 = mergeEnable enM0 $ register 0
+  in withClockResetEnable clk rst en (f enM)
+
+testBench
+  :: Signal System Bool
+testBench = done
+ where
+  enM = True :> True :> False :> True :> Nil
+  en  = True :> True :> True  :> True :> False :> True :> Nil
+  enM0 = stimuliGenerator clk rst enM
+  en0 = toEnable $ stimuliGenerator clk rst en
+  inp = CEP.delay clk enableGen 0 $ inp + 1
+  expectedOutput =
+    outputVerifier clk rst $ 0 :> 1 :> 2 :> 2 :> 4 :> 4 :> 6 :> Nil
+  done = expectedOutput $ topEntity clk rst en0 enM0 inp
+  clk = tbSystemClockGen (not <$> done)
+  rst = systemResetGen


### PR DESCRIPTION
The "hidden" counterpart to `Clash.Explicit.Signal.enable`.

Also corrected some outdated documentation from before we added enables,
and some copy-paste mistakes in the documentation.

* The current implementation of `mergeEnable` was written for components with single clock domains. Is this enough?

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
