### PR TITLE
Report changes in constantSpec / reduceNonRepPrim

### DIFF
--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -485,7 +485,7 @@ reduceIterateI (TransformContext is0 ctx) n aTy vTy f0 a = do
   --   in
   --     (a :> el1 :> el2 :> el3 :> ..)
   --
-  pure (Letrec (zip elementIds elems) vec)
+  changed (Letrec (zip elementIds elems) vec)
 
 -- | Replace an application of the @Clash.Sized.Vector.traverse#@ primitive on
 -- vectors of a known length @n@, by the fully unrolled recursive "definition"

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -275,7 +275,7 @@ applyDebug lvl _transformations _fromLimit name exprOld hasChanged exprNew =
                      ]
             ) (return ())
 
-  Monad.when (lvl >= DebugApplied && not hasChanged && not (exprOld `aeqTerm` exprNew)) $
+  Monad.when (lvl >= DebugSilent && not hasChanged && not (exprOld `aeqTerm` exprNew)) $
     error $ $(curLoc) ++ "Expression changed without notice(" ++ name ++  "): before"
                       ++ before ++ "\nafter:\n" ++ after
 


### PR DESCRIPTION
These transformations were previously not reporting all times when
they were applied / changed the input term. However, the check for
this was only enabled with DebugApplied or higher, which meant CI
would not identify these mistakes (as CI uses DebugSilent).

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files