### PR TITLE
Move `specializeNorm` / `specialise`

### DIFF
--- a/clash-lib/src/Clash/Normalize/Transformations/ANF.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/ANF.hs
@@ -44,8 +44,8 @@ import Clash.Core.Util (mkSelectorCase)
 import Clash.Core.Var (Id)
 import Clash.Core.VarEnv (InScopeSet, extendInScopeSet, extendInScopeSetList)
 import Clash.Netlist.Util (bindsExistentials)
+import Clash.Normalize.Transformations.Specialize (specialize)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession)
-import Clash.Normalize.Util (specializeNorm)
 import Clash.Rewrite.Combinators (bottomupR)
 import Clash.Rewrite.Types
   (Transform, TransformContext(..), tcCache)
@@ -332,9 +332,9 @@ nonRepANF ctx@(TransformContext is0 _) e@(App appConPrim arg)
         -- This is a situation similar to Note [CaseLet deshadow]
         let (binds1,body1) = deshadowLetExpr is0 binds body
         in  changed (Letrec binds1 (App appConPrim body1))
-      (True,Case {})  -> specializeNorm ctx e
-      (True,Lam {})   -> specializeNorm ctx e
-      (True,TyLam {}) -> specializeNorm ctx e
+      (True,Case {})  -> specialize ctx e
+      (True,Lam {})   -> specialize ctx e
+      (True,TyLam {}) -> specialize ctx e
       _               -> return e
 
 nonRepANF _ e = return e

--- a/clash-lib/src/Clash/Normalize/Transformations/Cast.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Cast.hs
@@ -23,8 +23,8 @@ import Clash.Core.Type (normalizeType)
 import Clash.Core.Var (varName)
 import Clash.Core.VarEnv (InScopeSet)
 import Clash.Debug (trace)
+import Clash.Normalize.Transformations.Specialize (specialize)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession)
-import Clash.Normalize.Util (specializeNorm)
 import Clash.Rewrite.Types
   (TransformContext(..), bindings, curFun, tcCache, workFreeBinders)
 import Clash.Rewrite.Util (changed, mkDerivedName, mkTmBinderFor)
@@ -62,7 +62,7 @@ argCastSpec ctx e@(App f (stripTicks -> Cast e' _ _))
     True -> go
     False -> warn go
  where
-  go = specializeNorm ctx e
+  go = specialize ctx e
   warn = trace (unwords
     [ "WARNING:", $(curLoc), "specializing a function on a non work-free"
     , "cast. Generated HDL implementation might contain duplicate work."

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -9,49 +9,79 @@
   Transformations for specialisation.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Clash.Normalize.Transformations.Specialize
   ( appProp
   , constantSpec
+  , specialize
   , nonRepSpec
   , typeSpec
   ) where
 
+import Control.Arrow ((***), (&&&))
+import Control.DeepSeq (deepseq)
+import Control.Exception (throw)
+import Control.Lens ((%=))
 import qualified Control.Lens as Lens
+import qualified Control.Monad as Monad
 import Control.Monad.Extra (orM)
 import qualified Control.Monad.Writer as Writer (listen)
+import Data.Bifunctor (bimap)
+import Data.Coerce (coerce)
 import qualified Data.Either as Either
+import Data.Functor.Const (Const(..))
+import qualified Data.Map.Strict as Map
 import qualified Data.Monoid as Monoid (getAny)
+import qualified Data.Set.Ordered as OSet
+import qualified Data.Set.Ordered.Extra as OSet
+import qualified Data.Text as Text
 import GHC.Stack (HasCallStack)
 
-import Clash.Core.FreeVars (termFreeTyVars, typeFreeVars)
-import Clash.Core.Name (NameSort(..), nameSort)
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Types.Basic (InlineSpec (..))
+#else
+import BasicTypes (InlineSpec (..))
+#endif
+
+import Clash.Core.FreeVars (freeLocalVars, termFreeTyVars, typeFreeVars)
+import Clash.Core.Name
+  (NameSort(..), Name(nameSort), appendToName, mkUnsafeInternalName)
+import Clash.Core.Pretty (showPpr)
 import Clash.Core.Subst
-  (deShadowAlt, deShadowTerm, extendIdSubst, extendTvSubst, mkSubst, substTm)
 import Clash.Core.Term
   ( Term(..), TickInfo, collectArgs, collectArgsTicks, mkApps, mkTicks, patIds
-  , patVars)
-import Clash.Core.TermInfo (isLocalVar, isVar, piResultTy, termType)
-import Clash.Core.Type (Type, applyFunTy)
-import Clash.Core.Var (Var(..))
+  , patVars, mkAbstraction)
+import Clash.Core.TermInfo (isLocalVar, isVar, piResultTy, termType, isPolyFun)
+import Clash.Core.Type (Type(VarTy), applyFunTy, normalizeType)
+import Clash.Core.Var (Var(..), Id, TyVar)
 import Clash.Core.VarEnv
   ( InScopeSet, extendInScopeSet, extendInScopeSetList, lookupVarEnv
-  , mkInScopeSet, mkVarSet, unionInScope)
-import Clash.Driver.Types (Binding(..))
+  , mkInScopeSet, mkVarSet, unionInScope, elemVarSet)
+import Clash.Debug (traceIf, traceM)
+import Clash.Driver.Types (Binding(..), TransformationInfo(..), hasTransformationInfo)
 import Clash.Netlist.Util (representableType)
 import Clash.Rewrite.Combinators (topdownR)
 import Clash.Rewrite.Types
-  ( TransformContext(..), bindings, censor, customReprs, tcCache
-  , typeTranslator, workFreeBinders)
-import Clash.Rewrite.Util (mkDerivedName, mkTmBinderFor, setChanged, changed)
+  ( TransformContext(..), bindings, censor, curFun, customReprs, extra, tcCache
+  , typeTranslator, workFreeBinders, debugOpts, topEntities)
+import Clash.Rewrite.Util
+  ( mkBinderFor, mkDerivedName, mkFunction, mkTmBinderFor, setChanged, changed
+  , normalizeTermTypes, normalizeId)
 import Clash.Rewrite.WorkFree (isWorkFree)
-import Clash.Normalize.Types (NormRewrite, NormalizeSession)
+import Clash.Normalize.Types
+  ( NormRewrite, NormalizeSession, specialisationCache, specialisationHistory
+  , specialisationLimit)
 import Clash.Normalize.Util
-  ( constantSpecInfo, csrFoundConstant, csrNewBindings, csrNewTerm
-  , specializeNorm)
+  (constantSpecInfo, csrFoundConstant, csrNewBindings, csrNewTerm)
+import Clash.Unique
+  ( eltsUniqMap, eltsUniqSet, extendUniqMapWith, unitUniqSet, filterUniqMap
+  , lookupUniqMap)
+import Clash.Util (ClashException(..))
 
 -- | Propagate arguments of application inwards; except for 'Lam' where the
 -- argument becomes let-bound. 'appProp' tries to propagate as many arguments
@@ -232,11 +262,11 @@ constantSpec ctx@(TransformContext is0 tfCtx) e@(App e1 e2)
          let newBindings = csrNewBindings specInfo in
          if null newBindings then
            -- Whole of e2 is constant
-           specializeNorm ctx (App e1 e2)
+           specialize ctx (App e1 e2)
          else do
            -- Parts of e2 are constant
            let is1 = extendInScopeSetList is0 (fst <$> csrNewBindings specInfo)
-           (body, isSpec) <- Writer.listen $ specializeNorm
+           (body, isSpec) <- Writer.listen $ specialize
              (TransformContext is1 tfCtx)
              (App e1 (csrNewTerm specInfo))
 
@@ -248,6 +278,208 @@ constantSpec ctx@(TransformContext is0 tfCtx) e@(App e1 e2)
         return e
 constantSpec _ e = return e
 {-# SCC constantSpec #-}
+
+-- | Specialise an application on its argument
+specialize :: NormRewrite
+specialize ctx e = case e of
+  (TyApp e1 ty) -> specialize' ctx e (collectArgsTicks e1) (Right ty)
+  (App e1 e2)   -> specialize' ctx e (collectArgsTicks e1) (Left  e2)
+  _             -> return e
+
+-- | Specialise an application on its argument
+specialize'
+  :: TransformContext
+  -- ^ Transformation context
+  -> Term
+  -- ^ Original term
+  -> (Term, [Either Term Type], [TickInfo])
+  -- ^ Function part of the term, split into root and applied arguments
+  -> Either Term Type
+  -- ^ Argument to specialize on
+  -> NormalizeSession Term
+specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
+  opts <- Lens.view debugOpts
+  tcm <- Lens.view tcCache
+
+  -- Don't specialise TopEntities
+  topEnts <- Lens.view topEntities
+  if f `elemVarSet` topEnts
+  then do
+    case specArgIn of
+      Left _ -> do
+        traceM ("Not specializing TopEntity: " ++ showPpr (varName f))
+        return e
+      Right tyArg ->
+        traceIf (hasTransformationInfo AppliedTerm opts) ("Dropping type application on TopEntity: " ++ showPpr (varName f) ++ "\ntype:\n" ++ showPpr tyArg) $
+        -- TopEntities aren't allowed to be semantically polymorphic.
+        -- But using type equality constraints they may be syntactically polymorphic.
+        -- > topEntity :: forall dom . (dom ~ "System") => Signal dom Bool -> Signal dom Bool
+        -- The TyLam's in the body will have been removed by 'Clash.Normalize.Util.substWithTyEq'.
+        -- So we drop the TyApp ("specialising" on it) and change the varType to match.
+        let newVarTy = piResultTy tcm (varType f) tyArg
+        in  changed (mkApps (mkTicks (Var f{varType = newVarTy}) ticks) args)
+  else do -- NondecreasingIndentation
+
+  let specArg = bimap (normalizeTermTypes tcm) (normalizeType tcm) specArgIn
+      -- Create binders and variable references for free variables in 'specArg'
+      -- (specBndrsIn,specVars) :: ([Either Id TyVar], [Either Term Type])
+      (specBndrsIn,specVars) = specArgBndrsAndVars specArg
+      argLen  = length args
+      specBndrs :: [Either Id TyVar]
+      specBndrs = map (Lens.over Lens._Left (normalizeId tcm)) specBndrsIn
+      specAbs :: Either Term Type
+      specAbs = either (Left . (`mkAbstraction` specBndrs)) (Right . id) specArg
+  -- Determine if 'f' has already been specialized on (a type-normalized) 'specArg'
+  specM <- Map.lookup (f,argLen,specAbs) <$> Lens.use (extra.specialisationCache)
+  case specM of
+    -- Use previously specialized function
+    Just f' ->
+      traceIf (hasTransformationInfo AppliedTerm opts)
+        ("Using previous specialization of " ++ showPpr (varName f) ++ " on " ++
+          (either showPpr showPpr) specAbs ++ ": " ++ showPpr (varName f')) $
+        changed $ mkApps (mkTicks (Var f') ticks) (args ++ specVars)
+    -- Create new specialized function
+    Nothing -> do
+      -- Determine if we can specialize f
+      bodyMaybe <- fmap (lookupUniqMap (varName f)) $ Lens.use bindings
+      case bodyMaybe of
+        Just (Binding _ sp inl _ bodyTm) -> do
+          -- Determine if we see a sequence of specialisations on a growing argument
+          specHistM <- lookupUniqMap f <$> Lens.use (extra.specialisationHistory)
+          specLim   <- Lens.use (extra . specialisationLimit)
+          if maybe False (> specLim) specHistM
+            then throw (ClashException
+                        sp
+                        (unlines [ "Hit specialization limit " ++ show specLim ++ " on function `" ++ showPpr (varName f) ++ "'.\n"
+                                 , "The function `" ++ showPpr f ++ "' is most likely recursive, and looks like it is being indefinitely specialized on a growing argument.\n"
+                                 , "Body of `" ++ showPpr f ++ "':\n" ++ showPpr bodyTm ++ "\n"
+                                 , "Argument (in position: " ++ show argLen ++ ") that triggered termination:\n" ++ (either showPpr showPpr) specArg
+                                 , "Run with '-fclash-spec-limit=N' to increase the specialization limit to N."
+                                 ])
+                        Nothing)
+            else do
+              let existingNames = collectBndrsMinusApps bodyTm
+                  newNames      = [ mkUnsafeInternalName ("pTS" `Text.append` Text.pack (show n)) n
+                                  | n <- [(0::Int)..]
+                                  ]
+              -- Make new binders for existing arguments
+              (boundArgs,argVars) <- fmap (unzip . map (either (Left &&& Left . Var) (Right &&& Right . VarTy))) $
+                                     Monad.zipWithM
+                                       (mkBinderFor is0 tcm)
+                                       (existingNames ++ newNames)
+                                       args
+              -- Determine name the resulting specialized function, and the
+              -- form of the specialized-on argument
+              (fId,inl',specArg') <- case specArg of
+                Left a@(collectArgsTicks -> (Var g,gArgs,_gTicks)) -> if isPolyFun tcm a
+                    then do
+                      -- In case we are specialising on an argument that is a
+                      -- global function then we use that function's name as the
+                      -- name of the specialized higher-order function.
+                      -- Additionally, we will return the body of the global
+                      -- function, instead of a variable reference to the
+                      -- global function.
+                      --
+                      -- This will turn things like @mealy g k@ into a new
+                      -- binding @g'@ where both the body of @mealy@ and @g@
+                      -- are inlined, meaning the state-transition-function
+                      -- and the memory element will be in a single function.
+                      gTmM <- fmap (lookupUniqMap (varName g)) $ Lens.use bindings
+                      return (g,maybe inl bindingSpec gTmM, maybe specArg (Left . (`mkApps` gArgs) . bindingTerm) gTmM)
+                    else return (f,inl,specArg)
+                _ -> return (f,inl,specArg)
+              -- Create specialized functions
+              let newBody = mkAbstraction (mkApps bodyTm (argVars ++ [specArg'])) (boundArgs ++ specBndrs)
+              newf <- mkFunction (varName fId) sp inl' newBody
+              -- Remember specialization
+              (extra.specialisationHistory) %= extendUniqMapWith f 1 (+)
+              (extra.specialisationCache)  %= Map.insert (f,argLen,specAbs) newf
+              -- use specialized function
+              let newExpr = mkApps (mkTicks (Var newf) ticks) (args ++ specVars)
+              newf `deepseq` changed newExpr
+        Nothing -> return e
+  where
+    collectBndrsMinusApps :: Term -> [Name a]
+    collectBndrsMinusApps = reverse . go []
+      where
+        go bs (Lam v e')    = go (coerce (varName v):bs)  e'
+        go bs (TyLam tv e') = go (coerce (varName tv):bs) e'
+        go bs (App e' _) = case go [] e' of
+          []  -> bs
+          bs' -> init bs' ++ bs
+        go bs (TyApp e' _) = case go [] e' of
+          []  -> bs
+          bs' -> init bs' ++ bs
+        go bs _ = bs
+
+-- Specialising non Var's is used by nonRepANF
+specialize' _ctx _ (appE,args,ticks) (Left specArg) = do
+  -- Create binders and variable references for free variables in 'specArg'
+  let (specBndrs,specVars) = specArgBndrsAndVars (Left specArg)
+  -- Create specialized function
+      newBody = mkAbstraction specArg specBndrs
+  -- See if there's an existing binder that's alpha-equivalent to the
+  -- specialized function
+  existing <- filterUniqMap ((`aeqTerm` newBody) . bindingTerm) <$> Lens.use bindings
+  -- Create a new function if an alpha-equivalent binder doesn't exist
+  newf <- case eltsUniqMap existing of
+    [] -> do (cf,sp) <- Lens.use curFun
+             mkFunction (appendToName (varName cf) "_specF") sp NoUserInline newBody
+    (b:_) -> return (bindingId b)
+  -- Create specialized argument
+  let newArg  = Left $ mkApps (Var newf) specVars
+  -- Use specialized argument
+  let newExpr = mkApps (mkTicks appE ticks) (args ++ [newArg])
+  changed newExpr
+
+specialize' _ e _ _ = return e
+
+-- Note [Collect free-variables in an insertion-ordered set]
+--
+-- In order for the specialization cache to work, 'specArgBndrsAndVars' should
+-- yield (alpha equivalent) results for the same specialization. While collecting
+-- free variables in a given term or type it should therefore keep a stable
+-- ordering based on the order in which it finds free vars. To see why,
+-- consider the following two pseudo-code calls to 'specialise':
+--
+--     specialise {f ('a', x[123], y[456])}
+--     specialise {f ('b', x[456], y[123])}
+--
+-- Collecting the binders in a VarSet would yield the following (unique ordered)
+-- sets:
+--
+--     {x[123], y[456]}
+--     {y[123], x[456]}
+--
+-- ..and therefore breaking specializing caching. We now track them in insert-
+-- ordered sets, yielding:
+--
+--     {x[123], y[456]}
+--     {x[456], y[123]}
+--
+
+-- | Create binders and variable references for free variables in 'specArg'
+specArgBndrsAndVars
+  :: Either Term Type
+  -> ([Either Id TyVar], [Either Term Type])
+specArgBndrsAndVars specArg =
+  -- See Note [Collect free-variables in an insertion-ordered set]
+  let unitFV :: Var a -> Const (OSet.OLSet TyVar, OSet.OLSet Id) (Var a)
+      unitFV v@(Id {}) = Const (mempty, coerce (OSet.singleton (coerce v)))
+      unitFV v@(TyVar {}) = Const (coerce (OSet.singleton (coerce v)), mempty)
+
+      (specFTVs,specFVs) = case specArg of
+        Left tm  -> (OSet.toListL *** OSet.toListL) . getConst $
+                    Lens.foldMapOf freeLocalVars unitFV tm
+        Right ty -> (eltsUniqSet (Lens.foldMapOf typeFreeVars unitUniqSet ty),[] :: [Id])
+
+      specTyBndrs = map Right specFTVs
+      specTmBndrs = map Left  specFVs
+
+      specTyVars  = map (Right . VarTy) specFTVs
+      specTmVars  = map (Left . Var) specFVs
+
+  in  (specTyBndrs ++ specTmBndrs,specTyVars ++ specTmVars)
 
 -- | Specialize functions on their non-representable argument
 nonRepSpec :: HasCallStack => NormRewrite
@@ -266,7 +498,7 @@ nonRepSpec ctx e@(App e1 e2)
        if nonRepE2 && not localVar
          then do
            e2' <- inlineInternalSpecialisationArgument e2
-           specializeNorm ctx (App e1 e2')
+           specialize ctx (App e1 e2')
          else return e
   where
     -- | If the argument on which we're specialising ia an internal function,
@@ -301,7 +533,7 @@ typeSpec ctx e@(TyApp e1 ty)
   | (Var {},  args) <- collectArgs e1
   , null $ Lens.toListOf typeFreeVars ty
   , (_, []) <- Either.partitionEithers args
-  = specializeNorm ctx e
+  = specialize ctx e
 
 typeSpec _ e = return e
 {-# SCC typeSpec #-}

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -18,7 +18,6 @@ module Clash.Normalize.Util
  , shouldReduce
  , alreadyInlined
  , addNewInline
- , specializeNorm
  , isRecursiveBndr
  , isClosed
  , callGraph
@@ -87,7 +86,7 @@ import           Clash.Rewrite.Types
   (RewriteMonad, TransformContext(..), bindings, curFun, debugOpts, extra,
    tcCache)
 import           Clash.Rewrite.Util
-  (runRewrite, specialise, mkTmBinderFor, mkDerivedName)
+  (runRewrite, mkTmBinderFor, mkDerivedName)
 import           Clash.Unique
 import           Clash.Util              (SrcSpan, makeCachedU)
 
@@ -158,10 +157,6 @@ addNewInline f cf =
                      cf
                      (unitVarEnv f 1)
                      (\_ hm -> extendVarEnvWith f 1 (+) hm)
-
--- | Specialize under the Normalization Monad
-specializeNorm :: NormRewrite
-specializeNorm = specialise specialisationCache specialisationHistory specialisationLimit
 
 -- | Determine if a term is closed
 isClosed :: TyConMap


### PR DESCRIPTION
The functions that perform most of the work for transformations like `constantSpec` were defined across two Util modules. This can be simplified and the simplified version moved to the `Clash.Normalize.Transformations.Specialize` module where it is easier to find.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
