### PR TITLE
Use debian-bindist image in pack-test stage

### DIFF
--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -66,7 +66,7 @@ debian-bindist:
 debian-bindist-test:
   extends: .run-on-nightly-and-changes
   needs: ["debian-bindist"]
-  image: ubuntu:focal
+  image: docker.pkg.github.com/clash-lang/clash-compiler/bindist-debian-focal:2021-06-16
   stage: pack-test
   script:
     - apt-get update


### PR DESCRIPTION
The tests run on the debian-bindist-test do not use the CI image
used to make the bindist in the first place. This means it lacks
dependencies needed to properly test the built package.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files