### PR TITLE
Upgrade CI docker image

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -1,75 +1,108 @@
-FROM ubuntu:focal
+# syntax=docker/dockerfile:1.2
 
-ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/bin:/root/.ghcup/bin:$PATH
+# Using buildkit we can build the different dependencies for CI independently,
+# meaning upgrading one dependency won't force the others to be rebuilt. As a
+# bonus, the host running 'docker build' will build the stages in parallel.
+#
+# To use buildkit, you need to set DOCKER_BUILDKIT=1 in your shell
 
-ARG DEPS_GHC="curl libc6-dev libgmp-dev pkg-config libnuma-dev"
-ARG DEPS_CABAL="zlib1g-dev"
-ARG DEPS_GHDL="clang gcc gnat llvm-9-dev"
-ARG DEPS_SYMBIYOSYS="tclsh git python python3 build-essential bison flex libreadline-dev gawk tcl-dev libffi-dev autoconf cmake"
-ARG DEPS_CLASH="libtinfo-dev libtinfo5"
-ARG DEPS_CLASH_COSIM="make"
+ARG UBUNTU_VERSION=focal-20210416
+FROM ubuntu:$UBUNTU_VERSION AS builder
 
+LABEL vendor="QBayLogic B.V." maintainer="devops@qbaylogic.com"
+ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8 PREFIX=/opt
+
+ARG DEPS_COMMON="autoconf bison build-essential ca-certificates clang curl flex gcc g++ git make zlib1g-dev"
 RUN apt-get update \
- # GHDL compilation fails without dist-upgrade
- && apt-get dist-upgrade -y \
- && apt-get install -y --no-install-recommends --no-install-suggests \
-      $DEPS_GHC $DEPS_CABAL \
-      $DEPS_GHDL $DEPS_IVERILOG \
-      $DEPS_SYMBIYOSYS \
-      $DEPS_CLASH $DEPS_CLASH_COSIM \
-      ca-certificates iverilog pixz jq zstd \
-      git ssh \
- && curl -L 'https://github.com/ghdl/ghdl/archive/v0.37.tar.gz' \
-      | tar -xz \
- && apt-get autoremove -y --purge \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- && cd /ghdl-0.37 \
- && ./configure --with-llvm-config=llvm-config-9 --prefix=/opt \
- && make -j$(nproc) \
- && make install \
- && cd .. \
- && rm -rf ghdl-0.37
+ && apt-get install -y --no-install-recommends $DEPS_COMMON
 
-ARG YOSYS_VERSION="8cfed1a97957e4c096d1e0a0304d978bcb27e116"
+FROM builder AS build-ghdl
+
+ARG DEPS_GHDL="gnat llvm-11-dev"
+RUN apt-get install -y --no-install-recommends $DEPS_GHDL
+
+ARG ghdl_version="1.0.0"
+RUN curl -L "https://github.com/ghdl/ghdl/archive/v$ghdl_version.tar.gz" \
+        | tar -xz \
+ && cd ghdl-$ghdl_version \
+ && ./configure --with-llvm-config=llvm-config-11 --prefix=$PREFIX \
+ && make -j$(nproc) \
+ && make install
+
+FROM builder AS build-iverilog
+
+ARG DEPS_IVERILOG="gperf"
+RUN apt-get install -y --no-install-recommends $DEPS_IVERILOG
+
+ARG iverilog_version="10_3"
+RUN curl -L "https://github.com/steveicarus/iverilog/archive/v$iverilog_version.tar.gz" \
+        | tar -xz \
+ && cd iverilog-$iverilog_version \
+ && sh autoconf.sh \
+ && ./configure --prefix=$PREFIX \
+ && make -j$(nproc) \
+ && make install
+
+FROM builder AS build-symbiyosys
+
+ARG DEPS_YOSYS="libffi-dev libreadline-dev pkg-config tcl-dev"
+ARG DEPS_Z3="python3 python3-distutils"
+RUN apt-get install -y --no-install-recommends $DEPS_YOSYS $DEPS_Z3
+
+ARG yosys_version="8cfed1a97957e4c096d1e0a0304d978bcb27e116"
 RUN git clone https://github.com/YosysHQ/yosys.git yosys \
  && cd yosys \
- && make -j$(nproc) \
- && make install \
+ && git checkout $yosys_version \
+ && make PREFIX=$PREFIX -j$(nproc) \
+ && make PREFIX=$PREFIX install \
  && cd .. \
  && rm -Rf yosys
 
-ARG Z3_VERSION="z3-4.8.10"
-RUN curl -L "https://github.com/Z3Prover/z3/archive/refs/tags/$Z3_VERSION.tar.gz" \
+ARG z3_version="z3-4.8.10"
+RUN curl -L "https://github.com/Z3Prover/z3/archive/refs/tags/$z3_version.tar.gz" \
       | tar -xz \
- && cd z3-$Z3_VERSION \
- && python scripts/mk_make.py \
+ && cd z3-$z3_version \
+ && python3 scripts/mk_make.py \
  && cd build \
- && make -j$(nproc) \
- && make install \
+ && make PREFIX=$PREFIX -j$(nproc) \
+ && make PREFIX=$PREFIX install \
  && cd ../.. \
- && rm -Rf z3-$Z3_VERSION
+ && rm -Rf z3-$z3_version
 
-ARG SYMBIYOSYS_VERSION="66a458958dc93f8e12418d425e4c31848889937b"
+ARG symbiyosys_version="66a458958dc93f8e12418d425e4c31848889937b"
 RUN git clone https://github.com/cliffordwolf/SymbiYosys.git SymbiYosys \
  && cd SymbiYosys \
- && git checkout $SYMBIYOSYS_VERSION \
- && make install \
+ && git checkout $symbiyosys_version \
+ && make PREFIX=$PREFIX -j$(nproc) install \
  && cd .. \
  && rm -Rf SymbiYosys
 
-ARG GHCUP_VERSION="0.1.14"
-ARG GHCUP_URL="https://downloads.haskell.org/~ghcup/${GHCUP_VERSION}/x86_64-linux-ghcup-${GHCUP_VERSION}"
-ARG GHCUP_BIN=/usr/bin/ghcup
+FROM builder AS build-ghc
 
-ARG cabal_version
-ENV CABAL_VERSION=$cabal_version
-RUN curl $GHCUP_URL --output $GHCUP_BIN \
- && chmod +x $GHCUP_BIN \
- && ghcup install cabal ${CABAL_VERSION} \
- && ghcup set cabal ${CABAL_VERSION}
+ARG ghcup_version="0.1.15.2"
 
+# Must be explicitly set
 ARG ghc_version
-ENV GHC_VERSION=$ghc_version
-RUN ghcup install ghc ${GHC_VERSION} \
- && ghcup set ghc ${GHC_VERSION}
+ARG cabal_version
+
+RUN curl "https://downloads.haskell.org/~ghcup/$ghcup_version/x86_64-linux-ghcup-$ghcup_version" --output /usr/bin/ghcup \
+ && chmod +x /usr/bin/ghcup \
+ && ghcup install ghc $ghc_version --set \
+ && ghcup install cabal $cabal_version --set
+
+ARG UBUNTU_VERSION=focal-20210416
+FROM ubuntu:$UBUNTU_VERSION AS run
+
+LABEL vendor="QBayLogic B.V." maintainer="devops@qbaylogic.com"
+ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH="$PATH:/opt/bin:/root/.ghcup/bin"
+
+ARG DEPS_RUNTIME="ca-certificates gcc git jq libc6-dev libgmp10-dev libgnat-9 libllvm11 libreadline8 libtinfo-dev libtcl8.6 make python3 ssh zlib1g-dev zstd"
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends $DEPS_RUNTIME \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build-ghdl /opt /opt
+COPY --from=build-iverilog /opt /opt
+COPY --from=build-symbiyosys /opt /opt
+COPY --from=build-ghc /root/.ghcup /root/.ghcup

--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -7,8 +7,12 @@ NAME="clash-ci-"
 DIR=$(dirname "$0")
 now=$(date +%F)
 
-GHC_VERSIONS=(  "9.0.1"   "8.10.4"  "8.8.4"   "8.6.5")
+GHC_VERSIONS=(  "9.0.1"   "8.10.2"  "8.8.4"   "8.6.5")
 CABAL_VERSIONS=("3.4.0.0" "3.2.0.0" "3.2.0.0" "3.0.0.0")
+
+# We want to use docker buildkit so that our layers are built in parallel. This
+# is ignored completely on versions of docker which don't support buildkit.
+export DOCKER_BUILDKIT=1
 
 for i in "${!GHC_VERSIONS[@]}"
 do
@@ -18,11 +22,9 @@ do
   docker build \
     --build-arg cabal_version=${CABAL_VERSION} \
     --build-arg ghc_version=${GHC_VERSION} \
-    -t "${REPO}/${NAME}${GHC_VERSION}:$now" "$DIR"
-
-  docker tag \
-    "${REPO}/${NAME}${GHC_VERSION}:$now" \
-    "${REPO}/${NAME}${GHC_VERSION}:latest"
+    -t "${REPO}/${NAME}${GHC_VERSION}:$now" \
+    -t "${REPO}/${NAME}${GHC_VERSION}:latest" \
+    "$DIR"
 done
 
 read -p "Push to GitHub? (y/N) " push

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-05-14
+  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-23
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,5 +1,5 @@
 .common:
-  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-02
+  image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-$GHC_VERSION:2021-06-23
   timeout: 2 hours
   stage: build
   variables:

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -49,11 +49,17 @@ ghc --version
 # This might happen during tags on GitLab CI
 CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH:-no_branch_set_by_ci}
 
+# Set MULTIPLE_HIDDEN on when not building a tag, unless it is already set.
+if [[ $CI_COMMIT_TAG != "" ]]; then
+  MULTIPLE_HIDDEN=${MULTIPLE_HIDDEN:-no}
+else
+  MULTIPLE_HIDDEN=${MULTIPLE_HIDDEN:-yes}
+fi
+
 # File may exist as part of a dist.tar.zst
 if [ ! -f cabal.project.local ]; then
   cp .ci/cabal.project.local .
 
-  MULTIPLE_HIDDEN=${MULTIPLE_HIDDEN:-yes}
   if [[ "$MULTIPLE_HIDDEN" == "yes" ]]; then
     sed -i 's/flags: +doctests/flags: +doctests +multiple-hidden/g' cabal.project.local
   elif [[ "$MULTIPLE_HIDDEN" == "no" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
             ghc: 8.8.4
             multiple_hidden: yes
 
-          - name: GHC 8.10.4, Multiple Hidden
-            ghc: 8.10.4
+          - name: GHC 8.10.2, Multiple Hidden
+            ghc: 8.10.2
             multiple_hidden: yes
 
           - name: GHC 9.0.1, Multiple Hidden
@@ -34,7 +34,7 @@ jobs:
 
     # Run steps inside the clash CI docker image
     container:
-      image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-${{ matrix.ghc }}:2021-06-02
+      image: docker.pkg.github.com/clash-lang/clash-compiler/clash-ci-${{ matrix.ghc }}:2021-06-23
 
       credentials:
         username: clash-lang-builder

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ include:
 # Default GHC / Cabal version. Used for generating Haddock and releasing to
 # Hackage.
 variables:
-  GHC_VERSION: 8.10.4
+  GHC_VERSION: 8.10.2
 
 stages:
   - pre
@@ -40,7 +40,7 @@ tests-8.8:
 tests-8.10:
   extends: .common-trigger
   variables:
-    GHC_VERSION: 8.10.4
+    GHC_VERSION: 8.10.2
 
 tests-9.0:
   extends: .common-trigger
@@ -52,7 +52,7 @@ stack-build:
   needs: []
   stage: test
   variables:
-    GHC_VERSION: 8.10.4
+    GHC_VERSION: 8.10.2
   script:
     - .ci/stack_build.sh
   # Run on shared runners


### PR DESCRIPTION
The CI docker image is now multi-stage, and uses buildkit on compatible
machines to build stages in parallel. This means that changes to the
dockerfile (like updating a dependency build from source) will now
no longer force any other dependencies to be rebuilt.

As a bonus, the final stage now only has dependencies needed to build
and run clash-testsuite, meaning the image is ~0.7GB smaller.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files