### PR TITLE
VHDL: no div/rem/mod by zero in gen'd code

### DIFF
--- a/changelog/2021-07-14T16_25_33+02_00_div_zero
+++ b/changelog/2021-07-14T16_25_33+02_00_div_zero
@@ -1,0 +1,1 @@
+FIXED: div/rem/mod now avoid division by zero during VHDL simulation. Due to the use of concurrent statements, even unreachable code would previously result in simulation error.

--- a/clash-lib/prims/common/Clash_Sized_Internal_Index.primitives
+++ b/clash-lib/prims/common/Clash_Sized_Internal_Index.primitives
@@ -1,8 +1,0 @@
-[ { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.Index.quot#"
-    , "kind"      : "Expression"
-    , "type"      : "quot# :: Index n -> Index n -> Index n"
-    , "template"  : "~ARG[0] / ~ARG[1]"
-    }
-  }
-]

--- a/clash-lib/prims/common/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/common/Clash_Sized_Internal_Signed.primitives
@@ -12,11 +12,4 @@
     , "template"  : "~ARG[1] - ~ARG[2]"
     }
   }
-, { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.Signed.quot#"
-    , "kind"      : "Expression"
-    , "type"      : "quot# :: Signed n -> Signed n -> Signed n"
-    , "template"  : "~ARG[0] / ~ARG[1]"
-    }
-  }
 ]

--- a/clash-lib/prims/common/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/common/Clash_Sized_Internal_Unsigned.primitives
@@ -13,13 +13,6 @@
     }
   }
 , { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.Unsigned.quot#"
-    , "kind"      : "Expression"
-    , "type"      : "quot# :: Unsigned n -> Unsigned n -> Unsigned n"
-    , "template"  : "~ARG[0] / ~ARG[1]"
-    }
-  }
-, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.unsignedToWord"
     , "kind"      : "Expression"
     , "template"  : "~ARG[0]"

--- a/clash-lib/prims/common/GHC_Base.primitives
+++ b/clash-lib/prims/common/GHC_Base.primitives
@@ -4,11 +4,4 @@
     , "primType"  : "Function"
     }
   }
-, { "BlackBox" :
-    { "name"      : "GHC.Base.quotInt"
-    , "kind"      : "Expression"
-    , "type"      : "quotInt :: Int -> Int -> Int"
-    , "template"  : "~ARG[0] / ~ARG[1]"
-    }
-  }
 ]

--- a/clash-lib/prims/common/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/common/GHC_Integer_Type.primitives
@@ -13,13 +13,6 @@
     }
   }
 , { "BlackBox" :
-    { "name"      : "GHC.Integer.Type.quotInteger"
-    , "kind"      : "Expression"
-    , "type"      : "quotInteger :: Integer -> Integer -> Integer"
-    , "template"  : "~ARG[0] / ~ARG[1]"
-    }
-  }
-, { "BlackBox" :
     { "name"      : "GHC.Integer.Type.leInteger"
     , "kind"      : "Expression"
     , "type"      : "leInteger :: Integer -> Integer -> Bool"

--- a/clash-lib/prims/common/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/common/GHC_Num_Integer.primitives
@@ -41,13 +41,6 @@
   }
 }
 , { "BlackBox" :
-  { "name"      : "GHC.Num.Integer.integerQuot"
-  , "kind"      : "Expression"
-  , "type"      : "integerQuot :: Integer -> Integer -> Integer"
-  , "template"  : "~ARG[0] / ~ARG[1]"
-  }
-}
-, { "BlackBox" :
   { "name"      : "GHC.Num.Integer.integerLe"
   , "kind"      : "Expression"
   , "type"      : "integerLe :: Integer -> Integer -> Bool"

--- a/clash-lib/prims/common/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/common/GHC_Num_Natural.primitives
@@ -59,15 +59,6 @@
     }
   },
   {
-    "BlackBox": {
-      "name": "GHC.Num.Natural.naturalQuot",
-      "kind": "Expression",
-      "type": "naturalQuot :: Natural -> Natural -> Natural",
-      "template": "~ARG[0] / ~ARG[1]",
-      "warning": "GHC.Num.Natural.naturalQuot: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
-    }
-  },
-  {
     "Primitive": {
       "name": "GHC.Num.Natural.naturalGcd",
       "workInfo" : "Never",

--- a/clash-lib/prims/common/GHC_Prim.primitives
+++ b/clash-lib/prims/common/GHC_Prim.primitives
@@ -31,13 +31,6 @@
     }
   }
 , { "BlackBox" :
-    { "name"      : "GHC.Prim.quotInt#"
-    , "kind"      : "Expression"
-    , "type"      : "quotInt# :: Int# -> Int# -> Int#"
-    , "template"  : "~ARG[0] / ~ARG[1]"
-    }
-  }
-, { "BlackBox" :
     { "name"      : "GHC.Prim.plusWord#"
     , "kind"      : "Expression"
     , "type"      : "plusWord# :: Word# -> Word# -> Word#"
@@ -49,13 +42,6 @@
     , "kind"      : "Expression"
     , "type"      : "minusWord# :: Word# -> Word# -> Word#"
     , "template"  : "~ARG[0] - ~ARG[1]"
-    }
-  }
-, { "BlackBox" :
-    { "name"      : "GHC.Prim.quotWord#"
-    , "kind"      : "Expression"
-    , "type"      : "quotWord# :: Word# -> Word# -> Word#"
-    , "template"  : "~ARG[0] / ~ARG[1]"
     }
   }
 ]

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Index.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Index.primitives
@@ -135,4 +135,11 @@
     , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN~VAR[bv][1][0+:~SIZE[~TYPO]]~ELSE{{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~ARG[1]}~FI~ELSE~SIZE[~TYPO]'d0~FI"
     }
   }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Index.quot#"
+    , "kind"      : "Expression"
+    , "type"      : "quot# :: Index n -> Index n -> Index n"
+    , "template"  : "~ARG[0] / ~ARG[1]"
+    }
+  }
 ]

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Signed.primitives
@@ -203,4 +203,11 @@
     , "template"  : "~IF~SIZE[~TYP[2]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[2]]]~THEN$signed({~VAR[s][2][~LIT[0]-1],~VAR[s][2][0+:(~SIZE[~TYPO]-1)]})~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[2]]) {~VAR[s][2][~LIT[0]-1]}},~VAR[s][2]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"
     }
   }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Signed.quot#"
+    , "kind"      : "Expression"
+    , "type"      : "quot# :: Signed n -> Signed n -> Signed n"
+    , "template"  : "~ARG[0] / ~ARG[1]"
+    }
+  }
 ]

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Unsigned.primitives
@@ -186,4 +186,11 @@
     , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN~VAR[bv][1][0+:~SIZE[~TYPO]]~ELSE{{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~ARG[1]}~FI~ELSE~SIZE[~TYPO]'d0~FI"
     }
   }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.quot#"
+    , "kind"      : "Expression"
+    , "type"      : "quot# :: Unsigned n -> Unsigned n -> Unsigned n"
+    , "template"  : "~ARG[0] / ~ARG[1]"
+    }
+  }
 ]

--- a/clash-lib/prims/commonverilog/GHC_Base.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Base.primitives
@@ -5,4 +5,11 @@
     , "template"  : "~ARG[0] % ~ARG[1]"
     }
   }
+, { "BlackBox" :
+    { "name"      : "GHC.Base.quotInt"
+    , "kind"      : "Expression"
+    , "type"      : "quotInt :: Int -> Int -> Int"
+    , "template"  : "~ARG[0] / ~ARG[1]"
+    }
+  }
 ]

--- a/clash-lib/prims/commonverilog/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Integer_Type.primitives
@@ -186,4 +186,11 @@
     , "template"  : "(~ARG[0] < ~SIZE[~TYPO]'sd0) ? -~SIZE[~TYPO]'sd1 : ((~ARG[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SIZE[~TYPO]'sd1)"
     }
   }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.quotInteger"
+    , "kind"      : "Expression"
+    , "type"      : "quotInteger :: Integer -> Integer -> Integer"
+    , "template"  : "~ARG[0] / ~ARG[1]"
+    }
+  }
 ]

--- a/clash-lib/prims/commonverilog/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Num_Integer.primitives
@@ -241,4 +241,11 @@ endfunction"
     , "template"  : "(~ARG[0] < ~ARG[1]) ? -~SIZE[~TYPO]'d0 : ((~ARG[0] == ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d2)"
     }
   }
+, { "BlackBox" :
+  { "name"      : "GHC.Num.Integer.integerQuot"
+  , "kind"      : "Expression"
+  , "type"      : "integerQuot :: Integer -> Integer -> Integer"
+  , "template"  : "~ARG[0] / ~ARG[1]"
+  }
+}
 ]

--- a/clash-lib/prims/commonverilog/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Num_Natural.primitives
@@ -110,4 +110,13 @@ endfunction"
   , "template"  : "(~ARG[0] < ~ARG[1]) ? -~SIZE[~TYPO]'d0 : ((~ARG[0] == ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d2)"
   }
 }
+, {
+    "BlackBox": {
+      "name": "GHC.Num.Natural.naturalQuot",
+      "kind": "Expression",
+      "type": "naturalQuot :: Natural -> Natural -> Natural",
+      "template": "~ARG[0] / ~ARG[1]",
+      "warning": "GHC.Num.Natural.naturalQuot: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
+    }
+}
 ]

--- a/clash-lib/prims/commonverilog/GHC_Prim.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Prim.primitives
@@ -475,4 +475,18 @@ end
 // bitReverse64 end"
     }
   }
+, { "BlackBox" :
+    { "name"      : "GHC.Prim.quotInt#"
+    , "kind"      : "Expression"
+    , "type"      : "quotInt# :: Int# -> Int# -> Int#"
+    , "template"  : "~ARG[0] / ~ARG[1]"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Prim.quotWord#"
+    , "kind"      : "Expression"
+    , "type"      : "quotWord# :: Word# -> Word# -> Word#"
+    , "template"  : "~ARG[0] / ~ARG[1]"
+    }
+  }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
@@ -480,16 +480,26 @@ end process;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.quot#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "quot# :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
-    , "template"  : "std_logic_vector(unsigned(~ARG[1]) / unsigned(~ARG[2]))"
+    , "template"  :
+"~RESULT <= std_logic_vector(unsigned(~ARG[1]) / unsigned(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] /= std_logic_vector(to_unsigned(0,~SIZE[~TYP[2]]))) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.rem#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rem# :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
-    , "template"  : "std_logic_vector(unsigned(~ARG[1]) rem unsigned(~ARG[2]))"
+    , "template"  :
+"~RESULT <= std_logic_vector(unsigned(~ARG[1]) rem unsigned(~ARG[2]))
+    -- pragma translate_off
+    when (~ARG[2] /= std_logic_vector(to_unsigned(0,~SIZE[~TYP[2]]))) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBoxHaskell" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.primitives
@@ -116,9 +116,14 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.rem#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rem# :: Index n -> Index n -> Index n"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBoxHaskell" :
@@ -133,6 +138,18 @@
     , "kind"      : "Expression"
     , "type"      : "resize# :: KnownNat m => Index n -> Index m"
     , "template"  : "~IF~SIZE[~TYP[1]]~THENresize(~ARG[1],~SIZE[~TYPO])~ELSEunsigned'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Index.quot#"
+    , "kind"      : "Declaration"
+    , "type"      : "quot# :: Index n -> Index n -> Index n"
+    , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
@@ -134,9 +134,14 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.rem#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rem# :: Signed n -> Signed n -> Signed n"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
@@ -156,7 +161,11 @@ begin
   ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
              (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
              (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
+      -- pragma translate_off
+      when (~VAR[divider][1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
   ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
 -- divSigned end"
@@ -164,9 +173,14 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.mod#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "mod# :: Signed n -> Signed n -> Signed n"
-    , "template"  : "~ARG[0] mod ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] mod ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBoxHaskell" :
@@ -265,6 +279,18 @@ end block;
     , "kind"      : "Expression"
     , "type"      : "truncateB# :: KnownNat m => Signed (n + m) -> Signed m"
     , "template"  : "~IF~SIZE[~TYPO]~THEN~VAR[s][1](~LIT[0]-1 downto 0)~ELSEsigned'(0 downto 1 => '0')~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Signed.quot#"
+    , "kind"      : "Declaration"
+    , "type"      : "quot# :: Signed n -> Signed n -> Signed n"
+    , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
@@ -125,9 +125,14 @@
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.rem#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "rem# :: Unsigned n -> Unsigned n -> Unsigned n"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBoxHaskell" :
@@ -218,6 +223,18 @@
     , "kind"      : "Expression"
     , "type"      : "resize# :: KnownNat m => Unsigned n -> Unsigned m"
     , "template"  : "~IF~SIZE[~TYP[1]]~THENresize(~ARG[1],~LIT[0])~ELSEunsigned'(~SIZE[~TYPO]-1 downto 0 => '0')~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.quot#"
+    , "kind"      : "Declaration"
+    , "type"      : "quot# :: Unsigned n -> Unsigned n -> Unsigned n"
+    , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/GHC_Base.primitives
+++ b/clash-lib/prims/vhdl/GHC_Base.primitives
@@ -1,8 +1,13 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Base.remInt"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "remInt :: Int -> Int -> Int"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
@@ -14,7 +19,11 @@
 ~GENSYM[divInt][0] : block
   signal ~GENSYM[quot_res][1] : ~TYP[1];
 begin
-  ~SYM[1] <= ~ARG[0] / ~ARG[1];
+  ~SYM[1] <= ~ARG[0] / ~ARG[1]
+      -- pragma translate_off
+      when (ARG[1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
   ~RESULT <= ~SYM[1] - 1 when ((~ARG[0] = abs ~ARG[0]) /= (~ARG[1] = abs ~ARG[1])) else
              ~SYM[1];
 end block;
@@ -23,9 +32,26 @@ end block;
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.modInt"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "modInt :: Int -> Int -> Int"
-    , "template"  : "~ARG[0] mod ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] mod ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Base.quotInt"
+    , "kind"      : "Declaration"
+    , "type"      : "quotInt :: Int -> Int -> Int"
+    , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/GHC_Classes.primitives
+++ b/clash-lib/prims/vhdl/GHC_Classes.primitives
@@ -50,7 +50,11 @@ begin
   ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
              (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
              (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
+      -- pragma translate_off
+      when (~VAR[divider][1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
   ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
 -- divInt# end"

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
@@ -52,7 +52,11 @@ begin
   ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
              (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
              (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
+      -- pragma translate_off
+      when (~VAR[divider][1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
   ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
 -- divInteger end"
@@ -77,31 +81,51 @@ end block;
   signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYP[0]] downto 0);
   signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYP[0]] downto 0);
   signal ~GENSYM[div_res][5] : signed(~SIZE[~TYP[0]]-1 downto 0);
+  signal ~GENSYM[mod_res][6] : signed(~SIZE[~TYP[0]]-1 downto 0);
 begin
   ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
   ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
   ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1)   when ~SYM[1] else
              (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) - 1)   when ~SYM[2] else
              (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
+      -- pragma translate_off
+      when (~VAR[divider][1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
   ~SYM[5] <= signed(~SYM[4](~SIZE[~TYP[0]]-1 downto 0));
-  ~RESULT <= (~SYM[5], ~VAR[dividend][0] mod ~VAR[divider][1]);
+  ~SYM[6] <= ~VAR[dividend][0] mod ~VAR[divider][1]
+      -- pragma translate_off
+      when (~VAR[divider][1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+  ~RESULT <= (~SYM[5], ~SYM[6]);
 end block;
 -- divModInteger end"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.quotRemInteger"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "quotRemInteger :: Integer -> Integer -> (# Integer, Integer #)"
-    , "template"  : "(~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+    , "template"  :
+"~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.remInteger"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "remInteger :: Integer -> Integer -> Integer"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
@@ -262,6 +286,18 @@ end block;
   else to_signed(1, ~SIZE[~TYPO]);
 -- end signumInteger
 "
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Integer.Type.quotInteger"
+    , "kind"      : "Declaration"
+    , "type"      : "quotInteger :: Integer -> Integer -> Integer"
+    , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 ]

--- a/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
@@ -79,7 +79,11 @@ begin
   ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
              (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
              (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
+      -- pragma translate_off
+      when (~VAR[divider][1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
   ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
 -- integerDiv end"
@@ -104,31 +108,51 @@ end block;
   signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYP[0]] downto 0);
   signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYP[0]] downto 0);
   signal ~GENSYM[div_res][5] : signed(~SIZE[~TYP[0]]-1 downto 0);
+  signal ~GENSYM[mod_res][6] : signed(~SIZE[~TYP[0]]-1 downto 0);
 begin
   ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
   ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
   ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1)   when ~SYM[1] else
              (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) - 1)   when ~SYM[2] else
              (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1];
+  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
+      -- pragma translate_off
+      when (~VAR[divider][1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
   ~SYM[5] <= signed(~SYM[4](~SIZE[~TYP[0]]-1 downto 0));
-  ~RESULT <= (~SYM[5], ~VAR[dividend][0] mod ~VAR[divider][1]);
+  ~SYM[6] <= ~VAR[dividend][0] mod ~VAR[divider][1]
+      -- pragma translate_off
+      when (~VAR[divider][1] /= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+  ~RESULT <= (~SYM[5], ~SYM[6]);
 end block;
 -- integerDivMod end"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Num.Integer.integerQuotRem#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "integerQuotRem :: Integer -> Integer -> (# Integer, Integer #)"
-    , "template"  : "(~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+    , "template"  :
+"~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Num.Integer.integerRem"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "integerRem :: Integer -> Integer -> Integer"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
@@ -324,4 +348,16 @@ end block;
 "
     }
   }
+, { "BlackBox" :
+  { "name"      : "GHC.Num.Integer.integerQuot"
+  , "kind"      : "Declaration"
+  , "type"      : "integerQuot :: Integer -> Integer -> Integer"
+  , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
+  }
+}
 ]

--- a/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
@@ -20,9 +20,14 @@
   }
   , { "BlackBox" :
     { "name"      : "GHC.Num.Natural.naturalRem"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "naturalRem :: Natural -> Natural -> Natural"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     , "warning": "GHC.Num.Natural.naturalRem: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -109,6 +114,19 @@
          \"01\" when ~ARG[0] = ~ARG[1] else
          \"10\";
 -- end naturalCompare"
+  }
+}
+, { "BlackBox":
+  { "name": "GHC.Num.Natural.naturalQuot"
+  , "kind": "Declaration"
+  , "type": "naturalQuot :: Natural -> Natural -> Natural"
+  , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
+  , "warning": "GHC.Num.Natural.naturalQuot: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 ]

--- a/clash-lib/prims/vhdl/GHC_Prim.primitives
+++ b/clash-lib/prims/vhdl/GHC_Prim.primitives
@@ -56,16 +56,26 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.remInt#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "remInt# :: Int# -> Int# -> Int#"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.quotRemInt#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "quotRemInt# :: Int# -> Int# -> (#Int#, Int##)"
-    , "template"  : "(~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+    , "template"  : "
+~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
@@ -201,16 +211,26 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.remWord#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "remWord# :: Word# -> Word# -> Word#"
-    , "template"  : "~ARG[0] rem ~ARG[1]"
+    , "template"  :
+"~RESULT <= ~ARG[0] rem ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.quotRemWord#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "quotRemWord# :: Word# -> Word# -> (#Word#, Word##)"
-    , "template"  : "(~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+    , "template"  : "
+~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
+    -- pragma translate_on
+    ;"
     }
   }
 , { "BlackBox" :
@@ -1233,6 +1253,30 @@ begin
 ~RESULT(~SYM[1]) <= ~VAR[x][0](63-~SYM[1]);
 end generate;
 -- bitReverse64 end"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Prim.quotInt#"
+    , "kind"      : "Declaration"
+    , "type"      : "quotInt# :: Int# -> Int# -> Int#"
+    , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "GHC.Prim.quotWord#"
+    , "kind"      : "Declaration"
+    , "type"      : "quotWord# :: Word# -> Word# -> Word#"
+    , "template"  :
+"~RESULT <= ~ARG[0] / ~ARG[1]
+    -- pragma translate_off
+    when (~ARG[1] /= 0) else (others => 'X')
+    -- pragma translate_on
+    ;"
     }
   }
 ]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -330,6 +330,7 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS(runTest "BangData" def{hdlSim=False})
         , runTest "Trace" def{hdlSim=False}
         , NEEDS_PRIMS(runTest "DivMod" def{hdlSim=False})
+        , NEEDS_PRIMS(runTest "DivZero" def)
         , NEEDS_PRIMS(runTest "LambdaDrop" def{hdlSim=False})
         , runTest "IrrefError" def{hdlSim=False}
 #ifdef CLASH_MULTIPLE_HIDDEN

--- a/tests/shouldwork/Basic/DivZero.hs
+++ b/tests/shouldwork/Basic/DivZero.hs
@@ -1,0 +1,33 @@
+{-# OPTIONS_GHC -fconstraint-solver-iterations=5 #-}
+module DivZero where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import GHC.Natural
+import qualified Data.List as L
+
+type T8 = (BitVector 8, Unsigned 8, Signed 8, Index 8, Int, Word, Integer)
+
+topEntity :: T8 -> T8
+topEntity (b,u,s,x,i,w,nX) =
+  ( 4 `quot` b
+  , 4 `quot` u
+  , 4 `quot` s
+  , 4 `quot` x
+  , 4 `quot` i
+  , 4 `quot` w
+  , 4 `quot` nX)
+{-# NOINLINE topEntity #-}
+
+t8ToEnum :: T8 -> (BitVector 8, Unsigned 8, Signed 8, Index 8, Int, Word, Int)
+t8ToEnum (b,u,s,x,i,w,nX) = (b,u,s,x,i,w, fromEnum nX)
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = pure (0, 0, 0, 0, 0, 0, 0)
+    expectedOutput = outputVerifierBitVector' clk rst
+                       ($(bLit (L.replicate (3 * 8 + 3 + 3 * 64) '.')) :> Nil)
+    done           = expectedOutput (pack . t8ToEnum . topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen


### PR DESCRIPTION
Because Clash translates to concurrent assignments, things like

```
if y /= 0 then quot x y else 0
```

would result in a VHDL sim error (at least on GHDL) because all subterms of the if-then-else expression would be evaluated
concurrently, and `x / y` would throw a sim error whenever `y=0` even though that result could never be observed.
