### PR TITLE
VHDL: don't overflow natural range in shift/rotate

### DIFF
--- a/changelog/2021-07-14T16_41_45+02_00_shift_no_overflow
+++ b/changelog/2021-07-14T16_41_45+02_00_shift_no_overflow
@@ -1,0 +1,1 @@
+FIXED: Don't overflow the range of VHDL's natural type in shift/rotate, leading to simulation issues. Shift now saturates to a 31-bit shift amount. For rotate, in simulation only, the rotate amount is modulo the word width of the rotated value.

--- a/changelog/2021-07-16T13_43_48+02_00_shift_no_overflow2
+++ b/changelog/2021-07-16T13_43_48+02_00_shift_no_overflow2
@@ -1,0 +1,1 @@
+FIXED: shiftL for Clash datatypes does not cause a crash anymore when running Clash code with a really large shift amount.

--- a/changelog/2021-07-16T18_54_42+02_00_truncate_signed_frominteger_prim
+++ b/changelog/2021-07-16T18_54_42+02_00_truncate_signed_frominteger_prim
@@ -1,0 +1,1 @@
+FIXED: VHDL generated for Signed.fromInteger now truncates, like the Clash simulation, when the result is smaller than the argument

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -265,6 +265,7 @@ Library
                       Clash.Primitives.GHC.Word
                       Clash.Primitives.Intel.ClockGen
                       Clash.Primitives.Sized.ToInteger
+                      Clash.Primitives.Sized.Signed
                       Clash.Primitives.Sized.Vector
                       Clash.Primitives.Verification
 

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
@@ -541,11 +541,24 @@ end process;
     , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(shift_left(unsigned(~ARG[1]), to_integer(~ARG[2])))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][2]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= std_logic_vector(shift_left(unsigned(~ARG[1]),~SYM[1]))
+      -- pragma translate_off
+      when (~ARG[2] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -553,11 +566,24 @@ end process;
     , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(shift_right(unsigned(~ARG[1]),to_integer(~ARG[2])))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftR][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][2]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= std_logic_vector(shift_right(unsigned(~ARG[1]),~SYM[1]))
+      -- pragma translate_off
+      when (~ARG[2] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -565,7 +591,11 @@ end process;
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2])))
+"~RESULT <= std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2]
+    -- pragma translate_off
+    mod ~SIZE[~TYP[1]]
+    -- pragma translate_on
+    )))
     -- pragma translate_off
     when (~ARG[2] >= 0) else (others => 'X')
     -- pragma translate_on
@@ -577,7 +607,11 @@ end process;
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2])))
+"~RESULT <= std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2]
+    -- pragma translate_off
+    mod ~SIZE[~TYP[1]]
+    -- pragma translate_on
+    )))
     -- pragma translate_off
     when (~ARG[2] >= 0) else (others => 'X')
     -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
@@ -223,11 +223,24 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~RESULT <= shift_left(~ARG[1],to_integer(~ARG[2]))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][2]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_left(~ARG[1],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[2] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -235,11 +248,24 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~RESULT <= shift_right(~ARG[1],to_integer(~ARG[2]))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftR][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][2]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_right(~ARG[1],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[2] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -247,7 +273,11 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~RESULT <= rotate_left(~ARG[1],to_integer(~ARG[2]))
+"~RESULT <= rotate_left(~ARG[1],to_integer(~ARG[2]
+    -- pragma translate_off
+    mod ~SIZE[~TYP[1]]
+    -- pragma translate_on
+    ))
     -- pragma translate_off
     when (~ARG[2] >= 0) else (others => 'X')
     -- pragma translate_on
@@ -259,7 +289,11 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~RESULT <= rotate_right(~ARG[1],to_integer(~ARG[2]))
+"~RESULT <= rotate_right(~ARG[1],to_integer(~ARG[2]
+    -- pragma translate_off
+    mod ~SIZE[~TYP[1]]
+    -- pragma translate_on
+    ))
     -- pragma translate_off
     when (~ARG[2] >= 0) else (others => 'X')
     -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
@@ -108,7 +108,8 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Signed (n :: Nat)"
-    , "template"  : "resize(~ARG[1],~LIT[0])"
+    , "format"    : "Haskell"
+    , "templateFunction" : "Clash.Primitives.Sized.Signed.fromIntegerTF"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
@@ -174,11 +174,24 @@
     , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~RESULT <= shift_left(~ARG[1],to_integer(~ARG[2]))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][2]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_left(~ARG[1],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[2] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -186,11 +199,24 @@
     , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~RESULT <= shift_right(~ARG[1],to_integer(~ARG[2]))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][2]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_right(~ARG[1],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[2] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -198,7 +224,11 @@
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~RESULT <= rotate_left(~ARG[1],to_integer(~ARG[2]))
+"~RESULT <= rotate_left(~ARG[1],to_integer(~ARG[2]
+    -- pragma translate_off
+    mod ~SIZE[~TYP[1]]
+    -- pragma translate_on
+    ))
     -- pragma translate_off
     when (~ARG[2] >= 0) else (others => 'X')
     -- pragma translate_on
@@ -210,7 +240,11 @@
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~RESULT <= rotate_right(~ARG[1],to_integer(~ARG[2]))
+"~RESULT <= rotate_right(~ARG[1],to_integer(~ARG[2]
+    -- pragma translate_off
+    mod ~SIZE[~TYP[1]]
+    -- pragma translate_on
+    ))
     -- pragma translate_off
     when (~ARG[2] >= 0) else (others => 'X')
     -- pragma translate_on

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
@@ -189,11 +189,24 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "shiftRInteger :: Integer -> Int# -> Integer"
     , "template"  :
-"~RESULT <= shift_right(~ARG[0], to_integer(~ARG[1]))
-    -- pragma translate_off
-    when (~ARG[1] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftR][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_right(~ARG[0],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[1] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -201,11 +214,24 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "shiftLInteger :: Integer -> Int# -> Integer"
     , "template"  :
-"~RESULT <= shift_left(~ARG[0], to_integer(~ARG[1]))
-    -- pragma translate_off
-    when (~ARG[1] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_left(~ARG[0],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[1] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
@@ -216,11 +216,20 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerShiftR# :: Integer -> Word# -> Integer"
     , "template"  :
-"~RESULT <= shift_right(~ARG[0], to_integer(~VAR[count][1](30 downto 0)))
-    -- pragma translate_off
-    when (~ARG[1] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftR][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_right(~ARG[0],~SYM[1]);
+end block;"
     }
   }
 , { "BlackBox" :
@@ -228,11 +237,20 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerShiftL# :: Integer -> Word# -> Integer"
     , "template"  :
-"~RESULT <= shift_left(~ARG[0], to_integer(~VAR[count][1](30 downto 0)))
-    -- pragma translate_off
-    when (~ARG[1] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_left(~ARG[0],~SYM[1]);
+end block;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
@@ -85,11 +85,20 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalShiftL# :: Natural -> Word# -> Natural"
   , "template"  :
-"~RESULT <= shift_left(~ARG[0],to_integer(~VAR[count][1](30 downto 0)))
-    -- pragma translate_off
-    when (~ARG[1] >= to_unsigned(0, ~SIZE[~TYP[1]]-1)) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_left(~ARG[0],~SYM[1]);
+end block;"
   }
 }
 , { "BlackBox" :
@@ -97,11 +106,20 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalShiftR# :: Natural -> Word# -> Natural"
   , "template"  :
-"~RESULT <= shift_right(~ARG[0], to_integer(~VAR[count][1](30 downto 0)))
-    -- pragma translate_off
-    when (~ARG[1] >= to_unsigned(0, ~SIZE[~TYP[1]]-1)) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftR][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_right(~ARG[0],~SYM[1]);
+end block;"
   }
 }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Prim.primitives
+++ b/clash-lib/prims/vhdl/GHC_Prim.primitives
@@ -176,11 +176,24 @@
     , "kind"      : "Declaration"
     , "type"      : "uncheckedIShiftL# :: Int# -> Int# -> Int#"
     , "template"  :
-"~RESULT <= shift_left(~ARG[0],to_integer(~ARG[1]))
-    -- pragma translate_off
-    when (~ARG[1] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_left(~ARG[0],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[1] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -188,18 +201,49 @@
     , "kind"      : "Declaration"
     , "type"      : "uncheckedIShiftRA# :: Int# -> Int# -> Int#"
     , "template"  :
-"~RESULT <= shift_right(~ARG[0],to_integer(~ARG[1]))
-    -- pragma translate_off
-    when (~ARG[1] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftR][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_right(~ARG[0],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[1] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.uncheckedIShiftRL#"
-    , "kind"      : "Expression"
+    , "kind"      : "Declaration"
     , "type"      : "uncheckedIShiftRL# :: Int# -> Int# -> Int#"
-    , "template"  : "~ARG[0] srl to_integer(~ARG[1])"
+    , "template"  :
+"~GENSYM[~RESULT_shiftRL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= ~ARG[0] srl ~SYM[1]
+      -- pragma translate_off
+      when (~ARG[1] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -266,11 +310,24 @@
     , "kind"      : "Declaration"
     , "type"      : "uncheckedShiftL# :: Word# -> Int# -> Word#"
     , "template"  :
-"~RESULT <= shift_left(~ARG[0],to_integer(~ARG[1]))
-    -- pragma translate_off
-    when (~ARG[1] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftL][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_left(~ARG[0],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[1] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :
@@ -278,11 +335,24 @@
     , "kind"      : "Declaration"
     , "type"      : "uncheckedShiftR# :: Word# -> Int# -> Word#"
     , "template"  :
-"~RESULT <= shift_right(~ARG[0],to_integer(~ARG[1]))
-    -- pragma translate_off
-    when (~ARG[1] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+"~GENSYM[~RESULT_shiftR][0] : block
+  signal ~GENSYM[sh][1] : natural;
+begin
+  ~SYM[1] <=
+      -- pragma translate_off
+      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
+      -- pragma translate_on
+      to_integer(~VAR[shI][1]
+      -- pragma translate_off
+      (30 downto 0)
+      -- pragma translate_on
+      );
+  ~RESULT <= shift_right(~ARG[0],~SYM[1])
+      -- pragma translate_off
+      when (~ARG[1] >= 0) else (others => 'X')
+      -- pragma translate_on
+      ;
+end block;"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/src/Clash/Primitives/Sized/Signed.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Signed.hs
@@ -1,0 +1,43 @@
+{-|
+  Copyright   :  (C) 2021 QBayLogic
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  VHDL Blackbox implementations for "Clash.Sized.Internal.Signed.toInteger#".
+-}
+
+{-# LANGUAGE OverloadedStrings #-}
+module Clash.Primitives.Sized.Signed (fromIntegerTF) where
+
+import Control.Monad.State (State)
+import Data.Monoid (Ap(getAp))
+import Data.Text.Prettyprint.Doc.Extra (Doc, tupled)
+
+import Clash.Backend (Backend, expr)
+import Clash.Netlist.Types
+  (BlackBoxContext (..), Expr (..), HWType (..), Literal (..), Modifier (..),
+   TemplateFunction (..))
+
+fromIntegerTF :: TemplateFunction
+fromIntegerTF = TemplateFunction used valid fromIntegerTFTemplate
+ where
+  used = [0,1]
+  valid bbCtx = case bbInputs bbCtx of
+    [kn,_] -> case kn of
+      (Literal _ (NumLit _),_,True) -> True
+      _ -> False
+    _ -> False
+
+fromIntegerTFTemplate
+  :: Backend s
+  => BlackBoxContext
+  -> State s Doc
+fromIntegerTFTemplate bbCtx = getAp $ do
+  let [(Literal _ (NumLit sz),_,_), (i@(Identifier iV m), Signed szI, _)] = bbInputs bbCtx
+  case compare sz (toInteger szI) of
+    LT -> let sl = Sliced (Signed szI,fromInteger sz-1,0)
+              m1 = Just (maybe sl (`Nested` sl) m)
+           in expr False (Identifier iV m1)
+    EQ -> expr False i
+    GT -> "resize" <> tupled (sequenceA [expr False i
+                                        ,expr False (Literal Nothing (NumLit sz))])

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -9,6 +9,7 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -510,12 +511,10 @@ complement# = \(S a) -> fromInteger_INLINE sz mB mask (complement a)
 
 shiftL#,shiftR#,rotateL#,rotateR# :: forall n . KnownNat n => Signed n -> Int -> Signed n
 {-# NOINLINE shiftL# #-}
-shiftL# =
-  \(S n) b ->
-    if b >= 0 then
-      fromInteger_INLINE sz mB mask (shiftL n b)
-    else
-      error "'shiftL' undefined for negative numbers"
+shiftL# = \(S n) b ->
+  if | b < 0     -> error $ "'shiftL' undefined for negative number: " ++ show b
+     | b > sz    -> S 0
+     | otherwise -> fromInteger_INLINE sz mB mask (shiftL n b)
  where
   sz   = fromInteger (natVal (Proxy @n)) - 1
   mB   = 1 `shiftL` sz
@@ -527,7 +526,7 @@ shiftR# =
     if b >= 0 then
       fromInteger_INLINE sz mB mask (shiftR n b)
     else
-      error "'shiftR' undefined for negative numbers"
+      error $ "'shiftR' undefined for negative number: " ++ show b
  where
   sz   = fromInteger (natVal (Proxy @n)) - 1
   mB   = 1 `shiftL` sz
@@ -545,7 +544,7 @@ rotateL# =
           b''  = sz - b'
       in  fromInteger_INLINE sz1 mB maskM (l .|. r)
     else
-      error "'rotateL undefined for negative numbers"
+      error $ "'rotateL undefined for negative number: " ++ show b
  where
   sz    = fromInteger (natVal (Proxy @n))
   sz1   = sz-1
@@ -564,7 +563,7 @@ rotateR# =
           b'' = sz - b'
       in  fromInteger_INLINE sz1 mB maskM (l .|. r)
     else
-      error "'rotateR' undefined for negative numbers"
+      error $ "'rotateR' undefined for negative number: " ++ show b
  where
   sz    = fromInteger (natVal (Proxy @n))
   sz1   = sz - 1

--- a/tests/shouldwork/Numbers/ShiftRotate.hs
+++ b/tests/shouldwork/Numbers/ShiftRotate.hs
@@ -15,6 +15,7 @@ import Data.Word
 import ShiftRotateBase
 
 topEntity = testall
+{-# NOINLINE topEntity #-}
 
 expected :: Vec _ ( Vec Ops (Unsigned 8)
                   , Vec Ops (Signed 8)

--- a/tests/shouldwork/Numbers/ShiftRotateBase.hs
+++ b/tests/shouldwork/Numbers/ShiftRotateBase.hs
@@ -8,9 +8,10 @@ import Data.Int
 
 testpattern = 0b1010011000
 
--- test with shift/rotate amounts: 0..16,200
+-- test with shift/rotate amounts: 0..16,200, and a really large
+-- non-power-of-two.
 amounts :: Vec _ Int
-amounts = $(listToVecTH [0::Int ..16]) :< 200
+amounts = $(listToVecTH [0::Int ..16]) :< 200 :< (maxBound - 5)
 
 testall v i
   = ( testAs @(Unsigned 8)  v i


### PR DESCRIPTION
Haskell `shift{R;L}` and `rotate{R;L}` take an `Int` as the shift amount. In VHDL, `shift_{left;right}` and `rotate_{left;right}` take a `natural` as a shift amount. On 64 bit systems Haskell's `maxBound :: Int` is larger than VHDL's `natural'high` (in (nearly) all VHDL simulators).

So for `shift_{left;right}` we saturate the shift amount to `natural'high`, and for `rotate_{left;right}` we mask the shift amount with `natural'high`, all in order for the VHDL simulator not to error out with an out-of-bounds exception when the shift/rotate amount is larger than `natural'high`.
