### PR TITLE
VHDL: don't overflow integer range in RAM/ROM

### DIFF
--- a/changelog/2021-07-14T16_36_27+02_00_vhdl_to_integer_no_overflow
+++ b/changelog/2021-07-14T16_36_27+02_00_vhdl_to_integer_no_overflow
@@ -1,0 +1,1 @@
+FIXED: Don't overflow VHDL's integer type when addressing RAM/ROM in simulation.Addresses are masked to 32 bits to be sure to keep it within the simulator's range.

--- a/changelog/2021-07-16T16_35_52+02_00_mem_xexception
+++ b/changelog/2021-07-16T16_35_52+02_00_mem_xexception
@@ -1,0 +1,1 @@
+CHANGED: RAM/ROM functions: They now throw `XExeception` for out-of-bounds address inputs, so this condition no longer aborts simulation.

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives
@@ -21,13 +21,13 @@
   signal ~GENSYM[rd][4]  : integer range 0 to ~LENGTH[~TYP[5]] - 1;
   signal ~GENSYM[wr][5]  : integer range 0 to ~LENGTH[~TYP[5]] - 1;
 begin
-  ~SYM[4] <= to_integer(~ARG[6])
+  ~SYM[4] <= to_integer(~VAR[rdI][6](31 downto 0))
   -- pragma translate_off
                 mod ~LENGTH[~TYP[5]]
   -- pragma translate_on
                 ;
 
-  ~SYM[5] <= to_integer(~ARG[8])
+  ~SYM[5] <= to_integer(~VAR[wrI][8](31 downto 0))
   -- pragma translate_off
                 mod ~LENGTH[~TYP[5]]
   -- pragma translate_on
@@ -80,13 +80,13 @@ end block;
   signal ~GENSYM[rd][4]  : integer range 0 to ~LIT[5] - 1;
   signal ~GENSYM[wr][5]  : integer range 0 to ~LIT[5] - 1;
 begin
-  ~SYM[4] <= to_integer(~ARG[6])
+  ~SYM[4] <= to_integer(~VAR[rdI][6](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[5]
   -- pragma translate_on
                 ;
 
-  ~SYM[5] <= to_integer(~ARG[8])
+  ~SYM[5] <= to_integer(~VAR[wrI][8](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[5]
   -- pragma translate_on
@@ -140,13 +140,13 @@ end block;
   signal ~GENSYM[rd][4]  : integer range 0 to ~LIT[5] - 1;
   signal ~GENSYM[wr][5]  : integer range 0 to ~LIT[5] - 1;
 begin
-  ~SYM[4] <= to_integer(~ARG[7])
+  ~SYM[4] <= to_integer(~VAR[rdI][7](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[5]
   -- pragma translate_on
                 ;
 
-  ~SYM[5] <= to_integer(~ARG[9])
+  ~SYM[5] <= to_integer(~VAR[wrI][9](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[5]
   -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives
@@ -36,13 +36,13 @@
   signal ~GENSYM[rd][5]  : integer range 0 to ~LIT[5]-1;
   signal ~GENSYM[wr][6]  : integer range 0 to ~LIT[5]-1;
 begin
-  ~SYM[5] <= to_integer(~ARG[7])
+  ~SYM[5] <= to_integer(~VAR[rdI][7](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[5]
   -- pragma translate_on
                 ;
 
-  ~SYM[6] <= to_integer(~ARG[9])
+  ~SYM[6] <= to_integer(~VAR[wrI][9](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[5]
   -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Explicit_RAM.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_RAM.primitives
@@ -24,13 +24,13 @@
   signal ~GENSYM[rd][2] : integer range 0 to ~LIT[6] - 1;
   signal ~GENSYM[wr][3] : integer range 0 to ~LIT[6] - 1;
 begin
-  ~SYM[2] <= to_integer(~ARG[7])
+  ~SYM[2] <= to_integer(~VAR[rdI][7](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[6]
   -- pragma translate_on
                 ;
 
-  ~SYM[3] <= to_integer(~ARG[9])
+  ~SYM[3] <= to_integer(~VAR[wrI][9](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[6]
   -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives
@@ -18,7 +18,7 @@
 begin
   ~SYM[2] <= ~LIT[5];
 
-  ~SYM[3] <= to_integer(~ARG[6])
+  ~SYM[3] <= to_integer(~VAR[rdI][6](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[1]
   -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives
@@ -30,7 +30,7 @@
   signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[4]-1) := ~SYM[1](~FILE[~LIT[5]]);
   signal ~GENSYM[rd][3] : integer range 0 to ~LIT[4]-1;
 begin
-  ~SYM[3] <= to_integer(~ARG[6])
+  ~SYM[3] <=to_integer(~VAR[rdI][6](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[4]
   -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM.primitives
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM.primitives
@@ -14,7 +14,7 @@
 begin
   ~SYM[1] <= ~LIT[1];
 
-  ~SYM[2] <= to_integer(~ARG[2])
+  ~SYM[2] <= to_integer(~VAR[rdI][2](31 downto 0))
   -- pragma translate_off
                       mod ~LIT[0]
   -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.primitives
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.primitives
@@ -27,7 +27,7 @@
   signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[1]-1) := ~SYM[1](~FILE[~LIT[2]]);
   signal ~GENSYM[rd][3] : integer range 0 to ~LIT[1]-1;
 begin
-  ~SYM[3] <= to_integer(~ARG[3])
+  ~SYM[3] <= to_integer(~VAR[rdI][3](31 downto 0))
   -- pragma translate_off
                 mod ~LIT[1]
   -- pragma translate_on

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -660,6 +660,7 @@ runClashTest = defaultMain $ clashTestRoot
         , NEEDS_PRIMS_GHC(runTest "ResetSynchronizerSync" def)
         , NEEDS_PRIMS_GHC(runTest "ResetLow" def)
         , NEEDS_PRIMS_GHC(runTest "Rom" def)
+        , NEEDS_PRIMS_GHC(runTest "RomNegative" def)
         , runTest "SigP" def{hdlSim=False}
         , outputTest ("tests" </> "shouldwork" </> "Signal") [VHDL] [] [] "T1102A" "main"
         , outputTest ("tests" </> "shouldwork" </> "Signal") [VHDL] [] [] "T1102B" "main"

--- a/tests/shouldwork/Signal/RomNegative.hs
+++ b/tests/shouldwork/Signal/RomNegative.hs
@@ -1,0 +1,27 @@
+module RomNegative where
+
+import Clash.Prelude
+import qualified Clash.Explicit.Prelude as Explicit
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock System
+  -> Reset System
+  -> Enable System
+  -> Signal System (Signed 64)
+  -> Signal System (Unsigned 8)
+topEntity = exposeClockResetEnable go
+ where
+  go rd = mux ((< 0) <$> rd) 0 (unpack <$> romFile d256 "memory.list" rd)
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = Explicit.register clk rst enableGen minBound
+                       (testInput + 1)
+    expectedOutput = outputVerifier' clk rst $ replicate d10 0
+    done           = expectedOutput . ignoreFor clk rst enableGen d1 0 $
+                       topEntity clk rst enableGen testInput
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen


### PR DESCRIPTION
Most RAM and ROM functions take an `Int` as either a read or write index. On 64-bit systems `maxBound :: Int` and `minBound :: Int` exceed VHDL's `integer'high` and `integer'low` (on (nearly) all VHDL simulators). This poses an issue, because the blackbox
implementations use `to_integer` to convert the `signed (63 downto 0)` (then translation for `Int`) to VHDL's `integer`. So any value falling outside of the range would trigger an overflow exception in the VHDL simulator.

So we now masks all indexes to fit the `integer'low to integer'high` range.
