### PR TITLE
clash-cores New: Xilinx float sub, mul and div

### DIFF
--- a/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
@@ -46,6 +46,15 @@ module Clash.Cores.Xilinx.Floating
     addWith
   , add
   , E.AddDefDelay
+  , subWith
+  , sub
+  , E.SubDefDelay
+  , mulWith
+  , mul
+  , E.MulDefDelay
+  , divWith
+  , div
+  , E.DivDefDelay
     -- * Customizing IP
   , E.Config(..)
   , E.defConfig
@@ -54,7 +63,7 @@ module Clash.Cores.Xilinx.Floating
   , E.BMemUsage(..)
   ) where
 
-import Clash.Prelude hiding (add)
+import Clash.Prelude hiding (add, sub, mul, div)
 
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 
@@ -85,3 +94,81 @@ add
   -> DSignal dom (n + E.AddDefDelay) Float
 add = withFrozenCallStack $ hideEnable $ hideClock E.add
 {-# INLINE add #-}
+
+-- | Customizable floating point subtraction.
+subWith
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => E.Config
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + d) Float
+subWith cfg = withFrozenCallStack $ hideEnable . hideClock $ E.subWith cfg
+{-# INLINE subWith #-}
+
+-- | Floating point subtraction with default settings.
+sub
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , HasCallStack
+     )
+  => DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + E.SubDefDelay) Float
+sub = withFrozenCallStack $ hideEnable $ hideClock E.sub
+{-# INLINE sub #-}
+
+-- | Customizable floating point multiplication.
+mulWith
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => E.Config
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + d) Float
+mulWith cfg = withFrozenCallStack $ hideEnable . hideClock $ E.mulWith cfg
+{-# INLINE mulWith #-}
+
+-- | Floating point multiplication with default settings.
+mul
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , HasCallStack
+     )
+  => DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + E.MulDefDelay) Float
+mul = withFrozenCallStack $ hideEnable $ hideClock E.mul
+{-# INLINE mul #-}
+
+-- | Customizable floating point division.
+divWith
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => E.Config
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + d) Float
+divWith cfg = withFrozenCallStack $ hideEnable . hideClock $ E.divWith cfg
+{-# INLINE divWith #-}
+
+-- | Floating point division with default settings.
+div
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , HasCallStack
+     )
+  => DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + E.DivDefDelay) Float
+div = withFrozenCallStack $ hideEnable $ hideClock E.div
+{-# INLINE div #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/BlackBoxes.hs
@@ -10,6 +10,9 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 module Clash.Cores.Xilinx.Floating.BlackBoxes
   ( addTclTF
+  , subTclTF
+  , mulTclTF
+  , divTclTF
   ) where
 
 import Prelude
@@ -42,9 +45,33 @@ defHasCustom = HasCustom
   , hasBMemUsage = False
   }
 
+hasNoCustom :: HasCustom
+hasNoCustom = HasCustom
+  { addSubVal = Nothing
+  , hasArchOpt = False
+  , hasDspUsage = False
+  , hasBMemUsage = False
+  }
+
 addTclTF :: TemplateFunction
 addTclTF =
   binaryTclTF (defHasCustom { addSubVal = Just "Add" }) "Add_Subtract"
+
+subTclTF :: TemplateFunction
+subTclTF =
+  binaryTclTF (defHasCustom { addSubVal = Just "Subtract" }) "Add_Subtract"
+
+mulTclTF :: TemplateFunction
+mulTclTF = binaryTclTF hasCustom "Multiply"
+ where
+  hasCustom = HasCustom { addSubVal = Nothing
+                        , hasArchOpt = False
+                        , hasDspUsage = True
+                        , hasBMemUsage = False
+                        }
+
+divTclTF :: TemplateFunction
+divTclTF = binaryTclTF hasNoCustom "Divide"
 
 binaryTclTF
   :: HasCustom

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
@@ -49,6 +49,15 @@ module Clash.Cores.Xilinx.Floating.Explicit
     addWith
   , add
   , AddDefDelay
+  , subWith
+  , sub
+  , SubDefDelay
+  , mulWith
+  , mul
+  , MulDefDelay
+  , divWith
+  , div
+  , DivDefDelay
     -- * Customizing IP
   , Config(..)
   , defConfig
@@ -59,7 +68,7 @@ module Clash.Cores.Xilinx.Floating.Explicit
   , xilinxNaN
   ) where
 
-import Clash.Explicit.Prelude hiding (add)
+import Clash.Explicit.Prelude hiding (add, sub, mul, div)
 
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 
@@ -83,7 +92,7 @@ addWith
 addWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x + y
  where
-  und = withFrozenCallStack $ deepErrorX "Initial values of addFloat undefined"
+  und = withFrozenCallStack $ deepErrorX "Initial values of add undefined"
 {-# NOINLINE addWith #-}
 {-# ANN addWith (vhdlBinaryPrim 'addWith 'addTclTF "add") #-}
 {-# ANN addWith (veriBinaryPrim 'addWith 'addTclTF "add") #-}
@@ -104,6 +113,122 @@ add = withFrozenCallStack $ addWith defConfig
 
 -- | The default delay for floating point addition with default customization.
 type AddDefDelay = 11
+
+-- | Customizable floating point subtraction.
+subWith
+  :: forall d dom n
+   . ( KnownDomain dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => Config
+  -> Clock dom
+  -> Enable dom
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + d) Float
+subWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
+  delayI und en clk . conditionFloatF $ x - y
+ where
+  und = withFrozenCallStack $ deepErrorX "Initial values of sub undefined"
+{-# NOINLINE subWith #-}
+{-# ANN subWith (vhdlBinaryPrim 'subWith 'subTclTF "sub") #-}
+{-# ANN subWith (veriBinaryPrim 'subWith 'subTclTF "sub") #-}
+
+-- | Floating point subtraction with default settings.
+sub
+  :: forall dom n
+   . ( KnownDomain dom
+     , HasCallStack
+     )
+  => Clock dom
+  -> Enable dom
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + SubDefDelay) Float
+sub = withFrozenCallStack $ subWith defConfig
+{-# INLINE sub #-}
+
+-- | The default delay for floating point subtraction with default
+-- customization.
+type SubDefDelay = 11
+
+-- | Customizable floating point multiplication.
+mulWith
+  :: forall d dom n
+   . ( KnownDomain dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => Config
+  -> Clock dom
+  -> Enable dom
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + d) Float
+mulWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
+  delayI und en clk . conditionFloatF $ x * y
+ where
+  und = withFrozenCallStack $ deepErrorX "Initial values of mul undefined"
+{-# NOINLINE mulWith #-}
+{-# ANN mulWith (vhdlBinaryPrim 'mulWith 'mulTclTF "mul") #-}
+{-# ANN mulWith (veriBinaryPrim 'mulWith 'mulTclTF "mul") #-}
+
+-- | Floating point multiplication with default settings.
+mul
+  :: forall dom n
+   . ( KnownDomain dom
+     , HasCallStack
+     )
+  => Clock dom
+  -> Enable dom
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + MulDefDelay) Float
+mul = withFrozenCallStack $ mulWith defConfig
+{-# INLINE mul #-}
+
+-- | The default delay for floating point multiplication with default
+-- customization.
+type MulDefDelay = 8
+
+-- | Customizable floating point division.
+divWith
+  :: forall d dom n
+   . ( KnownDomain dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => Config
+  -> Clock dom
+  -> Enable dom
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + d) Float
+divWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
+  delayI und en clk . conditionFloatF $ x / y
+ where
+  und = withFrozenCallStack $ deepErrorX "Initial values of div undefined"
+{-# NOINLINE divWith #-}
+{-# ANN divWith (vhdlBinaryPrim 'divWith 'divTclTF "div") #-}
+{-# ANN divWith (veriBinaryPrim 'divWith 'divTclTF "div") #-}
+
+-- | Floating point division with default settings.
+div
+  :: forall dom n
+   . ( KnownDomain dom
+     , HasCallStack
+     )
+  => Clock dom
+  -> Enable dom
+  -> DSignal dom n Float
+  -> DSignal dom n Float
+  -> DSignal dom (n + DivDefDelay) Float
+div = withFrozenCallStack $ divWith defConfig
+{-# INLINE div #-}
+
+-- | The default delay for floating point division with default customization.
+type DivDefDelay = 28
 
 -- | Default customization options.
 --

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -435,7 +435,10 @@ runClashTest = defaultMain $ clashTestRoot
       --     [ runTest "Floating" def{ clashFlags=["-fclash-float-support"]
       --                             , buildTargets=[ "addBasicTB"
       --                                            , "addEnableTB"
-      --                                            , "addShortPLTB"]}
+      --                                            , "addShortPLTB"
+      --                                            , "subBasicTB"
+      --                                            , "mulBasicTB"
+      --                                            , "divBasicTB"]}
       --     ]
       --   ]
       , clashTestGroup "CSignal"

--- a/tests/shouldwork/Cores/Xilinx/Floating.hs
+++ b/tests/shouldwork/Cores/Xilinx/Floating.hs
@@ -131,7 +131,7 @@ addBasic clk x y = withClock clk $ withEnable enableGen $ F.add x y
 addBasicTB :: Signal XilinxSystem Bool
 addBasicTB =
   uncurry (basicRomTB addBasic)
-          $(romDataFromFile "samplerom.bin" addBasicSamples)
+          $(romDataFromFile "add-samplerom.bin" addBasicSamples)
 {-# ANN addBasicTB (TestBench 'addBasic) #-}
 
 addEnable
@@ -192,3 +192,48 @@ addShortPLTB =
                   , (3, 6, 9)
                   ])
 {-# ANN addShortPLTB (TestBench 'addShortPL) #-}
+
+subBasic
+  :: Clock XilinxSystem
+  -> DSignal XilinxSystem 0 Float
+  -> DSignal XilinxSystem 0 Float
+  -> DSignal XilinxSystem F.SubDefDelay Float
+subBasic clk x y = withClock clk $ withEnable enableGen $ F.sub x y
+{-# NOINLINE subBasic #-}
+{-# ANN subBasic (binTopAnn "subBasic") #-}
+
+subBasicTB :: Signal XilinxSystem Bool
+subBasicTB =
+  uncurry (basicRomTB subBasic)
+          $(romDataFromFile "sub-samplerom.bin" subBasicSamples)
+{-# ANN subBasicTB (TestBench 'subBasic) #-}
+
+mulBasic
+  :: Clock XilinxSystem
+  -> DSignal XilinxSystem 0 Float
+  -> DSignal XilinxSystem 0 Float
+  -> DSignal XilinxSystem F.MulDefDelay Float
+mulBasic clk x y = withClock clk $ withEnable enableGen $ F.mul x y
+{-# NOINLINE mulBasic #-}
+{-# ANN mulBasic (binTopAnn "mulBasic") #-}
+
+mulBasicTB :: Signal XilinxSystem Bool
+mulBasicTB =
+  uncurry (basicRomTB mulBasic)
+          $(romDataFromFile "mul-samplerom.bin" mulBasicSamples)
+{-# ANN mulBasicTB (TestBench 'mulBasic) #-}
+
+divBasic
+  :: Clock XilinxSystem
+  -> DSignal XilinxSystem 0 Float
+  -> DSignal XilinxSystem 0 Float
+  -> DSignal XilinxSystem F.DivDefDelay Float
+divBasic clk x y = withClock clk $ withEnable enableGen $ F.div x y
+{-# NOINLINE divBasic #-}
+{-# ANN divBasic (binTopAnn "divBasic") #-}
+
+divBasicTB :: Signal XilinxSystem Bool
+divBasicTB =
+  uncurry (basicRomTB divBasic)
+          $(romDataFromFile "div-samplerom.bin" divBasicSamples)
+{-# ANN divBasicTB (TestBench 'divBasic) #-}


### PR DESCRIPTION
Single-precision floating point operations, realized through instantiation of the Xilinx Floating-Point LogiCORE IP v7.1.

Further work on `Clash.Cores.Xilinx.Floating`, with more to come.

## Still TODO:

  - [ ] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files