### PR TITLE
Generate enums in VHDL

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -34,17 +34,17 @@ import Util (OverridingBool(..))
 genSystemVerilog
   :: String
   -> IO ()
-genSystemVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False) :: SystemVerilogState)
+genSystemVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False) (RenderEnums True) :: SystemVerilogState)
 
 genVHDL
   :: String
   -> IO ()
-genVHDL = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False):: VHDLState)
+genVHDL = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False) (RenderEnums True) :: VHDLState)
 
 genVerilog
   :: String
   -> IO ()
-genVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False):: VerilogState)
+genVerilog = doHDL (initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False) (RenderEnums True) :: VerilogState)
 
 doHDL
   :: HasCallStack

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -67,7 +67,7 @@ hdl :: HDL
 hdl = VHDL
 
 backend :: VHDLState
-backend = initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False)
+backend = initBackend WORD_SIZE_IN_BITS HDLSYN True PreserveCase Nothing (AggressiveXOptBB False) (RenderEnums True)
 
 runInputStage
   :: [FilePath]

--- a/changelog/2021-07-22T12_07_36+02_00_render_enums_vhdl.md
+++ b/changelog/2021-07-22T12_07_36+02_00_render_enums_vhdl.md
@@ -1,0 +1,35 @@
+CHANGED: Clash now renders ADTs with all zero-width fields as enumerations in VHDL.
+
+This makes generated code easier to follow, as more user-specified names are
+preserved in the final HDL. For types like
+
+```haskell
+data TrafficLight = Red | RedAmber | Amber | Green
+```
+
+VHDL which performs case analysis will now render something more like
+
+```vhdl
+with x select
+  y <= z_1 when TrafficLight'(Red),
+       z_2 when TrafficLight'(RedAmber),
+       z_3 when TrafficLight'(Amber),
+       z_4 when others;
+```
+
+instead of
+
+```vhdl
+with x select
+  y <= z_1 when "00",
+       z_2 when "01",
+       z_3 when "10",
+       z_4 when others;
+```
+
+Code which uses custom representations will continue to render `std_logic_vector`
+as before, as will code generated in (System)Verilog.
+
+The old behaviour (always rendering std_logic_vector) can be recovered by using
+the new -fclash-no-render-enums flag.
+

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -146,7 +146,7 @@ import Clash.GHCi.Leak
 
 -- clash additions
 import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB)
+import           Clash.Backend (AggressiveXOptBB, RenderEnums)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -2147,7 +2147,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2188,7 +2188,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
         -> GHC.Ghc ()
         -> IORef ClashOpts
         -> [FilePath]
@@ -2206,6 +2206,7 @@ makeHDL backend startAction optsRef srcs = do
                   lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
                   xOptBB = opt_aggressiveXOptBB opts1
+                  enums  = opt_renderEnums opts1
                   hdl    = Clash.Backend.hdlKind backend'
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2218,7 +2219,7 @@ makeHDL backend startAction optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB)
+                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB) (coerce enums)
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs

--- a/clash-ghc/src-bin-8.10/Clash/Main.hs
+++ b/clash-ghc/src-bin-8.10/Clash/Main.hs
@@ -91,7 +91,7 @@ import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 
 import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB)
+import           Clash.Backend (AggressiveXOptBB, RenderEnums)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -1005,7 +1005,7 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
   -> Ghc () -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _           _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend startAction r srcs = makeHDL backend startAction r $ fmap fst srcs

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -140,7 +140,7 @@ import Clash.GHCi.Leak
 
 -- clash additions
 import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB)
+import           Clash.Backend (AggressiveXOptBB, RenderEnums)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -1977,7 +1977,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2018,7 +2018,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
         -> GHC.Ghc ()
         -> IORef ClashOpts
         -> [FilePath]
@@ -2036,6 +2036,7 @@ makeHDL backend startAction optsRef srcs = do
                   lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
                   xOptBB = opt_aggressiveXOptBB opts1
+                  enums  = opt_renderEnums opts1
                   hdl    = Clash.Backend.hdlKind backend'
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2048,7 +2049,7 @@ makeHDL backend startAction optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB)
+                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB) (coerce enums)
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs
@@ -2087,13 +2088,13 @@ makeHDL backend startAction optsRef srcs = do
                   (startTime,prepTime)
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -89,7 +89,7 @@ import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 
 import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB)
+import           Clash.Backend (AggressiveXOptBB, RenderEnums)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -973,19 +973,19 @@ abiHash strs = do
 -----------------------------------------------------------------------------
 -- HDL Generation
 
-makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+makeHDL' :: Clash.Backend.Backend backend => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
          -> Ghc () -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _           _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend startAction r srcs = makeHDL backend startAction r $ fmap fst srcs
 
 makeVHDL :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VHDLState)
+makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> VHDLState)
 
 makeVerilog :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> VerilogState)
+makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> VerilogState)
 
 makeSystemVerilog :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -143,7 +143,7 @@ import Clash.GHCi.Leak
 
 -- clash additions
 import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB)
+import           Clash.Backend (AggressiveXOptBB, RenderEnums)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -2069,7 +2069,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2110,7 +2110,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
         -> Ghc ()
         -> IORef ClashOpts
         -> [FilePath]
@@ -2128,6 +2128,7 @@ makeHDL backend startAction optsRef srcs = do
                   lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
                   xOptBB = opt_aggressiveXOptBB opts1
+                  enums  = opt_renderEnums opts1
                   hdl    = Clash.Backend.hdlKind backend'
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2140,7 +2141,7 @@ makeHDL backend startAction optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB)
+                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB) (coerce enums)
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -86,7 +86,7 @@ import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 
 import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB)
+import           Clash.Backend (AggressiveXOptBB, RenderEnums)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -982,7 +982,7 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
   -> Ghc () -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _           _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend startAction r srcs = makeHDL backend startAction r $ fmap fst srcs

--- a/clash-ghc/src-bin-9.0/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.0/Clash/GHCi/UI.hs
@@ -101,6 +101,7 @@ import Control.Monad.Trans.Except
 import Data.Array
 import qualified Data.ByteString.Char8 as BS
 import Data.Char
+import Data.Coerce
 import Data.Function
 import Data.IORef ( IORef, modifyIORef, newIORef, readIORef, writeIORef )
 import Data.List ( elemIndices, find, group, intercalate, intersperse,
@@ -148,7 +149,7 @@ import Clash.GHCi.Leak
 
 -- clash additions
 import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB)
+import           Clash.Backend (AggressiveXOptBB, RenderEnums)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -2186,7 +2187,7 @@ exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
 makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
          -> IORef ClashOpts
          -> [FilePath]
          -> InputT GHCi ()
@@ -2227,7 +2228,7 @@ makeHDL' backend opts lst = go =<< case lst of
 
 makeHDL :: GHC.GhcMonad m
         => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
         -> Ghc ()
         -> IORef ClashOpts
         -> [FilePath]
@@ -2245,6 +2246,7 @@ makeHDL backend startAction optsRef srcs = do
                   lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
                   xOptBB = opt_aggressiveXOptBB opts1
+                  enums  = opt_renderEnums opts1
                   hdl    = Clash.Backend.hdlKind backend'
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2257,7 +2259,7 @@ makeHDL backend startAction optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc lw frcUdf (Clash.Backend.AggressiveXOptBB xOptBB)
+                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB) (coerce enums)
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs

--- a/clash-ghc/src-bin-9.0/Clash/Main.hs
+++ b/clash-ghc/src-bin-9.0/Clash/Main.hs
@@ -93,7 +93,7 @@ import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 
 import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB)
+import           Clash.Backend (AggressiveXOptBB, RenderEnums)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -1006,7 +1006,7 @@ abiHash strs = do
 
 makeHDL'
   :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> backend)
+  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
   -> Ghc () -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
 makeHDL' _       _           _ []   = throwGhcException (CmdLineError "No input files")
 makeHDL' backend startAction r srcs = makeHDL backend startAction r $ fmap fst srcs

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -88,6 +88,7 @@ flagsClash r = [
   , defFlag "fclash-aggressive-x-optimization-blackboxes" $ NoArg (liftEwM (setAggressiveXOptBB r))
   , defFlag "fclash-inline-workfree-limit"       $ IntSuffix (liftEwM . setInlineWFLimit r)
   , defFlag "fclash-edalize"                     $ NoArg (liftEwM (setEdalize r))
+  , defFlag "fclash-no-render-enums"             $ NoArg (liftEwM (setNoRenderEnums r))
   ]
 
 -- | Print deprecated flag warning
@@ -320,3 +321,6 @@ setRewriteHistoryFile r arg = do
  where
   setFile file opts =
     opts { opt_debug = (opt_debug opts) { dbg_historyFile = Just file } }
+
+setNoRenderEnums :: IORef ClashOpts -> IO ()
+setNoRenderEnums r = modifyIORef r (\c -> c { opt_renderEnums = False })

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -62,6 +62,8 @@ data Usage
 -- | Is '-fclash-aggresive-x-optimization-blackbox' set?
 newtype AggressiveXOptBB = AggressiveXOptBB Bool
 
+-- | Is '-fclash-render-enums' set?
+newtype RenderEnums = RenderEnums Bool
 
 -- | Kind of a HDL type. Used to determine whether types need conversions in
 -- order to cross top entity boundaries.
@@ -85,6 +87,7 @@ class HasIdentifierSet state => Backend state where
     -> PreserveCase
     -> Maybe (Maybe Int)
     -> AggressiveXOptBB
+    -> RenderEnums
     -> state
 
   -- | What HDL is the backend generating
@@ -153,3 +156,5 @@ class HasIdentifierSet state => Backend state where
   ifThenElseExpr :: state -> Bool
   -- | Whether -fclash-aggressive-x-optimization-blackboxes was set
   aggressiveXOptBB :: State state AggressiveXOptBB
+  -- | Whether -fclash-no-render-enums was set
+  renderEnums :: State state RenderEnums

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -86,6 +86,7 @@ data SystemVerilogState =
     , _hdlsyn    :: HdlSyn
     , _undefValue :: Maybe (Maybe Int)
     , _aggressiveXOptBB_ :: AggressiveXOptBB
+    , _renderEnums_ :: RenderEnums
     }
 
 makeLenses ''SystemVerilogState
@@ -94,7 +95,7 @@ instance HasIdentifierSet SystemVerilogState where
   identifierSet = idSeen
 
 instance Backend SystemVerilogState where
-  initBackend w hdlsyn_ esc lw undefVal xOpt = SystemVerilogState {
+  initBackend w hdlsyn_ esc lw undefVal xOpt enums = SystemVerilogState {
       _tyCache=HashSet.empty
     , _nameCache=HashMap.empty
     , _genDepth=0
@@ -112,6 +113,7 @@ instance Backend SystemVerilogState where
     , _hdlsyn=hdlsyn_
     , _undefValue=undefVal
     , _aggressiveXOptBB_=xOpt
+    , _renderEnums_=enums
     }
   hdlKind         = const SystemVerilog
   primDirs        = const $ do root <- primsRoot
@@ -176,6 +178,7 @@ instance Backend SystemVerilogState where
   getMemoryDataFiles = use memoryDataFiles
   ifThenElseExpr _ = True
   aggressiveXOptBB = use aggressiveXOptBB_
+  renderEnums = use renderEnums_
 
 type SystemVerilogM a = Ap (State SystemVerilogState) a
 

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -103,7 +103,7 @@ instance HasIdentifierSet VerilogState where
   identifierSet = idSeen
 
 instance Backend VerilogState where
-  initBackend iw hdlsyn_ esc lw undefVal xOpt = VerilogState
+  initBackend iw hdlsyn_ esc lw undefVal xOpt _enums = VerilogState
     { _genDepth=0
     , _idSeen=Id.emptyIdentifierSet esc lw Verilog
     , _srcSpan=noSrcSpan
@@ -179,6 +179,7 @@ instance Backend VerilogState where
   getMemoryDataFiles = use memoryDataFiles
   ifThenElseExpr _ = True
   aggressiveXOptBB = use aggressiveXOptBB_
+  renderEnums = pure (RenderEnums False)
 
 type VerilogM a = Ap (State VerilogState) a
 

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -353,8 +353,9 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
       hdlsyn    = opt_hdlSyn opts
       forceUnd  = opt_forceUndefined opts
       xOpt      = coerce (opt_aggressiveXOptBB opts)
+      enums     = coerce (opt_renderEnums opts)
       hdlState' = setModName modNameT
-                $ fromMaybe (initBackend iw hdlsyn escpIds lwIds forceUnd xOpt :: backend) hdlState
+                $ fromMaybe (initBackend iw hdlsyn escpIds lwIds forceUnd xOpt enums :: backend) hdlState
       hdlDir    = fromMaybe (Clash.Backend.name hdlState') (opt_hdlDir opts) </> topEntityS
       manPath   = hdlDir </> manifestFilename
       ite       = ifThenElseExpr hdlState'

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -348,6 +348,9 @@ data ClashOpts = ClashOpts
   -- ^ At what size do we cache normalized work-free top-level binders.
   , opt_edalize :: Bool
   -- ^ Generate an EDAM file for use with Edalize.
+  , opt_renderEnums :: Bool
+  -- ^ Render sum types with all zero-width fields as enums where supported, as
+  -- opposed to rendering them as bitvectors.
   }
 
 instance Hashable ClashOpts where
@@ -378,7 +381,8 @@ instance Hashable ClashOpts where
     opt_aggressiveXOpt `hashWithSalt`
     opt_aggressiveXOptBB `hashWithSalt`
     opt_inlineWFCacheLimit `hashWithSalt`
-    opt_edalize
+    opt_edalize `hashWithSalt`
+    opt_renderEnums
    where
     hashOverridingBool :: Int -> OverridingBool -> Int
     hashOverridingBool s1 Auto = hashWithSalt s1 (0 :: Int)
@@ -416,6 +420,7 @@ defClashOpts
   , opt_aggressiveXOptBB    = False
   , opt_inlineWFCacheLimit  = 10 -- TODO: find "optimal" value
   , opt_edalize             = False
+  , opt_renderEnums         = True
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -528,6 +528,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1606B" def{hdlSim=False}
         , runTest "T1742" def{hdlSim=False, buildTargets=BuildSpecific ["shell"]}
         , runTest "T1756" def{hdlSim=False}
+        , outputTest "T431" def{hdlTargets=[VHDL]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T431.hs
+++ b/tests/shouldwork/Issues/T431.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE CPP #-}
+
+module T431 where
+
+import qualified Prelude as P
+
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+
+data TrafficLight = Red | RedAmber | Amber | Green
+
+topEntity :: TrafficLight -> TrafficLight
+topEntity Red      = RedAmber
+topEntity RedAmber = Green
+topEntity Amber    = Red
+topEntity Green    = Amber
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise = P.error $ mconcat [ "Expected:\n\n  ", needle
+                                  , "\n\nIn:\n\n", haystack ]
+
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | needle `isInfixOf` haystack = P.error $ mconcat [ "Unexpected:\n\n  ", needle
+                                                    , "\n\nIn:\n\n", haystack ]
+  | otherwise = pure ()
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
+
+  -- no bit vector literals appear, so no double quotes appear
+  assertNotIn "\"" content
+
+  -- enum variants appear in the design
+  assertIn "TrafficLight'(Red)" content
+  assertIn "TrafficLight'(RedAmber)" content
+  assertIn "TrafficLight'(Amber)" content
+  assertIn "TrafficLight'(Green)" content

--- a/tests/shouldwork/Signal/T1102A.hs
+++ b/tests/shouldwork/Signal/T1102A.hs
@@ -25,5 +25,5 @@ mainVHDL = do
   content <- readFile (topDir </> show 'topEntity </> "top.vhdl")
 
   -- TODO: Could we remove bitvector noise?
-  assertIn "x_0 <= top_types.fromSLV(x);" content
+  assertIn "x_0 <= top_types.Tup2'(top_types.fromSLV(x));" content
   assertIn "y_0 <= x_0;" content

--- a/tests/shouldwork/Signal/T1102B.hs
+++ b/tests/shouldwork/Signal/T1102B.hs
@@ -25,5 +25,5 @@ mainVHDL = do
   content <- readFile (topDir </> show 'topEntity </> "top.vhdl")
 
   -- TODO: Could we remove bitvector noise?
-  assertIn "x_0 <= top_types.fromSLV(x);" content
+  assertIn "x_0 <= top_types.Tup5'(top_types.fromSLV(x));" content
   assertIn "y_0 <= x_0;" content

--- a/tests/src/Test/Tasty/Clash/CoreTest.hs
+++ b/tests/src/Test/Tasty/Clash/CoreTest.hs
@@ -56,7 +56,7 @@ mkBackend
   :: (Backend (TargetToState target))
   => SBuildTarget target
   -> TargetToState target
-mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True PreserveCase Nothing (AggressiveXOptBB False)
+mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True PreserveCase Nothing (AggressiveXOptBB False) (RenderEnums True)
 
 -- Run clash as far as having access to core for all bindings. This is used
 -- to test operations on core, such as transformations and evaluation.

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -85,7 +85,7 @@ type family TargetToState (target :: HDL) where
 mkBackend
   :: (Backend (TargetToState target))
   => SBuildTarget target -> TargetToState target
-mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True PreserveCase Nothing (AggressiveXOptBB False)
+mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True PreserveCase Nothing (AggressiveXOptBB False) (RenderEnums True)
 
 runToNetlistStage
   :: (Backend (TargetToState target))


### PR DESCRIPTION
The VHDL backend now generates enums for `Sum` types (the netlist type for ADTs where each constructor has only zero-width fields) instead of generating a `std_logic_vector` for the type. This makes it somewhat easier to follow the generated HDL, as it preserves more user-given names in the final output.

Part of #431, although for now I think the issue should remain open. Clash _could_ also generate enums for SystemVerilog, but that hasn't been done currently due to not testing against SystemVerilog in CI

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files