### PR TITLE
Add fromInteger @Signed template to known

### DIFF
--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -128,6 +128,7 @@ import           Clash.Netlist.Types
 import           Clash.Normalize                  (checkNonRecursive, cleanupGraph,
                                                    normalize, runNormalization)
 import           Clash.Normalize.Util             (callGraph, tvSubstWithTyEq)
+import qualified Clash.Primitives.Sized.Signed    as P
 import qualified Clash.Primitives.Sized.ToInteger as P
 import qualified Clash.Primitives.Sized.Vector    as P
 import qualified Clash.Primitives.GHC.Int         as P
@@ -544,6 +545,7 @@ knownTemplateFunctions =
     , ('P.alteraPllQsysTF, P.alteraPllQsysTF)
     , ('P.alteraPllTF, P.alteraPllTF)
     , ('P.altpllTF, P.altpllTF)
+    , ('P.fromIntegerTF, P.fromIntegerTF)
     ]
 
 -- | Compiles blackbox functions and parses blackbox templates.


### PR DESCRIPTION
Per PR #1120, we have a list of known `BlackBoxFunction`s and
`TemplateFunction`s, achieving quicker startup. Commit 2e4096a9f added a
new one, and this should be added to the list. VHDL generation now no
longer emits the line

```
Hint: Interpreting Clash.Primitives.Sized.Signed.fromIntegerTF
```

I don't think this needs a Changelog. It's a fix on `master` for an issue from a change that was merged 5 days ago and isn't in a release.

I noticed that the name `fromIntegerTF` is more ambiguous than the other names used under the qualifier `P`. It could be that in the future a slight change is needed to disambiguate this `fromIntegerTF` from a future TF with the same name.

## Still TODO:

  - [ ] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
