### PR TITLE
Added DSignal forward

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ write-ghc-environment-files: always
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2021-07-27T06:09:35Z
+index-state: 2021-07-27T11:17:48Z
 
 -- For some reason the `clash-testsuite` executable fails to run without
 -- this, as it cannot find the related library...

--- a/changelog/2021-07-26T23_38_10+02_00_dsignal_forward
+++ b/changelog/2021-07-26T23_38_10+02_00_dsignal_forward
@@ -1,0 +1,1 @@
+ADDED: Added `Clash.Explicit.Signal.Delayed.forward`, a function that can be used to retime a dsignal into the future without applying any logic.

--- a/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal/Delayed.hs
@@ -2,6 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd
+                  2021     , LUMI GUIDE FIETSDETECTIE B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
@@ -37,6 +38,7 @@ module Clash.Explicit.Signal.Delayed
     -- * Experimental
   , unsafeFromSignal
   , antiDelay
+  , forward
   )
 where
 
@@ -51,7 +53,7 @@ import GHC.TypeLits               (KnownNat, Nat, type (+), type (^), type (*))
 import Clash.Sized.Vector
 import Clash.Signal.Delayed.Internal
   (DSignal(..), dfromList, dfromList_lazy, fromSignal, toSignal,
-   unsafeFromSignal, antiDelay, feedback)
+   unsafeFromSignal, antiDelay, feedback, forward)
 
 import Clash.Explicit.Signal
   (KnownDomain, Clock, Domain, Reset, Signal, Enable, register, delay, bundle, unbundle)

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -2,6 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd
+                  2021     , LUMI GUIDE FIETSDETECTIE B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
@@ -34,6 +35,7 @@ module Clash.Signal.Delayed
     -- * Experimental
   , unsafeFromSignal
   , antiDelay
+  , forward
   )
 where
 
@@ -42,7 +44,7 @@ import           GHC.TypeLits
 
 import Clash.Signal.Delayed.Internal
   (DSignal(..), dfromList, dfromList_lazy, fromSignal, toSignal,
-   unsafeFromSignal, antiDelay, feedback)
+   unsafeFromSignal, antiDelay, feedback, forward)
 import qualified Clash.Explicit.Signal.Delayed as E
 import           Clash.Sized.Vector
 import           Clash.Signal


### PR DESCRIPTION
Added `Clash.Explicit.Signal.Delayed.forward`, a function that can be used to retime a dsignal into the future without applying any logic.

I was rewriting some older Clash code which used `coerce` for this. I can still use `unsafeCoerce` but I rather add a proper function.

See this google groups thread for reference:

https://groups.google.com/g/clash-language/c/9r950cOZLg0

I couldn't really come up with a small example that you could not solve easily with `antiDelay`. So if you guys have something better please let me know :). 

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

