### PR TITLE
Kloonbot return 0 for non @kloonbot comments

### DIFF
--- a/.ci/kloonbot.sh
+++ b/.ci/kloonbot.sh
@@ -27,11 +27,16 @@ parse_comment(){
   local cmd=$(echo "${line}" | awk '{print $2}')
   local commit=$(echo "${line}" | awk '{print $3}')
 
-  if [[ ${at} == "@kloonbot" && ${cmd} == "run_ci" ]]; then
-    echo $(echo "$commit" | tr -d '\n\r ')
+  if [[ ${at} == "@kloonbot" ]]; then
+    if [[ ${cmd} == "run_ci" ]]; then
+      echo $(echo "$commit" | tr -d '\n\r ')
+    else
+      echo "parse_comment: Could not parse comment" 1>&2
+      exit 1;
+    fi
   else
-    echo "parse_comment: Could not parse comment" 1>&2
-    exit 1;
+    echo "parse_comment: Comment not directed @kloonbot"
+    exit 0;
   fi
 }
 


### PR DESCRIPTION
Kloonbot now respects your boundaries more concerning private conversations, and returns a success exit code for any comment which doesn't start `@kloonbot`. Comments which start `@kloonbot` but are not valid commands still return a failure exit code.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
