### PR TITLE
Return "" for irrelevant comments in kloonbot

### DIFF
--- a/.ci/kloonbot.sh
+++ b/.ci/kloonbot.sh
@@ -35,7 +35,8 @@ parse_comment(){
       exit 1;
     fi
   else
-    echo "parse_comment: Comment not directed @kloonbot"
+    # When the comment is not directed @kloonbot, return an empty string.
+    echo ""
     exit 0;
   fi
 }
@@ -43,15 +44,18 @@ parse_comment(){
 if [[ $KBOT_AUTHOR_ASSOC =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
   commit=$(parse_comment)
 
-  pull_request_json=$(curl -H "${HEADERS}" "${KBOT_PULL_REQUEST_URL}")
-  is_fork=$(echo "$pull_request_json" | jq -r ".head.repo.fork")
+  # If the comment is empty, do nothing successfully.
+  if [[ ! -z ${commit} ]]; then
+    pull_request_json=$(curl -H "${HEADERS}" "${KBOT_PULL_REQUEST_URL}")
+    is_fork=$(echo "$pull_request_json" | jq -r ".head.repo.fork")
 
-  if [[ ${is_fork} == "true" ]]; then
-    # At this point we've established that:
-    #
-    #  1. This pull request is coming from a forked repo
-    #  2. A comment was made by someone trusted
-    #  3. The comment indicated CI should be run on local runners
-    kloon_fork_branch_to_local_branch "${pull_request_json}" "${commit}"
+    if [[ ${is_fork} == "true" ]]; then
+      # At this point we've established that:
+      #
+      #  1. This pull request is coming from a forked repo
+      #  2. A comment was made by someone trusted
+      #  3. The comment indicated CI should be run on local runners
+      kloon_fork_branch_to_local_branch "${pull_request_json}" "${commit}"
+    fi
   fi
 fi


### PR DESCRIPTION
Attempting to exit from the parse_comment function in kloonbot
only exits the subshell, meaning exiting 0 would set the result to
the echoed message and then use that message as a command. Now
kloonbot will return the empty string, and then check if the parsed
comment is empty before continuing.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
