### PR TITLE
Added zeroWidthSpec transformation

### DIFF
--- a/changelog/2021-08-05T15_03_12+02_00_zero_width_spec.md
+++ b/changelog/2021-08-05T15_03_12+02_00_zero_width_spec.md
@@ -1,0 +1,28 @@
+INTERNAL CHANGE: Added zeroWidthSpec transformation.
+
+A new transformation has been defined, which replaces lambda-bound variables
+for a zero-width value with the value itself in the body of the lambda. e.g.
+
+```haskell
+data AB = A | B
+
+ab :: KnownNat n => Index n -> AB -> AB
+ab n A = if n >  0 then A else B
+ab n B = if n == 0 then B else A
+```
+
+would see the values of n in the function body be replaced with 0 (the only
+possible value of the type `Index 1`)
+
+```haskell
+ab _ A = if 0 > 0 then A else B
+ab _ B = if 0 == 0 then B else A
+```
+
+the normalizer is then free to further normalize this to
+
+```haskell
+ab _ _ = B
+```
+
+where previously it would not be able to improve this during normalization.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -508,7 +508,8 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "VecFun" def
       ]
       , clashTestGroup "Issues" $
-        [ let _opts = def { hdlSim = False, hdlTargets = [Verilog] }
+        [ clashLibTest "T508" def
+        , let _opts = def { hdlSim = False, hdlTargets = [Verilog] }
            in runTest "T1187" _opts
         , clashLibTest "T1388" def{hdlTargets=[VHDL]}
         , outputTest "T1171" def

--- a/tests/shouldwork/Issues/T508.hs
+++ b/tests/shouldwork/Issues/T508.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module T508 where
+
+import Clash.Prelude
+
+import Clash.Backend
+import qualified Clash.Netlist.Id as Id
+import Clash.Netlist.Types
+
+import Test.Tasty.Clash
+import Test.Tasty.Clash.NetlistTest
+
+data AB = A | B
+
+ab :: KnownNat n => Index n -> AB -> AB
+ab n A = if n >  0 then A else B
+ab n B = if n == 0 then B else A
+{-# NOINLINE ab #-}
+
+topEntity = ab @1
+{-# NOINLINE topEntity #-}
+
+testPath :: FilePath
+testPath = "tests/shouldwork/Issues/T508.hs"
+
+abIsConstant :: Component -> IO ()
+abIsConstant (Component nm _ _ ds)
+  | Id.toText nm == "ab" =
+      case ds of
+        [Assignment{}] -> pure ()
+        _ -> error $ "Zero-width construct was not constant folded in: " <> show ds
+
+  | otherwise = pure ()
+
+mainCommon :: (Backend (TargetToState hdl)) => SBuildTarget hdl -> IO ()
+mainCommon hdl = do
+  netlist <- runToNetlistStage hdl id testPath
+  mapM_ (abIsConstant . snd) netlist
+
+mainVHDL :: IO ()
+mainVHDL = mainCommon SVHDL
+
+mainVerilog :: IO ()
+mainVerilog = mainCommon SVerilog
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = mainCommon SSystemVerilog

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -16,6 +16,7 @@
 --
 module Test.Tasty.Clash.NetlistTest
   ( runToNetlistStage
+  , TargetToState
   ) where
 
 import qualified Prelude as P


### PR DESCRIPTION
A new transformation has been defined, which replaces lambda-bound variables for a zero-width type with the only possible value of that type in the body of the lambda. e.g.

```haskell
data AB = A | B

ab :: KnownNat n => Index n -> AB -> AB
ab n A = if n >  0 then A else B
ab n B = if n == 0 then B else A
```

would see the values of n in the function body be replaced with 0 (the only possible value of the type `Index 1`)

```haskell
ab _ A = if 0 > 0 then A else B
ab _ B = if 0 == 0 then B else A
```

the normalizer is then free to further normalize this to

```haskell
ab _ _ = B
```

where previously it would not be able to improve this during normalization.

Fixes #508

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
