### PR TITLE
Qualify unsafeSynchronizer in Clash.Tutorial

### DIFF
--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -1656,10 +1656,10 @@ ptrSync clk1 clk2 rst2 en2 =
   'Clash.Explicit.Signal.register' clk2 rst2 en2 0 . 'Clash.Explicit.Signal.register' clk2 rst2 en2 0 . 'Clash.Explicit.Signal.unsafeSynchronizer' clk1 clk2
 @
 
-It uses the 'unsafeSynchronizer' primitive, which is needed to go from one clock
+It uses the 'Clash.Explicit.Signal.unsafeSynchronizer' primitive, which is needed to go from one clock
 domain to the other. All synchronizers are specified in terms of
-'unsafeSynchronizer' (see for example the <src/Clash-Prelude-RAM.html#line-103 source of asyncRam>).
-The 'unsafeSynchronizer' primitive is turned into a (bundle of) wire(s) by the
+'Clash.Explicit.Signal.unsafeSynchronizer' (see for example the <src/Clash-Prelude-RAM.html#line-103 source of asyncRam>).
+The 'Clash.Explicit.Signal.unsafeSynchronizer' primitive is turned into a (bundle of) wire(s) by the
 Clash compiler, so developers must ensure that it is only used as part of a
 proper synchronizer.
 


### PR DESCRIPTION
When building tags in CI, -multiple-hidden is used everywhere (in contrast to CI jobs on branches where it is on by default everywhere except 8.6.5). This means the haddock job fails, as unqualified references to `unsafeSynchronizer` in `Clash.Tutorial` will not refer to anything in scope (as it is only exported from the explicit prelude when multiple hidden is off).

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
