### PR TITLE
Preserve boolean combinatorial logic in HDL

### DIFF
--- a/changelog/2021-08-12T14_31_56+02_00_preserve_boolean_logic.md
+++ b/changelog/2021-08-12T14_31_56+02_00_preserve_boolean_logic.md
@@ -1,0 +1,1 @@
+FIXED: Clash now preserves boolean combinatorial logic better when generating HDL [#1881](https://github.com/clash-lang/clash-compiler/issues/1881)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -531,6 +531,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1756" def{hdlSim=False}
         , outputTest "T431" def{hdlTargets=[VHDL]}
         , clashLibTest "T779" def{hdlTargets=[Verilog]}
+        , outputTest "T1881" def{hdlSim=False}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
@@ -8,7 +8,7 @@ module RotateCScrambled
 
 import Clash.Prelude.Testbench
 import Clash.Prelude
-import Prelude
+import Prelude hiding (not)
 import Data.Maybe
 import GHC.Generics
 import Clash.Annotations.BitRepresentation

--- a/tests/shouldwork/Issues/T1881.hs
+++ b/tests/shouldwork/Issues/T1881.hs
@@ -1,0 +1,49 @@
+module T1881 where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+
+topEntity :: Bool -> Bool -> (Bool, Bool, Bool)
+topEntity a b = (a && b, a || b, not a)
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise = P.error $ mconcat [ "Expected:\n\n  ", needle
+                                  , "\n\nIn:\n\n", haystack ]
+
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
+
+  assertIn "and" content
+  assertIn "or" content
+  assertIn "not" content
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
+
+  -- Each of these operators should appear, instead of the options being
+  -- expanded out into multiplexers.
+  assertIn "&" content
+  assertIn "|" content
+  assertIn "~" content
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
+
+  -- Each of these operators should appear, instead of the options being
+  -- expanded out into multiplexers.
+  assertIn "&" content
+  assertIn "|" content
+  assertIn "~" content

--- a/tests/shouldwork/LoadModules/T1796.hs
+++ b/tests/shouldwork/LoadModules/T1796.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 
 module T1796 where


### PR DESCRIPTION
When rendering HDL, clash now better preserves boolean functions from GHC which may be targeted by the simplifier. This helps ensure they are rendered in HDL as the expected operator instead of being rendered as a multiplexer.

Fixes #1881.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
