### PR TITLE
Add missing warnings to Integer/Natural prims

### DIFF
--- a/clash-lib/prims/common/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/common/GHC_Integer_Type.primitives
@@ -3,6 +3,7 @@
     , "kind"      : "Expression"
     , "type"      : "plusInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] + ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.plusInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -10,6 +11,7 @@
     , "kind"      : "Expression"
     , "type"      : "minusInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] - ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.minusInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -17,6 +19,7 @@
     , "kind"      : "Expression"
     , "type"      : "leInteger :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] <= ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.leInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -24,6 +27,7 @@
     , "kind"      : "Expression"
     , "type"      : "gtInteger :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] > ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.gtInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -31,6 +35,7 @@
     , "kind"      : "Expression"
     , "type"      : "ltInteger :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] < ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.ltInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -38,6 +43,7 @@
     , "kind"      : "Expression"
     , "type"      : "geInteger :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] >= ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.geInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/common/GHC_Natural.primitives
+++ b/clash-lib/prims/common/GHC_Natural.primitives
@@ -4,7 +4,8 @@
       "name": "GHC.Natural.NatS#",
       "workInfo" : "Never",
       "primType": "Constructor",
-      "comment": "Needed to make the evaluator handle this constructor strictly"
+      "comment": "Needed to make the evaluator handle this constructor strictly",
+      "warning": "GHC.Natural.NatS#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   },
   {
@@ -46,7 +47,8 @@
     "Primitive": {
       "name": "GHC.Natural.gcdNatural",
       "workInfo" : "Never",
-      "primType": "Function"
+      "primType": "Function",
+      "warning": "GHC.Natural.gcdNatural: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/common/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/common/GHC_Num_Integer.primitives
@@ -3,6 +3,7 @@
   , "workInfo": "Never"
   , "primType": "Constructor"
   , "comment": "Needed to make the evaluator handle this constructor strictly"
+  , "warning": "GHC.Num.Integer.IS: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 ,  { "Primitive":
@@ -10,6 +11,7 @@
   , "workInfo": "Never"
   , "primType": "Constructor"
   , "comment": "Needed to make the evaluator handle this constructor strictly"
+  , "warning": "GHC.Num.Integer.IP: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "Primitive":
@@ -17,6 +19,7 @@
   , "workInfo": "Never"
   , "primType": "Constructor"
   , "comment": "Needed to make the evaluator handle this constructor strictly"
+  , "warning": "GHC.Num.Integer.IN: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "Primitive":
@@ -31,6 +34,7 @@
   , "kind"      : "Expression"
   , "type"      : "integerAdd :: Integer -> Integer -> Integer"
   , "template"  : "~ARG[0] + ~ARG[1]"
+  , "warning"   : "GHC.Num.Integer.integerAdd: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -38,6 +42,7 @@
   , "kind"      : "Expression"
   , "type"      : "integerSub :: Integer -> Integer -> Integer"
   , "template"  : "~ARG[0] - ~ARG[1]"
+  , "warning"   : "GHC.Num.Integer.integerSub: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -45,6 +50,7 @@
   , "kind"      : "Expression"
   , "type"      : "integerLe :: Integer -> Integer -> Bool"
   , "template"  : "~ARG[0] <= ~ARG[1]"
+  , "warning"   : "GHC.Num.Integer.integerLe: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -52,6 +58,7 @@
   , "kind"      : "Expression"
   , "type"      : "integerGt :: Integer -> Integer -> Bool"
   , "template"  : "~ARG[0] > ~ARG[1]"
+  , "warning"   : "GHC.Num.Integer.integerGt: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -59,6 +66,7 @@
   , "kind"      : "Expression"
   , "type"      : "integerLt :: Integer -> Integer -> Bool"
   , "template"  : "~ARG[0] < ~ARG[1]"
+  , "warning"   : "GHC.Num.Integer.integerLt: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -66,6 +74,7 @@
   , "kind"      : "Expression"
   , "type"      : "integerGe :: Integer -> Integer -> Bool"
   , "template"  : "~ARG[0] >= ~ARG[1]"
+  , "warning"   : "GHC.Num.Integer.integerGe: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 ]

--- a/clash-lib/prims/common/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/common/GHC_Num_Natural.primitives
@@ -4,7 +4,8 @@
       "name": "GHC.Num.Natural.NS",
       "workInfo" : "Never",
       "primType": "Constructor",
-      "comment": "Needed to make the evaluator handle this constructor strictly"
+      "comment": "Needed to make the evaluator handle this constructor strictly",
+      "warning": "GHC.Num.Natural.NS: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   },
   {
@@ -12,7 +13,8 @@
       "name": "GHC.Num.Natural.NB",
       "workInfo" : "Never",
       "primType": "Constructor",
-      "comment": "Needed to make the evaluator handle this constructor strictly"
+      "comment": "Needed to make the evaluator handle this constructor strictly",
+      "warning": "GHC.Num.Natural.NB: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   },
   {
@@ -28,7 +30,8 @@
     "Primitive": {
       "name": "GHC.Num.Natural.naturalSub",
       "workInfo" : "Never",
-      "primType": "Function"
+      "primType": "Function",
+      "warning": "GHC.Num.Natural.naturalSub: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   },
   {
@@ -62,14 +65,16 @@
     "Primitive": {
       "name": "GHC.Num.Natural.naturalGcd",
       "workInfo" : "Never",
-      "primType": "Function"
+      "primType": "Function",
+      "warning": "GHC.Num.Natural.naturalGcd: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   },
   {
     "Primitive": {
       "name": "GHC.Num.Natural.naturalLcm",
       "workInfo" : "Never",
-      "primType": "Function"
+      "primType": "Function",
+      "warning": "GHC.Num.Natural.naturalLcm: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/commonverilog/GHC_Integer_Logarithms.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Integer_Logarithms.primitives
@@ -18,6 +18,7 @@ endfunction"
         }
       ]
     , "template"  : "~INCLUDENAME[0](~ARG[0],~ARG[1])"
+    , "warning"   : "GHC.Integer.Logarithms.integerLogBase#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/commonverilog/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Integer_Type.primitives
@@ -4,6 +4,7 @@
     , "kind"      : "Declaration"
     , "type"      : "smallInteger :: Int# -> Integer"
     , "template"  : "assign ~RESULT = $signed(~ARG[0]);"
+    , "warning"   : "GHC.Integer.Type.smallInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -12,6 +13,7 @@
     , "kind"      : "Declaration"
     , "type"      : "integerToInt :: Integer -> Int#"
     , "template"  : "assign ~RESULT = $signed(~ARG[0]);"
+    , "warning"   : "GHC.Integer.Type.integerToInt: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -19,6 +21,7 @@
     , "kind"      : "Expression"
     , "type"      : "timesInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] * ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.timesInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -26,6 +29,7 @@
     , "kind"      : "Expression"
     , "type"      : "negateInteger :: Integer -> Integer"
     , "template"  : "-~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.negateInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -33,6 +37,7 @@
     , "kind"      : "Expression"
     , "type"      : "absInteger :: Integer -> Integer"
     , "template"  : "(~ARG[0] < ~SIZE[~TYPO]'sd0) ? -~ARG[0] : ~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.absInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -40,6 +45,7 @@
     , "kind"      : "Expression"
     , "type"      : "remInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] % ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.remInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -47,6 +53,7 @@
     , "kind"      : "Expression"
     , "type"      : "eqInteger :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] == ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.eqInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -54,6 +61,7 @@
     , "kind"      : "Expression"
     , "type"      : "neqInteger :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] != ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.neqInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -61,6 +69,7 @@
     , "kind"      : "Expression"
     , "type"      : "eqInteger :: Integer -> Integer -> Bool"
     , "template"  : "(~ARG[0] == ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Integer.Type.eqInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -68,6 +77,7 @@
     , "kind"      : "Expression"
     , "type"      : "neqInteger :: Integer -> Integer -> Bool"
     , "template"  : "(~ARG[0] != ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Integer.Type.neqInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -75,6 +85,7 @@
     , "kind"      : "Expression"
     , "type"      : "leInteger :: Integer -> Integer -> Bool"
     , "template"  : "(~ARG[0] <= ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Integer.Type.leInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -82,6 +93,7 @@
     , "kind"      : "Expression"
     , "type"      : "gtInteger :: Integer -> Integer -> Bool"
     , "template"  : "(~ARG[0] > ~ARG[1] ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Integer.Type.gtInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -89,6 +101,7 @@
     , "kind"      : "Expression"
     , "type"      : "ltInteger :: Integer -> Integer -> Bool"
     , "template"  : "(~ARG[0] < ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Integer.Type.ltInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -96,6 +109,7 @@
     , "kind"      : "Expression"
     , "type"      : "geInteger :: Integer -> Integer -> Bool"
     , "template"  : "(~ARG[0] >= ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Integer.Type.geInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -103,6 +117,7 @@
     , "kind"      : "Expression"
     , "type"      : "shiftRInteger :: Integer -> Int# -> Integer"
     , "template"  : "~ARG[0] >>> ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.shiftRInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -110,6 +125,7 @@
     , "kind"      : "Expression"
     , "type"      : "shiftLInteger :: Integer -> Int# -> Integer"
     , "template"  : "~ARG[0] <<< ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.shiftLInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -117,6 +133,7 @@
     , "kind"      : "Expression"
     , "type"      : "testBitInteger :: Integer -> Int# -> Bool"
     , "template"  : "~VAR[input][0][~ARG[1]] == 1'b1"
+    , "warning"   : "GHC.Integer.Type.testBitInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -125,6 +142,7 @@
     , "kind"      : "Declaration"
     , "type"      : "wordToInteger :: Word# -> Integer"
     , "template"  : "assign ~RESULT = $signed(~ARG[0]);"
+    , "warning"   : "GHC.Integer.Type.wordToInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -133,6 +151,7 @@
     , "kind"      : "Declaration"
     , "type"      : "integerToWord :: Integer -> Word#"
     , "template"  : "assign ~RESULT = $unsigned(~ARG[0]);"
+    , "warning"   : "GHC.Integer.Type.integerToWord: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -142,6 +161,7 @@
     , "type"      : "integerToWord :: Integer -> Word64#"
     , "comment"   : "only used by 32 bit GHC"
     , "template"  : "assign ~RESULT = $unsigned(~ARG[0]);"
+    , "warning"   : "GHC.Integer.Type.integerToWord64: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -149,6 +169,7 @@
     , "kind"      : "Expression"
     , "type"      : "bitInteger :: Int -> Integer"
     , "template"  : "1 << ~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.bitInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -156,6 +177,7 @@
     , "kind"      : "Expression"
     , "type"      : "complementInteger :: Integer -> Integer"
     , "template"  : "~ ~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.complementInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -163,6 +185,7 @@
     , "kind"      : "Expression"
     , "type"      : "xorInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] ^ ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.xorInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -170,6 +193,7 @@
     , "kind"      : "Expression"
     , "type"      : "orInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] | ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.orInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -177,6 +201,7 @@
     , "kind"      : "Expression"
     , "type"      : "andInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] & ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.andInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -184,6 +209,7 @@
     , "kind"      : "Expression"
     , "type"      : "$wsignumInteger :: Integer -> Integer"
     , "template"  : "(~ARG[0] < ~SIZE[~TYPO]'sd0) ? -~SIZE[~TYPO]'sd1 : ((~ARG[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SIZE[~TYPO]'sd1)"
+    , "warning"   : "GHC.Integer.Type.$wsignumInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -191,6 +217,7 @@
     , "kind"      : "Expression"
     , "type"      : "quotInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] / ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.quotInteger: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/commonverilog/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Num_Integer.primitives
@@ -31,6 +31,7 @@
     , "kind"      : "Declaration"
     , "type"      : "integerToInt :: Integer -> Int#"
     , "template"  : "assign ~RESULT = $signed(~ARG[0]);"
+    , "warning"   : "GHC.Num.Integer.integerToInt#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -38,6 +39,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerMul :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] * ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerMul: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -45,6 +47,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerNegate :: Integer -> Integer"
     , "template"  : "-~ARG[0]"
+    , "warning"   : "GHC.Num.Integer.integerNegate: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -52,6 +55,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerAbs :: Integer -> Integer"
     , "template"  : "(~ARG[0] < ~SIZE[~TYPO]'sd0) ? -~ARG[0] : ~ARG[0]"
+    , "warning"   : "GHC.Num.Integer.integerAbs: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -59,6 +63,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerRem :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] % ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerRem: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -66,6 +71,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerEq :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] == ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerEq: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -73,6 +79,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerNe :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] != ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerNe: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -80,6 +87,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerEq :: Integer -> Integer -> Int#"
     , "template"  : "(~ARG[0] == ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Num.Integer.integerEq#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -87,6 +95,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerNe# :: Integer -> Integer -> Int#"
     , "template"  : "(~ARG[0] != ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Num.Integer.integerNe#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -94,6 +103,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerLe :: Integer -> Integer -> Int#"
     , "template"  : "(~ARG[0] <= ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Num.Integer.integerLe#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -101,6 +111,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerGt# :: Integer -> Integer -> Int#"
     , "template"  : "(~ARG[0] > ~ARG[1] ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Num.Integer.integerGt#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -108,6 +119,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerLt# :: Integer -> Integer -> Int#"
     , "template"  : "(~ARG[0] < ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Num.Integer.integerLt#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -115,6 +127,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerGe# :: Integer -> Integer -> Int#"
     , "template"  : "(~ARG[0] >= ~ARG[1]) ? ~SIZE[~TYPO]'sd1 : ~SIZE[~TYPO]'sd0"
+    , "warning"   : "GHC.Num.Integer.integerGe#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -122,6 +135,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerShiftR :: Integer -> Word# -> Integer"
     , "template"  : "~ARG[0] >>> ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerShiftR#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -129,6 +143,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerShiftL :: Integer -> Word# -> Integer"
     , "template"  : "~ARG[0] <<< ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerShiftL#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -136,6 +151,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerTestBit :: Integer -> Word# -> Bool"
     , "template"  : "~VAR[input][0][~ARG[1]] == 1'b1"
+    , "warning"   : "GHC.Num.Integer.integerTestBit#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -144,6 +160,7 @@
     , "kind"      : "Declaration"
     , "type"      : "integerFromWord# :: Word# -> Integer"
     , "template"  : "assign ~RESULT = $signed(~ARG[0]);"
+    , "warning"   : "GHC.Num.Integer.integerFromWord#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -152,6 +169,7 @@
     , "kind"      : "Declaration"
     , "type"      : "integerToWord# :: Integer -> Word#"
     , "template"  : "assign ~RESULT = $unsigned(~ARG[0]);"
+    , "warning"   : "GHC.Num.Integer.integerToWord#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -161,6 +179,7 @@
     , "type"      : "integerToWord64# :: Integer -> Word64#"
     , "comment"   : "only used by 32 bit GHC"
     , "template"  : "assign ~RESULT = $unsigned(~ARG[0]);"
+    , "warning"   : "GHC.Num.Integer.integerToWord64#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -168,6 +187,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerBit# :: Word# -> Integer"
     , "template"  : "1 << ~ARG[0]"
+    , "warning"   : "GHC.Num.Integer.integerBit#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -175,6 +195,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerComplement :: Integer -> Integer"
     , "template"  : "~ ~ARG[0]"
+    , "warning"   : "GHC.Num.Integer.integerComplement: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -182,6 +203,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerXor :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] ^ ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerXor: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -189,6 +211,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerOr :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] | ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerOr: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -196,6 +219,7 @@
     , "kind"      : "Expression"
     , "type"      : "andInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] & ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerAnd: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -203,6 +227,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerSignum :: Integer -> Integer"
     , "template"  : "(~ARG[0] < ~SIZE[~TYPO]'sd0) ? -~SIZE[~TYPO]'sd1 : ((~ARG[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SIZE[~TYPO]'sd1)"
+    , "warning"   : "GHC.Num.Integer.integerSignum: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
   , { "BlackBox" :
@@ -210,6 +235,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerSignum :: Integer -> Int#"
     , "template"  : "(~ARG[0] < ~SIZE[~TYPO]'sd0) ? -~SIZE[~TYPO]'sd1 : ((~ARG[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SIZE[~TYPO]'sd1)"
+    , "warning"   : "GHC.Num.Integer.$wintegerSignum: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -232,6 +258,7 @@ endfunction"
         }
       ]
     , "template"  : "~INCLUDENAME[0](~ARG[0],~ARG[1])"
+    , "warning"   : "GHC.Num.Integer.integerLogBase#: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -239,6 +266,7 @@ endfunction"
     , "kind"      : "Expression"
     , "type"      : "integerCompare :: Integer -> Integer -> Ordering"
     , "template"  : "(~ARG[0] < ~ARG[1]) ? -~SIZE[~TYPO]'d0 : ((~ARG[0] == ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d2)"
+    , "warning"   : "GHC.Num.Integer.integerCompare: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -246,6 +274,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "integerQuot :: Integer -> Integer -> Integer"
   , "template"  : "~ARG[0] / ~ARG[1]"
+  , "warning"   : "GHC.Num.Integer.integerQuot: Integers are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 ]

--- a/clash-lib/prims/commonverilog/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Num_Natural.primitives
@@ -23,6 +23,7 @@
     , "kind"      : "Expression"
     , "type"      : "naturalRem :: Natural -> Natural -> Natural"
     , "template"  : "~ARG[0] % ~ARG[1]"
+    , "warning"   : "GHC.Num.Natural.naturalRem: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -45,6 +46,7 @@ endfunction"
       }
     ]
   , "template"  : "~INCLUDENAME[0](~ARG[0],~ARG[1])"
+  , "warning"   : "GHC.Num.Natural.naturalLogBase#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -52,6 +54,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalEq :: Natural -> Natural -> Int#"
   , "template"  : "(~ARG[0] == ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d0"
+  , "warning"   : "GHC.Num.Natural.naturalEq#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -59,6 +62,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalNe# :: Natural -> Natural -> Int#"
   , "template"  : "(~ARG[0] != ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d0"
+  , "warning"   : "GHC.Num.Natural.naturalNe#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -66,6 +70,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalLe :: Natural -> Natural -> Int#"
   , "template"  : "(~ARG[0] <= ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d0"
+  , "warning"   : "GHC.Num.Natural.naturalLe#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -73,6 +78,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalGt# :: Natural -> Natural -> Int#"
   , "template"  : "(~ARG[0] > ~ARG[1] ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d0"
+  , "warning"   : "GHC.Num.Natural.naturalGt#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -80,6 +86,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalLt# :: Natural -> Natural -> Int#"
   , "template"  : "(~ARG[0] < ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d0"
+  , "warning"   : "GHC.Num.Natural.naturalLt#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -87,6 +94,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalGe# :: Natural -> Natural -> Int#"
   , "template"  : "(~ARG[0] >= ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d0"
+  , "warning"   : "GHC.Num.Natural.naturalGe#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -94,6 +102,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalShiftL# :: Natural -> Word# -> Natural"
   , "template"  : "~ARG[0] <<< ~ARG[1]"
+  , "warning"   : "GHC.Num.Natural.naturalShiftL#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -101,6 +110,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalShiftR# :: Natuarl -> Word# -> Natural"
   , "template"  : "~ARG[0] >>> ~ARG[1]"
+  , "warning"   : "GHC.Num.Natural.naturalShiftR#: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -108,6 +118,7 @@ endfunction"
   , "kind"      : "Expression"
   , "type"      : "naturalCompare :: Natural -> Natural -> Ordering"
   , "template"  : "(~ARG[0] < ~ARG[1]) ? -~SIZE[~TYPO]'d0 : ((~ARG[0] == ~ARG[1]) ? ~SIZE[~TYPO]'d1 : ~SIZE[~TYPO]'d2)"
+  , "warning"   : "GHC.Num.Natural.naturalCompare: Naturals are dynamically sized in simulation, but fixed-length after synthesization. Use carefully."
   }
 }
 , {

--- a/clash-lib/prims/systemverilog/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/systemverilog/GHC_Integer_Type.primitives
@@ -23,6 +23,7 @@ assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
 assign ~SYM[6] = ~SYM[3] / ~SYM[5];
 assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // divInteger end"
+    , "warning"   : "GHC.Integer.Type.divInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -40,6 +41,7 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
                  ~SYM[0] :
                  ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInteger end"
+    , "warning"   : "GHC.Integer.Type.modInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -77,6 +79,7 @@ assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[
 
 assign ~RESULT = {~SYM[7],~SYM[9]};
 // divModInteger end"
+    , "warning"   : "GHC.Integer.Type.divModInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -92,6 +95,7 @@ assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
 assign ~RESULT = {~SYM[0],~SYM[1]};
 // quotRemInteger end"
+    , "warning"   : "GHC.Integer.Type.quotRemInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/systemverilog/GHC_Num_Integer.primitives
@@ -23,6 +23,7 @@ assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
 assign ~SYM[6] = ~SYM[3] / ~SYM[5];
 assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // integerDiv end"
+    , "warning"   : "GHC.Num.Integer.integerDiv: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -40,6 +41,7 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
                  ~SYM[0] :
                  ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // integerMod end"
+    , "warning"   : "GHC.Num.Integer.integerMod: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -77,6 +79,7 @@ assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[
 
 assign ~RESULT = {~SYM[7],~SYM[9]};
 // integerDivMod end"
+    , "warning"   : "GHC.Num.Integer.integerDivMod#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -92,6 +95,7 @@ assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
 assign ~RESULT = {~SYM[0],~SYM[1]};
 // integerQuotRem end"
+    , "warning"   : "GHC.Num.Integer.integerQuotRem#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/verilog/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/verilog/GHC_Integer_Type.primitives
@@ -23,6 +23,7 @@ assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
 assign ~SYM[6] = ~SYM[3] / ~SYM[5];
 assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // divInteger end"
+    , "warning"   : "GHC.Integer.Type.divInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -40,6 +41,7 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
                  ~SYM[0] :
                  ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // modInteger end"
+    , "warning"   : "GHC.Integer.Type.modInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -79,6 +81,7 @@ assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[
 
 assign ~RESULT = {~SYM[7],~SYM[9]};
 // divModInteger end"
+    , "warning"   : "GHC.Integer.Type.divModInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -94,6 +97,7 @@ assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
 assign ~RESULT = {~SYM[0],~SYM[1]};
 // quotRemInteger end"
+    , "warning"   : "GHC.Integer.Type.quotRemInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/verilog/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/verilog/GHC_Num_Integer.primitives
@@ -23,6 +23,7 @@ assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
 assign ~SYM[6] = ~SYM[3] / ~SYM[5];
 assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
 // integerDiv end"
+    , "warning"   : "GHC.Num.Integer.integerDiv: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -40,6 +41,7 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
                  ~SYM[0] :
                  ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
 // integerMod end"
+    , "warning"   : "GHC.Num.Integer.integerMod: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -79,6 +81,7 @@ assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[
 
 assign ~RESULT = {~SYM[7],~SYM[9]};
 // integerDivMod end"
+    , "warning"   : "GHC.Num.Integer.integerDivMod#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -94,6 +97,7 @@ assign ~SYM[1] = ~ARG[0] % ~ARG[1];
 
 assign ~RESULT = {~SYM[0],~SYM[1]};
 // integerQuotRem end"
+    , "warning"   : "GHC.Num.Integer.integerQuotRem#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/vhdl/GHC_Integer_Logarithms.primitives
+++ b/clash-lib/prims/vhdl/GHC_Integer_Logarithms.primitives
@@ -3,6 +3,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerLogBase# :: Integer -> Integer -> Int#"
     , "template"  : "integer(floor(log(real(~ARG[1]),real(~ARG[0]))))"
+    , "warning"   : "GHC.Integer.Logarithms.integerLogBase#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
@@ -4,6 +4,7 @@
     , "kind"      : "Expression"
     , "type"      : "smallInteger :: Int# -> Integer"
     , "template"  : "~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.smallInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -12,6 +13,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerToInt :: Integer -> Int#"
     , "template"  : "~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.integerToInt: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -19,6 +21,7 @@
     , "kind"      : "Expression"
     , "type"      : "timesInteger :: Integer -> Integer -> Integer"
     , "template"  : "resize(~ARG[0] * ~ARG[1],~SIZE[~TYPO])"
+    , "warning"   : "GHC.Integer.Type.timesInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -26,6 +29,7 @@
     , "kind"      : "Expression"
     , "type"      : "negateInteger :: Integer -> Integer"
     , "template"  : "-~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.negateInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -33,6 +37,7 @@
     , "kind"      : "Expression"
     , "type"      : "absInteger :: Integer -> Integer"
     , "template"  : "abs ~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.absInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -60,6 +65,7 @@ begin
   ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
 -- divInteger end"
+    , "warning"   : "GHC.Integer.Type.divInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -67,6 +73,7 @@ end block;
     , "kind"      : "Expression"
     , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] mod ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.modInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -102,6 +109,7 @@ begin
   ~RESULT <= (~SYM[5], ~SYM[6]);
 end block;
 -- divModInteger end"
+    , "warning"   : "GHC.Integer.Type.divModInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -114,6 +122,7 @@ end block;
     when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
     -- pragma translate_on
     ;"
+    , "warning"   : "GHC.Integer.Type.quotRemInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -126,6 +135,7 @@ end block;
     when (~ARG[1] /= 0) else (others => 'X')
     -- pragma translate_on
     ;"
+    , "warning"   : "GHC.Integer.Type.remInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -133,6 +143,7 @@ end block;
     , "kind"      : "Expression"
     , "type"      : "eqInteger :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] = ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.eqInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -140,6 +151,7 @@ end block;
     , "kind"      : "Expression"
     , "type"      : "neqInteger :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] /= ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.neqInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -147,6 +159,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "eqInteger# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] = ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Integer.Type.eqInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -154,6 +167,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "neqInteger# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] /= ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Integer.Type.neqInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -161,6 +175,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "leInteger# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] <= ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Integer.Type.leInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -168,6 +183,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "gtInteger# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] > ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Integer.Type.gtInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -175,6 +191,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "ltInteger# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] < ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Integer.Type.ltInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -182,6 +199,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "geInteger# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] >= ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Integer.Type.geInteger#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -207,6 +225,7 @@ begin
       -- pragma translate_on
       ;
 end block;"
+    , "warning"   : "GHC.Integer.Type.shiftRInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -232,6 +251,7 @@ begin
       -- pragma translate_on
       ;
 end block;"
+    , "warning"   : "GHC.Integer.Type.shiftLInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -239,6 +259,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "testBitInteger :: Integer -> Int# -> Bool"
     , "template"  : "~VAR[input][0](to_integer(~ARG[1])) = '1'"
+    , "warning"   : "GHC.Integer.Type.testBitInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -247,6 +268,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "wordToInteger :: Word# -> Integer"
     , "template"  : "signed(std_logic_vector(~ARG[0]))"
+    , "warning"   : "GHC.Integer.Type.wordToInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -255,6 +277,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerToWord :: Integer -> Word#"
     , "template"  : "unsigned(std_logic_vector(~ARG[0]))"
+    , "warning"   : "GHC.Integer.Type.integerToWord: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -264,6 +287,7 @@ end block;"
     , "type"      : "integerToWord :: Integer -> Word64#"
     , "comment"   : "only used by 32 bit GHC"
     , "template"  : "unsigned(std_logic_vector(~ARG[0]))"
+    , "warning"   : "GHC.Integer.Type.integerToWord64: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -271,6 +295,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "bitInteger :: Int -> Integer"
     , "template"  : "shift_left(to_signed(1, ~SIZE[~TYPO]),to_integer(~ARG[0]))"
+    , "warning"   : "GHC.Integer.Type.bitInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -278,6 +303,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "complementInteger :: Integer -> Integer"
     , "template"  : "not ~ARG[0]"
+    , "warning"   : "GHC.Integer.Type.complementInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -285,6 +311,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "xorInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] xor ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.xorInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -292,6 +319,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "orInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] or ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.orInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -299,6 +327,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "andInteger :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] and ~ARG[1]"
+    , "warning"   : "GHC.Integer.Type.andInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -312,6 +341,7 @@ end block;"
   else to_signed(1, ~SIZE[~TYPO]);
 -- end signumInteger
 "
+    , "warning"   : "GHC.Integer.Type.$wsignumInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -324,6 +354,7 @@ end block;"
     when (~ARG[1] /= 0) else (others => 'X')
     -- pragma translate_on
     ;"
+    , "warning"   : "GHC.Integer.Type.quotInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 ]

--- a/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
@@ -39,6 +39,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerToInt :: Integer -> Int#"
     , "template"  : "~ARG[0]"
+    , "warning"   : "GHC.Num.Integer.integerToInt#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -46,6 +47,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerMul :: Integer -> Integer -> Integer"
     , "template"  : "resize(~ARG[0] * ~ARG[1],~SIZE[~TYPO])"
+    , "warning"   : "GHC.Num.Integer.integerMul: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -53,6 +55,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerNegate :: Integer -> Integer"
     , "template"  : "-~ARG[0]"
+    , "warning"   : "GHC.Num.Integer.integerNegate: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -60,6 +63,7 @@
     , "kind"      : "Expression"
     , "type"      : "integerAbs :: Integer -> Integer"
     , "template"  : "abs ~ARG[0]"
+    , "warning"   : "GHC.Num.Integer.integerAbs: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -87,6 +91,7 @@ begin
   ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
 end block;
 -- integerDiv end"
+    , "warning"   : "GHC.Num.Integer.integerDiv: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -94,6 +99,7 @@ end block;
     , "kind"      : "Expression"
     , "type"      : "integerMod :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] mod ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerMod: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -129,6 +135,7 @@ begin
   ~RESULT <= (~SYM[5], ~SYM[6]);
 end block;
 -- integerDivMod end"
+    , "warning"   : "GHC.Num.Integer.integerDivMod#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -141,6 +148,7 @@ end block;
     when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
     -- pragma translate_on
     ;"
+    , "warning"   : "GHC.Num.Integer.integerQuotRem#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -153,6 +161,7 @@ end block;
     when (~ARG[1] /= 0) else (others => 'X')
     -- pragma translate_on
     ;"
+    , "warning"   : "GHC.Num.Integer.integerRem: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -160,6 +169,7 @@ end block;
     , "kind"      : "Expression"
     , "type"      : "integerEq :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] = ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerEq: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -167,6 +177,7 @@ end block;
     , "kind"      : "Expression"
     , "type"      : "integerNe :: Integer -> Integer -> Bool"
     , "template"  : "~ARG[0] /= ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerNe: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -174,6 +185,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerEq# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] = ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Num.Integer.integerEq#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -181,6 +193,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerNe# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] /= ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Num.Integer.integerNe#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -188,6 +201,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerLe# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] <= ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Num.Integer.integerLe#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -195,6 +209,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerGt# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] > ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Num.Integer.integerGt#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -202,6 +217,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerLt# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] < ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Num.Integer.integerLt#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -209,6 +225,7 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerGe# :: Integer -> Integer -> Int#"
     , "template"  : "~RESULT <= to_signed(1,~SIZE[~TYPO]) when ~ARG[0] >= ~ARG[1] else to_signed(0,~SIZE[~TYPO]);"
+    , "warning"   : "GHC.Num.Integer.integerGe#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -230,6 +247,7 @@ begin
       );
   ~RESULT <= shift_right(~ARG[0],~SYM[1]);
 end block;"
+    , "warning"   : "GHC.Num.Integer.integerShiftR#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -251,6 +269,7 @@ begin
       );
   ~RESULT <= shift_left(~ARG[0],~SYM[1]);
 end block;"
+    , "warning"   : "GHC.Num.Integer.integerShiftL#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -258,6 +277,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerTestBit :: Integer -> Word# -> Bool"
     , "template"  : "~VAR[input][0](to_integer(~ARG[1])) = '1'"
+    , "warning"   : "GHC.Num.Integer.integerTestBit#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -266,6 +286,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerFromWord :: Word# -> Integer"
     , "template"  : "signed(std_logic_vector(~ARG[0]))"
+    , "warning"   : "GHC.Num.Integer.integerFromWord#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -274,6 +295,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerToWord :: Integer -> Word#"
     , "template"  : "unsigned(std_logic_vector(~ARG[0]))"
+    , "warning"   : "GHC.Num.Integer.integerToWord#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -283,6 +305,7 @@ end block;"
     , "type"      : "integerToWord :: Integer -> Word64#"
     , "comment"   : "only used by 32 bit GHC"
     , "template"  : "unsigned(std_logic_vector(~ARG[0]))"
+    , "warning"   : "GHC.Num.Integer.integerToWord64#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -290,6 +313,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerBit :: Word# -> Integer"
     , "template"  : "shift_left(to_signed(1, ~SIZE[~TYPO]),to_integer(~ARG[0]))"
+    , "warning"   : "GHC.Num.Integer.integerBit#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -297,6 +321,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerComplement :: Integer -> Integer"
     , "template"  : "not ~ARG[0]"
+    , "warning"   : "GHC.Num.Integer.integerComplement: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -304,6 +329,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerXor :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] xor ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerXor: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -311,6 +337,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerOr :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] or ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerOr: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -318,6 +345,7 @@ end block;"
     , "kind"      : "Expression"
     , "type"      : "integerAnd :: Integer -> Integer -> Integer"
     , "template"  : "~ARG[0] and ~ARG[1]"
+    , "warning"   : "GHC.Num.Integer.integerAnd: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -331,6 +359,7 @@ end block;"
   else to_signed(1, ~SIZE[~TYPO]);
 -- end integerSigmum
 "
+    , "warning"   : "GHC.Num.Integer.integerSignum: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -344,6 +373,7 @@ end block;"
   else to_signed(1, ~SIZE[~TYPO]);
 -- end signumInteger
 "
+    , "warning"   : "GHC.Num.Integer.$wintegerSignum: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -351,6 +381,7 @@ end block;"
   , "kind"      : "Expression"
   , "type"      : "integerLogBase# :: Integer -> Integer -> Int#"
   , "template"  : "integer(floor(log(real(~ARG[1]),real(~ARG[0]))))"
+  , "warning"   : "GHC.Num.Integer.integerLogBase#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -364,6 +395,7 @@ end block;"
            \"10\";
 -- end integerCompare
 "
+    , "warning"   : "GHC.Num.Integer.integerCompare: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -376,6 +408,7 @@ end block;"
     when (~ARG[1] /= 0) else (others => 'X')
     -- pragma translate_on
     ;"
+  , "warning"   : "GHC.Num.Integer.integerQuot: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 ]

--- a/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
@@ -36,6 +36,7 @@
     , "kind"      : "Expression"
     , "type"      : "naturalLogBase# :: Natural -> Natural -> Word#"
     , "template"  : "to_unsigned(integer(floor(log(real(to_integer(~ARG[1])),real(to_integer(~ARG[0]))))),~SIZE[~TYPO])"
+    , "warning"   : "GHC.Num.Natural.naturalLogBase#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
 , { "BlackBox" :
@@ -43,6 +44,7 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalEq# :: Natural -> Natural -> Int#"
   , "template"  : "~RESULT <= to_unsigned(1,~SIZE[~TYPO]) when ~ARG[0] = ~ARG[1] else to_unsigned(0,~SIZE[~TYPO]);"
+  , "warning"   : "GHC.Num.Natural.naturalEq#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -50,6 +52,7 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalNe# :: Natural -> Natural -> Int#"
   , "template"  : "~RESULT <= to_unsigned(1,~SIZE[~TYPO]) when ~ARG[0] /= ~ARG[1] else to_unsigned(0,~SIZE[~TYPO]);"
+  , "warning"   : "GHC.Num.Natural.naturalNe#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -57,6 +60,7 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalLe# :: Natural -> Natural -> Int#"
   , "template"  : "~RESULT <= to_unsigned(1,~SIZE[~TYPO]) when ~ARG[0] <= ~ARG[1] else to_unsigned(0,~SIZE[~TYPO]);"
+  , "warning"   : "GHC.Num.Natural.naturalLe#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -64,6 +68,7 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalGt# :: Natural -> Natural -> Int#"
   , "template"  : "~RESULT <= to_unsigned(1,~SIZE[~TYPO]) when ~ARG[0] > ~ARG[1] else to_unsigned(0,~SIZE[~TYPO]);"
+  , "warning"   : "GHC.Num.Natural.naturalGt#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -71,6 +76,7 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalLt# :: Natural -> Natural -> Int#"
   , "template"  : "~RESULT <= to_unsigned(1,~SIZE[~TYPO]) when ~ARG[0] < ~ARG[1] else to_unsigned(0,~SIZE[~TYPO]);"
+  , "warning"   : "GHC.Num.Natural.naturalLt#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -78,6 +84,7 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalGe# :: Natural -> Natural -> Int#"
   , "template"  : "~RESULT <= to_unsigned(1,~SIZE[~TYPO]) when ~ARG[0] >= ~ARG[1] else to_unsigned(0,~SIZE[~TYPO]);"
+  , "warning"   : "GHC.Num.Natural.naturalGe#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -99,6 +106,7 @@ begin
       );
   ~RESULT <= shift_left(~ARG[0],~SYM[1]);
 end block;"
+  , "warning"   : "GHC.Num.Natural.naturalShiftL#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :
@@ -120,6 +128,7 @@ begin
       );
   ~RESULT <= shift_right(~ARG[0],~SYM[1]);
 end block;"
+  , "warning"   : "GHC.Num.Natural.naturalShiftR#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
 , { "BlackBox" :


### PR DESCRIPTION
The dynamic-size warning on primitives using Integer / Natural is not consistently included in the .primitives files. This is down to
a mix of legacy (the warning existed after integer prims) and new primitives being added and not having the warning (either by
forgetting or the primitives around them not having the warning).

To be conservative, the warning applies to all primitives in `GHC.Integer.Type`, `GHC.Integer.Logarithms`, `GHC.Num.Integer`, `GHC.Natural` and `GHC.Num.Natural`. As I understand it, the warning only triggers when the primitive is rendered in HDL so this should be okay.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
