### PR TITLE
BiSignal bundling

### DIFF
--- a/clash-lib/prims/common/Clash_Signal_BiSignal.primitives
+++ b/clash-lib/prims/common/Clash_Signal_BiSignal.primitives
@@ -28,7 +28,7 @@
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Signal.BiSignal.bundle#"
+    { "name" : "Clash.Signal.BiSignal.unbundle#"
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :

--- a/clash-lib/prims/common/Clash_Signal_BiSignal.primitives
+++ b/clash-lib/prims/common/Clash_Signal_BiSignal.primitives
@@ -27,4 +27,28 @@
     , "template" : "~DEVNULL[~ARG[2]]"
     }
   }
+, { "BlackBox" :
+    { "name" : "Clash.Signal.BiSignal.bundle#"
+    , "workInfo" : "Never"
+    , "kind" : "Expression"
+    , "type" :
+"unbundle#
+  :: KnownNat n                  --ARG[0]
+  => BiSignalIn ds dom n         --ARG[1]
+  -> Vec n (BiSignalIn ds dom 1)"
+    , "template" : "~DEVNULL[~ARG[1]]"
+    }
+  }
+, { "BlackBox" :
+    { "name" : "Clash.Signal.BiSignal.bundle#"
+    , "workInfo" : "Never"
+    , "kind" : "Expression"
+    , "type" :
+"bundle#
+  :: KnownNat n                   --ARG[0]
+  => Vec n (BiSignalOut ds dom 1) --ARG[1]
+  -> BiSignalOut ds dom n"
+    , "template" : "~DEVNULL[~ARG[1]]"
+    }
+  }
 ]

--- a/clash-lib/prims/common/Clash_Signal_BiSignal.primitives
+++ b/clash-lib/prims/common/Clash_Signal_BiSignal.primitives
@@ -28,26 +28,18 @@
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Signal.BiSignal.unbundle#"
+    { "name" : "Clash.Signal.BiSignal.unbundle"
     , "workInfo" : "Never"
     , "kind" : "Expression"
-    , "type" :
-"unbundle#
-  :: KnownNat n                  --ARG[0]
-  => BiSignalIn ds dom n         --ARG[1]
-  -> Vec n (BiSignalIn ds dom 1)"
+    , "type" : "unbundle :: KnownNat n => BiSignalIn ds dom n -> Vec n (BiSignalIn ds dom 1)"
     , "template" : "~DEVNULL[~ARG[1]]"
     }
   }
 , { "BlackBox" :
-    { "name" : "Clash.Signal.BiSignal.bundle#"
+    { "name" : "Clash.Signal.BiSignal.bundle"
     , "workInfo" : "Never"
     , "kind" : "Expression"
-    , "type" :
-"bundle#
-  :: KnownNat n                   --ARG[0]
-  => Vec n (BiSignalOut ds dom 1) --ARG[1]
-  -> BiSignalOut ds dom n"
+    , "type" : "bundle :: KnownNat n => Vec n (BiSignalOut ds dom 1) -> BiSignalOut ds dom n"
     , "template" : "~DEVNULL[~ARG[1]]"
     }
   }

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -272,7 +272,7 @@ import           Clash.Annotations.Primitive    (hasBlackBox)
 import           Clash.Promoted.Nat             (SNat(..), snatToNum)
 import           Clash.Signal.Bundle
   (Bundle (..), EmptyTuple(..), TaggedEmptyTuple(..), vecBundle#)
-import           Clash.Signal.BiSignal
+import           Clash.Signal.BiSignal          hiding (bundle, unbundle)
 import           Clash.Signal.Internal
 import           Clash.Signal.Internal.Ambiguous
   (knownVDomain, clockPeriod, activeEdge, resetKind, initBehavior, resetPolarity)

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -282,6 +282,7 @@ mergeBiSignalOuts = mconcat . V.toList
 unbundle :: KnownNat n => BiSignalIn ds dom n -> Vec n (BiSignalIn ds dom 1)
 unbundle = unbundle#
 {-# NOINLINE unbundle #-}
+{-# ANN unbundle hasBlackBox #-}
 
 unbundle# :: KnownNat n => BiSignalIn ds dom n -> Vec n (BiSignalIn ds dom 1)
 unbundle# (BiSignalIn ds s) = fmap (BiSignalIn ds) unb
@@ -289,13 +290,13 @@ unbundle# (BiSignalIn ds s) = fmap (BiSignalIn ds) unb
     f Nothing = V.repeat Nothing
     f (Just bv) = fmap (Just . V.v2bv . V.singleton) (V.bv2v bv)
     unb = B.unbundle $ fmap f s
-{-# NOINLINE unbundle# #-}
 
 -- | Bundle an `n` length vector of 1 bit 'BiSignalOut'
 -- into a single `n` bit 'BiSignalOut'
 bundle :: KnownNat n => Vec n (BiSignalOut ds dom 1) -> BiSignalOut ds dom n
 bundle = bundle#
 {-# NOINLINE bundle #-}
+{-# ANN bundle hasBlackBox #-}
 
 bundle# :: KnownNat n => Vec n (BiSignalOut ds dom 1) -> BiSignalOut ds dom n
 bundle# vs = BiSignalOut (fmap bun $ seqA $ fmap getSigs vs)
@@ -304,7 +305,6 @@ bundle# vs = BiSignalOut (fmap bun $ seqA $ fmap getSigs vs)
     seqA = V.traverse# id
     bun s = fmap (fmap (V.v2bv . fmap lsb) . seqA) (B.bundle s)
     getSigs (BiSignalOut xs) = xs
-{-# NOINLINE bundle# #-}
 
 writeToBiSignal#
   :: HasCallStack


### PR DESCRIPTION
As discussed in https://github.com/clash-lang/clash-compiler/issues/1905.

One of the things I am still on the fence about is the internal representation of `BiSignalIn` and  `BiSignalOut` with this change. Now you can unbundle a `BiSIgnalIn` into a a vector of `BiSIgnalIn` of size 1. If you then write to a single of those `BiSIgnalIn` and not the others this is write lost when bundling the `BiSIgnalOut`. It would be possible to change the internal representation to `Vec n (Maybe Bit)` to allow this.

However the current draft doesn't compile to hardware with an evaluator error:

```
*** Exception: Evaluator.instantiate: Not a tylambda: Lambda (Id {varName = Name {nameSort = System, nameOcc = "x", nameUniq = 443533, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 443533, varType = AppTy (AppTy (ConstTy Arrow) (AppTy (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Signal.Internal.Signal", nameUniq = 8214565720324361849, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (SymTy "System"))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Maybe.Maybe", nameUniq = 3674937295934324792, nameLoc = UnhelpfulSpan "<no location info>"}))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Sized.Internal.BitVector.BitVector", nameUniq = 8214565720324361881, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (NumTy 1)))))) (AppTy (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Signal.Internal.Signal", nameUniq = 8214565720324361849, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (SymTy "System"))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Maybe.Maybe", nameUniq = 3674937295934324792, nameLoc = UnhelpfulSpan "<no location info>"}))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Sized.Internal.BitVector.BitVector", nameUniq = 8214565720324361881, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (NumTy 1))))), idScope = LocalId}) (App (Lam (Id {varName = Name {nameSort = System, nameOcc = "x", nameUniq = 443532, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 443532, varType = AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.[]", nameUniq = 3674937295934324788, nameLoc = UnhelpfulSpan "<no location info>"}))) (AppTy (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Signal.Internal.Signal", nameUniq = 8214565720324361849, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (SymTy "System"))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Maybe.Maybe", nameUniq = 3674937295934324792, nameLoc = UnhelpfulSpan "<no location info>"}))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Sized.Internal.BitVector.BitVector", nameUniq = 8214565720324361881, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (NumTy 1))))), idScope = LocalId}) (App (Prim (PrimInfo {primName = "GHC.Base.map", primType = ForAllTy (TyVar {varName = Name {nameSort = User, nameOcc = "a", nameUniq = 6989586621679628865, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 6989586621679628865, varType = AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Prim.TYPE", nameUniq = 3674937295934324912, nameLoc = UnhelpfulSpan "<no location info>"}))) (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.LiftedRep", nameUniq = 3891110078048108766, nameLoc = UnhelpfulSpan "<no location info>"})))}) (ForAllTy (TyVar {varName = Name {nameSort = User, nameOcc = "b", nameUniq = 6989586621679628866, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 6989586621679628866, varType = AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Prim.TYPE", nameUniq = 3674937295934324912, nameLoc = UnhelpfulSpan "<no location info>"}))) (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.LiftedRep", nameUniq = 3891110078048108766, nameLoc = UnhelpfulSpan "<no location info>"})))}) (AppTy (AppTy (ConstTy Arrow) (AppTy (AppTy (ConstTy Arrow) (VarTy (TyVar {varName = Name {nameSort = User, nameOcc = "a", nameUniq = 6989586621679628865, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 6989586621679628865, varType = AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Prim.TYPE", nameUniq = 3674937295934324912, nameLoc = UnhelpfulSpan "<no location info>"}))) (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.LiftedRep", nameUniq = 3891110078048108766, nameLoc = UnhelpfulSpan "<no location info>"})))}))) (VarTy (TyVar {varName = Name {nameSort = User, nameOcc = "b", nameUniq = 6989586621679628866, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 6989586621679628866, varType = AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Prim.TYPE", nameUniq = 3674937295934324912, nameLoc = UnhelpfulSpan "<no location info>"}))) (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.LiftedRep", nameUniq = 3891110078048108766, nameLoc = UnhelpfulSpan "<no location info>"})))})))) (AppTy (AppTy (ConstTy Arrow) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.[]", nameUniq = 3674937295934324788, nameLoc = UnhelpfulSpan "<no location info>"}))) (VarTy (TyVar {varName = Name {nameSort = User, nameOcc = "a", nameUniq = 6989586621679628865, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 6989586621679628865, varType = AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Prim.TYPE", nameUniq = 3674937295934324912, nameLoc = UnhelpfulSpan "<no location info>"}))) (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.LiftedRep", nameUniq = 3891110078048108766, nameLoc = UnhelpfulSpan "<no location info>"})))})))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.[]", nameUniq = 3674937295934324788, nameLoc = UnhelpfulSpan "<no location info>"}))) (VarTy (TyVar {varName = Name {nameSort = User, nameOcc = "b", nameUniq = 6989586621679628866, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 6989586621679628866, varType = AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Prim.TYPE", nameUniq = 3674937295934324912, nameLoc = UnhelpfulSpan "<no location info>"}))) (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.LiftedRep", nameUniq = 3891110078048108766, nameLoc = UnhelpfulSpan "<no location info>"})))})))))), primWorkInfo = WorkVariable, primMultiResult = SingleResult})) (Var (Id {varName = Name {nameSort = System, nameOcc = "x", nameUniq = 443532, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 443532, varType = AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Types.[]", nameUniq = 3674937295934324788, nameLoc = UnhelpfulSpan "<no location info>"}))) (AppTy (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Signal.Internal.Signal", nameUniq = 8214565720324361849, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (SymTy "System"))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Maybe.Maybe", nameUniq = 3674937295934324792, nameLoc = UnhelpfulSpan "<no location info>"}))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Sized.Internal.BitVector.BitVector", nameUniq = 8214565720324361881, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (NumTy 1))))), idScope = LocalId})))) (Var (Id {varName = Name {nameSort = System, nameOcc = "x", nameUniq = 443533, nameLoc = UnhelpfulSpan "<no location info>"}, varUniq = 443533, varType = AppTy (AppTy (ConstTy Arrow) (AppTy (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Signal.Internal.Signal", nameUniq = 8214565720324361849, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (SymTy "System"))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Maybe.Maybe", nameUniq = 3674937295934324792, nameLoc = UnhelpfulSpan "<no location info>"}))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Sized.Internal.BitVector.BitVector", nameUniq = 8214565720324361881, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (NumTy 1)))))) (AppTy (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Signal.Internal.Signal", nameUniq = 8214565720324361849, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (SymTy "System"))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "GHC.Maybe.Maybe", nameUniq = 3674937295934324792, nameLoc = UnhelpfulSpan "<no location info>"}))) (AppTy (ConstTy (TyCon (Name {nameSort = User, nameOcc = "Clash.Sized.Internal.BitVector.BitVector", nameUniq = 8214565720324361881, nameLoc = UnhelpfulSpan "<no location info>"}))) (LitTy (NumTy 1))))), idScope = LocalId})))
CallStack (from HasCallStack):
  error, called at src-ghc/Clash/GHC/Evaluator.hs:333:23 in clash-ghc-1.5.0-inplace:Clash.GHC.Evaluator
```
with the following example:

```Haskell
import Clash.Explicit.Prelude hiding (bundle, unbundle)
import Prelude (odd)
import qualified Clash.Explicit.Prelude as P
import Clash.Signal.BiSignal

intToVecBv :: Maybe Int -> Vec 64 (Maybe (BitVector 1))
intToVecBv Nothing = repeat Nothing
intToVecBv (Just i) = fmap (Just . v2bv . singleton) $ bv2v $ pack i

toMaybe :: Bool -> a -> Maybe a
toMaybe True a = Just a
toMaybe False _ = Nothing

-- | Write on odd cyles
f :: Clock System
  -> Reset System
  -> Enable System
  -> BiSignalIn 'Floating System (BitSize Int)
  -> (Signal System Int, BiSignalOut 'Floating System (BitSize Int))
f clk rst en s = (read, out)
  where
    read = readFromBiSignal s
    out = bundle $ writeToBiSignal <$> (unbundle s) <*> (P.unbundle write)
    counter = register clk rst en 0 $ counter + 1
    write = fmap intToVecBv $ toMaybe <$> (fmap odd counter) <*> counter

topEntity
  :: Clock System
  -> Reset System
  -> Enable System
  -> BiSignalIn 'Floating System (BitSize Int)
  -> Signal System Int
topEntity clk rst en s = fst $ f clk rst en s
```

I don't think I used any construct which should be unsynthesizable. But maybe the best way forward is to create blackboxes for these functions since there is a lot of type conversion violence which I think can be ignored in HDL.

Pinging the evaluator guru @alex-mckenna!

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
