### PR TITLE
Add multiple-hidden flag to clash-testsuite

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -10,7 +10,7 @@ package *
 
 package clash-prelude
   ghc-options: -Werror
-  flags: +doctests -experimental-evaluator
+  flags: +doctests +multiple-hidden -experimental-evaluator
   tests: True
   benchmarks: True
 
@@ -40,7 +40,7 @@ package clash-cores
 package clash-testsuite
   ghc-options: -Werror
   -- enable cosim
-  flags: +cosim -experimental-evaluator
+  flags: +cosim +multiple-hidden -experimental-evaluator
 
 package clash-benchmark
   ghc-options: -Werror

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -60,10 +60,8 @@ fi
 if [ ! -f cabal.project.local ]; then
   cp .ci/cabal.project.local .
 
-  if [[ "$MULTIPLE_HIDDEN" == "yes" ]]; then
-    sed -i 's/flags: +doctests/flags: +doctests +multiple-hidden/g' cabal.project.local
-  elif [[ "$MULTIPLE_HIDDEN" == "no" ]]; then
-    sed -i 's/flags: +doctests/flags: +doctests -multiple-hidden/g' cabal.project.local
+  if [[ "$MULTIPLE_HIDDEN" == "no" ]]; then
+    sed -i 's/+multiple-hidden/-multiple-hidden/g' cabal.project.local
   fi
 
   if [[ "$CI_COMMIT_BRANCH" =~ "^partial-evaluator-" ]]; then

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -25,6 +25,15 @@ flag experimental-evaluator
   default: False
   manual: True
 
+flag multiple-hidden
+  description:
+    Allow multiple hidden clocks, resets, and enables to be used. This is an
+    experimental feature, possibly triggering confusing error messages. By
+    default, it is enabled on development versions of Clash and disabled on
+    releases.
+  default: True
+  manual: True
+
 common basic-config
   default-language: Haskell2010
   ghc-options: -Wall -Wcompat
@@ -70,6 +79,9 @@ common basic-config
 
   if flag(experimental-evaluator)
     cpp-options:       -DEXPERIMENTAL_EVALUATOR
+
+  if flag(multiple-hidden)
+    cpp-options:       -DCLASH_MULTIPLE_HIDDEN
 
 library
   import: basic-config


### PR DESCRIPTION
Some tests in the testsuite are behind a `#ifdef` which checks for multiple hidden, however multiple hidden is not a flag of `clash-testsuite`. This is added, and the CI script updated to use this flag in both the testsuite and prelude.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
