### PR TITLE
Add HasType / InferType classes

### DIFF
--- a/changelog/2021-08-31T16_58_13+02_00_hastype_class.md
+++ b/changelog/2021-08-31T16_58_13+02_00_hastype_class.md
@@ -1,0 +1,1 @@
+INTERNAL CHANGE: Added HasType and InferType classes for getting / inferring core types from data representing some typed "thing".

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -81,6 +81,7 @@ import           Unique              (getKey)
 import           Clash.Class.BitPack (pack,unpack)
 import           Clash.Core.DataCon  (DataCon (..))
 import           Clash.Core.Evaluator.Types
+import           Clash.Core.HasType  (piResultTys, applyTypeToArgs)
 import           Clash.Core.Literal  (Literal (..))
 import           Clash.Core.Name
   (Name (..), NameSort (..), mkUnsafeSystemName)
@@ -88,7 +89,6 @@ import           Clash.Core.Pretty   (showPpr)
 import           Clash.Core.Term
   (IsMultiPrim (..), Pat (..), PrimInfo (..), Term (..), WorkInfo (..), mkApps,
    PrimUnfolding(..))
-import           Clash.Core.TermInfo (piResultTys, applyTypeToArgs)
 import           Clash.Core.Type
   (Type (..), ConstTy (..), LitTy (..), TypeView (..), mkFunTy, mkTyConApp,
    splitFunForallTy, tyView)

--- a/clash-ghc/src-ghc/Clash/GHC/PartialEval/Eval.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/PartialEval/Eval.hs
@@ -38,13 +38,13 @@ import           BasicTypes (InlineSpec(..))
 #endif
 
 import           Clash.Core.DataCon (DataCon(..))
+import           Clash.Core.HasType
 import           Clash.Core.Literal (Literal(..))
 import           Clash.Core.PartialEval.AsTerm
 import           Clash.Core.PartialEval.Monad
 import           Clash.Core.PartialEval.NormalForm
 import           Clash.Core.Subst (substTy)
 import           Clash.Core.Term
-import           Clash.Core.TermInfo
 import           Clash.Core.TyCon (tyConDataCons)
 import           Clash.Core.Type
 import           Clash.Core.TysPrim (integerPrimTy)
@@ -602,8 +602,8 @@ apply val arg = do
     f ->
       error ("apply: Cannot apply " <> show arg <> " to " <> show f)
  where
-  -- Somewhat of a cheat, but very quick to implement.
-  valueType tcm = termType tcm . asTerm
+  -- TODO Write an instance for InferType Value and use that instead
+  valueType tcm = inferCoreTypeOf tcm . asTerm
 
 applyTy :: Value -> Type -> Eval Value
 applyTy val ty = do

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -188,6 +188,7 @@ Library
                       Clash.Core.EqSolver
                       Clash.Core.Evaluator.Types
                       Clash.Core.FreeVars
+                      Clash.Core.HasType
                       Clash.Core.Literal
                       Clash.Core.Name
                       Clash.Core.PartialEval

--- a/clash-lib/src/Clash/Core/Evaluator/Types.hs
+++ b/clash-lib/src/Clash/Core/Evaluator/Types.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 {-|
-  Copyright     : (C) 2020, QBayLogic B.V.
+  Copyright     : (C) 2020-2021, QBayLogic B.V.
   License       : BSD2 (see the file LICENSE)
-  Maintainer    : Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer    : QBayLogic B.V. <devops@qbaylogic.com>
 
   Types for the Partial Evaluator
 -}
@@ -17,10 +17,10 @@ import Data.Maybe (fromMaybe, isJust)
 import Data.Text.Prettyprint.Doc (hsep)
 
 import Clash.Core.DataCon (DataCon)
+import Clash.Core.HasType
 import Clash.Core.Literal (Literal(CharLiteral))
 import Clash.Core.Pretty (fromPpr, ppr, showPpr)
 import Clash.Core.Term (Term(..), PrimInfo(..), TickInfo, Alt)
-import Clash.Core.TermInfo (termType)
 import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (Type)
 import Clash.Core.Var (Id, IdScope(..), TyVar)
@@ -56,7 +56,7 @@ whnf
 whnf eval tcm isSubj m
   | isSubj =
       -- See [Note: empty case expressions]
-      let ty = termType tcm (mTerm m)
+      let ty = inferCoreTypeOf tcm (mTerm m)
        in go (stackPush (Scrutinise ty []) m)
   | otherwise = go m
   where
@@ -228,7 +228,7 @@ instance ClashPretty StackFrame where
   clashPretty (Apply i) = hsep ["Apply", fromPpr i]
   clashPretty (Instantiate t) = hsep ["Instantiate", fromPpr t]
   clashPretty (PrimApply p tys vs ts) =
-    hsep ["PrimApply", fromPretty (primName p), "::", fromPpr (primType p),
+    hsep ["PrimApply", fromPretty (primName p), "::", fromPpr (coreTypeOf p),
           "; type args=", fromPpr tys,
           "; val args=", fromPpr (map valToTerm vs),
           "term args=", fromPpr ts]
@@ -349,4 +349,3 @@ getTerm = mTerm
 
 setTerm :: Term -> Machine -> Machine
 setTerm x m = m { mTerm = x }
-

--- a/clash-lib/src/Clash/Core/HasType.hs
+++ b/clash-lib/src/Clash/Core/HasType.hs
@@ -1,0 +1,220 @@
+{-|
+Copyright   : (C) 2021, QBayLogic B.V.
+License     : BSD2 (see the file LICENSE)
+Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
+
+Utility class to extract type information from data which has a type.
+-}
+
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Clash.Core.HasType
+  ( HasType(..)
+  , InferType(..)
+  , applyTypeToArgs
+  , piResultTy
+  , piResultTys
+  ) where
+
+import qualified Data.Text as Text (isInfixOf)
+import Data.Text.Prettyprint.Doc (line)
+import GHC.Stack (HasCallStack)
+
+import Clash.Core.DataCon (DataCon(dcType))
+import Clash.Core.FreeVars
+import Clash.Core.Literal (Literal(..))
+import Clash.Core.Name (Name(nameOcc))
+import Clash.Core.Pretty
+import Clash.Core.Subst
+import Clash.Core.Term (Term(..), IsMultiPrim(..), PrimInfo(..), collectArgs)
+import Clash.Core.TyCon (TyConMap)
+import Clash.Core.Type
+import Clash.Core.TysPrim
+import Clash.Core.Var (Var(varType))
+import Clash.Core.VarEnv
+import Clash.Debug (debugIsOn)
+import Clash.Util (pprPanic)
+import qualified Clash.Util.Interpolate as I
+
+class HasType a where
+  coreTypeOf :: a -> Type
+
+instance HasType DataCon where
+  coreTypeOf = dcType
+
+instance HasType Literal where
+  coreTypeOf = \case
+    IntegerLiteral _ -> integerPrimTy
+    IntLiteral _ -> intPrimTy
+    WordLiteral _ -> wordPrimTy
+    StringLiteral _ -> stringPrimTy
+    FloatLiteral _ -> floatPrimTy
+    DoubleLiteral _ -> doublePrimTy
+    CharLiteral _ -> charPrimTy
+    Int64Literal _ -> int64PrimTy
+    Word64Literal _ -> word64PrimTy
+    NaturalLiteral _ -> naturalPrimTy
+    ByteArrayLiteral _ -> byteArrayPrimTy
+
+instance HasType PrimInfo where
+  coreTypeOf pr =
+    case primMultiResult pr of
+      SingleResult -> primType pr
+
+      -- See Note [MultiResult type] in Clash.Normalize.Transformations.MultiPrim
+      MultiResult
+        | let (primArgs, primResTy) = splitFunForallTy (primType pr)
+        , TyConApp tupTcNm tupArgs <- tyView primResTy
+        , Text.isInfixOf "GHC.Tuple.(" (nameOcc tupTcNm)
+        -> mkPolyFunTy primResTy (primArgs <> fmap Right tupArgs)
+
+        | otherwise
+        -> error "PrimInfo.coreTypeOf: MultiResult primitive without tuple type"
+
+instance HasType Type where
+  coreTypeOf = id
+
+instance HasType (Var a) where
+  coreTypeOf = varType
+
+class InferType a where
+  inferCoreTypeOf :: TyConMap -> a -> Type
+
+instance InferType Term where
+  inferCoreTypeOf tcm = go
+   where
+    go = \case
+      Var i -> coreTypeOf i
+      Data dc -> coreTypeOf dc
+      Literal l -> coreTypeOf l
+      Prim pr -> coreTypeOf pr
+      Lam i x -> mkFunTy (coreTypeOf i) (go x)
+      TyLam i x -> ForAllTy i (go x)
+
+      x@App{} ->
+        case collectArgs x of
+          (fun, args) -> applyTypeToArgs x tcm (go fun) args
+
+      x@TyApp{} ->
+        case collectArgs x of
+          (fun, args) -> applyTypeToArgs x tcm (go fun) args
+
+      Letrec _ x -> go x
+      Case _ ty _ -> ty
+      Cast _ _ a -> a
+      Tick _ x -> go x
+
+-- | Get the result type of a polymorphic function given a list of arguments
+applyTypeToArgs
+  :: Term
+  -- ^ The complete term, used for error messages.
+  -> TyConMap
+  -> Type
+  -> [Either Term Type]
+  -> Type
+applyTypeToArgs e m opTy args = go opTy args
+ where
+  go opTy' []               = opTy'
+  go opTy' (Right ty:args') = goTyArgs opTy' [ty] args'
+  go opTy' (Left a:args')   = case splitFunTy m opTy' of
+    Just (_,resTy) -> go resTy args'
+    _ -> error [I.i|
+        Unexpected application. The term
+
+          #{showPpr e}
+
+        applied an argument
+
+          #{showPpr a}
+
+        to something with the non-function type
+
+          #{showPpr opTy'}
+      |]
+
+  goTyArgs opTy' revTys (Right ty:args') = goTyArgs opTy' (ty:revTys) args'
+  goTyArgs opTy' revTys args'            = go (piResultTys m opTy' (reverse revTys)) args'
+
+-- | Like 'piResultTys', but only applies a single type. If multiple types are
+-- being applied use 'piResultTys', as it is more efficient to only substitute
+-- once with many types.
+piResultTy
+  :: HasCallStack
+  => TyConMap
+  -> Type
+  -> Type
+  -> Type
+piResultTy m ty arg =
+  piResultTys m ty [arg]
+
+-- | @(piResultTys f_ty [ty1, ..., tyn])@ gives the type of @(f ty1 .. tyn)@
+-- where @f :: f_ty@
+--
+-- 'piResultTys' is interesting because:
+--
+--    1. 'f_ty' may have more foralls than there are args
+--    2. Less obviously, it may have fewer foralls
+--
+-- Fore case 2. think of:
+--
+--   piResultTys (forall a . a) [forall b.b, Int]
+--
+-- This really can happen, such as situations involving 'undefined's type:
+--
+--   undefined :: forall a. a
+--
+--   undefined (forall b. b -> b) Int
+--
+-- This term should have the type @(Int -> Int)@, but notice that there are
+-- more type args than foralls in 'undefined's type.
+--
+-- For efficiency reasons, when there are no foralls, we simply drop arrows from
+-- a function type/kind.
+piResultTys
+  :: HasCallStack
+  => TyConMap
+  -> Type
+  -> [Type]
+  -> Type
+piResultTys _ ty [] = ty
+piResultTys m ty origArgs@(arg:args)
+  | Just ty' <- coreView1 m ty
+  = piResultTys m ty' origArgs
+  | FunTy a res <- tyView ty
+  -- TODO coreView is used here because the partial evaluator will sometimes
+  -- encounter / not encounter a Signal as an argument unexpectedly. When PR
+  -- #1064 is merged the coreView calls should be removed again.
+  = if debugIsOn && not (aeqType (coreView m a) (coreView m arg)) then error [I.i|
+      Unexpected application. A function with type:
+
+        #{showPpr ty}
+
+      Got applied to an argument of type:
+
+        #{showPpr arg}
+    |]
+    else
+      piResultTys m res args
+  | ForAllTy tv res <- ty
+  = go (extendVarEnv tv arg emptyVarEnv) res args
+  | otherwise
+  = pprPanic "piResultTys1" (ppr ty <> line <> ppr origArgs)
+ where
+  inScope = mkInScopeSet (tyFVsOfTypes (ty:origArgs))
+
+  go env ty' [] = substTy (mkTvSubst inScope env) ty'
+  go env ty' allArgs@(arg':args')
+    | Just ty'' <- coreView1 m ty'
+    = go env ty'' allArgs
+    | FunTy _ res <- tyView ty'
+    = go env res args'
+    | ForAllTy tv res <- ty'
+    = go (extendVarEnv tv arg' env) res args'
+    | VarTy tv <- ty'
+    , Just ty'' <- lookupVarEnv tv env
+      -- Deals with (piResultTys  (forall a.a) [forall b.b, Int])
+    = piResultTys m ty'' allArgs
+    | otherwise
+    = pprPanic "piResultTys2" (ppr ty' <> line <> ppr origArgs <> line <> ppr allArgs)

--- a/clash-lib/src/Clash/Core/Literal.hs
+++ b/clash-lib/src/Clash/Core/Literal.hs
@@ -15,9 +15,7 @@
 
 module Clash.Core.Literal
   ( Literal (..)
-  , literalType
-  )
-where
+  ) where
 
 import Control.DeepSeq                        (NFData (..))
 import Data.Binary                            (Binary)
@@ -26,14 +24,6 @@ import Data.Primitive.ByteArray               (ByteArray)
 import Data.Primitive.ByteArray.Extra         ()
 import Data.Word                              (Word32, Word64)
 import GHC.Generics                           (Generic)
-
-import {-# SOURCE #-} Clash.Core.Type         (Type)
-import Clash.Core.TysPrim                     (intPrimTy, integerPrimTy,
-                                               charPrimTy, stringPrimTy,
-                                               wordPrimTy,
-                                               int64PrimTy, word64PrimTy,
-                                               floatPrimTy, doublePrimTy,
-                                               naturalPrimTy, byteArrayPrimTy)
 
 {-
 Note [Storage of floating point in Literal]
@@ -67,18 +57,3 @@ data Literal
   | NaturalLiteral  !Integer
   | ByteArrayLiteral !ByteArray
   deriving (Eq,Ord,Show,Generic,NFData,Hashable,Binary)
-
--- | Determines the Type of a Literal
-literalType :: Literal
-            -> Type
-literalType (IntegerLiteral  _) = integerPrimTy
-literalType (IntLiteral      _) = intPrimTy
-literalType (WordLiteral     _) = wordPrimTy
-literalType (StringLiteral   _) = stringPrimTy
-literalType (FloatLiteral    _) = floatPrimTy
-literalType (DoubleLiteral   _) = doublePrimTy
-literalType (CharLiteral     _) = charPrimTy
-literalType (Int64Literal    _) = int64PrimTy
-literalType (Word64Literal   _) = word64PrimTy
-literalType (NaturalLiteral  _) = naturalPrimTy
-literalType (ByteArrayLiteral _) = byteArrayPrimTy

--- a/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
@@ -79,6 +79,8 @@ data Neutral a
   | NeCase   !a !Type ![(Pat, a)]
   deriving (Show)
 
+-- TODO Write an instance (InferType a) => InferType (Neutral a)
+
 -- | A term which has been potentially evaluated to WHNF. If evaluation has
 -- occurred, then there will be no redexes at the head of the Value, but
 -- sub-terms may still have redexes. Data constructors are only considered to
@@ -100,6 +102,8 @@ data Value
   | VTick     !Value !TickInfo
   | VThunk    !Term !LocalEnv
   deriving (Show)
+
+-- TODO Write an instance InferType Value
 
 mkValueTicks :: Value -> [TickInfo] -> Value
 mkValueTicks = foldl VTick

--- a/clash-lib/src/Clash/Core/TermInfo.hs
+++ b/clash-lib/src/Clash/Core/TermInfo.hs
@@ -6,24 +6,16 @@
 module Clash.Core.TermInfo where
 
 import Data.Maybe (fromMaybe)
-import Data.Text.Prettyprint.Doc (line)
 import Data.Text (isInfixOf)
 import GHC.Stack (HasCallStack)
 
-import Clash.Core.DataCon
-import Clash.Core.FreeVars
-import Clash.Core.Literal
+import Clash.Core.HasType
 import Clash.Core.Name
-import Clash.Core.Pretty
-import Clash.Core.Subst
 import Clash.Core.Term
 import Clash.Core.TyCon (tyConDataCons, TyConMap)
 import Clash.Core.Type
 import Clash.Core.Var
-import Clash.Core.VarEnv
-import Clash.Debug (debugIsOn)
 import Clash.Unique (lookupUniqMap)
-import Clash.Util
 import Clash.Util.Interpolate as I
 
 termSize :: Term -> Word
@@ -45,52 +37,6 @@ termSize (Case subj _ alts) = sum (subjSz:altSzs)
  where
   subjSz = termSize subj
   altSzs = map (termSize . snd) alts
-
--- | Determine the type of a term
-termType :: TyConMap -> Term -> Type
-termType m e = case e of
-  Var t          -> varType t
-  Data dc        -> dcType dc
-  Literal l      -> literalType l
-  Prim p         -> goPrimType p
-  Lam v e'       -> mkFunTy (varType v) (termType m e')
-  TyLam tv e'    -> ForAllTy tv (termType m e')
-  App _ _        -> case collectArgs e of
-                      (fun, args) -> applyTypeToArgs e m (termType m fun) args
-  TyApp _ _      -> case collectArgs e of
-                      (fun, args) -> applyTypeToArgs e m (termType m fun) args
-  Letrec _ e'    -> termType m e'
-  Case _ ty _    -> ty
-  Cast _ _ ty2   -> ty2
-  Tick _ e'      -> termType m e'
- where
-  goPrimType = \case
-    PrimInfo{primMultiResult=SingleResult, primType} -> primType
-    p@PrimInfo{primMultiResult=MultiResult} -> multiPrimType p
-
--- | Type of multi prim primitive belonging to given primitive. See
--- 'Clash.Normalize.Transformations.setupMultiResultPrim' for more information.
---
--- Example, given:
---
--- @
---   /\v1 -> t1 -> t2 -> (t3, t4)
--- @
---
--- produces:
---
--- @
---   /\v1 -> t1 -> t2 -> t3 -> t4 -> (t3, t4)
--- @
---
-multiPrimType :: PrimInfo -> Type
-multiPrimType primInfo =
-  if "GHC.Tuple.(," `isInfixOf` nameOcc tupTcNm
-  then mkPolyFunTy primResTy (primArgs <> map Right tupEls)
-  else error (multPrimErr primInfo)
- where
-  (primArgs, primResTy) = splitFunForallTy (primType primInfo)
-  TyConApp tupTcNm tupEls = tyView primResTy
 
 multPrimErr :: PrimInfo -> String
 multPrimErr primInfo =  [I.i|
@@ -132,154 +78,13 @@ multiPrimInfo tcm primInfo
     , mpi_resultTypes = tupEls }
 multiPrimInfo _ _ = Nothing
 
--- | Get the result type of a polymorphic function given a list of arguments
-applyTypeToArgs
-  :: Term
-  -> TyConMap
-  -> Type
-  -> [Either Term Type]
-  -> Type
-applyTypeToArgs e m opTy args = go opTy args
- where
-  go opTy' []               = opTy'
-  go opTy' (Right ty:args') = goTyArgs opTy' [ty] args'
-  go opTy' (Left _:args')   = case splitFunTy m opTy' of
-    Just (_,resTy) -> go resTy args'
-    _ -> error $ unlines ["applyTypeToArgs:"
-                         ,"Expression: " ++ showPpr e
-                         ,"Type: " ++ showPpr opTy
-                         ,"Args: " ++ unlines (map (either showPpr showPpr) args)
-                         ]
-
-  goTyArgs opTy' revTys (Right ty:args') = goTyArgs opTy' (ty:revTys) args'
-  goTyArgs opTy' revTys args'            = go (piResultTys m opTy' (reverse revTys)) args'
-
--- | Like 'piResultTyMaybe', but errors out when a type application is not
--- valid.
---
--- Do not iterate 'piResultTy', because it's inefficient to substitute one
--- variable at a time; instead use 'piResultTys'
-piResultTy
-  :: HasCallStack
-  => TyConMap
-  -> Type
-  -> Type
-  -> Type
-piResultTy m ty arg = case piResultTyMaybe m ty arg of
-  Just res -> res
-  Nothing  -> pprPanic "piResultTy" (ppr ty <> line <> ppr arg)
-
--- | Like 'piResultTys' but for a single argument.
---
--- Do not iterate 'piResultTyMaybe', because it's inefficient to substitute one
--- variable at a time; instead use 'piResultTys'
-piResultTyMaybe
-  :: HasCallStack
-  => TyConMap
-  -> Type
-  -> Type
-  -> Maybe Type
-piResultTyMaybe m ty arg
-  | Just ty' <- coreView1 m ty
-  = piResultTyMaybe m ty' arg
-  | FunTy a res <- tyView ty
-  -- TODO coreView is used here because the partial evaluator will sometimes
-  -- encounter / not encounter a Signal as an argument unexpectedly. When PR
-  -- #1064 is merged the coreView calls should be removed again.
-  = if debugIsOn && not (aeqType (coreView m a) (coreView m arg)) then error [I.i|
-      Unexpected application. A function with type:
-
-        #{showPpr ty}
-
-      Got applied to an argument of type:
-
-        #{showPpr arg}
-    |]
-    else
-      Just res
-  | ForAllTy tv res <- ty
-  = let emptySubst = mkSubst (mkInScopeSet (tyFVsOfTypes [arg,res]))
-    in  Just (substTy (extendTvSubst emptySubst tv arg) res)
-  | otherwise
-  = Nothing
-
--- | @(piResultTys f_ty [ty1, ..., tyn])@ gives the type of @(f ty1 .. tyn)@
--- where @f :: f_ty@
---
--- 'piResultTys' is interesting because:
---
---    1. 'f_ty' may have more foralls than there are args
---    2. Less obviously, it may have fewer foralls
---
--- Fore case 2. think of:
---
---   piResultTys (forall a . a) [forall b.b, Int]
---
--- This really can happen, such as situations involving 'undefined's type:
---
---   undefined :: forall a. a
---
---   undefined (forall b. b -> b) Int
---
--- This term should have the type @(Int -> Int)@, but notice that there are
--- more type args than foralls in 'undefined's type.
---
--- For efficiency reasons, when there are no foralls, we simply drop arrows from
--- a function type/kind.
-piResultTys
-  :: HasCallStack
-  => TyConMap
-  -> Type
-  -> [Type]
-  -> Type
-piResultTys _ ty [] = ty
-piResultTys m ty origArgs@(arg:args)
-  | Just ty' <- coreView1 m ty
-  = piResultTys m ty' origArgs
-  | FunTy a res <- tyView ty
-  -- TODO coreView is used here because the partial evaluator will sometimes
-  -- encounter / not encounter a Signal as an argument unexpectedly. When PR
-  -- #1064 is merged the coreView calls should be removed again.
-  = if debugIsOn && not (aeqType (coreView m a) (coreView m arg)) then error [I.i|
-      Unexpected application. A function with type:
-
-        #{showPpr ty}
-
-      Got applied to an argument of type:
-
-        #{showPpr arg}
-    |]
-    else
-      piResultTys m res args
-  | ForAllTy tv res <- ty
-  = go (extendVarEnv tv arg emptyVarEnv) res args
-  | otherwise
-  = pprPanic "piResultTys1" (ppr ty <> line <> ppr origArgs)
- where
-  inScope = mkInScopeSet (tyFVsOfTypes (ty:origArgs))
-
-  go env ty' [] = substTy (mkTvSubst inScope env) ty'
-  go env ty' allArgs@(arg':args')
-    | Just ty'' <- coreView1 m ty'
-    = go env ty'' allArgs
-    | FunTy _ res <- tyView ty'
-    = go env res args'
-    | ForAllTy tv res <- ty'
-    = go (extendVarEnv tv arg' env) res args'
-    | VarTy tv <- ty'
-    , Just ty'' <- lookupVarEnv tv env
-      -- Deals with (piResultTys  (forall a.a) [forall b.b, Int])
-    = piResultTys m ty'' allArgs
-    | otherwise
-    = pprPanic "piResultTys2" (ppr ty' <> line <> ppr origArgs <> line <> ppr allArgs)
-
 -- | Does a term have a function type?
 isFun :: TyConMap -> Term -> Bool
-isFun m t = isFunTy m (termType m t)
+isFun m t = isFunTy m (inferCoreTypeOf m t)
 
 -- | Does a term have a function or polymorphic type?
 isPolyFun :: TyConMap -> Term -> Bool
-isPolyFun m t = isPolyFunCoreTy m (termType m t)
+isPolyFun m t = isPolyFunCoreTy m (inferCoreTypeOf m t)
 
 -- | Is a term a term-abstraction?
 isLam :: Term -> Bool

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -43,12 +43,12 @@ import           Unique                  (getKey)
 import Clash.Core.DataCon
 import Clash.Core.EqSolver
 import Clash.Core.FreeVars               (tyFVsOfTypes, typeFreeVars, freeLocalIds)
+import Clash.Core.HasType
 import Clash.Core.Name
   (Name (..), OccName, mkUnsafeInternalName, mkUnsafeSystemName)
 import Clash.Core.Pretty                 (showPpr)
 import Clash.Core.Subst
 import Clash.Core.Term
-import Clash.Core.TermInfo               (termType)
 import Clash.Core.TyCon                  (TyConMap, tyConDataCons)
 import Clash.Core.Type
 import Clash.Core.TysPrim                (typeNatKind)
@@ -681,7 +681,7 @@ mkSelectorCase
   -> Int -- ^ n'th DataCon
   -> Int -- ^ n'th field
   -> m Term
-mkSelectorCase caller inScope tcm scrut dcI fieldI = go (termType tcm scrut)
+mkSelectorCase caller inScope tcm scrut dcI fieldI = go (inferCoreTypeOf tcm scrut)
   where
     go (coreView1 tcm -> Just ty') = go ty'
     go scrutTy@(tyView -> TyConApp tc args) =

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -99,6 +99,7 @@ import           Clash.Annotations.TopEntity.Extra ()
 import           Clash.Backend
 import           Clash.Core.PartialEval as PE     (Evaluator)
 import           Clash.Core.Evaluator.Types as WHNF (Evaluator)
+import           Clash.Core.HasType
 import           Clash.Core.Name                  (Name (..))
 import           Clash.Core.Pretty                (PrettyOptions(..), showPpr')
 import           Clash.Core.Type
@@ -226,7 +227,7 @@ splitTopEntityT
 splitTopEntityT tcm bindingsMap tt@(TopEntityT id_ (Just t@(Synthesize {})) _) =
   case lookupVarEnv id_ bindingsMap of
     Just (Binding _id sp _ _ _) ->
-      tt{topAnnotation=Just (splitTopAnn tcm sp (varType id_) t)}
+      tt{topAnnotation=Just (splitTopAnn tcm sp (coreTypeOf id_) t)}
     Nothing ->
       error "Internal error in 'splitTopEntityT'. Please report as a bug."
 splitTopEntityT _ _ t = t
@@ -234,7 +235,7 @@ splitTopEntityT _ _ t = t
 -- | Remove constraints such as 'a ~ 3'.
 removeForAll :: TopEntityT -> TopEntityT
 removeForAll (TopEntityT var annM isTb) =
-  TopEntityT var{varType=tvSubstWithTyEq (varType var)} annM isTb
+  TopEntityT var{varType=tvSubstWithTyEq (coreTypeOf var)} annM isTb
 
 -- | Given a list of all found top entities and _maybe_ a top entity (+dependencies)
 -- passed in by '-main-is', return the list of top entities Clash needs to

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -68,8 +68,9 @@ import Clash.Annotations.BitRepresentation  (FieldAnn)
 import Clash.Annotations.Primitive          (HDL(..))
 import Clash.Annotations.TopEntity          (TopEntity)
 import Clash.Backend                        (Backend)
+import Clash.Core.HasType
 import Clash.Core.Type                      (Type)
-import Clash.Core.Var                       (Attr', Id, varType)
+import Clash.Core.Var                       (Attr', Id)
 import Clash.Core.TyCon                     (TyConMap)
 import Clash.Core.VarEnv                    (VarEnv)
 import Clash.Driver.Types                   (BindingMap, ClashOpts)
@@ -795,8 +796,8 @@ netlistTypes
   -> [Type]
 netlistTypes = \case
   NetlistId _ t -> [t]
-  CoreId i -> [varType i]
-  MultiId is -> map varType is
+  CoreId i -> [coreTypeOf i]
+  MultiId is -> map coreTypeOf is
 
 -- | Return the type of a 'NetlistId', fails on 'MultiId'
 netlistTypes1
@@ -805,7 +806,7 @@ netlistTypes1
   -> Type
 netlistTypes1 = \case
   NetlistId _ t -> t
-  CoreId i -> varType i
+  CoreId i -> coreTypeOf i
   m -> error ("netlistTypes1 MultiId: " ++ show m)
 
 -- | Type of declaration, concurrent or sequential

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -44,6 +44,7 @@ import           Clash.Annotations.BitRepresentation.Internal
 import           Clash.Core.Evaluator.Types as WHNF (Evaluator)
 import           Clash.Core.FreeVars
   (freeLocalIds, globalIds, globalIdOccursIn, localIdDoesNotOccurIn)
+import           Clash.Core.HasType
 import           Clash.Core.PartialEval as PE     (Evaluator)
 import           Clash.Core.Pretty                (PrettyOptions(..), showPpr, showPpr', ppr)
 import           Clash.Core.Subst
@@ -178,7 +179,7 @@ normalize' nm = do
       tcm <- Lens.view tcCache
       topEnts <- Lens.view topEntities
       let isTop = nm `elemVarSet` topEnts
-          ty0 = varType nm'
+          ty0 = coreTypeOf nm'
           ty1 = if isTop then tvSubstWithTyEq ty0 else ty0
 
       -- check for polymorphic types
@@ -205,7 +206,7 @@ normalize' nm = do
             let usedBndrs = Lens.toListOf globalIds (bindingTerm tmNorm)
             traceIf (nm `elem` usedBndrs)
                     (concat [ $(curLoc),"Expr belonging to bndr: ",nmS ," (:: "
-                            , showPpr (varType (bindingId tmNorm))
+                            , showPpr (coreTypeOf (bindingId tmNorm))
                             , ") remains recursive after normalization:\n"
                             , showPpr (bindingTerm tmNorm) ])
                     (return ())
@@ -231,7 +232,7 @@ normalize' nm = do
             opts <- Lens.view debugOpts
             traceIf (dbg_invariants opts)
                     (concat [$(curLoc), "Expr belonging to bndr: ", nmS, " (:: "
-                            , showPpr (varType nm')
+                            , showPpr (coreTypeOf nm')
                             , ") has a non-representable return type."
                             , " Not normalising:\n", showPpr tm] )
                     (return ([],(nm,(Binding nm' sp inl pr tm))))

--- a/clash-lib/src/Clash/Normalize/Transformations/ANF.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/ANF.hs
@@ -32,12 +32,13 @@ import Clash.Signal.Internal (Signal(..))
 
 import Clash.Core.DataCon (DataCon(..))
 import Clash.Core.FreeVars (localIdsDoNotOccurIn)
+import Clash.Core.HasType
 import Clash.Core.Name (mkUnsafeSystemName, nameOcc)
 import Clash.Core.Subst (deshadowLetExpr, freshenTm)
 import Clash.Core.Term
   ( Alt, CoreContext(..), LetBinding, Pat(..), PrimInfo(..), Term(..)
   , collectArgs, collectTicks, mkTicks, partitionTicks, stripTicks)
-import Clash.Core.TermInfo (isCon, isLocalVar, isPrim, isVar, termType)
+import Clash.Core.TermInfo (isCon, isLocalVar, isPrim, isVar)
 import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (Type, TypeView(..), coreView, tyView)
 import Clash.Core.Util (mkSelectorCase)
@@ -276,7 +277,7 @@ collectANF ctx e@(App appf arg)
 
 collectANF _ (Letrec binds body) = do
   tcm <- Lens.view tcCache
-  let isSimIO = isSimIOTy tcm (termType tcm body)
+  let isSimIO = isSimIOTy tcm (inferCoreTypeOf tcm body)
   untranslatable <- lift (isUntranslatable False body)
   let localVar = isLocalVar body
   -- See Note [ANF no let-bind]

--- a/clash-lib/src/Clash/Normalize/Transformations/XOptimize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/XOptimize.hs
@@ -26,13 +26,13 @@ import Clash.XException (errorX)
 
 import Clash.Annotations.Primitive (extractPrim)
 import Clash.Core.DataCon (DataCon)
+import Clash.Core.HasType
 import Clash.Core.Term
   ( Alt, IsMultiPrim(..), LetBinding, Pat(..), PrimInfo(..), Term(..)
   , WorkInfo(..), collectArgs, PrimUnfolding(..))
-import Clash.Core.TermInfo (termType)
 import Clash.Core.Type (TyVar, Type)
 import Clash.Core.Util (mkInternalVar)
-import Clash.Core.Var (Id, Var(..))
+import Clash.Core.Var (Id)
 import Clash.Core.VarEnv (InScopeSet)
 import Clash.Netlist.BlackBox.Types (Element(Err))
 import Clash.Netlist.Types (BlackBox(..))
@@ -90,9 +90,9 @@ xOptimize _ e = return e
 xOptimizeSingle :: InScopeSet -> Term -> Alt -> NormalizeSession Term
 xOptimizeSingle is subj (DataPat dc tvs vars, expr) = do
   tcm    <- Lens.view tcCache
-  subjId <- mkInternalVar is "subj" (termType tcm subj)
+  subjId <- mkInternalVar is "subj" (inferCoreTypeOf tcm subj)
 
-  let fieldTys = fmap varType vars
+  let fieldTys = fmap coreTypeOf vars
   lets <- Monad.zipWithM (mkFieldSelector is subjId dc tvs fieldTys) vars [0..]
 
   changed (Letrec ((subjId, subj) : lets) expr)

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -15,8 +15,8 @@ import           GHC.Stack                       (HasCallStack)
 import           Clash.Annotations.Primitive     (HDL(..))
 import           Clash.Backend
   (Backend, blockDecl, hdlKind)
+import           Clash.Core.HasType
 import           Clash.Core.Term                 (Term(Var), varToId)
-import           Clash.Core.TermInfo             (termType)
 import           Clash.Core.TermLiteral          (termToDataError)
 import           Clash.Util                      (indexNote)
 import           Clash.Netlist                   (mkExpr)
@@ -72,7 +72,7 @@ checkBBF _isD _primName args _ty =
   bindMaybe (Just nm) t = do
     tcm <- Lens.use tcCache
     newId <- Id.make (Text.pack nm)
-    (expr0, decls) <- mkExpr False Concurrent (NetlistId newId (termType tcm t)) t
+    (expr0, decls) <- mkExpr False Concurrent (NetlistId newId (inferCoreTypeOf tcm t)) t
     pure
       ( newId
       , decls ++ [sigDecl Bool newId, Assignment newId expr0] )


### PR DESCRIPTION
This PR introduces some new classes for inspecting things in Clash core:

```haskell
class HasType a where
  coreTypeOf :: a -> Type

class InferType a where
  inferCoreTypeOf :: TyConMap -> a -> Type
```

These functions can then be used to extract type information from any typed _thing_ that exists in core.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
