### PR TITLE
Add HasFreeVars class

### DIFF
--- a/changelog/2021-09-02T11_55_35+02_00_hasfreevars_class.md
+++ b/changelog/2021-09-02T11_55_35+02_00_hasfreevars_class.md
@@ -1,0 +1,1 @@
+INTERNAL CHANGE: Added HasFreeVars class for getting free variables from data "containing" variables

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -189,6 +189,7 @@ Library
                       Clash.Core.Evaluator.Types
                       Clash.Core.FreeVars
                       Clash.Core.HasType
+                      Clash.Core.HasFreeVars
                       Clash.Core.Literal
                       Clash.Core.Name
                       Clash.Core.PartialEval
@@ -282,6 +283,7 @@ Library
   Other-Modules:      Clash.Annotations.TopEntity.Extra
                       Control.Applicative.Extra
                       Data.Aeson.Extra
+                      Data.IntMap.Extra
                       Data.List.Extra
                       Data.Map.Ordered.Extra
                       Data.Monoid.Extra

--- a/clash-lib/src/Clash/Core/HasFreeVars.hs
+++ b/clash-lib/src/Clash/Core/HasFreeVars.hs
@@ -1,0 +1,93 @@
+{-|
+Copyright   : (C) 2021, QBayLogic B.V.
+License     : BSD2 (see the file LICENSE)
+Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
+
+Utility class to extract free variables from data which has variables.
+-}
+
+{-# LANGUAGE FlexibleInstances #-}
+
+module Clash.Core.HasFreeVars
+  ( HasFreeVars(..)
+  ) where
+
+import Control.Lens as Lens (foldMapOf)
+import Data.Monoid (All(..), Any(..))
+
+import Clash.Core.FreeVars
+import Clash.Core.Term (Term)
+import Clash.Core.Type (Type(..))
+import Clash.Core.Var (Var)
+import Clash.Core.VarEnv
+
+class HasFreeVars a where
+  {-# MINIMAL freeVarsOf #-}
+
+  freeVarsOf :: a -> VarSet
+
+  {-# INLINE isClosed #-}
+  -- | Something is closed if it has no free variables.
+  -- This function may be replaced with a more efficient implementation.
+  isClosed :: a -> Bool
+  isClosed = nullVarSet . freeVarsOf
+
+  {-# INLINE elemFreeVars #-}
+  -- | Check if a variable is free in the given value.
+  -- This function may be replaced with a more efficient implementation.
+  elemFreeVars :: Var a -> a -> Bool
+  elemFreeVars v = elemVarSet v . freeVarsOf
+
+  {-# INLINE notElemFreeVars #-}
+  -- | Check if a variable is not free in the given value.
+  -- This function may be replaced with a more efficient implementation.
+  notElemFreeVars :: Var a -> a -> Bool
+  notElemFreeVars x = notElemVarSet x . freeVarsOf
+
+  {-# INLINE subsetFreeVars #-}
+  -- | Check if all variables in a set are free in the given value.
+  -- This function may be replaced with a more efficient implementation.
+  subsetFreeVars :: VarSet -> a -> Bool
+  subsetFreeVars xs = subsetVarSet xs . freeVarsOf
+
+  {-# INLINE disjointFreeVars #-}
+  -- | Check if no variables in a set are free in the given value.
+  -- This function may be replaced with a more efficient implementation.
+  disjointFreeVars :: VarSet -> a -> Bool
+  disjointFreeVars xs = disjointVarSet xs . freeVarsOf
+
+instance HasFreeVars Term where
+  {-# INLINE freeVarsOf #-}
+  freeVarsOf =
+    Lens.foldMapOf freeLocalVars unitVarSet
+
+  elemFreeVars v e =
+    getAny (Lens.foldMapOf freeLocalVars (Any . (== v)) e)
+
+  notElemFreeVars v e =
+    getAll (Lens.foldMapOf freeLocalVars (All . (/= v)) e)
+
+  disjointFreeVars vs e =
+    getAll (Lens.foldMapOf freeLocalVars (All . (`notElem` vs)) e)
+
+instance HasFreeVars Type where
+  {-# INLINE freeVarsOf #-}
+  freeVarsOf =
+    Lens.foldMapOf typeFreeVars unitVarSet
+
+  isClosed ty =
+    case ty of
+      VarTy{} -> False
+      ForAllTy{} -> getAll (Lens.foldMapOf typeFreeVars (const (All False)) ty)
+      AppTy l r -> isClosed l && isClosed r
+      _ -> True
+
+  elemFreeVars v ty =
+    getAny (Lens.foldMapOf typeFreeVars (Any . (== v)) ty)
+
+  notElemFreeVars v ty =
+    getAll (Lens.foldMapOf typeFreeVars (All . (/= v)) ty)
+
+instance (Foldable f, HasFreeVars a) => HasFreeVars (f a) where
+  {-# INLINE freeVarsOf #-}
+  freeVarsOf = foldMap freeVarsOf

--- a/clash-lib/src/Clash/Core/HasType.hs
+++ b/clash-lib/src/Clash/Core/HasType.hs
@@ -23,7 +23,7 @@ import Data.Text.Prettyprint.Doc (line)
 import GHC.Stack (HasCallStack)
 
 import Clash.Core.DataCon (DataCon(dcType))
-import Clash.Core.FreeVars
+import Clash.Core.HasFreeVars
 import Clash.Core.Literal (Literal(..))
 import Clash.Core.Name (Name(nameOcc))
 import Clash.Core.Pretty
@@ -202,7 +202,7 @@ piResultTys m ty origArgs@(arg:args)
   | otherwise
   = pprPanic "piResultTys1" (ppr ty <> line <> ppr origArgs)
  where
-  inScope = mkInScopeSet (tyFVsOfTypes (ty:origArgs))
+  inScope = mkInScopeSet (freeVarsOf (ty:origArgs))
 
   go env ty' [] = substTy (mkTvSubst inScope env) ty'
   go env ty' allArgs@(arg':args')

--- a/clash-lib/src/Clash/Core/PartialEval/AsTerm.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/AsTerm.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2020 QBayLogic B.V.
+Copyright   : (C) 2020-2021, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -18,7 +18,7 @@ module Clash.Core.PartialEval.AsTerm
 import Data.Bifunctor (first, second)
 import Data.Graph (SCC(..), flattenSCCs)
 
-import Clash.Core.FreeVars (localFVsOfTerms)
+import Clash.Core.HasFreeVars
 import Clash.Core.PartialEval.NormalForm
 import Clash.Core.Term (Term(..), LetBinding, Pat, Alt, mkApps)
 import Clash.Core.Util (sccLetBindings)
@@ -49,7 +49,7 @@ removeUnusedBindings bs x
   | null used = x
   | otherwise = Letrec used x
  where
-  free = localFVsOfTerms [x]
+  free = freeVarsOf x
   used = flattenSCCs $ filter isUsed (sccLetBindings bs)
 
   isUsed = \case

--- a/clash-lib/src/Clash/Core/PartialEval/Monad.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/Monad.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2020, QBayLogic B.V.
+Copyright   : (C) 2020-2021, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -73,7 +73,7 @@ import qualified Control.Monad.RWS.Strict as RWS
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
 
-import           Clash.Core.FreeVars (localFVsOfTerms, tyFVsOfTypes)
+import           Clash.Core.HasFreeVars
 import           Clash.Core.Name (OccName)
 import           Clash.Core.PartialEval.AsTerm
 import           Clash.Core.PartialEval.NormalForm
@@ -174,7 +174,7 @@ withTyVar i a x = do
   modifyLocalEnv goLocal x
  where
   goGlobal env@GlobalEnv{genvInScope=inScope} =
-    let fvs = unitVarSet i `unionVarSet` tyFVsOfTypes [a]
+    let fvs = unitVarSet i `unionVarSet` freeVarsOf a
         iss = mkInScopeSet fvs `unionInScope` inScope
      in env { genvInScope = iss }
 
@@ -201,8 +201,8 @@ withId i v x = do
   modifyLocalEnv goLocal x
  where
   goGlobal env@GlobalEnv{genvInScope=inScope} =
-    --  TODO Is it a hack to use asTerm here?
-    let fvs = unitVarSet i `unionVarSet` localFVsOfTerms [asTerm v]
+    -- TODO Change this to use an instance HasFreeVars Value
+    let fvs = unitVarSet i `unionVarSet` freeVarsOf (asTerm v)
         iss = mkInScopeSet fvs `unionInScope` inScope
      in env { genvInScope = iss }
 

--- a/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
@@ -80,6 +80,7 @@ data Neutral a
   deriving (Show)
 
 -- TODO Write an instance (InferType a) => InferType (Neutral a)
+-- TODO Write an instance (HasFreeVars a) => HasFreeVars (Neutral a)
 
 -- | A term which has been potentially evaluated to WHNF. If evaluation has
 -- occurred, then there will be no redexes at the head of the Value, but
@@ -104,6 +105,7 @@ data Value
   deriving (Show)
 
 -- TODO Write an instance InferType Value
+-- TODO Write an instance HasFreeVars Value
 
 mkValueTicks :: Value -> [TickInfo] -> Value
 mkValueTicks = foldl VTick

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -51,6 +51,8 @@ module Clash.Core.VarEnv
     -- *** Searching
   , elemVarSet
   , notElemVarSet
+  , subsetVarSet
+  , disjointVarSet
     -- ** Conversions
     -- *** Lists
   , mkVarSet
@@ -324,6 +326,13 @@ subsetVarSet
   -- ^ Set of variables B
   -> Bool
 subsetVarSet = subsetUniqSet
+
+-- | Are the sets of variables disjoint
+disjointVarSet
+  :: VarSet
+  -> VarSet
+  -> Bool
+disjointVarSet = disjointUniqSet
 
 -- | Check whether a varset is empty
 nullVarSet

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -74,7 +74,8 @@ import           Clash.Annotations.BitRepresentation.Internal
 import           Clash.Backend           (HWKind(..), hdlHWTypeKind)
 import           Clash.Core.DataCon      (DataCon (..))
 import           Clash.Core.EqSolver     (typeEq)
-import           Clash.Core.FreeVars     (localIdOccursIn, typeFreeVars, typeFreeVars')
+import           Clash.Core.FreeVars     (typeFreeVars, typeFreeVars')
+import           Clash.Core.HasFreeVars  (elemFreeVars)
 import           Clash.Core.HasType
 import qualified Clash.Core.Literal      as C
 import           Clash.Core.Name
@@ -787,7 +788,7 @@ mkUniqueNormalized is0 topMM (args, binds, res) = do
         -- we need to add a redirection as most synthesis tools don't allow reads
         -- from output ports. Note that if the result is renamed anyway, we don't
         -- have to do anything here.
-        resultRead = any (localIdOccursIn res) exprs
+        resultRead = any (elemFreeVars res) exprs
         recResult = modifyVarName (`appendToName` "_rec") res
         resRenameM1 = resRenameM0 <|> orNothing resultRead (res, recResult)
 

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -43,7 +43,8 @@ import           Clash.Annotations.BitRepresentation.Internal
   (CustomReprs)
 import           Clash.Core.Evaluator.Types as WHNF (Evaluator)
 import           Clash.Core.FreeVars
-  (freeLocalIds, globalIds, globalIdOccursIn, localIdDoesNotOccurIn)
+  (freeLocalIds, globalIds, globalIdOccursIn)
+import           Clash.Core.HasFreeVars           (notElemFreeVars)
 import           Clash.Core.HasType
 import           Clash.Core.PartialEval as PE     (Evaluator)
 import           Clash.Core.Pretty                (PrettyOptions(..), showPpr, showPpr', ppr)
@@ -329,7 +330,7 @@ flattenNode c@(CLeaf (nm,(Binding _ _ _ _ e))) = do
       Right (ids,[(bId,bExpr)],_) -> do
         let (fun,args,ticks) = collectArgsTicks bExpr
         case stripArgs ids (reverse ids) (reverse args) of
-          Just remainder | bId `localIdDoesNotOccurIn` bExpr ->
+          Just remainder | bId `notElemFreeVars` bExpr ->
                return (Right ((nm,mkApps (mkTicks fun ticks) (reverse remainder)),[]))
           _ -> return (Right ((nm,e),[]))
       _ -> return (Right ((nm,e),[]))
@@ -344,7 +345,7 @@ flattenNode b@(CBranch (nm,(Binding _ _ _ _ e)) us) = do
       Right (ids,[(bId,bExpr)],_) -> do
         let (fun,args,ticks) = collectArgsTicks bExpr
         case stripArgs ids (reverse ids) (reverse args) of
-          Just remainder | bId `localIdDoesNotOccurIn` bExpr ->
+          Just remainder | bId `notElemFreeVars` bExpr ->
                return (Right ((nm,mkApps (mkTicks fun ticks) (reverse remainder)),us))
           _ -> return (Right ((nm,e),us))
       _ -> do

--- a/clash-lib/src/Clash/Normalize/Transformations/ANF.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/ANF.hs
@@ -31,7 +31,7 @@ import GHC.Stack (HasCallStack)
 import Clash.Signal.Internal (Signal(..))
 
 import Clash.Core.DataCon (DataCon(..))
-import Clash.Core.FreeVars (localIdsDoNotOccurIn)
+import Clash.Core.HasFreeVars (disjointFreeVars)
 import Clash.Core.HasType
 import Clash.Core.Name (mkUnsafeSystemName, nameOcc)
 import Clash.Core.Subst (deshadowLetExpr, freshenTm)
@@ -43,7 +43,7 @@ import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (Type, TypeView(..), coreView, tyView)
 import Clash.Core.Util (mkSelectorCase)
 import Clash.Core.Var (Id)
-import Clash.Core.VarEnv (InScopeSet, extendInScopeSet, extendInScopeSetList)
+import Clash.Core.VarEnv (InScopeSet, extendInScopeSet, extendInScopeSetList, mkVarSet)
 import Clash.Netlist.Util (bindsExistentials)
 import Clash.Normalize.Transformations.Specialize (specialize)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession)
@@ -336,7 +336,7 @@ collectANF ctx (Case subj ty alts) = do
 
     case alts' of
       [(DataPat _ [] xs,altExpr)]
-        | xs `localIdsDoNotOccurIn` altExpr || isSimIOAlt
+        | mkVarSet xs `disjointFreeVars` altExpr || isSimIOAlt
         -> return altExpr
       _ -> return (Case subj' ty alts')
   where

--- a/clash-lib/src/Clash/Rewrite/WorkFree.hs
+++ b/clash-lib/src/Clash/Rewrite/WorkFree.hs
@@ -26,6 +26,7 @@ import Control.Monad.State.Class (MonadState)
 import qualified Data.Text.Extra as Text
 import GHC.Stack (HasCallStack)
 
+import Clash.Core.HasFreeVars
 import Clash.Core.FreeVars
 import Clash.Core.HasType
 import Clash.Core.Pretty (showPpr)
@@ -128,7 +129,7 @@ isConstant :: Term -> Bool
 isConstant e = case collectArgs e of
   (Data _, args)   -> all (either isConstant (const True)) args
   (Prim _, args) -> all (either isConstant (const True)) args
-  (Lam _ _, _)     -> not (hasLocalFreeVars e)
+  (Lam _ _, _)     -> isClosed e
   (Literal _,_)    -> True
   _                -> False
 
@@ -188,7 +189,7 @@ isWorkFreeIsh tcm e =
           WorkVariable -> all isConstantArg args
           _            -> all isWorkFreeIshArg args
 
-        (Lam _ _, _)       -> not (hasLocalFreeVars e)
+        (Lam _ _, _)       -> isClosed e
         (Literal _,_)      -> True
         _                  -> False
  where

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -69,6 +69,7 @@ module Clash.Unique
   , elemUniqSetDirectly
     -- *** Misc
   , subsetUniqSet
+  , disjointUniqSet
   , differenceUniqSet
     -- ** Conversions
     -- *** Lists
@@ -81,6 +82,11 @@ import           Control.DeepSeq (NFData)
 import           Data.Binary (Binary)
 import           Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
+
+#if !MIN_VERSION_containers(0,6,2)
+import qualified Data.IntMap.Extra as IntMap
+#endif
+
 import qualified Data.List   as List
 import           Data.Text.Prettyprint.Doc
 import           GHC.Stack
@@ -420,6 +426,13 @@ subsetUniqSet
   -- ^ Set B
   -> Bool
 subsetUniqSet (UniqSet e1) (UniqSet e2) = IntMap.null (IntMap.difference e1 e2)
+
+-- | Check whether A and B are disjoint
+disjointUniqSet
+  :: UniqSet a
+  -> UniqSet a
+  -> Bool
+disjointUniqSet (UniqSet e1) (UniqSet e2) = IntMap.disjoint e1 e2
 
 -- | Take the difference of two sets
 differenceUniqSet

--- a/clash-lib/src/Data/IntMap/Extra.hs
+++ b/clash-lib/src/Data/IntMap/Extra.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE CPP #-}
+
+module Data.IntMap.Extra where
+
+#if !MIN_VERSION_containers(0,6,2)
+import Data.IntMap.Internal
+
+-- TODO We can remove this when support for GHC 8.6 is dropped.
+
+-- | /O(n+m)/. Check whether the key sets of two maps are disjoint
+-- (i.e. their 'intersection' is empty).
+--
+-- > disjoint (fromList [(2,'a')]) (fromList [(1,()), (3,())])   == True
+-- > disjoint (fromList [(2,'a')]) (fromList [(1,'a'), (2,'b')]) == False
+-- > disjoint (fromList [])        (fromList [])                 == True
+--
+-- > disjoint a b == null (intersection a b)
+--
+disjoint :: IntMap a -> IntMap b -> Bool
+disjoint Nil _ = True
+disjoint _ Nil = True
+disjoint (Tip kx _) ys = notMember kx ys
+disjoint xs (Tip ky _) = notMember ky xs
+disjoint t1@(Bin p1 m1 l1 r1) t2@(Bin p2 m2 l2 r2)
+  | shorter m1 m2 = disjoint1
+  | shorter m2 m1 = disjoint2
+  | p1 == p2      = disjoint l1 l2 && disjoint r1 r2
+  | otherwise     = True
+  where
+    disjoint1 | nomatch p2 p1 m1 = True
+              | zero p2 m1       = disjoint l1 t2
+              | otherwise        = disjoint r1 t2
+    disjoint2 | nomatch p1 p2 m2 = True
+              | zero p1 m2       = disjoint t1 l2
+              | otherwise        = disjoint t1 r2
+#endif


### PR DESCRIPTION
This PR introduces a new class for inspecting free variables in Clash core:

```haskell
class HasFreeVars a where
  {-# MINIMAL freeVarsOf #-}

  freeVarsOf :: a -> VarSet

  isClosed :: a - > Bool
  isClosed = nullVarSet . freeVarsOf
```

Instances are available for extracting information from a single "thing", e.g. `Term`, as well as a collection of things (any `Foldable f`).

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
