### PR TITLE
Remove Type/Kind distinction

### DIFF
--- a/clash-lib/src/Clash/Core/PartialEval/Monad.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/Monad.hs
@@ -79,7 +79,7 @@ import           Clash.Core.PartialEval.AsTerm
 import           Clash.Core.PartialEval.NormalForm
 import           Clash.Core.Subst (Subst, mkTvSubst)
 import           Clash.Core.TyCon (TyConMap)
-import           Clash.Core.Type (Kind, KindOrType, Type)
+import           Clash.Core.Type (Type)
 import           Clash.Core.Util (mkUniqSystemId, mkUniqSystemTyVar)
 import           Clash.Core.Var (Id, TyVar, Var)
 import           Clash.Core.VarEnv
@@ -285,15 +285,15 @@ getInScope = genvInScope <$> getGlobalEnv
 getUniqueId :: OccName -> Type -> Eval Id
 getUniqueId = getUniqueVar mkUniqSystemId
 
-getUniqueTyVar :: OccName -> Kind -> Eval TyVar
+getUniqueTyVar :: OccName -> Type -> Eval TyVar
 getUniqueTyVar = getUniqueVar mkUniqSystemTyVar
 
 getUniqueVar
   :: ((Supply, InScopeSet)
-         -> (OccName, KindOrType)
+         -> (OccName, Type)
          -> ((Supply, InScopeSet), Var a))
   -> OccName
-  -> KindOrType
+  -> Type
   -> Eval (Var a)
 getUniqueVar f name ty = do
   env <- getGlobalEnv

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -58,7 +58,7 @@ import Clash.Core.Name                  (Name (..))
 import Clash.Core.Term
   (Pat (..), Term (..), TickInfo (..), NameMod (..), CoreContext (..), primArg, PrimInfo(primName))
 import Clash.Core.TyCon                 (TyCon (..), TyConName, isTupleTyConLike)
-import Clash.Core.Type                  (ConstTy (..), Kind, LitTy (..),
+import Clash.Core.Type                  (ConstTy (..), LitTy (..),
                                          Type (..), TypeView (..), tyView)
 import Clash.Core.Var                   (Id, TyVar, Var (..), IdScope(..))
 import Clash.Debug                      (trace)
@@ -465,11 +465,8 @@ pprForAll tvs = do
 pprTvBndr :: Monad m => TyVar -> m ClashDoc
 pprTvBndr tv = do
   tv'   <- pprM tv
-  kind' <- pprKind (varType tv)
+  kind' <- pprType (varType tv)
   return $ tyParens $ tv' <> (annotate (AnnSyntax Type) $ space <> dcolon <+> kind')
-
-pprKind :: Monad m => Kind -> m ClashDoc
-pprKind = pprType
 
 pprTcApp :: Monad m => TypePrec -> (TypePrec -> Type -> m ClashDoc)
   -> TyConName -> [Type] -> m ClashDoc

--- a/clash-lib/src/Clash/Core/TyCon.hs
+++ b/clash-lib/src/Clash/Core/TyCon.hs
@@ -33,7 +33,7 @@ import GHC.Generics
 -- Internal Imports
 import Clash.Core.DataCon                     (DataCon)
 import Clash.Core.Name
-import {-# SOURCE #-} Clash.Core.Type         (Kind, Type)
+import {-# SOURCE #-} Clash.Core.Type         (Type)
 import Clash.Core.Var                         (TyVar)
 import Clash.Unique
 
@@ -43,7 +43,7 @@ data TyCon
   = AlgTyCon
   { tyConUniq   :: {-# UNPACK #-} !Unique
   , tyConName   :: !TyConName   -- ^ Name of the TyCon
-  , tyConKind   :: !Kind        -- ^ Kind of the TyCon
+  , tyConKind   :: !Type        -- ^ Type of the TyCon
   , tyConArity  :: !Int         -- ^ Number of type arguments
   , algTcRhs    :: !AlgTyConRhs -- ^ DataCon definitions
   , isClassTc   :: !Bool        -- ^ Is this a class dictionary?
@@ -52,7 +52,7 @@ data TyCon
   | FunTyCon
   { tyConUniq   :: {-# UNPACK #-} !Unique
   , tyConName   :: !TyConName      -- ^ Name of the TyCon
-  , tyConKind   :: !Kind           -- ^ Kind of the TyCon
+  , tyConKind   :: !Type           -- ^ Type of the TyCon
   , tyConArity  :: !Int            -- ^ Number of type arguments
   , tyConSubst  :: [([Type],Type)] -- ^ List of: ([LHS match types], RHS type)
   }
@@ -60,7 +60,7 @@ data TyCon
   | PrimTyCon
   { tyConUniq    :: {-# UNPACK #-} !Unique
   , tyConName    :: !TyConName  -- ^ Name of the TyCon
-  , tyConKind    :: !Kind       -- ^ Kind of the TyCon
+  , tyConKind    :: !Type       -- ^ Type of the TyCon
   , tyConArity   :: !Int        -- ^ Number of type arguments
   }
   -- | To close the loop on the type hierarchy
@@ -105,7 +105,7 @@ data AlgTyConRhs
 
 -- | Create a Kind out of a TyConName
 mkKindTyCon :: TyConName
-            -> Kind
+            -> Type
             -> TyCon
 mkKindTyCon name kind
   = PrimTyCon (nameUniq name) name kind 0

--- a/clash-lib/src/Clash/Core/Type.hs-boot
+++ b/clash-lib/src/Clash/Core/Type.hs-boot
@@ -20,10 +20,7 @@ import                Clash.Core.Name
 import {-# SOURCE #-} Clash.Core.TyCon
 
 data Type
-
-type Kind   = Type
 type TyName = Name Type
-type KiName = Name Kind
 
 instance Generic  Type
 instance Show     Type

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -332,7 +332,7 @@ tyNatSize _ ty = throwE $ $(curLoc) ++ "Cannot reduce to an integer:\n" ++ showP
 
 mkUniqSystemTyVar
   :: (Supply, InScopeSet)
-  -> (OccName, Kind)
+  -> (OccName, Type)
   -> ((Supply, InScopeSet), TyVar)
 mkUniqSystemTyVar (supply,inScope) (nm, ki) =
   ((supply',extendInScopeSet inScope v'), v')
@@ -718,7 +718,7 @@ mkInternalVar
   => InScopeSet
   -> OccName
   -- ^ Name of the identifier
-  -> KindOrType
+  -> Type
   -> m Id
 mkInternalVar inScope name ty = do
   i <- getUniqueM

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -40,7 +40,7 @@ import Data.Hashable                    (Hashable(hashWithSalt))
 import GHC.Generics                     (Generic)
 import Clash.Core.Name                  (Name (..))
 import {-# SOURCE #-} Clash.Core.Term   (Term, TmName)
-import {-# SOURCE #-} Clash.Core.Type   (Kind, Type, TyName)
+import {-# SOURCE #-} Clash.Core.Type   (Type, TyName)
 import Clash.Unique
 
 
@@ -68,7 +68,7 @@ data Var a
   { varName :: !(Name a)
   , varUniq :: {-# UNPACK #-} !Unique
   -- ^ Invariant: forall x . varUniq x ~ nameUniq (varName x)
-  , varType :: Kind
+  , varType :: Type
   }
   -- | Constructor for term variables
   | Id
@@ -122,7 +122,7 @@ modifyVarName f (Id n _ t s) =
 
 -- | Make a type variable
 mkTyVar
-  :: Kind
+  :: Type
   -> TyName
   -> TyVar
 mkTyVar tyKind tyName = TyVar tyName (nameUniq tyName) tyKind

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -71,7 +71,7 @@ import           Clash.Core.Subst
   (substTmEnv, aeqTerm, aeqType, extendIdSubst, mkSubst, substTm)
 import           Clash.Core.Term
 import           Clash.Core.TyCon            (TyConMap)
-import           Clash.Core.Type             (Type (..), normalizeType, typeKind)
+import           Clash.Core.Type             (Type (..), normalizeType)
 import           Clash.Core.Var
   (Id, IdScope (..), TyVar, Var (..), mkGlobalId, mkLocalId, mkTyVar)
 import           Clash.Core.VarEnv
@@ -338,7 +338,7 @@ mkBinderFor is tcm name (Left term) = do
 
 mkBinderFor is tcm name (Right ty) = do
   name' <- cloneNameWithInScopeSet is name
-  let ki = typeKind tcm ty
+  let ki = inferCoreTypeOf tcm ty
   return (Right (mkTyVar ki (coerce name')))
 
 -- | Inline the binders in a let-binding that have a certain property


### PR DESCRIPTION
The distinction between `Type` and `Kind` is not particularly relevant since GHC has had `Type :: Type` for a while now. This PR somewhat tentatively removes the synonyms for kinds and replaces `typeKind` with an instance of `InferCoreType` for `Type`.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
