### PR TITLE
Change Data.Text.Prettyprint.Doc to Prettyprinter

### DIFF
--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
@@ -18,7 +18,7 @@ import           Clash.Netlist.Types
 import           Control.Monad.State             (State())
 import           Data.Monoid                     (Ap(getAp))
 import           Data.Text as TextS
-import           Data.Text.Prettyprint.Doc.Extra
+import           Prettyprinter.Extra
 import           Prelude
 
 -- | Generates HDL for ECP5 bidirectional buffer BB

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -14,9 +14,9 @@ import           Prelude
 
 import           Control.Monad.State
 import           Data.Monoid (Ap(getAp))
-import           Data.Text.Prettyprint.Doc.Extra
 import           GHC.Stack
   (HasCallStack, prettyCallStack, callStack)
+import           Prettyprinter.Extra
 
 import           Clash.Backend
 import qualified Clash.Netlist.Id as Id

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/BlackBoxes.hs
@@ -26,7 +26,7 @@ import Clash.Backend (Backend)
 import Clash.Netlist.Types
   (BlackBoxContext(..), Expr(..), HWType(..), Literal(..), Modifier(..),
    TemplateFunction(..))
-import Data.Text.Prettyprint.Doc.Extra (Doc)
+import Prettyprinter.Extra (Doc)
 
 import Clash.Cores.Xilinx.Floating.Internal
 

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -156,7 +156,7 @@ Library
                       lens                    >= 4.10     && < 5.1.0,
                       mtl                     >= 2.1.2    && < 2.3,
                       ordered-containers      >= 0.2      && < 0.3,
-                      prettyprinter           >= 1.2.0.1  && < 2.0,
+                      prettyprinter           >= 1.7      && < 2.0,
                       pretty-show             >= 1.9      && < 2.0,
                       primitive               >= 0.5.0.1  && < 1.0,
                       template-haskell        >= 2.8.0.0  && < 2.18,
@@ -277,7 +277,7 @@ Library
 
                       Clash.Verification.Pretty
 
-                      Data.Text.Prettyprint.Doc.Extra
+                      Prettyprinter.Extra
 
   Other-Modules:      Clash.Annotations.TopEntity.Extra
                       Data.Aeson.Extra

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -16,7 +16,7 @@ import Data.Monoid                          (Ap)
 import Data.Text                            (Text)
 import qualified Data.Text.Lazy             as LT
 import Control.Monad.State                  (State)
-import Data.Text.Prettyprint.Doc.Extra      (Doc)
+import Prettyprinter.Extra                  (Doc)
 
 #if MIN_VERSION_ghc(9,0,0)
 import GHC.Types.SrcLoc (SrcSpan)

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -35,8 +35,7 @@ import           Data.Monoid                          (Ap(Ap))
 import           Data.Monoid.Extra                    ()
 import qualified Data.Text.Lazy                       as Text
 import qualified Data.Text                            as TextS
-import           Data.Text.Prettyprint.Doc.Extra
-import qualified Data.Text.Prettyprint.Doc.Extra      as PP
+import           Prettyprinter.Extra                  as PP
 import qualified System.FilePath
 
 import           Clash.Annotations.Primitive          (HDL (..))

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -41,9 +41,9 @@ import           Data.Monoid.Extra                    ()
 import qualified Data.Text.Lazy                       as T
 import qualified Data.Text                            as TextS
 import           Data.Text.Extra
-import qualified Data.Text.Prettyprint.Doc            as PP
-import           Data.Text.Prettyprint.Doc.Extra
 import           GHC.Stack                            (HasCallStack)
+import qualified Prettyprinter as PP
+import           Prettyprinter.Extra
 import qualified System.FilePath
 import           Text.Printf
 

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -51,7 +51,7 @@ import           Data.List.Extra                      ((<:>))
 import           Data.Text.Lazy                       (pack)
 import qualified Data.Text.Lazy                       as Text
 import qualified Data.Text                            as TextS
-import           Data.Text.Prettyprint.Doc.Extra
+import           Prettyprinter.Extra
 import qualified System.FilePath
 import           GHC.Stack                            (HasCallStack)
 

--- a/clash-lib/src/Clash/Core/Evaluator/Types.hs
+++ b/clash-lib/src/Clash/Core/Evaluator/Types.hs
@@ -14,7 +14,7 @@ import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap (insert, lookup)
 import Data.List (foldl')
 import Data.Maybe (fromMaybe, isJust)
-import Data.Text.Prettyprint.Doc (hsep)
+import Prettyprinter (hsep)
 
 import Clash.Core.DataCon (DataCon)
 import Clash.Core.HasType

--- a/clash-lib/src/Clash/Core/HasType.hs
+++ b/clash-lib/src/Clash/Core/HasType.hs
@@ -19,8 +19,8 @@ module Clash.Core.HasType
   ) where
 
 import qualified Data.Text as Text (isInfixOf)
-import Data.Text.Prettyprint.Doc (line)
 import GHC.Stack (HasCallStack)
+import Prettyprinter (line)
 
 import Clash.Core.DataCon (DataCon(dcType))
 import Clash.Core.HasFreeVars

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -39,8 +39,6 @@ import Data.Binary.IEEE754              (wordToDouble, wordToFloat)
 import Data.List.Extra                  ((<:>))
 import qualified Data.Text              as T
 import Data.Maybe                       (fromMaybe)
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Internal
 import GHC.Show                         (showMultiLineString)
 import GHC.Stack                        (HasCallStack)
 #if MIN_VERSION_ghc(9,0,0)
@@ -48,6 +46,8 @@ import qualified GHC.Utils.Outputable   as GHC
 #else
 import qualified Outputable             as GHC
 #endif
+import Prettyprinter
+import Prettyprinter.Internal
 import System.Environment               (lookupEnv)
 import System.IO.Unsafe                 (unsafePerformIO)
 import Text.Read                        (readMaybe)

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -58,11 +58,11 @@ module Clash.Core.Subst
 where
 
 import           Data.Coerce               (coerce)
-import           Data.Text.Prettyprint.Doc
 import qualified Data.List                 as List
 import qualified Data.List.Extra           as List
 import           Data.Ord                  (comparing)
 import           GHC.Stack                 (HasCallStack)
+import           Prettyprinter
 
 import           Clash.Core.HasFreeVars
 import           Clash.Core.Pretty         (ppr, fromPpr)

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -101,10 +101,10 @@ import           Data.Coerce               (coerce)
 import qualified Data.List                 as List
 import qualified Data.List.Extra           as List
 import           Data.Maybe                (fromMaybe)
-import           Data.Text.Prettyprint.Doc
 import           GHC.Exts                  (Any)
 import           GHC.Generics              (Generic)
 import           GHC.Stack                 (HasCallStack)
+import           Prettyprinter
 
 import           Clash.Core.Pretty         ()
 import           Clash.Core.Var

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -56,13 +56,13 @@ import           Data.Text.Lazy                   (Text)
 import qualified Data.Text.Lazy                   as Text
 import           Data.Text.Lazy.Encoding          as Text
 import qualified Data.Text.Lazy.IO                as Text
-import           Data.Text.Prettyprint.Doc.Extra
-  (Doc, LayoutOptions (..), PageWidth (..) , layoutPretty, renderLazy)
 import qualified Data.Time.Clock                  as Clock
 import           GHC.Stack                        (HasCallStack)
 import qualified Language.Haskell.Interpreter     as Hint
 import qualified Language.Haskell.Interpreter.Extension as Hint
 import qualified Language.Haskell.Interpreter.Unsafe as Hint
+import           Prettyprinter.Extra
+  (Doc, LayoutOptions (..), PageWidth (..) , layoutPretty, renderLazy)
 import qualified System.Directory                 as Directory
 import           System.Directory
   (doesPathExist, listDirectory, doesDirectoryExist, createDirectoryIfMissing,

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -37,11 +37,11 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as LText
 import qualified Data.Text.Lazy.Encoding as LText
 import           Data.Text (Text)
-import           Data.Text.Prettyprint.Doc.Extra (renderOneLine)
 import           Data.Time (UTCTime)
 import qualified Data.Set as Set
 import           Data.String (IsString)
 import           GHC.Generics (Generic)
+import           Prettyprinter.Extra (renderOneLine)
 import           System.IO.Error (isDoesNotExistError)
 import           System.FilePath (takeDirectory, (</>))
 import           System.Directory (listDirectory, doesFileExist)

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -28,8 +28,8 @@ import           Data.Maybe                     (isJust)
 import           Data.Set                       (Set)
 import qualified Data.Set                       as Set
 import           Data.Text                      (Text)
-import           Data.Text.Prettyprint.Doc
 import           GHC.Generics                   (Generic)
+import           Prettyprinter
 
 #if MIN_VERSION_ghc(9,0,0)
 import           GHC.Types.Basic                (InlineSpec)

--- a/clash-lib/src/Clash/Edalize/Edam.hs
+++ b/clash-lib/src/Clash/Edalize/Edam.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright       : (C) 2020, QBayLogic
+Copyright       : (C) 2020-2021, QBayLogic
 License         : BSD2 (see the file LICENSE)
 Maintainer      : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -26,7 +26,7 @@ module Clash.Edalize.Edam
 import Data.Default
 import Data.Maybe
 import Data.Text (Text)
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 
 -- | EDAM data structure to be given to an Edalize backend. This contains all
 -- information needed to generate a project scaffolding. Note that hooks and
@@ -316,4 +316,3 @@ flagList = squotes . hsep
 
 commaList :: [Doc ann] -> Doc ann
 commaList = vsep . punctuate comma
-

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -37,9 +37,9 @@ import           Data.Monoid                     (Ap(getAp))
 import qualified Data.Text
 import           Data.Text.Lazy                  (Text)
 import qualified Data.Text.Lazy                  as Text
-import qualified Data.Text.Prettyprint.Doc       as PP
-import           Data.Text.Prettyprint.Doc.Extra
 import           GHC.Stack                       (HasCallStack)
+import qualified Prettyprinter as PP
+import           Prettyprinter.Extra
 import           System.FilePath                 (replaceBaseName, takeBaseName,
                                                   takeFileName, (<.>))
 import           Text.Printf

--- a/clash-lib/src/Clash/Netlist/Id/Internal.hs
+++ b/clash-lib/src/Clash/Netlist/Id/Internal.hs
@@ -16,11 +16,11 @@ import {-# SOURCE #-} Clash.Netlist.Types
 import           Control.Arrow (second)
 import qualified Data.Char as Char
 import qualified Data.List as List
-import qualified Data.Text.Prettyprint.Doc as PP
 import qualified Data.Text as Text
 import           Data.Text (Text)
 import           Data.Text.Extra (showt)
 import qualified Data.Maybe as Maybe
+import qualified Prettyprinter as PP
 import           Text.Read (readMaybe)
 import           GHC.Stack
 

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -53,9 +53,9 @@ import qualified Data.Set                   as Set
 import Data.Text                            (Text)
 
 import Data.Typeable                        (Typeable)
-import Data.Text.Prettyprint.Doc.Extra      (Doc)
 import GHC.Generics                         (Generic)
 import GHC.Stack
+import Prettyprinter.Extra                  (Doc)
 import Language.Haskell.TH.Syntax           (Lift)
 
 #if MIN_VERSION_ghc(9,0,0)

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -53,8 +53,8 @@ import           Data.Text               (Text)
 import qualified Data.Text               as Text
 import           Data.Text.Extra         (showt)
 import           Data.Text.Lazy          (toStrict)
-import           Data.Text.Prettyprint.Doc.Extra
 import           GHC.Stack               (HasCallStack)
+import           Prettyprinter.Extra
 
 #if MIN_VERSION_ghc(9,0,0)
 import           GHC.Utils.Monad         (zipWith3M)

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -31,7 +31,7 @@ import qualified Data.Map                         as Map
 import qualified Data.Maybe                       as Maybe
 import qualified Data.Set                         as Set
 import qualified Data.Set.Lens                    as Lens
-import           Data.Text.Prettyprint.Doc        (vcat)
+import           Prettyprinter (vcat)
 
 #if MIN_VERSION_ghc(9,0,0)
 import           GHC.Types.Basic                  (InlineSpec (..))

--- a/clash-lib/src/Clash/Pretty.hs
+++ b/clash-lib/src/Clash/Pretty.hs
@@ -2,8 +2,6 @@
 
 module Clash.Pretty where
 
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.String
 import Data.Maybe (fromMaybe)
 import qualified System.Console.Terminal.Size as Terminal
 import System.Environment (lookupEnv)
@@ -11,6 +9,8 @@ import System.IO.Unsafe (unsafePerformIO)
 import Text.Read (readMaybe)
 import qualified Clash.Util.Interpolate as I
 import GHC.Stack (HasCallStack)
+import Prettyprinter
+import Prettyprinter.Render.String
 
 unsafeLookupEnvWord :: HasCallStack => String -> Word -> Word
 unsafeLookupEnvWord key dflt =

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -89,8 +89,8 @@ import           Data.String
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
 import           Data.Text.Extra                 (showt)
-import           Data.Text.Prettyprint.Doc.Extra
 import           GHC.Stack                       (HasCallStack)
+import           Prettyprinter.Extra
 
 import           Clash.Annotations.Primitive     (HDL (..), Primitive (..))
 import           Clash.Backend                   hiding (fromBV, toBV)

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -22,7 +22,7 @@ import Clash.Netlist.Util
 import Control.Monad.State
 import Data.Monoid (Ap(getAp))
 import qualified Data.String.Interpolate.IsString as I
-import Data.Text.Prettyprint.Doc.Extra
+import Prettyprinter.Extra
 
 import qualified Data.Text as TextS
 import Data.Text.Extra (showt)

--- a/clash-lib/src/Clash/Primitives/Sized/Signed.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Signed.hs
@@ -11,7 +11,7 @@ module Clash.Primitives.Sized.Signed (fromIntegerTF) where
 
 import Control.Monad.State (State)
 import Data.Monoid (Ap(getAp))
-import Data.Text.Prettyprint.Doc.Extra (Doc, tupled)
+import Prettyprinter.Extra (Doc, tupled)
 
 import Clash.Backend (Backend, expr)
 import Clash.Netlist.Types

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -22,13 +22,13 @@ import           Data.Maybe                         (fromMaybe)
 import           Data.Monoid                        (Ap(getAp))
 import           Data.Text.Extra                    (showt)
 import           Data.Text.Lazy                     (pack)
-import           Data.Text.Prettyprint.Doc.Extra
-  (Doc, string, renderLazy, layoutPretty, LayoutOptions(..),
-   PageWidth(AvailablePerLine))
 import           Text.Trifecta.Result               (Result(Success))
 import qualified Data.String.Interpolate            as I
 import qualified Data.String.Interpolate.Util       as I
 import           GHC.Stack                          (HasCallStack)
+import           Prettyprinter.Extra
+  (Doc, string, renderLazy, layoutPretty, LayoutOptions(..),
+   PageWidth(AvailablePerLine))
 
 import           Clash.Backend
   (Backend, hdlTypeErrValue, expr, blockDecl)

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -8,9 +8,9 @@ import Data.Either
 import qualified Control.Lens                    as Lens
 import           Control.Monad.State             (State)
 import           Data.Monoid                     (Ap(getAp))
-import           Data.Text.Prettyprint.Doc.Extra (Doc)
 import qualified Data.Text                       as Text
 import           GHC.Stack                       (HasCallStack)
+import           Prettyprinter.Extra             (Doc)
 
 import           Clash.Annotations.Primitive     (HDL(..))
 import           Clash.Backend

--- a/clash-lib/src/Clash/Unique.hs
+++ b/clash-lib/src/Clash/Unique.hs
@@ -88,8 +88,8 @@ import qualified Data.IntMap.Extra as IntMap
 #endif
 
 import qualified Data.List   as List
-import           Data.Text.Prettyprint.Doc
 import           GHC.Stack
+import           Prettyprinter
 
 import           Clash.Pretty
 

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -1,7 +1,8 @@
 {-|
-  Copyright   :  (C) 2012-2016, University of Twente
+  Copyright   :  (C) 2012-2016, University of Twente,
+                     2021,      QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Assortment of utility function used in the Clash library
 -}
@@ -32,8 +33,6 @@ import qualified Data.List.Extra      as List
 import Data.Maybe                     (fromMaybe, listToMaybe, catMaybes)
 import Data.Map.Ordered               (OMap)
 import qualified Data.Map.Ordered     as OMap
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.String
 import Data.Time.Clock                (UTCTime)
 import qualified Data.Time.Clock      as Clock
 import qualified Data.Time.Format     as Clock
@@ -43,6 +42,8 @@ import GHC.Base                       (Int(..),isTrue#,(==#),(+#))
 import GHC.Integer.Logarithms         (integerLogBase#)
 import qualified GHC.LanguageExtensions.Type as LangExt
 import GHC.Stack                      (HasCallStack, callStack, prettyCallStack)
+import Prettyprinter
+import Prettyprinter.Render.String
 import Type.Reflection                (tyConPackage, typeRepTyCon, typeOf)
 import qualified Language.Haskell.TH  as TH
 

--- a/clash-lib/src/Prettyprinter/Extra.hs
+++ b/clash-lib/src/Prettyprinter/Extra.hs
@@ -2,8 +2,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Data.Text.Prettyprint.Doc.Extra
-  ( module Data.Text.Prettyprint.Doc.Extra
+module Prettyprinter.Extra
+  ( module Prettyprinter.Extra
   , LayoutOptions (..)
   , PageWidth (..)
   , layoutCompact
@@ -16,9 +16,9 @@ import           Control.Applicative
 import           Data.String                           (IsString (..))
 import           Data.Text                             as T
 import           Data.Text.Lazy                        as LT
-import qualified Data.Text.Prettyprint.Doc             as PP
-import           Data.Text.Prettyprint.Doc.Internal    hiding (Doc)
-import           Data.Text.Prettyprint.Doc.Render.Text
+import qualified Prettyprinter                         as PP
+import           Prettyprinter.Internal hiding (Doc)
+import           Prettyprinter.Render.Text
 
 type Doc = PP.Doc ()
 

--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -47,7 +47,7 @@ import           Language.Haskell.TH.Lib
 import           Language.Haskell.TH.Ppr
 
 import           Control.Lens.Internal.TH     (conAppsT)
-#if !(MIN_VERSION_th_abstraction(0,4,0))
+#if MIN_VERSION_th_abstraction(0,3,0) && !(MIN_VERSION_th_abstraction(0,4,0))
 import           Control.Lens.Internal.TH     (bndrName)
 #endif
 

--- a/clash-term/clash-term.cabal
+++ b/clash-term/clash-term.cabal
@@ -27,7 +27,6 @@ executable clash-term
   Build-Depends:      base              >= 4.3.1.0  && < 5,
                       clash-lib,
                       binary            >= 0.8.5    && < 0.11,
-                      prettyprinter     >= 1.2.0.1  && < 2.0,
                       bytestring        >= 0.10.0.2 && < 0.11,
                       rewrite-inspector == 0.1.0.11
 

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -12,6 +12,12 @@ let
       overrides = self: super: {
         # External overrides
 
+        # TODO Remove when prettyprinter-1.7.1 is in nixpkgs
+        prettyprinter =
+         self.callCabal2nix "prettyprinter" (builtins.fetchTarball {
+          url = "https://hackage.haskell.org/package/prettyprinter-1.7.1/prettyprinter-1.7.1.tar.gz";
+        }) {};
+
         ghc-typelits-knownnat =
          self.callCabal2nix "ghc-typelits-knownnat" sources.ghc-typelits-knownnat {};
 


### PR DESCRIPTION
The new version of `prettyprinter` (1.7.1) adds a `DEPRECATED` pragma to the old-style modules for the library. To prevent CI failing, now is the time to switch over to the new-style module names.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
