### PR TITLE
Don't use newest prettyprinter release

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -156,7 +156,11 @@ Library
                       lens                    >= 4.10     && < 5.1.0,
                       mtl                     >= 2.1.2    && < 2.3,
                       ordered-containers      >= 0.2      && < 0.3,
-                      prettyprinter           >= 1.2.0.1  && < 2.0,
+                      -- TODO upper bound needed on prettyprinter until we can
+                      -- switch to 1.7 on both nix and debian. 1.7.1 has
+                      -- DEPRECATED pragmas on the old module names which
+                      -- break CI
+                      prettyprinter           >= 1.2.0.1  && < 1.7.1,
                       pretty-show             >= 1.9      && < 2.0,
                       primitive               >= 0.5.0.1  && < 1.0,
                       template-haskell        >= 2.8.0.0  && < 2.18,

--- a/clash-term/clash-term.cabal
+++ b/clash-term/clash-term.cabal
@@ -27,7 +27,6 @@ executable clash-term
   Build-Depends:      base              >= 4.3.1.0  && < 5,
                       clash-lib,
                       binary            >= 0.8.5    && < 0.11,
-                      prettyprinter     >= 1.2.0.1  && < 2.0,
                       bytestring        >= 0.10.0.2 && < 0.11,
                       rewrite-inspector == 0.1.0.11
 


### PR DESCRIPTION
The new version of `prettyprinter` (1.7.1) adds a `DEPRECATED` pragma to the old-style modules for the library. To prevent CI failing, the upper bound is lowered to not pick this version.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
