### PR TITLE
Keep casts of the form `x ~ Integer`

### DIFF
--- a/changelog/2021-09-14T20_09_01+02_00_fix1927
+++ b/changelog/2021-09-14T20_09_01+02_00_fix1927
@@ -1,0 +1,1 @@
+FIXED: Don't error out on `counter ~ (Index numStages)` like equalities [#1927](https://github.com/clash-lang/clash-compiler/issues/1927)

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -659,6 +659,8 @@ isSizedCast (TyConApp tc1 _) (TyConApp tc2 _) = do
         ,tc2 `hasKey` naturalTyConKey &&
           tc1Nm == "Clash.Sized.Internal.Unsigned.Unsigned"
         ])
+-- XXX: a work-around for issue #1927, the real fix is to handle all casts
+isSizedCast (TyVarTy {}) (TyConApp tc2 _) = return (tc2 `hasKey` integerTyConKey)
 isSizedCast _ _ = return False
 
 hasPrimCo :: Coercion -> C2C (Maybe Type)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -533,6 +533,7 @@ runClashTest = defaultMain $ clashTestRoot
         , clashLibTest "T779" def{hdlTargets=[Verilog]}
         , outputTest "T1881" def{hdlSim=False}
         , runTest "T1921" def{hdlTargets=[Verilog], hdlSim=False}
+        , runTest "T1927" def{hdlTargets=[Verilog], hdlSim=False}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T1927.hs
+++ b/tests/shouldwork/Issues/T1927.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+module T1927 where
+
+import Clash.Prelude
+import Control.Monad
+
+topEntity
+  :: Signal System (Vec 1 (Signed 1))
+  -> Signal System (Maybe (Vec 1 (Signed 1, Signed 1)))
+  -> Clock System -> Reset System -> Enable System
+  -> Signal System (Maybe (Vec 1 (Signed 1, Signed 1)))
+topEntity angles xs c r e = exposeClockResetEnable (machine @8 angles xs) c r e
+
+machine
+  :: forall numStages pairs coord angle dom counter
+   . HiddenClockResetEnable dom
+  => (1 <= numStages)
+  => (KnownNat numStages, KnownNat pairs)
+  => (Default coord, NFDataX coord)
+  => (Default angle, NFDataX angle)
+  => counter ~ (Index numStages)
+  => Signal dom (Vec pairs angle)
+  -> Signal dom (Maybe (Vec pairs (coord, coord)))
+  -> Signal dom (Maybe (Vec pairs (coord, coord)))
+machine thetas coords = mealy transition def $ liftA2 (liftM2 zip) coords (return <$> thetas)
+  where
+    transition :: (counter, Vec pairs ((coord, coord), angle))
+               -> Maybe (Vec pairs ((coord, coord), angle))
+               -> ( (counter, Vec pairs ((coord, coord), angle))
+                  , Maybe (Vec pairs (coord, coord))
+                  )
+    transition (k, xyzs) maybeInputs = case (k == 0, maybeInputs)
+                                         of (True, Nothing) -> ((0, xyzs), Just $ map fst xyzs)
+                                            (True, Just xyzs0) -> ((0, xyzs0), Just $ map fst xyzs)
+                                            (False, _) -> ((satSucc SatWrap k, xyzs), Nothing)


### PR DESCRIPTION
Really a work-around until we properly handle all casts.

Fixes #1927

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files