### PR TITLE
clash-testsuite: three fixes

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -147,7 +147,7 @@ runClashTest = defaultMain $ clashTestRoot
         , let _opts = def { buildTargets = BuildSpecific ["system"]
                           , hdlTargets = [Verilog]
                           , hdlSim = True
-                          , vvpStderrEmptyFail = False
+                          , vvpStdoutNonEmptyFail = False
                           }
            in runTest "I2Ctest" _opts
         ]
@@ -669,7 +669,7 @@ runClashTest = defaultMain $ clashTestRoot
         ]
       , clashTestGroup "SimIO"
         [ let _opts = def { hdlTargets=[Verilog]
-                          , vvpStderrEmptyFail=False
+                          , vvpStdoutNonEmptyFail=False
                           , buildTargets=BuildSpecific ["topEntity"]
                           }
            in runTest "Test00" _opts

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -118,8 +118,8 @@ data TestOptions =
     , buildTargets :: BuildTargets
     -- ^ Indicates what should be built to an executable. Defaults to @["testBench"]@
     -- if 'hdlSim' is set, otherwise @["topEntity"]@.
-    , vvpStderrEmptyFail :: Bool
-    -- ^ Whether an empty stderr means test failure when running VVP
+    , vvpStdoutNonEmptyFail :: Bool
+    -- ^ Whether a non-empty stdout means test failure when running VVP
     }
 
 allTargets :: [HDL]
@@ -138,7 +138,7 @@ instance Default TestOptions where
       , ghcFlags=[]
       , clashFlags=[]
       , buildTargets=BuildAuto
-      , vvpStderrEmptyFail=True
+      , vvpStdoutNonEmptyFail=True
       }
 
 -- | Directory where testbenches live.
@@ -319,7 +319,7 @@ verilogTests opts@TestOptions{..} tmpDir = (buildTests, simTests)
 
   simName t = "iverilog (sim " <> t <> ")"
   simTests =
-    [ (simName t, singleTest (simName t) (IVerilogSimTest expectSimFail vvpStderrEmptyFail tmpDir t))
+    [ (simName t, singleTest (simName t) (IVerilogSimTest expectSimFail vvpStdoutNonEmptyFail tmpDir t))
     | t <- getBuildTargets opts ]
 
 -- | Generate two test trees for testing SystemVerilog: one for building designs and

--- a/tests/src/Test/Tasty/Iverilog.hs
+++ b/tests/src/Test/Tasty/Iverilog.hs
@@ -61,8 +61,8 @@ instance IsTest IVerilogMakeTest where
 data IVerilogSimTest = IVerilogSimTest
   { ivsExpectFailure :: Maybe (TestExitCode, T.Text)
     -- ^ Expected failure code and output (if any)
-  , ivsStderrEmptyFail :: Bool
-    -- ^ Whether empty stderr means failure
+  , ivsStdoutNonEmptyFail :: Bool
+    -- ^ Whether a non-empty stdout means failure
   , ivsSourceDirectory :: IO FilePath
     -- ^ Directory containing executables produced by 'IVerilogMakeTest'
   , ivsTop :: String
@@ -84,7 +84,7 @@ instance IsTest IVerilogSimTest where
       Just exit -> run optionSet (failingVvp src [topExe] exit) progressCallback
    where
     vvp workDir args =
-      TestProgram "vvp" args NoGlob PrintNeither ivsStderrEmptyFail (Just workDir)
+      TestProgram "vvp" args NoGlob PrintNeither ivsStdoutNonEmptyFail (Just workDir)
 
     failingVvp workDir args (testExit, expectedErr) =
       TestFailingProgram


### PR DESCRIPTION
- The logic for `TestExitCode` in `runFailingProgram` was wrong:
  - `TestExitCode`: correct
  - `NoTestExitCode`: correct
  - `TestSpecificExitCode`:
     - A program succeeding will always report error, even if
     `TestSpecificExitCode 0` is used.
     - A program failing will always report success, even if the
     specific exit code did not match the intended one.

Because all current tests use 'TestExitCode', the wrong logic was not a
problem in practice so far.

- The error message for `runProgram` with its `stdF` argument set to
True would be the wrong error message for that failure condition, even
mentioning an incorrect return code of the program!

- We have a test to check that a program, or alternatively specificly
VVP, does not produce anything on stdout. However, this was in many
places named and documented as if it checked that it _does_ produce
something on stderr. Names and documentation adapted so they now
correspond to the actual functionality (which was correct).

Finally, some minor tuning to messages.

## Still TODO:

  - [ ] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
