### PR TITLE
CI: Allow tasks to be interrupted

### DIFF
--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -2,7 +2,6 @@ hackage-sdist:
   extends: .common
   needs: []
   stage: pack
-  interruptible: false
   script:
     - .ci/build_sdist.sh clash-prelude
     - .ci/build_sdist.sh clash-lib
@@ -82,6 +81,7 @@ debian-bindist-test:
 .snap:
   image: docker.pkg.github.com/clash-lang/clash-compiler/snapcraft:2020-11-20
   stage: publish
+  interruptible: false
   cache:
     key: snap-last-run-hash-$CI_COMMIT_REF_SLUG
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,7 @@
+# Make all tasks interruptible by default
+default:
+  interruptible: true
+
 include:
   - '/.ci/gitlab/common.yml'
   - '/.ci/gitlab/publish.yml'
@@ -132,7 +136,10 @@ snap-stable:
     - if: '$CI_COMMIT_TAG != null' # tags
 
 # Work around https://gitlab.com/gitlab-org/gitlab/-/issues/216629
+#
+# If we ever remove this, we may have to rethink the use of the interruptible flag
 .github_status:
+  # interruptible: false
   image: curlimages/curl
   variables:
     GIT_SUBMODULE_STRATEGY: recursive


### PR DESCRIPTION
This could save a lot of CI time.
By allowing the CI runners to abort tasks when you push a newer commit.
And start testing that new commit right away, instead of wasting time testing the old commit.

In the past we've disabled this because aborted tasks looked like failed tasks on GitHub.
But with the current way of setting the GitHub CI status via separate tasks, this shouldn't happen anymore.

All tasks that push content to external services are explicitly marked 
as uninterruptible: hackage, snap and all the github status tasks.

