### PR TITLE
New function: runUntil

### DIFF
--- a/changelog/2021-09-24T13_40_34+02_00_run_until
+++ b/changelog/2021-09-24T13_40_34+02_00_run_until
@@ -1,0 +1,1 @@
+NEW: `runUntil`, a function to sample a signal until it returns a value that satisfies the user-given test. It is a convenience function that, among others, allow easy running of a `testBench` style function in Haskell simulation, logging assertion failures to stderr.

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -78,6 +78,12 @@ import Clash.XException      (ShowX (..), XException)
 -- function simply returns the third 'Signal' unaltered as its result. This
 -- function is used by 'outputVerifier'.
 --
+-- === Usage in @clashi@ #assert-clashi#
+--
+-- __NB__: When simulating a component that uses 'assert' in @clashi@, usually,
+-- the warnings are only logged the first time the component is simulated.
+-- Issuing @:reload@ in @clashi@ will discard the cached result of the
+-- computation, and warnings will once again be emitted.
 --
 -- __NB__: This function /can/ be used in synthesizable designs.
 assert
@@ -219,6 +225,9 @@ outputVerifier' =
 -- synthesizable in the sense that HDL simulators will run it. If @testDom@ and
 -- @circuitDom@ refer to the same domain, it can also be synthesized into
 -- hardware.
+--
+-- __NB__: This function uses 'assert'. When simulating this function in
+-- @clashi@, read the [note](#assert-clashi).
 --
 -- Example:
 --

--- a/clash-prelude/src/Clash/Prelude/Testbench.hs
+++ b/clash-prelude/src/Clash/Prelude/Testbench.hs
@@ -56,6 +56,12 @@ import Clash.XException                   (ShowX)
 -- function simply returns the third 'Signal' unaltered as its result. This
 -- function is used by 'outputVerifier''.
 --
+-- === Usage in @clashi@ #assert-clashi#
+--
+-- __NB__: When simulating a component that uses 'assert' in @clashi@, usually,
+-- the warnings are only logged the first time the component is simulated.
+-- Issuing @:reload@ in @clashi@ will discard the cached result of the
+-- computation, and warnings will once again be emitted.
 --
 -- __NB__: This function /can/ be used in synthesizable designs.
 assert
@@ -113,7 +119,13 @@ stimuliGenerator
 stimuliGenerator = hideReset (hideClock E.stimuliGenerator)
 {-# INLINE stimuliGenerator #-}
 
--- |
+-- | Compare a signal (coming from a circuit) to a vector of samples. If a
+-- sample from the signal is not equal to the corresponding sample in the
+-- vector, print to stderr and continue testing. This function is
+-- synthesizable in the sense that HDL simulators will run it.
+--
+-- __NB__: This function uses 'assert'. When simulating this function in
+-- @clashi@, read the [note](#assert-clashi).
 --
 -- Example:
 --


### PR DESCRIPTION
`runUntil`, a function to sample a signal until it returns a value that
satisfies the user-given test. It is a convenience function that, among
others, allow easy running of a `testBench` style function in Haskell
simulation, logging assertion failures to stderr


## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
