### PR TITLE
Assorted doc fixes

### DIFF
--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -178,6 +178,15 @@ import Clash.XException
 >>> let windowD3 = windowD @2
 -}
 
+{- $hiding
+"Clash.Explicit.Prelude" re-exports most of the Haskell "Prelude" with the
+exception of those functions that the Clash API defines to work on 'Vec' from
+"Clash.Sized.Vector" instead of on lists as the Haskell Prelude does. In
+addition, for the 'Clash.Class.Parity.odd' and 'Clash.Class.Parity.even'
+functions a type class called 'Clash.Class.Parity.Parity' is available at
+"Clash.Class.Parity".
+-}
+
 -- | Give a window over a 'Signal'
 --
 -- @

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -140,6 +140,14 @@ import Clash.XException
 >>> let rP clk rst en = registerB clk rst en (8::Int,8::Int)
 -}
 
+{- $hiding
+"Clash.Explicit.Prelude.Safe" re-exports most of the Haskell "Prelude" with the
+exception of those functions that the Clash API defines to work on 'Vec' from
+"Clash.Sized.Vector" instead of on lists as the Haskell Prelude does. In
+addition, for the 'Clash.Class.Parity.odd' and 'Clash.Class.Parity.even'
+functions a type class called 'Clash.Class.Parity.Parity' is available at
+"Clash.Class.Parity".
+-}
 
 -- | Create a 'register' function for product-type like signals (e.g.
 -- @('Signal' a, 'Signal' b)@)

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -455,9 +455,9 @@ biTbClockGen done = (testClk, circuitClk)
 --     testInput      = 'Clash.Explicit.Testbench.stimuliGenerator' clkA1 rstA1 $('Clash.Sized.Vector.listToVecTH' [1::Unsigned 8,2,3,4,5,6,7,8])
 --     expectedOutput = 'Clash.Explicit.Testbench.outputVerifier'   clkB2 rstB2 $('Clash.Sized.Vector.listToVecTH' [(0,0) :: (Unsigned 8, Unsigned 8),(1,2),(3,4),(5,6),(7,8)])
 --     done           = expectedOutput (topEntity clkA1 rstA1 enableGen clkB2 testInput)
---     done'          = not \<$\> done
---     clkA1          = 'tbClockGen' \@\"Fast\" (unsafeSynchronizer clkB2 clkA1 done')
---     clkB2          = 'tbClockGen' \@\"Slow\" done'
+--     notDone        = not \<$\> done
+--     clkA1          = 'tbClockGen' \@\"Fast\" (unsafeSynchronizer clkB2 clkA1 notDone)
+--     clkB2          = 'tbClockGen' \@\"Slow\" notDone
 --     rstA1          = 'Clash.Signal.resetGen' \@\"Fast\"
 --     rstB2          = 'Clash.Signal.resetGen' \@\"Slow\"
 -- @

--- a/clash-prelude/src/Clash/HaskellPrelude.hs
+++ b/clash-prelude/src/Clash/HaskellPrelude.hs
@@ -4,10 +4,12 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V <devops@qbaylogic.com>
 
-"Clash.HaskellPrelude" re-exports most of the Haskell "Prelude" with the exception of
-the following: (++), (!!), concat, drop, even, foldl, foldl1, foldr, foldr1, head,
-init, iterate, last, length, map, odd, repeat, replicate, reverse, scanl, scanr,
-splitAt, tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3.
+"Clash.HaskellPrelude" re-exports most of the Haskell "Prelude" with the
+exception of those functions that the Clash API defines to work on
+'Clash.Sized.Vector.Vec' from "Clash.Sized.Vector" instead of on lists as the
+Haskell Prelude does. In addition, for the 'Clash.Class.Parity.odd' and
+'Clash.Class.Parity.even' functions a type class called
+'Clash.Class.Parity.Parity' is available at "Clash.Class.Parity".
 -}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -207,15 +207,12 @@ import           Clash.XException
 
 {- $hiding
 "Clash.Prelude" re-exports most of the Haskell "Prelude" with the exception of
-the following: (++), (!!), concat, drop, even, foldl, foldl1, foldr, foldr1, head,
-init, iterate, last, length, map, odd, repeat, replicate, reverse, scanl, scanr,
-splitAt, tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3.
-
-It instead exports the identically named functions defined in terms of
-'Clash.Sized.Vector.Vec' at "Clash.Sized.Vector". For the 'odd' end 'even'
-function a type class called Parity is available at 'Clash.Class.Parity'.
+those functions that the Clash API defines to work on 'Vec' from
+"Clash.Sized.Vector" instead of on lists as the Haskell Prelude does.
+In addition, for the 'Clash.Class.Parity.odd' and 'Clash.Class.Parity.even'
+functions a type class called 'Clash.Class.Parity.Parity' is available at
+"Clash.Class.Parity".
 -}
-
 
 -- | Give a window over a 'Signal'
 --

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -156,13 +156,12 @@ import           Clash.XException
 -}
 
 {- $hiding
-"Clash.Prelude" re-exports most of the Haskell "Prelude" with the exception of
-the following: (++), (!!), concat, drop, foldl, foldl1, foldr, foldr1, head,
-init, iterate, last, length, map, repeat, replicate, reverse, scanl, scanr,
-splitAt, tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3.
-
-It instead exports the identically named functions defined in terms of
-'Clash.Sized.Vector.Vec' at "Clash.Sized.Vector".
+"Clash.Prelude.Safe" re-exports most of the Haskell "Prelude" with the exception
+of those functions that the Clash API defines to work on 'Vec' from
+"Clash.Sized.Vector" instead of on lists as the Haskell Prelude does. In
+addition, for the 'Clash.Class.Parity.odd' and 'Clash.Class.Parity.even'
+functions a type class called 'Clash.Class.Parity.Parity' is available at
+"Clash.Class.Parity".
 -}
 
 -- | Create a 'register' function for product-type like signals (e.g. '(Signal a, Signal b)')

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -1,8 +1,11 @@
 {-|
 Copyright : © 2014-2016, Christiaan Baaij,
               2017-2019, Myrtle Software Ltd
-              2017     , QBayLogic, Google Inc.
+              2017     , QBayLogic, Google Inc.,
+              2021     , QBayLogic B.V.
+
 Licence   : Creative Commons 4.0 (CC BY 4.0) (https://creativecommons.org/licenses/by/4.0/)
+Maintainer:  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -1088,14 +1091,13 @@ We will use @blockRam#@ as an example, for which the Haskell/Clash code is:
 module BlockRam where
 
 import Clash.Explicit.Prelude
-import qualified Data.Vector           as V
-import           GHC.Stack             (HasCallStack, withFrozenCallStack)
+import Clash.Annotations.Primitive (hasBlackBox)
+import Clash.Signal.Internal (Clock, Signal (..), (.&&.))
+import Clash.Sized.Vector (Vec, toList)
+import Clash.XException (defaultSeqX)
 
-import Clash.Signal.Internal
-  (Clock, Signal (..), (.&&.))
-import Clash.Sized.Vector     (Vec, toList)
-import Clash.XException       (defaultSeqX)
-
+import qualified Data.Vector as V
+import GHC.Stack (HasCallStack, withFrozenCallStack)
 
 blockRam#
   :: ( KnownDomain dom
@@ -1135,6 +1137,7 @@ blockRam# (Clock _) gen content rd wen =
       Just wa -> ram V.// [(wa,d)]
     _ -> ram
 {\-\# NOINLINE blockRam# \#\-\}
+{\-\# ANN blockRam# hasBlackBox \#\-\}
 @
 
 And for which the /declaration/ primitive is:


### PR DESCRIPTION
~~The documentation on the HaskellPrelude imports was missing in 2 of 4
places it was supposed to be. Also updated `Clash.Prelude.Safe` to
mention `even` and `odd` just like `Clash.Prelude` does, and added some
markup.~~
The documentation on the HaskellPrelude imports was missing in 2 of 4
places it was supposed to be. Rewritten to explain rather than
exhaustively list, also avoiding the need to update across all files
(Clash.Prelude.Safe was out-of-date already).

Added the `hasBlackBox` annotation to the example in the tutorial
because we should encourage our users to add that annotation.
Reformatted the import list in the example and added an import for
`hasBlackBox`.

In the example for `Clash.Explicit.Testbench.tbClockGen`, a signal
called `done'` (note prime) was defined as the logical inverse of the
`done` signal. Renamed it to `notDone` to avoid confusion.

## Still TODO:

  - [ ] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
