### PR TITLE
Tidy up TyCon and kind inference

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -72,7 +72,7 @@ import GHC.Types.Literal (Literal (..), LitNumType (..))
 import GHC.Unit.Module (moduleName, moduleNameString)
 import GHC.Types.Name
   (Name, nameModule_maybe, nameOccName, nameUnique, getSrcSpan)
-import GHC.Builtin.Names  (tYPETyConKey, integerTyConKey, naturalTyConKey)
+import GHC.Builtin.Names  (integerTyConKey, naturalTyConKey)
 import GHC.Types.Name.Occurrence (occNameString)
 import GHC.Utils.Outputable (showPpr)
 import GHC.Data.Pair (Pair (..))
@@ -123,7 +123,7 @@ import Literal    (Literal (..), LitNumType (..))
 import Module     (moduleName, moduleNameString)
 import Name       (Name, nameModule_maybe,
                    nameOccName, nameUnique, getSrcSpan)
-import PrelNames  (tYPETyConKey, integerTyConKey, naturalTyConKey)
+import PrelNames  (integerTyConKey, naturalTyConKey)
 import OccName    (occNameString)
 import Outputable (showPpr)
 import Pair       (Pair (..))
@@ -223,7 +223,6 @@ makeTyCon tc = tycon
       | isTupleTyCon tc     = mkTupleTyCon
       | isAlgTyCon tc       = mkAlgTyCon
       | isPrimTyCon tc      = mkPrimTyCon
-      | tc `hasKey` tYPETyConKey = mkSuperKindTyCon
       | otherwise           = mkVoidTyCon
       where
         tcArity = tyConArity tc
@@ -289,13 +288,6 @@ makeTyCon tc = tycon
             , C.tyConKind    = tcKind
             , C.tyConArity   = tcArity
             }
-
-        mkSuperKindTyCon = do
-          tcName <- coreToName tyConName tyConUnique qualifiedNameString tc
-          return C.SuperKindTyCon
-                   { C.tyConUniq = C.nameUniq tcName
-                   , C.tyConName = tcName
-                   }
 
         mkVoidTyCon = do
           tcName <- coreToName tyConName tyConUnique qualifiedNameString tc

--- a/clash-lib/src/Clash/Core/TyCon.hs
+++ b/clash-lib/src/Clash/Core/TyCon.hs
@@ -1,7 +1,8 @@
 {-|
   Copyright   :  (C) 2012-2016, University of Twente
+                     2021,      QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Type Constructors in CoreHW
 -}
@@ -63,18 +64,12 @@ data TyCon
   , tyConKind    :: !Kind       -- ^ Kind of the TyCon
   , tyConArity   :: !Int        -- ^ Number of type arguments
   }
-  -- | To close the loop on the type hierarchy
-  | SuperKindTyCon
-  { tyConUniq    :: {-# UNPACK #-} !Unique
-  , tyConName    :: !TyConName  -- ^ Name of the TyCon
-  }
   deriving (Generic,NFData,Binary)
 
 instance Show TyCon where
   show (AlgTyCon       {tyConName = n}) = "AlgTyCon: " ++ show n
   show (FunTyCon       {tyConName = n}) = "FunTyCon: " ++ show n
   show (PrimTyCon      {tyConName = n}) = "PrimTyCon: " ++ show n
-  show (SuperKindTyCon {tyConName = n}) = "SuperKindTyCon: " ++ show n
 
 instance Eq TyCon where
   (==) = (==) `on` tyConUniq

--- a/clash-lib/src/Clash/Core/TysPrim.hs
+++ b/clash-lib/src/Clash/Core/TysPrim.hs
@@ -1,8 +1,9 @@
 {-|
   Copyright   :  (C) 2012-2016, University of Twente,
-                     2016     , Myrtle Software Ltd
+                     2016     , Myrtle Software Ltd,
+                     2021     , QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Builtin Type and Kind definitions
 -}
@@ -46,21 +47,18 @@ import {-# SOURCE #-} Clash.Core.Type
 import           Clash.Unique
 
 -- | Builtin Name
-tySuperKindTyConName, liftedTypeKindTyConName, typeNatKindTyConName, typeSymbolKindTyConName :: TyConName
-tySuperKindTyConName      = mkUnsafeSystemName "tYPE" (getKey tYPETyConKey)
-liftedTypeKindTyConName   = mkUnsafeSystemName "*" (getKey liftedTypeKindTyConKey)
+liftedTypeKindTyConName, typeNatKindTyConName, typeSymbolKindTyConName :: TyConName
+liftedTypeKindTyConName   = mkUnsafeSystemName "Type" (getKey liftedTypeKindTyConKey)
 typeNatKindTyConName      = mkUnsafeSystemName "Nat" (getKey typeNatKindConNameKey)
 typeSymbolKindTyConName   = mkUnsafeSystemName "Symbol" (getKey typeSymbolKindConNameKey)
 
 -- | Builtin Kind
-liftedTypeKindTc, tySuperKindTc, typeNatKindTc, typeSymbolKindTc :: TyCon
-tySuperKindTc    = SuperKindTyCon (nameUniq tySuperKindTyConName) tySuperKindTyConName
-liftedTypeKindTc = mkKindTyCon liftedTypeKindTyConName tySuperKind
-typeNatKindTc    = mkKindTyCon typeNatKindTyConName tySuperKind
-typeSymbolKindTc = mkKindTyCon typeSymbolKindTyConName tySuperKind
+liftedTypeKindTc, typeNatKindTc, typeSymbolKindTc :: TyCon
+liftedTypeKindTc = mkKindTyCon liftedTypeKindTyConName liftedTypeKind
+typeNatKindTc    = mkKindTyCon typeNatKindTyConName liftedTypeKind
+typeSymbolKindTc = mkKindTyCon typeSymbolKindTyConName liftedTypeKind
 
-liftedTypeKind, tySuperKind, typeNatKind, typeSymbolKind :: Type
-tySuperKind    = mkTyConTy tySuperKindTyConName
+liftedTypeKind, typeNatKind, typeSymbolKind :: Type
 liftedTypeKind = mkTyConTy liftedTypeKindTyConName
 typeNatKind    = mkTyConTy typeNatKindTyConName
 typeSymbolKind = mkTyConTy typeSymbolKindTyConName
@@ -141,8 +139,7 @@ byteArrayPrimTy = mkTyConTy byteArrayPrimTyConName
 
 tysPrimMap :: TyConMap
 tysPrimMap = List.foldl' (\s (k,x) -> extendUniqMap k x s) emptyUniqMap
-  [  (tySuperKindTyConName , tySuperKindTc)
-  ,  (liftedTypeKindTyConName , liftedTypeKindTc)
+  [  (liftedTypeKindTyConName , liftedTypeKindTc)
   ,  (typeNatKindTyConName , typeNatKindTc)
   ,  (typeSymbolKindTyConName , typeSymbolKindTc)
   ,  (intPrimTyConName , intPrimTc)

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -71,7 +71,7 @@ import           Clash.Core.Subst
   (substTmEnv, aeqTerm, aeqType, extendIdSubst, mkSubst, substTm)
 import           Clash.Core.Term
 import           Clash.Core.TyCon            (TyConMap)
-import           Clash.Core.Type             (Type (..), normalizeType, typeKind)
+import           Clash.Core.Type             (Type (..), normalizeType)
 import           Clash.Core.Var
   (Id, IdScope (..), TyVar, Var (..), mkGlobalId, mkLocalId, mkTyVar)
 import           Clash.Core.VarEnv
@@ -338,7 +338,7 @@ mkBinderFor is tcm name (Left term) = do
 
 mkBinderFor is tcm name (Right ty) = do
   name' <- cloneNameWithInScopeSet is name
-  let ki = typeKind tcm ty
+  let ki = inferCoreKindOf tcm ty
   return (Right (mkTyVar ki (coerce name')))
 
 -- | Inline the binders in a let-binding that have a certain property


### PR DESCRIPTION
This PR makes some small changes around the handling of types and kind inference, namely

  * `SuperKindTyCon` is removed, and replaced with `liftedTypeKind`. As GHC does not have `SuperKindTyCon`, the behaviour in Clash now matches the behaviour in GHC

  * The name of `liftedTypeKind` is changed from "*" to "Type" in GHC versions where `-NoStarIsType` is supported

  * `typeKind` is moved to an instance of `InferType Type`

  * synyonms `coreKindOf` and `inferCoreKindOf` are created which have `Kind` in the type instead of `Type` for clarity

This allows the benefits of the classy `HasType` approach to be used for kind inference as well, while still allowing callers to differentiate between types and kinds where they see fit.

Removing the `SuperKindTyCon` makes things easier when generating arbitrary types / kinds in the upcoming `clash-hedgehog` package.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
