### PR TITLE
Suggestion: store memory as literal string

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -256,6 +256,7 @@ Library
                       Clash.Normalize.Util
 
                       Clash.Primitives.DSL
+                      Clash.Primitives.ROM.File
                       Clash.Primitives.Types
                       Clash.Primitives.Util
 

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives
@@ -54,4 +54,69 @@ end block;
 -- romFile end"
     }
   }
+, { "BlackBox" :
+    { "name" : "Clash.Explicit.ROM.File.romString#"
+    , "kind" : "Declaration"
+    , "type" :
+
+"romString#
+  :: ( KnownNat m           --            ARG[0]
+     , KnownDomain dom      --            ARG[1]
+     )
+  => Clock dom              -- clk,       ARG[2]
+  -> Enable dom             -- en,        ARG[3]
+  -> SNat n                 -- sz,        ARG[4]
+  -> String                 -- contents,  ARG[5]
+  -> Signal dom Int         -- rd,        ARG[6]
+  -> Signal dom (BitVector m)"
+    , "template" :
+"-- romString begin
+~GENSYM[~COMPNAME_romString][0] : block
+  type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
+
+  impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is
+    FILE RomFile : text open read_mode is RomFileName;
+    variable RomFileLine : line;
+    variable ROM : ~SYM[4](0 to ~LIT[4]-1);
+  begin
+    for i in ROM'range loop
+      readline(RomFile,RomFileLine);
+      read(RomFileLine,ROM(i));
+    end loop;
+    return ROM;
+  end function;
+
+  signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[4]-1) := ~SYM[1](\"~INCLUDENAME[0].bin\");
+  signal ~GENSYM[rd][3] : integer range 0 to ~LIT[4]-1;
+begin
+  ~SYM[3] <= to_integer(~VAR[rdI][6](31 downto 0))
+  -- pragma translate_off
+                mod ~LIT[4]
+  -- pragma translate_on
+                ;
+  ~IF ~ISACTIVEENABLE[3] ~THEN
+  ~GENSYM[romStringSync][7] : process (~ARG[2])
+  begin
+    if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then
+      if ~ARG[3] then
+        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
+      end if;
+    end if;
+  end process;~ELSE
+  ~SYM[7] : process (~ARG[2])
+  begin
+    if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then
+      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
+    end if;
+  end process;~FI
+end block;
+-- romString end"
+    , "includes"  : [ {"extension": "bin"
+                      ,"name": "mem"
+                      ,"format": "Haskell"
+                      ,"templateFunction": "Clash.Primitives.ROM.File.romStringTF"
+                      }
+                    ]
+    }
+  }
 ]

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -130,6 +130,7 @@ import qualified Clash.Primitives.Sized.Vector    as P
 import qualified Clash.Primitives.GHC.Int         as P
 import qualified Clash.Primitives.GHC.Word        as P
 import qualified Clash.Primitives.Intel.ClockGen  as P
+import qualified Clash.Primitives.ROM.File        as P
 import qualified Clash.Primitives.Verification    as P
 import           Clash.Primitives.Types
 import           Clash.Signal.Internal
@@ -545,6 +546,7 @@ knownTemplateFunctions =
     , ('P.alteraPllTF, P.alteraPllTF)
     , ('P.altpllTF, P.altpllTF)
     , ('P.fromIntegerTF, P.fromIntegerTF)
+    , ('P.romStringTF, P.romStringTF)
     ]
 
 -- | Compiles blackbox functions and parses blackbox templates.

--- a/clash-lib/src/Clash/Primitives/ROM/File.hs
+++ b/clash-lib/src/Clash/Primitives/ROM/File.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Primitives.ROM.File
+  ( romStringTF
+  ) where
+
+import Control.Monad.State (State)
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import Data.String (fromString)
+
+import Clash.Backend (Backend)
+import Clash.Netlist.Types
+  (BlackBoxContext(..), Expr(..), Literal(..), TemplateFunction(..))
+
+romStringTF
+  :: TemplateFunction
+romStringTF = TemplateFunction used valid romStringTemplate
+ where
+  used = [5]
+  valid = const True
+
+romStringTemplate
+  :: Backend s
+  => BlackBoxContext
+  -> State s Doc
+romStringTemplate bbCtx = pure bbText
+ where
+  (BlackBoxE "GHC.CString.unpackCString#" [] [] [] _ contentBBCtx _, _, _) =
+    bbInputs bbCtx !! 5
+  (Literal Nothing (StringLit content), _, _) = head $ bbInputs contentBBCtx
+
+  bbText = fromString $ content

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -645,6 +645,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "Ram" def
         , runTest "ResetGen" def
         , runTest "RomFile" def
+        , runTest "RomString" def{hdlTargets=[VHDL]}
         , outputTest "BlockRamLazy" def
         , runTest "BlockRamTest" def{hdlSim=False}
         , runTest "Compression" def

--- a/tests/shouldwork/Signal/RomString.hs
+++ b/tests/shouldwork/Signal/RomString.hs
@@ -1,0 +1,28 @@
+module RomString where
+
+import Clash.Prelude
+import qualified Clash.Explicit.Prelude as E
+import Clash.Explicit.ROM.File (createMemString, romString)
+import Clash.Explicit.Testbench
+
+createMemString "memData" Nothing [0 :: Unsigned 8 .. 255]
+
+topEntity
+  :: Clock System
+  -> Enable System
+  -> Signal System (Unsigned 8)
+  -> Signal System (Unsigned 8)
+topEntity clk en = fmap unpack . romString clk en memData
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput = E.register clk rst en 0 (testInput + 1)
+    expectedOutput =
+      outputVerifier' clk rst $(listToVecTH [0::Unsigned 8,0,1,2,3,4,5,6,7,8])
+    done =
+      expectedOutput (ignoreFor clk rst en d1 0 $ topEntity clk en testInput)
+    clk = tbSystemClockGen (not <$> done)
+    rst = systemResetGen
+    en = enableGen

--- a/tests/src/Test/Tasty/Ghdl.hs
+++ b/tests/src/Test/Tasty/Ghdl.hs
@@ -124,9 +124,12 @@ instance IsTest GhdlSimTest where
     let workDir = src </> "work"
 
     -- See Note [copy data files hack]
-    lists <- glob (src </> "*/memory.list")
-    forM_ lists $ \memFile ->
+    lists1 <- glob (src </> "*/memory.list")
+    forM_ lists1 $ \memFile ->
       copyFile memFile (workDir </> "memory.list")
+    lists2 <- glob (src </> "*/memF0913FE5901895A5.bin")
+    forM_ lists2 $ \memFile ->
+      copyFile memFile (workDir </> "memF0913FE5901895A5.bin")
 
     case gstExpectFailure of
       Nothing -> run optionSet (program workDir gstTop) progressCallback


### PR DESCRIPTION
When you want to generate the contents of a memory, rather than read it
in from a pre-generated file, one could use Template Haskell and
`qRunIO` to create it on the fly while compiling or loading into the
interpreter. Our documentation refers to this as something
["for those of us who like to live on the edge"](https://hackage.haskell.org/package/clash-prelude-1.5.0/candidate/docs/Clash-Sized-Fixed.html#creatingdatafiles).
It is brittle for many reasons.

Additionally, our `Vec` has performance issues when they get long, for a
pretty small value of "long". And lists don't work either.

So here is another idea. Using Template Haskell, we convert a list of
`BitPack`able values to the string contents of a file such as `romFile`
consumes. We don't write it to a file, though, but store it as a literal
string in our Haskell module. `romString` then is the variant of
`romFile` that uses this string while simulating in Haskell, and the
black box definition for `romString` uses the include mechanism to
write a file called `memXYZ.bin` next to the generated HDL, whereupon
the mechanism in HDL is identical to `romFile`'s mechanism.

When I create a `MemString` that holds 4 MiB of 32-bit data, the
resulting data file is 33 MiB (ASCII binary digits and newline), and so
is the object file for the Haskell module containing that `MemString`.
As can be seen from the `BlackBoxContext`, the `memStringContents` is
stored as `unpackCString# "literal"#`, and it is an efficient storage
method (well, apart from the binary digits bit of it, which we might
improve upon later by implementing hexadecimal digits for memory files).

If people like this idea, I can work it out further, this is a first
draft to gauge enthousiasm.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
