### PR TITLE
Improve documentation on hidden arguments

### DIFF
--- a/changelog/2021-10-13T16_03_06+02_00_hidden_doc
+++ b/changelog/2021-10-13T16_03_06+02_00_hidden_doc
@@ -1,0 +1,1 @@
+CHANGED: The documentation on hidden clocks, resets, and enables has been corrected and extended in `Clash.Signal`.

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -2,9 +2,10 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2019, Myrtle Software,
                   2017     , Google Inc.
-                  2020     , Ben Gamari
+                  2020     , Ben Gamari,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 Clash has synchronous 'Signal's in the form of:
 
@@ -455,16 +456,20 @@ unsafeSynchronizer _clk1 _clk2 =
 --
 -- Note: this unsafeSynchronizer is defined to be consistent with the vhdl and verilog
 -- implementations however as only synchronous signals are represented in Clash this
--- cannot be done precisely and can lead to odd behaviour. For example,
+-- cannot be done precisely and can lead to odd behavior. For example,
+--
 -- @
 -- sample $ unsafeSynchronizer @Dom2 @Dom7 . unsafeSynchronizer @Dom7 @Dom2 $ fromList [0..10]
 -- > [0,4,4,4,7,7,7,7,11,11,11..
 -- @
+--
 -- is quite different from the identity,
+--
 -- @
 -- sample $ fromList [0..10]
 -- > [0,1,2,3,4,5,6,7,8,9,10..
 -- @
+--
 -- with values appearing from the "future".
 veryUnsafeSynchronizer
   :: Int

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -1,9 +1,10 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017-2019, Myrtle Software Ltd
-                  2017,      Google Inc.
+                  2017     , Google Inc.,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE ConstraintKinds #-}
@@ -395,8 +396,9 @@ class KnownSymbol dom => KnownDomain (dom :: Domain) where
   -- | Returns 'SDomainConfiguration' corresponding to an instance's 'DomainConfiguration'.
   --
   -- Example usage:
-  -- > knownDomain @System
   --
+  -- >>> knownDomain @System
+  -- SDomainConfiguration (SSymbol @"System") (SNat @10000) SRising SAsynchronous SDefined SActiveHigh
   knownDomain :: SDomainConfiguration dom (KnownConf dom)
 
 -- | Version of 'knownDomain' that takes a 'SSymbol'. For example:
@@ -429,7 +431,7 @@ instance KnownDomain IntelSystem where
 
 -- | Convenience value to allow easy "subclassing" of System domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
--- change the period but leave all other settings in tact use:
+-- change the period but leave all other settings intact use:
 --
 -- > createDomain vSystem{vName="System10", vPeriod=10}
 --
@@ -447,7 +449,7 @@ type System = ("System" :: Domain)
 
 -- | Convenience value to allow easy "subclassing" of IntelSystem domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
--- change the period but leave all other settings in tact use:
+-- change the period but leave all other settings intact use:
 --
 -- > createDomain vIntelSystem{vName="Intel10", vPeriod=10}
 --
@@ -464,7 +466,7 @@ type IntelSystem = ("IntelSystem" :: Domain)
 
 -- | Convenience value to allow easy "subclassing" of XilinxSystem domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
--- change the period but leave all other settings in tact use:
+-- change the period but leave all other settings intact use:
 --
 -- > createDomain vXilinxSystem{vName="Xilinx10", vPeriod=10}
 --


### PR DESCRIPTION
This is a partial backport of #1849.

Documentation in Clash.Signal is corrected and extended. Parts of the
existing documentation were not rendered before this commit due to
incorrect interaction between CPP #ifdef and Haddock syntax.

A developer note [Going from WithSingleDomain to WithSpecificDomain] is
added in the source, explaining the code.

Because this is a partial backport, the original Changelog entry in [changelog/2021-08-24T17_12_59+02_00_andEnable](https://github.com/clash-lang/clash-compiler/blob/086a8c1d13fef1a93c8f86d99a54bdbc5bbdc12c/changelog/2021-08-24T17_12_59+02_00_andEnable) has been split. I suggest we change that file when merging CHANGELOG.md for the 1.4 point release into master to:

```
DEPRECATED: The function `Clash.Explicit.Signal.enable` is renamed to `andEnable` and the existing name deprecated.
ADDED: `Clash.Signal.andEnable` is the `HiddenEnable` version of `Clash.Explicit.Signal.andEnable` (formerly known as `enable`).
CHANGED: A warning about possible hard-to-debug issues has been added to the `Clash.Signal` documentation on hidden clocks, resets, and enables, in the form of the section named "Monomorphism restriction leads to surprising behavior".
```

I did not backport that section on monomorphism because I did not want to describe the issue using the `with...` and `expose...` functions as I think those should not be used in that way at all. While the section is useful to our users of 1.4 now already, I suggest we let it lie for 1.4 and only properly introduce the thing with 1.6 and `andEnable`.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
