### PR TITLE
Fix example topEntities in doc on hidden args

### DIFF
--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -413,13 +413,12 @@ components such as PLLs and 'resetSynchronizer':
 topEntity
   :: Clock  System
   -> Reset  System
-  -> Enable System
   -> Signal System Bit
   -> Signal System (BitVector 8)
-topEntity clk rst ena key1 =
+topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol \@\"altpll50\") clk rst
-         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable) ena
-    in   'exposeClockResetEnable' leds pllOut rstSync ena
+         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable) enableGen
+    in   'exposeClockResetEnable' leds pllOut rstSync enableGen
   where
     key1R  = isRising 1 key1
     leds   = mealy blinkerT (1, False, 0) key1R
@@ -431,13 +430,12 @@ or, using the alternative method:
 topEntity
   :: Clock  System
   -> Reset  System
-  -> Enable System
   -> Signal System Bit
   -> Signal System (BitVector 8)
-topEntity clk rst ena key1 =
+topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol \@\"altpll50\") clk rst
-         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable) ena
-    in   'withClockResetEnable' pllOut rstSync ena leds
+         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable) enableGen
+    in   'withClockResetEnable' pllOut rstSync enableGen leds
   where
     key1R  = isRising 1 key1
     leds   = mealy blinkerT (1, False, 0) key1R


### PR DESCRIPTION
When I "fixed" these in #1849 I "fixed" them worse.

`resetSynchronizer` ignores its `Enable` argument, so it doesn't need
one passed in either; it would accomplish nothing and cause confusion.
~~And since the top entity contains its own PLL, any signal coming from
outside (the `ena` argument) will almost certainly not be synchronized
to the clock coming out of the PLL and should not be passed to `leds`.~~
_(Actually, as pointed out by @christiaanb, the clocks could very well be in
phase.)_
So we should get rid of the `Enable` argument.

#1957 for 1.4 already contains this fix, as I noticed it while creating that PR.

## Still TODO:

  - [ ] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
