### PR TITLE
Fix applyTyVarSubsts for LitT

### DIFF
--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -1,6 +1,7 @@
 {-|
   Copyright   :  (C) 2019     , Google Inc.,
                      2021     , QBayLogic B.V.
+                     2021     , Myrtle.ai
   License     :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}


### PR DESCRIPTION
When trying to upgrade from clash 1.2 to 1.4 I hit this issue:

```
    Exception when trying to run compile-time code:
      TODO applyTyVarSubsts: LitT (NumTyLit 8)
```

[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

Write a description of your PR here. Briefly describe the solution, taking more care with larger changes to outline the intention of the PR, or any compromises made in the final design. If there is no associated issue, it is helpful to also include the motivation for this PR.

[comment]: # (Add a line of the form "Fixes: #xxxx" for each related issue closed by this pull request, where #xxxx is an issue number.)

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)