### PR TITLE
resetSynchronizer: drop unused Enable input

### DIFF
--- a/changelog/2021-10-14T17_46_59+02_00_resetsync_no_ena
+++ b/changelog/2021-10-14T17_46_59+02_00_resetsync_no_ena
@@ -1,0 +1,1 @@
+CHANGED: `resetSynchronizer` now no longer takes an `Enable` argument. The argument was already marked for removal and was ignored.

--- a/clash-prelude/src/Clash/Annotations/TopEntity.hs
+++ b/clash-prelude/src/Clash/Annotations/TopEntity.hs
@@ -1,8 +1,9 @@
 {-|
 Copyright  :  (C) 2015-2016, University of Twente,
-                  2017     , Google Inc.
+                  2017     , Google Inc.,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 'TopEntity' annotations allow us to control hierarchy and naming aspects of the
 Clash compiler. We have the 'Synthesize' and 'TestBench' annotation.
@@ -103,7 +104,6 @@ topEntity clk20 rstBtn enaBtn modeBtn =
     'Clash.Prelude.resetSynchronizer'
       clk50
       ('Clash.Signal.unsafeFromLowPolarity' pllStable)
-      enableGen
 
 blinkerT
   :: (BitVector 8, Bool, Index 16650001)

--- a/clash-prelude/src/Clash/Explicit/Reset.hs
+++ b/clash-prelude/src/Clash/Explicit/Reset.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright  :  (C) 2020, QBayLogic B.V.
+Copyright  :  (C) 2020-2021, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -92,13 +92,12 @@ import           GHC.TypeLits (type (+), KnownNat)
 -- topEntity
 --   :: Clock  System
 --   -> Reset  System
---   -> Enable System
 --   -> Signal System Bit
 --   -> Signal System (BitVector 8)
--- topEntity clk asyncRst ena key1 =
---   withClockResetEnable clk rst ena leds
+-- topEntity clk asyncRst key1 =
+--   withClockResetEnable clk rst enableGen leds
 --  where
---   rst   = 'resetSynchronizer' clk asyncRst ena
+--   rst   = 'resetSynchronizer' clk asyncRst
 --   key1R = isRising 1 key1
 --   leds  = mealy blinkerT (1, False, 0) key1R
 -- @
@@ -115,9 +114,9 @@ import           GHC.TypeLits (type (+), KnownNat)
 --   -> Reset  System
 --   -> Signal System Bit
 --   -> Signal System (BitVector 8)
--- topEntity clk rst ena key1 =
+-- topEntity clk rst key1 =
 --     let  (pllOut,pllStable) = altpll (SSymbol @"altpll50") clk rst
---          rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable) ena
+--          rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable)
 --     in   exposeClockResetEnable leds pllOut rstSync enableGen
 --   where
 --     key1R  = isRising 1 key1
@@ -163,10 +162,8 @@ resetSynchronizer
    . KnownDomain dom
   => Clock dom
   -> Reset dom
-  -> Enable dom
-  -- ^ Warning: this argument will be removed in future versions of Clash.
   -> Reset dom
-resetSynchronizer clk rst _ = rstOut
+resetSynchronizer clk rst = rstOut
  where
   isActiveHigh = case resetPolarity @dom of { SActiveHigh -> True; _ -> False }
   rstOut =
@@ -290,4 +287,4 @@ convertReset clkA clkB rstA0 = rstA2
   rstA2 =
     case (sameDomain @domA @domB) of
       Just Refl -> rstA0
-      Nothing   -> resetSynchronizer clkB rstA1 enableGen
+      Nothing   -> resetSynchronizer clkB rstA1

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -413,13 +413,12 @@ components such as PLLs and 'resetSynchronizer':
 topEntity
   :: Clock  System
   -> Reset  System
-  -> Enable System
   -> Signal System Bit
   -> Signal System (BitVector 8)
-topEntity clk rst ena key1 =
+topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol \@\"altpll50\") clk rst
-         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable) ena
-    in   'exposeClockResetEnable' leds pllOut rstSync ena
+         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable)
+    in   'exposeClockResetEnable' leds pllOut rstSync enableGen
   where
     key1R  = isRising 1 key1
     leds   = mealy blinkerT (1, False, 0) key1R
@@ -431,13 +430,12 @@ or, using the alternative method:
 topEntity
   :: Clock  System
   -> Reset  System
-  -> Enable System
   -> Signal System Bit
   -> Signal System (BitVector 8)
-topEntity clk rst ena key1 =
+topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol \@\"altpll50\") clk rst
-         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable) ena
-    in   'withClockResetEnable' pllOut rstSync ena leds
+         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable)
+    in   'withClockResetEnable' pllOut rstSync enableGen leds
   where
     key1R  = isRising 1 key1
     leds   = mealy blinkerT (1, False, 0) key1R

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -917,7 +917,7 @@ topEntity clk rst =
     'exposeClockResetEnable' ('mealy' blinkerT (1,False,0) . Clash.Prelude.isRising 1) pllOut rstSync 'enableGen'
   where
     (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' \@Dom50 (SSymbol \@\"altpll50\") clk ('Clash.Signal.unsafeFromLowPolarity' rst)
-    rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeFromLowPolarity' pllStable) enableGen
+    rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeFromLowPolarity' pllStable)
 
 blinkerT (leds,mode,cntr) key1R = ((leds',mode',cntr'),leds)
   where
@@ -2555,7 +2555,6 @@ topEntity clk20 rstBtn modeBtn =
     'Clash.Signal.resetSynchronizer'
       clk50
       (unsafeFromLowPolarity pllStable)
-      en
 
 flipMode :: LedMode -> LedMode
 flipMode Rotate = Complement

--- a/examples/Blinker.hs
+++ b/examples/Blinker.hs
@@ -85,7 +85,6 @@ topEntity clk20 rstBtn modeBtn =
     resetSynchronizer
       clk50
       (unsafeFromLowPolarity pllStable)
-      en
 
 flipMode :: LedMode -> LedMode
 flipMode Rotate = Complement

--- a/tests/shouldwork/Issues/T1742.hs
+++ b/tests/shouldwork/Issues/T1742.hs
@@ -22,6 +22,6 @@ topEntity
 topEntity clk rstnButton = exposeClockResetEnable top clk rst en where
   en = enableGen
   rst = unsafeFromLowPolarity rstnButton
-  rstSync = resetSynchronizer clk rst en
+  rstSync = resetSynchronizer clk rst
 
 makeTopEntityWithName 'topEntity "shell"

--- a/tests/shouldwork/Signal/ResetSynchronizer.hs
+++ b/tests/shouldwork/Signal/ResetSynchronizer.hs
@@ -56,9 +56,8 @@ polyTopEntity
   -> Signal dom ResetCount
 polyTopEntity clk asyncRst = counter
  where
-  ena = enableGen
-  counter = register clk rst ena RRRRRRR (fmap succResetCount counter)
-  rst = resetSynchronizer clk asyncRst ena
+  counter = register clk rst enableGen RRRRRRR (fmap succResetCount counter)
+  rst = resetSynchronizer clk asyncRst
 
 topEntity :: Clock System -> Reset System -> Signal System ResetCount
 topEntity = polyTopEntity @System


### PR DESCRIPTION
The input was unused and marked to be removed.

The example in `Clash.Signal` that was changed in PR #1849 is now
changed to be closer to what it was before that PR.

This supersedes PR #1958
## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
