### PR TITLE
Enable port visibility for QuestaSim

### DIFF
--- a/tests/src/Test/Tasty/Modelsim.hs
+++ b/tests/src/Test/Tasty/Modelsim.hs
@@ -66,7 +66,8 @@ instance IsTest ModelsimSimTest where
     forM_ lists $ \memFile ->
       copyFile memFile (src </> "memory.list")
 
-    let args = ["-batch", "-do", doScript, msimTop]
+    -- TODO: remove -voptargs=+acc=p for a next release of questa intel edition
+    let args = ["-voptargs=+acc=p","-batch", "-do", doScript, msimTop]
     case msimExpectFailure of
       Nothing -> run optionSet (vsim src args) progressCallback
       Just exit -> run optionSet (failingVsim src args exit) progressCallback


### PR DESCRIPTION
Very strangely Questa Intel Starter FPGA Edition-64 2021.2 Revision 2021.04 doesn't simulate the Clash-generated SystemVerilog correctly unless we turn on port visibility: -voptargs=+acc=p

Without it, we get assertion errors on:

* T1524
* Transpose

Both seem to involve two-dimensional vectors. Perhaps that is a clue.

NB: adding this flag does not affect ModelSim Intel/Altera Starter Edition. So users can still run the testsuite with that version of Model/QuestaSim.