### PR TITLE
Remove blackboxes for GHC.Types.I# and GHC.Types.W#

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -1595,13 +1595,6 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
             [charDc] = tyConDataCons charTc
         in  reduce (mkApps (Data charDc) [Left (Literal (CharLiteral c))])
 
-  "GHC.Types.I#"
-    | isSubj
-    , [Lit (IntLiteral i)] <- args
-    ->  let (_,tyView -> TyConApp intTcNm []) = splitFunForallTy ty
-            (Just intTc) = lookupUniqMap intTcNm tcm
-            [intDc] = tyConDataCons intTc
-        in  reduce (mkApps (Data intDc) [Left (Literal (IntLiteral i))])
   "GHC.Int.I8#"
     | isSubj
     , [Lit (IntLiteral i)] <- args
@@ -1631,13 +1624,6 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
             [intDc] = tyConDataCons intTc
         in  reduce (mkApps (Data intDc) [Left (Literal (IntLiteral i))])
 
-  "GHC.Types.W#"
-    | isSubj
-    , [Lit (WordLiteral c)] <- args
-    ->  let (_,tyView -> TyConApp wordTcNm []) = splitFunForallTy ty
-            (Just wordTc) = lookupUniqMap wordTcNm tcm
-            [wordDc] = tyConDataCons wordTc
-        in  reduce (mkApps (Data wordDc) [Left (Literal (WordLiteral c))])
   "GHC.Word.W8#"
     | isSubj
     , [Lit (WordLiteral c)] <- args

--- a/clash-lib/prims/common/GHC_Types.primitives
+++ b/clash-lib/prims/common/GHC_Types.primitives
@@ -12,20 +12,4 @@
     , "template"  : "~ARG[0]"
     }
   }
-, { "BlackBox" :
-    { "name"      : "GHC.Types.I#"
-    , "workInfo"  : "Never"
-    , "kind"      : "Expression"
-    , "type"      : "I# :: Int# -> Int"
-    , "template"  : "~ARG[0]"
-    }
-  }
-, { "BlackBox" :
-    { "name"      : "GHC.Types.W#"
-    , "workInfo"  : "Never"
-    , "kind"      : "Expression"
-    , "type"      : "W# :: Word# -> Word"
-    , "template"  : "~ARG[0]"
-    }
-  }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
@@ -591,7 +591,7 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer(~ARG[2]
+"~RESULT <= std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer((~ARG[2])
     -- pragma translate_off
     mod ~SIZE[~TYP[1]]
     -- pragma translate_on
@@ -607,7 +607,7 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer(~ARG[2]
+"~RESULT <= std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer((~ARG[2])
     -- pragma translate_off
     mod ~SIZE[~TYP[1]]
     -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
@@ -273,7 +273,7 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~RESULT <= rotate_left(~ARG[1],to_integer(~ARG[2]
+"~RESULT <= rotate_left(~ARG[1],to_integer((~ARG[2])
     -- pragma translate_off
     mod ~SIZE[~TYP[1]]
     -- pragma translate_on
@@ -289,7 +289,7 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~RESULT <= rotate_right(~ARG[1],to_integer(~ARG[2]
+"~RESULT <= rotate_right(~ARG[1],to_integer((~ARG[2])
     -- pragma translate_off
     mod ~SIZE[~TYP[1]]
     -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
@@ -224,7 +224,7 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~RESULT <= rotate_left(~ARG[1],to_integer(~ARG[2]
+"~RESULT <= rotate_left(~ARG[1],to_integer((~ARG[2])
     -- pragma translate_off
     mod ~SIZE[~TYP[1]]
     -- pragma translate_on
@@ -240,7 +240,7 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~RESULT <= rotate_right(~ARG[1],to_integer(~ARG[2]
+"~RESULT <= rotate_right(~ARG[1],to_integer((~ARG[2])
     -- pragma translate_off
     mod ~SIZE[~TYP[1]]
     -- pragma translate_on

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1676,18 +1676,6 @@ expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   , let k' = max 1 k
   = exprLit (Just (Unsigned k',k')) (NumLit (n-1))
 
-expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
-  | pNm == "GHC.Types.I#"
-  , [Literal _ (NumLit n)] <- extractLiterals bbCtx
-  = do iw <- Ap $ use intWidth
-       exprLit (Just (Signed iw,iw)) (NumLit n)
-
-expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
-  | pNm == "GHC.Types.W#"
-  , [Literal _ (NumLit n)] <- extractLiterals bbCtx
-  = do iw <- Ap $ use intWidth
-       exprLit (Just (Unsigned iw,iw)) (NumLit n)
-
 expr_ b (BlackBoxE _ libs imps inc bs bbCtx b') = do
   parenIf (b || b') (Ap (renderBlackBox libs imps inc bs bbCtx <*> pure 0))
 

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -617,13 +617,11 @@ renderTag b (Lit n) =
   mkLit (Literal (Just (Signed _,_)) i)                                 = Literal Nothing i  -- Integer, Int#
   mkLit (Literal (Just (Unsigned _,_)) i)                               = Literal Nothing i  -- KnownNat, Natural, Word#
 
-  -- TODO Remove the blackboxes for GHC.Types.I# and GHC.Types.W#.
-  -- Then we can use these two rules for Int and Word
-  -- mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Signed _,_)) i])   = Literal Nothing i
-  mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Unsigned _,_)) i]) = Literal Nothing i  -- SNat
+  mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Signed _,_)) i])   = Literal Nothing i  -- Int
+  mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Unsigned _,_)) i]) = Literal Nothing i  -- SNat, Word
 
-  mkLit (BlackBoxE pNm _ _ _ _ bbCtx _) | pNm `elem` ["GHC.Types.I#","GHC.Int.I8#", "GHC.Int.I16#", "GHC.Int.I32#", "GHC.Int.I64#"
-                                                     ,"GHC.Types.W#","GHC.Word.W8#","GHC.Word.W16#","GHC.Word.W32#","GHC.Word.W64#"
+  mkLit (BlackBoxE pNm _ _ _ _ bbCtx _) | pNm `elem` ["GHC.Int.I8#", "GHC.Int.I16#", "GHC.Int.I32#", "GHC.Int.I64#"
+                                                     ,"GHC.Word.W8#","GHC.Word.W16#","GHC.Word.W32#","GHC.Word.W64#"
                                                      ]
                                         , [Literal _ i] <- extractLiterals bbCtx
                                         = Literal Nothing i

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -43,9 +43,9 @@ import           Clash.Netlist.BlackBox.Types
    Element(Component, Typ, TypElem, Text), Decl(Decl), emptyBlackBoxMeta)
 import           Clash.Netlist.Types
   (Identifier, TemplateFunction, BlackBoxContext, HWType(Vector),
-   Declaration(..), Expr(BlackBoxE, Literal, Identifier), Literal(NumLit),
+   Declaration(..), Expr(Literal, Identifier,DataCon), Literal(NumLit),
    BlackBox(BBTemplate, BBFunction), TemplateFunction(..), WireOrReg(Wire),
-   Modifier(Indexed, Nested), bbInputs, bbResults, emptyBBContext, tcCache,
+   Modifier(Indexed, Nested, DC), HWType(..), bbInputs, bbResults, emptyBBContext, tcCache,
    bbFunctions)
 import qualified Clash.Netlist.Id                   as Id
 import           Clash.Netlist.Util                 (typeSize)
@@ -307,8 +307,8 @@ indexIntVerilogTemplate bbCtx = getAp $ case typeSize vTy of
   ixI ix0 = case ix0 of
     Literal _ (NumLit i) ->
       fromInteger i
-    BlackBoxE "GHC.Types.I#" _ _ _ _ ixCtx _ ->
-      let (ix1,_,_) = head (bbInputs ixCtx)
-      in  ixI ix1
+    DataCon (Signed _) (DC (Void{},_)) [Literal (Just (Signed _,_)) (NumLit i)] ->
+      fromInteger i
     _ ->
       error ($(curLoc) ++ "Unexpected literal: " ++ show ix)
+


### PR DESCRIPTION
As mentioned in PR #1948, it is not necessary to have boxed literal types like Int and Word as blackboxes. We can instead render their data constructors directly.

Closes #1966

I have a feeling this PR needs to be benchmarked, locally I think I see some slowdown in the testsuite.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
