### PR TITLE
Keep recursive and non-recursive let in Clash Core

### DIFF
--- a/changelog/2021-11-01T16_46_50+01_00_rec_nonrec_let.md
+++ b/changelog/2021-11-01T16_46_50+01_00_rec_nonrec_let.md
@@ -1,0 +1,1 @@
+CHANGED: Clash now keeps information about which let bindings are recursive from GHC core. This can be used to avoid performing free variable calculations, or sorting bindings in normalization.

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator.hs
@@ -213,8 +213,9 @@ stepTyApp x ty m tcm =
   (term, args, _) = collectArgsTicks (TyApp x ty)
   tys' = fst . splitFunForallTy . inferCoreTypeOf tcm $ TyApp x ty
 
-stepLetRec :: [LetBinding] -> Term -> Step
-stepLetRec bs x m _ = Just (allocate bs x m)
+stepLet :: Bind Term -> Term -> Step
+stepLet (NonRec i b) x m _ = Just (allocate [(i,b)] x m)
+stepLet (Rec bs) x m _ = Just (allocate bs x m)
 
 stepCase :: Term -> Type -> [Alt] -> Step
 stepCase scrut ty alts m _ =
@@ -245,7 +246,7 @@ ghcStep m = case mTerm m of
   TyLam v x -> stepTyLam v x m
   App x y -> stepApp x y m
   TyApp x ty -> stepTyApp x ty m
-  Letrec bs x -> stepLetRec bs x m
+  Let bs x -> stepLet bs x m
   Case s ty as -> stepCase s ty as m
   Cast x a b -> stepCast x a b m
   Tick t x -> stepTick t x m

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -434,12 +434,12 @@ coreToTerm primMap unlocs = term
       (e1',sp) <- termSP (getSrcSpan x) e1
       x'  <- coreToIdSP sp x
       e2' <- term e2
-      return (C.Letrec [(x', e1')] e2')
+      return (C.Let (C.NonRec x' e1') e2')
 
     term' (Let (Rec xes) e) = do
       xes' <- mapM go xes
       e'   <- term e
-      return (C.Letrec xes' e')
+      return (C.Let (C.Rec xes') e')
      where
       go (x,b) = do
         (b',sp) <- termSP (getSrcSpan x) b
@@ -460,7 +460,7 @@ coreToTerm primMap unlocs = term
      if usesBndr
       then do
         ct <- caseTerm (C.Var b')
-        return (C.Letrec [(b', e')] ct)
+        return (C.Let (C.NonRec b' e') ct)
       else caseTerm e'
 
     term' (Cast e co) = do

--- a/clash-lib/src/Clash/Core/HasType.hs
+++ b/clash-lib/src/Clash/Core/HasType.hs
@@ -142,7 +142,7 @@ instance InferType Term where
         case collectArgs x of
           (fun, args) -> applyTypeToArgs x tcm (go fun) args
 
-      Letrec _ x -> go x
+      Let _ x -> go x
       Case _ ty _ -> ty
       Cast _ _ a -> a
       Tick _ x -> go x

--- a/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
@@ -37,7 +37,7 @@ import Data.Map.Strict (Map)
 
 import Clash.Core.DataCon (DataCon)
 import Clash.Core.Literal
-import Clash.Core.Term (Term(..), PrimInfo(primName), TickInfo, Pat)
+import Clash.Core.Term (Bind, Term(..), PrimInfo(primName), TickInfo, Pat)
 import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (Type, TyVar)
 import Clash.Core.Util (undefinedPrims)
@@ -75,7 +75,7 @@ data Neutral a
   | NePrim   !PrimInfo !(Args a)
   | NeApp    !(Neutral a) !a
   | NeTyApp  !(Neutral a) !Type
-  | NeLetrec ![(Id, a)] !a
+  | NeLet    !(Bind a) !a
   | NeCase   !a !Type ![(Pat, a)]
   deriving (Show)
 

--- a/clash-lib/src/Clash/Core/TermInfo.hs
+++ b/clash-lib/src/Clash/Core/TermInfo.hs
@@ -29,9 +29,10 @@ termSize (App e1 e2)  = termSize e1 + termSize e2
 termSize (TyApp e _)  = termSize e
 termSize (Cast e _ _) = termSize e
 termSize (Tick _ e)   = termSize e
-termSize (Letrec bndrs e) = sum (bodySz:bndrSzs)
+termSize (Let (NonRec _ x) e) = termSize x + termSize e
+termSize (Let (Rec xs) e) = sum (bodySz:bndrSzs)
  where
-  bndrSzs = map (termSize . snd) bndrs
+  bndrSzs = map (termSize . snd) xs
   bodySz  = termSize e
 termSize (Case subj _ alts) = sum (subjSz:altSzs)
  where
@@ -88,8 +89,8 @@ isPolyFun m t = isPolyFunCoreTy m (inferCoreTypeOf m t)
 
 -- | Is a term a recursive let-binding?
 isLet :: Term -> Bool
-isLet (Letrec {}) = True
-isLet _           = False
+isLet Let{} = True
+isLet _ = False
 
 -- | Is a term a variable reference?
 isVar :: Term -> Bool

--- a/clash-lib/src/Clash/Normalize/Transformations/ANF.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/ANF.hs
@@ -400,10 +400,10 @@ nonRepANF ctx@(TransformContext is0 _) e@(App appConPrim arg)
   = do
     untranslatable <- isUntranslatable False arg
     case (untranslatable,stripTicks arg) of
-      (True,Letrec binds body) ->
+      (True,Let binds body) ->
         -- This is a situation similar to Note [CaseLet deshadow]
         let (binds1,body1) = deshadowLetExpr is0 binds body
-        in  changed (Letrec binds1 (App appConPrim body1))
+        in  changed (Let binds1 (App appConPrim body1))
       (True,Case {})  -> specialize ctx e
       (True,Lam {})   -> specialize ctx e
       (True,TyLam {}) -> specialize ctx e

--- a/clash-lib/src/Clash/Normalize/Transformations/Cast.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Cast.hs
@@ -105,10 +105,10 @@ elimCastCast _ c@(Cast (stripTicks -> Cast e tyA tyB) tyB' tyC) = do
 elimCastCast _ e = return e
 {-# SCC elimCastCast #-}
 
--- | Push a cast over a Letrec into it's body
+-- | Push a cast over a Let into it's body
 letCast :: HasCallStack => NormRewrite
-letCast _ (Cast (stripTicks -> Letrec binds body) ty1 ty2) =
-  changed $ Letrec binds (Cast body ty1 ty2)
+letCast _ (Cast (stripTicks -> Let binds body) ty1 ty2) =
+  changed $ Let binds (Cast body ty1 ty2)
 letCast _ e = return e
 {-# SCC letCast #-}
 

--- a/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
@@ -50,7 +50,7 @@ import Clash.Core.Name (mkUnsafeSystemName, nameOcc)
 import Clash.Core.Subst
 import Clash.Core.Term
   ( LetBinding, Pat(..), PrimInfo(..), Term(..), collectArgs, collectArgsTicks
-  , collectTicks, isLambdaBodyCtx, isTickCtx, mkApps, mkLams, mkTicks
+  , collectTicks, isLambdaBodyCtx, isTickCtx, mkApps, mkLams, mkTicks, Bind(..)
   , partitionTicks, stripTicks)
 import Clash.Core.TermInfo (isCon, isLet, isLocalVar, isTick)
 import Clash.Core.TyCon (tyConDataCons)
@@ -84,7 +84,7 @@ not the complete names. So we use mkUnsafeSystemName to recreate the same Name.
 
 -- | Remove unused let-bindings
 deadCode :: HasCallStack => NormRewrite
-deadCode _ e@(Letrec binds body) =
+deadCode _ e@(Let binds body) =
   case removeUnusedBinders binds body of
     Just t -> changed t
     Nothing -> return e
@@ -428,7 +428,7 @@ topLet (TransformContext is0 ctx) e
     then return e
     else do tcm <- Lens.view tcCache
             argId <- mkTmBinderFor is0 tcm (mkUnsafeSystemName "result" 0) e
-            changed (Letrec [(argId, e)] (Var argId))
+            changed (Let (NonRec argId e) (Var argId))
 
 topLet (TransformContext is0 ctx) e@(Letrec binds body)
   | all (\c -> isLambdaBodyCtx c || isTickCtx c) ctx
@@ -439,9 +439,15 @@ topLet (TransformContext is0 ctx) e@(Letrec binds body)
       then return e
       else do
         tcm <- Lens.view tcCache
-        let is2 = extendInScopeSetList is0 (map fst binds)
+        let is2 = extendInScopeSetList is0 (fmap fst binds)
         argId <- mkTmBinderFor is2 tcm (mkUnsafeSystemName "result" 0) body
-        changed (Letrec (binds ++ [(argId,body)]) (Var argId))
+
+        -- TODO We would like this to be
+        --
+        -- Let binds (Let (NonRec argId body) (Var argId))
+        --
+        -- but this makes tests/shouldwork/SimIO/Test00.hs fail.
+        changed (Letrec (binds ++ [(argId, body)]) (Var argId))
 
 topLet _ e = return e
 {-# SCC topLet #-}

--- a/clash-lib/src/Clash/Normalize/Transformations/MultiPrim.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/MultiPrim.hs
@@ -28,6 +28,7 @@ import Clash.Core.Term
 import Clash.Core.TermInfo (multiPrimInfo')
 import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (Type(..), mkPolyFunTy, splitFunForallTy)
+import Clash.Core.Util (listToLets)
 import Clash.Core.Var (mkLocalId)
 import Clash.Normalize.Types (NormRewrite, primitives)
 import Clash.Primitives.Types (Primitive(..))
@@ -123,6 +124,6 @@ setupMultiResultPrim' tcm primInfo@PrimInfo{primType} =
     }
 
   letTerm =
-    Letrec
+    listToLets
       ((resId,multiPrimBind):multiPrimSelectBinds)
       (mkTmApps (mkTyApps (Data tupTc) resTypes) (map Var resIds))

--- a/clash-lib/src/Clash/Rewrite/WorkFree.hs
+++ b/clash-lib/src/Clash/Rewrite/WorkFree.hs
@@ -111,7 +111,8 @@ isWorkFree cache bndrs = go True
 
       Lam _ e -> andM [go False e, allM goArg args]
       TyLam _ e -> andM [go False e, allM goArg args]
-      Letrec bs e -> andM [go False e, allM (go False . snd) bs, allM goArg args]
+      Let (NonRec _ x) e -> andM [go False e, go False x, allM goArg args]
+      Let (Rec bs) e -> andM [go False e, allM (go False . snd) bs, allM goArg args]
       Case s _ [(_, a)] -> andM [go False s, go False a, allM goArg args]
       Case e _ _ -> andM [go False e, allM goArg args]
       Cast e _ _ -> andM [go False e, allM goArg args]


### PR DESCRIPTION
In GHC core, the difference between recursive and non-recursive binders is preserved. In Clash, this difference is not preserved in let expressions / the bindings map, which leads to sometimes needing to calculate the connected components of the bindings.

However, since Letrec is used a lot (i.e. in normalization) it is painful to simply differentiate everywhere immediately. As a compromise, this is kept as a pattern synonym so existing code should work as it did before. In the future we can migrate these cases until only `Let NonRec{}` and `Let Rec{}` are used in code. Until this time, the assumption is made that `NonRec` is _always_ non-recursive, but `Rec` holds recursive and _potentially_ recursive bindings.

The parts of the compiler where it is easier to change the definitions now have been changed.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
