### PR TITLE
Add `-fclash-partial-evaluator` flag

### DIFF
--- a/changelog/2021-11-01T17_47_27+01_00_partial_evaluator_flag.md
+++ b/changelog/2021-11-01T17_47_27+01_00_partial_evaluator_flag.md
@@ -1,0 +1,1 @@
+ADDED: Clash now has a `-fclash-partial-evaluator` flag for enabling the partial evaluator in builds which support it.

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -89,6 +89,7 @@ flagsClash r = [
   , defFlag "fclash-inline-workfree-limit"       $ IntSuffix (liftEwM . setInlineWFLimit r)
   , defFlag "fclash-edalize"                     $ NoArg (liftEwM (setEdalize r))
   , defFlag "fclash-no-render-enums"             $ NoArg (liftEwM (setNoRenderEnums r))
+  , defFlag "fclash-partial-evaluator"           $ NoArg (liftEwM (setPartialEvaluator r))
   ]
 
 -- | Print deprecated flag warning
@@ -324,3 +325,6 @@ setRewriteHistoryFile r arg = do
 
 setNoRenderEnums :: IORef ClashOpts -> IO ()
 setNoRenderEnums r = modifyIORef r (\c -> c { opt_renderEnums = False })
+
+setPartialEvaluator :: IORef ClashOpts -> IO ()
+setPartialEvaluator r = modifyIORef r (\c -> c { opt_partialEvaluator = True })

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -357,6 +357,9 @@ data ClashOpts = ClashOpts
   , opt_renderEnums :: Bool
   -- ^ Render sum types with all zero-width fields as enums where supported, as
   -- opposed to rendering them as bitvectors.
+  , opt_partialEvaluator :: Bool
+  -- ^ Whether to use the partial evaluator as a first pass in normalization
+  -- as a whole-program normalization pass.
   }
 
 instance Hashable ClashOpts where
@@ -388,7 +391,8 @@ instance Hashable ClashOpts where
     opt_aggressiveXOptBB `hashWithSalt`
     opt_inlineWFCacheLimit `hashWithSalt`
     opt_edalize `hashWithSalt`
-    opt_renderEnums
+    opt_renderEnums `hashWithSalt`
+    opt_partialEvaluator
    where
     hashOverridingBool :: Int -> OverridingBool -> Int
     hashOverridingBool s1 Auto = hashWithSalt s1 (0 :: Int)
@@ -427,6 +431,7 @@ defClashOpts
   , opt_inlineWFCacheLimit  = 10 -- TODO: find "optimal" value
   , opt_edalize             = False
   , opt_renderEnums         = True
+  , opt_partialEvaluator    = False
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -165,6 +165,7 @@ runNormalization opts supply globals typeTrans reprs tcm tupTcm peEval eval prim
                   (opt_newInlineStrat opts)
                   (opt_ultra opts)
                   (opt_inlineWFCacheLimit opts)
+                  (opt_partialEvaluator opts)
 
 
 normalize

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -16,6 +16,11 @@ import Clash.Normalize.Types
 import Clash.Rewrite.Combinators
 import Clash.Rewrite.Types
 import Clash.Rewrite.Util
+import Clash.Util (pprTraceDebug)
+
+partialEvaluatorBefore :: NormRewrite -> NormRewrite
+partialEvaluatorBefore =
+  pprTraceDebug "Clash: Partial Evaluation is not available in this build of clash" mempty
 
 -- [Note: bottomup traversal evalConst]
 --
@@ -25,6 +30,9 @@ import Clash.Rewrite.Util
 -- not in WHNF, which is what some of the evaluation rules for certain primitive
 -- operations expect. Using a bottom-up traversal works around this bug by
 -- ensuring that the values under the constructor are in WHNF.
+--
+-- TODO We can fix the above now, as we keep track of strictness information
+-- in data constructors (see dcArgStrict constructor).
 --
 -- Using a bottomup traversal ensures that constants are reduced to NF, even if
 -- constructors are lazy, thus ensuring more sensible/smaller generated HDL.

--- a/clash-lib/src/Clash/Normalize/Strategy.hs-boot
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs-boot
@@ -1,6 +1,7 @@
-module Clash.Normalize.Strategy (constantPropagation, normalization) where
+module Clash.Normalize.Strategy (constantPropagation, normalization, partialEvaluatorBefore) where
 
 import Clash.Normalize.Types (NormRewrite)
 
 normalization :: NormRewrite
 constantPropagation :: NormRewrite
+partialEvaluatorBefore :: NormRewrite -> NormRewrite

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -1,8 +1,9 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
                          2017, Google Inc.
+                         2021, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Types used in Normalize modules
 -}
@@ -70,6 +71,8 @@ data NormalizeState
   -- flag.
   , _inlineWFCacheLimit :: !Word
   -- ^ At what size do we cache normalized work-free top-level binders.
+  , _partialEvaluator :: Bool
+  -- ^ Whether to run the partial evaluator as the first step in normalization.
   }
 
 makeLenses ''NormalizeState

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -101,6 +101,7 @@ instance Default NormalizeState where
     , _newInlineStrategy=True
     , _normalizeUltra=False
     , _inlineWFCacheLimit=10
+    , _partialEvaluator=False
     }
 
 instance Default InScopeSet where


### PR DESCRIPTION
The partial evaluator is now exposed to users through a command line flag for clash. This means as the evaluator becomes more stable it can be enabled (experimentally) and should produce increasingly more meaningful results.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
