### PR TITLE
clash-lib: Add enableToBit

### DIFF
--- a/changelog/2021-11-08T10_15_39+00_00_add_enable_to_bit
+++ b/changelog/2021-11-08T10_15_39+00_00_add_enable_to_bit
@@ -1,0 +1,5 @@
+# clash-lib: Add enableToBit
+
+Enable used to be a `Bool` in the Blackbox DSL, so we could use `boolToBit`.
+However it now has its own type in the DSL (`Enable domainName`), so we need a
+new conversion function in order to convert it to a Bool.

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -1,6 +1,7 @@
 {-|
   Copyright   :  (C) 2019, Myrtle Software Ltd.
                      2020-2021, QBayLogic B.V.
+                     2021, Myrtle.ai
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 


### PR DESCRIPTION
Enable used to be a Bool in the DSL, so we could use `boolToBit`.
However it now has its own type in the DSL (Enable domainName), so we
need a new conversion function in order to convert it to a Bool.
This should work for all backends as they all currently normalize Enable
to a Bool.

I have tested this on the `1.4` branch and it worked well (for the VHDL backend, I didn't test the others).
If this is accepted, could we backport/release it in `1.4`? It shouldn't be a breaking change.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
