### PR TITLE
Use SHA256 for cache invalidation

### DIFF
--- a/changelog/2021-11-06T20_01_38+01_00_use_sha256_for_cache_invalidation
+++ b/changelog/2021-11-06T20_01_38+01_00_use_sha256_for_cache_invalidation
@@ -1,0 +1,1 @@
+CHANGED (internal): Manifest files now use SHA256 for a cache invalidation digest ([#1985](https://github.com/clash-lang/clash-compiler/pull/1985))

--- a/clash-lib/tests/Clash/Tests/Driver/Manifest.hs
+++ b/clash-lib/tests/Clash/Tests/Driver/Manifest.hs
@@ -62,7 +62,7 @@ genPort =
 genManifest :: Q.Gen Manifest
 genManifest =
   Manifest
-    <$> Q.arbitrary -- hash
+    <$> genDigest -- hash
     <*> Q.arbitrary -- flags
     <*> Q.listOf genPort -- ports
     <*> coerce @(Q.Gen [ArbitraryText]) @(Q.Gen [Text]) Q.arbitrary -- comp names


### PR DESCRIPTION
Before this commit, we used `hashable`s `hash`. For the purposes of
cache invalidation, it is very important that if `hash a == hash b`,
the chance that `a /= b` is vanishingly small. It is not clear that
`hashable` satisfies this requirement, whereas a cryptographically
secure hash such as SHA-256 clearly does.

## TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
