### PR TITLE
Remove `Hashable Term` and `Hashable Type`

### DIFF
--- a/changelog/2021-11-06T19_59_52+01_00_remove_hashable_type
+++ b/changelog/2021-11-06T19_59_52+01_00_remove_hashable_type
@@ -1,0 +1,1 @@
+CHANGED (internal): Removed instances of `Hashable Term` and `Hashable Type` ([#XXXX](https://github.com/clash-lang/clash-compiler/pull/XXXX))

--- a/clash-lib/src/Clash/Core/DataCon.hs
+++ b/clash-lib/src/Clash/Core/DataCon.hs
@@ -56,7 +56,7 @@ data DataCon
   -- ^ Argument strictness
   , dcFieldLabels :: [Text.Text]
   -- ^ Names of fields. Used when data constructor is referring to a record type.
-  } deriving (Generic,NFData,Hashable,Binary)
+  } deriving (Generic,NFData,Binary)
 
 instance Show DataCon where
   show = show . dcName

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -72,6 +73,7 @@ import qualified Data.List                 as List
 import qualified Data.List.Extra           as List
 import           Data.Ord                  (comparing)
 import           GHC.Stack                 (HasCallStack)
+import           GHC.SrcLoc.Extra          ()
 
 import           Clash.Core.HasFreeVars
 import           Clash.Core.Pretty         (ppr, fromPpr)
@@ -834,12 +836,8 @@ acmpType' = go
   go env (AppTy s1 t1) (AppTy s2 t2) =
     go env s1 s2 `thenCompare` go env t1 t2
   go _ (LitTy l1) (LitTy l2) = compare l1 l2
-  go env (AnnType _ t1) (AnnType _ t2) =
-    -- XXX: maybe ignore annotations, like we ignore ticks, i.e.
-    --
-    -- go env (AnnType t1) t2 = go env t1 t2
-    -- go env t1 (AnnType t2) = go env t1 t2
-    go env t1 t2
+  go env (AnnType a1 t1) (AnnType a2 t2) =
+    compare a1 a2 `thenCompare` go env t1 t2
   go _ t1 t2 = compare (getRank t1) (getRank t2)
 
   getRank :: Type -> Word
@@ -863,7 +861,7 @@ eqType = go
     tv1 == tv2 && go (varType tv1) (varType tv2) && go t1 t2
   go (AppTy s1 t1) (AppTy s2 t2) = go s1 s2 && go t1 t2
   go (LitTy l1) (LitTy l2) = l1 == l2
-  go (AnnType _ t1) (AnnType _ t2) = go t1 t2
+  go (AnnType a1 t1) (AnnType a2 t2) = a1 == a2 && go t1 t2
   go _ _ = False
 
 -- | Alpha equality for terms
@@ -939,10 +937,8 @@ acmpTerm' inScope = go (mkRnEnv inScope)
     go env e1 e2 `thenCompare`
     acmpType' env l1 l2 `thenCompare`
     acmpType' env r1 r2
-  -- Look through ticks for aeq
-  go env (Tick _ e1) e2 = go env e1 e2
-  go env e1 (Tick _ e2) = go env e1 e2
-
+  go env (Tick t1 e1) (Tick t2 e2) =
+    compare t1 t2 `thenCompare` go env e1 e2
   go _ e1 e2 = compare (getRank e1) (getRank e2)
 
   goAlt env (DataPat c1 tvs1 ids1,e1) (DataPat c2 tvs2 ids2,e2) =
@@ -1032,3 +1028,6 @@ instance Eq Term where
 
 instance Ord Term where
   compare = acmpTerm
+
+deriving instance Ord TickInfo
+

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Clash.Core.Term
   ( Term (.., Letrec)
@@ -63,7 +64,7 @@ import qualified Data.DList                    as DList
 import Data.Either                             (lefts, rights)
 import Data.Foldable                           (foldl')
 import Data.Maybe                              (catMaybes)
-import Data.Hashable                           (Hashable)
+import Data.Hashable                           (Hashable (hashWithSalt))
 import Data.List                               (nub, partition)
 import Data.Text                               (Text)
 import GHC.Generics
@@ -82,6 +83,9 @@ import {-# SOURCE #-} Clash.Core.Type          (Type)
 import Clash.Core.Var                          (Var, Id, TyVar)
 import Clash.Util                              (curLoc)
 
+import GHC.TypeLits
+  (TypeError, ErrorMessage (Text, (:<>:)))
+
 -- | Term representation in the CoreHW language: System F + LetRec + Case
 data Term
   = Var     !Id                             -- ^ Variable reference
@@ -97,7 +101,14 @@ data Term
                                             -- alternatives, list of alternatives
   | Cast    !Term !Type !Type               -- ^ Cast a term from one type to another
   | Tick    !TickInfo !Term                 -- ^ Annotated term
-  deriving (Show,Generic,NFData,Hashable,Binary)
+  deriving (Show, Generic, NFData, Binary)
+
+instance TypeError (
+        'Text "A broken implementation of Hashable Type has been "
+  ':<>: 'Text "removed in Clash 1.4.7. If this is an issue for you, please submit "
+  ':<>: 'Text "an issue report at https://github.com/clash-lang/clash-compiler/issues."
+  ) => Hashable Term where
+    hashWithSalt = error "Term.hashWithSalt: unreachable"
 
 -- TODO When it is possible, remove this pattern.
 pattern Letrec :: [LetBinding] -> Term -> Term
@@ -120,7 +131,7 @@ data TickInfo
   | NoDeDup
   -- ^ Do not deduplicate, i.e. /keep/, an expression inside a case-alternative;
   -- do not try to share expressions between multiple branches.
-  deriving (Eq,Show,Generic,NFData,Hashable,Binary)
+  deriving (Eq, Show, Generic, NFData, Binary)
 
 -- | Tag to indicate which instance/register name modifier was used
 data NameMod
@@ -151,7 +162,7 @@ data PrimInfo = PrimInfo
   --
   -- See: 'Clash.Normalize.Transformations.setupMultiResultPrim'
   , primUnfolding :: !PrimUnfolding
-  } deriving (Show,Generic,NFData,Hashable,Binary)
+  } deriving (Show, Generic, NFData, Binary)
 
 data PrimUnfolding
   = NoUnfolding
@@ -200,7 +211,7 @@ data Pat
   -- ^ Literal pattern
   | DefaultPat
   -- ^ Default pattern
-  deriving (Eq,Ord,Show,Generic,NFData,Hashable,Binary)
+  deriving (Eq, Ord, Show, Generic, NFData, Binary)
 
 type Alt = (Pat,Term)
 
@@ -266,7 +277,7 @@ data CoreContext
   -- ^ Body of a Cast
   | TickC TickInfo
   -- ^ Body of a Tick
-  deriving (Show, Generic, NFData, Hashable, Binary)
+  deriving (Show, Generic, NFData, Binary)
 
 -- | A list of @CoreContext@ describes the complete navigation path from the
 -- top-level to a specific sub-expression.

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Clash.Core.Type
   ( Type (..)
@@ -60,7 +61,7 @@ where
 import           Control.DeepSeq        as DS
 import           Data.Binary            (Binary)
 import           Data.Coerce            (coerce)
-import           Data.Hashable          (Hashable)
+import           Data.Hashable          (Hashable (hashWithSalt))
 import           Data.List              (foldl')
 import           Data.List.Extra        (splitAtList)
 import           Data.Maybe             (isJust, mapMaybe)
@@ -68,6 +69,7 @@ import           GHC.Base               (isTrue#,(==#))
 import           GHC.Generics           (Generic(..))
 import           GHC.Integer            (smallInteger)
 import           GHC.Integer.Logarithms (integerLogBase#)
+import           GHC.TypeLits           (type TypeError, ErrorMessage(Text, (:<>:)))
 
 -- GHC API
 #if MIN_VERSION_ghc(9,0,0)
@@ -130,7 +132,14 @@ data Type
   | AppTy    !Type !Type        -- ^ Type Application
   | LitTy    !LitTy             -- ^ Type literal
   | AnnType  [Attr'] !Type      -- ^ Annotated type, see Clash.Annotations.SynthesisAttributes
-  deriving (Show,Generic,NFData,Hashable,Binary)
+  deriving (Show, Generic, NFData, Binary)
+
+instance TypeError (
+        'Text "A broken implementation of Hashable Type has been "
+  ':<>: 'Text "removed in Clash 1.4.7. If this is an issue for you, please submit "
+  ':<>: 'Text "an issue report at https://github.com/clash-lang/clash-compiler/issues."
+  ) => Hashable Type where
+    hashWithSalt = error "Type.hashWithSalt: unreachable"
 
 -- | An easier view on types
 data TypeView

--- a/clash-lib/src/Clash/Core/Type.hs-boot
+++ b/clash-lib/src/Clash/Core/Type.hs-boot
@@ -13,7 +13,6 @@ module Clash.Core.Type where
 
 import Control.DeepSeq                  (NFData)
 import Data.Binary                      (Binary)
-import Data.Hashable                    (Hashable)
 import GHC.Generics                     (Generic)
 
 import                Clash.Core.Name
@@ -28,7 +27,6 @@ type KiName = Name Kind
 instance Generic  Type
 instance Show     Type
 instance NFData   Type
-instance Hashable Type
 instance Binary   Type
 
 mkTyConTy :: TyConName -> Type

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -23,10 +23,10 @@ import qualified Data.Aeson.Encode.Pretty as Aeson
 import           Data.Aeson
   (ToJSON(toJSON), FromJSON(parseJSON), KeyValue ((.=)), (.:), (.:?))
 import           Data.Aeson.Types (Parser)
+import qualified Data.Binary as Binary
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as ByteStringLazy
 import           Data.ByteString (ByteString)
-import qualified Data.Binary as Binary
 import           Data.Char (toLower)
 import           Data.Either (fromRight)
 import           Data.Hashable (hash)
@@ -421,6 +421,8 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
     , opt_hdlDir = Nothing
     }
 
+  -- TODO: Binary encoding does not account for alpha equivalence (nor should
+  --       it?), so the cache behaves more pessimisticly than it could.
   topHash = Sha256.hashlazy $ Binary.encode
     ( tops
     , hashCompiledPrimMap primMap

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -31,7 +31,6 @@ import           Data.Bifunctor                   (first, second)
 import           Data.Char                        (ord)
 import           Data.Either                      (partitionEithers, rights)
 import           Data.Foldable                    (foldlM)
-import qualified Data.HashMap.Strict              as HashMapS
 import qualified Data.HashMap.Lazy                as HashMap
 import           Data.List                        (elemIndex, partition, sortOn)
 import           Data.List.Extra                  (zipEqual)
@@ -196,7 +195,7 @@ runNetlistMonad isTb opts reprs s tops p tcm typeTrans iw
         , _isTestBench=isTb
         , _backEndITE=ite
         , _backend=be
-        , _htyCache=HashMapS.empty
+        , _htyCache=mempty
         }
 
 -- | Generate names for all binders in "BindingMap", except for the ones already

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -47,6 +47,7 @@ import Data.HashSet                         (HashSet)
 import qualified Data.List                  as List
 import Data.IntMap                          (IntMap, empty)
 import Data.Map.Ordered                     (OMap)
+import Data.Map                             (Map)
 import Data.Maybe                           (mapMaybe)
 import Data.Monoid                          (Ap(..))
 import qualified Data.Set                   as Set
@@ -126,7 +127,7 @@ newtype NetlistMonad a =
   deriving newtype (Functor, Monad, Applicative, MonadReader NetlistEnv,
                     Strict.MonadState NetlistState, Strict.MonadIO, MonadFail)
 
-type HWMap = HashMap Type (Either String FilteredHWType)
+type HWMap = Map Type (Either String FilteredHWType)
 
 -- | See 'is_freshCache'
 type FreshCache = HashMap Text (IntMap Word)

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -46,6 +46,8 @@ import qualified Data.IntSet             as IntSet
 import           Control.Applicative     (Alternative((<|>)))
 import           Data.List               (unzip4, partition)
 import qualified Data.List               as List
+import qualified Data.Map                as Map
+import           Data.Map                (Map)
 import           Data.Maybe
   (catMaybes, fromMaybe, isNothing, mapMaybe, isJust, listToMaybe, maybeToList)
 import           Text.Printf             (printf)
@@ -371,19 +373,19 @@ coreTypeToHWType
   -- ^ Type to convert to HWType
   -> State HWMap (Either String FilteredHWType)
 coreTypeToHWType builtInTranslation reprs m ty = do
-  htyM <- HashMap.lookup ty <$> get
+  htyM <- Map.lookup ty <$> get
   case htyM of
     Just hty -> return hty
     _ -> do
       hty0M <- builtInTranslation reprs m ty
       hty1  <- go hty0M ty
-      modify (HashMap.insert ty hty1)
+      modify (Map.insert ty hty1)
       return hty1
  where
   -- Try builtin translation; for now this is hardcoded to be the one in ghcTypeToHWType
   go :: Maybe (Either String FilteredHWType)
      -> Type
-     -> State (HashMap Type (Either String FilteredHWType))
+     -> State (Map Type (Either String FilteredHWType))
               (Either String FilteredHWType)
   go (Just hwtyE) _ = pure $ maybeConvertToCustomRepr reprs ty <$> hwtyE
   -- Strip transparant types:
@@ -647,7 +649,7 @@ representableType
   -> Bool
 representableType builtInTranslation reprs stringRepresentable m =
     either (const False) isRepresentable .
-    flip evalState HashMap.empty .
+    flip evalState mempty .
     coreTypeToHWType' builtInTranslation reprs m
   where
     isRepresentable hty = case hty of

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -312,7 +312,7 @@ constantSpec ctx@(TransformContext is0 tfCtx) e@(App e1 e2)
 constantSpec _ e = return e
 {-# SCC constantSpec #-}
 
--- | Specialise an application on its argument
+-- | Specialize an application on its argument
 specialize :: NormRewrite
 specialize ctx e = case e of
   (TyApp e1 ty) -> specialize' ctx e (collectArgsTicks e1) (Right ty)
@@ -342,7 +342,7 @@ We may also not want to look at ticks, as then the specialization cache will
 miss on virtually every lookup which could add to normalization time.
 -}
 
--- | Specialise an application on its argument
+-- | Specialize an application on its argument
 specialize'
   :: TransformContext
   -- ^ Transformation context
@@ -357,7 +357,7 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
   opts <- Lens.view debugOpts
   tcm <- Lens.view tcCache
 
-  -- Don't specialise TopEntities
+  -- Don't specialize TopEntities
   topEnts <- Lens.view topEntities
   if f `elemVarSet` topEnts
   then do
@@ -371,7 +371,7 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
         -- But using type equality constraints they may be syntactically polymorphic.
         -- > topEntity :: forall dom . (dom ~ "System") => Signal dom Bool -> Signal dom Bool
         -- The TyLam's in the body will have been removed by 'Clash.Normalize.Util.substWithTyEq'.
-        -- So we drop the TyApp ("specialising" on it) and change the varType to match.
+        -- So we drop the TyApp ("specializing" on it) and change the varType to match.
         let newVarTy = piResultTy tcm (coreTypeOf f) tyArg
         in  changed (mkApps (mkTicks (Var f{varType = newVarTy}) ticks) args)
   else do -- NondecreasingIndentation
@@ -402,7 +402,7 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
       bodyMaybe <- fmap (lookupUniqMap (varName f)) $ Lens.use bindings
       case bodyMaybe of
         Just (Binding _ sp inl _ bodyTm _) -> do
-          -- Determine if we see a sequence of specialisations on a growing argument
+          -- Determine if we see a sequence of specializations on a growing argument
           specHistM <- lookupUniqMap f <$> Lens.use (extra.specialisationHistory)
           specLim   <- Lens.use (extra . specialisationLimit)
           if maybe False (> specLim) specHistM

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -32,7 +32,6 @@ import Control.Monad.State                   (MonadState (..))
 import Control.Monad.State.Strict            (State)
 import Control.Monad.Writer                  (MonadWriter (..))
 import Data.Binary                           (Binary)
-import Data.Hashable                         (Hashable)
 import Data.HashMap.Strict                   (HashMap)
 import Data.IntMap.Strict                    (IntMap)
 import Data.Monoid                           (Any)
@@ -67,7 +66,7 @@ data RewriteStep
   -- ^ Term before `apply`
   , t_after  :: Term
   -- ^ Term after `apply`
-  } deriving (Show, Generic, NFData, Hashable, Binary)
+  } deriving (Show, Generic, NFData, Binary)
 
 -- | State of a rewriting session
 data RewriteState extra

--- a/clash-lib/src/GHC/SrcLoc/Extra.hs
+++ b/clash-lib/src/GHC/SrcLoc/Extra.hs
@@ -31,6 +31,12 @@ import SrcLoc
 import FastString                           (FastString (..), bytesFS, mkFastStringByteList)
 #endif
 
+
+#if MIN_VERSION_ghc(9,0,0)
+deriving instance Ord SrcSpan
+deriving instance Ord UnhelpfulSpanReason
+#endif
+
 deriving instance Generic SrcSpan
 instance Hashable SrcSpan
 


### PR DESCRIPTION
Hashable states that for an instance to be lawful it should observe that
`a == b` implies `hash a == hash b`. Note that without this law, the
resulting hash cannot be used in probabilistic data structures such as
`HashMap`s. Because `Eq Term` and `Eq Type` are defined such that they
account for alpha equivalency, an instance for `Hashable Term` is
non-trivial - and indeed unable to be derived with `Generic`. Hence, the
instance removed in this commit did not observe the proper laws.

While this commit chooses to remove the instance, this isn't strictly
necessary:

 * Krzysztof Maziarz et al, have shown that a lawful instance is possible
   with reasonable complexity bounds[1]. However, its implementation is
   non-trivial, and Clash's only valid use of the instance is in its
   netlist stage, where it is easily replaced by a reliance on `Ord`.

 * `Eq` and `Ord` could be defined such that they do *not* account for
   alpha equivalency. But, this would make them harder to use in various
   containers. (*~~This will be proposed as an alternative to this PR soon.~~* nvm, next weekend it is.)

[1] https://arxiv.org/abs/2105.02856

## CI failure
It currently fails CI, as the netlist needs term equality (not alpha equality) for it to work. Alternatively, `AnnType ann0 t` and `AnnType ann1 t` could be considered not alpha equivalent when `ann0 /= ann1`:

https://github.com/clash-lang/clash-compiler/blob/365cbde57dfeff67f4f971de9a076d5dc8ac1a72/clash-lib/src/Clash/Core/Subst.hs#L823-L828

In any case, I want to emphasize that the status quo is **completely broken**. It is not an option to keep `Hashable` as it is - it will make Clash probabilistically miss type annotations.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
  - [x] Pass CI
