### PR TITLE
Only perform no-notice change check in `AppliedName` debug mode

### DIFF
--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -245,7 +245,9 @@ applyDebug name exprOld hasChanged exprNew = do
                        ]
               )
 
-    Monad.when (dbg_invariants opts && not hasChanged && not (exprOld `aeqTerm` exprNew)) $
+    -- TODO find out a way to enable this again in DebugSilent mode without
+    -- making CI very slow.
+    Monad.when (hasDebugInfo AppliedName name opts && not hasChanged && not (exprOld `aeqTerm` exprNew)) $
       error $ $(curLoc) ++ "Expression changed without notice(" ++ name ++  "): before"
                         ++ before ++ "\nafter:\n" ++ after
 


### PR DESCRIPTION
We compile with `DebugSilent` in the testsuite, because it performs additional checks. But the "Expression changed without notice" check turned out to be very expensive, causing very long CI times.

So for now, we stop doing the check in DebugSilent mode.

Fixes #1987
