### PR TITLE
Use structural equality in "No notice change" check

### DIFF
--- a/changelog/2021-11-07T22_31_23+01_00_structural_equality
+++ b/changelog/2021-11-07T22_31_23+01_00_structural_equality
@@ -1,0 +1,1 @@
+ADDED: Structural equality on `Term` (`Clash.Core.Subst.eqTerm`) and `Type` (`Clash.Core.Subst.eqType`)

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -186,10 +186,16 @@ appProp :: HasCallStack => NormRewrite
 appProp ctx@(TransformContext is _) = \case
   e@App {}
     | let (fun,args,ticks) = collectArgsTicks e
-    -> go is (deShadowTerm is fun) args ticks
+    -> do (eN,hasChanged) <- Writer.listen (go is (deShadowTerm is fun) args ticks)
+          if Monoid.getAny hasChanged
+            then return eN
+            else return e
   e@TyApp {}
     | let (fun,args,ticks) = collectArgsTicks e
-    -> go is (deShadowTerm is fun) args ticks
+    -> do (eN,hasChanged) <- Writer.listen (go is (deShadowTerm is fun) args ticks)
+          if Monoid.getAny hasChanged
+            then return eN
+            else return e
   e          -> return e
  where
   go :: InScopeSet -> Term -> [Either Term Type] -> [TickInfo] -> NormalizeSession Term

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -68,7 +68,7 @@ import           Clash.Core.HasType
 import           Clash.Core.Name
 import           Clash.Core.Pretty           (showPpr)
 import           Clash.Core.Subst
-  (substTmEnv, aeqTerm, aeqType, extendIdSubst, mkSubst, substTm)
+  (substTmEnv, aeqTerm, aeqType, extendIdSubst, mkSubst, substTm, eqTerm)
 import           Clash.Core.Term
 import           Clash.Core.TyCon            (TyConMap)
 import           Clash.Core.Type             (Type (..), normalizeType)
@@ -245,7 +245,7 @@ applyDebug name exprOld hasChanged exprNew = do
                        ]
               )
 
-    Monad.when (dbg_invariants opts && not hasChanged && not (exprOld `aeqTerm` exprNew)) $
+    Monad.when (dbg_invariants opts && not hasChanged && not (exprOld `eqTerm` exprNew)) $
       error $ $(curLoc) ++ "Expression changed without notice(" ++ name ++  "): before"
                         ++ before ++ "\nafter:\n" ++ after
 

--- a/clash-lib/src/Data/List/Extra.hs
+++ b/clash-lib/src/Data/List/Extra.hs
@@ -11,6 +11,7 @@ module Data.List.Extra
   , equalLength
   , countEq
   , zipEqual
+  , all2
 
   -- * From Control.Monad.Extra
   , anyM
@@ -85,6 +86,13 @@ equalLength :: [a] -> [b] -> Bool
 equalLength [] [] = True
 equalLength (_:as) (_:bs) = equalLength as bs
 equalLength _ _ = False
+
+-- | Like 'all', but the predicate operates over two lists. Asserts to 'False'
+-- when the lists are of unequal length
+all2 :: (a -> b -> Bool) -> [a] -> [b] -> Bool
+all2 _ [] [] = True
+all2 p (a:as) (b:bs) = p a b && all2 p as bs
+all2 _ _ _ = False
 
 -- | Return number of occurrences of an item in a list
 countEq


### PR DESCRIPTION
This brings the `DebugSilent` run for Reducer down from 4m30s to 13s. A very welcome improvement for CI.

Fixes #1987

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
