### PR TITLE
Change bit indexing to use `Word` parameter in `replaceBit#` (#1983)

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -2022,11 +2022,11 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
         op :: KnownNat n => BitVector n -> Int -> Proxy n -> (Integer,Integer)
         op u i _ = (toInteger m, toInteger v)
           where Bit m v = (BitVector.index# u i)
-  "Clash.Sized.Internal.BitVector.replaceBit#" -- :: :: KnownNat n => BitVector n -> Int -> Bit -> BitVector n
+  "Clash.Sized.Internal.BitVector.replaceBit#" -- :: :: KnownNat n => BitVector n -> Word -> Bit -> BitVector n
     | Just (_, n) <- extractKnownNat tcm tys
     , [ _
       , PrimVal bvP _ [_, Lit (NaturalLiteral mskBv), Lit (IntegerLiteral bv)]
-      , valArgs -> Just [Literal (IntLiteral i)]
+      , valArgs -> Just [Literal (WordLiteral i)]
       , PrimVal bP _ [Lit (WordLiteral mskB), Lit (IntegerLiteral b)]
       ] <- args
     , primName bvP == "Clash.Sized.Internal.BitVector.fromInteger#"
@@ -2039,7 +2039,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
       where
         op :: KnownNat n => BitVector n -> Int -> Bit -> Proxy n -> (Integer,Integer)
         -- op bv i b _ = (BitVector.unsafeMask res, BitVector.unsafeToInteger res)
-        op bv i b _ = splitBV (BitVector.replaceBit# bv i b)
+        op bv i b _ = splitBV (BitVector.replaceBit# bv (fromIntegral i) b)
   "Clash.Sized.Internal.BitVector.setSlice#"
   -- :: SNat (m+1+i) -> BitVector (m + 1 + i) -> SNat m -> SNat n -> BitVector (m + 1 - n) -> BitVector (m + 1 + i)
     | mTy : iTy : nTy : _ <- tys

--- a/clash-prelude/src/Clash/Prelude/BitIndex.hs
+++ b/clash-prelude/src/Clash/Prelude/BitIndex.hs
@@ -94,7 +94,7 @@ split v = split# (pack v)
 -- *** Exception: replaceBit: 6 is out of range [5..0]
 -- ...
 replaceBit :: (BitPack a, Enum i) => i -> Bit -> a -> a
-replaceBit i b v = unpack (replaceBit# (pack v) (fromEnum i) b)
+replaceBit i b v = unpack (replaceBit# (pack v) (fromIntegral . fromEnum $ i) b)
 
 {-# INLINE setSlice #-}
 -- | Set the bits between bit index @m@ and bit index @n@.

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -735,7 +735,7 @@ instance KnownNat n => CoArbitrary (Signed n) where
 type instance Index   (Signed n) = Int
 type instance IxValue (Signed n) = Bit
 instance KnownNat n => Ixed (Signed n) where
-  ix i f s = unpack# <$> BV.replaceBit# (pack# s) i
+  ix i f s = unpack# <$> BV.replaceBit# (pack# s) (fromIntegral i)
                      <$> f (BV.index# (pack# s) i)
 
 instance (KnownNat n) => Ix (Signed n) where

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -655,7 +655,7 @@ instance KnownNat n => CoArbitrary (Unsigned n) where
 type instance Index   (Unsigned n) = Int
 type instance IxValue (Unsigned n) = Bit
 instance KnownNat n => Ixed (Unsigned n) where
-  ix i f s = unpack# <$> BV.replaceBit# (pack# s) i
+  ix i f s = unpack# <$> BV.replaceBit# (pack# s) (fromIntegral i)
                      <$> f (BV.index# (pack# s) i)
 
 instance (KnownNat n) => Ix (Unsigned n) where


### PR DESCRIPTION
This is more of a proof-of-concept for #1983 than a fully tested fix. With it applied, I can see that it is an effective workaround for https://github.com/YosysHQ/yosys/issues/3051, at least in the simple case. I haven't tried anything more complex yet; a good test case should be https://github.com/gergoerdi/clash-calculator which is where I initially noticed this.