### PR TITLE
Show days when pretty printing durations

### DIFF
--- a/changelog/2021-11-09T16_33_04+01_00_show_days_time.md
+++ b/changelog/2021-11-09T16_33_04+01_00_show_days_time.md
@@ -1,0 +1,1 @@
+CHANGED: Clash now shows days in time strings for compile runs which take longer than a day [#1989](https://github.com/clash-lang/clash-compiler/compare/issue-1989).

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -263,11 +263,11 @@ pkgIdFromTypeable :: Typeable a => a -> String
 pkgIdFromTypeable = tyConPackage . typeRepTyCon . typeOf
 
 reportTimeDiff :: UTCTime -> UTCTime -> String
-reportTimeDiff start end =
+reportTimeDiff end start =
   Clock.formatTime Clock.defaultTimeLocale fmt
     (Clock.UTCTime (toEnum 0) (fromRational (toRational diff)))
  where
-  diff = Clock.diffUTCTime start end
+  diff = Clock.diffUTCTime end start
   fmt  | diff >= 86400
        = "%-Dd%-Hh%-Mm%-S%03Qs"
        | diff >= 3600

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -268,7 +268,9 @@ reportTimeDiff start end =
     (Clock.UTCTime (toEnum 0) (fromRational (toRational diff)))
  where
   diff = Clock.diffUTCTime start end
-  fmt  | diff >= 3600
+  fmt  | diff >= 86400
+       = "%-Dd%-Hh%-Mm%-S%03Qs"
+       | diff >= 3600
        = "%-Hh%-Mm%-S%03Qs"
        | diff >= 60
        = "%-Mm%-S%03Qs"

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -269,11 +269,11 @@ reportTimeDiff end start =
  where
   diff = Clock.diffUTCTime end start
   fmt  | diff >= 86400
-       = "%-Dd%-Hh%-Mm%-S%03Qs"
+       = "%-Dd%-Hh%-Mm%-Ss"
        | diff >= 3600
-       = "%-Hh%-Mm%-S%03Qs"
+       = "%-Hh%-Mm%-Ss"
        | diff >= 60
-       = "%-Mm%-S%03Qs"
+       = "%-Mm%-Ss"
        | otherwise
        = "%-S%03Qs"
 

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -263,14 +263,15 @@ pkgIdFromTypeable :: Typeable a => a -> String
 pkgIdFromTypeable = tyConPackage . typeRepTyCon . typeOf
 
 reportTimeDiff :: UTCTime -> UTCTime -> String
-reportTimeDiff end start =
-  Clock.formatTime Clock.defaultTimeLocale fmt
+reportTimeDiff end start
+  | diff >= Clock.nominalDay = show days <> "d" <> Clock.formatTime Clock.defaultTimeLocale fmt
+    (Clock.UTCTime (toEnum 0) (fromRational (toRational hms)))
+  | otherwise = Clock.formatTime Clock.defaultTimeLocale fmt
     (Clock.UTCTime (toEnum 0) (fromRational (toRational diff)))
  where
   diff = Clock.diffUTCTime end start
-  fmt  | diff >= 86400
-       = "%-Dd%-Hh%-Mm%-Ss"
-       | diff >= 3600
+  (days,hms) = divMod @Integer (floor diff) (floor Clock.nominalDay)
+  fmt  | diff >= 3600
        = "%-Hh%-Mm%-Ss"
        | diff >= 60
        = "%-Mm%-Ss"


### PR DESCRIPTION
When showing time stats for parts of Clash, if something takes longer
than a day, it shows as 23h59mXs, where X is some large number of
seconds. When a can be measured in days, it should instead show a
message like '2d7h30m45s' instead.

Closes #1989

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
