### PR TITLE
Don't prefix package name in `_types` package in VHDL

### DIFF
--- a/changelog/2021-11-11T11_29_26+01_00_unqualify_package_body_vhdl.md
+++ b/changelog/2021-11-11T11_29_26+01_00_unqualify_package_body_vhdl.md
@@ -1,0 +1,1 @@
+CHANGED: Types defined in the package head are no longer qualified in the package body when rendering VHDL [#1996](https://github.com/clash-lang/clash-compiler/issues/1996).

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -548,6 +548,7 @@ runClashTest = defaultMain $ clashTestRoot
             hdlTargets=[VHDL]
           , expectClashFail=Just (NoTestExitCode, "NOT:WARNING")
           }
+        , outputTest "T1996" def{hdlTargets=[VHDL]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T1996.hs
+++ b/tests/shouldwork/Issues/T1996.hs
@@ -1,0 +1,25 @@
+module T1996 where
+
+import qualified Prelude as P
+import           Data.List (isInfixOf)
+import           System.Environment (getArgs)
+import           System.FilePath ((</>), takeDirectory)
+
+import           Clash.Prelude
+
+topEntity :: (Int, Int) -> (Int, Int)
+topEntity = id
+
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | needle `isInfixOf` haystack =
+      P.error $ P.concat [ "Did not expect:\n\n  ", needle
+                         , "\n\nIn:\n\n", haystack ]
+  | otherwise = return ()
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content  <- readFile (topDir </> show 'topEntity </> "T1996_topEntity_types.vhdl")
+
+  assertNotIn "T1996_topEntity_types." content


### PR DESCRIPTION
Similar to ece7f26 for SystemVerilog, types should not appear
qualified in the package body for the types package in VHDL.

Fixes #1996.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
