### PR TITLE
Keep recursion info in BindingMap

### DIFF
--- a/changelog/2021-11-12T16_43_20+01_00_recursion_info_bindings.md
+++ b/changelog/2021-11-12T16_43_20+01_00_recursion_info_bindings.md
@@ -1,0 +1,1 @@
+CHANGED: Clash now stores recursion info in the Binding type, which can be used to avoid free variable checks

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -226,7 +226,7 @@ splitTopEntityT
   -> TopEntityT
 splitTopEntityT tcm bindingsMap tt@(TopEntityT id_ (Just t@(Synthesize {})) _) =
   case lookupVarEnv id_ bindingsMap of
-    Just (Binding _id sp _ _ _) ->
+    Just (Binding _id sp _ _ _ _) ->
       tt{topAnnotation=Just (splitTopAnn tcm sp (coreTypeOf id_) t)}
     Nothing ->
       error "Internal error in 'splitTopEntityT'. Please report as a bug."

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -79,6 +79,11 @@ data Binding a = Binding
     -- ^ The term representation for this binding. This is polymorphic so
     -- alternate representations can be used if more appropriate (i.e. in the
     -- evaluator this can be Value for evaluated bindings).
+  , bindingRecursive :: Bool
+    -- ^ Whether the binding is recursive.
+    --
+    -- TODO Ideally the BindingMap would store recursive and non-recursive
+    -- bindings in a way similar to Let / Letrec. GHC also does this.
   } deriving (Binary, Functor, Generic, NFData, Show)
 
 -- | Global function binders

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -376,7 +376,7 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
       -- Determine if we can specialize f
       bodyMaybe <- fmap (lookupUniqMap (varName f)) $ Lens.use bindings
       case bodyMaybe of
-        Just (Binding _ sp inl _ bodyTm) -> do
+        Just (Binding _ sp inl _ bodyTm _) -> do
           -- Determine if we see a sequence of specialisations on a growing argument
           specHistM <- lookupUniqMap f <$> Lens.use (extra.specialisationHistory)
           specLim   <- Lens.use (extra . specialisationLimit)

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -408,7 +408,7 @@ normalizeTopLvlBndr
   -> Id
   -> Binding Term
   -> NormalizeSession (Binding Term)
-normalizeTopLvlBndr isTop nm (Binding nm' sp inl pr tm) = makeCachedU nm (extra.normalized) $ do
+normalizeTopLvlBndr isTop nm (Binding nm' sp inl pr tm _) = makeCachedU nm (extra.normalized) $ do
   tcm <- Lens.view tcCache
   let nmS = showPpr (varName nm)
   -- We deshadow the term because sometimes GHC gives us
@@ -422,7 +422,8 @@ normalizeTopLvlBndr isTop nm (Binding nm' sp inl pr tm) = makeCachedU nm (extra.
   tm3 <- rewriteExpr ("normalization",normalization) (nmS,tm2) (nm',sp)
   curFun .= old
   let ty' = inferCoreTypeOf tcm tm3
-  return (Binding nm'{varType = ty'} sp inl pr tm3)
+  let r' = nm' `globalIdOccursIn` tm3
+  return (Binding nm'{varType = ty'} sp inl pr tm3 r')
 
 -- | Turn type equality constraints into substitutions and apply them.
 --


### PR DESCRIPTION
In GenerateBindings, the recursion information about global bindings
is currently discarded by Clash. However, much like the recursion info
for let bindings, this can be used to make the partial evaluator more
efficient - as non-recursive global bindings can always be inlined
without consuming fuel.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
