### PR TITLE
Fix asyncRam#: multiple clocks, undefineds, laziness, seqX

### DIFF
--- a/changelog/2021-11-19T16_19_41+01_00_asyncram_multi_clk_fix
+++ b/changelog/2021-11-19T16_19_41+01_00_asyncram_multi_clk_fix
@@ -1,0 +1,2 @@
+FIXED: `asyncRam` with different read and write clocks produced the wrong results in Haskell simulation.([#2006](https://github.com/clash-lang/clash-compiler/pull/2006))
+FIXED: `Clash.Explicit.RAM.asyncRam#` incorrectly treated an _undefined_ write enable as asserted. It now causes an _undefined_ value to be written instead. This problem did not propagate to the other `asyncRam` functions, where the same condition would simultaneously lead to an undefined write address, which would be handled correctly.([#2006](https://github.com/clash-lang/clash-compiler/pull/2006))

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -409,6 +409,7 @@ test-suite unittests
                  Clash.Tests.FixedExhaustive
                  Clash.Tests.NFDataX
                  Clash.Tests.NumNewtypes
+                 Clash.Tests.Ram
                  Clash.Tests.Reset
                  Clash.Tests.Resize
                  Clash.Tests.Signal

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -235,7 +235,7 @@ we need to disregard the first few output samples, because the initial content o
 'Clash.Prelude.RAM.asyncRam' is /undefined/, and consequently, the first few
 output samples are also /undefined/. We use the utility function
 'Clash.XException.printX' to conveniently filter out the undefinedness and
-replace it with the string "X" in the few leading outputs.
+replace it with the string @\"undefined\"@ in the first few leading outputs.
 
 @
 >>> printX $ sampleN 32 $ system2 prog systemClockGen resetGen enableGen
@@ -365,7 +365,7 @@ prog2 = -- 0 := 4
 When we simulate our system we see that it works. This time again,
 we need to disregard the first sample, because the initial output of a
 'blockRam' is /undefined/. We use the utility function 'Clash.XException.printX'
-to conveniently filter out the undefinedness and replace it with the string "X".
+to conveniently filter out the undefinedness and replace it with the string @\"undefined\"@.
 
 @
 >>> printX $ sampleN 34 $ system3 prog2 systemClockGen resetGen enableGen
@@ -718,7 +718,8 @@ prog2 = -- 0 := 4
 -- | Create a blockRAM with space for @n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is /undefined/
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'XException'
 --
 -- @
 -- bram40
@@ -764,7 +765,8 @@ blockRam = \clk gen content rd wrM ->
 -- | Create a blockRAM with space for 2^@n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is /undefined/
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'XException'
 --
 -- @
 -- bram32
@@ -791,9 +793,7 @@ blockRamPow2
   -> Enable dom
   -- ^ Global enable
   -> Vec (2^n) a
-  -- ^ Initial content of the BRAM, also
-  -- determines the size, @2^n@, of
-  -- the BRAM.
+  -- ^ Initial content of the BRAM
   --
   -- __NB__: __MUST__ be a constant.
   -> Signal dom (Unsigned n)
@@ -811,7 +811,7 @@ data ResetStrategy (r :: Bool) where
   ClearOnReset :: ResetStrategy 'True
   NoClearOnReset :: ResetStrategy 'False
 
--- | Version of blockram that has no default values set. May be cleared to a
+-- | Version of blockram that has no default values set. May be cleared to an
 -- arbitrary state using a reset function.
 blockRamU
    :: forall n dom a r addr
@@ -834,7 +834,7 @@ blockRamU
   -> SNat n
   -- ^ Number of elements in BRAM
   -> (Index n -> a)
-  -- ^ If applicable (see first argument), reset BRAM using this function.
+  -- ^ If applicable (see 'ResetStrategy' argument), reset BRAM using this function.
   -> Signal dom addr
   -- ^ Read address @r@
   -> Signal dom (Maybe (addr, a))

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -140,7 +140,8 @@ import Clash.XException      (errorX, maybeIsX, seqX, fromJustX, XException (..)
 -- | Create a blockRAM with space for 2^@n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'XException'
 -- * __NB__: This function might not work for specific combinations of
 -- code-generation backends and hardware targets. Please check the support table
 -- below:
@@ -186,7 +187,8 @@ blockRamFilePow2 = \clk en file rd wrM -> withFrozenCallStack
 -- | Create a blockRAM with space for @n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'XException'
 -- * __NB__: This function might not work for specific combinations of
 -- code-generation backends and hardware targets. Please check the support table
 -- below:

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -42,7 +42,8 @@ import Clash.XException       (deepErrorX, seqX, NFDataX)
 -- | A ROM with a synchronous read port, with space for 2^@n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 --
 -- Additional helpful information:
 --
@@ -68,7 +69,8 @@ romPow2 = rom
 -- | A ROM with a synchronous read port, with space for @n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 --
 -- Additional helpful information:
 --
@@ -81,7 +83,7 @@ rom
   -> Enable dom
   -- ^ Global enable
   -> Vec n a
-  -- ^ ROM content
+  -- ^ ROM content, also determines the size, @n@, of the ROM
   --
   -- __NB:__ must be a constant
   -> Signal dom addr
@@ -100,7 +102,7 @@ rom#
   -> Enable dom
   -- ^ Global enable
   -> Vec n a
-  -- ^ ROM content
+  -- ^ ROM content, also determines the size, @n@, of the ROM
   --
   -- __NB:__ must be a constant
   -> Signal dom Int

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -109,7 +109,8 @@ import Clash.XException             (NFDataX(deepErrorX))
 -- | A ROM with a synchronous read port, with space for 2^@n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 -- * __NB__: This function might not work for specific combinations of
 -- code-generation backends and hardware targets. Please check the support table
 -- below:
@@ -150,7 +151,8 @@ romFilePow2 = \clk en -> romFile clk en (pow2SNat (SNat @n))
 -- | A ROM with a synchronous read port, with space for @n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 -- * __NB__: This function might not work for specific combinations of
 -- code-generation backends and hardware targets. Please check the support table
 -- below:

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -1,9 +1,10 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2019, Myrtle Software Ltd,
-                  2017     , Google Inc.
+                  2017     , Google Inc.,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 BlockRAM primitives
 
@@ -231,10 +232,10 @@ system2 instrs = memOut
 
 Again, we can simulate our system and see that it works. This time however,
 we need to disregard the first few output samples, because the initial content of an
-'Clash.Prelude.RAM.asyncRam' is 'Clash.XException.undefined', and consequently, the first few
-output samples are also 'Clash.XException.undefined'. We use the utility function
+'Clash.Prelude.RAM.asyncRam' is /undefined/, and consequently, the first few
+output samples are also /undefined/. We use the utility function
 'Clash.XException.printX' to conveniently filter out the undefinedness and
-replace it with the string "X" in the few leading outputs.
+replace it with the string @\"undefined\"@ in the few leading outputs.
 
 @
 >>> printX $ sampleN @System 32 (system2 prog)
@@ -362,8 +363,8 @@ prog2 = -- 0 := 4
 
 When we simulate our system we see that it works. This time again,
 we need to disregard the first sample, because the initial output of a
-'blockRam' is 'Clash.XException.undefined'. We use the utility function 'Clash.XException.printX'
-to conveniently filter out the undefinedness and replace it with the string "X".
+'blockRam' is /undefined/. We use the utility function 'Clash.XException.printX'
+to conveniently filter out the undefinedness and replace it with the string @\"undefined\"@.
 
 @
 >>> printX $ sampleN @System 34 (system3 prog2)
@@ -674,7 +675,8 @@ prog2 = -- 0 := 4
 -- | Create a blockRAM with space for @n@ elements.
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'Clash.XException.undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 --
 -- @
 -- bram40
@@ -771,7 +773,8 @@ blockRam1 =
 -- | Create a blockRAM with space for 2^@n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'Clash.XException.undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 --
 -- @
 -- bram32
@@ -795,7 +798,7 @@ blockRamPow2
      , KnownNat n
      )
   => Vec (2^n) a
-  -- ^ Initial content of the BRAM, also determines the size, @2^n@, of the BRAM.
+  -- ^ Initial content of the BRAM
   --
   -- __NB__: __MUST__ be a constant.
   -> Signal dom (Unsigned n)

--- a/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
@@ -106,7 +106,8 @@ import           Clash.Sized.Unsigned         (Unsigned)
 -- | Create a blockRAM with space for 2^@n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 -- * __NB__: This function might not work for specific combinations of
 -- code-generation backends and hardware targets. Please check the support table
 -- below:
@@ -152,7 +153,8 @@ blockRamFilePow2 = \fp rd wrM -> withFrozenCallStack
 -- | Create a blockRAM with space for @n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 -- * __NB__: This function might not work for specific combinations of
 -- code-generation backends and hardware targets. Please check the support table
 -- below:

--- a/clash-prelude/src/Clash/Prelude/RAM.hs
+++ b/clash-prelude/src/Clash/Prelude/RAM.hs
@@ -1,9 +1,10 @@
 {-|
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017-2019, Myrtle Software Ltd
-                  2017     , Google Inc.
+                  2017     , Google Inc.,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 RAM primitives with a combinational read port.
 -}
@@ -34,7 +35,8 @@ import           Clash.Sized.Unsigned (Unsigned)
 
 -- | Create a RAM with space for @n@ elements.
 --
--- * __NB__: Initial content of the RAM is 'undefined'
+-- * __NB__: Initial content of the RAM is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 --
 -- Additional helpful information:
 --
@@ -60,7 +62,8 @@ asyncRam = \sz rd wrM -> withFrozenCallStack
 
 -- | Create a RAM with space for 2^@n@ elements
 --
--- * __NB__: Initial content of the RAM is 'undefined'
+-- * __NB__: Initial content of the RAM is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 --
 -- Additional helpful information:
 --

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -1,9 +1,10 @@
 {-|
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017     , Google Inc.
-                  2019     , Myrtle Software Ltd
+                  2019     , Myrtle Software Ltd,
+                  2021     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 ROMs
 -}
@@ -50,7 +51,7 @@ import           Clash.XException     (NFDataX, errorX)
 asyncRom
   :: (KnownNat n, Enum addr)
   => Vec n a
-  -- ^ ROM content
+  -- ^ ROM content, also determines the size, @n@, of the ROM
   --
   -- __NB:__ must be a constant
   -> addr
@@ -83,7 +84,7 @@ asyncRomPow2 = asyncRom
 asyncRom#
   :: forall n a . KnownNat n
   => Vec n a
-  -- ^ ROM content
+  -- ^ ROM content, also determines the size, @n@, of the ROM
   --
   -- __NB:__ must be a constant
   -> Int
@@ -122,7 +123,7 @@ rom
      , HiddenClock dom
      , HiddenEnable dom  )
   => Vec n a
-  -- ^ ROM content
+  -- ^ ROM content, also determines the size, @n@, of the ROM
   --
   -- __NB:__ must be a constant
   -> Signal dom (Unsigned m)
@@ -135,7 +136,8 @@ rom = hideEnable (hideClock E.rom)
 -- | A ROM with a synchronous read port, with space for 2^@n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 --
 -- Additional helpful information:
 --

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -158,7 +158,7 @@ asyncRomFile
   -> BitVector m
   -- ^ The value of the ROM at address @rd@
 asyncRomFile sz file = asyncRomFile# sz file . fromEnum
--- Leave 'asyncRom' eta-reduced, see Note [Eta-reduction and unsafePerformIO initMem]
+-- Leave 'asyncRomFile#' eta-reduced, see Note [Eta-reduction and unsafePerformIO initMem]
 {-# INLINE asyncRomFile #-}
 
 -- Note [Eta-reduction and unsafePerformIO initMem]
@@ -257,7 +257,8 @@ asyncRomFile# sz file = (content !) -- Leave "(content !)" eta-reduced, see
 -- | A ROM with a synchronous read port, with space for @n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 -- * __NB__: This function might not work for specific combinations of
 -- code-generation backends and hardware targets. Please check the support table
 -- below:
@@ -298,7 +299,8 @@ romFile = hideEnable (hideClock E.romFile)
 -- | A ROM with a synchronous read port, with space for 2^@n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 -- * __NB__: This function might not work for specific combinations of
 -- code-generation backends and hardware targets. Please check the support table
 -- below:

--- a/clash-prelude/tests/Clash/Tests/Ram.hs
+++ b/clash-prelude/tests/Clash/Tests/Ram.hs
@@ -1,0 +1,130 @@
+-- Assert correct behavior:
+--
+-- Undefined enable:
+--    The written-to address should read 'undefined', but other addresses
+--    should still have their data.
+--
+-- Undefined write address:
+--    All addresses should read 'undefined'.
+--
+-- OOB write address
+--    All addresses should read 'undefined.
+--
+-- Undefined write data:
+--    The written-to address should read 'undefined', but other addresses
+--    should still have their data.
+--
+-- Deasserted enable
+--    It shouldn't matter that other write inputs are 'undefined'.
+--
+-- Deasserted enable, OOB address
+--    It shouldn't matter that it is out of bounds.
+--
+-- OOB read address
+--    The sample should be undefined, nothing more.
+--
+-- Read address strictness
+--    If the read result is not used, out-of-bounds read address shouldn't
+--    matter (equivalent to issue #1458).
+
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Clash.Tests.Ram (tests) where
+
+import qualified Data.List as L
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.RAM
+
+type Ram = (   Signal System Int
+            -> Signal System Bool
+            -> Signal System Int
+            -> Signal System Int
+            -> Signal System (Maybe Int)
+           )
+
+ram :: Ram
+ram rd we wr din =
+  maybeIsX <$> asyncRam# clockGen clockGen enableGen d2 rd we wr din
+
+maskOobRead :: Ram
+maskOobRead rd we wr din =
+  maybeIsX <$> mux (rd .<. 2) ram0 (pure 4)
+ where
+  ram0 = asyncRam# clockGen clockGen enableGen d2 rd we wr din
+
+type Samples = [(Int, Bool, Int, Int, Maybe Int)]
+
+initMem, undefEn, undefWAddr, oobWAddr, undefWData, enFalse, enFalseOobWAddr,
+  oobRAddr, oobRAddrStrict
+  :: Samples
+
+--                               rd  enable     waddr      wdata      dout
+initMem =                     [ ( 0, True     , 0        , 0        , Nothing)
+                              , ( 0, True     , 1        , 1        , Just 0 )
+                              ]
+
+undefEn = initMem <>          [ ( 0, undefined, 0        , 2        , Just 0 )
+                              , ( 0, False    , 0        , 3        , Nothing)
+                              , ( 1, False    , 0        , 3        , Just 1 )
+                              ]
+
+undefWAddr = initMem <>       [ ( 0, True     , undefined, 2        , Just 0 )
+                              , ( 0, False    , 0        , 3        , Nothing)
+                              , ( 1, False    , 0        , 3        , Nothing)
+                              ]
+
+oobWAddr = initMem <>         [ ( 0, True     , 3        , 2        , Just 0 )
+                              , ( 0, False    , 0        , 3        , Nothing)
+                              , ( 1, False    , 0        , 3        , Nothing)
+                              ]
+
+undefWData = initMem <>       [ ( 0, True     , 0        , undefined, Just 0 )
+                              , ( 0, False    , 0        , 3        , Nothing)
+                              , ( 1, False    , 0        , 3        , Just 1 )
+                              ]
+
+enFalse = initMem <>          [ ( 0, False    , undefined, undefined, Just 0)
+                              , ( 0, False    , undefined, undefined, Just 0)
+                              , ( 1, False    , undefined, undefined, Just 1)
+                              ]
+
+enFalseOobWAddr = initMem <>  [ ( 0, False    , 255      , 2        , Just 0 )
+                              , ( 0, False    , 0        , 3        , Just 0 )
+                              , ( 1, False    , 0        , 3        , Just 1 )
+                              ]
+
+oobRAddr = initMem <>         [ ( 2, False    , 0        , 3        , Nothing)
+                              , ( 0, False    , 0        , 3        , Just 0 )
+                              , ( 1, False    , 0        , 3        , Just 1 )
+                              ]
+
+oobRAddrStrict = initMem <>   [ ( 1, False    , 0        , 3        , Just 1 )
+                              , ( 2, False    , 0        , 3        , Just 4 )
+                              , ( 0, False    , 0        , 3        , Just 0 )
+                              ]
+
+ramAssertion
+  :: Ram
+  -> Samples
+  -> Assertion
+ramAssertion ram0 samples = actual @?= expectedOutput
+ where
+  (rd, we, wr, din, expectedOutput) = L.unzip5 samples
+  actual = sampleN (L.length samples) $ ram0 (fromList rd)
+                                             (fromList we)
+                                             (fromList wr)
+                                             (fromList din)
+tests :: TestTree
+tests = testGroup "Ram"
+  [ testCase "Undefined enable" $ ramAssertion ram undefEn
+  , testCase "Undefined write address" $ ramAssertion ram undefWAddr
+  , testCase "OOB write address" $ ramAssertion ram oobWAddr
+  , testCase "Undefined write data" $ ramAssertion ram undefWData
+  , testCase "Deasserted enable" $ ramAssertion ram enFalse
+  , testCase "Deasserted enable, OOB address" $ ramAssertion ram enFalseOobWAddr
+  , testCase "OOB read address" $ ramAssertion ram oobRAddr
+  , testCase "Read address strictness" $ ramAssertion maskOobRead oobRAddrStrict
+  ]

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -12,6 +12,7 @@ import qualified Clash.Tests.Fixed
 import qualified Clash.Tests.FixedExhaustive
 import qualified Clash.Tests.NFDataX
 import qualified Clash.Tests.NumNewtypes
+import qualified Clash.Tests.Ram
 import qualified Clash.Tests.Reset
 import qualified Clash.Tests.Resize
 import qualified Clash.Tests.Signal
@@ -35,6 +36,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.FixedExhaustive.tests
   , Clash.Tests.NFDataX.tests
   , Clash.Tests.NumNewtypes.tests
+  , Clash.Tests.Ram.tests
   , Clash.Tests.Reset.tests
   , Clash.Tests.Resize.tests
   , Clash.Tests.Signal.tests

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -653,6 +653,11 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "AndSpecificEnable" def
 #endif
         , runTest "Ram" def
+        , clashTestGroup "Ram"
+          [ runTest "RMultiTop" def
+          , runTest "RWMulti35" def
+          , runTest "RWMulti53" def
+          ]
         , runTest "ResetGen" def
         , runTest "RomFile" def
         , outputTest "BlockRamLazy" def

--- a/tests/shouldwork/Signal/Ram/RMulti.hs
+++ b/tests/shouldwork/Signal/Ram/RMulti.hs
@@ -1,0 +1,47 @@
+-- An asyncRam with different read and write clocks
+--
+-- Test reading with a fast clock. Memory is initialized through the write port,
+-- but after that the write side is dormant.
+module RMulti where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+import qualified Prelude as P
+
+createDomain vSystem{vName="P10", vPeriod=10000}
+createDomain vSystem{vName="P20", vPeriod=20000}
+
+ram
+  :: Clock P20
+  -> Clock P10
+  -> Signal P10 (Unsigned 1)
+  -> Signal P20 (Maybe (Unsigned 1, Unsigned 2))
+  -> Signal P10 (Unsigned 2)
+ram wClk rClk = asyncRamPow2 wClk rClk enableGen
+
+tbOutput
+  :: Clock P20
+  -> Clock P10
+  -> Signal P10 (Unsigned 2)
+tbOutput wClk rClk = output
+ where
+  wrM = stimuliGenerator wClk wNoReset $
+          Just (0, 1) :> Just (1,2) :> Nothing :> Nil
+  rd = delay rClk enableGen 0 $ rd + 1
+  output = ignoreFor rClk rNoReset enableGen d2 0 $ ram wClk rClk rd wrM
+  wNoReset = unsafeFromHighPolarity @P20 (pure False)
+  rNoReset = unsafeFromHighPolarity @P10 (pure False)
+
+tb
+  :: ( KnownNat n
+     , 1 <= n)
+  => Vec n (Unsigned 2)
+  -> Signal P10 Bool
+tb expectedSamples = done
+ where
+  output = tbOutput wClk rClk
+  expectedOutput = outputVerifier' rClk noReset expectedSamples
+  done = expectedOutput output
+  (rClk, wClk) = biTbClockGen (not <$> done) :: (Clock P10, Clock P20)
+  noReset = unsafeFromHighPolarity @P10 (pure False)
+{-# INLINE tb #-}

--- a/tests/shouldwork/Signal/Ram/RMultiTop.hs
+++ b/tests/shouldwork/Signal/Ram/RMultiTop.hs
@@ -1,0 +1,19 @@
+module RMultiTop where
+
+import Clash.Explicit.Prelude
+
+import RMulti
+
+topEntity
+  :: Clock P20
+  -> Clock P10
+  -> Signal P10 (Unsigned 1)
+  -> Signal P20 (Maybe (Unsigned 1, Unsigned 2))
+  -> Signal P10 (Unsigned 2)
+topEntity = ram
+{-# NOINLINE topEntity #-}
+
+testBench
+  :: Signal P10 Bool
+testBench = tb $(listToVecTH $ sampleN 20 $ tbOutput clockGen clockGen)
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Signal/Ram/RWMulti.hs
+++ b/tests/shouldwork/Signal/Ram/RWMulti.hs
@@ -1,0 +1,80 @@
+-- An asyncRam with different read and write clocks
+--
+-- Test write-port-to-read-port data propagation behavior for clocks with a
+-- small coprime factor in the periods. When active edges on both ports
+-- coincide, it should exhibit "read old data" behavior.
+--
+-- The following diagrams show the expected behavior. Time is on the horizontal
+-- axis, data is located at the time of the respective active edge. 'w' is the
+-- data being written to the RAM and 'r' is the data read from the RAM. Two
+-- diagrams are given, depending on which of the two clocks is the slower one.
+--
+-- Period relation 5-3 / 3-5:
+--
+-- w 0    1    2    3    4    5    6    7    8    9
+-- r X  0  1  1  2  2  3  4  4  5  5  6  7  7  8  8
+--
+-- w 0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+-- r X    1    3    4    6    8    9    B    D    E
+
+{-# OPTIONS_GHC "-Wno-orphans" #-}
+
+module RWMulti where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+createDomain vSystem{vName="P30", vPeriod=30000}
+createDomain vSystem{vName="P50", vPeriod=50000}
+
+ram
+  :: forall wdom rdom
+   . ( KnownDomain rdom
+     , KnownDomain wdom)
+  => Clock wdom
+  -> Clock rdom
+  -> Signal wdom (Unsigned 4)
+  -> Signal rdom (Unsigned 4)
+ram wClk rClk wrD = asyncRamPow2 wClk rClk enableGen rd wrM
+ where
+  rd = pure (0 :: Unsigned 1)
+  wrM = (\d -> Just (0, d)) <$> wrD
+
+tbOutput
+  :: forall wdom rdom
+   . ( KnownDomain rdom
+     , KnownDomain wdom)
+  => (  Clock wdom
+      -> Clock rdom
+      -> Signal wdom (Unsigned 4)
+      -> Signal rdom (Unsigned 4))
+  -> Clock wdom
+  -> Clock rdom
+  -> Signal rdom (Unsigned 4)
+tbOutput top wClk rClk = output
+ where
+  wrD = delay wClk enableGen 0 $ wrD + 1
+  output = ignoreFor rClk noReset enableGen d1 0 $ top wClk rClk wrD
+  noReset = unsafeFromHighPolarity @rdom (pure False)
+{-# INLINE tbOutput #-}
+
+tb
+  :: forall wdom rdom n
+   . ( KnownDomain rdom
+     , KnownDomain wdom
+     , KnownNat n
+     , 1 <= n)
+  => (  Clock wdom
+      -> Clock rdom
+      -> Signal wdom (Unsigned 4)
+      -> Signal rdom (Unsigned 4))
+  -> Vec n (Unsigned 4)
+  -> Signal rdom Bool
+tb top expectedSamples = done
+ where
+  output = tbOutput top wClk rClk
+  expectedOutput = outputVerifier' rClk noReset expectedSamples
+  done = expectedOutput output
+  (rClk, wClk) = biTbClockGen (not <$> done) :: (Clock rdom, Clock wdom)
+  noReset = unsafeFromHighPolarity @rdom (pure False)
+{-# INLINE tb #-}

--- a/tests/shouldwork/Signal/Ram/RWMulti35.hs
+++ b/tests/shouldwork/Signal/Ram/RWMulti35.hs
@@ -1,0 +1,21 @@
+module RWMulti35 where
+
+import Clash.Prelude
+
+import RWMulti
+
+topEntity
+  :: Clock P30
+  -> Clock P50
+  -> Signal P30 (Unsigned 4)
+  -> Signal P50 (Unsigned 4)
+topEntity = ram
+{-# NOINLINE topEntity #-}
+
+testBench
+  :: Signal P50 Bool
+testBench =
+  tb topEntity $(listToVecTH
+                 $ sampleN 20 $ tbOutput (ram @P30 @P50) clockGen clockGen)
+-- testBench = tb topEntity $(listToVecTH [0 :: Unsigned 4, 1, 3, 4, 6, 8, 9, 11, 13, 14])
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Signal/Ram/RWMulti53.hs
+++ b/tests/shouldwork/Signal/Ram/RWMulti53.hs
@@ -1,0 +1,22 @@
+module RWMulti53 where
+
+import Clash.Prelude
+
+import RWMulti
+
+topEntity
+  :: Clock P50
+  -> Clock P30
+  -> Signal P50 (Unsigned 4)
+  -> Signal P30 (Unsigned 4)
+topEntity = ram
+{-# NOINLINE topEntity #-}
+
+testBench
+  :: Signal P30 Bool
+testBench =
+  tb topEntity $(listToVecTH
+                 $ sampleN 20 $ tbOutput (ram @P50 @P30) clockGen clockGen)
+-- testBench = tb topEntity $(listToVecTH [0 :: Unsigned 4, 0, 1, 1, 2, 2, 3, 4,
+--                                         4, 5, 5, 6, 7, 7, 8, 8])
+{-# NOINLINE testBench #-}


### PR DESCRIPTION
1. In Haskell simulation, the way read samples were produced, with
`unsafeSynchronizer`, was simply wrong. It would compress and duplicate
samples while traversing clock domains, which is not a correct model of
how it works.

The generated HDL was fine, it only affected Haskell simulation.

2. The Haskell model of `asyncRAM#` treated an _undefined_ write enable
as an asserted enable. But an _undefined_ value in Haskell can
correspond to any value whatsoever in HDL, so HDL simulation might or
might not write. With this commit, the `XException` of the write enable
is written as the value in the RAM, since it could have either been
written to or not been written to. On the next read of that address, it
will return the `XException`.

This issue did not propagate to `asyncRam` and `asyncRamPow2`, since
there, the same condition also causes the write address to be undefined,
and this is properly handled by the primitive.

3. The Haskell model threw an `XException` when an out-of-bounds write
address was used, halting simulation, as the whole `Signal` evaluated to
`XException`, not just the sample. Now, every address in RAM is
filled with an `XException`, to model that an OOB address might get
treated as some actual address in hardware.

4. The `asyncRAM#` primitive was also too strict in most of its inputs.
Combinatorially feeding the read output to the write-side inputs would
lock up the simulation, while it is a valid circuit. This problem did
not propagate to the `asyncRam` and `asyncRamPow2` functions, which are
lazy enough because the signals go through `Signal`'s `fmap` and `<*>`.

5. Several `seq(X)`s have been added to avoid memory leaks.

Additionally, documentation for memory components was harmonized and
corrected.


By the way, I did not copy the multi-clock `Signal` traversal from `veryUnsafeSynchronizer`. Rather, I only took the concept of a relative timekeeping from it, which allows using `Int` as the value doesn't grow as time passes in the simulation. I constructed the multi-clock `Signal` traversal for `asyncRam` from scratch to gain a proper insight into its operation. In the end, it turned out to be nearly identical to `veryUnsafeSynchronizer` apart from the sign of `relTime` and the way signals propagate across the domain boundary (the latter is deliberate and matches simulation of the generated HDL).

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
