### PR TITLE
JSON compliant blackboxes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,8 @@
     80,
     90
   ],
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "files.associations": {
+    "*.primitives": "jsonc"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,6 @@
   ],
   "editor.tabSize": 2,
   "files.associations": {
-    "*.primitives": "jsonc"
+    "*.primitives": "json"
   }
 }

--- a/clash-lib/prims/common/Clash_Explicit_Signal.primitives
+++ b/clash-lib/prims/common/Clash_Explicit_Signal.primitives
@@ -3,11 +3,12 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type" :
-"veryUnsafeSynchronizer
-  :: Int                         -- ARG[0]
-  -> Int                         -- ARG[1]
-  -> Signal dom1 a               -- ARG[2]
-  -> Signal dom2 a"
+      [  "veryUnsafeSynchronizer"
+      , "  :: Int                         -- ARG[0]"
+      , "  -> Int                         -- ARG[1]"
+      , "  -> Signal dom1 a               -- ARG[2]"
+      , "  -> Signal dom2 a"
+      ]
     , "template"  : "~ARG[2]"
     }
   }

--- a/clash-lib/prims/common/Clash_Explicit_Testbench.primitives
+++ b/clash-lib/prims/common/Clash_Explicit_Testbench.primitives
@@ -3,14 +3,15 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type" :
-"unsafeSimSynchronizer
-  :: forall dom1 dom2 a
-   . ( KnownDomain dom1         -- ARG[0]
-     , KnownDomain dom2 )       -- ARG[1]
-  => Clock dom1                 -- ARG[2]
-  -> Clock dom2                 -- ARG[3]
-  -> Signal dom1 a              -- ARG[4]
-  -> Signal dom2 a"
+      [ "unsafeSimSynchronizer"
+      , "  :: forall dom1 dom2 a"
+      , "   . ( KnownDomain dom1         -- ARG[0]"
+      , "     , KnownDomain dom2 )       -- ARG[1]"
+      , "  => Clock dom1                 -- ARG[2]"
+      , "  -> Clock dom2                 -- ARG[3]"
+      , "  -> Signal dom1 a              -- ARG[4]"
+      , "  -> Signal dom2 a"
+      ]
     , "template"  : "~ARG[4]"
     , "warning"   : "Clash.Explicit.Testbench.unsafeSimSynchronizer is not safely synthesizable!"
     }

--- a/clash-lib/prims/common/Clash_Signal_BiSignal.primitives
+++ b/clash-lib/prims/common/Clash_Signal_BiSignal.primitives
@@ -3,13 +3,14 @@
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"veryUnsafeToBiSignalIn
-  :: ( HasCallStack                -- ARG[0]
-     , KnownNat n                  -- ARG[1]
-     , Given (SBiSignalDefault ds) -- ARG[2]
-     )
-  => BiSignalOut ds d n            -- ARG[3]
-  -> BiSignalIn ds d n"
+      [ "veryUnsafeToBiSignalIn"
+      , "  :: ( HasCallStack                -- ARG[0]"
+      , "     , KnownNat n                  -- ARG[1]"
+      , "     , Given (SBiSignalDefault ds) -- ARG[2]"
+      , "     )"
+      , "  => BiSignalOut ds d n            -- ARG[3]"
+      , "  -> BiSignalIn ds d n"
+      ]
     , "template" : "~DEVNULL[~ARG[3]]"
     }
   }
@@ -18,12 +19,13 @@
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"mergeBiSignalOuts
-  :: ( HasCallStack                         -- ARG[0]
-     , KnownNat n                           -- ARG[1]
-     )
-  => Vec n (BiSignalOut defaultState dom m) -- ARG[2]
-  -> BiSignalOut defaultState dom m"
+      [ "mergeBiSignalOuts"
+      , "  :: ( HasCallStack                         -- ARG[0]"
+      , "     , KnownNat n                           -- ARG[1]"
+      , "     )"
+      , "  => Vec n (BiSignalOut defaultState dom m) -- ARG[2]"
+      , "  -> BiSignalOut defaultState dom m"
+      ]
     , "template" : "~DEVNULL[~ARG[2]]"
     }
   }

--- a/clash-lib/prims/common/Clash_Signal_Trace.primitives
+++ b/clash-lib/prims/common/Clash_Signal_Trace.primitives
@@ -3,13 +3,14 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      :
-"traceSignal1
-  :: ( BitPack a    -- ARG[0]
-     , NFDataX a    -- ARG[1]
-     , Typeable a ) -- ARG[2]
-  => String         -- ARG[3]
-  -> Signal dom a   -- ARG[4]
-  -> Signal dom a"
+      [ "traceSignal1"
+      , "  :: ( BitPack a    -- ARG[0]"
+      , "     , NFDataX a    -- ARG[1]"
+      , "     , Typeable a ) -- ARG[2]"
+      , "  => String         -- ARG[3]"
+      , "  -> Signal dom a   -- ARG[4]"
+      , "  -> Signal dom a"
+    ]
     , "template" : "~ARG[4]"
     }
   }
@@ -18,14 +19,15 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      :
-"traceVecSignal1
-  :: ( KnownNat n             -- ARG[0]
-     , BitPack a              -- ARG[1]
-     , NFDataX a              -- ARG[2]
-     , Typeable a )           -- ARG[3]
-  => String                   -- ARG[4]
-  -> Signal dom (Vec (n+1) a) -- ARG[5]
-  -> Signal dom (Vec (n+1) a)"
+      [ "traceVecSignal1"
+      , "  :: ( KnownNat n             -- ARG[0]"
+      , "     , BitPack a              -- ARG[1]"
+      , "     , NFDataX a              -- ARG[2]"
+      , "     , Typeable a )           -- ARG[3]"
+      , "  => String                   -- ARG[4]"
+      , "  -> Signal dom (Vec (n+1) a) -- ARG[5]"
+      , "  -> Signal dom (Vec (n+1) a)"
+      ]
     , "template" : "~ARG[5]"
     }
   }
@@ -34,15 +36,16 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      :
-"traceSignal
-  :: forall dom a
-   . ( KnownDomain dom -- ARG[0]
-     , BitPack a       -- ARG[1]
-     , NFDataX a       -- ARG[2]
-     , Typeable a )    -- ARG[3]
-  => String            -- ARG[4]
-  -> Signal dom a      -- ARG[5]
-  -> Signal dom a"
+      [ "traceSignal"
+      , "  :: forall dom a"
+      , "   . ( KnownDomain dom -- ARG[0]"
+      , "     , BitPack a       -- ARG[1]"
+      , "     , NFDataX a       -- ARG[2]"
+      , "     , Typeable a )    -- ARG[3]"
+      , "  => String            -- ARG[4]"
+      , "  -> Signal dom a      -- ARG[5]"
+      , "  -> Signal dom a"
+      ]
     , "template" : "~ARG[5]"
     }
   }
@@ -51,16 +54,17 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      :
-"traceVecSignal
-  :: forall dom a n
-   . ( KnownDomain dom        -- ARG[0]
-     , KnownNat n             -- ARG[1]
-     , BitPack a              -- ARG[2]
-     , NFDataX a              -- ARG[3]
-     , Typeable a )           -- ARG[4]
-  => String                   -- ARG[5]
-  -> Signal dom (Vec (n+1) a) -- ARG[6]
-  -> Signal dom (Vec (n+1) a)"
+      [ "traceVecSignal"
+      , "  :: forall dom a n"
+      , "   . ( KnownDomain dom        -- ARG[0]"
+      , "     , KnownNat n             -- ARG[1]"
+      , "     , BitPack a              -- ARG[2]"
+      , "     , NFDataX a              -- ARG[3]"
+      , "     , Typeable a )           -- ARG[4]"
+      , "  => String                   -- ARG[5]"
+      , "  -> Signal dom (Vec (n+1) a) -- ARG[6]"
+      , "  -> Signal dom (Vec (n+1) a)"
+      ]
     , "template" : "~ARG[6]"
     }
   }

--- a/clash-lib/prims/common/GHC_IO_Exception.primitives
+++ b/clash-lib/prims/common/GHC_IO_Exception.primitives
@@ -3,11 +3,12 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "assertError :: HasCallStack => Bool -> a -> a"
-    , "comment"   : "It would be nice if we could use a HDL assertion, however,
-                     because in HDL, case alternatives are evaluated
-                     concurrently, we would end up with the assertion being
-                     triggered, even when the result of that branch is not
-                     chosen in the multiplexer"
+    , "comment"   : [ "It would be nice if we could use a HDL assertion, however,"
+                    , "because in HDL, case alternatives are evaluated"
+                    , "concurrently, we would end up with the assertion being"
+                    , "triggered, even when the result of that branch is not"
+                    , "chosen in the multiplexer"
+                    ]
     , "template"  : "~ARG[2]"
     }
   }

--- a/clash-lib/prims/commonverilog/Clash_Intel_DDR.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Intel_DDR.primitives
@@ -2,48 +2,50 @@
     { "name" : "Clash.Intel.DDR.altddioOut#"
     , "kind" : "Declaration"
     , "type" :
-"altddioOut#
-  :: ( HasCallStack             -- ARG[0]
-     , KnownConfi~ fast domf    -- ARG[1]
-     , KnownConfi~ slow doms    -- ARG[2]
-     , KnownNat m )             -- ARG[3]
-  => SSymbol deviceFamily       -- ARG[4]
-  -> Clock slow                 -- ARG[5]
-  -> Reset slow                 -- ARG[6]
-  -> Enable slow                -- ARG[7]
-  -> Signal slow (BitVector m)  -- ARG[8]
-  -> Signal slow (BitVector m)  -- ARG[9]
-  -> Signal fast (BitVector m)"
+      [ "altddioOut#"
+      , "  :: ( HasCallStack             -- ARG[0]"
+      , "     , KnownConfi~ fast domf    -- ARG[1]"
+      , "     , KnownConfi~ slow doms    -- ARG[2]"
+      , "     , KnownNat m )             -- ARG[3]"
+      , "  => SSymbol deviceFamily       -- ARG[4]"
+      , "  -> Clock slow                 -- ARG[5]"
+      , "  -> Reset slow                 -- ARG[6]"
+      , "  -> Enable slow                -- ARG[7]"
+      , "  -> Signal slow (BitVector m)  -- ARG[8]"
+      , "  -> Signal slow (BitVector m)  -- ARG[9]"
+      , "  -> Signal fast (BitVector m)"
+      ]
     , "libraries" : ["altera_mf"]
     , "template" :
-"// altddioOut begin
-altddio_out
-  #(
-    .extend_oe_disable (\"OFF\"),
-    .intended_device_family (~LIT[4]),
-    .invert_output (\"OFF\"),
-    .lpm_hint (\"UNUSED\"),
-    .lpm_type (\"altddio_out\"),
-    .oe_reg (\"UNREGISTERED\"),
-    .power_up_high (\"OFF\"),
-    .width (~SIZE[~TYPO])
-  )
-  ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] (~IF ~ISSYNC[2] ~THEN
-    .sclr (~ARG[6]),
-    .aclr (1'b0),~ELSE
-    .aclr (~ARG[6]),
-    .sclr (1'b0),~FI
-    .datain_h (~ARG[8]),
-    .datain_l (~ARG[9]),
-    .outclock (~ARG[5]),
-    .outclocken (~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),
-    .dataout (~RESULT),
-    .aset (1'b0),
-    .sset (1'b0),
-    .oe (1'b1),
-    .oe_out ()
-  );
-// altddioOut end"
+      [ "// altddioOut begin"
+      , "altddio_out"
+      , "  #("
+      , "    .extend_oe_disable (\"OFF\"),"
+      , "    .intended_device_family (~LIT[4]),"
+      , "    .invert_output (\"OFF\"),"
+      , "    .lpm_hint (\"UNUSED\"),"
+      , "    .lpm_type (\"altddio_out\"),"
+      , "    .oe_reg (\"UNREGISTERED\"),"
+      , "    .power_up_high (\"OFF\"),"
+      , "    .width (~SIZE[~TYPO])"
+      , "  )"
+      , "  ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] (~IF ~ISSYNC[2] ~THEN"
+      , "    .sclr (~ARG[6]),"
+      , "    .aclr (1'b0),~ELSE"
+      , "    .aclr (~ARG[6]),"
+      , "    .sclr (1'b0),~FI"
+      , "    .datain_h (~ARG[8]),"
+      , "    .datain_l (~ARG[9]),"
+      , "    .outclock (~ARG[5]),"
+      , "    .outclocken (~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),"
+      , "    .dataout (~RESULT),"
+      , "    .aset (1'b0),"
+      , "    .sset (1'b0),"
+      , "    .oe (1'b1),"
+      , "    .oe_out ()"
+      , "  );"
+      , "// altddioOut end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/commonverilog/Clash_Magic.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Magic.primitives
@@ -2,10 +2,11 @@
     { "name" : "Clash.Magic.nameHint"
     , "kind" : "Declaration"
     , "type" :
-"nameHint
-  :: SSymbol sym  -- ARG[0]
-  -> a            -- ARG[1]
-  -> a"
+      [ "nameHint"
+      , "  :: SSymbol sym  -- ARG[0]"
+      , "  -> a            -- ARG[1]"
+      , "  -> a"
+      ]
     , "resultName" : { "template" : "~NAME[0]" }
     , "template" : "assign ~RESULT = ~ARG[1];"
     }

--- a/clash-lib/prims/commonverilog/Clash_Promoted_Nat.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Promoted_Nat.primitives
@@ -2,23 +2,26 @@
     { "name"      : "Clash.Promoted.Nat.flogBaseSNat"
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
-    , "type"      : "Clash.Promoted.Nat.flogBaseSNat :: (2 <= base, 1 <= x)
-                                                     => SNat base -- ARG[2]
-                                                     -> SNat x    -- ARG[3]
-                                                     -> SNat (FLog base x"
+    , "type"      :
+      [ "Clash.Promoted.Nat.flogBaseSNat :: (2 <= base, 1 <= x)"
+      , "                                => SNat base -- ARG[2]"
+      , "                                -> SNat x    -- ARG[3]"
+      , "                                -> SNat (FLog base x"
+      ]
     , "imports"   : ["~INCLUDENAME[0].inc"]
     , "includes" :
       [ { "name" : "flogBase"
         , "extension" : "inc"
         , "template" :
-"// floor of logBase
-function integer ~INCLUDENAME[0];
-  input integer base, value;
-  begin
-    for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)
-      value = value / base;
-  end
-endfunction"
+          [ "// floor of logBase"
+          , " function integer ~INCLUDENAME[0];"
+          , "   input integer base, value;"
+          , "   begin"
+          , "     for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)"
+          , "       value = value / base;"
+          , "   end"
+          , " endfunction"
+]
         }
       ]
     , "template"  : "~INCLUDENAME[0](~LIT[2],~LIT[3])"
@@ -28,22 +31,25 @@ endfunction"
     { "name"      : "Clash.Promoted.Nat.clogBaseSNat"
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
-    , "type"      : "Clash.Promoted.Nat.clogBaseSNat :: (2 <= base, 1 <= x)
-                                                     => SNat base -- ARG[2]
-                                                     -> SNat x    -- ARG[3]
-                                                     -> SNat (CLog base x"
+    , "type"      :
+      [ "Clash.Promoted.Nat.clogBaseSNat :: (2 <= base, 1 <= x)"
+      , "                                => SNat base -- ARG[2]"
+      , "                                -> SNat x    -- ARG[3]"
+      , "                                -> SNat (CLog base x"
+      ]
     , "imports"   : ["~INCLUDENAME[0].inc"]
     , "includes" :
       [ { "name" : "clogBase"
         , "extension" : "inc"
         , "template" :
-"// ceiling of logBase
-function integer ~INCLUDENAME[0];
-  input integer base, value;
-  begin
-    for (~INCLUDENAME[0] = 0; base ** ~INCLUDENAME[0] < value; ~~INCLUDENAME[0]=~INCLUDENAME[0]+1);
-  end
-endfunction"
+          [ "// ceiling of logBase"
+          , "function integer ~INCLUDENAME[0];"
+          , "  input integer base, value;"
+          , "  begin"
+          , "    for (~INCLUDENAME[0] = 0; base ** ~INCLUDENAME[0] < value; ~~INCLUDENAME[0]=~INCLUDENAME[0]+1);"
+          , "  end"
+          , "endfunction"
+          ]
         }
       ]
     , "template"  : "~INCLUDENAME[0](~LIT[2],~LIT[3])"
@@ -53,23 +59,26 @@ endfunction"
     { "name"      : "Clash.Promoted.Nat.logBaseSNat"
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
-    , "type"      : "Clash.Promoted.Nat.logBaseSNat :: (FLog base x ~ CLog base x)
-                                                    => SNat base -- ARG[1]
-                                                    -> SNat x    -- ARG[2]
-                                                    -> SNat (Log base x)"
+    , "type"      :
+      [ "Clash.Promoted.Nat.logBaseSNat :: (FLog base x ~ CLog base x)"
+      , "                               => SNat base -- ARG[1]"
+      , "                               -> SNat x    -- ARG[2]"
+      , "                               -> SNat (Log base x)"
+      ]
     , "imports"   : ["~INCLUDENAME[0].inc"]
     , "includes" :
       [ { "name" : "clogBase"
         , "extension" : "inc"
         , "template" :
-"// logBaseSNat begin
-function integer ~INCLUDENAME[0];
-  input integer base, value;
-  begin
-    for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)
-      value = value / base;
-  end
-endfunction"
+          [ "// logBaseSNat begin"
+          , "function integer ~INCLUDENAME[0];"
+          , "  input integer base, value;"
+          , "  begin"
+          , "    for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)"
+          , "      value = value / base;"
+          , "  end"
+          , "endfunction"
+          ]
         }
       ]
     , "template"  :  "~INCLUDENAME[0](~LIT[1],~LIT[2])"

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.primitives
@@ -195,10 +195,11 @@
     { "name" : "Clash.Sized.Internal.BitVector.index#"
     , "kind" : "Expression"
     , "type" :
-"index# :: KnownNat n  -- ARG[0]
-        => BitVector n -- ARG[1]
-        -> Int         -- ARG[2]
-        -> Bit"
+      [ "index# :: KnownNat n  -- ARG[0]"
+      , "       => BitVector n -- ARG[1]"
+      , "       -> Int         -- ARG[2]"
+      , "       -> Bit"
+      ]
     , "template" : "~VAR[bv][1][~ARG[2]]"
     }
   }
@@ -207,10 +208,11 @@
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"slice# :: BitVector (m + 1 + i) -- ARG[0]
-        -> SNat m                -- ARG[1]
-        -> SNat n                -- ARG[2]
-        -> BitVector (m + 1 - n)"
+      [ "slice# :: BitVector (m + 1 + i) -- ARG[0]"
+      , "       -> SNat m                -- ARG[1]"
+      , "       -> SNat n                -- ARG[2]"
+      , "       -> BitVector (m + 1 - n)"
+      ]
     , "template" : "~VAR[bv][0][~LIT[1] : ~LIT[2]]"
     }
   }
@@ -219,9 +221,10 @@
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"msb# :: KnownNat n  -- ARG[0]
-      => BitVector n -- ARG[1]
-      -> Bit"
+      [ "msb# :: KnownNat n  -- ARG[0]"
+      , "     => BitVector n -- ARG[1]"
+      , "     -> Bit"
+      ]
     , "template" : "~IF ~SIZE[~TYP[1]] ~THEN ~VAR[bv][1][~SIZE[~TYP[1]]-1] ~ELSE 1'b0 ~FI"
     }
   }
@@ -230,8 +233,9 @@
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"lsb# :: BitVector n -- ARG[0]
-      -> Bit"
+      [ "lsb# :: BitVector n -- ARG[0]"
+      , "      -> Bit"
+      ]
     , "template" : "~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0][0] ~ELSE 1'b0 ~FI"
     }
   }

--- a/clash-lib/prims/commonverilog/Clash_Xilinx_ClockGen.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Xilinx_ClockGen.primitives
@@ -3,21 +3,23 @@
     , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "type"      :
-"clockWizard
-  :: ( KnownDomain domIn confIn       -- ARG[0]
-     , KnownDomain domOut confOut )   -- ARG[1]
-  => SSymbol name                    -- ARG[2]
-  -> Clock  pllIn                    -- ARG[3]
-  -> Reset pllIn                     -- ARG[4]
-  -> (Clock pllOut, Enable pllOut)"
+      [ "clockWizard"
+      , "  :: ( KnownDomain domIn confIn       -- ARG[0]"
+      , "     , KnownDomain domOut confOut )   -- ARG[1]"
+      , "  => SSymbol name                    -- ARG[2]"
+      , "  -> Clock  pllIn                    -- ARG[3]"
+      , "  -> Reset pllIn                     -- ARG[4]"
+      , "  -> (Clock pllOut, Enable pllOut)"
+      ]
     , "template" :
-"// clockWizard begin
-~NAME[2] ~GENSYM[clockWizard_inst][2]
-(.CLK_IN1  (~ARG[3])
-,.RESET    (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI ~ARG[4])
-,.CLK_OUT1 (~RESULT[1])
-,.LOCKED   (~RESULT[0]));
-// clockWizard end"
+      [ "// clockWizard begin"
+      , "~NAME[2] ~GENSYM[clockWizard_inst][2]"
+      , "(.CLK_IN1  (~ARG[3])"
+      , ",.RESET    (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI ~ARG[4])"
+      , ",.CLK_OUT1 (~RESULT[1])"
+      , ",.LOCKED   (~RESULT[0]));"
+      , "// clockWizard end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -25,23 +27,25 @@
     , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "type"      :
-"clockWizardDifferential
-  :: ( KnownDomain domIn confIn       -- ARG[0]
-     , KnownDomain domOut confOut )   -- ARG[1]
-  :: SSymbol name                    -- ARG[2]
-  -> Clock  pllIn                    -- ARG[3]
-  -> Clock  pllIn                    -- ARG[4]
-  -> Reset pllIn                     -- ARG[5]
-  -> (Clock pllOut, Enable pllOut)"
+      [ "clockWizardDifferential"
+      , "  :: ( KnownDomain domIn confIn       -- ARG[0]"
+      , "     , KnownDomain domOut confOut )   -- ARG[1]"
+      , "  :: SSymbol name                    -- ARG[2]"
+      , "  -> Clock  pllIn                    -- ARG[3]"
+      , "  -> Clock  pllIn                    -- ARG[4]"
+      , "  -> Reset pllIn                     -- ARG[5]"
+      , "  -> (Clock pllOut, Enable pllOut)"
+      ]
     , "template" :
-"// clockWizardDifferential begin
-~NAME[2] ~GENSYM[clockWizardDifferential_inst][2]
-(.CLK_IN1_D_clk_n (~ARG[3])
-,.CLK_IN1_D_clk_n (~ARG[4])
-,.RESET           (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI ~ARG[5])
-,.CLK_OUT1        (~RESULT[1])
-,.LOCKED          (~RESULT[0]));
-// clockWizardDifferential end"
+      [ "// clockWizardDifferential begin"
+      , "~NAME[2] ~GENSYM[clockWizardDifferential_inst][2]"
+      , "(.CLK_IN1_D_clk_n (~ARG[3])"
+      , ",.CLK_IN1_D_clk_n (~ARG[4])"
+      , ",.RESET           (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI ~ARG[5])"
+      , ",.CLK_OUT1        (~RESULT[1])"
+      , ",.LOCKED          (~RESULT[0]));"
+      , "// clockWizardDifferential end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/commonverilog/GHC_Integer_Logarithms.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Integer_Logarithms.primitives
@@ -7,14 +7,15 @@
       [ { "name" : "integerLogBase"
         , "extension" : "inc"
         , "template" :
-"// integer logBase
-function integer ~INCLUDENAME[0];
-  input integer base, value;
-  begin
-    for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)
-      value = value / base;
-  end
-endfunction"
+          [ "// integer logBase"
+          , "function integer ~INCLUDENAME[0];"
+          , "  input integer base, value;"
+          , "  begin"
+          , "    for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)"
+          , "      value = value / base;"
+          , "  end"
+          , "endfunction"
+          ]
         }
       ]
     , "template"  : "~INCLUDENAME[0](~ARG[0],~ARG[1])"

--- a/clash-lib/prims/commonverilog/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Num_Integer.primitives
@@ -247,14 +247,15 @@
       [ { "name" : "integerLogBase"
         , "extension" : "inc"
         , "template" :
-"// integer logBase
-function integer ~INCLUDENAME[0];
-input integer base, value;
-begin
-  for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)
-    value = value / base;
-end
-endfunction"
+          [ "// integer logBase"
+          , "function integer ~INCLUDENAME[0];"
+          , "input integer base, value;"
+          , "begin"
+          , "  for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)"
+          , "    value = value / base;"
+          , "end"
+          , "endfunction"
+          ]
         }
       ]
     , "template"  : "~INCLUDENAME[0](~ARG[0],~ARG[1])"

--- a/clash-lib/prims/commonverilog/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Num_Natural.primitives
@@ -35,14 +35,15 @@
     [ { "name" : "naturalLogBase"
       , "extension" : "inc"
       , "template" :
-"// natural logBase
-function integer ~INCLUDENAME[0];
-input [~SIZE[~TYP[0]]-1:0] base, value;
-begin
-  for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)
-    value = value / base;
-end
-endfunction"
+        [ "// natural logBase"
+        , "function integer ~INCLUDENAME[0];"
+        , "input [~SIZE[~TYP[0]]-1:0] base, value;"
+        , "begin"
+        , "  for (~INCLUDENAME[0] = 0; value >= base; ~INCLUDENAME[0]=~INCLUDENAME[0]+1)"
+        , "    value = value / base;"
+        , "end"
+        , "endfunction"
+        ]
       }
     ]
   , "template"  : "~INCLUDENAME[0](~ARG[0],~ARG[1])"

--- a/clash-lib/prims/commonverilog/GHC_Prim.primitives
+++ b/clash-lib/prims/commonverilog/GHC_Prim.primitives
@@ -286,10 +286,11 @@
     , "kind"      : "Declaration"
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "template"  :
-"// byteSwap16 begin~IF ~IW64 ~THEN
-assign ~RESULT = {~VAR[w][0][63:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~ELSE
-assign ~RESULT = {~VAR[w][0][31:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~FI
-// byteSwap16 end"
+      [ "// byteSwap16 begin~IF ~IW64 ~THEN"
+      , "assign ~RESULT = {~VAR[w][0][63:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~ELSE"
+      , "assign ~RESULT = {~VAR[w][0][31:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~FI"
+      , "// byteSwap16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -298,10 +299,11 @@ assign ~RESULT = {~VAR[w][0][31:16],~VAR[w][0][7:0],~VAR[w][0][15:8]};~FI
     , "kind"      : "Declaration"
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "template"  :
-"// byteSwap32 begin~IF ~IW64 ~THEN
-assign ~RESULT = {~VAR[w][0][63:32],~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~ELSE
-assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~FI
-// byteSwap32 end"
+      [ "// byteSwap32 begin~IF ~IW64 ~THEN"
+      , "assign ~RESULT = {~VAR[w][0][63:32],~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~ELSE"
+      , "assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~FI"
+      , "// byteSwap32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -310,10 +312,11 @@ assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][
     , "kind"      : "Declaration"
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "template"  :
-"// byteSwap64 begin
-assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]
-                 ,~VAR[w][0][39:32],~VAR[w][0][47:40],~VAR[w][0][55:48],~VAR[w][0][63:56]};
-// byteSwap64 end"
+      [ "// byteSwap64 begin"
+      , "assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]"
+      , "                 ,~VAR[w][0][39:32],~VAR[w][0][47:40],~VAR[w][0][55:48],~VAR[w][0][63:56]};"
+      , "// byteSwap64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -322,11 +325,12 @@ assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][
     , "kind"      : "Declaration"
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "template"  :
-"// byteSwap begin~IF ~IW64 ~THEN
-assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]
-                 ,~VAR[w][0][39:32],~VAR[w][0][47:40],~VAR[w][0][55:48],~VAR[w][0][63:56]};~ELSE
-assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~FI
-// byteSwap end"
+      [ "// byteSwap begin~IF ~IW64 ~THEN"
+      , "assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]"
+      , "                 ,~VAR[w][0][39:32],~VAR[w][0][47:40],~VAR[w][0][55:48],~VAR[w][0][63:56]};~ELSE"
+      , "assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][31:24]};~FI"
+      , "// byteSwap end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -335,9 +339,10 @@ assign ~RESULT = {~VAR[w][0][7:0],~VAR[w][0][15:8],~VAR[w][0][23:16],~VAR[w][0][
     , "kind"      : "Declaration"
     , "type"      : "narrow8Int# :: Int# -> Int#"
     , "template"  :
-"// narrow8Int begin
-assign ~RESULT = $signed(~VAR[i][0][7:0]);
-// narrow8Int end"
+      [ "// narrow8Int begin"
+      , "assign ~RESULT = $signed(~VAR[i][0][7:0]);"
+      , "// narrow8Int end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -346,9 +351,10 @@ assign ~RESULT = $signed(~VAR[i][0][7:0]);
     , "kind"      : "Declaration"
     , "type"      : "narrow16Int# :: Int# -> Int#"
     , "template"  :
-"// narrow16Int begin
-assign ~RESULT = $signed(~VAR[i][0][15:0]);
-// narrow16Int end"
+      [ "// narrow16Int begin"
+      , "assign ~RESULT = $signed(~VAR[i][0][15:0]);"
+      , "// narrow16Int end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -357,9 +363,10 @@ assign ~RESULT = $signed(~VAR[i][0][15:0]);
     , "kind"      : "Declaration"
     , "type"      : "narrow32Int# :: Int# -> Int#"
     , "template"  :
-"// narrow32Int begin
-assign ~RESULT = $signed(~VAR[i][0][31:0]);
-// narrow32Int end"
+      [ "// narrow32Int begin"
+      , "assign ~RESULT = $signed(~VAR[i][0][31:0]);"
+      , "// narrow32Int end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -368,9 +375,10 @@ assign ~RESULT = $signed(~VAR[i][0][31:0]);
     , "kind"      : "Declaration"
     , "type"      : "narrow8Int# :: Word# -> Word#"
     , "template"  :
-"// narrow8Word begin
-assign ~RESULT = $unsigned(~VAR[w][0][7:0]);
-// narrow8Word end"
+      [ "// narrow8Word begin"
+      , "assign ~RESULT = $unsigned(~VAR[w][0][7:0]);"
+      , "// narrow8Word end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -379,9 +387,10 @@ assign ~RESULT = $unsigned(~VAR[w][0][7:0]);
     , "kind"      : "Declaration"
     , "type"      : "narrow16Word# :: Word# -> Word#"
     , "template"  :
-"// narrow16Word begin
-assign ~RESULT = $unsigned(~VAR[w][0][15:0]);
-// narrow16Word end"
+      [ "// narrow16Word begin"
+      , "assign ~RESULT = $unsigned(~VAR[w][0][15:0]);"
+      , "// narrow16Word end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -390,9 +399,10 @@ assign ~RESULT = $unsigned(~VAR[w][0][15:0]);
     , "kind"      : "Declaration"
     , "type"      : "narrow32Int# :: Word# -> Word#"
     , "template"  :
-"// narrow32Word begin
-assign ~RESULT = $unsigned(~VAR[w][0][31:0]);
-// narrow32Word end"
+      [ "// narrow32Word begin"
+      , "assign ~RESULT = $unsigned(~VAR[w][0][31:0]);"
+      , "// narrow32Word end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -401,14 +411,15 @@ assign ~RESULT = $unsigned(~VAR[w][0][31:0]);
     , "kind"      : "Declaration"
     , "type"      : "bitReverse# :: Word# -> Word#"
     , "template"  :
-"// bitReverse begin
-genvar ~GENSYM[i][0];
-~GENERATE
-for (~SYM[0] = 0; ~SYM[0] < ~IF ~IW64 ~THEN 64 ~ELSE 32 ~FI; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse][2]
-  assign ~RESULT[~SYM[0]] = ~VAR[x][0][~IF ~IW64 ~THEN 63 ~ELSE 31 ~FI-~SYM[0]];
-end
-~ENDGENERATE
-// bitReverse end"
+      [ "// bitReverse begin"
+      , "genvar ~GENSYM[i][0];"
+      , "~GENERATE"
+      , "for (~SYM[0] = 0; ~SYM[0] < ~IF ~IW64 ~THEN 64 ~ELSE 32 ~FI; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse][2]"
+      , "  assign ~RESULT[~SYM[0]] = ~VAR[x][0][~IF ~IW64 ~THEN 63 ~ELSE 31 ~FI-~SYM[0]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// bitReverse end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -417,14 +428,15 @@ end
     , "kind"      : "Declaration"
     , "type"      : "bitReverse8# :: Word# -> Word#"
     , "template"  :
-"// bitReverse8 begin
-genvar ~GENSYM[i][0];
-~GENERATE
-for (~SYM[0] = 0; ~SYM[0] < 8; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse8][2]
-  assign ~RESULT[~SYM[0]] = ~VAR[x][0][7-~SYM[0]];
-end
-~ENDGENERATE
-// bitReverse8 end"
+      [ "// bitReverse8 begin"
+      , "genvar ~GENSYM[i][0];"
+      , "~GENERATE"
+      , "for (~SYM[0] = 0; ~SYM[0] < 8; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse8][2]"
+      , "  assign ~RESULT[~SYM[0]] = ~VAR[x][0][7-~SYM[0]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// bitReverse8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -433,14 +445,15 @@ end
     , "kind"      : "Declaration"
     , "type"      : "bitReverse16# :: Word# -> Word#"
     , "template"  :
-"// bitReverse16 begin
-genvar ~GENSYM[i][0];
-~GENERATE
-for (~SYM[0] = 0; ~SYM[0] < 16; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse16][2]
-  assign ~RESULT[~SYM[0]] = ~VAR[x][0][15-~SYM[0]];
-end
-~ENDGENERATE
-// bitReverse16 end"
+      [ "// bitReverse16 begin"
+      , "genvar ~GENSYM[i][0];"
+      , "~GENERATE"
+      , "for (~SYM[0] = 0; ~SYM[0] < 16; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse16][2]"
+      , "  assign ~RESULT[~SYM[0]] = ~VAR[x][0][15-~SYM[0]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// bitReverse16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -449,14 +462,15 @@ end
     , "kind"      : "Declaration"
     , "type"      : "bitReverse32# :: Word# -> Word#"
     , "template"  :
-"// bitReverse32 begin
-genvar ~GENSYM[i][0];
-~GENERATE
-for (~SYM[0] = 0; ~SYM[0] < 32; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse32][2]
-  assign ~RESULT[~SYM[0]] = ~VAR[x][0][31-~SYM[0]];
-end
-~ENDGENERATE
-// bitReverse32 end"
+      [ "// bitReverse32 begin"
+      , "genvar ~GENSYM[i][0];"
+      , "~GENERATE"
+      , "for (~SYM[0] = 0; ~SYM[0] < 32; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse32][2]"
+      , "  assign ~RESULT[~SYM[0]] = ~VAR[x][0][31-~SYM[0]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// bitReverse32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -465,14 +479,15 @@ end
     , "kind"      : "Declaration"
     , "type"      : "bitReverse64# :: Word# -> Word#"
     , "template"  :
-"// bitReverse64 begin
-genvar ~GENSYM[i][0];
-~GENERATE
-for (~SYM[0] = 0; ~SYM[0] < 64; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse64][2]
-  assign ~RESULT[~SYM[0]] = ~VAR[x][0][63-~SYM[0]];
-end
-~ENDGENERATE
-// bitReverse64 end"
+      [ "// bitReverse64 begin"
+      , "genvar ~GENSYM[i][0];"
+      , "~GENERATE"
+      , "for (~SYM[0] = 0; ~SYM[0] < 64; ~SYM[0]=~SYM[0]+1) begin : ~GENSYM[bitReverse64][2]"
+      , "  assign ~RESULT[~SYM[0]] = ~VAR[x][0][63-~SYM[0]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// bitReverse64 end"
+      ]
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.primitives
@@ -2,193 +2,201 @@
     { "name" : "Clash.Explicit.BlockRam.blockRam#"
     , "kind" : "Declaration"
     , "type" :
-"blockRam#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  -> Enable dom      -- en,   ARG[4]
-  -> Vec n a         -- init, ARG[5]
-  -> Signal dom Int  -- rd,   ARG[6]
-  -> Signal dom Bool -- wren, ARG[7]
-  -> Signal dom Int  -- wr,   ARG[8]
-  -> Signal dom a    -- din,  ARG[9]
-  -> Signal dom a"
+      [ "blockRam#"
+      , "  :: ( KnownDomain dom        ARG[0]"
+      , "     , HasCallStack  --       ARG[1]"
+      , "     , Undefined a ) --       ARG[2]"
+      , "  => Clock dom       -- clk,  ARG[3]"
+      , "  -> Enable dom      -- en,   ARG[4]"
+      , "  -> Vec n a         -- init, ARG[5]"
+      , "  -> Signal dom Int  -- rd,   ARG[6]"
+      , "  -> Signal dom Bool -- wren, ARG[7]"
+      , "  -> Signal dom Int  -- wr,   ARG[8]"
+      , "  -> Signal dom a    -- din,  ARG[9]"
+      , "  -> Signal dom a"
+      ]
     , "template" :
-"// blockRam begin
-~SIGD[~GENSYM[RAM][1]][5];
-logic [~SIZE[~TYP[9]]-1:0] ~GENSYM[~RESULT_q][2];
-initial begin
-  ~SYM[1] = ~CONST[5];
-end~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN
-  if (~ARG[4]) begin
-    if (~ARG[7]) begin
-      ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];
-    end
-    ~SYM[2] <= ~SYM[1][~ARG[6]];
-  end~ELSE
-  if (~ARG[7] & ~ARG[4]) begin
-    ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];
-  end
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~SYM[1][~ARG[6]];
-  end~FI
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]
-  if (~ARG[7]) begin
-    ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];
-  end
-  ~SYM[2] <= ~SYM[1][~ARG[6]];
-end~FI
-assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[9]];
-// blockRam end"
+      [ "// blockRam begin"
+      , "~SIGD[~GENSYM[RAM][1]][5];"
+      , "logic [~SIZE[~TYP[9]]-1:0] ~GENSYM[~RESULT_q][2];"
+      , "initial begin"
+      , "  ~SYM[1] = ~CONST[5];"
+      , "end~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN"
+      , "  if (~ARG[4]) begin"
+      , "    if (~ARG[7]) begin"
+      , "      ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];"
+      , "    end"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[6]];"
+      , "  end~ELSE"
+      , "  if (~ARG[7] & ~ARG[4]) begin"
+      , "    ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];"
+      , "  end"
+      , "  if (~ARG[4]) begin"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[6]];"
+      , "  end~FI"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]"
+      , "  if (~ARG[7]) begin"
+      , "    ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];"
+      , "  end"
+      , "  ~SYM[2] <= ~SYM[1][~ARG[6]];"
+      , "end~FI"
+      , "assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[9]];"
+      , "// blockRam end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.blockRamU#"
     , "kind" : "Declaration"
     , "type" :
-"blockRamU#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  -> Enable dom      -- en,   ARG[4]
-  -> SNat n          -- len,  ARG[5]
-  -> Signal dom Int  -- rd,   ARG[6]
-  -> Signal dom Bool -- wren, ARG[7]
-  -> Signal dom Int  -- wr,   ARG[8]
-  -> Signal dom a    -- din,  ARG[9]
-  -> Signal dom a"
+      [ "blockRamU#"
+      , "  :: ( KnownDomain dom        ARG[0]"
+      , "     , HasCallStack  --       ARG[1]"
+      , "     , Undefined a ) --       ARG[2]"
+      , "  => Clock dom       -- clk,  ARG[3]"
+      , "  -> Enable dom      -- en,   ARG[4]"
+      , "  -> SNat n          -- len,  ARG[5]"
+      , "  -> Signal dom Int  -- rd,   ARG[6]"
+      , "  -> Signal dom Bool -- wren, ARG[7]"
+      , "  -> Signal dom Int  -- wr,   ARG[8]"
+      , "  -> Signal dom a    -- din,  ARG[9]"
+      , "  -> Signal dom a"
+      ]
     , "template" :
-"// blockRamU begin,
-~TYPO ~GENSYM[~RESULT_RAM][1] [0:~LIT[5]-1];
-logic [~SIZE[~TYP[9]]-1:0] ~GENSYM[~RESULT_q][2];~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN
-  if (~ARG[4]) begin
-    if (~ARG[7]) begin
-      ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];
-    end
-    ~SYM[2] <= ~SYM[1][~ARG[6]];
-  end~ELSE
-  if (~ARG[7] & ~ARG[4]) begin
-    ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];
-  end
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~SYM[1][~ARG[6]];
-  end~FI
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]
-  if (~ARG[7]) begin
-    ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];
-  end
-  ~SYM[2] <= ~SYM[1][~ARG[6]];
-end~FI
-assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[9]];
-// blockRamU end"
+      [ "// blockRamU begin,"
+      , "~TYPO ~GENSYM[~RESULT_RAM][1] [0:~LIT[5]-1];"
+      , "logic [~SIZE[~TYP[9]]-1:0] ~GENSYM[~RESULT_q][2];~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN"
+      , "  if (~ARG[4]) begin"
+      , "    if (~ARG[7]) begin"
+      , "      ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];"
+      , "    end"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[6]];"
+      , "  end~ELSE"
+      , "  if (~ARG[7] & ~ARG[4]) begin"
+      , "    ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];"
+      , "  end"
+      , "  if (~ARG[4]) begin"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[6]];"
+      , "  end~FI"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]"
+      , "  if (~ARG[7]) begin"
+      , "    ~SYM[1][~ARG[8]] <= ~TOBV[~ARG[9]][~TYP[9]];"
+      , "  end"
+      , "  ~SYM[2] <= ~SYM[1][~ARG[6]];"
+      , "end~FI"
+      , "assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[9]];"
+      , "// blockRamU end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.blockRam1#"
     , "kind" : "Declaration"
     , "type" :
-"blockRam1#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  -> Enable dom      -- en,   ARG[4]
-  -> SNat n          -- len,  ARG[5]
-  -> a               -- init, ARG[6]
-  -> Signal dom Int  -- rd,   ARG[7]
-  -> Signal dom Bool -- wren, ARG[8]
-  -> Signal dom Int  -- wr,   ARG[9]
-  -> Signal dom a    -- din,  ARG[10]
-  -> Signal dom a"
+      [ "blockRam1#"
+      , "  :: ( KnownDomain dom        ARG[0]"
+      , "     , HasCallStack  --       ARG[1]"
+      , "     , Undefined a ) --       ARG[2]"
+      , "  => Clock dom       -- clk,  ARG[3]"
+      , "  -> Enable dom      -- en,   ARG[4]"
+      , "  -> SNat n          -- len,  ARG[5]"
+      , "  -> a               -- init, ARG[6]"
+      , "  -> Signal dom Int  -- rd,   ARG[7]"
+      , "  -> Signal dom Bool -- wren, ARG[8]"
+      , "  -> Signal dom Int  -- wr,   ARG[9]"
+      , "  -> Signal dom a    -- din,  ARG[10]"
+      , "  -> Signal dom a"
+      ]
     , "template" :
-"// blockRam1 begin,
-~TYPO ~GENSYM[~RESULT_RAM][1] [0:~LIT[5]-1];
-logic [~SIZE[~TYP[10]]-1:0] ~GENSYM[~RESULT_q][2];
-initial begin
-  ~SYM[1] = '{default: ~CONST[6]};
-end~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN
-  if (~ARG[4]) begin
-    if (~ARG[8]) begin
-      ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];
-    end
-    ~SYM[2] <= ~SYM[1][~ARG[7]];
-  end~ELSE
-  if (~ARG[8] & ~ARG[4]) begin
-    ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];
-  end
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~SYM[1][~ARG[7]];
-  end~FI
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]
-  if (~ARG[8]) begin
-    ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];
-  end
-  ~SYM[2] <= ~SYM[1][~ARG[7]];
-end~FI
-assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[10]];
-// blockRam1 end"
+      [ "// blockRam1 begin,"
+      , "~TYPO ~GENSYM[~RESULT_RAM][1] [0:~LIT[5]-1];"
+      , "logic [~SIZE[~TYP[10]]-1:0] ~GENSYM[~RESULT_q][2];"
+      , "initial begin"
+      , "  ~SYM[1] = '{default: ~CONST[6]};"
+      , "end~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN"
+      , "  if (~ARG[4]) begin"
+      , "    if (~ARG[8]) begin"
+      , "      ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];"
+      , "    end"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[7]];"
+      , "  end~ELSE"
+      , "  if (~ARG[8] & ~ARG[4]) begin"
+      , "    ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];"
+      , "  end"
+      , "  if (~ARG[4]) begin"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[7]];"
+      , "  end~FI"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]"
+      , "  if (~ARG[8]) begin"
+      , "    ~SYM[1][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];"
+      , "  end"
+      , "  ~SYM[2] <= ~SYM[1][~ARG[7]];"
+      , "end~FI"
+      , "assign ~RESULT = ~FROMBV[~SYM[2]][~TYP[10]];"
+      , "// blockRam1 end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.trueDualPortBlockRam#"
     , "kind" : "Declaration"
     , "type" :
-"trueDualPortBlockRam# ::
-  forall nAddrs domA domB a .
-  ( HasCallStack           ~ARG[0]
-  , KnownNat nAddrs        ~ARG[1]
-  , KnownDomain domA       ~ARG[2]
-  , KnownDomain domB       ~ARG[3]
-  , NFDataX a              ~ARG[4]
-  , BitPack a              ~ARG[5]
-  ) =>
-
-  Clock domA ->                   ~ARG[6]
-  Signal domA Bool ->             ~ARG[7]
-  Signal domA (Index nAddrs) ->   ~ARG[8]
-  Signal domA a ->                ~ARG[9]
-
-  Clock domB ->                   ~ARG[10]
-  Signal domB Bool ->             ~ARG[11]
-  Signal domB (Index nAddrs) ->   ~ARG[12]
-  Signal domB a ->                ~ARG[13]
-  (Signal domA a, Signal domB a)"
+      [ "trueDualPortBlockRam# ::"
+      , "  forall nAddrs domA domB a ."
+      , "  ( HasCallStack           ~ARG[0]"
+      , "  , KnownNat nAddrs        ~ARG[1]"
+      , "  , KnownDomain domA       ~ARG[2]"
+      , "  , KnownDomain domB       ~ARG[3]"
+      , "  , NFDataX a              ~ARG[4]"
+      , "  , BitPack a              ~ARG[5]"
+      , "  ) =>"
+      , ""
+      , "  Clock domA ->                   ~ARG[6]"
+      , "  Signal domA Bool ->             ~ARG[7]"
+      , "  Signal domA (Index nAddrs) ->   ~ARG[8]"
+      , "  Signal domA a ->                ~ARG[9]"
+      , ""
+      , "  Clock domB ->                   ~ARG[10]"
+      , "  Signal domB Bool ->             ~ARG[11]"
+      , "  Signal domB (Index nAddrs) ->   ~ARG[12]"
+      , "  Signal domB a ->                ~ARG[13]"
+      , "  (Signal domA a, Signal domB a)"
+      ]
     , "template" :
-"// trueDualPortBlockRam begin
-// Shared memory
-logic [~SIZE[~TYP[9]]-1:0] ~GENSYM[mem][0] [~LIT[1]-1:0];
-
-~SIGD[~GENSYM[data_slow][1]][9];
-~SIGD[~GENSYM[data_fast][2]][13];
-
-// Port A
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[6]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[8]];
-    if(~ARG[7]) begin
-        ~SYM[1] <= ~ARG[9];
-        ~SYM[0][~ARG[8]] <= ~ARG[9];
-    end
-end
-
-// Port B
-always @(~IF~ACTIVEEDGE[Rising][3]~THENposedge~ELSEnegedge~FI ~ARG[10]) begin
-    ~SYM[2] <= ~SYM[0][~ARG[12]];
-    if(~ARG[11]) begin
-        ~SYM[2] <= ~ARG[13];
-        ~SYM[0][~ARG[12]] <= ~ARG[13];
-    end
-end
-
-assign ~RESULT = {~SYM[1], ~SYM[2]};
-// end trueDualPortBlockRam"
+      [ "// trueDualPortBlockRam begin"
+      , "// Shared memory"
+      , "logic [~SIZE[~TYP[9]]-1:0] ~GENSYM[mem][0] [~LIT[1]-1:0];"
+      , ""
+      , "~SIGD[~GENSYM[data_slow][1]][9];"
+      , "~SIGD[~GENSYM[data_fast][2]][13];"
+      , ""
+      , "// Port A"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[6]) begin"
+      , "    ~SYM[1] <= ~SYM[0][~ARG[8]];"
+      , "    if(~ARG[7]) begin"
+      , "        ~SYM[1] <= ~ARG[9];"
+      , "        ~SYM[0][~ARG[8]] <= ~ARG[9];"
+      , "    end"
+      , "end"
+      , ""
+      , "// Port B"
+      , "always @(~IF~ACTIVEEDGE[Rising][3]~THENposedge~ELSEnegedge~FI ~ARG[10]) begin"
+      , "    ~SYM[2] <= ~SYM[0][~ARG[12]];"
+      , "    if(~ARG[11]) begin"
+      , "        ~SYM[2] <= ~ARG[13];"
+      , "        ~SYM[0][~ARG[12]] <= ~ARG[13];"
+      , "    end"
+      , "end"
+      , ""
+      , "assign ~RESULT = {~SYM[1], ~SYM[2]};"
+      , "// end trueDualPortBlockRam"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam_File.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam_File.primitives
@@ -2,51 +2,54 @@
     { "name" : "Clash.Explicit.BlockRam.File.blockRamFile#"
     , "kind" : "Declaration"
     , "type" :
-"blockRamFile#
-  :: ( KnownDomain dom         --       ARG[0]
-     , KnownNat m              --       ARG[1]
-     , HasCallStack )          --       ARG[2]
-  => Clock dom                 -- clk,  ARG[3]
-  => Enable dom                -- en,   ARG[4]
-  -> SNat n                    -- sz,   ARG[5]
-  -> FilePath                  -- file, ARG[6]
-  -> Signal dom Int            -- rd,   ARG[7]
-  -> Signal dom Bool           -- wren, ARG[8]
-  -> Signal dom Int            -- wr,   ARG[9]
-  -> Signal dom (BitVector m)  -- din,  ARG[10]
-  -> Signal dom (BitVector m)"
+      [ "blockRamFile#"
+      , "  :: ( KnownDomain dom         --       ARG[0]"
+      , "     , KnownNat m              --       ARG[1]"
+      , "     , HasCallStack )          --       ARG[2]"
+      , "  => Clock dom                 -- clk,  ARG[3]"
+      , "  => Enable dom                -- en,   ARG[4]"
+      , "  -> SNat n                    -- sz,   ARG[5]"
+      , "  -> FilePath                  -- file, ARG[6]"
+      , "  -> Signal dom Int            -- rd,   ARG[7]"
+      , "  -> Signal dom Bool           -- wren, ARG[8]"
+      , "  -> Signal dom Int            -- wr,   ARG[9]"
+      , "  -> Signal dom (BitVector m)  -- din,  ARG[10]"
+      , "  -> Signal dom (BitVector m)"
+      ]
     , "template" :
-"// blockRamFile begin
-~SIGDO[~GENSYM[RAM][1]] [0:~LIT[5]-1];
-~SIGD[~GENSYM[~RESULT_q][2]][10];
-
-initial begin
-  $readmemb(~FILE[~LIT[6]],~SYM[1]);
-end
-~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRamFile][3]~IF ~VIVADO ~THEN
-  if (~ARG[4]) begin
-    if (~ARG[8]) begin
-      ~SYM[1][~ARG[9]] <= ~ARG[10];
-    end
-    ~SYM[2] <= ~SYM[1][~ARG[7]];
-  end~ELSE
-  if (~ARG[8] & ~ARG[4]) begin
-    ~SYM[1][~ARG[9]] <= ~ARG[10];
-  end
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~SYM[1][~ARG[7]];
-  end~FI
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]
-  if (~ARG[8]) begin
-    ~SYM[1][~ARG[9]] <= ~ARG[10];
-  end
-  ~SYM[2] <= ~SYM[1][~ARG[7]];
-end~FI
-
-assign ~RESULT = ~SYM[2];
-// blockRamFile end"
+      [ "// blockRamFile begin"
+      , "~SIGDO[~GENSYM[RAM][1]] [0:~LIT[5]-1];"
+      , "~SIGD[~GENSYM[~RESULT_q][2]][10];"
+      , ""
+      , ""
+      , "initial begin"
+      , "  $readmemb(~FILE[~LIT[6]],~SYM[1]);"
+      , "end"
+      , "~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRamFile][3]~IF ~VIVADO ~THEN"
+      , "  if (~ARG[4]) begin"
+      , "    if (~ARG[8]) begin"
+      , "      ~SYM[1][~ARG[9]] <= ~ARG[10];"
+      , "    end"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[7]];"
+      , "  end~ELSE"
+      , "  if (~ARG[8] & ~ARG[4]) begin"
+      , "    ~SYM[1][~ARG[9]] <= ~ARG[10];"
+      , "  end"
+      , "  if (~ARG[4]) begin"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[7]];"
+      , "  end~FI"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]"
+      , "  if (~ARG[8]) begin"
+      , "    ~SYM[1][~ARG[9]] <= ~ARG[10];"
+      , "  end"
+      , "  ~SYM[2] <= ~SYM[1][~ARG[7]];"
+      , "end~FI"
+      , ""
+      , "assign ~RESULT = ~SYM[2];"
+      , "// blockRamFile end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_DDR.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_DDR.primitives
@@ -2,92 +2,96 @@
     { "name" : "Clash.Explicit.DDR.ddrIn#"
     , "kind" : "Declaration"
     , "type" :
-"ddrIn# :: forall a slow fast n pFast gated synchronous.
-           ( HasCallStack          -- ARG[0]
-           , Undefined a           -- ARG[1]
-           , KnownConfi~ fast domf -- ARG[2]
-           , KnownConfi~ slow doms -- ARG[3]
-        => Clock slow              -- ARG[4], clk
-        -> Reset slow              -- ARG[5], rst
-        -> Enable slow             -- ARG[6], en
-        -> a                       -- ARG[7]
-        -> a                       -- ARG[8]
-        -> a                       -- ARG[9]
-        -> Signal fast a           -- ARG[10]
-        -> Signal slow (a,a)"
+      [ "ddrIn# :: forall a slow fast n pFast gated synchronous."
+      , "           ( HasCallStack          -- ARG[0]"
+      , "           , Undefined a           -- ARG[1]"
+      , "           , KnownConfi~ fast domf -- ARG[2]"
+      , "           , KnownConfi~ slow doms -- ARG[3]"
+      , "        => Clock slow              -- ARG[4], clk"
+      , "        -> Reset slow              -- ARG[5], rst"
+      , "        -> Enable slow             -- ARG[6], en"
+      , "        -> a                       -- ARG[7]"
+      , "        -> a                       -- ARG[8]"
+      , "        -> a                       -- ARG[9]"
+      , "        -> Signal fast a           -- ARG[10]"
+      , "        -> Signal slow (a,a)"
+      ]
     , "template" :
-"// ddrIn begin
-~SIGD[~GENSYM[data_Pos][1]][9];
-~SIGD[~GENSYM[data_Neg][2]][9];
-~SIGD[~GENSYM[data_Neg_Latch][3]][9];
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[1] <= ~ARG[8];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[1] <= ~ARG[10];
-  end
-end
-always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[2] <= ~ARG[9];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[2] <= ~ARG[10];
-  end
-end
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[3] <= ~ARG[7];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[3] <= ~SYM[2];
-  end
-end
-
-assign ~RESULT = {~SYM[3], ~SYM[1]};
-// ddrIn end"
+      [ "// ddrIn begin"
+      , "~SIGD[~GENSYM[data_Pos][1]][9];"
+      , "~SIGD[~GENSYM[data_Neg][2]][9];"
+      , "~SIGD[~GENSYM[data_Neg_Latch][3]][9];"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[1] <= ~ARG[8];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[1] <= ~ARG[10];"
+      , "  end"
+      , "end"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[2] <= ~ARG[9];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[2] <= ~ARG[10];"
+      , "  end"
+      , "end"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[3] <= ~ARG[7];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[3] <= ~SYM[2];"
+      , "  end"
+      , "end"
+      , ""
+      , "assign ~RESULT = {~SYM[3], ~SYM[1]};"
+      , "// ddrIn end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.DDR.ddrOut#"
     , "kind" : "Declaration"
     , "type" :
-"ddrOut# :: ( HasCallStack               -- ARG[0]
-            , Undefined a                -- ARG[1]
-            , KnownConfi~ fast domf      -- ARG[2]
-            , KnownConfi~ slow doms      -- ARG[3]
-         => Clock slow                   -- ARG[4]
-         -> Reset slow                   -- ARG[5]
-         -> Enable slow                  -- ARG[6]
-         -> a                            -- ARG[7]
-         -> Signal slow a                -- ARG[8]
-         -> Signal slow a                -- ARG[9]
-         -> Signal fast a"
+      [ "ddrOut# :: ( HasCallStack               -- ARG[0]"
+      , "            , Undefined a                -- ARG[1]"
+      , "            , KnownConfi~ fast domf      -- ARG[2]"
+      , "            , KnownConfi~ slow doms      -- ARG[3]"
+      , "         => Clock slow                   -- ARG[4]"
+      , "         -> Reset slow                   -- ARG[5]"
+      , "         -> Enable slow                  -- ARG[6]"
+      , "         -> a                            -- ARG[7]"
+      , "         -> Signal slow a                -- ARG[8]"
+      , "         -> Signal slow a                -- ARG[9]"
+      , "         -> Signal fast a"
+      ]
     , "template" :
-"// ddrOut begin
-~SIGD[~GENSYM[data_Pos][1]][7];
-~SIGD[~GENSYM[data_Neg][2]][7];
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[1] <= ~ARG[7];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[1] <= ~ARG[8];
-  end
-end
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[2] <= ~ARG[7];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[2] <= ~ARG[9];
-  end
-end
-
-always @(*) begin
-  if (~ARG[4]) begin
-    ~RESULT = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI;
-  end else begin
-    ~RESULT = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
-  end
-end
-// ddrOut end"
+      [ "// ddrOut begin"
+      , "~SIGD[~GENSYM[data_Pos][1]][7];"
+      , "~SIGD[~GENSYM[data_Neg][2]][7];"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[1] <= ~ARG[7];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[1] <= ~ARG[8];"
+      , "  end"
+      , "end"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[2] <= ~ARG[7];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[2] <= ~ARG[9];"
+      , "  end"
+      , "end"
+      , ""
+      , "always @(*) begin"
+      , "  if (~ARG[4]) begin"
+      , "    ~RESULT = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI;"
+      , "  end else begin"
+      , "    ~RESULT = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;"
+      , "  end"
+      , "end"
+      , "// ddrOut end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_RAM.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_RAM.primitives
@@ -2,30 +2,32 @@
     { "name" : "Clash.Explicit.RAM.asyncRam#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRam#
-  :: ( HasCallStack              -- ARG[0]
-     , KnownDomain wdom wconf    -- ARG[1]
-     , KnownDomain rdom rconf )  -- ARG[2]
-  => Clock wdom                  -- ^ wclk, ARG[3]
-  -> Clock rdom                  -- ^ rclk, ARG[4]
-  -> Enable wdom                 -- ^ wen,  ARG[5]
-  -> SNat n                      -- ^ sz,   ARG[6]
-  -> Signal rdom Int             -- ^ rd,   ARG[7]
-  -> Signal wdom Bool            -- ^ en,   ARG[8]
-  -> Signal wdom Int             -- ^ wr,   ARG[9]
-  -> Signal wdom a               -- ^ din,  ARG[10]
-  -> Signal rdom a"
+      [ "asyncRam#"
+      , "  :: ( HasCallStack              -- ARG[0]"
+      , "     , KnownDomain wdom wconf    -- ARG[1]"
+      , "     , KnownDomain rdom rconf )  -- ARG[2]"
+      , "  => Clock wdom                  -- ^ wclk, ARG[3]"
+      , "  -> Clock rdom                  -- ^ rclk, ARG[4]"
+      , "  -> Enable wdom                 -- ^ wen,  ARG[5]"
+      , "  -> SNat n                      -- ^ sz,   ARG[6]"
+      , "  -> Signal rdom Int             -- ^ rd,   ARG[7]"
+      , "  -> Signal wdom Bool            -- ^ en,   ARG[8]"
+      , "  -> Signal wdom Int             -- ^ wr,   ARG[9]"
+      , "  -> Signal wdom a               -- ^ din,  ARG[10]"
+      , "  -> Signal rdom a"
+      ]
     , "template" :
-"// asyncRam begin
-logic [~SIZE[~TYP[10]]-1:0] ~GENSYM[RAM][0] [0:~LIT[6]-1];
-always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_Ram][1]
-  if (~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] & ~ELSE ~FI ~ARG[8]) begin
-    ~SYM[0][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];
-  end
-end
-
-assign ~RESULT = ~FROMBV[~SYM[0][\\~ARG[7]\\]][~TYPO];
-// asyncRam end"
+      [ "// asyncRam begin"
+      , "logic [~SIZE[~TYP[10]]-1:0] ~GENSYM[RAM][0] [0:~LIT[6]-1];"
+      , "always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_Ram][1]"
+      , "  if (~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] & ~ELSE ~FI ~ARG[8]) begin"
+      , "    ~SYM[0][~ARG[9]] <= ~TOBV[~ARG[10]][~TYP[10]];"
+      , "  end"
+      , "end"
+      , ""
+      , "assign ~RESULT = ~FROMBV[~SYM[0][\\~ARG[7]\\]][~TYPO];"
+      , "// asyncRam end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_ROM.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_ROM.primitives
@@ -2,31 +2,33 @@
     { "name" : "Clash.Explicit.ROM.rom#"
     , "kind" : "Declaration"
     , "type" :
-"rom# :: ( KnownDomain dom        ARG[0]
-         , KnownNat n    --       ARG[1]
-         , Undefined a ) --       ARG[2]
-      => Clock dom       -- clk,  ARG[3]
-      => Enable dom      -- en,   ARG[4]
-      -> Vec n a         -- init, ARG[5]
-      -> Signal dom Int  -- rd,   ARG[6]
-      -> Signal dom a"
+      [ "rom# :: ( KnownDomain dom        ARG[0]"
+      , "         , KnownNat n    --       ARG[1]"
+      , "         , Undefined a ) --       ARG[2]"
+      , "      => Clock dom       -- clk,  ARG[3]"
+      , "      => Enable dom      -- en,   ARG[4]"
+      , "      -> Vec n a         -- init, ARG[5]"
+      , "      -> Signal dom Int  -- rd,   ARG[6]"
+      , "      -> Signal dom a"
+      ]
     , "template" :
-"// rom begin
-~SIGD[~GENSYM[ROM][1]][5];
-assign ~SYM[1] = ~LIT[5];
-
-logic [~SIZE[~TYPO]-1:0] ~GENSYM[~RESULT_q][2];~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_rom][3]
-  if (~ARG[4]) begin
-    ~SYM[2] <= ~SYM[1][~ARG[6]];
-  end
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]
-  ~SYM[2] <= ~SYM[1][~ARG[6]];
-end~FI
-
-assign ~RESULT = ~FROMBV[~SYM[2]][~TYPO];
-// rom end"
+      [ "// rom begin"
+      , "~SIGD[~GENSYM[ROM][1]][5];"
+      , "assign ~SYM[1] = ~LIT[5];"
+      , ""
+      , "logic [~SIZE[~TYPO]-1:0] ~GENSYM[~RESULT_q][2];~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_rom][3]"
+      , "  if (~ARG[4]) begin"
+      , "    ~SYM[2] <= ~SYM[1][~ARG[6]];"
+      , "  end"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]"
+      , "  ~SYM[2] <= ~SYM[1][~ARG[6]];"
+      , "end~FI"
+      , ""
+      , "assign ~RESULT = ~FROMBV[~SYM[2]][~TYPO];"
+      , "// rom end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_ROM_File.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_ROM_File.primitives
@@ -2,34 +2,36 @@
     { "name" : "Clash.Explicit.ROM.File.romFile#"
     , "kind" : "Declaration"
     , "type" :
-"romFile# :: ( KnownNat m             --       ARG[0]
-             , KnownDomain dom )      --       ARG[1]
-          => Clock dom                -- clk,  ARG[2]
-          -> Enable dom               -- en,   ARG[3]
-          -> SNat n                   -- sz,   ARG[4]
-          -> FilePath                 -- file, ARG[5]
-          -> Signal dom Int           -- rd,   ARG[6]
-          -> Signal dom (BitVector m)"
+      [ "romFile# :: ( KnownNat m             --       ARG[0]"
+      , "             , KnownDomain dom )      --       ARG[1]"
+      , "          => Clock dom                -- clk,  ARG[2]"
+      , "          -> Enable dom               -- en,   ARG[3]"
+      , "          -> SNat n                   -- sz,   ARG[4]"
+      , "          -> FilePath                 -- file, ARG[5]"
+      , "          -> Signal dom Int           -- rd,   ARG[6]"
+      , "          -> Signal dom (BitVector m)"
+      ]
     , "template" :
-"// romFile begin
-~SIGDO[~GENSYM[ROM][0]] [0:~LIT[4]-1];
-
-initial begin
-  $readmemb(~FILE[~LIT[5]],~SYM[0]);
-end
-
-~SIGDO[~GENSYM[~RESULT_q][1]];~IF ~ISACTIVEENABLE[3] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~COMPNAME_romFile][2]
-  if (~ARG[3]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[6]];
-  end
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~SYM[2]
-  ~SYM[1] <= ~SYM[0][~ARG[6]];
-end~FI
-
-assign ~RESULT = ~SYM[1];
-// romFile end"
+      [ "// romFile begin"
+      , "~SIGDO[~GENSYM[ROM][0]] [0:~LIT[4]-1];"
+      , ""
+      , "initial begin"
+      , "  $readmemb(~FILE[~LIT[5]],~SYM[0]);"
+      , "end"
+      , ""
+      , "~SIGDO[~GENSYM[~RESULT_q][1]];~IF ~ISACTIVEENABLE[3] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~COMPNAME_romFile][2]"
+      , "  if (~ARG[3]) begin"
+      , "    ~SYM[1] <= ~SYM[0][~ARG[6]];"
+      , "  end"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~SYM[2]"
+      , "  ~SYM[1] <= ~SYM[0][~ARG[6]];"
+      , "end~FI"
+      , ""
+      , "assign ~RESULT = ~SYM[1];"
+      , "// romFile end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.primitives
@@ -2,59 +2,63 @@
     { "name" : "Clash.Explicit.Testbench.assert"
     , "kind" : "Declaration"
     , "type" :
-"assert
-  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0], ARG[1], ARG[2])
-  => Clock dom                             -- ARG[3]
-  -> Reset dom                             -- ARG[4]
-  -> String                                -- ARG[5]
-  -> Signal dom a                          -- Checked value  (ARG[6])
-  -> Signal dom a                          -- Expected value (ARG[7])
-  -> Signal dom b                          -- Return valued  (ARG[8])
-  -> Signal dom b"
+      [ "assert"
+      , "  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0], ARG[1], ARG[2])"
+      , "  => Clock dom                             -- ARG[3]"
+      , "  -> Reset dom                             -- ARG[4]"
+      , "  -> String                                -- ARG[5]"
+      , "  -> Signal dom a                          -- Checked value  (ARG[6])"
+      , "  -> Signal dom a                          -- Expected value (ARG[7])"
+      , "  -> Signal dom b                          -- Return valued  (ARG[8])"
+      , "  -> Signal dom b"
+      ]
     , "template" :
-"// assert begin
-// pragma translate_off
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin
-  if (~ARG[6] !== ~ARG[7]) begin
-    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[5], ~TOBV[~ARG[7]][~TYP[7]], ~TOBV[~ARG[6]][~TYP[6]]);
-    $stop;
-  end
-end
-// pragma translate_on
-assign ~RESULT = ~ARG[8];
-// assert end"
+      [ "// assert begin"
+      , "// pragma translate_off"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin"
+      , "  if (~ARG[6] !== ~ARG[7]) begin"
+      , "    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[5], ~TOBV[~ARG[7]][~TYP[7]], ~TOBV[~ARG[6]][~TYP[6]]);"
+      , "    $stop;"
+      , "  end"
+      , "end"
+      , "// pragma translate_on"
+      , "assign ~RESULT = ~ARG[8];"
+      , "// assert end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.Testbench.assertBitVector"
     , "kind" : "Declaration"
     , "type" :
-"assertBitVector
-  :: ( KnownDomain dom        --                 ARG[0]
-     , KnownNat n )           --                 ARG[1]
-  => Clock dom                --                 ARG[2]
-  -> Reset dom                --                 ARG[3]
-  -> String                   --                 ARG[4]
-  -> Signal dom (BitVector n) -- Checked value  (ARG[5])
-  -> Signal dom (BitVector n) -- Expected value (ARG[6])
-  -> Signal dom b             -- Return valued  (ARG[7])
-  -> Signal dom b"
+      [ "assertBitVector"
+      , "  :: ( KnownDomain dom        --                 ARG[0]"
+      , "     , KnownNat n )           --                 ARG[1]"
+      , "  => Clock dom                --                 ARG[2]"
+      , "  -> Reset dom                --                 ARG[3]"
+      , "  -> String                   --                 ARG[4]"
+      , "  -> Signal dom (BitVector n) -- Checked value  (ARG[5])"
+      , "  -> Signal dom (BitVector n) -- Expected value (ARG[6])"
+      , "  -> Signal dom b             -- Return valued  (ARG[7])"
+      , "  -> Signal dom b"
+      ]
     , "template" :
-"// assertBitVector begin
-// pragma translate_off
-wire ~TYP[6] ~GENSYM[maskXor][0]  = ~ARG[6] ^ ~ARG[6];
-wire ~TYP[6] ~GENSYM[checked][1]  = ~ARG[5] ^ ~SYM[0];
-wire ~TYP[6] ~GENSYM[expected][2] = ~ARG[6] ^ ~SYM[0];
-
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin
-  if (~SYM[1] !== ~SYM[2]) begin
-    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[4], ~TOBV[~ARG[6]][~TYP[6]], ~TOBV[~ARG[5]][~TYP[5]]);
-    $stop;
-  end
-end
-// pragma translate_on
-assign ~RESULT = ~ARG[7];
-// assertBitVector end"
+      [ "// assertBitVector begin"
+      , "// pragma translate_off"
+      , "wire ~TYP[6] ~GENSYM[maskXor][0]  = ~ARG[6] ^ ~ARG[6];"
+      , "wire ~TYP[6] ~GENSYM[checked][1]  = ~ARG[5] ^ ~SYM[0];"
+      , "wire ~TYP[6] ~GENSYM[expected][2] = ~ARG[6] ^ ~SYM[0];"
+      , ""
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin"
+      , "  if (~SYM[1] !== ~SYM[2]) begin"
+      , "    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[4], ~TOBV[~ARG[6]][~TYP[6]], ~TOBV[~ARG[5]][~TYP[5]]);"
+      , "    $stop;"
+      , "  end"
+      , "end"
+      , "// pragma translate_on"
+      , "assign ~RESULT = ~ARG[7];"
+      , "// assertBitVector end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -63,29 +67,31 @@ assign ~RESULT = ~ARG[7];
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
-"tbClockGen
-  :: KnownDomain dom     -- ARG[0]
-  => Signal dom Bool      -- ARG[1]
-  -> Clock dom"
+      [ "tbClockGen"
+      , "  :: KnownDomain dom     -- ARG[0]"
+      , "  => Signal dom Bool      -- ARG[1]"
+      , "  -> Clock dom"
+      ]
     , "template" :
-"// tbClockGen begin
-// pragma translate_off
-// 1 = 0.1ps
-localparam ~GENSYM[half_period][0] = (~PERIOD[0]0 / 2);
-always begin
-  ~RESULT = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;
-  #30000 forever begin
-    if (~ ~ARG[1]) begin
-      $finish;
-    end
-    ~RESULT = ~ ~RESULT;
-    #~SYM[0];
-    ~RESULT = ~ ~RESULT;
-    #~SYM[0];
-  end
-end
-// pragma translate_on
-// tbClockGen end"
+      [ "// tbClockGen begin"
+      , "// pragma translate_off"
+      , "// 1 = 0.1ps"
+      , "localparam ~GENSYM[half_period][0] = (~PERIOD[0]0 / 2);"
+      , "always begin"
+      , "  ~RESULT = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;"
+      , "  #30000 forever begin"
+      , "    if (~ ~ARG[1]) begin"
+      , "      $finish;"
+      , "    end"
+      , "    ~RESULT = ~ ~RESULT;"
+      , "    #~SYM[0];"
+      , "    ~RESULT = ~ ~RESULT;"
+      , "    #~SYM[0];"
+      , "  end"
+      , "end"
+      , "// pragma translate_on"
+      , "// tbClockGen end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives
@@ -2,47 +2,49 @@
     { "name" : "Clash.Intel.DDR.altddioIn"
     , "kind" : "Declaration"
     , "type" :
-"altddioIn
-  :: ( HasCallStack               -- ARG[0]
-     , KnownConfi~ fast domf      -- ARG[1]
-     , KnownConfi~ slow doms      -- ARG[2]
-     , KnownNat m )               -- ARG[3]
-  => SSymbol deviceFamily         -- ARG[4]
-  -> Clock slow                   -- ARG[5]
-  -> Reset slow                   -- ARG[6]
-  -> Enable slow                  -- ARG[7]
-  -> Signal fast (BitVector m)    -- ARG[8]
-  -> Signal slow (BitVector m,BitVector m)"
+      [ "altddioIn"
+      , "  :: ( HasCallStack               -- ARG[0]"
+      , "     , KnownConfi~ fast domf      -- ARG[1]"
+      , "     , KnownConfi~ slow doms      -- ARG[2]"
+      , "     , KnownNat m )               -- ARG[3]"
+      , "  => SSymbol deviceFamily         -- ARG[4]"
+      , "  -> Clock slow                   -- ARG[5]"
+      , "  -> Reset slow                   -- ARG[6]"
+      , "  -> Enable slow                  -- ARG[7]"
+      , "  -> Signal fast (BitVector m)    -- ARG[8]"
+      , "  -> Signal slow (BitVector m,BitVector m)"
+      ]
     , "libraries" : ["altera_mf"]
     , "template" :
-"// altddioIn begin
-~SIGD[~GENSYM[dataout_l][1]][8];
-~SIGD[~GENSYM[dataout_h][2]][8];
-
-altddio_in
-  #(
-    .intended_device_family (~LIT[4]),
-    .invert_input_clocks (\"OFF\"),
-    .lpm_hint (\"UNUSED\"),
-    .lpm_type (\"altddio_in\"),
-    .power_up_high (\"OFF\"),
-    .width (~SIZE[~TYP[8]])
-  )
-  ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[2] ~THEN
-    .sclr (~ARG[6]),
-    .aclr (1'b0),~ELSE
-    .aclr (~ARG[6]),
-    .sclr (1'b0),~FI
-    .datain (~ARG[8]),
-    .inclock (~ARG[5]),
-    .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN~ARG[7]~ELSE1'b1,~FI),
-    .dataout_h (~SYM[2]),
-    .dataout_l (~SYM[1]),
-    .aset (1'b0),
-    .sset (1'b0)
-  );
-assign ~RESULT = {~SYM[1],~SYM[2]};
-// altddioIn end"
+      [ "// altddioIn begin"
+      , "~SIGD[~GENSYM[dataout_l][1]][8];"
+      , "~SIGD[~GENSYM[dataout_h][2]][8];"
+      , ""
+      , "altddio_in"
+      , "  #("
+      , "    .intended_device_family (~LIT[4]),"
+      , "    .invert_input_clocks (\"OFF\"),"
+      , "    .lpm_hint (\"UNUSED\"),"
+      , "    .lpm_type (\"altddio_in\"),"
+      , "    .power_up_high (\"OFF\"),"
+      , "    .width (~SIZE[~TYP[8]])"
+      , "  )"
+      , "  ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[2] ~THEN"
+      , "    .sclr (~ARG[6]),"
+      , "    .aclr (1'b0),~ELSE"
+      , "    .aclr (~ARG[6]),"
+      , "    .sclr (1'b0),~FI"
+      , "    .datain (~ARG[8]),"
+      , "    .inclock (~ARG[5]),"
+      , "    .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN~ARG[7]~ELSE1'b1,~FI),"
+      , "    .dataout_h (~SYM[2]),"
+      , "    .dataout_l (~SYM[1]),"
+      , "    .aset (1'b0),"
+      , "    .sset (1'b0)"
+      , "  );"
+      , "assign ~RESULT = {~SYM[1],~SYM[2]};"
+      , "// altddioIn end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Prelude_ROM.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Prelude_ROM.primitives
@@ -2,17 +2,19 @@
     { "name" : "Clash.Prelude.ROM.asyncRom#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRom# :: KnownNat n -- ^ ARG[0]
-           => Vec n a    -- ^ ARG[1]
-           -> Int        -- ^ ARG[2]
-           -> a"
+      [ "asyncRom# :: KnownNat n -- ^ ARG[0]"
+      , "          => Vec n a    -- ^ ARG[1]"
+      , "          -> Int        -- ^ ARG[2]"
+      , "          -> a"
+      ]
     , "template" :
-"// asyncRom begin
-~SIGD[~GENSYM[ROM][0]][1];
-assign ~SYM[0] = ~LIT[1];
-
-assign ~RESULT = ~FROMBV[~SYM[0][\\~ARG[2]\\]][~TYPO];
-// asyncRom end"
+      [ "// asyncRom begin"
+      , "~SIGD[~GENSYM[ROM][0]][1];"
+      , "assign ~SYM[0] = ~LIT[1];"
+      , ""
+      , "assign ~RESULT = ~FROMBV[~SYM[0][\\~ARG[2]\\]][~TYPO];"
+      , "// asyncRom end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Prelude_ROM_File.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Prelude_ROM_File.primitives
@@ -2,21 +2,23 @@
     { "name" : "Clash.Prelude.ROM.File.asyncRomFile#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRomFile :: KnownNat m -- ARG[0]
-              => SNat n     -- sz,   ARG[1]
-              -> FilePath   -- file, ARG[2]
-              -> Int        -- rd,   ARG[3]
-              -> BitVector m"
+      [ "asyncRomFile :: KnownNat m -- ARG[0]"
+      , "             => SNat n     -- sz,   ARG[1]"
+      , "             -> FilePath   -- file, ARG[2]"
+      , "             -> Int        -- rd,   ARG[3]"
+      , "             -> BitVector m"
+      ]
     , "template" :
-"// asyncRomFile begin
-~SIGDO[~GENSYM[ROM][0]] [0:~LIT[1]-1];
-
-initial begin
-  $readmemb(~FILE[~LIT[2]],~SYM[0]);
-end
-
-assign ~RESULT = ~SYM[0][~ARG[3]];
-// asyncRomFile end"
+      [ "// asyncRomFile begin"
+      , "~SIGDO[~GENSYM[ROM][0]] [0:~LIT[1]-1];"
+      , ""
+      , "initial begin"
+      , "  $readmemb(~FILE[~LIT[2]],~SYM[0]);"
+      , "end"
+      , ""
+      , "assign ~RESULT = ~SYM[0][~ARG[3]];"
+      , "// asyncRomFile end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Signal_BiSignal.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Signal_BiSignal.primitives
@@ -1,19 +1,21 @@
 [ { "BlackBox" :
-    { "name" : "Clash.Signal.BiSignal.writeToBiSignal#",
-      "kind" : "Declaration",
-      "renderVoid": "RenderVoid",
-      "type" :
-"writeToBiSignal#
-  :: HasCallStack                   -- ARG[0]
-  => BiSignalIn ds d n              -- ARG[1]
-  -> Signal d (Maybe (BitVector n)) -- ARG[2]
-  -> Signal d Bool                  -- ARG[3]
-  -> Signal d (BitVector n)         -- ARG[4]
-  -> BiSignalOut ds d n",
-      "template":
-"// writeToBiSignal# begin
-assign ~ARG[1] = (~ARG[3] == 1'b1) ? ~ARG[4] : {~SIZE[~TYP[1]] {1'bz}};
-// writeToBiSignal# end"
+    { "name" : "Clash.Signal.BiSignal.writeToBiSignal#"
+    , "kind" : "Declaration"
+    , "renderVoid": "RenderVoid"
+    , "type" :
+        [ "writeToBiSignal#"
+        , "  :: HasCallStack                   -- ARG[0]"
+        , "  => BiSignalIn ds d n              -- ARG[1]"
+        , "  -> Signal d (Maybe (BitVector n)) -- ARG[2]"
+        , "  -> Signal d Bool                  -- ARG[3]"
+        , "  -> Signal d (BitVector n)         -- ARG[4]"
+        , "  -> BiSignalOut ds d n"
+        ]
+    , "template":
+      [ "// writeToBiSignal# begin"
+      , "assign ~ARG[1] = (~ARG[3] == 1'b1) ? ~ARG[4] : {~SIZE[~TYP[1]] {1'bz}};"
+      , "// writeToBiSignal# end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -21,15 +23,17 @@ assign ~ARG[1] = (~ARG[3] == 1'b1) ? ~ARG[4] : {~SIZE[~TYP[1]] {1'bz}};
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"readFromBiSignal#
-  :: ( HasCallStack    -- ARG[0]
-     , KnownNat n)     -- ARG[1]
-  => BiSignalIn ds d n -- ARG[2]
-  -> Signal d (BitVector n)"
+      [ "readFromBiSignal#"
+      , "  :: ( HasCallStack    -- ARG[0]"
+      , "     , KnownNat n)     -- ARG[1]"
+      , "  => BiSignalIn ds d n -- ARG[2]"
+      , "  -> Signal d (BitVector n)"
+      ]
     , "template" :
-"// readFromBiSignal begin
-assign ~RESULT = ~ARG[2];
-// readFromBiSignal end"
+      [ "// readFromBiSignal begin"
+      , "assign ~RESULT = ~ARG[2];"
+      , "// readFromBiSignal end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.primitives
@@ -2,83 +2,89 @@
     { "name" : "Clash.Signal.Internal.delay#"
     , "kind" : "Declaration"
     , "type" :
-"delay#
-  :: ( KnownDomain dom        -- ARG[0]
-     , Undefined a )          -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Enable dom               -- ARG[3]
-  -> a                        -- ARG[4]
-  -> Signal clk a             -- ARG[5]
-  -> Signal clk a"
+      [ "delay#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , Undefined a )          -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Enable dom               -- ARG[3]"
+      , "  -> a                        -- ARG[4]"
+      , "  -> Signal clk a             -- ARG[5]"
+      , "  -> Signal clk a"
+      ]
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[4]~ELSE~FI" }
     , "template" :
-"// delay begin~IF ~ISACTIVEENABLE[3] ~THEN
-always_ff @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~RESULT_delay][1]
-  if (~ARG[3]) begin
-    ~RESULT <= ~ARG[5];
-  end
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~SYM[1]
-  ~RESULT <= ~ARG[5];
-end~FI
-// delay end"
+      [ "// delay begin~IF ~ISACTIVEENABLE[3] ~THEN"
+      , "always_ff @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~RESULT_delay][1]"
+      , "  if (~ARG[3]) begin"
+      , "    ~RESULT <= ~ARG[5];"
+      , "  end"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~SYM[1]"
+      , "  ~RESULT <= ~ARG[5];"
+      , "end~FI"
+      , "// delay end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.asyncRegister#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRegister#
-  :: ( KnownDomain dom        -- ARG[0]
-     , NFDataX a )            -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Reset dom                -- ARG[3]
-  -> Enable dom               -- ARG[4]
-  -> a                        -- ARG[5] (powerup value)
-  -> a                        -- ARG[6] (reset value)
-  -> Signal clk a             -- ARG[7]
-  -> Signal clk a"
+      [ "asyncRegister#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , NFDataX a )            -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Reset dom                -- ARG[3]"
+      , "  -> Enable dom               -- ARG[4]"
+      , "  -> a                        -- ARG[5] (powerup value)"
+      , "  -> a                        -- ARG[6] (reset value)"
+      , "  -> Signal clk a             -- ARG[7]"
+      , "  -> Signal clk a"
+      ]
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[5]~ELSE~FI" }
     , "template" :
-"// async register begin
-always_ff @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~VAR[rst][3]~FI) begin : ~GENSYM[~RESULT_register][1]
-  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~VAR[rst][3]) begin
-    ~RESULT <= ~CONST[6];
-  end else ~FI~IF ~ISACTIVEENABLE[4] ~THEN if (~ARG[4]) ~ELSE ~FI begin
-    ~RESULT <= ~ARG[7];
-  end
-end
-// async register end"
+      [ "// async register begin"
+      , "always_ff @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~VAR[rst][3]~FI) begin : ~GENSYM[~RESULT_register][1]"
+      , "  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~VAR[rst][3]) begin"
+      , "    ~RESULT <= ~CONST[6];"
+      , "  end else ~FI~IF ~ISACTIVEENABLE[4] ~THEN if (~ARG[4]) ~ELSE ~FI begin"
+      , "    ~RESULT <= ~ARG[7];"
+      , "  end"
+      , "end"
+      , "// async register end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.register#"
     , "kind" : "Declaration"
     , "type" :
-"register#
-  :: ( KnownDomain dom        -- ARG[0]
-     , Undefined a )          -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Reset dom                -- ARG[3]
-  -> Enable dom               -- ARG[4]
-  -> a                        -- ARG[5] (powerup value)
-  -> a                        -- ARG[6] (reset value)
-  -> Signal clk a             -- ARG[7]
-  -> Signal clk a"
+      [ "register#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , Undefined a )          -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Reset dom                -- ARG[3]"
+      , "  -> Enable dom               -- ARG[4]"
+      , "  -> a                        -- ARG[5] (powerup value)"
+      , "  -> a                        -- ARG[6] (reset value)"
+      , "  -> Signal clk a             -- ARG[7]"
+      , "  -> Signal clk a"
+      ]
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[5]~ELSE~FI" }
     , "template" :
-"// register begin
-always_ff @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISSYNC[0] ~THEN ~ELSE~IF ~ISUNDEFINED[6] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~VAR[rst][3]~FI~FI) begin : ~GENSYM[~RESULT_register][1]
-  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~VAR[rst][3]) begin
-    ~RESULT <= ~CONST[6];
-  end else ~FI~IF ~ISACTIVEENABLE[4] ~THEN if (~ARG[4]) ~ELSE ~FI begin
-    ~RESULT <= ~ARG[7];
-  end
-end
-// register end"
+      [ "// register begin"
+      , "always_ff @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISSYNC[0] ~THEN ~ELSE~IF ~ISUNDEFINED[6] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~VAR[rst][3]~FI~FI) begin : ~GENSYM[~RESULT_register][1]"
+      , "  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~VAR[rst][3]) begin"
+      , "    ~RESULT <= ~CONST[6];"
+      , "  end else ~FI~IF ~ISACTIVEENABLE[4] ~THEN if (~ARG[4]) ~ELSE ~FI begin"
+      , "    ~RESULT <= ~ARG[7];"
+      , "  end"
+      , "end"
+      , "// register end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -87,25 +93,27 @@ end
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
-"clockGen
-  :: KnownDomain dom     -- ARG[0]
-  => Clock dom"
+      [ "clockGen"
+      , "  :: KnownDomain dom     -- ARG[0]"
+      , "  => Clock dom"
+      ]
     , "template" :
-"// clockGen begin
-// pragma translate_off
-// 1 = 0.1ps
-localparam ~GENSYM[half_period][0] = (~PERIOD[0]0 / 2);
-always begin
-  ~RESULT = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;
-  #30000 forever begin
-    ~RESULT = ~ ~RESULT;
-    #~SYM[0];
-    ~RESULT = ~ ~RESULT;
-    #~SYM[0];
-  end
-end
-// pragma translate_on
-// clockGen end"
+      [ "// clockGen begin"
+      , "// pragma translate_off"
+      , "// 1 = 0.1ps"
+      , "localparam ~GENSYM[half_period][0] = (~PERIOD[0]0 / 2);"
+      , "always begin"
+      , "  ~RESULT = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;"
+      , "  #30000 forever begin"
+      , "    ~RESULT = ~ ~RESULT;"
+      , "    #~SYM[0];"
+      , "    ~RESULT = ~ ~RESULT;"
+      , "    #~SYM[0];"
+      , "  end"
+      , "end"
+      , "// pragma translate_on"
+      , "// clockGen end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -114,22 +122,23 @@ end
     , "kind" : "Declaration"
     , "type" : "resetGenN :: (KnownDomain dom, 1 <= n) => SNat n -> Reset dom"
     , "template" :
-"// resetGen begin
-// pragma translate_off
-~IF~ISSYNC[0]~THEN
-localparam ~GENSYM[reset_period][1] = 29998 + (~LIT[2] * ~PERIOD[0]0);
-initial begin
-  #1 ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;
-  #~SYM[1] ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;
-end~ELSE
-localparam ~SYM[1] = 30001 + ((~LIT[2] - 1) * ~PERIOD[0]0);
-initial begin
-  #1     ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;
-  #~SYM[1] ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;
-end
-~FI
-// pragma translate_on
-// resetGen end"
+      [ "// resetGen begin"
+      , "// pragma translate_off"
+      , "~IF~ISSYNC[0]~THEN"
+      , "localparam ~GENSYM[reset_period][1] = 29998 + (~LIT[2] * ~PERIOD[0]0);"
+      , "initial begin"
+      , "  #1 ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;"
+      , "  #~SYM[1] ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;"
+      , "end~ELSE"
+      , "localparam ~SYM[1] = 30001 + ((~LIT[2] - 1) * ~PERIOD[0]0);"
+      , "initial begin"
+      , "  #1     ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;"
+      , "  #~SYM[1] ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;"
+      , "end"
+      , "~FI"
+      , "// pragma translate_on"
+      , "// resetGen end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.primitives
@@ -1,19 +1,21 @@
 [ { "BlackBox" :
-    { "name"      : "Clash.Sized.Internal.BitVector.replaceBit#"
-    , "kind"      : "Declaration"
+    { "name"   : "Clash.Sized.Internal.BitVector.replaceBit#"
+    , "kind"   : "Declaration"
     , "type" :
-"replaceBit# :: KnownNat n  -- ARG[0]
-             => BitVector n -- ARG[1]
-             -> Int         -- ARG[2]
-             -> Bit         -- ARG[3]
-             -> BitVector n"
+      [ "replaceBit# :: KnownNat n  -- ARG[0]"
+      , "             => BitVector n -- ARG[1]"
+      , "             -> Int         -- ARG[2]"
+      , "             -> Bit         -- ARG[3]"
+      , "             -> BitVector n"
+      ]
     , "template" :
-"// replaceBit start
-always_comb begin
-  ~RESULT = ~ARG[1];
-  ~RESULT[~ARG[2]] = ~ARG[3];
-end
-// replaceBit end"
+      [ "// replaceBit start"
+      , "always_comb begin"
+      , "  ~RESULT = ~ARG[1];"
+      , "  ~RESULT[~ARG[2]] = ~ARG[3];"
+      , "end"
+      , "// replaceBit end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -21,19 +23,21 @@ end
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"setSlice# :: SNat (m + 1 + i)
-           -> BitVector (m + 1 + i) -- ARG[1]
-           -> SNat m                -- ARG[2]
-           -> SNat n                -- ARG[3]
-           -> BitVector (m + 1 - n) -- ARG[4]
-           -> BitVector (m + 1 + i)"
+      [ "setSlice# :: SNat (m + 1 + i)"
+      , "           -> BitVector (m + 1 + i) -- ARG[1]"
+      , "           -> SNat m                -- ARG[2]"
+      , "           -> SNat n                -- ARG[3]"
+      , "           -> BitVector (m + 1 - n) -- ARG[4]"
+      , "           -> BitVector (m + 1 + i)"
+      ]
     , "template" :
-"// setSlice begin
-always_comb begin
-  ~RESULT = ~ARG[1];
-  ~RESULT[~LIT[2] : ~LIT[3]] = ~ARG[4];
-end
-// setSlice end"
+      [ "// setSlice begin"
+      , "always_comb begin"
+      , "  ~RESULT = ~ARG[1];"
+      , "  ~RESULT[~LIT[2] : ~LIT[3]] = ~ARG[4];"
+      , "end"
+      , "// setSlice end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -41,15 +45,17 @@ end
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"split# :: KnownNat n        -- ARG[0]
-        => BitVector (m + n) -- ARG[1]
-        -> (BitVector m, BitVector n)"
+      [ "split# :: KnownNat n        -- ARG[0]"
+      , "       => BitVector (m + n) -- ARG[1]"
+      , "       -> (BitVector m, BitVector n)"
+      ]
     , "template" :
-"// split begin
-assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
-                 , ~VAR[bv][1][(~LIT[0]-1) : 0]
-                 };
-// split end"
+      [ "// split begin"
+      , "assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]"
+      , "                 , ~VAR[bv][1][(~LIT[0]-1) : 0]"
+      , "                 };"
+      , "// split end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -57,11 +63,12 @@ assign ~RESULT = { ~VAR[bv][1][$high(~VAR[bv][1]) : ~LIT[0]]
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"// rotateL begin
-logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
-// rotateL end"
+      [ "// rotateL begin"
+      , "logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];"
+      , "// rotateL end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -69,11 +76,12 @@ assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"// rotateR begin
-logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
-// rotateR end"
+      [ "// rotateR begin"
+      , "logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];"
+      , "// rotateR end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Signed.primitives
@@ -3,26 +3,27 @@
     , "kind"      : "Declaration"
     , "type"      : "div# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "template"  :
-"// divSigned begin
-logic ~GENSYM[resultPos][1];
-logic ~GENSYM[dividerNeg][2];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
-
-assign ~SYM[1] = ~VAR[dividend][1][~SIZE[~TYPO]-1] == ~VAR[divider][2][~SIZE[~TYPO]-1];
-assign ~SYM[2] = ~VAR[divider][2][~SIZE[~TYPO]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][1][~SIZE[~TYPO]-1]},~VAR[dividend][1]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][2][~SIZE[~TYPO]-1]} ,~VAR[divider][2]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
-// divSigned end"
+      [ "// divSigned begin"
+      , "logic ~GENSYM[resultPos][1];"
+      , "logic ~GENSYM[dividerNeg][2];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][1][~SIZE[~TYPO]-1] == ~VAR[divider][2][~SIZE[~TYPO]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][2][~SIZE[~TYPO]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][1][~SIZE[~TYPO]-1]},~VAR[dividend][1]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][2][~SIZE[~TYPO]-1]} ,~VAR[divider][2]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);"
+      , "// divSigned end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -30,16 +31,17 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "kind"      : "Declaration"
     , "type"      : "mod# :: Signed n -> Signed n -> Signed n"
     , "template"  :
-"// modSigned begin
-// remainder
-~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 (~SYM[0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// modSigned end"
+      [ "// modSigned begin"
+      , "// remainder"
+      , "~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 (~SYM[0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// modSigned end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -47,11 +49,12 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"// rotateL begin
-logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = $signed(~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]]);
-// rotateL end"
+      [ "// rotateL begin"
+      , "logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = $signed(~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]]);"
+      , "// rotateL end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -59,11 +62,12 @@ assign ~RESULT = $signed(~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]]);
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"// rotateR begin
-logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = $signed(~SYM[0][~SIZE[~TYPO]-1 : 0]);
-// rotateR end"
+      [ "// rotateR begin"
+      , "logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = $signed(~SYM[0][~SIZE[~TYPO]-1 : 0]);"
+      , "// rotateR end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_Unsigned.primitives
@@ -3,11 +3,12 @@
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"// rotateL begin
-logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
-// rotateL end"
+      [ "// rotateL begin"
+      , "logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];"
+      , "// rotateL end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -15,11 +16,12 @@ assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"// rotateR begin
-logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
-// rotateR end"
+      [ "// rotateR begin"
+      , "logic [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];"
+      , "// rotateR end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Sized_Vector.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Vector.primitives
@@ -35,21 +35,23 @@
     , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
-"select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
-        => SNat f                        -- ARG[1]
-        -> SNat s                        -- ARG[2]
-        -> SNat n                        -- ARG[3]
-        -> Vec i a                       -- ARG[4]
-        -> Vec n a"
+      [ "select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]"
+      , "        => SNat f                        -- ARG[1]"
+      , "        -> SNat s                        -- ARG[2]"
+      , "        -> SNat n                        -- ARG[3]"
+      , "        -> Vec i a                       -- ARG[4]"
+      , "        -> Vec n a"
+      ]
     , "template" :
-"// select begin
-genvar ~GENSYM[n][1];
-~GENERATE
-  for (~SYM[1]=0; ~SYM[1] < ~LIT[3]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[select][2]
-    assign ~RESULT[~SYM[1]] = ~VAR[vec][4][~LIT[1] + (~LIT[2] * ~SYM[1])];
-  end
-~ENDGENERATE
-// select end"
+      [ "// select begin"
+      , "genvar ~GENSYM[n][1];"
+      , "~GENERATE"
+      , "  for (~SYM[1]=0; ~SYM[1] < ~LIT[3]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[select][2]"
+      , "    assign ~RESULT[~SYM[1]] = ~VAR[vec][4][~LIT[1] + (~LIT[2] * ~SYM[1])];"
+      , "  end"
+      , "~ENDGENERATE"
+      , "// select end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -66,14 +68,15 @@ genvar ~GENSYM[n][1];
     , "kind"      : "Declaration"
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "template"  :
-"// concat begin
-genvar ~GENSYM[n][1];
-~GENERATE
-  for (~SYM[1]=0; ~SYM[1] < $size(~VAR[vec][0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[concat][2]
-    assign ~RESULT[~SYM[1]*~LENGTH[~TYPEL[~TYP[0]]] : ~SYM[1]*~LENGTH[~TYPEL[~TYP[0]]]+(~LENGTH[~TYPEL[~TYP[0]]]-1)] = ~FROMBV[~VAR[vec][0][\\~SYM[1]\\]][~TYPEL[~TYP[0]]];
-  end
-~ENDGENERATE
-// concat end"
+      [ "// concat begin"
+      , "genvar ~GENSYM[n][1];"
+      , "~GENERATE"
+      , "  for (~SYM[1]=0; ~SYM[1] < $size(~VAR[vec][0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[concat][2]"
+      , "    assign ~RESULT[~SYM[1]*~LENGTH[~TYPEL[~TYP[0]]] : ~SYM[1]*~LENGTH[~TYPEL[~TYP[0]]]+(~LENGTH[~TYPEL[~TYP[0]]]-1)] = ~FROMBV[~VAR[vec][0][\\~SYM[1]\\]][~TYPEL[~TYP[0]]];"
+      , "  end"
+      , "~ENDGENERATE"
+      , "// concat end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -82,20 +85,21 @@ genvar ~GENSYM[n][1];
     , "kind"      : "Declaration"
     , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
     , "template"  :
-"// splitAt begin~IF~LENGTH[~TYPO]~THEN
-assign ~RESULT = ~ARG[1];~ELSE
-logic [0:~LENGTH[~TYP[1]]-1] [0:~SIZE[~TYPEL[~TYP[1]]]-1] ~GENSYM[vec][0];
-assign ~SYM[0] = ~TOBV[~ARG[1]][~TYP[1]];
-~GENERATE
-  if (~LIT[0] == ~LENGTH[~TYP[1]]) begin : ~GENSYM[no_split][1]
-    assign ~RESULT = {~SYM[0]};
-  end else begin : ~GENSYM[do_split][2]
-    assign ~RESULT = {~SYM[0][0:~LIT[0]-1]
-                     ,~SYM[0][~LIT[0]:~LENGTH[~TYP[1]]-1]
-                     };
-  end
-~ENDGENERATE~FI
-// splitAt end"
+      [ "// splitAt begin~IF~LENGTH[~TYPO]~THEN"
+      , "assign ~RESULT = ~ARG[1];~ELSE"
+      , "logic [0:~LENGTH[~TYP[1]]-1] [0:~SIZE[~TYPEL[~TYP[1]]]-1] ~GENSYM[vec][0];"
+      , "assign ~SYM[0] = ~TOBV[~ARG[1]][~TYP[1]];"
+      , "~GENERATE"
+      , "  if (~LIT[0] == ~LENGTH[~TYP[1]]) begin : ~GENSYM[no_split][1]"
+      , "    assign ~RESULT = {~SYM[0]};"
+      , "  end else begin : ~GENSYM[do_split][2]"
+      , "    assign ~RESULT = {~SYM[0][0:~LIT[0]-1]"
+      , "                     ,~SYM[0][~LIT[0]:~LENGTH[~TYP[1]]-1]"
+      , "                     };"
+      , "  end"
+      , "~ENDGENERATE~FI"
+      , "// splitAt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -103,19 +107,21 @@ assign ~SYM[0] = ~TOBV[~ARG[1]][~TYP[1]];
     , "workInfo"  : "Never"
     , "kind"      : "Declaration"
     , "type" :
- "unconcat :: KnownNat n     -- ARG[0]
-           => SNat m         -- ARG[1]
-           -> Vec (n * m) a  -- ARG[2]
-           -> Vec n (Vec m a)"
+      [ "unconcat :: KnownNat n     -- ARG[0]"
+      , "         => SNat m         -- ARG[1]"
+      , "         -> Vec (n * m) a  -- ARG[2]"
+      , "         -> Vec n (Vec m a)"
+      ]
     , "template" :
-"// unconcat begin~DEVNULL[~ARG[0]]
-genvar ~GENSYM[n][1];
-~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[unconcat][2]
-    assign ~RESULT[~SYM[1]] = ~TOBV[~VAR[vec][2][\\(~SYM[1] * ~LIT[1]) : ((~SYM[1] * ~LIT[1]) + ~LIT[1] - 1)\\]][~TYPEL[~TYPO]];
-  end
-~ENDGENERATE
-// unconcat end"
+      [ "// unconcat begin~DEVNULL[~ARG[0]]"
+      , "genvar ~GENSYM[n][1];"
+      , "~GENERATE"
+      , "  for (~SYM[1] = 0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[unconcat][2]"
+      , "    assign ~RESULT[~SYM[1]] = ~TOBV[~VAR[vec][2][\\(~SYM[1] * ~LIT[1]) : ((~SYM[1] * ~LIT[1]) + ~LIT[1] - 1)\\]][~TYPEL[~TYPO]];"
+      , "  end"
+      , "~ENDGENERATE"
+      , "// unconcat end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -124,21 +130,22 @@ genvar ~GENSYM[n][1];
     , "kind"      : "Declaration"
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "template" :
-"// map begin
-genvar ~GENSYM[n][1];
-~GENERATE
-for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]~IF~SIZE[~TYP[1]]~THEN
-  ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];
-  assign ~SYM[3] = ~FROMBV[~VAR[vec][1][\\~SYM[1]\\]][~TYPEL[~TYP[1]]];~ELSE ~FI
-  ~TYPEL[~TYPO] ~GENSYM[map_out][4];
-  ~INST 0
-    ~OUTPUT <= ~SYM[4]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
-  ~INST
-  assign ~RESULT[~SYM[1]] = ~TOBV[~SYM[4]][~TYPEL[~TYPO]];
-end
-~ENDGENERATE
-// map end"
+      [ "// map begin"
+      , "genvar ~GENSYM[n][1];"
+      , "~GENERATE"
+      , "for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]~IF~SIZE[~TYP[1]]~THEN"
+      , "  ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];"
+      , "  assign ~SYM[3] = ~FROMBV[~VAR[vec][1][\\~SYM[1]\\]][~TYPEL[~TYP[1]]];~ELSE ~FI"
+      , "  ~TYPEL[~TYPO] ~GENSYM[map_out][4];"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~SYM[4]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~"
+      , "  ~INST"
+      , "  assign ~RESULT[~SYM[1]] = ~TOBV[~SYM[4]][~TYPEL[~TYPO]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// map end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -147,24 +154,25 @@ end
     , "kind"      : "Declaration"
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "template"  :
-"// imap begin
-genvar ~GENSYM[n][1];
-~GENERATE
-for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
-  ~INDEXTYPE[~LIT[0]] ~GENSYM[i][3];
-  assign ~SYM[3] = ~SYM[1];~IF~SIZE[~TYP[2]]~THEN
-  ~TYPEL[~TYP[2]] ~GENSYM[imap_in][4];
-  assign ~SYM[4] = ~FROMBV[~VAR[vec][2][\\~SYM[1]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI
-  ~TYPEL[~TYPO] ~GENSYM[imap_out][5];
-  ~INST 1
-    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[3]~ ~INDEXTYPE[~LIT[0]]~
-    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
-  ~INST
-  assign ~RESULT[~SYM[1]] = ~TOBV[~SYM[5]][~TYPEL[~TYPO]];
-end
-~ENDGENERATE
-// imap end"
+      [ "// imap begin"
+      , "genvar ~GENSYM[n][1];"
+      , "~GENERATE"
+      , "for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]"
+      , "  ~INDEXTYPE[~LIT[0]] ~GENSYM[i][3];"
+      , "  assign ~SYM[3] = ~SYM[1];~IF~SIZE[~TYP[2]]~THEN"
+      , "  ~TYPEL[~TYP[2]] ~GENSYM[imap_in][4];"
+      , "  assign ~SYM[4] = ~FROMBV[~VAR[vec][2][\\~SYM[1]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI"
+      , "  ~TYPEL[~TYPO] ~GENSYM[imap_out][5];"
+      , "  ~INST 1"
+      , "    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[3]~ ~INDEXTYPE[~LIT[0]]~"
+      , "    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "  assign ~RESULT[~SYM[1]] = ~TOBV[~SYM[5]][~TYPEL[~TYPO]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// imap end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -173,24 +181,25 @@ end
     , "kind"      : "Declaration"
     , "type"      : "imap_go :: Index n -> (Index n -> a -> b) -> Vec m a -> Vec m b"
     , "template"  :
-"// imap begin
-genvar ~GENSYM[n][1];
-~GENERATE
-for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
-  ~TYP[0] ~GENSYM[i][3];
-  assign ~SYM[3] = ~SYM[1] + ~ARG[0];~IF~SIZE[~TYP[2]]~THEN
-  ~TYPEL[~TYP[2]] ~GENSYM[imap_in][4];
-  assign ~SYM[4] = ~FROMBV[~VAR[vec][2][\\~SYM[1]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI
-  ~TYPEL[~TYPO] ~GENSYM[imap_out][5];
-  ~INST 1
-    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[3]~ ~TYP[0]~
-    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
-  ~INST
-  assign ~RESULT[~SYM[1]] = ~TOBV[~SYM[5]][~TYPEL[~TYPO]];
-end
-~ENDGENERATE
-// imap end"
+      [ "// imap begin"
+      , "genvar ~GENSYM[n][1];"
+      , "~GENERATE"
+      , "for (~SYM[1]=0; ~SYM[1] < $size(~RESULT); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]"
+      , "  ~TYP[0] ~GENSYM[i][3];"
+      , "  assign ~SYM[3] = ~SYM[1] + ~ARG[0];~IF~SIZE[~TYP[2]]~THEN"
+      , "  ~TYPEL[~TYP[2]] ~GENSYM[imap_in][4];"
+      , "  assign ~SYM[4] = ~FROMBV[~VAR[vec][2][\\~SYM[1]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI"
+      , "  ~TYPEL[~TYPO] ~GENSYM[imap_out][5];"
+      , "  ~INST 1"
+      , "    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[3]~ ~TYP[0]~"
+      , "    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "  assign ~RESULT[~SYM[1]] = ~TOBV[~SYM[5]][~TYPEL[~TYPO]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// imap end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -199,24 +208,25 @@ end
     , "kind"      : "Declaration"
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "template"  :
-"// zipWith begin
-genvar ~GENSYM[n][2];
-~GENERATE
-for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][3]~IF~SIZE[~TYP[1]]~THEN
-  ~TYPEL[~TYP[1]] ~GENSYM[zipWith_in1][4];
-  assign ~SYM[4] = ~FROMBV[~VAR[vec1][1][\\~SYM[2]\\]][~TYPEL[~TYP[1]]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN
-  ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][5];
-  assign ~SYM[5] = ~FROMBV[~VAR[vec2][2][\\~SYM[2]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI
-  ~TYPEL[~TYPO] ~GENSYM[zipWith_out][6];
-  ~INST 0
-    ~OUTPUT <= ~SYM[6]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[1]]~
-    ~INPUT  <= ~SYM[5]~ ~TYPEL[~TYP[2]]~
-  ~INST
-  assign ~RESULT[~SYM[2]] = ~TOBV[~SYM[6]][~TYPEL[~TYPO]];
-end
-~ENDGENERATE
-// zipWith end"
+      [ "// zipWith begin"
+      , "genvar ~GENSYM[n][2];"
+      , "~GENERATE"
+      , "for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][3]~IF~SIZE[~TYP[1]]~THEN"
+      , "  ~TYPEL[~TYP[1]] ~GENSYM[zipWith_in1][4];"
+      , "  assign ~SYM[4] = ~FROMBV[~VAR[vec1][1][\\~SYM[2]\\]][~TYPEL[~TYP[1]]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN"
+      , "  ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][5];"
+      , "  assign ~SYM[5] = ~FROMBV[~VAR[vec2][2][\\~SYM[2]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI"
+      , "  ~TYPEL[~TYPO] ~GENSYM[zipWith_out][6];"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~SYM[6]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[1]]~"
+      , "    ~INPUT  <= ~SYM[5]~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "  assign ~RESULT[~SYM[2]] = ~TOBV[~SYM[6]][~TYPEL[~TYPO]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// zipWith end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -225,27 +235,28 @@ end
     , "kind"      : "Declaration"
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "template"  :
-"// foldr start~IF ~LENGTH[~TYP[2]] ~THEN
-~SIGDO[~GENSYM[intermediate][0]] [0:~LENGTH[~TYP[2]]];
-assign ~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];
-
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr_loop][4]~IF~SIZE[~TYP[2]]~THEN
-  ~TYPEL[~TYP[2]] ~GENSYM[foldr_in][5];
-  assign ~SYM[5] = ~FROMBV[~VAR[xs][2][\\~SYM[3]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI
-  ~INST 0
-    ~OUTPUT <= ~SYM[0][~SYM[3]]~ ~TYP[1]~
-    ~INPUT <= ~SYM[5]~ ~TYPEL[~TYP[2]]~
-    ~INPUT <= ~SYM[0][~SYM[3]+1]~ ~TYP[1]~
-  ~INST
-end
-~ENDGENERATE
-
-assign ~RESULT = ~SYM[0][0];
-~ELSE
-assign ~RESULT = ~ARG[1];
-~FI// foldr end"
+      [ "// foldr start~IF ~LENGTH[~TYP[2]] ~THEN"
+      , "~SIGDO[~GENSYM[intermediate][0]] [0:~LENGTH[~TYP[2]]];"
+      , "assign ~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];"
+      , ""
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr_loop][4]~IF~SIZE[~TYP[2]]~THEN"
+      , "  ~TYPEL[~TYP[2]] ~GENSYM[foldr_in][5];"
+      , "  assign ~SYM[5] = ~FROMBV[~VAR[xs][2][\\~SYM[3]\\]][~TYPEL[~TYP[2]]];~ELSE ~FI"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~SYM[0][~SYM[3]]~ ~TYP[1]~"
+      , "    ~INPUT <= ~SYM[5]~ ~TYPEL[~TYP[2]]~"
+      , "    ~INPUT <= ~SYM[0][~SYM[3]+1]~ ~TYP[1]~"
+      , "  ~INST"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = ~SYM[0][0];"
+      , "~ELSE"
+      , "assign ~RESULT = ~ARG[1];"
+      , "~FI// foldr end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -260,12 +271,13 @@ assign ~RESULT = ~ARG[1];
     , "kind"      : "Declaration"
     , "type"      : "replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a"
     , "template" :
-"// replaceVec start
-always_comb begin
-  ~RESULT = ~ARG[1];
-  ~RESULT[~ARG[2]] = ~TOBV[~ARG[3]][~TYP[3]];
-end
-// replaceVec end"
+      [ "// replaceVec start"
+      , "always_comb begin"
+      , "  ~RESULT = ~ARG[1];"
+      , "  ~RESULT[~ARG[2]] = ~TOBV[~ARG[3]][~TYP[3]];"
+      , "end"
+      , "// replaceVec end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -282,18 +294,19 @@ end
     , "kind"      : "Declaration"
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "template"  :
-"// transpose begin
-genvar ~GENSYM[row_index][1];
-genvar ~GENSYM[col_index][2];
-~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~VAR[matrix][1]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]
-    for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[transpose_inner][4]~IF ~VIVADO ~THEN
-      assign ~RESULT[~SYM[2]][($size(~VAR[matrix][1])-~SYM[1])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 : ($size(~VAR[matrix][1])-~SYM[1]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~VAR[matrix][1][~SYM[1]][($size(~RESULT)-~SYM[2])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 : ($size(~RESULT)-~SYM[2]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]];~ELSE
-      assign ~RESULT[~SYM[2]][~SYM[1]] = ~VAR[matrix][1][~SYM[1]][~SYM[2]];~FI
-    end
-  end
-~ENDGENERATE
-// transpose end"
+      [ "// transpose begin"
+      , "genvar ~GENSYM[row_index][1];"
+      , "genvar ~GENSYM[col_index][2];"
+      , "~GENERATE"
+      , "  for (~SYM[1] = 0; ~SYM[1] < $size(~VAR[matrix][1]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]"
+      , "    for (~SYM[2] = 0; ~SYM[2] < $size(~RESULT); ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[transpose_inner][4]~IF ~VIVADO ~THEN"
+      , "      assign ~RESULT[~SYM[2]][($size(~VAR[matrix][1])-~SYM[1])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 : ($size(~VAR[matrix][1])-~SYM[1]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~VAR[matrix][1][~SYM[1]][($size(~RESULT)-~SYM[2])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 : ($size(~RESULT)-~SYM[2]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]];~ELSE"
+      , "      assign ~RESULT[~SYM[2]][~SYM[1]] = ~VAR[matrix][1][~SYM[1]][~SYM[2]];~FI"
+      , "    end"
+      , "  end"
+      , "~ENDGENERATE"
+      , "// transpose end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -302,14 +315,15 @@ genvar ~GENSYM[col_index][2];
     , "kind"      : "Declaration"
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "template"  :
-"// reverse begin
-genvar ~GENSYM[n][1];
-~GENERATE
-  for (~SYM[1] = 0; ~SYM[1] < $size(~VAR[vec][0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]
-    assign ~RESULT[$high(~VAR[vec][0]) - ~SYM[1]] = ~VAR[vec][0][~SYM[1]];
-  end
-~ENDGENERATE
-// reverse end"
+      [ "// reverse begin"
+      , "genvar ~GENSYM[n][1];"
+      , "~GENERATE"
+      , "  for (~SYM[1] = 0; ~SYM[1] < $size(~VAR[vec][0]); ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]"
+      , "    assign ~RESULT[$high(~VAR[vec][0]) - ~SYM[1]] = ~VAR[vec][0][~SYM[1]];"
+      , "  end"
+      , "~ENDGENERATE"
+      , "// reverse end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -317,9 +331,10 @@ genvar ~GENSYM[n][1];
     , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
-"concatBitVector# :: (KnownNat n,KnownNat m) -- (ARG[0],ARG[1])
-                  => Vec n (BitVector m)     -- ARG[2]
-                  -> BitVector (n * m)"
+      [ "concatBitVector# :: (KnownNat n,KnownNat m) -- (ARG[0],ARG[1])"
+      , "                 => Vec n (BitVector m)     -- ARG[2]"
+      , "                 -> BitVector (n * m)"
+      ]
     , "template" : "~TOBV[~ARG[2]][~TYP[2]]"
     }
   }
@@ -328,9 +343,10 @@ genvar ~GENSYM[n][1];
     , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
-"unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
-                    => BitVector (n * m)        -- ARG[2]
-                    -> Vec n (BitVector m)"
+      [ "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])"
+      , "                   => BitVector (n * m)        -- ARG[2]"
+      , "                   -> Vec n (BitVector m)"
+      ]
     , "template" : "~FROMBV[~ARG[2]][~TYPO]"
     }
   }
@@ -340,18 +356,19 @@ genvar ~GENSYM[n][1];
     , "kind"      : "Declaration"
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
-"// rotateLeftS begin
-localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
-
-~GENERATE
-if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
-  assign ~RESULT = ~VAR[vec][1];
-end else begin : ~GENSYM[do_shift][4]
-  assign ~RESULT[0:~LIT[0]-~SYM[2]-1] = ~VAR[vec][1][~SYM[2]:~LIT[0]-1];
-  assign ~RESULT[~LIT[0]-~SYM[2]:~LIT[0]-1] = ~VAR[vec][1][0:~SYM[2]-1];
-end
-~ENDGENERATE
-// rotateLeftS end"
+      [ "// rotateLeftS begin"
+      , "localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];"
+      , ""
+      , "~GENERATE"
+      , "if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]"
+      , "  assign ~RESULT = ~VAR[vec][1];"
+      , "end else begin : ~GENSYM[do_shift][4]"
+      , "  assign ~RESULT[0:~LIT[0]-~SYM[2]-1] = ~VAR[vec][1][~SYM[2]:~LIT[0]-1];"
+      , "  assign ~RESULT[~LIT[0]-~SYM[2]:~LIT[0]-1] = ~VAR[vec][1][0:~SYM[2]-1];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// rotateLeftS end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -360,18 +377,19 @@ end
     , "kind"      : "Declaration"
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
-"// rotateRightS begin
-localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
-
-~GENERATE
-if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
-  assign ~RESULT = ~VAR[vec][1];
-end else begin : ~GENSYM[do_shift][4]
-  assign ~RESULT[0:~SYM[2]-1] = ~VAR[vec][1][~LIT[0]-~SYM[2]:~LIT[0]-1];
-  assign ~RESULT[~SYM[2]:~LIT[0]-1] = ~VAR[vec][1][0:~LIT[0]-~SYM[2]-1];
-end
-~ENDGENERATE
-// rotateRightS end"
+      [ "// rotateRightS begin"
+      , "localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];"
+      , ""
+      , "~GENERATE"
+      , "if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]"
+      , "  assign ~RESULT = ~VAR[vec][1];"
+      , "end else begin : ~GENSYM[do_shift][4]"
+      , "  assign ~RESULT[0:~SYM[2]-1] = ~VAR[vec][1][~LIT[0]-~SYM[2]:~LIT[0]-1];"
+      , "  assign ~RESULT[~SYM[2]:~LIT[0]-1] = ~VAR[vec][1][0:~LIT[0]-~SYM[2]-1];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// rotateRightS end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives
@@ -2,91 +2,95 @@
     { "name" : "Clash.Xilinx.DDR.iddr"
     , "kind" : "Declaration"
     , "type" :
-"iddr
-  :: ( HasCallStack               -- ARG[0]
-     , KnownConfi~ fast domf      -- ARG[1]
-     , KnownConfi~ slow doms      -- ARG[2]
-     , KnownNat m )               -- ARG[3]
-  -> Clock slow                   -- ARG[4]
-  -> Reset slow                   -- ARG[5]
-  -> Enable slow                  -- ARG[6]
-  -> Signal fast (BitVector m)    -- ARG[7]
-  -> Signal slow (BitVector m,BitVector m)"
+      [ "iddr"
+      , "  :: ( HasCallStack               -- ARG[0]"
+      , "     , KnownConfi~ fast domf      -- ARG[1]"
+      , "     , KnownConfi~ slow doms      -- ARG[2]"
+      , "     , KnownNat m )               -- ARG[3]"
+      , "  -> Clock slow                   -- ARG[4]"
+      , "  -> Reset slow                   -- ARG[5]"
+      , "  -> Enable slow                  -- ARG[6]"
+      , "  -> Signal fast (BitVector m)    -- ARG[7]"
+      , "  -> Signal slow (BitVector m,BitVector m)"
+      ]
     , "template" :
-"// iddr begin
-~SIGD[~GENSYM[dataout_l][1]][7];
-~SIGD[~GENSYM[dataout_h][2]][7];
-~SIGD[~GENSYM[d][3]][7];
-assign ~SYM[3] = ~ARG[7];
-
-genvar ~GENSYM[i][8];
-~GENERATE
-for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
-  IDDR #(
-    .DDR_CLK_EDGE(\"SAME_EDGE\"),
-    .INIT_Q1(1'b0),
-    .INIT_Q2(1'b0),
-    .SRTYPE(~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~GENSYM[~COMPNAME_IDDR][9] (
-    .Q1(~SYM[1][~SYM[8]]),
-    .Q2(~SYM[2][~SYM[8]]),
-    .C(~ARG[4]),
-    .CE(~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),
-    .D(~SYM[3][~SYM[8]]),
-    .R(~ARG[5]),
-    .S(1'b0)
-  );
-end
-~ENDGENERATE
-
-assign ~RESULT = {~SYM[2],~SYM[1]};
-// iddr end"
+      [ "// iddr begin"
+      , "~SIGD[~GENSYM[dataout_l][1]][7];"
+      , "~SIGD[~GENSYM[dataout_h][2]][7];"
+      , "~SIGD[~GENSYM[d][3]][7];"
+      , "assign ~SYM[3] = ~ARG[7];"
+      , ""
+      , "genvar ~GENSYM[i][8];"
+      , "~GENERATE"
+      , "for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]"
+      , "  IDDR #("
+      , "    .DDR_CLK_EDGE(\"SAME_EDGE\"),"
+      , "    .INIT_Q1(1'b0),"
+      , "    .INIT_Q2(1'b0),"
+      , "    .SRTYPE(~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)"
+      , "  ) ~GENSYM[~COMPNAME_IDDR][9] ("
+      , "    .Q1(~SYM[1][~SYM[8]]),"
+      , "    .Q2(~SYM[2][~SYM[8]]),"
+      , "    .C(~ARG[4]),"
+      , "    .CE(~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),"
+      , "    .D(~SYM[3][~SYM[8]]),"
+      , "    .R(~ARG[5]),"
+      , "    .S(1'b0)"
+      , "  );"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = {~SYM[2],~SYM[1]};"
+      , "// iddr end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Xilinx.DDR.oddr#"
     , "kind" : "Declaration"
     , "type" :
-"oddr#
-  :: ( KnownConfi~ fast domf      -- ARG[0]
-     , KnownConfi~ slow doms      -- ARG[1]
-     , KnownNat m )               -- ARG[2]
-  => Clock slow                   -- ARG[3]
-  -> Reset slow                   -- ARG[4]
-  -> Enable slow                  -- ARG[5]
-  -> Signal slow (BitVector m)    -- ARG[6]
-  -> Signal slow (BitVector m)    -- ARG[7]
-  -> Signal fast (BitVector m)"
+      [ "oddr#"
+      , "  :: ( KnownConfi~ fast domf      -- ARG[0]"
+      , "     , KnownConfi~ slow doms      -- ARG[1]"
+      , "     , KnownNat m )               -- ARG[2]"
+      , "  => Clock slow                   -- ARG[3]"
+      , "  -> Reset slow                   -- ARG[4]"
+      , "  -> Enable slow                  -- ARG[5]"
+      , "  -> Signal slow (BitVector m)    -- ARG[6]"
+      , "  -> Signal slow (BitVector m)    -- ARG[7]"
+      , "  -> Signal fast (BitVector m)"
+      ]
     , "template" :
-"// oddr begin
-~SIGD[~GENSYM[datain_l][1]][7];
-~SIGD[~GENSYM[datain_h][2]][7];
-~SIGD[~GENSYM[q][3]][7];
-
-assign ~SYM[1] = ~ARG[6];
-assign ~SYM[2] = ~ARG[7];
-
-genvar ~GENSYM[i][8];
-~GENERATE
-for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
-  ODDR #(
-    .DDR_CLK_EDGE(\"SAME_EDGE\"),
-    .INIT(1'b0),
-    .SRTYPE(~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~GENSYM[~COMPNAME_ODDR][9] (
-    .Q(~SYM[3][~SYM[8]]),
-    .C(~ARG[3]),
-    .CE(~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),
-    .D1(~SYM[1][~SYM[8]]),
-    .D2(~SYM[2][~SYM[8]]),
-    .R(~ARG[4]),
-    .S(1'b0)
-  );
-end
-~ENDGENERATE
-
-assign ~RESULT = ~SYM[3];
-// oddr end"
+      [ "// oddr begin"
+      , "~SIGD[~GENSYM[datain_l][1]][7];"
+      , "~SIGD[~GENSYM[datain_h][2]][7];"
+      , "~SIGD[~GENSYM[q][3]][7];"
+      , ""
+      , "assign ~SYM[1] = ~ARG[6];"
+      , "assign ~SYM[2] = ~ARG[7];"
+      , ""
+      , "genvar ~GENSYM[i][8];"
+      , "~GENERATE"
+      , "for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]"
+      , "  ODDR #("
+      , "    .DDR_CLK_EDGE(\"SAME_EDGE\"),"
+      , "    .INIT(1'b0),"
+      , "    .SRTYPE(~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)"
+      , "  ) ~GENSYM[~COMPNAME_ODDR][9] ("
+      , "    .Q(~SYM[3][~SYM[8]]),"
+      , "    .C(~ARG[3]),"
+      , "    .CE(~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),"
+      , "    .D1(~SYM[1][~SYM[8]]),"
+      , "    .D2(~SYM[2][~SYM[8]]),"
+      , "    .R(~ARG[4]),"
+      , "    .S(1'b0)"
+      , "  );"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = ~SYM[3];"
+      , "// oddr end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/GHC_Base.primitives
+++ b/clash-lib/prims/systemverilog/GHC_Base.primitives
@@ -3,14 +3,15 @@
     , "kind"      : "Declaration"
     , "type"      : "divInt :: Int -> Int -> Int"
     , "template"  :
-"// divInt begin
-// divide (rounds towards zero)
-~SIGD[~GENSYM[quot_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
-
-// round toward minus infinity
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
-// divInt end"
+      [ "// divInt begin"
+      , "// divide (rounds towards zero)"
+      , "~SIGD[~GENSYM[quot_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];"
+      , ""
+      , "// round toward minus infinity"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;"
+      , "// divInt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -18,16 +19,17 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "kind"      : "Declaration"
     , "type"      : "modInt :: Int -> Int -> Int"
     , "template"  :
-"// modInt begin
-// remainder
-~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// modInt end"
+      [ "// modInt begin"
+      , "// remainder"
+      , "~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// modInt end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/GHC_Classes.primitives
+++ b/clash-lib/prims/systemverilog/GHC_Classes.primitives
@@ -3,26 +3,27 @@
     , "kind"      : "Declaration"
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "template"  :
-"// divInt# begin
-logic ~GENSYM[resultPos][1];
-logic ~GENSYM[dividerNeg][2];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
-// divInt# end"
+      [ "// divInt# begin"
+      , "logic ~GENSYM[resultPos][1];"
+      , "logic ~GENSYM[dividerNeg][2];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);"
+      , "// divInt# end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -30,16 +31,17 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "kind"      : "Declaration"
     , "type"      : "modInt# :: Int# -> Int# -> Int#"
     , "template"  :
-"// modInt# begin
-// remainder
-~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// modInt# end"
+      [ "// modInt# begin"
+      , "// remainder"
+      , "~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// modInt# end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/systemverilog/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/systemverilog/GHC_Integer_Type.primitives
@@ -3,26 +3,27 @@
     , "kind"      : "Declaration"
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "template"  :
-"// divInteger begin
-logic ~GENSYM[resultPos][1];
-logic ~GENSYM[dividerNeg][2];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
-// divInteger end"
+      [ "// divInteger begin"
+      , "logic ~GENSYM[resultPos][1];"
+      , "logic ~GENSYM[dividerNeg][2];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);"
+      , "// divInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.divInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -31,16 +32,17 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "kind"      : "Declaration"
     , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "template"  :
-"// modInteger begin
-// remainder
-~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// modInteger end"
+      [ "// modInteger begin"
+      , "// remainder"
+      , "~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// modInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.modInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -49,36 +51,37 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "kind"      : "Declaration"
     , "type"      : "divModInteger :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"// divModInteger begin
-logic ~GENSYM[resultPos][1];
-logic ~GENSYM[dividerNeg][2];
-logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];
-logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];
-logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];
-logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];
-logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);
-
-logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[rem_res][8];
-logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[mod_res][9];
-assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];
-assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?
-                 ~SYM[8] :
-                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);
-
-assign ~RESULT = {~SYM[7],~SYM[9]};
-// divModInteger end"
+      [ "// divModInteger begin"
+      , "logic ~GENSYM[resultPos][1];"
+      , "logic ~GENSYM[dividerNeg][2];"
+      , "logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];"
+      , "logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];"
+      , "logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];"
+      , "logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];"
+      , "logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);"
+      , ""
+      , "logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[rem_res][8];"
+      , "logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[mod_res][9];"
+      , "assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , "assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?"
+      , "                 ~SYM[8] :"
+      , "                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);"
+      , ""
+      , "assign ~RESULT = {~SYM[7],~SYM[9]};"
+      , "// divModInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.divModInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -87,14 +90,15 @@ assign ~RESULT = {~SYM[7],~SYM[9]};
     , "kind"      : "Declaration"
     , "type"      : "quotRemInteger :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"// quotRemInteger begin
-~SIGD[~GENSYM[quot_res][0]][0];
-~SIGD[~GENSYM[rem_res][1]][0];
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
-assign ~SYM[1] = ~ARG[0] % ~ARG[1];
-
-assign ~RESULT = {~SYM[0],~SYM[1]};
-// quotRemInteger end"
+      [ "// quotRemInteger begin"
+      , "~SIGD[~GENSYM[quot_res][0]][0];"
+      , "~SIGD[~GENSYM[rem_res][1]][0];"
+      , "assign ~SYM[0] = ~ARG[0] / ~ARG[1];"
+      , "assign ~SYM[1] = ~ARG[0] % ~ARG[1];"
+      , ""
+      , "assign ~RESULT = {~SYM[0],~SYM[1]};"
+      , "// quotRemInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.quotRemInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }

--- a/clash-lib/prims/systemverilog/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/systemverilog/GHC_Num_Integer.primitives
@@ -3,26 +3,27 @@
     , "kind"      : "Declaration"
     , "type"      : "integerDiv :: Integer -> Integer -> Integer"
     , "template"  :
-"// integerDiv begin
-logic ~GENSYM[resultPos][1];
-logic ~GENSYM[dividerNeg][2];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
-logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
-// integerDiv end"
+      [ "// integerDiv begin"
+      , "logic ~GENSYM[resultPos][1];"
+      , "logic ~GENSYM[dividerNeg][2];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];"
+      , "logic signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);"
+      , "// integerDiv end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerDiv: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -31,16 +32,17 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "kind"      : "Declaration"
     , "type"      : "integerMod :: Integer -> Integer -> Integer"
     , "template"  :
-"// integerMod begin
-// remainder
-~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// integerMod end"
+      [ "// integerMod begin"
+      , "// remainder"
+      , "~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// integerMod end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerMod: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -49,36 +51,37 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "kind"      : "Declaration"
     , "type"      : "integerDivMod :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"// integerDivMod begin
-logic ~GENSYM[resultPos][1];
-logic ~GENSYM[dividerNeg][2];
-logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];
-logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];
-logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];
-logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];
-logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);
-
-logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[rem_res][8];
-logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[mod_res][9];
-assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];
-assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?
-                 ~SYM[8] :
-                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);
-
-assign ~RESULT = {~SYM[7],~SYM[9]};
-// integerDivMod end"
+      [ "// integerDivMod begin"
+      , "logic ~GENSYM[resultPos][1];"
+      , "logic ~GENSYM[dividerNeg][2];"
+      , "logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];"
+      , "logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];"
+      , "logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];"
+      , "logic signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];"
+      , "logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);"
+      , ""
+      , "logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[rem_res][8];"
+      , "logic signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[mod_res][9];"
+      , "assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , "assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?"
+      , "                 ~SYM[8] :"
+      , "                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);"
+      , ""
+      , "assign ~RESULT = {~SYM[7],~SYM[9]};"
+      , "// integerDivMod end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerDivMod#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -87,14 +90,15 @@ assign ~RESULT = {~SYM[7],~SYM[9]};
     , "kind"      : "Declaration"
     , "type"      : "integerQuotRem :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"// integerQuotRem begin
-~SIGD[~GENSYM[quot_res][0]][0];
-~SIGD[~GENSYM[rem_res][1]][0];
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
-assign ~SYM[1] = ~ARG[0] % ~ARG[1];
-
-assign ~RESULT = {~SYM[0],~SYM[1]};
-// integerQuotRem end"
+      [ "// integerQuotRem begin"
+      , "~SIGD[~GENSYM[quot_res][0]][0];"
+      , "~SIGD[~GENSYM[rem_res][1]][0];"
+      , "assign ~SYM[0] = ~ARG[0] / ~ARG[1];"
+      , "assign ~SYM[1] = ~ARG[0] % ~ARG[1];"
+      , ""
+      , "assign ~RESULT = {~SYM[0],~SYM[1]};"
+      , "// integerQuotRem end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerQuotRem#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }

--- a/clash-lib/prims/systemverilog/GHC_Prim.primitives
+++ b/clash-lib/prims/systemverilog/GHC_Prim.primitives
@@ -3,14 +3,15 @@
     , "kind"      : "Declaration"
     , "type"      : "quotRemInt# :: Int# -> Int# -> (#Int#, Int##)"
     , "template"  :
-"// quotRemInt begin
-~SIGD[~GENSYM[quot_res][0]][0];
-~SIGD[~GENSYM[rem_res][1]][0];
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
-assign ~SYM[1] = ~ARG[0] % ~ARG[1];
-
-assign ~RESULT = {~SYM[0],~SYM[1]};
-// quotRemInt end"
+      [ "// quotRemInt begin"
+      , "~SIGD[~GENSYM[quot_res][0]][0];"
+      , "~SIGD[~GENSYM[rem_res][1]][0];"
+      , "assign ~SYM[0] = ~ARG[0] / ~ARG[1];"
+      , "assign ~SYM[1] = ~ARG[0] % ~ARG[1];"
+      , ""
+      , "assign ~RESULT = {~SYM[0],~SYM[1]};"
+      , "// quotRemInt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -18,14 +19,15 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
     , "kind"      : "Declaration"
     , "type"      : "quotRemWord# :: Word# -> Word# -> (#Word#, Word##)"
     , "template"  :
-"// quotRemWord begin
-~SIGD[~GENSYM[quot_res][0]][0];
-~SIGD[~GENSYM[rem_res][1]][0];
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
-assign ~SYM[1] = ~ARG[0] % ~ARG[1];
-
-assign ~RESULT = {~SYM[0],~SYM[1]};
-// quotRemWord end"
+      [ "// quotRemWord begin"
+      , "~SIGD[~GENSYM[quot_res][0]][0];"
+      , "~SIGD[~GENSYM[rem_res][1]][0];"
+      , "assign ~SYM[0] = ~ARG[0] / ~ARG[1];"
+      , "assign ~SYM[1] = ~ARG[0] % ~ARG[1];"
+      , ""
+      , "assign ~RESULT = {~SYM[0],~SYM[1]};"
+      , "// quotRemWord end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -37,51 +39,53 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
       [ { "name" : "depth2Index"
         , "extension" : "inc"
         , "template" :
-"// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0];
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0];"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt8 begin
-localparam ~GENSYM[width][0] = 8;
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
-
-logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt8 end"
+      [ "// popCnt8 begin"
+      , "localparam ~GENSYM[width][0] = 8;"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);"
+      , ""
+      , "logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -93,51 +97,53 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "depth2Index"
         , "extension" : "inc"
         , "template" :
-"// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0];
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0];"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt16 begin
-localparam ~GENSYM[width][0] = 16;
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
-
-logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt16 end"
+      [ "// popCnt16 begin"
+      , "localparam ~GENSYM[width][0] = 16;"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);"
+      , ""
+      , "logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -149,51 +155,53 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "depth2Index"
         , "extension" : "inc"
         , "template" :
-"// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0];
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0];"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt32 begin
-localparam ~GENSYM[width][0] = 32;
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
-
-logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt32 end"
+      [ "// popCnt32 begin"
+      , "localparam ~GENSYM[width][0] = 32;"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);"
+      , ""
+      , "logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -205,51 +213,53 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "depth2Index"
         , "extension" : "inc"
         , "template" :
-"// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0];
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0];"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt64 begin
-localparam ~GENSYM[width][0] = 64;
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
-
-logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt64 end"
+      [ "// popCnt64 begin"
+      , "localparam ~GENSYM[width][0] = 64;"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);"
+      , ""
+      , "logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -261,51 +271,53 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "depth2Index"
         , "extension" : "inc"
         , "template" :
-"// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0];
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0];"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0] = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt begin
-localparam ~GENSYM[width][0] = ~SIZE[~TYPO];
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);
-
-logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt end"
+      [ "// popCnt begin"
+      , "localparam ~GENSYM[width][0] = ~SIZE[~TYPO];"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = $clog2(~SYM[0]);"
+      , ""
+      , "logic [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0](~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -317,63 +329,65 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz8 begin
-logic [0:7] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][7:0];
-
-logic [0:7] ~GENSYM[e][2];
-genvar ~GENSYM[n][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:5] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage1][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:3] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 3;
-logic [5:0] i;
-assign i = ~SYM[4][0:5];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz8 end"
+      [ "// clz8 begin"
+      , "logic [0:7] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][7:0];"
+      , ""
+      , "logic [0:7] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[n][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:5] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage1][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:3] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 3;"
+      , "logic [5:0] i;"
+      , "assign i = ~SYM[4][0:5];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -385,79 +399,81 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz16 begin
-logic [0:15] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][15:0];
-
-logic [0:15] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:11] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:7] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:4] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 4;
-logic [7:0] i;
-assign i = ~SYM[9][0:7];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz16 end"
+      [ "// clz16 begin"
+      , "logic [0:15] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][15:0];"
+      , ""
+      , "logic [0:15] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:11] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:7] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:4] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 4;"
+      , "logic [7:0] i;"
+      , "assign i = ~SYM[9][0:7];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -469,95 +485,97 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz32 begin
-logic [0:31] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][31:0];
-
-logic [0:31] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:23] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:15] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:9] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  logic [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:5] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 5;
-logic [9:0] i;
-assign i = ~SYM[12][0:9];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz32 end"
+      [ "// clz32 begin"
+      , "logic [0:31] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][31:0];"
+      , ""
+      , "logic [0:31] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:23] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:15] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:9] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  logic [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:5] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 5;"
+      , "logic [9:0] i;"
+      , "assign i = ~SYM[12][0:9];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -569,111 +587,113 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz64 begin
-logic [0:63] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][63:0];
-
-logic [0:63] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:47] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:31] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:19] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  logic [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:11] ~GENSYM[d][15];
-genvar ~GENSYM[i4][16];
-~GENERATE
-for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
-  localparam n = 5;
-  logic [9:0] i;
-  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:6] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 6;
-logic [11:0] i;
-assign i = ~SYM[15][0:11];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz64 end"
+      [ "// clz64 begin"
+      , "logic [0:63] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][63:0];"
+      , ""
+      , "logic [0:63] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:47] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:31] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:19] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  logic [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:11] ~GENSYM[d][15];"
+      , "genvar ~GENSYM[i4][16];"
+      , "~GENERATE"
+      , "for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]"
+      , "  localparam n = 5;"
+      , "  logic [9:0] i;"
+      , "  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:6] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 6;"
+      , "logic [11:0] i;"
+      , "assign i = ~SYM[15][0:11];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -685,186 +705,188 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz begin
-~IF ~IW64 ~THEN
-logic [0:63] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][63:0];
-
-logic [0:63] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:47] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:31] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:19] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  logic [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:11] ~GENSYM[d][15];
-genvar ~GENSYM[i4][16];
-~GENERATE
-for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
-  localparam n = 5;
-  logic [9:0] i;
-  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:6] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 6;
-logic [11:0] i;
-assign i = ~SYM[15][0:11];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-~ELSE
-logic [0:31] ~SYM[1];
-assign ~SYM[1] = ~VAR[i][0][31:0];
-
-logic [0:31] ~SYM[2];
-genvar ~SYM[3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:23] ~SYM[4];
-genvar ~SYM[5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:15] ~SYM[9];
-genvar ~SYM[10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:9] ~SYM[12];
-genvar ~SYM[13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]
-  localparam n = 4;
-  logic [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:5] ~SYM[7];
-~GENERATE
-if (1) begin
-localparam n = 5;
-logic [9:0] i;
-assign i = ~SYM[12][0:9];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-~FI
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz end"
+[ "// clz begin"
+      , "~IF ~IW64 ~THEN"
+      , "logic [0:63] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][63:0];"
+      , ""
+      , "logic [0:63] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:47] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:31] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:19] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  logic [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:11] ~GENSYM[d][15];"
+      , "genvar ~GENSYM[i4][16];"
+      , "~GENERATE"
+      , "for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]"
+      , "  localparam n = 5;"
+      , "  logic [9:0] i;"
+      , "  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:6] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 6;"
+      , "logic [11:0] i;"
+      , "assign i = ~SYM[15][0:11];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , "~ELSE"
+      , "logic [0:31] ~SYM[1];"
+      , "assign ~SYM[1] = ~VAR[i][0][31:0];"
+      , ""
+      , "logic [0:31] ~SYM[2];"
+      , "genvar ~SYM[3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:23] ~SYM[4];"
+      , "genvar ~SYM[5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:15] ~SYM[9];"
+      , "genvar ~SYM[10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:9] ~SYM[12];"
+      , "genvar ~SYM[13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]"
+      , "  localparam n = 4;"
+      , "  logic [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:5] ~SYM[7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 5;"
+      , "logic [9:0] i;"
+      , "assign i = ~SYM[12][0:9];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , "~FI"
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -876,68 +898,70 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz8 begin
-logic [0:7] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<8;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-logic [0:7] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:5] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:3] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 3;
-logic [5:0] i;
-assign i = ~SYM[4][0:5];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz8 end"
+      [ "// ctz8 begin"
+      , "logic [0:7] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<8;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:7] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:5] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:3] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 3;"
+      , "logic [5:0] i;"
+      , "assign i = ~SYM[4][0:5];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -949,84 +973,86 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz16 begin
-logic [0:15] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<16;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-logic [0:15] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:11] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:7] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:4] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 4;
-logic [7:0] i;
-assign i = ~SYM[9][0:7];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz16 end"
+      [ "// ctz16 begin"
+      , "logic [0:15] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<16;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:15] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:11] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:7] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:4] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 4;"
+      , "logic [7:0] i;"
+      , "assign i = ~SYM[9][0:7];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1038,100 +1064,102 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz32 begin
-logic [0:31] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-logic [0:31] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:23] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:15] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:9] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  logic [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:5] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 5;
-logic [9:0] i;
-assign i = ~SYM[12][0:9];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz32 end"
+      [ "// ctz32 begin"
+      , "logic [0:31] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:31] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:23] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:15] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:9] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  logic [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:5] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 5;"
+      , "logic [9:0] i;"
+      , "assign i = ~SYM[12][0:9];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1143,116 +1171,118 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz64 begin
-logic [0:63] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-logic [0:63] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:47] a;
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:31] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:19] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  logic [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:11] ~GENSYM[d][15];
-genvar ~GENSYM[i4][16];
-~GENERATE
-for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
-  localparam n = 5;
-  logic [9:0] i;
-  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:6] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 6;
-logic [11:0] i;
-assign i = ~SYM[15][0:11];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz64 end"
+      [ "// ctz64 begin"
+      , "logic [0:63] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:63] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:47] a;"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:31] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:19] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  logic [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:11] ~GENSYM[d][15];"
+      , "genvar ~GENSYM[i4][16];"
+      , "~GENERATE"
+      , "for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]"
+      , "  localparam n = 5;"
+      , "  logic [9:0] i;"
+      , "  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:6] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 6;"
+      , "logic [11:0] i;"
+      , "assign i = ~SYM[15][0:11];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1264,196 +1294,198 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz begin
-~IF ~IW64 ~THEN
-logic [0:63] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-logic [0:63] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:47] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:31] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:19] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  logic [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:11] ~GENSYM[d][15];
-genvar ~GENSYM[i4][16];
-~GENERATE
-for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
-  localparam n = 5;
-  logic [9:0] i;
-  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:6] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 6;
-logic [11:0] i;
-assign i = ~SYM[15][0:11];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-~ELSE
-logic [0:31] ~SYM[1];
-genvar ~SYM[18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~SYM[19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-logic [0:31] ~SYM[2];
-genvar ~SYM[3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-logic [0:23] ~SYM[4];
-genvar ~SYM[5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]
-  localparam n = 2;
-  logic [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:15] ~SYM[9];
-genvar ~SYM[10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]
-  localparam n = 3;
-  logic [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:9] ~SYM[12];
-genvar ~SYM[13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]
-  localparam n = 4;
-  logic [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always_comb begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-logic [0:5] ~SYM[7];
-~GENERATE
-if (1) begin
-localparam n = 5;
-logic [9:0] i;
-assign i = ~SYM[12][0:9];
-always_comb begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-~FI
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz end"
+      [ "// ctz begin"
+      , "~IF ~IW64 ~THEN"
+      , "logic [0:63] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:63] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:47] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:31] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:19] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  logic [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:11] ~GENSYM[d][15];"
+      , "genvar ~GENSYM[i4][16];"
+      , "~GENERATE"
+      , "for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]"
+      , "  localparam n = 5;"
+      , "  logic [9:0] i;"
+      , "  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:6] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 6;"
+      , "logic [11:0] i;"
+      , "assign i = ~SYM[15][0:11];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , "~ELSE"
+      , "logic [0:31] ~SYM[1];"
+      , "genvar ~SYM[18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~SYM[19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:31] ~SYM[2];"
+      , "genvar ~SYM[3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:23] ~SYM[4];"
+      , "genvar ~SYM[5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]"
+      , "  localparam n = 2;"
+      , "  logic [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:15] ~SYM[9];"
+      , "genvar ~SYM[10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]"
+      , "  localparam n = 3;"
+      , "  logic [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:9] ~SYM[12];"
+      , "genvar ~SYM[13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]"
+      , "  localparam n = 4;"
+      , "  logic [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always_comb begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "logic [0:5] ~SYM[7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 5;"
+      , "logic [9:0] i;"
+      , "assign i = ~SYM[12][0:9];"
+      , "always_comb begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , "~FI"
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam.primitives
@@ -2,204 +2,212 @@
     { "name" : "Clash.Explicit.BlockRam.blockRam#"
     , "kind" : "Declaration"
     , "type" :
-"blockRam#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  => Enable dom      -- en,   ARG[4]
-  -> Vec n a         -- init, ARG[5]
-  -> Signal dom Int  -- rd,   ARG[6]
-  -> Signal dom Bool -- wren, ARG[7]
-  -> Signal dom Int  -- wr,   ARG[8]
-  -> Signal dom a    -- din,  ARG[9]
-  -> Signal dom a"
+      [ "blockRam#"
+      , "  :: ( KnownDomain dom        ARG[0]"
+      , "     , HasCallStack  --       ARG[1]"
+      , "     , Undefined a ) --       ARG[2]"
+      , "  => Clock dom       -- clk,  ARG[3]"
+      , "  => Enable dom      -- en,   ARG[4]"
+      , "  -> Vec n a         -- init, ARG[5]"
+      , "  -> Signal dom Int  -- rd,   ARG[6]"
+      , "  -> Signal dom Bool -- wren, ARG[7]"
+      , "  -> Signal dom Int  -- wr,   ARG[8]"
+      , "  -> Signal dom a    -- din,  ARG[9]"
+      , "  -> Signal dom a"
+      ]
     , "outputReg" : true
     , "template" :
-"// blockRam begin
-reg ~TYPO ~GENSYM[~RESULT_RAM][1] [0:~LENGTH[~TYP[5]]-1];
-
-reg ~TYP[5] ~GENSYM[ram_init][3];
-integer ~GENSYM[i][4];
-initial begin
-  ~SYM[3] = ~CONST[5];
-  for (~SYM[4]=0; ~SYM[4] < ~LENGTH[~TYP[5]]; ~SYM[4] = ~SYM[4] + 1) begin
-    ~SYM[1][~LENGTH[~TYP[5]]-1-~SYM[4]] = ~SYM[3][~SYM[4]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
-  end
-end
-~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN
-  if (~ARG[4]) begin
-    if (~ARG[7]) begin
-      ~SYM[1][~ARG[8]] <= ~ARG[9];
-    end
-    ~RESULT <= ~SYM[1][~ARG[6]];
-  end~ELSE
-  if (~ARG[7] & ~ARG[4]) begin
-    ~SYM[1][~ARG[8]] <= ~ARG[9];
-  end
-  if (~ARG[4]) begin
-    ~RESULT <= ~SYM[1][~ARG[6]];
-  end~FI
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]
-  if (~ARG[7]) begin
-    ~SYM[1][~ARG[8]] <= ~ARG[9];
-  end
-  ~RESULT <= ~SYM[1][~ARG[6]];
-end~FI
-// blockRam end"
+      [ "// blockRam begin"
+      , "reg ~TYPO ~GENSYM[~RESULT_RAM][1] [0:~LENGTH[~TYP[5]]-1];"
+      , ""
+      , "reg ~TYP[5] ~GENSYM[ram_init][3];"
+      , "integer ~GENSYM[i][4];"
+      , "initial begin"
+      , "  ~SYM[3] = ~CONST[5];"
+      , "  for (~SYM[4]=0; ~SYM[4] < ~LENGTH[~TYP[5]]; ~SYM[4] = ~SYM[4] + 1) begin"
+      , "    ~SYM[1][~LENGTH[~TYP[5]]-1-~SYM[4]] = ~SYM[3][~SYM[4]*~SIZE[~TYPO]+:~SIZE[~TYPO]];"
+      , "  end"
+      , "end"
+      , "~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN"
+      , "  if (~ARG[4]) begin"
+      , "    if (~ARG[7]) begin"
+      , "      ~SYM[1][~ARG[8]] <= ~ARG[9];"
+      , "    end"
+      , "    ~RESULT <= ~SYM[1][~ARG[6]];"
+      , "  end~ELSE"
+      , "  if (~ARG[7] & ~ARG[4]) begin"
+      , "    ~SYM[1][~ARG[8]] <= ~ARG[9];"
+      , "  end"
+      , "  if (~ARG[4]) begin"
+      , "    ~RESULT <= ~SYM[1][~ARG[6]];"
+      , "  end~FI"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]"
+      , "  if (~ARG[7]) begin"
+      , "    ~SYM[1][~ARG[8]] <= ~ARG[9];"
+      , "  end"
+      , "  ~RESULT <= ~SYM[1][~ARG[6]];"
+      , "end~FI"
+      , "// blockRam end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.blockRamU#"
     , "kind" : "Declaration"
     , "type" :
-"blockRamU#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  -> Enable dom      -- en,   ARG[4]
-  -> SNat n          -- len,  ARG[5]
-  -> Signal dom Int  -- rd,   ARG[6]
-  -> Signal dom Bool -- wren, ARG[7]
-  -> Signal dom Int  -- wr,   ARG[8]
-  -> Signal dom a    -- din,  ARG[9]
-  -> Signal dom a"
+      [ "blockRamU#"
+      , " :: ( KnownDomain dom        ARG[0]"
+      , "    , HasCallStack  --       ARG[1]"
+      , "    , Undefined a ) --       ARG[2]"
+      , " => Clock dom       -- clk,  ARG[3]"
+      , " -> Enable dom      -- en,   ARG[4]"
+      , " -> SNat n          -- len,  ARG[5]"
+      , " -> Signal dom Int  -- rd,   ARG[6]"
+      , " -> Signal dom Bool -- wren, ARG[7]"
+      , " -> Signal dom Int  -- wr,   ARG[8]"
+      , " -> Signal dom a    -- din,  ARG[9]"
+      , " -> Signal dom a"
+      ]
     , "outputReg" : true
     , "template" :
-"// blockRamU begin
-reg ~TYPO ~GENSYM[~RESULT_RAM][0] [0:~LIT[5]-1];
-
-~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN
-  if (~ARG[4]) begin
-    if (~ARG[7]) begin
-      ~SYM[0][~ARG[8]] <= ~ARG[9];
-    end
-    ~RESULT <= ~SYM[0][~ARG[6]];
-  end~ELSE
-  if (~ARG[7] & ~ARG[4]) begin
-    ~SYM[0][~ARG[8]] <= ~ARG[9];
-  end
-  if (~ARG[4]) begin
-    ~RESULT <= ~SYM[0][~ARG[6]];
-  end~FI
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]
-  if (~ARG[7]) begin
-    ~SYM[0][~ARG[8]] <= ~ARG[9];
-  end
-  ~RESULT <= ~SYM[0][~ARG[6]];
-end~FI
-// blockRamU end"
+      [ "// blockRamU begin"
+      , "reg ~TYPO ~GENSYM[~RESULT_RAM][0] [0:~LIT[5]-1];"
+      , ""
+      , "~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN"
+      , "  if (~ARG[4]) begin"
+      , "    if (~ARG[7]) begin"
+      , "      ~SYM[0][~ARG[8]] <= ~ARG[9];"
+      , "    end"
+      , "    ~RESULT <= ~SYM[0][~ARG[6]];"
+      , "  end~ELSE"
+      , "  if (~ARG[7] & ~ARG[4]) begin"
+      , "    ~SYM[0][~ARG[8]] <= ~ARG[9];"
+      , "  end"
+      , "  if (~ARG[4]) begin"
+      , "    ~RESULT <= ~SYM[0][~ARG[6]];"
+      , "  end~FI"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]"
+      , "  if (~ARG[7]) begin"
+      , "    ~SYM[0][~ARG[8]] <= ~ARG[9];"
+      , "  end"
+      , "  ~RESULT <= ~SYM[0][~ARG[6]];"
+      , "end~FI"
+      , "// blockRamU end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.blockRam1#"
     , "kind" : "Declaration"
     , "type" :
-"blockRam1#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  -> Enable dom      -- en,   ARG[4]
-  -> SNat n          -- len,  ARG[5]
-  -> a               -- init, ARG[6]
-  -> Signal dom Int  -- rd,   ARG[7]
-  -> Signal dom Bool -- wren, ARG[8]
-  -> Signal dom Int  -- wr,   ARG[9]
-  -> Signal dom a    -- din,  ARG[10]
-  -> Signal dom a"
+      [ "blockRam1#"
+      , "  :: ( KnownDomain dom        ARG[0]"
+      , "     , HasCallStack  --       ARG[1]"
+      , "     , Undefined a ) --       ARG[2]"
+      , "  => Clock dom       -- clk,  ARG[3]"
+      , "  -> Enable dom      -- en,   ARG[4]"
+      , "  -> SNat n          -- len,  ARG[5]"
+      , "  -> a               -- init, ARG[6]"
+      , "  -> Signal dom Int  -- rd,   ARG[7]"
+      , "  -> Signal dom Bool -- wren, ARG[8]"
+      , "  -> Signal dom Int  -- wr,   ARG[9]"
+      , "  -> Signal dom a    -- din,  ARG[10]"
+      , "  -> Signal dom a"
+      ]
     , "outputReg" : true
     , "template" :
-"// blockRam1 begin
-reg ~TYPO ~GENSYM[~RESULT_RAM][0] [0:~LIT[5]-1];
-integer ~GENSYM[i][1];
-initial begin
-    for (~SYM[1]=0;~SYM[1]<~LIT[5];~SYM[1]=~SYM[1]+1) begin
-        ~SYM[0][~SYM[1]] = ~CONST[6];
-    end
-end
-
-~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN
-  if (~ARG[4]) begin
-    if (~ARG[8]) begin
-      ~SYM[0][~ARG[9]] <= ~ARG[10];
-    end
-    ~RESULT <= ~SYM[0][~ARG[7]];
-  end~ELSE
-  if (~ARG[8] & ~ARG[4]) begin
-    ~SYM[0][~ARG[9]] <= ~ARG[10];
-  end
-  if (~ARG[4]) begin
-    ~RESULT <= ~SYM[0][~ARG[7]];
-  end~FI
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]
-  if (~ARG[8]) begin
-    ~SYM[0][~ARG[9]] <= ~ARG[10];
-  end
-  ~RESULT <= ~SYM[0][~ARG[7]];
-end~FI
-// blockRam1 end"
+      [ "// blockRam1 begin"
+      , "reg ~TYPO ~GENSYM[~RESULT_RAM][0] [0:~LIT[5]-1];"
+      , "integer ~GENSYM[i][1];"
+      , "initial begin"
+      , "    for (~SYM[1]=0;~SYM[1]<~LIT[5];~SYM[1]=~SYM[1]+1) begin"
+      , "        ~SYM[0][~SYM[1]] = ~CONST[6];"
+      , "    end"
+      , "end"
+      , ""
+      , "~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN"
+      , "  if (~ARG[4]) begin"
+      , "    if (~ARG[8]) begin"
+      , "      ~SYM[0][~ARG[9]] <= ~ARG[10];"
+      , "    end"
+      , "    ~RESULT <= ~SYM[0][~ARG[7]];"
+      , "  end~ELSE"
+      , "  if (~ARG[8] & ~ARG[4]) begin"
+      , "    ~SYM[0][~ARG[9]] <= ~ARG[10];"
+      , "  end"
+      , "  if (~ARG[4]) begin"
+      , "    ~RESULT <= ~SYM[0][~ARG[7]];"
+      , "  end~FI"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]"
+      , "  if (~ARG[8]) begin"
+      , "    ~SYM[0][~ARG[9]] <= ~ARG[10];"
+      , "  end"
+      , "  ~RESULT <= ~SYM[0][~ARG[7]];"
+      , "end~FI"
+      , "// blockRam1 end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.trueDualPortBlockRam#"
     , "kind" : "Declaration"
     , "type" :
-"trueDualPortBlockRam# ::
-  forall nAddrs domA domB a .
-  ( HasCallStack           ~ARG[0]
-  , KnownNat nAddrs        ~ARG[1]
-  , KnownDomain domA       ~ARG[2]
-  , KnownDomain domB       ~ARG[3]
-  , NFDataX a              ~ARG[4]
-  , BitPack a              ~ARG[5]
-  ) =>
-
-  Clock domA ->                   ~ARG[6]
-  Signal domA Bool ->             ~ARG[7]
-  Signal domA (Index nAddrs) ->   ~ARG[8]
-  Signal domA a ->                ~ARG[9]
-
-  Clock domB ->                   ~ARG[10]
-  Signal domB Bool ->             ~ARG[11]
-  Signal domB (Index nAddrs) ->   ~ARG[12]
-  Signal domB a ->                ~ARG[13]
-  (Signal domA a, Signal domB a)"
+      [ "trueDualPortBlockRam# ::"
+      , "  forall nAddrs domA domB a ."
+      , "  ( HasCallStack           ~ARG[0]"
+      , "  , KnownNat nAddrs        ~ARG[1]"
+      , "  , KnownDomain domA       ~ARG[2]"
+      , "  , KnownDomain domB       ~ARG[3]"
+      , "  , NFDataX a              ~ARG[4]"
+      , "  , BitPack a              ~ARG[5]"
+      , "  ) =>"
+      , ""
+      , "  Clock domA ->                   ~ARG[6]"
+      , "  Signal domA Bool ->             ~ARG[7]"
+      , "  Signal domA (Index nAddrs) ->   ~ARG[8]"
+      , "  Signal domA a ->                ~ARG[9]"
+      , ""
+      , "  Clock domB ->                   ~ARG[10]"
+      , "  Signal domB Bool ->             ~ARG[11]"
+      , "  Signal domB (Index nAddrs) ->   ~ARG[12]"
+      , "  Signal domB a ->                ~ARG[13]"
+      , "  (Signal domA a, Signal domB a)"
+      ]
     , "template" :
-"// trueDualPortBlockRam begin
-// Shared memory
-reg [~SIZE[~TYP[9]]-1:0] ~GENSYM[mem][0] [~LIT[1]-1:0];
-
-reg ~SIGD[~GENSYM[data_slow][1]][9];
-reg ~SIGD[~GENSYM[data_fast][2]][13];
-
-// Port A
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[6]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[8]];
-    if(~ARG[7]) begin
-        ~SYM[1] <= ~ARG[9];
-        ~SYM[0][~ARG[8]] <= ~ARG[9];
-    end
-end
-
-// Port B
-always @(~IF~ACTIVEEDGE[Rising][3]~THENposedge~ELSEnegedge~FI ~ARG[10]) begin
-    ~SYM[2] <= ~SYM[0][~ARG[12]];
-    if(~ARG[11]) begin
-        ~SYM[2] <= ~ARG[13];
-        ~SYM[0][~ARG[12]] <= ~ARG[13];
-    end
-end
-
-assign ~RESULT = {~SYM[1], ~SYM[2]};
-// end trueDualPortBlockRam"
+      [ "// trueDualPortBlockRam begin"
+      , "// Shared memory"
+      , "reg [~SIZE[~TYP[9]]-1:0] ~GENSYM[mem][0] [~LIT[1]-1:0];"
+      , ""
+      , "reg ~SIGD[~GENSYM[data_slow][1]][9];"
+      , "reg ~SIGD[~GENSYM[data_fast][2]][13];"
+      , ""
+      , "// Port A"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[6]) begin"
+      , "    ~SYM[1] <= ~SYM[0][~ARG[8]];"
+      , "    if(~ARG[7]) begin"
+      , "        ~SYM[1] <= ~ARG[9];"
+      , "        ~SYM[0][~ARG[8]] <= ~ARG[9];"
+      , "    end"
+      , "end"
+      , ""
+      , "// Port B"
+      , "always @(~IF~ACTIVEEDGE[Rising][3]~THENposedge~ELSEnegedge~FI ~ARG[10]) begin"
+      , "    ~SYM[2] <= ~SYM[0][~ARG[12]];"
+      , "    if(~ARG[11]) begin"
+      , "        ~SYM[2] <= ~ARG[13];"
+      , "        ~SYM[0][~ARG[12]] <= ~ARG[13];"
+      , "    end"
+      , "end"
+      , ""
+      , "assign ~RESULT = {~SYM[1], ~SYM[2]};"
+      , "// end trueDualPortBlockRam"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam_File.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam_File.primitives
@@ -2,49 +2,51 @@
     { "name" : "Clash.Explicit.BlockRam.File.blockRamFile#"
     , "kind" : "Declaration"
     , "type" :
-"blockRamFile#
-  :: ( KnownDomain dom         --       ARG[0]
-     , KnownNat m              --       ARG[1]
-     , HasCallStack )          --       ARG[2]
-  => Clock dom                 -- clk,  ARG[3]
-  => Enable dom                -- en,   ARG[4]
-  -> SNat n                    -- sz,   ARG[5]
-  -> FilePath                  -- file, ARG[6]
-  -> Signal dom Int            -- rd,   ARG[7]
-  -> Signal dom Bool           -- wren, ARG[8]
-  -> Signal dom Int            -- wr,   ARG[9]
-  -> Signal dom (BitVector m)  -- din,  ARG[10]
-  -> Signal dom (BitVector m)"
+      [ "blockRamFile#"
+      , "  :: ( KnownDomain dom         --       ARG[0]"
+      , "     , KnownNat m              --       ARG[1]"
+      , "     , HasCallStack )          --       ARG[2]"
+      , "  => Clock dom                 -- clk,  ARG[3]"
+      , "  => Enable dom                -- en,   ARG[4]"
+      , "  -> SNat n                    -- sz,   ARG[5]"
+      , "  -> FilePath                  -- file, ARG[6]"
+      , "  -> Signal dom Int            -- rd,   ARG[7]"
+      , "  -> Signal dom Bool           -- wren, ARG[8]"
+      , "  -> Signal dom Int            -- wr,   ARG[9]"
+      , "  -> Signal dom (BitVector m)  -- din,  ARG[10]"
+      , "  -> Signal dom (BitVector m)"
+      ]
     , "outputReg" : true
     , "template" :
-"// blockRamFile begin
-reg ~TYPO ~GENSYM[RAM][1] [0:~LIT[5]-1];
-
-initial begin
-  $readmemb(~FILE[~LIT[6]],~SYM[1]);
-end
-~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRamFile][3]~IF ~VIVADO ~THEN
-  if (~ARG[4]) begin
-    if (~ARG[8]) begin
-      ~SYM[1][~ARG[9]] <= ~ARG[10];
-    end
-    ~RESULT <= ~SYM[1][~ARG[7]];
-  end~ELSE
-  if (~ARG[8] & ~ARG[4]) begin
-    ~SYM[1][~ARG[9]] <= ~ARG[10];
-  end
-  if (~ARG[4]) begin
-    ~RESULT <= ~SYM[1][~ARG[7]];
-  end~FI
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]
-  if (~ARG[8]) begin
-    ~SYM[1][~ARG[9]] <= ~ARG[10];
-  end
-  ~RESULT <= ~SYM[1][~ARG[7]];
-end~FI
-// blockRamFile end"
+      [ "// blockRamFile begin"
+      , "reg ~TYPO ~GENSYM[RAM][1] [0:~LIT[5]-1];"
+      , ""
+      , "initial begin"
+      , "  $readmemb(~FILE[~LIT[6]],~SYM[1]);"
+      , "end"
+      , "~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_blockRamFile][3]~IF ~VIVADO ~THEN"
+      , "  if (~ARG[4]) begin"
+      , "    if (~ARG[8]) begin"
+      , "      ~SYM[1][~ARG[9]] <= ~ARG[10];"
+      , "    end"
+      , "    ~RESULT <= ~SYM[1][~ARG[7]];"
+      , "  end~ELSE"
+      , "  if (~ARG[8] & ~ARG[4]) begin"
+      , "    ~SYM[1][~ARG[9]] <= ~ARG[10];"
+      , "  end"
+      , "  if (~ARG[4]) begin"
+      , "    ~RESULT <= ~SYM[1][~ARG[7]];"
+      , "  end~FI"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[3]"
+      , "  if (~ARG[8]) begin"
+      , "    ~SYM[1][~ARG[9]] <= ~ARG[10];"
+      , "  end"
+      , "  ~RESULT <= ~SYM[1][~ARG[7]];"
+      , "end~FI"
+      , "// blockRamFile end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Explicit_DDR.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_DDR.primitives
@@ -2,87 +2,91 @@
     { "name" : "Clash.Explicit.DDR.ddrIn#"
     , "kind" : "Declaration"
     , "type" :
-"ddrIn# :: forall a slow fast n pFast gated synchronous.
-           ( HasCallStack          -- ARG[0]
-           , Undefined a           -- ARG[1]
-           , KnownConfi~ fast domf -- ARG[2]
-           , KnownConfi~ slow doms -- ARG[3]
-        => Clock slow              -- ARG[4]
-        -> Reset slow              -- ARG[5]
-        -> Enable slow             -- ARG[6]
-        -> a                       -- ARG[7]
-        -> a                       -- ARG[8]
-        -> a                       -- ARG[9]
-        -> Signal fast a           -- ARG[10]
-        -> Signal slow (a,a)"
+      [ "ddrIn# :: forall a slow fast n pFast gated synchronous."
+      , "           ( HasCallStack          -- ARG[0]"
+      , "           , Undefined a           -- ARG[1]"
+      , "           , KnownConfi~ fast domf -- ARG[2]"
+      , "           , KnownConfi~ slow doms -- ARG[3]"
+      , "        => Clock slow              -- ARG[4]"
+      , "        -> Reset slow              -- ARG[5]"
+      , "        -> Enable slow             -- ARG[6]"
+      , "        -> a                       -- ARG[7]"
+      , "        -> a                       -- ARG[8]"
+      , "        -> a                       -- ARG[9]"
+      , "        -> Signal fast a           -- ARG[10]"
+      , "        -> Signal slow (a,a)"
+      ]
     , "template" :
-"// ddrIn begin
-reg ~SIGD[~GENSYM[data_Pos][1]][9];
-reg ~SIGD[~GENSYM[data_Neg][2]][9];
-reg ~SIGD[~GENSYM[data_Neg_Latch][3]][9];
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[1] <= ~ARG[8];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[1] <= ~ARG[10];
-  end
-end
-always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[2] <= ~ARG[9];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[2] <= ~ARG[10];
-  end
-end
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[3] <= ~ARG[7];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[3] <= ~SYM[2];
-  end
-end
-
-assign ~RESULT = {~SYM[3], ~SYM[1]};
-// ddrIn end"
+      [ "// ddrIn begin"
+      , "reg ~SIGD[~GENSYM[data_Pos][1]][9];"
+      , "reg ~SIGD[~GENSYM[data_Neg][2]][9];"
+      , "reg ~SIGD[~GENSYM[data_Neg_Latch][3]][9];"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[1] <= ~ARG[8];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[1] <= ~ARG[10];"
+      , "  end"
+      , "end"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[2] <= ~ARG[9];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[2] <= ~ARG[10];"
+      , "  end"
+      , "end"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[3] <= ~ARG[7];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[3] <= ~SYM[2];"
+      , "  end"
+      , "end"
+      , ""
+      , "assign ~RESULT = {~SYM[3], ~SYM[1]};"
+      , "// ddrIn end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.DDR.ddrOut#"
     , "kind" : "Declaration"
     , "type" :
-"ddrOut# :: ( HasCallStack               -- ARG[0]
-            , Undefined a                -- ARG[1]
-            , KnownConfi~ fast domf      -- ARG[2]
-            , KnownConfi~ slow doms      -- ARG[3]
-         => Clock slow                   -- ARG[4]
-         -> Reset slow                   -- ARG[5]
-         -> Enable slow                  -- ARG[6]
-         -> a                            -- ARG[7]
-         -> Signal slow a                -- ARG[8]
-         -> Signal slow a                -- ARG[9]
-         -> Signal fast a"
+      [ "ddrOut# :: ( HasCallStack               -- ARG[0]"
+      , "            , Undefined a                -- ARG[1]"
+      , "            , KnownConfi~ fast domf      -- ARG[2]"
+      , "            , KnownConfi~ slow doms      -- ARG[3]"
+      , "         => Clock slow                   -- ARG[4]"
+      , "         -> Reset slow                   -- ARG[5]"
+      , "         -> Enable slow                  -- ARG[6]"
+      , "         -> a                            -- ARG[7]"
+      , "         -> Signal slow a                -- ARG[8]"
+      , "         -> Signal slow a                -- ARG[9]"
+      , "         -> Signal fast a"
+      ]
     , "template" :
-"// ddrOut begin
-reg ~SIGD[~GENSYM[data_Pos][1]][7];
-reg ~SIGD[~GENSYM[data_Neg][2]][7];
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[1] <= ~ARG[7];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[1] <= ~ARG[8];
-  end
-end
-always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
-  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-    ~SYM[2] <= ~ARG[7];
-  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-    ~SYM[2] <= ~ARG[9];
-  end
-end
-
-assign ~RESULT = ~ARG[4] ? ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1] : ~SYM[2]~ELSE~SYM[2] : ~SYM[1]~FI;
-
-// ddrOut end"
+      [ "// ddrOut begin"
+      , "reg ~SIGD[~GENSYM[data_Pos][1]][7];"
+      , "reg ~SIGD[~GENSYM[data_Neg][2]][7];"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[1] <= ~ARG[7];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[1] <= ~ARG[8];"
+      , "  end"
+      , "end"
+      , "always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]"
+      , "  if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin"
+      , "    ~SYM[2] <= ~ARG[7];"
+      , "  end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin"
+      , "    ~SYM[2] <= ~ARG[9];"
+      , "  end"
+      , "end"
+      , ""
+      , "assign ~RESULT = ~ARG[4] ? ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1] : ~SYM[2]~ELSE~SYM[2] : ~SYM[1]~FI;"
+      , ""
+      , "// ddrOut end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Explicit_RAM.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_RAM.primitives
@@ -2,30 +2,32 @@
     { "name" : "Clash.Explicit.RAM.asyncRam#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRam#
-  :: ( HasCallStack              -- ARG[0]
-     , KnownDomain wdom wconf    -- ARG[1]
-     , KnownDomain rdom rconf )  -- ARG[2]
-  => Clock wdom                  -- ^ wclk, ARG[3]
-  -> Clock rdom                  -- ^ rclk, ARG[4]
-  -> Enable wdom                 -- ^ wen,  ARG[5]
-  -> SNat n                      -- ^ sz,   ARG[6]
-  -> Signal rdom Int             -- ^ rd,   ARG[7]
-  -> Signal wdom Bool            -- ^ en,   ARG[8]
-  -> Signal wdom Int             -- ^ wr,   ARG[9]
-  -> Signal wdom a               -- ^ din,  ARG[10]
-  -> Signal rdom a"
+      [ "asyncRam#"
+      , "  :: ( HasCallStack              -- ARG[0]"
+      , "     , KnownDomain wdom wconf    -- ARG[1]"
+      , "     , KnownDomain rdom rconf )  -- ARG[2]"
+      , "  => Clock wdom                  -- ^ wclk, ARG[3]"
+      , "  -> Clock rdom                  -- ^ rclk, ARG[4]"
+      , "  -> Enable wdom                 -- ^ wen,  ARG[5]"
+      , "  -> SNat n                      -- ^ sz,   ARG[6]"
+      , "  -> Signal rdom Int             -- ^ rd,   ARG[7]"
+      , "  -> Signal wdom Bool            -- ^ en,   ARG[8]"
+      , "  -> Signal wdom Int             -- ^ wr,   ARG[9]"
+      , "  -> Signal wdom a               -- ^ din,  ARG[10]"
+      , "  -> Signal rdom a"
+      ]
     , "template" :
-"// asyncRam begin
-reg ~TYPO ~GENSYM[RAM][0] [0:~LIT[6]-1];
-always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_Ram][1]
-  if (~ARG[8] ~IF ~ISACTIVEENABLE[5] ~THEN & ~ARG[5] ~ELSE ~FI) begin
-    ~SYM[0][~ARG[9]] <= ~ARG[10];
-  end
-end
-
-assign ~RESULT = ~SYM[0][~ARG[7]];
-// asyncRam end"
+      [ "// asyncRam begin"
+      , "reg ~TYPO ~GENSYM[RAM][0] [0:~LIT[6]-1];"
+      , "always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_Ram][1]"
+      , "  if (~ARG[8] ~IF ~ISACTIVEENABLE[5] ~THEN & ~ARG[5] ~ELSE ~FI) begin"
+      , "    ~SYM[0][~ARG[9]] <= ~ARG[10];"
+      , "  end"
+      , "end"
+      , ""
+      , "assign ~RESULT = ~SYM[0][~ARG[7]];"
+      , "// asyncRam end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM.primitives
@@ -2,37 +2,39 @@
     { "name" : "Clash.Explicit.ROM.rom#"
     , "kind" : "Declaration"
     , "type" :
-"rom# :: ( KnownDomain dom        ARG[0]
-         , KnownNat n    --       ARG[1]
-         , Undefined a ) --       ARG[2]
-      => Clock dom       -- clk,  ARG[3]
-      -> Enable dom      -- en,   ARG[4]
-      -> Vec n a         -- init, ARG[5]
-      -> Signal dom Int  -- rd,   ARG[6]
-      -> Signal dom a"
+      [ "rom# :: ( KnownDomain dom        ARG[0]"
+      , "        , KnownNat n    --       ARG[1]"
+      , "        , Undefined a ) --       ARG[2]"
+      , "     => Clock dom       -- clk,  ARG[3]"
+      , "     -> Enable dom      -- en,   ARG[4]"
+      , "     -> Vec n a         -- init, ARG[5]"
+      , "     -> Signal dom Int  -- rd,   ARG[6]"
+      , "     -> Signal dom a"
+      ]
     , "outputReg" : true
     , "template" :
-"// rom begin
-reg ~TYPO ~GENSYM[ROM][1] [0:~LIT[1]-1];
-
-reg ~TYP[5] ~GENSYM[rom_init][3];
-integer ~GENSYM[i][4];
-initial begin
-  ~SYM[3] = ~LIT[5];
-  for (~SYM[4]=0; ~SYM[4] < ~LIT[1]; ~SYM[4] = ~SYM[4] + 1) begin
-    ~SYM[1][~LIT[1]-1-~SYM[4]] = ~SYM[3][~SYM[4]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
-  end
-end
-~IF ~ISACTIVEENABLE[4] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_rom][5]
-  if (~ARG[4]) begin
-    ~RESULT <= ~SYM[1][~ARG[6]];
-  end
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]
-  ~RESULT <= ~SYM[1][~ARG[6]];
-end~FI
-// rom end"
+      [ "// rom begin"
+      , "reg ~TYPO ~GENSYM[ROM][1] [0:~LIT[1]-1];"
+      , ""
+      , "reg ~TYP[5] ~GENSYM[rom_init][3];"
+      , "integer ~GENSYM[i][4];"
+      , "initial begin"
+      , "  ~SYM[3] = ~LIT[5];"
+      , "  for (~SYM[4]=0; ~SYM[4] < ~LIT[1]; ~SYM[4] = ~SYM[4] + 1) begin"
+      , "    ~SYM[1][~LIT[1]-1-~SYM[4]] = ~SYM[3][~SYM[4]*~SIZE[~TYPO]+:~SIZE[~TYPO]];"
+      , "  end"
+      , "end"
+      , "~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~GENSYM[~COMPNAME_rom][5]"
+      , "  if (~ARG[4]) begin"
+      , "    ~RESULT <= ~SYM[1][~ARG[6]];"
+      , "  end"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin : ~SYM[5]"
+      , "  ~RESULT <= ~SYM[1][~ARG[6]];"
+      , "end~FI"
+      , "// rom end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM_File.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM_File.primitives
@@ -2,32 +2,34 @@
     { "name" : "Clash.Explicit.ROM.File.romFile#"
     , "kind" : "Declaration"
     , "type" :
-"romFile# :: ( KnownNat m             --       ARG[0]
-             , KnownDomain dom      ) --       ARG[1]
-          => Clock dom                -- clk,  ARG[2]
-          -> Enable dom               -- en,   ARG[3]
-          -> SNat n                   -- sz,   ARG[4]
-          -> FilePath                 -- file, ARG[5]
-          -> Signal dom Int           -- rd,   ARG[6]
-          -> Signal dom (BitVector m)"
+      [ "romFile# :: ( KnownNat m             --       ARG[0]"
+      , "             , KnownDomain dom      ) --       ARG[1]"
+      , "          => Clock dom                -- clk,  ARG[2]"
+      , "          -> Enable dom               -- en,   ARG[3]"
+      , "          -> SNat n                   -- sz,   ARG[4]"
+      , "          -> FilePath                 -- file, ARG[5]"
+      , "          -> Signal dom Int           -- rd,   ARG[6]"
+      , "          -> Signal dom (BitVector m)"
+      ]
     , "outputReg" : true
     , "template" :
-"// romFile begin
-reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[4]-1];
-
-initial begin
-  $readmemb(~FILE[~LIT[5]],~SYM[0]);
-end
-~IF ~ISACTIVEENABLE[3] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~COMPNAME_romFile][2]
-  if (~ARG[3]) begin
-    ~RESULT <= ~SYM[0][~ARG[6]];
-  end
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~SYM[2]
-  ~RESULT <= ~SYM[0][~ARG[6]];
-end~FI
-// romFile end"
+      [ "// romFile begin"
+      , "reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[4]-1];"
+      , ""
+      , "initial begin"
+      , "  $readmemb(~FILE[~LIT[5]],~SYM[0]);"
+      , "end"
+      , "~IF ~ISACTIVEENABLE[3] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~COMPNAME_romFile][2]"
+      , "  if (~ARG[3]) begin"
+      , "    ~RESULT <= ~SYM[0][~ARG[6]];"
+      , "  end"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~SYM[2]"
+      , "  ~RESULT <= ~SYM[0][~ARG[6]];"
+      , "end~FI"
+      , "// romFile end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives
@@ -2,59 +2,63 @@
     { "name" : "Clash.Explicit.Testbench.assert"
     , "kind" : "Declaration"
     , "type" :
-"assert
-  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0], ARG[1], ARG[2])
-  => Clock dom                             -- ARG[3]
-  -> Reset dom                             -- ARG[4]
-  -> String                                -- ARG[5]
-  -> Signal dom a                          -- Checked value  (ARG[6])
-  -> Signal dom a                          -- Expected value (ARG[7])
-  -> Signal dom b                          -- Return valued  (ARG[8])
-  -> Signal dom b"
+      [ "assert"
+      , "  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0], ARG[1], ARG[2])"
+      , "  => Clock dom                             -- ARG[3]"
+      , "  -> Reset dom                             -- ARG[4]"
+      , "  -> String                                -- ARG[5]"
+      , "  -> Signal dom a                          -- Checked value  (ARG[6])"
+      , "  -> Signal dom a                          -- Expected value (ARG[7])"
+      , "  -> Signal dom b                          -- Return valued  (ARG[8])"
+      , "  -> Signal dom b"
+    ]
     , "template" :
-"// assert begin
-// pragma translate_off
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin
-  if (~ARG[6] !== ~ARG[7]) begin
-    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[5], ~ARG[7], ~ARG[6]);
-    $finish;
-  end
-end
-// pragma translate_on
-assign ~RESULT = ~ARG[8];
-// assert end"
+      [ "// assert begin"
+      , "// pragma translate_off"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin"
+      , "  if (~ARG[6] !== ~ARG[7]) begin"
+      , "    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[5], ~ARG[7], ~ARG[6]);"
+      , "    $finish;"
+      , "  end"
+      , "end"
+      , "// pragma translate_on"
+      , "assign ~RESULT = ~ARG[8];"
+      , "// assert end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.Testbench.assertBitVector"
     , "kind" : "Declaration"
     , "type" :
-"assertBitVector
-  :: ( KnownDomain dom        --                 ARG[0]
-     , KnownNat n             --                 ARG[1]
-  => Clock dom                --                 ARG[2]
-  -> Reset dom                --                 ARG[3]
-  -> String                   --                 ARG[4]
-  -> Signal dom (BitVector n) -- Checked value  (ARG[5])
-  -> Signal dom (BitVector n) -- Expected value (ARG[6])
-  -> Signal dom b             -- Return valued  (ARG[7])
-  -> Signal dom b"
+      [ "assertBitVector"
+      , "  :: ( KnownDomain dom        --                 ARG[0]"
+      , "     , KnownNat n             --                 ARG[1]"
+      , "  => Clock dom                --                 ARG[2]"
+      , "  -> Reset dom                --                 ARG[3]"
+      , "  -> String                   --                 ARG[4]"
+      , "  -> Signal dom (BitVector n) -- Checked value  (ARG[5])"
+      , "  -> Signal dom (BitVector n) -- Expected value (ARG[6])"
+      , "  -> Signal dom b             -- Return valued  (ARG[7])"
+      , "  -> Signal dom b"
+      ]
     , "template" :
-"// assertBitVector begin
-// pragma translate_off
-wire ~TYP[5] ~GENSYM[maskXor][0]  = ~ARG[6] ^ ~ARG[6];
-wire ~TYP[5] ~GENSYM[checked][1]  = ~ARG[5] ^ ~SYM[0];
-wire ~TYP[5] ~GENSYM[expected][2] = ~ARG[6] ^ ~SYM[0];
-
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin
-  if (~SYM[1] !== ~SYM[2]) begin
-    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[4], ~ARG[6], ~ARG[5]);
-    $finish;
-  end
-end
-// pragma translate_on
-assign ~RESULT = ~ARG[7];
-// assertBitVector end"
+      [ "// assertBitVector begin"
+      , "// pragma translate_off"
+      , "wire ~TYP[5] ~GENSYM[maskXor][0]  = ~ARG[6] ^ ~ARG[6];"
+      , "wire ~TYP[5] ~GENSYM[checked][1]  = ~ARG[5] ^ ~SYM[0];"
+      , "wire ~TYP[5] ~GENSYM[expected][2] = ~ARG[6] ^ ~SYM[0];"
+      , ""
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin"
+      , "  if (~SYM[1] !== ~SYM[2]) begin"
+      , "    $display(\"@%0tns: %s, expected: %b, actual: %b\", $time, ~LIT[4], ~ARG[6], ~ARG[5]);"
+      , "    $finish;"
+      , "  end"
+      , "end"
+      , "// pragma translate_on"
+      , "assign ~RESULT = ~ARG[7];"
+      , "// assertBitVector end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -63,32 +67,34 @@ assign ~RESULT = ~ARG[7];
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
-"tbClockGen
-  :: KnownDomain dom     -- ARG[0]
-  => Signal dom Bool      -- ARG[1]
-  -> Clock dom"
+      [ "tbClockGen"
+      , "  :: KnownDomain dom     -- ARG[0]"
+      , "  => Signal dom Bool      -- ARG[1]"
+      , "  -> Clock dom"
+      ]
     , "template" :
-"// tbClockGen begin
-// pragma translate_off
-reg ~TYPO ~GENSYM[clk][0];
-// 1 = 0.1ps
-localparam ~GENSYM[half_period][1] = (~PERIOD[0]0 / 2);
-always begin
-  // Delay of 1 mitigates race conditions (https://github.com/steveicarus/iverilog/issues/160)
-  #1 ~SYM[0] = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;
-  #30000 forever begin
-    if (~ ~ARG[1]) begin
-      $finish;
-    end
-    ~SYM[0] = ~ ~SYM[0];
-    #~SYM[1];
-    ~SYM[0] = ~ ~SYM[0];
-    #~SYM[1];
-  end
-end
-assign ~RESULT = ~SYM[0];
-// pragma translate_on
-// tbClockGen end"
+      [ "// tbClockGen begin"
+      , "// pragma translate_off"
+      , "reg ~TYPO ~GENSYM[clk][0];"
+      , "// 1 = 0.1ps"
+      , "localparam ~GENSYM[half_period][1] = (~PERIOD[0]0 / 2);"
+      , "always begin"
+      , "  // Delay of 1 mitigates race conditions (https://github.com/steveicarus/iverilog/issues/160)"
+      , "  #1 ~SYM[0] = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;"
+      , "  #30000 forever begin"
+      , "    if (~ ~ARG[1]) begin"
+      , "      $finish;"
+      , "    end"
+      , "    ~SYM[0] = ~ ~SYM[0];"
+      , "    #~SYM[1];"
+      , "    ~SYM[0] = ~ ~SYM[0];"
+      , "    #~SYM[1];"
+      , "  end"
+      , "end"
+      , "assign ~RESULT = ~SYM[0];"
+      , "// pragma translate_on"
+      , "// tbClockGen end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Intel_DDR.primitives
+++ b/clash-lib/prims/verilog/Clash_Intel_DDR.primitives
@@ -2,47 +2,49 @@
     { "name" : "Clash.Intel.DDR.altddioIn"
     , "kind" : "Declaration"
     , "type" :
-"altddioIn
-  :: ( HasCallStack               -- ARG[0]
-     , KnownConfi~ fast domf      -- ARG[1]
-     , KnownConfi~ slow doms      -- ARG[2]
-     , KnownNat m )               -- ARG[3]
-  => SSymbol deviceFamily         -- ARG[4]
-  -> Clock slow                   -- ARG[5]
-  -> Reset slow                   -- ARG[6]
-  -> Enable slow                  -- ARG[7]
-  -> Signal fast (BitVector m)    -- ARG[8]
-  -> Signal slow (BitVector m,BitVector m)"
+      [ "altddioIn"
+      , "  :: ( HasCallStack               -- ARG[0]"
+      , "     , KnownConfi~ fast domf      -- ARG[1]"
+      , "     , KnownConfi~ slow doms      -- ARG[2]"
+      , "     , KnownNat m )               -- ARG[3]"
+      , "  => SSymbol deviceFamily         -- ARG[4]"
+      , "  -> Clock slow                   -- ARG[5]"
+      , "  -> Reset slow                   -- ARG[6]"
+      , "  -> Enable slow                  -- ARG[7]"
+      , "  -> Signal fast (BitVector m)    -- ARG[8]"
+      , "  -> Signal slow (BitVector m,BitVector m)"
+      ]
     , "libraries" : ["altera_mf"]
     , "template" :
-"// altddioIn begin
-wire ~SIGD[~GENSYM[dataout_l][1]][8];
-wire ~SIGD[~GENSYM[dataout_h][2]][8];
-
-altddio_in
-  #(
-    .intended_device_family (~LIT[4]),
-    .invert_input_clocks (\"OFF\"),
-    .lpm_hint (\"UNUSED\"),
-    .lpm_type (\"altddio_in\"),
-    .power_up_high (\"OFF\"),
-    .width (~SIZE[~TYP[7]])
-  )
-  ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[2] ~THEN
-    .sclr (~ARG[6]),
-    .aclr (1'b0),~ELSE
-    .aclr (~ARG[6]),
-    .sclr (1'b0),~FI
-    .datain (~ARG[8]),~
-    .inclock (~ARG[5]),
-    .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),
-    .dataout_h (~SYM[2]),
-    .dataout_l (~SYM[1]),
-    .aset (1'b0),
-    .sset (1'b0)
-  );
-assign ~RESULT = {~SYM[1],~SYM[2]};
-// altddioIn end"
+      [ "// altddioIn begin"
+      , "wire ~SIGD[~GENSYM[dataout_l][1]][8];"
+      , "wire ~SIGD[~GENSYM[dataout_h][2]][8];"
+      , ""
+      , "altddio_in"
+      , "  #("
+      , "    .intended_device_family (~LIT[4]),"
+      , "    .invert_input_clocks (\"OFF\"),"
+      , "    .lpm_hint (\"UNUSED\"),"
+      , "    .lpm_type (\"altddio_in\"),"
+      , "    .power_up_high (\"OFF\"),"
+      , "    .width (~SIZE[~TYP[7]])"
+      , "  )"
+      , "  ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[2] ~THEN"
+      , "    .sclr (~ARG[6]),"
+      , "    .aclr (1'b0),~ELSE"
+      , "    .aclr (~ARG[6]),"
+      , "    .sclr (1'b0),~FI"
+      , "    .datain (~ARG[8]),~"
+      , "    .inclock (~ARG[5]),"
+      , "    .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),"
+      , "    .dataout_h (~SYM[2]),"
+      , "    .dataout_l (~SYM[1]),"
+      , "    .aset (1'b0),"
+      , "    .sset (1'b0)"
+      , "  );"
+      , "assign ~RESULT = {~SYM[1],~SYM[2]};"
+      , "// altddioIn end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Prelude_ROM.primitives
+++ b/clash-lib/prims/verilog/Clash_Prelude_ROM.primitives
@@ -2,25 +2,27 @@
     { "name" : "Clash.Prelude.ROM.asyncRom#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRom# :: KnownNat n -- ^ ARG[0]
-           => Vec n a    -- ^ ARG[1]
-           -> Int        -- ^ ARG[2]
-           -> a"
+      [ "asyncRom# :: KnownNat n -- ^ ARG[0]"
+      , "           => Vec n a    -- ^ ARG[1]"
+      , "           -> Int        -- ^ ARG[2]"
+      , "           -> a"
+      ]
     , "template" :
-"// asyncRom begin
-wire ~TYPO ~GENSYM[ROM][0] [0:~LIT[0]-1];
-
-wire ~TYP[1] ~GENSYM[romflat][1];
-assign ~SYM[1] = ~LIT[1];
-genvar ~GENSYM[i][2];
-~GENERATE
-for (~SYM[2]=0; ~SYM[2] < ~LIT[0]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
-  assign ~SYM[0][(~LIT[0]-1)-~SYM[2]] = ~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
-end
-~ENDGENERATE
-
-assign ~RESULT = ~SYM[0][~ARG[2]];
-// asyncRom end"
+      [ "// asyncRom begin"
+      , "wire ~TYPO ~GENSYM[ROM][0] [0:~LIT[0]-1];"
+      , ""
+      , "wire ~TYP[1] ~GENSYM[romflat][1];"
+      , "assign ~SYM[1] = ~LIT[1];"
+      , "genvar ~GENSYM[i][2];"
+      , "~GENERATE"
+      , "for (~SYM[2]=0; ~SYM[2] < ~LIT[0]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]"
+      , "  assign ~SYM[0][(~LIT[0]-1)-~SYM[2]] = ~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = ~SYM[0][~ARG[2]];"
+      , "// asyncRom end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Prelude_ROM_File.primitives
+++ b/clash-lib/prims/verilog/Clash_Prelude_ROM_File.primitives
@@ -2,21 +2,23 @@
     { "name" : "Clash.Prelude.ROM.File.asyncRomFile#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRomFile :: KnownNat m -- ARG[0]
-              => SNat n     -- sz,   ARG[1]
-              -> FilePath   -- file, ARG[2]
-              -> Int        -- rd,   ARG[3]
-              -> BitVector m"
+      [ "asyncRomFile :: KnownNat m -- ARG[0]"
+      , "              => SNat n     -- sz,   ARG[1]"
+      , "              -> FilePath   -- file, ARG[2]"
+      , "              -> Int        -- rd,   ARG[3]"
+      , "              -> BitVector m"
+      ]
     , "template" :
-"// asyncRomFile begin
-reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[1]-1];
-
-initial begin
-  $readmemb(~FILE[~LIT[2]],~SYM[0]);
-end
-
-assign ~RESULT = ~SYM[0][~ARG[3]];
-// asyncRomFile end"
+        [ "// asyncRomFile begin"
+        , "reg ~TYPO ~GENSYM[ROM][0] [0:~LIT[1]-1];"
+        , ""
+        , "initial begin"
+        , "  $readmemb(~FILE[~LIT[2]],~SYM[0]);"
+        , "end"
+        , ""
+        , "assign ~RESULT = ~SYM[0][~ARG[3]];"
+        , "// asyncRomFile end"
+        ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Signal_BiSignal.primitives
+++ b/clash-lib/prims/verilog/Clash_Signal_BiSignal.primitives
@@ -1,35 +1,39 @@
 [ { "BlackBox" :
-    { "name" : "Clash.Signal.BiSignal.writeToBiSignal#",
-      "kind" : "Declaration",
-      "renderVoid": "RenderVoid",
-      "type" :
-"writeToBiSignal#
-  :: HasCallStack                   -- ARG[0]
-  => BiSignalIn ds d n              -- ARG[1]
-  -> Signal d (Maybe (BitVector n)) -- ARG[2]
-  -> Signal d Bool                  -- ARG[3]
-  -> Signal d (BitVector n)         -- ARG[4]
-  -> BiSignalOut ds d n",
-      "template":
-"// writeToBiSignal# begin
-assign ~ARG[1] = (~ARG[3] == 1'b1) ? ~ARG[4] : {~SIZE[~TYP[1]] {1'bz}};
-// writeToBiSignal# end"
-    }
+    { "name" : "Clash.Signal.BiSignal.writeToBiSignal#"
+    , "kind" : "Declaration"
+    , "renderVoid": "RenderVoid"
+    , "type" :
+        [ "writeToBiSignal#"
+        , "  :: HasCallStack                   -- ARG[0]"
+        , "  => BiSignalIn ds d n              -- ARG[1]"
+        , "  -> Signal d (Maybe (BitVector n)) -- ARG[2]"
+        , "  -> Signal d Bool                  -- ARG[3]"
+        , "  -> Signal d (BitVector n)         -- ARG[4]"
+        , "  -> BiSignalOut ds d n"
+        ]
+      , "template":
+        [ "// writeToBiSignal# begin"
+        , "assign ~ARG[1] = (~ARG[3] == 1'b1) ? ~ARG[4] : {~SIZE[~TYP[1]] {1'bz}};"
+        , "// writeToBiSignal# end"
+        ]
+      }
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.BiSignal.readFromBiSignal#"
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"readFromBiSignal#
-  :: ( HasCallStack    -- ARG[0]
-     , KnownNat n)     -- ARG[1]
-  => BiSignalIn ds d n -- ARG[2]
-  -> Signal d (BitVector n)"
+        [ "readFromBiSignal#"
+        , "  :: ( HasCallStack    -- ARG[0]"
+        , "     , KnownNat n)     -- ARG[1]"
+        , "  => BiSignalIn ds d n -- ARG[2]"
+        , "  -> Signal d (BitVector n)"
+        ]
     , "template" :
-"// readFromBiSignal begin
-assign ~RESULT = ~ARG[2];
-// readFromBiSignal end"
+      [ "// readFromBiSignal begin"
+      , "assign ~RESULT = ~ARG[2];"
+      , "// readFromBiSignal end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.primitives
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.primitives
@@ -2,86 +2,92 @@
     { "name" : "Clash.Signal.Internal.delay#"
     , "kind" : "Declaration"
     , "type" :
-"delay#
-  :: ( KnownDomain dom        -- ARG[0]
-     , Undefined a )          -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Enable dom               -- ARG[3]
-  -> a                        -- ARG[4]
-  -> Signal clk a             -- ARG[5]
-  -> Signal clk a"
+      [ "delay#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , Undefined a )          -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Enable dom               -- ARG[3]"
+      , "  -> a                        -- ARG[4]"
+      , "  -> Signal clk a             -- ARG[5]"
+      , "  -> Signal clk a"
+      ]
     , "outputReg" : true
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[4]~ELSE~FI" }
     , "template" :
-"// delay begin~IF ~ISACTIVEENABLE[3] ~THEN
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~RESULT_delay][1]
-  if (~ARG[3]) begin
-    ~RESULT <= ~ARG[5];
-  end
-end~ELSE
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~SYM[1]
-  ~RESULT <= ~ARG[5];
-end~FI
-// delay end"
+      [ "// delay begin~IF ~ISACTIVEENABLE[3] ~THEN"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~GENSYM[~RESULT_delay][1]"
+      , "  if (~ARG[3]) begin"
+      , "    ~RESULT <= ~ARG[5];"
+      , "  end"
+      , "end~ELSE"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin : ~SYM[1]"
+      , "  ~RESULT <= ~ARG[5];"
+      , "end~FI"
+      , "// delay end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.asyncRegister#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRegister#
-  :: ( KnownDomain dom        -- ARG[0]
-     , NFDataX a )            -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Reset dom                -- ARG[3]
-  -> Enable dom               -- ARG[4]
-  -> a                        -- ARG[5] (powerup value)
-  -> a                        -- ARG[6] (reset value)
-  -> Signal clk a             -- ARG[7]
-  -> Signal clk a"
+      [ "asyncRegister#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , NFDataX a )            -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Reset dom                -- ARG[3]"
+      , "  -> Enable dom               -- ARG[4]"
+      , "  -> a                        -- ARG[5] (powerup value)"
+      , "  -> a                        -- ARG[6] (reset value)"
+      , "  -> Signal clk a             -- ARG[7]"
+      , "  -> Signal clk a"
+      ]
     , "outputReg" : true
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[5]~ELSE~FI" }
     , "template" :
-"// async register begin
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~VAR[rst][3]~FI) begin : ~GENSYM[~RESULT_register][1]
-  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~VAR[rst][3]) begin
-    ~RESULT <= ~CONST[6];
-  end else ~FI~IF ~ISACTIVEENABLE[4] ~THENif (~ARG[4]) ~ELSE~FIbegin
-    ~RESULT <= ~ARG[7];
-  end
-end
-// async register end"
+      [ "// async register begin"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~VAR[rst][3]~FI) begin : ~GENSYM[~RESULT_register][1]"
+      , "  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~VAR[rst][3]) begin"
+      , "    ~RESULT <= ~CONST[6];"
+      , "  end else ~FI~IF ~ISACTIVEENABLE[4] ~THENif (~ARG[4]) ~ELSE~FIbegin"
+      , "    ~RESULT <= ~ARG[7];"
+      , "  end"
+      , "end"
+      , "// async register end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.register#"
     , "kind" : "Declaration"
     , "type" :
-"register#
-  :: ( KnownDomain dom        -- ARG[0]
-     , Undefined a )          -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Reset dom                -- ARG[3]
-  -> Enable dom               -- ARG[4]
-  -> a                        -- ARG[5] (powerup value)
-  -> a                        -- ARG[6] (reset value)
-  -> Signal clk a             -- ARG[7]
-  -> Signal clk a"
+      [ "register#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , Undefined a )          -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Reset dom                -- ARG[3]"
+      , "  -> Enable dom               -- ARG[4]"
+      , "  -> a                        -- ARG[5] (powerup value)"
+      , "  -> a                        -- ARG[6] (reset value)"
+      , "  -> Signal clk a             -- ARG[7]"
+      , "  -> Signal clk a"
+      ]
     , "outputReg" : true
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[5]~ELSE~FI" }
     , "template" :
-"// register begin
-always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISSYNC[0] ~THEN ~ELSE~IF ~ISUNDEFINED[6] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~VAR[rst][3]~FI~FI) begin : ~GENSYM[~RESULT_register][1]
-  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~VAR[rst][3]) begin
-    ~RESULT <= ~CONST[6];
-  end else ~FI~IF ~ISACTIVEENABLE[4] ~THENif (~ARG[4]) ~ELSE~FIbegin
-    ~RESULT <= ~ARG[7];
-  end
-end
-// register end"
+      [ "// register begin"
+      , "always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]~IF ~ISSYNC[0] ~THEN ~ELSE~IF ~ISUNDEFINED[6] ~THEN ~ELSE or ~IF ~ISACTIVEHIGH[0] ~THEN posedge ~ELSE negedge ~FI ~VAR[rst][3]~FI~FI) begin : ~GENSYM[~RESULT_register][1]"
+      , "  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif (~IF ~ISACTIVEHIGH[0] ~THEN ~ELSE ! ~FI~VAR[rst][3]) begin"
+      , "    ~RESULT <= ~CONST[6];"
+      , "  end else ~FI~IF ~ISACTIVEENABLE[4] ~THENif (~ARG[4]) ~ELSE~FIbegin"
+      , "    ~RESULT <= ~ARG[7];"
+      , "  end"
+      , "end"
+      , "// register end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -90,28 +96,30 @@ end
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
-"clockGen
-  :: KnownDomain dom     -- ARG[0]
-  => Clock dom"
+      [ "clockGen"
+      , "  :: KnownDomain dom     -- ARG[0]"
+      , "  => Clock dom"
+      ]
     , "template" :
-"// clockGen begin
-// pragma translate_off
-reg ~TYPO ~GENSYM[clk][0];
-// 1 = 0.1ps
-localparam ~GENSYM[half_period][1] = (~PERIOD[0]0 / 2);
-always begin
-  // Delay of 1 mitigates race conditions (https://github.com/steveicarus/iverilog/issues/160)
-  #1 ~SYM[0] = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;
-  #30000 forever begin
-    ~SYM[0] = ~ ~SYM[0];
-    #~SYM[1];
-    ~SYM[0] = ~ ~SYM[0];
-    #~SYM[1];
-  end
-end
-assign ~RESULT = ~SYM[0];
-// pragma translate_on
-// clockGen end"
+      [ "// clockGen begin"
+      , "// pragma translate_off"
+      , "reg ~TYPO ~GENSYM[clk][0];"
+      , "// 1 = 0.1ps"
+      , "localparam ~GENSYM[half_period][1] = (~PERIOD[0]0 / 2);"
+      , "always begin"
+      , "  // Delay of 1 mitigates race conditions (https://github.com/steveicarus/iverilog/issues/160)"
+      , "  #1 ~SYM[0] = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;"
+      , "  #30000 forever begin"
+      , "    ~SYM[0] = ~ ~SYM[0];"
+      , "    #~SYM[1];"
+      , "    ~SYM[0] = ~ ~SYM[0];"
+      , "    #~SYM[1];"
+      , "  end"
+      , "end"
+      , "assign ~RESULT = ~SYM[0];"
+      , "// pragma translate_on"
+      , "// clockGen end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -120,25 +128,26 @@ assign ~RESULT = ~SYM[0];
     , "kind" : "Declaration"
     , "type" : "resetGenN :: (KnownDomain dom, 1 <= n) => SNat n -> Reset dom"
     , "template" :
-"// resetGen on
-// pragma translate_off
-~IF~ISSYNC[0]~THEN
-reg ~TYPO ~GENSYM[rst][0];
-localparam ~GENSYM[reset_period][1] = 29998 + (~LIT[2] * ~PERIOD[0]0);
-initial begin
-  #1 ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;
-  #~SYM[1] ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;
-end
-assign ~RESULT = ~SYM[0];~ELSE
-reg ~TYPO ~SYM[0];
-localparam ~SYM[1] = 30001 + ((~LIT[2] - 1) * ~PERIOD[0]0);
-initial begin
-  #1     ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;
-  #~SYM[1] ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;
-end
-assign ~RESULT = ~SYM[0]; ~FI
-// pragma translate_on
-// resetGen end"
+      [ "// resetGen on"
+      , "// pragma translate_off"
+      , "~IF~ISSYNC[0]~THEN"
+      , "reg ~TYPO ~GENSYM[rst][0];"
+      , "localparam ~GENSYM[reset_period][1] = 29998 + (~LIT[2] * ~PERIOD[0]0);"
+      , "initial begin"
+      , "  #1 ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;"
+      , "  #~SYM[1] ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;"
+      , "end"
+      , "assign ~RESULT = ~SYM[0];~ELSE"
+      , "reg ~TYPO ~SYM[0];"
+      , "localparam ~SYM[1] = 30001 + ((~LIT[2] - 1) * ~PERIOD[0]0);"
+      , "initial begin"
+      , "  #1     ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;"
+      , "  #~SYM[1] ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;"
+      , "end"
+      , "assign ~RESULT = ~SYM[0]; ~FI"
+      , "// pragma translate_on"
+      , "// resetGen end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.primitives
@@ -2,19 +2,21 @@
     { "name"      : "Clash.Sized.Internal.BitVector.replaceBit#"
     , "kind"      : "Declaration"
     , "type" :
-"replaceBit# :: KnownNat n  -- ARG[0]
-             => BitVector n -- ARG[1]
-             -> Int         -- ARG[2]
-             -> Bit         -- ARG[3]
-             -> BitVector n"
+      [ "replaceBit# :: KnownNat n  -- ARG[0]"
+      , "             => BitVector n -- ARG[1]"
+      , "             -> Int         -- ARG[2]"
+      , "             -> Bit         -- ARG[3]"
+      , "             -> BitVector n"
+      ]
     , "outputReg" : true
     , "template" :
-"// replaceBit start
-always @(*) begin
-  ~RESULT = ~ARG[1];
-  ~RESULT[~ARG[2]] = ~VAR[din][3];
-end
-// replaceBit end"
+      [ "// replaceBit start"
+      , "always @(*) begin"
+      , "  ~RESULT = ~ARG[1];"
+      , "  ~RESULT[~ARG[2]] = ~VAR[din][3];"
+      , "end"
+      , "// replaceBit end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -22,29 +24,32 @@ end
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"setSlice# :: SNat (m + 1 + i)
-           -> BitVector (m + 1 + i) -- ARG[1]
-           -> SNat m                -- ARG[2]
-           -> SNat n                -- ARG[3]
-           -> BitVector (m + 1 - n) -- ARG[4]
-           -> BitVector (m + 1 + i)"
+      [ "setSlice# :: SNat (m + 1 + i)"
+      , "           -> BitVector (m + 1 + i) -- ARG[1]"
+      , "           -> SNat m                -- ARG[2]"
+      , "           -> SNat n                -- ARG[3]"
+      , "           -> BitVector (m + 1 - n) -- ARG[4]"
+      , "           -> BitVector (m + 1 + i)"
+      ]
     , "outputReg" : true
     , "template" :
-"// setSlice begin
-always @(*) begin
-  ~RESULT = ~ARG[1];
-  ~RESULT[~LIT[2] : ~LIT[3]] = ~VAR[din][4];
-end
-// setSlice end"
+      [ "// setSlice begin"
+      , "always @(*) begin"
+      , "  ~RESULT = ~ARG[1];"
+      , "  ~RESULT[~LIT[2] : ~LIT[3]] = ~VAR[din][4];"
+      , "end"
+      , "// setSlice end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.split#"
     , "kind" : "Expression"
     , "type" :
-"split# :: KnownNat n        -- ARG[0]
-        => BitVector (m + n) -- ARG[1]
-        -> (BitVector m, BitVector n)"
+      [ "split# :: KnownNat n        -- ARG[0]"
+      , "        => BitVector (m + n) -- ARG[1]"
+      , "        -> (BitVector m, BitVector n)"
+      ]
     , "template" : "~ARG[1]"
     }
   }
@@ -53,11 +58,12 @@ end
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"// rotateL begin
-wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
-// rotateL end"
+      [ "// rotateL begin"
+      , "wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];"
+      , "// rotateL end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -65,11 +71,12 @@ assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"// rotateR begin
-wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
-// rotateR end"
+      [ "// rotateR begin"
+      , "wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[bv][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];"
+      , "// rotateR end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Signed.primitives
@@ -3,26 +3,27 @@
     , "kind"      : "Declaration"
     , "type"      : "div# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "template"  :
-"// divSigned begin
-wire ~GENSYM[resultPos][1];
-wire ~GENSYM[dividerNeg][2];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
-
-assign ~SYM[1] = ~VAR[dividend][1][~SIZE[~TYPO]-1] == ~VAR[divider][2][~SIZE[~TYPO]-1];
-assign ~SYM[2] = ~VAR[divider][2][~SIZE[~TYPO]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][1][~SIZE[~TYPO]-1]},~VAR[dividend][1]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][2][~SIZE[~TYPO]-1]} ,~VAR[divider][2]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
-// divSigned end"
+      [ "// divSigned begin"
+      , "wire ~GENSYM[resultPos][1];"
+      , "wire ~GENSYM[dividerNeg][2];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][1][~SIZE[~TYPO]-1] == ~VAR[divider][2][~SIZE[~TYPO]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][2][~SIZE[~TYPO]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][1][~SIZE[~TYPO]-1]},~VAR[dividend][1]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][2][~SIZE[~TYPO]-1]} ,~VAR[divider][2]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);"
+      , "// divSigned end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -30,16 +31,17 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "kind"      : "Declaration"
     , "type"      : "mod# :: Signed n -> Signed n -> Signed n"
     , "template"  :
-"// modSigned begin
-// remainder
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 (~SYM[0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// modSigned end"
+      [ "// modSigned begin"
+      , "// remainder"
+      , "wire ~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 (~SYM[0] == ~SIZE[~TYPO]'sd0 ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// modSigned end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -47,11 +49,12 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"// rotateL begin
-wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = $signed(~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]]);
-// rotateL end"
+      [ "// rotateL begin"
+      , "wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = $signed(~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]]);"
+      , "// rotateL end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -59,11 +62,12 @@ assign ~RESULT = $signed(~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]]);
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"// rotateR begin
-wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = $signed(~SYM[0][~SIZE[~TYPO]-1 : 0]);
-// rotateR end"
+      [ "// rotateR begin"
+      , "wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[s][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = $signed(~SYM[0][~SIZE[~TYPO]-1 : 0]);"
+      , "// rotateR end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_Unsigned.primitives
@@ -3,11 +3,12 @@
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"// rotateL begin
-wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
-// rotateL end"
+      [ "// rotateL begin"
+      , "wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} << (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];"
+      , "// rotateL end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -15,11 +16,12 @@ assign ~RESULT = ~SYM[0][2*~SIZE[~TYPO]-1 : ~SIZE[~TYPO]];
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"// rotateR begin
-wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];
-assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);
-assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];
-// rotateR end"
+      [ "// rotateR begin"
+      , "wire [2*~SIZE[~TYPO]-1:0] ~GENSYM[u][0];"
+      , "assign ~SYM[0] = {~ARG[1],~ARG[1]} >> (~ARG[2] % ~SIZE[~TYPO]);"
+      , "assign ~RESULT = ~SYM[0][~SIZE[~TYPO]-1 : 0];"
+      , "// rotateR end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Sized_Vector.primitives
+++ b/clash-lib/prims/verilog/Clash_Sized_Vector.primitives
@@ -35,29 +35,31 @@
     , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
-"select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
-        => SNat f                        -- ARG[1]
-        -> SNat s                        -- ARG[2]
-        -> SNat n                        -- ARG[3]
-        -> Vec i a                       -- ARG[4]
-        -> Vec n a"
+      [ "select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]"
+      , "       => SNat f                        -- ARG[1]"
+      , "       -> SNat s                        -- ARG[2]"
+      , "       -> SNat n                        -- ARG[3]"
+      , "       -> Vec i a                       -- ARG[4]"
+      , "       -> Vec n a"
+      ]
     , "template" :
-"// select begin
-wire ~TYPEL[~TYPO] ~SYM[1] [0:~LENGTH[~TYP[4]]-1];
-genvar ~GENSYM[i][2];
-~GENERATE
-for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[4]]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
-  assign ~SYM[1][(~LENGTH[~TYP[4]]-1)-~SYM[2]] = ~VAR[vec][4][~SYM[2]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];
-end
-~ENDGENERATE
-
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4]=0; ~SYM[4] < ~LIT[3]; ~SYM[4] = ~SYM[4] + 1) begin : ~GENSYM[select][5]
-  assign ~RESULT[(~LIT[3]-1-~SYM[4])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[1][~LIT[1] + (~LIT[2] * ~SYM[4])];
-end
-~ENDGENERATE
-// select end"
+      [ "// select begin"
+      , "wire ~TYPEL[~TYPO] ~SYM[1] [0:~LENGTH[~TYP[4]]-1];"
+      , "genvar ~GENSYM[i][2];"
+      , "~GENERATE"
+      , "for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[4]]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]"
+      , "  assign ~SYM[1][(~LENGTH[~TYP[4]]-1)-~SYM[2]] = ~VAR[vec][4][~SYM[2]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4]=0; ~SYM[4] < ~LIT[3]; ~SYM[4] = ~SYM[4] + 1) begin : ~GENSYM[select][5]"
+      , "  assign ~RESULT[(~LIT[3]-1-~SYM[4])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[1][~LIT[1] + (~LIT[2] * ~SYM[4])];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// select end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -89,10 +91,11 @@ end
     , "workInfo"  : "Never"
     , "kind" : "Expression"
     , "type" :
- "unconcat :: KnownNat n     -- ARG[0]
-           => SNat m         -- ARG[1]
-           -> Vec (n * m) a  -- ARG[2]
-           -> Vec n (Vec m a)"
+      [ "unconcat :: KnownNat n     -- ARG[0]"
+      , "          => SNat m         -- ARG[1]"
+      , "          -> Vec (n * m) a  -- ARG[2]"
+      , "          -> Vec n (Vec m a)"
+      ]
     , "template" : "~ARG[2]~DEVNULL[~ARG[0]]~DEVNULL[~ARG[1]]"
     }
   }
@@ -102,21 +105,22 @@ end
     , "kind"      : "Declaration"
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "template"  :
-"// map begin
-genvar ~GENSYM[i][1];
-~GENERATE
-for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]~IF~SIZE[~TYP[1]]~THEN
-  wire ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];
-  assign ~SYM[3] = ~VAR[vec][1][~SYM[1]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI
-  ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~GENSYM[map_out][4];
-  ~INST 0
-    ~OUTPUT <= ~SYM[4]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
-  ~INST
-  assign ~RESULT[~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[4];
-end
-~ENDGENERATE
-// map end"
+      [ "// map begin"
+      , "genvar ~GENSYM[i][1];"
+      , "~GENERATE"
+      , "for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]~IF~SIZE[~TYP[1]]~THEN"
+      , "  wire ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];"
+      , "  assign ~SYM[3] = ~VAR[vec][1][~SYM[1]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI"
+      , "  ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~GENSYM[map_out][4];"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~SYM[4]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~"
+      , "  ~INST"
+      , "  assign ~RESULT[~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[4];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// map end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -125,25 +129,26 @@ end
     , "kind"      : "Declaration"
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "template"  :
-"// imap begin
-genvar ~GENSYM[i][1];
-~GENERATE
-for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
-  wire [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~GENSYM[map_index][3];~IF~SIZE[~TYP[2]]~THEN
-  wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];
-  assign ~SYM[4] = ~VAR[vec][2][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
-  ~OUTPUTWIREREG[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
-
-  assign ~SYM[3] = ~SIZE[~INDEXTYPE[~LIT[0]]]'d~MAXINDEX[~TYPO] - ~SYM[1][0+:~SIZE[~INDEXTYPE[~LIT[0]]]];
-  ~INST 1
-    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[3]~ ~INDEXTYPE[~LIT[0]]~
-    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
-  ~INST
-  assign ~RESULT[~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
-end
-~ENDGENERATE
-// imap end"
+      [ "// imap begin"
+      , "genvar ~GENSYM[i][1];"
+      , "~GENERATE"
+      , "for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]"
+      , "  wire [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~GENSYM[map_index][3];~IF~SIZE[~TYP[2]]~THEN"
+      , "  wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];"
+      , "  assign ~SYM[4] = ~VAR[vec][2][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI"
+      , "  ~OUTPUTWIREREG[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];"
+      , ""
+      , "  assign ~SYM[3] = ~SIZE[~INDEXTYPE[~LIT[0]]]'d~MAXINDEX[~TYPO] - ~SYM[1][0+:~SIZE[~INDEXTYPE[~LIT[0]]]];"
+      , "  ~INST 1"
+      , "    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[3]~ ~INDEXTYPE[~LIT[0]]~"
+      , "    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "  assign ~RESULT[~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// imap end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -152,25 +157,26 @@ end
     , "kind"      : "Declaration"
     , "type"      : "imap :: Index n -> (Index n -> a -> b) -> Vec m a -> Vec m b"
     , "template"  :
-"// imap begin
-genvar ~GENSYM[i][1];
-~GENERATE
-for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
-  wire ~TYP[0] ~GENSYM[map_index][3];~IF~SIZE[~TYP[2]]~THEN
-  wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];
-  assign ~SYM[4] = ~VAR[vec][2][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
-  ~OUTPUTWIREREG[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
-
-  assign ~SYM[3] = ~SIZE[~TYP[0]]'d~MAXINDEX[~TYPO] - ~SYM[1][0+:~SIZE[~TYP[0]]] + ~ARG[0];
-  ~INST 1
-    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[3]~ ~TYP[0]~
-    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
-  ~INST
-  assign ~RESULT[~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
-end
-~ENDGENERATE
-// imap end"
+      [ "// imap begin"
+      , "genvar ~GENSYM[i][1];"
+      , "~GENERATE"
+      , "for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]"
+      , "  wire ~TYP[0] ~GENSYM[map_index][3];~IF~SIZE[~TYP[2]]~THEN"
+      , "  wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];"
+      , "  assign ~SYM[4] = ~VAR[vec][2][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI"
+      , "  ~OUTPUTWIREREG[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];"
+      , ""
+      , "  assign ~SYM[3] = ~SIZE[~TYP[0]]'d~MAXINDEX[~TYPO] - ~SYM[1][0+:~SIZE[~TYP[0]]] + ~ARG[0];"
+      , "  ~INST 1"
+      , "    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[3]~ ~TYP[0]~"
+      , "    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "  assign ~RESULT[~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// imap end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -179,24 +185,25 @@ end
     , "kind"      : "Declaration"
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "template"  :
-"// zipWith start
-genvar ~GENSYM[i][2];
-~GENERATE
-for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][6]~IF~SIZE[~TYP[1]]~THEN
-  wire ~TYPEL[~TYP[1]] ~GENSYM[zipWith_in1][3];
-  assign ~SYM[3] = ~VAR[vec1][1][~SYM[2]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN
-  wire ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][4];
-  assign ~SYM[4] = ~VAR[vec2][2][~SYM[2]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
-  ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~SYM[5];
-  ~INST 0
-    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
-    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
-  ~INST
-  assign ~RESULT[~SYM[2]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
-end
-~ENDGENERATE
-// zipWith end"
+      [ "// zipWith start"
+      , "genvar ~GENSYM[i][2];"
+      , "~GENERATE"
+      , "for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][6]~IF~SIZE[~TYP[1]]~THEN"
+      , "  wire ~TYPEL[~TYP[1]] ~GENSYM[zipWith_in1][3];"
+      , "  assign ~SYM[3] = ~VAR[vec1][1][~SYM[2]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN"
+      , "  wire ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][4];"
+      , "  assign ~SYM[4] = ~VAR[vec2][2][~SYM[2]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI"
+      , "  ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~SYM[5];"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~"
+      , "    ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "  assign ~RESULT[~SYM[2]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// zipWith end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -205,32 +212,33 @@ end
     , "kind"      : "Declaration"
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "template"  :
-"// foldr start~IF ~LENGTH[~TYP[2]] ~THEN
-wire ~TYPO ~GENSYM[intermediate][0] [0:~LENGTH[~TYP[2]]];
-assign ~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];
-
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr][4]~IF~SIZE[~TYP[2]]~THEN
-  wire ~TYPEL[~TYP[2]] ~GENSYM[foldr_in1][5];
-  assign ~SYM[5] = ~VAR[xs][2][(~LENGTH[~TYP[2]]-1-~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
-  wire ~TYPO ~GENSYM[foldr_in2][6];
-  ~OUTPUTWIREREG[0] ~TYPO ~GENSYM[foldr_out][7];
-
-  assign ~SYM[6] = ~SYM[0][~SYM[3]+1];
-  ~INST 0
-    ~OUTPUT <= ~SYM[7]~ ~TYP[1]~
-    ~INPUT  <= ~SYM[5]~ ~TYPEL[~TYP[2]]~
-    ~INPUT  <= ~SYM[6]~ ~TYP[1]~
-  ~INST
-  assign ~SYM[0][~SYM[3]] = ~SYM[7];
-end
-~ENDGENERATE
-
-assign ~RESULT = ~SYM[0][0];
-~ELSE
-assign ~RESULT = ~ARG[1];
-~FI// foldr end"
+      [ "// foldr start~IF ~LENGTH[~TYP[2]] ~THEN"
+      , "wire ~TYPO ~GENSYM[intermediate][0] [0:~LENGTH[~TYP[2]]];"
+      , "assign ~SYM[0][~LENGTH[~TYP[2]]] = ~ARG[1];"
+      , ""
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr][4]~IF~SIZE[~TYP[2]]~THEN"
+      , "  wire ~TYPEL[~TYP[2]] ~GENSYM[foldr_in1][5];"
+      , "  assign ~SYM[5] = ~VAR[xs][2][(~LENGTH[~TYP[2]]-1-~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI"
+      , "  wire ~TYPO ~GENSYM[foldr_in2][6];"
+      , "  ~OUTPUTWIREREG[0] ~TYPO ~GENSYM[foldr_out][7];"
+      , ""
+      , "  assign ~SYM[6] = ~SYM[0][~SYM[3]+1];"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~SYM[7]~ ~TYP[1]~"
+      , "    ~INPUT  <= ~SYM[5]~ ~TYPEL[~TYP[2]]~"
+      , "    ~INPUT  <= ~SYM[6]~ ~TYP[1]~"
+      , "  ~INST"
+      , "  assign ~SYM[0][~SYM[3]] = ~SYM[7];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = ~SYM[0][0];"
+      , "~ELSE"
+      , "assign ~RESULT = ~ARG[1];"
+      , "~FI// foldr end"
+      ]
     }
   }
 , { "BlackBoxHaskell" :
@@ -243,14 +251,15 @@ assign ~RESULT = ~ARG[1];
     , "kind"      : "Declaration"
     , "type"      : "replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a"
     , "template"  :
-"// vector replace begin
-genvar ~GENSYM[i][0];
-~GENERATE
-for (~SYM[0]=0;~SYM[0]<~LENGTH[~TYPO];~SYM[0]=~SYM[0]+1) begin : ~GENSYM[vector_replace][1]
-  assign ~RESULT[(~MAXINDEX[~TYPO]-~SYM[0])*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]] = ~ARG[2] == ~SYM[0] ? ~ARG[3] : ~VAR[vec][1][(~MAXINDEX[~TYPO]-~SYM[0])*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]];
-end
-~ENDGENERATE
-// vector replace end"
+      [ "// vector replace begin"
+      , "genvar ~GENSYM[i][0];"
+      , "~GENERATE"
+      , "for (~SYM[0]=0;~SYM[0]<~LENGTH[~TYPO];~SYM[0]=~SYM[0]+1) begin : ~GENSYM[vector_replace][1]"
+      , "  assign ~RESULT[(~MAXINDEX[~TYPO]-~SYM[0])*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]] = ~ARG[2] == ~SYM[0] ? ~ARG[3] : ~VAR[vec][1][(~MAXINDEX[~TYPO]-~SYM[0])*~SIZE[~TYP[3]]+:~SIZE[~TYP[3]]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// vector replace end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -283,17 +292,18 @@ end
     , "kind"      : "Declaration"
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "template"  :
-"// transpose begin
-genvar ~GENSYM[row_index][1];
-genvar ~GENSYM[col_index][2];
-~GENERATE
-for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYP[1]]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]
-  for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[transpose_inner][4]
-    assign ~RESULT[((~SYM[2]*~SIZE[~TYPEL[~TYPO]])+(~SYM[1]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~VAR[matrix][1][((~SYM[1]*~SIZE[~TYPEL[~TYP[1]]])+(~SYM[2]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]];
-  end
-end
-~ENDGENERATE
-// transpose end"
+      [ "// transpose begin"
+      , "genvar ~GENSYM[row_index][1];"
+      , "genvar ~GENSYM[col_index][2];"
+      , "~GENERATE"
+      , "for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYP[1]]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[transpose_outer][3]"
+      , "  for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[transpose_inner][4]"
+      , "    assign ~RESULT[((~SYM[2]*~SIZE[~TYPEL[~TYPO]])+(~SYM[1]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]] = ~VAR[matrix][1][((~SYM[1]*~SIZE[~TYPEL[~TYP[1]]])+(~SYM[2]*~SIZE[~TYPEL[~TYPEL[~TYPO]]]))+:~SIZE[~TYPEL[~TYPEL[~TYPO]]]];"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , "// transpose end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -302,14 +312,15 @@ end
     , "kind"      : "Declaration"
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "template"  :
-"// reverse begin
-genvar ~GENSYM[i][1];
-~GENERATE
-for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]
-  assign ~RESULT[(~LENGTH[~TYPO] - 1 - ~SYM[1])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~VAR[vec][0][~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];
-end
-~ENDGENERATE
-// reverse end"
+      [ "// reverse begin"
+      , "genvar ~GENSYM[i][1];"
+      , "~GENERATE"
+      , "for (~SYM[1] = 0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[reverse][2]"
+      , "  assign ~RESULT[(~LENGTH[~TYPO] - 1 - ~SYM[1])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~VAR[vec][0][~SYM[1]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]];"
+      , "end"
+      , "~ENDGENERATE"
+      , "// reverse end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -317,9 +328,10 @@ end
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"concatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
-                  => Vec n (BitVector m)      -- ARG[2]
-                  -> BitVector (n * m)"
+      [ "concatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])"
+      , "                  => Vec n (BitVector m)      -- ARG[2]"
+      , "                  -> BitVector (n * m)"
+      ]
     , "template" : "~ARG[2]"
     }
   }
@@ -328,9 +340,10 @@ end
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
-                    => BitVector (n * m)        -- ARG[2]
-                    -> Vec n (BitVector m)"
+      [ "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])"
+      , "                   => BitVector (n * m)        -- ARG[2]"
+      , "                   -> Vec n (BitVector m)"
+      ]
     , "template" : "~ARG[2]"
     }
   }
@@ -340,19 +353,20 @@ end
     , "kind"      : "Declaration"
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
-"// rotateLeftS begin
-localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
-
-~GENERATE
-if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
-  assign ~RESULT = ~VAR[vec][1];
-end else begin : ~GENSYM[do_shift][4]
-  assign ~RESULT = {~VAR[vec][1][((~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]])-1 : 0]
-                   ,~VAR[vec][1][~SIZE[~TYPO]-1 : (~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]]]
-                   };
-end
-~ENDGENERATE
-// rotateLeftS end"
+      [ "// rotateLeftS begin"
+      , "localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];"
+      , ""
+      , "~GENERATE"
+      , "if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]"
+      , "  assign ~RESULT = ~VAR[vec][1];"
+      , "end else begin : ~GENSYM[do_shift][4]"
+      , "  assign ~RESULT = {~VAR[vec][1][((~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]])-1 : 0]"
+      , "                   ,~VAR[vec][1][~SIZE[~TYPO]-1 : (~LIT[0]-~SYM[2])*~SIZE[~TYPEL[~TYPO]]]"
+      , "                   };"
+      , "end"
+      , "~ENDGENERATE"
+      , "// rotateLeftS end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -361,19 +375,20 @@ end
     , "kind"      : "Declaration"
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
-"// rotateRightS begin
-localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];
-
-~GENERATE
-if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]
-  assign ~RESULT = ~VAR[vec][1];
-end else begin : ~GENSYM[do_shift][4]
-  assign ~RESULT = {~VAR[vec][1][(~SYM[2]*~SIZE[~TYPEL[~TYPO]])-1 : 0]
-                   ,~VAR[vec][1][~SIZE[~TYPO]-1 : ~SYM[2]*~SIZE[~TYPEL[~TYPO]]]
-                   };
-end
-~ENDGENERATE
-// rotateRightS end"
+      [ "// rotateRightS begin"
+      , "localparam ~GENSYM[shift_amount][2] = ~LIT[2] % ~LIT[0];"
+      , ""
+      , "~GENERATE"
+      , "if (~SYM[2] == 0) begin : ~GENSYM[no_shift][3]"
+      , "  assign ~RESULT = ~VAR[vec][1];"
+      , "end else begin : ~GENSYM[do_shift][4]"
+      , "  assign ~RESULT = {~VAR[vec][1][(~SYM[2]*~SIZE[~TYPEL[~TYPO]])-1 : 0]"
+      , "                   ,~VAR[vec][1][~SIZE[~TYPO]-1 : ~SYM[2]*~SIZE[~TYPEL[~TYPO]]]"
+      , "                   };"
+      , "end"
+      , "~ENDGENERATE"
+      , "// rotateRightS end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives
@@ -2,91 +2,95 @@
     { "name" : "Clash.Xilinx.DDR.iddr"
     , "kind" : "Declaration"
     , "type" :
-"iddr
-  :: ( HasCallStack            -- ARG[0]
-     , KnownConfi~ fast domf   -- ARG[1]
-     , KnownConfi~ slow doms   -- ARG[2]
-     , KnownNat m )            -- ARG[3]
-  -> Clock slow                -- ARG[4]
-  -> Reset slow                -- ARG[5]
-  -> Enable slow               -- ARG[6]
-  -> Signal fast (BitVector m) -- ARG[7]
-  -> Signal slow (BitVector m,BitVector m)"
+      [ "iddr"
+      , "  :: ( HasCallStack            -- ARG[0]"
+      , "     , KnownConfi~ fast domf   -- ARG[1]"
+      , "     , KnownConfi~ slow doms   -- ARG[2]"
+      , "     , KnownNat m )            -- ARG[3]"
+      , "  -> Clock slow                -- ARG[4]"
+      , "  -> Reset slow                -- ARG[5]"
+      , "  -> Enable slow               -- ARG[6]"
+      , "  -> Signal fast (BitVector m) -- ARG[7]"
+      , "  -> Signal slow (BitVector m,BitVector m)"
+      ]
     , "template" :
-"// iddr begin
-wire ~SIGD[~GENSYM[dataout_l][1]][7];
-wire ~SIGD[~GENSYM[dataout_h][2]][7];
-wire ~SIGD[~GENSYM[d][3]][7];
-assign ~SYM[3] = ~ARG[7];
-
-genvar ~GENSYM[i][8];
-~GENERATE
-for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
-  IDDR #(
-    .DDR_CLK_EDGE(\"SAME_EDGE\"),
-    .INIT_Q1(1'b0),
-    .INIT_Q2(1'b0),
-    .SRTYPE(~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~GENSYM[~COMPNAME_IDDR][9] (
-    .Q1(~SYM[1][~SYM[8]]),
-    .Q2(~SYM[2][~SYM[8]]),
-    .C(~ARG[4]),
-    .CE(~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),
-    .D(~SYM[3][~SYM[8]]),
-    .R(~ARG[5]),
-    .S(1'b0)
-  );
-end
-~ENDGENERATE
-
-assign ~RESULT = {~SYM[2],~SYM[1]};
-// iddr end"
+      [ "// iddr begin"
+      , "wire ~SIGD[~GENSYM[dataout_l][1]][7];"
+      , "wire ~SIGD[~GENSYM[dataout_h][2]][7];"
+      , "wire ~SIGD[~GENSYM[d][3]][7];"
+      , "assign ~SYM[3] = ~ARG[7];"
+      , ""
+      , "genvar ~GENSYM[i][8];"
+      , "~GENERATE"
+      , "for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]"
+      , "  IDDR #("
+      , "    .DDR_CLK_EDGE(\"SAME_EDGE\"),"
+      , "    .INIT_Q1(1'b0),"
+      , "    .INIT_Q2(1'b0),"
+      , "    .SRTYPE(~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)"
+      , "  ) ~GENSYM[~COMPNAME_IDDR][9] ("
+      , "    .Q1(~SYM[1][~SYM[8]]),"
+      , "    .Q2(~SYM[2][~SYM[8]]),"
+      , "    .C(~ARG[4]),"
+      , "    .CE(~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),"
+      , "    .D(~SYM[3][~SYM[8]]),"
+      , "    .R(~ARG[5]),"
+      , "    .S(1'b0)"
+      , "  );"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = {~SYM[2],~SYM[1]};"
+      , "// iddr end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Xilinx.DDR.oddr#"
     , "kind" : "Declaration"
     , "type" :
-"oddr#
-  :: ( KnownConfi~ fast domf    -- ARG[0]
-     , KnownConfi~ slow doms    -- ARG[1]
-     , KnownNat m )             -- ARG[2]
-  => Clock slow                 -- ARG[3]
-  -> Reset slow                 -- ARG[4]
-  -> Enable slow                -- ARG[5]
-  -> Signal slow (BitVector m)  -- ARG[6]
-  -> Signal slow (BitVector m)  -- ARG[7]
-  -> Signal fast (BitVector m)"
+      [ "oddr#"
+      , "  :: ( KnownConfi~ fast domf    -- ARG[0]"
+      , "     , KnownConfi~ slow doms    -- ARG[1]"
+      , "     , KnownNat m )             -- ARG[2]"
+      , "  => Clock slow                 -- ARG[3]"
+      , "  -> Reset slow                 -- ARG[4]"
+      , "  -> Enable slow                -- ARG[5]"
+      , "  -> Signal slow (BitVector m)  -- ARG[6]"
+      , "  -> Signal slow (BitVector m)  -- ARG[7]"
+      , "  -> Signal fast (BitVector m)"
+      ]
     , "template" :
-"// oddr begin
-wire ~SIGD[~GENSYM[datain_l][1]][7];
-wire ~SIGD[~GENSYM[datain_h][2]][7];
-wire ~SIGD[~GENSYM[q][3]][7];
-
-assign ~SYM[1] = ~ARG[6];
-assign ~SYM[2] = ~ARG[7];
-
-genvar ~GENSYM[i][8];
-~GENERATE
-for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
-  ODDR #(
-    .DDR_CLK_EDGE(\"SAME_EDGE\"),
-    .INIT(1'b0),
-    .SRTYPE(~IF ~ISSYNC[1] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-  ) ~GENSYM[~COMPNAME_ODDR][9] (
-    .Q(~SYM[3][~SYM[8]]),
-    .C(~ARG[3]),
-    .CE(~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),
-    .D1(~SYM[1][~SYM[8]]),
-    .D2(~SYM[2][~SYM[8]]),
-    .R(~ARG[4]),
-    .S(1'b0)
-  );
-end
-~ENDGENERATE
-
-assign ~RESULT = ~SYM[3];
-// oddr end"
+      [ "// oddr begin"
+      , "wire ~SIGD[~GENSYM[datain_l][1]][7];"
+      , "wire ~SIGD[~GENSYM[datain_h][2]][7];"
+      , "wire ~SIGD[~GENSYM[q][3]][7];"
+      , ""
+      , "assign ~SYM[1] = ~ARG[6];"
+      , "assign ~SYM[2] = ~ARG[7];"
+      , ""
+      , "genvar ~GENSYM[i][8];"
+      , "~GENERATE"
+      , "for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]"
+      , "  ODDR #("
+      , "    .DDR_CLK_EDGE(\"SAME_EDGE\"),"
+      , "    .INIT(1'b0),"
+      , "    .SRTYPE(~IF ~ISSYNC[1] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)"
+      , "  ) ~GENSYM[~COMPNAME_ODDR][9] ("
+      , "    .Q(~SYM[3][~SYM[8]]),"
+      , "    .C(~ARG[3]),"
+      , "    .CE(~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),"
+      , "    .D1(~SYM[1][~SYM[8]]),"
+      , "    .D2(~SYM[2][~SYM[8]]),"
+      , "    .R(~ARG[4]),"
+      , "    .S(1'b0)"
+      , "  );"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = ~SYM[3];"
+      , "// oddr end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/GHC_Base.primitives
+++ b/clash-lib/prims/verilog/GHC_Base.primitives
@@ -3,14 +3,15 @@
     , "kind"      : "Declaration"
     , "type"      : "divInt :: Int -> Int -> Int"
     , "template"  :
-"// divInt begin
-// divide (rounds towards zero)
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];
-
-// round toward minus infinity
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;
-// divInt end"
+      [ "// divInt begin"
+      , "// divide (rounds towards zero)"
+      , "wire ~SIGD[~GENSYM[quot_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] / ~VAR[divider][1];"
+      , ""
+      , "// round toward minus infinity"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ? ~SYM[0] : ~SYM[0] - ~SIZE[~TYPO]'sd1;"
+      , "// divInt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -18,16 +19,17 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "kind"      : "Declaration"
     , "type"      : "modInt :: Int -> Int -> Int"
     , "template" :
-"// modInt begin
-// remainder
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// modInt end"
+      [ "// modInt begin"
+      , "// remainder"
+      , "wire ~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 ((~VAR[dividend][0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// modInt end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/GHC_Classes.primitives
+++ b/clash-lib/prims/verilog/GHC_Classes.primitives
@@ -3,26 +3,27 @@
     , "kind"      : "Declaration"
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "template"  :
-"// divInt# begin
-wire ~GENSYM[resultPos][1];
-wire ~GENSYM[dividerNeg][2];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
-// divInt# end"
+      [ "// divInt# begin"
+      , "wire ~GENSYM[resultPos][1];"
+      , "wire ~GENSYM[dividerNeg][2];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);"
+      , "// divInt# end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -30,16 +31,17 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "kind"      : "Declaration"
     , "type"      : "modInt# :: Int# -> Int# -> Int#"
     , "template"  :
-"// modInt# begin
-// remainder
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// modInt# end"
+      [ "// modInt# begin"
+      , "// remainder"
+      , "wire ~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// modInt# end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/verilog/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/verilog/GHC_Integer_Type.primitives
@@ -3,26 +3,27 @@
     , "kind"      : "Declaration"
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "template"  :
-"// divInteger begin
-wire ~GENSYM[resultPos][1];
-wire ~GENSYM[dividerNeg][2];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
-// divInteger end"
+      [ "// divInteger begin"
+      , "wire ~GENSYM[resultPos][1];"
+      , "wire ~GENSYM[dividerNeg][2];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);"
+      , "// divInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.divInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -31,16 +32,17 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "kind"      : "Declaration"
     , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "template"  :
-"// modInteger begin
-// remainder
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// modInteger end"
+      [ "// modInteger begin"
+      , "// remainder"
+      , "wire ~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// modInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.modInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -49,38 +51,39 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "kind"      : "Declaration"
     , "type"      : "divModInteger :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"// divModInteger begin
-wire ~GENSYM[resultPos][1];
-wire ~GENSYM[dividerNeg][2];
-wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];
-wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];
-wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];
-wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];
-wire signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);
-
-wire ~SIGD[~GENSYM[rem_res][8]][0];
-wire ~SIGD[~GENSYM[mod_res][9]][0];
-assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?
-                 ~SYM[8] :
-                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);
-
-assign ~RESULT = {~SYM[7],~SYM[9]};
-// divModInteger end"
+      [ "// divModInteger begin"
+      , "wire ~GENSYM[resultPos][1];"
+      , "wire ~GENSYM[dividerNeg][2];"
+      , "wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];"
+      , "wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];"
+      , "wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];"
+      , "wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];"
+      , "wire signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);"
+      , ""
+      , "wire ~SIGD[~GENSYM[rem_res][8]][0];"
+      , "wire ~SIGD[~GENSYM[mod_res][9]][0];"
+      , "assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?"
+      , "                 ~SYM[8] :"
+      , "                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);"
+      , ""
+      , "assign ~RESULT = {~SYM[7],~SYM[9]};"
+      , "// divModInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.divModInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -89,14 +92,15 @@ assign ~RESULT = {~SYM[7],~SYM[9]};
     , "kind"      : "Declaration"
     , "type"      : "quotRemInteger :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"// quotRemInteger begin
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-wire ~SIGD[~GENSYM[rem_res][1]][0];
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
-assign ~SYM[1] = ~ARG[0] % ~ARG[1];
-
-assign ~RESULT = {~SYM[0],~SYM[1]};
-// quotRemInteger end"
+      [ "// quotRemInteger begin"
+      , "wire ~SIGD[~GENSYM[quot_res][0]][0];"
+      , "wire ~SIGD[~GENSYM[rem_res][1]][0];"
+      , "assign ~SYM[0] = ~ARG[0] / ~ARG[1];"
+      , "assign ~SYM[1] = ~ARG[0] % ~ARG[1];"
+      , ""
+      , "assign ~RESULT = {~SYM[0],~SYM[1]};"
+      , "// quotRemInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.quotRemInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }

--- a/clash-lib/prims/verilog/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/verilog/GHC_Num_Integer.primitives
@@ -3,26 +3,27 @@
     , "kind"      : "Declaration"
     , "type"      : "integerDiv :: Integer -> Integer -> Integer"
     , "template"  :
-"// integerDiv begin
-wire ~GENSYM[resultPos][1];
-wire ~GENSYM[dividerNeg][2];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];
-wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
-// integerDiv end"
+      [ "// integerDiv begin"
+      , "wire ~GENSYM[resultPos][1];"
+      , "wire ~GENSYM[dividerNeg][2];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividend2][3];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividendE][4];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[dividerE][5];"
+      , "wire signed [~SIZE[~TYPO]:0] ~GENSYM[quot_res][6];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYPO]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYPO]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYPO]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYPO]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYPO]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);"
+      , "// integerDiv end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerDiv: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -31,16 +32,17 @@ assign ~RESULT = $signed(~SYM[6][~SIZE[~TYPO]-1:0]);
     , "kind"      : "Declaration"
     , "type"      : "integerMod :: Integer -> Integer -> Integer"
     , "template"  :
-"// integerMod begin
-// remainder
-wire ~SIGD[~GENSYM[rem_res][0]][0];
-assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?
-                 ~SYM[0] :
-                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);
-// integerMod end"
+      [ "// integerMod begin"
+      , "// remainder"
+      , "wire ~SIGD[~GENSYM[rem_res][0]][0];"
+      , "assign ~SYM[0] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~TYPO]-1]) ?"
+      , "                 ~SYM[0] :"
+      , "                 ((~SYM[0] == ~SIZE[~TYPO]'sd0) ? ~SIZE[~TYPO]'sd0 : ~SYM[0] + ~VAR[divider][1]);"
+      , "// integerMod end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerMod: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -49,38 +51,39 @@ assign ~RESULT = (~VAR[dividend][0][~SIZE[~TYPO]-1] == ~VAR[divider][1][~SIZE[~T
     , "kind"      : "Declaration"
     , "type"      : "integerDivMod :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"// integerDivMod begin
-wire ~GENSYM[resultPos][1];
-wire ~GENSYM[dividerNeg][2];
-wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];
-wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];
-wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];
-wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];
-wire signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];
-
-assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];
-assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;
-assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension
-assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension
-
-assign ~SYM[3] = ~SYM[1] ? ~SYM[4]
-                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)
-                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));
-
-assign ~SYM[6] = ~SYM[3] / ~SYM[5];
-assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);
-
-wire ~SIGD[~GENSYM[rem_res][8]][0];
-wire ~SIGD[~GENSYM[mod_res][9]][0];
-assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];
-
-// modulo
-assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?
-                 ~SYM[8] :
-                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);
-
-assign ~RESULT = {~SYM[7],~SYM[9]};
-// integerDivMod end"
+      [ "// integerDivMod begin"
+      , "wire ~GENSYM[resultPos][1];"
+      , "wire ~GENSYM[dividerNeg][2];"
+      , "wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividend2][3];"
+      , "wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividendE][4];"
+      , "wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[dividerE][5];"
+      , "wire signed [~SIZE[~TYP[0]]:0] ~GENSYM[quot_res][6];"
+      , "wire signed [~SIZE[~TYP[0]]-1:0] ~GENSYM[div_res][7];"
+      , ""
+      , "assign ~SYM[1] = ~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1];"
+      , "assign ~SYM[2] = ~VAR[divider][1][~SIZE[~TYP[0]]-1] == 1'b1;"
+      , "assign ~SYM[4] = $signed({{~VAR[dividend][0][~SIZE[~TYP[0]]-1]},~VAR[dividend][0]});  // sign extension"
+      , "assign ~SYM[5] = $signed({{~VAR[divider][1][~SIZE[~TYP[0]]-1]} ,~VAR[divider][1]} );  // sign extension"
+      , ""
+      , "assign ~SYM[3] = ~SYM[1] ? ~SYM[4]"
+      , "                         : (~SYM[2] ? (~SYM[4] - ~SYM[5] - ~SIZE[~TYP[0]]'sd1)"
+      , "                                    : (~SYM[4] - ~SYM[5] + ~SIZE[~TYP[0]]'sd1));"
+      , ""
+      , "assign ~SYM[6] = ~SYM[3] / ~SYM[5];"
+      , "assign ~SYM[7] = $signed(~SYM[6][~SIZE[~TYP[0]]-1:0]);"
+      , ""
+      , "wire ~SIGD[~GENSYM[rem_res][8]][0];"
+      , "wire ~SIGD[~GENSYM[mod_res][9]][0];"
+      , "assign ~SYM[8] = ~VAR[dividend][0] % ~VAR[divider][1];"
+      , ""
+      , "// modulo"
+      , "assign ~SYM[9] = (~VAR[dividend][0][~SIZE[~TYP[0]]-1] == ~VAR[divider][1][~SIZE[~TYP[0]]-1]) ?"
+      , "                 ~SYM[8] :"
+      , "                 ((~SYM[8] == ~SIZE[~TYP[0]]'sd0) ? ~SIZE[~TYP[0]]'sd0 : ~SYM[8] + ~VAR[divider][1]);"
+      , ""
+      , "assign ~RESULT = {~SYM[7],~SYM[9]};"
+      , "// integerDivMod end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerDivMod#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -89,14 +92,15 @@ assign ~RESULT = {~SYM[7],~SYM[9]};
     , "kind"      : "Declaration"
     , "type"      : "integerQuotRem :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"// integerQuotRem begin
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-wire ~SIGD[~GENSYM[rem_res][1]][0];
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
-assign ~SYM[1] = ~ARG[0] % ~ARG[1];
-
-assign ~RESULT = {~SYM[0],~SYM[1]};
-// integerQuotRem end"
+      [ "// integerQuotRem begin"
+      , "wire ~SIGD[~GENSYM[quot_res][0]][0];"
+      , "wire ~SIGD[~GENSYM[rem_res][1]][0];"
+      , "assign ~SYM[0] = ~ARG[0] / ~ARG[1];"
+      , "assign ~SYM[1] = ~ARG[0] % ~ARG[1];"
+      , ""
+      , "assign ~RESULT = {~SYM[0],~SYM[1]};"
+      , "// integerQuotRem end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerQuotRem#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }

--- a/clash-lib/prims/verilog/GHC_Prim.primitives
+++ b/clash-lib/prims/verilog/GHC_Prim.primitives
@@ -3,14 +3,15 @@
     , "kind"      : "Declaration"
     , "type"      : "quotRemInt# :: Int# -> Int# -> (#Int#, Int##)"
     , "template"  :
-"// quotRemInt begin
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-wire ~SIGD[~GENSYM[rem_res][1]][0];
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
-assign ~SYM[1] = ~ARG[0] % ~ARG[1];
-
-assign ~RESULT = {~SYM[0],~SYM[1]};
-// quotRemInt end"
+      [ "// quotRemInt begin"
+      , "wire ~SIGD[~GENSYM[quot_res][0]][0];"
+      , "wire ~SIGD[~GENSYM[rem_res][1]][0];"
+      , "assign ~SYM[0] = ~ARG[0] / ~ARG[1];"
+      , "assign ~SYM[1] = ~ARG[0] % ~ARG[1];"
+      , ""
+      , "assign ~RESULT = {~SYM[0],~SYM[1]};"
+      , "// quotRemInt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -18,14 +19,15 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
     , "kind"      : "Declaration"
     , "type"      : "quotRemWord# :: Word# -> Word# -> (#Word#, Word##)"
     , "template"  :
-"// quotRemWord begin
-wire ~SIGD[~GENSYM[quot_res][0]][0];
-wire ~SIGD[~GENSYM[rem_res][1]][0];
-assign ~SYM[0] = ~ARG[0] / ~ARG[1];
-assign ~SYM[1] = ~ARG[0] % ~ARG[1];
-
-assign ~RESULT = {~SYM[0],~SYM[1]};
-// quotRemWord end"
+      [ "// quotRemWord begin"
+      , "wire ~SIGD[~GENSYM[quot_res][0]][0];"
+      , "wire ~SIGD[~GENSYM[rem_res][1]][0];"
+      , "assign ~SYM[0] = ~ARG[0] / ~ARG[1];"
+      , "assign ~SYM[1] = ~ARG[0] % ~ARG[1];"
+      , ""
+      , "assign ~RESULT = {~SYM[0],~SYM[1]};"
+      , "// quotRemWord end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -37,61 +39,63 @@ assign ~RESULT = {~SYM[0],~SYM[1]};
       [ { "name" : "popCnt8"
         , "extension" : "inc"
         , "template" :
-"// ceiling of log2
-function integer ~INCLUDENAME[0]_clog2;
-  input integer value;
-  begin
-    value = value-1;
-    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)
-      value = value>>1;
-  end
-endfunction
-
-// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0]_depth2Index;
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// ceiling of log2"
+          , "function integer ~INCLUDENAME[0]_clog2;"
+          , "  input integer value;"
+          , "  begin"
+          , "    value = value-1;"
+          , "    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)"
+          , "      value = value>>1;"
+          , "  end"
+          , "endfunction"
+          , ""
+          , "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0]_depth2Index;"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt8 begin
-localparam ~GENSYM[width][0] = 8;
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);
-
-wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt8 end"
+      [ "// popCnt8 begin"
+      , "localparam ~GENSYM[width][0] = 8;"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);"
+      , ""
+      , "wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -103,61 +107,63 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "popCnt16"
         , "extension" : "inc"
         , "template" :
-"// ceiling of log2
-function integer ~INCLUDENAME[0]_clog2;
-  input integer value;
-  begin
-    value = value-1;
-    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)
-      value = value>>1;
-  end
-endfunction
-
-// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0]_depth2Index;
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// ceiling of log2"
+          , "function integer ~INCLUDENAME[0]_clog2;"
+          , "  input integer value;"
+          , "  begin"
+          , "    value = value-1;"
+          , "    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)"
+          , "      value = value>>1;"
+          , "  end"
+          , "endfunction"
+          , ""
+          , "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0]_depth2Index;"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt16 begin
-localparam ~GENSYM[width][0] = 16;
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);
-
-wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt16 end"
+      [ "// popCnt16 begin"
+      , "localparam ~GENSYM[width][0] = 16;"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);"
+      , ""
+      , "wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -169,61 +175,63 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "popCnt32"
         , "extension" : "inc"
         , "template" :
-"// ceiling of log2
-function integer ~INCLUDENAME[0]_clog2;
-  input integer value;
-  begin
-    value = value-1;
-    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)
-      value = value>>1;
-  end
-endfunction
-
-// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0]_depth2Index;
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// ceiling of log2"
+          , "function integer ~INCLUDENAME[0]_clog2;"
+          , "  input integer value;"
+          , "  begin"
+          , "    value = value-1;"
+          , "    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)"
+          , "      value = value>>1;"
+          , "  end"
+          , "endfunction"
+          , ""
+          , "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0]_depth2Index;"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt32 begin
-localparam ~GENSYM[width][0] = 32;
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);
-
-wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt32 end"
+      [ "// popCnt32 begin"
+      , "localparam ~GENSYM[width][0] = 32;"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);"
+      , ""
+      , "wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -235,61 +243,63 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "popCnt64"
         , "extension" : "inc"
         , "template" :
-"// ceiling of log2
-function integer ~INCLUDENAME[0]_clog2;
-  input integer value;
-  begin
-    value = value-1;
-    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)
-      value = value>>1;
-  end
-endfunction
-
-// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0]_depth2Index;
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// ceiling of log2"
+          , "function integer ~INCLUDENAME[0]_clog2;"
+          , "  input integer value;"
+          , "  begin"
+          , "    value = value-1;"
+          , "    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)"
+          , "      value = value>>1;"
+          , "  end"
+          , "endfunction"
+          , ""
+          , "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0]_depth2Index;"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt64 begin
-localparam ~GENSYM[width][0] = 64;
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);
-
-wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt64 end"
+      [ "// popCnt64 begin"
+      , "localparam ~GENSYM[width][0] = 64;"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);"
+      , ""
+      , "wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -301,61 +311,63 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "popCnt"
         , "extension" : "inc"
         , "template" :
-"// ceiling of log2
-function integer ~INCLUDENAME[0]_clog2;
-  input integer value;
-  begin
-    value = value-1;
-    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)
-      value = value>>1;
-  end
-endfunction
-
-// given a level and a depth, calculate the corresponding index into the
-// intermediate array
-function integer ~INCLUDENAME[0]_depth2Index;
-  input integer levels;
-  input integer depth;
-
-  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);
-endfunction"
+          [ "// ceiling of log2"
+          , "function integer ~INCLUDENAME[0]_clog2;"
+          , "  input integer value;"
+          , "  begin"
+          , "    value = value-1;"
+          , "    for (~INCLUDENAME[0]_clog2=0; value>0; ~INCLUDENAME[0]_clog2=~INCLUDENAME[0]_clog2+1)"
+          , "      value = value>>1;"
+          , "  end"
+          , "endfunction"
+          , ""
+          , "// given a level and a depth, calculate the corresponding index into the"
+          , "// intermediate array"
+          , "function integer ~INCLUDENAME[0]_depth2Index;"
+          , "  input integer levels;"
+          , "  input integer depth;"
+          , ""
+          , "  ~INCLUDENAME[0]_depth2Index = (2 ** levels) - (2 ** depth);"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// popCnt begin
-localparam ~GENSYM[width][0] = ~SIZE[~TYPO];
-
-// depth of the tree
-localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);
-
-wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];
-
-// put input into the first half of the intermediate array
-genvar ~GENSYM[i][4];
-~GENERATE
-for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]
-  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);
-end
-~ENDGENERATE
-
-// Create the tree of instantiated components
-genvar ~GENSYM[d][6];
-genvar ~GENSYM[i][7];
-~GENERATE
-if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]
-  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]
-    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]
-      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] =
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +
-             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];
-    end
-  end
-end
-~ENDGENERATE
-
-// The last element of the intermediate array holds the result
-assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
-// popCnt end"
+      [ "// popCnt begin"
+      , "localparam ~GENSYM[width][0] = ~SIZE[~TYPO];"
+      , ""
+      , "// depth of the tree"
+      , "localparam ~GENSYM[levels][2] = ~INCLUDENAME[0]_clog2(~SYM[0]);"
+      , ""
+      , "wire [~SYM[2]:0] ~GENSYM[intermediate][3] [0:(2*~SYM[0])-2];"
+      , ""
+      , "// put input into the first half of the intermediate array"
+      , "genvar ~GENSYM[i][4];"
+      , "~GENERATE"
+      , "for (~SYM[4] = 0; ~SYM[4] < ~SYM[0]; ~SYM[4]=~SYM[4]+1) begin : ~GENSYM[mk_array][11]"
+      , "  assign ~SYM[3][~SYM[4]] = $unsigned(~VAR[input][0][~SYM[4]]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// Create the tree of instantiated components"
+      , "genvar ~GENSYM[d][6];"
+      , "genvar ~GENSYM[i][7];"
+      , "~GENERATE"
+      , "if (~SYM[2] != 0) begin : ~GENSYM[make_tree][8]"
+      , "  for (~SYM[6] = ~SYM[2]; ~SYM[6] > 0; ~SYM[6]=~SYM[6]-1) begin : ~GENSYM[tree_depth][9]"
+      , "    for (~SYM[7] = 0; ~SYM[7] < (2**(~SYM[6]-1)); ~SYM[7] = ~SYM[7]+1) begin : ~GENSYM[tree_depth_loop][10]"
+      , "      assign ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6])+~SYM[7]] ="
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])] +"
+      , "             ~SYM[3][~INCLUDENAME[0]_depth2Index(~SYM[2]+1,~SYM[6]+1)+(2*~SYM[7])+1];"
+      , "    end"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "// The last element of the intermediate array holds the result"
+      , "assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);"
+      , "// popCnt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -367,63 +379,65 @@ assign ~RESULT = $unsigned(~SYM[3][(2*~SYM[0])-2]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz8 begin
-wire [0:7] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][7:0];
-
-wire [0:7] ~GENSYM[e][2];
-genvar ~GENSYM[n][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:5] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage1][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:3] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 3;
-wire [5:0] i;
-assign i = ~SYM[4][0:5];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz8 end"
+      [ "// clz8 begin"
+      , "wire [0:7] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][7:0];"
+      , ""
+      , "wire [0:7] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[n][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:5] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage1][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:3] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 3;"
+      , "wire [5:0] i;"
+      , "assign i = ~SYM[4][0:5];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -435,79 +449,81 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz16 begin
-wire [0:15] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][15:0];
-
-wire [0:15] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:11] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:7] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:4] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 4;
-wire [7:0] i;
-assign i = ~SYM[9][0:7];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz16 end"
+      [ "// clz16 begin"
+      , "wire [0:15] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][15:0];"
+      , ""
+      , "wire [0:15] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:11] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:7] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:4] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 4;"
+      , "wire [7:0] i;"
+      , "assign i = ~SYM[9][0:7];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -519,95 +535,97 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz32 begin
-wire [0:31] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][31:0];
-
-wire [0:31] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:23] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:15] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:9] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  wire [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:5] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 5;
-wire [9:0] i;
-assign i = ~SYM[12][0:9];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz32 end"
+      [ "// clz32 begin"
+      , "wire [0:31] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][31:0];"
+      , ""
+      , "wire [0:31] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:23] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:15] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:9] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  wire [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:5] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 5;"
+      , "wire [9:0] i;"
+      , "assign i = ~SYM[12][0:9];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -619,111 +637,113 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz64 begin
-wire [0:63] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][63:0];
-
-wire [0:63] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:47] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:31] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:19] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  wire [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:11] ~GENSYM[d][15];
-genvar ~GENSYM[i4][16];
-~GENERATE
-for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
-  localparam n = 5;
-  wire [9:0] i;
-  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:6] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 6;
-wire [11:0] i;
-assign i = ~SYM[15][0:11];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz64 end"
+      [ "// clz64 begin"
+      , "wire [0:63] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][63:0];"
+      , ""
+      , "wire [0:63] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:47] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:31] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:19] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  wire [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:11] ~GENSYM[d][15];"
+      , "genvar ~GENSYM[i4][16];"
+      , "~GENERATE"
+      , "for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]"
+      , "  localparam n = 5;"
+      , "  wire [9:0] i;"
+      , "  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:6] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 6;"
+      , "wire [11:0] i;"
+      , "assign i = ~SYM[15][0:11];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -735,185 +755,187 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// clz begin~IF ~IW64 ~THEN
-wire [0:63] ~GENSYM[v][1];
-assign ~SYM[1] = ~VAR[i][0][63:0];
-
-wire [0:63] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:47] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:31] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:19] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  wire [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:11] ~GENSYM[d][15];
-genvar ~GENSYM[i4][16];
-~GENERATE
-for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
-  localparam n = 5;
-  wire [9:0] i;
-  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:6] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 6;
-wire [11:0] i;
-assign i = ~SYM[15][0:11];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-~ELSE
-wire [0:31] ~SYM[1];
-assign ~SYM[1] = ~VAR[i][0][31:0];
-
-wire [0:31] ~SYM[2];
-genvar ~SYM[3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:23] ~SYM[4];
-genvar ~SYM[5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:15] ~SYM[9];
-genvar ~SYM[10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:9] ~SYM[12];
-genvar ~SYM[13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]
-  localparam n = 4;
-  wire [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:5] ~SYM[7];
-~GENERATE
-if (1) begin
-localparam n = 5;
-wire [9:0] i;
-assign i = ~SYM[12][0:9];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-~FI
-assign ~RESULT = $unsigned(~SYM[7]);
-// clz end"
+      [ "// clz begin~IF ~IW64 ~THEN"
+      , "wire [0:63] ~GENSYM[v][1];"
+      , "assign ~SYM[1] = ~VAR[i][0][63:0];"
+      , ""
+      , "wire [0:63] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:47] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:31] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:19] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  wire [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:11] ~GENSYM[d][15];"
+      , "genvar ~GENSYM[i4][16];"
+      , "~GENERATE"
+      , "for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]"
+      , "  localparam n = 5;"
+      , "  wire [9:0] i;"
+      , "  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:6] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 6;"
+      , "wire [11:0] i;"
+      , "assign i = ~SYM[15][0:11];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , "~ELSE"
+      , "wire [0:31] ~SYM[1];"
+      , "assign ~SYM[1] = ~VAR[i][0][31:0];"
+      , ""
+      , "wire [0:31] ~SYM[2];"
+      , "genvar ~SYM[3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:23] ~SYM[4];"
+      , "genvar ~SYM[5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:15] ~SYM[9];"
+      , "genvar ~SYM[10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:9] ~SYM[12];"
+      , "genvar ~SYM[13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]"
+      , "  localparam n = 4;"
+      , "  wire [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:5] ~SYM[7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 5;"
+      , "wire [9:0] i;"
+      , "assign i = ~SYM[12][0:9];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , "~FI"
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// clz end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -925,68 +947,70 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+      ]
         }
       ]
     , "template" :
-"// ctz8 begin
-wire [0:7] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<8;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-wire [0:7] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:5] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:3] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 3;
-wire [5:0] i;
-assign i = ~SYM[4][0:5];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz8 end"
+      [ "// ctz8 begin"
+      , "wire [0:7] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<8;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "wire [0:7] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<4;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:5] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<2;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:3] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 3;"
+      , "wire [5:0] i;"
+      , "assign i = ~SYM[4][0:5];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -998,84 +1022,86 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz16 begin
-wire [0:15] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<16;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-wire [0:15] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:11] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:7] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:4] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 4;
-wire [7:0] i;
-assign i = ~SYM[9][0:7];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz16 end"
+      [ "// ctz16 begin"
+      , "wire [0:15] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<16;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "wire [0:15] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<8;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:11] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<4;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:7] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<2;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:4] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 4;"
+      , "wire [7:0] i;"
+      , "assign i = ~SYM[9][0:7];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1087,100 +1113,102 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz32 begin
-wire [0:31] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-wire [0:31] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:23] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:15] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:9] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  wire [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:5] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 5;
-wire [9:0] i;
-assign i = ~SYM[12][0:9];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz32 end"
+      [ "// ctz32 begin"
+      , "wire [0:31] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "wire [0:31] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:23] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:15] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:9] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  wire [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:5] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 5;"
+      , "wire [9:0] i;"
+      , "assign i = ~SYM[12][0:9];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1192,116 +1220,118 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "  input [1:0] a;"
+          , "  case (a)"
+          , "    2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "    2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "    2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "    default: ~INCLUDENAME[0] = 2'b00;"
+          , "  endcase"
+          , "endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz64 begin
-wire [0:63] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-wire [0:63] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:47] a;
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:31] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:19] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  wire [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:11] ~GENSYM[d][15];
-genvar ~GENSYM[i4][16];
-~GENERATE
-for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
-  localparam n = 5;
-  wire [9:0] i;
-  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:6] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 6;
-wire [11:0] i;
-assign i = ~SYM[15][0:11];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz64 end"
+      [ "// ctz64 begin"
+      , "wire [0:63] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "wire [0:63] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:47] a;"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:31] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:19] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  wire [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:11] ~GENSYM[d][15];"
+      , "genvar ~GENSYM[i4][16];"
+      , "~GENERATE"
+      , "for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]"
+      , "  localparam n = 5;"
+      , "  wire [9:0] i;"
+      , "  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:6] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 6;"
+      , "wire [11:0] i;"
+      , "assign i = ~SYM[15][0:11];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1313,195 +1343,197 @@ assign ~RESULT = $unsigned(~SYM[7]);
       [ { "name" : "enc"
         , "extension" : "inc"
         , "template" :
-"function [1:0] ~INCLUDENAME[0];
-  input [1:0] a;
-  case (a)
-    2'b00:   ~INCLUDENAME[0] = 2'b10;
-    2'b01:   ~INCLUDENAME[0] = 2'b01;
-    2'b10:   ~INCLUDENAME[0] = 2'b00;
-    default: ~INCLUDENAME[0] = 2'b00;
-  endcase
-endfunction"
+          [ "function [1:0] ~INCLUDENAME[0];"
+          , "   input [1:0] a;"
+          , "   case (a)"
+          , "     2'b00:   ~INCLUDENAME[0] = 2'b10;"
+          , "     2'b01:   ~INCLUDENAME[0] = 2'b01;"
+          , "     2'b10:   ~INCLUDENAME[0] = 2'b00;"
+          , "     default: ~INCLUDENAME[0] = 2'b00;"
+          , "   endcase"
+          , " endfunction"
+          ]
         }
       ]
     , "template" :
-"// ctz begin~IF ~IW64 ~THEN
-wire [0:63] ~GENSYM[v][1];
-genvar ~GENSYM[k][18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-wire [0:63] ~GENSYM[e][2];
-genvar ~GENSYM[i][3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:47] ~GENSYM[a][4];
-genvar ~GENSYM[i1][5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:31] ~GENSYM[b][9];
-genvar ~GENSYM[i2][10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:19] ~GENSYM[c][12];
-genvar ~GENSYM[i3][13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]
-  localparam n = 4;
-  wire [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:11] ~GENSYM[d][15];
-genvar ~GENSYM[i4][16];
-~GENERATE
-for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]
-  localparam n = 5;
-  wire [9:0] i;
-  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:6] ~GENSYM[res][7];
-~GENERATE
-if (1) begin
-localparam n = 6;
-wire [11:0] i;
-assign i = ~SYM[15][0:11];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-~ELSE
-wire [0:31] ~SYM[1];
-genvar ~SYM[18];
-~GENERATE
-for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~SYM[19]
-  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];
-end
-~ENDGENERATE
-
-wire [0:31] ~SYM[2];
-genvar ~SYM[3];
-~GENERATE
-for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]
-  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);
-end
-~ENDGENERATE
-
-reg [0:23] ~SYM[4];
-genvar ~SYM[5];
-~GENERATE
-for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]
-  localparam n = 2;
-  wire [3:0] i;
-  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:15] ~SYM[9];
-genvar ~SYM[10];
-~GENERATE
-for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]
-  localparam n = 3;
-  wire [5:0] i;
-  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:9] ~SYM[12];
-genvar ~SYM[13];
-~GENERATE
-for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]
-  localparam n = 4;
-  wire [7:0] i;
-  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];
-  always @(*) begin
-    case (i[n-1+n])
-      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-    endcase
-  end
-end
-~ENDGENERATE
-
-reg [0:5] ~SYM[7];
-~GENERATE
-if (1) begin
-localparam n = 5;
-wire [9:0] i;
-assign i = ~SYM[12][0:9];
-always @(*) begin
-  case (i[n-1+n])
-    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};
-    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};
-  endcase
-end
-end
-~ENDGENERATE
-~FI
-assign ~RESULT = $unsigned(~SYM[7]);
-// ctz end"
+      [ "// ctz begin~IF ~IW64 ~THEN"
+      , "wire [0:63] ~GENSYM[v][1];"
+      , "genvar ~GENSYM[k][18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<64;~SYM[18]=~SYM[18]+1) begin : ~GENSYM[reverse][19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "wire [0:63] ~GENSYM[e][2];"
+      , "genvar ~GENSYM[i][3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<32;~SYM[3]=~SYM[3]+1) begin : ~GENSYM[enc_stage][8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:47] ~GENSYM[a][4];"
+      , "genvar ~GENSYM[i1][5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<16;~SYM[5]=~SYM[5]+1) begin : ~GENSYM[mux_stage][6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:31] ~GENSYM[b][9];"
+      , "genvar ~GENSYM[i2][10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<8;~SYM[10]=~SYM[10]+1) begin : ~GENSYM[mux_stage2][11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:19] ~GENSYM[c][12];"
+      , "genvar ~GENSYM[i3][13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<4;~SYM[13]=~SYM[13]+1) begin : ~GENSYM[mux_stage3][14]"
+      , "  localparam n = 4;"
+      , "  wire [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:11] ~GENSYM[d][15];"
+      , "genvar ~GENSYM[i4][16];"
+      , "~GENERATE"
+      , "for (~SYM[16]=0;~SYM[16]<2;~SYM[16]=~SYM[16]+1) begin : ~GENSYM[mux_stage4][17]"
+      , "  localparam n = 5;"
+      , "  wire [9:0] i;"
+      , "  assign i = ~SYM[12][~SYM[16]*10:~SYM[16]*10+9];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[15][~SYM[16]*6:~SYM[16]*6+5] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:6] ~GENSYM[res][7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 6;"
+      , "wire [11:0] i;"
+      , "assign i = ~SYM[15][0:11];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , "~ELSE"
+      , "wire [0:31] ~SYM[1];"
+      , "genvar ~SYM[18];"
+      , "~GENERATE"
+      , "for (~SYM[18]=0;~SYM[18]<32;~SYM[18]=~SYM[18]+1) begin : ~SYM[19]"
+      , "  assign ~SYM[1][~SYM[18]] = ~ARG[0][~SYM[18]];"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "wire [0:31] ~SYM[2];"
+      , "genvar ~SYM[3];"
+      , "~GENERATE"
+      , "for (~SYM[3]=0;~SYM[3]<16;~SYM[3]=~SYM[3]+1) begin : ~SYM[8]"
+      , "  assign ~SYM[2][~SYM[3]*2:~SYM[3]*2+1] = ~INCLUDENAME[0](~SYM[1][~SYM[3]*2:~SYM[3]*2+1]);"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:23] ~SYM[4];"
+      , "genvar ~SYM[5];"
+      , "~GENERATE"
+      , "for (~SYM[5]=0;~SYM[5]<8;~SYM[5]=~SYM[5]+1) begin : ~SYM[6]"
+      , "  localparam n = 2;"
+      , "  wire [3:0] i;"
+      , "  assign i = ~SYM[2][~SYM[5]*4:~SYM[5]*4+3];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[4][~SYM[5]*3:~SYM[5]*3+2] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:15] ~SYM[9];"
+      , "genvar ~SYM[10];"
+      , "~GENERATE"
+      , "for (~SYM[10]=0;~SYM[10]<4;~SYM[10]=~SYM[10]+1) begin : ~SYM[11]"
+      , "  localparam n = 3;"
+      , "  wire [5:0] i;"
+      , "  assign i = ~SYM[4][~SYM[10]*6:~SYM[10]*6+5];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[9][~SYM[10]*4:~SYM[10]*4+3] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:9] ~SYM[12];"
+      , "genvar ~SYM[13];"
+      , "~GENERATE"
+      , "for (~SYM[13]=0;~SYM[13]<2;~SYM[13]=~SYM[13]+1) begin : ~SYM[14]"
+      , "  localparam n = 4;"
+      , "  wire [7:0] i;"
+      , "  assign i = ~SYM[9][~SYM[13]*8:~SYM[13]*8+7];"
+      , "  always @(*) begin"
+      , "    case (i[n-1+n])"
+      , "      1'b0    : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "      default : ~SYM[12][~SYM[13]*5:~SYM[13]*5+4] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "    endcase"
+      , "  end"
+      , "end"
+      , "~ENDGENERATE"
+      , ""
+      , "reg [0:5] ~SYM[7];"
+      , "~GENERATE"
+      , "if (1) begin"
+      , "localparam n = 5;"
+      , "wire [9:0] i;"
+      , "assign i = ~SYM[12][0:9];"
+      , "always @(*) begin"
+      , "  case (i[n-1+n])"
+      , "    1'b0    : ~SYM[7] = {i[n-1+n] && i[n-1],1'b0,i[2*n-2:n]};"
+      , "    default : ~SYM[7] = {i[n-1+n] && i[n-1],~ i[n-1],i[n-2:0]};"
+      , "  endcase"
+      , "end"
+      , "end"
+      , "~ENDGENERATE"
+      , "~FI"
+      , "assign ~RESULT = $unsigned(~SYM[7]);"
+      , "// ctz end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives
@@ -2,237 +2,245 @@
     { "name" : "Clash.Explicit.BlockRam.blockRam#"
     , "kind" : "Declaration"
     , "type" :
-"blockRam#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  -> Enable dom      -- en,   ARG[4]
-  -> Vec n a         -- init, ARG[5]
-  -> Signal dom Int  -- rd,   ARG[6]
-  -> Signal dom Bool -- wren, ARG[7]
-  -> Signal dom Int  -- wr,   ARG[8]
-  -> Signal dom a    -- din,  ARG[9]
-  -> Signal dom a"
+      [ "blockRam#"
+      , "  :: ( KnownDomain dom        ARG[0]"
+      , "     , HasCallStack  --       ARG[1]"
+      , "     , Undefined a ) --       ARG[2]"
+      , "  => Clock dom       -- clk,  ARG[3]"
+      , "  -> Enable dom      -- en,   ARG[4]"
+      , "  -> Vec n a         -- init, ARG[5]"
+      , "  -> Signal dom Int  -- rd,   ARG[6]"
+      , "  -> Signal dom Bool -- wren, ARG[7]"
+      , "  -> Signal dom Int  -- wr,   ARG[8]"
+      , "  -> Signal dom a    -- din,  ARG[9]"
+      , "  -> Signal dom a"
+      ]
     , "template" :
-"-- blockRam begin
-~GENSYM[~RESULT_blockRam][1] : block
-  signal ~GENSYM[~RESULT_RAM][2] : ~TYP[5] := ~CONST[5];
-  signal ~GENSYM[rd][4]  : integer range 0 to ~LENGTH[~TYP[5]] - 1;
-  signal ~GENSYM[wr][5]  : integer range 0 to ~LENGTH[~TYP[5]] - 1;
-begin
-  ~SYM[4] <= to_integer(~VAR[rdI][6](31 downto 0))
-  -- pragma translate_off
-                mod ~LENGTH[~TYP[5]]
-  -- pragma translate_on
-                ;
-
-  ~SYM[5] <= to_integer(~VAR[wrI][8](31 downto 0))
-  -- pragma translate_off
-                mod ~LENGTH[~TYP[5]]
-  -- pragma translate_on
-                ;
-~IF ~VIVADO ~THEN
-  ~SYM[6] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
-        ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];
-      end if;
-      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
-    end if;
-  end process; ~ELSE
-  ~SYM[6] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
-        ~SYM[2](~SYM[5]) <= ~ARG[9];
-      end if;
-      ~RESULT <= ~SYM[2](~SYM[4]);
-    end if;
-  end process; ~FI
-end block;
---end blockRam"
+      [ "-- blockRam begin"
+      , "~GENSYM[~RESULT_blockRam][1] : block"
+      , "  signal ~GENSYM[~RESULT_RAM][2] : ~TYP[5] := ~CONST[5];"
+      , "  signal ~GENSYM[rd][4]  : integer range 0 to ~LENGTH[~TYP[5]] - 1;"
+      , "  signal ~GENSYM[wr][5]  : integer range 0 to ~LENGTH[~TYP[5]] - 1;"
+      , "begin"
+      , "  ~SYM[4] <= to_integer(~VAR[rdI][6](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LENGTH[~TYP[5]]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , ""
+      , "  ~SYM[5] <= to_integer(~VAR[wrI][8](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LENGTH[~TYP[5]]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , "~IF ~VIVADO ~THEN"
+      , "  ~SYM[6] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then"
+      , "        ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];"
+      , "      end if;"
+      , "      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));"
+      , "    end if;"
+      , "  end process; ~ELSE"
+      , "  ~SYM[6] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then"
+      , "        ~SYM[2](~SYM[5]) <= ~ARG[9];"
+      , "      end if;"
+      , "      ~RESULT <= ~SYM[2](~SYM[4]);"
+      , "    end if;"
+      , "  end process; ~FI"
+      , "end block;"
+      , "--end blockRam"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.blockRamU#"
     , "kind" : "Declaration"
     , "type" :
-"blockRamU#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  -> Enable dom      -- en,   ARG[4]
-  -> SNat n          -- len,  ARG[5]
-  -> Signal dom Int  -- rd,   ARG[6]
-  -> Signal dom Bool -- wren, ARG[7]
-  -> Signal dom Int  -- wr,   ARG[8]
-  -> Signal dom a    -- din,  ARG[9]
-  -> Signal dom a"
+      [ "blockRamU#"
+      , "  :: ( KnownDomain dom        ARG[0]"
+      , "     , HasCallStack  --       ARG[1]"
+      , "     , Undefined a ) --       ARG[2]"
+      , "  => Clock dom       -- clk,  ARG[3]"
+      , "  -> Enable dom      -- en,   ARG[4]"
+      , "  -> SNat n          -- len,  ARG[5]"
+      , "  -> Signal dom Int  -- rd,   ARG[6]"
+      , "  -> Signal dom Bool -- wren, ARG[7]"
+      , "  -> Signal dom Int  -- wr,   ARG[8]"
+      , "  -> Signal dom a    -- din,  ARG[9]"
+      , "  -> Signal dom a"
+      ]
     , "template" :
-"-- blockRamU begin
-~GENSYM[~RESULT_blockRam][1] : block~IF~VIVADO~THEN
-  type ~GENSYM[ram_t][8] is array (0 to integer'(~LIT[5])-1) of std_logic_vector(~SIZE[~TYP[9]]-1 downto 0);~ELSE
-  type ~SYM[8] is array (0 to integer'(~LIT[5])-1) of ~TYP[9];~FI
-  signal ~GENSYM[~RESULT_RAM][2] : ~SYM[8];
-  signal ~GENSYM[rd][4]  : integer range 0 to ~LIT[5] - 1;
-  signal ~GENSYM[wr][5]  : integer range 0 to ~LIT[5] - 1;
-begin
-  ~SYM[4] <= to_integer(~VAR[rdI][6](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[5]
-  -- pragma translate_on
-                ;
-
-  ~SYM[5] <= to_integer(~VAR[wrI][8](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[5]
-  -- pragma translate_on
-                ;
-~IF ~VIVADO ~THEN
-  ~SYM[6] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
-        ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];
-      end if;
-      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
-    end if;
-  end process; ~ELSE
-  ~SYM[6] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
-        ~SYM[2](~SYM[5]) <= ~ARG[9];
-      end if;
-      ~RESULT <= ~SYM[2](~SYM[4]);
-    end if;
-  end process; ~FI
-end block;
---end blockRamU"
+      [ "-- blockRamU begin"
+      , "~GENSYM[~RESULT_blockRam][1] : block~IF~VIVADO~THEN"
+      , "  type ~GENSYM[ram_t][8] is array (0 to integer'(~LIT[5])-1) of std_logic_vector(~SIZE[~TYP[9]]-1 downto 0);~ELSE"
+      , "  type ~SYM[8] is array (0 to integer'(~LIT[5])-1) of ~TYP[9];~FI"
+      , "  signal ~GENSYM[~RESULT_RAM][2] : ~SYM[8];"
+      , "  signal ~GENSYM[rd][4]  : integer range 0 to ~LIT[5] - 1;"
+      , "  signal ~GENSYM[wr][5]  : integer range 0 to ~LIT[5] - 1;"
+      , "begin"
+      , "  ~SYM[4] <= to_integer(~VAR[rdI][6](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[5]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , ""
+      , "  ~SYM[5] <= to_integer(~VAR[wrI][8](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[5]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , "~IF ~VIVADO ~THEN"
+      , "  ~SYM[6] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then"
+      , "        ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];"
+      , "      end if;"
+      , "      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));"
+      , "    end if;"
+      , "  end process; ~ELSE"
+      , "  ~SYM[6] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then"
+      , "        ~SYM[2](~SYM[5]) <= ~ARG[9];"
+      , "      end if;"
+      , "      ~RESULT <= ~SYM[2](~SYM[4]);"
+      , "    end if;"
+      , "  end process; ~FI"
+      , "end block;"
+      , "--end blockRamU"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.blockRam1#"
     , "kind" : "Declaration"
     , "type" :
-"blockRam1#
-  :: ( KnownDomain dom        ARG[0]
-     , HasCallStack  --       ARG[1]
-     , Undefined a ) --       ARG[2]
-  => Clock dom       -- clk,  ARG[3]
-  -> Enable dom      -- en,   ARG[4]
-  -> SNat n          -- len,  ARG[5]
-  -> a               -- init, ARG[6]
-  -> Signal dom Int  -- rd,   ARG[7]
-  -> Signal dom Bool -- wren, ARG[8]
-  -> Signal dom Int  -- wr,   ARG[9]
-  -> Signal dom a    -- din,  ARG[10]
-  -> Signal dom a"
+      [ "blockRam1#"
+      , "  :: ( KnownDomain dom        ARG[0]"
+      , "     , HasCallStack  --       ARG[1]"
+      , "     , Undefined a ) --       ARG[2]"
+      , "  => Clock dom       -- clk,  ARG[3]"
+      , "  -> Enable dom      -- en,   ARG[4]"
+      , "  -> SNat n          -- len,  ARG[5]"
+      , "  -> a               -- init, ARG[6]"
+      , "  -> Signal dom Int  -- rd,   ARG[7]"
+      , "  -> Signal dom Bool -- wren, ARG[8]"
+      , "  -> Signal dom Int  -- wr,   ARG[9]"
+      , "  -> Signal dom a    -- din,  ARG[10]"
+      , "  -> Signal dom a"
+      ]
     , "template" :
-"-- blockRam1 begin
-~GENSYM[~RESULT_blockRam][1] : block~IF~VIVADO~THEN
-  type ~GENSYM[ram_t][8] is array (0 to integer'(~LIT[5])-1) of std_logic_vector(~SIZE[~TYP[6]]-1 downto 0);~ELSE
-  type ~SYM[8] is array (0 to integer'(~LIT[5])-1) of ~TYP[6];~FI
-  signal ~GENSYM[~RESULT_RAM][2] : ~SYM[8] := (others => ~IF~VIVADO~THEN~TOBV[~CONST[6]][~TYP[6]]~ELSE~CONST[6]~FI);
-  signal ~GENSYM[rd][4]  : integer range 0 to ~LIT[5] - 1;
-  signal ~GENSYM[wr][5]  : integer range 0 to ~LIT[5] - 1;
-begin
-  ~SYM[4] <= to_integer(~VAR[rdI][7](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[5]
-  -- pragma translate_on
-                ;
-
-  ~SYM[5] <= to_integer(~VAR[wrI][9](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[5]
-  -- pragma translate_on
-                ;
-~IF ~VIVADO ~THEN
-  ~SYM[6] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
-        ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[10]][~TYP[10]];
-      end if;
-      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
-    end if;
-  end process; ~ELSE
-  ~SYM[6] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
-        ~SYM[2](~SYM[5]) <= ~ARG[10];
-      end if;
-      ~RESULT <= ~SYM[2](~SYM[4]);
-    end if;
-  end process; ~FI
-end block;
---end blockRam1"
+      [ "-- blockRam1 begin"
+      , "~GENSYM[~RESULT_blockRam][1] : block~IF~VIVADO~THEN"
+      , "  type ~GENSYM[ram_t][8] is array (0 to integer'(~LIT[5])-1) of std_logic_vector(~SIZE[~TYP[6]]-1 downto 0);~ELSE"
+      , "  type ~SYM[8] is array (0 to integer'(~LIT[5])-1) of ~TYP[6];~FI"
+      , "  signal ~GENSYM[~RESULT_RAM][2] : ~SYM[8] := (others => ~IF~VIVADO~THEN~TOBV[~CONST[6]][~TYP[6]]~ELSE~CONST[6]~FI);"
+      , "  signal ~GENSYM[rd][4]  : integer range 0 to ~LIT[5] - 1;"
+      , "  signal ~GENSYM[wr][5]  : integer range 0 to ~LIT[5] - 1;"
+      , "begin"
+      , "  ~SYM[4] <= to_integer(~VAR[rdI][7](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[5]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , ""
+      , "  ~SYM[5] <= to_integer(~VAR[wrI][9](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[5]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , "~IF ~VIVADO ~THEN"
+      , "  ~SYM[6] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then"
+      , "        ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[10]][~TYP[10]];"
+      , "      end if;"
+      , "      ~RESULT <= fromSLV(~SYM[2](~SYM[4]));"
+      , "    end if;"
+      , "  end process; ~ELSE"
+      , "  ~SYM[6] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then"
+      , "        ~SYM[2](~SYM[5]) <= ~ARG[10];"
+      , "      end if;"
+      , "      ~RESULT <= ~SYM[2](~SYM[4]);"
+      , "    end if;"
+      , "  end process; ~FI"
+      , "end block;"
+      , "--end blockRam1"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.BlockRam.trueDualPortBlockRam#"
     , "kind" : "Declaration"
     , "type" :
-"trueDualPortBlockRam# ::
-  forall nAddrs domA domB a .
-  ( HasCallStack           ~ARG[0]
-  , KnownNat nAddrs        ~ARG[1]
-  , KnownDomain domA       ~ARG[2]
-  , KnownDomain domB       ~ARG[3]
-  , NFDataX a              ~ARG[4]
-  , BitPack a              ~ARG[5]
-  ) =>
-
-  Clock domA ->                   ~ARG[6]
-  Signal domA Bool ->             ~ARG[7]
-  Signal domA (Index nAddrs) ->   ~ARG[8]
-  Signal domA a ->                ~ARG[9]
-
-  Clock domB ->                   ~ARG[10]
-  Signal domB Bool ->             ~ARG[11]
-  Signal domB (Index nAddrs) ->   ~ARG[12]
-  Signal domB a ->                ~ARG[13]
-  (Signal domA a, Signal domB a)"
+      [ "trueDualPortBlockRam# ::"
+      , "  forall nAddrs domA domB a ."
+      , "  ( HasCallStack           ~ARG[0]"
+      , "  , KnownNat nAddrs        ~ARG[1]"
+      , "  , KnownDomain domA       ~ARG[2]"
+      , "  , KnownDomain domB       ~ARG[3]"
+      , "  , NFDataX a              ~ARG[4]"
+      , "  , BitPack a              ~ARG[5]"
+      , "  ) =>"
+      , ""
+      , "  Clock domA ->                   ~ARG[6]"
+      , "  Signal domA Bool ->             ~ARG[7]"
+      , "  Signal domA (Index nAddrs) ->   ~ARG[8]"
+      , "  Signal domA a ->                ~ARG[9]"
+      , ""
+      , "  Clock domB ->                   ~ARG[10]"
+      , "  Signal domB Bool ->             ~ARG[11]"
+      , "  Signal domB (Index nAddrs) ->   ~ARG[12]"
+      , "  Signal domB a ->                ~ARG[13]"
+      , "  (Signal domA a, Signal domB a)"
+      ]
     , "template" :
-"-- trueDualPortBlockRam begin
-~GENSYM[~RESULT_trueDualPortBlockRam][1] : block
-  -- Shared memory
-  type mem_type is array ( ~LIT[1]-1 downto 0 ) of ~TYP[9];
-  shared variable mem : mem_type;
-  signal ~GENSYM[a_dout][2] : ~TYP[9];
-  signal ~GENSYM[b_dout][3] : ~TYP[13];
-begin
-
-  -- Port A
-  process(~ARG[6])
-  begin
-      if(rising_edge(~ARG[6])) then
-          if(~ARG[7]) then
-              mem(to_integer(~ARG[8])) := ~ARG[9];
-          end if;
-          ~SYM[2] <= mem(to_integer(~ARG[8]));
-      end if;
-  end process;
-
-  -- Port B
-  process(~ARG[10])
-  begin
-      if(rising_edge(~ARG[10])) then
-          if(~ARG[11]) then
-              mem(to_integer(~ARG[12])) := ~ARG[13];
-          end if;
-          ~SYM[3] <= mem(to_integer(~ARG[12]));
-      end if;
-  end process;
-
-  ~RESULT <= (~SYM[2], ~SYM[3]);
-end block;
--- end trueDualPortBlockRam"
+      [ "-- trueDualPortBlockRam begin"
+      , "~GENSYM[~RESULT_trueDualPortBlockRam][1] : block"
+      , "  -- Shared memory"
+      , "  type mem_type is array ( ~LIT[1]-1 downto 0 ) of ~TYP[9];"
+      , "  shared variable mem : mem_type;"
+      , "  signal ~GENSYM[a_dout][2] : ~TYP[9];"
+      , "  signal ~GENSYM[b_dout][3] : ~TYP[13];"
+      , "begin"
+      , ""
+      , "  -- Port A"
+      , "  process(~ARG[6])"
+      , "  begin"
+      , "      if(rising_edge(~ARG[6])) then"
+      , "          if(~ARG[7]) then"
+      , "              mem(to_integer(~ARG[8])) := ~ARG[9];"
+      , "          end if;"
+      , "          ~SYM[2] <= mem(to_integer(~ARG[8]));"
+      , "      end if;"
+      , "  end process;"
+      , ""
+      , "  -- Port B"
+      , "  process(~ARG[10])"
+      , "  begin"
+      , "      if(rising_edge(~ARG[10])) then"
+      , "          if(~ARG[11]) then"
+      , "              mem(to_integer(~ARG[12])) := ~ARG[13];"
+      , "          end if;"
+      , "          ~SYM[3] <= mem(to_integer(~ARG[12]));"
+      , "      end if;"
+      , "  end process;"
+      , ""
+      , "  ~RESULT <= (~SYM[2], ~SYM[3]);"
+      , "end block;"
+      , "-- end trueDualPortBlockRam"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives
@@ -2,94 +2,96 @@
     { "name" : "Clash.Explicit.BlockRam.File.blockRamFile#"
     , "kind" : "Declaration"
     , "type" :
-"blockRamFile#
-  :: ( KnownDomain dom        -- ARG[0]
-     , KnownNat m             -- ARG[1]
-     , HasCallStack )         -- ARG[2]
-  => Clock dom                -- clk,  ARG[3]
-  => Enable dom               -- en,   ARG[4]
-  -> SNat n                   -- sz,   ARG[5]
-  -> FilePath                 -- file, ARG[6]
-  -> Signal dom Int           -- rd,   ARG[7]
-  -> Signal dom Bool          -- wren, ARG[8]
-  -> Signal dom Int           -- wr,   ARG[9]
-  -> Signal dom (BitVector m) -- din,  ARG[10]
-  -> Signal dom (BitVector m)"
+      [ "blockRamFile#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , KnownNat m             -- ARG[1]"
+      , "     , HasCallStack )         -- ARG[2]"
+      , "  => Clock dom                -- clk,  ARG[3]"
+      , "  => Enable dom               -- en,   ARG[4]"
+      , "  -> SNat n                   -- sz,   ARG[5]"
+      , "  -> FilePath                 -- file, ARG[6]"
+      , "  -> Signal dom Int           -- rd,   ARG[7]"
+      , "  -> Signal dom Bool          -- wren, ARG[8]"
+      , "  -> Signal dom Int           -- wr,   ARG[9]"
+      , "  -> Signal dom (BitVector m) -- din,  ARG[10]"
+      , "  -> Signal dom (BitVector m)"
+      ]
     , "template" :
-"-- blockRamFile begin
-~GENSYM[~COMPNAME_blockRamFile][1] : block
-  type ~GENSYM[RamType][7] is array(natural range <>) of bit_vector(~LIT[1]-1 downto 0);
-
-  impure function ~GENSYM[InitRamFromFile][2] (RamFileName : in string) return ~SYM[7] is
-    FILE RamFile : text open read_mode is RamFileName;
-    variable RamFileLine : line;
-    variable RAM : ~SYM[7](0 to ~LIT[5]-1);
-  begin
-    for i in RAM'range loop
-      readline(RamFile,RamFileLine);
-      read(RamFileLine,RAM(i));
-    end loop;
-    return RAM;
-  end function;
-
-  signal ~GENSYM[RAM][3] : ~SYM[7](0 to ~LIT[5]-1) := ~SYM[2](~FILE[~LIT[6]]);
-  signal ~GENSYM[rd][5]  : integer range 0 to ~LIT[5]-1;
-  signal ~GENSYM[wr][6]  : integer range 0 to ~LIT[5]-1;
-begin
-  ~SYM[5] <= to_integer(~VAR[rdI][7](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[5]
-  -- pragma translate_on
-                ;
-
-  ~SYM[6] <= to_integer(~VAR[wrI][9](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[5]
-  -- pragma translate_on
-                ;
-  ~IF ~VIVADO ~THEN ~IF ~ISACTIVEENABLE[4] ~THEN
-  ~GENSYM[blockRamFile_sync][10] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[4] then
-        if ~ARG[8] then
-          ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
-        end if;
-        ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
-      end if;
-    end if;
-  end process;~ELSE
-  ~SYM[10] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[8] then
-        ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
-      end if;
-      ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
-    end if;
-  end process;~FI ~ELSE ~IF ~ISACTIVEENABLE[4] ~THEN
-  ~SYM[10] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[8] and ~ARG[4] then
-        ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
-      end if;
-      if ~ARG[4] then
-        ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
-      end if;
-    end if;
-  end process;~ELSE
-  ~SYM[10] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if ~ARG[8] then
-        ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
-      end if;
-      ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
-    end if;
-  end process;~FI ~FI
-end block;
--- blockRamFile end"
+      [ "-- blockRamFile begin"
+      , "~GENSYM[~COMPNAME_blockRamFile][1] : block"
+      , "  type ~GENSYM[RamType][7] is array(natural range <>) of bit_vector(~LIT[1]-1 downto 0);"
+      , ""
+      , "  impure function ~GENSYM[InitRamFromFile][2] (RamFileName : in string) return ~SYM[7] is"
+      , "    FILE RamFile : text open read_mode is RamFileName;"
+      , "    variable RamFileLine : line;"
+      , "    variable RAM : ~SYM[7](0 to ~LIT[5]-1);"
+      , "  begin"
+      , "    for i in RAM'range loop"
+      , "      readline(RamFile,RamFileLine);"
+      , "      read(RamFileLine,RAM(i));"
+      , "    end loop;"
+      , "    return RAM;"
+      , "  end function;"
+      , ""
+      , "  signal ~GENSYM[RAM][3] : ~SYM[7](0 to ~LIT[5]-1) := ~SYM[2](~FILE[~LIT[6]]);"
+      , "  signal ~GENSYM[rd][5]  : integer range 0 to ~LIT[5]-1;"
+      , "  signal ~GENSYM[wr][6]  : integer range 0 to ~LIT[5]-1;"
+      , "begin"
+      , "  ~SYM[5] <= to_integer(~VAR[rdI][7](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[5]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , ""
+      , "  ~SYM[6] <= to_integer(~VAR[wrI][9](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[5]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , "  ~IF ~VIVADO ~THEN ~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "  ~GENSYM[blockRamFile_sync][10] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[4] then"
+      , "        if ~ARG[8] then"
+      , "          ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);"
+      , "        end if;"
+      , "        ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;~ELSE"
+      , "  ~SYM[10] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[8] then"
+      , "        ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);"
+      , "      end if;"
+      , "      ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));"
+      , "    end if;"
+      , "  end process;~FI ~ELSE ~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "  ~SYM[10] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[8] and ~ARG[4] then"
+      , "        ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);"
+      , "      end if;"
+      , "      if ~ARG[4] then"
+      , "        ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;~ELSE"
+      , "  ~SYM[10] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if ~ARG[8] then"
+      , "        ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);"
+      , "      end if;"
+      , "      ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));"
+      , "    end if;"
+      , "  end process;~FI ~FI"
+      , "end block;"
+      , "-- blockRamFile end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives
@@ -2,165 +2,169 @@
     { "name" : "Clash.Explicit.DDR.ddrIn#"
     , "kind" : "Declaration"
     , "type" :
-"ddrIn# :: forall a slow fast n pFast enabled synchronous.
-           ( HasCallStack           -- ARG[0]
-           , Undefined a            -- ARG[1]
-           , KnownConfi~ fast domf  -- ARG[2]
-           , KnownConfi~ slow doms  -- ARG[3]
-        => Clock slow               -- ARG[4]
-        -> Reset slow               -- ARG[5]
-        -> Enable slow              -- ARG[6]
-        -> a                        -- ARG[7]
-        -> a                        -- ARG[8]
-        -> a                        -- ARG[9]
-        -> Signal fast a            -- ARG[10]
-        -> Signal slow (a,a)"
+      [ "ddrIn# :: forall a slow fast n pFast enabled synchronous."
+      , "           ( HasCallStack           -- ARG[0]"
+      , "           , Undefined a            -- ARG[1]"
+      , "           , KnownConfi~ fast domf  -- ARG[2]"
+      , "           , KnownConfi~ slow doms  -- ARG[3]"
+      , "        => Clock slow               -- ARG[4]"
+      , "        -> Reset slow               -- ARG[5]"
+      , "        -> Enable slow              -- ARG[6]"
+      , "        -> a                        -- ARG[7]"
+      , "        -> a                        -- ARG[8]"
+      , "        -> a                        -- ARG[9]"
+      , "        -> Signal fast a            -- ARG[10]"
+      , "        -> Signal slow (a,a)"
+      ]
     , "template" :
-"-- ddrIn begin
-~GENSYM[~COMPNAME_ddrIn][0] : block
-  signal ~GENSYM[data_Pos][1]       : ~TYP[9];
-  signal ~GENSYM[data_Neg][2]       : ~TYP[9];
-  signal ~GENSYM[data_Neg_Latch][3] : ~TYP[9];
-begin
- ~IF ~ISSYNC[3] ~THEN
-  -- sync
-  -------------
-  ~GENSYM[~COMPNAME_ddrIn_pos][6] : process(~ARG[4])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-        ~SYM[1] <= ~ARG[8];
-      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
-        ~SYM[1] <= ~ARG[10];
-      end if;
-    end if;
-  end process;
-
-  ~GENSYM[~COMPNAME_ddrIn_neg][7] : process(~ARG[4])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then
-      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-        ~SYM[2] <= ~ARG[9];
-      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
-        ~SYM[2] <= ~ARG[10];
-      end if;
-    end if;
-  end process;
-
-  ~GENSYM[~COMPNAME_ddrIn_neg_latch][8] : process(~ARG[4])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-        ~SYM[3] <= ~ARG[7];
-      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
-        ~SYM[3] <= ~SYM[2];
-      end if;
-    end if;
-  end process;
- ~ELSE
-  -- async
-  --------------
-  ~SYM[6] : process(~ARG[4],~ARG[5]~VARS[9])
-  begin
-    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-      ~SYM[1] <= ~ARG[8];
-    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-      ~SYM[1] <= ~ARG[10];
-    end if;
-  end process;
-
-  ~SYM[7] : process(~ARG[4],~ARG[5]~VARS[9])
-  begin
-    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-      ~SYM[2] <= ~ARG[9];
-    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then
-      ~SYM[2] <= ~ARG[10];
-    end if;
-  end process;
-
-  ~SYM[8] : process(~ARG[4],~ARG[5],~SYM[2])
-  begin
-    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-      ~SYM[3] <= ~ARG[7];
-    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-      ~SYM[3] <= ~SYM[2];
-    end if;
-  end process;
- ~FI
-  ~RESULT <= (~SYM[3], ~SYM[1]);
-end block;
--- ddrIn end"
+      [ "-- ddrIn begin"
+      , "~GENSYM[~COMPNAME_ddrIn][0] : block"
+      , "  signal ~GENSYM[data_Pos][1]       : ~TYP[9];"
+      , "  signal ~GENSYM[data_Neg][2]       : ~TYP[9];"
+      , "  signal ~GENSYM[data_Neg_Latch][3] : ~TYP[9];"
+      , "begin"
+      , " ~IF ~ISSYNC[3] ~THEN"
+      , "  -- sync"
+      , "  -------------"
+      , "  ~GENSYM[~COMPNAME_ddrIn_pos][6] : process(~ARG[4])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then"
+      , "      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "        ~SYM[1] <= ~ARG[8];"
+      , "      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI"
+      , "        ~SYM[1] <= ~ARG[10];"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;"
+      , ""
+      , "  ~GENSYM[~COMPNAME_ddrIn_neg][7] : process(~ARG[4])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then"
+      , "      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "        ~SYM[2] <= ~ARG[9];"
+      , "      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI"
+      , "        ~SYM[2] <= ~ARG[10];"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;"
+      , ""
+      , "  ~GENSYM[~COMPNAME_ddrIn_neg_latch][8] : process(~ARG[4])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then"
+      , "      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "        ~SYM[3] <= ~ARG[7];"
+      , "      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI"
+      , "        ~SYM[3] <= ~SYM[2];"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;"
+      , " ~ELSE"
+      , "  -- async"
+      , "  --------------"
+      , "  ~SYM[6] : process(~ARG[4],~ARG[5]~VARS[9])"
+      , "  begin"
+      , "    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "      ~SYM[1] <= ~ARG[8];"
+      , "    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then"
+      , "      ~SYM[1] <= ~ARG[10];"
+      , "    end if;"
+      , "  end process;"
+      , ""
+      , "  ~SYM[7] : process(~ARG[4],~ARG[5]~VARS[9])"
+      , "  begin"
+      , "    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "      ~SYM[2] <= ~ARG[9];"
+      , "    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then"
+      , "      ~SYM[2] <= ~ARG[10];"
+      , "    end if;"
+      , "  end process;"
+      , ""
+      , "  ~SYM[8] : process(~ARG[4],~ARG[5],~SYM[2])"
+      , "  begin"
+      , "    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "      ~SYM[3] <= ~ARG[7];"
+      , "    elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then"
+      , "      ~SYM[3] <= ~SYM[2];"
+      , "    end if;"
+      , "  end process;"
+      , " ~FI"
+      , "  ~RESULT <= (~SYM[3], ~SYM[1]);"
+      , "end block;"
+      , "-- ddrIn end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Explicit.DDR.ddrOut#"
     , "kind" : "Declaration"
     , "type" :
-"ddrOut# :: ( HasCallStack               -- ARG[0]
-            , Undefined a                -- ARG[1]
-            , KnownConfi~ fast domf      -- ARG[2]
-            , KnownConfi~ slow doms      -- ARG[3]
-         => Clock slow                   -- ARG[4]
-         -> Reset slow                   -- ARG[5]
-         -> Enable slow                  -- ARG[6]
-         -> a                            -- ARG[7]
-         -> Signal slow a                -- ARG[8]
-         -> Signal slow a                -- ARG[9]
-         -> Signal fast a"
+      [ "ddrOut# :: ( HasCallStack               -- ARG[0]"
+      , "            , Undefined a                -- ARG[1]"
+      , "            , KnownConfi~ fast domf      -- ARG[2]"
+      , "            , KnownConfi~ slow doms      -- ARG[3]"
+      , "         => Clock slow                   -- ARG[4]"
+      , "         -> Reset slow                   -- ARG[5]"
+      , "         -> Enable slow                  -- ARG[6]"
+      , "         -> a                            -- ARG[7]"
+      , "         -> Signal slow a                -- ARG[8]"
+      , "         -> Signal slow a                -- ARG[9]"
+      , "         -> Signal fast a"
+      ]
     , "template" :
-"-- ddrOut begin
-~GENSYM[~COMPNAME_ddrIn][0] : block
-  signal ~GENSYM[data_Pos][1] : ~TYP[7];
-  signal ~GENSYM[data_Neg][2] : ~TYP[7];
-begin
- ~IF ~ISSYNC[3] ~THEN
-  -- sync
-  -------------
-  ~GENSYM[~COMPNAME_ddrOut_pos][5] : process(~ARG[4])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-        ~SYM[1] <= ~ARG[7];
-      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
-        ~SYM[1] <= ~ARG[8];
-      end if;
-    end if;
-  end process;
-
-  ~GENSYM[~COMPNAME_ddrOut_neg][6] : process(~ARG[4])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-        ~SYM[2] <= ~ARG[7];
-      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
-        ~SYM[2] <= ~ARG[9];
-      end if;
-    end if;
-  end process;
- ~ELSE
-  -- async
-  --------------
-  ~SYM[5] : process(~ARG[4],~ARG[5]~VARS[8])
-  begin
-    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-      ~SYM[1] <= ~ARG[7];
-    elsif ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-      ~SYM[1] <= ~ARG[8];
-    end if;
-  end process;
-
-  ~SYM[6] : process(~ARG[4],~ARG[5]~VARS[9])
-  begin
-    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-      ~SYM[2] <= ~ARG[7];
-    elsif ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-      ~SYM[2] <= ~ARG[9];
-    end if;
-  end process;
- ~FI
-  ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1' ~IF ~ISACTIVEENABLE[6] ~THEN and ~ARG[6] ~ELSE ~FI) else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
-end block;
--- ddrOut end"
+      [ "-- ddrOut begin"
+      , "~GENSYM[~COMPNAME_ddrIn][0] : block"
+      , "  signal ~GENSYM[data_Pos][1] : ~TYP[7];"
+      , "  signal ~GENSYM[data_Neg][2] : ~TYP[7];"
+      , "begin"
+      , " ~IF ~ISSYNC[3] ~THEN"
+      , "  -- sync"
+      , "  -------------"
+      , "  ~GENSYM[~COMPNAME_ddrOut_pos][5] : process(~ARG[4])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then"
+      , "      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "        ~SYM[1] <= ~ARG[7];"
+      , "      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI"
+      , "        ~SYM[1] <= ~ARG[8];"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;"
+      , ""
+      , "  ~GENSYM[~COMPNAME_ddrOut_neg][6] : process(~ARG[4])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then"
+      , "      if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "        ~SYM[2] <= ~ARG[7];"
+      , "      els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI"
+      , "        ~SYM[2] <= ~ARG[9];"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;"
+      , " ~ELSE"
+      , "  -- async"
+      , "  --------------"
+      , "  ~SYM[5] : process(~ARG[4],~ARG[5]~VARS[8])"
+      , "  begin"
+      , "    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "      ~SYM[1] <= ~ARG[7];"
+      , "    elsif ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then"
+      , "      ~SYM[1] <= ~ARG[8];"
+      , "    end if;"
+      , "  end process;"
+      , ""
+      , "  ~SYM[6] : process(~ARG[4],~ARG[5]~VARS[9])"
+      , "  begin"
+      , "    if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then"
+      , "      ~SYM[2] <= ~ARG[7];"
+      , "    elsif ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then"
+      , "      ~SYM[2] <= ~ARG[9];"
+      , "    end if;"
+      , "  end process;"
+      , " ~FI"
+      , "  ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1' ~IF ~ISACTIVEENABLE[6] ~THEN and ~ARG[6] ~ELSE ~FI) else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;"
+      , "end block;"
+      , "-- ddrOut end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Explicit_RAM.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_RAM.primitives
@@ -2,53 +2,55 @@
     { "name" : "Clash.Explicit.RAM.asyncRam#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRam#
-  :: ( HasCallStack              -- ARG[0]
-     , KnownDomain wdom wconf    -- ARG[1]
-     , KnownDomain rdom rconf )  -- ARG[2]
-  => Clock wdom                  -- ^ wclk, ARG[3]
-  -> Clock rdom                  -- ^ rclk, ARG[4]
-  -> Enable wdom                 -- ^ wen,  ARG[5]
-  -> SNat n                      -- ^ sz,   ARG[6]
-  -> Signal rdom Int             -- ^ rd,   ARG[7]
-  -> Signal wdom Bool            -- ^ en,   ARG[8]
-  -> Signal wdom Int             -- ^ wr,   ARG[9]
-  -> Signal wdom a               -- ^ din,  ARG[10]
-  -> Signal rdom a"
+      [ "asyncRam#"
+      , "  :: ( HasCallStack              -- ARG[0]"
+      , "     , KnownDomain wdom wconf    -- ARG[1]"
+      , "     , KnownDomain rdom rconf )  -- ARG[2]"
+      , "  => Clock wdom                  -- ^ wclk, ARG[3]"
+      , "  -> Clock rdom                  -- ^ rclk, ARG[4]"
+      , "  -> Enable wdom                 -- ^ wen,  ARG[5]"
+      , "  -> SNat n                      -- ^ sz,   ARG[6]"
+      , "  -> Signal rdom Int             -- ^ rd,   ARG[7]"
+      , "  -> Signal wdom Bool            -- ^ en,   ARG[8]"
+      , "  -> Signal wdom Int             -- ^ wr,   ARG[9]"
+      , "  -> Signal wdom a               -- ^ din,  ARG[10]"
+      , "  -> Signal rdom a"
+      ]
     , "template" :
-"-- asyncRam begin
-~GENSYM[~COMPNAME_asyncRam][0] : block~IF ~VIVADO ~THEN
-  type ~GENSYM[RamType][4] is array(natural range <>) of std_logic_vector(~SIZE[~TYP[10]]-1 downto 0);~ELSE
-  type ~SYM[4] is array(natural range <>) of ~TYP[10];~FI
-  signal ~GENSYM[RAM][1] : ~SYM[4](0 to ~LIT[6]-1);
-  signal ~GENSYM[rd][2] : integer range 0 to ~LIT[6] - 1;
-  signal ~GENSYM[wr][3] : integer range 0 to ~LIT[6] - 1;
-begin
-  ~SYM[2] <= to_integer(~VAR[rdI][7](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[6]
-  -- pragma translate_on
-                ;
-
-  ~SYM[3] <= to_integer(~VAR[wrI][9](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[6]
-  -- pragma translate_on
-                ;
-  ~GENSYM[asyncRam_sync][7] : process(~ARG[3])
-  begin
-    if ~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-      if (~ARG[8] ~IF ~ISACTIVEENABLE[5] ~THEN and ~ARG[5] ~ELSE ~FI) then~IF ~VIVADO ~THEN
-        ~SYM[1](~SYM[3]) <= ~TOBV[~ARG[10]][~TYP[10]];~ELSE
-        ~SYM[1](~SYM[3]) <= ~ARG[10];~FI
-      end if;
-    end if;
-  end process;
-  ~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[1](~SYM[2])][~TYP[10]];~ELSE
-  ~RESULT <= ~SYM[1](~SYM[2]);~FI
-end block;
--- asyncRam end"
+      [ "-- asyncRam begin"
+      , "~GENSYM[~COMPNAME_asyncRam][0] : block~IF ~VIVADO ~THEN"
+      , "  type ~GENSYM[RamType][4] is array(natural range <>) of std_logic_vector(~SIZE[~TYP[10]]-1 downto 0);~ELSE"
+      , "  type ~SYM[4] is array(natural range <>) of ~TYP[10];~FI"
+      , "  signal ~GENSYM[RAM][1] : ~SYM[4](0 to ~LIT[6]-1);"
+      , "  signal ~GENSYM[rd][2] : integer range 0 to ~LIT[6] - 1;"
+      , "  signal ~GENSYM[wr][3] : integer range 0 to ~LIT[6] - 1;"
+      , "begin"
+      , "  ~SYM[2] <= to_integer(~VAR[rdI][7](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[6]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , ""
+      , "  ~SYM[3] <= to_integer(~VAR[wrI][9](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[6]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , "  ~GENSYM[asyncRam_sync][7] : process(~ARG[3])"
+      , "  begin"
+      , "    if ~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then"
+      , "      if (~ARG[8] ~IF ~ISACTIVEENABLE[5] ~THEN and ~ARG[5] ~ELSE ~FI) then~IF ~VIVADO ~THEN"
+      , "        ~SYM[1](~SYM[3]) <= ~TOBV[~ARG[10]][~TYP[10]];~ELSE"
+      , "        ~SYM[1](~SYM[3]) <= ~ARG[10];~FI"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;"
+      , "  ~IF ~VIVADO ~THEN"
+      , "  ~RESULT <= ~FROMBV[~SYM[1](~SYM[2])][~TYP[10]];~ELSE"
+      , "  ~RESULT <= ~SYM[1](~SYM[2]);~FI"
+      , "end block;"
+      , "-- asyncRam end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives
@@ -2,36 +2,38 @@
     { "name" : "Clash.Explicit.ROM.rom#"
     , "kind" : "Declaration"
     , "type" :
-"rom# :: ( KnownDomain dom        ARG[0]
-         , KnownNat n    --       ARG[1]
-         , Undefined a ) --       ARG[2]
-      => Clock dom       -- clk,  ARG[3]
-      -> Enable dom      -- en,   ARG[4]
-      -> Vec n a         -- init, ARG[5]
-      -> Signal dom Int  -- rd,   ARG[6]
-      -> Signal dom a"
+      [ "rom# :: ( KnownDomain dom        ARG[0]"
+      , "        , KnownNat n    --       ARG[1]"
+      , "        , Undefined a ) --       ARG[2]"
+      , "     => Clock dom       -- clk,  ARG[3]"
+      , "     -> Enable dom      -- en,   ARG[4]"
+      , "     -> Vec n a         -- init, ARG[5]"
+      , "     -> Signal dom Int  -- rd,   ARG[6]"
+      , "     -> Signal dom a"
+      ]
     , "template" :
-"-- rom begin
-~GENSYM[~COMPNAME_rom][1] : block
-  signal ~GENSYM[ROM][2] : ~TYP[5];
-  signal ~GENSYM[rd][3]  : integer range 0 to ~LIT[1]-1;
-begin
-  ~SYM[2] <= ~LIT[5];
-
-  ~SYM[3] <= to_integer(~VAR[rdI][6](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[1]
-  -- pragma translate_on
-                ;
-  ~GENSYM[romSync][6] : process (~ARG[3])
-  begin
-    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI) then~IF ~VIVADO ~THEN
-      ~RESULT <= ~FROMBV[~SYM[2](~SYM[3])][~TYPO];~ELSE
-      ~RESULT <= ~SYM[2](~SYM[3]);~FI
-    end if;
-  end process;
-end block;
--- rom end"
+      [ "-- rom begin"
+      , "~GENSYM[~COMPNAME_rom][1] : block"
+      , "  signal ~GENSYM[ROM][2] : ~TYP[5];"
+      , "  signal ~GENSYM[rd][3]  : integer range 0 to ~LIT[1]-1;"
+      , "begin"
+      , "  ~SYM[2] <= ~LIT[5];"
+      , ""
+      , "  ~SYM[3] <= to_integer(~VAR[rdI][6](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[1]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , "  ~GENSYM[romSync][6] : process (~ARG[3])"
+      , "  begin"
+      , "    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI) then~IF ~VIVADO ~THEN"
+      , "      ~RESULT <= ~FROMBV[~SYM[2](~SYM[3])][~TYPO];~ELSE"
+      , "      ~RESULT <= ~SYM[2](~SYM[3]);~FI"
+      , "    end if;"
+      , "  end process;"
+      , "end block;"
+      , "-- rom end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives
@@ -2,56 +2,58 @@
     { "name" : "Clash.Explicit.ROM.File.romFile#"
     , "kind" : "Declaration"
     , "type" :
-"romFile# :: ( KnownNat m           --       ARG[0]
-             , KnownDomain dom      --       ARG[1]
-          => Clock dom              -- clk,  ARG[2]
-          -> Enable dom             -- en,   ARG[3]
-          -> SNat n                 -- sz,   ARG[4]
-          -> FilePath               -- file, ARG[5]
-          -> Signal dom Int         -- rd,   ARG[6]
-          -> Signal dom (BitVector m)"
+      [ "romFile# :: ( KnownNat m           --       ARG[0]"
+      , "             , KnownDomain dom      --       ARG[1]"
+      , "          => Clock dom              -- clk,  ARG[2]"
+      , "          -> Enable dom             -- en,   ARG[3]"
+      , "          -> SNat n                 -- sz,   ARG[4]"
+      , "          -> FilePath               -- file, ARG[5]"
+      , "          -> Signal dom Int         -- rd,   ARG[6]"
+      , "          -> Signal dom (BitVector m)"
+      ]
     , "template" :
-"-- romFile begin
-~GENSYM[~COMPNAME_romFile][0] : block
-  type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
-
-  impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is
-    FILE RomFile : text open read_mode is RomFileName;
-    variable RomFileLine : line;
-    variable ROM : ~SYM[4](0 to ~LIT[4]-1);
-  begin
-    for i in ROM'range loop
-      readline(RomFile,RomFileLine);
-      read(RomFileLine,ROM(i));
-    end loop;
-    return ROM;
-  end function;
-
-  signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[4]-1) := ~SYM[1](~FILE[~LIT[5]]);
-  signal ~GENSYM[rd][3] : integer range 0 to ~LIT[4]-1;
-begin
-  ~SYM[3] <=to_integer(~VAR[rdI][6](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[4]
-  -- pragma translate_on
-                ;
-  ~IF ~ISACTIVEENABLE[3] ~THEN
-  ~GENSYM[romFileSync][7] : process (~ARG[2])
-  begin
-    if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then
-      if ~ARG[3] then
-        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
-      end if;
-    end if;
-  end process;~ELSE
-  ~SYM[7] : process (~ARG[2])
-  begin
-    if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then
-      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
-    end if;
-  end process;~FI
-end block;
--- romFile end"
+      [ "-- romFile begin"
+      , "~GENSYM[~COMPNAME_romFile][0] : block"
+      , "  type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);"
+      , ""
+      , "  impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is"
+      , "    FILE RomFile : text open read_mode is RomFileName;"
+      , "    variable RomFileLine : line;"
+      , "    variable ROM : ~SYM[4](0 to ~LIT[4]-1);"
+      , "  begin"
+      , "    for i in ROM'range loop"
+      , "      readline(RomFile,RomFileLine);"
+      , "      read(RomFileLine,ROM(i));"
+      , "    end loop;"
+      , "    return ROM;"
+      , "  end function;"
+      , ""
+      , "  signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[4]-1) := ~SYM[1](~FILE[~LIT[5]]);"
+      , "  signal ~GENSYM[rd][3] : integer range 0 to ~LIT[4]-1;"
+      , "begin"
+      , "  ~SYM[3] <=to_integer(~VAR[rdI][6](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[4]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , "  ~IF ~ISACTIVEENABLE[3] ~THEN"
+      , "  ~GENSYM[romFileSync][7] : process (~ARG[2])"
+      , "  begin"
+      , "    if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then"
+      , "      if ~ARG[3] then"
+      , "        ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));"
+      , "      end if;"
+      , "    end if;"
+      , "  end process;~ELSE"
+      , "  ~SYM[7] : process (~ARG[2])"
+      , "  begin"
+      , "    if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then"
+      , "      ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));"
+      , "    end if;"
+      , "  end process;~FI"
+      , "end block;"
+      , "-- romFile end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Explicit_Testbench.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_Testbench.primitives
@@ -2,156 +2,162 @@
     { "name" : "Clash.Explicit.Testbench.assert"
     , "kind" : "Declaration"
     , "type" :
-"assert
-  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0],ARG[1],ARG[2])
-  => Clock dom                             -- ARG[3]
-  -> Reset dom                             -- ARG[4]
-  -> String                                -- ARG[5]
-  -> Signal dom a                          -- Checked value  (ARG[6])
-  -> Signal dom a                          -- Expected value (ARG[7])
-  -> Signal dom b                          -- Return valued  (ARG[8])
-  -> Signal dom b"
+      [ "assert"
+      , "  :: (KnownDomain dom, Eq a, ShowX a)      -- (ARG[0],ARG[1],ARG[2])"
+      , "  => Clock dom                             -- ARG[3]"
+      , "  -> Reset dom                             -- ARG[4]"
+      , "  -> String                                -- ARG[5]"
+      , "  -> Signal dom a                          -- Checked value  (ARG[6])"
+      , "  -> Signal dom a                          -- Expected value (ARG[7])"
+      , "  -> Signal dom b                          -- Return valued  (ARG[8])"
+      , "  -> Signal dom b"
+      ]
     , "imports": ["~INCLUDENAME[0].all"]
     , "includes" :
       [ { "name" : "slv2string"
         , "extension" : "vhdl"
         , "template" :
-"-- helper function of Clash.Explicit.Testbench.assert
-library IEEE;
-use IEEE.STD_LOGIC_1164.ALL;
-
-package ~INCLUDENAME[0] is
-  function slv2string (slv : std_logic_vector) return STRING;
-end;
-
-package body ~INCLUDENAME[0] is
-  function slv2string (slv : std_logic_vector) return STRING is
-     variable result : string (1 to slv'length);
-     variable res_l : string (1 to 3);
-     variable r : integer;
-   begin
-     r := 1;
-     for i in slv'range loop
-        res_l := std_logic'image(slv(i));
-        result(r) := res_l(2);
-        r := r + 1;
-     end loop;
-     return result;
-  end slv2string;
-end;"
+          [ "-- helper function of Clash.Explicit.Testbench.assert"
+          , "library IEEE;"
+          , "use IEEE.STD_LOGIC_1164.ALL;"
+          , ""
+          , "package ~INCLUDENAME[0] is"
+          , "  function slv2string (slv : std_logic_vector) return STRING;"
+          , "end;"
+          , ""
+          , "package body ~INCLUDENAME[0] is"
+          , "  function slv2string (slv : std_logic_vector) return STRING is"
+          , "     variable result : string (1 to slv'length);"
+          , "     variable res_l : string (1 to 3);"
+          , "     variable r : integer;"
+          , "   begin"
+          , "     r := 1;"
+          , "     for i in slv'range loop"
+          , "        res_l := std_logic'image(slv(i));"
+          , "        result(r) := res_l(2);"
+          , "        r := r + 1;"
+          , "     end loop;"
+          , "     return result;"
+          , "  end slv2string;"
+          , "end;"
+          ]
         }
       ]
     , "template" :
-"-- assert begin
-~GENSYM[assert][0] : block
-  -- pragma translate_off
-  signal ~GENSYM[actual][2] : ~TYP[6];
-  signal ~GENSYM[expected][3] : ~TYP[7];
-  -- pragma translate_on
-begin
-  -- pragma translate_off
-  ~SYM[2] <= ~ARG[6];
-  ~SYM[3] <= ~ARG[7];
-  process(~ARG[3]) is
-  begin
-    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])) then
-      assert (toSLV(~SYM[2]) = toSLV(~SYM[3])) report (~LIT[5] & \", expected: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[3])) & \", actual: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[2]))) severity error;
-    end if;
-  end process;
-  -- pragma translate_on
-  ~RESULT <= ~ARG[8];
-end block;
--- assert end"
+      [ "-- assert begin"
+      , "~GENSYM[assert][0] : block"
+      , "  -- pragma translate_off"
+      , "  signal ~GENSYM[actual][2] : ~TYP[6];"
+      , "  signal ~GENSYM[expected][3] : ~TYP[7];"
+      , "  -- pragma translate_on"
+      , "begin"
+      , "  -- pragma translate_off"
+      , "  ~SYM[2] <= ~ARG[6];"
+      , "  ~SYM[3] <= ~ARG[7];"
+      , "  process(~ARG[3]) is"
+      , "  begin"
+      , "    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])) then"
+      , "      assert (toSLV(~SYM[2]) = toSLV(~SYM[3])) report (~LIT[5] & \", expected: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[3])) & \", actual: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[2]))) severity error;"
+      , "    end if;"
+      , "  end process;"
+      , "  -- pragma translate_on"
+      , "  ~RESULT <= ~ARG[8];"
+      , "end block;"
+      , "-- assert end"
+      ]
     }
   }
 ,{ "BlackBox" :
     { "name" : "Clash.Explicit.Testbench.assertBitVector"
     , "kind" : "Declaration"
     , "type" :
-"assertBitVector
-  :: ( KnownDomain dom        --                 ARG[0]
-     , KnownNat n )           --                 ARG[1]
-  => Clock dom                --                 ARG[2]
-  -> Reset dom                --                 ARG[3]
-  -> String                   --                 ARG[4]
-  -> Signal dom (BitVector n) -- Checked value  (ARG[5])
-  -> Signal dom (BitVector n) -- Expected value (ARG[6])
-  -> Signal dom b             -- Return valued  (ARG[7])
-  -> Signal dom b"
+      [ "assertBitVector"
+      , "  :: ( KnownDomain dom        --                 ARG[0]"
+      , "     , KnownNat n )           --                 ARG[1]"
+      , "  => Clock dom                --                 ARG[2]"
+      , "  -> Reset dom                --                 ARG[3]"
+      , "  -> String                   --                 ARG[4]"
+      , "  -> Signal dom (BitVector n) -- Checked value  (ARG[5])"
+      , "  -> Signal dom (BitVector n) -- Expected value (ARG[6])"
+      , "  -> Signal dom b             -- Return valued  (ARG[7])"
+      , "  -> Signal dom b"
+      ]
     , "imports" : ["~INCLUDENAME[0].all"]
     , "includes" :
       [{ "name" : "assertBitVector"
       , "extension" : "vhdl"
       , "template" :
-"-- helper functions of Clash.Explicit.Testbench.assertBitVector
-library IEEE;
-use IEEE.STD_LOGIC_1164.ALL;
-
-package ~INCLUDENAME[0] is
-  function non_std_match (l, r : std_logic_vector) return boolean;
-  function slv2string (slv : std_logic_vector) return STRING;
-end;
-
-package body ~INCLUDENAME[0] is
-  type match_table_type is array (std_ulogic, std_ulogic) of boolean;
-  constant match_table: match_table_type :=
-    ('0' | 'L' => ('0' | 'L' | '-' => true, others => false),
-     '1' | 'H' => ('1' | 'H' | '-' => true, others => false),
-     '-' => ('-' => true, others => false),
-     others    =>             ('-' => true, others => false)
-    );
-  -- non_std_match is like std_match
-  -- But only accepts '-' as don't care in its the second argument r.
-  function non_std_match (l, r : std_logic_vector) return boolean is
-    alias la : std_logic_vector (l'length downto 1) is l;
-    alias ra : std_logic_vector (r'length downto 1) is r;
-  begin
-    for i in l'range loop
-       if not match_table (l (i), r (i)) then
-         return false;
-       end if;
-    end loop;
-    return true;
-  end non_std_match;
-
-  function slv2string (slv : std_logic_vector) return STRING is
-     variable result : string (1 to slv'length);
-     variable res_l : string (1 to 3);
-     variable r : integer;
-   begin
-     r := 1;
-     for i in slv'range loop
-        res_l := std_logic'image(slv(i));
-        result(r) := res_l(2);
-        r := r + 1;
-     end loop;
-     return result;
-  end slv2string;
-
-end;
-"
+        [ "-- helper functions of Clash.Explicit.Testbench.assertBitVector"
+        , "library IEEE;"
+        , "use IEEE.STD_LOGIC_1164.ALL;"
+        , ""
+        , "package ~INCLUDENAME[0] is"
+        , "  function non_std_match (l, r : std_logic_vector) return boolean;"
+        , "  function slv2string (slv : std_logic_vector) return STRING;"
+        , "end;"
+        , ""
+        , "package body ~INCLUDENAME[0] is"
+        , "  type match_table_type is array (std_ulogic, std_ulogic) of boolean;"
+        , "  constant match_table: match_table_type :="
+        , "    ('0' | 'L' => ('0' | 'L' | '-' => true, others => false),"
+        , "     '1' | 'H' => ('1' | 'H' | '-' => true, others => false),"
+        , "     '-' => ('-' => true, others => false),"
+        , "     others    =>             ('-' => true, others => false)"
+        , "    );"
+        , "  -- non_std_match is like std_match"
+        , "  -- But only accepts '-' as don't care in its the second argument r."
+        , "  function non_std_match (l, r : std_logic_vector) return boolean is"
+        , "    alias la : std_logic_vector (l'length downto 1) is l;"
+        , "    alias ra : std_logic_vector (r'length downto 1) is r;"
+        , "  begin"
+        , "    for i in l'range loop"
+        , "       if not match_table (l (i), r (i)) then"
+        , "         return false;"
+        , "       end if;"
+        , "    end loop;"
+        , "    return true;"
+        , "  end non_std_match;"
+        , ""
+        , "  function slv2string (slv : std_logic_vector) return STRING is"
+        , "     variable result : string (1 to slv'length);"
+        , "     variable res_l : string (1 to 3);"
+        , "     variable r : integer;"
+        , "   begin"
+        , "     r := 1;"
+        , "     for i in slv'range loop"
+        , "        res_l := std_logic'image(slv(i));"
+        , "        result(r) := res_l(2);"
+        , "        r := r + 1;"
+        , "     end loop;"
+        , "     return result;"
+        , "  end slv2string;"
+        , ""
+        , "end;"
+        , ""
+        ]
       }]
     , "template" :
-"-- assertBitVector begin
-~GENSYM[assert][0] : block
-  -- pragma translate_off
-  signal ~GENSYM[actual][2] : ~TYP[5];
-  signal ~GENSYM[expected][3] : ~TYP[6];
-  -- pragma translate_on
-begin
-  -- pragma translate_off
-  ~SYM[2] <= ~ARG[5];
-  ~SYM[3] <= ~ARG[6];
-  process(~ARG[2]) is
-  begin
-    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then
-      assert (~INCLUDENAME[0].non_std_match(toSLV(~SYM[2]),toSLV(~SYM[3]))) report (~LIT[4] & \", expected: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[3])) & \", actual: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[2]))) severity error;
-    end if;
-  end process;
-  -- pragma translate_on
-  ~RESULT <= ~ARG[7];
-end block;
--- assertBitVector end"
+      [ "-- assertBitVector begin"
+      , "~GENSYM[assert][0] : block"
+      , "  -- pragma translate_off"
+      , "  signal ~GENSYM[actual][2] : ~TYP[5];"
+      , "  signal ~GENSYM[expected][3] : ~TYP[6];"
+      , "  -- pragma translate_on"
+      , "begin"
+      , "  -- pragma translate_off"
+      , "  ~SYM[2] <= ~ARG[5];"
+      , "  ~SYM[3] <= ~ARG[6];"
+      , "  process(~ARG[2]) is"
+      , "  begin"
+      , "    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then"
+      , "      assert (~INCLUDENAME[0].non_std_match(toSLV(~SYM[2]),toSLV(~SYM[3]))) report (~LIT[4] & \", expected: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[3])) & \", actual: \" & ~INCLUDENAME[0].slv2string(toSLV(~SYM[2]))) severity error;"
+      , "    end if;"
+      , "  end process;"
+      , "  -- pragma translate_on"
+      , "  ~RESULT <= ~ARG[7];"
+      , "end block;"
+      , "-- assertBitVector end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -160,29 +166,31 @@ end block;
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.tbClockGen is not synthesizable!"
     , "type" :
-"tbClockGen
-  :: KnownDomain dom     -- ARG[0]
-  => Signal dom Bool     -- ARG[1]
-  -> Clock dom"
+      [ "tbClockGen"
+      , "  :: KnownDomain dom     -- ARG[0]"
+      , "  => Signal dom Bool     -- ARG[1]"
+      , "  -> Clock dom"
+      ]
     , "template" :
-"-- tbClockGen begin
--- pragma translate_off
-~GENSYM[clkGen][0] : process is
-  constant ~GENSYM[half_periodH][1] : time := ~PERIOD[0]000 fs / 2;
-  constant ~GENSYM[half_periodL][2] : time := ~PERIOD[0]000 fs - ~SYM[1];
-begin
-  ~RESULT <= ~IF~ACTIVEEDGE[Rising][0]~THEN'0'~ELSE'1'~FI;
-  wait for 3000 ps;
-  while ~ARG[1] loop
-    ~RESULT <= not ~RESULT;
-    wait for ~SYM[1];
-    ~RESULT <= not ~RESULT;
-    wait for ~SYM[2];
-  end loop;
-  wait;
-end process;
--- pragma translate_on
--- tbClockGen end"
+      [ "-- tbClockGen begin"
+      , "-- pragma translate_off"
+      , "~GENSYM[clkGen][0] : process is"
+      , "  constant ~GENSYM[half_periodH][1] : time := ~PERIOD[0]000 fs / 2;"
+      , "  constant ~GENSYM[half_periodL][2] : time := ~PERIOD[0]000 fs - ~SYM[1];"
+      , "begin"
+      , "  ~RESULT <= ~IF~ACTIVEEDGE[Rising][0]~THEN'0'~ELSE'1'~FI;"
+      , "  wait for 3000 ps;"
+      , "  while ~ARG[1] loop"
+      , "    ~RESULT <= not ~RESULT;"
+      , "    wait for ~SYM[1];"
+      , "    ~RESULT <= not ~RESULT;"
+      , "    wait for ~SYM[2];"
+      , "  end loop;"
+      , "  wait;"
+      , "end process;"
+      , "-- pragma translate_on"
+      , "-- tbClockGen end"
+      ]
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives
+++ b/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives
@@ -2,96 +2,100 @@
     { "name" : "Clash.Intel.DDR.altddioIn"
     , "kind" : "Declaration"
     , "type" :
-"altddioIn
-  :: ( HasCallStack               -- ARG[0]
-     , KnownConfi~ fast domf      -- ARG[1]
-     , KnownConfi~ slow doms      -- ARG[2]
-     , KnownNat m )               -- ARG[3]
-  => SSymbol deviceFamily         -- ARG[4]
-  -> Clock slow                   -- ARG[5]
-  -> Reset slow                   -- ARG[6]
-  -> Enable slow                  -- ARG[7]
-  -> Signal fast (BitVector m)    -- ARG[8]
-  -> Signal slow (BitVector m,BitVector m)"
+      [ "altddioIn"
+      , "  :: ( HasCallStack               -- ARG[0]"
+      , "     , KnownConfi~ fast domf      -- ARG[1]"
+      , "     , KnownConfi~ slow doms      -- ARG[2]"
+      , "     , KnownNat m )               -- ARG[3]"
+      , "  => SSymbol deviceFamily         -- ARG[4]"
+      , "  -> Clock slow                   -- ARG[5]"
+      , "  -> Reset slow                   -- ARG[6]"
+      , "  -> Enable slow                  -- ARG[7]"
+      , "  -> Signal fast (BitVector m)    -- ARG[8]"
+      , "  -> Signal slow (BitVector m,BitVector m)"
+      ]
     , "libraries" : ["altera_mf"]
     , "imports" : ["altera_mf.altera_mf_components.all"]
     , "template" :
-"-- altddioIn begin
-~GENSYM[~COMPNAME_ALTDDIO_IN][0] : block
-  signal ~GENSYM[dataout_l][1] : ~TYP[8];
-  signal ~GENSYM[dataout_h][2] : ~TYP[8];~IF ~ISACTIVEENABLE[7] ~THEN
-  signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
-begin~IF ~ISACTIVEENABLE[5] ~THEN
-  ~SYM[4] <= '1' when (~ARG[7]) else '0';~ELSE ~FI
-  ~GENSYM[~COMPNAME_ALTDDIO_IN][7] : ALTDDIO_IN
-  GENERIC MAP (
-    intended_device_family => ~LIT[4],
-    invert_input_clocks => \"OFF\",
-    lpm_hint => \"UNUSED\",
-    lpm_type => \"altddio_in\",
-    power_up_high => \"OFF\",
-    width => ~SIZE[~TYP[8]]
-  )
-  PORT MAP (~IF ~ISSYNC[6] ~THEN
-    sclr      => ~ARG[6],~ELSE
-    aclr      => ~ARG[6],~FI
-    datain    => ~ARG[8],~IF ~ISACTIVEENABLE[5] ~THEN
-    inclocken => ~SYM[4],~ELSE ~FI
-    inclock   => ~ARG[5],
-    dataout_h => ~SYM[2],
-    dataout_l => ~SYM[1]
-  );
-  ~RESULT <= (~SYM[1],~SYM[2]);
-end block;
--- altddioIn end"
+      [ "-- altddioIn begin"
+      , "~GENSYM[~COMPNAME_ALTDDIO_IN][0] : block"
+      , "  signal ~GENSYM[dataout_l][1] : ~TYP[8];"
+      , "  signal ~GENSYM[dataout_h][2] : ~TYP[8];~IF ~ISACTIVEENABLE[7] ~THEN"
+      , "  signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI"
+      , "begin~IF ~ISACTIVEENABLE[5] ~THEN"
+      , "  ~SYM[4] <= '1' when (~ARG[7]) else '0';~ELSE ~FI"
+      , "  ~GENSYM[~COMPNAME_ALTDDIO_IN][7] : ALTDDIO_IN"
+      , "  GENERIC MAP ("
+      , "    intended_device_family => ~LIT[4],"
+      , "    invert_input_clocks => \"OFF\","
+      , "    lpm_hint => \"UNUSED\","
+      , "    lpm_type => \"altddio_in\","
+      , "    power_up_high => \"OFF\","
+      , "    width => ~SIZE[~TYP[8]]"
+      , "  )"
+      , "  PORT MAP (~IF ~ISSYNC[6] ~THEN"
+      , "    sclr      => ~ARG[6],~ELSE"
+      , "    aclr      => ~ARG[6],~FI"
+      , "    datain    => ~ARG[8],~IF ~ISACTIVEENABLE[5] ~THEN"
+      , "    inclocken => ~SYM[4],~ELSE ~FI"
+      , "    inclock   => ~ARG[5],"
+      , "    dataout_h => ~SYM[2],"
+      , "    dataout_l => ~SYM[1]"
+      , "  );"
+      , "  ~RESULT <= (~SYM[1],~SYM[2]);"
+      , "end block;"
+      , "-- altddioIn end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Intel.DDR.altddioOut#"
     , "kind" : "Declaration"
     , "type" :
-"altddioOut#
-  :: ( HasCallStack             -- ARG[0]
-     , KnownConfi~ fast domf    -- ARG[1]
-     , KnownConfi~ slow doms    -- ARG[2]
-     , KnownNat m )             -- ARG[3]
-  => SSymbol deviceFamily       -- ARG[4]
-  -> Clock slow                 -- ARG[5]
-  -> Reset slow                 -- ARG[6]
-  -> Enable slow                -- ARG[7]
-  -> Signal slow (BitVector m)  -- ARG[8]
-  -> Signal slow (BitVector m)  -- ARG[9]
-  -> Signal fast (BitVector m)"
+      [ "altddioOut#"
+      , "  :: ( HasCallStack             -- ARG[0]"
+      , "     , KnownConfi~ fast domf    -- ARG[1]"
+      , "     , KnownConfi~ slow doms    -- ARG[2]"
+      , "     , KnownNat m )             -- ARG[3]"
+      , "  => SSymbol deviceFamily       -- ARG[4]"
+      , "  -> Clock slow                 -- ARG[5]"
+      , "  -> Reset slow                 -- ARG[6]"
+      , "  -> Enable slow                -- ARG[7]"
+      , "  -> Signal slow (BitVector m)  -- ARG[8]"
+      , "  -> Signal slow (BitVector m)  -- ARG[9]"
+      , "  -> Signal fast (BitVector m)"
+      ]
     , "libraries" : ["altera_mf"]
     , "imports" : ["altera_mf.altera_mf_components.all"]
     , "template" :
-"-- altddioOut begin
-~GENSYM[~COMPNAME_ALTDDIO_OUT][0] : block ~IF ~ISACTIVEENABLE[7] ~THEN
-  signal ~GENSYM[ce_logic][1] : std_logic; ~ELSE ~FI
-begin~IF ~ISACTIVEENABLE[7] ~THEN
-  ~SYM[3] <= '1' when (~ARG[7]) else '0'; ~ELSE ~FI
-  ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] : ALTDDIO_OUT
-    GENERIC MAP (
-      extend_oe_disable => \"OFF\",
-      intended_device_family => ~LIT[4],
-      invert_output => \"OFF\",
-      lpm_hint => \"UNUSED\",
-      lpm_type => \"altddio_out\",
-      oe_reg => \"UNREGISTERED\",
-      power_up_high => \"OFF\",
-      width => ~SIZE[~TYPO]
-    )
-    PORT MAP (~IF ~ISSYNC[2] ~THEN
-      sclr       => ~ARG[6],~ELSE
-      aclr       => ~ARG[6],~FI ~IF ~ISACTIVEENABLE[7] ~THEN
-      outclocken => ~SYM[1],~ELSE ~FI
-      outclock   => ~ARG[5],
-      datain_h   => ~ARG[7],
-      datain_l   => ~ARG[8],
-      dataout    => ~RESULT
-    );
-end block;
--- altddioOut end"
+      [ "-- altddioOut begin"
+      , "~GENSYM[~COMPNAME_ALTDDIO_OUT][0] : block ~IF ~ISACTIVEENABLE[7] ~THEN"
+      , "  signal ~GENSYM[ce_logic][1] : std_logic; ~ELSE ~FI"
+      , "begin~IF ~ISACTIVEENABLE[7] ~THEN"
+      , "  ~SYM[3] <= '1' when (~ARG[7]) else '0'; ~ELSE ~FI"
+      , "  ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] : ALTDDIO_OUT"
+      , "    GENERIC MAP ("
+      , "      extend_oe_disable => \"OFF\","
+      , "      intended_device_family => ~LIT[4],"
+      , "      invert_output => \"OFF\","
+      , "      lpm_hint => \"UNUSED\","
+      , "      lpm_type => \"altddio_out\","
+      , "      oe_reg => \"UNREGISTERED\","
+      , "      power_up_high => \"OFF\","
+      , "      width => ~SIZE[~TYPO]"
+      , "    )"
+      , "    PORT MAP (~IF ~ISSYNC[2] ~THEN"
+      , "      sclr       => ~ARG[6],~ELSE"
+      , "      aclr       => ~ARG[6],~FI ~IF ~ISACTIVEENABLE[7] ~THEN"
+      , "      outclocken => ~SYM[1],~ELSE ~FI"
+      , "      outclock   => ~ARG[5],"
+      , "      datain_h   => ~ARG[7],"
+      , "      datain_l   => ~ARG[8],"
+      , "      dataout    => ~RESULT"
+      , "    );"
+      , "end block;"
+      , "-- altddioOut end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Magic.primitives
+++ b/clash-lib/prims/vhdl/Clash_Magic.primitives
@@ -2,10 +2,11 @@
     { "name" : "Clash.Magic.nameHint"
     , "kind" : "Declaration"
     , "type" :
-"nameHint
-  :: SSymbol sym  -- ARG[0]
-  -> a            -- ARG[1]
-  -> a"
+      [ "nameHint"
+      , "  :: SSymbol sym  -- ARG[0]"
+      , "  -> a            -- ARG[1]"
+      , "  -> a"
+      ]
     , "resultName" : { "template" : "~NAME[0]" }
     , "template" : "~RESULT <= ~ARG[1];"
     }

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM.primitives
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM.primitives
@@ -2,27 +2,29 @@
     { "name" : "Clash.Prelude.ROM.asyncRom#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRom# :: KnownNat n -- ^ ARG[0]
-           => Vec n a    -- ^ ARG[1]
-           -> Int        -- ^ ARG[2]
-           -> a"
+      [ "asyncRom# :: KnownNat n -- ^ ARG[0]"
+      , "           => Vec n a    -- ^ ARG[1]"
+      , "           -> Int        -- ^ ARG[2]"
+      , "           -> a"
+      ]
     , "template" :
-"-- asyncRom begin
-~GENSYM[asyncRom][0] : block
-  signal ~GENSYM[ROM][1] : ~TYP[1];
-  signal ~GENSYM[rd][2] : integer range 0 to ~LIT[0]-1;
-begin
-  ~SYM[1] <= ~LIT[1];
-
-  ~SYM[2] <= to_integer(~VAR[rdI][2](31 downto 0))
-  -- pragma translate_off
-                      mod ~LIT[0]
-  -- pragma translate_on
-                      ;~IF ~VIVADO ~THEN
-  ~RESULT <= ~FROMBV[~SYM[1](~SYM[2])][~TYPO];~ELSE
-  ~RESULT <= ~SYM[1](~SYM[2]);~FI
-end block;
--- asyncRom end"
+      [ "-- asyncRom begin"
+      , "~GENSYM[asyncRom][0] : block"
+      , "  signal ~GENSYM[ROM][1] : ~TYP[1];"
+      , "  signal ~GENSYM[rd][2] : integer range 0 to ~LIT[0]-1;"
+      , "begin"
+      , "  ~SYM[1] <= ~LIT[1];"
+      , ""
+      , "  ~SYM[2] <= to_integer(~VAR[rdI][2](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                      mod ~LIT[0]"
+      , "  -- pragma translate_on"
+      , "                      ;~IF ~VIVADO ~THEN"
+      , "  ~RESULT <= ~FROMBV[~SYM[1](~SYM[2])][~TYPO];~ELSE"
+      , "  ~RESULT <= ~SYM[1](~SYM[2]);~FI"
+      , "end block;"
+      , "-- asyncRom end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.primitives
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.primitives
@@ -2,40 +2,42 @@
     { "name" : "Clash.Prelude.ROM.File.asyncRomFile#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRomFile# :: KnownNat m -- ARG[0]
-               => SNat n     -- sz,   ARG[1]
-               -> FilePath   -- file, ARG[2]
-               -> Int        -- rd,   ARG[3]
-               -> BitVector m"
+      [ "asyncRomFile# :: KnownNat m -- ARG[0]"
+      , "               => SNat n     -- sz,   ARG[1]"
+      , "               -> FilePath   -- file, ARG[2]"
+      , "               -> Int        -- rd,   ARG[3]"
+      , "               -> BitVector m"
+      ]
     , "template" :
-"-- asyncRomFile begin
-~GENSYM[asyncROMFile][0] : block
-  type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
-
-  impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is
-    FILE RomFile : text open read_mode is RomFileName;
-    variable RomFileLine : line;
-    variable ROM : ~SYM[4](0 to ~LIT[1]-1);
-  begin
-    for i in ROM'range loop
-      readline(RomFile,RomFileLine);
-      read(RomFileLine,ROM(i));
-    end loop;
-    return ROM;
-  end function;
-
-  signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[1]-1) := ~SYM[1](~FILE[~LIT[2]]);
-  signal ~GENSYM[rd][3] : integer range 0 to ~LIT[1]-1;
-begin
-  ~SYM[3] <= to_integer(~VAR[rdI][3](31 downto 0))
-  -- pragma translate_off
-                mod ~LIT[1]
-  -- pragma translate_on
-                ;
-
-  ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
-end block;
--- asyncRomFile end"
+      [ "-- asyncRomFile begin"
+      , "~GENSYM[asyncROMFile][0] : block"
+      , "  type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);"
+      , ""
+      , "  impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is"
+      , "    FILE RomFile : text open read_mode is RomFileName;"
+      , "    variable RomFileLine : line;"
+      , "    variable ROM : ~SYM[4](0 to ~LIT[1]-1);"
+      , "  begin"
+      , "    for i in ROM'range loop"
+      , "      readline(RomFile,RomFileLine);"
+      , "      read(RomFileLine,ROM(i));"
+      , "    end loop;"
+      , "    return ROM;"
+      , "  end function;"
+      , ""
+      , "  signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[1]-1) := ~SYM[1](~FILE[~LIT[2]]);"
+      , "  signal ~GENSYM[rd][3] : integer range 0 to ~LIT[1]-1;"
+      , "begin"
+      , "  ~SYM[3] <= to_integer(~VAR[rdI][3](31 downto 0))"
+      , "  -- pragma translate_off"
+      , "                mod ~LIT[1]"
+      , "  -- pragma translate_on"
+      , "                ;"
+      , ""
+      , "  ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));"
+      , "end block;"
+      , "-- asyncRomFile end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Promoted_Nat.primitives
+++ b/clash-lib/prims/vhdl/Clash_Promoted_Nat.primitives
@@ -2,10 +2,12 @@
     { "name"      : "Clash.Promoted.Nat.flogBaseSNat"
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
-    , "type"      : "Clash.Promoted.Nat.flogBaseSNat :: (2 <= base, 1 <= x)
-                                                     => SNat base -- ARG[2]
-                                                     -> SNat x    -- ARG[3]
-                                                     -> SNat (FLog base x)"
+    , "type"      :
+      [ "Clash.Promoted.Nat.flogBaseSNat :: (2 <= base, 1 <= x)"
+      , "                                => SNat base -- ARG[2]"
+      , "                                -> SNat x    -- ARG[3]"
+      , "                                -> SNat (FLog base x)"
+      ]
     , "template"  : "integer(floor(log(real(~LIT[3]),real(~LIT[2]))))"
     }
   }
@@ -13,10 +15,12 @@
     { "name"      : "Clash.Promoted.Nat.clogBaseSNat"
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
-    , "type"      : "Clash.Promoted.Nat.clogBaseSNat :: (2 <= base, 1 <= x)
-                                                     => SNat base -- ARG[2]
-                                                     -> SNat x    -- ARG[3]
-                                                     -> SNat (CLog base x)"
+    , "type"      :
+      [ "Clash.Promoted.Nat.clogBaseSNat :: (2 <= base, 1 <= x)"
+      , "                                => SNat base -- ARG[2]"
+      , "                                -> SNat x    -- ARG[3]"
+      , "                                -> SNat (CLog base x)"
+      ]
     , "template"  : "integer(ceiling(log(real(~LIT[3]),real(~LIT[2]))))"
     }
   }
@@ -24,10 +28,12 @@
     { "name"      : "Clash.Promoted.Nat.logBaseSNat"
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
-    , "type"      : "Clash.Promoted.Nat.logBaseSNat :: (FLog base x ~ CLog base x)
-                                                    => SNat base -- ARG[1]
-                                                    -> SNat x    -- ARG[2]
-                                                    -> SNat (Log base x)"
+    , "type"      :
+      [ "Clash.Promoted.Nat.logBaseSNat :: (FLog base x ~ CLog base x)"
+      , "                               => SNat base -- ARG[1]"
+      , "                               -> SNat x    -- ARG[2]"
+      , "                               -> SNat (Log base x)"
+      ]
     , "template"  : "integer(ceiling(log(real(~LIT[2]),real(~LIT[1]))))"
     }
   }

--- a/clash-lib/prims/vhdl/Clash_Signal_BiSignal.primitives
+++ b/clash-lib/prims/vhdl/Clash_Signal_BiSignal.primitives
@@ -1,19 +1,21 @@
 [ { "BlackBox" :
-    { "name" : "Clash.Signal.BiSignal.writeToBiSignal#",
-      "kind" : "Declaration",
-      "renderVoid": "RenderVoid",
-      "type" :
-"writeToBiSignal#
-  :: HasCallStack                   -- ARG[0]
-  => BiSignalIn ds d n              -- ARG[1]
-  -> Signal d (Maybe (BitVector n)) -- ARG[2]
-  -> Signal d Bool                  -- ARG[3]
-  -> Signal d (BitVector n)         -- ARG[4]
-  -> BiSignalOut ds d n",
-      "template":
-"-- writeToBiSignal# begin
-~ARG[1] <= ~ARG[4] when ~ARG[3] else (~SIZE[~TYP[1]]-1 downto 0 => 'Z');
--- writeToBiSignal# end"
+    { "name" : "Clash.Signal.BiSignal.writeToBiSignal#"
+    ,  "kind" : "Declaration"
+    ,  "renderVoid": "RenderVoid"
+    ,  "type" :
+        [ "writeToBiSignal#"
+        , "  :: HasCallStack                   -- ARG[0]"
+        , "  => BiSignalIn ds d n              -- ARG[1]"
+        , "  -> Signal d (Maybe (BitVector n)) -- ARG[2]"
+        , "  -> Signal d Bool                  -- ARG[3]"
+        , "  -> Signal d (BitVector n)         -- ARG[4]"
+        , "  -> BiSignalOut ds d n"
+        ]
+    , "template":
+      [ "-- writeToBiSignal# begin"
+      , "~ARG[1] <= ~ARG[4] when ~ARG[3] else (~SIZE[~TYP[1]]-1 downto 0 => 'Z');"
+      , "-- writeToBiSignal# end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -21,15 +23,17 @@
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"readFromBiSignal#
-  :: ( HasCallStack    -- ARG[0]
-     , KnownNat n)     -- ARG[1]
-  => BiSignalIn ds d n -- ARG[2]
-  -> Signal d (BitVector n)"
+      [ "readFromBiSignal#"
+      , "  :: ( HasCallStack    -- ARG[0]"
+      , "     , KnownNat n)     -- ARG[1]"
+      , "  => BiSignalIn ds d n -- ARG[2]"
+      , "  -> Signal d (BitVector n)"
+      ]
     , "template" :
-"-- readFromBiSignal begin
-~RESULT <= ~ARG[2];
--- readFromBiSignal end"
+      [ "-- readFromBiSignal begin"
+      , "~RESULT <= ~ARG[2];"
+      , "-- readFromBiSignal end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.primitives
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.primitives
@@ -2,127 +2,133 @@
     { "name" : "Clash.Signal.Internal.delay#"
     , "kind" : "Declaration"
     , "type" :
-"delay#
-  :: ( KnownDomain dom        -- ARG[0]
-     , Undefined a )          -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Enable dom               -- ARG[3]
-  -> a                        -- ARG[4]
-  -> Signal clk a             -- ARG[5]
-  -> Signal clk a"
+      [ "delay#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , Undefined a )          -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Enable dom               -- ARG[3]"
+      , "  -> a                        -- ARG[4]"
+      , "  -> Signal clk a             -- ARG[5]"
+      , "  -> Signal clk a"
+      ]
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[4]~ELSE~FI" }
     , "template" :
-"-- delay begin~IF ~ISACTIVEENABLE[3] ~THEN
-~GENSYM[~RESULT_delay][4] : process(~ARG[2])
-begin
-  if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    if ~ARG[3] then
-      ~RESULT <= ~ARG[5];
-    end if;
-  end if;
-end process;~ELSE
-~SYM[4] : process(~ARG[2])
-begin
-  if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    ~RESULT <= ~ARG[5];
-  end if;
-end process;~FI
--- delay end"
+      [ "-- delay begin~IF ~ISACTIVEENABLE[3] ~THEN"
+      , "~GENSYM[~RESULT_delay][4] : process(~ARG[2])"
+      , "begin"
+      , "  if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then"
+      , "    if ~ARG[3] then"
+      , "      ~RESULT <= ~ARG[5];"
+      , "    end if;"
+      , "  end if;"
+      , "end process;~ELSE"
+      , "~SYM[4] : process(~ARG[2])"
+      , "begin"
+      , "  if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then"
+      , "    ~RESULT <= ~ARG[5];"
+      , "  end if;"
+      , "end process;~FI"
+      , "-- delay end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.asyncRegister#"
     , "kind" : "Declaration"
     , "type" :
-"asyncRegister#
-  :: ( KnownDomain dom        -- ARG[0]
-     , NFDataX a )            -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Reset dom                -- ARG[3]
-  -> Enable dom               -- ARG[4]
-  -> a                        -- ARG[5] (powerup value)
-  -> a                        -- ARG[6] (reset value)
-  -> Signal clk a             -- ARG[7]
-  -> Signal clk a"
+      [ "asyncRegister#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , NFDataX a )            -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Reset dom                -- ARG[3]"
+      , "  -> Enable dom               -- ARG[4]"
+      , "  -> a                        -- ARG[5] (powerup value)"
+      , "  -> a                        -- ARG[6] (reset value)"
+      , "  -> Signal clk a             -- ARG[7]"
+      , "  -> Signal clk a"
+      ]
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[5]~ELSE~FI" }
     , "template" :
-"-- async register begin
-~SYM[2] : process(~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE,~ARG[3]~FI)
-begin
-  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
-    ~RESULT <= ~CONST[6];
-  els~FIif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    ~IF ~ISACTIVEENABLE[4] ~THEN
-    if ~ARG[4] then
-      ~RESULT <= ~ARG[7];
-    end if;
-    ~ELSE
-    ~RESULT <= ~ARG[7];
-    ~FI
-  end if;
-end process;
--- async register end"
+      [ "-- async register begin"
+      , "~SYM[2] : process(~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE,~ARG[3]~FI)"
+      , "begin"
+      , "  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then"
+      , "    ~RESULT <= ~CONST[6];"
+      , "  els~FIif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then"
+      , "    ~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "    if ~ARG[4] then"
+      , "      ~RESULT <= ~ARG[7];"
+      , "    end if;"
+      , "    ~ELSE"
+      , "    ~RESULT <= ~ARG[7];"
+      , "    ~FI"
+      , "  end if;"
+      , "end process;"
+      , "-- async register end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Signal.Internal.register#"
     , "kind" : "Declaration"
     , "type" :
-"register#
-  :: ( KnownDomain dom        -- ARG[0]
-     , NFDataX a )            -- ARG[1]
-  => Clock dom                -- ARG[2]
-  -> Reset dom                -- ARG[3]
-  -> Enable dom               -- ARG[4]
-  -> a                        -- ARG[5] (powerup value)
-  -> a                        -- ARG[6] (reset value)
-  -> Signal clk a             -- ARG[7]
-  -> Signal clk a"
+      [ "register#"
+      , "  :: ( KnownDomain dom        -- ARG[0]"
+      , "     , NFDataX a )            -- ARG[1]"
+      , "  => Clock dom                -- ARG[2]"
+      , "  -> Reset dom                -- ARG[3]"
+      , "  -> Enable dom               -- ARG[4]"
+      , "  -> a                        -- ARG[5] (powerup value)"
+      , "  -> a                        -- ARG[6] (reset value)"
+      , "  -> Signal clk a             -- ARG[7]"
+      , "  -> Signal clk a"
+    ]
     , "resultName" : { "template" : "~CTXNAME" }
     , "resultInit" : { "template" : "~IF~ISINITDEFINED[0]~THEN~CONST[5]~ELSE~FI" }
     , "template" :
-"-- register begin~IF ~ISACTIVEENABLE[4] ~THEN ~IF ~ISSYNC[0] ~THEN
-~GENSYM[~RESULT_register][2] : process(~ARG[2])
-begin
-  if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
-      ~RESULT <= ~CONST[6];
-    els~FIif ~ARG[4] then
-      ~RESULT <= ~ARG[7];
-    end if;
-  end if;
-end process;~ELSE
-~SYM[2] : process(~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE,~ARG[3]~FI)
-begin
-  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
-    ~RESULT <= ~CONST[6];
-  els~FIif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    if ~ARG[4] then
-      ~RESULT <= ~ARG[7];
-    end if;
-  end if;
-end process;~FI~ELSE ~IF ~ISSYNC[0] ~THEN
-~SYM[2] : process(~ARG[2])
-begin
-  if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
-      ~RESULT <= ~CONST[6];
-    else
-      ~FI~RESULT <= ~ARG[7];
-    ~IF ~ISUNDEFINED[6] ~THEN ~ELSEend if;~FI
-  end if;
-end process;~ELSE
-~SYM[2] : process(~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE,~ARG[3]~FI)
-begin
-  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
-    ~RESULT <= ~CONST[6];
-  els~FIif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-    ~RESULT <= ~ARG[7];
-  end if;
-end process;~FI~FI
--- register end"
+      [ "-- register begin~IF ~ISACTIVEENABLE[4] ~THEN ~IF ~ISSYNC[0] ~THEN"
+      , "~GENSYM[~RESULT_register][2] : process(~ARG[2])"
+      , "begin"
+      , "  if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then"
+      , "    ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then"
+      , "      ~RESULT <= ~CONST[6];"
+      , "    els~FIif ~ARG[4] then"
+      , "      ~RESULT <= ~ARG[7];"
+      , "    end if;"
+      , "  end if;"
+      , "end process;~ELSE"
+      , "~SYM[2] : process(~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE,~ARG[3]~FI)"
+      , "begin"
+      , "  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then"
+      , "    ~RESULT <= ~CONST[6];"
+      , "  els~FIif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then"
+      , "    if ~ARG[4] then"
+      , "      ~RESULT <= ~ARG[7];"
+      , "    end if;"
+      , "  end if;"
+      , "end process;~FI~ELSE ~IF ~ISSYNC[0] ~THEN"
+      , "~SYM[2] : process(~ARG[2])"
+      , "begin"
+      , "  if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then"
+      , "    ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then"
+      , "      ~RESULT <= ~CONST[6];"
+      , "    else"
+      , "      ~FI~RESULT <= ~ARG[7];"
+      , "    ~IF ~ISUNDEFINED[6] ~THEN ~ELSEend if;~FI"
+      , "  end if;"
+      , "end process;~ELSE"
+      , "~SYM[2] : process(~ARG[2]~IF ~ISUNDEFINED[6] ~THEN ~ELSE,~ARG[3]~FI)"
+      , "begin"
+      , "  ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then"
+      , "    ~RESULT <= ~CONST[6];"
+      , "  els~FIif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then"
+      , "    ~RESULT <= ~ARG[7];"
+      , "  end if;"
+      , "end process;~FI~FI"
+      , "-- register end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -131,31 +137,34 @@ end process;~FI~FI
     , "kind" : "Declaration"
     , "warning" : "Clash.Signal.Internal.clockGen is not synthesizable!"
     , "type" :
-"clockGen
-  :: KnownDomain dom     -- ARG[0]
-  => Clock dom"
+      [ "clockGen"
+      , "  :: KnownDomain dom     -- ARG[0]"
+      , "  => Clock dom"
+      ]
     , "comment" :
-        "ModelSim and Vivado seem to round time values to an integer number of picoseconds.
-        Use two half periods to prevent rounding errors from affecting the full period."
+        [ "ModelSim and Vivado seem to round time values to an integer number of picoseconds."
+        , "Use two half periods to prevent rounding errors from affecting the full period."
+        ]
     , "template" :
-"-- clockGen begin
--- pragma translate_off
-~GENSYM[clkGen][0] : process is
-  constant ~GENSYM[half_periodH][1] : time := ~PERIOD[0]000 fs / 2;
-  constant ~GENSYM[half_periodL][2] : time := ~PERIOD[0]000 fs - ~SYM[1];
-begin
-  ~RESULT <= ~IF~ACTIVEEDGE[Rising][0]~THEN'0'~ELSE'1'~FI;
-  wait for 3000 ps;
-  loop
-    ~RESULT <= not ~RESULT;
-    wait for ~SYM[1];
-    ~RESULT <= not ~RESULT;
-    wait for ~SYM[2];
-  end loop;
-  wait;
-end process;
--- pragma translate_on
--- clockGen end"
+      [ "-- clockGen begin"
+      , "-- pragma translate_off"
+      , "~GENSYM[clkGen][0] : process is"
+      , "  constant ~GENSYM[half_periodH][1] : time := ~PERIOD[0]000 fs / 2;"
+      , "  constant ~GENSYM[half_periodL][2] : time := ~PERIOD[0]000 fs - ~SYM[1];"
+      , "begin"
+      , "  ~RESULT <= ~IF~ACTIVEEDGE[Rising][0]~THEN'0'~ELSE'1'~FI;"
+      , "  wait for 3000 ps;"
+      , "  loop"
+      , "    ~RESULT <= not ~RESULT;"
+      , "    wait for ~SYM[1];"
+      , "    ~RESULT <= not ~RESULT;"
+      , "    wait for ~SYM[2];"
+      , "  end loop;"
+      , "  wait;"
+      , "end process;"
+      , "-- pragma translate_on"
+      , "-- clockGen end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -164,12 +173,13 @@ end process;
     , "kind" : "Declaration"
     , "type" : "resetGenN :: (KnownDomain dom, 1 <= n) => SNat n -> Reset dom"
     , "template" :
-"-- resetGen begin
--- pragma translate_off
-~RESULT <= ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI,
-         ~IF ~ISACTIVEHIGH[0] ~THEN '0' ~ELSE '1' ~FI after ~IF~ISSYNC[0]~THEN(2999 ps + (integer'(~LIT[2]) * ~PERIOD[0] ps))~ELSE(3001 ps + integer'(~LIT[2] - 1) * ~PERIOD[0] ps)~FI;
--- pragma translate_on
--- resetGen end"
+      [ "-- resetGen begin"
+      , "-- pragma translate_off"
+      , "~RESULT <= ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI,"
+      , "         ~IF ~ISACTIVEHIGH[0] ~THEN '0' ~ELSE '1' ~FI after ~IF~ISSYNC[0]~THEN(2999 ps + (integer'(~LIT[2]) * ~PERIOD[0] ps))~ELSE(3001 ps + integer'(~LIT[2] - 1) * ~PERIOD[0] ps)~FI;"
+      , "-- pragma translate_on"
+      , "-- resetGen end"
+      ]
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
@@ -127,35 +127,36 @@
     , "kind"      : "Declaration"
     , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> Bit"
     , "template"  :
-"-- reduceAnd begin,
-~IF~SIZE[~TYP[1]]~THEN
-~GENSYM[reduceAnd][0] : block
-  function and_reduce (arg : std_logic_vector) return std_logic is
-    variable upper, lower : std_logic;
-    variable half         : integer;
-    variable argi         : std_logic_vector (arg'length - 1 downto 0);
-    variable result       : std_logic;
-  begin
-    if (arg'length < 1) then
-      result := '1';
-    else
-      argi := arg;
-      if (argi'length = 1) then
-        result := argi(argi'left);
-      else
-        half   := (argi'length + 1) / 2; -- lsb-biased tree
-        upper  := and_reduce (argi (argi'left downto half));
-        lower  := and_reduce (argi (half - 1 downto argi'right));
-        result := upper and lower;
-      end if;
-    end if;
-    return result;
-  end;
-begin
-  ~RESULT <= and_reduce(~ARG[1]);
-end block;~ELSE
-~RESULT <= '1';~FI
--- reduceAnd end"
+      [ "-- reduceAnd begin,"
+      , "~IF~SIZE[~TYP[1]]~THEN"
+      , "~GENSYM[reduceAnd][0] : block"
+      , "  function and_reduce (arg : std_logic_vector) return std_logic is"
+      , "    variable upper, lower : std_logic;"
+      , "    variable half         : integer;"
+      , "    variable argi         : std_logic_vector (arg'length - 1 downto 0);"
+      , "    variable result       : std_logic;"
+      , "  begin"
+      , "    if (arg'length < 1) then"
+      , "      result := '1';"
+      , "    else"
+      , "      argi := arg;"
+      , "      if (argi'length = 1) then"
+      , "        result := argi(argi'left);"
+      , "      else"
+      , "        half   := (argi'length + 1) / 2; -- lsb-biased tree"
+      , "        upper  := and_reduce (argi (argi'left downto half));"
+      , "        lower  := and_reduce (argi (half - 1 downto argi'right));"
+      , "        result := upper and lower;"
+      , "      end if;"
+      , "    end if;"
+      , "    return result;"
+      , "  end;"
+      , "begin"
+      , "  ~RESULT <= and_reduce(~ARG[1]);"
+      , "end block;~ELSE"
+      , "~RESULT <= '1';~FI"
+      , "-- reduceAnd end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -163,34 +164,35 @@ end block;~ELSE
     , "kind"      : "Declaration"
     , "type"      : "reduceOr# :: KnownNat n => BitVector n -> Bit"
     , "template"  :
-"-- reduceOr begin ~IF~SIZE[~TYP[1]]~THEN
-~GENSYM[reduceOr][0] : block
-  function or_reduce (arg : std_logic_vector) return std_logic is
-    variable upper, lower : std_logic;
-    variable half         : integer;
-    variable argi         : std_logic_vector (arg'length - 1 downto 0);
-    variable result       : std_logic;
-  begin
-    if (arg'length < 1) then
-      result := '0';
-    else
-      argi := arg;
-      if (argi'length = 1) then
-        result := argi(argi'left);
-      else
-        half   := (argi'length + 1) / 2; -- lsb-biased tree
-        upper  := or_reduce (argi (argi'left downto half));
-        lower  := or_reduce (argi (half - 1 downto argi'right));
-        result := upper or lower;
-      end if;
-    end if;
-    return result;
-  end;
-begin
-  ~RESULT <= or_reduce(~ARG[1]);
-end block;~ELSE
-~RESULT <= '0'; ~FI
--- reduceOr end"
+      [ "-- reduceOr begin ~IF~SIZE[~TYP[1]]~THEN"
+      , "~GENSYM[reduceOr][0] : block"
+      , "  function or_reduce (arg : std_logic_vector) return std_logic is"
+      , "    variable upper, lower : std_logic;"
+      , "    variable half         : integer;"
+      , "    variable argi         : std_logic_vector (arg'length - 1 downto 0);"
+      , "    variable result       : std_logic;"
+      , "  begin"
+      , "    if (arg'length < 1) then"
+      , "      result := '0';"
+      , "    else"
+      , "      argi := arg;"
+      , "      if (argi'length = 1) then"
+      , "        result := argi(argi'left);"
+      , "      else"
+      , "        half   := (argi'length + 1) / 2; -- lsb-biased tree"
+      , "        upper  := or_reduce (argi (argi'left downto half));"
+      , "        lower  := or_reduce (argi (half - 1 downto argi'right));"
+      , "        result := upper or lower;"
+      , "      end if;"
+      , "    end if;"
+      , "    return result;"
+      , "  end;"
+      , "begin"
+      , "  ~RESULT <= or_reduce(~ARG[1]);"
+      , "end block;~ELSE"
+      , "~RESULT <= '0'; ~FI"
+      , "-- reduceOr end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -198,102 +200,107 @@ end block;~ELSE
     , "kind"      : "Declaration"
     , "type"      : "reduceXor# :: KnownNat n => BitVector n -> Bit"
     , "template"  :
-"-- reduceXor begin ~IF~SIZE[~TYP[1]]~THEN
-~GENSYM[reduceXor][0] : block
-  function xor_reduce (arg : std_logic_vector) return std_logic is
-    variable upper, lower : std_logic;
-    variable half         : integer;
-    variable argi         : std_logic_vector (arg'length - 1 downto 0);
-    variable result       : std_logic;
-  begin
-    if (arg'length < 1) then
-      result := '0';
-    else
-      argi := arg;
-      if (argi'length = 1) then
-        result := argi(argi'left);
-      else
-        half   := (argi'length + 1) / 2; -- lsb-biased tree
-        upper  := xor_reduce (argi (argi'left downto half));
-        lower  := xor_reduce (argi (half - 1 downto argi'right));
-        result := upper xor lower;
-      end if;
-    end if;
-    return result;
-  end;
-begin
-  ~RESULT <= xor_reduce(~ARG[1]);
-end block;~ELSE
-~RESULT <= '0';~FI
--- reduceXor end"
+      [ "-- reduceXor begin ~IF~SIZE[~TYP[1]]~THEN"
+      , "~GENSYM[reduceXor][0] : block"
+      , "  function xor_reduce (arg : std_logic_vector) return std_logic is"
+      , "    variable upper, lower : std_logic;"
+      , "    variable half         : integer;"
+      , "    variable argi         : std_logic_vector (arg'length - 1 downto 0);"
+      , "    variable result       : std_logic;"
+      , "  begin"
+      , "    if (arg'length < 1) then"
+      , "      result := '0';"
+      , "    else"
+      , "      argi := arg;"
+      , "      if (argi'length = 1) then"
+      , "        result := argi(argi'left);"
+      , "      else"
+      , "        half   := (argi'length + 1) / 2; -- lsb-biased tree"
+      , "        upper  := xor_reduce (argi (argi'left downto half));"
+      , "        lower  := xor_reduce (argi (half - 1 downto argi'right));"
+      , "        result := upper xor lower;"
+      , "      end if;"
+      , "    end if;"
+      , "    return result;"
+      , "  end;"
+      , "begin"
+      , "  ~RESULT <= xor_reduce(~ARG[1]);"
+      , "end block;~ELSE"
+      , "~RESULT <= '0';~FI"
+      , "-- reduceXor end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.index#"
     , "kind" : "Declaration"
     , "type" :
-"index# :: KnownNat n  -- ARG[0]
-        => BitVector n -- ARG[1]
-        -> Int         -- ARG[2]
-        -> Bit"
+      [ "index# :: KnownNat n  -- ARG[0]"
+      , "       => BitVector n -- ARG[1]"
+      , "       -> Int         -- ARG[2]"
+      , "       -> Bit"
+      ]
     , "template" :
-"-- indexBitVector begin ~IF~SIZE[~TYP[1]]~THEN~IF ~ISVAR[1] ~THEN
-~GENSYM[indexBitVector][0] : block
-  signal ~GENSYM[vec_index][1] : integer range 0 to ~SIZE[~TYP[1]]-1;
-begin
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~SIZE[~TYP[1]]
-  -- pragma translate_on
-               ;
-
-  ~RESULT <= ~ARG[1](~SYM[1]);
-end block;~ELSE
-~SYM[0] : block
-  signal ~SYM[1] : integer range 0 to ~SIZE[~TYP[1]]-1;
-begin
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~SIZE[~TYP[1]]
-  -- pragma translate_on
-               ;
-
-  ~RESULT <= ~VAR[bv][1](~SYM[1]);
-end block;~FI~ELSE
-~RESULT <= ~ERRORO;~FI
--- indexBitVector end"
+      [ "-- indexBitVector begin ~IF~SIZE[~TYP[1]]~THEN~IF ~ISVAR[1] ~THEN"
+      , "~GENSYM[indexBitVector][0] : block"
+      , "  signal ~GENSYM[vec_index][1] : integer range 0 to ~SIZE[~TYP[1]]-1;"
+      , "begin"
+      , "  ~SYM[1] <= to_integer(~ARG[2])"
+      , "  -- pragma translate_off"
+      , "               mod ~SIZE[~TYP[1]]"
+      , "  -- pragma translate_on"
+      , "               ;"
+      , ""
+      , "  ~RESULT <= ~ARG[1](~SYM[1]);"
+      , "end block;~ELSE"
+      , "~SYM[0] : block"
+      , "  signal ~SYM[1] : integer range 0 to ~SIZE[~TYP[1]]-1;"
+      , "begin"
+      , "  ~SYM[1] <= to_integer(~ARG[2])"
+      , "  -- pragma translate_off"
+      , "               mod ~SIZE[~TYP[1]]"
+      , "  -- pragma translate_on"
+      , "               ;"
+      , ""
+      , "  ~RESULT <= ~VAR[bv][1](~SYM[1]);"
+      , "end block;~FI~ELSE"
+      , "~RESULT <= ~ERRORO;~FI"
+      , "-- indexBitVector end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Sized.Internal.BitVector.replaceBit#"
     , "kind" : "Declaration"
     , "type" :
-"replaceBit# :: KnownNat n  -- ARG[0]
-             => BitVector n -- ARG[1]
-             -> Int         -- ARG[2]
-             -> Bit         -- ARG[3]
-             -> BitVector n"
+      [ "replaceBit# :: KnownNat n  -- ARG[0]"
+      , "             => BitVector n -- ARG[1]"
+      , "             -> Int         -- ARG[2]"
+      , "             -> Bit         -- ARG[3]"
+      , "             -> BitVector n"
+      ]
     , "template" :
-"-- replaceBit begin ~IF~SIZE[~TYP[1]]~THEN
-~GENSYM[replaceBit][0] : block
-  signal ~GENSYM[vec_index][1] : integer range 0 to ~SIZE[~TYP[1]]-1;
-begin
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~SIZE[~TYP[1]]
-  -- pragma translate_on
-               ;
-
-  process(~SYM[1],~VAR[b][3]~VARS[1])
-    variable ~GENSYM[ivec][2] : ~TYP[1];
-  begin
-    ~SYM[2] := ~ARG[1];
-    ~SYM[2](~SYM[1]) := ~ARG[3];
-    ~RESULT <= ~SYM[2];
-  end process;
-end block; ~ELSE
-~RESULT <= ~ERRORO;~FI
--- replaceBit end"
+      [ "-- replaceBit begin ~IF~SIZE[~TYP[1]]~THEN"
+      , "~GENSYM[replaceBit][0] : block"
+      , "  signal ~GENSYM[vec_index][1] : integer range 0 to ~SIZE[~TYP[1]]-1;"
+      , "begin"
+      , "  ~SYM[1] <= to_integer(~ARG[2])"
+      , "  -- pragma translate_off"
+      , "               mod ~SIZE[~TYP[1]]"
+      , "  -- pragma translate_on"
+      , "               ;"
+      , ""
+      , "  process(~SYM[1],~VAR[b][3]~VARS[1])"
+      , "    variable ~GENSYM[ivec][2] : ~TYP[1];"
+      , "  begin"
+      , "    ~SYM[2] := ~ARG[1];"
+      , "    ~SYM[2](~SYM[1]) := ~ARG[3];"
+      , "    ~RESULT <= ~SYM[2];"
+      , "  end process;"
+      , "end block; ~ELSE"
+      , "~RESULT <= ~ERRORO;~FI"
+      , "-- replaceBit end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -301,22 +308,24 @@ end block; ~ELSE
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"setSlice# :: SNat (m + 1 + i)
-           => BitVector (m + 1 + i) -- ARG[1]
-           -> SNat m                -- ARG[2]
-           -> SNat n                -- ARG[3]
-           -> BitVector (m + 1 - n) -- ARG[4]
-           -> BitVector (m + 1 + i)"
+      [ "setSlice# :: SNat (m + 1 + i)"
+      , "           => BitVector (m + 1 + i) -- ARG[1]"
+      , "           -> SNat m                -- ARG[2]"
+      , "           -> SNat n                -- ARG[3]"
+      , "           -> BitVector (m + 1 - n) -- ARG[4]"
+      , "           -> BitVector (m + 1 + i)"
+      ]
     , "template" :
-"-- setSlice begin
-~GENSYM[setSlice][0] : process(~VAR[bv][1]~VARS[4])
-  variable ~GENSYM[ivec][1] : ~TYP[1];
-begin
-  ~SYM[1] := ~VAR[bv][1];
-  ~SYM[1](~LIT[2] downto ~LIT[3]) := ~ARG[4];
-  ~RESULT <= ~SYM[1];
-end process;
--- setSlice end"
+      [ "-- setSlice begin"
+      , "~GENSYM[setSlice][0] : process(~VAR[bv][1]~VARS[4])"
+      , "  variable ~GENSYM[ivec][1] : ~TYP[1];"
+      , "begin"
+      , "  ~SYM[1] := ~VAR[bv][1];"
+      , "  ~SYM[1](~LIT[2] downto ~LIT[3]) := ~ARG[4];"
+      , "  ~RESULT <= ~SYM[1];"
+      , "end process;"
+      , "-- setSlice end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -324,10 +333,11 @@ end process;
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"slice# :: BitVector (m + 1 + i) -- ARG[0]
-        -> SNat m                -- ARG[1]
-        -> SNat n                -- ARG[2]
-        -> BitVector (m + 1 - n)"
+      [ "slice# :: BitVector (m + 1 + i) -- ARG[0]"
+      , "       -> SNat m                -- ARG[1]"
+      , "       -> SNat n                -- ARG[2]"
+      , "       -> BitVector (m + 1 - n)"
+      ]
     , "template" : "~VAR[bv][0](~LIT[1] downto ~LIT[2])"
     }
   }
@@ -336,9 +346,10 @@ end process;
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"split# :: KnownNat n        -- ARG[0]
-        => BitVector (m + n) -- ARG[1]
-        -> (BitVector m, BitVector n)"
+      [ "split# :: KnownNat n        -- ARG[0]"
+      , "       => BitVector (m + n) -- ARG[1]"
+      , "       -> (BitVector m, BitVector n)"
+      ]
     , "template" : "(~VAR[bv][1](~VAR[bv][1]'high downto ~LIT[0]),~VAR[bv][1](~LIT[0]-1 downto 0))"
     }
   }
@@ -347,9 +358,10 @@ end process;
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"msb# :: KnownNat n  -- ARG[0]
-      => BitVector n -- ARG[1]
-      -> Bit"
+      [ "msb# :: KnownNat n  -- ARG[0]"
+      , "      => BitVector n -- ARG[1]"
+      , "      -> Bit"
+      ]
     , "template" : "~IF ~SIZE[~TYP[1]] ~THEN ~VAR[bv][1](~VAR[bv][1]'high) ~ELSE \"0\" ~FI"
     }
   }
@@ -358,8 +370,9 @@ end process;
     , "workInfo" : "Never"
     , "kind" : "Expression"
     , "type" :
-"lsb# :: BitVector n -- ARG[0]
-      -> Bit"
+      [ "lsb# :: BitVector n -- ARG[0]"
+      , "      -> Bit"
+      ]
     , "template" : "~IF ~SIZE[~TYP[0]] ~THEN ~VAR[bv][0](0) ~ELSE \"0\" ~FI"
     }
   }
@@ -483,11 +496,12 @@ end process;
     , "kind"      : "Declaration"
     , "type"      : "quot# :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(unsigned(~ARG[1]) / unsigned(~ARG[2]))
-    -- pragma translate_off
-    when (~ARG[2] /= std_logic_vector(to_unsigned(0,~SIZE[~TYP[2]]))) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= std_logic_vector(unsigned(~ARG[1]) / unsigned(~ARG[2]))"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] /= std_logic_vector(to_unsigned(0,~SIZE[~TYP[2]]))) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -495,11 +509,12 @@ end process;
     , "kind"      : "Declaration"
     , "type"      : "rem# :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(unsigned(~ARG[1]) rem unsigned(~ARG[2]))
-    -- pragma translate_off
-    when (~ARG[2] /= std_logic_vector(to_unsigned(0,~SIZE[~TYP[2]]))) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= std_logic_vector(unsigned(~ARG[1]) rem unsigned(~ARG[2]))"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] /= std_logic_vector(to_unsigned(0,~SIZE[~TYP[2]]))) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBoxHaskell" :
@@ -541,24 +556,25 @@ end process;
     , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][2]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= std_logic_vector(shift_left(unsigned(~ARG[1]),~SYM[1]))
-      -- pragma translate_off
-      when (~ARG[2] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][2]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= std_logic_vector(shift_left(unsigned(~ARG[1]),~SYM[1]))"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[2] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -566,24 +582,25 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~GENSYM[~RESULT_shiftR][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][2]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= std_logic_vector(shift_right(unsigned(~ARG[1]),~SYM[1]))
-      -- pragma translate_off
-      when (~ARG[2] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftR][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][2]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= std_logic_vector(shift_right(unsigned(~ARG[1]),~SYM[1]))"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[2] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -591,15 +608,16 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer((~ARG[2])
-    -- pragma translate_off
-    mod ~SIZE[~TYP[1]]
-    -- pragma translate_on
-    )))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= std_logic_vector(rotate_left(unsigned(~ARG[1]),to_integer((~ARG[2])"
+      , "    -- pragma translate_off"
+      , "    mod ~SIZE[~TYP[1]]"
+      , "    -- pragma translate_on"
+      , "    )))"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] >= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -607,15 +625,16 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "template"  :
-"~RESULT <= std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer((~ARG[2])
-    -- pragma translate_off
-    mod ~SIZE[~TYP[1]]
-    -- pragma translate_on
-    )))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= std_logic_vector(rotate_right(unsigned(~ARG[1]),to_integer((~ARG[2])"
+      , "    -- pragma translate_off"
+      , "    mod ~SIZE[~TYP[1]]"
+      , "    -- pragma translate_on"
+      , "    )))"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] >= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.primitives
@@ -119,11 +119,12 @@
     , "kind"      : "Declaration"
     , "type"      : "rem# :: Index n -> Index n -> Index n"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBoxHaskell" :
@@ -145,11 +146,12 @@
     , "kind"      : "Declaration"
     , "type"      : "quot# :: Index n -> Index n -> Index n"
     , "template"  :
-"~RESULT <= ~ARG[0] / ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] / ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
@@ -138,11 +138,12 @@
     , "kind"      : "Declaration"
     , "type"      : "rem# :: Signed n -> Signed n -> Signed n"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -150,26 +151,27 @@
     , "kind"      : "Declaration"
     , "type"      : "div# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "template"  :
-"-- divSigned begin
-~GENSYM[divSigned][0] : block
-  signal ~GENSYM[resultPos][1] : boolean;
-  signal ~GENSYM[dividerNeg][2] : boolean;
-  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);
-  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);
-begin
-  ~SYM[1] <= ~VAR[dividend][1](~VAR[dividend][1]'high) = ~VAR[divider][2](~VAR[divider][2]'high);
-  ~SYM[2] <= ~VAR[divider][2](~VAR[divider][2]'high) = '1';
-  ~SYM[3] <= resize(~VAR[dividend][1],~SIZE[~TYPO]+1)   when ~SYM[1] else
-             (resize(~VAR[dividend][1],~SIZE[~TYPO]+1) - resize(~VAR[divider][2],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
-             (resize(~VAR[dividend][1],~SIZE[~TYPO]+1) - resize(~VAR[divider][2],~SIZE[~TYPO]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][2]
-      -- pragma translate_off
-      when (~VAR[divider][2] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
-end block;
--- divSigned end"
+      [ "-- divSigned begin"
+      , "~GENSYM[divSigned][0] : block"
+      , "  signal ~GENSYM[resultPos][1] : boolean;"
+      , "  signal ~GENSYM[dividerNeg][2] : boolean;"
+      , "  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);"
+      , "  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);"
+      , "begin"
+      , "  ~SYM[1] <= ~VAR[dividend][1](~VAR[dividend][1]'high) = ~VAR[divider][2](~VAR[divider][2]'high);"
+      , "  ~SYM[2] <= ~VAR[divider][2](~VAR[divider][2]'high) = '1';"
+      , "  ~SYM[3] <= resize(~VAR[dividend][1],~SIZE[~TYPO]+1)   when ~SYM[1] else"
+      , "             (resize(~VAR[dividend][1],~SIZE[~TYPO]+1) - resize(~VAR[divider][2],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else"
+      , "             (resize(~VAR[dividend][1],~SIZE[~TYPO]+1) - resize(~VAR[divider][2],~SIZE[~TYPO]+1) + 1);"
+      , "  ~SYM[4] <= ~SYM[3] / ~VAR[divider][2]"
+      , "      -- pragma translate_off"
+      , "      when (~VAR[divider][2] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));"
+      , "end block;"
+      , "-- divSigned end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -177,11 +179,12 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "mod# :: Signed n -> Signed n -> Signed n"
     , "template"  :
-"~RESULT <= ~ARG[0] mod ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] mod ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBoxHaskell" :
@@ -223,24 +226,25 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][2]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_left(~ARG[1],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[2] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][2]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_left(~ARG[1],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[2] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -248,24 +252,25 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~GENSYM[~RESULT_shiftR][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][2]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_right(~ARG[1],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[2] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftR][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][2]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_right(~ARG[1],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[2] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -273,15 +278,16 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~RESULT <= rotate_left(~ARG[1],to_integer((~ARG[2])
-    -- pragma translate_off
-    mod ~SIZE[~TYP[1]]
-    -- pragma translate_on
-    ))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= rotate_left(~ARG[1],to_integer((~ARG[2])"
+      , "    -- pragma translate_off"
+      , "    mod ~SIZE[~TYP[1]]"
+      , "    -- pragma translate_on"
+      , "    ))"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] >= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -289,15 +295,16 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "template"  :
-"~RESULT <= rotate_right(~ARG[1],to_integer((~ARG[2])
-    -- pragma translate_off
-    mod ~SIZE[~TYP[1]]
-    -- pragma translate_on
-    ))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= rotate_right(~ARG[1],to_integer((~ARG[2])"
+      , "    -- pragma translate_off"
+      , "    mod ~SIZE[~TYP[1]]"
+      , "    -- pragma translate_on"
+      , "    ))"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] >= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -321,11 +328,12 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "quot# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "template"  :
-"~RESULT <= ~ARG[1] / ~ARG[2]
-    -- pragma translate_off
-    when (~ARG[2] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[1] / ~ARG[2]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
@@ -128,11 +128,12 @@
     , "kind"      : "Declaration"
     , "type"      : "rem# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBoxHaskell" :
@@ -174,24 +175,25 @@
     , "kind"      : "Declaration"
     , "type"      : "shiftL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][2]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_left(~ARG[1],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[2] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][2]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_left(~ARG[1],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[2] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -199,24 +201,25 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "shiftR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][2]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_right(~ARG[1],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[2] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][2](~SIZE[~TYP[2]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][2]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_right(~ARG[1],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[2] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -224,15 +227,16 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~RESULT <= rotate_left(~ARG[1],to_integer((~ARG[2])
-    -- pragma translate_off
-    mod ~SIZE[~TYP[1]]
-    -- pragma translate_on
-    ))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= rotate_left(~ARG[1],to_integer((~ARG[2])"
+      , "    -- pragma translate_off"
+      , "    mod ~SIZE[~TYP[1]]"
+      , "    -- pragma translate_on"
+      , "    ))"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] >= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -240,15 +244,16 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "template"  :
-"~RESULT <= rotate_right(~ARG[1],to_integer((~ARG[2])
-    -- pragma translate_off
-    mod ~SIZE[~TYP[1]]
-    -- pragma translate_on
-    ))
-    -- pragma translate_off
-    when (~ARG[2] >= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= rotate_right(~ARG[1],to_integer((~ARG[2])"
+      , "    -- pragma translate_off"
+      , "    mod ~SIZE[~TYP[1]]"
+      , "    -- pragma translate_on"
+      , "    ))"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[2] >= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -264,11 +269,12 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "quot# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "template"  :
-"~RESULT <= ~ARG[0] / ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] / ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives
@@ -35,18 +35,20 @@
     , "workInfo"  : "Never"
     , "kind" : "Declaration"
     , "type" :
-"select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
-        => SNat f                        -- ARG[1]
-        -> SNat s                        -- ARG[2]
-        -> SNat n                        -- ARG[3]
-        -> Vec i a                       -- ARG[4]
-        -> Vec n a"
+      [ "select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]"
+      , "        => SNat f                        -- ARG[1]"
+      , "        -> SNat s                        -- ARG[2]"
+      , "        -> SNat n                        -- ARG[3]"
+      , "        -> Vec i a                       -- ARG[4]"
+      , "        -> Vec n a"
+      ]
     , "template" :
-"-- select begin
-~GENSYM[select][0] : for ~GENSYM[i][1] in ~RESULT'range generate
-  ~RESULT(~SYM[1]) <= ~VAR[vec][4](~LIT[1]+(~LIT[2]*~SYM[1]));
-end generate;
--- select end"
+      [ "-- select begin"
+      , "~GENSYM[select][0] : for ~GENSYM[i][1] in ~RESULT'range generate"
+      , "  ~RESULT(~SYM[1]) <= ~VAR[vec][4](~LIT[1]+(~LIT[2]*~SYM[1]));"
+      , "end generate;"
+      , "-- select end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -63,13 +65,14 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "template"  :
-"-- concat begin
-~GENSYM[concat][0] : for ~GENSYM[i][1] in 0 to (~LENGTH[~TYP[0]] - 1) generate
-begin~IF ~VIVADO ~THEN
-~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= fromSLV(~VAR[vec][0](~SYM[1]));~ELSE
-~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~VAR[vec][0](~SYM[1]);~FI
-end generate;
--- concat end"
+      [ "-- concat begin"
+      , "~GENSYM[concat][0] : for ~GENSYM[i][1] in 0 to (~LENGTH[~TYP[0]] - 1) generate"
+      , "begin~IF ~VIVADO ~THEN"
+      , "~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= fromSLV(~VAR[vec][0](~SYM[1]));~ELSE"
+      , "~RESULT(~SYM[1] * ~LENGTH[~TYPEL[~TYP[0]]] to ((~SYM[1]+1) * ~LENGTH[~TYPEL[~TYP[0]]]) - 1) <= ~VAR[vec][0](~SYM[1]);~FI"
+      , "end generate;"
+      , "-- concat end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -85,18 +88,20 @@ end generate;
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"unconcat :: KnownNat n     -- ARG[0]
-          => SNat m         -- ARG[1]
-          -> Vec (n * m) a  -- ARG[2]
-          -> Vec n (Vec m a)"
+      [ "unconcat :: KnownNat n     -- ARG[0]"
+      , "          => SNat m         -- ARG[1]"
+      , "          -> Vec (n * m) a  -- ARG[2]"
+      , "          -> Vec n (Vec m a)"
+      ]
     , "template" :
-"-- unconcat begin~DEVNULL[~ARG[0]]
-~GENSYM[unconcat][0] : for ~GENSYM[i][2] in ~RESULT'range generate
-begin~IF ~VIVADO ~THEN
-  ~RESULT(~SYM[2]) <= ~TOBV[~VAR[vec][2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];~ELSE
-  ~RESULT(~SYM[2]) <= ~VAR[vec][2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1));~FI
-end generate;
--- unconcat end"
+      [ "-- unconcat begin~DEVNULL[~ARG[0]]"
+      , "~GENSYM[unconcat][0] : for ~GENSYM[i][2] in ~RESULT'range generate"
+      , "begin~IF ~VIVADO ~THEN"
+      , "  ~RESULT(~SYM[2]) <= ~TOBV[~VAR[vec][2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1))][~TYPEL[~TYPO]];~ELSE"
+      , "  ~RESULT(~SYM[2]) <= ~VAR[vec][2]((~SYM[2] * ~LIT[1]) to ((~SYM[2] * ~LIT[1]) + ~LIT[1] - 1));~FI"
+      , "end generate;"
+      , "-- unconcat end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -105,25 +110,26 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "template"  :
-"-- map begin
-~GENSYM[map][0] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[1]]~THEN
-  signal ~GENSYM[map_in][2]  : ~TYPEL[~TYP[1]];~ELSE ~FI
-  signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];
-begin~IF~SIZE[~TYP[1]]~THEN
-  ~SYM[2] <= fromSLV(~VAR[vec][1](~SYM[1]));~ELSE ~FI
-  ~INST 0
-    ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
-  ~INST
-  ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
-end generate;~ELSE
-begin
-  ~INST 0
-    ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~VAR[vec][1](~SYM[1])~ ~TYPEL[~TYP[1]]~
-  ~INST
-end generate;~FI
--- map end"
+      [ "-- map begin"
+      , "~GENSYM[map][0] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[1]]~THEN"
+      , "  signal ~GENSYM[map_in][2]  : ~TYPEL[~TYP[1]];~ELSE ~FI"
+      , "  signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];"
+      , "begin~IF~SIZE[~TYP[1]]~THEN"
+      , "  ~SYM[2] <= fromSLV(~VAR[vec][1](~SYM[1]));~ELSE ~FI"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~"
+      , "  ~INST"
+      , "  ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];"
+      , "end generate;~ELSE"
+      , "begin"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~VAR[vec][1](~SYM[1])~ ~TYPEL[~TYP[1]]~"
+      , "  ~INST"
+      , "end generate;~FI"
+      , "-- map end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -132,36 +138,37 @@ end generate;~FI
     , "kind"      : "Declaration"
     , "type"      : "imap :: KnownNat n => (Index n -> a -> b) -> Vec n a -> Vec n b"
     , "template"  :
-"-- imap begin
-~GENSYM[imap][0] : block
-  function ~GENSYM[max][6] (l,r : in natural) return natural is
-  begin
-    if l > r then return l;
-    else return r;
-    end if;
-  end function;
-begin
-  ~GENSYM[imap][5] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN
-    signal ~GENSYM[map_in][2]  : ~TYPEL[~TYP[2]];~ELSE ~FI
-    signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];
-  begin~IF~SIZE[~TYP[2]]~THEN
-    ~SYM[2] <= fromSLV(~VAR[vec][2](~SYM[1]));~ELSE ~FI
-    ~INST 1
-      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
-      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
-      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[2]]~
-    ~INST
-    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
-  end generate;~ELSE
-  begin
-    ~INST 1
-      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~
-      ~INPUT  <= ~VAR[vec][2](~SYM[1])~ ~TYPEL[~TYP[2]]~
-    ~INST
-  end generate;~FI
-end block;
--- imap end"
+      [ "-- imap begin"
+      , "~GENSYM[imap][0] : block"
+      , "  function ~GENSYM[max][6] (l,r : in natural) return natural is"
+      , "  begin"
+      , "    if l > r then return l;"
+      , "    else return r;"
+      , "    end if;"
+      , "  end function;"
+      , "begin"
+      , "  ~GENSYM[imap][5] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN"
+      , "    signal ~GENSYM[map_in][2]  : ~TYPEL[~TYP[2]];~ELSE ~FI"
+      , "    signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];"
+      , "  begin~IF~SIZE[~TYP[2]]~THEN"
+      , "    ~SYM[2] <= fromSLV(~VAR[vec][2](~SYM[1]));~ELSE ~FI"
+      , "    ~INST 1"
+      , "      ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~"
+      , "      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~"
+      , "      ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[2]]~"
+      , "    ~INST"
+      , "    ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];"
+      , "  end generate;~ELSE"
+      , "  begin"
+      , "    ~INST 1"
+      , "      ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~"
+      , "      ~INPUT  <= to_unsigned(~SYM[1],~SYM[6](1,integer(ceil(log2(real(~LIT[0]))))))~ ~INDEXTYPE[~LIT[0]]~"
+      , "      ~INPUT  <= ~VAR[vec][2](~SYM[1])~ ~TYPEL[~TYP[2]]~"
+      , "    ~INST"
+      , "  end generate;~FI"
+      , "end block;"
+      , "-- imap end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -170,31 +177,32 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "imap_go :: Index n -> (Index n -> a -> b) -> Vec m a -> Vec m b"
     , "template"  :
-"-- imap_go begin
-~GENSYM[imap][5] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN
-  signal ~GENSYM[map_in][2]  : ~TYPEL[~TYP[2]];~ELSE ~FI
-  signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];
-  signal ~GENSYM[i2][4]      : ~TYP[0];
-begin~IF~SIZE[~TYP[2]]~THEN
-  ~SYM[2] <= fromSLV(~VAR[vec][2](~SYM[1]));~ELSE ~FI
-  ~SYM[4] <= ~ARG[0] + to_unsigned(~SYM[1],~SIZE[~TYP[0]]);
-  ~INST 1
-    ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[4]~ ~TYP[0]~
-    ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[2]]~
-  ~INST
-  ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
-end generate;~ELSE
-  signal ~SYM[4] : ~TYP[0];
-begin
-  ~SYM[4] <= ~ARG[0] + to_unsigned(~SYM[1],~SIZE[~TYP[0]]);
-  ~INST 1
-    ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[4]~ ~TYP[0]~
-    ~INPUT  <= ~VAR[vec][2](~SYM[1])~ ~TYPEL[~TYP[2]]~
-  ~INST
-end generate;~FI
--- imap_go end"
+      [ "-- imap_go begin"
+      , "~GENSYM[imap][5] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN"
+      , "  signal ~GENSYM[map_in][2]  : ~TYPEL[~TYP[2]];~ELSE ~FI"
+      , "  signal ~GENSYM[map_out][3] : ~TYPEL[~TYPO];"
+      , "  signal ~GENSYM[i2][4]      : ~TYP[0];"
+      , "begin~IF~SIZE[~TYP[2]]~THEN"
+      , "  ~SYM[2] <= fromSLV(~VAR[vec][2](~SYM[1]));~ELSE ~FI"
+      , "  ~SYM[4] <= ~ARG[0] + to_unsigned(~SYM[1],~SIZE[~TYP[0]]);"
+      , "  ~INST 1"
+      , "    ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[4]~ ~TYP[0]~"
+      , "    ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "  ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];"
+      , "end generate;~ELSE"
+      , "  signal ~SYM[4] : ~TYP[0];"
+      , "begin"
+      , "  ~SYM[4] <= ~ARG[0] + to_unsigned(~SYM[1],~SIZE[~TYP[0]]);"
+      , "  ~INST 1"
+      , "    ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[4]~ ~TYP[0]~"
+      , "    ~INPUT  <= ~VAR[vec][2](~SYM[1])~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "end generate;~FI"
+      , "-- imap_go end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -203,29 +211,30 @@ end generate;~FI
     , "kind"      : "Declaration"
     , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "template"  :
-"-- zipWith begin
-~GENSYM[zipWith][0] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[1]]~THEN
-  signal ~GENSYM[zipWith_in1][2] : ~TYPEL[~TYP[1]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN
-  signal ~GENSYM[zipWith_in2][6] : ~TYPEL[~TYP[2]];~ELSE ~FI
-  signal ~GENSYM[zipWith_out][3] : ~TYPEL[~TYPO];
-begin~IF~SIZE[~TYP[1]]~THEN
-  ~SYM[2] <= fromSLV(~VAR[vec1][1](~SYM[1]));~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN
-  ~SYM[6] <= fromSLV(~VAR[vec2][2](~SYM[1]));~ELSE ~FI
-  ~INST 0
-    ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~
-    ~INPUT  <= ~SYM[6]~ ~TYPEL[~TYP[2]]~
-  ~INST
-  ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];
-end generate;~ELSE
-begin
-  ~INST 0
-    ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~
-    ~INPUT  <= ~VAR[vec1][1](~SYM[1])~ ~TYPEL[~TYP[1]]~
-    ~INPUT  <= ~VAR[vec2][2](~SYM[1])~ ~TYPEL[~TYP[2]]~
-  ~INST
-end generate;~FI
--- zipWith end"
+      [ "-- zipWith begin"
+      , "~GENSYM[zipWith][0] : for ~GENSYM[i][1] in ~RESULT'range generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[1]]~THEN"
+      , "  signal ~GENSYM[zipWith_in1][2] : ~TYPEL[~TYP[1]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN"
+      , "  signal ~GENSYM[zipWith_in2][6] : ~TYPEL[~TYP[2]];~ELSE ~FI"
+      , "  signal ~GENSYM[zipWith_out][3] : ~TYPEL[~TYPO];"
+      , "begin~IF~SIZE[~TYP[1]]~THEN"
+      , "  ~SYM[2] <= fromSLV(~VAR[vec1][1](~SYM[1]));~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN"
+      , "  ~SYM[6] <= fromSLV(~VAR[vec2][2](~SYM[1]));~ELSE ~FI"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~SYM[3]~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~SYM[2]~ ~TYPEL[~TYP[1]]~"
+      , "    ~INPUT  <= ~SYM[6]~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "  ~RESULT(~SYM[1]) <= ~TOBV[~SYM[3]][~TYPEL[~TYPO]];"
+      , "end generate;~ELSE"
+      , "begin"
+      , "  ~INST 0"
+      , "    ~OUTPUT <= ~RESULT(~SYM[1])~ ~TYPEL[~TYPO]~"
+      , "    ~INPUT  <= ~VAR[vec1][1](~SYM[1])~ ~TYPEL[~TYP[1]]~"
+      , "    ~INPUT  <= ~VAR[vec2][2](~SYM[1])~ ~TYPEL[~TYP[2]]~"
+      , "  ~INST"
+      , "end generate;~FI"
+      , "-- zipWith end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -234,35 +243,36 @@ end generate;~FI
     , "kind"      : "Declaration"
     , "type"      : "foldr :: (a -> b -> b) -> b -> Vec n a -> b"
     , "template"  :
-"-- foldr begin~IF ~LENGTH[~TYP[2]] ~THEN
-~GENSYM[foldr][0] : block
-  type ~GENSYM[foldr_res_type][1] is array (natural range <>) of ~TYP[1];
-  signal ~GENSYM[intermediate][2] : ~SYM[1] (0 to ~LENGTH[~TYP[2]]);
-begin
-  ~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];
-
-  foldr_loop : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[2]] - 1) generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN
-    signal ~GENSYM[foldr_in][4] : ~TYPEL[~TYP[2]];~ELSE ~FI
-  begin~IF~SIZE[~TYP[2]]~THEN
-    ~SYM[4] <= fromSLV(~VAR[vec][2](~SYM[3]));~ELSE ~FI
-    ~INST 0
-      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
-      ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
-      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
-    ~INST
-  end generate;~ELSE
-  begin
-    ~INST 0
-      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~
-      ~INPUT  <= ~VAR[vec][2](~SYM[3])~ ~TYPEL[~TYP[2]]~
-      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~
-    ~INST
-  end generate;~FI
-
-  ~RESULT <= ~SYM[2](0);
-end block;~ELSE
-~RESULT <= ~ARG[1];~FI
--- foldr end"
+      [ "-- foldr begin~IF ~LENGTH[~TYP[2]] ~THEN"
+      , "~GENSYM[foldr][0] : block"
+      , "  type ~GENSYM[foldr_res_type][1] is array (natural range <>) of ~TYP[1];"
+      , "  signal ~GENSYM[intermediate][2] : ~SYM[1] (0 to ~LENGTH[~TYP[2]]);"
+      , "begin"
+      , "  ~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];"
+      , ""
+      , "  foldr_loop : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[2]] - 1) generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN"
+      , "    signal ~GENSYM[foldr_in][4] : ~TYPEL[~TYP[2]];~ELSE ~FI"
+      , "  begin~IF~SIZE[~TYP[2]]~THEN"
+      , "    ~SYM[4] <= fromSLV(~VAR[vec][2](~SYM[3]));~ELSE ~FI"
+      , "    ~INST 0"
+      , "      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~"
+      , "      ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~"
+      , "      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~"
+      , "    ~INST"
+      , "  end generate;~ELSE"
+      , "  begin"
+      , "    ~INST 0"
+      , "      ~OUTPUT <= ~SYM[2](~SYM[3])~ ~TYP[1]~"
+      , "      ~INPUT  <= ~VAR[vec][2](~SYM[3])~ ~TYPEL[~TYP[2]]~"
+      , "      ~INPUT  <= ~SYM[2](~SYM[3]+1)~ ~TYP[1]~"
+      , "    ~INST"
+      , "  end generate;~FI"
+      , ""
+      , "  ~RESULT <= ~SYM[2](0);"
+      , "end block;~ELSE"
+      , "~RESULT <= ~ARG[1];~FI"
+      , "-- foldr end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -270,19 +280,20 @@ end block;~ELSE
     , "kind"      : "Declaration"
     , "type"      : "index_int :: KnownNat n => Vec n a -> Int -> a"
     , "template"  :
-"-- index begin
-~IF~SIZE[~TYP[1]]~THEN~GENSYM[indexVec][0] : block
-  signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
-begin
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~LIT[0]
-  -- pragma translate_on
-               ;~IF ~VIVADO ~THEN
-  ~RESULT <= fromSLV(~VAR[vec][1](~SYM[1]));~ELSE
-  ~RESULT <= ~VAR[vec][1](~SYM[1]);~FI
-end block;~ELSE~RESULT <= ~ERRORO;~FI
--- index end"
+      [ "-- index begin"
+      , "~IF~SIZE[~TYP[1]]~THEN~GENSYM[indexVec][0] : block"
+      , "  signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;"
+      , "begin"
+      , "  ~SYM[1] <= to_integer(~ARG[2])"
+      , "  -- pragma translate_off"
+      , "               mod ~LIT[0]"
+      , "  -- pragma translate_on"
+      , "               ;~IF ~VIVADO ~THEN"
+      , "  ~RESULT <= fromSLV(~VAR[vec][1](~SYM[1]));~ELSE"
+      , "  ~RESULT <= ~VAR[vec][1](~SYM[1]);~FI"
+      , "end block;~ELSE~RESULT <= ~ERRORO;~FI"
+      , "-- index end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -290,26 +301,27 @@ end block;~ELSE~RESULT <= ~ERRORO;~FI
     , "kind"      : "Declaration"
     , "type"      : "replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a"
     , "template"  :
-"-- replace begin
-~GENSYM[replaceVec][0] : block
-  signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;
-begin
-  ~SYM[1] <= to_integer(~ARG[2])
-  -- pragma translate_off
-               mod ~LIT[0]
-  -- pragma translate_on
-               ;
-
-  process(~SYM[1]~VARS[1]~VARS[3])
-    variable ~GENSYM[ivec][2] : ~TYP[1];
-  begin
-    ~SYM[2] := ~ARG[1];~IF ~VIVADO ~THEN
-    ~SYM[2](~SYM[1]) := ~TOBV[~ARG[3]][~TYP[3]];~ELSE
-    ~SYM[2](~SYM[1]) := ~ARG[3];~FI
-    ~RESULT <= ~SYM[2];
-  end process;
-end block;
--- replace end"
+      [ "-- replace begin"
+      , "~GENSYM[replaceVec][0] : block"
+      , "  signal ~GENSYM[vec_index][1] : integer range 0 to ~LIT[0]-1;"
+      , "begin"
+      , "  ~SYM[1] <= to_integer(~ARG[2])"
+      , "  -- pragma translate_off"
+      , "               mod ~LIT[0]"
+      , "  -- pragma translate_on"
+      , "               ;"
+      , ""
+      , "  process(~SYM[1]~VARS[1]~VARS[3])"
+      , "    variable ~GENSYM[ivec][2] : ~TYP[1];"
+      , "  begin"
+      , "    ~SYM[2] := ~ARG[1];~IF ~VIVADO ~THEN"
+      , "    ~SYM[2](~SYM[1]) := ~TOBV[~ARG[3]][~TYP[3]];~ELSE"
+      , "    ~SYM[2](~SYM[1]) := ~ARG[3];~FI"
+      , "    ~RESULT <= ~SYM[2];"
+      , "  end process;"
+      , "end block;"
+      , "-- replace end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -342,14 +354,15 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)"
     , "template"  :
-"-- transpose begin
-~GENSYM[transpose_outer][2] : for ~GENSYM[row_index][3] in 0 to (~LENGTH[~TYP[1]] - 1) generate
-  ~GENSYM[transpose_inner][4] : for ~GENSYM[col_index][5] in ~RESULT'range generate~IF ~VIVADO ~THEN
-    ~RESULT(~SYM[5])((~LENGTH[~TYP[1]]-~SYM[3])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~LENGTH[~TYP[1]]-~SYM[3]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]) <= ~VAR[vec][1](~SYM[3])((~RESULT'length-~SYM[5])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~RESULT'length-~SYM[5]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]);~ELSE
-    ~RESULT(~SYM[5])(~SYM[3]) <= ~VAR[matrix][1](~SYM[3])(~SYM[5]);~FI
-  end generate;
-end generate;
--- transpose end"
+      [ "-- transpose begin"
+      , "~GENSYM[transpose_outer][2] : for ~GENSYM[row_index][3] in 0 to (~LENGTH[~TYP[1]] - 1) generate"
+      , "  ~GENSYM[transpose_inner][4] : for ~GENSYM[col_index][5] in ~RESULT'range generate~IF ~VIVADO ~THEN"
+      , "    ~RESULT(~SYM[5])((~LENGTH[~TYP[1]]-~SYM[3])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~LENGTH[~TYP[1]]-~SYM[3]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]) <= ~VAR[vec][1](~SYM[3])((~RESULT'length-~SYM[5])*~SIZE[~TYPEL[~TYPEL[~TYPO]]]-1 downto (~RESULT'length-~SYM[5]-1)*~SIZE[~TYPEL[~TYPEL[~TYPO]]]);~ELSE"
+      , "    ~RESULT(~SYM[5])(~SYM[3]) <= ~VAR[matrix][1](~SYM[3])(~SYM[5]);~FI"
+      , "  end generate;"
+      , "end generate;"
+      , "-- transpose end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -358,11 +371,12 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "reverse :: Vec n a -> Vec n a"
     , "template"  :
-"-- reverse begin
-~GENSYM[reverse_loop][2] : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[0]] - 1) generate
-  ~RESULT(~VAR[vec][0]'high - ~SYM[3]) <= ~VAR[vec][0](~SYM[3]);
-end generate;
--- reverse end"
+      [ "-- reverse begin"
+      , "~GENSYM[reverse_loop][2] : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[0]] - 1) generate"
+      , "  ~RESULT(~VAR[vec][0]'high - ~SYM[3]) <= ~VAR[vec][0](~SYM[3]);"
+      , "end generate;"
+      , "-- reverse end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -370,15 +384,17 @@ end generate;
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"concatBitVector# :: (KnownNat n,KnownNat m) -- (ARG[0],ARG[1])
-                  => Vec n (BitVector m)     -- ARG[2]
-                  -> BitVector (n * m)"
+      [ "concatBitVector# :: (KnownNat n,KnownNat m) -- (ARG[0],ARG[1])"
+      , "                  => Vec n (BitVector m)     -- ARG[2]"
+      , "                  -> BitVector (n * m)"
+      ]
     , "template" :
-"-- concatBitVector begin
-~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[2]] - 1) generate
-  ~RESULT(((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1])) <= ~TYPMO'(~VAR[vec][2](~VAR[vec][2]'high - ~SYM[3]));
-end generate;
--- concatBitVector end"
+      [ "-- concatBitVector begin"
+      , "~GENSYM[concatBitVectorIter_loop][2] : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[2]] - 1) generate"
+      , "  ~RESULT(((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1])) <= ~TYPMO'(~VAR[vec][2](~VAR[vec][2]'high - ~SYM[3]));"
+      , "end generate;"
+      , "-- concatBitVector end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -386,15 +402,17 @@ end generate;
     , "workInfo" : "Never"
     , "kind" : "Declaration"
     , "type" :
-"unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
-                    => BitVector (n * m)        -- ARG[2]
-                    -> Vec n (BitVector m)"
+      [ "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])"
+      , "                    => BitVector (n * m)        -- ARG[2]"
+      , "                    -> Vec n (BitVector m)"
+      ]
     , "template" :
-"-- unconcatBitVector begin
-~GENSYM[unconcatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~RESULT'range generate
-  ~RESULT(~RESULT'high - ~SYM[3]) <= ~VAR[vec][2](((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1]));
-end generate;
--- unconcatBitVector end"
+      [ "-- unconcatBitVector begin"
+      , "~GENSYM[unconcatBitVectorIter_loop][2] : for ~GENSYM[i][3] in ~RESULT'range generate"
+      , "  ~RESULT(~RESULT'high - ~SYM[3]) <= ~VAR[vec][2](((~SYM[3] * ~LIT[1]) + ~LIT[1] - 1) downto (~SYM[3] * ~LIT[1]));"
+      , "end generate;"
+      , "-- unconcatBitVector end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -403,20 +421,21 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "rotateLeftS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
-"-- rotateLeftS begin
-~GENSYM[rotateLeftS][0] : block
-  constant ~GENSYM[shift_amount][2] : natural := ~LIT[2] mod ~LIT[0];
-begin
-  ~GENSYM[no_shift][3] : if ~SYM[2] = 0 generate
-    ~RESULT <= ~VAR[vec][1];
-  end generate;
-
-  ~GENSYM[do_shift][4] : if ~SYM[2] /= 0 generate
-    ~RESULT <= ~VAR[vec][1](~SYM[2] to ~LIT[0]-1) &
-               ~VAR[vec][1](0 to ~SYM[2]-1);
-  end generate;
-end block;
--- rotateLeftS end"
+      [ "-- rotateLeftS begin"
+      , "~GENSYM[rotateLeftS][0] : block"
+      , "  constant ~GENSYM[shift_amount][2] : natural := ~LIT[2] mod ~LIT[0];"
+      , "begin"
+      , "  ~GENSYM[no_shift][3] : if ~SYM[2] = 0 generate"
+      , "    ~RESULT <= ~VAR[vec][1];"
+      , "  end generate;"
+      , ""
+      , "  ~GENSYM[do_shift][4] : if ~SYM[2] /= 0 generate"
+      , "    ~RESULT <= ~VAR[vec][1](~SYM[2] to ~LIT[0]-1) &"
+      , "               ~VAR[vec][1](0 to ~SYM[2]-1);"
+      , "  end generate;"
+      , "end block;"
+      , "-- rotateLeftS end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -425,20 +444,21 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "rotateRightS :: KnownNat n => Vec n a -> SNat d -> Vec n a"
     , "template"  :
-"-- rotateRightS begin
-~GENSYM[rotateLeftS][0] : block
-  constant ~GENSYM[shift_amount][2] : natural := ~LIT[2] mod ~LIT[0];
-begin
-  ~GENSYM[no_shift][3] : if ~SYM[2] = 0 generate
-    ~RESULT <= ~VAR[vec][1];
-  end generate;
-
-  ~GENSYM[do_shift][4] : if ~SYM[2] /= 0 generate
-    ~RESULT <= ~VAR[vec][1](~LIT[0]-~SYM[2] to ~LIT[0]-1) &
-               ~VAR[vec][1](0 to ~LIT[0]-~SYM[2]-1);
-  end generate;
-end block;
--- rotateRightS end"
+      [ "-- rotateRightS begin"
+      , "~GENSYM[rotateLeftS][0] : block"
+      , "  constant ~GENSYM[shift_amount][2] : natural := ~LIT[2] mod ~LIT[0];"
+      , "begin"
+      , "  ~GENSYM[no_shift][3] : if ~SYM[2] = 0 generate"
+      , "    ~RESULT <= ~VAR[vec][1];"
+      , "  end generate;"
+      , ""
+      , "  ~GENSYM[do_shift][4] : if ~SYM[2] /= 0 generate"
+      , "    ~RESULT <= ~VAR[vec][1](~LIT[0]-~SYM[2] to ~LIT[0]-1) &"
+      , "               ~VAR[vec][1](0 to ~LIT[0]-~SYM[2]-1);"
+      , "  end generate;"
+      , "end block;"
+      , "-- rotateRightS end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Xilinx_ClockGen.primitives
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_ClockGen.primitives
@@ -3,32 +3,34 @@
     , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "type"      :
-"clockWizard
-  :: ( KnownDomain domIn confIn       -- ARG[0]
-     , KnownDomain domOut confOut )   -- ARG[1]
-  => SSymbol name                    -- ARG[2]
-  -> Clock  pllIn                    -- ARG[3]
-  -> Reset pllIn                     -- ARG[4]
-  -> (Clock pllOut, Enable pllOut)"
+      [ "clockWizard"
+      , "  :: ( KnownDomain domIn confIn       -- ARG[0]"
+      , "     , KnownDomain domOut confOut )   -- ARG[1]"
+      , "  => SSymbol name                    -- ARG[2]"
+      , "  -> Clock  pllIn                    -- ARG[3]"
+      , "  -> Reset pllIn                     -- ARG[4]"
+      , "  -> (Clock pllOut, Enable pllOut)"
+      ]
     , "template" :
-"-- clockWizard begin
-~GENSYM[clockWizard][0] : block
-  signal ~GENSYM[pllOut][1]  : std_logic;
-  signal ~GENSYM[locked][2]  : std_logic;
-  signal ~GENSYM[pllLock][3] : boolean;
-
-  component ~NAME[2]
-    port (CLK_IN1  : in std_logic;
-          RESET    : in std_logic;
-          CLK_OUT1 : out std_logic;
-          LOCKED   : out std_logic);
-  end component;
-begin
-  ~GENSYM[clockWizard_inst][4] : component ~NAME[2] port map (~ARG[3],~IF ~ISACTIVEHIGH[0] ~THEN ~ARG[4] ~ELSE NOT(~ARG[4]) ~FI,~SYM[1],~SYM[2]);
-  ~SYM[3] <= true when ~SYM[2] = '1' else false;
-  ~RESULT <= (~SYM[1],~SYM[3]);
-end block;
--- clockWizard end"
+      [ "-- clockWizard begin"
+      , "~GENSYM[clockWizard][0] : block"
+      , "  signal ~GENSYM[pllOut][1]  : std_logic;"
+      , "  signal ~GENSYM[locked][2]  : std_logic;"
+      , "  signal ~GENSYM[pllLock][3] : boolean;"
+      , ""
+      , "  component ~NAME[2]"
+      , "    port (CLK_IN1  : in std_logic;"
+      , "          RESET    : in std_logic;"
+      , "          CLK_OUT1 : out std_logic;"
+      , "          LOCKED   : out std_logic);"
+      , "  end component;"
+      , "begin"
+      , "  ~GENSYM[clockWizard_inst][4] : component ~NAME[2] port map (~ARG[3],~IF ~ISACTIVEHIGH[0] ~THEN ~ARG[4] ~ELSE NOT(~ARG[4]) ~FI,~SYM[1],~SYM[2]);"
+      , "  ~SYM[3] <= true when ~SYM[2] = '1' else false;"
+      , "  ~RESULT <= (~SYM[1],~SYM[3]);"
+      , "end block;"
+      , "-- clockWizard end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -36,35 +38,37 @@ end block;
     , "workInfo"  : "Always"
     , "kind"      : "Declaration"
     , "type"      :
-"clockWizardDifferential
-  :: ( KnownDomain domIn confIn       -- ARG[0]
-     , KnownDomain domOut confOut )   -- ARG[1]
-  => SSymbol name                    -- ARG[2]
-  -> Clock pllIn                     -- ARG[3]
-  -> Clock pllIn                     -- ARG[4]
-  -> Reset pllIn                     -- ARG[5]
-  -> (Clock pllOut, Enable pllOut)"
+      [ "clockWizardDifferential"
+      , "  :: ( KnownDomain domIn confIn       -- ARG[0]"
+      , "     , KnownDomain domOut confOut )   -- ARG[1]"
+      , "  => SSymbol name                    -- ARG[2]"
+      , "  -> Clock pllIn                     -- ARG[3]"
+      , "  -> Clock pllIn                     -- ARG[4]"
+      , "  -> Reset pllIn                     -- ARG[5]"
+      , "  -> (Clock pllOut, Enable pllOut)"
+      ]
     , "template" :
-"-- clockWizardDifferential begin
-~GENSYM[clockWizardDifferential][0] : block
-  signal ~GENSYM[pllOut][1]  : std_logic;
-  signal ~GENSYM[locked][2]  : std_logic;
-  signal ~GENSYM[pllLock][3] : boolean;
-
-  component ~NAME[2]
-    port (CLK_IN1_D_clk_n : in std_logic;
-          CLK_IN1_D_clk_p : in std_logic;
-          RESET           : in std_logic;
-          CLK_OUT1        : out std_logic;
-          LOCKED          : out std_logic);
-  end component;
-begin
-  ~GENSYM[clockWizardDifferential_inst][4] : component ~NAME[2]
-    port map (~ARG[3],~ARG[4],~IF ~ISACTIVEHIGH[0] ~THEN ~ARG[5] ~ELSE NOT(~ARG[5]) ~FI,~SYM[1],~SYM[2]);
-  ~SYM[3] <= true when ~SYM[2] = '1' else false;
-  ~RESULT <= (~SYM[1],~SYM[3]);
-end block;
--- clockWizardDifferential end"
+      [ "-- clockWizardDifferential begin"
+      , "~GENSYM[clockWizardDifferential][0] : block"
+      , "  signal ~GENSYM[pllOut][1]  : std_logic;"
+      , "  signal ~GENSYM[locked][2]  : std_logic;"
+      , "  signal ~GENSYM[pllLock][3] : boolean;"
+      , ""
+      , "  component ~NAME[2]"
+      , "    port (CLK_IN1_D_clk_n : in std_logic;"
+      , "          CLK_IN1_D_clk_p : in std_logic;"
+      , "          RESET           : in std_logic;"
+      , "          CLK_OUT1        : out std_logic;"
+      , "          LOCKED          : out std_logic);"
+      , "  end component;"
+      , "begin"
+      , "  ~GENSYM[clockWizardDifferential_inst][4] : component ~NAME[2]"
+      , "    port map (~ARG[3],~ARG[4],~IF ~ISACTIVEHIGH[0] ~THEN ~ARG[5] ~ELSE NOT(~ARG[5]) ~FI,~SYM[1],~SYM[2]);"
+      , "  ~SYM[3] <= true when ~SYM[2] = '1' else false;"
+      , "  ~RESULT <= (~SYM[1],~SYM[3]);"
+      , "end block;"
+      , "-- clockWizardDifferential end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives
@@ -2,102 +2,106 @@
     { "name" : "Clash.Xilinx.DDR.iddr"
     , "kind" : "Declaration"
     , "type" :
-"iddr
-  :: ( HasCallStack             -- ARG[0]
-     , KnownConfi~ fast domf    -- ARG[1]
-     , KnownConfi~ slow doms    -- ARG[2]
-     , KnownNat m )             -- ARG[3]
-  -> Clock slow                 -- ARG[4]
-  -> Reset slow                 -- ARG[5]
-  -> Enable slow                -- ARG[6]
-  -> Signal fast (BitVector m)  -- ARG[7]
-  -> Signal slow (BitVector m,BitVector m)"
+      [ "iddr"
+      , "  :: ( HasCallStack             -- ARG[0]"
+      , "     , KnownConfi~ fast domf    -- ARG[1]"
+      , "     , KnownConfi~ slow doms    -- ARG[2]"
+      , "     , KnownNat m )             -- ARG[3]"
+      , "  -> Clock slow                 -- ARG[4]"
+      , "  -> Reset slow                 -- ARG[5]"
+      , "  -> Enable slow                -- ARG[6]"
+      , "  -> Signal fast (BitVector m)  -- ARG[7]"
+      , "  -> Signal slow (BitVector m,BitVector m)"
+      ]
     , "libraries" : ["UNISIM"]
     , "imports" : ["UNISIM.vcomponents.all"]
     , "template" :
-"-- iddr begin
-~GENSYM[~COMPNAME_IDDR][0] : block
-  signal ~GENSYM[dataout_l][1] : ~TYP[7];
-  signal ~GENSYM[dataout_h][2] : ~TYP[7];
-  signal ~GENSYM[d][3]         : ~TYP[7];~IF ~ISACTIVEENABLE[4] ~THEN
-  signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
-begin~IF ~ISACTIVEENABLE[4] ~THEN
-  ~SYM[4] <= '1' when (~ARG[6]) else '0';~ELSE ~FI
-  ~SYM[3] <= ~ARG[7];
-
-  ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
-  begin
-    ~GENSYM[~COMPNAME_IDDR_inst][9] : IDDR
-    generic map (
-      DDR_CLK_EDGE => \"SAME_EDGE\",
-      INIT_Q1      => '0',
-      INIT_Q2      => '0',
-      SRTYPE       => ~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-    port map (
-      Q1 => ~SYM[1](~SYM[8]),   -- 1-bit output for positive edge of clock
-      Q2 => ~SYM[2](~SYM[8]),   -- 1-bit output for negative edge of clock
-      C  => ~ARG[4],   -- 1-bit clock input
-      CE => ~IF ~ISACTIVEENABLE[6] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
-      D  => ~SYM[3](~SYM[8]),   -- 1-bit DDR data input
-      R  => ~ARG[5],   -- 1-bit reset
-      S  => '0'        -- 1-bit set
-    );
-  end generate;
-
-  ~RESULT <= (~SYM[2], ~SYM[1]);
-end block;
--- iddr# end"
+      [ "-- iddr begin"
+      , "~GENSYM[~COMPNAME_IDDR][0] : block"
+      , "  signal ~GENSYM[dataout_l][1] : ~TYP[7];"
+      , "  signal ~GENSYM[dataout_h][2] : ~TYP[7];"
+      , "  signal ~GENSYM[d][3]         : ~TYP[7];~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "  signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI"
+      , "begin~IF ~ISACTIVEENABLE[4] ~THEN"
+      , "  ~SYM[4] <= '1' when (~ARG[6]) else '0';~ELSE ~FI"
+      , "  ~SYM[3] <= ~ARG[7];"
+      , ""
+      , "  ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate"
+      , "  begin"
+      , "    ~GENSYM[~COMPNAME_IDDR_inst][9] : IDDR"
+      , "    generic map ("
+      , "      DDR_CLK_EDGE => \"SAME_EDGE\","
+      , "      INIT_Q1      => '0',"
+      , "      INIT_Q2      => '0',"
+      , "      SRTYPE       => ~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)"
+      , "    port map ("
+      , "      Q1 => ~SYM[1](~SYM[8]),   -- 1-bit output for positive edge of clock"
+      , "      Q2 => ~SYM[2](~SYM[8]),   -- 1-bit output for negative edge of clock"
+      , "      C  => ~ARG[4],   -- 1-bit clock input"
+      , "      CE => ~IF ~ISACTIVEENABLE[6] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input"
+      , "      D  => ~SYM[3](~SYM[8]),   -- 1-bit DDR data input"
+      , "      R  => ~ARG[5],   -- 1-bit reset"
+      , "      S  => '0'        -- 1-bit set"
+      , "    );"
+      , "  end generate;"
+      , ""
+      , "  ~RESULT <= (~SYM[2], ~SYM[1]);"
+      , "end block;"
+      , "-- iddr# end"
+      ]
     }
   }
 , { "BlackBox" :
     { "name" : "Clash.Xilinx.DDR.oddr#"
     , "kind" : "Declaration"
     , "type" :
-"oddr#
-  :: ( KnownConfi~ fast domf     -- ARG[0]
-     , KnownConfi~ slow doms     -- ARG[1]
-     , KnownNat m )              -- ARG[2]
-  => Clock slow                  -- ARG[3]
-  -> Reset slow                  -- ARG[4]
-  -> Enable slow                 -- ARG[5]
-  -> Signal slow (BitVector m)   -- ARG[6]
-  -> Signal slow (BitVector m)   -- ARG[7]
-  -> Signal fast (BitVector m)"
+      [ "oddr#"
+      , "  :: ( KnownConfi~ fast domf     -- ARG[0]"
+      , "     , KnownConfi~ slow doms     -- ARG[1]"
+      , "     , KnownNat m )              -- ARG[2]"
+      , "  => Clock slow                  -- ARG[3]"
+      , "  -> Reset slow                  -- ARG[4]"
+      , "  -> Enable slow                 -- ARG[5]"
+      , "  -> Signal slow (BitVector m)   -- ARG[6]"
+      , "  -> Signal slow (BitVector m)   -- ARG[7]"
+      , "  -> Signal fast (BitVector m)"
+      ]
     , "libraries" : ["UNISIM"]
     , "imports" : ["UNISIM.vcomponents.all"]
     , "template" :
-"-- oddr begin
-~GENSYM[~COMPNAME_ODDR][0] : block
-  signal ~GENSYM[dataout_l][1] : ~TYPO;
-  signal ~GENSYM[dataout_h][2] : ~TYPO;
-  signal ~GENSYM[q][3]         : ~TYPO;~IF ~ISACTIVEENABLE[5] ~THEN
-  signal ~GENSYM[ce_logic][4]  : std_logic;~ELSE ~FI
-begin~IF ~ISACTIVEENABLE[5] ~THEN
-  ~SYM[4] <= '1' when (~ARG[5]) else '0';~ELSE ~FI
-  ~SYM[1] <= ~ARG[6];
-  ~SYM[2] <= ~ARG[7];
-
-  ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
-  begin
-    ~GENSYM[~COMPNAME_ODDR_inst][9] : ODDR
-    generic map(
-      DDR_CLK_EDGE => \"SAME_EDGE\",
-      INIT => '0',
-      SRTYPE => ~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)
-    port map (
-      Q  => ~SYM[3](~SYM[8]),    -- 1-bit DDR output
-      C  => ~ARG[3],   -- 1-bit clock input
-      CE => ~IF ~ISACTIVEENABLE[5] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
-      D1 => ~SYM[1](~SYM[8]),    -- 1-bit data input (positive edge)
-      D2 => ~SYM[2](~SYM[8]),    -- 1-bit data input (negative edge)
-      R  => ~ARG[4],    -- 1-bit reset input
-      S  => '0'         -- 1-bit set input
-    );
-  end generate;
-
-  ~RESULT <= ~SYM[3];
-end block;
--- oddr end"
+      [ "-- oddr begin"
+      , "~GENSYM[~COMPNAME_ODDR][0] : block"
+      , "  signal ~GENSYM[dataout_l][1] : ~TYPO;"
+      , "  signal ~GENSYM[dataout_h][2] : ~TYPO;"
+      , "  signal ~GENSYM[q][3]         : ~TYPO;~IF ~ISACTIVEENABLE[5] ~THEN"
+      , "  signal ~GENSYM[ce_logic][4]  : std_logic;~ELSE ~FI"
+      , "begin~IF ~ISACTIVEENABLE[5] ~THEN"
+      , "  ~SYM[4] <= '1' when (~ARG[5]) else '0';~ELSE ~FI"
+      , "  ~SYM[1] <= ~ARG[6];"
+      , "  ~SYM[2] <= ~ARG[7];"
+      , ""
+      , "  ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate"
+      , "  begin"
+      , "    ~GENSYM[~COMPNAME_ODDR_inst][9] : ODDR"
+      , "    generic map("
+      , "      DDR_CLK_EDGE => \"SAME_EDGE\","
+      , "      INIT => '0',"
+      , "      SRTYPE => ~IF ~ISSYNC[2] ~THEN \"SYNC\" ~ELSE \"ASYNC\" ~FI)"
+      , "    port map ("
+      , "      Q  => ~SYM[3](~SYM[8]),    -- 1-bit DDR output"
+      , "      C  => ~ARG[3],   -- 1-bit clock input"
+      , "      CE => ~IF ~ISACTIVEENABLE[5] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input"
+      , "      D1 => ~SYM[1](~SYM[8]),    -- 1-bit data input (positive edge)"
+      , "      D2 => ~SYM[2](~SYM[8]),    -- 1-bit data input (negative edge)"
+      , "      R  => ~ARG[4],    -- 1-bit reset input"
+      , "      S  => '0'         -- 1-bit set input"
+      , "    );"
+      , "  end generate;"
+      , ""
+      , "  ~RESULT <= ~SYM[3];"
+      , "end block;"
+      , "-- oddr end"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/GHC_Base.primitives
+++ b/clash-lib/prims/vhdl/GHC_Base.primitives
@@ -3,11 +3,12 @@
     , "kind"      : "Declaration"
     , "type"      : "remInt :: Int -> Int -> Int"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -15,19 +16,20 @@
     , "kind"      : "Declaration"
     , "type"      : "divInt :: Int -> Int -> Int"
     , "template"  :
-"-- divInt begin
-~GENSYM[divInt][0] : block
-  signal ~GENSYM[quot_res][1] : ~TYP[1];
-begin
-  ~SYM[1] <= ~ARG[0] / ~ARG[1]
-      -- pragma translate_off
-      when (ARG[1] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~RESULT <= ~SYM[1] - 1 when ((~ARG[0] = abs ~ARG[0]) /= (~ARG[1] = abs ~ARG[1])) else
-             ~SYM[1];
-end block;
--- divInt end"
+      [ "-- divInt begin"
+      , "~GENSYM[divInt][0] : block"
+      , "  signal ~GENSYM[quot_res][1] : ~TYP[1];"
+      , "begin"
+      , "  ~SYM[1] <= ~ARG[0] / ~ARG[1]"
+      , "      -- pragma translate_off"
+      , "      when (ARG[1] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~RESULT <= ~SYM[1] - 1 when ((~ARG[0] = abs ~ARG[0]) /= (~ARG[1] = abs ~ARG[1])) else"
+      , "             ~SYM[1];"
+      , "end block;"
+      , "-- divInt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -35,11 +37,12 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "modInt :: Int -> Int -> Int"
     , "template"  :
-"~RESULT <= ~ARG[0] mod ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] mod ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -47,11 +50,12 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "quotInt :: Int -> Int -> Int"
     , "template"  :
-"~RESULT <= ~ARG[0] / ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] / ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 ]

--- a/clash-lib/prims/vhdl/GHC_Classes.primitives
+++ b/clash-lib/prims/vhdl/GHC_Classes.primitives
@@ -38,26 +38,27 @@
     , "kind"      : "Declaration"
     , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "template"  :
-"-- divInt# begin
-~GENSYM[divInt][0] : block
-  signal ~GENSYM[resultPos][1] : boolean;
-  signal ~GENSYM[dividerNeg][2] : boolean;
-  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);
-  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);
-begin
-  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
-  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
-  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
-             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
-             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
-      -- pragma translate_off
-      when (~VAR[divider][1] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
-end block;
--- divInt# end"
+      [ "-- divInt# begin"
+      , "~GENSYM[divInt][0] : block"
+      , "  signal ~GENSYM[resultPos][1] : boolean;"
+      , "  signal ~GENSYM[dividerNeg][2] : boolean;"
+      , "  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);"
+      , "  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);"
+      , "begin"
+      , "  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);"
+      , "  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';"
+      , "  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);"
+      , "  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]"
+      , "      -- pragma translate_off"
+      , "      when (~VAR[divider][1] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));"
+      , "end block;"
+      , "-- divInt# end"
+      ]
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.primitives
@@ -45,26 +45,27 @@
     , "kind"      : "Declaration"
     , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "template"   :
-"-- divInteger begin
-~GENSYM[divInteger][0] : block
-  signal ~GENSYM[resultPos][1] : boolean;
-  signal ~GENSYM[dividerNeg][2] : boolean;
-  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);
-  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);
-begin
-  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
-  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
-  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
-             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
-             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
-      -- pragma translate_off
-      when (~VAR[divider][1] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
-end block;
--- divInteger end"
+      [ "-- divInteger begin"
+      , "~GENSYM[divInteger][0] : block"
+      , "  signal ~GENSYM[resultPos][1] : boolean;"
+      , "  signal ~GENSYM[dividerNeg][2] : boolean;"
+      , "  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);"
+      , "  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);"
+      , "begin"
+      , "  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);"
+      , "  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';"
+      , "  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);"
+      , "  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]"
+      , "      -- pragma translate_off"
+      , "      when (~VAR[divider][1] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));"
+      , "end block;"
+      , "-- divInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.divInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -81,34 +82,35 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "divModInteger :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"-- divModInteger begin
-~GENSYM[divModInteger][0] : block
-  signal ~GENSYM[resultPos][1] : boolean;
-  signal ~GENSYM[dividerNeg][2] : boolean;
-  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYP[0]] downto 0);
-  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYP[0]] downto 0);
-  signal ~GENSYM[div_res][5] : signed(~SIZE[~TYP[0]]-1 downto 0);
-  signal ~GENSYM[mod_res][6] : signed(~SIZE[~TYP[0]]-1 downto 0);
-begin
-  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
-  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
-  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1)   when ~SYM[1] else
-             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) - 1)   when ~SYM[2] else
-             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
-      -- pragma translate_off
-      when (~VAR[divider][1] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~SYM[5] <= signed(~SYM[4](~SIZE[~TYP[0]]-1 downto 0));
-  ~SYM[6] <= ~VAR[dividend][0] mod ~VAR[divider][1]
-      -- pragma translate_off
-      when (~VAR[divider][1] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~RESULT <= (~SYM[5], ~SYM[6]);
-end block;
--- divModInteger end"
+      [ "-- divModInteger begin"
+      , "~GENSYM[divModInteger][0] : block"
+      , "  signal ~GENSYM[resultPos][1] : boolean;"
+      , "  signal ~GENSYM[dividerNeg][2] : boolean;"
+      , "  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYP[0]] downto 0);"
+      , "  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYP[0]] downto 0);"
+      , "  signal ~GENSYM[div_res][5] : signed(~SIZE[~TYP[0]]-1 downto 0);"
+      , "  signal ~GENSYM[mod_res][6] : signed(~SIZE[~TYP[0]]-1 downto 0);"
+      , "begin"
+      , "  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);"
+      , "  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';"
+      , "  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1)   when ~SYM[1] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) - 1)   when ~SYM[2] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) + 1);"
+      , "  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]"
+      , "      -- pragma translate_off"
+      , "      when (~VAR[divider][1] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~SYM[5] <= signed(~SYM[4](~SIZE[~TYP[0]]-1 downto 0));"
+      , "  ~SYM[6] <= ~VAR[dividend][0] mod ~VAR[divider][1]"
+      , "      -- pragma translate_off"
+      , "      when (~VAR[divider][1] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~RESULT <= (~SYM[5], ~SYM[6]);"
+      , "end block;"
+      , "-- divModInteger end"
+      ]
     , "warning"   : "GHC.Integer.Type.divModInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -117,11 +119,12 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "quotRemInteger :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     , "warning"   : "GHC.Integer.Type.quotRemInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -130,11 +133,12 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "remInteger :: Integer -> Integer -> Integer"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     , "warning"   : "GHC.Integer.Type.remInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -207,24 +211,25 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "shiftRInteger :: Integer -> Int# -> Integer"
     , "template"  :
-"~GENSYM[~RESULT_shiftR][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_right(~ARG[0],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[1] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftR][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_right(~ARG[0],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[1] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     , "warning"   : "GHC.Integer.Type.shiftRInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -233,24 +238,25 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "shiftLInteger :: Integer -> Int# -> Integer"
     , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_left(~ARG[0],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[1] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_left(~ARG[0],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[1] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     , "warning"   : "GHC.Integer.Type.shiftLInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -334,13 +340,15 @@ end block;"
     { "name"      : "GHC.Integer.Type.$wsignumInteger"
     , "kind"      : "Declaration"
     , "type"      : "$wsignumInteger :: Integer -> Integer"
-    , "template"  : "
--- begin signumInteger
-~RESULT <= to_signed(-1, ~SIZE[~TYPO]) when ~ARG[0] < 0
-  else to_signed(0, ~SIZE[~TYPO])  when ~ARG[0] = 0
-  else to_signed(1, ~SIZE[~TYPO]);
--- end signumInteger
-"
+    , "template"  :
+      [ ""
+      , "-- begin signumInteger"
+      , "~RESULT <= to_signed(-1, ~SIZE[~TYPO]) when ~ARG[0] < 0"
+      , "  else to_signed(0, ~SIZE[~TYPO])  when ~ARG[0] = 0"
+      , "  else to_signed(1, ~SIZE[~TYPO]);"
+      , "-- end signumInteger"
+      , ""
+      ]
     , "warning"   : "GHC.Integer.Type.$wsignumInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -349,11 +357,12 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "quotInteger :: Integer -> Integer -> Integer"
     , "template"  :
-"~RESULT <= ~ARG[0] / ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] / ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     , "warning"   : "GHC.Integer.Type.quotInteger: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }

--- a/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Integer.primitives
@@ -13,10 +13,11 @@
     , "kind": "Declaration"
     , "type": "integerToNaturalThrow :: Integer -> Natural"
     , "template":
-"-- integerToNaturalThrow begin
-~RESULT <= ~ERRORO when ~ARG[0] < ~SIZE[~TYP[0]]'d0 else
-           resize(unsigned(std_logic_vector(~ARG[0])),~SIZE[~TYPO]);
--- integerToNaturalThrow end"
+      [ "-- integerToNaturalThrow begin"
+      , "~RESULT <= ~ERRORO when ~ARG[0] < ~SIZE[~TYP[0]]'d0 else"
+      , "           resize(unsigned(std_logic_vector(~ARG[0])),~SIZE[~TYPO]);"
+      , "-- integerToNaturalThrow end"
+      ]
     , "warning": "GHC.Num.Integer.integerToNaturalThrow: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -26,10 +27,11 @@
     , "kind": "Declaration"
     , "type": "integerToNatural :: Integer -> Natural"
     , "template":
-"-- integerToNaturalClamp begin
-~RESULT <= to_unsigned(0,~SIZE[~TYPO]]) when ~ARG[0] < ~SIZE[~TYP[0]]'d0 else
-           resize(unsigned(std_logic_vector(~ARG[0])),~SIZE[~TYPO]);
--- integerToNaturalClamp end"
+      [ "-- integerToNaturalClamp begin"
+      , "~RESULT <= to_unsigned(0,~SIZE[~TYPO]]) when ~ARG[0] < ~SIZE[~TYP[0]]'d0 else"
+      , "           resize(unsigned(std_logic_vector(~ARG[0])),~SIZE[~TYPO]);"
+      , "-- integerToNaturalClamp end"
+      ]
     , "warning": "GHC.Num.Integer.integerToNaturalClamp: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -71,26 +73,27 @@
     , "kind"      : "Declaration"
     , "type"      : "integerDiv :: Integer -> Integer -> Integer"
     , "template"   :
-"-- integerDiv begin
-~GENSYM[integerDiv][0] : block
-  signal ~GENSYM[resultPos][1] : boolean;
-  signal ~GENSYM[dividerNeg][2] : boolean;
-  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);
-  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);
-begin
-  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
-  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
-  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else
-             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else
-             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
-      -- pragma translate_off
-      when (~VAR[divider][1] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));
-end block;
--- integerDiv end"
+      [ "-- integerDiv begin"
+      , "~GENSYM[integerDiv][0] : block"
+      , "  signal ~GENSYM[resultPos][1] : boolean;"
+      , "  signal ~GENSYM[dividerNeg][2] : boolean;"
+      , "  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYPO] downto 0);"
+      , "  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYPO] downto 0);"
+      , "begin"
+      , "  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);"
+      , "  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';"
+      , "  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYPO]+1)   when ~SYM[1] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) - 1)   when ~SYM[2] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYPO]+1) - resize(~VAR[divider][1],~SIZE[~TYPO]+1) + 1);"
+      , "  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]"
+      , "      -- pragma translate_off"
+      , "      when (~VAR[divider][1] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~RESULT <= signed(~SYM[4](~SIZE[~TYPO]-1 downto 0));"
+      , "end block;"
+      , "-- integerDiv end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerDiv: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -107,34 +110,35 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerDivMod :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"-- integerDivMod begin
-~GENSYM[integerDivMod][0] : block
-  signal ~GENSYM[resultPos][1] : boolean;
-  signal ~GENSYM[dividerNeg][2] : boolean;
-  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYP[0]] downto 0);
-  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYP[0]] downto 0);
-  signal ~GENSYM[div_res][5] : signed(~SIZE[~TYP[0]]-1 downto 0);
-  signal ~GENSYM[mod_res][6] : signed(~SIZE[~TYP[0]]-1 downto 0);
-begin
-  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);
-  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';
-  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1)   when ~SYM[1] else
-             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) - 1)   when ~SYM[2] else
-             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) + 1);
-  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]
-      -- pragma translate_off
-      when (~VAR[divider][1] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~SYM[5] <= signed(~SYM[4](~SIZE[~TYP[0]]-1 downto 0));
-  ~SYM[6] <= ~VAR[dividend][0] mod ~VAR[divider][1]
-      -- pragma translate_off
-      when (~VAR[divider][1] /= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-  ~RESULT <= (~SYM[5], ~SYM[6]);
-end block;
--- integerDivMod end"
+      [ "-- integerDivMod begin"
+      , "~GENSYM[integerDivMod][0] : block"
+      , "  signal ~GENSYM[resultPos][1] : boolean;"
+      , "  signal ~GENSYM[dividerNeg][2] : boolean;"
+      , "  signal ~GENSYM[dividend2][3] : signed(~SIZE[~TYP[0]] downto 0);"
+      , "  signal ~GENSYM[quot_res][4] : signed(~SIZE[~TYP[0]] downto 0);"
+      , "  signal ~GENSYM[div_res][5] : signed(~SIZE[~TYP[0]]-1 downto 0);"
+      , "  signal ~GENSYM[mod_res][6] : signed(~SIZE[~TYP[0]]-1 downto 0);"
+      , "begin"
+      , "  ~SYM[1] <= ~VAR[dividend][0](~VAR[dividend][0]'high) = ~VAR[divider][1](~VAR[divider][1]'high);"
+      , "  ~SYM[2] <= ~VAR[divider][1](~VAR[divider][1]'high) = '1';"
+      , "  ~SYM[3] <= resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1)   when ~SYM[1] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) - 1)   when ~SYM[2] else"
+      , "             (resize(~VAR[dividend][0],~SIZE[~TYP[0]]+1) - resize(~VAR[divider][1],~SIZE[~TYP[0]]+1) + 1);"
+      , "  ~SYM[4] <= ~SYM[3] / ~VAR[divider][1]"
+      , "      -- pragma translate_off"
+      , "      when (~VAR[divider][1] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~SYM[5] <= signed(~SYM[4](~SIZE[~TYP[0]]-1 downto 0));"
+      , "  ~SYM[6] <= ~VAR[dividend][0] mod ~VAR[divider][1]"
+      , "      -- pragma translate_off"
+      , "      when (~VAR[divider][1] /= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "  ~RESULT <= (~SYM[5], ~SYM[6]);"
+      , "end block;"
+      , "-- integerDivMod end"
+      ]
     , "warning"   : "GHC.Num.Integer.integerDivMod#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -143,11 +147,12 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerQuotRem :: Integer -> Integer -> (# Integer, Integer #)"
     , "template"  :
-"~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     , "warning"   : "GHC.Num.Integer.integerQuotRem#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -156,11 +161,12 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerRem :: Integer -> Integer -> Integer"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     , "warning"   : "GHC.Num.Integer.integerRem: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -233,20 +239,21 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "integerShiftR# :: Integer -> Word# -> Integer"
     , "template"  :
-"~GENSYM[~RESULT_shiftR][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_right(~ARG[0],~SYM[1]);
-end block;"
+      [ "~GENSYM[~RESULT_shiftR][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_right(~ARG[0],~SYM[1]);"
+      , "end block;"
+      ]
     , "warning"   : "GHC.Num.Integer.integerShiftR#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -255,20 +262,21 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "integerShiftL# :: Integer -> Word# -> Integer"
     , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_left(~ARG[0],~SYM[1]);
-end block;"
+      [ "~GENSYM[~RESULT_shiftL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_left(~ARG[0],~SYM[1]);"
+      , "end block;"
+      ]
     , "warning"   : "GHC.Num.Integer.integerShiftL#: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -352,13 +360,15 @@ end block;"
     { "name"      : "GHC.Num.Integer.integerSigmum"
     , "kind"      : "Declaration"
     , "type"      : "integerSigmum :: Integer -> Integer"
-    , "template"  : "
--- begin integerSigmum
-~RESULT <= to_signed(-1, ~SIZE[~TYPO]) when ~ARG[0] < 0
-  else to_signed(0, ~SIZE[~TYPO])  when ~ARG[0] = 0
-  else to_signed(1, ~SIZE[~TYPO]);
--- end integerSigmum
-"
+    , "template"  :
+      [ ""
+      , "-- begin integerSigmum"
+      , "~RESULT <= to_signed(-1, ~SIZE[~TYPO]) when ~ARG[0] < 0"
+      , "  else to_signed(0, ~SIZE[~TYPO])  when ~ARG[0] = 0"
+      , "  else to_signed(1, ~SIZE[~TYPO]);"
+      , "-- end integerSigmum"
+      , ""
+      ]
     , "warning"   : "GHC.Num.Integer.integerSignum: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -366,13 +376,15 @@ end block;"
     { "name"      : "GHC.Num.Integer.$wintegerSignum"
     , "kind"      : "Declaration"
     , "type"      : "$wsignumInteger :: Integer -> Int#"
-    , "template"  : "
--- begin signumInteger
-~RESULT <= to_signed(-1, ~SIZE[~TYPO]) when ~ARG[0] < 0
-  else to_signed(0, ~SIZE[~TYPO])  when ~ARG[0] = 0
-  else to_signed(1, ~SIZE[~TYPO]);
--- end signumInteger
-"
+    , "template"  :
+      [ ""
+      , "-- begin signumInteger"
+      , "~RESULT <= to_signed(-1, ~SIZE[~TYPO]) when ~ARG[0] < 0"
+      , "  else to_signed(0, ~SIZE[~TYPO])  when ~ARG[0] = 0"
+      , "  else to_signed(1, ~SIZE[~TYPO]);"
+      , "-- end signumInteger"
+      , ""
+      ]
     , "warning"   : "GHC.Num.Integer.$wintegerSignum: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -388,13 +400,15 @@ end block;"
     { "name"      : "GHC.Num.Integer.integerCompare"
     , "kind"      : "Declaration"
     , "type"      : "integerCompare :: Integer -> Integer -> Ordering"
-    , "template"  : "
--- begin integerCompare
-~RESULT <= \"00\" when ~ARG[0] < ~ARG[1] else
-           \"01\" when ~ARG[0] = ~ARG[1] else
-           \"10\";
--- end integerCompare
-"
+    , "template"  :
+      [ ""
+      , "-- begin integerCompare"
+      , "~RESULT <= \"00\" when ~ARG[0] < ~ARG[1] else"
+      , "           \"01\" when ~ARG[0] = ~ARG[1] else"
+      , "           \"10\";"
+      , "-- end integerCompare"
+      , ""
+      ]
     , "warning"   : "GHC.Num.Integer.integerCompare: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -403,11 +417,12 @@ end block;"
   , "kind"      : "Declaration"
   , "type"      : "integerQuot :: Integer -> Integer -> Integer"
   , "template"  :
-"~RESULT <= ~ARG[0] / ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+    [ "~RESULT <= ~ARG[0] / ~ARG[1]"
+    , "    -- pragma translate_off"
+    , "    when (~ARG[1] /= 0) else (others => 'X')"
+    , "    -- pragma translate_on"
+    , "    ;"
+    ]
   , "warning"   : "GHC.Num.Integer.integerQuot: Integers are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }

--- a/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
+++ b/clash-lib/prims/vhdl/GHC_Num_Natural.primitives
@@ -23,11 +23,12 @@
     , "kind"      : "Declaration"
     , "type"      : "naturalRem :: Natural -> Natural -> Natural"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     , "warning": "GHC.Num.Natural.naturalRem: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
     }
   }
@@ -92,20 +93,21 @@
   , "kind"      : "Declaration"
   , "type"      : "naturalShiftL# :: Natural -> Word# -> Natural"
   , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_left(~ARG[0],~SYM[1]);
-end block;"
+    [ "~GENSYM[~RESULT_shiftL][0] : block"
+    , "  signal ~GENSYM[sh][1] : natural;"
+    , "begin"
+    , "  ~SYM[1] <="
+    , "      -- pragma translate_off"
+    , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+    , "      -- pragma translate_on"
+    , "      to_integer(~VAR[shI][1]"
+    , "      -- pragma translate_off"
+    , "      (30 downto 0)"
+    , "      -- pragma translate_on"
+    , "      );"
+    , "  ~RESULT <= shift_left(~ARG[0],~SYM[1]);"
+    , "end block;"
+    ]
   , "warning"   : "GHC.Num.Natural.naturalShiftL#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
@@ -114,20 +116,21 @@ end block;"
   , "kind"      : "Declaration"
   , "type"      : "naturalShiftR# :: Natural -> Word# -> Natural"
   , "template"  :
-"~GENSYM[~RESULT_shiftR][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_right(~ARG[0],~SYM[1]);
-end block;"
+    [ "~GENSYM[~RESULT_shiftR][0] : block"
+    , "  signal ~GENSYM[sh][1] : natural;"
+    , "begin"
+    , "  ~SYM[1] <="
+    , "      -- pragma translate_off"
+    , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+    , "      -- pragma translate_on"
+    , "      to_integer(~VAR[shI][1]"
+    , "      -- pragma translate_off"
+    , "      (30 downto 0)"
+    , "      -- pragma translate_on"
+    , "      );"
+    , "  ~RESULT <= shift_right(~ARG[0],~SYM[1]);"
+    , "end block;"
+    ]
   , "warning"   : "GHC.Num.Natural.naturalShiftR#: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }
@@ -136,11 +139,12 @@ end block;"
   , "kind"      : "Declaration"
   , "type"      : "naturalCompare :: Natural -> Natural -> Ordering"
   , "template"  :
-"-- begin naturalCompare
-~RESULT <= \"00\" when ~ARG[0] < ~ARG[1] else
-         \"01\" when ~ARG[0] = ~ARG[1] else
-         \"10\";
--- end naturalCompare"
+    [ "-- begin naturalCompare"
+    , "~RESULT <= \"00\" when ~ARG[0] < ~ARG[1] else"
+    , "         \"01\" when ~ARG[0] = ~ARG[1] else"
+    , "         \"10\";"
+    , "-- end naturalCompare"
+    ]
   }
 }
 , { "BlackBox":
@@ -148,11 +152,12 @@ end block;"
   , "kind": "Declaration"
   , "type": "naturalQuot :: Natural -> Natural -> Natural"
   , "template"  :
-"~RESULT <= ~ARG[0] / ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+    [ "~RESULT <= ~ARG[0] / ~ARG[1]"
+    , "    -- pragma translate_off"
+    , "    when (~ARG[1] /= 0) else (others => 'X')"
+    , "    -- pragma translate_on"
+    , "    ;"
+    ]
   , "warning": "GHC.Num.Natural.naturalQuot: Naturals are dynamically sized in simulation, but fixed-length after synthesis. Use carefully."
   }
 }

--- a/clash-lib/prims/vhdl/GHC_Prim.primitives
+++ b/clash-lib/prims/vhdl/GHC_Prim.primitives
@@ -59,23 +59,26 @@
     , "kind"      : "Declaration"
     , "type"      : "remInt# :: Int# -> Int# -> Int#"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.quotRemInt#"
     , "kind"      : "Declaration"
     , "type"      : "quotRemInt# :: Int# -> Int# -> (#Int#, Int##)"
-    , "template"  : "
-~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
-    -- pragma translate_on
-    ;"
+    , "template"  :
+      [ ""
+      , "~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -176,24 +179,25 @@
     , "kind"      : "Declaration"
     , "type"      : "uncheckedIShiftL# :: Int# -> Int# -> Int#"
     , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_left(~ARG[0],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[1] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_left(~ARG[0],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[1] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -201,24 +205,25 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "uncheckedIShiftRA# :: Int# -> Int# -> Int#"
     , "template"  :
-"~GENSYM[~RESULT_shiftR][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_right(~ARG[0],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[1] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftR][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_right(~ARG[0],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[1] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -226,24 +231,25 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "uncheckedIShiftRL# :: Int# -> Int# -> Int#"
     , "template"  :
-"~GENSYM[~RESULT_shiftRL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= ~ARG[0] srl ~SYM[1]
-      -- pragma translate_off
-      when (~ARG[1] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftRL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= ~ARG[0] srl ~SYM[1]"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[1] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -258,23 +264,26 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "remWord# :: Word# -> Word# -> Word#"
     , "template"  :
-"~RESULT <= ~ARG[0] rem ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] rem ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.quotRemWord#"
     , "kind"      : "Declaration"
     , "type"      : "quotRemWord# :: Word# -> Word# -> (#Word#, Word##)"
-    , "template"  : "
-~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))
-    -- pragma translate_on
-    ;"
+    , "template"  :
+      [ ""
+      , "~RESULT <= (~ARG[0] / ~ARG[1], ~ARG[0] rem ~ARG[1])"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else ((others => 'X'), (others => 'X'))"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -310,24 +319,25 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "uncheckedShiftL# :: Word# -> Int# -> Word#"
     , "template"  :
-"~GENSYM[~RESULT_shiftL][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_left(~ARG[0],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[1] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftL][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_left(~ARG[0],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[1] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -335,24 +345,25 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "uncheckedShiftR# :: Word# -> Int# -> Word#"
     , "template"  :
-"~GENSYM[~RESULT_shiftR][0] : block
-  signal ~GENSYM[sh][1] : natural;
-begin
-  ~SYM[1] <=
-      -- pragma translate_off
-      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else
-      -- pragma translate_on
-      to_integer(~VAR[shI][1]
-      -- pragma translate_off
-      (30 downto 0)
-      -- pragma translate_on
-      );
-  ~RESULT <= shift_right(~ARG[0],~SYM[1])
-      -- pragma translate_off
-      when (~ARG[1] >= 0) else (others => 'X')
-      -- pragma translate_on
-      ;
-end block;"
+      [ "~GENSYM[~RESULT_shiftR][0] : block"
+      , "  signal ~GENSYM[sh][1] : natural;"
+      , "begin"
+      , "  ~SYM[1] <="
+      , "      -- pragma translate_off"
+      , "      natural'high when (~VAR[shI][1](~SIZE[~TYP[1]]-1 downto 31) /= 0) else"
+      , "      -- pragma translate_on"
+      , "      to_integer(~VAR[shI][1]"
+      , "      -- pragma translate_off"
+      , "      (30 downto 0)"
+      , "      -- pragma translate_on"
+      , "      );"
+      , "  ~RESULT <= shift_right(~ARG[0],~SYM[1])"
+      , "      -- pragma translate_off"
+      , "      when (~ARG[1] >= 0) else (others => 'X')"
+      , "      -- pragma translate_on"
+      , "      ;"
+      , "end block;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -410,40 +421,41 @@ end block;"
     , "kind"      : "Declaration"
     , "type"      : "popCnt8 :: Word# -> Word#"
     , "template"  :
-"-- popCnt8 begin
-~GENSYM[popCnt8][0] : block
-  -- given a level and a depth, calculate the corresponding index into the
-  -- intermediate array
-  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
-  begin
-    return (2 ** levels - 2 ** depth);
-  end function;
-
-  constant ~GENSYM[width][2] : natural := 8;
-  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
-  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
-  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
-begin
-  -- put input into the first half of the intermediate array
-  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
-  end generate;
-
-  -- Create the tree of adders
-  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
-    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
-      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
-        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
-      end generate;
-    end generate;
-  end generate;
-
-  -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
-end block;
--- popCnt8 end"
+      [ "-- popCnt8 begin"
+      , "~GENSYM[popCnt8][0] : block"
+      , "  -- given a level and a depth, calculate the corresponding index into the"
+      , "  -- intermediate array"
+      , "  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is"
+      , "  begin"
+      , "    return (2 ** levels - 2 ** depth);"
+      , "  end function;"
+      , ""
+      , "  constant ~GENSYM[width][2] : natural := 8;"
+      , "  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));"
+      , "  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);"
+      , "  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);"
+      , "begin"
+      , "  -- put input into the first half of the intermediate array"
+      , "  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate"
+      , "    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);"
+      , "  end generate;"
+      , ""
+      , "  -- Create the tree of adders"
+      , "  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate"
+      , "    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate"
+      , "      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate"
+      , "        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <="
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +"
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);"
+      , "      end generate;"
+      , "    end generate;"
+      , "  end generate;"
+      , ""
+      , "  -- The last element of the intermediate array holds the result"
+      , "  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- popCnt8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -451,40 +463,41 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "popCnt16 :: Word# -> Word#"
     , "template"  :
-"-- popCnt16 begin
-~GENSYM[popCnt16][0] : block
-  -- given a level and a depth, calculate the corresponding index into the
-  -- intermediate array
-  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
-  begin
-    return (2 ** levels - 2 ** depth);
-  end function;
-
-  constant ~GENSYM[width][2] : natural := 16;
-  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
-  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
-  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
-begin
-  -- put input into the first half of the intermediate array
-  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
-  end generate;
-
-  -- Create the tree of adders
-  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
-    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
-      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
-        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
-      end generate;
-    end generate;
-  end generate;
-
-  -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
-end block;
--- popCnt16 end"
+      [ "-- popCnt16 begin"
+      , "~GENSYM[popCnt16][0] : block"
+      , "  -- given a level and a depth, calculate the corresponding index into the"
+      , "  -- intermediate array"
+      , "  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is"
+      , "  begin"
+      , "    return (2 ** levels - 2 ** depth);"
+      , "  end function;"
+      , ""
+      , "  constant ~GENSYM[width][2] : natural := 16;"
+      , "  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));"
+      , "  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);"
+      , "  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);"
+      , "begin"
+      , "  -- put input into the first half of the intermediate array"
+      , "  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate"
+      , "    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);"
+      , "  end generate;"
+      , ""
+      , "  -- Create the tree of adders"
+      , "  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate"
+      , "    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate"
+      , "      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate"
+      , "        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <="
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +"
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);"
+      , "      end generate;"
+      , "    end generate;"
+      , "  end generate;"
+      , ""
+      , "  -- The last element of the intermediate array holds the result"
+      , "  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- popCnt16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -492,40 +505,41 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "popCnt32 :: Word# -> Word#"
     , "template"  :
-"-- popCnt32 begin
-~GENSYM[popCnt32][0] : block
-  -- given a level and a depth, calculate the corresponding index into the
-  -- intermediate array
-  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
-  begin
-    return (2 ** levels - 2 ** depth);
-  end function;
-
-  constant ~GENSYM[width][2] : natural := 32;
-  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
-  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
-  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
-begin
-  -- put input into the first half of the intermediate array
-  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
-  end generate;
-
-  -- Create the tree of adders
-  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
-    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
-      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
-        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
-      end generate;
-    end generate;
-  end generate;
-
-  -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
-end block;
--- popCnt32 end"
+      [ "-- popCnt32 begin"
+      , "~GENSYM[popCnt32][0] : block"
+      , "  -- given a level and a depth, calculate the corresponding index into the"
+      , "  -- intermediate array"
+      , "  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is"
+      , "  begin"
+      , "    return (2 ** levels - 2 ** depth);"
+      , "  end function;"
+      , ""
+      , "  constant ~GENSYM[width][2] : natural := 32;"
+      , "  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));"
+      , "  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);"
+      , "  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);"
+      , "begin"
+      , "  -- put input into the first half of the intermediate array"
+      , "  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate"
+      , "    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);"
+      , "  end generate;"
+      , ""
+      , "  -- Create the tree of adders"
+      , "  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate"
+      , "    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate"
+      , "      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate"
+      , "        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <="
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +"
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);"
+      , "      end generate;"
+      , "    end generate;"
+      , "  end generate;"
+      , ""
+      , "  -- The last element of the intermediate array holds the result"
+      , "  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- popCnt32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -533,40 +547,41 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "popCnt64 :: Word# -> Word#"
     , "template"  :
-"-- popCnt64 begin
-~GENSYM[popCnt64][0] : block
-  -- given a level and a depth, calculate the corresponding index into the
-  -- intermediate array
-  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
-  begin
-    return (2 ** levels - 2 ** depth);
-  end function;
-
-  constant ~GENSYM[width][2] : natural := 64;
-  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
-  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
-  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
-begin
-  -- put input into the first half of the intermediate array
-  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
-  end generate;
-
-  -- Create the tree of adders
-  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
-    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
-      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
-        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
-      end generate;
-    end generate;
-  end generate;
-
-  -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
-end block;
--- popCnt64 end"
+      [ "-- popCnt64 begin"
+      , "~GENSYM[popCnt64][0] : block"
+      , "  -- given a level and a depth, calculate the corresponding index into the"
+      , "  -- intermediate array"
+      , "  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is"
+      , "  begin"
+      , "    return (2 ** levels - 2 ** depth);"
+      , "  end function;"
+      , ""
+      , "  constant ~GENSYM[width][2] : natural := 64;"
+      , "  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));"
+      , "  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);"
+      , "  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);"
+      , "begin"
+      , "  -- put input into the first half of the intermediate array"
+      , "  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate"
+      , "    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);"
+      , "  end generate;"
+      , ""
+      , "  -- Create the tree of adders"
+      , "  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate"
+      , "    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate"
+      , "      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate"
+      , "        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <="
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +"
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);"
+      , "      end generate;"
+      , "    end generate;"
+      , "  end generate;"
+      , ""
+      , "  -- The last element of the intermediate array holds the result"
+      , "  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- popCnt64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -574,40 +589,41 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "popCnt :: Word# -> Word#"
     , "template"  :
-"-- popCnt begin
-~GENSYM[popCnt][0] : block
-  -- given a level and a depth, calculate the corresponding index into the
-  -- intermediate array
-  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
-  begin
-    return (2 ** levels - 2 ** depth);
-  end function;
-
-  constant ~GENSYM[width][2] : natural := ~SIZE[~TYPO];
-  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));
-  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);
-  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);
-begin
-  -- put input into the first half of the intermediate array
-  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate
-    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);
-  end generate;
-
-  -- Create the tree of adders
-  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate
-    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate
-      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate
-        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <=
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +
-          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);
-      end generate;
-    end generate;
-  end generate;
-
-  -- The last element of the intermediate array holds the result
-  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);
-end block;
--- popCnt end"
+      [ "-- popCnt begin"
+      , "~GENSYM[popCnt][0] : block"
+      , "  -- given a level and a depth, calculate the corresponding index into the"
+      , "  -- intermediate array"
+      , "  function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is"
+      , "  begin"
+      , "    return (2 ** levels - 2 ** depth);"
+      , "  end function;"
+      , ""
+      , "  constant ~GENSYM[width][2] : natural := ~SIZE[~TYPO];"
+      , "  constant ~GENSYM[levels][3] : natural := natural (ceil (log2 (real (~SYM[2]))));"
+      , "  type ~GENSYM[popCnt_res_vec][4] is array (natural range <>) of unsigned(~SYM[3] downto 0);"
+      , "  signal ~GENSYM[intermediate][5] : ~SYM[4](0 to (2*~SYM[2])-2);"
+      , "begin"
+      , "  -- put input into the first half of the intermediate array"
+      , "  ~GENSYM[make_array][6]: for ~GENSYM[i][7] in 0 to (~SYM[2] - 1) generate"
+      , "    ~SYM[5](~SYM[7]) <= resize(~VAR[input][0](~SYM[7] downto ~SYM[7]),~SYM[3]+1);"
+      , "  end generate;"
+      , ""
+      , "  -- Create the tree of adders"
+      , "  ~GENSYM[make_tree][8] : if ~SYM[3] /= 0 generate"
+      , "    ~GENSYM[tree_depth][9] : for ~GENSYM[d][10] in ~SYM[3]-1 downto 0 generate"
+      , "      ~GENSYM[tree_depth_loop][11] : for ~GENSYM[i][12] in 0 to (natural(2**~SYM[10]) - 1) generate"
+      , "        ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+1)+~SYM[12]) <="
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])) +"
+      , "          ~SYM[5](~SYM[1](~SYM[3]+1,~SYM[10]+2)+(2*~SYM[12])+1);"
+      , "      end generate;"
+      , "    end generate;"
+      , "  end generate;"
+      , ""
+      , "  -- The last element of the intermediate array holds the result"
+      , "  ~RESULT <= resize(~SYM[5]((2*~SYM[2])-2),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- popCnt end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -615,42 +631,43 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "clz8 :: Word# -> Word#"
     , "template"  :
-"-- clz8 begin
-~GENSYM[clz8][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-  function ~GENSYM[clz8][3] (constant v : unsigned(0 to 7)) return unsigned is
-    variable e : unsigned(0 to 7);     -- 8
-    variable a : unsigned(0 to 2*3-1); -- 6
-  begin
-    for i in 0 to 3 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-    for i in 0 to 1 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-    return ~SYM[2](3,a(0 to 5));
-  end function;
-begin
-  ~RESULT <= resize(~SYM[3](~ARG[0](7 downto 0)),~SIZE[~TYPO]);
-end block;
--- clz8 end"
+      [ "-- clz8 begin"
+      , "~GENSYM[clz8][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clz8][3] (constant v : unsigned(0 to 7)) return unsigned is"
+      , "    variable e : unsigned(0 to 7);     -- 8"
+      , "    variable a : unsigned(0 to 2*3-1); -- 6"
+      , "  begin"
+      , "    for i in 0 to 3 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;"
+      , "    for i in 0 to 1 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;"
+      , "    return ~SYM[2](3,a(0 to 5));"
+      , "  end function;"
+      , "begin"
+      , "  ~RESULT <= resize(~SYM[3](~ARG[0](7 downto 0)),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- clz8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -658,44 +675,45 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "clz16 :: Word# -> Word#"
     , "template"  :
-"-- clz16 begin
-~GENSYM[clz16][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-  function ~GENSYM[clz16][3] (constant v : unsigned(0 to 15)) return unsigned is
-    variable e : unsigned(0 to 15);    -- 16
-    variable a : unsigned(0 to 4*3-1); -- 12
-    variable b : unsigned(0 to 2*4-1); -- 8
-  begin
-    for i in 0 to 7 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-    for i in 0 to 3 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 1 loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-    return ~SYM[2](4,b(0 to 7));
-  end function;
-begin
-  ~RESULT <= resize(~SYM[3](~ARG[0](15 downto 0)),~SIZE[~TYPO]);
-end block;
--- clz16 end"
+      [ "-- clz16 begin"
+      , "~GENSYM[clz16][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clz16][3] (constant v : unsigned(0 to 15)) return unsigned is"
+      , "    variable e : unsigned(0 to 15);    -- 16"
+      , "    variable a : unsigned(0 to 4*3-1); -- 12"
+      , "    variable b : unsigned(0 to 2*4-1); -- 8"
+      , "  begin"
+      , "    for i in 0 to 7 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;"
+      , "    for i in 0 to 3 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;"
+      , "    for i in 0 to 1 loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;"
+      , "    return ~SYM[2](4,b(0 to 7));"
+      , "  end function;"
+      , "begin"
+      , "  ~RESULT <= resize(~SYM[3](~ARG[0](15 downto 0)),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- clz16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -703,46 +721,47 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "clz32 :: Word# -> Word#"
     , "template"  :
-"-- clz32 begin
-~GENSYM[clz32][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-  function ~GENSYM[clz32][3] (constant v : unsigned(0 to 31)) return unsigned is
-    variable e : unsigned(0 to 31);    -- 32
-    variable a : unsigned(0 to 8*3-1); -- 24
-    variable b : unsigned(0 to 4*4-1); -- 16
-    variable c : unsigned(0 to 2*5-1); -- 10
-  begin
-    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
-    return ~SYM[2](5,c(0 to 9));
-  end function;
-begin
-  ~RESULT <= resize(~SYM[3](~ARG[0](31 downto 0)),~SIZE[~TYPO]);
-end block;
--- clz32 end"
+      [ "-- clz32 begin"
+      , "~GENSYM[clz32][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clz32][3] (constant v : unsigned(0 to 31)) return unsigned is"
+      , "    variable e : unsigned(0 to 31);    -- 32"
+      , "    variable a : unsigned(0 to 8*3-1); -- 24"
+      , "    variable b : unsigned(0 to 4*4-1); -- 16"
+      , "    variable c : unsigned(0 to 2*5-1); -- 10"
+      , "  begin"
+      , "    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;"
+      , "    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;"
+      , "    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;"
+      , "    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;"
+      , "    return ~SYM[2](5,c(0 to 9));"
+      , "  end function;"
+      , "begin"
+      , "  ~RESULT <= resize(~SYM[3](~ARG[0](31 downto 0)),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- clz32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -750,48 +769,49 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "clz64 :: Word# -> Word#"
     , "template"  :
-"-- clz64 begin
-~GENSYM[clz64][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
-    variable e : unsigned(0 to 63);     -- 64
-    variable a : unsigned(0 to 16*3-1); -- 48
-    variable b : unsigned(0 to 8*4-1);  -- 32
-    variable c : unsigned(0 to 4*5-1);  -- 20
-    variable d : unsigned(0 to 2*6-1);  -- 12
-  begin
-    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
-    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
-    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
-    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
-    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
-    return ~SYM[2](6,d(0 to 11));
-  end function;
-begin
-  ~RESULT <= resize(~SYM[3](~ARG[0]),~SIZE[~TYPO]);
-end block;
--- clz64 end"
+      [ "-- clz64 begin"
+      , "~GENSYM[clz64][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is"
+      , "    variable e : unsigned(0 to 63);     -- 64"
+      , "    variable a : unsigned(0 to 16*3-1); -- 48"
+      , "    variable b : unsigned(0 to 8*4-1);  -- 32"
+      , "    variable c : unsigned(0 to 4*5-1);  -- 20"
+      , "    variable d : unsigned(0 to 2*6-1);  -- 12"
+      , "  begin"
+      , "    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;"
+      , "    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;"
+      , "    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;"
+      , "    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;"
+      , "    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;"
+      , "    return ~SYM[2](6,d(0 to 11));"
+      , "  end function;"
+      , "begin"
+      , "  ~RESULT <= resize(~SYM[3](~ARG[0]),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- clz64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -799,66 +819,67 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "clz :: Word# -> Word#"
     , "template"  :
-"-- clz begin
-~GENSYM[clz][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-~IF ~IW64 ~THEN
-  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
-    variable e : unsigned(0 to 63);     -- 64
-    variable a : unsigned(0 to 16*3-1); -- 48
-    variable b : unsigned(0 to 8*4-1);  -- 32
-    variable c : unsigned(0 to 4*5-1);  -- 20
-    variable d : unsigned(0 to 2*6-1);  -- 12
-  begin
-    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
-    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
-    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
-    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
-    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
-    return ~SYM[2](6,d(0 to 11));
-  end function;
-~ELSE
-  function ~GENSYM[clz32][4] (constant v : unsigned(0 to 31)) return unsigned is
-    variable e : unsigned(0 to 31);    -- 32
-    variable a : unsigned(0 to 8*3-1); -- 24
-    variable b : unsigned(0 to 4*4-1); -- 16
-    variable c : unsigned(0 to 2*5-1); -- 10
-  begin
-    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
-    return ~SYM[2](5,c(0 to 9));
-  end function;
-~FI
-begin
-~IF ~IW64 ~THEN
-  ~RESULT <= resize(~SYM[3](~ARG[0]),~SIZE[~TYPO]);
-~ELSE
-  ~RESULT <= resize(~SYM[4](~ARG[0]),~SIZE[~TYPO]);
-~FI
-end block;
--- clz end"
+      [ "-- clz begin"
+      , "~GENSYM[clz][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , "~IF ~IW64 ~THEN"
+      , "  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is"
+      , "    variable e : unsigned(0 to 63);     -- 64"
+      , "    variable a : unsigned(0 to 16*3-1); -- 48"
+      , "    variable b : unsigned(0 to 8*4-1);  -- 32"
+      , "    variable c : unsigned(0 to 4*5-1);  -- 20"
+      , "    variable d : unsigned(0 to 2*6-1);  -- 12"
+      , "  begin"
+      , "    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;"
+      , "    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;"
+      , "    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;"
+      , "    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;"
+      , "    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;"
+      , "    return ~SYM[2](6,d(0 to 11));"
+      , "  end function;"
+      , "~ELSE"
+      , "  function ~GENSYM[clz32][4] (constant v : unsigned(0 to 31)) return unsigned is"
+      , "    variable e : unsigned(0 to 31);    -- 32"
+      , "    variable a : unsigned(0 to 8*3-1); -- 24"
+      , "    variable b : unsigned(0 to 4*4-1); -- 16"
+      , "    variable c : unsigned(0 to 2*5-1); -- 10"
+      , "  begin"
+      , "    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;"
+      , "    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;"
+      , "    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;"
+      , "    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;"
+      , "    return ~SYM[2](5,c(0 to 9));"
+      , "  end function;"
+      , "~FI"
+      , "begin"
+      , "~IF ~IW64 ~THEN"
+      , "  ~RESULT <= resize(~SYM[3](~ARG[0]),~SIZE[~TYPO]);"
+      , "~ELSE"
+      , "  ~RESULT <= resize(~SYM[4](~ARG[0]),~SIZE[~TYPO]);"
+      , "~FI"
+      , "end block;"
+      , "-- clz end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -866,51 +887,52 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "ctz8 :: Word# -> Word#"
     , "template"  :
-"-- ctz8 begin
-~GENSYM[ctz8][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-  function ~GENSYM[clz8][3] (constant v : unsigned(0 to 7)) return unsigned is
-    variable e : unsigned(0 to 7);     -- 8
-    variable a : unsigned(0 to 2*3-1); -- 6
-  begin
-    for i in 0 to 3 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-    for i in 0 to 1 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-    return ~SYM[2](3,a(0 to 5));
-  end function;
-
-  signal ~GENSYM[w_reversed][5] : ~TYP[0];
-begin
-  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
-    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
-  end generate;
-~IF ~IW64 ~THEN
-  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 56)),~SIZE[~TYPO]);
-~ELSE
-  ~RESULT <= resize(~SYM[3](~SYM[5](31 downto 24)),~SIZE[~TYPO]);
-~FI
-end block;
--- ctz8 end"
+      [ "-- ctz8 begin"
+      , "~GENSYM[ctz8][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clz8][3] (constant v : unsigned(0 to 7)) return unsigned is"
+      , "    variable e : unsigned(0 to 7);     -- 8"
+      , "    variable a : unsigned(0 to 2*3-1); -- 6"
+      , "  begin"
+      , "    for i in 0 to 3 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;"
+      , "    for i in 0 to 1 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;"
+      , "    return ~SYM[2](3,a(0 to 5));"
+      , "  end function;"
+      , ""
+      , "  signal ~GENSYM[w_reversed][5] : ~TYP[0];"
+      , "begin"
+      , "  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate"
+      , "    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);"
+      , "  end generate;"
+      , "~IF ~IW64 ~THEN"
+      , "  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 56)),~SIZE[~TYPO]);"
+      , "~ELSE"
+      , "  ~RESULT <= resize(~SYM[3](~SYM[5](31 downto 24)),~SIZE[~TYPO]);"
+      , "~FI"
+      , "end block;"
+      , "-- ctz8 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -918,53 +940,54 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "ctz16 :: Word# -> Word#"
     , "template"  :
-"-- ctz16 begin
-~GENSYM[ctz16][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-  function ~GENSYM[clz16][3] (constant v : unsigned(0 to 15)) return unsigned is
-    variable e : unsigned(0 to 15);    -- 16
-    variable a : unsigned(0 to 4*3-1); -- 12
-    variable b : unsigned(0 to 2*4-1); -- 8
-  begin
-    for i in 0 to 7 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-    for i in 0 to 3 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 1 loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-    return ~SYM[2](4,b(0 to 7));
-  end function;
-
-  signal ~GENSYM[w_reversed][5] : ~TYP[0];
-begin
-  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
-    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
-  end generate;
-~IF ~IW64 ~THEN
-  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 48)),~SIZE[~TYPO]);
-~ELSE
-  ~RESULT <= resize(~SYM[3](~SYM[5](31 downto 16)),~SIZE[~TYPO]);
-~FI
-end block;
--- ctz16 end"
+      [ "-- ctz16 begin"
+      , "~GENSYM[ctz16][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clz16][3] (constant v : unsigned(0 to 15)) return unsigned is"
+      , "    variable e : unsigned(0 to 15);    -- 16"
+      , "    variable a : unsigned(0 to 4*3-1); -- 12"
+      , "    variable b : unsigned(0 to 2*4-1); -- 8"
+      , "  begin"
+      , "    for i in 0 to 7 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;"
+      , "    for i in 0 to 3 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;"
+      , "    for i in 0 to 1 loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;"
+      , "    return ~SYM[2](4,b(0 to 7));"
+      , "  end function;"
+      , ""
+      , "  signal ~GENSYM[w_reversed][5] : ~TYP[0];"
+      , "begin"
+      , "  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate"
+      , "    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);"
+      , "  end generate;"
+      , "~IF ~IW64 ~THEN"
+      , "  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 48)),~SIZE[~TYPO]);"
+      , "~ELSE"
+      , "  ~RESULT <= resize(~SYM[3](~SYM[5](31 downto 16)),~SIZE[~TYPO]);"
+      , "~FI"
+      , "end block;"
+      , "-- ctz16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -972,55 +995,56 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "ctz32 :: Word# -> Word#"
     , "template"  :
-"-- ctz32 begin
-~GENSYM[ctz32][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-  function ~GENSYM[clz32][3] (constant v : unsigned(0 to 31)) return unsigned is
-    variable e : unsigned(0 to 31);    -- 32
-    variable a : unsigned(0 to 8*3-1); -- 24
-    variable b : unsigned(0 to 4*4-1); -- 16
-    variable c : unsigned(0 to 2*5-1); -- 10
-  begin
-    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
-    return ~SYM[2](5,c(0 to 9));
-  end function;
-
-  signal ~GENSYM[w_reversed][5] : ~TYP[0];
-begin
-  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
-    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[3]);
-  end generate;
-~IF ~IW64 ~THEN
-  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 32)),~SIZE[~TYPO]);
-~ELSE
-  ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);
-~FI
-end block;
--- ctz32 end"
+      [ "-- ctz32 begin"
+      , "~GENSYM[ctz32][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clz32][3] (constant v : unsigned(0 to 31)) return unsigned is"
+      , "    variable e : unsigned(0 to 31);    -- 32"
+      , "    variable a : unsigned(0 to 8*3-1); -- 24"
+      , "    variable b : unsigned(0 to 4*4-1); -- 16"
+      , "    variable c : unsigned(0 to 2*5-1); -- 10"
+      , "  begin"
+      , "    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;"
+      , "    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;"
+      , "    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;"
+      , "    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;"
+      , "    return ~SYM[2](5,c(0 to 9));"
+      , "  end function;"
+      , ""
+      , "  signal ~GENSYM[w_reversed][5] : ~TYP[0];"
+      , "begin"
+      , "  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate"
+      , "    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[3]);"
+      , "  end generate;"
+      , "~IF ~IW64 ~THEN"
+      , "  ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 32)),~SIZE[~TYPO]);"
+      , "~ELSE"
+      , "  ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);"
+      , "~FI"
+      , "end block;"
+      , "-- ctz32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1028,54 +1052,55 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "ctz64 :: Word# -> Word#"
     , "template"  :
-"-- ctz64 begin
-~GENSYM[ctz64][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
-    variable e : unsigned(0 to 63);     -- 64
-    variable a : unsigned(0 to 16*3-1); -- 48
-    variable b : unsigned(0 to 8*4-1);  -- 32
-    variable c : unsigned(0 to 4*5-1);  -- 20
-    variable d : unsigned(0 to 2*6-1);  -- 12
-  begin
-    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
-    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
-    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
-    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
-    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
-    return ~SYM[2](6,d(0 to 11));
-  end function;
-
-  signal ~GENSYM[w_reversed][5] : ~TYP[0];
-begin
-  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
-    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
-  end generate;
-
-  ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);
-end block;
--- ctz64 end"
+      [ "-- ctz64 begin"
+      , "~GENSYM[ctz64][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is"
+      , "    variable e : unsigned(0 to 63);     -- 64"
+      , "    variable a : unsigned(0 to 16*3-1); -- 48"
+      , "    variable b : unsigned(0 to 8*4-1);  -- 32"
+      , "    variable c : unsigned(0 to 4*5-1);  -- 20"
+      , "    variable d : unsigned(0 to 2*6-1);  -- 12"
+      , "  begin"
+      , "    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;"
+      , "    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;"
+      , "    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;"
+      , "    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;"
+      , "    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;"
+      , "    return ~SYM[2](6,d(0 to 11));"
+      , "  end function;"
+      , ""
+      , "  signal ~GENSYM[w_reversed][5] : ~TYP[0];"
+      , "begin"
+      , "  ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate"
+      , "    ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);"
+      , "  end generate;"
+      , ""
+      , "  ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);"
+      , "end block;"
+      , "-- ctz64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1083,72 +1108,73 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "ctz :: Word# -> Word#"
     , "template"  :
-"-- ctz begin
-~GENSYM[ctz][0] : block
-  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-  begin
-    case a is
-      when \"00\" => return \"10\";
-      when \"01\" => return \"01\";
-      when \"10\" => return \"00\";
-      when others => return \"00\";
-    end case;
-  end function;
-
-  function ~GENSYM[clzi][2] (
-    constant n : in natural;
-    constant i : in unsigned) return unsigned is
-    variable v : unsigned(i'length-1 downto 0):=i;
-  begin
-    if v(n-1+n)='0' then
-      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-    else
-      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-    end if;
-  end function;
-
-~IF ~IW64 ~THEN
-  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
-    variable e : unsigned(0 to 63);     -- 64
-    variable a : unsigned(0 to 16*3-1); -- 48
-    variable b : unsigned(0 to 8*4-1);  -- 32
-    variable c : unsigned(0 to 4*5-1);  -- 20
-    variable d : unsigned(0 to 2*6-1);  -- 12
-  begin
-    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
-    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
-    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
-    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
-    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
-    return ~SYM[2](6,d(0 to 11));
-  end function;
-~ELSE
-  function ~GENSYM[clz32][4] (constant v : unsigned(0 to 31)) return unsigned is
-    variable e : unsigned(0 to 31);    -- 32
-    variable a : unsigned(0 to 8*3-1); -- 24
-    variable b : unsigned(0 to 4*4-1); -- 16
-    variable c : unsigned(0 to 2*5-1); -- 10
-  begin
-    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
-    return ~SYM[2](5,c(0 to 9));
-  end function;
-~FI
-
-  signal ~GENSYM[w_reversed][6] : ~TYP[0];
-begin
-  ~GENSYM[reverse_loop][7] : for ~GENSYM[n][8] in ~VAR[w][0]'range generate
-    ~SYM[6](~VAR[w][0]'high - ~SYM[8]) <= ~VAR[w][0](~SYM[8]);
-  end generate;
-~IF ~IW64 ~THEN
-  ~RESULT <= resize(~SYM[3](~SYM[6]),~SIZE[~TYPO]);
-~ELSE
-  ~RESULT <= resize(~SYM[4](~SYM[6]),~SIZE[~TYPO]);
-~FI
-end block;
--- ctz end"
+      [ "-- ctz begin"
+      , "~GENSYM[ctz][0] : block"
+      , "  function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is"
+      , "  begin"
+      , "    case a is"
+      , "      when \"00\" => return \"10\";"
+      , "      when \"01\" => return \"01\";"
+      , "      when \"10\" => return \"00\";"
+      , "      when others => return \"00\";"
+      , "    end case;"
+      , "  end function;"
+      , ""
+      , "  function ~GENSYM[clzi][2] ("
+      , "    constant n : in natural;"
+      , "    constant i : in unsigned) return unsigned is"
+      , "    variable v : unsigned(i'length-1 downto 0):=i;"
+      , "  begin"
+      , "    if v(n-1+n)='0' then"
+      , "      return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);"
+      , "    else"
+      , "      return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);"
+      , "    end if;"
+      , "  end function;"
+      , ""
+      , "~IF ~IW64 ~THEN"
+      , "  function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is"
+      , "    variable e : unsigned(0 to 63);     -- 64"
+      , "    variable a : unsigned(0 to 16*3-1); -- 48"
+      , "    variable b : unsigned(0 to 8*4-1);  -- 32"
+      , "    variable c : unsigned(0 to 4*5-1);  -- 20"
+      , "    variable d : unsigned(0 to 2*6-1);  -- 12"
+      , "  begin"
+      , "    for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;"
+      , "    for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;"
+      , "    for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;"
+      , "    for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;"
+      , "    for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;"
+      , "    return ~SYM[2](6,d(0 to 11));"
+      , "  end function;"
+      , "~ELSE"
+      , "  function ~GENSYM[clz32][4] (constant v : unsigned(0 to 31)) return unsigned is"
+      , "    variable e : unsigned(0 to 31);    -- 32"
+      , "    variable a : unsigned(0 to 8*3-1); -- 24"
+      , "    variable b : unsigned(0 to 4*4-1); -- 16"
+      , "    variable c : unsigned(0 to 2*5-1); -- 10"
+      , "  begin"
+      , "    for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;"
+      , "    for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;"
+      , "    for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;"
+      , "    for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;"
+      , "    return ~SYM[2](5,c(0 to 9));"
+      , "  end function;"
+      , "~FI"
+      , ""
+      , "  signal ~GENSYM[w_reversed][6] : ~TYP[0];"
+      , "begin"
+      , "  ~GENSYM[reverse_loop][7] : for ~GENSYM[n][8] in ~VAR[w][0]'range generate"
+      , "    ~SYM[6](~VAR[w][0]'high - ~SYM[8]) <= ~VAR[w][0](~SYM[8]);"
+      , "  end generate;"
+      , "~IF ~IW64 ~THEN"
+      , "  ~RESULT <= resize(~SYM[3](~SYM[6]),~SIZE[~TYPO]);"
+      , "~ELSE"
+      , "  ~RESULT <= resize(~SYM[4](~SYM[6]),~SIZE[~TYPO]);"
+      , "~FI"
+      , "end block;"
+      , "-- ctz end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1157,10 +1183,11 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "byteSwap16# :: Word# -> Word#"
     , "template"  :
-"-- byteSwap16 begin~IF ~IW64 ~THEN
-~RESULT <= ~VAR[w][0](63 downto 16) & ~VAR[w][0](7 downto 0) & ~VAR[w][0](15 downto 8);~ELSE
-~RESULT <= ~VAR[w][0](31 downto 16) & ~VAR[w][0](7 downto 0) & ~VAR[w][0](15 downto 8);~FI
--- byteSwap16 end"
+      [ "-- byteSwap16 begin~IF ~IW64 ~THEN"
+      , "~RESULT <= ~VAR[w][0](63 downto 16) & ~VAR[w][0](7 downto 0) & ~VAR[w][0](15 downto 8);~ELSE"
+      , "~RESULT <= ~VAR[w][0](31 downto 16) & ~VAR[w][0](7 downto 0) & ~VAR[w][0](15 downto 8);~FI"
+      , "-- byteSwap16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1169,12 +1196,13 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "byteSwap32# :: Word# -> Word#"
     , "template"  :
-"-- byteSwap32 begin~IF ~IW64 ~THEN
-~RESULT <= ~VAR[w][0](63 downto 32) & ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
-                                    & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~ELSE
-~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
-         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~FI
--- byteSwap32 end"
+      [ "-- byteSwap32 begin~IF ~IW64 ~THEN"
+      , "~RESULT <= ~VAR[w][0](63 downto 32) & ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)"
+      , "                                    & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~ELSE"
+      , "~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)"
+      , "         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~FI"
+      , "-- byteSwap32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1183,12 +1211,13 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "byteSwap64# :: Word# -> Word#"
     , "template"  :
-"-- byteSwap64 begin
-~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
-         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24)
-         & ~VAR[w][0](39 downto 32) & ~VAR[w][0](47 downto 40)
-         & ~VAR[w][0](55 downto 48) & ~VAR[w][0](63 downto 56);
--- byteSwap64 end"
+      [ "-- byteSwap64 begin"
+      , "~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)"
+      , "         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24)"
+      , "         & ~VAR[w][0](39 downto 32) & ~VAR[w][0](47 downto 40)"
+      , "         & ~VAR[w][0](55 downto 48) & ~VAR[w][0](63 downto 56);"
+      , "-- byteSwap64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1197,14 +1226,15 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "byteSwap# :: Word# -> Word#"
     , "template"  :
-"-- byteSwap begin ~IF ~IW64 ~THEN
-~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
-         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24)
-         & ~VAR[w][0](39 downto 32) & ~VAR[w][0](47 downto 40)
-         & ~VAR[w][0](55 downto 48) & ~VAR[w][0](63 downto 56);~ELSE
-~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)
-         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~FI
--- byteSwap end"
+      [ "-- byteSwap begin ~IF ~IW64 ~THEN"
+      , "~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)"
+      , "         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24)"
+      , "         & ~VAR[w][0](39 downto 32) & ~VAR[w][0](47 downto 40)"
+      , "         & ~VAR[w][0](55 downto 48) & ~VAR[w][0](63 downto 56);~ELSE"
+      , "~RESULT <= ~VAR[w][0](7  downto 0 ) & ~VAR[w][0](15 downto 8)"
+      , "         & ~VAR[w][0](23 downto 16) & ~VAR[w][0](31 downto 24);~FI"
+      , "-- byteSwap end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1261,12 +1291,13 @@ end block;
     , "kind"      : "Declaration"
     , "type"      : "bitReverse# :: Word# -> Word#"
     , "template"  :
-"-- bitReverse begin
-~GENSYM[bitReverse][0] : for ~GENSYM[i][1] in 0 to ~IF ~IW64 ~THEN 63 ~ELSE 31 ~FI generate
-begin
-~RESULT(~SYM[1]) <= ~VAR[x][0](~IF ~IW64 ~THEN 63 ~ELSE 31 ~FI-~SYM[1]);
-end generate;
--- bitReverse end"
+      [ "-- bitReverse begin"
+      , "~GENSYM[bitReverse][0] : for ~GENSYM[i][1] in 0 to ~IF ~IW64 ~THEN 63 ~ELSE 31 ~FI generate"
+      , "begin"
+      , "~RESULT(~SYM[1]) <= ~VAR[x][0](~IF ~IW64 ~THEN 63 ~ELSE 31 ~FI-~SYM[1]);"
+      , "end generate;"
+      , "-- bitReverse end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1275,12 +1306,13 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "bitReverse8# :: Word# -> Word#"
     , "template"  :
-"-- bitReverse8 begin
-~GENSYM[bitReverse8][0] : for ~GENSYM[i][1] in 0 to 7 generate
-begin
-~RESULT(~SYM[1]) <= ~VAR[x][0](7-~SYM[1]);
-end generate;
--- bitReverse8 end"
+      [ "-- bitReverse8 begin"
+      , "~GENSYM[bitReverse8][0] : for ~GENSYM[i][1] in 0 to 7 generate"
+      , "begin"
+      , "~RESULT(~SYM[1]) <= ~VAR[x][0](7-~SYM[1]);"
+      , "end generate;"
+      , "-- bitReverse8 end"
+    ]
     }
   }
 , { "BlackBox" :
@@ -1289,12 +1321,13 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "bitReverse16# :: Word# -> Word#"
     , "template"  :
-"-- bitReverse16 begin
-~GENSYM[bitReverse16][0] : for ~GENSYM[i][1] in 0 to 15 generate
-begin
-~RESULT(~SYM[1]) <= ~VAR[x][0](15-~SYM[1]);
-end generate;
--- bitReverse16 end"
+      [ "-- bitReverse16 begin"
+      , "~GENSYM[bitReverse16][0] : for ~GENSYM[i][1] in 0 to 15 generate"
+      , "begin"
+      , "~RESULT(~SYM[1]) <= ~VAR[x][0](15-~SYM[1]);"
+      , "end generate;"
+      , "-- bitReverse16 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1303,12 +1336,13 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "bitReverse32# :: Word# -> Word#"
     , "template"  :
-"-- bitReverse32 begin
-~GENSYM[bitReverse32][0] : for ~GENSYM[i][1] in 0 to 31 generate
-begin
-~RESULT(~SYM[1]) <= ~VAR[x][0](31-~SYM[1]);
-end generate;
--- bitReverse32 end"
+      [ "-- bitReverse32 begin"
+      , "~GENSYM[bitReverse32][0] : for ~GENSYM[i][1] in 0 to 31 generate"
+      , "begin"
+      , "~RESULT(~SYM[1]) <= ~VAR[x][0](31-~SYM[1]);"
+      , "end generate;"
+      , "-- bitReverse32 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1317,12 +1351,13 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "bitReverse64# :: Word# -> Word#"
     , "template"  :
-"-- bitReverse64 begin
-~GENSYM[bitReverse64][0] : for ~GENSYM[i][1] in 0 to 63 generate
-begin
-~RESULT(~SYM[1]) <= ~VAR[x][0](63-~SYM[1]);
-end generate;
--- bitReverse64 end"
+      [ "-- bitReverse64 begin"
+      , "~GENSYM[bitReverse64][0] : for ~GENSYM[i][1] in 0 to 63 generate"
+      , "begin"
+      , "~RESULT(~SYM[1]) <= ~VAR[x][0](63-~SYM[1]);"
+      , "end generate;"
+      , "-- bitReverse64 end"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1330,11 +1365,12 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "quotInt# :: Int# -> Int# -> Int#"
     , "template"  :
-"~RESULT <= ~ARG[0] / ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] / ~ARG[1]"
+      , "    -- pragma translate_off"
+      , "    when (~ARG[1] /= 0) else (others => 'X')"
+      , "    -- pragma translate_on"
+      , "    ;"
+      ]
     }
   }
 , { "BlackBox" :
@@ -1342,11 +1378,12 @@ end generate;
     , "kind"      : "Declaration"
     , "type"      : "quotWord# :: Word# -> Word# -> Word#"
     , "template"  :
-"~RESULT <= ~ARG[0] / ~ARG[1]
-    -- pragma translate_off
-    when (~ARG[1] /= 0) else (others => 'X')
-    -- pragma translate_on
-    ;"
+      [ "~RESULT <= ~ARG[0] / ~ARG[1]"
+      ,"    -- pragma translate_off"
+      ,"    when (~ARG[1] /= 0) else (others => 'X')"
+      ,"    -- pragma translate_on"
+      ,"    ;"
+      ]
     }
   }
 ]

--- a/clash-lib/src/Clash/Primitives/Types.hs
+++ b/clash-lib/src/Clash/Primitives/Types.hs
@@ -48,7 +48,7 @@ import           Data.Hashable                (Hashable)
 import qualified Data.HashMap.Strict          as H
 import           Data.List                    (intercalate)
 import qualified Data.Text                    as S
-import           Data.Text.Lazy               (Text)
+import           Data.Text.Lazy               as T (Text,unlines)
 import           GHC.Generics                 (Generic)
 import           GHC.Stack                    (HasCallStack)
 import           Text.Read                    (readMaybe)
@@ -286,9 +286,13 @@ instance FromJSON UnresolvedPrimitive where
       parseTemplate c =
         (,) <$> ((,) <$> (c .:? "format" >>= traverse parseTemplateFormat) .!= TTemplate
                      <*> (c .:? "templateFunction" >>= traverse parseBBFN') .!= defTemplateFunction)
-            <*> (Just . TInline <$> c .: "template" <|>
-                 Just . TFile   <$> c .: "file" <|>
-                 pure Nothing)
+            <*> ( Just . TInline <$>
+                    (   c .: "template"
+                    <|> T.unlines <$> c .: "template"
+                    )
+                <|> Just . TFile   <$> c .: "file"
+                <|> pure Nothing
+                )
 
       parseInclude c =
         (,) <$> ((,) <$> c .: "name" <*> c .: "extension")


### PR DESCRIPTION
This PR:

- Adds support for formatting multi-line strings in black-box files as arrays of strings.
  Existing black-boxes using multi-line strings remain supported.
- Re-formats _all_ primitives in clash with multi-line strings into this form
- Adds a setting to the project vscode settings, associating `.primitives` files as `.jsonc`

Backwards compatibility is preserved as I'm aware there are other repos out that would be broken by a breaking change in schema. 

The motivation for this is "Developer UX". By making these files valid JSON, syntax highlighting / editor support / auto format become available using any tool which operates on JSON. It also significantly reduces the signal to noise ratio in the editors error bar

In changing the formatting of the black-boxes, `template`, `comments`, and `type` fields have been modified. However, I could find no use of `type` or `comments`, so I guess they're advisory only?

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
