### PR TITLE
Use pointer equality to shortcut `eqTerm`

### DIFF
--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -271,6 +271,7 @@ Library
 
                       Clash.Unique
                       Clash.Util
+                      Clash.Util.Eq
                       Clash.Util.Graph
                       Clash.Util.Interpolate
                       Clash.Pretty

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -88,6 +88,7 @@ import           Clash.Rewrite.Types
 import           Clash.Rewrite.WorkFree
 import           Clash.Unique
 import           Clash.Util
+import           Clash.Util.Eq               (fastEqBy)
 import qualified Clash.Util.Interpolate as I
 
 -- | Lift an action working in the '_extra' state to the 'RewriteMonad'
@@ -245,7 +246,8 @@ applyDebug name exprOld hasChanged exprNew = do
                        ]
               )
 
-    Monad.when (dbg_invariants opts && not hasChanged && not (exprOld `eqTerm` exprNew)) $
+    let exprNotEqual = not (fastEqBy eqTerm exprOld exprNew)
+    Monad.when (dbg_invariants opts && not hasChanged && exprNotEqual) $
       error $ $(curLoc) ++ "Expression changed without notice(" ++ name ++  "): before"
                         ++ before ++ "\nafter:\n" ++ after
 

--- a/clash-lib/src/Clash/Util/Eq.hs
+++ b/clash-lib/src/Clash/Util/Eq.hs
@@ -1,0 +1,46 @@
+{-|
+  Copyright  :  (C) 2021     , QBayLogic B.V.
+  License    :  BSD2 (see the file LICENSE)
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Utilities related to the 'Eq' type class.
+-}
+{-# LANGUAGE MagicHash #-}
+
+module Clash.Util.Eq
+  ( fastEq
+  , fastEqBy
+  ) where
+
+import GHC.Exts (isTrue#, reallyUnsafePtrEquality#)
+
+-- | Compare two values using pointer equality. If that fails, use 'Eq' to
+-- determine equality. Note that this function will only shortcut for values
+-- that are the same, but will always use 'Eq' for values that differ.
+--
+-- Values are evaluated to WHNF before comparison. This function can therefore
+-- not be used if any of its arguments is expected to be bottom.
+fastEq :: Eq a => a -> a -> Bool
+fastEq = fastEqBy (==)
+
+-- | Compare two values using pointer equality. If that fails, use given function
+-- to determine equality. Note that this function will only shortcut for values
+-- that are the same, but will always use the given function for values that
+-- differ.
+--
+-- Values are evaluated to WHNF before comparison. This function can therefore
+-- not be used if any of its arguments is expected to be bottom.
+fastEqBy :: (a -> a -> Bool) -> a -> a -> Bool
+fastEqBy f a1 a2
+  | a1 `pointerEq` a2 = True
+  | otherwise = f a1 a2
+
+{-# NOINLINE pointerEq #-}
+-- | Compares two values by comparing their positions on the heap. This function
+-- will return 'True' if the values are the same object, 'False' otherwise. Note
+-- that 'False' does *not* mean that the values are *not* the same. Values are
+-- evaluated to WHNF before comparison.
+--
+-- Note: copied from @unordered-containers@.
+pointerEq :: a -> a -> Bool
+pointerEq !x !y = isTrue# (reallyUnsafePtrEquality# x y)


### PR DESCRIPTION
This speeds up the testsuite by ~10%. On my laptop using `-p VHDL.clash`,
I see 758.23s before the patch, and 682.40s after. When synthesizing our
I2C testcase, I see the following normalization times:

|      | Before patch | After patch | B/A  |
|------|--------------|-------------|------|
| Bit  | 0.428        | 0.311       | 1.38 |
| Byte | 0.223        | 0.166       | 1.34 |
| Top  | 0.017        | 0.012       | 1.42 |

[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
