### PR TITLE
Add flag to generate verilator shims

### DIFF
--- a/changelog/2021-11-23T17_08_17+01_00_clash_verilator_flag.md
+++ b/changelog/2021-11-23T17_08_17+01_00_clash_verilator_flag.md
@@ -1,0 +1,1 @@
+ADDED: Clash can now generate shims for using verilator to simulate top entities when called with `-fclash-verilator`.

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -89,6 +89,7 @@ flagsClash r = [
   , defFlag "fclash-inline-workfree-limit"       $ IntSuffix (liftEwM . setInlineWFLimit r)
   , defFlag "fclash-edalize"                     $ NoArg (liftEwM (setEdalize r))
   , defFlag "fclash-no-render-enums"             $ NoArg (liftEwM (setNoRenderEnums r))
+  , defFlag "fclash-verilator"                   $ NoArg (liftEwM (setVerilator r))
   ]
 
 -- | Print deprecated flag warning
@@ -324,3 +325,6 @@ setRewriteHistoryFile r arg = do
 
 setNoRenderEnums :: IORef ClashOpts -> IO ()
 setNoRenderEnums r = modifyIORef r (\c -> c { opt_renderEnums = False })
+
+setVerilator :: IORef ClashOpts -> IO ()
+setVerilator r = modifyIORef r (\c -> c { opt_verilator = True })

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -362,6 +362,8 @@ data ClashOpts = ClashOpts
   , opt_renderEnums :: Bool
   -- ^ Render sum types with all zero-width fields as enums where supported, as
   -- opposed to rendering them as bitvectors.
+  , opt_verilator :: Bool
+  -- ^ Generate shims for top entities for use with Verilator.
   }
 
 instance Hashable ClashOpts where
@@ -393,7 +395,8 @@ instance Hashable ClashOpts where
     opt_aggressiveXOptBB `hashWithSalt`
     opt_inlineWFCacheLimit `hashWithSalt`
     opt_edalize `hashWithSalt`
-    opt_renderEnums
+    opt_renderEnums `hashWithSalt`
+    opt_verilator
    where
     hashOverridingBool :: Int -> OverridingBool -> Int
     hashOverridingBool s1 Auto = hashWithSalt s1 (0 :: Int)
@@ -432,6 +435,7 @@ defClashOpts
   , opt_inlineWFCacheLimit  = 10 -- TODO: find "optimal" value
   , opt_edalize             = False
   , opt_renderEnums         = True
+  , opt_verilator           = False
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.


### PR DESCRIPTION
Clash can now be called with `-fclash-verilator` which generates the required C++ shim for simulating a top entity.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
