### PR TITLE
Fix typo in clockGen documentation

### DIFF
--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -850,7 +850,7 @@ clockTag
 clockTag (Clock dom) = dom
 
 -- | Clock generator for simulations. Do __not__ use this clock generator for
--- for the /testBench/ function, use 'Clash.Explicit.Testbench.tbClockGen' instead.
+-- the /testBench/ function, use 'Clash.Explicit.Testbench.tbClockGen' instead.
 --
 -- To be used like:
 --


### PR DESCRIPTION
This change removes a duplicate `for`.
