### PR TITLE
Refactor `LoadInterfaceFiles` to prevent O(n^2) binder loading

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -138,9 +138,9 @@ generateBindings startAction useColor primDirs importDirs dbs hdl modName dflags
    , customBitRepresentations
    , primGuards
    , domainConfs ) <- loadModules startAction useColor hdl modName dflagsM importDirs
+  startTime <- Clock.getCurrentTime
   primMapR <- generatePrimMap unresolvedPrims primGuards (concat [pFP, primDirs, importDirs])
   tdir <- maybe ghcLibDir (pure . GHC.topDir) dflagsM
-  startTime <- Clock.getCurrentTime
   primMapC <-
     sequence $ HashMap.map
                  (sequence . fmap (compilePrimitive importDirs dbs tdir))

--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -6,29 +6,41 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 
 module Clash.GHC.LoadInterfaceFiles
   ( loadExternalExprs
   , loadExternalBinders
   , getUnresolvedPrimitives
   , LoadedBinders(..)
-  , mergeLoadedBinders
-  , emptyLb
   )
 where
 
 -- External Modules
 import           Control.Monad.IO.Class      (MonadIO (..))
+import           Control.Monad               (forM_, join)
+import           Control.Monad.State.Strict
+  (StateT, gets, MonadState (get), MonadTrans (lift), execStateT)
+import           Control.Monad.Trans.State.Strict (modify)
+import           Control.Monad.Extra         (unlessM)
 import qualified Data.ByteString.Lazy.UTF8   as BLU
 import qualified Data.ByteString.Lazy        as BL
+import qualified Data.Sequence               as Seq
+import           Data.Sequence               (Seq)
 import           Data.Either                 (partitionEithers)
-import           Data.List                   (elemIndex, foldl')
+import           Data.Foldable               (foldl')
+import           Data.List                   (elemIndex)
 import qualified Data.Text                   as Text
 import           Data.Maybe                  (isNothing, mapMaybe, catMaybes)
+import           Data.Map.Strict             (Map)
+import qualified Data.Map.Strict             as Map
+import           Data.Set                    (Set)
+import qualified Data.Set                    as Set
 import           Data.Word                   (Word8)
 
 -- GHC API
@@ -58,7 +70,6 @@ import qualified GHC.IfaceToCore as TcIface
 import qualified GHC.Tc.Utils.Monad as TcRnMonad
 import qualified GHC.Tc.Types as TcRnTypes
 import qualified GHC.Types.Unique.FM as UniqFM
-import qualified GHC.Types.Unique.Set as UniqSet
 import qualified GHC.Types.Var as Var
 import qualified GHC.Unit.Types as UnitTypes
 #else
@@ -85,7 +96,6 @@ import qualified TcIface
 import qualified TcRnMonad
 import qualified TcRnTypes
 import qualified UniqFM
-import qualified UniqSet
 import qualified Var
 #endif
 
@@ -103,49 +113,128 @@ import qualified Clash.Util.Interpolate              as I
 
 -- | Data structure tracking loaded binders (and their related data)
 data LoadedBinders = LoadedBinders
-  { lbBinders :: [(CoreSyn.CoreBndr, CoreSyn.CoreExpr)]
+  { lbBinders :: !(Map CoreSyn.CoreBndr CoreSyn.CoreExpr)
   -- ^ Binder + expression it's binding
-  , lbClassOps :: [(CoreSyn.CoreBndr, Int)]
+  , lbClassOps :: !(Map CoreSyn.CoreBndr Int)
   -- ^ Type class dict projection functions
-  , lbUnlocatable :: [CoreSyn.CoreBndr]
+  , lbUnlocatable :: !(Set CoreSyn.CoreBndr)
   -- ^ Binders with missing unfoldings
-  , lbPrims :: [Either UnresolvedPrimitive FilePath]
+  , lbPrims :: !(Seq (Either UnresolvedPrimitive FilePath))
   -- ^ Primitives; either an primitive data structure or a path to a directory
   -- containing json files
-  , lbReprs :: [DataRepr']
+  , lbReprs :: !(Seq DataRepr')
   -- ^ Custom data representations
+  , lbCache :: !DeclCache
+  -- ^ Loaded module cache
   }
 
-mergeLoadedBinders :: [LoadedBinders] -> LoadedBinders
-mergeLoadedBinders lbs =
-  LoadedBinders {
-    lbBinders=concat (map lbBinders lbs)
-  , lbClassOps=concat (map lbClassOps lbs)
-  , lbUnlocatable=concat (map lbUnlocatable lbs)
-  , lbPrims=concat (map lbPrims lbs)
-  , lbReprs=concat (map lbReprs lbs)
-  }
+type LoadedBinderT m a = StateT LoadedBinders m a
+
+-- | Stores modules with easy binder lookup
+type DeclCache = Map GHC.Module (Maybe (Map GHC.Name IfaceSyn.IfaceDecl))
+
+
+-- | Collects free variables in an expression, and splits them into "normal"
+-- free variables and class ops.
+bndrsInExpr :: CoreSyn.CoreExpr -> ([CoreSyn.CoreBndr], [(CoreSyn.CoreBndr, Int)])
+bndrsInExpr e = partitionEithers (map go freeVars)
+ where
+  freeVars = CoreFVs.exprSomeFreeVarsList isInteresting e
+  isInteresting v = Var.isId v && isNothing (Id.isDataConId_maybe v)
+
+  go :: Var.Var -> Either Var.Id (CoreSyn.CoreBndr, Int)
+  go v = case Id.isClassOpId_maybe v of
+    Just cls -> Right (v, goClsOp v cls)
+    Nothing -> Left v
+
+  goClsOp :: Var.Var -> GHC.Class -> Int
+  goClsOp v c =
+    case elemIndex v (Class.classAllSelIds c) of
+      Nothing -> error [I.i|
+        Internal error: couldn't find class method
+
+          #{showPpr DynFlags.unsafeGlobalDynFlags v}
+
+        in class
+
+          #{showPpr DynFlags.unsafeGlobalDynFlags c}
+      |]
+      Just n -> n
+
+-- | Add a binder to the appropriate fields of 'LoadedBinders', and recursively
+-- load binders found in the optionally supplied expression.
+addBndrM ::
+  GHC.GhcMonad m =>
+  HDL ->
+  CoreSyn.CoreBndr ->
+  Maybe CoreSyn.CoreExpr ->
+  LoadedBinderT m ()
+addBndrM hdl bndr exprM =
+  case exprM of
+    Nothing ->
+      modify $ \lb@LoadedBinders{..} ->
+        lb{lbUnlocatable=Set.insert bndr lbUnlocatable}
+    Just expr -> do
+      -- Add current expression and its class ops
+      let (fvs, clsOps) = bndrsInExpr expr
+      modify $ \lb@LoadedBinders{..} ->
+        lb { lbBinders=Map.insert bndr expr lbBinders
+           , lbClassOps=mapInsertAll lbClassOps clsOps }
+
+      -- Load all free variables - if not yet loaded
+      forM_ fvs $ \v ->
+        unlessM (isLoadedBinderM v) (loadExprFromIface hdl v)
+ where
+  -- Insert a list of keys and values into a 'Map'
+  mapInsertAll :: Ord k => Map k a -> [(k, a)] -> Map k a
+  mapInsertAll = foldl' (\m (k, v) -> Map.insert k v m)
+
+
+isLoadedBinderM :: Monad m => CoreSyn.CoreBndr -> LoadedBinderT m Bool
+isLoadedBinderM bndr = gets $ \LoadedBinders{..} ->
+     Map.member bndr lbBinders
+  || Map.member bndr lbClassOps
+  || Set.member bndr lbUnlocatable
 
 emptyLb :: LoadedBinders
-emptyLb = LoadedBinders [] [] [] [] []
+emptyLb = LoadedBinders
+  { lbBinders = mempty
+  , lbClassOps = mempty
+  , lbUnlocatable = mempty
+  , lbPrims = mempty
+  , lbReprs = mempty
+  , lbCache = mempty
+  }
 
-collectLbBinders :: LoadedBinders -> [CoreSyn.CoreBndr]
-collectLbBinders LoadedBinders{lbBinders, lbUnlocatable, lbClassOps} =
-  concat [map fst lbBinders, lbUnlocatable, map fst lbClassOps]
+#if MIN_VERSION_ghc(9,0,0)
+notBoot :: UnitTypes.IsBootInterface
+notBoot = UnitTypes.NotBoot
+#else
+notBoot :: Bool
+notBoot = False
+#endif
 
 runIfl :: GHC.GhcMonad m => GHC.Module -> TcRnTypes.IfL a -> m a
 runIfl modName action = do
+  let
+    localEnv = TcRnTypes.IfLclEnv
+      { TcRnTypes.if_mod = modName
+      , TcRnTypes.if_boot = notBoot
+      , TcRnTypes.if_loc = text "runIfl"
+      , TcRnTypes.if_nsubst = Nothing
+      , TcRnTypes.if_implicits_env = Nothing
+      , TcRnTypes.if_tv_env = UniqFM.emptyUFM
+      , TcRnTypes.if_id_env = UniqFM.emptyUFM
+      }
+
+    globalEnv = TcRnTypes.IfGblEnv
+      { TcRnTypes.if_doc = text "Clash.runIfl"
+      , TcRnTypes.if_rec_types = Nothing
+      }
+
   hscEnv <- GHC.getSession
-  let localEnv = TcRnTypes.IfLclEnv modName
-#if MIN_VERSION_ghc(9,0,0)
-                   UnitTypes.NotBoot
-#else
-                   False
-#endif
-                   (text "runIfl") Nothing Nothing UniqFM.emptyUFM UniqFM.emptyUFM
-  let globalEnv = TcRnTypes.IfGblEnv (text "Clash.runIfl") Nothing
-  MonadUtils.liftIO $ TcRnMonad.initTcRnIf 'r' hscEnv globalEnv
-                        localEnv action
+  MonadUtils.liftIO $
+    TcRnMonad.initTcRnIf 'r' hscEnv globalEnv localEnv action
 
 loadDecl :: IfaceSyn.IfaceDecl -> TcRnTypes.IfL GHC.TyThing
 loadDecl = TcIface.tcIfaceDecl False
@@ -168,145 +257,134 @@ loadIface foundMod = do
                                            ]
                          in traceIf True msg' (return Nothing)
 
-loadExternalBinders
-  :: GHC.GhcMonad m
-  => HDL
-  -> [CoreSyn.CoreBndr]
-  -> m LoadedBinders
-loadExternalBinders hdl bndrs = do
-  loaded <- mergeLoadedBinders <$> mapM (loadExprFromIface hdl) bndrs
-  fst <$>
-    loadExternalExprs'
-      hdl
-      loaded
-      (UniqSet.mkUniqSet (collectLbBinders loaded))
-      (map snd (lbBinders loaded))
+-- | Given a list of top-level binders, recursively load all the binders,
+-- primitives, and type classes it is using. (Exported function.)
+loadExternalBinders :: GHC.GhcMonad m => HDL -> [CoreSyn.CoreBndr] -> m LoadedBinders
+loadExternalBinders hdl bndrs =
+  flip execStateT emptyLb $
+    mapM_ (loadExprFromIface hdl) bndrs
 
-loadExternalExprs
-  :: GHC.GhcMonad m
-  => HDL
-  -> UniqSet.UniqSet CoreSyn.CoreBndr
-  -> [CoreSyn.CoreBind]
-  -> m LoadedBinders
-loadExternalExprs hdl = go emptyLb
-  where
-    go loaded _ [] =
-      return loaded
-    go loaded0 visited0 (CoreSyn.NonRec _ e:bs) = do
-      (loaded1, visited1) <- loadExternalExprs' hdl loaded0 visited0 [e]
-      go loaded1 visited1 bs
-    go loaded0 visited0 (CoreSyn.Rec bs:bs') = do
-      (loaded1, visited1) <- loadExternalExprs' hdl loaded0 visited0 (map snd bs)
-      go loaded1 visited1 bs'
-
--- | Used by entry points: 'loadExternalExprs', 'loadExternalBinders'
-loadExternalExprs'
-  :: GHC.GhcMonad m
-  => HDL
-  -> LoadedBinders
-  -> UniqSet.UniqSet CoreSyn.CoreBndr
-  -> [CoreSyn.CoreExpr]
-  -> m ( LoadedBinders, UniqSet.UniqSet CoreSyn.CoreBndr)
-loadExternalExprs' _hdl loaded visited [] =
-  return (loaded, visited)
-loadExternalExprs' hdl loaded0 visited0 (e:es) = do
-  let
-    isInteresting v =
-         Var.isId v
-      && not (v `UniqSet.elementOfUniqSet` visited0)
-      && isNothing (Id.isDataConId_maybe v)
-
-    fvs0 = CoreFVs.exprSomeFreeVarsList isInteresting e
-    fvs1 = map (\v -> maybe (Left v) (Right . (v,)) (Id.isClassOpId_maybe v)) fvs0
-    (fvs2, clsOps0) = partitionEithers fvs1
-    clsOps1 = map goClsOp clsOps0
-
-  loaded1 <- mergeLoadedBinders <$> mapM (loadExprFromIface hdl) fvs2
-
-  loadExternalExprs'
-    hdl
-    (mergeLoadedBinders [loaded0, loaded1, emptyLb{lbClassOps=clsOps1}])
-    (foldl' UniqSet.addListToUniqSet visited0 [collectLbBinders loaded1, map fst clsOps0])
-    (es ++ map snd (lbBinders loaded1))
+-- Given a list of binds, recursively load all its binders, primitives, and
+-- type classes it is using. (Exported function.)
+loadExternalExprs :: GHC.GhcMonad m => HDL -> [CoreSyn.CoreBind] -> m LoadedBinders
+loadExternalExprs hdl binds0 =
+  flip execStateT initLb $
+    mapM_ (\(b, e) -> addBndrM hdl b (Just e)) binds1
  where
-  goClsOp :: (Var.Var, GHC.Class) -> (CoreSyn.CoreBndr, Int)
-  goClsOp (v, c) =
-    case elemIndex v (Class.classAllSelIds c) of
-      Nothing -> error [I.i|
-        Internal error: couldn't find class-method
+  -- 'lbBinders' is preinitialized with all binders in given binds, as the given
+  -- binders can't be loaded from precompiled modules
+  initLb = emptyLb{lbBinders=Map.fromList binds1}
+  binds1 = CoreSyn.flattenBinds binds0
 
-          #{showPpr DynFlags.unsafeGlobalDynFlags v}
+-- | Try to fetch a IfaceDecl from a 'DeclCache'. If a module has not been loaded
+-- before, load it using GHC. Additionally, add annotations mentioned in the
+-- module to 'LoadedBinders'.
+getIfaceDeclM ::
+  forall m.
+  GHC.GhcMonad m =>
+  HDL ->
+  -- | Binder to load
+  CoreSyn.CoreBndr ->
+  -- | Declaration, if found
+  LoadedBinderT m (Maybe (GHC.Module, IfaceSyn.IfaceDecl))
+getIfaceDeclM hdl bndr = do
+  let modM = Name.nameModule_maybe bndrName
+  join <$> mapM go modM
+ where
+  bndrName = Var.varName bndr
 
-        in class
+  go :: GHC.Module -> LoadedBinderT m (Maybe (GHC.Module, IfaceSyn.IfaceDecl))
+  go nameMod = do
+    LoadedBinders{lbCache} <- get
+    case Map.lookup nameMod lbCache of
+      Nothing -> do
+        -- Not loaded before
+        ifaceM <- lift (runIfl nameMod (loadIface nameMod))
+        case ifaceM of
+          Just iface -> do
+            -- Add binder : decl map to cache
+            let
+              decls = map snd (GHC.mi_decls iface)
+              names = map IfaceSyn.ifName decls
+            let declMap = Just (Map.fromList (zip names decls))
+            modify (\lb -> lb{lbCache=Map.insert nameMod declMap lbCache})
 
-          #{showPpr DynFlags.unsafeGlobalDynFlags c}
-      |]
-      Just n -> (v, n)
+            -- Load annotations and add them to state
+            loadAnnotationsM hdl nameMod iface
+          Nothing ->
+            -- XXX: 'runIfl' should probably error hard if this happens?
+            modify (\lb -> lb{lbCache=Map.insert nameMod Nothing lbCache})
 
-loadExprFromIface
-  :: GHC.GhcMonad m
-  => HDL
-  -> CoreSyn.CoreBndr
-  -> m LoadedBinders
+        -- Update cache and try again
+        go nameMod
+
+      Just Nothing ->
+        -- Loaded before, but couldn't find decl
+        pure Nothing
+      Just (Just declMap) ->
+        -- Loaded before, decl found
+        pure ((nameMod,) <$> Map.lookup bndrName declMap)
+
+loadAnnotationsM ::
+  GHC.GhcMonad m =>
+  HDL ->
+  GHC.Module ->
+  GHC.ModIface ->
+  StateT LoadedBinders m ()
+loadAnnotationsM hdl modName iface = do
+  anns <- lift (runIfl modName (TcIface.tcIfaceAnnotations (GHC.mi_anns iface)))
+  primFPs <- loadPrimitiveAnnotations hdl anns
+  let reprs = loadCustomReprAnnotations anns
+  modify $ \lb@LoadedBinders{..} -> lb
+    { lbPrims = lbPrims <> Seq.fromList primFPs
+    , lbReprs = lbReprs <> Seq.fromList reprs
+    }
+
+loadExprFromIface ::
+  GHC.GhcMonad m =>
+  HDL ->
+  CoreSyn.CoreBndr ->
+  LoadedBinderT m ()
 loadExprFromIface hdl bndr = do
-  let moduleM = Name.nameModule_maybe $ Var.varName bndr
-  case moduleM of
-    Just nameMod -> runIfl nameMod $ do
-      ifaceM <- loadIface nameMod
-      case ifaceM of
-        Nothing ->
-          return (emptyLb{lbUnlocatable=[bndr]})
-        Just iface -> do
-          let decls = map snd (GHC.mi_decls iface)
-          let nameFun = GHC.getOccName $ Var.varName bndr
-          let declM = filter ((== nameFun) . Name.nameOccName . IfaceSyn.ifName) decls
-          anns <- TcIface.tcIfaceAnnotations (GHC.mi_anns iface)
-          primFPs   <- loadPrimitiveAnnotations hdl anns
-          let reprs  = loadCustomReprAnnotations anns
-              lb     = emptyLb{lbPrims=primFPs, lbReprs=reprs}
-          case declM of
-            [namedDecl] -> do
-              tyThing <- loadDecl namedDecl
-              case loadExprFromTyThing bndr tyThing of
-                Left bndr1 -> return (lb{lbBinders=[bndr1]})
-                Right unloc -> return (lb{lbUnlocatable=[unloc]})
-            _ -> return (lb{lbUnlocatable=[bndr]})
-    Nothing ->
-      return (emptyLb{lbUnlocatable=[bndr]})
+  namedDeclM <- getIfaceDeclM hdl bndr
+  case namedDeclM of
+    Nothing -> addBndrM hdl bndr Nothing
+    Just (nameMod, namedDecl) -> do
+      tyThing <- lift (runIfl nameMod (loadDecl namedDecl))
+      addBndrM hdl bndr (loadExprFromTyThing bndr tyThing)
 
 
-loadCustomReprAnnotations
-  :: [Annotations.Annotation]
-  -> [DataRepr']
+loadCustomReprAnnotations :: [Annotations.Annotation] -> [DataRepr']
 loadCustomReprAnnotations anns =
-  catMaybes $ map go $ catMaybes $ zipWith filterNameless anns reprs
-    where
-        env         = Annotations.mkAnnEnv anns
-        deserialize = GhcPlugins.deserializeWithData :: [Word8] -> DataReprAnn
+  mapMaybe go $ catMaybes $ zipWith filterNameless anns reprs
+ where
+  env = Annotations.mkAnnEnv anns
+  deserialize = GhcPlugins.deserializeWithData :: [Word8] -> DataReprAnn
+
 #if MIN_VERSION_ghc(9,0,0)
-        reprs       = let (mEnv,nEnv) = Annotations.deserializeAnns deserialize env
-                       in ModuleEnv.moduleEnvElts mEnv <> NameEnv.nameEnvElts nEnv
+  (mEnv, nEnv) = Annotations.deserializeAnns deserialize env
+  reprs = ModuleEnv.moduleEnvElts mEnv <> NameEnv.nameEnvElts nEnv
 #else
-        reprs       = UniqFM.eltsUFM (Annotations.deserializeAnns deserialize env)
+  reprs = UniqFM.eltsUFM (Annotations.deserializeAnns deserialize env)
 #endif
 
-        filterNameless
-          :: Annotation
-          -> [DataReprAnn]
-          -> Maybe (Name.Name, [DataReprAnn])
-        filterNameless (Annotation ann_target _) reprs' =
-          (,reprs') <$> getAnnTargetName_maybe ann_target
+  filterNameless :: Annotation -> [DataReprAnn] -> Maybe (Name.Name, [DataReprAnn])
+  filterNameless (Annotation ann_target _) reprs' =
+    (,reprs') <$> getAnnTargetName_maybe ann_target
 
-        go
-          :: (Name.Name, [DataReprAnn])
-          -> Maybe DataRepr'
-        go (_name, [])      = Nothing
-        go (_name,  [repr]) = Just $ dataReprAnnToDataRepr' repr
-        go (name, reprs')   =
-          error $ $(curLoc) ++ "Multiple DataReprAnn annotations for same type: \n\n"
-                            ++ (Outputable.showPpr DynFlags.unsafeGlobalDynFlags name)
-                            ++ "\n\nReprs:\n\n"
-                            ++ show reprs'
+  go :: (Name.Name, [DataReprAnn]) -> Maybe DataRepr'
+  go (_name, []) = Nothing
+  go (_name,  [repr]) = Just $ dataReprAnnToDataRepr' repr
+  go (name, reprs')   =
+    error [I.i|
+      Multiple DataReprAnn annotations for same type:
+
+        #{Outputable.showPpr DynFlags.unsafeGlobalDynFlags name}
+
+      Reprs:
+
+        #{reprs'}
+    |]
 
 loadPrimitiveAnnotations ::
   MonadIO m
@@ -327,7 +405,7 @@ getUnresolvedPrimitives
   :: MonadIO m
   => HDL
   -> (Annotations.CoreAnnTarget, Primitive)
-  -> m ([Either UnresolvedPrimitive FilePath])
+  -> m [Either UnresolvedPrimitive FilePath]
 getUnresolvedPrimitives hdl targetPrim =
   case targetPrim of
     (_, Primitive hdls fp) | hdl `elem` hdls -> pure [Right fp]
@@ -362,37 +440,27 @@ getUnresolvedPrimitives hdl targetPrim =
       -- currently targeting.
       pure []
 
-loadExprFromTyThing
-  :: CoreSyn.CoreBndr
-  -> GHC.TyThing
-  -> Either
-       (CoreSyn.CoreBndr,CoreSyn.CoreExpr)  -- Located Binder
-       CoreSyn.CoreBndr                     -- unlocatable Var
+loadExprFromTyThing :: CoreSyn.CoreBndr -> GHC.TyThing -> Maybe CoreSyn.CoreExpr
 loadExprFromTyThing bndr tyThing = case tyThing of
   GHC.AnId _id | Var.isId _id ->
     let _idInfo    = Var.idInfo _id
         unfolding  = IdInfo.unfoldingInfo _idInfo
     in case unfolding of
       CoreSyn.CoreUnfolding {} ->
-        Left (bndr, CoreSyn.unfoldingTemplate unfolding)
-      (CoreSyn.DFunUnfolding dfbndrs dc es) ->
-        let dcApp  = MkCore.mkCoreConApps dc es
-            dfExpr = MkCore.mkCoreLams dfbndrs dcApp
-        in Left (bndr,dfExpr)
+        Just (CoreSyn.unfoldingTemplate unfolding)
+      CoreSyn.DFunUnfolding dfbndrs dc es ->
+        Just (MkCore.mkCoreLams dfbndrs (MkCore.mkCoreConApps dc es))
       CoreSyn.NoUnfolding
 #if MIN_VERSION_ghc(9,0,0)
         | Demand.isDeadEndSig $ IdInfo.strictnessInfo _idInfo
 #else
         | Demand.isBottomingSig $ IdInfo.strictnessInfo _idInfo
 #endif
-        -> Left
-            ( bndr
-            , MkCore.mkAbsentErrorApp
-                (Var.varType _id)
-                ("no_unfolding " ++ showPpr unsafeGlobalDynFlags bndr)
-            )
-      _ -> Right bndr
-  _ -> Right bndr
+        -> do
+          let noUnfoldingErr = "no_unfolding " ++ showPpr unsafeGlobalDynFlags bndr
+          Just (MkCore.mkAbsentErrorApp (Var.varType _id) noUnfoldingErr)
+      _ -> Nothing
+  _ -> Nothing
 
 #if MIN_VERSION_ghc(9,0,0)
 -- | Get the 'name' of an annotation target if it exists.

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -48,6 +48,7 @@ import           Data.Char                       (isDigit)
 import           Data.Generics.Uniplate.DataOnly (transform)
 import           Data.Data                       (Data)
 import           Data.Functor                    ((<&>))
+import           Data.Foldable                   (toList)
 import           Data.HashMap.Strict             (HashMap)
 import qualified Data.HashMap.Strict             as HashMap
 import           Data.Typeable                   (Typeable)
@@ -58,6 +59,7 @@ import qualified Data.Text                       as Text
 import qualified Data.Text.Encoding              as Text
 import qualified Data.Time.Clock                 as Clock
 import qualified Data.Set                        as Set
+import qualified Data.Sequence                   as Seq
 import           Debug.Trace
 import           Language.Haskell.TH.Syntax      (lift)
 import           GHC.Natural                     (naturalFromInteger)
@@ -216,7 +218,7 @@ loadExternalModule hdl modName0 = Exception.gtry $ do
   tyThings <- catMaybes <$> mapM GHC.lookupGlobalName (GHC.modInfoExports modInfo)
   let rootIds = [id_ | GHC.AnId id_ <- tyThings]
   loaded <- loadExternalBinders hdl rootIds
-  let allBinders = makeRecursiveGroups (lbBinders loaded)
+  let allBinders = makeRecursiveGroups (Map.assocs (lbBinders loaded))
   return (rootIds, FamInstEnv.emptyFamInstEnv, modName1, loaded, allBinders)
 
 setupGhc
@@ -369,13 +371,13 @@ loadLocalModule hdl modName = do
   -- Because tidiedMods is in topological order, binders is also, and hence
   -- the binders belonging to the "root" module are the last binders
   let rootIds = map fst . CoreSyn.flattenBinds $ last binders
-  loaded0 <- loadExternalExprs hdl (UniqSet.mkUniqSet binderIds) (concat binders)
+  loaded0 <- loadExternalExprs hdl (concat binders)
 
   -- Find local primitive annotations
   localPrims <- findPrimitiveAnnotations hdl binderIds
-  let loaded1 = loaded0{lbPrims=lbPrims loaded0 ++ localPrims}
+  let loaded1 = loaded0{lbPrims=lbPrims loaded0 <> Seq.fromList localPrims}
 
-  let allBinders = concat binders ++ makeRecursiveGroups (lbBinders loaded0)
+  let allBinders = concat binders ++ makeRecursiveGroups (Map.assocs (lbBinders loaded0))
   pure (rootIds, modFamInstEnvs', rootModule, loaded1, allBinders)
 
 nameString :: Name.Name -> String
@@ -433,7 +435,7 @@ loadModules startAction useColor hdl modName dflagsM idirs = do
 
     modTime <- startTime `deepseq` length allBinderIds `seq` MonadUtils.liftIO Clock.getCurrentTime
     let modStartDiff = reportTimeDiff modTime startTime
-    MonadUtils.liftIO $ putStrLn $ "GHC: Parsing and optimising modules took: " ++ modStartDiff
+    MonadUtils.liftIO $ putStrLn $ "GHC: Parsing and optimizing modules took: " ++ modStartDiff
 
     extTime <- modTime `deepseq` length lbUnlocatable `deepseq` MonadUtils.liftIO Clock.getCurrentTime
     let extModDiff = reportTimeDiff extTime modTime
@@ -514,7 +516,7 @@ loadModules startAction useColor hdl modName dflagsM idirs = do
         , tid `Set.member` allBenchIds  -- indicate whether top entity is test bench
         )
 
-    let reprs1 = lbReprs ++ reprs'
+    let reprs1 = lbReprs <> Seq.fromList reprs'
 
     annTime <-
       extTime
@@ -549,12 +551,12 @@ loadModules startAction useColor hdl modName dflagsM idirs = do
         knownConfMap = HashMap.fromList (zip knownConfNms knownConfDs)
 
     return ( allBinders
-           , lbClassOps
-           , lbUnlocatable
+           , Map.assocs lbClassOps
+           , Set.toList lbUnlocatable
            , famInstEnvs'
            , topEntities2
-           , lbPrims
-           , reprs1
+           , toList lbPrims
+           , toList reprs1
            , primGuards
            , knownConfMap
            )


### PR DESCRIPTION
In particular, this line:

    let declM = filter ((== nameFun) . Name.nameOccName . IfaceSyn.ifName) decls

caused linear lookups for every binder used in a design. This refactor
makes Clash load a module once (through the GHC API) and use an index
for subsequent lookups. Additionally, annotations are now loaded once
per module instead of once per binder.

This speeds up the testsuite by ~10% on my machine.