### PR TITLE
Compile Concurrently at Synthesis Boundaries

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -65,7 +65,7 @@ doHDL b src = do
   generateHDL (buildCustomReprs reprs) domainConfs bindingsMap (Just b) primMap tcm tupTcm
     (ghcTypeToHWType WORD_SIZE_IN_BITS True) ghcEvaluator evaluator topEntities Nothing
     defClashOpts{opt_cachehdl = False, opt_debug = debugSilent, opt_clear = True}
-    (startTime,prepTime)
+    startTime
 
 main :: IO ()
 main = genVHDL "./examples/FIR.hs"

--- a/benchmark/benchmark-concurrency.hs
+++ b/benchmark/benchmark-concurrency.hs
@@ -1,0 +1,35 @@
+import Criterion.Main
+import Data.List (isPrefixOf, partition)
+import Data.Time (getCurrentTime)
+import System.Environment (getArgs, withArgs)
+
+import Clash.Driver
+import Clash.GHC.PartialEval
+import Clash.GHC.Evaluator
+
+import BenchmarkCommon
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let (idirs0,rest)         = partition ((== "-i") . take 2) args
+      idirs1                = ".":map (drop 2) idirs0
+      (fileArgs,optionArgs) = break (isPrefixOf "-") rest
+      tests | null fileArgs = concurrencyTests
+            | otherwise     = fileArgs
+
+  withArgs optionArgs (defaultMain $ fmap (benchFile idirs1) tests)
+ where
+  concurrencyTests =
+    [ "benchmark/tests/ManyEntitiesEqual.hs"
+    , "benchmark/tests/ManyEntitiesVaried.hs"
+    ]
+
+benchFile :: [FilePath] -> FilePath -> Benchmark
+benchFile idirs src =
+  env ((,) <$> runInputStage idirs src <*> getCurrentTime) $
+    \ ~((bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs,_,_),startTime) -> do
+      bench ("Generating HDL: " ++ src)
+            (nfIO (generateHDL reprs domainConfs bindingsMap (Just backend)
+                               primMap tcm tupTcm typeTrans ghcEvaluator
+                               evaluator topEntities Nothing (opts idirs) startTime))

--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -4,6 +4,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
+import           Clash.Signal (VDomainConfiguration)
+
 import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
 import           Clash.Core.TyCon
 import           Clash.Core.Var
@@ -20,8 +22,10 @@ import           Criterion.Main
 
 import qualified Control.Concurrent.Supply    as Supply
 import           Control.DeepSeq              (NFData(..), rwhnf)
+import           Data.HashMap.Strict          (HashMap)
 import           Data.IntMap.Strict           (IntMap)
 import           Data.List                    (isPrefixOf, partition)
+import           Data.Text                    (Text)
 import           System.Environment           (getArgs, withArgs)
 
 import BenchmarkCommon
@@ -46,7 +50,7 @@ main = do
 benchFile :: [FilePath] -> FilePath -> Benchmark
 benchFile idirs src =
   env (setupEnv idirs src) $
-    \ ~((bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity),supplyN) -> do
+    \ ~((bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,_domainConfs,topEntityNames,topEntity),supplyN) -> do
       bench ("normalization of " ++ src)
             (nf (normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans
                                  ghcEvaluator
@@ -59,7 +63,7 @@ setupEnv
   -> FilePath
   -> IO ((BindingMap, TyConMap, IntMap TyConName
          ,[TopEntityT]
-         ,CompiledPrimMap, CustomReprs, [Id], Id
+         ,CompiledPrimMap, CustomReprs, HashMap Text VDomainConfiguration, [Id], Id
          )
         ,Supply.Supply
         )

--- a/benchmark/clash-benchmark.cabal
+++ b/benchmark/clash-benchmark.cabal
@@ -19,6 +19,7 @@ library
                        containers,
                        ghc,
                        mtl,
+                       text,
                        unordered-containers,
 
                        clash-ghc,
@@ -36,9 +37,22 @@ executable clash-benchmark-normalization
                        deepseq,
                        directory,
                        filepath,
+                       text,
                        unordered-containers,
 
                        clash-benchmark,
                        clash-ghc,
                        clash-lib,
                        clash-prelude
+
+executable clash-benchmark-concurrency
+  main-is:             benchmark-concurrency.hs
+  default-language:    Haskell2010
+  ghc-options:         -O2 -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base,
+                       criterion,
+                       time,
+
+                       clash-lib,
+                       clash-ghc,
+                       clash-benchmark

--- a/benchmark/clash-benchmark.cabal
+++ b/benchmark/clash-benchmark.cabal
@@ -29,7 +29,7 @@ library
 executable clash-benchmark-normalization
   main-is:             benchmark-normalization.hs
   default-language:    Haskell2010
-  ghc-options:         -O2 -Wall -Wcompat
+  ghc-options:         -O2 -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base,
                        concurrent-supply,
                        containers,

--- a/benchmark/profiling/prepare/profile-normalization-prepare.hs
+++ b/benchmark/profiling/prepare/profile-normalization-prepare.hs
@@ -24,7 +24,7 @@ prepareFile idirs fIn = do
   putStrLn $ "Preparing: " ++ fIn
   let fOut = fIn ++ ".bin"
   inp <- runInputStage idirs fIn
-  let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,topEntityNames,topEntity) = inp
+  let (bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,_domainConfs,topEntityNames,topEntity) = inp
       inp' :: NormalizationInputs
       inp' = (bindingsMap,tcm,tupTcm, fmap (fmap removeBBfunc) primMap, reprs,topEntityNames,topEntity)
   putStrLn $ "Serialising to : " ++ fOut

--- a/benchmark/profiling/run/profile-netlist-run.hs
+++ b/benchmark/profiling/run/profile-netlist-run.hs
@@ -41,7 +41,7 @@ benchFile idirs src = do
       topEntityS = Text.unpack (nameOcc (varName topEntity))
       modName    = takeWhile (/= '.') topEntityS
       hdlState'  = setModName (Text.pack modName) backend
-      (compNames, seen) = genTopNames Nothing True PreserveCase hdl topEntities
+      (compNames, seen) = genTopNames opts1 hdl topEntities
       topEntityMap = mkVarEnv (zip (map topId topEntities) topEntities)
       prefixM    = Nothing
       ite        = ifThenElseExpr hdlState'

--- a/benchmark/tests/ManyEntitiesEqual.hs
+++ b/benchmark/tests/ManyEntitiesEqual.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE RankNTypes #-}
+
+module ManyEntitiesEqual where
+
+import Clash.Prelude
+
+-- When compiling different top entities in parallel, the best case is that
+-- every entity takes roughly the same amount of time to compile. This means
+-- we avoid situations where slower compiling entities take up all cores,
+-- lowering compiler throughput.
+--
+-- The sizes here are either powers of 2, or numbers halfway between two powers
+-- of 2. This gives a reasonable variation in time to compile, while still
+-- compiling with a reasonable specialization limit (under 100) and amount of
+-- time for each entity (under 10s).
+
+stage
+  :: (HiddenClockResetEnable System, KnownNat n)
+  => (Unsigned n)
+  -> Signal System (Unsigned n)
+  -> Signal System (Unsigned n)
+stage i s = let delay = register i $ xor <$> delay <*> s in delay
+
+entity
+  :: (HiddenClockResetEnable System, KnownNat n)
+  => SNat n
+  -> Signal System (Unsigned n)
+  -> Signal System (Unsigned n)
+entity n =
+  foldr (.) id $ map stage $ iterate n (+ 1) 1
+
+type Top n =
+  HiddenClockResetEnable System
+    => Signal System (Unsigned n)
+    -> Signal System (Unsigned n)
+
+{-# NOINLINE top0 #-}
+{-# ANN top0 (defSyn "top_0") #-}
+top0 :: Top 64
+top0 = entity (SNat @64)
+
+{-# NOINLINE top1 #-}
+{-# ANN top1 (defSyn "top_1") #-}
+top1 :: Top 64
+top1 = entity (SNat @64)
+
+{-# NOINLINE top2 #-}
+{-# ANN top2 (defSyn "top_2") #-}
+top2 :: Top 64
+top2 = entity (SNat @64)
+
+{-# NOINLINE top3 #-}
+{-# ANN top3 (defSyn "top_3") #-}
+top3 :: Top 64
+top3 = entity (SNat @64)
+
+{-# NOINLINE top4 #-}
+{-# ANN top4 (defSyn "top_4") #-}
+top4 :: Top 64
+top4 = entity (SNat @64)
+
+{-# NOINLINE top5 #-}
+{-# ANN top5 (defSyn "top_5") #-}
+top5 :: Top 64
+top5 = entity (SNat @64)
+
+{-# NOINLINE top6 #-}
+{-# ANN top6 (defSyn "top_6") #-}
+top6 :: Top 64
+top6 = entity (SNat @64)
+
+{-# NOINLINE top7 #-}
+{-# ANN top7 (defSyn "top_7") #-}
+top7 :: Top 64
+top7 = entity (SNat @64)

--- a/benchmark/tests/ManyEntitiesVaried.hs
+++ b/benchmark/tests/ManyEntitiesVaried.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE RankNTypes #-}
+
+module ManyEntitiesVaried where
+
+import Clash.Prelude
+
+-- When compiling different top entities in parallel, it is probably atypical
+-- that each entity takes the same amount of time to normalize. If we have more
+-- entities to compile than cores available, we may also experience a scenario
+-- where faster compiling entities have to wait on slower entities.
+--
+-- The sizes here are either powers of 2, or numbers halfway between two powers
+-- of 2. This gives a reasonable variation in time to compile, while still
+-- compiling with a reasonable specialization limit (under 100) and amount of
+-- time for each entity (under 10s).
+
+stage
+  :: (HiddenClockResetEnable System, KnownNat n)
+  => (Unsigned n)
+  -> Signal System (Unsigned n)
+  -> Signal System (Unsigned n)
+stage i s = let delay = register i $ xor <$> delay <*> s in delay
+
+entity
+  :: (HiddenClockResetEnable System, KnownNat n)
+  => SNat n
+  -> Signal System (Unsigned n)
+  -> Signal System (Unsigned n)
+entity n =
+  foldr (.) id $ map stage $ iterate n (+ 1) 1
+
+type Top n =
+  HiddenClockResetEnable System
+    => Signal System (Unsigned n)
+    -> Signal System (Unsigned n)
+
+{-# NOINLINE top0 #-}
+{-# ANN top0 (defSyn "top_0") #-}
+top0 :: Top 24
+top0 = entity (SNat @24)
+
+{-# NOINLINE top1 #-}
+{-# ANN top1 (defSyn "top_1") #-}
+top1 :: Top 32
+top1 = entity (SNat @32)
+
+{-# NOINLINE top2 #-}
+{-# ANN top2 (defSyn "top_2") #-}
+top2 :: Top 48
+top2 = entity (SNat @48)
+
+{-# NOINLINE top3 #-}
+{-# ANN top3 (defSyn "top_3") #-}
+top3 :: Top 64
+top3 = entity (SNat @64)
+
+{-# NOINLINE top4 #-}
+{-# ANN top4 (defSyn "top_4") #-}
+top4 :: Top 96
+top4 = entity (SNat @96)
+
+-- At 128 we blow a specialization limit of 100, and take more than 10s to
+-- normalize on my machine. If Clash becomes quicker we can increase the limit
+-- we generate to here. -- Alex

--- a/changelog/2022-01-14T09_39_07+01_00_async_at_synthesis_boundaries.md
+++ b/changelog/2022-01-14T09_39_07+01_00_async_at_synthesis_boundaries.md
@@ -1,0 +1,1 @@
+CHANGED: Clash can now compile multiple entities asynchronously, providing speedups to designs with multiple entities to build [#2034](https://github.com/clash-lang/clash-compiler/pull/2034)

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -68,7 +68,7 @@ flag use-ghc-paths
 executable clash
   Main-Is:            src-ghc/Batch.hs
   Build-Depends:      base, clash-ghc
-  GHC-Options:        -Wall -Wcompat
+  GHC-Options:        -Wall -Wcompat -threaded -rtsopts
   if flag(dynamic)
     GHC-Options: -dynamic
   extra-libraries:    pthread

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -2249,7 +2249,7 @@ makeHDL backend startAction optsRef srcs = do
                   topEntities
                   mainTopEntity
                   opts2
-                  (startTime,prepTime)
+                  startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
 makeVHDL = makeHDL' (Clash.Backend.initBackend @VHDLState)

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -2079,7 +2079,7 @@ makeHDL backend startAction optsRef srcs = do
                   topEntities
                   mainTopEntity
                   opts2
-                  (startTime,prepTime)
+                  startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
 makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> VHDLState)

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -2171,7 +2171,7 @@ makeHDL backend startAction optsRef srcs = do
                   topEntities
                   mainTopEntity
                   opts2
-                  (startTime,prepTime)
+                  startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
 makeVHDL = makeHDL' (Clash.Backend.initBackend @VHDLState)

--- a/clash-ghc/src-bin-9.0/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.0/Clash/GHCi/UI.hs
@@ -2288,7 +2288,7 @@ makeHDL backend startAction optsRef srcs = do
                   topEntities
                   mainTopEntity
                   opts2
-                  (startTime,prepTime)
+                  startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
 makeVHDL = makeHDL' (Clash.Backend.initBackend @VHDLState)

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -130,6 +130,7 @@ Library
                       aeson-pretty            >= 0.8      && < 0.9,
                       ansi-terminal           >= 0.8.0.0  && < 0.12,
                       array,
+                      async                   >= 2.2.0    && < 2.3,
                       attoparsec              >= 0.10.4.0 && < 0.15,
                       base                    >= 4.11     && < 5,
                       base16-bytestring       >= 0.1.1    && < 1.1,

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -2,7 +2,7 @@
   Copyright   :  (C) 2012-2016, University of Twente,
                      2016-2017, Myrtle Software Ltd,
                      2017-2018, Google Inc.,
-                     2021     , QBayLogic B.V.
+                     2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -224,23 +224,22 @@ genNames newInlineStrat prefixM is env bndrs =
 -- | Generate names for top entities. Should be executed at the very start of
 -- the synthesis process and shared between all passes.
 genTopNames
-  :: Maybe StrictText.Text
-  -- ^ Prefix
-  -> Bool
-  -- ^ Allow escaped identifiers?
-  -> PreserveCase
-  -- ^ Lower case basic ids?
+  :: ClashOpts
   -> HDL
   -- ^ HDL to generate identifiers for
   -> [TopEntityT]
   -> (VarEnv Identifier, IdentifierSet)
-genTopNames prefixM esc lw hdl tops =
+genTopNames opts hdl tops =
   -- TODO: Report error if fixed top entities have conflicting names
   flip runState (Id.emptyIdentifierSet esc lw hdl) $ do
     env0 <- foldlM goFixed emptyVarEnv fixedTops
     env1 <- foldlM goNonFixed env0 nonFixedTops
     pure env1
  where
+  prefixM = opt_componentPrefix opts
+  esc = opt_escapedIds opts
+  lw = opt_lowerCaseBasicIds opts
+
   fixedTops = [(topId, ann) | TopEntityT{topId, topAnnotation=Just ann} <- tops]
   nonFixedTops = [topId | TopEntityT{topId, topAnnotation=Nothing} <- tops]
 

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017-2019, Myrtle Software Ltd
                   2017     , Google Inc.,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -502,7 +502,7 @@ data VDomainConfiguration
   , vResetPolarity :: ResetPolarity
   -- ^ Corresponds to '_resetPolarity' on 'DomainConfiguration'
   }
-  deriving (Eq, Show, Read)
+  deriving (Eq, Generic, NFData, Show, Read)
 
 -- | Convert 'SDomainConfiguration' to 'VDomainConfiguration'. Should be used in combination with
 -- 'createDomain' only.

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -98,7 +98,7 @@ runToNetlistStage target f src = do
   (bm, tcm, tupTcm, tes, pm, rs, _)
     <- generateBindings (return ()) Auto pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
 
-  let (compNames, initIs) = genTopNames Nothing True PreserveCase hdl tes
+  let (compNames, initIs) = genTopNames opts hdl tes
       teNames = fmap topId tes
       te      = topId (P.head tes)
       reprs   = buildCustomReprs rs


### PR DESCRIPTION
This PR starts the work of making Clash compile concurrently, by generating HDL for different entities asynchronously. For designs with many entities, this can already provide a fairly dramatic improvement as seen in the new `clash-benchmark-concurrency` suite:

Before:

```
ManyEntitiesEqual
time                 27.66 s    (27.43 s .. 28.11 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.39 s    (27.29 s .. 27.48 s)
std dev              144.0 ms   (75.86 ms .. 203.0 ms)
variance introduced by outliers: 19% (moderately inflated)

ManyEntitiesVaried
time                 14.56 s    (14.18 s .. 14.97 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 14.72 s    (14.64 s .. 14.80 s)
std dev              107.4 ms   (2.795 ms .. 130.4 ms)
variance introduced by outliers: 19% (moderately inflated)
```

After:

```
ManyEntitiesEqual
time                 4.215 s    (4.033 s .. 4.389 s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 4.195 s    (4.152 s .. 4.219 s)
std dev              44.01 ms   (6.522 ms .. 56.38 ms)
variance introduced by outliers: 19% (moderately inflated)

ManyEntitiesVaried
time                 7.790 s    (7.172 s .. 8.436 s)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 7.603 s    (7.475 s .. 7.771 s)
std dev              163.1 ms   (27.67 ms .. 208.1 ms)
variance introduced by outliers: 19% (moderately inflated)
```

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] ~Change the message when ignoring a cache to mention the entity~ Only print the message when ignoring a cache once

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
