### PR TITLE
Efficient constants for initializing memories

### DIFF
--- a/changelog/2022-01-31T08_51_47+01_00_memblob
+++ b/changelog/2022-01-31T08_51_47+01_00_memblob
@@ -1,0 +1,1 @@
+ADDED: The `MemBlob` structure: efficient constants for initializing memories. Depending on how the content is constructed, a `Vec` for the initial memory content can turn out to be prohibitively slow. In these cases, `MemBlob` can store your content efficiently. [#2041](https://github.com/clash-lang/clash-compiler/pull/2041)

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -1,8 +1,9 @@
 {-|
   Copyright   :  (C) 2013-2016, University of Twente,
-                     2016-2017, Myrtle Software Ltd
+                     2016-2017, Myrtle Software Ltd,
+                     2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE CPP #-}
@@ -232,6 +233,12 @@ ghcTypeToHWType iw = go
           let filtered = [replicate sz1 (isVoid, fElHWTy)]
           return (FilteredHWType vecHWTy filtered)
 
+        "Clash.Explicit.BlockRam.Internal.MemBlob" -> do
+          let [nTy, mTy] = args
+          n0 <- liftE (tyNatSize m nTy)
+          m0 <- liftE (tyNatSize m mTy)
+          returnN (MemBlob (fromInteger n0) (fromInteger m0))
+
         "Clash.Sized.RTree.RTree" -> do
           let [szTy,elTy] = args
           sz0     <- liftE (tyNatSize m szTy)
@@ -252,6 +259,7 @@ ghcTypeToHWType iw = go
           return (FilteredHWType vecHWTy filtered)
 
         "String" -> returnN String
+        "GHC.Prim.Addr#" -> returnN String
         "GHC.Types.[]" -> case tyView (head args) of
           (TyConApp (nameOcc -> "GHC.Types.Char") []) -> returnN String
           _ -> throwE $ "Can't translate type: " ++ showPpr ty

--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam_Blob.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam_Blob.primitives
@@ -1,0 +1,46 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Explicit.BlockRam.Blob.blockRamBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"blockRamBlob#
+  :: KnownDomain dom           --       ARG[0]
+  => Clock dom                 -- clk,  ARG[1]
+  -> Enable dom                -- en,   ARG[2]
+  -> MemBlob n m               -- init, ARG[3]
+  -> Signal dom Int            -- rd,   ARG[4]
+  -> Signal dom Bool           -- wren, ARG[5]
+  -> Signal dom Int            -- wr,   ARG[6]
+  -> Signal dom (BitVector m)  -- din,  ARG[7]
+  -> Signal dom (BitVector m)"
+    , "template" :
+"// blockRamBlob begin
+~SIGD[~GENSYM[RAM][1]][3];
+logic [~SIZE[~TYP[7]]-1:0] ~GENSYM[~RESULT_q][2];
+initial begin
+  ~SYM[1] = ~CONST[3];
+end~IF ~ISACTIVEENABLE[2] ~THEN
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[1]) begin : ~GENSYM[~COMPNAME_blockRam][3]~IF ~VIVADO ~THEN
+  if (~ARG[2]) begin
+    if (~ARG[5]) begin
+      ~SYM[1][~ARG[6]] <= ~ARG[7];
+    end
+    ~SYM[2] <= ~SYM[1][~ARG[4]];
+  end~ELSE
+  if (~ARG[5] & ~ARG[2]) begin
+    ~SYM[1][~ARG[6]] <= ~ARG[7];
+  end
+  if (~ARG[2]) begin
+    ~SYM[2] <= ~SYM[1][~ARG[4]];
+  end~FI
+end~ELSE
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[1]) begin : ~SYM[3]
+  if (~ARG[5]) begin
+    ~SYM[1][~ARG[6]] <= ~ARG[7];
+  end
+  ~SYM[2] <= ~SYM[1][~ARG[4]];
+end~FI
+assign ~RESULT = ~SYM[2];
+// blockRamBlob end"
+    }
+  }
+]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_ROM_Blob.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_ROM_Blob.primitives
@@ -1,0 +1,31 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Explicit.ROM.Blob.romBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"romBlob#
+  :: KnownDomain dom  --       ARG[0]
+  => Clock dom        -- clk,  ARG[1]
+  -> Enable dom       -- en,   ARG[2]
+  -> MemBlob n m      -- init, ARG[3]
+  -> Signal dom Int   -- rd,   ARG[4]
+  -> Signal dom (BitVector m)"
+    , "template" :
+"// romBlob begin
+~SIGD[~GENSYM[ROM][1]][3];
+assign ~SYM[1] = ~CONST[3];
+
+logic [~SIZE[~TYPO]-1:0] ~GENSYM[~RESULT_q][2];~IF ~ISACTIVEENABLE[2] ~THEN
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[1]) begin : ~GENSYM[~COMPNAME_rom][3]
+  if (~ARG[2]) begin
+    ~SYM[2] <= ~SYM[1][~ARG[4]];
+  end
+end~ELSE
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[1]) begin : ~SYM[3]
+  ~SYM[2] <= ~SYM[1][~ARG[4]];
+end~FI
+
+assign ~RESULT = ~SYM[2];
+// rom end"
+    }
+  }
+]

--- a/clash-lib/prims/systemverilog/Clash_Prelude_ROM_Blob.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Prelude_ROM_Blob.primitives
@@ -1,0 +1,18 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Prelude.ROM.Blob.asyncRomBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"asyncRomBlob#
+  :: MemBlob n m  -- ARG[0]
+  -> Int          -- ARG[1]
+  -> BitVector m"
+    , "template" :
+"// asyncRomBlob begin
+~SIGD[~GENSYM[ROM][0]][0];
+assign ~SYM[0] = ~CONST[0];
+
+assign ~RESULT = ~SYM[0][~ARG[1]];
+// asyncRomBlob end"
+    }
+  }
+]

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam_Blob.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam_Blob.primitives
@@ -1,0 +1,52 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Explicit.BlockRam.Blob.blockRamBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"blockRamBlob#
+  :: KnownDomain dom           --       ARG[0]
+  => Clock dom                 -- clk,  ARG[1]
+  -> Enable dom                -- en,   ARG[2]
+  -> MemBlob n m               -- init, ARG[3]
+  -> Signal dom Int            -- rd,   ARG[4]
+  -> Signal dom Bool           -- wren, ARG[5]
+  -> Signal dom Int            -- wr,   ARG[6]
+  -> Signal dom (BitVector m)  -- din,  ARG[7]
+  -> Signal dom (BitVector m)"
+    , "outputReg" : true
+    , "template" :
+"// blockRamBlob begin
+reg ~TYPO ~GENSYM[~RESULT_RAM][1] [0:~LENGTH[~TYP[3]]-1];
+
+reg ~TYP[3] ~GENSYM[ram_init][3];
+integer ~GENSYM[i][4];
+initial begin
+  ~SYM[3] = ~CONST[3];
+  for (~SYM[4]=0; ~SYM[4] < ~LENGTH[~TYP[3]]; ~SYM[4] = ~SYM[4] + 1) begin
+    ~SYM[1][~LENGTH[~TYP[3]]-1-~SYM[4]] = ~SYM[3][~SYM[4]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+  end
+end
+~IF ~ISACTIVEENABLE[2] ~THEN
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[1]) begin : ~GENSYM[~RESULT_blockRam][5]~IF ~VIVADO ~THEN
+  if (~ARG[2]) begin
+    if (~ARG[5]) begin
+      ~SYM[1][~ARG[6]] <= ~ARG[7];
+    end
+    ~RESULT <= ~SYM[1][~ARG[4]];
+  end~ELSE
+  if (~ARG[5] & ~ARG[2]) begin
+    ~SYM[1][~ARG[6]] <= ~ARG[7];
+  end
+  if (~ARG[2]) begin
+    ~RESULT <= ~SYM[1][~ARG[4]];
+  end~FI
+end~ELSE
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[1]) begin : ~SYM[5]
+  if (~ARG[5]) begin
+    ~SYM[1][~ARG[6]] <= ~ARG[7];
+  end
+  ~RESULT <= ~SYM[1][~ARG[4]];
+end~FI
+// blockRamBlob end"
+    }
+  }
+]

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM_Blob.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM_Blob.primitives
@@ -1,0 +1,37 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Explicit.ROM.Blob.romBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"romBlob#
+  :: KnownDomain dom  --       ARG[0]
+  => Clock dom        -- clk,  ARG[1]
+  -> Enable dom       -- en,   ARG[2]
+  -> MemBlob n m      -- init, ARG[3]
+  -> Signal dom Int   -- rd,   ARG[4]
+  -> Signal dom (BitVector m)"
+    , "outputReg" : true
+    , "template" :
+"// romBlob begin
+reg ~TYPO ~GENSYM[ROM][1] [0:~LENGTH[~TYP[3]]-1];
+
+reg ~TYP[3] ~GENSYM[rom_init][3];
+integer ~GENSYM[i][4];
+initial begin
+  ~SYM[3] = ~CONST[3];
+  for (~SYM[4]=0; ~SYM[4] < ~LENGTH[~TYP[3]]; ~SYM[4] = ~SYM[4] + 1) begin
+    ~SYM[1][~LENGTH[~TYP[3]]-1-~SYM[4]] = ~SYM[3][~SYM[4]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+  end
+end
+~IF ~ISACTIVEENABLE[2] ~THEN
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[1]) begin : ~GENSYM[~COMPNAME_rom][5]
+  if (~ARG[2]) begin
+    ~RESULT <= ~SYM[1][~ARG[4]];
+  end
+end~ELSE
+always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[1]) begin : ~SYM[5]
+  ~RESULT <= ~SYM[1][~ARG[4]];
+end~FI
+// romBlob end"
+    }
+  }
+]

--- a/clash-lib/prims/verilog/Clash_Prelude_ROM_Blob.primitives
+++ b/clash-lib/prims/verilog/Clash_Prelude_ROM_Blob.primitives
@@ -1,0 +1,26 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Prelude.ROM.Blob.asyncRomBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"asyncRomBlob#
+  :: MemBlob n m  -- ARG[0]
+  -> Int          -- ARG[1]
+  -> BitVector m"
+    , "template" :
+"// asyncRomBlob begin
+wire ~TYPO ~GENSYM[ROM][0] [0:~LENGTH[~TYP[0]]-1];
+
+wire ~TYP[0] ~GENSYM[romflat][1];
+assign ~SYM[1] = ~CONST[0];
+genvar ~GENSYM[i][2];
+~GENERATE
+for (~SYM[2]=0; ~SYM[2] < ~LENGTH[~TYP[0]]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]
+  assign ~SYM[0][(~LENGTH[~TYP[0]]-1)-~SYM[2]] = ~SYM[1][~SYM[2]*~SIZE[~TYPO]+:~SIZE[~TYPO]];
+end
+~ENDGENERATE
+
+assign ~RESULT = ~SYM[0][~ARG[1]];
+// asyncRomBlob end"
+    }
+  }
+]

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_Blob.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_Blob.primitives
@@ -1,0 +1,46 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Explicit.BlockRam.Blob.blockRamBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"blockRamBlob#
+  :: KnownDomain dom           --       ARG[0]
+  => Clock dom                 -- clk,  ARG[1]
+  -> Enable dom                -- en,   ARG[2]
+  -> MemBlob n m               -- init, ARG[3]
+  -> Signal dom Int            -- rd,   ARG[4]
+  -> Signal dom Bool           -- wren, ARG[5]
+  -> Signal dom Int            -- wr,   ARG[6]
+  -> Signal dom (BitVector m)  -- din,  ARG[7]
+  -> Signal dom (BitVector m)"
+    , "template" :
+"-- blockRamBlob begin
+~GENSYM[~RESULT_blockRam][1] : block
+  signal ~GENSYM[~RESULT_RAM][2] : ~TYP[3] := ~CONST[3];
+  signal ~GENSYM[rd][4]  : integer range 0 to ~LENGTH[~TYP[3]] - 1;
+  signal ~GENSYM[wr][5]  : integer range 0 to ~LENGTH[~TYP[3]] - 1;
+begin
+  ~SYM[4] <= to_integer(~VAR[rdI][4](31 downto 0))
+  -- pragma translate_off
+                mod ~LENGTH[~TYP[3]]
+  -- pragma translate_on
+                ;
+
+  ~SYM[5] <= to_integer(~VAR[wrI][6](31 downto 0))
+  -- pragma translate_off
+                mod ~LENGTH[~TYP[3]]
+  -- pragma translate_on
+                ;
+  ~SYM[6] : process(~ARG[1])
+  begin
+    if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[1]) then
+      if ~ARG[5]~IF~ISACTIVEENABLE[2]~THEN and ~ARG[2]~ELSE~FI then
+        ~SYM[2](~SYM[5]) <= ~ARG[7];
+      end if;
+      ~RESULT <= ~SYM[2](~SYM[4]);
+    end if;
+  end process;
+end block;
+-- blockRamBlob end"
+    }
+  }
+]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_Blob.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_Blob.primitives
@@ -1,0 +1,35 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Explicit.ROM.Blob.romBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"romBlob#
+  :: KnownDomain dom  --       ARG[0]
+  => Clock dom        -- clk,  ARG[1]
+  -> Enable dom       -- en,   ARG[2]
+  -> MemBlob n m      -- init, ARG[3]
+  -> Signal dom Int   -- rd,   ARG[4]
+  -> Signal dom (BitVector m)"
+    , "template" :
+"-- romBlob begin
+~GENSYM[~COMPNAME_rom][1] : block
+  signal ~GENSYM[ROM][2] : ~TYP[3];
+  signal ~GENSYM[rd][3]  : integer range 0 to ~LENGTH[~TYP[3]]-1;
+begin
+  ~SYM[2] <= ~CONST[3];
+
+  ~SYM[3] <= to_integer(~VAR[rdI][4](31 downto 0))
+  -- pragma translate_off
+                mod ~LENGTH[~TYP[3]]
+  -- pragma translate_on
+                ;
+  ~GENSYM[romSync][6] : process (~ARG[1])
+  begin
+    if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[1])~IF~ISACTIVEENABLE[2]~THEN and ~ARG[2]~ELSE~FI) then
+      ~RESULT <= ~SYM[2](~SYM[3]);
+    end if;
+  end process;
+end block;
+-- romBlob end"
+    }
+  }
+]

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM_Blob.primitives
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM_Blob.primitives
@@ -1,0 +1,27 @@
+[ { "BlackBox" :
+    { "name" : "Clash.Prelude.ROM.Blob.asyncRomBlob#"
+    , "kind" : "Declaration"
+    , "type" :
+"asyncRomBlob#
+  :: MemBlob n m  -- ARG[0]
+  -> Int          -- ARG[1]
+  -> BitVector m"
+    , "template" :
+"-- asyncRomBlob begin
+~GENSYM[asyncRom][0] : block
+  signal ~GENSYM[ROM][1] : ~TYP[0];
+  signal ~GENSYM[rd][2] : integer range 0 to ~LENGTH[~TYP[0]]-1;
+begin
+  ~SYM[1] <= ~CONST[0];
+
+  ~SYM[2] <= to_integer(~VAR[rdI][1](31 downto 0))
+  -- pragma translate_off
+                      mod ~LENGTH[~TYP[0]]
+  -- pragma translate_on
+                      ;
+  ~RESULT <= ~SYM[1](~SYM[2]);
+end block;
+-- asyncRomBlob end"
+    }
+  }
+]

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -851,7 +851,7 @@ mkExpr _ _ _ (stripTicks -> Core.Literal l) = do
 #else
     ByteArrayLiteral (ByteArray ba) -> return (HW.Literal Nothing (NumLit (Jp# (BN# ba))),[])
 #endif
-    _ -> error $ $(curLoc) ++ "not an integer or char literal"
+    StringLiteral s  -> return (HW.Literal Nothing $ StringLit s, [])
 
 mkExpr bbEasD declType bndr app =
  let (appF,args,ticks) = collectArgsTicks app
@@ -1086,6 +1086,11 @@ mkDcApplication [dstHType] bndr dc args = do
       Vector _ _ -> case argExprsFiltered of
                       [e1,e2] -> return (HW.DataCon dstHType VecAppend [e1,e2])
                       _ -> error $ $(curLoc) ++ "Unexpected number of arguments for `Cons`: " ++ showPpr args
+      MemBlob _ _ ->
+        case compare 6 (length argExprsFiltered) of
+          EQ -> return (HW.DataCon dstHType (DC (dstHType,0)) argExprsFiltered)
+          LT -> error $ $(curLoc) ++ "Over-applied constructor"
+          GT -> error $ $(curLoc) ++ "Under-applied constructor"
       RTree 0 _ -> case argExprsFiltered of
                       [e] -> return (HW.DataCon dstHType RTreeAppend [e])
                       _ -> error $ $(curLoc) ++ "Unexpected number of arguments for `LR`: " ++ showPpr args

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -1,8 +1,9 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
-                    2017     , Myrtle Software Ltd
+                    2017     , Myrtle Software Ltd,
+                    2022     , QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Types used in BlackBox modules
 -}
@@ -130,7 +131,7 @@ data Element
   | Err !(Maybe Int)
   -- ^ Error value hole
   | TypElem !Element
-  -- ^ Select element type from a vector type
+  -- ^ Select element type from a vector-like type
   | CompName
   -- ^ Hole for the name of the component in which the blackbox is instantiated
   | IncludeName !Int
@@ -139,11 +140,11 @@ data Element
   | Size !Element
   -- ^ Size of a type hole
   | Length !Element
-  -- ^ Length of a vector hole
+  -- ^ Length of a vector-like hole
   | Depth !Element
   -- ^ Depth of a tree hole
   | MaxIndex !Element
-  -- ^ Max index into a vector
+  -- ^ Max index into a vector-like type
   | FilePath !Element
   -- ^ Hole containing a filepath for a data file
   | Template [Element] [Element]

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -431,6 +431,8 @@ data HWType
   -- ^ Unsigned integer of a specified size
   | Vector !Size !HWType
   -- ^ Vector type
+  | MemBlob !Size !Size
+  -- ^ MemBlob type
   | RTree !Size !HWType
   -- ^ RTree type
   | Sum !Text [Text]

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -683,6 +683,7 @@ typeSize (Index u) = fromMaybe 0 (clogBase 2 u)
 typeSize (Signed i) = i
 typeSize (Unsigned i) = i
 typeSize (Vector n el) = n * typeSize el
+typeSize (MemBlob n m) = n * m
 typeSize (RTree d el) = (2^d) * typeSize el
 typeSize t@(SP _ cons) = conSize t +
   maximum (map (sum . map typeSize . snd) cons)

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -51,7 +51,7 @@ Maintainer:           QBayLogic B.V. <devops@qbaylogic.com>
 Copyright:            Copyright © 2013-2016, University of Twente,
                                   2016-2017, Myrtle Software Ltd,
                                   2017-2019, QBayLogic B.V., Google Inc.,
-                                  2021,      QBayLogic B.V.
+                                  2021-2022, QBayLogic B.V.
 Category:             Hardware
 Build-type:           Simple
 
@@ -198,12 +198,15 @@ Library
                       Clash.Clocks.Deriving
 
                       Clash.Explicit.BlockRam
+                      Clash.Explicit.BlockRam.Blob
                       Clash.Explicit.BlockRam.File
+                      Clash.Explicit.BlockRam.Internal
                       Clash.Explicit.DDR
                       Clash.Explicit.Mealy
                       Clash.Explicit.Moore
                       Clash.Explicit.RAM
                       Clash.Explicit.ROM
+                      Clash.Explicit.ROM.Blob
                       Clash.Explicit.ROM.File
                       Clash.Explicit.Prelude
                       Clash.Explicit.Prelude.Safe
@@ -236,12 +239,14 @@ Library
                       Clash.Prelude.BitIndex
                       Clash.Prelude.BitReduction
                       Clash.Prelude.BlockRam
+                      Clash.Prelude.BlockRam.Blob
                       Clash.Prelude.BlockRam.File
                       Clash.Prelude.DataFlow
                       Clash.Prelude.Mealy
                       Clash.Prelude.Moore
                       Clash.Prelude.RAM
                       Clash.Prelude.ROM
+                      Clash.Prelude.ROM.Blob
                       Clash.Prelude.ROM.File
                       Clash.Prelude.Safe
                       Clash.Prelude.Testbench
@@ -386,6 +391,7 @@ test-suite unittests
       ghc-typelits-extra,
 
       base,
+      bytestring,
       deepseq,
       hedgehog      >= 1.0.3    && < 1.1,
       hint          >= 0.7      && < 0.10,
@@ -402,6 +408,7 @@ test-suite unittests
                  Clash.Tests.BitPack
                  Clash.Tests.BitVector
                  Clash.Tests.BlockRam
+                 Clash.Tests.BlockRam.Blob
                  Clash.Tests.Counter
                  Clash.Tests.DerivingDataRepr
                  Clash.Tests.DerivingDataReprTypes

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -738,6 +738,10 @@ prog2 = -- 0 := 4
 -- * See "Clash.Explicit.BlockRam#usingrams" for more information on how to use a
 -- Block RAM.
 -- * Use the adapter 'readNew' for obtaining write-before-read semantics like this: @'readNew' clk rst ('blockRam' clk inits) rd wrM@.
+-- * A large 'Vec' for the initial content might be too inefficient, depending
+-- on how it is constructed. See 'Clash.Explicit.BlockRam.File.blockRamFile' and
+-- 'Clash.Explicit.BlockRam.Blob.blockRamBlob' for different approaches that
+-- scale well.
 blockRam
   :: ( KnownDomain dom
      , HasCallStack
@@ -785,6 +789,10 @@ blockRam = \clk gen content rd wrM ->
 -- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
 -- Block RAM.
 -- * Use the adapter 'readNew' for obtaining write-before-read semantics like this: @'readNew' clk rst ('blockRamPow2' clk inits) rd wrM@.
+-- * A large 'Vec' for the initial content might be too inefficient, depending
+-- on how it is constructed. See 'Clash.Explicit.BlockRam.File.blockRamFilePow2'
+-- and 'Clash.Explicit.BlockRam.Blob.blockRamBlobPow2' for different approaches
+-- that scale well.
 blockRamPow2
   :: ( KnownDomain dom
      , HasCallStack

--- a/clash-prelude/src/Clash/Explicit/BlockRam/Blob.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/Blob.hs
@@ -1,0 +1,384 @@
+{-|
+Copyright  :  (C) 2021-2022, QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+= Efficient bundling of initial RAM content with the compiled code
+
+Leveraging Template Haskell, the initial content for the blockRAM components in
+this module is stored alongside the compiled Haskell code. It covers use cases
+where passing the initial content as a 'Clash.Sized.Vector.Vec' turns out to be
+problematically slow.
+
+The data is stored efficiently, with very little overhead (worst-case 7%, often
+no overhead at all).
+
+Unlike "Clash.Explicit.BlockRam.File", "Clash.Explicit.BlockRam.Blob"
+generates practically the same HDL as "Clash.Explicit.BlockRam" and is
+compatible with all tools consuming the generated HDL.
+-}
+
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+module Clash.Explicit.BlockRam.Blob
+  ( -- * BlockRAMs initialized with a 'MemBlob'
+    blockRamBlob
+  , blockRamBlobPow2
+    -- * Creating and inspecting 'MemBlob'
+  , MemBlob
+  , createMemBlob
+  , memBlobTH
+  , unpackMemBlob
+    -- * Internal
+  , blockRamBlob#
+  ) where
+
+import Control.Exception (catch, throw)
+import Control.Monad (forM_)
+import Control.Monad.ST (ST, runST)
+import Control.Monad.ST.Unsafe (unsafeInterleaveST, unsafeIOToST, unsafeSTToIO)
+import Data.Array.MArray (newListArray)
+import qualified Data.ByteString.Lazy as L
+import Data.Maybe (isJust)
+import GHC.Arr (STArray, unsafeReadSTArray, unsafeWriteSTArray)
+import GHC.Stack (withFrozenCallStack)
+import GHC.TypeLits (KnownNat, type (^))
+import Language.Haskell.TH
+  (DecsQ, ExpQ, integerL, litE, litT, mkName, normalB, numTyLit, sigD,
+   stringPrimL, valD, varP)
+
+import Clash.Annotations.Primitive (hasBlackBox)
+import Clash.Explicit.BlockRam.Internal
+  (MemBlob(..), packBVs, unpackMemBlob, unpackMemBlob0)
+import Clash.Explicit.Signal (KnownDomain, Enable, fromEnable)
+import Clash.Promoted.Nat (natToInteger, natToNum)
+import Clash.Signal.Bundle (unbundle)
+import Clash.Signal.Internal (Clock, Signal(..), (.&&.))
+import Clash.Sized.Internal.BitVector (Bit(..), BitVector(..))
+import Clash.Sized.Internal.Unsigned (Unsigned)
+import Clash.XException
+  (maybeIsX, deepErrorX, defaultSeqX, fromJustX, XException (..), seqX)
+
+-- $setup
+-- >>> :set -XTemplateHaskell
+-- >>> :set -fplugin GHC.TypeLits.Normalise
+-- >>> :set -fplugin GHC.TypeLits.KnownNat.Solver
+-- >>> :m -Prelude
+-- >>> import Clash.Explicit.Prelude
+
+-- | Create a blockRAM with space for @n@ elements
+--
+-- * __NB__: Read value is delayed by 1 cycle
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
+--
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
+-- Block RAM.
+-- * Use the adapter 'Clash.Explicit.BlockRam.readNew' for obtaining
+-- write-before-read semantics like this: @'Clash.Explicit.BlockRam.readNew'
+-- clk rst en ('blockRamBlob' clk en content) rd wrM@.
+blockRamBlob
+  :: forall dom addr m n
+   . ( KnownDomain dom
+     , Enum addr
+     )
+  => Clock dom
+  -- ^ 'Clock' to synchronize to
+  -> Enable dom
+  -- ^ 'Enable' line
+  -> MemBlob n m
+  -- ^ Initial content of the RAM, also determines the size, @n@, of the RAM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom addr
+  -- ^ Read address @r@
+  -> Signal dom (Maybe (addr, BitVector m))
+  -- ^ (write address @w@, value to write)
+  -> Signal dom (BitVector m)
+  -- ^ Value of the blockRAM at address @r@ from the previous clock cycle
+blockRamBlob = \clk gen content rd wrM ->
+  let en       = isJust <$> wrM
+      (wr,din) = unbundle (fromJustX <$> wrM)
+  in blockRamBlob# clk gen content (fromEnum <$> rd) en (fromEnum <$> wr) din
+{-# INLINE blockRamBlob #-}
+
+-- | Create a blockRAM with space for 2^@n@ elements
+--
+-- * __NB__: Read value is delayed by 1 cycle
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'XException'
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
+-- Block RAM.
+-- * Use the adapter 'Clash.Explicit.BlockRam.readNew' for obtaining
+-- write-before-read semantics like this: @'Clash.Explicit.BlockRam.readNew'
+-- clk rst en ('blockRamBlobPow2' clk en content) rd wrM@.
+blockRamBlobPow2
+  :: forall dom m n
+   . ( KnownDomain dom
+     , KnownNat n
+     )
+  => Clock dom
+  -- ^ 'Clock' to synchronize to
+  -> Enable dom
+  -- ^ 'Enable' line
+  -> MemBlob (2^n) m
+  -- ^ Initial content of the RAM, also determines the size, 2^@n@, of the RAM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom (Unsigned n)
+  -- ^ Read address @r@
+  -> Signal dom (Maybe (Unsigned n, BitVector m))
+  -- ^ (write address @w@, value to write)
+  -> Signal dom (BitVector m)
+  -- ^ Value of the blockRAM at address @r@ from the previous clock cycle
+blockRamBlobPow2 = blockRamBlob
+{-# INLINE blockRamBlobPow2 #-}
+
+-- | BlockRAM primitive
+blockRamBlob#
+  :: forall dom m n
+   . KnownDomain dom
+  => Clock dom
+  -- ^ 'Clock' to synchronize to
+  -> Enable dom
+  -- ^ 'Enable' line
+  -> MemBlob n m
+  -- ^ Initial content of the RAM, also determines the size, @n@, of the RAM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom Int
+  -- ^ Read address @r@
+  -> Signal dom Bool
+  -- ^ Write enable
+  -> Signal dom Int
+  -- ^ Write address @w@
+  -> Signal dom (BitVector m)
+  -- ^ Value to write (at address @w@)
+  -> Signal dom (BitVector m)
+  -- ^ Value of the blockRAM at address @r@ from the previous clock cycle
+blockRamBlob# !_ gen content@MemBlob{} = \rd wen waS wd -> runST $ do
+  bvList <- unsafeIOToST (unpackMemBlob0 content)
+  ramStart <- newListArray (0,szI-1) bvList
+  go
+    ramStart
+    (withFrozenCallStack (deepErrorX "blockRamBlob: intial value undefined"))
+    (fromEnable gen)
+    rd
+    (fromEnable gen .&&. wen)
+    waS
+    wd
+ where
+  szI = natToNum @n @Int
+
+  go :: STArray s Int (BitVector m) -> BitVector m -> Signal dom Bool
+     -> Signal dom Int -> Signal dom Bool -> Signal dom Int
+     -> Signal dom (BitVector m) -> ST s (Signal dom (BitVector m))
+  go !ram o ret@(~(re :- res)) rt@(~(r :- rs)) et@(~(e :- en)) wt@(~(w :- wr))
+     dt@(~(d :- din)) = do
+    o `seqX` (o :-) <$> (ret `seq` rt `seq` et `seq` wt `seq` dt `seq`
+      unsafeInterleaveST
+        (do o' <- unsafeIOToST
+                    (catch (if re then unsafeSTToIO (ram `safeAt` r) else pure o)
+                    (\err@XException {} -> pure (throw err)))
+            d `defaultSeqX` upd ram e w d
+            go ram o' res rs en wr din))
+
+  upd :: STArray s Int (BitVector m) -> Bool -> Int -> BitVector m -> ST s ()
+  upd ram we waddr d = case maybeIsX we of
+    Nothing -> case maybeIsX waddr of
+      Nothing -> -- Put the XException from `waddr` as the value in all
+                 -- locations of `ram`.
+                 forM_ [0..(szI-1)] (\i -> unsafeWriteSTArray ram i (seq waddr d))
+      Just wa -> -- Put the XException from `we` as the value at address
+                 -- `waddr`.
+                 safeUpdate wa (seq we d) ram
+    Just True -> case maybeIsX waddr of
+      Nothing -> -- Put the XException from `waddr` as the value in all
+                 -- locations of `ram`.
+                 forM_ [0..(szI-1)] (\i -> unsafeWriteSTArray ram i (seq waddr d))
+      Just wa -> safeUpdate wa d ram
+    _ -> return ()
+
+  safeAt :: STArray s Int (BitVector m) -> Int -> ST s (BitVector m)
+  safeAt s i =
+    if (0 <= i) && (i < szI) then
+      unsafeReadSTArray s i
+    else pure $
+      withFrozenCallStack
+        (deepErrorX ("blockRamBlob: read address " <> show i <>
+                     " not in range [0.." <> show szI <> ")"))
+  {-# INLINE safeAt #-}
+
+  safeUpdate :: Int -> BitVector m -> STArray s Int (BitVector m) -> ST s ()
+  safeUpdate i a s =
+    if (0 <= i) && (i < szI) then
+      unsafeWriteSTArray s i a
+    else
+      let d = withFrozenCallStack
+                (deepErrorX ("blockRam: write address " <> show i <>
+                             " not in range [0.." <> show szI <> ")"))
+       in forM_ [0..(szI-1)] (\j -> unsafeWriteSTArray s j d)
+  {-# INLINE safeUpdate #-}
+{-# ANN blockRamBlob# hasBlackBox #-}
+{-# NOINLINE blockRamBlob# #-}
+
+-- | Create a 'MemBlob' binding from a list of values
+--
+-- Since this uses Template Haskell, nothing in the arguments given to
+-- 'createMemBlob' can refer to something defined in the same module.
+--
+-- === __Example__
+--
+-- @
+-- 'createMemBlob' @8 "content" 'Nothing' [15 .. 17]
+--
+-- ram clk en = 'blockRamBlob' clk en content
+-- @
+--
+-- The 'Data.Maybe.Maybe' datatype has don't care bits, where the actual value
+-- does not matter. But the bits need a defined value in the memory. Either 0 or
+-- 1 can be used, and both are valid representations of the data.
+--
+-- >>> import qualified Prelude as P
+-- >>> let es = P.map pack [ Nothing, Just (7 :: Unsigned 8), Just 8 ]
+-- >>> :{
+-- createMemBlob "content0" (Just 0) es
+-- createMemBlob "content1" (Just 1) es
+-- x = 1
+-- :}
+--
+-- >>> let pr = mapM_ (putStrLn . show)
+-- >>> pr es
+-- 0b0_...._....
+-- 0b1_0000_0111
+-- 0b1_0000_1000
+-- >>> pr $ unpackMemBlob content0
+-- 0b0_0000_0000
+-- 0b1_0000_0111
+-- 0b1_0000_1000
+-- >>> pr $ unpackMemBlob content1
+-- 0b0_1111_1111
+-- 0b1_0000_0111
+-- 0b1_0000_1000
+-- >>> :{
+-- createMemBlob "contentN" Nothing es
+-- x = 1
+-- :}
+-- <BLANKLINE>
+-- <interactive>:...: error:
+--     packBVs: cannot convert don't care values. Please specify a mapping to a definite value.
+--
+-- Note how we hinted to @clashi@ that our multi-line command was a list of
+-- declarations by including a dummy declaration @x = 1@. Without this trick,
+-- @clashi@ would expect an expression and the Template Haskell would not work.
+createMemBlob
+  :: forall m f
+   . ( Foldable f
+     , KnownNat m
+     )
+  => String
+  -- ^ Name of the binding to generate
+  -> Maybe Bit
+  -- ^ Value to map don't care bits to. 'Nothing' means throwing an error on
+  -- don't care bits.
+  -> f (BitVector m)
+  -- ^ The content for the 'MemBlob'
+  -> DecsQ
+createMemBlob name care es =
+  case packed of
+    Left err -> fail err
+    Right _ -> sequence
+      [ sigD name0 [t| MemBlob $(n) $(m) |]
+      , valD (varP name0) (normalB [| MemBlob { memBlobRunsLen = $(runsLen)
+                                              , memBlobRuns = $(runs)
+                                              , memBlobEndsLen = $(endsLen)
+                                              , memBlobEnds = $(ends)
+                                              } |]) []
+      ]
+ where
+  name0 = mkName name
+  n = litT . numTyLit . toInteger $ len
+  m = litT . numTyLit $ natToInteger @m
+  runsLen = litE . integerL . toInteger $ L.length runsB
+  runs = litE . stringPrimL $ L.unpack runsB
+  endsLen = litE . integerL . toInteger $ L.length endsB
+  ends = litE . stringPrimL $ L.unpack endsB
+  Right (len, runsB, endsB) = packed
+  packed = packBVs care es
+
+-- | Create a 'MemBlob' from a list of values
+--
+-- Since this uses Template Haskell, nothing in the arguments given to
+-- 'memBlobTH' can refer to something defined in the same module.
+--
+-- === __Example__
+--
+-- @
+-- ram clk en = 'blockRamBlob' clk en $(memBlobTH @8 Nothing [15 .. 17])
+-- @
+--
+-- The 'Data.Maybe.Maybe' datatype has don't care bits, where the actual value
+-- does not matter. But the bits need a defined value in the memory. Either 0 or
+-- 1 can be used, and both are valid representations of the data.
+--
+-- >>> import qualified Prelude as P
+-- >>> let es = P.map pack [ Nothing, Just (7 :: Unsigned 8), Just 8 ]
+-- >>> content0 = $(memBlobTH (Just 0) es)
+-- >>> content1 = $(memBlobTH (Just 1) es)
+-- >>> let pr = mapM_ (putStrLn . show)
+-- >>> pr es
+-- 0b0_...._....
+-- 0b1_0000_0111
+-- 0b1_0000_1000
+-- >>> pr $ unpackMemBlob content0
+-- 0b0_0000_0000
+-- 0b1_0000_0111
+-- 0b1_0000_1000
+-- >>> pr $ unpackMemBlob content1
+-- 0b0_1111_1111
+-- 0b1_0000_0111
+-- 0b1_0000_1000
+-- >>> $(memBlobTH Nothing es)
+-- <BLANKLINE>
+-- <interactive>:...: error:
+--     • packBVs: cannot convert don't care values. Please specify a mapping to a definite value.
+--     • In the untyped splice: $(memBlobTH Nothing es)
+memBlobTH
+  :: forall m f
+   . ( Foldable f
+     , KnownNat m
+     )
+  => Maybe Bit
+  -- ^ Value to map don't care bits to. 'Nothing' means throwing an error on
+  -- don't care bits.
+  -> f (BitVector m)
+  -- ^ The content for the 'MemBlob'
+  -> ExpQ
+memBlobTH care es =
+  case packed of
+    Left err -> fail err
+    Right _ -> [| MemBlob { memBlobRunsLen = $(runsLen)
+                          , memBlobRuns = $(runs)
+                          , memBlobEndsLen = $(endsLen)
+                          , memBlobEnds = $(ends)
+                          }
+                    :: MemBlob $(n) $(m) |]
+ where
+  n = litT . numTyLit . toInteger $ len
+  m = litT . numTyLit $ natToInteger @m
+  runsLen = litE . integerL . toInteger $ L.length runsB
+  runs = litE . stringPrimL $ L.unpack runsB
+  endsLen = litE . integerL . toInteger $ L.length endsB
+  ends = litE . stringPrimL $ L.unpack endsB
+  Right (len, runsB, endsB) = packed
+  packed = packBVs care es

--- a/clash-prelude/src/Clash/Explicit/BlockRam/Internal.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/Internal.hs
@@ -1,0 +1,191 @@
+{-|
+Copyright  :  (C) 2021-2022, QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Clash.Explicit.BlockRam.Internal where
+
+import Data.Bits ((.&.), (.|.), shiftL, xor)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as L
+import Data.ByteString.Builder (Builder, toLazyByteString, word8, word64BE)
+import qualified Data.ByteString.Unsafe as B
+import Data.Foldable (foldl')
+import Data.Word (Word64)
+import GHC.Exts (Addr#)
+import GHC.TypeLits (KnownNat, Nat)
+import Numeric.Natural (Natural)
+import System.IO.Unsafe (unsafePerformIO)
+
+import Clash.Promoted.Nat (natToNum)
+import Clash.Sized.Internal.BitVector (Bit(..), BitVector(..))
+
+-- | Efficient storage of memory content
+--
+-- It holds @n@ words of @'BitVector' m@.
+data MemBlob (n :: Nat) (m :: Nat) where
+  MemBlob
+    :: ( KnownNat n
+       , KnownNat m
+       )
+    => { memBlobRunsLen :: !Int
+       , memBlobRuns :: Addr#
+       , memBlobEndsLen :: !Int
+       , memBlobEnds :: Addr#
+       }
+    -> MemBlob n m
+
+instance Show (MemBlob n m) where
+  showsPrec _ x@MemBlob{} =
+    ("$(memBlobTH @" ++) . shows (natToNum @m @Int) . (" Nothing " ++) .
+      shows (unpackMemBlob x) . (')':)
+
+-- | Convert a 'MemBlob' back to a list
+--
+-- __NB__: Not synthesizable
+unpackMemBlob
+  :: forall n m
+   . MemBlob n m
+  -> [BitVector m]
+unpackMemBlob = unsafePerformIO . unpackMemBlob0
+
+unpackMemBlob0
+  :: forall n m
+   . MemBlob n m
+  -> IO [BitVector m]
+unpackMemBlob0 MemBlob{..} = do
+  runsB <- B.unsafePackAddressLen memBlobRunsLen memBlobRuns
+  endsB <- B.unsafePackAddressLen memBlobEndsLen memBlobEnds
+  return $ map (BV 0) $
+    unpackNats (natToNum @n) (natToNum @m) runsB endsB
+
+packBVs
+  :: forall m f
+   . ( Foldable f
+     , KnownNat m
+     )
+  => Maybe Bit
+  -> f (BitVector m)
+  -> Either String (Int, L.ByteString, L.ByteString)
+packBVs care es =
+  case lenOrErr of
+    Nothing  -> Left err
+    Just len -> let (runs, ends) = packAsNats mI knownBVVal es
+                in Right (len, runs, ends)
+ where
+  lenOrErr = case care of
+               Just (Bit 0 _) -> Just $ length es
+               _              -> foldl' lenOrErr0 (Just 0) es
+  lenOrErr0 (Just len) (BV 0 _) = Just $ len + 1
+  lenOrErr0 _          _        = Nothing
+
+  knownBVVal bv@(BV _ val) = case care of
+    Just (Bit 0 bm) -> maskBVVal bm bv
+    _               -> val
+
+  maskBVVal _ (BV 0    val) = val
+  maskBVVal 0 (BV mask val) = val .&. (mask `xor` fullMask)
+  maskBVVal _ (BV mask val) = val .|. mask
+
+  mI = natToNum @m @Int
+  fullMask = (1 `shiftL` mI) - 1
+  err = "packBVs: cannot convert don't care values. " ++
+        "Please specify a mapping to a definite value."
+
+packAsNats
+  :: forall a f
+   . Foldable f
+  => Int
+  -> (a -> Natural)
+  -> f a
+  -> (L.ByteString, L.ByteString)
+packAsNats width trans es = (toLazyByteString runs0, toLazyByteString ends)
+ where
+  (runL, endL) = width `divMod` 8
+  ends | endC0 > 0 = word64BE endA0 <> ends0
+       | otherwise = ends0
+  (runs0, ends0, endC0, endA0) = foldr pack0 (mempty, mempty, 0, 0) es
+
+  pack0 :: a -> (Builder, Builder, Int, Word64) ->
+           (Builder, Builder, Int, Word64)
+  pack0 val (runs1, ends1, endC1, endA1) =
+    let (ends2, endC2, endA2) = packEnd val2 ends1 endC1 endA1
+        (val2, runs2) = packRun runL (trans val) runs1
+    in (runs2, ends2, endC2, endA2)
+
+  packRun :: Int -> Natural -> Builder -> (Natural, Builder)
+  packRun 0    val1 runs1 = (val1, runs1)
+  packRun runC val1 runs1 = let (val2, runB) = val1 `divMod` 256
+                                runs2 = word8 (fromIntegral runB) <> runs1
+                            in packRun (runC - 1) val2 runs2
+
+  packEnd :: Natural -> Builder -> Int -> Word64 -> (Builder, Int, Word64)
+  packEnd val2 ends1 endC1 endA1
+    | endL == 0   = (ends1, endC1, endA1)
+    | endC2 <= 64 = let endA2 = endA1 * (2 ^ endL) + valEnd
+                    in (ends1, endC2, endA2)
+    | otherwise   = let ends2 = word64BE endA1 <> ends1
+                    in (ends2, endL, valEnd)
+   where
+    endC2 = endC1 + endL
+    valEnd = fromIntegral val2
+
+unpackNats
+  :: Int
+  -> Int
+  -> B.ByteString
+  -> B.ByteString
+  -> [Natural]
+unpackNats 0 _ _ _ = []
+unpackNats len width runBs endBs
+  | width < 8 = ends
+  | otherwise = go (head ends) runL runBs (tail ends)
+ where
+  (runL, endL) = width `divMod` 8
+  ends = if endL == 0 then
+           repeat 0
+         else
+           unpackEnds endL len $ unpackW64s endBs
+
+  go val 0    runBs0 ~(end0:ends0) = val : go end0 runL runBs0 ends0
+  go _   _    runBs0 _             | B.null runBs0 = []
+  go val runC runBs0 ends0
+    = let Just (runB, runBs1) = B.uncons runBs0
+          val0 = val * 256 + fromIntegral runB
+      in go val0 (runC - 1) runBs1 ends0
+
+unpackW64s
+  :: B.ByteString
+  -> [Word64]
+unpackW64s = go 8 0
+ where
+  go :: Int -> Word64 -> B.ByteString -> [Word64]
+  go 8 _   endBs | B.null endBs = []
+  go 0 val endBs = val : go 8 0 endBs
+  go n val endBs = let Just (endB, endBs0) = B.uncons endBs
+                       val0 = val * 256 + fromIntegral endB
+                   in go (n - 1) val0 endBs0
+
+unpackEnds
+  :: Int
+  -> Int
+  -> [Word64]
+  -> [Natural]
+unpackEnds _    _   []     = []
+unpackEnds endL len (w:ws) = go endCInit w ws
+ where
+  endPerWord = 64 `div` endL
+  leader = len `mod` endPerWord
+  endCInit | leader == 0 = endPerWord
+           | otherwise   = leader
+
+  go 0 _    []       = []
+  go 0 _    (w0:ws0) = go endPerWord w0 ws0
+  go n endA ws0      = let (endA0, valEnd) = endA `divMod` (2 ^ endL)
+                       in fromIntegral valEnd : go (n - 1) endA0 ws0

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -32,7 +32,12 @@ module Clash.Explicit.Prelude
   , asyncRomPow2
   , rom
   , romPow2
-    -- ** ROMs initialized with a data file
+    -- ** ROMs defined by a 'MemBlob'
+  , asyncRomBlob
+  , asyncRomBlobPow2
+  , romBlob
+  , romBlobPow2
+    -- ** ROMs defined by a data file
   , asyncRomFile
   , asyncRomFilePow2
   , romFile
@@ -46,6 +51,14 @@ module Clash.Explicit.Prelude
   , blockRamU
   , blockRam1
   , ResetStrategy(..)
+    -- ** BlockRAM primitives initialized with a 'MemBlob'
+  , blockRamBlob
+  , blockRamBlobPow2
+    -- *** Creating and inspecting 'MemBlob'
+  , MemBlob
+  , createMemBlob
+  , memBlobTH
+  , unpackMemBlob
     -- ** BlockRAM primitives initialized with a data file
   , blockRamFile
   , blockRamFilePow2
@@ -144,11 +157,13 @@ import Clash.Class.Resize
 import Clash.Magic
 import Clash.NamedTypes
 import Clash.Explicit.BlockRam
+import Clash.Explicit.BlockRam.Blob
 import Clash.Explicit.BlockRam.File
 import Clash.Explicit.Mealy
 import Clash.Explicit.Moore
 import Clash.Explicit.RAM
 import Clash.Explicit.ROM
+import Clash.Explicit.ROM.Blob
 import Clash.Explicit.ROM.File
 import Clash.Explicit.Prelude.Safe
 import Clash.Explicit.Reset

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -34,12 +34,25 @@ module Clash.Explicit.Prelude.Safe
   , asyncRomPow2
   , rom
   , romPow2
+    -- ** ROMs defined by a 'MemBlob'
+  , asyncRomBlob
+  , asyncRomBlobPow2
+  , romBlob
+  , romBlobPow2
     -- * RAM primitives with a combinational read port
   , asyncRam
   , asyncRamPow2
     -- * BlockRAM primitives
   , blockRam
   , blockRamPow2
+    -- ** BlockRAM primitives initialized with a 'MemBlob'
+  , blockRamBlob
+  , blockRamBlobPow2
+    -- *** Creating and inspecting 'MemBlob'
+  , MemBlob
+  , createMemBlob
+  , memBlobTH
+  , unpackMemBlob
     -- ** BlockRAM read/write conflict resolution
   , readNew
     -- * Utility functions
@@ -110,14 +123,17 @@ import Clash.Class.Resize
 import Clash.NamedTypes
 
 import Clash.Explicit.BlockRam
+import Clash.Explicit.BlockRam.Blob
 import Clash.Explicit.Mealy
 import Clash.Explicit.Moore
 import Clash.Explicit.RAM
 import Clash.Explicit.ROM
+import Clash.Explicit.ROM.Blob
 import Clash.Explicit.Signal
 import Clash.Explicit.Signal.Delayed
 import Clash.Explicit.Synchronizer
   (dualFlipFlopSynchronizer, asyncFIFOSynchronizer)
+import Clash.Prelude.ROM.Blob (asyncRomBlob, asyncRomBlobPow2)
 import Clash.Prelude.ROM             (asyncRom, asyncRomPow2)
 import Clash.Promoted.Nat
 import Clash.Promoted.Nat.TH

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -50,6 +50,10 @@ import Clash.XException       (deepErrorX, seqX, NFDataX)
 --
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Explicit.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
+-- * A large 'Vec' for the content might be too inefficient, depending on how it
+-- is constructed. See 'Clash.Explicit.ROM.File.romFilePow2' and
+-- 'Clash.Explicit.ROM.Blob.romBlobPow2' for different approaches that scale
+-- well.
 romPow2
   :: (KnownDomain dom, KnownNat n, NFDataX a)
   => Clock dom
@@ -77,6 +81,9 @@ romPow2 = rom
 --
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Explicit.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
+-- * A large 'Vec' for the content might be too inefficient, depending on how it
+-- is constructed. See 'Clash.Explicit.ROM.File.romFile' and
+-- 'Clash.Explicit.ROM.Blob.romBlob' for different approaches that scale well.
 rom
   :: (KnownDomain dom, KnownNat n, NFDataX a, Enum addr)
   => Clock dom

--- a/clash-prelude/src/Clash/Explicit/ROM/Blob.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/Blob.hs
@@ -1,0 +1,153 @@
+{-|
+Copyright  :  (C) 2021-2022, QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+= Efficient bundling of ROM content with the compiled code
+
+Leveraging Template Haskell, the content for the ROM components in this module
+is stored alongside the compiled Haskell code. It covers use cases where passing
+the initial content as a 'Clash.Sized.Vector.Vec' turns out to be
+problematically slow.
+
+The data is stored efficiently, with very little overhead (worst-case 7%, often
+no overhead at all).
+
+Unlike "Clash.Explicit.ROM.File", "Clash.Explicit.ROM.Blob" generates
+practically the same HDL as "Clash.Explicit.ROM" and is compatible with all
+tools consuming the generated HDL.
+-}
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+module Clash.Explicit.ROM.Blob
+  ( -- * ROMs defined by a 'MemBlob'
+    romBlob
+  , romBlobPow2
+    -- * Creating and inspecting 'MemBlob'
+  , MemBlob
+  , createMemBlob
+  , memBlobTH
+  , unpackMemBlob
+    -- * Internal
+  , romBlob#
+  ) where
+
+import Data.Array (listArray)
+import Data.Array.Base (unsafeAt)
+import GHC.Stack (withFrozenCallStack)
+import GHC.TypeLits (KnownNat, type (^))
+
+import Clash.Annotations.Primitive (hasBlackBox)
+import Clash.Explicit.BlockRam.Blob (createMemBlob, memBlobTH)
+import Clash.Explicit.BlockRam.Internal (MemBlob(..), unpackMemBlob)
+import Clash.Promoted.Nat (natToNum)
+import Clash.Signal.Internal
+  (Clock (..), KnownDomain, Signal (..), Enable, fromEnable)
+import Clash.Sized.Internal.BitVector (BitVector)
+import Clash.Sized.Internal.Unsigned (Unsigned)
+import Clash.XException (deepErrorX, seqX)
+
+-- | A ROM with a synchronous read port, with space for @n@ elements
+--
+-- * __NB__: Read value is delayed by 1 cycle
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Sized.Fixed#creatingdatafiles" and
+-- "Clash.Explicit.BlockRam#usingrams" for ideas on how to use ROMs and RAMs
+romBlob
+  :: forall dom addr m n
+   . ( KnownDomain dom
+     , Enum addr
+     )
+  => Clock dom
+  -- ^ 'Clock' to synchronize to
+  -> Enable dom
+  -- ^ 'Enable' line
+  -> MemBlob n m
+  -- ^ ROM content, also determines the size, @n@, of the ROM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom addr
+  -- ^ Read address @r@
+  -> Signal dom (BitVector m)
+  -- ^ The value of the ROM at address @r@ from the previous clock cycle
+romBlob = \clk en content rd -> romBlob# clk en content (fromEnum <$> rd)
+{-# INLINE romBlob #-}
+
+-- | A ROM with a synchronous read port, with space for 2^@n@ elements
+--
+-- * __NB__: Read value is delayed by 1 cycle
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Sized.Fixed#creatingdatafiles" and
+-- "Clash.Explicit.BlockRam#usingrams" for ideas on how to use ROMs and RAMs
+romBlobPow2
+  :: forall dom m n
+   . ( KnownDomain dom
+     , KnownNat n
+     )
+  => Clock dom
+  -- ^ 'Clock' to synchronize to
+  -> Enable dom
+  -- ^ 'Enable' line
+  -> MemBlob (2^n) m
+  -- ^ ROM content, also determines the size, 2^@n@, of the ROM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom (Unsigned n)
+  -- ^ Read address @r@
+  -> Signal dom (BitVector m)
+  -- ^ The value of the ROM at address @r@ from the previous clock cycle
+romBlobPow2 = romBlob
+{-# INLINE romBlobPow2 #-}
+
+-- | ROM primitive
+romBlob#
+  :: forall dom m n
+   . KnownDomain dom
+  => Clock dom
+  -- ^ 'Clock' to synchronize to
+  -> Enable dom
+  -- ^ 'Enable' line
+  -> MemBlob n m
+  -- ^ ROM content, also determines the size, @n@, of the ROM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom Int
+  -- ^ Read address @r@
+  -> Signal dom (BitVector m)
+  -- ^ The value of the ROM at address @r@ from the previous clock cycle
+romBlob# !_ en content@MemBlob{} =
+  go
+    (withFrozenCallStack (deepErrorX "romBlob: initial value undefined"))
+    (fromEnable en)
+ where
+  szI = natToNum @n @Int
+  arr = listArray (0,szI-1) $ unpackMemBlob content
+
+  go o (e :- es) rd@(~(r :- rs)) =
+    let o1 = if e then safeAt r else o
+    -- See [Note: register strictness annotations]
+    in  o `seqX` o :- (rd `seq` go o1 es rs)
+
+  safeAt :: Int -> BitVector m
+  safeAt i =
+    if (0 <= i) && (i < szI) then
+      unsafeAt arr i
+    else
+      withFrozenCallStack
+        (deepErrorX ("romBlob: address " ++ show i ++
+                     " not in range [0.." ++ show szI ++ ")"))
+  {-# INLINE safeAt #-}
+{-# NOINLINE romBlob# #-}
+{-# ANN romBlob# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -2,7 +2,7 @@
   Copyright   :  (C) 2013-2016, University of Twente,
                      2017-2019, Myrtle Software Ltd
                      2017     , Google Inc.,
-                     2021     , QBayLogic B.V.
+                     2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -60,7 +60,12 @@ module Clash.Prelude
   , asyncRomPow2
   , rom
   , romPow2
-    -- ** ROMs initialized with a data file
+    -- ** ROMs defined by a 'MemBlob'
+  , asyncRomBlob
+  , asyncRomBlobPow2
+  , romBlob
+  , romBlobPow2
+    -- ** ROMs defined by a data file
   , asyncRomFile
   , asyncRomFilePow2
   , romFile
@@ -74,6 +79,14 @@ module Clash.Prelude
   , blockRamU
   , blockRam1
   , E.ResetStrategy(..)
+    -- ** BlockRAM primitives initialized with a 'MemBlob'
+  , blockRamBlob
+  , blockRamBlobPow2
+    -- *** Creating and inspecting 'MemBlob'
+  , MemBlob
+  , createMemBlob
+  , memBlobTH
+  , unpackMemBlob
     -- ** BlockRAM primitives initialized with a data file
   , blockRamFile
   , blockRamFilePow2
@@ -176,7 +189,9 @@ import           Clash.Hidden
 import           Clash.Magic
 import           Clash.NamedTypes
 import           Clash.Prelude.BlockRam
+import           Clash.Prelude.BlockRam.Blob
 import           Clash.Prelude.BlockRam.File
+import           Clash.Prelude.ROM.Blob
 import           Clash.Prelude.ROM.File
 import           Clash.Prelude.Safe
 #ifdef CLASH_MULTIPLE_HIDDEN

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2019, Myrtle Software Ltd,
                   2017     , Google Inc.,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -692,6 +692,10 @@ prog2 = -- 0 := 4
 -- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
 -- Block RAM.
 -- * Use the adapter 'readNew' for obtaining write-before-read semantics like this: @readNew (blockRam inits) rd wrM@.
+-- * A large 'Vec' for the initial content might be too inefficient, depending
+-- on how it is constructed. See 'Clash.Prelude.BlockRam.File.blockRamFile' and
+-- 'Clash.Prelude.BlockRam.Blob.blockRamBlob' for different approaches that
+-- scale well.
 blockRam
   :: ( HasCallStack
      , HiddenClock dom
@@ -790,6 +794,10 @@ blockRam1 =
 -- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
 -- Block RAM.
 -- * Use the adapter 'readNew' for obtaining write-before-read semantics like this: @readNew (blockRamPow2 inits) rd wrM@.
+-- * A large 'Vec' for the initial content might be too inefficient, depending
+-- on how it is constructed. See 'Clash.Prelude.BlockRam.File.blockRamFilePow2'
+-- and 'Clash.Prelude.BlockRam.Blob.blockRamBlobPow2' for different approaches
+-- that scale well.
 blockRamPow2
   :: ( HasCallStack
      , HiddenClock dom

--- a/clash-prelude/src/Clash/Prelude/BlockRam/Blob.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/Blob.hs
@@ -1,0 +1,107 @@
+{-|
+Copyright  :  (C) 2022     , QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+= Efficient bundling of initial RAM content with the compiled code
+
+Leveraging Template Haskell, the initial content for the blockRAM components in
+this module is stored alongside the compiled Haskell code. It covers use cases
+where passing the initial content as a 'Clash.Sized.Vector.Vec' turns out to be
+problematically slow.
+
+The data is stored efficiently, with very little overhead (worst-case 7%, often
+no overhead at all).
+
+Unlike "Clash.Prelude.BlockRam.File", "Clash.Prelude.BlockRam.Blob" generates
+practically the same HDL as "Clash.Prelude.BlockRam" and is compatible with all
+tools consuming the generated HDL.
+-}
+
+{-# LANGUAGE Safe #-}
+
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+module Clash.Prelude.BlockRam.Blob
+  ( -- * BlockRAMs initialized with a 'E.MemBlob'
+    blockRamBlob
+  , blockRamBlobPow2
+    -- * Creating and inspecting 'E.MemBlob'
+  , E.MemBlob
+  , E.createMemBlob
+  , E.memBlobTH
+  , E.unpackMemBlob
+  )
+where
+
+import GHC.TypeLits (KnownNat, type (^))
+
+import qualified Clash.Explicit.BlockRam.Blob as E
+import Clash.Signal (hideClock, hideEnable, HiddenClock, HiddenEnable, Signal)
+import Clash.Sized.BitVector (BitVector)
+import Clash.Sized.Unsigned (Unsigned)
+
+-- | Create a blockRAM with space for @n@ elements
+--
+-- * __NB__: Read value is delayed by 1 cycle
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
+--
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
+-- Block RAM.
+-- * Use the adapter 'Clash.Prelude.BlockRam.readNew' for obtaining
+-- write-before-read semantics like this: @'Clash.Prelude.BlockRam.readNew'
+-- ('blockRamBlob' content) rd wrM@.
+blockRamBlob
+  :: forall dom addr m n
+   . ( HiddenClock dom
+     , HiddenEnable dom
+     , Enum addr
+     )
+  => E.MemBlob n m
+  -- ^ Initial content of the RAM, also determines the size, @n@, of the RAM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom addr
+  -- ^ Read address @r@
+  -> Signal dom (Maybe (addr, BitVector m))
+  -- ^ (write address @w@, value to write)
+  -> Signal dom (BitVector m)
+  -- ^ Value of the blockRAM at address @r@ from the previous clock cycle
+blockRamBlob = hideEnable (hideClock E.blockRamBlob)
+{-# INLINE blockRamBlob #-}
+
+-- | Create a blockRAM with space for 2^@n@ elements
+--
+-- * __NB__: Read value is delayed by 1 cycle
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
+-- Block RAM.
+-- * Use the adapter 'Clash.Prelude.BlockRam.readNew' for obtaining
+-- write-before-read semantics like this: @'Clash.Prelude.BlockRam.readNew'
+-- ('blockRamBlobPow2' content) rd wrM@.
+blockRamBlobPow2
+  :: forall dom m n
+   . ( HiddenClock dom
+     , HiddenEnable dom
+     , KnownNat n
+     )
+  => E.MemBlob (2^n) m
+  -- ^ Initial content of the RAM, also determines the size, 2^@n@, of the RAM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom (Unsigned n)
+  -- ^ Read address @r@
+  -> Signal dom (Maybe (Unsigned n, BitVector m))
+  -- ^ (write address @w@, value to write)
+  -> Signal dom (BitVector m)
+  -- ^ Value of the blockRAM at address @r@ from the previous clock cycle
+blockRamBlobPow2 = hideEnable (hideClock E.blockRamBlobPow2)
+{-# INLINE blockRamBlobPow2 #-}

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -49,6 +49,10 @@ import           Clash.XException     (NFDataX, errorX)
 --
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
+-- * A large 'Vec' for the content might be too inefficient, depending on how it
+-- is constructed. See 'Clash.Prelude.ROM.File.asyncRomFile' and
+-- 'Clash.Prelude.ROM.Blob.asyncRomBlob' for different approaches that scale
+-- well.
 asyncRom
   :: (KnownNat n, Enum addr)
   => Vec n a
@@ -68,6 +72,10 @@ asyncRom = \content rd -> asyncRom# content (fromEnum rd)
 --
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
+-- * A large 'Vec' for the content might be too inefficient, depending on how it
+-- is constructed. See 'Clash.Prelude.ROM.File.asyncRomFilePow2' and
+-- 'Clash.Prelude.ROM.Blob.asyncRomBlobPow2' for different approaches that scale
+-- well.
 asyncRomPow2
   :: KnownNat n
   => Vec (2^n) a
@@ -118,6 +126,9 @@ asyncRom# content = safeAt
 --
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
+-- * A large 'Vec' for the content might be too inefficient, depending on how it
+-- is constructed. See 'Clash.Prelude.ROM.File.romFile' and
+-- 'Clash.Prelude.ROM.Blob.romBlob' for different approaches that scale well.
 rom
   :: forall dom n m a
    . ( NFDataX a
@@ -146,6 +157,10 @@ rom = hideEnable (hideClock E.rom)
 --
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
+-- * A large 'Vec' for the content might be too inefficient, depending on how it
+-- is constructed. See 'Clash.Prelude.ROM.File.romFilePow2' and
+-- 'Clash.Prelude.ROM.Blob.romBlobPow2' for different approaches that scale
+-- well.
 romPow2
   :: forall dom n a
    . ( KnownNat n

--- a/clash-prelude/src/Clash/Prelude/ROM/Blob.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/Blob.hs
@@ -1,0 +1,175 @@
+{-|
+Copyright  :  (C) 2022     , QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+= Efficient bundling of ROM content with the compiled code
+
+Leveraging Template Haskell, the content for the ROM components in this module
+is stored alongside the compiled Haskell code. It covers use cases where passing
+the initial content as a 'Clash.Sized.Vector.Vec' turns out to be
+problematically slow.
+
+The data is stored efficiently, with very little overhead (worst-case 7%, often
+no overhead at all).
+
+Unlike "Clash.Prelude.ROM.File", "Clash.Prelude.ROM.Blob" generates practically
+the same HDL as "Clash.Prelude.ROM" and is compatible with all tools consuming
+the generated HDL.
+-}
+
+{-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+module Clash.Prelude.ROM.Blob
+  ( -- * Asynchronous ROM defined by a 'MemBlob'
+    asyncRomBlob
+  , asyncRomBlobPow2
+    -- * Synchronous 'MemBlob' ROM synchronized to an arbitrary clock
+  , romBlob
+  , romBlobPow2
+    -- * Creating and inspecting 'MemBlob'
+  , MemBlob
+  , createMemBlob
+  , memBlobTH
+  , unpackMemBlob
+    -- * Internal
+  , asyncRomBlob#
+  )
+where
+
+import Data.Array (listArray)
+import Data.Array.Base (unsafeAt)
+import GHC.Stack (withFrozenCallStack)
+import GHC.TypeLits (KnownNat, type (^))
+
+import Clash.Annotations.Primitive (hasBlackBox)
+import qualified Clash.Explicit.ROM.Blob as E
+import Clash.Explicit.BlockRam.Blob (createMemBlob, memBlobTH)
+import Clash.Explicit.BlockRam.Internal (MemBlob(..), unpackMemBlob)
+import Clash.Promoted.Nat (natToNum)
+import Clash.Signal (hideClock, hideEnable, HiddenClock, HiddenEnable)
+import Clash.Signal.Internal (Signal)
+import Clash.Sized.Internal.BitVector (BitVector)
+import Clash.Sized.Internal.Unsigned (Unsigned)
+import Clash.XException (deepErrorX)
+
+-- | An asynchronous/combinational ROM with space for @n@ elements
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Sized.Fixed#creatingdatafiles" and
+-- "Clash.Prelude.BlockRam#usingrams" for ideas on how to use ROMs and RAMs.
+asyncRomBlob
+  :: Enum addr
+  => MemBlob n m
+  -- ^ ROM content, also determines the size, @n@, of the ROM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> addr
+  -- ^ Read address @r@
+  -> BitVector m
+  -- ^ The value of the ROM at address @r@
+asyncRomBlob = \content rd -> asyncRomBlob# content (fromEnum rd)
+{-# INLINE asyncRomBlob #-}
+
+-- | An asynchronous/combinational ROM with space for 2^@n@ elements
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Sized.Fixed#creatingdatafiles" and
+-- "Clash.Prelude.BlockRam#usingrams" for ideas on how to use ROMs and RAMs.
+asyncRomBlobPow2
+  :: KnownNat n
+  => MemBlob (2^n) m
+  -- ^ ROM content, also determines the size, 2^@n@, of the ROM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Unsigned n
+  -- ^ Read address @r@
+  -> BitVector m
+  -- ^ The value of the ROM at address @r@
+asyncRomBlobPow2 = asyncRomBlob
+{-# INLINE asyncRomBlobPow2 #-}
+
+-- | asyncROM primitive
+asyncRomBlob#
+  :: forall m n
+   . MemBlob n m
+  -- ^ ROM content, also determines the size, @n@, of the ROM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Int
+  -- ^ Read address @r@
+  -> BitVector m
+  -- ^ The value of the ROM at address @r@
+asyncRomBlob# content@MemBlob{} = safeAt
+  where
+    szI = natToNum @n @Int
+    arr = listArray (0,szI-1) $ unpackMemBlob content
+
+    safeAt :: Int -> BitVector m
+    safeAt i =
+      if (0 <= i) && (i < szI) then
+        unsafeAt arr i
+      else
+        withFrozenCallStack
+          (deepErrorX ("asyncRom: address " ++ show i ++
+                       " not in range [0.." ++ show szI ++ ")"))
+{-# ANN asyncRomBlob# hasBlackBox #-}
+{-# NOINLINE asyncRomBlob# #-}
+
+-- | A ROM with a synchronous read port, with space for @n@ elements
+--
+-- * __NB__: Read value is delayed by 1 cycle
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Sized.Fixed#creatingdatafiles" and
+-- "Clash.Explicit.BlockRam#usingrams" for ideas on how to use ROMs and RAMs.
+romBlob
+  :: forall dom addr m n
+   . ( HiddenClock dom
+     , HiddenEnable dom
+     , Enum addr
+     )
+  => MemBlob n m
+  -- ^ ROM content, also determines the size, @n@, of the ROM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom addr
+  -- ^ Read address @r@
+  -> Signal dom (BitVector m)
+  -- ^ The value of the ROM at address @r@ from the previous clock cycle
+romBlob = hideEnable (hideClock E.romBlob)
+{-# INLINE romBlob #-}
+
+-- | A ROM with a synchronous read port, with space for 2^@n@ elements
+--
+-- * __NB__: Read value is delayed by 1 cycle
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
+--
+-- Additional helpful information:
+--
+-- * See "Clash.Sized.Fixed#creatingdatafiles" and
+-- "Clash.Explicit.BlockRam#usingrams" for ideas on how to use ROMs and RAMs.
+romBlobPow2
+  :: forall dom m n
+   . ( HiddenClock dom
+     , HiddenEnable dom
+     , KnownNat n
+     )
+  => MemBlob (2^n) m
+  -- ^ ROM content, also determines the size, 2^@n@, of the ROM
+  --
+  -- __NB__: __MUST__ be a constant
+  -> Signal dom (Unsigned n)
+  -- ^ Read address @r@
+  -> Signal dom (BitVector m)
+  -- ^ The value of the ROM at address @r@ from the previous clock cycle
+romBlobPow2 = hideEnable (hideClock E.romBlobPow2)
+{-# INLINE romBlobPow2 #-}

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -2,7 +2,7 @@
   Copyright   :  (C) 2013-2016, University of Twente,
                      2017-2019, Myrtle Software Ltd
                      2017     , Google Inc.,
-                     2021     , QBayLogic B.V.
+                     2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -50,12 +50,25 @@ module Clash.Prelude.Safe
   , asyncRomPow2
   , rom
   , romPow2
+    -- ** ROMs defined by a 'MemBlob'
+  , asyncRomBlob
+  , asyncRomBlobPow2
+  , romBlob
+  , romBlobPow2
     -- * RAM primitives with a combinational read port
   , asyncRam
   , asyncRamPow2
     -- * BlockRAM primitives
   , blockRam
   , blockRamPow2
+    -- ** BlockRAM primitives initialized with a 'MemBlob'
+  , blockRamBlob
+  , blockRamBlobPow2
+    -- *** Creating and inspecting 'MemBlob'
+  , MemBlob
+  , createMemBlob
+  , memBlobTH
+  , unpackMemBlob
     -- ** BlockRAM read/write conflict resolution
   , readNew
     -- * Utility functions
@@ -128,11 +141,13 @@ import           Clash.Class.Resize
 import           Clash.Hidden
 import           Clash.NamedTypes
 import           Clash.Prelude.BlockRam
+import           Clash.Prelude.BlockRam.Blob
 import qualified Clash.Explicit.Prelude.Safe as E
 import           Clash.Prelude.Mealy         (mealy, mealyB, (<^>))
 import           Clash.Prelude.Moore         (moore, mooreB)
 import           Clash.Prelude.RAM           (asyncRam,asyncRamPow2)
 import           Clash.Prelude.ROM           (asyncRom,asyncRomPow2,rom,romPow2)
+import           Clash.Prelude.ROM.Blob
 import           Clash.Promoted.Nat
 import           Clash.Promoted.Nat.TH
 import           Clash.Promoted.Nat.Literals

--- a/clash-prelude/tests/Clash/Tests/BlockRam/Blob.hs
+++ b/clash-prelude/tests/Clash/Tests/BlockRam/Blob.hs
@@ -1,0 +1,36 @@
+module Clash.Tests.BlockRam.Blob where
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as L
+import Data.Functor.Identity
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Numeric.Natural
+import Test.Tasty
+import Test.Tasty.Hedgehog
+
+import Clash.Explicit.BlockRam.Internal (packAsNats, unpackNats)
+
+roundTripProperty :: Property
+roundTripProperty = property $ do
+  len <- forAll $ Gen.integral $ Range.linear 0 256
+  width <- forAll $ Gen.integral $ Range.linear 1 128
+  es <- forAll $ Gen.list (Range.singleton len) $
+    Gen.integral_ $ Range.constant 0 (2 ^ width - 1)
+  tripping (len, width, es) encode decode
+ where
+  encode :: (Int, Int, [Natural]) -> (Int, Int, B.ByteString, B.ByteString)
+  encode (len, width, es) = let (runs, ends) = packAsNats width id es
+                            in (len, width, L.toStrict runs, L.toStrict ends)
+  decode :: (Int, Int, B.ByteString, B.ByteString)
+         -> Identity (Int, Int, [Natural])
+  decode (len, width, runs, ends) =
+    let es = take 300 $ unpackNats len width runs ends
+    in Identity (len, width, es)
+
+tests :: TestTree
+tests = testGroup "BlockRam"
+  [ testGroup "Blob"
+    [ testProperty "Round trip" roundTripProperty ]
+  ]

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -6,6 +6,7 @@ import qualified Clash.Tests.AutoReg
 import qualified Clash.Tests.BitPack
 import qualified Clash.Tests.BitVector
 import qualified Clash.Tests.BlockRam
+import qualified Clash.Tests.BlockRam.Blob
 import qualified Clash.Tests.Counter
 import qualified Clash.Tests.DerivingDataRepr
 import qualified Clash.Tests.Fixed
@@ -30,6 +31,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.BitPack.tests
   , Clash.Tests.BitVector.tests
   , Clash.Tests.BlockRam.tests
+  , Clash.Tests.BlockRam.Blob.tests
   , Clash.Tests.Counter.tests
   , Clash.Tests.DerivingDataRepr.tests
   , Clash.Tests.Fixed.tests

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -659,6 +659,9 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "BlockRamFile" def
         , runTest "BlockRam0" def
         , runTest "BlockRam1" def
+        , clashTestGroup "BlockRam"
+          [ runTest "Blob" def
+          ]
         , runTest "AndEnable" def
 #ifdef CLASH_MULTIPLE_HIDDEN
         , runTest "AndSpecificEnable" def
@@ -691,6 +694,14 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "ResetLow" def
         , runTest "Rom" def
         , runTest "RomNegative" def
+        , clashTestGroup "ROM"
+          [ runTest "Async" def
+          , runTest "AsyncBlob" def
+          , runTest "Blob" def
+            -- TODO: When issue #2039 is fixed, it should be possible to drop
+            -- compile-ultra.
+          , runTest "BlobVec" def{clashFlags=["-fclash-compile-ultra"]}
+          ]
         , runTest "SigP" def{hdlSim=False}
         , outputTest "T1102A" def{hdlTargets=[VHDL]}
         , outputTest "T1102B" def{hdlTargets=[VHDL]}

--- a/tests/shouldwork/Signal/BlockRam/Blob.hs
+++ b/tests/shouldwork/Signal/BlockRam/Blob.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+module Blob where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+createMemBlob @4 "content" Nothing [4 .. 7]
+
+topEntity
+  :: Clock System
+  -> Enable System
+  -> Signal System (Unsigned 2)
+  -> Signal System (Maybe (Unsigned 2, Unsigned 4))
+  -> Signal System (Unsigned 4, Unsigned 4)
+topEntity clk en rd wrM =
+  let ram en0 = unpack <$> blockRamBlob clk en0 content rd wrM0
+      wrM0 = fmap (fmap (\(wr, din) -> (wr, pack din))) wrM
+  in bundle (ram enableGen, ram en)
+{-# NOINLINE topEntity #-}
+
+samples :: Vec _ (Unsigned 2, Maybe (Unsigned 2, Unsigned 4), Unsigned 4)
+samples =
+  -- rd  wrM          out
+
+     -- Read initial contents
+     (0, Nothing     , 15)
+  :> (1, Nothing     ,  4)
+  :> (2, Nothing     ,  5)
+     -- Write and read back
+  :> (3, Just (0,  8),  6)
+  :> (0, Just (1,  9),  7)
+  :> (1, Just (2, 10),  8)
+  :> (2, Just (3, 11),  9)
+  :> (3, Nothing     , 10)
+  :> (3, Nothing     , 11)
+  :> Nil
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    (rd, wrM, expect) = unzip3 samples
+    rdInput = stimuliGenerator clk rst rd
+    wrMInput = stimuliGenerator clk rst wrM
+    expectedOutput =
+      outputVerifier' clk rst $ zip expect expect
+    done = expectedOutput $ ignoreFor clk rst en d1 (15, 15) $
+             topEntity clk en rdInput wrMInput
+    clk = tbSystemClockGen (not <$> done)
+    rst = systemResetGen
+    en = enableGen
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Signal/ROM/Async.hs
+++ b/tests/shouldwork/Signal/ROM/Async.hs
@@ -1,0 +1,23 @@
+module Async where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Signal System (Unsigned 4)
+  -> Signal System (Unsigned 8)
+topEntity = fmap (asyncRomPow2 content)
+ where content = $(listToVecTH [1 :: Unsigned 8 .. 16])
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput = register clk rst en 0 (testInput + 1)
+    expectedOutput =
+      outputVerifier' clk rst $ $(listToVecTH $ [1 :: Unsigned 8 .. 8])
+    done = expectedOutput $ topEntity testInput
+    clk = tbSystemClockGen (not <$> done)
+    rst = systemResetGen
+    en = enableGen
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Signal/ROM/AsyncBlob.hs
+++ b/tests/shouldwork/Signal/ROM/AsyncBlob.hs
@@ -1,0 +1,24 @@
+module AsyncBlob where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+createMemBlob @8 "content" Nothing [1 .. 16]
+
+topEntity
+  :: Signal System (Unsigned 4)
+  -> Signal System (Unsigned 8)
+topEntity = fmap (unpack . asyncRomBlobPow2 content)
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput = register clk rst en 0 (testInput + 1)
+    expectedOutput =
+      outputVerifier' clk rst $ $(listToVecTH $ [1 :: Unsigned 8 .. 8])
+    done = expectedOutput $ topEntity testInput
+    clk = tbSystemClockGen (not <$> done)
+    rst = systemResetGen
+    en = enableGen
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Signal/ROM/Blob.hs
+++ b/tests/shouldwork/Signal/ROM/Blob.hs
@@ -1,0 +1,29 @@
+module Blob where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+createMemBlob @8 "content" Nothing [1 .. 16]
+
+topEntity
+  :: Clock System
+  -> Enable System
+  -> Signal System (Unsigned 4)
+  -> Signal System (Unsigned 8, Unsigned 8)
+topEntity clk en rd =
+  let rom0 en0 = unpack <$> romBlob clk en0 content rd
+  in bundle (rom0 enableGen, rom0 en)
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput = register clk rst en 0 (testInput + 1)
+    expectedOutput = outputVerifier' clk rst $ map (\n -> (n, n)) $
+                       $(listToVecTH $ [0 :: Unsigned 8 .. 8])
+    done = expectedOutput $ ignoreFor clk rst en d1 (0, 0) $
+             topEntity clk en testInput
+    clk = tbSystemClockGen (not <$> done)
+    rst = systemResetGen
+    en = enableGen
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Signal/ROM/BlobVec.hs
+++ b/tests/shouldwork/Signal/ROM/BlobVec.hs
@@ -1,0 +1,36 @@
+module BlobVec where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock System
+  -> Signal System (Unsigned 4)
+  -> Signal System (Vec 3 (BitVector 8))
+
+topEntity clk addr = bundle $ romBlob clk enableGen <$> blobs <*> pure addr
+ where
+  blobs =    $(memBlobTH @8 Nothing [ 1 .. 15])
+          :> $(memBlobTH @8 Nothing [17 .. 31])
+          :> $(memBlobTH @8 Nothing [33 .. 47])
+          :> Nil
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput = register clk rst en 0 (testInput + 1)
+    expectedOutput =
+      outputVerifier' clk rst $ transpose
+        (   $(listToVecTH $ [ 0 :: BitVector 8 ..  8])
+         :> $(listToVecTH $ [16 :: BitVector 8 .. 24])
+         :> $(listToVecTH $ [32 :: BitVector 8 .. 40])
+         :> Nil
+        )
+    done =
+      expectedOutput $ ignoreFor clk rst en d1 (0 :> 16 :> 32 :> Nil) $
+        topEntity clk testInput
+    clk = tbSystemClockGen (not <$> done)
+    rst = systemResetGen
+    en = enableGen
+{-# NOINLINE testBench #-}


### PR DESCRIPTION
Define a new data type, `MemBlob`, and provide new memory primitive
variants that can use a `MemBlob` for their initial contents.

Currently, we provide two ways of initializing memories: with a `Vec`
and with a file. In some cases, `Vec` can be prohibitively inefficient;
depending on how the `Vec` is constructed, this can already happen with
a few tens of memory locations. Files allow for very large and arbitrary
contents, but generating the contents of the file in the same
compilation run as generating the HDL is very brittle and is a great way
to shoot oneself in the foot. This is why our current documentation
refers to this as "living on the edge".

This new mechanism dubbed `MemBlob` provides the user with Template
Haskell constructing functions which store the data alongside the
compiled Haskell code with very little overhead (max 7%, often no
overhead at all). The Template Haskell functions are the only way of
constructing a concrete `MemBlob`.

The `MemBlob` is a new Clash netlist type, and the template language for
primitives can refer to such an argument with ~CONST for its value, and
~LENGTH and others for its type information, just like with a normal
`Vec`. Primitives for the memory functions are very similar to the
existing primitives, but can even be slightly simpler because the data
is always of type `BitVector m`.

A basic functionality test for `asyncRom` is also included as I had
written the code anyway to debug a silly issue with `asyncRomBlob`.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
