### PR TITLE
Various small fixes - part 10

### DIFF
--- a/.ci/bindist/README.md
+++ b/.ci/bindist/README.md
@@ -28,7 +28,9 @@ triggered on any other branch a _beta_ release gets made.
 ## Releasing a new version major version (1.x)
 1. Change version numbers in:
   * `clash-prelude/clash-prelude.cabal`
+  * `clash-prelude-hedgehog/clash-prelude-hedgehog.cabal`
   * `clash-lib/clash-lib.cabal`
+  * `clash-lib-hedgehog/clash-lib-hedgehog.cabal`
   * `clash-ghc/clash-ghc.cabal`
   * `clash-ghc/clash-cores.cabal`
   * `.ci/bindist/linux/snap/snap/snapcraft.yaml`

--- a/clash-lib/prims/commonverilog/Clash_Explicit_SimIO.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Explicit_SimIO.primitives
@@ -120,7 +120,7 @@
     }
   }
 , { "Primitive" :
-    { "name"     : "Clash.Explicit.SimIO.unSimIO#"
+    { "name"     : "Clash.Explicit.SimIO.unSimIO"
     , "primType" : "Function"
     }
   }

--- a/clash-lib/prims/systemverilog/Clash_Prelude_ROM.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Prelude_ROM.primitives
@@ -9,7 +9,7 @@
     , "template" :
 "// asyncRom begin
 ~SIGD[~GENSYM[ROM][0]][1];
-assign ~SYM[0] = ~LIT[1];
+assign ~SYM[0] = ~CONST[1];
 
 assign ~RESULT = ~FROMBV[~SYM[0][\\~ARG[2]\\]][~TYPO];
 // asyncRom end"

--- a/clash-lib/prims/verilog/Clash_Prelude_ROM.primitives
+++ b/clash-lib/prims/verilog/Clash_Prelude_ROM.primitives
@@ -11,7 +11,7 @@
 wire ~TYPO ~GENSYM[ROM][0] [0:~LIT[0]-1];
 
 wire ~TYP[1] ~GENSYM[romflat][1];
-assign ~SYM[1] = ~LIT[1];
+assign ~SYM[1] = ~CONST[1];
 genvar ~GENSYM[i][2];
 ~GENERATE
 for (~SYM[2]=0; ~SYM[2] < ~LIT[0]; ~SYM[2]=~SYM[2]+1) begin : ~GENSYM[mk_array][3]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives
@@ -16,7 +16,7 @@
   signal ~GENSYM[ROM][2] : ~TYP[5];
   signal ~GENSYM[rd][3]  : integer range 0 to ~LIT[1]-1;
 begin
-  ~SYM[2] <= ~LIT[5];
+  ~SYM[2] <= ~CONST[5];
 
   ~SYM[3] <= to_integer(~VAR[rdI][6](31 downto 0))
   -- pragma translate_off

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM.primitives
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM.primitives
@@ -12,7 +12,7 @@
   signal ~GENSYM[ROM][1] : ~TYP[1];
   signal ~GENSYM[rd][2] : integer range 0 to ~LIT[0]-1;
 begin
-  ~SYM[1] <= ~LIT[1];
+  ~SYM[1] <= ~CONST[1];
 
   ~SYM[2] <= to_integer(~VAR[rdI][2](31 downto 0))
   -- pragma translate_off

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives
@@ -313,14 +313,6 @@ end block;
     }
   }
 , { "BlackBox" :
-    { "name"      : "Clash.Sized.Vector.maxIndex"
-    , "workInfo"  : "Constant"
-    , "kind"      : "Expression"
-    , "type"      : "maxIndex :: KnownNat n => Vec n a -> Int"
-    , "template"  : "to_signed(~LIT[0] - 1,~SIZE[~TYPO])"
-    }
-  }
-, { "BlackBox" :
     { "name"      : "Clash.Sized.Vector.length"
     , "workInfo"  : "Constant"
     , "kind"      : "Expression"

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -1,7 +1,8 @@
 {-|
-Copyright  :  (C) 2018, Google Inc.
+Copyright  :  (C) 2018, Google Inc.,
+                  2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 This module contains:
 
@@ -58,6 +59,7 @@ import Clash.Annotations.BitRepresentation.Util
 import qualified Clash.Annotations.BitRepresentation.Util
   as Util
 
+import           Clash.Annotations.Primitive (hasBlackBox)
 import           Clash.Class.BitPack
   (BitPack, BitSize, pack, packXWith, unpack)
 import           Clash.Class.Resize         (resize)
@@ -851,6 +853,7 @@ buildPack dataRepr@(DataReprAnn _name _size constrs) = do
 dontApplyInHDL :: (a -> b) -> a -> b
 dontApplyInHDL f a = f a
 {-# NOINLINE dontApplyInHDL #-}
+{-# ANN dontApplyInHDL hasBlackBox #-}
 
 buildUnpackField
   :: Name

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017     , Google Inc.,
                   2019     , Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -116,6 +116,7 @@ import GHC.TypeLits          (KnownNat)
 import Numeric               (readInt)
 import System.IO
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Class.BitPack   (BitPack, BitSize, pack)
 import Clash.Promoted.Nat    (SNat (..), pow2SNat, natToNum, snatToNum)
 import Clash.Sized.Internal.BitVector (Bit(..), BitVector(..), undefined#)
@@ -414,6 +415,7 @@ blockRamFile# (Clock _) ena sz file = \rd wen waS wd -> runST $ do
                 Nothing -> undefined#
   parseBV' = fmap fst . listToMaybe . readInt 2 (`elem` "01") digitToInt
 {-# NOINLINE blockRamFile# #-}
+{-# ANN blockRamFile# hasBlackBox #-}
 
 -- | __NB:__ Not synthesizable
 initMem :: KnownNat n => FilePath -> IO [BitVector n]

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -35,6 +35,7 @@ import GHC.Stack             (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits          (KnownNat)
 import qualified Data.Sequence as Seq
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Explicit.Signal (unbundle, KnownDomain, andEnable)
 import Clash.Promoted.Nat    (SNat (..), snatToNum, pow2SNat)
 import Clash.Signal.Internal (Clock (..), Signal (..), Enable, fromEnable)
@@ -209,3 +210,4 @@ asyncRam# !_ !_ en sz rd we wr din = dout
         in d <$ s
     {-# INLINE safeUpdate #-}
 {-# NOINLINE asyncRam# #-}
+{-# ANN asyncRam# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -129,6 +129,6 @@ rom# !_ en content =
     else
       withFrozenCallStack
         (deepErrorX ("rom: address " ++ show i ++
-                     "not in range [0.." ++ show szI ++ ")"))
+                     " not in range [0.." ++ show szI ++ ")"))
   {-# INLINE safeAt #-}
 {-# NOINLINE rom# #-}

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -33,6 +33,7 @@ import GHC.Stack              (withFrozenCallStack)
 import GHC.TypeLits           (KnownNat, type (^))
 import Prelude hiding         (length)
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Signal.Internal
   (Clock (..), KnownDomain, Signal (..), Enable, fromEnable)
 import Clash.Sized.Unsigned   (Unsigned)
@@ -132,3 +133,4 @@ rom# !_ en content =
                      " not in range [0.." ++ show szI ++ ")"))
   {-# INLINE safeAt #-}
 {-# NOINLINE rom# #-}
+{-# ANN rom# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017     , Google Inc.,
                   2019     , Myrtle Software Ltd.,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -97,7 +97,8 @@ import Data.Array                   (listArray)
 import Data.Array.Base              (unsafeAt)
 import GHC.TypeLits                 (KnownNat)
 import System.IO.Unsafe             (unsafePerformIO)
---
+
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Explicit.BlockRam.File (initMem, memFile)
 import Clash.Promoted.Nat           (SNat (..), pow2SNat, snatToNum)
 import Clash.Sized.BitVector        (BitVector)
@@ -222,3 +223,4 @@ romFile# clk en sz file rd =
                   " not in range [0.." ++ show szI ++ ")")
   {-# INLINE safeAt #-}
 {-# NOINLINE romFile# #-}
+{-# ANN romFile# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/SimIO.hs
+++ b/clash-prelude/src/Clash/Explicit/SimIO.hs
@@ -1,5 +1,6 @@
 {-|
-  Copyright   :  (C) 2019, Google Inc
+  Copyright   :  (C) 2019, Google Inc.,
+                     2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -69,6 +70,7 @@ data SimIO a = SimIO {unSimIO :: !(IO a)}
 #else
 newtype SimIO a = SimIO {unSimIO :: IO a}
 #endif
+{-# ANN unSimIO hasBlackBox #-}
 
 instance Functor SimIO where
   fmap = fmapSimIO#
@@ -76,6 +78,7 @@ instance Functor SimIO where
 fmapSimIO# :: (a -> b) -> SimIO a -> SimIO b
 fmapSimIO# f (SimIO m) = SimIO (fmap f m)
 {-# NOINLINE fmapSimIO# #-}
+{-# ANN fmapSimIO# hasBlackBox #-}
 
 instance Applicative SimIO where
   pure  = pureSimIO#
@@ -84,10 +87,12 @@ instance Applicative SimIO where
 pureSimIO# :: a -> SimIO a
 pureSimIO# a = SimIO (pure a)
 {-# NOINLINE pureSimIO# #-}
+{-# ANN pureSimIO# hasBlackBox #-}
 
 apSimIO# :: SimIO (a -> b) -> SimIO a -> SimIO b
 apSimIO# (SimIO f) (SimIO m) = SimIO (f <*> m)
 {-# NOINLINE apSimIO# #-}
+{-# ANN apSimIO# hasBlackBox #-}
 
 instance Monad SimIO where
   return = pureSimIO#
@@ -100,6 +105,7 @@ bindSimIO# (SimIO m) k = SimIO (m >>= (\x -> x `seqX` unSimIO (k x)))
 bindSimIO# (SimIO m) k = SimIO (m >>= (\x -> x `seqX` coerce k x))
 #endif
 {-# NOINLINE bindSimIO# #-}
+{-# ANN bindSimIO# hasBlackBox #-}
 
 -- | Display a string on /stdout/
 display

--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -1,8 +1,9 @@
 {-|
 Copyright  :  (C) 2017-2018, Google Inc
                   2019     , Myrtle Software
+                  2022     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 PLL and other clock-related components for Intel (Altera) FPGAs
 -}
@@ -14,6 +15,7 @@ module Clash.Intel.ClockGen
   , alteraPll
   ) where
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Clocks           (Clocks (..))
 import Clash.Promoted.Symbol  (SSymbol)
 import Clash.Signal.Internal
@@ -57,6 +59,7 @@ altpll
   -- ^ (Stable PLL clock, PLL lock)
 altpll !_ = knownDomain @domIn `seq` knownDomain @domOut `seq` clocks
 {-# NOINLINE altpll #-}
+{-# ANN altpll hasBlackBox #-}
 
 -- | A clock source that corresponds to the Intel/Quartus \"Altera PLL\"
 -- component (Arria V, Stratix V, Cyclone V) with settings to provide a stable
@@ -100,3 +103,4 @@ alteraPll
   -> t
 alteraPll !_ = clocks
 {-# NOINLINE alteraPll #-}
+{-# ANN alteraPll hasBlackBox #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/File.hs
@@ -125,7 +125,7 @@ import           Clash.Sized.Unsigned         (Unsigned)
 --
 -- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
 -- Block RAM.
--- * Use the adapter 'Clash.Prelude.BlockRam.readNew' for obtaining write-before-read semantics like this: @'Clash.Prelude.BlockRam.readNew' clk ('blockRamFilePow2' clk file) rd wrM@.
+-- * Use the adapter 'Clash.Prelude.BlockRam.readNew' for obtaining write-before-read semantics like this: @'Clash.Prelude.BlockRam.readNew' ('blockRamFilePow2' file) rd wrM@.
 -- * See "Clash.Prelude.BlockRam.File#usingramfiles" for more information on how
 -- to instantiate a Block RAM with the contents of a data file.
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
@@ -172,7 +172,7 @@ blockRamFilePow2 = \fp rd wrM -> withFrozenCallStack
 --
 -- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
 -- Block RAM.
--- * Use the adapter 'Clash.Prelude.BlockRam.readNew' for obtaining write-before-read semantics like this: @'Clash.Prelude.BlockRam.readNew' clk ('blockRamFile' clk size file) rd wrM@.
+-- * Use the adapter 'Clash.Prelude.BlockRam.readNew' for obtaining write-before-read semantics like this: @'Clash.Prelude.BlockRam.readNew' ('blockRamFile' size file) rd wrM@.
 -- * See "Clash.Prelude.BlockRam.File#usingramfiles" for more information on how
 -- to instantiate a Block RAM with the contents of a data file.
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -109,7 +109,8 @@ asyncRom# content = safeAt
 -- | A ROM with a synchronous read port, with space for @n@ elements
 --
 -- * __NB__: Read value is delayed by 1 cycle
--- * __NB__: Initial output value is 'undefined'
+-- * __NB__: Initial output value is /undefined/, reading it will throw an
+-- 'Clash.XException.XException'
 --
 -- Additional helpful information:
 --

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -35,6 +35,7 @@ import           GHC.Stack            (withFrozenCallStack)
 import           GHC.TypeLits         (KnownNat, type (^))
 import           Prelude              hiding (length)
 
+import           Clash.Annotations.Primitive (hasBlackBox)
 import qualified Clash.Explicit.ROM   as E
 import           Clash.Signal
 import           Clash.Sized.Unsigned (Unsigned)
@@ -105,6 +106,7 @@ asyncRom# content = safeAt
           (errorX ("asyncRom: address " ++ show i ++
                   " not in range [0.." ++ show szI ++ ")"))
 {-# NOINLINE asyncRom# #-}
+{-# ANN asyncRom# hasBlackBox #-}
 
 -- | A ROM with a synchronous read port, with space for @n@ elements
 --

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017     , Google Inc.,
                   2019     , Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -98,6 +98,7 @@ import           Data.Array                   (listArray,(!))
 import           GHC.TypeLits                 (KnownNat)
 import           System.IO.Unsafe             (unsafePerformIO)
 
+import           Clash.Annotations.Primitive (hasBlackBox)
 import           Clash.Explicit.BlockRam.File (initMem, memFile)
 import qualified Clash.Explicit.ROM.File      as E
 import           Clash.Promoted.Nat           (SNat (..), pow2SNat, snatToNum)
@@ -253,6 +254,7 @@ asyncRomFile# sz file = (content !) -- Leave "(content !)" eta-reduced, see
     content = listArray (0,szI-1) mem
     szI     = snatToNum sz
 {-# NOINLINE asyncRomFile# #-}
+{-# ANN asyncRomFile# hasBlackBox #-}
 
 -- | A ROM with a synchronous read port, with space for @n@ elements
 --

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -1,8 +1,9 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016     , Myrtle Software Ltd
+                  2022     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
@@ -82,6 +83,8 @@ import Language.Haskell.TH.Compat
 #endif
 import Numeric.Natural    (Natural)
 import Unsafe.Coerce      (unsafeCoerce)
+
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.XException   (ShowX (..), showsPrecXWith)
 
 {- $setup
@@ -265,6 +268,7 @@ infixl 7 `mulSNat`
 powSNat :: SNat a -> SNat b -> SNat (a^b)
 powSNat SNat SNat = SNat
 {-# NOINLINE powSNat #-}
+{-# ANN powSNat hasBlackBox #-}
 infixr 8 `powSNat`
 
 -- | Division of two singleton natural numbers
@@ -292,6 +296,7 @@ flogBaseSNat :: (2 <= base, 1 <= x)
              -> SNat (FLog base x)
 flogBaseSNat SNat SNat = SNat
 {-# NOINLINE flogBaseSNat #-}
+{-# ANN flogBaseSNat hasBlackBox #-}
 
 -- | Ceiling of the logarithm of a natural number
 clogBaseSNat :: (2 <= base, 1 <= x)
@@ -300,6 +305,7 @@ clogBaseSNat :: (2 <= base, 1 <= x)
              -> SNat (CLog base x)
 clogBaseSNat SNat SNat = SNat
 {-# NOINLINE clogBaseSNat #-}
+{-# ANN clogBaseSNat hasBlackBox #-}
 
 -- | Exact integer logarithm of a natural number
 --
@@ -310,6 +316,7 @@ logBaseSNat :: (FLog base x ~ CLog base x)
             -> SNat (Log base x)
 logBaseSNat SNat SNat = SNat
 {-# NOINLINE logBaseSNat #-}
+{-# ANN logBaseSNat hasBlackBox #-}
 
 -- | Power of two of a singleton natural number
 pow2SNat :: SNat a -> SNat (2^a)

--- a/clash-prelude/src/Clash/Promoted/Nat/Unsafe.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat/Unsafe.hs
@@ -1,7 +1,8 @@
 {-|
 Copyright  :  (C) 2015-2016, University of Twente
+                  2022     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE Unsafe #-}
@@ -13,9 +14,11 @@ where
 import Data.Reflection    (reifyNat)
 import Unsafe.Coerce      (unsafeCoerce)
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Promoted.Nat (SNat, snatProxy)
 
 -- | I hope you know what you're doing
 unsafeSNat :: Integer -> SNat k
 unsafeSNat i = reifyNat i $ (\p -> unsafeCoerce (snatProxy p))
 {-# NOINLINE unsafeSNat #-}
+{-# ANN unsafeSNat hasBlackBox #-}

--- a/clash-prelude/src/Clash/Promoted/Symbol.hs
+++ b/clash-prelude/src/Clash/Promoted/Symbol.hs
@@ -1,14 +1,16 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente
+                  2022     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
-{-# LANGUAGE Safe #-}
+-- Annotations are not allowed in safe Haskell
+-- {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}
 
@@ -20,9 +22,13 @@ import Language.Haskell.TH.Syntax
 import GHC.Show     (appPrec)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 
+import Clash.Annotations.Primitive (hasBlackBox)
+
 -- | Singleton value for a type-level string @s@
 data SSymbol (s :: Symbol) where
   SSymbol :: KnownSymbol s => SSymbol s
+
+{-# ANN SSymbol hasBlackBox #-}
 
 instance KnownSymbol s => Lift (SSymbol (s :: Symbol)) where
 --  lift :: t -> Q Exp

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -175,7 +175,7 @@ instance HasBiSignalDefault 'Floating where
 type role BiSignalIn nominal nominal nominal
 
 -- | The /in/ part of an __inout__ port.
--- BiSignalIn has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+-- BiSignalIn has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i BiSignalIn
 -- type role BiSignalIn nominal nominal nominal
@@ -193,7 +193,7 @@ type role BiSignalOut nominal nominal nominal
 -- Wraps (multiple) writing signals. The semantics are such that only one of
 -- the signals may write at a single time step.
 --
--- BiSignalOut has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+-- BiSignalOut has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i BiSignalOut
 -- type role BiSignalOut nominal nominal nominal

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -1,8 +1,9 @@
 {-|
 Copyright  :  (C) 2017, Google Inc.
                   2019, Myrtle Software Ltd
+                  2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 Wires are fundamentally bidirectional, and in traditional HDLs we can exploit
 this aspect by explicitly marking the endpoint, or port, of such a wire as
@@ -119,6 +120,7 @@ import           Data.Kind                  (Type)
 import           Data.List                  (intercalate)
 import           Data.Maybe                 (fromMaybe,isJust)
 
+import           Clash.Annotations.Primitive (hasBlackBox)
 import           Clash.Class.HasDomain
 import           Clash.Class.BitPack        (BitPack (..))
 import           Clash.Sized.BitVector      (BitVector)
@@ -244,6 +246,7 @@ readFromBiSignal# (BiSignalIn ds s) =
     SPullDown  -> fromMaybe minBound <$> s
     SPullUp    -> fromMaybe maxBound <$> s
 {-# NOINLINE readFromBiSignal# #-}
+{-# ANN readFromBiSignal# hasBlackBox #-}
 
 -- | Read the value from an __inout__ port
 readFromBiSignal
@@ -263,6 +266,7 @@ mergeBiSignalOuts
   -> BiSignalOut defaultState dom m
 mergeBiSignalOuts = mconcat . V.toList
 {-# NOINLINE mergeBiSignalOuts #-}
+{-# ANN mergeBiSignalOuts hasBlackBox #-}
 
 writeToBiSignal#
   :: HasCallStack
@@ -274,6 +278,7 @@ writeToBiSignal#
 -- writeToBiSignal# = writeToBiSignal#
 writeToBiSignal# _ maybeSignal _ _ = BiSignalOut [maybeSignal]
 {-# NOINLINE writeToBiSignal# #-}
+{-# ANN writeToBiSignal# hasBlackBox #-}
 
 -- | Write to an __inout__ port
 writeToBiSignal
@@ -320,3 +325,4 @@ veryUnsafeToBiSignalIn (BiSignalOut signals) = prepend# result biSignalOut'
     -- Recursive step
     biSignalOut' = veryUnsafeToBiSignalIn $ BiSignalOut $ map tail# signals
 {-# NOINLINE veryUnsafeToBiSignalIn #-}
+{-# ANN veryUnsafeToBiSignalIn hasBlackBox #-}

--- a/clash-prelude/src/Clash/Signal/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle.hs
@@ -1,9 +1,9 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017-2019, Myrtle Software Ltd, Google Inc.
-                       2019, QBayLogic B.V.
+                  2019,2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 The Product/Signal isomorphism
 -}
@@ -32,6 +32,7 @@ import GHC.Generics
 import GHC.TypeLits                 (KnownNat)
 import Prelude                      hiding (head, map, tail)
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Signal.Bundle.Internal (deriveBundleTuples)
 import Clash.Signal.Internal        (Signal (..), Domain)
 import Clash.Sized.BitVector        (Bit, BitVector)
@@ -155,6 +156,7 @@ instance KnownNat n => Bundle (Vec n a) where
   unbundle = sequenceA . fmap lazyV
 
 {-# NOINLINE vecBundle# #-}
+{-# ANN vecBundle# hasBlackBox #-}
 vecBundle# :: Vec n (Signal t a) -> Signal t (Vec n a)
 vecBundle# = traverse# id
 

--- a/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Internal.hs
@@ -91,7 +91,7 @@ let numbers
 -- | A synchronized signal with samples of type @a@, synchronized to clock
 -- @clk@, that has accumulated @delay@ amount of samples delay along its path.
 --
--- DSignal has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+-- DSignal has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i DSignal
 -- type role DSignal nominal nominal representational

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -675,7 +675,7 @@ because some VHDL simulators don't support fractions of picoseconds.
 * __NB__: Whether 'System' has good defaults depends on your target platform.
 Check out 'IntelSystem' and 'XilinxSystem' too!
 
-Signals have the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+Signals have the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 
 >>> :i Signal
 type role Signal nominal representational

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -1,8 +1,9 @@
 {-|
 Copyright  :  (C) 2018, Google Inc.
                   2019, Myrtle Software Ltd
+                  2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 Utilities for tracing signals and dumping them in various ways. Example usage:
 
@@ -87,6 +88,7 @@ module Clash.Signal.Trace
   ) where
 
 -- Clash:
+import           Clash.Annotations.Primitive (hasBlackBox)
 import           Clash.Signal.Internal (fromList)
 import           Clash.Signal
   (KnownDomain(..), SDomainConfiguration(..), Signal, bundle, unbundle)
@@ -232,6 +234,7 @@ traceSignal traceName signal =
       unsafePerformIO $
         traceSignal# traceMap# (snatToNum period) traceName signal
 {-# NOINLINE traceSignal #-}
+{-# ANN traceSignal hasBlackBox #-}
 
 -- | Trace a single signal. Will emit an error if a signal with the same name
 -- was previously registered.
@@ -252,6 +255,7 @@ traceSignal1
 traceSignal1 traceName signal =
   unsafePerformIO (traceSignal# traceMap# 1 traceName signal)
 {-# NOINLINE traceSignal1 #-}
+{-# ANN traceSignal1 hasBlackBox #-}
 
 -- | Trace a single vector signal: each element in the vector will show up as
 -- a different trace. If the trace name already exists, this function will emit
@@ -278,6 +282,7 @@ traceVecSignal traceName signal =
       unsafePerformIO $
         traceVecSignal# traceMap# (snatToNum period) traceName signal
 {-# NOINLINE traceVecSignal #-}
+{-# ANN traceVecSignal hasBlackBox #-}
 
 -- | Trace a single vector signal: each element in the vector will show up as
 -- a different trace. If the trace name already exists, this function will emit
@@ -300,6 +305,7 @@ traceVecSignal1
 traceVecSignal1 traceName signal =
   unsafePerformIO $ traceVecSignal# traceMap# 1 traceName signal
 {-# NOINLINE traceVecSignal1 #-}
+{-# ANN traceVecSignal1 hasBlackBox #-}
 
 iso8601Format :: UTCTime -> String
 iso8601Format = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S"

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -171,7 +171,7 @@ import Clash.XException
 -- The 'Num' operators for this type saturate to 'maxBound' on overflow and
 -- 'minBound' on underflow, and use truncation as the rounding method.
 --
--- Fixed has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+-- Fixed has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i Fixed
 -- type role Fixed representational nominal nominal

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -211,7 +211,7 @@ type role BitVector nominal
 -- * Bit indices are descending
 -- * 'Num' instance performs /unsigned/ arithmetic.
 --
--- BitVector has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+-- BitVector has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i BitVector
 -- type role BitVector nominal

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2019     , Gergő Érdi
                   2016-2019, Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -178,6 +178,7 @@ import Test.QuickCheck.Arbitrary  (Arbitrary (..), CoArbitrary (..),
                                    arbitraryBoundedIntegral,
                                    coarbitraryIntegral, shrinkIntegral)
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
                                    SaturationMode (..))
 import Clash.Class.Resize         (Resize (..))
@@ -227,6 +228,8 @@ data BitVector (n :: Nat) =
        }
   deriving (Data, Generic)
 
+{-# ANN BV hasBlackBox #-}
+
 -- * Bit
 
 -- | Bit
@@ -238,14 +241,18 @@ data Bit =
       }
   deriving (Data, Generic)
 
+{-# ANN Bit hasBlackBox #-}
+
 -- * Constructions
 -- ** Initialisation
 {-# NOINLINE high #-}
+{-# ANN high hasBlackBox #-}
 -- | logic '1'
 high :: Bit
 high = Bit 0 1
 
 {-# NOINLINE low #-}
+{-# ANN low hasBlackBox #-}
 -- | logic '0'
 low :: Bit
 low = Bit 0 0
@@ -284,10 +291,12 @@ instance Eq Bit where
 eq## :: Bit -> Bit -> Bool
 eq## b1 b2 = eq# (pack# b1) (pack# b2)
 {-# NOINLINE eq## #-}
+{-# ANN eq## hasBlackBox #-}
 
 neq## :: Bit -> Bit -> Bool
 neq## b1 b2 = neq# (pack# b1) (pack# b2)
 {-# NOINLINE neq## #-}
+{-# ANN neq## hasBlackBox #-}
 
 instance Ord Bit where
   (<)  = lt##
@@ -298,12 +307,16 @@ instance Ord Bit where
 lt##,ge##,gt##,le## :: Bit -> Bit -> Bool
 lt## b1 b2 = lt# (pack# b1) (pack# b2)
 {-# NOINLINE lt## #-}
+{-# ANN lt## hasBlackBox #-}
 ge## b1 b2 = ge# (pack# b1) (pack# b2)
 {-# NOINLINE ge## #-}
+{-# ANN ge## hasBlackBox #-}
 gt## b1 b2 = gt# (pack# b1) (pack# b2)
 {-# NOINLINE gt## #-}
+{-# ANN gt## hasBlackBox #-}
 le## b1 b2 = le# (pack# b1) (pack# b2)
 {-# NOINLINE le## #-}
+{-# ANN le## hasBlackBox #-}
 
 instance Enum Bit where
   toEnum     = fromInteger## 0## . toInteger
@@ -328,6 +341,7 @@ instance Num Bit where
 fromInteger## :: Word# -> Integer -> Bit
 fromInteger## m# i = Bit ((W# m#) `mod` 2) (fromInteger i `mod` 2)
 {-# NOINLINE fromInteger## #-}
+{-# ANN fromInteger## hasBlackBox #-}
 
 instance Real Bit where
   toRational b = if eq## b low then 0 else 1
@@ -372,19 +386,23 @@ and##, or##, xor## :: Bit -> Bit -> Bit
 and## (Bit m1 v1) (Bit m2 v2) = Bit mask (v1 .&. v2 .&. complement mask)
   where mask = (m1.&.v2 .|. m1.&.m2 .|. m2.&.v1)
 {-# NOINLINE and## #-}
+{-# ANN and## hasBlackBox #-}
 
 or## (Bit m1 v1) (Bit m2 v2) = Bit mask ((v1 .|. v2) .&. complement mask)
   where mask = m1 .&. complement v2 .|.  m1.&.m2  .|.  m2 .&. complement v1
 {-# NOINLINE or## #-}
+{-# ANN or## hasBlackBox #-}
 
 xor## (Bit m1 v1) (Bit m2 v2) = Bit mask ((v1 `xor` v2) .&. complement mask)
   where mask = m1 .|. m2
 {-# NOINLINE xor## #-}
+{-# ANN xor## hasBlackBox #-}
 
 complement## :: Bit -> Bit
 complement## (Bit m v) = Bit m (complementB v .&. complementB m)
   where complementB (W# b#) = W# (int2Word# (eqWord# b# 0##))
 {-# NOINLINE complement## #-}
+{-# ANN complement## hasBlackBox #-}
 
 -- *** BitPack
 pack# :: Bit -> BitVector 1
@@ -394,6 +412,7 @@ pack# (Bit (W# m) (W# b)) = BV (NS m) (NS b)
 pack# (Bit (W# m) (W# b)) = BV (NatS# m) (NatS# b)
 #endif
 {-# NOINLINE pack# #-}
+{-# ANN pack# hasBlackBox #-}
 
 unpack# :: BitVector 1 -> Bit
 unpack# (BV m b) = Bit (go m) (go b)
@@ -406,6 +425,7 @@ unpack# (BV m b) = Bit (go m) (go b)
   go (NatJ# w) = W# (bigNatToWord w)
 #endif
 {-# NOINLINE unpack# #-}
+{-# ANN unpack# hasBlackBox #-}
 
 -- * Instances
 instance NFData (BitVector n) where
@@ -503,11 +523,13 @@ instance KnownNat n => Eq (BitVector n) where
   (/=) = neq#
 
 {-# NOINLINE eq# #-}
+{-# ANN eq# hasBlackBox #-}
 eq# :: KnownNat n => BitVector n -> BitVector n -> Bool
 eq# (BV 0 v1) (BV 0 v2 ) = v1 == v2
 eq# bv1 bv2 = undefErrorI "==" bv1 bv2
 
 {-# NOINLINE neq# #-}
+{-# ANN neq# hasBlackBox #-}
 neq# :: KnownNat n => BitVector n -> BitVector n -> Bool
 neq# (BV 0 v1) (BV 0 v2) = v1 /= v2
 neq# bv1 bv2 = undefErrorI "/=" bv1 bv2
@@ -520,15 +542,19 @@ instance KnownNat n => Ord (BitVector n) where
 
 lt#,ge#,gt#,le# :: KnownNat n => BitVector n -> BitVector n -> Bool
 {-# NOINLINE lt# #-}
+{-# ANN lt# hasBlackBox #-}
 lt# (BV 0 n) (BV 0 m) = n < m
 lt# bv1 bv2 = undefErrorI "<" bv1 bv2
 {-# NOINLINE ge# #-}
+{-# ANN ge# hasBlackBox #-}
 ge# (BV 0 n) (BV 0 m) = n >= m
 ge# bv1 bv2 = undefErrorI ">=" bv1 bv2
 {-# NOINLINE gt# #-}
+{-# ANN gt# hasBlackBox #-}
 gt# (BV 0 n) (BV 0 m) = n > m
 gt# bv1 bv2 = undefErrorI ">" bv1 bv2
 {-# NOINLINE le# #-}
+{-# ANN le# hasBlackBox #-}
 le# (BV 0 n) (BV 0 m) = n <= m
 le#  bv1 bv2 = undefErrorI "<=" bv1 bv2
 
@@ -612,10 +638,12 @@ instance KnownNat n => Bounded (BitVector n) where
 minBound# :: BitVector n
 minBound# = BV 0 0
 {-# NOINLINE minBound# #-}
+{-# ANN minBound# hasBlackBox #-}
 
 maxBound# :: forall n. KnownNat n => BitVector n
 maxBound# = let m = 1 `shiftL` natToNum @n in BV 0 (m-1)
 {-# NOINLINE maxBound# #-}
+{-# ANN maxBound# hasBlackBox #-}
 
 instance KnownNat n => Num (BitVector n) where
   (+)         = (+#)
@@ -628,6 +656,7 @@ instance KnownNat n => Num (BitVector n) where
 
 (+#),(-#),(*#) :: forall n . KnownNat n => BitVector n -> BitVector n -> BitVector n
 {-# NOINLINE (+#) #-}
+{-# ANN (+#) hasBlackBox #-}
 (+#) = go
   where
     go (BV 0 i) (BV 0 j) = BV 0 (addMod m i j)
@@ -640,6 +669,7 @@ instance KnownNat n => Num (BitVector n) where
 #endif
 
 {-# NOINLINE (-#) #-}
+{-# ANN (-#) hasBlackBox #-}
 (-#) = go
   where
     go (BV 0 i) (BV 0 j) = BV 0 (subMod m i j)
@@ -652,6 +682,7 @@ instance KnownNat n => Num (BitVector n) where
 #endif
 
 {-# NOINLINE (*#) #-}
+{-# ANN (*#) hasBlackBox #-}
 (*#) = go
  where
   go (BV 0 i) (BV 0 j) = BV 0 (mulMod2 m i j)
@@ -664,6 +695,7 @@ instance KnownNat n => Num (BitVector n) where
 #endif
 
 {-# NOINLINE negate# #-}
+{-# ANN negate# hasBlackBox #-}
 negate# :: forall n . KnownNat n => BitVector n -> BitVector n
 negate# = go
  where
@@ -677,6 +709,7 @@ negate# = go
 #endif
 
 {-# NOINLINE fromInteger# #-}
+{-# ANN fromInteger# hasBlackBox #-}
 fromInteger# :: KnownNat n => Natural -> Integer -> BitVector n
 fromInteger# m i = sz `seq` mx
   where
@@ -698,11 +731,13 @@ instance (KnownNat m, KnownNat n) => ExtendingNum (BitVector m) (BitVector n) wh
   mul = times#
 
 {-# NOINLINE plus# #-}
+{-# ANN plus# hasBlackBox #-}
 plus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)
 plus# (BV 0 a) (BV 0 b) = BV 0 (a + b)
 plus# bv1 bv2 = undefErrorP "add" bv1 bv2
 
 {-# NOINLINE minus# #-}
+{-# ANN minus# hasBlackBox #-}
 minus# :: forall m n . (KnownNat m, KnownNat n) => BitVector m -> BitVector n
                                                 -> BitVector (Max m n + 1)
 minus# = go
@@ -717,6 +752,7 @@ minus# = go
 #endif
 
 {-# NOINLINE times# #-}
+{-# ANN times# hasBlackBox #-}
 times# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (m + n)
 times# (BV 0 a) (BV 0 b) = BV 0 (a * b)
 times# bv1 bv2 = undefErrorP "mul" bv1 bv2
@@ -735,13 +771,16 @@ instance KnownNat n => Integral (BitVector n) where
 
 quot#,rem# :: KnownNat n => BitVector n -> BitVector n -> BitVector n
 {-# NOINLINE quot# #-}
+{-# ANN quot# hasBlackBox #-}
 quot# (BV 0 i) (BV 0 j) = BV 0 (i `quot` j)
 quot# bv1 bv2 = undefErrorP "quot" bv1 bv2
 {-# NOINLINE rem# #-}
+{-# ANN rem# hasBlackBox #-}
 rem# (BV 0 i) (BV 0 j) = BV 0 (i `rem` j)
 rem# bv1 bv2 = undefErrorP "rem" bv1 bv2
 
 {-# NOINLINE toInteger# #-}
+{-# ANN toInteger# hasBlackBox #-}
 toInteger# :: KnownNat n => BitVector n -> Integer
 toInteger# (BV 0 i) = naturalToInteger i
 toInteger# bv = undefErrorU "toInteger" bv
@@ -780,6 +819,7 @@ countTrailingZerosBV = V.foldl (\l r -> if eq## r low then 1 + l else 0) 0 . V.b
 {-# INLINE countTrailingZerosBV #-}
 
 {-# NOINLINE reduceAnd# #-}
+{-# ANN reduceAnd# hasBlackBox #-}
 reduceAnd# :: KnownNat n => BitVector n -> Bit
 reduceAnd# bv@(BV 0 i) = Bit 0 (W# (int2Word# (dataToTag# check)))
   where
@@ -790,6 +830,7 @@ reduceAnd# bv@(BV 0 i) = Bit 0 (W# (int2Word# (dataToTag# check)))
 reduceAnd# bv = V.foldl (.&.) 1 (V.bv2v bv)
 
 {-# NOINLINE reduceOr# #-}
+{-# ANN reduceOr# hasBlackBox #-}
 reduceOr# :: KnownNat n => BitVector n -> Bit
 reduceOr# (BV 0 i) = Bit 0 (W# (int2Word# (dataToTag# check)))
   where
@@ -797,6 +838,7 @@ reduceOr# (BV 0 i) = Bit 0 (W# (int2Word# (dataToTag# check)))
 reduceOr# bv = V.foldl (.|.) 0 (V.bv2v bv)
 
 {-# NOINLINE reduceXor# #-}
+{-# ANN reduceXor# hasBlackBox #-}
 reduceXor# :: KnownNat n => BitVector n -> Bit
 reduceXor# (BV 0 i) = Bit 0 (fromIntegral (popCount i `mod` 2))
 reduceXor# bv = undefErrorU "reduceXor" bv
@@ -807,6 +849,7 @@ instance Default (BitVector n) where
 -- * Accessors
 -- ** Length information
 {-# NOINLINE size# #-}
+{-# ANN size# hasBlackBox #-}
 size# :: KnownNat n => BitVector n -> Int
 #if MIN_VERSION_base(4,15,0)
 size# bv = fromIntegral (natVal bv)
@@ -815,6 +858,7 @@ size# bv = fromInteger (natVal bv)
 #endif
 
 {-# NOINLINE maxIndex# #-}
+{-# ANN maxIndex# hasBlackBox #-}
 maxIndex# :: KnownNat n => BitVector n -> Int
 #if MIN_VERSION_base(4,15,0)
 maxIndex# bv = fromIntegral (natVal bv) - 1
@@ -824,6 +868,7 @@ maxIndex# bv = fromInteger (natVal bv) - 1
 
 -- ** Indexing
 {-# NOINLINE index# #-}
+{-# ANN index# hasBlackBox #-}
 index# :: KnownNat n => BitVector n -> Int -> Bit
 index# bv@(BV m v) i
     | i >= 0 && i < sz = Bit (W# (int2Word# (dataToTag# (testBit m i))))
@@ -843,6 +888,7 @@ index# bv@(BV m v) i
                          ]
 
 {-# NOINLINE msb# #-}
+{-# ANN msb# hasBlackBox #-}
 -- | MSB
 msb# :: forall n . KnownNat n => BitVector n -> Bit
 msb# (BV m v)
@@ -868,12 +914,14 @@ msb# (BV m v)
 #endif
 
 {-# NOINLINE lsb# #-}
+{-# ANN lsb# hasBlackBox #-}
 -- | LSB
 lsb# :: BitVector n -> Bit
 lsb# (BV m v) = Bit (W# (int2Word# (dataToTag# (testBit m 0))))
                     (W# (int2Word# (dataToTag# (testBit v 0))))
 
 {-# NOINLINE slice# #-}
+{-# ANN slice# hasBlackBox #-}
 slice# :: BitVector (m + 1 + i) -> SNat m -> SNat n -> BitVector (m + 1 - n)
 slice# (BV msk i) m n = BV (shiftR (msk .&. mask) n')
                            (shiftR (i   .&. mask) n')
@@ -887,6 +935,7 @@ slice# (BV msk i) m n = BV (shiftR (msk .&. mask) n')
 
 -- ** Concatenation
 {-# NOINLINE (++#) #-}
+{-# ANN (++#) hasBlackBox #-}
 -- | Concatenate two 'BitVector's
 (++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)
 (BV m1 v1) ++# bv2@(BV m2 v2) = BV (m1' .|. m2) (v1' .|. v2)
@@ -903,6 +952,7 @@ slice# (BV msk i) m n = BV (shiftR (msk .&. mask) n')
 
 -- * Modifying BitVectors
 {-# NOINLINE replaceBit# #-}
+{-# ANN replaceBit# hasBlackBox #-}
 replaceBit# :: KnownNat n => BitVector n -> Int -> Bit -> BitVector n
 replaceBit# bv@(BV m v) i (Bit mb b)
 #if MIN_VERSION_base(4,15,0)
@@ -926,6 +976,7 @@ replaceBit# bv@(BV m v) i (Bit mb b)
                           ]
 
 {-# NOINLINE setSlice# #-}
+{-# ANN setSlice# hasBlackBox #-}
 setSlice#
   :: forall m i n
    . SNat (m + 1 + i)
@@ -947,6 +998,7 @@ setSlice# SNat =
   complementN = complementMod (natVal (Proxy @(m + 1 + i)))
 
 {-# NOINLINE split# #-}
+{-# ANN split# hasBlackBox #-}
 split#
   :: forall n m
    . KnownNat n
@@ -972,6 +1024,7 @@ split# (BV m i) =
 
 and#, or#, xor# :: forall n . KnownNat n => BitVector n -> BitVector n -> BitVector n
 {-# NOINLINE and# #-}
+{-# ANN and# hasBlackBox #-}
 and# =
   \(BV m1 v1) (BV m2 v2) ->
     let mask = (m1.&.v2 .|. m1.&.m2 .|. m2.&.v1)
@@ -980,6 +1033,7 @@ and# =
     complementN = complementMod (natVal (Proxy @n))
 
 {-# NOINLINE or# #-}
+{-# ANN or# hasBlackBox #-}
 or# =
   \(BV m1 v1) (BV m2 v2) ->
     let mask = m1 .&. complementN v2  .|.  m1.&.m2  .|.  m2 .&. complementN v1
@@ -988,6 +1042,7 @@ or# =
     complementN = complementMod (natVal (Proxy @n))
 
 {-# NOINLINE xor# #-}
+{-# ANN xor# hasBlackBox #-}
 xor# =
   \(BV m1 v1) (BV m2 v2) ->
     let mask  = m1 .|. m2
@@ -996,6 +1051,7 @@ xor# =
     complementN = complementMod (natVal (Proxy @n))
 
 {-# NOINLINE complement# #-}
+{-# ANN complement# hasBlackBox #-}
 complement# :: forall n . KnownNat n => BitVector n -> BitVector n
 complement# = \(BV m v) -> BV m (complementN v .&. complementN m)
   where complementN = complementMod (natVal (Proxy @n))
@@ -1004,6 +1060,7 @@ shiftL#, shiftR#, rotateL#, rotateR#
   :: forall n . KnownNat n => BitVector n -> Int -> BitVector n
 
 {-# NOINLINE shiftL# #-}
+{-# ANN shiftL# hasBlackBox #-}
 shiftL# = \(BV msk v) i ->
   if | i < 0
      -> error $ "'shiftL' undefined for negative number: " ++ show i
@@ -1021,12 +1078,14 @@ shiftL# = \(BV msk v) i ->
 #endif
 
 {-# NOINLINE shiftR# #-}
+{-# ANN shiftR# hasBlackBox #-}
 shiftR# (BV m v) i
   | i < 0     = error
               $ "'shiftR' undefined for negative number: " ++ show i
   | otherwise = BV (shiftR m i) (shiftR v i)
 
 {-# NOINLINE rotateL# #-}
+{-# ANN rotateL# hasBlackBox #-}
 rotateL# =
   \(BV msk v) b ->
     if b >= 0 then
@@ -1061,6 +1120,7 @@ rotateL# =
 #endif
 
 {-# NOINLINE rotateR# #-}
+{-# ANN rotateR# hasBlackBox #-}
 rotateR# =
   \(BV msk v) b ->
     if b >= 0 then
@@ -1116,6 +1176,7 @@ truncateB# = \(BV msk i) -> BV (msk `mod` m) (i `mod` m)
   where m = 1 `shiftL` fromInteger (natVal (Proxy @a))
 #endif
 {-# NOINLINE truncateB# #-}
+{-# ANN truncateB# hasBlackBox #-}
 
 instance KnownNat n => Lift (BitVector n) where
   lift bv@(BV m i) = sigE [| fromInteger# m $(litE (IntegerL (toInteger i))) |] (decBitVector (natVal bv))
@@ -1253,6 +1314,7 @@ checkUnpackUndef _ bv = res
     ty = typeOf res
     res = undefError (show ty ++ ".unpack") [bv]
 {-# NOINLINE checkUnpackUndef #-}
+{-# ANN checkUnpackUndef hasBlackBox #-}
 
 -- | Create a BitVector with all its bits undefined
 undefined# :: forall n . KnownNat n => BitVector n
@@ -1264,6 +1326,7 @@ undefined# =
 #endif
   in  BV (m-1) 0
 {-# NOINLINE undefined# #-}
+{-# ANN undefined# hasBlackBox #-}
 
 -- | Check if one BitVector is similar to another, interpreting undefined bits
 -- in the second argument as being "don't care" bits. This is a more lenient

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2019, Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -98,6 +98,7 @@ import Test.QuickCheck.Arbitrary  (Arbitrary (..), CoArbitrary (..),
                                    arbitraryBoundedIntegral,
                                    coarbitraryIntegral, shrinkIntegral)
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Class.BitPack.Internal (BitPack (..), packXWith)
 import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
                                    SaturationMode (..))
@@ -161,6 +162,8 @@ newtype Index (n :: Nat) =
 #endif
   deriving (Data, Generic)
 
+{-# ANN I hasBlackBox #-}
+
 {-# NOINLINE size# #-}
 size# :: (KnownNat n, 1 <= n) => Index n -> Int
 size# = BV.size# . pack#
@@ -181,10 +184,12 @@ fromSNat :: (KnownNat m, n + 1 <= m) => SNat n -> Index m
 fromSNat = snatToNum
 
 {-# NOINLINE pack# #-}
+{-# ANN pack# hasBlackBox #-}
 pack# :: Index n -> BitVector (CLog 2 n)
 pack# (I i) = BV 0 (naturalFromInteger i)
 
 {-# NOINLINE unpack# #-}
+{-# ANN unpack# hasBlackBox #-}
 unpack# :: (KnownNat n, 1 <= n) => BitVector (CLog 2 n) -> Index n
 unpack# (BV 0 i) = fromInteger_INLINE (naturalToInteger i)
 unpack# bv = undefError "Index.unpack" [bv]
@@ -194,10 +199,12 @@ instance Eq (Index n) where
   (/=) = neq#
 
 {-# NOINLINE eq# #-}
+{-# ANN eq# hasBlackBox #-}
 eq# :: (Index n) -> (Index n) -> Bool
 (I n) `eq#` (I m) = n == m
 
 {-# NOINLINE neq# #-}
+{-# ANN neq# hasBlackBox #-}
 neq# :: (Index n) -> (Index n) -> Bool
 (I n) `neq#` (I m) = n /= m
 
@@ -209,12 +216,16 @@ instance Ord (Index n) where
 
 lt#,ge#,gt#,le# :: Index n -> Index n -> Bool
 {-# NOINLINE lt# #-}
+{-# ANN lt# hasBlackBox #-}
 lt# (I n) (I m) = n < m
 {-# NOINLINE ge# #-}
+{-# ANN ge# hasBlackBox #-}
 ge# (I n) (I m) = n >= m
 {-# NOINLINE gt# #-}
+{-# ANN gt# hasBlackBox #-}
 gt# (I n) (I m) = n > m
 {-# NOINLINE le# #-}
+{-# ANN le# hasBlackBox #-}
 le# (I n) (I m) = n <= m
 
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
@@ -255,6 +266,7 @@ maxBound# =
     0 -> errorX "maxBound of 'Index 0' is undefined"
     n -> fromInteger_INLINE (n - 1)
 {-# NOINLINE maxBound# #-}
+{-# ANN maxBound# hasBlackBox #-}
 
 -- | Operators report an error on overflow and underflow
 instance KnownNat n => Num (Index n) where
@@ -268,12 +280,15 @@ instance KnownNat n => Num (Index n) where
 
 (+#),(-#),(*#) :: KnownNat n => Index n -> Index n -> Index n
 {-# NOINLINE (+#) #-}
+{-# ANN (+#) hasBlackBox #-}
 (+#) (I a) (I b) = fromInteger_INLINE $ a + b
 
 {-# NOINLINE (-#) #-}
+{-# ANN (-#) hasBlackBox #-}
 (-#) (I a) (I b) = fromInteger_INLINE $ a - b
 
 {-# NOINLINE (*#) #-}
+{-# ANN (*#) hasBlackBox #-}
 (*#) (I a) (I b) = fromInteger_INLINE $ a * b
 
 negate# :: KnownNat n => Index n -> Index n
@@ -282,6 +297,7 @@ negate# i = maxBound -# i +# 1
 
 fromInteger# :: KnownNat n => Integer -> Index n
 {-# NOINLINE fromInteger# #-}
+{-# ANN fromInteger# hasBlackBox #-}
 fromInteger# = fromInteger_INLINE
 {-# INLINE fromInteger_INLINE #-}
 fromInteger_INLINE :: forall n . (HasCallStack, KnownNat n) => Integer -> Index n
@@ -300,9 +316,11 @@ instance ExtendingNum (Index m) (Index n) where
 
 plus#, minus# :: Index m -> Index n -> Index (m + n - 1)
 {-# NOINLINE plus# #-}
+{-# ANN plus# hasBlackBox #-}
 plus# (I a) (I b) = I (a + b)
 
 {-# NOINLINE minus# #-}
+{-# ANN minus# hasBlackBox #-}
 minus# (I a) (I b) =
   let z   = a - b
       err = error ("Clash.Sized.Index.minus: result " ++ show z ++
@@ -311,6 +329,7 @@ minus# (I a) (I b) =
   in  res
 
 {-# NOINLINE times# #-}
+{-# ANN times# hasBlackBox #-}
 times# :: Index m -> Index n -> Index (((m - 1) * (n - 1)) + 1)
 times# (I a) (I b) = I (a * b)
 
@@ -416,11 +435,14 @@ instance KnownNat n => Integral (Index n) where
 
 quot#,rem# :: Index n -> Index n -> Index n
 {-# NOINLINE quot# #-}
+{-# ANN quot# hasBlackBox #-}
 (I a) `quot#` (I b) = I (a `div` b)
 {-# NOINLINE rem# #-}
+{-# ANN rem# hasBlackBox #-}
 (I a) `rem#` (I b) = I (a `rem` b)
 
 {-# NOINLINE toInteger# #-}
+{-# ANN toInteger# hasBlackBox #-}
 toInteger# :: Index n -> Integer
 toInteger# (I n) = n
 
@@ -464,6 +486,7 @@ instance Resize Index where
 resize# :: KnownNat m => Index n -> Index m
 resize# (I i) = fromInteger_INLINE i
 {-# NOINLINE resize# #-}
+{-# ANN resize# hasBlackBox #-}
 
 instance KnownNat n => Lift (Index n) where
   lift u@(I i) = sigE [| fromInteger# i |] (decIndex (natVal u))

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -140,7 +140,7 @@ type role Index nominal
 -- *** Exception: X: Clash.Sized.Index: result 8 is out of bounds: [0..7]
 -- ...
 --
--- Index has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+-- Index has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i Index
 -- type role Index nominal

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -168,7 +168,7 @@ type role Signed nominal
 -- >>> satAdd SatSymmetric (-2) (-3) :: Signed 3
 -- -3
 --
--- Signed has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+-- Signed has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i Signed
 -- type role Signed nominal

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016     , Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -125,6 +125,7 @@ import Test.QuickCheck.Arbitrary      (Arbitrary (..), CoArbitrary (..),
                                        arbitraryBoundedIntegral,
                                        coarbitraryIntegral)
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Class.BitPack            (BitPack (..), packXWith, bitCoerce)
 import Clash.Class.Num                (ExtendingNum (..), SaturatingNum (..),
                                        SaturationMode (..))
@@ -201,7 +202,10 @@ newtype Unsigned (n :: Nat) =
 #endif
   deriving (Data, Generic)
 
+{-# ANN U hasBlackBox #-}
+
 {-# NOINLINE size# #-}
+{-# ANN size# hasBlackBox #-}
 size# :: KnownNat n => Unsigned n -> Int
 #if MIN_VERSION_base(4,15,0)
 size# u = fromIntegral (natVal u)
@@ -236,10 +240,12 @@ instance KnownNat n => BitPack (Unsigned n) where
   unpack = unpack#
 
 {-# NOINLINE pack# #-}
+{-# ANN pack# hasBlackBox #-}
 pack# :: Unsigned n -> BitVector n
 pack# (U i) = BV 0 i
 
 {-# NOINLINE unpack# #-}
+{-# ANN unpack# hasBlackBox #-}
 unpack# :: KnownNat n => BitVector n -> Unsigned n
 unpack# (BV 0 i) = U i
 unpack# bv = undefError "Unsigned.unpack" [bv]
@@ -249,10 +255,12 @@ instance Eq (Unsigned n) where
   (/=) = neq#
 
 {-# NOINLINE eq# #-}
+{-# ANN eq# hasBlackBox #-}
 eq# :: Unsigned n -> Unsigned n -> Bool
 eq# (U v1) (U v2) = v1 == v2
 
 {-# NOINLINE neq# #-}
+{-# ANN neq# hasBlackBox #-}
 neq# :: Unsigned n -> Unsigned n -> Bool
 neq# (U v1) (U v2) = v1 /= v2
 
@@ -264,12 +272,16 @@ instance Ord (Unsigned n) where
 
 lt#,ge#,gt#,le# :: Unsigned n -> Unsigned n -> Bool
 {-# NOINLINE lt# #-}
+{-# ANN lt# hasBlackBox #-}
 lt# (U n) (U m) = n < m
 {-# NOINLINE ge# #-}
+{-# ANN ge# hasBlackBox #-}
 ge# (U n) (U m) = n >= m
 {-# NOINLINE gt# #-}
+{-# ANN gt# hasBlackBox #-}
 gt# (U n) (U m) = n > m
 {-# NOINLINE le# #-}
+{-# ANN le# hasBlackBox #-}
 le# (U n) (U m) = n <= m
 
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
@@ -344,10 +356,12 @@ instance KnownNat n => Bounded (Unsigned n) where
 minBound# :: Unsigned n
 minBound# = U 0
 {-# NOINLINE minBound# #-}
+{-# ANN minBound# hasBlackBox #-}
 
 maxBound# :: forall n. KnownNat n => Unsigned n
 maxBound# = let m = 1 `shiftL` (natToNum @n) in  U (m - 1)
 {-# NOINLINE maxBound# #-}
+{-# ANN maxBound# hasBlackBox #-}
 
 instance KnownNat n => Num (Unsigned n) where
   (+)         = (+#)
@@ -360,6 +374,7 @@ instance KnownNat n => Num (Unsigned n) where
 
 (+#),(-#),(*#) :: forall n . KnownNat n => Unsigned n -> Unsigned n -> Unsigned n
 {-# NOINLINE (+#) #-}
+{-# ANN (+#) hasBlackBox #-}
 (+#) = \(U i) (U j) -> U (addMod m i j)
 #if MIN_VERSION_base(4,15,0)
   where m = 1 `naturalShiftL` naturalToWord (natVal (Proxy @n))
@@ -368,6 +383,7 @@ instance KnownNat n => Num (Unsigned n) where
 #endif
 
 {-# NOINLINE (-#) #-}
+{-# ANN (-#) hasBlackBox #-}
 (-#) = \(U i) (U j) -> U (subMod m i j)
 #if MIN_VERSION_base(4,15,0)
   where m = 1 `naturalShiftL` naturalToWord (natVal (Proxy @n))
@@ -376,6 +392,7 @@ instance KnownNat n => Num (Unsigned n) where
 #endif
 
 {-# NOINLINE (*#) #-}
+{-# ANN (*#) hasBlackBox #-}
 (*#) = \(U i) (U j) -> U (mulMod2 m i j)
 #if MIN_VERSION_base(4,15,0)
   where m = (1 `naturalShiftL` naturalToWord (natVal (Proxy @n))) - 1
@@ -384,6 +401,7 @@ instance KnownNat n => Num (Unsigned n) where
 #endif
 
 {-# NOINLINE negate# #-}
+{-# ANN negate# hasBlackBox #-}
 negate# :: forall n . KnownNat n => Unsigned n -> Unsigned n
 negate# = \(U i) -> U (negateMod m i)
 #if MIN_VERSION_base(4,15,0)
@@ -393,6 +411,7 @@ negate# = \(U i) -> U (negateMod m i)
 #endif
 
 {-# NOINLINE fromInteger# #-}
+{-# ANN fromInteger# hasBlackBox #-}
 fromInteger# :: forall n . KnownNat n => Integer -> Unsigned n
 #if MIN_VERSION_base(4,15,0)
 fromInteger# = \x -> U (integerToNatural (x `mod` m))
@@ -412,10 +431,12 @@ instance (KnownNat m, KnownNat n) => ExtendingNum (Unsigned m) (Unsigned n) wher
   mul = times#
 
 {-# NOINLINE plus# #-}
+{-# ANN plus# hasBlackBox #-}
 plus# :: Unsigned m -> Unsigned n -> Unsigned (Max m n + 1)
 plus# (U a) (U b) = U (a + b)
 
 {-# NOINLINE minus# #-}
+{-# ANN minus# hasBlackBox #-}
 minus# :: forall m n . (KnownNat m, KnownNat n) => Unsigned m -> Unsigned n
                                                 -> Unsigned (Max m n + 1)
 minus# = \(U a) (U b) -> U (subMod mask a b)
@@ -429,6 +450,7 @@ minus# = \(U a) (U b) -> U (subMod mask a b)
 #endif
 
 {-# NOINLINE times# #-}
+{-# ANN times# hasBlackBox #-}
 times# :: Unsigned m -> Unsigned n -> Unsigned (m + n)
 times# (U a) (U b) = U (a * b)
 
@@ -446,11 +468,14 @@ instance KnownNat n => Integral (Unsigned n) where
 
 quot#,rem# :: Unsigned n -> Unsigned n -> Unsigned n
 {-# NOINLINE quot# #-}
+{-# ANN quot# hasBlackBox #-}
 quot# (U i) (U j) = U (i `quot` j)
 {-# NOINLINE rem# #-}
+{-# ANN rem# hasBlackBox #-}
 rem# (U i) (U j) = U (i `rem` j)
 
 {-# NOINLINE toInteger# #-}
+{-# ANN toInteger# hasBlackBox #-}
 toInteger# :: Unsigned n -> Integer
 toInteger# (U i) = naturalToInteger i
 
@@ -482,24 +507,29 @@ instance KnownNat n => Bits (Unsigned n) where
   popCount u        = popCount (pack# u)
 
 {-# NOINLINE and# #-}
+{-# ANN and# hasBlackBox #-}
 and# :: Unsigned n -> Unsigned n -> Unsigned n
 and# (U v1) (U v2) = U (v1 .&. v2)
 
 {-# NOINLINE or# #-}
+{-# ANN or# hasBlackBox #-}
 or# :: Unsigned n -> Unsigned n -> Unsigned n
 or# (U v1) (U v2) = U (v1 .|. v2)
 
 {-# NOINLINE xor# #-}
+{-# ANN xor# hasBlackBox #-}
 xor# :: Unsigned n -> Unsigned n -> Unsigned n
 xor# (U v1) (U v2) = U (v1 `xor` v2)
 
 {-# NOINLINE complement# #-}
+{-# ANN complement# hasBlackBox #-}
 complement# :: forall n . KnownNat n => Unsigned n -> Unsigned n
 complement# = \(U i) -> U (complementN i)
   where complementN = complementMod (natVal (Proxy @n))
 
 shiftL#, shiftR#, rotateL#, rotateR# :: forall n .KnownNat n => Unsigned n -> Int -> Unsigned n
 {-# NOINLINE shiftL# #-}
+{-# ANN shiftL# hasBlackBox #-}
 shiftL# = \(U v) i ->
 #if MIN_VERSION_base(4,15,0)
   let i' = fromIntegral i in
@@ -519,6 +549,7 @@ shiftL# = \(U v) i ->
 #endif
 
 {-# NOINLINE shiftR# #-}
+{-# ANN shiftR# hasBlackBox #-}
 -- shiftR# doesn't need the KnownNat constraint
 -- But having the same type signature for all shift and rotate functions
 -- makes implementing the Evaluator easier.
@@ -528,6 +559,7 @@ shiftR# (U v) i
   | otherwise = U (shiftR v i)
 
 {-# NOINLINE rotateL# #-}
+{-# ANN rotateL# hasBlackBox #-}
 rotateL# =
   \(U n) b ->
     if b >= 0 then
@@ -554,6 +586,7 @@ rotateL# =
 #endif
 
 {-# NOINLINE rotateR# #-}
+{-# ANN rotateR# hasBlackBox #-}
 rotateR# =
   \(U n) b ->
     if b >= 0 then
@@ -591,6 +624,7 @@ instance Resize Unsigned where
   truncateB  = resize#
 
 {-# NOINLINE resize# #-}
+{-# ANN resize# hasBlackBox #-}
 resize# :: forall n m . KnownNat m => Unsigned n -> Unsigned m
 resize# = \(U i) -> if i >= m then U (i `mod` m) else U i
 #if MIN_VERSION_base(4,15,0)
@@ -709,6 +743,7 @@ unsignedToWord (U (NatS# u#)) = W# u#
 unsignedToWord (U (NatJ# u#)) = W# (bigNatToWord u#)
 #endif
 {-# NOINLINE unsignedToWord #-}
+{-# ANN unsignedToWord hasBlackBox #-}
 
 unsigned8toWord8 :: Unsigned 8 -> Word8
 #if MIN_VERSION_base(4,15,0)
@@ -719,6 +754,7 @@ unsigned8toWord8 (U (NatS# u#)) = W8# (narrow8Word# u#)
 unsigned8toWord8 (U (NatJ# u#)) = W8# (narrow8Word# (bigNatToWord u#))
 #endif
 {-# NOINLINE unsigned8toWord8 #-}
+{-# ANN unsigned8toWord8 hasBlackBox #-}
 
 unsigned16toWord16 :: Unsigned 16 -> Word16
 #if MIN_VERSION_base(4,15,0)
@@ -729,6 +765,7 @@ unsigned16toWord16 (U (NatS# u#)) = W16# (narrow16Word# u#)
 unsigned16toWord16 (U (NatJ# u#)) = W16# (narrow16Word# (bigNatToWord u#))
 #endif
 {-# NOINLINE unsigned16toWord16 #-}
+{-# ANN unsigned16toWord16 hasBlackBox #-}
 
 unsigned32toWord32 :: Unsigned 32 -> Word32
 #if MIN_VERSION_base(4,15,0)
@@ -739,6 +776,7 @@ unsigned32toWord32 (U (NatS# u#)) = W32# (narrow32Word# u#)
 unsigned32toWord32 (U (NatJ# u#)) = W32# (narrow32Word# (bigNatToWord u#))
 #endif
 {-# NOINLINE unsigned32toWord32 #-}
+{-# ANN unsigned32toWord32 hasBlackBox #-}
 
 {-# RULES
 "bitCoerce/Unsigned WORD_SIZE_IN_BITS -> Word" bitCoerce = unsignedToWord

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -180,7 +180,7 @@ type role Unsigned nominal
 -- >>> satSub SatSymmetric 2 3 :: Unsigned 3
 -- 0
 --
--- Unsigned has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#roles type role>
+-- Unsigned has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i Unsigned
 -- type role Unsigned nominal

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -1,7 +1,8 @@
 {-|
 Copyright  :  (C) 2016, University of Twente
+                  2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE CPP #-}
@@ -65,6 +66,7 @@ import Language.Haskell.TH.Compat
 import Prelude                     hiding ((++), (!!))
 import Test.QuickCheck             (Arbitrary (..), CoArbitrary (..))
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Class.BitPack         (BitPack (..), packXWith)
 import Clash.Promoted.Nat          (SNat (..), UNat (..), pow2SNat, snatToNum,
                                     subSNat, toUNat)
@@ -114,11 +116,13 @@ textract :: RTree 0 a -> a
 textract (LR_ x)   = x
 textract (BR_ _ _) = error $ "textract: nodes hold no values"
 {-# NOINLINE textract #-}
+{-# ANN textract hasBlackBox #-}
 
 tsplit :: RTree (d+1) a -> (RTree d a,RTree d a)
 tsplit (BR_ l r) = (l,r)
 tsplit (LR_ _)   = error $ "tsplit: leaf is atomic"
 {-# NOINLINE tsplit #-}
+{-# ANN tsplit hasBlackBox #-}
 
 -- | Leaf of a perfect depth tree
 --
@@ -370,6 +374,7 @@ tdfold _ f g = go SNat
     go sn (BR_ l r) = let sn' = sn `subSNat` d1
                       in  g sn' (go sn' l) (go sn' r)
 {-# NOINLINE tdfold #-}
+{-# ANN tdfold hasBlackBox #-}
 
 data TfoldTree (a :: Type) (f :: TyFun Nat Type) :: Type
 type instance Apply (TfoldTree a) d = a
@@ -398,6 +403,7 @@ treplicate sn a = go (toUNat sn)
     go UZero      = LR a
     go (USucc un) = BR (go un) (go un)
 {-# NOINLINE treplicate #-}
+{-# ANN treplicate hasBlackBox #-}
 
 -- | \"'trepeat' @a@\" creates a tree with as many copies of /a/ as demanded by
 -- the context.

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -1905,6 +1905,8 @@ rotateRightS xs d = go (snatToInteger d `mod` natVal (asNatProxy xs)) xs
 --
 -- >>> toList (1:>2:>3:>Nil)
 -- [1,2,3]
+--
+-- __NB:__ this function is not synthesizable
 toList :: Vec n a -> [a]
 toList = foldr (:) []
 {-# INLINE toList #-}
@@ -1921,8 +1923,8 @@ toList = foldr (:) []
 -- >>> Vec.fromList [1,2,3,4,5] :: Maybe (Vec 10 Int)
 -- Nothing
 --
--- __NB:__ use `listToVecTH` if you want to make a /statically known/ vector
--- __NB:__ this function is not synthesizable
+-- * __NB:__ use `listToVecTH` if you want to make a /statically known/ vector
+-- * __NB:__ this function is not synthesizable
 --
 fromList :: forall n a. (KnownNat n) => [a] -> Maybe (Vec n a)
 fromList xs
@@ -1949,8 +1951,8 @@ fromList xs
 -- 1 :> 2 :> 3 :> 4 :> 5 :> *** Exception: Clash.Sized.Vector.unsafeFromList: vector larger than list
 -- ...
 --
--- __NB:__ use `listToVecTH` if you want to make a /statically known/ vector
--- __NB:__ this function is not synthesizable
+-- * __NB:__ use `listToVecTH` if you want to make a /statically known/ vector
+-- * __NB:__ this function is not synthesizable
 --
 unsafeFromList :: forall n a. (KnownNat n) => [a] -> Vec n a
 unsafeFromList = unfoldr SNat go

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2016,      University of Twente,
                   2017,      QBayLogic, Google Inc.
                   2017-2019, Myrtle Software Ltd,
-                  2021,      QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -214,6 +214,7 @@ seqX :: a -> b -> b
 seqX a b = unsafeDupablePerformIO
   (catch (evaluate a >> return b) (\(XException _) -> return b))
 {-# NOINLINE seqX #-}
+{-# ANN seqX hasBlackBox #-}
 infixr 0 `seqX`
 
 -- | Like 'seqX', but will also catch ErrorCall exceptions which are thrown.
@@ -450,6 +451,7 @@ forceX x = x `deepseqX` x
 deepseqX :: NFDataX a => a -> b -> b
 deepseqX a b = rnfX a `seq` b
 {-# NOINLINE deepseqX #-}
+{-# ANN deepseqX hasBlackBox #-}
 infixr 0 `deepseqX`
 
 -- | Reduce to weak head normal form


### PR DESCRIPTION
I suggest we add further minor stuff we want in 1.6 here and merge it shortly before actually doing 1.6. Perhaps then we should also consider whether to backport this. The first commit can only be backported in half; the `XException` that is adjusted does not exist in 1.4 and is thus not an issue.

  - [ ] ~~Write a changelog entry (see changelog/README.md)~~
  - [ ] Check copyright notices are up to date in edited files
