### PR TITLE
Fix Snapcraft nightly by reverting snapcraft version

### DIFF
--- a/.ci/bindist/linux/snap/Dockerfile
+++ b/.ci/bindist/linux/snap/Dockerfile
@@ -1,9 +1,10 @@
-# This Dockerfile is:
-#
-#   https://github.com/snapcore/snapcraft/pull/3384
-#   + xenial => focal
-#
-FROM ubuntu:focal as builder
+ARG RISK=edge
+ARG UBUNTU=xenial
+
+FROM ubuntu:$UBUNTU as builder
+ARG RISK
+ARG UBUNTU
+RUN echo "Building snapcraft:$RISK in ubuntu:$UBUNTU"
 
 # Grab dependencies
 RUN apt-get update
@@ -25,15 +26,9 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 RUN mkdir -p /snap/core18
 RUN unsquashfs -d /snap/core18/current core18.snap
 
-# Grab the core20 snap (which snapcraft uses as a base) from the stable channel
-# and unpack it in the proper place.
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core20' | jq '.download_url' -r) --output core20.snap
-RUN mkdir -p /snap/core20
-RUN unsquashfs -d /snap/core20/current core20.snap
-
-# Grab the snapcraft snap from the stable channel and unpack it in the proper
+# Grab the snapcraft snap from the $RISK channel and unpack it in the proper
 # place.
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel='$RISK | jq '.download_url' -r) --output snapcraft.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 
@@ -47,10 +42,9 @@ RUN chmod +x /snap/bin/snapcraft
 
 # Multi-stage build, only need the snaps from the builder. Copy them one at a
 # time so they can be cached.
-FROM ubuntu:focal
+FROM ubuntu:$UBUNTU
 COPY --from=builder /snap/core /snap/core
 COPY --from=builder /snap/core18 /snap/core18
-COPY --from=builder /snap/core20 /snap/core20
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 

--- a/.ci/bindist/linux/snap/Dockerfile
+++ b/.ci/bindist/linux/snap/Dockerfile
@@ -26,6 +26,12 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 RUN mkdir -p /snap/core18
 RUN unsquashfs -d /snap/core18/current core18.snap
 
+# Grab the core20 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core20' | jq '.download_url' -r) --output core20.snap
+RUN mkdir -p /snap/core20
+RUN unsquashfs -d /snap/core20/current core20.snap
+
 # Grab the snapcraft snap from the $RISK channel and unpack it in the proper
 # place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel='$RISK | jq '.download_url' -r) --output snapcraft.snap
@@ -45,6 +51,7 @@ RUN chmod +x /snap/bin/snapcraft
 FROM ubuntu:$UBUNTU
 COPY --from=builder /snap/core /snap/core
 COPY --from=builder /snap/core18 /snap/core18
+COPY --from=builder /snap/core20 /snap/core20
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 

--- a/.ci/bindist/linux/snap/Dockerfile
+++ b/.ci/bindist/linux/snap/Dockerfile
@@ -1,5 +1,5 @@
-ARG RISK=edge
-ARG UBUNTU=xenial
+ARG RISK=stable
+ARG UBUNTU=focal
 
 FROM ubuntu:$UBUNTU as builder
 ARG RISK

--- a/.ci/bindist/linux/snap/Dockerfile
+++ b/.ci/bindist/linux/snap/Dockerfile
@@ -32,9 +32,9 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 RUN mkdir -p /snap/core20
 RUN unsquashfs -d /snap/core20/current core20.snap
 
-# Grab the snapcraft snap from the $RISK channel and unpack it in the proper
-# place.
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel='$RISK | jq '.download_url' -r) --output snapcraft.snap
+# Grab the snapcraft v6751, the last working version of snapcraft:
+# https://forum.snapcraft.io/t/snapcraft-failed-in-container/27921
+RUN curl -L https://api.snapcraft.io/api/v1/snaps/download/vMTKRaLjnOJQetI78HjntT37VuoyssFE_6751.snap --output snapcraft.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -79,7 +79,7 @@ debian-bindist-test:
 
 # Use binary distribution built in `snap-bindist` to build a snap package.
 .snap:
-  image: ghcr.io/clash-lang/snapcraft:2022-01-20
+  image: ghcr.io/clash-lang/snapcraft:2022-01-23
   stage: publish
   interruptible: false
   cache:


### PR DESCRIPTION
https://github.com/clash-lang/clash-compiler/pull/2043 accidentally broke our [snapcraft nightly job](https://gitlab.com/clash-lang/clash-compiler/-/jobs/2005061587) by updating to the latest snapcraft version. This PR pulls the latest version of the Snapcraft Dockerfile, reapplies our previously applied patches, and locks Snapcraft to the last known version.

@alex-mckenna I've assigned you as I'm away Mon-Wed. The PR should be good to go, but feel free to fix any obvious mistakes & merge.