### PR TITLE
Don't treat package name as prefix in publish_sdist

### DIFF
--- a/.ci/publish_sdist.sh
+++ b/.ci/publish_sdist.sh
@@ -3,8 +3,8 @@ set -eu -o pipefail
 
 PASSWORD=$(echo $HACKAGE_PASSWORD | base64 --decode --ignore-garbage)
 
-SDIST=$(find $1-*.tar.gz | grep -v docs)
-DDIST=$(find $1-*.tar.gz | grep docs)
+SDIST=$(find . -type f -regex "\./$1-[0-9\.]+\.tar\.gz")
+DDIST=$(find . -type f -regex "\./$1-[0-9\.]+-docs\.tar\.gz")
 
 set +u
 


### PR DESCRIPTION
Treating the package name as a prefix means that publishing a
package like clash-prelude will also attempt to publish
clash-prelude-hedgehog at the same time. While this works for the
packages themselves, haddock documentation must be uploaded one
archive at a time or it fails.