### PR TITLE
Improved Compiler API 1

### DIFF
--- a/.ci/build_clash_dev.sh
+++ b/.ci/build_clash_dev.sh
@@ -4,7 +4,7 @@ set -xeou pipefail
 # Check that clash-dev works
 cabal --write-ghc-environment-files=always v2-build clash-prelude
 echo "" > clash-dev.result
-echo 'genVHDL "./examples/FIR.hs" >> writeFile "clash-dev.result" "success"' | ./clash-dev
+echo 'main >> writeFile "clash-dev.result" "success"' | ./clash-dev
 if [[ "$(cat clash-dev.result)" != "success" ]]; then
   echo "clash-dev test failed"
   exit 1

--- a/Clash.hs
+++ b/Clash.hs
@@ -19,18 +19,11 @@ import Clash.Backend.VHDL
 import Clash.Backend.Verilog
 import Clash.Netlist.BlackBox.Types
 import Clash.Netlist.Types (PreserveCase(..))
-import Clash.Annotations.BitRepresentation.Internal (buildCustomReprs)
 import Clash.Util
 
 import Control.DeepSeq
 import qualified Data.Time.Clock as Clock
 import GHC.Stack (HasCallStack)
-
-#if MIN_VERSION_ghc(9,0,0)
-import GHC.Utils.Misc (OverridingBool(..))
-#else
-import Util (OverridingBool(..))
-#endif
 
 genSystemVerilog
   :: String
@@ -56,16 +49,15 @@ doHDL
 doHDL b src = do
   startTime <- Clock.getCurrentTime
   pd      <- primDirs b
-  (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <-
-    generateBindings (return ()) Auto pd ["."] [] (hdlKind b) src Nothing
-  prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` reprs `deepseq` Clock.getCurrentTime
+  let opts = defClashOpts { opt_cachehdl = False, opt_debug = debugSilent, opt_clear = True }
+  (clashEnv, clashDesign) <-
+    generateBindings opts (return ()) pd ["."] [] (hdlKind b) src Nothing
+  prepTime <- startTime `deepseq` designBindings clashDesign `deepseq` envTyConMap clashEnv `deepseq` envCustomReprs clashEnv `deepseq` Clock.getCurrentTime
   let prepStartDiff = reportTimeDiff prepTime startTime
   putStrLn $ "Loading dependencies took " ++ prepStartDiff
 
-  generateHDL (buildCustomReprs reprs) domainConfs bindingsMap (Just b) primMap tcm tupTcm
-    (ghcTypeToHWType WORD_SIZE_IN_BITS) ghcEvaluator evaluator topEntities Nothing
-    defClashOpts{opt_cachehdl = False, opt_debug = debugSilent, opt_clear = True}
-    startTime
+  generateHDL clashEnv clashDesign (Just b)
+    (ghcTypeToHWType WORD_SIZE_IN_BITS) ghcEvaluator evaluator Nothing startTime
 
 main :: IO ()
 main = genVHDL "./examples/FIR.hs"

--- a/benchmark/benchmark-concurrency.hs
+++ b/benchmark/benchmark-concurrency.hs
@@ -28,8 +28,8 @@ main = do
 benchFile :: [FilePath] -> FilePath -> Benchmark
 benchFile idirs src =
   env ((,) <$> runInputStage idirs src <*> getCurrentTime) $
-    \ ~((bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs,_,_),startTime) -> do
+    \ ~((clashEnv, clashDesign),startTime) -> do
       bench ("Generating HDL: " ++ src)
-            (nfIO (generateHDL reprs domainConfs bindingsMap (Just backend)
-                               primMap tcm tupTcm typeTrans ghcEvaluator
-                               evaluator topEntities Nothing (opts idirs) startTime))
+            (nfIO (generateHDL clashEnv clashDesign (Just backend)
+                               typeTrans ghcEvaluator
+                               evaluator Nothing startTime))

--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -9,6 +9,7 @@ import           Clash.Driver.Types
 
 import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
+import           Clash.GHC.NetlistTypes       (ghcTypeToHWType)
 
 import           Clash.Netlist.Types          (TopEntityT(topId))
 
@@ -46,7 +47,7 @@ benchFile idirs src =
             (nf (normalizeEntity
                    clashEnv
                    (designBindings clashDesign)
-                   typeTrans
+                   (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
                    ghcEvaluator
                    evaluator
                    (fmap topId (designEntities clashDesign))

--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -4,28 +4,19 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
-import           Clash.Signal (VDomainConfiguration)
-
-import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
-import           Clash.Core.TyCon
-import           Clash.Core.Var
 import           Clash.Driver
 import           Clash.Driver.Types
 
 import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
 
-import           Clash.Netlist.Types          (TopEntityT)
-import           Clash.Primitives.Types
+import           Clash.Netlist.Types          (TopEntityT(topId))
 
 import           Criterion.Main
 
 import qualified Control.Concurrent.Supply    as Supply
 import           Control.DeepSeq              (NFData(..), rwhnf)
-import           Data.HashMap.Strict          (HashMap)
-import           Data.IntMap.Strict           (IntMap)
 import           Data.List                    (isPrefixOf, partition)
-import           Data.Text                    (Text)
 import           System.Environment           (getArgs, withArgs)
 
 import BenchmarkCommon
@@ -50,27 +41,26 @@ main = do
 benchFile :: [FilePath] -> FilePath -> Benchmark
 benchFile idirs src =
   env (setupEnv idirs src) $
-    \ ~((bindingsMap,tcm,tupTcm,_topEntities,primMap,reprs,_domainConfs,topEntityNames,topEntity),supplyN) -> do
+    \ ~(clashEnv, clashDesign, supplyN) -> do
       bench ("normalization of " ++ src)
-            (nf (normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans
-                                 ghcEvaluator
-                                 evaluator
-                                 topEntityNames
-                                 (opts idirs) supplyN :: _ -> BindingMap) topEntity)
+            (nf (normalizeEntity
+                   clashEnv
+                   (designBindings clashDesign)
+                   typeTrans
+                   ghcEvaluator
+                   evaluator
+                   (fmap topId (designEntities clashDesign))
+                   supplyN)
+                   (topId (head (designEntities clashDesign))))
 
 setupEnv
   :: [FilePath]
   -> FilePath
-  -> IO ((BindingMap, TyConMap, IntMap TyConName
-         ,[TopEntityT]
-         ,CompiledPrimMap, CustomReprs, HashMap Text VDomainConfiguration, [Id], Id
-         )
-        ,Supply.Supply
-        )
+  -> IO (ClashEnv, ClashDesign, Supply.Supply)
 setupEnv idirs src = do
-  inp <- runInputStage idirs src
+  (clashEnv, clashDesign) <- runInputStage idirs src
   supplyN <- Supply.newSupply
-  return (inp,supplyN)
+  return (clashEnv, clashDesign ,supplyN)
 
 instance NFData Supply.Supply where
   rnf = rwhnf

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -5,6 +5,7 @@ import           Clash.Driver.Types
 
 import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
+import           Clash.GHC.NetlistTypes       (ghcTypeToHWType)
 
 import qualified Control.Concurrent.Supply    as Supply
 import           Control.DeepSeq              (deepseq)
@@ -42,7 +43,8 @@ benchFile idirs src = do
                    , envCustomReprs = reprs
                    }
 
-      res = normalizeEntity clashEnv bindingsMap typeTrans
+      res = normalizeEntity clashEnv bindingsMap
+                   (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
                    ghcEvaluator
                    evaluator
                    topEntityNames supplyN topEntity

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -98,11 +98,11 @@ import Control.Monad.Trans.Except
 import Data.Array
 import qualified Data.ByteString.Char8 as BS
 import Data.Char
-import Data.Coerce
 import Data.Function
 import Data.IORef ( IORef, modifyIORef, newIORef, readIORef, writeIORef )
 import Data.List ( find, group, intercalate, intersperse, isPrefixOf,
                    isSuffixOf, nub, partition, sort, sortBy, (\\) )
+import Data.Proxy
 import qualified Data.Set as S
 import Data.Maybe
 import Data.Map (Map)
@@ -145,8 +145,7 @@ import GHC.TopHandler ( topHandler )
 import Clash.GHCi.Leak
 
 -- clash additions
-import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB, RenderEnums)
+import           Clash.Backend (Backend(initBackend, hdlKind, primDirs))
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -158,8 +157,6 @@ import           Clash.GHC.Evaluator
 import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.GHCi.Common
-import           Clash.Netlist.BlackBox.Types (HdlSyn)
-import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
@@ -2140,11 +2137,13 @@ runExceptGhcMonad act = handleSourceError GHC.printException $
 exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
-makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-         -> IORef ClashOpts
-         -> [FilePath]
-         -> InputT GHCi ()
+makeHDL'
+  :: forall backend
+   . Backend backend
+  => Proxy backend
+  -> IORef ClashOpts
+  -> [FilePath]
+  -> InputT GHCi ()
 makeHDL' backend opts lst = go =<< case lst of
   srcs@(_:_) -> return srcs
   []         -> do
@@ -2180,26 +2179,21 @@ makeHDL' backend opts lst = go =<< case lst of
     _ <- GHC.setSessionDynFlags dflags
     reloadModule ""
 
-makeHDL :: GHC.GhcMonad m
-        => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-        -> GHC.Ghc ()
-        -> IORef ClashOpts
-        -> [FilePath]
-        -> m ()
-makeHDL backend startAction optsRef srcs = do
+makeHDL
+  :: forall backend m
+   . (GHC.GhcMonad m, Backend backend)
+  => Proxy backend
+  -> GHC.Ghc ()
+  -> IORef ClashOpts
+  -> [FilePath]
+  -> m ()
+makeHDL Proxy startAction optsRef srcs = do
   dflags <- GHC.getSessionDynFlags
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
               let opts1  = opts0 { opt_color = useColor dflags }
               let iw     = opt_intWidth opts1
-                  syn    = opt_hdlSyn opts1
-                  esc    = opt_escapedIds opts1
-                  lw     = opt_lowerCaseBasicIds opts1
-                  frcUdf = opt_forceUndefined opts1
-                  xOptBB = opt_aggressiveXOptBB opts1
-                  enums  = opt_renderEnums opts1
-                  hdl    = Clash.Backend.hdlKind backend'
+                  hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
                                  hidir <- hiDir dflags
@@ -2211,12 +2205,12 @@ makeHDL backend startAction optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB) (coerce enums)
+                  backend = initBackend @backend opts2
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs
 
-              primDirs <- Clash.Backend.primDirs backend'
+              primDirs_ <- primDirs backend
 
               forM_ srcs $ \src -> do
                 -- Generate bindings:
@@ -2233,7 +2227,7 @@ makeHDL backend startAction optsRef srcs = do
                 Clash.Driver.generateHDL
                   clashEnv
                   clashDesign
-                  (Just backend')
+                  (Just backend)
                   (ghcTypeToHWType iw)
                   ghcEvaluator
                   evaluator
@@ -2241,13 +2235,13 @@ makeHDL backend startAction optsRef srcs = do
                   startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend @VHDLState)
+makeVHDL = makeHDL' (Proxy @VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend @VerilogState)
+makeVerilog = makeHDL' (Proxy @VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend @SystemVerilogState)
+makeSystemVerilog = makeHDL' (Proxy @SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -151,7 +151,7 @@ import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import qualified Clash.Driver
-import           Clash.Driver.Types (ClashOpts(..))
+import           Clash.Driver.Types (ClashOpts(..), ClashEnv(..), ClashDesign(..))
 
 import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
@@ -163,8 +163,6 @@ import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
-
-import           Clash.Annotations.BitRepresentation.Internal (buildCustomReprs)
 
 -----------------------------------------------------------------------------
 
@@ -2196,7 +2194,6 @@ makeHDL backend startAction optsRef srcs = do
               let opts1  = opts0 { opt_color = useColor dflags }
               let iw     = opt_intWidth opts1
                   syn    = opt_hdlSyn opts1
-                  color  = opt_color opts1
                   esc    = opt_escapedIds opts1
                   lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
@@ -2224,30 +2221,23 @@ makeHDL backend startAction optsRef srcs = do
               forM_ srcs $ \src -> do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <-
-                  generateBindings startAction color primDirs idirs dbs hdl src (Just dflags)
+                (clashEnv, clashDesign) <- generateBindings opts2 startAction primDirs_ idirs dbs hdl src (Just dflags)
 
-                let getMain = getMainTopEntity src bindingsMap topEntities
+                let getMain = getMainTopEntity src clashDesign
                 mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
-                prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
+                prepTime <- startTime `deepseq` designBindings clashDesign `deepseq` envTyConMap clashEnv `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
 
                 -- Generate HDL:
                 Clash.Driver.generateHDL
-                  (buildCustomReprs reprs)
-                  domainConfs
-                  bindingsMap
+                  clashEnv
+                  clashDesign
                   (Just backend')
-                  primMap
-                  tcm
-                  tupTcm
                   (ghcTypeToHWType iw)
                   ghcEvaluator
                   evaluator
-                  topEntities
                   mainTopEntity
-                  opts2
                   startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()

--- a/clash-ghc/src-bin-8.10/Clash/Main.hs
+++ b/clash-ghc/src-bin-8.10/Clash/Main.hs
@@ -81,6 +81,7 @@ import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except (throwE, runExceptT)
 import Data.Char
 import Data.List ( isPrefixOf, partition, intercalate, nub )
+import Data.Proxy
 import Data.Maybe
 
 -- clash additions
@@ -90,16 +91,13 @@ import           Exception (gcatch)
 import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 
-import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB, RenderEnums)
+import           Clash.Backend (Backend)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import           Clash.Driver.Types
   (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
-import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
-import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir, setWantedLanguageExtensions)
 import           Clash.GHC.Util (handleClashException)
@@ -1004,20 +1002,24 @@ abiHash strs = do
 -- HDL Generation
 
 makeHDL'
-  :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-  -> Ghc () -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
-makeHDL' _       _           _ []   = throwGhcException (CmdLineError "No input files")
-makeHDL' backend startAction r srcs = makeHDL backend startAction r $ fmap fst srcs
+  :: forall backend
+   . Backend backend
+  => Proxy backend
+  -> Ghc ()
+  -> IORef ClashOpts
+  -> [(String,Maybe Phase)]
+  -> Ghc ()
+makeHDL' _     _           _ []   = throwGhcException (CmdLineError "No input files")
+makeHDL' proxy startAction r srcs = makeHDL proxy startAction r $ fmap fst srcs
 
 makeVHDL :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend @VHDLState)
+makeVHDL = makeHDL' (Proxy @VHDLState)
 
 makeVerilog :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend @VerilogState)
+makeVerilog = makeHDL' (Proxy @VerilogState)
 
 makeSystemVerilog :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend @SystemVerilogState)
+makeSystemVerilog = makeHDL' (Proxy @SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -93,11 +93,11 @@ import Control.Monad.Trans.Except
 import Data.Array
 import qualified Data.ByteString.Char8 as BS
 import Data.Char
-import Data.Coerce
 import Data.Function
 import Data.IORef ( IORef, modifyIORef, newIORef, readIORef, writeIORef )
 import Data.List ( find, group, intercalate, intersperse, isPrefixOf, nub,
                    partition, sort, sortBy )
+import Data.Proxy
 import qualified Data.Set as S
 import Data.Maybe
 import Data.Map (Map)
@@ -139,8 +139,7 @@ import GHC.TopHandler ( topHandler )
 import Clash.GHCi.Leak
 
 -- clash additions
-import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB, RenderEnums)
+import           Clash.Backend (Backend(initBackend, hdlKind, primDirs))
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -153,8 +152,6 @@ import           Clash.GHC.Evaluator
 import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.GHCi.Common
-import           Clash.Netlist.BlackBox.Types (HdlSyn)
-import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
@@ -1971,11 +1968,13 @@ runExceptGhcMonad act = handleSourceError GHC.printException $
 exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
-makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-         -> IORef ClashOpts
-         -> [FilePath]
-         -> InputT GHCi ()
+makeHDL'
+  :: forall backend
+   . Backend backend
+  => Proxy backend
+  -> IORef ClashOpts
+  -> [FilePath]
+  -> InputT GHCi ()
 makeHDL' backend opts lst = go =<< case lst of
   srcs@(_:_) -> return srcs
   []         -> do
@@ -2011,26 +2010,21 @@ makeHDL' backend opts lst = go =<< case lst of
     _ <- GHC.setSessionDynFlags dflags
     reloadModule ""
 
-makeHDL :: GHC.GhcMonad m
-        => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-        -> GHC.Ghc ()
-        -> IORef ClashOpts
-        -> [FilePath]
-        -> m ()
-makeHDL backend startAction optsRef srcs = do
+makeHDL
+  :: forall backend m
+   . (GHC.GhcMonad m, Backend backend)
+  => Proxy backend
+  -> GHC.Ghc ()
+  -> IORef ClashOpts
+  -> [FilePath]
+  -> m ()
+makeHDL Proxy startAction optsRef srcs = do
   dflags <- GHC.getSessionDynFlags
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0 <- readIORef optsRef
               let opts1  = opts0 { opt_color = useColor dflags }
                   iw     = opt_intWidth opts1
-                  syn    = opt_hdlSyn opts1
-                  esc    = opt_escapedIds opts1
-                  lw     = opt_lowerCaseBasicIds opts1
-                  frcUdf = opt_forceUndefined opts1
-                  xOptBB = opt_aggressiveXOptBB opts1
-                  enums  = opt_renderEnums opts1
-                  hdl    = Clash.Backend.hdlKind backend'
+                  hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
                                  hidir <- hiDir dflags
@@ -2042,12 +2036,12 @@ makeHDL backend startAction optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB) (coerce enums)
+                  backend = initBackend @backend opts2
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs
 
-              primDirs <- Clash.Backend.primDirs backend'
+              primDirs_ <- primDirs backend
 
               forM_ srcs $ \src -> do
                 -- Generate bindings:
@@ -2063,7 +2057,7 @@ makeHDL backend startAction optsRef srcs = do
                 Clash.Driver.generateHDL
                   clashEnv
                   clashDesign
-                  (Just backend')
+                  (Just backend)
                   (ghcTypeToHWType iw)
                   ghcEvaluator
                   evaluator
@@ -2071,13 +2065,13 @@ makeHDL backend startAction optsRef srcs = do
                   startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> VHDLState)
+makeVHDL = makeHDL' (Proxy @VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> VerilogState)
+makeVerilog = makeHDL' (Proxy @VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend :: Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> SystemVerilogState)
+makeSystemVerilog = makeHDL' (Proxy @SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in TcRnDriver.

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -145,7 +145,7 @@ import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import qualified Clash.Driver
-import           Clash.Driver.Types (ClashOpts(..))
+import           Clash.Driver.Types (ClashOpts(..), ClashEnv(..), ClashDesign(..))
 
 import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
@@ -158,8 +158,6 @@ import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
-
-import           Clash.Annotations.BitRepresentation.Internal (buildCustomReprs)
 
 -----------------------------------------------------------------------------
 
@@ -2027,7 +2025,6 @@ makeHDL backend startAction optsRef srcs = do
               let opts1  = opts0 { opt_color = useColor dflags }
                   iw     = opt_intWidth opts1
                   syn    = opt_hdlSyn opts1
-                  color  = opt_color opts1
                   esc    = opt_escapedIds opts1
                   lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
@@ -2055,29 +2052,22 @@ makeHDL backend startAction optsRef srcs = do
               forM_ srcs $ \src -> do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <-
-                  generateBindings startAction color primDirs idirs dbs hdl src (Just dflags)
-                let getMain = getMainTopEntity src bindingsMap topEntities
+                (clashEnv, clashDesign) <- generateBindings opts2 startAction primDirs_ idirs dbs hdl src (Just dflags)
+                let getMain = getMainTopEntity src clashDesign
                 mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
-                prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
+                prepTime <- startTime `deepseq` designBindings clashDesign `deepseq` envTyConMap clashEnv `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
 
                 -- Generate HDL:
                 Clash.Driver.generateHDL
-                  (buildCustomReprs reprs)
-                  domainConfs
-                  bindingsMap
+                  clashEnv
+                  clashDesign
                   (Just backend')
-                  primMap
-                  tcm
-                  tupTcm
                   (ghcTypeToHWType iw)
                   ghcEvaluator
                   evaluator
-                  topEntities
                   mainTopEntity
-                  opts2
                   startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -148,7 +148,7 @@ import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import qualified Clash.Driver
-import           Clash.Driver.Types (ClashOpts(..))
+import           Clash.Driver.Types (ClashOpts(..), ClashEnv(..), ClashDesign(..))
 
 import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
@@ -160,8 +160,6 @@ import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
-
-import           Clash.Annotations.BitRepresentation.Internal (buildCustomReprs)
 
 -----------------------------------------------------------------------------
 
@@ -2118,7 +2116,6 @@ makeHDL backend startAction optsRef srcs = do
               let opts1  = opts0 { opt_color = useColor dflags }
               let iw     = opt_intWidth opts1
                   syn    = opt_hdlSyn opts1
-                  color  = opt_color opts1
                   esc    = opt_escapedIds opts1
                   lw     = opt_lowerCaseBasicIds opts1
                   frcUdf = opt_forceUndefined opts1
@@ -2146,30 +2143,23 @@ makeHDL backend startAction optsRef srcs = do
               forM_ srcs $ \src -> do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgConfFile p) <- packageDBFlags dflags]
-                (bindingsMap,tcm,tupTcm,topEntities,primMap,reprs,domainConfs) <-
-                  generateBindings startAction color primDirs idirs dbs hdl src (Just dflags)
+                (clashEnv, clashDesign) <- generateBindings opts2 startAction primDirs_ idirs dbs hdl src (Just dflags)
 
-                let getMain = getMainTopEntity src bindingsMap topEntities
+                let getMain = getMainTopEntity src clashDesign
                 mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
-                prepTime <- startTime `deepseq` bindingsMap `deepseq` tcm `deepseq` Clock.getCurrentTime
+                prepTime <- startTime `deepseq` designBindings clashDesign `deepseq` envTyConMap clashEnv `deepseq` Clock.getCurrentTime
                 let prepStartDiff = reportTimeDiff prepTime startTime
                 putStrLn $ "GHC+Clash: Loading modules cumulatively took " ++ prepStartDiff
 
                 -- Generate HDL:
                 Clash.Driver.generateHDL
-                  (buildCustomReprs reprs)
-                  domainConfs
-                  bindingsMap
+                  clashEnv
+                  clashDesign
                   (Just backend')
-                  primMap
-                  tcm
-                  tupTcm
                   (ghcTypeToHWType iw)
                   ghcEvaluator
                   evaluator
-                  topEntities
                   mainTopEntity
-                  opts2
                   startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -76,6 +76,7 @@ import System.FilePath
 import Control.Monad
 import Data.Char
 import Data.List
+import Data.Proxy
 import Data.Maybe
 
 -- clash additions
@@ -85,16 +86,13 @@ import           Exception (gcatch)
 import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 
-import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB, RenderEnums)
+import           Clash.Backend (Backend)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import           Clash.Driver.Types
   (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
-import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
-import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir, setWantedLanguageExtensions)
 import           Clash.GHC.Util (handleClashException)
@@ -981,20 +979,24 @@ abiHash strs = do
 -- HDL Generation
 
 makeHDL'
-  :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-  -> Ghc () -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
-makeHDL' _       _           _ []   = throwGhcException (CmdLineError "No input files")
-makeHDL' backend startAction r srcs = makeHDL backend startAction r $ fmap fst srcs
+  :: forall backend
+   . Backend backend
+  => Proxy backend
+  -> Ghc ()
+  -> IORef ClashOpts
+  -> [(String,Maybe Phase)]
+  -> Ghc ()
+makeHDL' _     _           _ []   = throwGhcException (CmdLineError "No input files")
+makeHDL' proxy startAction r srcs = makeHDL proxy startAction r $ fmap fst srcs
 
 makeVHDL :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend @VHDLState)
+makeVHDL = makeHDL' (Proxy @VHDLState)
 
 makeVerilog :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend @VerilogState)
+makeVerilog = makeHDL' (Proxy @VerilogState)
 
 makeSystemVerilog :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend @SystemVerilogState)
+makeSystemVerilog = makeHDL' (Proxy @SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-ghc/src-bin-9.0/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.0/Clash/GHCi/UI.hs
@@ -101,11 +101,11 @@ import Control.Monad.Trans.Except
 import Data.Array
 import qualified Data.ByteString.Char8 as BS
 import Data.Char
-import Data.Coerce
 import Data.Function
 import Data.IORef ( IORef, modifyIORef, newIORef, readIORef, writeIORef )
 import Data.List ( elemIndices, find, group, intercalate, intersperse,
                    isPrefixOf, isSuffixOf, nub, partition, sort, sortBy, (\\) )
+import Data.Proxy
 import qualified Data.Set as S
 import Data.Maybe
 import Data.Map (Map)
@@ -148,8 +148,7 @@ import GHC.TopHandler ( topHandler )
 import Clash.GHCi.Leak
 
 -- clash additions
-import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB, RenderEnums)
+import           Clash.Backend (Backend(initBackend, hdlKind, primDirs))
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
@@ -160,8 +159,6 @@ import           Clash.GHC.GenerateBindings
 import           Clash.GHC.NetlistTypes
 import           Clash.GHC.PartialEval
 import           Clash.GHCi.Common
-import           Clash.Netlist.BlackBox.Types (HdlSyn)
-import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion, reportTimeDiff)
 import qualified Data.Time.Clock as Clock
 import qualified Paths_clash_ghc
@@ -2179,11 +2176,13 @@ runExceptGhcMonad act = handleSourceError GHC.printException $
 exceptT :: Applicative m => Either e a -> ExceptT e m a
 exceptT = ExceptT . pure
 
-makeHDL' :: Clash.Backend.Backend backend
-         => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-         -> IORef ClashOpts
-         -> [FilePath]
-         -> InputT GHCi ()
+makeHDL'
+  :: forall backend
+   . Backend backend
+  => Proxy backend
+  -> IORef ClashOpts
+  -> [FilePath]
+  -> InputT GHCi ()
 makeHDL' backend opts lst = go =<< case lst of
   srcs@(_:_) -> return srcs
   []         -> do
@@ -2219,26 +2218,21 @@ makeHDL' backend opts lst = go =<< case lst of
     _ <- GHC.setSessionDynFlags dflags
     reloadModule ""
 
-makeHDL :: GHC.GhcMonad m
-        => Clash.Backend.Backend backend
-        => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-        -> Ghc ()
-        -> IORef ClashOpts
-        -> [FilePath]
-        -> m ()
-makeHDL backend startAction optsRef srcs = do
+makeHDL
+  :: forall backend m
+   . (GHC.GhcMonad m, Backend backend)
+  => Proxy backend
+  -> Ghc ()
+  -> IORef ClashOpts
+  -> [FilePath]
+  -> m ()
+makeHDL Proxy startAction optsRef srcs = do
   dflags <- GHC.getSessionDynFlags
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
               let opts1  = opts0 { opt_color = useColor dflags }
               let iw     = opt_intWidth opts1
-                  syn    = opt_hdlSyn opts1
-                  esc    = opt_escapedIds opts1
-                  lw     = opt_lowerCaseBasicIds opts1
-                  frcUdf = opt_forceUndefined opts1
-                  xOptBB = opt_aggressiveXOptBB opts1
-                  enums  = opt_renderEnums opts1
-                  hdl    = Clash.Backend.hdlKind backend'
+                  hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
                                  hidir <- hiDir dflags
@@ -2250,17 +2244,17 @@ makeHDL backend startAction optsRef srcs = do
                   idirs = importPaths dflags
                   opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
                                 , opt_importPaths = idirs}
-                  backend' = backend iw syn esc lw frcUdf (coerce xOptBB) (coerce enums)
+                  backend = initBackend @backend opts2
 
               checkMonoLocalBinds dflags
               checkImportDirs opts0 idirs
 
-              primDirs <- Clash.Backend.primDirs backend'
+              primDirs_ <- primDirs backend
 
               forM_ srcs $ \src -> do
                 -- Generate bindings:
                 let dbs = reverse [p | PackageDB (PkgDbPath p) <- packageDBFlags dflags]
-                (clashEnv, clashDesign) <- generateBindings opts2 startAction primDirs idirs dbs hdl src (Just dflags)
+                (clashEnv, clashDesign) <- generateBindings opts2 startAction primDirs_ idirs dbs hdl src (Just dflags)
 
                 let getMain = getMainTopEntity src clashDesign
                 mainTopEntity <- traverse getMain (GHC.mainFunIs dflags)
@@ -2272,7 +2266,7 @@ makeHDL backend startAction optsRef srcs = do
                 Clash.Driver.generateHDL
                   clashEnv
                   clashDesign
-                  (Just backend')
+                  (Just backend)
                   (ghcTypeToHWType iw)
                   ghcEvaluator
                   evaluator
@@ -2280,13 +2274,13 @@ makeHDL backend startAction optsRef srcs = do
                   startTime
 
 makeVHDL :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend @VHDLState)
+makeVHDL = makeHDL' (Proxy @VHDLState)
 
 makeVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend @VerilogState)
+makeVerilog = makeHDL' (Proxy @VerilogState)
 
 makeSystemVerilog :: IORef ClashOpts -> [FilePath] -> InputT GHCi ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend @SystemVerilogState)
+makeSystemVerilog = makeHDL' (Proxy @SystemVerilogState)
 
 -----------------------------------------------------------------------------
 -- | @:type@ command. See also Note [TcRnExprMode] in GHC.Tc.Module.

--- a/clash-ghc/src-bin-9.0/Clash/Main.hs
+++ b/clash-ghc/src-bin-9.0/Clash/Main.hs
@@ -81,6 +81,7 @@ import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except (throwE, runExceptT)
 import Data.Char
 import Data.List ( isPrefixOf, partition, intercalate, nub )
+import Data.Proxy
 import qualified Data.Set as Set
 import Data.Maybe
 import Prelude
@@ -92,16 +93,13 @@ import           Control.Monad.Catch (catch)
 import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Version (showVersion)
 
-import qualified Clash.Backend
-import           Clash.Backend (AggressiveXOptBB, RenderEnums)
+import           Clash.Backend (Backend)
 import           Clash.Backend.SystemVerilog (SystemVerilogState)
 import           Clash.Backend.VHDL    (VHDLState)
 import           Clash.Backend.Verilog (VerilogState)
 import           Clash.Driver.Types
   (ClashOpts (..), defClashOpts)
 import           Clash.GHC.ClashFlags
-import           Clash.Netlist.BlackBox.Types (HdlSyn (..))
-import           Clash.Netlist.Types (PreserveCase)
 import           Clash.Util (clashLibVersion)
 import           Clash.GHC.LoadModules (ghcLibDir, setWantedLanguageExtensions)
 import           Clash.GHC.Util (handleClashException)
@@ -1005,20 +1003,24 @@ abiHash strs = do
 -- HDL Generation
 
 makeHDL'
-  :: Clash.Backend.Backend backend
-  => (Int -> HdlSyn -> Bool -> PreserveCase -> Maybe (Maybe Int) -> AggressiveXOptBB -> RenderEnums -> backend)
-  -> Ghc () -> IORef ClashOpts -> [(String,Maybe Phase)] -> Ghc ()
-makeHDL' _       _           _ []   = throwGhcException (CmdLineError "No input files")
-makeHDL' backend startAction r srcs = makeHDL backend startAction r $ fmap fst srcs
+  :: forall backend
+   . Backend backend
+  => Proxy backend
+  -> Ghc ()
+  -> IORef ClashOpts
+  -> [(String,Maybe Phase)]
+  -> Ghc ()
+makeHDL' _     _           _ []   = throwGhcException (CmdLineError "No input files")
+makeHDL' proxy startAction r srcs = makeHDL proxy startAction r $ fmap fst srcs
 
 makeVHDL :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVHDL = makeHDL' (Clash.Backend.initBackend @VHDLState)
+makeVHDL = makeHDL' (Proxy @VHDLState)
 
 makeVerilog :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeVerilog = makeHDL' (Clash.Backend.initBackend @VerilogState)
+makeVerilog = makeHDL' (Proxy @VerilogState)
 
 makeSystemVerilog :: Ghc () -> IORef ClashOpts -> [(String, Maybe Phase)] -> Ghc ()
-makeSystemVerilog = makeHDL' (Clash.Backend.initBackend @SystemVerilogState)
+makeSystemVerilog = makeHDL' (Proxy @SystemVerilogState)
 
 -- -----------------------------------------------------------------------------
 -- Util

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -11,7 +11,6 @@
 
 module Clash.Backend where
 
-import Data.HashMap.Strict                  (HashMap)
 import Data.HashSet                         (HashSet)
 import Data.Monoid                          (Ap)
 import Data.Text                            (Text)
@@ -25,10 +24,10 @@ import GHC.Types.SrcLoc (SrcSpan)
 import SrcLoc (SrcSpan)
 #endif
 
+import Clash.Driver.Types (ClashOpts)
 import {-# SOURCE #-} Clash.Netlist.Types
 import Clash.Netlist.BlackBox.Types
 
-import Clash.Signal.Internal                (VDomainConfiguration)
 import Clash.Annotations.Primitive          (HDL)
 
 #ifdef CABAL
@@ -80,19 +79,9 @@ data HWKind
   -- ^ User defined type that's not interchangeable with any others, even if
   -- the underlying structures are the same. Similar to an ADT in Haskell.
 
-type DomainMap = HashMap Text VDomainConfiguration
-
 class HasIdentifierSet state => Backend state where
   -- | Initial state for state monad
-  initBackend
-    :: Int
-    -> HdlSyn
-    -> Bool
-    -> PreserveCase
-    -> Maybe (Maybe Int)
-    -> AggressiveXOptBB
-    -> RenderEnums
-    -> state
+  initBackend :: ClashOpts -> state
 
   -- | What HDL is the backend generating
   hdlKind :: state -> HDL

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright  :  (C) 2015-2016, University of Twente,
                     2017     , Myrtle Software Ltd, Google Inc.,
-                    2021     , QBayLogic B.V.
+                    2021-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -11,6 +11,7 @@
 
 module Clash.Backend where
 
+import Data.HashMap.Strict                  (HashMap)
 import Data.HashSet                         (HashSet)
 import Data.Monoid                          (Ap)
 import Data.Text                            (Text)
@@ -27,6 +28,7 @@ import SrcLoc (SrcSpan)
 import {-# SOURCE #-} Clash.Netlist.Types
 import Clash.Netlist.BlackBox.Types
 
+import Clash.Signal.Internal                (VDomainConfiguration)
 import Clash.Annotations.Primitive          (HDL)
 
 #ifdef CABAL
@@ -77,6 +79,8 @@ data HWKind
   | UserType
   -- ^ User defined type that's not interchangeable with any others, even if
   -- the underlying structures are the same. Similar to an ADT in Haskell.
+
+type DomainMap = HashMap Text VDomainConfiguration
 
 class HasIdentifierSet state => Backend state where
   -- | Initial state for state monad

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
-                     2021     , QBayLogic B.V.
+                     2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -26,6 +26,7 @@ import           Control.Monad                        (forM,join,zipWithM)
 import           Control.Monad.State                  (State, StateT)
 import           Data.Bifunctor                       (first)
 import           Data.Bits                            (testBit, Bits)
+import           Data.Coerce                          (coerce)
 import           Data.Function                        (on)
 import           Data.HashMap.Lazy                    (HashMap)
 import qualified Data.HashMap.Lazy                    as HashMap
@@ -63,6 +64,7 @@ import           Clash.Annotations.BitRepresentation.Util
 import           Clash.Backend
 import           Clash.Core.Var                       (Attr'(..),attrName)
 import           Clash.Debug                          (traceIf)
+import           Clash.Driver.Types                   (ClashOpts(..))
 import           Clash.Netlist.BlackBox.Types         (HdlSyn (..))
 import           Clash.Netlist.BlackBox.Util
   (extractLiterals, renderBlackBox, renderFilePath)
@@ -117,7 +119,7 @@ instance HasIdentifierSet VHDLState where
   identifierSet = idSeen
 
 instance Backend VHDLState where
-  initBackend w hdlsyn_ esc lw undefVal xOpt enums = VHDLState
+  initBackend opts = VHDLState
     { _tyCache=mempty
     , _nameCache=mempty
     , _modNm=""
@@ -127,15 +129,15 @@ instance Backend VHDLState where
     , _includes=[]
     , _dataFiles=[]
     , _memoryDataFiles=[]
-    , _idSeen=Id.emptyIdentifierSet esc lw VHDL
+    , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) VHDL
     , _tyPkgCtx=False
-    , _intWidth=w
-    , _hdlsyn=hdlsyn_
-    , _undefValue=undefVal
+    , _intWidth=opt_intWidth opts
+    , _hdlsyn=opt_hdlSyn opts
+    , _undefValue=opt_forceUndefined opts
     , _productFieldNameCache=mempty
     , _enumNameCache=mempty
-    , _aggressiveXOptBB_=xOpt
-    , _renderEnums_=enums
+    , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
+    , _renderEnums_=coerce (opt_renderEnums opts)
     }
   hdlKind         = const VHDL
   primDirs        = const $ do root <- primsRoot

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
-                     2021     , QBayLogic B.V.
+                     2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -37,6 +37,7 @@ import           Control.Monad                        (forM)
 import           Control.Monad.State                  (State)
 import           Data.Bifunctor                       (first, second)
 import           Data.Bits                            (Bits, testBit)
+import           Data.Coerce                          (coerce)
 import           Data.Function                        (on)
 import           Data.HashMap.Strict                  (HashMap)
 import qualified Data.HashMap.Strict                  as HashMap
@@ -65,6 +66,7 @@ import           Clash.Annotations.BitRepresentation.Util
 import           Clash.Core.Var                       (Attr'(..))
 import           Clash.Backend
 import           Clash.Debug                          (traceIf)
+import           Clash.Driver.Types                   (ClashOpts(..))
 import           Clash.Netlist.BlackBox.Types         (HdlSyn)
 import           Clash.Netlist.BlackBox.Util
   (extractLiterals, renderBlackBox, renderFilePath)
@@ -103,9 +105,9 @@ instance HasIdentifierSet VerilogState where
   identifierSet = idSeen
 
 instance Backend VerilogState where
-  initBackend iw hdlsyn_ esc lw undefVal xOpt _enums = VerilogState
+  initBackend opts = VerilogState
     { _genDepth=0
-    , _idSeen=Id.emptyIdentifierSet esc lw Verilog
+    , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) Verilog
     , _srcSpan=noSrcSpan
     , _includes=[]
     , _imports=HashSet.empty
@@ -113,10 +115,10 @@ instance Backend VerilogState where
     , _dataFiles=[]
     , _memoryDataFiles=[]
     , _customConstrs=HashMap.empty
-    , _intWidth=iw
-    , _hdlsyn=hdlsyn_
-    , _undefValue=undefVal
-    , _aggressiveXOptBB_=xOpt
+    , _intWidth=opt_intWidth opts
+    , _hdlsyn=opt_hdlSyn opts
+    , _undefValue=opt_forceUndefined opts
+    , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
     }
   hdlKind         = const Verilog
   primDirs        = const $ do root <- primsRoot

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -41,7 +41,6 @@ import qualified Data.ByteString                  as ByteString
 import qualified Data.ByteString.Lazy             as ByteStringLazy
 import qualified Data.ByteString.Lazy.Char8       as ByteStringLazyChar8
 import           Data.Char                        (isAscii, isAlphaNum)
-import           Data.Coerce                      (coerce)
 import           Data.Default
 import           Data.Hashable                    (hash)
 import           Data.HashMap.Strict              (HashMap)
@@ -380,13 +379,8 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
   let topNm = lookupVarEnv' compNames topEntity
       (modNameS, fmap Data.Text.pack -> prefixM) = prefixModuleName (hdlKind (undefined :: backend)) (opt_componentPrefix opts) annM modName1
       modNameT  = Data.Text.pack modNameS
-      iw        = opt_intWidth opts
-      forceUnd  = opt_forceUndefined opts
-      xOpt      = coerce (opt_aggressiveXOptBB opts)
-      enums     = coerce (opt_renderEnums opts)
       hdlState' = setModName modNameT
-                  -- TODO initBackend should just take ClashOpts as an argument.
-                $ fromMaybe (initBackend iw (opt_hdlSyn opts) (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) forceUnd xOpt enums :: backend) hdlState
+                $ fromMaybe (initBackend @backend opts) hdlState
       hdlDir    = fromMaybe (Clash.Backend.name hdlState') (opt_hdlDir opts) </> topEntityS
       manPath   = hdlDir </> manifestFilename
       ite       = ifThenElseExpr hdlState'

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -3,7 +3,7 @@
                      2016-2017, Myrtle Software Ltd,
                      2017     , QBayLogic, Google Inc.
                      2020-2022, QBayLogic,
-                     20222    , Google Inc.
+                     2022     , Google Inc.
 
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -48,7 +48,6 @@ import           Data.HashMap.Strict              (HashMap)
 import qualified Data.HashMap.Strict              as HashMap
 import qualified Data.HashSet                     as HashSet
 import           Data.Proxy                       (Proxy(..))
-import           Data.IntMap                      (IntMap)
 import           Data.List                        (intercalate)
 import           Data.Maybe                       (fromMaybe, maybeToList, mapMaybe)
 import qualified Data.Map.Ordered                 as OMap
@@ -112,7 +111,7 @@ import           Clash.Core.Name                  (Name (..))
 import           Clash.Core.Pretty                (PrettyOptions(..), showPpr')
 import           Clash.Core.Type
   (Type(ForAllTy, LitTy, AnnType), TypeView(..), tyView, mkFunTy, LitTy(SymTy))
-import           Clash.Core.TyCon                 (TyConMap, TyConName)
+import           Clash.Core.TyCon                 (TyConMap)
 import           Clash.Core.Util                  (shouldSplit)
 import           Clash.Core.Var
   (Id, varName, varUniq, varType)
@@ -303,18 +302,9 @@ prefixModuleName hdl compPrefix annM modName =
 -- | Create a set of target HDL files for a set of functions
 generateHDL
   :: forall backend . Backend backend
-  => CustomReprs
-  -> HashMap Data.Text.Text VDomainConfiguration
-  -- ^ Known domains to configurations
-  -> BindingMap
-  -- ^ Set of functions
+  => ClashEnv
+  -> ClashDesign
   -> Maybe backend
-  -> CompiledPrimMap
-  -- ^ Primitive / BlackBox Definitions
-  -> TyConMap
-  -- ^ TyCon cache
-  -> IntMap TyConName
-  -- ^ Tuple TyCon cache
   -> (CustomReprs -> TyConMap -> Type ->
       State HWMap (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
@@ -322,17 +312,17 @@ generateHDL
   -- ^ Hardcoded evaluator for partial evaluation
   -> WHNF.Evaluator
   -- ^ Hardcoded evaluator for WHNF (old evaluator)
-  -> [TopEntityT]
-  -- ^ All topentities
   -> Maybe (TopEntityT, [TopEntityT])
   -- ^ Main top entity to compile. If Nothing, all top entities in previous
   -- argument will be compiled.
-  -> ClashOpts
-  -- ^ Debug information level for the normalization process
   -> Clock.UTCTime
   -> IO ()
-generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans peEval eval
-  topEntities0 mainTopEntity opts startTime = do
+generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = do
+    let bindingsMap = designBindings design
+    let tcm = envTyConMap env
+    let topEntities0 = designEntities design
+    let opts = envOpts env
+
     removeHistoryFile (dbg_historyFile (opt_debug opts))
 
     unless (opt_cachehdl opts) $
@@ -371,6 +361,11 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
     -> TopEntityT
     -> IO ()
   go compNames seenV edamFilesV ioLockV deps topEntityMap (TopEntityT topEntity annM isTb) = do
+  let domainConfs = designDomains design
+  let bindingsMap = designBindings design
+  let primMap = envPrimitives env
+  let topEntities0 = designEntities design
+  let opts = envOpts env
   prevTime <- Clock.getCurrentTime
   let topEntityS = Data.Text.unpack (nameOcc (varName topEntity))
 
@@ -449,9 +444,8 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
 
       -- 2. Normalize topEntity
       supplyN <- Supply.newSupply
-      let transformedBindings = normalizeEntity reprs bindingsMap primMap tcm tupTcm
-                                  typeTrans peEval eval topEntityNames opts supplyN
-                                  topEntity
+      let transformedBindings = normalizeEntity env bindingsMap typeTrans peEval
+                                eval topEntityNames supplyN topEntity
 
       normTime <- transformedBindings `deepseq` Clock.getCurrentTime
       let prepNormDiff = reportTimeDiff normTime prevTime
@@ -463,8 +457,8 @@ generateHDL reprs domainConfs bindingsMap hdlState primMap tcm tupTcm typeTrans 
       (topComponent, netlist) <- modifyMVar seenV $ \seen -> do
         (topComponent, netlist, seen') <-
           -- TODO My word, this has far too many arguments.
-          genNetlist isTb opts reprs transformedBindings topEntityMap compNames
-            primMap tcm typeTrans iw ite (SomeBackend hdlState') seen hdlDir prefixM topEntity
+          genNetlist env isTb transformedBindings topEntityMap compNames
+            typeTrans ite (SomeBackend hdlState') seen hdlDir prefixM topEntity
 
         pure (seen', (topComponent, netlist))
 
@@ -1061,15 +1055,9 @@ copyDataFiles idirs targetDir = mapM copyDataFile
 
 -- | Normalize a complete hierarchy
 normalizeEntity
-  :: CustomReprs
+  :: ClashEnv
   -> BindingMap
   -- ^ All bindings
-  -> CompiledPrimMap
-  -- ^ BlackBox HDL templates
-  -> TyConMap
-  -- ^ TyCon cache
-  -> IntMap TyConName
-  -- ^ Tuple TyCon cache
   -> (CustomReprs -> TyConMap -> Type ->
       State HWMap (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
@@ -1079,22 +1067,19 @@ normalizeEntity
   -- ^ Hardcoded evaluator for WHNF (old evaluator)
   -> [Id]
   -- ^ TopEntities
-  -> ClashOpts
-  -- ^ Debug information level for the normalization process
   -> Supply.Supply
   -- ^ Unique supply
   -> Id
   -- ^ root of the hierarchy
   -> BindingMap
-normalizeEntity reprs bindingsMap primMap tcm tupTcm typeTrans peEval eval topEntities
-  opts supply tm = transformedBindings
+normalizeEntity env bindingsMap typeTrans peEval eval topEntities supply tm = transformedBindings
   where
     doNorm = do norm <- normalize [tm]
                 let normChecked = checkNonRecursive norm
                 cleaned <- cleanupGraph tm normChecked
                 return cleaned
-    transformedBindings = runNormalization opts supply bindingsMap
-                            typeTrans reprs tcm tupTcm peEval eval primMap emptyVarEnv
+    transformedBindings = runNormalization env supply bindingsMap
+                            typeTrans peEval eval emptyVarEnv
                             topEntities doNorm
 
 -- | topologically sort the top entities

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -25,6 +25,7 @@ import           Control.DeepSeq                (NFData(rnf), deepseq)
 import           Data.Binary                    (Binary)
 import           Data.Fixed
 import           Data.Hashable
+import           Data.HashMap.Strict            (HashMap)
 import           Data.IntMap.Strict             (IntMap)
 import           Data.Maybe                     (isJust)
 import           Data.Set                       (Set)
@@ -52,7 +53,6 @@ import           Util                           (OverridingBool(..))
 import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
 import           Clash.Signal.Internal
 
-import           Clash.Backend                  (DomainMap)
 import           Clash.Core.Term                (Term)
 import           Clash.Core.TyCon               (TyConMap, TyConName)
 import           Clash.Core.Var                 (Id)
@@ -117,6 +117,7 @@ data Binding a = Binding
 --
 -- Global functions cannot be mutually recursive, only self-recursive.
 type BindingMap = VarEnv (Binding Term)
+type DomainMap = HashMap Text VDomainConfiguration
 
 -- | Information to show about transformations during compilation.
 --

--- a/clash-lib/src/Clash/Netlist/Types.hs-boot
+++ b/clash-lib/src/Clash/Netlist/Types.hs-boot
@@ -1,13 +1,15 @@
 {-|
-  Copyright   :  (C) 2018, Google Inc
+  Copyright   :  (C) 2018, Google Inc,
+                     2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE RoleAnnotations #-}
 
 module Clash.Netlist.Types where
 
+import Control.DeepSeq (NFData)
 import Control.Lens (Lens')
 import Data.Hashable
 
@@ -19,6 +21,9 @@ data Declaration
 data Component
 data Expr
 data BlackBox
+data TopEntityT
+
+instance NFData BlackBox
 
 class Monad m => IdentifierSetMonad m where
   identifierSetM :: (IdentifierSet -> IdentifierSet) -> m IdentifierSet
@@ -32,3 +37,4 @@ data PreserveCase = PreserveCase | ToLower
 instance Hashable PreserveCase
 instance Eq PreserveCase
 instance Show PreserveCase
+instance NFData PreserveCase

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -66,7 +66,7 @@ import           Clash.Core.VarEnv
    mkVarEnv, mkVarSet, notElemVarEnv, notElemVarSet, nullVarEnv, unionVarEnv)
 import           Clash.Debug                      (traceIf)
 import           Clash.Driver.Types
-  (BindingMap, Binding(..), ClashOpts (..), DebugOpts(..), ClashEnv(..))
+  (BindingMap, Binding(..), DebugOpts(..), ClashEnv(..))
 import           Clash.Netlist.Types
   (HWMap, FilteredHWType(..))
 import           Clash.Netlist.Util

--- a/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2018, Google Inc.,
-                    2021     , QBayLogic B.V.
+                    2021-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -67,10 +67,10 @@ import Clash.Netlist.BlackBox.Util (getUsedArguments)
 import Clash.Netlist.Util (splitNormalized)
 import Clash.Normalize.Primitives (removedArg)
 import Clash.Normalize.Transformations.Reduce (reduceBinders)
-import Clash.Normalize.Types (NormRewrite, NormalizeSession, primitives)
+import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Primitives.Types (Primitive(..), UsedArguments(..))
 import Clash.Rewrite.Types
-  (TransformContext(..), bindings, curFun, extra, tcCache, workFreeBinders)
+  (TransformContext(..), bindings, curFun, tcCache, workFreeBinders, primitives)
 import Clash.Rewrite.Util
   (changed, isFromInt, isUntranslatable, mkTmBinderFor, removeUnusedBinders, setChanged)
 import Clash.Rewrite.WorkFree
@@ -93,7 +93,7 @@ deadCode _ e = return e
 
 removeUnusedExpr :: HasCallStack => NormRewrite
 removeUnusedExpr _ e@(collectArgsTicks -> (p@(Prim pInfo),args,ticks)) = do
-  bbM <- HashMap.lookup (primName pInfo) <$> Lens.use (extra.primitives)
+  bbM <- HashMap.lookup (primName pInfo) <$> Lens.view primitives
   let
     usedArgs0 =
       case Monad.join (extractPrim <$> bbM) of

--- a/clash-lib/src/Clash/Normalize/Transformations/MultiPrim.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/MultiPrim.hs
@@ -2,8 +2,9 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2018, Google Inc.
+                    2022     , QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Transformations on primitives with multiple results.
 -}
@@ -30,9 +31,9 @@ import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (Type(..), mkPolyFunTy, splitFunForallTy)
 import Clash.Core.Util (listToLets)
 import Clash.Core.Var (mkLocalId)
-import Clash.Normalize.Types (NormRewrite, primitives)
+import Clash.Normalize.Types (NormRewrite)
 import Clash.Primitives.Types (Primitive(..))
-import Clash.Rewrite.Types (extra, tcCache)
+import Clash.Rewrite.Types (tcCache, primitives)
 import Clash.Rewrite.Util (changed)
 
 -- Note [MultiResult type]
@@ -76,7 +77,7 @@ import Clash.Rewrite.Util (changed)
 setupMultiResultPrim :: HasCallStack => NormRewrite
 setupMultiResultPrim _ctx e@(Prim pInfo@PrimInfo{primMultiResult=SingleResult}) = do
   tcm <- Lens.view tcCache
-  prim <- Lens.use (extra . primitives . Lens.at (primName pInfo))
+  prim <- Lens.view (primitives . Lens.at (primName pInfo))
 
   case prim >>= extractPrim of
     Just (BlackBoxHaskell{multiResult=True}) ->

--- a/clash-lib/src/Clash/Normalize/Transformations/Reduce.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Reduce.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2018, Google Inc.,
-                    2021     , QBayLogic B.V.
+                    2021-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -37,9 +37,9 @@ import Clash.Core.Type (TypeView(..), mkTyConApp, tyView)
 import Clash.Core.Util (mkVec, shouldSplit, tyNatSize)
 import Clash.Normalize.PrimitiveReductions
 import Clash.Normalize.Primitives (removedArg)
-import Clash.Normalize.Types (NormRewrite, NormalizeSession, normalizeUltra)
+import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Normalize.Util (shouldReduce)
-import Clash.Rewrite.Types (TransformContext(..), extra, tcCache)
+import Clash.Rewrite.Types (TransformContext(..), tcCache, normalizeUltra)
 import Clash.Rewrite.Util (changed, isUntranslatableType, setChanged, whnfRW)
 import Clash.Unique (lookupUniqMap)
 
@@ -148,7 +148,7 @@ reduceConst _ e = return e
 reduceNonRepPrim :: HasCallStack => NormRewrite
 reduceNonRepPrim c@(TransformContext is0 ctx) e@(App _ _) | (Prim p, args, ticks) <- collectArgsTicks e = do
   tcm <- Lens.view tcCache
-  ultra <- Lens.use (extra.normalizeUltra)
+  ultra <- Lens.view normalizeUltra
   let eTy = inferCoreTypeOf tcm e
   case tyView eTy of
     (TyConApp vecTcNm@(nameOcc -> "Clash.Sized.Vector.Vec")

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2018, Google Inc.,
-                    2021     , QBayLogic B.V.
+                    2021-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -86,14 +86,13 @@ import Clash.Netlist.Util (representableType)
 import Clash.Rewrite.Combinators (topdownR)
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, censor, curFun, customReprs, extra, tcCache
-  , typeTranslator, workFreeBinders, debugOpts, topEntities)
+  , typeTranslator, workFreeBinders, debugOpts, topEntities, specializationLimit)
 import Clash.Rewrite.Util
   ( mkBinderFor, mkDerivedName, mkFunction, mkTmBinderFor, setChanged, changed
   , normalizeTermTypes, normalizeId)
 import Clash.Rewrite.WorkFree (isWorkFree)
 import Clash.Normalize.Types
-  ( NormRewrite, NormalizeSession, specialisationCache, specialisationHistory
-  , specialisationLimit)
+  ( NormRewrite, NormalizeSession, specialisationCache, specialisationHistory)
 import Clash.Normalize.Util
   (constantSpecInfo, csrFoundConstant, csrNewBindings, csrNewTerm)
 import Clash.Unique
@@ -404,7 +403,7 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
         Just (Binding _ sp inl _ bodyTm _) -> do
           -- Determine if we see a sequence of specializations on a growing argument
           specHistM <- lookupUniqMap f <$> Lens.use (extra.specialisationHistory)
-          specLim   <- Lens.use (extra . specialisationLimit)
+          specLim   <- Lens.view specializationLimit
           if maybe False (> specLim) specHistM
             then throw (ClashException
                         sp

--- a/clash-lib/src/Clash/Normalize/Transformations/XOptimize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/XOptimize.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2018, Google Inc.,
-                    2021     , QBayLogic B.V.
+                    2021-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -36,9 +36,10 @@ import Clash.Core.Var (Id)
 import Clash.Core.VarEnv (InScopeSet)
 import Clash.Netlist.BlackBox.Types (Element(Err))
 import Clash.Netlist.Types (BlackBox(..))
-import Clash.Normalize.Types (NormRewrite, NormalizeSession, primitives)
+import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Primitives.Types (Primitive(..))
-import Clash.Rewrite.Types (TransformContext(..), aggressiveXOpt, extra, tcCache)
+import Clash.Rewrite.Types
+  (TransformContext(..), aggressiveXOpt, tcCache, primitives)
 import Clash.Rewrite.Util (changed)
 import Clash.Util (MonadUnique, curLoc)
 
@@ -143,7 +144,7 @@ mkFieldSelector is0 subj dc tvs fieldTys nm index = do
 --
 isPrimError :: Term -> NormalizeSession Bool
 isPrimError (collectArgs -> (Prim pInfo, _)) = do
-  prim <- Lens.use (extra . primitives . Lens.at (primName pInfo))
+  prim <- Lens.view (primitives . Lens.at (primName pInfo))
 
   case prim >>= extractPrim of
     Just p  -> return (isErr p)

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -1,8 +1,9 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
                          2017, Google Inc.
+                         2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
-  Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
   Types used in Normalize modules
 -}
@@ -11,7 +12,7 @@
 
 module Clash.Normalize.Types where
 
-import Control.Lens               (makeLenses)
+import qualified Control.Lens as Lens
 import Control.Monad.State.Strict (State)
 import Data.Map                   (Map)
 import Data.Set                   (Set)
@@ -22,7 +23,6 @@ import Clash.Core.Type        (Type)
 import Clash.Core.Var         (Id)
 import Clash.Core.VarEnv      (VarEnv)
 import Clash.Driver.Types     (BindingMap)
-import Clash.Primitives.Types (CompiledPrimMap)
 import Clash.Rewrite.Types    (Rewrite, RewriteMonad)
 
 -- | State of the 'NormalizeMonad'
@@ -38,23 +38,12 @@ data NormalizeState
   -- * Elem: (name of specialized function,type of specialized function)
   , _specialisationHistory :: VarEnv Int
   -- ^ Cache of how many times a function was specialized
-  , _specialisationLimit :: !Int
-  -- ^ Number of time a function 'f' can be specialized
   , _inlineHistory   :: VarEnv (VarEnv Int)
   -- ^ Cache of function where inlining took place:
   --
   -- * Key: function where inlining took place
   --
   -- * Elem: (functions which were inlined, number of times inlined)
-  , _inlineLimit     :: !Int
-  -- ^ Number of times a function 'f' can be inlined in a function 'g'
-  , _inlineFunctionLimit :: !Word
-  -- ^ Size of a function below which it is always inlined if it is not
-  -- recursive
-  , _inlineConstantLimit :: !Word
-  -- ^ Size of a constant below which it is always inlined; 0 = no limit
-  , _primitives :: CompiledPrimMap
-  -- ^ Primitive Definitions
   , _primitiveArgs :: Map Text (Set Int)
   -- ^ Cache for looking up constantness of blackbox arguments
   , _recursiveComponents :: VarEnv Bool
@@ -62,18 +51,9 @@ data NormalizeState
   --
   -- NB: there are only no mutually-recursive component, only self-recursive
   -- ones.
-  , _newInlineStrategy :: Bool
-  -- ^ Flattening stage should use the new (no-)inlining strategy
-  , _normalizeUltra :: Bool
-  -- ^ High-effort normalization session, trading performance improvement for
-  -- potentially much longer compile times. Follows the 'Clash.Driver.opt_ultra'
-  -- flag.
-  , _inlineWFCacheLimit :: !Word
-  -- ^ At what size do we cache normalized work-free top-level binders.
   }
 
-makeLenses ''NormalizeState
-
+Lens.makeLenses ''NormalizeState
 
 -- | State monad that stores specialisation and inlining information
 type NormalizeMonad = State NormalizeState
@@ -95,4 +75,4 @@ data TermClassification
   }
   deriving Show
 
-makeLenses ''TermClassification
+Lens.makeLenses ''TermClassification

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -1,6 +1,6 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
-                    2021     , QBayLogic B.V.
+                    2021-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -83,7 +83,7 @@ import           Clash.Normalize.Types
 import           Clash.Primitives.Util   (constantArgs)
 import           Clash.Rewrite.Types
   (RewriteMonad, TransformContext(..), bindings, curFun, debugOpts, extra,
-   tcCache)
+   tcCache, primitives)
 import           Clash.Rewrite.Util
   (runRewrite, mkTmBinderFor, mkDerivedName)
 import           Clash.Unique
@@ -106,7 +106,7 @@ isConstantArg nm i = do
   case Map.lookup nm argMap of
     Nothing -> do
       -- Constant args not yet calculated, or primitive does not exist
-      prims <- Lens.use (extra.primitives)
+      prims <- Lens.view primitives
       case extractPrim =<< HashMapS.lookup nm prims of
         Nothing ->
           -- Primitive does not exist:

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016     , Myrtle Software Ltd,
                     2017     , Google Inc.,
-                    2021     , QBayLogic B.V.
+                    2021-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -81,7 +81,7 @@ import           Clash.Core.VarEnv
 import           Clash.Debug
 import           Clash.Driver.Types
   (TransformationInfo(..), DebugOpts(..), BindingMap, Binding(..), IsPrim(..),
-  hasDebugInfo, isDebugging)
+  ClashEnv(..), ClashOpts(..), hasDebugInfo, isDebugging)
 import           Clash.Netlist.Util          (representableType)
 import           Clash.Pretty                (clashPretty, showDoc)
 import           Clash.Rewrite.Types
@@ -279,9 +279,9 @@ runRewriteSession :: RewriteEnv
                   -> RewriteMonad extra a
                   -> a
 runRewriteSession r s m =
-  traceIf (dbg_countTransformations (_debugOpts r))
+  traceIf (dbg_countTransformations (opt_debug (envOpts (_clashEnv r))))
     ("Clash: Transformations:\n" ++ Text.unpack (showCounters (s' ^. transformCounters))) $
-    traceIf (None < dbg_transformationInfo (_debugOpts r))
+    traceIf (None < dbg_transformationInfo (opt_debug (envOpts (_clashEnv r))))
       ("Clash: Applied " ++ show (s' ^. transformCounter) ++ " transformations")
       a
   where

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright  :  (C) 2020 QBayLogic B.V.
+  Copyright  :  (C) 2020,2022 QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -22,7 +22,7 @@ import qualified Clash.Core.Literal as C
 import qualified Clash.Core.Type as C
 import qualified Clash.Core.Var as C
 import Clash.Core.VarEnv (InScopeSet, emptyVarSet, emptyVarEnv, emptyInScopeSet)
-import Clash.Driver.Types (debugSilent)
+import Clash.Driver.Types (ClashEnv(..), ClashOpts(..), defClashOpts, debugSilent)
 import Clash.Rewrite.Types
 import Clash.Rewrite.Util (runRewrite)
 import Clash.Normalize.Types
@@ -60,16 +60,17 @@ lookupTM u tm = case HashMap.lookup u tm of
 
 instance Default RewriteEnv where
   def = RewriteEnv
-    { _debugOpts=debugSilent
-    , _aggressiveXOpt=False
+    { _clashEnv = ClashEnv
+        { envOpts = defClashOpts { opt_debug = debugSilent }
+        , envTyConMap = emptyUniqMap
+        , envTupleTyCons = IntMap.empty
+        , envPrimitives = HashMap.empty
+        , envCustomReprs = buildCustomReprs []
+        }
     , _typeTranslator=error "_typeTranslator: NYI"
-    , _tcCache=emptyUniqMap
-    , _tupleTcCache=IntMap.empty
     , _peEvaluator=error "_peEvaluator: NYI"
     , _evaluator=error "_evaluator: NYI"
     , _topEntities=emptyVarSet
-    , _customReprs=buildCustomReprs []
-    , _fuelLimit=10
     }
 
 instance Default extra => Default (RewriteState extra) where
@@ -90,17 +91,9 @@ instance Default NormalizeState where
     { _normalized=emptyVarEnv
     , _specialisationCache=Map.empty
     , _specialisationHistory=emptyVarEnv
-    , _specialisationLimit=20
     , _inlineHistory=emptyVarEnv
-    , _inlineLimit=20
-    , _inlineFunctionLimit=15
-    , _inlineConstantLimit=0
-    , _primitives=HashMap.empty
     , _primitiveArgs=Map.empty
     , _recursiveComponents=emptyVarEnv
-    , _newInlineStrategy=True
-    , _normalizeUltra=False
-    , _inlineWFCacheLimit=10
     }
 
 instance Default InScopeSet where

--- a/tests/shouldwork/Issues/T1568.hs
+++ b/tests/shouldwork/Issues/T1568.hs
@@ -41,7 +41,8 @@ mainCommon
   => SBuildTarget target
   -> IO ()
 mainCommon hdl = do
-  (bm, _, _) <- runToCoreStage hdl id testPath
+  (_, design, _) <- runToCoreStage hdl id testPath
+  let bm = designBindings design
 
   checkTE "T1568.f" bm
   checkTE "T1568.topEntity" bm

--- a/tests/src/Test/Tasty/Clash/CoreTest.hs
+++ b/tests/src/Test/Tasty/Clash/CoreTest.hs
@@ -1,9 +1,8 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-
-#include "MachDeps.h"
 
 module Test.Tasty.Clash.CoreTest
   ( TargetToState
@@ -26,8 +25,6 @@ import Clash.Core.TyCon
 import Clash.Core.Var
 import Clash.Core.VarEnv
 import Clash.Driver.Types
-import Clash.Netlist.BlackBox.Types (HdlSyn(Other))
-import Clash.Netlist.Types (PreserveCase(..))
 
 import Clash.GHC.GenerateBindings
 import Clash.GHC.PartialEval
@@ -45,12 +42,6 @@ mkClashOpts = defClashOpts
   , opt_errorExtra   = True
   }
 
-mkBackend
-  :: (Backend (TargetToState target))
-  => SBuildTarget target
-  -> TargetToState target
-mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True PreserveCase Nothing (AggressiveXOptBB False) (RenderEnums True)
-
 -- Run clash as far as having access to core for all bindings. This is used
 -- to test operations on core, such as transformations and evaluation.
 --
@@ -59,20 +50,21 @@ mkBackend _ = initBackend WORD_SIZE_IN_BITS Other True PreserveCase Nothing (Agg
 -- problems standing in the way of this however.
 --
 runToCoreStage
-  :: (Backend (TargetToState target))
+  :: forall target
+   . (Backend (TargetToState target))
   => SBuildTarget target
   -> (ClashOpts -> ClashOpts)
   -> FilePath
   -> IO (ClashEnv, ClashDesign, Supply)
-runToCoreStage target f src = do
+runToCoreStage _target f src = do
   ids <- newSupply
   pds <- primDirs backend
   (env, design) <- generateBindings opts (return ()) pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
 
   return (env, design, ids)
  where
-  backend = mkBackend target
   opts = f mkClashOpts
+  backend = initBackend @(TargetToState target) opts
 
 findBinding
   :: OccName

--- a/tests/src/Test/Tasty/Clash/CoreTest.hs
+++ b/tests/src/Test/Tasty/Clash/CoreTest.hs
@@ -32,12 +32,6 @@ import Clash.Netlist.Types (PreserveCase(..))
 import Clash.GHC.GenerateBindings
 import Clash.GHC.PartialEval
 
-#if MIN_VERSION_ghc(9,0,0)
-import           GHC.Utils.Misc
-#else
-import           Util
-#endif
-
 import Test.Tasty.Clash
 
 type family TargetToState (target :: HDL) where
@@ -69,14 +63,13 @@ runToCoreStage
   => SBuildTarget target
   -> (ClashOpts -> ClashOpts)
   -> FilePath
-  -> IO (BindingMap, TyConMap, Supply)
+  -> IO (ClashEnv, ClashDesign, Supply)
 runToCoreStage target f src = do
   ids <- newSupply
   pds <- primDirs backend
-  (bm, tcm, _, _, _, _, _) <- generateBindings
-    (return ()) Auto pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
+  (env, design) <- generateBindings opts (return ()) pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
 
-  return (bm, tcm, ids)
+  return (env, design, ids)
  where
   backend = mkBackend target
   opts = f mkClashOpts

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -44,12 +44,6 @@ import           Clash.Netlist
 import           Clash.Netlist.BlackBox.Types (HdlSyn(Other))
 import           Clash.Netlist.Types hiding (backend, hdlDir)
 
-#if MIN_VERSION_ghc(9,0,0)
-import           GHC.Utils.Misc
-#else
-import           Util
-#endif
-
 import qualified Control.Concurrent.Supply as Supply
 import           Control.DeepSeq (force)
 import           Control.Monad.State.Strict (State)
@@ -94,34 +88,31 @@ runToNetlistStage
   -> IO [(ComponentMeta, Component)]
 runToNetlistStage target f src = do
   pds <- primDirs backend
-  (bm, tcm, tupTcm, tes, pm, rs, _)
-    <- generateBindings (return ()) Auto pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
+  (env, design) <- generateBindings opts (return ()) pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
 
-  let (compNames, initIs) = genTopNames opts hdl tes
-      teNames = fmap topId tes
-      te      = topId (P.head tes)
-      reprs   = buildCustomReprs rs
-      tes2    = mkVarEnv (P.zip (P.map topId tes) tes)
+  let (compNames, initIs) = genTopNames opts hdl (designEntities design)
+      teNames = fmap topId (designEntities design)
+      te      = topId (P.head (designEntities design))
+      tes2    = mkVarEnv (P.zip (P.map topId (designEntities design)) (designEntities design))
 
   supplyN <- Supply.newSupply
 
-  let transformedBindings = normalizeEntity reprs bm pm tcm tupTcm typeTrans
+  let transformedBindings = normalizeEntity env (designBindings design) typeTrans
           ghcEvaluator
           evaluator
-          teNames opts supplyN te
+          teNames supplyN te
 
   fmap (\(_,x,_) -> force (P.map snd (OMap.assocs x))) $
-    netlistFrom (transformedBindings, tcm, tes2, compNames, pm, reprs, te, initIs)
+    netlistFrom (env, transformedBindings, tes2, compNames, te, initIs)
  where
   backend = mkBackend target
   opts = f mkClashOpts
   hdl = buildTargetToHdl target
 
-  netlistFrom (bm, tcm, tes, compNames, pm, rs, te, seen) =
-    genNetlist False opts rs bm tes compNames pm tcm typeTrans
-      iw ite (SomeBackend hdlSt) seen hdlDir Nothing te
+  netlistFrom (env, bm, tes, compNames, te, seen) =
+    genNetlist env False bm tes compNames typeTrans
+      ite (SomeBackend hdlSt) seen hdlDir Nothing te
    where
-    iw      = opt_intWidth opts
     teS     = Text.unpack . nameOcc $ varName te
     modN    = takeWhile (/= '.') teS
     hdlSt   = setModName (Text.pack modN) backend


### PR DESCRIPTION
A first move towards the goals of #1932. This PR introduces the `ClashEnv` and `ClashDesign` types, and makes some basic changes to tidy up the public interfaces of functions like `generateBindings`, `generateHDL` and `initBackend`. See the individual commit messages for more information.

This PR should be prioritised for 1.6, merging post-release will _ruin_ backports for the 1.6 series of releases, which I very much want to avoid. Further work to #1932 will be delayed until 1.8 is planned (unless it can be implemented without making backports more difficult).

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
