### PR TITLE
Black Boxes for `toEnum` / `fromEnum`

### DIFF
--- a/changelog/2022-01-31T12_23_39+01_00_spurious_integer_warnings.md
+++ b/changelog/2022-01-31T12_23_39+01_00_spurious_integer_warnings.md
@@ -1,0 +1,1 @@
+CHANGED: toEnum/fromEnum on sized types is now less eager to report warnings about integer functions being used [#2046](https://github.com/clash-lang/clash-compiler/issues/2046).

--- a/changelog/2022-01-31T16_53_31+01_00_werror_clash.md
+++ b/changelog/2022-01-31T16_53_31+01_00_werror_clash.md
@@ -1,0 +1,1 @@
+CHANGED: Clash now respects the -Werror option from GHC

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -53,6 +53,7 @@ import Packages         ( pprPackages, pprPackagesSimple )
 import DriverPhases
 import BasicTypes       ( failed )
 import DynFlags hiding (WarnReason(..))
+import EnumSet as EnumSet
 import ErrUtils
 import FastString
 import Outputable
@@ -86,7 +87,7 @@ import Data.Maybe
 import           Paths_clash_ghc
 import           Clash.GHCi.UI (makeHDL)
 import           Exception (gcatch)
-import           Data.IORef (IORef, newIORef, readIORef)
+import           Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import qualified Data.Version (showVersion)
 
 import           Clash.Backend (Backend)
@@ -234,6 +235,10 @@ main' postLoadMode dflags0 args flagWarnings startAction clashOpts = do
         -- Leftover ones are presumably files
   (dflags3, fileish_args, dynamicFlagWarnings) <-
       GHC.parseDynamicFlags dflags2 args
+
+  -- Propagate -Werror to Clash
+  liftIO . modifyIORef' clashOpts $ \opts ->
+    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
 
   let dflags4 = case lang of
                 HscInterpreted | not (gopt Opt_ExternalInterpreter dflags3) ->

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -50,6 +50,7 @@ import Packages         ( pprPackages, pprPackagesSimple )
 import DriverPhases
 import BasicTypes       ( failed )
 import DynFlags hiding (WarnReason(..))
+import EnumSet as EnumSet
 import ErrUtils
 import FastString
 import Outputable
@@ -83,7 +84,7 @@ import Data.Maybe
 import           Paths_clash_ghc
 import           Clash.GHCi.UI (makeHDL)
 import           Exception (gcatch)
-import           Data.IORef (IORef, newIORef, readIORef)
+import           Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import qualified Data.Version (showVersion)
 
 import           Clash.Backend (Backend)
@@ -229,6 +230,10 @@ main' postLoadMode dflags0 args flagWarnings startAction clashOpts = do
         -- Leftover ones are presumably files
   (dflags3, fileish_args, dynamicFlagWarnings) <-
       GHC.parseDynamicFlags dflags2 args
+
+  -- Propagate -Werror to Clash
+  liftIO . modifyIORef' clashOpts $ \opts ->
+    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
 
   let dflags4 = case lang of
                 HscInterpreted | not (gopt Opt_ExternalInterpreter dflags3) ->

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_BitVector.primitives
@@ -92,6 +92,14 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.toEnum##"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum## :: Int -> Bit"
+    , "template"  : "~VAR[i][0][0] ? 1'b1 : 1'b0"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.and##"
     , "kind"      : "Expression"
     , "type"      : "and## :: Bit -> Bit -> Bit"
@@ -166,6 +174,13 @@
     , "workInfo"         : "Never"
     , "templateFunction" : "Clash.Primitives.Sized.ToInteger.bvToIntegerVerilog"
     }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.fromEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "fromEnum# :: KnownNat n => BitVector n -> Int"
+    , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[bv][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[bv][1]})~FI~ELSE~SIZE[~TYPO]'sd0~FI" }
   }
 , { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.size#"
@@ -285,6 +300,14 @@
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Integer -> BitVector n"
     , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[2]]]~THEN$unsigned(~VAR[i][2][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[2]]) {1'b0}},~VAR[i][2]})~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.toEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum# :: KnownNat n => Int -> BitVector n"
+    , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Index.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Index.primitives
@@ -65,6 +65,22 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Index.fromEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "fromEnum# :: KnownNat n => Index n -> Int"
+    , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Index.toEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum# :: KnownNat n => Int -> Index n"
+    , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.+#"
     , "kind"      : "Expression"
     , "type"      : "(+#) :: KnownNat n => Index n -> Index n -> Index n"

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Signed.primitives
@@ -47,6 +47,14 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Signed.fromEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "fromEnum# :: KnownNat n => Signed n -> Int"
+    , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$signed(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.size#"
     , "workInfo"  : "Constant"
     , "kind"      : "Expression"
@@ -114,6 +122,14 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Signed (n :: Nat)"
+    , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$signed(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Signed.toEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum# :: KnownNat n => Int -> Signed n"
     , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$signed(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$signed({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
     }
   }

--- a/clash-lib/prims/commonverilog/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/commonverilog/Clash_Sized_Internal_Unsigned.primitives
@@ -47,6 +47,14 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.fromEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "fromEnum# :: KnownNat n => Unsigned n -> Int"
+    , "template"  : "~IF~SIZE[~TYP[1]]~THEN~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI~ELSE~SIZE[~TYPO]'sd0~FI"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.size#"
     , "workInfo"  : "Constant"
     , "kind"      : "Expression"
@@ -105,6 +113,14 @@
     , "workInfo"  : "Never"
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Unsigned n"
+    , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.toEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum# :: KnownNat n => Int -> Unsigned n"
     , "template"  : "~IF~CMPLE[~SIZE[~TYPO]][~SIZE[~TYP[1]]]~THEN$unsigned(~VAR[i][1][0+:~SIZE[~TYPO]])~ELSE$unsigned({{(~SIZE[~TYPO]-~SIZE[~TYP[1]]) {1'b0}},~VAR[i][1]})~FI"
     }
   }

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives
@@ -87,6 +87,14 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.toEnum##"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum## :: Int -> Bit"
+    , "template"  : "~ARG[0](0)"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.BitVector.and##"
     , "kind"      : "Expression"
     , "type"      : "and## :: Bit -> Bit -> Bit"
@@ -455,6 +463,22 @@ end process;
     , "kind"      : "Expression"
     , "type"      : "fromInteger# :: KnownNat n => Integer -> Integer -> BitVector n"
     , "template"  : "std_logic_vector(resize(unsigned(std_logic_vector(~ARG[2])),~SIZE[~TYPO]))"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.toEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum# :: KnownNat n => Int -> BitVector n"
+    , "template"  : "std_logic_vector(resize(unsigned(std_logic_vector(~ARG[1])),~SIZE[~TYPO]))"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.BitVector.fromEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "fromEnum# :: KnownNat n => BitVector n -> Int"
+    , "template"  : "~IF~SIZE[~TYP[1]]~THENsigned(std_logic_vector(resize(unsigned(~ARG[1]),~SIZE[~TYPO])))~ELSEto_signed(0,~SIZE[~TYPO])~FI"
     }
   }
 , { "BlackBox" :

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.primitives
@@ -65,6 +65,22 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Index.toEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum# :: KnownNat n => Int -> Index n"
+    , "template"  : "resize(unsigned(std_logic_vector(~ARG[1])),~SIZE[~TYPO])"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Index.fromEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "fromEnum# :: KnownNat n => Index n -> Int"
+    , "template"  : "~IF~SIZE[~TYP[1]]~THENsigned(std_logic_vector(resize(~ARG[1],~SIZE[~TYPO])))~ELSEto_signed(0,~SIZE[~TYPO])~FI"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Index.+#"
     , "kind"      : "Expression"
     , "type"      : "(+#) :: KnownNat n => Index n -> Index n -> Index n"

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives
@@ -113,6 +113,22 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Signed.toEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum# :: KnownNat n => Int -> Signed n"
+    , "template"  : "resize(signed(std_logic_vector(~ARG[1])),~SIZE[~TYPO])"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Signed.fromEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "fromEnum# :: KnownNat n => Signed n -> Int"
+    , "template"  : "~IF~SIZE[~TYP[1]]~THENresize(~ARG[1],~SIZE[~TYPO])~ELSEto_signed(0,~SIZE[~TYPO])~FI"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Signed.plus#"
     , "kind"      : "Expression"
     , "type"      : "plus# :: Signed m -> Signed n -> Signed (1 + Max m n)"

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives
@@ -103,6 +103,22 @@
     }
   }
 , { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.toEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "toEnum# :: KnownNat n => Int -> Unsigned n"
+    , "template"  : "resize(unsigned(std_logic_vector(~ARG[1])),~SIZE[~TYPO])"
+    }
+  }
+, { "BlackBox" :
+    { "name"      : "Clash.Sized.Internal.Unsigned.fromEnum#"
+    , "workInfo"  : "Never"
+    , "kind"      : "Expression"
+    , "type"      : "fromEnum# :: KnownNat n => Unsigned n -> Int"
+    , "template"  : "~IF~SIZE[~TYP[1]]~THENsigned(std_logic_vector(resize(~ARG[1],~SIZE[~TYPO])))~ELSEto_signed(0,~SIZE[~TYPO])~FI"
+    }
+  }
+, { "BlackBox" :
     { "name"      : "Clash.Sized.Internal.Unsigned.plus#"
     , "kind"      : "Expression"
     , "type"      : "plus# :: Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -288,7 +288,11 @@ debugAll = debugApplied { dbg_transformationInfo = TryTerm }
 
 -- | Options passed to Clash compiler
 data ClashOpts = ClashOpts
-  { opt_inlineLimit :: Int
+  { opt_werror :: Bool
+  -- ^ Are warnings treated as errors.
+  --
+  -- Command line flag: -Werror
+  , opt_inlineLimit :: Int
   -- ^ Change the number of times a function f can undergo inlining inside
   -- some other function g. This prevents the size of g growing dramatically.
   --
@@ -392,6 +396,7 @@ data ClashOpts = ClashOpts
 
 instance NFData ClashOpts where
   rnf o =
+    opt_werror o `deepseq`
     opt_inlineLimit o `deepseq`
     opt_specLimit o `deepseq`
     opt_inlineFunctionLimit o `deepseq`
@@ -422,6 +427,7 @@ instance NFData ClashOpts where
 
 instance Eq ClashOpts where
   s0 == s1 =
+    opt_werror s0 == opt_werror s1 &&
     opt_inlineLimit s0 == opt_inlineLimit s1 &&
     opt_specLimit s0 == opt_specLimit s1 &&
     opt_inlineFunctionLimit s0 == opt_inlineFunctionLimit s1 &&
@@ -459,6 +465,7 @@ instance Eq ClashOpts where
 instance Hashable ClashOpts where
   hashWithSalt s ClashOpts {..} =
     s `hashWithSalt`
+    opt_werror `hashWithSalt`
     opt_inlineLimit `hashWithSalt`
     opt_specLimit `hashWithSalt`
     opt_inlineFunctionLimit `hashWithSalt`
@@ -495,7 +502,8 @@ instance Hashable ClashOpts where
 defClashOpts :: ClashOpts
 defClashOpts
   = ClashOpts
-  { opt_inlineLimit         = 20
+  { opt_werror              = False
+  , opt_inlineLimit         = 20
   , opt_specLimit           = 20
   , opt_inlineFunctionLimit = 15
   , opt_inlineConstantLimit = 0

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2019, Myrtle Software Ltd,
-                  2021     , QBayLogic B.V.
+                  2021-2022, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -42,6 +42,9 @@ module Clash.Sized.Internal.Index
   , ge#
   , gt#
   , le#
+    -- ** Enum
+  , toEnum#
+  , fromEnum#
     -- ** Enum (not synthesizable)
   , enumFrom#
   , enumFromThen#
@@ -98,6 +101,7 @@ import Test.QuickCheck.Arbitrary  (Arbitrary (..), CoArbitrary (..),
                                    arbitraryBoundedIntegral,
                                    coarbitraryIntegral, shrinkIntegral)
 
+import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Class.BitPack.Internal (BitPack (..), packXWith)
 import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
                                    SaturationMode (..))
@@ -222,12 +226,22 @@ le# (I n) (I m) = n <= m
 instance KnownNat n => Enum (Index n) where
   succ           = (+# fromInteger# 1)
   pred           = (-# fromInteger# 1)
-  toEnum         = fromInteger# . toInteger
-  fromEnum       = fromEnum . toInteger#
+  toEnum         = toEnum#
+  fromEnum       = fromEnum#
   enumFrom       = enumFrom#
   enumFromThen   = enumFromThen#
   enumFromTo     = enumFromTo#
   enumFromThenTo = enumFromThenTo#
+
+toEnum# :: forall n. KnownNat n => Int -> Index n
+toEnum# = fromInteger# . toInteger
+{-# NOINLINE toEnum# #-}
+{-# ANN toEnum# hasBlackBox #-}
+
+fromEnum# :: forall n. KnownNat n => Index n -> Int
+fromEnum# = fromEnum . toInteger#
+{-# NOINLINE fromEnum# #-}
+{-# ANN fromEnum# hasBlackBox #-}
 
 enumFrom# :: forall n. KnownNat n => Index n -> [Index n]
 enumFrom# x = [x .. maxBound]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -551,6 +551,15 @@ runClashTest = defaultMain $ clashTestRoot
           }
         , outputTest "T1996" def{hdlTargets=[VHDL]}
         , runTest "T2040" def{hdlTargets=[VHDL],clashFlags=["-fclash-compile-ultra"]}
+        -- TODO I wanted to call this T2046A since there are multiple tests
+        -- for T2046. However, doing so completely breaks HDL loading because
+        -- it completely ignores the BuildSpecific...
+        , runTest "T2046" def
+            { hdlSim=False
+            , clashFlags=["-Werror"]
+            , buildTargets=BuildSpecific["top_bit", "top_bitvector", "top_index", "top_signed", "top_unsigned"]
+            }
+        , runTest "T2046B" def{clashFlags=["-Werror"]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2046.hs
+++ b/tests/shouldwork/Issues/T2046.hs
@@ -1,0 +1,55 @@
+module T2046 where
+
+import Clash.Prelude
+import Data.Proxy
+
+topGeneric
+  :: forall ix n
+   . Enum ix
+  => KnownNat n
+  => Proxy ix
+  -> Vec n Int
+  -> Int
+  -> Int
+topGeneric Proxy x i =
+  x !! toEnum @ix i
+
+topBit
+  :: Vec 2 Int
+  -> Int
+  -> Int
+topBit = topGeneric (Proxy @Bit)
+{-# NOINLINE topBit #-}
+{-# ANN topBit (defSyn "top_bit") #-}
+
+topBitVector
+  :: Vec 5 Int
+  -> Int
+  -> Int
+topBitVector = topGeneric (Proxy @(BitVector 3))
+{-# NOINLINE topBitVector #-}
+{-# ANN topBitVector (defSyn "top_bitvector") #-}
+
+topIndex
+  :: Vec 5 Int
+  -> Int
+  -> Int
+topIndex = topGeneric (Proxy @(Index 5))
+{-# NOINLINE topIndex #-}
+{-# ANN topIndex (defSyn "top_index") #-}
+
+topSigned
+  :: Vec 5 Int
+  -> Int
+  -> Int
+topSigned = topGeneric (Proxy @(Signed 4))
+{-# NOINLINE topSigned #-}
+{-# ANN topSigned (defSyn "top_signed") #-}
+
+topUnsigned
+  :: Vec 5 Int
+  -> Int
+  -> Int
+topUnsigned = topGeneric (Proxy @(Unsigned 3))
+{-# NOINLINE topUnsigned #-}
+{-# ANN topUnsigned (defSyn "top_unsigned") #-}

--- a/tests/shouldwork/Issues/T2046B.hs
+++ b/tests/shouldwork/Issues/T2046B.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE ViewPatterns #-}
+
+module T2046B where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+import T2046BType (T2046B)
+
+topEntity :: T2046B -> T2046B
+topEntity ((a, b), (c, d), (e, f), (g, h), i) =
+  ( (toEnum (fromEnum a), toEnum (fromEnum b))
+  , (toEnum (fromEnum c), toEnum (fromEnum d))
+  , (toEnum (fromEnum e), toEnum (fromEnum f))
+  , (toEnum (fromEnum g), toEnum (fromEnum h))
+  , toEnum (fromEnum i)
+  )
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+ where
+  testInput = stimuliGenerator clk rst
+    $(listToVecTH [( (0, 0), (0, 0), (0, 0), (0, 0), 0)
+                  , ((0, 1), (0, 1), (0, 1), (0, 1), 1) :: T2046B])
+
+  expectedOutput = outputVerifier' clk rst
+    $(listToVecTH [( (0, 0), (0, 0), (0, 0), (0, 0), 0)
+                   , ((0, 1), (0, 1), (0, 1), (0, 1), 1) :: T2046B])
+
+  done = expectedOutput (topEntity <$> testInput)
+  clk  = tbSystemClockGen (not <$> done)
+  rst  = systemResetGen

--- a/tests/shouldwork/Issues/T2046BType.hs
+++ b/tests/shouldwork/Issues/T2046BType.hs
@@ -1,0 +1,11 @@
+module T2046BType where
+
+import Clash.Prelude
+
+type T2046B =
+  ( (Index 1, Index 2)
+  , (Unsigned 1, Unsigned 2)
+  , (Signed 1, Signed 2)
+  , (BitVector 1, BitVector 2)
+  , Bit
+  )


### PR DESCRIPTION
This PR introduces black boxes for `toEnum` / `fromEnum` on the numeric types in `Clash.Sized.Internal`, suppressing the seemingly spurious integer black box warnings previously seen in #1918. As an added bonus, a commit is included which propagates the `-Werror` flag from GHC to Clash, allowing primitive warnings to be thrown as `ClashException` when desired.

Fixes #2046

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] Add a test based on `toEnum`, the current test uses `fromEnum` only

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
