### PR TITLE
Use `CACHE_FALLBACK_KEY` on GitLab CI

### DIFF
--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -3,6 +3,7 @@
   timeout: 2 hours
   stage: build
   variables:
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-$GHC_VERSION
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   retry:
@@ -11,7 +12,7 @@
       - runner_system_failure
       - stuck_or_timeout_failure
   cache:
-    key: cabal-store-$CI_JOB_NAME-$GHC_VERSION
+    key: $CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$GHC_VERSION
     when: always
     paths:
       - cache.tar.zst


### PR DESCRIPTION
We've been seeing a lot of dependency rebuilds, likely due to parallel
CI runs overwriting each other's cache. Using a branch-specific cache,
plus a fallback on master hopefully mitigates this.

I've also taken the opportunity to remove the `cabal-store` part of the
cache key, as it is used to cache more than just Cabal.
