### PR TITLE
Change RewriteMonad to use RWST from `transformers`

### DIFF
--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -44,15 +44,16 @@ benchFile idirs src =
   env (setupEnv idirs src) $
     \ ~(clashEnv, clashDesign, supplyN) -> do
       bench ("normalization of " ++ src)
-            (nf (normalizeEntity
-                   clashEnv
-                   (designBindings clashDesign)
-                   (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
-                   ghcEvaluator
-                   evaluator
-                   (fmap topId (designEntities clashDesign))
-                   supplyN)
-                   (topId (head (designEntities clashDesign))))
+            (nfIO
+              (normalizeEntity
+                 clashEnv
+                 (designBindings clashDesign)
+                 (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                 ghcEvaluator
+                 evaluator
+                 (fmap topId (designEntities clashDesign))
+                 supplyN
+                 (topId (head (designEntities clashDesign)))))
 
 setupEnv
   :: [FilePath]

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -60,7 +60,7 @@ runNormalisationStage idirs src = do
   (env, design) <- runInputStage idirs src
   let topEntityNames = fmap topId (designEntities design)
   let topEntity = head topEntityNames
-  let transformedBindings =
+  transformedBindings <-
         normalizeEntity env (designBindings design)
           (ghcTypeToHWType (opt_intWidth (opts idirs)))
           ghcEvaluator

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 import           Clash.Driver
-import           Clash.Driver.Types
+import           Clash.Driver.Types           (ClashEnv(..), ClashOpts(opt_intWidth))
 
 import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
@@ -43,7 +43,7 @@ benchFile idirs src = do
                    , envCustomReprs = reprs
                    }
 
-      res = normalizeEntity clashEnv bindingsMap
+  res <- normalizeEntity clashEnv bindingsMap
                    (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
                    ghcEvaluator
                    evaluator

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -440,8 +440,8 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
 
       -- 2. Normalize topEntity
       supplyN <- Supply.newSupply
-      let transformedBindings = normalizeEntity env bindingsMap typeTrans peEval
-                                eval topEntityNames supplyN topEntity
+      transformedBindings <- normalizeEntity env bindingsMap typeTrans peEval
+                               eval topEntityNames supplyN topEntity
 
       normTime <- transformedBindings `deepseq` Clock.getCurrentTime
       let prepNormDiff = reportTimeDiff normTime prevTime
@@ -1067,7 +1067,7 @@ normalizeEntity
   -- ^ Unique supply
   -> Id
   -- ^ root of the hierarchy
-  -> BindingMap
+  -> IO BindingMap
 normalizeEntity env bindingsMap typeTrans peEval eval topEntities supply tm = transformedBindings
   where
     doNorm = do norm <- normalize [tm]

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -112,7 +112,7 @@ runNormalization
   -- ^ topEntities
   -> NormalizeSession a
   -- ^ NormalizeSession to run
-  -> a
+  -> IO a
 runNormalization env supply globals typeTrans peEval eval rcsMap topEnts =
   runRewriteSession rwEnv rwState
   where

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -111,9 +111,10 @@ runSingleTransformation
   -- ^ Transformation to perform
   -> C.Term
   -- ^ Term to transform
-  -> C.Term
-runSingleTransformation rwEnv rwState is trans term = t
- where (t, _, _) = runR (runRewrite "" is trans term) rwEnv rwState
+  -> IO C.Term
+runSingleTransformation rwEnv rwState is trans term = do
+  (t, _, _) <- runR (runRewrite "" is trans term) rwEnv rwState
+  pure t
 
 -- | Run a single transformation with an empty environment and empty
 -- InScopeSet. See Default instances ^ to inspect the precise definition of
@@ -123,7 +124,7 @@ runSingleTransformation rwEnv rwState is trans term = t
 -- include a type translator, evaluator, current function, or global heap. Maps,
 -- like the primitive and tycon map, are also empty. If the transformation under
 -- test needs these definitions, you should add them manually.
-runSingleTransformationDef :: Default extra => Rewrite extra -> C.Term -> C.Term
+runSingleTransformationDef :: Default extra => Rewrite extra -> C.Term -> IO C.Term
 runSingleTransformationDef = runSingleTransformation def def def
 
 

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -79,11 +79,12 @@ runToNetlistStage target f src = do
 
   supplyN <- Supply.newSupply
 
-  let transformedBindings = normalizeEntity env (designBindings design)
-          (ghcTypeToHWType (opt_intWidth opts))
-          ghcEvaluator
-          evaluator
-          teNames supplyN te
+  transformedBindings <-
+    normalizeEntity env (designBindings design)
+      (ghcTypeToHWType (opt_intWidth opts))
+      ghcEvaluator
+      evaluator
+      teNames supplyN te
 
   fmap (\(_,x,_) -> force (P.map snd (OMap.assocs x))) $
     netlistFrom (env, transformedBindings, tes2, compNames, te, initIs)


### PR DESCRIPTION
The RewriteMonad as implemented was the same as the CPS version
of the transformer from transformers-0.5.6.0 onwards. Since we now
also want a monad based in IO so we can use `async`, it makes more
sense to use the transformers implementation (preferring the more
space efficient CPS version if available) instead of rewriting all
instances to use IO.

This commit also removes the MonadFail instance for RewriteMonad.
It was only used in one place, where a potentially failing pattern
match was used. This is replaced with a call to `either` which throws
a more meaningful error message on failures.

For users using `transformers-0.5.6.2` or newer (i.e. GHC 8.10 or newer),
there is effectively no change in the implementation as the manually
implemented version was CPS'd anyway.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
