### PR TITLE
Fix issue #2069

### DIFF
--- a/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.primitives
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_BlockRam.primitives
@@ -171,19 +171,19 @@ logic [~SIZE[~TYP[9]]-1:0] ~GENSYM[mem][0] [~LIT[1]-1:0];
 
 // Port A
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[6]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[8]];
+    ~SYM[1] <= ~SYM[0][~IF~SIZE[~TYP[8]]~THEN~ARG[8]~ELSE0~FI];
     if(~ARG[7]) begin
         ~SYM[1] <= ~ARG[9];
-        ~SYM[0][~ARG[8]] <= ~ARG[9];
+        ~SYM[0][~IF~SIZE[~TYP[8]]~THEN~ARG[8]~ELSE0~FI] <= ~ARG[9];
     end
 end
 
 // Port B
 always @(~IF~ACTIVEEDGE[Rising][3]~THENposedge~ELSEnegedge~FI ~ARG[10]) begin
-    ~SYM[2] <= ~SYM[0][~ARG[12]];
+    ~SYM[2] <= ~SYM[0][~IF~SIZE[~TYP[12]]~THEN~ARG[12]~ELSE0~FI];
     if(~ARG[11]) begin
         ~SYM[2] <= ~ARG[13];
-        ~SYM[0][~ARG[12]] <= ~ARG[13];
+        ~SYM[0][~IF~SIZE[~TYP[12]]~THEN~ARG[12]~ELSE0~FI] <= ~ARG[13];
     end
 end
 

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam.primitives
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam.primitives
@@ -182,23 +182,24 @@ reg ~SIGD[~GENSYM[data_fast][2]][13];
 
 // Port A
 always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[6]) begin
-    ~SYM[1] <= ~SYM[0][~ARG[8]];
+    ~SYM[1] <= ~SYM[0][~IF~SIZE[~TYP[8]]~THEN~ARG[8]~ELSE0~FI];
     if(~ARG[7]) begin
         ~SYM[1] <= ~ARG[9];
-        ~SYM[0][~ARG[8]] <= ~ARG[9];
+        ~SYM[0][~IF~SIZE[~TYP[8]]~THEN~ARG[8]~ELSE0~FI] <= ~ARG[9];
     end
 end
 
 // Port B
 always @(~IF~ACTIVEEDGE[Rising][3]~THENposedge~ELSEnegedge~FI ~ARG[10]) begin
-    ~SYM[2] <= ~SYM[0][~ARG[12]];
+    ~SYM[2] <= ~SYM[0][~IF~SIZE[~TYP[12]]~THEN~ARG[12]~ELSE0~FI];
     if(~ARG[11]) begin
         ~SYM[2] <= ~ARG[13];
-        ~SYM[0][~ARG[12]] <= ~ARG[13];
+        ~SYM[0][~IF~SIZE[~TYP[12]]~THEN~ARG[12]~ELSE0~FI] <= ~ARG[13];
     end
 end
 
 assign ~RESULT = {~SYM[1], ~SYM[2]};
+
 // end trueDualPortBlockRam"
     }
   }

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives
@@ -213,9 +213,9 @@ begin
   begin
       if(rising_edge(~ARG[6])) then
           if(~ARG[7]) then
-              mem(to_integer(~ARG[8])) := ~ARG[9];
+              mem(~IF~SIZE[~TYP[8]]~THENto_integer(~ARG[8])~ELSE0~FI) := ~ARG[9];
           end if;
-          ~SYM[2] <= mem(to_integer(~ARG[8]));
+          ~SYM[2] <= mem(~IF~SIZE[~TYP[8]]~THENto_integer(~ARG[8])~ELSE0~FI);
       end if;
   end process;
 
@@ -224,9 +224,9 @@ begin
   begin
       if(rising_edge(~ARG[10])) then
           if(~ARG[11]) then
-              mem(to_integer(~ARG[12])) := ~ARG[13];
+              mem(~IF~SIZE[~TYP[12]]~THENto_integer(~ARG[12])~ELSE0~FI) := ~ARG[13];
           end if;
-          ~SYM[3] <= mem(to_integer(~ARG[12]));
+          ~SYM[3] <= mem(~IF~SIZE[~TYP[12]]~THENto_integer(~ARG[12])~ELSE0~FI);
       end if;
   end process;
 

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -377,6 +377,7 @@ This concludes the short introduction to using 'blockRam'.
 
 -}
 
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -424,6 +425,7 @@ import           GHC.Arr
 import qualified Data.Sequence          as Seq
 import           Data.Sequence          (Seq)
 import           Data.Tuple             (swap)
+import           GHC.Generics           (Generic)
 import           GHC.Stack              (HasCallStack, withFrozenCallStack)
 import           GHC.TypeLits           (KnownNat, type (^), type (<=))
 import           Unsafe.Coerce          (unsafeCoerce)
@@ -1112,6 +1114,7 @@ readNew clk rst en ram rdAddr wrM = mux wasSame wasWritten $ ram rdAddr wrM
 
 
 data RamOp n a = RamRead (Index n) | RamWrite (Index n) a
+  deriving (Generic, NFDataX)
 
 ramOpAddr :: RamOp n a -> Index n
 ramOpAddr (RamRead addr)    = addr

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -685,7 +685,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "SigP" def{hdlSim=False}
         , outputTest "T1102A" def{hdlTargets=[VHDL]}
         , outputTest "T1102B" def{hdlTargets=[VHDL]}
-
+        , runTest "T2069" def
         , clashTestGroup "BiSignal"
           [ runTest "Counter" def
           , runTest "CounterHalfTuple" def

--- a/tests/shouldwork/Signal/T2069.hs
+++ b/tests/shouldwork/Signal/T2069.hs
@@ -1,0 +1,27 @@
+module T2069 where
+
+import Clash.Explicit.BlockRam
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock System
+  -> Clock System
+  -> Signal System (RamOp 1 (Unsigned 8))
+  -> Signal System (RamOp 1 (Unsigned 8))
+  -> (Signal System (Unsigned 8), Signal System (Unsigned 8))
+topEntity = trueDualPortBlockRam
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput = register clk rst en
+                  (RamWrite 0 42, RamRead 0) $ pure (RamRead 0, RamRead 0)
+    expectedOutput = outputVerifier' clk rst $ (0,0) :> (0, 0) :> (42, 42) :> Nil
+    done = expectedOutput $ ignoreFor clk rst en d2 (0, 0) $ bundle $
+             uncurry (topEntity clk clk) $ unbundle testInput
+    clk = tbSystemClockGen (not <$> done)
+    rst = systemResetGen
+    en = enableGen
+{-# NOINLINE testBench #-}


### PR DESCRIPTION
When a true dual port blockRAM has only one memory location, the address
lines are eliminated from the HDL. This is special-cased and handled in
the black box.

## Still TODO:

  - [ ] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
