### PR TITLE
Revert "Cache dist-newstyle on CI (#2072)"

### DIFF
--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -23,6 +23,6 @@
     - tar -xf cache.tar.zst -C / || true
     - .ci/setup.sh
   after_script:
-    - tar -cf - $(ls -d /root/.cabal /root/.stack $(pwd)/dist-newstyle $(pwd)/.ci/bindist/linux/debian/*/build || true) | zstd -T${THREADS} -3 > cache.tar.zst
+    - tar -cf - $(ls -d /root/.cabal /root/.stack $(pwd)/.ci/bindist/linux/debian/*/build || true) | zstd -T${THREADS} -3 > cache.tar.zst
   tags:
     - local


### PR DESCRIPTION
This reverts commit eca1ab4d364ebae52f06f855cbd711b29e84c407.

https://gitlab.com/clash-lang/clash-compiler/-/jobs/2051235835

:-/