### PR TITLE
Clean up `clash-{prelude,lib}-hedgehog` flags

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -36,6 +36,14 @@ package clash-cores
   ghc-options: -Werror
   tests: True
 
+package clash-prelude-hedgehog
+  ghc-options: -Werror
+  tests: True
+
+package clash-lib-hedgehog
+  ghc-options: -Werror
+  tests: True
+
 package clash-testsuite
   ghc-options: -Werror
   -- enable cosim

--- a/cabal.project
+++ b/cabal.project
@@ -48,9 +48,6 @@ package clash-ghc
   ghc-options: +RTS -qn4 -A128M -RTS -j4
   executable-dynamic: True
 
-package clash-hedgehog
-  flags: +debug
-
 package clash-prelude
   ghc-options: +RTS -qn4 -A128M -RTS -j4
   -- workaround for plugins not loading in Haddock with GHC-8.6

--- a/clash-lib-hedgehog/src/Clash/Hedgehog/Core/Monad.hs
+++ b/clash-lib-hedgehog/src/Clash/Hedgehog/Core/Monad.hs
@@ -6,6 +6,7 @@ Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 Monad for random generation of clash-core types.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -29,7 +30,9 @@ module Clash.Hedgehog.Core.Monad
 
 import Control.Applicative (Alternative(..))
 import Control.Monad.IO.Class (MonadIO)
+#if __GLASGOW_HASKELL__ <= 806
 import Control.Monad.Fail (MonadFail)
+#endif
 import Control.Monad.Reader (MonadReader(..), ReaderT, runReaderT)
 import Control.Monad.Trans (MonadTrans)
 import Hedgehog (MonadGen(..))


### PR DESCRIPTION
@alex-mckenna Do you need the old `debug` flag?