### PR TITLE
Minor improvements to TDP blockRAM

### DIFF
--- a/changelog/2021-10-25T10_31_41+02_00_add_true_dualport_ram
+++ b/changelog/2021-10-25T10_31_41+02_00_add_true_dualport_ram
@@ -1,11 +1,3 @@
-ADDED: Added support for true dual ported block ram:
+ADDED: Added support for true dual-port block RAM:
     * Implicitly clocked: `Clash.Prelude.BlockRam.trueDualPortBlockRam` and
     * Explicitly clocked: `Clash.Explicit.BlockRam.trueDualPortBlockRam`
-
-Any value being written on a particular port is also the value that will be read
-on that port, e.i. the same-port read/write behavior is: WriteFirst. For mixed port
-read/write, when both ports have the same address, when there is a write on the portA,
-the output of port B is undefined and vice versa.
-
-NoOp to RamOp for `Clash.Explicit.BlockRam.trueDualPortBlockRam`, which pulls the
-enable signal of trueDualPortBlockRam low for the relevant port.

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -64,6 +64,9 @@ module Clash.Explicit.Prelude
   , blockRamFilePow2
   -- ** BlockRAM read/write conflict resolution
   , readNew
+    -- ** True dual-port block RAM
+  , trueDualPortBlockRam
+  , RamOp(..)
     -- * Utility functions
   , window
   , windowD

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -55,6 +55,9 @@ module Clash.Explicit.Prelude.Safe
   , unpackMemBlob
     -- ** BlockRAM read/write conflict resolution
   , readNew
+    -- ** True dual-port block RAM
+  , trueDualPortBlockRam
+  , RamOp(..)
     -- * Utility functions
   , isRising
   , isFalling

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -92,6 +92,9 @@ module Clash.Prelude
   , blockRamFilePow2
     -- ** BlockRAM read/write conflict resolution
   , readNew
+    -- ** True dual-port block RAM
+  , trueDualPortBlockRam
+  , RamOp(..)
     -- * Utility functions
   , window
   , windowD

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -71,6 +71,9 @@ module Clash.Prelude.Safe
   , unpackMemBlob
     -- ** BlockRAM read/write conflict resolution
   , readNew
+    -- ** True dual-port block RAM
+  , trueDualPortBlockRam
+  , RamOp(..)
     -- * Utility functions
   , isRising
   , isFalling

--- a/tests/shouldwork/Signal/DualBlockRam1.hs
+++ b/tests/shouldwork/Signal/DualBlockRam1.hs
@@ -1,32 +1,30 @@
-{-# OPTIONS_GHC -fconstraint-solver-iterations=0 #-}
+{-# OPTIONS_GHC -Wno-missing-signatures -Wno-partial-type-signatures #-}
 {-# OPTIONS_GHC -freverse-errors #-}
-{-# LANGUAGE PartialTypeSignatures #-}
 
 module DualBlockRam1 where
 
-import qualified Prelude as P
-
 import Clash.Explicit.Prelude
-import Clash.Explicit.BlockRam
 import Clash.Explicit.Testbench
-import Data.Bifunctor (bimap)
-import Clash.Sized.Internal.BitVector
+
 import Test.Tasty.Clash.CollectSimResults
+
 import DualBlockRamDefinitions
 import DualBlockRamTypes
 
-runTest = sampleN 250 testBench
+topEntity :: TdpRam B C
+topEntity = tdpRam
+{-#NOINLINE topEntity #-}
+
 testBench = strictAnd <$> doneA <*> (unsafeSynchronizer clk7 clk10 doneB)
   where
     -- Template haskell simulation
-    processSimOutput x = replace 0 undefined# $ tail x
-    simOutA = processSimOutput $(collectSimResults 250 $ pack <$> (fst simEntityBC))
-    simOutB = processSimOutput $(collectSimResults 175 $ pack <$> (snd simEntityBC))
+    simOutA = $(collectSimResults (length opsA) $ pack <$> (fst simEntityBC))
+    simOutB =
+      $(collectSimResults (length opsB * 14 `div` 10) $
+          pack <$> (snd simEntityBC))
 
     -- topEntity output
-    (portA, portB) = topOut clk10 rst10 clk7 rst7
-    actualOutputA = ignoreFor clk10 rst10 enableGen d1 (unpack $ head simOutA) portA
-    actualOutputB = ignoreFor clk7 rst7 enableGen d1 (unpack $ head simOutB) portB
+    (portA, portB) = topOut topEntity clk10 noRst10 clk7 noRst7
 
     -- Verification
     outputVerifierA = outputVerifierWith
@@ -34,9 +32,9 @@ testBench = strictAnd <$> doneA <*> (unsafeSynchronizer clk7 clk10 doneB)
     outoutVerifierB = outputVerifierWith
      (\clk rst -> assertBitVector clk rst "outputVerifierBitVector Port B")
 
-    doneA  = outputVerifierA clk10 rst10 simOutA $ pack <$> portA
+    doneA  = outputVerifierA clk10 noRst10 simOutA $ pack <$> portA
     doneA' = not <$> doneA
-    doneB  = outoutVerifierB clk7 rst7 simOutB $ pack <$> portB
+    doneB  = outoutVerifierB clk7 noRst7 simOutB $ pack <$> portB
     doneB' = not <$> doneB
 
     -- Testbench clocks

--- a/tests/shouldwork/Signal/DualBlockRamTypes.hs
+++ b/tests/shouldwork/Signal/DualBlockRamTypes.hs
@@ -1,6 +1,5 @@
-{-# OPTIONS_GHC -Wno-orphans #-}
-
 module DualBlockRamTypes where
+
 import Clash.Explicit.Prelude
 
 data ThisOrThat
@@ -9,3 +8,16 @@ data ThisOrThat
   deriving (Generic, BitPack, Show, ShowX, NFDataX, Lift, Eq)
 
 type Addr = Index 73
+
+type TdpRam (domA :: Domain) (domB :: Domain) =
+  -- Clocks
+  Clock  domA ->
+  Clock  domB ->
+
+  --Operations
+  Signal domA (RamOp 73 ThisOrThat) ->
+  Signal domB (RamOp 73 ThisOrThat) ->
+
+  --Output
+  ( Signal domA ThisOrThat
+  , Signal domB ThisOrThat )


### PR DESCRIPTION
- Rename `NoOp` to `RamNoOp`
- Add `Show` to `RamOp`
- Include TDP BRAM in the several Preludes
- Improve documentation
- Fix test benches: they didn't run the final test because the test
length was hardcoded to the wrong value; now it is computed.

`NoOp` was added later, and its name breaks a pattern. The type itself and its constructors are all prefixed with `Ram`, except for `NoOp`. This also makes it annoying to import unqualified, because it might clash with another thing that also does nothing ;-). So it is renamed to fit with the rest. And all are added to the Preludes, making it available unqualified in most Clash designs by default.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
