### PR TITLE
Construct `MemBlob` out of `BitPack`

### DIFF
--- a/tests/shouldwork/Signal/BlockRam/Blob.hs
+++ b/tests/shouldwork/Signal/BlockRam/Blob.hs
@@ -6,7 +6,7 @@ module Blob where
 import Clash.Explicit.Prelude
 import Clash.Explicit.Testbench
 
-createMemBlob @4 "content" Nothing [4 .. 7]
+createMemBlob "content" Nothing [4 :: Unsigned 4 .. 7]
 
 topEntity
   :: Clock System

--- a/tests/shouldwork/Signal/ROM/AsyncBlob.hs
+++ b/tests/shouldwork/Signal/ROM/AsyncBlob.hs
@@ -3,7 +3,7 @@ module AsyncBlob where
 import Clash.Explicit.Prelude
 import Clash.Explicit.Testbench
 
-createMemBlob @8 "content" Nothing [1 .. 16]
+createMemBlob "content" Nothing [1 :: Unsigned 8 .. 16]
 
 topEntity
   :: Signal System (Unsigned 4)

--- a/tests/shouldwork/Signal/ROM/Blob.hs
+++ b/tests/shouldwork/Signal/ROM/Blob.hs
@@ -3,7 +3,7 @@ module Blob where
 import Clash.Explicit.Prelude
 import Clash.Explicit.Testbench
 
-createMemBlob @8 "content" Nothing [1 .. 16]
+createMemBlob "content" Nothing [1 :: Unsigned 8 .. 16]
 
 topEntity
   :: Clock System

--- a/tests/shouldwork/Signal/ROM/BlobVec.hs
+++ b/tests/shouldwork/Signal/ROM/BlobVec.hs
@@ -10,9 +10,9 @@ topEntity
 
 topEntity clk addr = bundle $ romBlob clk enableGen <$> blobs <*> pure addr
  where
-  blobs =    $(memBlobTH @8 Nothing [ 1 .. 15])
-          :> $(memBlobTH @8 Nothing [17 .. 31])
-          :> $(memBlobTH @8 Nothing [33 .. 47])
+  blobs =    $(memBlobTH Nothing [ 1 :: BitVector 8 .. 15])
+          :> $(memBlobTH Nothing [17 :: BitVector 8 .. 31])
+          :> $(memBlobTH Nothing [33 :: BitVector 8 .. 47])
           :> Nil
 {-# NOINLINE topEntity #-}
 


### PR DESCRIPTION
We only accepted `BitVector`, but usability is improved if we accept
`BitPack` and just do the `pack` ourselves.

## Still TODO:

  - [ ] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
