### PR TITLE
Quick fix: don't include profiling builds in Snap distribution

### DIFF
--- a/.ci/bindist/linux/snap/snap/snapcraft.yaml
+++ b/.ci/bindist/linux/snap/snap/snapcraft.yaml
@@ -35,8 +35,10 @@ parts:
       - prepare
     stage-packages:
       - clash
-      - clash-prof
       - cabal-install-3.2
+      # To save time on CI, we currently don't build profiling packages anymore. We should
+      # probably selectively build them on release branches and nightlies.
+      #- clash-prof
     override-prime: |
       snapcraftctl prime
       apt-get install -y ghc


### PR DESCRIPTION
@alex-mckenna :eyes: 