### PR TITLE
Escape `#include` to prevent it being picked up by Clang CPP

### DIFF
--- a/changelog/2022-02-16T17_15_24+01_00_fix_2098
+++ b/changelog/2022-02-16T17_15_24+01_00_fix_2098
@@ -1,0 +1,1 @@
+Fixed: Clash now compiles for users of Clang - i.e., all macOS users.

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -810,11 +810,11 @@ pprVerilatorShim (Id.toText -> topNm) =
   -- the outlines lines in the file. It doesn't matter for code inside main,
   -- but is fatal for the #include directives.
   pretty $ Data.Text.pack [i|
-    #include <cstdlib>
+    \#include <cstdlib>
 
-    #include <verilated.h>
+    \#include <verilated.h>
 
-    #include "V#{topNm}.h"
+    \#include "V#{topNm}.h"
 
     int main(int argc, char **argv) {
       Verilated::commandArgs(argc, argv);


### PR DESCRIPTION
Fixes #2098


## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
