### PR TITLE
TDP BRAM: also swap names

### DIFF
--- a/changelog/2022-02-23T12_42_44+01_00_tdplabels
+++ b/changelog/2022-02-23T12_42_44+01_00_tdplabels
@@ -1,0 +1,1 @@
+FIXED: Sometimes `trueDualPortBlockRam` swapped the names of the ports in exception messages. [#2102](https://github.com/clash-lang/clash-compiler/pull/2102)

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -1278,9 +1278,12 @@ trueDualPortBlockRam#, trueDualPortBlockRamWrapper ::
   -- port enable is @False@, it is /undefined/.
 trueDualPortBlockRam# clkA enA weA addrA datA clkB enB weB addrB datB
   | snatToNum @Int (clockPeriod @domA) < snatToNum @Int (clockPeriod @domB)
-  = swap (trueDualPortBlockRamModel clkB enB weB addrB datB clkA enA weA addrA datA)
+  = swap (trueDualPortBlockRamModel labelB clkB enB weB addrB datB labelA clkA enA weA addrA datA)
   | otherwise
-  =       trueDualPortBlockRamModel clkA enA weA addrA datA clkB enB weB addrB datB
+  =       trueDualPortBlockRamModel labelA clkA enA weA addrA datA labelB clkB enB weB addrB datB
+ where
+  labelA = "Port A"
+  labelB = "Port B"
 {-# NOINLINE trueDualPortBlockRam# #-}
 {-# ANN trueDualPortBlockRam# hasBlackBox #-}
 
@@ -1298,12 +1301,14 @@ trueDualPortBlockRamModel ::
   , NFDataX a
   ) =>
 
+  String ->
   Clock domSlow ->
   Signal domSlow Bool ->
   Signal domSlow Bool ->
   Signal domSlow (Index nAddrs) ->
   Signal domSlow a ->
 
+  String ->
   Clock domFast ->
   Signal domFast Bool ->
   Signal domFast Bool ->
@@ -1311,9 +1316,9 @@ trueDualPortBlockRamModel ::
   Signal domFast a ->
 
   (Signal domSlow a, Signal domFast a)
-trueDualPortBlockRamModel !_clkA enA weA addrA datA !_clkB enB weB addrB datB =
-  ( deepErrorX "trueDualPortBlockRam: Port A: First value undefined" :- outA
-  , deepErrorX "trueDualPortBlockRam: Port B: First value undefined" :- outB )
+trueDualPortBlockRamModel labelA !_clkA enA weA addrA datA labelB !_clkB enB weB addrB datB =
+  ( deepErrorX ("trueDualPortBlockRam: " <> labelA <> ": First value undefined") :- outA
+  , deepErrorX ("trueDualPortBlockRam: " <> labelB <> ": First value undefined") :- outB )
  where
   (outA, outB) =
     go


### PR DESCRIPTION
Depending on which clock is faster, we swap port A and B of the TDP BRAM
in the Haskell model. But the XExceptions mentioning port names then
confusingly named the wrong port. Now the names correspond to what the
user wrote.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files