### PR TITLE
Only store Stack snapshots on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ steps.setup-haskell.outputs.stack-root }}
-            .stack-work/
-          key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('stack.yaml', '**/*.cabal') }}
+            ${{ steps.setup-haskell.outputs.stack-root }}/snapshots
+          key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('stack.yaml', '**/*.cabal', '.github/workflows/ci.yml') }}
           restore-keys: ${{ matrix.os }}-${{ matrix.ghc }}-
 
       # https://gitlab.haskell.org/haskell/ghcup-hs/-/issues/188


### PR DESCRIPTION
As seen in https://github.com/martijnbastiaan/doctest-parallel/blob/0ed93f3ea01ce4b184ca06d554fa7ae499ecf56c/.github/workflows/ci.yml#L35

I've removed `.stack-work` from the cache list, as it doesn't seem to work anyway..