### PR TITLE
make deriveAutoReg handle field with Unit type

### DIFF
--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2019     , Google Inc.,
                      2021     , QBayLogic B.V.
-                     2021     , Myrtle.ai
+                     2021-2022, Myrtle.ai
   License     :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -389,6 +389,7 @@ constraintsWantedFor clsNm [ty] = case ty of
       [VarT _] -> False  -- gets copied by "filter isOk" above
       [ConT _] -> False  -- we can just drop constraints like: "AutoReg Bool => ..."
       [LitT _] -> False  -- or "KnownNat 4 =>"
+      [TupleT 0] -> False  -- handle Unit ()
       [_] -> error ( "Error while deriveAutoReg: don't know how to handle: "
                   ++ pprint cls ++ " (" ++ pprint tys ++ ")" )
       _ -> False  -- see [NOTE: MultiParamTypeClasses]


### PR DESCRIPTION
[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

This fixes:
```
data Stupid = Stupid (Vec 2 ())
  deriving (Generic, NFDataX)

deriveAutoReg 'Stupid
```
which currently generates the following error:
```
src/Clash/Interface/Memory/StreamMM.hs:1:1: error:
    Exception when trying to run compile-time code:
      Error while deriveAutoReg: don't know how to handle: Clash.Class.AutoReg.Internal.AutoReg (())
```

[comment]: # (Add a line of the form "Fixes: #xxxx" for each related issue closed by this pull request, where #xxxx is an issue number.)

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
