### PR TITLE
`~ISUNDEFINED` for `BitVector` and product types

### DIFF
--- a/changelog/2022-03-08T15_44_00+01_00_issue_2117
+++ b/changelog/2022-03-08T15_44_00+01_00_issue_2117
@@ -1,0 +1,1 @@
+FIXED: Handle `~ISUNDEFINED` hole in black boxes for `BitVector` and for product types. This means that with `-fclash-aggressive-x-optimization-blackboxes`, resets are now omitted for _undefined_ reset values of such types as well. [#2117](https://github.com/clash-lang/clash-compiler/issues/2117)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -409,6 +409,12 @@ runClashTest = defaultMain $ clashTestRoot
           , buildTargets=BuildSpecific ["testEnableTB", "testBoolTB"]
           }
         , outputTest "LITrendering" def{hdlTargets=[Verilog]}
+        , runTest "T2117" def{
+            clashFlags=["-fclash-aggressive-x-optimization-blackboxes"]
+          , hdlTargets=[VHDL]
+          , buildTargets=BuildSpecific [ "testBenchUndefBV"
+                                       , "testBenchUndefTup"
+                                       , "testBenchPartialDefTup"]}
         ]
       , clashTestGroup "BoxedFunctions"
         [ runTest "DeadRecursiveBoxed" def{hdlSim=False}

--- a/tests/shouldwork/BlackBox/T2117.hs
+++ b/tests/shouldwork/BlackBox/T2117.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE BangPatterns #-}
+module T2117 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import Clash.Annotations.Primitive
+import Data.String.Interpolate.IsString (i)
+import Data.String.Interpolate.Util (unindent)
+
+undefBV
+  :: Signal System Bool
+undefBV = testUndefined @(BitVector 8) (deepErrorX "undefined value")
+{-# NOINLINE undefBV #-}
+
+undefTup
+  :: Signal System Bool
+undefTup = testUndefined @(Bit, Bit) (deepErrorX "undefined value")
+{-# NOINLINE undefTup #-}
+
+partialDefTup
+  :: Signal System Bool
+partialDefTup = testDefined @(Bit, Bit) (errorX "undefined value", 0)
+{-# NOINLINE partialDefTup #-}
+
+testBenchG
+  :: Signal System Bool
+  -> Signal System Bool
+testBenchG f = done
+ where
+  done = outputVerifier' clk rst (True :> Nil) f
+  clk  = tbSystemClockGen (not <$> done)
+  rst  = systemResetGen
+{-# INLINE testBenchG #-}
+
+testBenchUndefBV :: Signal System Bool
+testBenchUndefBV = testBenchG undefBV
+{-# NOINLINE testBenchUndefBV #-}
+{-# ANN testBenchUndefBV (TestBench 'undefBV) #-}
+
+testBenchUndefTup :: Signal System Bool
+testBenchUndefTup = testBenchG undefTup
+{-# NOINLINE testBenchUndefTup #-}
+{-# ANN testBenchUndefTup (TestBench 'undefTup) #-}
+
+testBenchPartialDefTup :: Signal System Bool
+testBenchPartialDefTup = testBenchG partialDefTup
+{-# NOINLINE testBenchPartialDefTup #-}
+{-# ANN testBenchPartialDefTup (TestBench 'partialDefTup) #-}
+
+-- Only call with XException-argument if you want the model to match the HDL.
+testUndefined
+  :: NFDataX a
+  => a
+  -> Signal System Bool
+testUndefined !_ = pure True
+{-# NOINLINE testUndefined #-}
+{-# ANN testUndefined (InlinePrimitive [VHDL] $ unindent [i|
+  [ { "BlackBox" :
+      { "name"      : "T2117.testUndefined"
+      , "kind"      : "Expression"
+      , "template"  : "~IF ~ISUNDEFINED[1] ~THEN true ~ELSE false ~FI"
+      }
+    }
+  ]
+  |]) #-}
+
+-- Only call with an argument that has bits defined if you want the model to
+-- match the HDL.
+testDefined
+  :: NFDataX a
+  => a
+  -> Signal System Bool
+testDefined !_ = pure True
+{-# NOINLINE testDefined #-}
+{-# ANN testDefined (InlinePrimitive [VHDL] $ unindent [i|
+  [ { "BlackBox" :
+      { "name"      : "T2117.testDefined"
+      , "kind"      : "Expression"
+      , "template"  : "~IF ~ISUNDEFINED[1] ~THEN false ~ELSE true ~FI"
+      }
+    }
+  ]
+  |]) #-}


### PR DESCRIPTION
Fixes #2117

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
