### PR TITLE
Fix missing libraries with snap package

### DIFF
--- a/.ci/bindist/linux/snap/snap/snapcraft.yaml
+++ b/.ci/bindist/linux/snap/snap/snapcraft.yaml
@@ -39,6 +39,15 @@ parts:
       # To save time on CI, we currently don't build profiling packages anymore. We should
       # probably selectively build them on release branches and nightlies.
       #- clash-prof
+      # The below packages are included in core20, but their -dev packages are
+      # not.  Include them here to avoid broken symlinks from dev sonames.
+      - libbsd0
+      - libffi7
+      - libgmp10
+      - libncurses6
+      - libncursesw6
+      - libtinfo6
+      - libyaml-0-2
     override-prime: |
       snapcraftctl prime
       apt-get install -y ghc


### PR DESCRIPTION
When building the snap, snapcraft is filtering out several shared library
packages (e.g., libgmp10) because they are included in the core20 snap.  This
causes a problem when the -dev versions of these packages are used (e.g.,
libgmp-dev) where the clash snap will have broken symbolic links to the
shared library packages.  Work around this issue by staging all the relevant
library packages so they are included in the snap as well.

Fixes #2124.