### PR TITLE
Remove leading / trailing '\\' in SDC signal names

### DIFF
--- a/changelog/2022-03-22T11_36_15+01_00_sdc_escaped_ids.md
+++ b/changelog/2022-03-22T11_36_15+01_00_sdc_escaped_ids.md
@@ -1,0 +1,1 @@
+FIXED: Clash no longer escapes extended identifiers when rendering SDC files

--- a/changelog/2022-03-22T11_36_15+01_00_sdc_escaped_ids.md
+++ b/changelog/2022-03-22T11_36_15+01_00_sdc_escaped_ids.md
@@ -1,1 +1,2 @@
-FIXED: Clash no longer escapes extended identifiers when rendering SDC files
+FIXED: Clash no longer escapes extended identifiers when rendering SDC files.
+CHANGED: Clash now always generates non-extended identifiers for port names, so that generated names play nicer with different vendor tools.

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -31,6 +31,7 @@ import           Data.Maybe                     (isJust)
 import           Data.Set                       (Set)
 import qualified Data.Set                       as Set
 import           Data.Text                      (Text)
+import qualified Data.Text as Text              (dropAround)
 
 #if MIN_VERSION_prettyprinter(1,7,0)
 import           Prettyprinter
@@ -548,7 +549,7 @@ pprSDC = vcat . fmap go . sdcClock
   go (i, dom) =
         -- VDomainConfiguration stores period in ps, SDC expects it in ns.
     let p        = MkFixed (toInteger $ vPeriod dom) :: Fixed E3
-        name     = braces (pretty i)
+        name     = braces (pretty (Text.dropAround (== '\\') i))
         period   = viaShow p
         waveform = braces ("0.000" <+> viaShow (p / 2))
         targets  = brackets ("get_ports" <+> name)

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -1129,7 +1129,7 @@ mkTopInput (ExpandedPortName hwty0 i0) = do
   return ([(i0, hwty1)], decls, expr, i1)
 
 mkTopInput epp@(ExpandedPortProduct p hwty ps) = do
-  pN <- Id.make p
+  pN <- Id.makeBasic p
   let netdecl = NetDecl Nothing pN hwty
   case hwty of
     Vector sz eHwty -> do
@@ -1272,7 +1272,7 @@ mkTopOutput (ExpandedPortName hwty0 i0) = do
     return ([(i0, hwty1)], [Assignment i0 bvExpr, NetDecl Nothing i1 hwty0], i1)
 
 mkTopOutput epp@(ExpandedPortProduct p hwty ps) = do
-  pN <- Id.make p
+  pN <- Id.makeBasic p
   let netdecl = NetDecl Nothing pN hwty
   case hwty of
     Vector {} -> do
@@ -1411,7 +1411,7 @@ mkTopInstInput (ExpandedPortName hwty0 pN) = do
           , pN' )
 
 mkTopInstInput epp@(ExpandedPortProduct pNameHint hwty0 ps) = do
-  pName <- Id.make pNameHint
+  pName <- Id.makeBasic pNameHint
 
   let
     pDecl = NetDecl Nothing pName hwty0
@@ -1508,7 +1508,7 @@ mkTopInstOutput (ExpandedPortName hwty0 portName) = do
           , assignName1 )
 
 mkTopInstOutput epp@(ExpandedPortProduct productNameHint hwty ps) = do
-  pName <- Id.make productNameHint
+  pName <- Id.makeBasic productNameHint
   let pDecl = NetDecl Nothing pName hwty
       (attrs, hwty') = stripAttributes hwty
   case hwty' of
@@ -1755,7 +1755,7 @@ expandTopEntityOrErr is ihwtys ohwty topM = do
         is not a product!
       |])
     Right eTop ->
-      evalState (traverse (either Id.addRaw Id.make) eTop) (Id.clearSet is)
+      evalState (traverse (either Id.addRaw Id.makeBasic) eTop) (Id.clearSet is)
 
 -- | Take a top entity and /expand/ its port names. I.e., make sure that every
 -- port that should be generated in the HDL is part of the data structure. It


### PR DESCRIPTION
In SDC files, escaped identifiers should not be rendered with
leading trailing backslashes as this causes faults in vendor tools
like Quartus.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
