### PR TITLE
better RTS options for executables, makes benchmarks more sensible

### DIFF
--- a/benchmark/clash-benchmark.cabal
+++ b/benchmark/clash-benchmark.cabal
@@ -29,7 +29,7 @@ library
 executable clash-benchmark-normalization
   main-is:             benchmark-normalization.hs
   default-language:    Haskell2010
-  ghc-options:         -O2 -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -O2 -Wall -Wcompat -threaded -rtsopts "-with-rtsopts=-N -A128m"
   build-depends:       base,
                        concurrent-supply,
                        containers,
@@ -48,7 +48,7 @@ executable clash-benchmark-normalization
 executable clash-benchmark-concurrency
   main-is:             benchmark-concurrency.hs
   default-language:    Haskell2010
-  ghc-options:         -O2 -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -O2 -Wall -Wcompat -threaded -rtsopts "-with-rtsopts=-N -A128m"
   build-depends:       base,
                        criterion,
                        time,

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -68,7 +68,7 @@ flag use-ghc-paths
 executable clash
   Main-Is:            src-ghc/Batch.hs
   Build-Depends:      base, clash-ghc
-  GHC-Options:        -Wall -Wcompat -threaded -rtsopts
+  GHC-Options:        -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-A128m
   if flag(dynamic)
     GHC-Options: -dynamic
   extra-libraries:    pthread
@@ -77,7 +77,7 @@ executable clash
 executable clashi
   Main-Is:            src-ghc/Interactive.hs
   Build-Depends:      base, clash-ghc
-  GHC-Options:        -Wall -Wcompat
+  GHC-Options:        -Wall -Wcompat -rtsopts -with-rtsopts=-A128m
   if flag(dynamic)
     GHC-Options: -dynamic
   extra-libraries:    pthread


### PR DESCRIPTION
Stumbled upon this while working on https://github.com/clash-lang/clash-compiler/pull/2074

This makes benchmarks run much faster. It brings them into agreement with the ghc-options set in the `cabal.project` file. 

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
