### PR TITLE
Add Show instances for clash-prelude-hedgehog types

### DIFF
--- a/changelog/2022-03-23T17_22_17+01_00_prelude_hedgehog_show.md
+++ b/changelog/2022-03-23T17_22_17+01_00_prelude_hedgehog_show.md
@@ -1,0 +1,1 @@
+FIXED: The types defined in `clash-prelude-hedgehog` now come with `Show` instances [#2133](https://github.com/clash-lang/clash-compiler/issues/2133)

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/BitVector.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/BitVector.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2021, QBayLogic B.V.
+Copyright   : (C) 2021-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -68,6 +68,9 @@ genBitVector =
 
 data SomeBitVector atLeast where
   SomeBitVector :: SNat n -> BitVector (atLeast + n) -> SomeBitVector atLeast
+
+instance KnownNat atLeast => Show (SomeBitVector atLeast) where
+  show (SomeBitVector SNat bv) = show bv
 
 genSomeBitVector
   :: forall m atLeast

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Index.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Index.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2021, QBayLogic B.V.
+Copyright   : (C) 2021-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -35,6 +35,9 @@ genIndex range =
 
 data SomeIndex atLeast where
   SomeIndex :: SNat n -> Index (atLeast + n) -> SomeIndex atLeast
+
+instance KnownNat atLeast => Show (SomeIndex atLeast) where
+  show (SomeIndex SNat ix) = show ix
 
 genSomeIndex
   :: (MonadGen m, KnownNat atLeast)

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/RTree.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/RTree.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2021, QBayLogic B.V.
+Copyright   : (C) 2021-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -33,6 +33,9 @@ genNonEmptyRTree = genRTree
 
 data SomeRTree atLeast a where
   SomeRTree :: SNat n -> RTree (atLeast + n) a -> SomeRTree atLeast a
+
+instance (KnownNat atLeast, Show a) => Show (SomeRTree atLeast a) where
+  show (SomeRTree SNat x) = show x
 
 genSomeRTree
   :: (MonadGen m, KnownNat atLeast)

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Signed.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Signed.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2021, QBayLogic B.V.
+Copyright   : (C) 2021-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -35,6 +35,9 @@ genSigned range =
 
 data SomeSigned atLeast where
   SomeSigned :: SNat n -> Signed (atLeast + n) -> SomeSigned atLeast
+
+instance KnownNat atLeast => Show (SomeSigned atLeast) where
+  show (SomeSigned SNat x) = show x
 
 genSomeSigned
   :: (MonadGen m, KnownNat atLeast)

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Unsigned.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Unsigned.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2021, QBayLogic B.V.
+Copyright   : (C) 2021-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -35,6 +35,9 @@ genUnsigned range =
 
 data SomeUnsigned atLeast where
   SomeUnsigned :: SNat n -> Unsigned (atLeast + n) -> SomeUnsigned atLeast
+
+instance KnownNat atLeast => Show (SomeUnsigned atLeast) where
+  show (SomeUnsigned SNat x) = show x
 
 genSomeUnsigned
   :: (MonadGen m, KnownNat atLeast)

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Vector.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Vector.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2021, QBayLogic B.V.
+Copyright   : (C) 2021-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -42,6 +42,9 @@ genNonEmptyVec = genVec
 
 data SomeVec atLeast a where
   SomeVec :: SNat n -> Vec (atLeast + n) a -> SomeVec atLeast a
+
+instance (KnownNat atLeast, Show a) => Show (SomeVec atLeast a) where
+  show (SomeVec SNat xs) = show xs
 
 genSomeVec
   :: (MonadGen m, KnownNat atLeast)


### PR DESCRIPTION
The existential types in clash-prelude-hedgehog were missing `Show`
instances, which are needed by hedgehog for anything generated with
`forAll` in order to show the generated values on failure.

Fixes #2133.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
