### PR TITLE
Fix and document Altera PLL's

### DIFF
--- a/changelog/2022-03-20T12_59_08+01_00_fix_alterapll
+++ b/changelog/2022-03-20T12_59_08+01_00_fix_alterapll
@@ -1,0 +1,1 @@
+FIXED: The `alteraPll` primitive was unusable since commit d325557750 (release v1.4.0), it now works again. [#2136](https://github.com/clash-lang/clash-compiler/pull/2136)

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -1,6 +1,6 @@
 {-|
-  Copyright   :  (C) 2018, Google Inc.,
-                     2021, QBayLogic B.V.
+  Copyright   :  (C) 2018     , Google Inc.,
+                     2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -80,7 +80,7 @@ alteraPllTemplate bbCtx = do
  alteraPll <- Id.makeBasic "altera_pll_block"
  alteraPll_inst <- Id.makeBasic instname0
 
- clocks <- Id.nextN (length tys - 1) =<< Id.make "pllOut"
+ clocks <- Id.nextN (length tys) =<< Id.make "pllOut"
 
   -- TODO: unsafeMake is dubious here: I don't think we take names in
   -- TODO: bbQsysIncName into account when generating fresh ids
@@ -89,15 +89,15 @@ alteraPllTemplate bbCtx = do
  let outclkPorts = map (\n -> instPort ("outclk_" <> showt n)) [(0 :: Int)..length clocks-1]
 
  getAp $ blockDecl alteraPll $ concat
-  [[ NetDecl Nothing locked  rstTy
+  [[ NetDecl Nothing locked Bit
    , NetDecl' Nothing Reg pllLock (Right Bool) Nothing]
   ,[ NetDecl Nothing clkNm ty | (clkNm,ty) <- zip clocks tys]
   ,[ InstDecl Comp Nothing [] compName alteraPll_inst [] $ NamedPortMap $ concat
       [ [ (instPort "refclk", In, clkTy, clk)
         , (instPort "rst", In, rstTy, rst)]
       , [ (p, Out, ty, Identifier k Nothing) | (k, ty, p) <- zip3 clocks tys outclkPorts ]
-      , [(instPort "locked", Out, rstTy, Identifier locked Nothing)]]
-   , CondAssignment pllLock Bool (Identifier locked Nothing) rstTy
+      , [(instPort "locked", Out, Bit, Identifier locked Nothing)]]
+   , CondAssignment pllLock Bool (Identifier locked Nothing) Bit
       [(Just (BitLit H),Literal Nothing (BoolLit True))
       ,(Nothing        ,Literal Nothing (BoolLit False))]
    , Assignment result (DataCon resTy (DC (resTy,0)) $ concat
@@ -136,7 +136,7 @@ altpllTemplate bbCtx = do
       , (instPort "areset", In, rstTy, rst)
       , (instPort "c0", Out, clkOutTy, Identifier pllOut Nothing)
       , (instPort "locked", Out, Bit, Identifier locked Nothing)]
-  , CondAssignment pllLock Bool (Identifier locked Nothing) rstTy
+  , CondAssignment pllLock Bool (Identifier locked Nothing) Bit
       [(Just (BitLit H),Literal Nothing (BoolLit True))
       ,(Nothing        ,Literal Nothing (BoolLit False))]
   , Assignment result (DataCon resTy (DC (resTy,0))

--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -6,6 +6,23 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 PLL and other clock-related components for Intel (Altera) FPGAs
+
+A PLL generates a stable clock signal for your circuit at a selectable
+frequency.
+
+If you haven't determined the frequency you want the circuit to run at, the
+predefined 100 MHz domain `Clash.Signal.System` can be a good starting point.
+The datasheet for your FPGA specifies lower and upper limits, but the true
+maximum frequency is determined by your circuit. The 'altpll' and 'alteraPll'
+components below show an example for when the oscillator connected to the FPGA
+runs at 50 MHz. If the oscillator runs at 100 MHz, change @DomInput@ to:
+
+@
+'Clash.Signal.createDomain' 'Clash.Signal.vSystem'{vName=\"DomInput\", vPeriod=10000}
+@
+
+We suggest you always use a PLL even if your oscillator runs at the frequency
+you want to run your circuit at.
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
@@ -31,28 +48,66 @@ import Clash.Signal.Internal
 --
 -- * 1 reference clock
 -- * 1 output clock
--- * a reset port
--- * a locked port
+-- * a reset input port
+-- * a locked output port
 --
--- You must use type applications to specify the output clock domain, e.g.:
---
--- @
--- -- outputs a clock running at 100 MHz
--- altpll @@"50MHzDom" @@"100MHzDom" (SSymbol @@"altpll50to100") clk50 rst
--- @
+-- The PLL lock output is asserted when the clock is stable, and is usually
+-- connected to reset circuitry to keep the circuit in reset while the clock is
+-- still stabilizing.
 --
 -- See also the [ALTPLL (Phase-Locked Loop) IP Core User Guide](https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/ug/ug_altpll.pdf)
+--
+-- === Example
+--
+-- ==== Using a PLL
+--
+-- When the oscillator connected to the FPGA runs at 50 MHz and the external
+-- reset signal is /active low/, this will generate a 100 MHz clock for the
+-- @'Clash.Signal.System'@ domain:
+--
+-- @
+-- 'Clash.Signal.createDomain' 'Clash.Signal.vSystem'{vName=\"DomInput\", vPeriod=20000}
+--
+-- topEntity
+--   :: 'Clock' DomInput
+--   -> 'Signal' DomInput 'Bool'
+--   -> [...]
+-- topEntity clkInp rstInp = [...]
+--  where
+--   (clk, pllStable) =
+--     'altpll' \@'Clash.Signal.System' ('SSymbol' \@\"altpll50to100\") clkInp
+--            ('Clash.Signal.unsafeFromLowPolarity' rstInp)
+--   rst = 'Clash.Signal.resetSynchronizer' clk ('Clash.Signal.unsafeFromLowPolarity' pllStable)
+-- @
+--
+-- 'Clash.Signal.resetSynchronizer' will keep the reset asserted when
+-- @pllStable@ is 'False', hence the use of
+-- @'Clash.Signal.unsafeFromLowPolarity' pllStable@. Your circuit will have
+-- signals of type @'Signal' 'Clash.Signal.System'@ and all the clocks and
+-- resets of your components will be the @clk@ and @rst@ signals generated here
+-- (modulo local resets, which will be based on @rst@ or never asserted at all
+-- if the component doesn't need a reset).
+--
+-- ==== Specifying the output frequency
+--
+-- If you don't have a top-level type signature specifying the output clock
+-- domain, you can use type applications to specify it, e.g.:
+--
+-- @
+-- 'Clash.Signal.createDomain' 'Clash.Signal.vSystem'{vName=\"Dom100MHz\", vPeriod=10000}
+--
+-- -- outputs a clock running at 100 MHz
+-- (clk100, pllLocked) = 'altpll' \@Dom100MHz ('SSymbol' \@\"altpll50to100\") clk50 rst50
+-- @
 altpll
   :: forall domOut domIn name
    . (KnownDomain domIn, KnownDomain domOut)
   => SSymbol name
-  -- ^ Name of the component instance.
+  -- ^ Name of the component instance
   --
-  -- Instantiate as follows:
-  --
-  -- > SSymbol @"altPLL50"
+  -- Instantiate as follows: @(SSymbol \@\"altpll50\")@
   -> Clock domIn
-  -- ^ Free running clock (i.e. a clock pin connected to a crystal)
+  -- ^ Free running clock (e.g. a clock pin connected to a crystal oscillator)
   -> Reset domIn
   -- ^ Reset for the PLL
   -> (Clock domOut, Signal domOut Bool)
@@ -72,32 +127,75 @@ altpll !_ = knownDomain @domIn `seq` knownDomain @domOut `seq` clocks
 -- * a reset input port
 -- * a locked output port
 --
--- The number of output clocks depend this function's inferred result type. An
--- instance with a single and double output clock can be instantiated using:
---
--- @
--- (outClk, pllLocked) = alteraPll clk rst
--- @
---
--- and
---
--- @
--- (outClk1, outClk2, pllLocked) = alteraPll clk rst
--- @
---
--- respectively.
+-- The PLL lock output is asserted when the clocks are stable, and is usually
+-- connected to reset circuitry to keep the circuit in reset while the clocks
+-- are still stabilizing.
 --
 -- See also the [Altera Phase-Locked Loop (Altera PLL) IP Core User Guide](https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/ug/altera_pll.pdf)
+--
+-- === Specifying outputs
+--
+-- The number of output clocks depends on this function's inferred result type.
+-- An instance with a single output clock can be instantiated using:
+--
+-- @
+-- 'Clash.Signal.createDomain' 'Clash.Signal.vSystem'{vName=\"Dom100MHz\", vPeriod=10000}
+--
+-- (clk100 :: 'Clock' Dom100MHz, pllLocked) =
+--   'alteraPll' ('SSymbol' \@\"alterapll50to100\") clk50 rst50
+-- @
+--
+-- An instance with two clocks can be instantiated using
+--
+-- @
+-- 'Clash.Signal.createDomain' 'Clash.Signal.vSystem'{vName=\"Dom100MHz\", vPeriod=10000}
+-- 'Clash.Signal.createDomain' 'Clash.Signal.vSystem'{vName=\"Dom150MHz\", vPeriod='Clash.Signal.hzToPeriod' 150e6}
+--
+-- (clk100 :: 'Clock' Dom100MHz, clk150 :: 'Clock' Dom150MHz, pllLocked) =
+--   'alteraPll' ('SSymbol' \@\"alterapllmulti\") clk50 rst50
+-- @
+--
+-- and so on up to 16 clocks.
+--
+-- If you don't have a top-level type signature specifying the output clock
+-- domains, you can specify them using a pattern type signature, as shown here.
+--
+-- === Example
+--
+-- When the oscillator connected to the FPGA runs at 50 MHz and the external
+-- reset signal is /active low/, this will generate a 100 MHz clock for the
+-- @'Clash.Signal.System'@ domain:
+--
+-- @
+-- 'Clash.Signal.createDomain' 'Clash.Signal.vSystem'{vName=\"DomInput\", vPeriod=20000}
+--
+-- topEntity
+--   :: 'Clock' DomInput
+--   -> 'Signal' DomInput 'Bool'
+--   -> [...]
+-- topEntity clkInp rstInp = [...]
+--  where
+--   (clk :: 'Clock' 'Clash.Signal.System', pllStable :: 'Signal' 'Clash.Signal.System' 'Bool')
+--     'alteraPll' ('SSymbol' \@\"alterapll50to100\") clkInp
+--               ('Clash.Signal.unsafeFromLowPolarity' rstInp)
+--   rst = 'Clash.Signal.resetSynchronizer' clk ('Clash.Signal.unsafeFromLowPolarity' pllStable)
+-- @
+--
+-- 'Clash.Signal.resetSynchronizer' will keep the reset asserted when
+-- @pllStable@ is 'False', hence the use of
+-- @'Clash.Signal.unsafeFromLowPolarity' pllStable@. Your circuit will have
+-- signals of type @'Signal' 'Clash.Signal.System'@ and all the clocks and
+-- resets of your components will be the @clk@ and @rst@ signals generated here
+-- (modulo local resets, which will be based on @rst@ or never asserted at all
+-- if the component doesn't need a reset).
 alteraPll
   :: (Clocks t, KnownDomain domIn, ClocksCxt t)
   => SSymbol name
-  -- ^ Name of the component instance.
+  -- ^ Name of the component instance
   --
-  -- Instantiate as follows:
-  --
-  -- > SSymbol @"alteraPLL50"
+  -- Instantiate as follows: @(SSymbol \@\"alterapll50\")@
   -> Clock domIn
-  -- ^ Free running clock (i.e. a clock pin connected to a crystal)
+  -- ^ Free running clock (e.g. a clock pin connected to a crystal oscillator)
   -> Reset domIn
   -- ^ Reset for the PLL
   -> t


### PR DESCRIPTION
Commit d325557750 introduced an off-by-one error in the number of clocks
to generate for `alteraPll`.

Additionally, the internal `locked` signal for `alteraPll` is changed to
be of type `Bit` like in `altpll`. The borrowing of the type of the
`Reset` input probably came about out of convenience back when resets
were still a simple type so it did not matter. Now it looked odd but
worked fine nonetheless.

Also adjusted the type in `CondAssignment` in `altpll`, which showed the
same pattern.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
