### PR TITLE
Improve `clash-prelude-hedgehog` generators

### DIFF
--- a/changelog/2022-03-24T11_33_42+01_00_hedgehog_gen_extreme_values.md
+++ b/changelog/2022-03-24T11_33_42+01_00_hedgehog_gen_extreme_values.md
@@ -1,0 +1,1 @@
+FIXED: Extreme values are now generated from the input range instead of the type's bounds [#2138](https://github.com/clash-lang/clash-compiler/issues/2138)

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Index.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Index.hs
@@ -29,8 +29,8 @@ genIndex :: (MonadGen m, KnownNat n) => Range (Index n) -> m (Index n)
 genIndex range =
   Gen.frequency
     [ (60, Gen.integral range)
-    , (20, Gen.constant minBound)
-    , (20, Gen.constant maxBound)
+    , (20, Gen.constant (Range.lowerBound 99 range))
+    , (20, Gen.constant (Range.upperBound 99 range))
     ]
 
 data SomeIndex atLeast where

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Index.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Index.hs
@@ -28,9 +28,8 @@ import Clash.Sized.Internal.Index
 genIndex :: (MonadGen m, KnownNat n) => Range (Index n) -> m (Index n)
 genIndex range =
   Gen.frequency
-    [ (60, Gen.integral range)
-    , (20, Gen.constant (Range.lowerBound 99 range))
-    , (20, Gen.constant (Range.upperBound 99 range))
+    [ (70, Gen.integral range)
+    , (30, Gen.constant (Range.upperBound 99 range))
     ]
 
 data SomeIndex atLeast where

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Signed.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Signed.hs
@@ -29,8 +29,8 @@ genSigned :: (MonadGen m, KnownNat n) => Range (Signed n) -> m (Signed n)
 genSigned range =
   Gen.frequency
     [ (60, Gen.integral range)
-    , (20, Gen.constant minBound)
-    , (20, Gen.constant maxBound)
+    , (20, Gen.constant (Range.lowerBound 99 range))
+    , (20, Gen.constant (Range.upperBound 99 range))
     ]
 
 data SomeSigned atLeast where

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Unsigned.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Unsigned.hs
@@ -28,9 +28,8 @@ import Clash.Sized.Internal.Unsigned
 genUnsigned :: (MonadGen m, KnownNat n) => Range (Unsigned n) -> m (Unsigned n)
 genUnsigned range =
   Gen.frequency
-    [ (60, Gen.integral range)
-    , (20, Gen.constant (Range.lowerBound 99 range))
-    , (20, Gen.constant (Range.upperBound 99 range))
+    [ (70, Gen.integral range)
+    , (30, Gen.constant (Range.upperBound 99 range))
     ]
 
 data SomeUnsigned atLeast where

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Unsigned.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Unsigned.hs
@@ -29,8 +29,8 @@ genUnsigned :: (MonadGen m, KnownNat n) => Range (Unsigned n) -> m (Unsigned n)
 genUnsigned range =
   Gen.frequency
     [ (60, Gen.integral range)
-    , (20, Gen.constant minBound)
-    , (20, Gen.constant maxBound)
+    , (20, Gen.constant (Range.lowerBound 99 range))
+    , (20, Gen.constant (Range.upperBound 99 range))
     ]
 
 data SomeUnsigned atLeast where


### PR DESCRIPTION
This PR improves the generation of extreme values, and ensures that values generated better fit within the `Range` specified by callers.

Fixes #2138

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
