### PR TITLE
Add top name to Backend state and use it in generated include names

### DIFF
--- a/changelog/2022-03-24T11_11_36+00_00_bbInclude_with_top_name
+++ b/changelog/2022-03-24T11_11_36+00_00_bbInclude_with_top_name
@@ -1,0 +1,1 @@
+CHANGE: Top entity name available in netlist context. Top entity name used in generated name for include files.

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -140,6 +140,10 @@ class HasIdentifierSet state => Backend state where
   hdlSyn           :: State state HdlSyn
   -- | setModName
   setModName       :: ModName -> state -> state
+  -- | Set the name of the current top entity
+  setTopName       :: Identifier -> state -> state
+  -- | Get the name of the current top entity
+  getTopName       :: State state Identifier
   -- | setSrcSpan
   setSrcSpan       :: SrcSpan -> State state ()
   -- | getSrcSpan

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -73,6 +73,7 @@ data SystemVerilogState =
     , _nameCache :: HashMap HWType Identifier -- ^ Cache for previously generated product type names
     , _genDepth  :: Int -- ^ Depth of current generative block
     , _modNm     :: ModName
+    , _topNm     :: Identifier
     , _idSeen    :: IdentifierSet
     , _oports    :: [Identifier]
     , _srcSpan   :: SrcSpan
@@ -105,6 +106,7 @@ instance Backend SystemVerilogState where
     , _nameCache=HashMap.empty
     , _genDepth=0
     , _modNm=""
+    , _topNm=Id.unsafeMake ""
     , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) SystemVerilog
     , _oports=[]
     , _srcSpan=noSrcSpan
@@ -163,6 +165,8 @@ instance Backend SystemVerilogState where
   fromBV hty id_  = simpleFromSLV hty (Text.toStrict id_)
   hdlSyn          = use hdlsyn
   setModName nm s = s {_modNm = nm}
+  setTopName nm s = s {_topNm = nm}
+  getTopName      = use topNm
   setSrcSpan      = (srcSpan .=)
   getSrcSpan      = use srcSpan
   blockDecl _ ds  = do

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -90,6 +90,7 @@ data VHDLState =
   -- ^ Cache for type names. Bool indicates whether this name includes length
   -- information in its first "part". See `tyName'` for more information.
   , _modNm     :: ModName
+  , _topNm     :: Identifier
   , _srcSpan   :: SrcSpan
   , _libraries :: [T.Text]
   , _packages  :: [T.Text]
@@ -126,6 +127,7 @@ instance Backend VHDLState where
     { _tyCache=mempty
     , _nameCache=mempty
     , _modNm=""
+    , _topNm=Id.unsafeMake ""
     , _srcSpan=noSrcSpan
     , _libraries=[]
     , _packages=[]
@@ -233,6 +235,8 @@ instance Backend VHDLState where
       qualTyName t <> "'" <> parens (pretty nm <> "_types.fromSLV" <> parens (pretty id_))
   hdlSyn          = use hdlsyn
   setModName nm s = s {_modNm = nm}
+  setTopName nm s = s {_topNm = nm}
+  getTopName      = use topNm
   setSrcSpan      = (srcSpan .=)
   getSrcSpan      = use srcSpan
   blockDecl nm ds = do

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -84,6 +84,7 @@ data VerilogState =
   VerilogState
     { _genDepth  :: Int -- ^ Depth of current generative block
     , _idSeen    :: IdentifierSet
+    , _topNm     :: Identifier
     , _srcSpan   :: SrcSpan
     , _includes  :: [(String,Doc)]
     , _imports   :: HashSet Text.Text
@@ -111,6 +112,7 @@ instance Backend VerilogState where
   initBackend opts = VerilogState
     { _genDepth=0
     , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) Verilog
+    , _topNm=Id.unsafeMake ""
     , _srcSpan=noSrcSpan
     , _includes=[]
     , _imports=HashSet.empty
@@ -163,6 +165,8 @@ instance Backend VerilogState where
     _ -> string e
   hdlSyn          = use hdlsyn
   setModName _    = id
+  setTopName nm s = s {_topNm = nm}
+  getTopName      = use topNm
   setSrcSpan      = (srcSpan .=)
   getSrcSpan      = use srcSpan
   blockDecl _ ds  = do

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -383,6 +383,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
       modNameT  = Data.Text.pack modNameS
       hdlState' = setDomainConfigurations domainConfs
                 $ setModName modNameT
+                $ setTopName topNm
                 $ fromMaybe (initBackend @backend opts) hdlState
       hdlDir    = fromMaybe (Clash.Backend.name hdlState') (opt_hdlDir opts) </> topEntityS
       manPath   = hdlDir </> manifestFilename

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -302,9 +302,13 @@ renderBlackBox libs imps includes bb bbCtx = do
                                   return (const t'))
                                inc
       iw <- iwWidth
+      topNm <- getTopName
       let incHash = hash (incForHash 0)
           nm'     = Text.concat
-                      [ Text.fromStrict nm
+                      [ Text.fromStrict (Id.toText topNm)
+                      , "_"
+                      , Text.fromStrict nm
+                      , "_"
                       , Text.pack (printf ("%0" ++ show (iw `div` 4) ++ "X") incHash)
                       ]
       pure nm'


### PR DESCRIPTION
[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

This PR adds the name of the top entity being compiled as extra context when generating netlists.
It is then used to make the name of includes "globally" unique so that we don't end up with name collisions for includes from multiple Synthesize/top entities.

[comment]: # (Add a line of the form "Fixes: #xxxx" for each related issue closed by this pull request, where #xxxx is an issue number.)

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
