### PR TITLE
Tweak haddock stylesheet for clash-prelude for narrower screens

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,6 +31,11 @@ package clash-prelude
   -- Don't pollute docs with 1024 SNat literals
   haddock-options: --optghc=-DHADDOCK_ONLY
 
+  -- Tweak haddock stylesheet to enable word wrapping of types.
+  -- We specify the default Linuwial theme as an alnernate
+  -- so we're able to import its css file from the custom theme.
+  haddock-options: --theme=doc/linuwial-wrap-types.css --theme=Linuwial
+
 package clash-testsuite
   flags: +cosim
 

--- a/clash-prelude/doc/linuwial-wrap-types.css
+++ b/clash-prelude/doc/linuwial-wrap-types.css
@@ -1,0 +1,6 @@
+@import "linuwial.css";
+
+/* Re-enable wordwrapping in (parts of) type signatures */
+#interface td.src {
+  white-space: normal !important;
+}


### PR DESCRIPTION
Re-enable wordwrapping in (parts of) type signatures.
Which makes type signatures much easier to read on narrower screens.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

# Results
### Fullscreen (on a 2560x1440 monitor)
Nothing changes here.
old:
![stock-full](https://user-images.githubusercontent.com/437852/159945073-757f38c4-2a27-4f20-b0b7-20155a6f8316.png)
new:
![wrapped-full](https://user-images.githubusercontent.com/437852/159945105-ea1318bb-28de-4a32-8244-c39c2387374f.png)

### Half width ~1280 wide
old:
![stock-half](https://user-images.githubusercontent.com/437852/159945129-99522ffc-6b2b-4a5d-9080-b65a9bea75c0.png)
new:
![wrapped-half](https://user-images.githubusercontent.com/437852/159945144-de5d2672-bc39-4872-a8d1-9783d65e585d.png)

### Quarter width ~640 wide
old:
![stock-quarter](https://user-images.githubusercontent.com/437852/159945164-d72b0ca1-c4f2-44bd-aa74-7aa694dfaa4a.png)
new:
![wrapped-quarter](https://user-images.githubusercontent.com/437852/159945175-bb79aea0-bcb3-4c5b-b36f-c724ca3ded8e.png)

