### PR TITLE
Various small fixes - part 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ git checkout 1.2
 
 Note that release branches might contain non-released patches.
 
-## GHC compatability
+## GHC compatibility
 |      | Linux | Windows | macOS |
 |------|-------|---------|-------|
 | 8.6  | ✔️     | ✔️      | ✔️     |

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -338,7 +338,7 @@ data ClashOpts = ClashOpts
   , opt_color :: OverridingBool
   -- ^ Show colors in debug output
   --
-  -- Command line flag: -fclash-no-prim-warn
+  -- Command line flag: -fdiagnostics-color
   , opt_intWidth :: Int
   -- ^ Set the bit width for the Int/Word/Integer types. The only allowed values
   -- are 32 or 64.

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2017     , Myrtle Software Ltd,
                     2017-2018, Google Inc.
-                    2020-2021, QBayLogic B.V.
+                    2020-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -740,9 +740,11 @@ data TemplateFunction where
     -> TemplateFunction
 
 instance Show BlackBox where
-  show (BBTemplate t)  = "BBTemplate " <> show t
-  show (BBFunction nm hsh _) =
-    "<TemplateFunction(nm=" ++ show nm ++ ", hash=" ++ show hsh ++ ")>"
+  showsPrec d (BBTemplate t) =
+    showParen (d > 10) $ ("BBTemplate " ++) . showsPrec 11 t
+  showsPrec _ (BBFunction nm hsh _) =
+    ("<TemplateFunction(nm=" ++) . shows nm . (", hash=" ++) . shows hsh .
+    (")>" ++)
 
 instance NFData TemplateFunction where
   rnf (TemplateFunction is f _) = rnf is `seq` f `seq` ()

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -25,7 +25,7 @@ module Clash.Primitives.DSL
     BlackBoxHaskellOpts(..)
   , blackBoxHaskell
 
-  -- * declarations
+  -- * Declarations
   , BlockState (..)
   , TExpr
   , declaration
@@ -139,10 +139,10 @@ instance Default BlackBoxHaskellOpts where
 -- | Create a blackBoxHaskell primitive. To be used as part of an annotation:
 --
 -- @
--- {-# ANN myFunction (blackBoxHaskell 'myFunction 'myBBF def{_ignoredArguments=[2,3]}) #-}
+-- {-\# ANN myFunction (blackBoxHaskell 'myFunction 'myBBF def{_ignoredArguments=[1,2]}) \#-}
 -- @
 --
--- [2,3] would mean this blackbox __ignores__ its second and third argument.
+-- @[1,2]@ would mean this blackbox __ignores__ its second and third argument.
 blackBoxHaskell
   :: Name
   -- ^ blackbox name

--- a/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
+++ b/clash-prelude/src/Clash/Class/AutoReg/Internal.hs
@@ -1,6 +1,6 @@
 {-|
   Copyright   :  (C) 2019     , Google Inc.,
-                     2021     , QBayLogic B.V.
+                     2021-2022, QBayLogic B.V.,
                      2021-2022, Myrtle.ai
   License     :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -107,7 +107,7 @@ import           Control.Lens.Internal.TH     (bndrName)
 class NFDataX a => AutoReg a where
   -- | For documentation see class 'AutoReg'.
   --
-  -- This is version with explicit clock/reset/enable,
+  -- This is the version with explicit clock\/reset\/enable inputs,
   -- "Clash.Prelude" exports an implicit version of this: 'Clash.Prelude.autoReg'
   autoReg
     :: (HasCallStack, KnownDomain dom)

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -416,6 +416,8 @@ module Clash.Explicit.BlockRam
   , RamOp(..)
     -- * Internal
   , blockRam#
+  , blockRamU#
+  , blockRam1#
   , trueDualPortBlockRam#
   )
 where

--- a/clash-prelude/src/Clash/Explicit/Mealy.hs
+++ b/clash-prelude/src/Clash/Explicit/Mealy.hs
@@ -80,8 +80,8 @@ let macT s (x,y) = (s',s)
 --   -> 'Signal' dom Int
 -- dualMac clk rst en (a,b) (x,y) = s1 + s2
 --   where
---     s1 = 'mealy' clk rst en mac 0 ('bundle' (a,x))
---     s2 = 'mealy' clk rst en mac 0 ('bundle' (b,y))
+--     s1 = 'mealy' clk rst en macT 0 ('bundle' (a,x))
+--     s2 = 'mealy' clk rst en macT 0 ('bundle' (b,y))
 -- @
 mealy
   :: ( KnownDomain dom

--- a/clash-prelude/src/Clash/Explicit/Moore.hs
+++ b/clash-prelude/src/Clash/Explicit/Moore.hs
@@ -72,8 +72,8 @@ import           Clash.XException                 (NFDataX)
 --   -> 'Signal' dom Int
 -- dualMac clk rst en (a,b) (x,y) = s1 + s2
 --   where
---     s1 = 'moore' clk rst en mac id 0 ('bundle' (a,x))
---     s2 = 'moore' clk rst en mac id 0 ('bundle' (b,y))
+--     s1 = 'moore' clk rst en macT id 0 ('bundle' (a,x))
+--     s2 = 'moore' clk rst en macT id 0 ('bundle' (b,y))
 -- @
 moore
   :: ( KnownDomain dom

--- a/clash-prelude/src/Clash/Num/Overflowing.hs
+++ b/clash-prelude/src/Clash/Num/Overflowing.hs
@@ -1,10 +1,18 @@
+{-|
+Copyright  :  (C) 2021-2022, QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Clash.Num.Overflowing
-  ( Overflowing(fromOverflowing, hasOverflowed)
+  ( Overflowing
+  , fromOverflowing
+  , hasOverflowed
   , toOverflowing
   , clearOverflow
   ) where
@@ -31,7 +39,9 @@ import Clash.XException (NFDataX, ShowX)
 --
 data Overflowing a = Overflowing
   { fromOverflowing :: a
+    -- ^ Retrieve the value
   , hasOverflowed :: Bool
+    -- ^ 'True' when a computation has overflowed
   }
   deriving stock (Generic, Show)
   deriving anyclass (Binary, Hashable, NFData, NFDataX, ShowX)

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -71,8 +71,8 @@ let macT s (x,y) = (s',s)
 --   -> 'Signal' dom Int
 -- dualMac (a,b) (x,y) = s1 + s2
 --   where
---     s1 = 'mealy' mac 0 ('Clash.Signal.bundle' (a,x))
---     s2 = 'mealy' mac 0 ('Clash.Signal.bundle' (b,y))
+--     s1 = 'mealy' macT 0 ('Clash.Signal.bundle' (a,x))
+--     s2 = 'mealy' macT 0 ('Clash.Signal.bundle' (b,y))
 -- @
 mealy
   :: ( HiddenClockResetEnable dom

--- a/clash-prelude/src/Clash/Prelude/Moore.hs
+++ b/clash-prelude/src/Clash/Prelude/Moore.hs
@@ -74,8 +74,8 @@ let macT s (x,y) = x * y + s
 --   -> 'Signal' dom Int
 -- dualMac (a,b) (x,y) = s1 + s2
 --   where
---     s1 = 'moore' mac id 0 ('Clash.Signal.bundle' (a,x))
---     s2 = 'moore' mac id 0 ('Clash.Signal.bundle' (b,y))
+--     s1 = 'moore' macT id 0 ('Clash.Signal.bundle' (a,x))
+--     s2 = 'moore' macT id 0 ('Clash.Signal.bundle' (b,y))
 -- @
 moore
   :: ( HiddenClockResetEnable dom

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -262,7 +262,7 @@ traceSignal1 traceName signal =
 -- an error.
 --
 -- __NB__ Works correctly when creating VCD files from traced signal in
--- multi-clock circuits. However 'traceSignal1' might be more convinient to
+-- multi-clock circuits. However 'traceSignal1' might be more convenient to
 -- use when the domain of your circuit is polymorphic.
 traceVecSignal
   :: forall dom a  n


### PR DESCRIPTION
Various small fixes

Please only merge just before releasing 1.6.3 so we can still amend this with further small fixes we find in the meantime. Please squash-merge so we don't get tiny commits in our repo.

Improve `Show BlackBox`: add parentheses for proper precedence for `BBTemplate`. It showed in `show (BlackBoxE ... (BBTemplate ...) ...)`, where the parentheses were missing, making it a surprising read.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files