### PR TITLE
Make sure the VHDL BB for Signed.fromInteger can handle any Netlist Expr

### DIFF
--- a/changelog/2022-04-01T16_38_37+02_00_fix_Signed.fromInteger_VHDL_BB
+++ b/changelog/2022-04-01T16_38_37+02_00_fix_Signed.fromInteger_VHDL_BB
@@ -1,0 +1,1 @@
+FIXED: The VHDL BB for Signed.fromInteger can now handle any Netlist Expr as input [#2149](https://github.com/clash-lang/clash-compiler/issues/2149)

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives.yaml
@@ -97,7 +97,7 @@
     kind: Expression
     type: 'fromInteger# ::
       KnownNat n => Integer -> Signed (n :: Nat)'
-    templateFunction: Clash.Primitives.Sized.Signed.fromIntegerTF
+    templateFunction: Clash.Primitives.Sized.Signed.fromIntegerTFvhdl
     workInfo: Never
 - BlackBox:
     name: Clash.Sized.Internal.Signed.toEnum#

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -596,7 +596,7 @@ knownTemplateFunctions =
     , ('P.alteraPllQsysTF, P.alteraPllQsysTF)
     , ('P.alteraPllTF, P.alteraPllTF)
     , ('P.altpllTF, P.altpllTF)
-    , ('P.fromIntegerTF, P.fromIntegerTF)
+    , ('P.fromIntegerTFvhdl, P.fromIntegerTFvhdl)
     ]
 
 -- | Compiles blackbox functions and parses blackbox templates.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -634,6 +634,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "Strict" def
         , runTest "T1019" def{hdlSim=False}
         , runTest "T1351" def
+        , runTest "T2149" def
         , outputTest "UndefinedConstantFolding" def{ghcFlags=["-itests/shouldwork/Numbers"]}
         , runTest "UnsignedZero" def
         ]

--- a/tests/shouldwork/Numbers/T2149.hs
+++ b/tests/shouldwork/Numbers/T2149.hs
@@ -1,0 +1,29 @@
+module T2149 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity :: Word -> Signed 8
+topEntity = fromIntegral
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst (negNr 42 :> posNr 41 :> negNr (-40) :> posNr (-39) :> Nil)
+    expectedOutput = outputVerifier' clk rst (42 :> 41 :> (-40) :> (-39) :> Nil)
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+
+
+-- | Use input as the lower byte of the output, and set its bits 31 and 63
+--
+-- By setting both bit 31 and 63, the sign-bit of the intermediate Integer is always set,
+-- no matter if we're representing it as a signed 64 or 32 bit number.
+negNr :: Signed 8 -> Word
+negNr x = unpack (resize (pack x)) .|. bit 31 .|. bit 63
+
+
+posNr :: Signed 8 -> Word
+posNr x = unpack (resize (pack x)) .|. bit 30


### PR DESCRIPTION
Previously it could only handle Identifier.
(And Literal, which is handled seperately in [Clash.Backend.VHDL.expr_](https://github.com/clash-lang/clash-compiler/blob/cb93b418865e244da50e1d2bc85fbc01bf761f3f/clash-lib/src/Clash/Backend/VHDL.hs#L1682-L1685))

I've also renamed it to make it clear this blackbox is VHDL only.

Fixes #2149

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

