### PR TITLE
Preserve non-recursive let in normalization

### DIFF
--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -29,6 +29,7 @@ module Clash.Core.Term
   , TmName
   , varToId
   , Bind(..)
+  , bindToList -- TODO Eventually all Letrec are removed and this isn't needed.
   , LetBinding
   , Pat (..)
   , patIds


### PR DESCRIPTION
In #1980, Clash started to keep the distinction between recursive
and non-recursive let expressions in Core (like GHC). However, for
convenience the old Letrec constructor is still used in some places
to avoid the need to fix every location at once.

The `inlineCleanup` transformation was one such place, however the
fix is relatively simple: when there is only one binder at the end
of cleanup and the original let expression was non-recursive, this
binding must also be non-recursive.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
