### PR TITLE
Clash FFI

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,7 @@
 -- root directory (i.e. patched copies, or forks) and will automatically be
 -- preferred by the solver over other versions.
 packages:
+  ./clash-ffi
   ./clash-ghc
   ./clash-lib
   ./clash-lib-hedgehog

--- a/clash-ffi/.gitignore
+++ b/clash-ffi/.gitignore
@@ -1,0 +1,5 @@
+lib/
+*.v
+*.vvp
+*.vpl
+*.so

--- a/clash-ffi/LICENSE
+++ b/clash-ffi/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2022 QBayLogic B.V.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/clash-ffi/README.md
+++ b/clash-ffi/README.md
@@ -45,57 +45,57 @@ All interaction with a simulator follows the same general process:
 
 General Functions
 
-| VPI Definition            | Supported | Haskell API Function(s)             |
-| :---                      | :---:     | :---                                |
-| vpi_chk_error             | YES       |                                     |
-| vpi_compare_objects       | YES       |                                     |
-| vpi_control               | YES       |                                     |
-| vpi_flush                 | NO        |                                     |
-| vpi_get                   | YES       |                                     |
-| vpi_get_cb_info           | YES       |                                     |
-| vpi_get_data              | NO        |                                     |
-| vpi_get_delays            | NO        |                                     |
-| vpi_get_str               | YES       |                                     |
-| vpi_get_systf_info        | NO        |                                     |
-| vpi_get_time              | YES       |                                     |
-| vpi_get_userdata          | NO        |                                     |
-| vpi_get_value             | YES       |                                     |
-| vpi_get_vlog_info         | YES       |                                     |
-| vpi_handle                | YES       |                                     |
-| vpi_handle_by_index       | YES       |                                     |
-| vpi_handle_by_multi_index | YES       |                                     |
-| vpi_handle_by_name        | YES       |                                     |
-| vpi_handle_multi          | NO        |                                     |
-| vpi_iterate               | YES       |                                     |
-| vpi_mcd_close             | NO        |                                     |
-| vpi_mcd_flush             | NO        |                                     |
-| vpi_mcd_name              | NO        |                                     |
-| vpi_mcd_open              | NO        |                                     |
-| vpi_mcd_printf            | NO        |                                     |
-| vpi_mcd_vprintf           | NO        |                                     |
-| vpi_printf                | YES       |                                     |
-| vpi_put_data              | NO        |                                     |
-| vpi_put_delays            | NO        |                                     |
-| vpi_put_userdata          | NO        |                                     |
-| vpi_put_value             | YES       |                                     |
-| vpi_register_cb           | NO        |                                     |
-| vpi_register_systf        | NO        |                                     |
-| vpi_remove_cb             | NO        |                                     |
-| vpi_scan                  | YES*      |                                     |
-| vpi_vprintf               | NO        |                                     |
+| VPI Definition            | Supported | Haskell API Function(s)               |
+| :---                      | :---:     | :---                                  |
+| vpi_chk_error             | YES       | simulationError, simulationErrorLevel |
+| vpi_compare_objects       | YES       | compareHandles                        |
+| vpi_control               | YES       | controlSimulator                      |
+| vpi_flush                 | NO        |                                       |
+| vpi_get                   | YES       | getProperty                           |
+| vpi_get_cb_info           | YES       | callbackInfo                          |
+| vpi_get_data              | NO        |                                       |
+| vpi_get_delays            | NO        |                                       |
+| vpi_get_str               | YES       | getProperty                           |
+| vpi_get_systf_info        | NO        |                                       |
+| vpi_get_time              | YES       | simulationTime                        |
+| vpi_get_userdata          | NO        |                                       |
+| vpi_get_value             | YES       | receiveValue, unsafeReceiveValue      |
+| vpi_get_vlog_info         | YES       | simulatorInfo                         |
+| vpi_handle                | YES       | childHandle                           |
+| vpi_handle_by_index       | YES       | childHandle                           |
+| vpi_handle_by_multi_index | YES       | childHandle                           |
+| vpi_handle_by_name        | YES       | childHandle                           |
+| vpi_handle_multi          | NO        |                                       |
+| vpi_iterate               | YES       | iterate, iterateAll                   |
+| vpi_mcd_close             | NO        |                                       |
+| vpi_mcd_flush             | NO        |                                       |
+| vpi_mcd_name              | NO        |                                       |
+| vpi_mcd_open              | NO        |                                       |
+| vpi_mcd_printf            | NO        |                                       |
+| vpi_mcd_vprintf           | NO        |                                       |
+| vpi_printf                | YES       | simPutStr, simPutStrLn                | 
+| vpi_put_data              | NO        |                                       |
+| vpi_put_delays            | NO        |                                       |
+| vpi_put_userdata          | NO        |                                       |
+| vpi_put_value             | YES       | sendValue, unsafeSendValue            |
+| vpi_register_cb           | YES       | registerCallback                      |
+| vpi_register_systf        | NO        |                                       |
+| vpi_remove_cb             | YES       | removeCallback                        |
+| vpi_scan                  | YES       | scan                                  |
+| vpi_vprintf               | NO        |                                       |
 
 Specific to IEEE 1364
 
-| VPI Definition            | Supported | Haskell API Function(s)             |
-| :---                      | :---:     | :---                                |
-| vpi_free_object           | YES       |                                     |
+| VPI Definition            | Supported | Haskell API Function(s)               |
+| :---                      | :---:     | :---                                  |
+| vpi_free_object           | YES       | freeHandle                            |
 
 Specific to IEEE 1800
 
-| VPI Definition            | Supported | Haskell API Function(s)             |
-| :---                      | :---:     | :---                                |
-| vpi_get64                 | YES       |                                     |
-| vpi_release_handle        | YES       |                                     |
+| VPI Definition            | Supported | Haskell API Function(s)               |
+| :---                      | :---:     | :---                                  |
+| vpi_get64                 | YES       | getProperty                           |
+| vpi_release_handle        | YES       | freeHandle                            |
 
 ### VHPI
 

--- a/clash-ffi/README.md
+++ b/clash-ffi/README.md
@@ -1,0 +1,107 @@
+# `clash-ffi` - Clash FFI with Simulator Tools
+
+  * See the LICENSE file for license and copyright details
+
+# Clash FFI
+
+This package provides FFI support for interfacing with simulation tools over
+a standard interface (e.g. VPI / VHPI / FLI). Currently only VPI is supported.
+
+All interaction with a simulator follows the same general process:
+
+  * the Haskell code performing the FFI is compiled as a shared library. Any
+    libraries specified as `foreign-library` in `clash-ffi.cabal` are copied
+    into a `lib/` directory in the project on successful build. Haskell FFI
+    code *must* export the entry point
+
+    ```c
+    void clash_ffi_main(void);
+    ```
+
+    This requires a foreign export in user code, i.e.
+
+    ```haskell
+    foreign export ccall "clash_ffi_main"
+      ffiMain :: IO ()
+
+    ffiMain :: IO ()
+    ffiMain = -- Some FFI code
+    ```
+
+    This main action is run during the start-of-simulation callback from VPI.
+    This means while it can register new callbacks, it should not run forever
+    as doing so would mean control is never returned to the simulator.
+
+  * The simulator is started with flags which load the library. For instance,
+    with `iverilog` the simulator is invoked with a command similar to
+
+    ```bash
+    vvp -L lib -l libclashffi-iverilog-vpi MODULE.vvp
+    ```
+
+## Supported API Functions
+
+### VPI
+
+General Functions
+
+| VPI Definition            | Supported | Haskell API Function(s)             |
+| :---                      | :---:     | :---                                |
+| vpi_chk_error             | YES       |                                     |
+| vpi_compare_objects       | YES       |                                     |
+| vpi_control               | YES       |                                     |
+| vpi_flush                 | NO        |                                     |
+| vpi_get                   | YES       |                                     |
+| vpi_get_cb_info           | YES       |                                     |
+| vpi_get_data              | NO        |                                     |
+| vpi_get_delays            | NO        |                                     |
+| vpi_get_str               | YES       |                                     |
+| vpi_get_systf_info        | NO        |                                     |
+| vpi_get_time              | YES       |                                     |
+| vpi_get_userdata          | NO        |                                     |
+| vpi_get_value             | YES       |                                     |
+| vpi_get_vlog_info         | YES       |                                     |
+| vpi_handle                | YES       |                                     |
+| vpi_handle_by_index       | YES       |                                     |
+| vpi_handle_by_multi_index | YES       |                                     |
+| vpi_handle_by_name        | YES       |                                     |
+| vpi_handle_multi          | NO        |                                     |
+| vpi_iterate               | YES       |                                     |
+| vpi_mcd_close             | NO        |                                     |
+| vpi_mcd_flush             | NO        |                                     |
+| vpi_mcd_name              | NO        |                                     |
+| vpi_mcd_open              | NO        |                                     |
+| vpi_mcd_printf            | NO        |                                     |
+| vpi_mcd_vprintf           | NO        |                                     |
+| vpi_printf                | YES       |                                     |
+| vpi_put_data              | NO        |                                     |
+| vpi_put_delays            | NO        |                                     |
+| vpi_put_userdata          | NO        |                                     |
+| vpi_put_value             | YES       |                                     |
+| vpi_register_cb           | NO        |                                     |
+| vpi_register_systf        | NO        |                                     |
+| vpi_remove_cb             | NO        |                                     |
+| vpi_scan                  | YES*      |                                     |
+| vpi_vprintf               | NO        |                                     |
+
+Specific to IEEE 1364
+
+| VPI Definition            | Supported | Haskell API Function(s)             |
+| :---                      | :---:     | :---                                |
+| vpi_free_object           | YES       |                                     |
+
+Specific to IEEE 1800
+
+| VPI Definition            | Supported | Haskell API Function(s)             |
+| :---                      | :---:     | :---                                |
+| vpi_get64                 | YES       |                                     |
+| vpi_release_handle        | YES       |                                     |
+
+### VHPI
+
+VHPI is not supported at this time.
+
+### FLI
+
+FLI is not supported at this time.
+

--- a/clash-ffi/README.md
+++ b/clash-ffi/README.md
@@ -50,7 +50,7 @@ General Functions
 | vpi_chk_error             | YES       | simulationError, simulationErrorLevel |
 | vpi_compare_objects       | YES       | compareHandles                        |
 | vpi_control               | YES       | controlSimulator                      |
-| vpi_flush                 | NO        |                                       |
+| vpi_flush                 | YES       | simFlushIO                            |
 | vpi_get                   | YES       | getProperty                           |
 | vpi_get_cb_info           | YES       | callbackInfo                          |
 | vpi_get_data              | NO        |                                       |

--- a/clash-ffi/Setup.hs
+++ b/clash-ffi/Setup.hs
@@ -1,0 +1,91 @@
+module Main where
+
+import Control.Monad
+import Data.Maybe
+import Distribution.PackageDescription.Utils
+import Distribution.Simple
+import Distribution.Simple.Build
+import Distribution.Simple.BuildPaths
+import Distribution.Simple.Setup
+import Distribution.Simple.Utils
+import Distribution.System
+import Distribution.Types.ForeignLib
+import Distribution.Types.ForeignLibType
+import Distribution.Types.GenericPackageDescription
+import Distribution.Types.HookedBuildInfo
+import Distribution.Types.LocalBuildInfo
+import Distribution.Types.PackageDescription
+import Distribution.Types.UnqualComponentName
+import Distribution.Verbosity
+import System.Directory
+import System.FilePath
+
+main :: IO ()
+main =
+  defaultMainWithHooks simpleUserHooks
+    { postBuild = ffiPostBuild }
+
+ffiPostBuild
+  :: Args
+  -> BuildFlags
+  -> PackageDescription
+  -> LocalBuildInfo
+  -> IO ()
+ffiPostBuild args flags desc info = do
+  -- Create lib/ in the project directory
+  let outPath = takeDirectory (fromJust $ pkgDescrFile info) </> "lib"
+  createDirectoryIfMissing True outPath
+
+  -- Copy each foreign library to lib/
+  forM_ (foreignLibs desc) $ \flib ->
+    let name = unUnqualComponentName (foreignLibName flib)
+        dLib = buildDir info </> name </> flibTargetName info flib
+     in copySoAsVpl outPath dLib
+
+  -- Do the normal post-build hook action
+  postBuild simpleUserHooks args flags desc info
+
+-- | Get the name of the library that will be written to disk when building
+-- the library. Lifted from `Distribution.Simple.GHC`.
+--
+flibTargetName :: LocalBuildInfo -> ForeignLib -> String
+flibTargetName lbi flib =
+    case (os, foreignLibType flib) of
+      (Windows, ForeignLibNativeShared) -> nm <.> "dll"
+      (Windows, ForeignLibNativeStatic) -> nm <.> "lib"
+      (Linux,   ForeignLibNativeShared) -> "lib" ++ nm <.> versionedExt
+      (_other,  ForeignLibNativeShared) ->
+        "lib" ++ nm <.> dllExtension (hostPlatform lbi)
+      (_other,  ForeignLibNativeStatic) ->
+        "lib" ++ nm <.> staticLibExtension (hostPlatform lbi)
+      (_any,    ForeignLibTypeUnknown)  -> cabalBug "unknown foreign lib type"
+  where
+    nm :: String
+    nm = unUnqualComponentName $ foreignLibName flib
+
+    os :: OS
+    os = let (Platform _ os') = hostPlatform lbi
+         in os'
+
+    -- If a foreign lib foo has lib-version-info 5:1:2 or
+    -- lib-version-linux 3.2.1, it should be built as libfoo.so.3.2.1
+    -- Libtool's version-info data is translated into library versions in a
+    -- nontrivial way: so refer to libtool documentation.
+    versionedExt :: String
+    versionedExt =
+      let nums = foreignLibVersion flib os
+      in foldl (<.>) "so" (map show nums)
+
+-- | Copy a file to the same directory, but change the extension to .vpl. This
+-- is needed for iverilog, as it will not load VPI modules which do not have
+-- either a .vpi or .vpl extension, unlike other simulators which will load
+-- the .so file that cabal normally produces.
+--
+copySoAsVpl :: FilePath -> FilePath -> IO ()
+copySoAsVpl outDir so =
+  -- We use installMaybeExecutable file because it preserves the permissions
+  -- of the original file. On my machine, just using installExecutableFile
+  -- meant the permissions were *slightly* different.
+  let outPath = replaceDirectory (replaceExtensions so "vpl") outDir
+   in installMaybeExecutableFile verbose so outPath
+

--- a/clash-ffi/cbits/entry_vpi.c
+++ b/clash-ffi/cbits/entry_vpi.c
@@ -1,0 +1,79 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// hs_init, hs_exit
+#include "HsFFI.h"
+
+#if defined(__GLASGOW_HASKELL__)
+// RtsConfig, hs_init_ghc
+#include "Rts.h"
+#endif
+
+#include "vpi_user.h"
+
+// This is exported from Haskell as the "actual" entry point of the program
+// that uses VPI. Cocotb does a similar thing, however they can interactively
+// load whatever module / function they want using the python API.
+extern void clash_ffi_main(void);
+
+typedef PLI_INT32 (*f_cb)(p_cb_data cb_data);
+
+static bool HASKELL_INITIALIZED = false;
+
+void hs_callback(PLI_INT32 reason, f_cb callback) {
+  s_cb_data data;
+
+  data.time = NULL;
+  data.reason = reason;
+  data.cb_rtn = callback;
+  data.user_data = NULL;
+
+  vpiHandle handle = vpi_register_cb(&data);
+  vpi_free_object(handle);
+}
+
+PLI_INT32 init_ghc(p_cb_data data) {
+  s_vpi_vlog_info info;
+
+  if(vpi_get_vlog_info(&info)) {
+#if defined(__GLASGOW_HASKELL__)
+    RtsConfig conf = defaultRtsConfig;
+    conf.rts_opts_enabled = RtsOptsAll;
+
+    // Initialize GHC with RTS options so we can accept them in cmdline args.
+    hs_init_ghc(&info.argc, &info.argv, conf);
+#else
+    hs_init(&info.argc, &info.argv);
+#endif
+
+    HASKELL_INITIALIZED = true;
+
+    // TODO We want some entry point to trampoline into that's defined in all
+    // things which use clash-ffi, e.g. testbenches.
+    clash_ffi_main();
+
+    return 0;
+  }
+  else {
+    return -1;
+  }
+}
+
+PLI_INT32 exit_ghc(p_cb_data data) {
+  if(HASKELL_INITIALIZED) {
+    hs_exit();
+  }
+
+  return 0;
+}
+
+void register_ghc_callbacks(void) {
+  hs_callback(cbStartOfSimulation, init_ghc);
+  hs_callback(cbEndOfSimulation, exit_ghc);
+}
+
+void (*vlog_startup_routines[])() = {
+  register_ghc_callbacks, 0
+};
+

--- a/clash-ffi/clash-ffi.cabal
+++ b/clash-ffi/clash-ffi.cabal
@@ -85,7 +85,7 @@ common vpi-config
 custom-setup
   setup-depends:
     base        >= 4.11  && < 5,
-    Cabal       >= 3.4.1 && < 3.5,
+    Cabal       >= 2.4   && < 3.5,
     directory   >= 1.3.6 && < 1.4,
     filepath    >= 1.4.2 && < 1.5,
 

--- a/clash-ffi/clash-ffi.cabal
+++ b/clash-ffi/clash-ffi.cabal
@@ -1,0 +1,110 @@
+cabal-version:      2.2
+
+name:               clash-ffi
+version:            1.5.0
+synopsis:           Interact with Simulators from Clash
+description:        Interact with Simulators from Clash
+bug-reports:        https://github.com/clash-lang/clash-compiler/issues
+license:            BSD-2-Clause
+license-file:       LICENSE
+author:             QBayLogic B.V.
+maintainer:         devops@qbaylogic.com
+copyright:          Copyright © 2022, QBayLogic B.V.
+category:           Hardware
+build-type:         Custom
+
+common basic-config
+  default-language: Haskell2010
+
+  default-extensions:
+    BangPatterns
+    DeriveAnyClass
+    DeriveGeneric
+    DerivingStrategies
+    GeneralizedNewtypeDeriving
+    ScopedTypeVariables
+    TypeApplications
+
+  include-dirs:
+    include
+
+  ghc-options:
+    -Wall -Wcompat -g
+
+  build-depends:
+    base                    >= 4.11     && < 5,
+    bytestring              >= 0.10.0.2 && < 0.12,
+    deepseq                 >= 1.4      && < 1.5,
+    derive-storable         >= 0.3.0.0  && < 0.4,
+    derive-storable-plugin  >= 0.2.3    && < 0.3,
+    mtl                     >= 2.2.2    && < 2.3,
+    pretty-show             >= 1.10     && < 1.11,
+
+    clash-prelude           >= 1.2      && < 2,
+
+  other-modules:
+    Clash.FFI.Monad
+    Clash.FFI.View
+
+common vpi-config
+  includes:
+    vpi_user.h
+
+  c-sources:
+    cbits/entry_vpi.c
+
+  cpp-options:
+    -DVERILOG=1
+
+  other-modules:
+    Clash.FFI.VPI.Callback
+    Clash.FFI.VPI.Callback.Reason
+    Clash.FFI.VPI.Control
+    Clash.FFI.VPI.Error
+    Clash.FFI.VPI.Error.Level
+    Clash.FFI.VPI.Error.State
+    Clash.FFI.VPI.Info
+    Clash.FFI.VPI.IO
+    Clash.FFI.VPI.Object
+    Clash.FFI.VPI.Object.Type
+    Clash.FFI.VPI.Module
+    Clash.FFI.VPI.Net
+    Clash.FFI.VPI.Parameter
+    Clash.FFI.VPI.Port
+    Clash.FFI.VPI.Property
+    Clash.FFI.VPI.Property.Type
+    Clash.FFI.VPI.Reg
+    Clash.FFI.VPI.Time
+    Clash.FFI.VPI.Value
+    Clash.FFI.VPI.Value.Delay
+    Clash.FFI.VPI.Value.Format
+    Clash.FFI.VPI.Value.Scalar
+    Clash.FFI.VPI.Value.Vector
+
+custom-setup
+  setup-depends:
+    base        >= 4.11  && < 5,
+    Cabal       >= 3.4.1 && < 3.5,
+    directory   >= 1.3.6 && < 1.4,
+    filepath    >= 1.4.2 && < 1.5,
+
+-- To accomodate differences between different simulators when defining the
+-- generic interface, different foreign libraries are produced for each tool.
+-- The code is shared between all simulators and each library defines it's name
+-- and includes the source files it needs for it's interface.
+
+foreign-library clash-iverilog-vpi
+  import: basic-config, vpi-config
+  type: native-shared
+  lib-version-info: 0:0:0
+  hs-source-dirs: src
+
+  cpp-options:
+    -DIVERILOG=1
+    -DVERILOG_2001=1
+    -DVERILOG_2005=1
+    -DVPI_VECVAL=1
+
+  other-modules:
+    Clash.FFI.Iverilog
+

--- a/clash-ffi/clash-ffi.cabal
+++ b/clash-ffi/clash-ffi.cabal
@@ -63,14 +63,16 @@ common vpi-config
     Clash.FFI.VPI.Error
     Clash.FFI.VPI.Error.Level
     Clash.FFI.VPI.Error.State
-    Clash.FFI.VPI.Info
     Clash.FFI.VPI.IO
-    Clash.FFI.VPI.Object
-    Clash.FFI.VPI.Object.Type
+    Clash.FFI.VPI.Info
+    Clash.FFI.VPI.Iterator
     Clash.FFI.VPI.Module
     Clash.FFI.VPI.Net
+    Clash.FFI.VPI.Object
+    Clash.FFI.VPI.Object.Type
     Clash.FFI.VPI.Parameter
     Clash.FFI.VPI.Port
+    Clash.FFI.VPI.Port.Direction
     Clash.FFI.VPI.Property
     Clash.FFI.VPI.Property.Type
     Clash.FFI.VPI.Reg

--- a/clash-ffi/clash-ffi.cabal
+++ b/clash-ffi/clash-ffi.cabal
@@ -34,11 +34,9 @@ common basic-config
   build-depends:
     base                    >= 4.11     && < 5,
     bytestring              >= 0.10.0.2 && < 0.12,
-    deepseq                 >= 1.4      && < 1.5,
     derive-storable         >= 0.3.0.0  && < 0.4,
     derive-storable-plugin  >= 0.2.3    && < 0.3,
     mtl                     >= 2.2.2    && < 2.3,
-    pretty-show             >= 1.10     && < 1.11,
 
     clash-prelude           >= 1.2      && < 2,
 
@@ -63,6 +61,7 @@ common vpi-config
     Clash.FFI.VPI.Error
     Clash.FFI.VPI.Error.Level
     Clash.FFI.VPI.Error.State
+    Clash.FFI.VPI.Handle
     Clash.FFI.VPI.IO
     Clash.FFI.VPI.Info
     Clash.FFI.VPI.Iterator

--- a/clash-ffi/clash-ffi.cabal
+++ b/clash-ffi/clash-ffi.cabal
@@ -29,7 +29,7 @@ common basic-config
     include
 
   ghc-options:
-    -Wall -Wcompat -g
+    -Wall -Wcompat -g -debug
 
   build-depends:
     base                    >= 4.11     && < 5,

--- a/clash-ffi/include/vpi_compatibility.h
+++ b/clash-ffi/include/vpi_compatibility.h
@@ -1,0 +1,130 @@
+/*******************************************************************************
+* vpi_compatibility.h
+*
+* IEEE 1800-2017 SystemVerilog Verification Procedural Interface (VPI)
+*
+* NOTE: THIS FILE IS INCLUDED BY vpi_user.h. DO NOT INCLUDE THIS FILE FROM
+* USER APPLICATION CODE.
+*
+* This file contains the macro definitions used by the SystemVerilog PLI
+* to implement backwards compatibility mode functionality.
+*
+******************************************************************************/
+#ifdef VPI_COMPATIBILITY_H
+#error "The vpi_compatibility.h file can only be included by vpi_user.h directly."
+#endif
+#define VPI_COMPATIBILITY_H
+/* Compatibility-mode variants of functions */
+#if VPI_COMPATIBILITY_VERSION_1800v2017
+#define VPI_COMPATIBILITY_VERSION_1800v2012
+#endif
+#if VPI_COMPATIBILITY_VERSION_1364v1995
+#if VPI_COMPATIBILITY_VERSION_1364v2001 || VPI_COMPATIBILITY_VERSION_1364v2005 || VPI_COMPATIBILITY_VERSION_1800v2005 || VPI_COMPATIBILITY_VERSION_1800v2009 || VPI_COMPATIBILITY_VERSION_1800v2012
+#error "Only one VPI_COMPATIBILITY_VERSION symbol definition is allowed."
+#endif
+#define vpi_compare_objects vpi_compare_objects_1364v1995
+#define vpi_control vpi_control_1364v1995
+#define vpi_get vpi_get_1364v1995
+#define vpi_get_str vpi_get_str_1364v1995
+#define vpi_get_value vpi_get_value_1364v1995
+#define vpi_handle vpi_handle_1364v1995
+#define vpi_handle_by_index vpi_handle_by_index_1364v1995
+#define vpi_handle_by_multi_index vpi_handle_by_multi_index_1364v1995
+#define vpi_handle_by_name vpi_handle_by_name_1364v1995
+#define vpi_handle_multi vpi_handle_multi_1364v1995
+#define vpi_iterate vpi_iterate_1364v1995
+#define vpi_put_value vpi_put_value_1364v1995
+#define vpi_register_cb vpi_register_cb_1364v1995
+#define vpi_scan vpi_scan_1364v1995
+#elif VPI_COMPATIBILITY_VERSION_1364v2001
+#if VPI_COMPATIBILITY_VERSION_1364v1995 || VPI_COMPATIBILITY_VERSION_1364v2005 || VPI_COMPATIBILITY_VERSION_1800v2005 || VPI_COMPATIBILITY_VERSION_1800v2009 || VPI_COMPATIBILITY_VERSION_1800v2012
+#error "Only one VPI_COMPATIBILITY_VERSION symbol definition is allowed."
+#endif
+#define vpi_compare_objects vpi_compare_objects_1364v2001
+#define vpi_control vpi_control_1364v2001
+#define vpi_get vpi_get_1364v2001
+#define vpi_get_str vpi_get_str_1364v2001
+#define vpi_get_value vpi_get_value_1364v2001
+#define vpi_handle vpi_handle_1364v2001
+#define vpi_handle_by_index vpi_handle_by_index_1364v2001
+#define vpi_handle_by_multi_index vpi_handle_by_multi_index_1364v2001
+#define vpi_handle_by_name vpi_handle_by_name_1364v2001
+#define vpi_handle_multi vpi_handle_multi_1364v2001
+#define vpi_iterate vpi_iterate_1364v2001
+#define vpi_put_value vpi_put_value_1364v2001
+#define vpi_register_cb vpi_register_cb_1364v2001
+#define vpi_scan vpi_scan_1364v2001
+#elif VPI_COMPATIBILITY_VERSION_1364v2005
+#if VPI_COMPATIBILITY_VERSION_1364v1995 || VPI_COMPATIBILITY_VERSION_1364v2001 || VPI_COMPATIBILITY_VERSION_1800v2005 || VPI_COMPATIBILITY_VERSION_1800v2009 || VPI_COMPATIBILITY_VERSION_1800v2012
+#error "Only one VPI_COMPATIBILITY_VERSION symbol definition is allowed."
+#endif
+#define vpi_compare_objects vpi_compare_objects_1364v2005
+#define vpi_control vpi_control_1364v2005
+#define vpi_get vpi_get_1364v2005
+#define vpi_get_str vpi_get_str_1364v2005
+#define vpi_get_value vpi_get_value_1364v2005
+#define vpi_handle vpi_handle_1364v2005
+#define vpi_handle_by_index vpi_handle_by_index_1364v2005
+#define vpi_handle_by_multi_index vpi_handle_by_multi_index_1364v2005
+#define vpi_handle_by_name vpi_handle_by_name_1364v2005
+#define vpi_handle_multi vpi_handle_multi_1364v2005
+#define vpi_iterate vpi_iterate_1364v2005
+#define vpi_put_value vpi_put_value_1364v2005
+#define vpi_register_cb vpi_register_cb_1364v2005
+#define vpi_scan vpi_scan_1364v2005
+#elif VPI_COMPATIBILITY_VERSION_1800v2005
+#if VPI_COMPATIBILITY_VERSION_1364v1995 || VPI_COMPATIBILITY_VERSION_1364v2001 || VPI_COMPATIBILITY_VERSION_1364v2005 || VPI_COMPATIBILITY_VERSION_1800v2009 || VPI_COMPATIBILITY_VERSION_1800v2012
+#error "Only one VPI_COMPATIBILITY_VERSION symbol definition is allowed."
+#endif
+#define vpi_compare_objects vpi_compare_objects_1800v2005
+#define vpi_control vpi_control_1800v2005
+#define vpi_get vpi_get_1800v2005
+#define vpi_get_str vpi_get_str_1800v2005
+#define vpi_get_value vpi_get_value_1800v2005
+#define vpi_handle vpi_handle_1800v2005
+#define vpi_handle_by_index vpi_handle_by_index_1800v2005
+#define vpi_handle_by_multi_index vpi_handle_by_multi_index_1800v2005
+#define vpi_handle_by_name vpi_handle_by_name_1800v2005
+#define vpi_handle_multi vpi_handle_multi_1800v2005
+#define vpi_iterate vpi_iterate_1800v2005
+#define vpi_put_value vpi_put_value_1800v2005
+#define vpi_register_cb vpi_register_cb_1800v2005
+#define vpi_scan vpi_scan_1800v2005
+#elif VPI_COMPATIBILITY_VERSION_1800v2009
+#if VPI_COMPATIBILITY_VERSION_1364v1995 || VPI_COMPATIBILITY_VERSION_1364v2001 || VPI_COMPATIBILITY_VERSION_1364v2005 || VPI_COMPATIBILITY_VERSION_1800v2005 || VPI_COMPATIBILITY_VERSION_1800v2012
+#error "Only one VPI_COMPATIBILITY_VERSION symbol definition is allowed."
+#endif
+#define vpi_compare_objects vpi_compare_objects_1800v2009
+#define vpi_control vpi_control_1800v2009
+#define vpi_get vpi_get_1800v2009
+#define vpi_get_str vpi_get_str_1800v2009
+#define vpi_get_value vpi_get_value_1800v2009
+#define vpi_handle vpi_handle_1800v2009
+#define vpi_handle_by_index vpi_handle_by_index_1800v2009
+#define vpi_handle_by_multi_index vpi_handle_by_multi_index_1800v2009
+#define vpi_handle_by_name vpi_handle_by_name_1800v2009
+#define vpi_handle_multi vpi_handle_multi_1800v2009
+#define vpi_iterate vpi_iterate_1800v2009
+#define vpi_put_value vpi_put_value_1800v2009
+#define vpi_register_cb vpi_register_cb_1800v2009
+#define vpi_scan vpi_scan_1800v2009
+#elif VPI_COMPATIBILITY_VERSION_1800v2012
+#if VPI_COMPATIBILITY_VERSION_1364v1995 || VPI_COMPATIBILITY_VERSION_1364v2001 || VPI_COMPATIBILITY_VERSION_1364v2005 || VPI_COMPATIBILITY_VERSION_1800v2005 || VPI_COMPATIBILITY_VERSION_1800v2009
+#error "Only one VPI_COMPATIBILITY_VERSION symbol definition is allowed."
+#endif
+#define vpi_compare_objects vpi_compare_objects_1800v2012
+#define vpi_control vpi_control_1800v2012
+#define vpi_get vpi_get_1800v2012
+#define vpi_get_str vpi_get_str_1800v2012
+#define vpi_get_value vpi_get_value_1800v2012
+#define vpi_handle vpi_handle_1800v2012
+#define vpi_handle_by_index vpi_handle_by_index_1800v2012
+#define vpi_handle_by_multi_index vpi_handle_by_multi_index_1800v2012
+#define vpi_handle_by_name vpi_handle_by_name_1800v2012
+#define vpi_handle_multi vpi_handle_multi_1800v2012
+#define vpi_iterate vpi_iterate_1800v2012
+#define vpi_put_value vpi_put_value_1800v2012
+#define vpi_register_cb vpi_register_cb_1800v2012
+#define vpi_scan vpi_scan_1800v2012
+#endif
+

--- a/clash-ffi/include/vpi_user.h
+++ b/clash-ffi/include/vpi_user.h
@@ -1,0 +1,1006 @@
+/*******************************************************************************
+ * vpi_user.h
+ *
+ * IEEE Std 1800 Programming Language Interface (PLI)
+ *
+ * This file contains the constant definitions, structure definitions, and
+ * routine declarations used by the SystemVerilog Verification Procedural
+ * Interface (VPI) access routines.
+ *
+ ******************************************************************************/
+
+/*******************************************************************************
+ * NOTE: the constant values 1 through 299 are reserved for use in this
+ * vpi_user.h file.
+ ******************************************************************************/
+
+#ifndef VPI_USER_H
+#define VPI_USER_H
+
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*----------------------------------------------------------------------------*/
+/*----------------------------- Portability Help -----------------------------*/
+/*----------------------------------------------------------------------------*/
+
+/* Define size-critical types on all OS platforms. */
+#if defined (_MSC_VER)
+typedef unsigned __int64 uint64_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int8 uint8_t;
+typedef signed __int64 int64_t;
+typedef signed __int32 int32_t;
+typedef signed __int8 int8_t;
+#elif defined(__MINGW32__)
+#include <stdint.h>
+#elif defined(__linux)
+#include <inttypes.h>
+#else
+#include <sys/types.h>
+#endif
+
+/* Sized variables */
+
+#ifndef SVPI_TYPES
+#define SVPI_TYPES
+typedef int64_t PLI_INT64;
+typedef uint64_t PLI_UINT64;
+#endif
+
+#ifndef PLI_TYPES
+#define PLI_TYPES
+typedef int              PLI_INT32;
+typedef unsigned int     PLI_UINT32;
+typedef short            PLI_INT16;
+typedef unsigned short   PLI_UINT16;
+typedef char             PLI_BYTE8;
+typedef unsigned char    PLI_UBYTE8;
+#endif
+
+/* Use to import a symbol */
+
+#if (defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
+#ifndef PLI_DLLISPEC
+#define PLI_DLLISPEC __declspec(dllimport)
+#define VPI_USER_DEFINED_DLLISPEC 1
+#endif
+#else
+#ifndef PLI_DLLISPEC
+#define PLI_DLLISPEC
+#endif
+#endif
+
+/* Use to export a symbol */
+
+#if (defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
+#ifndef PLI_DLLESPEC
+#define PLI_DLLESPEC __declspec(dllexport)
+#define VPI_USER_DEFINED_DLLESPEC 1
+#endif
+#else
+#ifndef PLI_DLLESPEC
+#define PLI_DLLESPEC
+#endif
+#endif
+
+/* Use to mark a function as external */
+
+#ifndef PLI_EXTERN
+#define PLI_EXTERN
+#endif
+
+/* Use to mark a variable as external */
+
+#ifndef PLI_VEXTERN
+#define PLI_VEXTERN extern
+#endif
+
+#ifndef PLI_PROTOTYPES
+#define PLI_PROTOTYPES
+#define PROTO_PARAMS(params) params
+
+/* object is defined imported by the application */
+
+#define XXTERN PLI_EXTERN PLI_DLLISPEC
+
+/* object is exported by the application */
+
+#define EETERN PLI_EXTERN PLI_DLLESPEC
+#endif
+
+/********************************** TYPEDEFS **********************************/
+
+typedef PLI_UINT32 *vpiHandle;
+
+/******************************** OBJECT TYPES ********************************/
+
+#define vpiAlways              1   /* always procedure */
+#define vpiAssignStmt          2   /* quasi-continuous assignment */
+#define vpiAssignment          3   /* procedural assignment */
+#define vpiBegin               4   /* block statement */
+#define vpiCase                5   /* case statement */
+#define vpiCaseItem            6   /* case statement item */
+#define vpiConstant            7   /* numerical constant or string literal */
+#define vpiContAssign          8   /* continuous assignment */
+#define vpiDeassign            9   /* deassignment statement */
+#define vpiDefParam           10   /* defparam */
+#define vpiDelayControl       11   /* delay statement (e.g., #10) */
+#define vpiDisable            12   /* named block disable statement */
+#define vpiEventControl       13   /* wait on event, e.g., @e */
+#define vpiEventStmt          14   /* event trigger, e.g., ->e */
+#define vpiFor                15   /* for statement */
+#define vpiForce              16   /* force statement */
+#define vpiForever            17   /* forever statement */
+#define vpiFork               18   /* fork-join block */
+#define vpiFuncCall           19   /* function call */
+#define vpiFunction           20   /* function */
+#define vpiGate               21   /* primitive gate */
+#define vpiIf                 22   /* if statement */
+#define vpiIfElse             23   /* if-else statement */
+#define vpiInitial            24   /* initial procedure */
+#define vpiIntegerVar         25   /* integer variable */
+#define vpiInterModPath       26   /* intermodule wire delay */
+#define vpiIterator           27   /* iterator */
+#define vpiIODecl             28   /* input/output declaration */
+#define vpiMemory             29   /* behavioral memory */
+#define vpiMemoryWord         30   /* single word of memory */
+#define vpiModPath            31   /* module path for path delays */
+#define vpiModule             32   /* module instance */
+#define vpiNamedBegin         33   /* named block statement */
+#define vpiNamedEvent         34   /* event variable */
+#define vpiNamedFork          35   /* named fork-join block */
+#define vpiNet                36   /* scalar or vector net */
+#define vpiNetBit             37   /* bit of vector net */
+#define vpiNullStmt           38   /* a semicolon. Ie. #10 ; */
+#define vpiOperation          39   /* behavioral operation */
+#define vpiParamAssign        40   /* module parameter assignment */
+#define vpiParameter          41   /* module parameter */
+#define vpiPartSelect         42   /* part-select */
+#define vpiPathTerm           43   /* terminal of module path */
+#define vpiPort               44   /* module port */
+#define vpiPortBit            45   /* bit of vector module port */
+#define vpiPrimTerm           46   /* primitive terminal */
+#define vpiRealVar            47   /* real variable */
+#define vpiReg                48   /* scalar or vector reg */
+#define vpiRegBit             49   /* bit of vector reg */
+#define vpiRelease            50   /* release statement */
+#define vpiRepeat             51   /* repeat statement */
+#define vpiRepeatControl      52   /* repeat control in an assign stmt */
+#define vpiSchedEvent         53   /* vpi_put_value() event */
+#define vpiSpecParam          54   /* specparam */
+#define vpiSwitch             55   /* transistor switch */
+#define vpiSysFuncCall        56   /* system function call */
+#define vpiSysTaskCall        57   /* system task call */
+#define vpiTableEntry         58   /* UDP state table entry */
+#define vpiTask               59   /* task */
+#define vpiTaskCall           60   /* task call */
+#define vpiTchk               61   /* timing check */
+#define vpiTchkTerm           62   /* terminal of timing check */
+#define vpiTimeVar            63   /* time variable */
+#define vpiTimeQueue          64   /* simulation event queue */
+#define vpiUdp                65   /* user-defined primitive */
+#define vpiUdpDefn            66   /* UDP definition */
+#define vpiUserSystf          67   /* user-defined system task/function */
+#define vpiVarSelect          68   /* variable array selection */
+#define vpiWait               69   /* wait statement */
+#define vpiWhile              70   /* while statement */
+
+/********************** object types added with 1364-2001 *********************/
+
+#define vpiAttribute         105   /* attribute of an object */
+#define vpiBitSelect         106   /* Bit-select of parameter, var select */
+#define vpiCallback          107   /* callback object */
+#define vpiDelayTerm         108   /* Delay term which is a load or driver */
+#define vpiDelayDevice       109   /* Delay object within a net */
+#define vpiFrame             110   /* reentrant task/func frame */
+#define vpiGateArray         111   /* gate instance array */
+#define vpiModuleArray       112   /* module instance array */
+#define vpiPrimitiveArray    113   /* vpiprimitiveArray type */
+#define vpiNetArray          114   /* multidimensional net */
+#define vpiRange             115   /* range declaration */
+#define vpiRegArray          116   /* multidimensional reg */
+#define vpiSwitchArray       117   /* switch instance array */
+#define vpiUdpArray          118   /* UDP instance array */
+#define vpiContAssignBit     128   /* Bit of a vector continuous assignment */
+#define vpiNamedEventArray   129   /* multidimensional named event */
+
+/********************** object types added with 1364-2005 *********************/
+
+#define vpiIndexedPartSelect 130   /* Indexed part-select object */
+#define vpiGenScopeArray     133   /* array of generated scopes */
+#define vpiGenScope          134   /* A generated scope */
+#define vpiGenVar            135   /* Object used to instantiate gen scopes */
+
+/*********************************** METHODS **********************************/
+/**************** methods used to traverse 1 to 1 relationships ***************/
+
+#define vpiCondition          71   /* condition expression */
+#define vpiDelay              72   /* net or gate delay */
+#define vpiElseStmt           73   /* else statement */
+#define vpiForIncStmt         74   /* increment statement in for loop */
+#define vpiForInitStmt        75   /* initialization statement in for loop */
+#define vpiHighConn           76   /* higher connection to port */
+#define vpiLhs                77   /* left-hand side of assignment */
+#define vpiIndex              78   /* index of var select, bit-select, etc. */
+#define vpiLeftRange          79   /* left range of vector or part-select */
+#define vpiLowConn            80   /* lower connection to port */
+#define vpiParent             81   /* parent object */
+#define vpiRhs                82   /* right-hand side of assignment */
+#define vpiRightRange         83   /* right range of vector or part-select */
+#define vpiScope              84   /* containing scope object */
+#define vpiSysTfCall          85   /* task function call */
+#define vpiTchkDataTerm       86   /* timing check data term */
+#define vpiTchkNotifier       87   /* timing check notifier */
+#define vpiTchkRefTerm        88   /* timing check reference term */
+
+/************* methods used to traverse 1 to many relationships ***************/
+
+#define vpiArgument           89   /* argument to (system) task/function */
+#define vpiBit                90   /* bit of vector net or port */
+#define vpiDriver             91   /* driver for a net */
+#define vpiInternalScope      92   /* internal scope in module */
+#define vpiLoad               93   /* load on net or reg */
+#define vpiModDataPathIn      94   /* data terminal of a module path */
+#define vpiModPathIn          95   /* Input terminal of a module path */
+#define vpiModPathOut         96   /* output terminal of a module path */
+#define vpiOperand            97   /* operand of expression */
+#define vpiPortInst           98   /* connected port instance */
+#define vpiProcess            99   /* process in module */
+#define vpiVariables         100   /* variables in module */
+#define vpiUse               101   /* usage */
+
+/******** methods which can traverse 1 to 1, or 1 to many relationships *******/
+
+#define vpiExpr              102   /* connected expression */
+#define vpiPrimitive         103   /* primitive (gate, switch, UDP) */
+#define vpiStmt              104   /* statement in process or task */
+
+/************************ methods added with 1364-2001 ************************/
+
+#define vpiActiveTimeFormat  119   /* active $timeformat() system task */
+#define vpiInTerm            120   /* To get to a delay device's drivers. */
+#define vpiInstanceArray     121   /* vpiInstance arrays */
+#define vpiLocalDriver       122   /* local drivers (within a module */
+#define vpiLocalLoad         123   /* local loads (within a module */
+#define vpiOutTerm           124   /* To get to a delay device's loads. */
+#define vpiPorts             125   /* Module port */
+#define vpiSimNet            126   /* simulated net after collapsing */
+#define vpiTaskFunc          127   /* task/function */
+
+/************************ methods added with 1364-2005 ************************/
+
+#define vpiBaseExpr          131   /* Indexed part-select's base expression */
+#define vpiWidthExpr         132   /* Indexed part-select's width expression */
+
+/************************ methods added with 1800-2009 ************************/
+
+#define vpiAutomatics        136   /* Automatic variables of a frame */
+
+/********************************* PROPERTIES *********************************/
+/************************** generic object properties *************************/
+
+#define vpiUndefined             -1   /* undefined property */
+#define vpiType                   1   /* type of object */
+#define vpiName                   2   /* local name of object */
+#define vpiFullName               3   /* full hierarchical name */
+#define vpiSize                   4   /* size of gate, net, port, etc. */
+#define vpiFile                   5   /* File name in which the object is used*/
+#define vpiLineNo                 6   /* line number where the object is used */
+
+/***************************** module properties ******************************/
+
+#define vpiTopModule              7   /* top-level module (Boolean) */
+#define vpiCellInstance           8   /* cell (Boolean) */
+#define vpiDefName                9   /* module definition name */
+#define vpiProtected             10   /* source protected module (Boolean) */
+#define vpiTimeUnit              11   /* module time unit */
+#define vpiTimePrecision         12   /* module time precision */
+#define vpiDefNetType            13   /* default net type */
+#define vpiUnconnDrive           14   /* unconnected port drive strength */
+#define vpiHighZ                   1   /* No default drive given */
+#define vpiPull1                   2   /* default pull1 drive */
+#define vpiPull0                   3   /* default pull0 drive */
+#define vpiDefFile               15   /* File name where the module is defined*/
+#define vpiDefLineNo             16   /* line number for module definition */
+#define vpiDefDelayMode          47   /* Default delay mode for a module */
+#define vpiDelayModeNone           1   /* no delay mode specified */
+#define vpiDelayModePath           2   /* path delay mode */
+#define vpiDelayModeDistrib        3   /* distributed delay mode */
+#define vpiDelayModeUnit           4   /* unit delay mode */
+#define vpiDelayModeZero           5   /* zero delay mode */
+#define vpiDelayModeMTM            6   /* min:typ:max delay mode */
+#define vpiDefDecayTime          48   /* Default decay time for a module */
+
+/*************************** port and net properties **************************/
+
+#define vpiScalar                17   /* scalar (Boolean) */
+#define vpiVector                18   /* vector (Boolean) */
+#define vpiExplicitName          19   /* port is explicitly named */
+#define vpiDirection             20   /* direction of port: */
+#define vpiInput                   1   /* input */
+#define vpiOutput                  2   /* output */
+#define vpiInout                   3   /* inout */
+#define vpiMixedIO                 4   /* mixed input-output */
+#define vpiNoDirection             5   /* no direction */
+#define vpiConnByName            21   /* connected by name (Boolean) */
+
+#define vpiNetType               22   /* net subtypes: */
+#define vpiWire                    1   /* wire net */
+#define vpiWand                    2   /* wire-and net */
+#define vpiWor                     3   /* wire-or net */
+#define vpiTri                     4   /* tri net */
+#define vpiTri0                    5   /* pull-down net */
+#define vpiTri1                    6   /* pull-up net */
+#define vpiTriReg                  7   /* three-state reg net */
+#define vpiTriAnd                  8   /* three-state wire-and net */
+#define vpiTriOr                   9   /* three-state wire-or net */
+#define vpiSupply1                10   /* supply-1 net */
+#define vpiSupply0                11   /* supply-0 net */
+#define vpiNone                   12   /* no default net type (1364-2001) */
+#define vpiUwire                  13   /* unresolved wire net (1364-2005) */
+
+#define vpiExplicitScalared      23   /* explicitly scalared (Boolean) */
+#define vpiExplicitVectored      24   /* explicitly vectored (Boolean) */
+#define vpiExpanded              25   /* expanded vector net (Boolean) */
+#define vpiImplicitDecl          26   /* implicitly declared net (Boolean) */
+#define vpiChargeStrength        27   /* charge decay strength of net */
+
+/* Defined as part of strengths section.
+#define vpiLargeCharge            0x10
+#define vpiMediumCharge           0x04
+#define vpiSmallCharge            0x02
+*/
+
+#define vpiArray                 28   /* variable array (Boolean) */
+#define vpiPortIndex             29   /* Port index */
+
+/************************ gate and terminal properties ************************/
+
+#define vpiTermIndex             30   /* Index of a primitive terminal */
+#define vpiStrength0             31   /* 0-strength of net or gate */
+#define vpiStrength1             32   /* 1-strength of net or gate */
+#define vpiPrimType              33   /* primitive subtypes: */
+#define vpiAndPrim                 1   /* and gate */
+#define vpiNandPrim                2   /* nand gate */
+#define vpiNorPrim                 3   /* nor gate */
+#define vpiOrPrim                  4   /* or gate */
+#define vpiXorPrim                 5   /* xor gate */
+#define vpiXnorPrim                6   /* xnor gate */
+#define vpiBufPrim                 7   /* buffer */
+#define vpiNotPrim                 8   /* not gate */
+#define vpiBufif0Prim              9   /* zero-enabled buffer */
+#define vpiBufif1Prim             10   /* one-enabled buffer */
+#define vpiNotif0Prim             11   /* zero-enabled not gate */
+#define vpiNotif1Prim             12   /* one-enabled not gate */
+#define vpiNmosPrim               13   /* nmos switch */
+#define vpiPmosPrim               14   /* pmos switch */
+#define vpiCmosPrim               15   /* cmos switch */
+#define vpiRnmosPrim              16   /* resistive nmos switch */
+#define vpiRpmosPrim              17   /* resistive pmos switch */
+#define vpiRcmosPrim              18   /* resistive cmos switch */
+#define vpiRtranPrim              19   /* resistive bidirectional */
+#define vpiRtranif0Prim           20   /* zero-enable resistive bidirectional */
+#define vpiRtranif1Prim           21   /* one-enable resistive bidirectional */
+#define vpiTranPrim               22   /* bidirectional */
+#define vpiTranif0Prim            23   /* zero-enabled bidirectional */
+#define vpiTranif1Prim            24   /* one-enabled bidirectional */
+#define vpiPullupPrim             25   /* pullup */
+#define vpiPulldownPrim           26   /* pulldown */
+#define vpiSeqPrim                27   /* sequential UDP */
+#define vpiCombPrim               28   /* combinational UDP */
+
+/**************** path, path terminal, timing check properties ****************/
+
+#define vpiPolarity              34   /* polarity of module path... */
+#define vpiDataPolarity          35   /* ...or data path: */
+#define vpiPositive                1   /* positive */
+#define vpiNegative                2   /* negative */
+#define vpiUnknown                 3   /* unknown (unspecified) */
+
+#define vpiEdge                  36   /* edge type of module path: */
+#define vpiNoEdge                  0x00     /* no edge */
+#define vpiEdge01                  0x01     /* 0 -> 1 */
+#define vpiEdge10                  0x02     /* 1 -> 0 */
+#define vpiEdge0x                  0x04     /* 0 -> x */
+#define vpiEdgex1                  0x08     /* x -> 1 */
+#define vpiEdge1x                  0x10     /* 1 -> x */
+#define vpiEdgex0                  0x20     /* x -> 0 */
+#define vpiPosedge                 (vpiEdgex1 | vpiEdge01 | vpiEdge0x)
+#define vpiNegedge                 (vpiEdgex0 | vpiEdge10 | vpiEdge1x)
+#define vpiAnyEdge                 (vpiPosedge | vpiNegedge)
+
+#define vpiPathType              37   /* path delay connection subtypes: */
+#define vpiPathFull                1   /* ( a *> b ) */
+#define vpiPathParallel            2   /* ( a => b ) */
+
+#define vpiTchkType              38   /* timing check subtypes: */
+#define vpiSetup                   1   /* $setup */
+#define vpiHold                    2   /* $hold */
+#define vpiPeriod                  3   /* $period */
+#define vpiWidth                   4   /* $width */
+#define vpiSkew                    5   /* $skew */
+#define vpiRecovery                6   /* $recovery */
+#define vpiNoChange                7   /* $nochange */
+#define vpiSetupHold               8   /* $setuphold */
+#define vpiFullskew                9   /* $fullskew -- added for 1364-2001 */
+#define vpiRecrem                 10   /* $recrem   -- added for 1364-2001 */
+#define vpiRemoval                11   /* $removal  -- added for 1364-2001 */
+#define vpiTimeskew               12   /* $timeskew -- added for 1364-2001 */
+
+/**************************** expression properties ***************************/
+
+#define vpiOpType                39   /* operation subtypes: */
+#define vpiMinusOp                 1   /* unary minus */
+#define vpiPlusOp                  2   /* unary plus */
+#define vpiNotOp                   3   /* unary not */
+#define vpiBitNegOp                4   /* bitwise negation */
+#define vpiUnaryAndOp              5   /* bitwise reduction AND */
+#define vpiUnaryNandOp             6   /* bitwise reduction NAND */
+#define vpiUnaryOrOp               7   /* bitwise reduction OR */
+#define vpiUnaryNorOp              8   /* bitwise reduction NOR */
+#define vpiUnaryXorOp              9   /* bitwise reduction XOR */
+#define vpiUnaryXNorOp            10   /* bitwise reduction XNOR */
+#define vpiSubOp                  11   /* binary subtraction */
+#define vpiDivOp                  12   /* binary division */
+#define vpiModOp                  13   /* binary modulus */
+#define vpiEqOp                   14   /* binary equality */
+#define vpiNeqOp                  15   /* binary inequality */
+#define vpiCaseEqOp               16   /* case (x and z) equality */
+#define vpiCaseNeqOp              17   /* case inequality */
+#define vpiGtOp                   18   /* binary greater than */
+#define vpiGeOp                   19   /* binary greater than or equal */
+#define vpiLtOp                   20   /* binary less than */
+#define vpiLeOp                   21   /* binary less than or equal */
+#define vpiLShiftOp               22   /* binary left shift */
+#define vpiRShiftOp               23   /* binary right shift */
+#define vpiAddOp                  24   /* binary addition */
+#define vpiMultOp                 25   /* binary multiplication */
+#define vpiLogAndOp               26   /* binary logical AND */
+#define vpiLogOrOp                27   /* binary logical OR */
+#define vpiBitAndOp               28   /* binary bitwise AND */
+#define vpiBitOrOp                29   /* binary bitwise OR */
+#define vpiBitXorOp               30   /* binary bitwise XOR */
+#define vpiBitXNorOp              31   /* binary bitwise XNOR */
+#define vpiBitXnorOp              vpiBitXNorOp /* added with 1364-2001 */
+#define vpiConditionOp            32   /* ternary conditional */
+#define vpiConcatOp               33   /* n-ary concatenation */
+#define vpiMultiConcatOp          34   /* repeated concatenation */
+#define vpiEventOrOp              35   /* event OR */
+#define vpiNullOp                 36   /* null operation */
+#define vpiListOp                 37   /* list of expressions */
+#define vpiMinTypMaxOp            38   /* min:typ:max: delay expression */
+#define vpiPosedgeOp              39   /* posedge */
+#define vpiNegedgeOp              40   /* negedge */
+#define vpiArithLShiftOp          41   /* arithmetic left shift  (1364-2001) */
+#define vpiArithRShiftOp          42   /* arithmetic right shift (1364-2001) */
+#define vpiPowerOp                43   /* arithmetic power op    (1364-2001) */
+
+#define vpiConstType             40   /* constant subtypes: */
+#define vpiDecConst                1   /* decimal integer */
+#define vpiRealConst               2   /* real */
+#define vpiBinaryConst             3   /* binary integer */
+#define vpiOctConst                4   /* octal integer */
+#define vpiHexConst                5   /* hexadecimal integer */
+#define vpiStringConst             6   /* string literal */
+#define vpiIntConst                7   /* integer constant (1364-2001) */
+#define vpiTimeConst               8   /* time constant */
+#define vpiBlocking              41   /* blocking assignment (Boolean) */
+#define vpiCaseType              42   /* case statement subtypes: */
+#define vpiCaseExact               1   /* exact match */
+#define vpiCaseX                   2   /* ignore X's */
+#define vpiCaseZ                   3   /* ignore Z's */
+#define vpiNetDeclAssign         43   /* assign part of decl (Boolean) */
+
+/************************** task/function properties **************************/
+
+#define vpiFuncType              44   /* function & system function type */
+#define vpiIntFunc                 1   /* returns integer */
+#define vpiRealFunc                2   /* returns real */
+#define vpiTimeFunc                3   /* returns time */
+#define vpiSizedFunc               4   /* returns an arbitrary size */
+#define vpiSizedSignedFunc         5   /* returns sized signed value */
+
+/** alias 1364-1995 system function subtypes to 1364-2001 function subtypes ***/
+
+#define vpiSysFuncType             vpiFuncType
+#define vpiSysFuncInt              vpiIntFunc
+#define vpiSysFuncReal             vpiRealFunc
+#define vpiSysFuncTime             vpiTimeFunc
+#define vpiSysFuncSized            vpiSizedFunc
+
+#define vpiUserDefn              45   /*user-defined system task/func(Boolean)*/
+#define vpiScheduled             46   /* object still scheduled (Boolean) */
+
+/*********************** properties added with 1364-2001 **********************/
+
+#define vpiActive                49   /* reentrant task/func frame is active */
+#define vpiAutomatic             50   /* task/func obj is automatic */
+#define vpiCell                  51   /* configuration cell */
+#define vpiConfig                52   /* configuration config file */
+#define vpiConstantSelect        53   /* (Boolean) bit-select or part-select
+                                         indices are constant expressions */
+#define vpiDecompile             54   /* decompile the object */
+#define vpiDefAttribute          55   /* Attribute defined for the obj */
+#define vpiDelayType             56   /* delay subtype */
+#define vpiModPathDelay            1   /* module path delay */
+#define vpiInterModPathDelay       2   /* intermodule path delay */
+#define vpiMIPDelay                3   /* module input port delay */
+#define vpiIteratorType          57   /* object type of an iterator */
+#define vpiLibrary               58   /* configuration library */
+#define vpiOffset                60   /* offset from LSB */
+#define vpiResolvedNetType       61   /* net subtype after resolution, returns
+                                         same subtypes as vpiNetType */
+#define vpiSaveRestartID         62   /* unique ID for save/restart data */
+#define vpiSaveRestartLocation   63   /* name of save/restart data file */
+/* vpiValid,vpiValidTrue,vpiValidFalse were deprecated in 1800-2009 */
+#define vpiValid                 64   /* reentrant task/func frame or automatic
+                                         variable is valid */
+#define vpiValidFalse              0
+#define vpiValidTrue               1
+#define vpiSigned                65   /* TRUE for vpiIODecl and any object in
+                                         the expression class if the object
+                                         has the signed attribute */
+#define vpiLocalParam            70   /* TRUE when a param is declared as a
+                                         localparam */
+#define vpiModPathHasIfNone      71   /* Mod path has an ifnone statement */
+
+/*********************** properties added with 1364-2005 **********************/
+
+#define vpiIndexedPartSelectType 72   /* Indexed part-select type */
+#define vpiPosIndexed              1   /* +: */
+#define vpiNegIndexed              2   /* -: */
+#define vpiIsMemory              73   /* TRUE for a one-dimensional reg array */
+#define vpiIsProtected           74   /* TRUE for protected design information */
+
+/*************** vpi_control() constants (added with 1364-2001) ***************/
+
+#define vpiStop                  66   /* execute simulator's $stop */
+#define vpiFinish                67   /* execute simulator's $finish */
+#define vpiReset                 68   /* execute simulator's $reset */
+#define vpiSetInteractiveScope   69   /* set simulator's interactive scope */
+
+/**************************** I/O related defines *****************************/
+
+#define VPI_MCD_STDOUT  0x00000001
+
+/*************************** STRUCTURE DEFINITIONS ****************************/
+
+/******************************* time structure *******************************/
+
+typedef struct t_vpi_time
+{
+  PLI_INT32  type;               /* [vpiScaledRealTime, vpiSimTime,
+                                     vpiSuppressTime] */
+  PLI_UINT32 high, low;          /* for vpiSimTime */
+  double     real;               /* for vpiScaledRealTime */
+} s_vpi_time, *p_vpi_time;
+
+/* time types */
+
+#define vpiScaledRealTime 1
+#define vpiSimTime        2
+#define vpiSuppressTime   3
+
+/****************************** delay structures ******************************/
+
+typedef struct t_vpi_delay
+{
+  struct t_vpi_time *da;         /* pointer to application-allocated
+                                    array of delay values */
+  PLI_INT32 no_of_delays;        /* number of delays */
+  PLI_INT32 time_type;           /* [vpiScaledRealTime, vpiSimTime,
+                                     vpiSuppressTime] */
+  PLI_INT32 mtm_flag;            /* true for mtm values */
+  PLI_INT32 append_flag;         /* true for append */
+  PLI_INT32 pulsere_flag;        /* true for pulsere values */
+} s_vpi_delay, *p_vpi_delay;
+
+/***************************** value structures *******************************/
+
+/* vector value */
+
+#ifndef VPI_VECVAL  /* added in 1364-2005 */
+#define VPI_VECVAL
+
+typedef struct t_vpi_vecval
+{
+  /* following fields are repeated enough times to contain vector */
+  PLI_UINT32 aval, bval;          /* bit encoding: ab: 00=0, 10=1, 11=X, 01=Z */
+} s_vpi_vecval, *p_vpi_vecval;
+
+#endif
+
+/* strength (scalar) value */
+
+typedef struct t_vpi_strengthval
+{
+  PLI_INT32 logic;               /* vpi[0,1,X,Z] */
+  PLI_INT32 s0, s1;              /* refer to strength coding below */
+} s_vpi_strengthval, *p_vpi_strengthval;
+
+/* strength values */
+
+#define vpiSupplyDrive     0x80
+#define vpiStrongDrive     0x40
+#define vpiPullDrive       0x20
+#define vpiWeakDrive       0x08
+#define vpiLargeCharge     0x10
+#define vpiMediumCharge    0x04
+#define vpiSmallCharge     0x02
+#define vpiHiZ             0x01
+
+/* generic value */
+
+typedef struct t_vpi_value
+{
+  PLI_INT32 format; /* vpi[[Bin,Oct,Dec,Hex]Str,Scalar,Int,Real,String,
+                           Vector,Strength,Suppress,Time,ObjType]Val */
+  union
+    {
+      PLI_BYTE8                *str;       /* string value */
+      PLI_INT32                 scalar;    /* vpi[0,1,X,Z] */
+      PLI_INT32                 integer;   /* integer value */
+      double                    real;      /* real value */
+      struct t_vpi_time        *time;      /* time value */
+      struct t_vpi_vecval      *vector;    /* vector value */
+      struct t_vpi_strengthval *strength;  /* strength value */
+      PLI_BYTE8                *misc;      /* ...other */
+    } value;
+} s_vpi_value, *p_vpi_value;
+
+typedef struct t_vpi_arrayvalue
+{
+   PLI_UINT32 format; /* vpi[Int,Real,Time,ShortInt,LongInt,ShortReal,
+                           RawTwoState,RawFourState]Val */
+   PLI_UINT32 flags;  /* array bit flags- vpiUserAllocFlag */
+   union
+   {
+       PLI_INT32 *integers;               /* integer values */
+       PLI_INT16 *shortints;              /* short integer values */
+       PLI_INT64 *longints;               /* long integer values */
+       PLI_BYTE8 *rawvals;                /* 2/4-state vector elements */
+       struct t_vpi_vecval *vectors;      /* 4-state vector elements */
+       struct t_vpi_time *times;          /* time values */
+       double *reals;                     /* real values */
+       float *shortreals;                 /* short real values */
+   } value;
+} s_vpi_arrayvalue, *p_vpi_arrayvalue;
+
+/* value formats */
+
+#define vpiBinStrVal          1
+#define vpiOctStrVal          2
+#define vpiDecStrVal          3
+#define vpiHexStrVal          4
+#define vpiScalarVal          5
+#define vpiIntVal             6
+#define vpiRealVal            7
+#define vpiStringVal          8
+#define vpiVectorVal          9
+#define vpiStrengthVal       10
+#define vpiTimeVal           11
+#define vpiObjTypeVal        12
+#define vpiSuppressVal       13
+#define vpiShortIntVal       14
+#define vpiLongIntVal        15
+#define vpiShortRealVal      16
+#define vpiRawTwoStateVal    17
+#define vpiRawFourStateVal   18
+
+/* delay modes */
+
+#define vpiNoDelay            1
+#define vpiInertialDelay      2
+#define vpiTransportDelay     3
+#define vpiPureTransportDelay 4
+
+/* force and release flags */
+
+#define vpiForceFlag          5
+#define vpiReleaseFlag        6
+
+/* scheduled event cancel flag */
+
+#define vpiCancelEvent        7
+
+/* bit mask for the flags argument to vpi_put_value() */
+
+#define vpiReturnEvent        0x1000
+
+/* bit flags for vpi_get_value_array flags field */
+
+#define vpiUserAllocFlag      0x2000
+
+/* bit flags for vpi_put_value_array flags field */
+
+#define vpiOneValue           0x4000
+#define vpiPropagateOff       0x8000
+
+/* scalar values */
+
+#define vpi0                  0
+#define vpi1                  1
+#define vpiZ                  2
+#define vpiX                  3
+#define vpiH                  4
+#define vpiL                  5
+#define vpiDontCare           6
+/*
+#define vpiNoChange           7   Defined under vpiTchkType, but
+                                  can be used here.
+*/
+
+/*********************** system task/function structure ***********************/
+
+typedef struct t_vpi_systf_data
+{
+  PLI_INT32 type;                       /* vpiSysTask, vpiSysFunc */
+  PLI_INT32 sysfunctype;                /* vpiSysTask, vpi[Int,Real,Time,Sized,
+                                                           SizedSigned]Func */
+  PLI_BYTE8 *tfname;                    /* first character must be '$' */
+  PLI_INT32 (*calltf)(PLI_BYTE8 *);
+  PLI_INT32 (*compiletf)(PLI_BYTE8 *);
+  PLI_INT32 (*sizetf)(PLI_BYTE8 *);     /* for sized function callbacks only */
+  PLI_BYTE8 *user_data;
+} s_vpi_systf_data, *p_vpi_systf_data;
+
+#define vpiSysTask            1
+#define vpiSysFunc            2
+
+/* the subtypes are defined under the vpiFuncType property */
+
+/**************** SystemVerilog execution information structure ***************/
+
+typedef struct t_vpi_vlog_info
+{
+  PLI_INT32 argc;
+  PLI_BYTE8 **argv;
+  PLI_BYTE8 *product;
+  PLI_BYTE8 *version;
+} s_vpi_vlog_info, *p_vpi_vlog_info;
+
+/*********************** PLI error information structure **********************/
+
+typedef struct t_vpi_error_info
+{
+  PLI_INT32 state;           /* vpi[Compile,PLI,Run] */
+  PLI_INT32 level;           /* vpi[Notice,Warning,Error,System,Internal] */
+  PLI_BYTE8 *message;
+  PLI_BYTE8 *product;
+  PLI_BYTE8 *code;
+  PLI_BYTE8 *file;
+  PLI_INT32 line;
+} s_vpi_error_info, *p_vpi_error_info;
+
+/* state when error occurred */
+
+#define vpiCompile              1
+#define vpiPLI                  2
+#define vpiRun                  3
+
+/* error severity levels */
+
+#define vpiNotice               1
+#define vpiWarning              2
+#define vpiError                3
+#define vpiSystem               4
+#define vpiInternal             5
+
+/**************************** callback structures *****************************/
+
+/* normal callback structure */
+
+typedef struct t_cb_data
+{
+  PLI_INT32    reason;                        /* callback reason */
+  PLI_INT32    (*cb_rtn)(struct t_cb_data *); /* call routine */
+  vpiHandle    obj;                           /* trigger object */
+  p_vpi_time   time;                          /* callback time */
+  p_vpi_value  value;                         /* trigger object value */
+  PLI_INT32    index;                         /* index of the memory word or
+                                                 var select that changed */
+  PLI_BYTE8   *user_data;
+} s_cb_data, *p_cb_data;
+
+/****************************** CALLBACK REASONS ******************************/
+
+/***************************** Simulation related *****************************/
+
+#define cbValueChange             1
+#define cbStmt                    2
+#define cbForce                   3
+#define cbRelease                 4
+
+/******************************** Time related ********************************/
+
+#define cbAtStartOfSimTime        5
+#define cbReadWriteSynch          6
+#define cbReadOnlySynch           7
+#define cbNextSimTime             8
+#define cbAfterDelay              9
+
+/******************************* Action related *******************************/
+
+#define cbEndOfCompile           10
+#define cbStartOfSimulation      11
+#define cbEndOfSimulation        12
+#define cbError                  13
+#define cbTchkViolation          14
+#define cbStartOfSave            15
+#define cbEndOfSave              16
+#define cbStartOfRestart         17
+#define cbEndOfRestart           18
+#define cbStartOfReset           19
+#define cbEndOfReset             20
+#define cbEnterInteractive       21
+#define cbExitInteractive        22
+#define cbInteractiveScopeChange 23
+#define cbUnresolvedSystf        24
+
+/**************************** Added with 1364-2001 ****************************/
+
+#define cbAssign                 25
+#define cbDeassign               26
+#define cbDisable                27
+#define cbPLIError               28
+#define cbSignal                 29
+
+/**************************** Added with 1364-2005 ****************************/
+#define cbNBASynch               30
+#define cbAtEndOfSimTime         31
+
+/**************************** FUNCTION DECLARATIONS ***************************/
+
+/* Include compatibility mode macro definitions. */
+#include "vpi_compatibility.h"
+
+/* callback related */
+
+XXTERN vpiHandle    vpi_register_cb     PROTO_PARAMS((p_cb_data cb_data_p));
+XXTERN PLI_INT32    vpi_remove_cb       PROTO_PARAMS((vpiHandle cb_obj));
+XXTERN void         vpi_get_cb_info     PROTO_PARAMS((vpiHandle object,
+                                                      p_cb_data cb_data_p));
+XXTERN vpiHandle    vpi_register_systf  PROTO_PARAMS((p_vpi_systf_data
+                                                      systf_data_p));
+XXTERN void         vpi_get_systf_info  PROTO_PARAMS((vpiHandle object,
+                                                      p_vpi_systf_data
+                                                      systf_data_p));
+
+/* for obtaining handles */
+
+XXTERN vpiHandle    vpi_handle_by_name  PROTO_PARAMS((PLI_BYTE8    *name,
+                                                      vpiHandle    scope));
+XXTERN vpiHandle    vpi_handle_by_index PROTO_PARAMS((vpiHandle    object,
+                                                      PLI_INT32    indx));
+
+/* for traversing relationships */
+
+XXTERN vpiHandle    vpi_handle          PROTO_PARAMS((PLI_INT32   type,
+                                                      vpiHandle   refHandle));
+XXTERN vpiHandle    vpi_handle_multi    PROTO_PARAMS((PLI_INT32   type,
+                                                      vpiHandle   refHandle1,
+                                                      vpiHandle   refHandle2,
+                                                      ... ));
+XXTERN vpiHandle    vpi_iterate         PROTO_PARAMS((PLI_INT32   type,
+                                                      vpiHandle   refHandle));
+XXTERN vpiHandle    vpi_scan            PROTO_PARAMS((vpiHandle   iterator));
+
+/* for processing properties */
+
+XXTERN PLI_INT32    vpi_get             PROTO_PARAMS((PLI_INT32   property,
+                                                      vpiHandle   object));
+XXTERN PLI_INT64    vpi_get64           PROTO_PARAMS((PLI_INT32   property,
+                                                      vpiHandle   object));
+XXTERN PLI_BYTE8   *vpi_get_str         PROTO_PARAMS((PLI_INT32   property,
+                                                      vpiHandle   object));
+
+/* delay processing */
+
+XXTERN void         vpi_get_delays      PROTO_PARAMS((vpiHandle object,
+                                                      p_vpi_delay delay_p));
+XXTERN void         vpi_put_delays      PROTO_PARAMS((vpiHandle object,
+                                                      p_vpi_delay delay_p));
+
+/* value processing */
+
+XXTERN void         vpi_get_value       PROTO_PARAMS((vpiHandle expr,
+                                                      p_vpi_value value_p));
+XXTERN vpiHandle    vpi_put_value       PROTO_PARAMS((vpiHandle object,
+                                                      p_vpi_value value_p,
+                                                      p_vpi_time time_p,
+                                                      PLI_INT32 flags));
+XXTERN void         vpi_get_value_array PROTO_PARAMS((vpiHandle object,
+                                                      p_vpi_arrayvalue arrayvalue_p,
+                                                      PLI_INT32 *index_p,
+                                                      PLI_UINT32 num));
+XXTERN void         vpi_put_value_array PROTO_PARAMS((vpiHandle object,
+                                                      p_vpi_arrayvalue arrayvalue_p,
+                                                      PLI_INT32 *index_p,
+                                                      PLI_UINT32 num));
+
+/* time processing */
+
+XXTERN void         vpi_get_time        PROTO_PARAMS((vpiHandle object,
+                                                      p_vpi_time time_p));
+
+/* I/O routines */
+
+XXTERN PLI_UINT32   vpi_mcd_open        PROTO_PARAMS((PLI_BYTE8 *fileName));
+XXTERN PLI_UINT32   vpi_mcd_close       PROTO_PARAMS((PLI_UINT32 mcd));
+XXTERN PLI_BYTE8   *vpi_mcd_name        PROTO_PARAMS((PLI_UINT32 cd));
+XXTERN PLI_INT32    vpi_mcd_printf      PROTO_PARAMS((PLI_UINT32 mcd,
+                                                      PLI_BYTE8 *format,
+                                                      ...));
+XXTERN PLI_INT32    vpi_printf          PROTO_PARAMS((PLI_BYTE8 *format,
+                                                      ...));
+
+/* utility routines */
+
+XXTERN PLI_INT32    vpi_compare_objects PROTO_PARAMS((vpiHandle object1,
+                                                      vpiHandle object2));
+XXTERN PLI_INT32    vpi_chk_error       PROTO_PARAMS((p_vpi_error_info
+                                                      error_info_p));
+/* vpi_free_object() was deprecated in 1800-2009 */
+XXTERN PLI_INT32    vpi_free_object     PROTO_PARAMS((vpiHandle object));
+XXTERN PLI_INT32    vpi_release_handle  PROTO_PARAMS((vpiHandle object));
+XXTERN PLI_INT32    vpi_get_vlog_info   PROTO_PARAMS((p_vpi_vlog_info
+                                                      vlog_info_p));
+
+/* routines added with 1364-2001 */
+
+XXTERN PLI_INT32    vpi_get_data        PROTO_PARAMS((PLI_INT32 id,
+                                                      PLI_BYTE8 *dataLoc,
+                                                      PLI_INT32 numOfBytes));
+XXTERN PLI_INT32    vpi_put_data        PROTO_PARAMS((PLI_INT32 id,
+                                                      PLI_BYTE8 *dataLoc,
+                                                      PLI_INT32 numOfBytes));
+XXTERN void        *vpi_get_userdata    PROTO_PARAMS((vpiHandle obj));
+XXTERN PLI_INT32    vpi_put_userdata    PROTO_PARAMS((vpiHandle obj,
+                                                      void *userdata));
+XXTERN PLI_INT32    vpi_vprintf         PROTO_PARAMS((PLI_BYTE8 *format,
+                                                      va_list ap));
+XXTERN PLI_INT32    vpi_mcd_vprintf     PROTO_PARAMS((PLI_UINT32 mcd,
+                                                      PLI_BYTE8 *format,
+                                                      va_list ap));
+XXTERN PLI_INT32    vpi_flush           PROTO_PARAMS((void));
+XXTERN PLI_INT32    vpi_mcd_flush       PROTO_PARAMS((PLI_UINT32 mcd));
+XXTERN PLI_INT32    vpi_control         PROTO_PARAMS((PLI_INT32 operation,
+                                                      ...));
+XXTERN vpiHandle    vpi_handle_by_multi_index PROTO_PARAMS((vpiHandle obj,
+                                                      PLI_INT32 num_index,
+                                                      PLI_INT32 *index_array));
+
+/****************************** GLOBAL VARIABLES ******************************/
+
+PLI_VEXTERN PLI_DLLESPEC void (*vlog_startup_routines[])();
+
+  /* array of function pointers, last pointer should be null */
+
+#undef PLI_EXTERN
+#undef PLI_VEXTERN
+
+#ifdef VPI_USER_DEFINED_DLLISPEC
+# undef VPI_USER_DEFINED_DLLISPEC
+# undef PLI_DLLISPEC
+#endif
+#ifdef VPI_USER_DEFINED_DLLESPEC
+# undef VPI_USER_DEFINED_DLLESPEC
+# undef PLI_DLLESPEC
+#endif
+
+#ifdef PLI_PROTOTYPES
+# undef PLI_PROTOTYPES
+# undef PROTO_PARAMS
+# undef XXTERN
+# undef EETERN
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VPI_USER_H */

--- a/clash-ffi/src/Clash/FFI/Iverilog.hs
+++ b/clash-ffi/src/Clash/FFI/Iverilog.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.FFI.Iverilog where
+
+import           Data.Foldable (for_)
+import           Data.String (fromString)
+
+import qualified Clash.FFI.VPI.IO as VPI
+import qualified Clash.FFI.VPI.Info as VPI
+import qualified Clash.FFI.VPI.Module as VPI
+import qualified Clash.FFI.VPI.Net as VPI
+import qualified Clash.FFI.VPI.Parameter as VPI
+import qualified Clash.FFI.VPI.Port as VPI
+import qualified Clash.FFI.VPI.Reg as VPI
+import qualified Clash.FFI.VPI.Time as VPI
+import qualified Clash.FFI.Monad as Sim
+import           Clash.FFI.View
+
+foreign export ccall "clash_ffi_main"
+  clashMain :: IO ()
+
+clashMain :: IO ()
+clashMain =
+  Sim.runSimAction $ do
+    VPI.simPutStrLn "Hello from Haskell"
+
+    cinfoPtr <- VPI.simulatorInfo Sim.stackPtr
+    info     <- unsafePeekReceive @VPI.Info cinfoPtr
+    VPI.simPutStrLn ("Found simulator: " <> fromString (show info))
+
+    ctimePtr <- VPI.simulationTime Sim.stackPtr VPI.Sim Nothing
+    time     <- unsafePeekReceive @VPI.Time ctimePtr
+    VPI.simPutStrLn ("Current time: " <> fromString (show time))
+
+    modules <- VPI.topModules
+
+    for_ modules $ \m -> do
+      mName <- VPI.moduleFullName m
+      VPI.simPutStrLn ("Found module: " <> mName)
+
+      params <- VPI.moduleParameters m
+
+      for_ @_ @_ @_ @() params $ \p -> do
+        pName <- VPI.parameterName p
+        pSize <- VPI.parameterSize @Int p
+        pVal  <- VPI.parameterValue p
+
+        VPI.simPutStrLn
+          ("Found parameter: " <> pName <> ", size " <> fromString (show pSize) <> ", value: " <> fromString (show pVal))
+
+      ports <- VPI.modulePorts m
+
+      for_ ports $ \p -> do
+        pName <- VPI.portName p
+        VPI.simPutStrLn ("Found port: " <> pName)
+
+      nets <- VPI.moduleNets m
+
+      for_ @_ @_ @_ @() nets $ \n -> do
+        nName <- VPI.netName n
+        nSize <- VPI.netSize @Int n
+        nVal  <- VPI.netValue n
+
+        VPI.simPutStrLn
+          ("Found net: " <> nName <> ", size " <> fromString (show nSize) <> ", value: " <> fromString (show nVal))
+
+      regs <- VPI.moduleRegs m
+
+      for_ @_ @_ @_ @() regs $ \r -> do
+        rName <- VPI.regName r
+        rSize <- VPI.regSize @Int r
+        rVal  <- VPI.regValue r
+
+        VPI.simPutStrLn
+          ("Found reg: " <> rName <> ", size " <> fromString (show rSize) <> ", value: " <> fromString (show rVal))
+

--- a/clash-ffi/src/Clash/FFI/Iverilog.hs
+++ b/clash-ffi/src/Clash/FFI/Iverilog.hs
@@ -88,7 +88,7 @@ clashMain =
 
 monitorCallback :: VPI.Reg -> VPI.CallbackInfo ByteString
 monitorCallback reg = VPI.CallbackInfo
-  { VPI.cbReason  = VPI.AfterValueChange (VPI.handleAsObject reg) VPI.Sim VPI.VectorFmt
+  { VPI.cbReason  = VPI.AfterValueChange reg VPI.Sim VPI.VectorFmt
   , VPI.cbRoutine = routine
   , VPI.cbIndex   = 0
   , VPI.cbData    = ""
@@ -106,6 +106,8 @@ monitorCallback reg = VPI.CallbackInfo
 
       VPI.simPutStrLn
         ("[" <> fromString (show time) <> "]: " <> hName <> " = " <> fromString (show value))
+
+      VPI.simFlushIO
 
       pure 0
 

--- a/clash-ffi/src/Clash/FFI/Iverilog.hs
+++ b/clash-ffi/src/Clash/FFI/Iverilog.hs
@@ -4,7 +4,6 @@
 
 module Clash.FFI.Iverilog where
 
-import qualified Control.Monad as Monad (void)
 import qualified Control.Monad.IO.Class as IO (liftIO)
 import           Data.ByteString (ByteString)
 import           Data.Foldable (for_)
@@ -84,8 +83,8 @@ clashMain =
         VPI.simPutStrLn
           ("Found reg: " <> rName <> ", size " <> fromString (show rSize) <> ", value: " <> fromString (show rVal))
 
-        Monad.void $ VPI.registerCallback (monitorCallback (VPI.regHandle r))
-        -- VPI.freeHandle (VPI.callbackHandle rCb)
+        rCb <- VPI.registerCallback (monitorCallback (VPI.regHandle r))
+        VPI.freeHandle (VPI.callbackHandle rCb)
 
 monitorCallback :: VPI.Handle -> VPI.CallbackInfo ByteString
 monitorCallback handle = VPI.CallbackInfo
@@ -97,8 +96,8 @@ monitorCallback handle = VPI.CallbackInfo
  where
   routine ptr =
     Sim.runSimAction $ do
-      hName  <- VPI.receiveProperty VPI.VpiName handle
-      size   <- VPI.getProperty VPI.VpiSize handle
+      hName  <- VPI.receiveProperty VPI.Name handle
+      size   <- VPI.getProperty VPI.Size handle
 
       cinfo  <- IO.liftIO (FFI.peek ptr)
       time   <- peekReceive @VPI.Time (VPI.ccbTime cinfo)

--- a/clash-ffi/src/Clash/FFI/Monad.hs
+++ b/clash-ffi/src/Clash/FFI/Monad.hs
@@ -1,0 +1,89 @@
+module Clash.FFI.Monad
+  ( SimCont
+  , liftCont
+  , SimAction
+  , runSimAction
+  , stackPtr
+  , heapPtr
+  , withNewPtr
+  , unsafeFreeWith
+  , unsafeFreePtr
+  , freePtr
+  , throw
+  ) where
+
+import           Control.Exception (Exception)
+import qualified Control.Exception as IO (throwIO)
+import qualified Control.Monad as Monad (unless)
+import           Control.Monad.IO.Class (MonadIO)
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Control.Monad.Cont (ContT(ContT), MonadCont)
+import qualified Control.Monad.Cont as Cont (runContT)
+import qualified Foreign.Marshal.Alloc as FFI (alloca, free, malloc)
+import           Foreign.Ptr (Ptr)
+import qualified Foreign.Ptr as FFI (nullPtr)
+import           Foreign.Storable (Storable)
+import           GHC.Stack (HasCallStack)
+
+newtype SimCont o i = SimCont (ContT o IO i)
+  deriving newtype (Applicative, Functor, Monad, MonadCont, MonadIO)
+
+liftCont :: ((i -> IO o) -> IO o) -> SimCont o i
+liftCont = SimCont . ContT
+
+type SimAction a = SimCont a a
+
+runSimAction :: SimAction a -> IO a
+runSimAction (SimCont cont) = Cont.runContT cont pure
+
+-- | Allocate memory that will be automatically deallocated when the action
+-- has finished. For long-lasting allocations, see 'heapPtr'.
+stackPtr :: (HasCallStack, Storable a) => SimCont b (Ptr a)
+stackPtr = SimCont (ContT FFI.alloca)
+
+-- | Allocate memory that will not be automatically deallocated when the action
+-- has finished. This must be deallocated with 'freePtr'. For memory which is
+-- only needed temporarily, 'stackPtr' should be preferred.
+heapPtr :: (HasCallStack, Storable a) => SimCont b (Ptr a)
+heapPtr = IO.liftIO FFI.malloc
+
+withNewPtr
+  :: Storable a
+  => SimCont c (Ptr a)
+  -> (Ptr a -> IO b)
+  -> SimCont c (Ptr a, b)
+withNewPtr alloc set = do
+  ptr <- alloc
+  res <- IO.liftIO (set ptr)
+  pure (ptr, res)
+
+-- | Free allocated memory using the provided function. If the memory was
+-- allocated with 'heapPtr' then 'unsafeFreePtr' should be used instead.
+--
+-- This function does not check if the pointer given is NULL, meaning it will
+-- panic if given NULL. It should only be used for pointers known to be valid.
+unsafeFreeWith :: HasCallStack => (a -> IO ()) -> a -> SimCont b ()
+unsafeFreeWith f = IO.liftIO . f
+
+-- | Free allocated memory that was allocated with 'heapPtr'. If the memory
+-- requires a destructor other than 'FFI.free', or a type other than 'Ptr a'
+-- then 'unsafeFreeWith' should be used instead.
+--
+-- This function does not check if the pointer given is NULL, meaning it will
+-- panic if given NULL. It should only be used for pointers known to be valid.
+unsafeFreePtr :: HasCallStack => Ptr a -> SimCont b ()
+unsafeFreePtr = unsafeFreeWith FFI.free
+
+-- | Free allocated memory that was allocated with 'heapPtr'. If the memory
+-- requires a destructor other than 'FFI.free', or a type other than 'Ptr a'
+-- then 'unsafeFreeWith' should be used instead.
+freePtr :: HasCallStack => Ptr a -> SimCont b ()
+freePtr =
+  unsafeFreeWith (\p -> Monad.unless (p == FFI.nullPtr) (FFI.free p))
+
+-- | Throw an exception in simulation. Unless caught this will cause the GHC
+-- RTS to exit, which will cause the simulator to stop / hang / enter a prompt.
+throw :: (HasCallStack, Exception e) => e -> SimCont b a
+throw ex =
+  IO.liftIO (IO.throwIO ex)
+

--- a/clash-ffi/src/Clash/FFI/Monad.hs
+++ b/clash-ffi/src/Clash/FFI/Monad.hs
@@ -6,6 +6,7 @@ module Clash.FFI.Monad
   , stackPtr
   , heapPtr
   , withNewPtr
+  , readPtr
   , unsafeFreeWith
   , unsafeFreePtr
   , freePtr
@@ -23,6 +24,7 @@ import qualified Foreign.Marshal.Alloc as FFI (alloca, free, malloc)
 import           Foreign.Ptr (Ptr)
 import qualified Foreign.Ptr as FFI (nullPtr)
 import           Foreign.Storable (Storable)
+import qualified Foreign.Storable as FFI (peek)
 import           GHC.Stack (HasCallStack)
 
 newtype SimCont o i = SimCont (ContT o IO i)
@@ -56,6 +58,9 @@ withNewPtr alloc set = do
   ptr <- alloc
   res <- IO.liftIO (set ptr)
   pure (ptr, res)
+
+readPtr :: HasCallStack => Storable a => Ptr a -> SimCont b a
+readPtr = IO.liftIO . FFI.peek
 
 -- | Free allocated memory using the provided function. If the memory was
 -- allocated with 'heapPtr' then 'unsafeFreePtr' should be used instead.

--- a/clash-ffi/src/Clash/FFI/Monad.hs
+++ b/clash-ffi/src/Clash/FFI/Monad.hs
@@ -78,12 +78,10 @@ unsafeFreePtr = unsafeFreeWith FFI.free
 -- requires a destructor other than 'FFI.free', or a type other than 'Ptr a'
 -- then 'unsafeFreeWith' should be used instead.
 freePtr :: HasCallStack => Ptr a -> SimCont b ()
-freePtr =
-  unsafeFreeWith (\p -> Monad.unless (p == FFI.nullPtr) (FFI.free p))
+freePtr = unsafeFreeWith (\p -> Monad.unless (p == FFI.nullPtr) (FFI.free p))
 
 -- | Throw an exception in simulation. Unless caught this will cause the GHC
 -- RTS to exit, which will cause the simulator to stop / hang / enter a prompt.
 throw :: (HasCallStack, Exception e) => e -> SimCont b a
-throw ex =
-  IO.liftIO (IO.throwIO ex)
+throw ex = IO.liftIO (IO.throwIO ex)
 

--- a/clash-ffi/src/Clash/FFI/VPI/Callback.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Callback.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Clash.FFI.VPI.Callback
+  ( module Clash.FFI.VPI.Callback.Reason
+  ) where
+
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Foreign.C.String (CString)
+import           Foreign.C.Types (CInt(..))
+import           Foreign.Ptr (FunPtr, Ptr)
+import qualified Foreign.Ptr as FFI (nullPtr)
+import           GHC.TypeNats (KnownNat, type (<=))
+
+import           Clash.FFI.View
+import           Clash.FFI.VPI.Callback.Reason
+import           Clash.FFI.VPI.Object
+import           Clash.FFI.VPI.Time
+import           Clash.FFI.VPI.Value
+
+data CCallback = forall n. (KnownNat n, 1 <= n) => CCallback
+  { ccbReason   :: CInt
+  , ccbRoutine  :: FunPtr (Ptr CCallback -> IO CInt)
+  , ccbObject   :: Handle
+  , ccbTime     :: Ptr CTime
+  , ccbValue    :: Ptr (CValue n)
+  , ccbIndex    :: CInt
+  , ccbData     :: CString
+  }
+
+-- TODO ^ This needs a storable instance
+
+data Callback extra = forall n. (KnownNat n, 1 <= n) => Callback
+  { cbReason  :: CallbackReason
+  , cbRoutine :: Ptr CCallback -> IO CInt
+  , cbObject  :: Handle
+  , cbTime    :: Maybe Time
+  , cbValue   :: Maybe (Value n)
+  , cbIndex   :: Int
+  , cbData    :: extra
+  }
+
+-- TODO CallbackReason should contain the handle, the time format and the
+-- value format when needed for that particular type of reason. Based on the
+-- reason we can say whether these are needed or just set to NULL.
+
+foreign import ccall "wrapper"
+  sendRoutine :: (Ptr CCallback -> IO CInt) -> IO (FunPtr (Ptr CCallback -> IO CInt))
+
+instance (UnsafeSend extra, Sent extra ~ CString) => UnsafeSend (Callback extra) where
+  type Sent (Callback extra) = CCallback
+
+  unsafeSend Callback{..} = do
+    reason <- unsafeSend cbReason
+    routine <- IO.liftIO (sendRoutine cbRoutine)
+    time <- unsafeSend cbTime
+    value <- unsafeSend cbValue
+    let index = fromIntegral cbIndex
+    bytes <- unsafeSend cbData
+
+    pure (CCallback reason routine cbObject time value index bytes)
+
+instance (Send extra, Sent extra ~ CString) => Send (Callback extra) where
+  send Callback{..} = do
+    reason <- send cbReason
+    routine <- IO.liftIO (sendRoutine cbRoutine)
+    time <- send cbTime
+    value <- send cbValue
+    let index = fromIntegral cbIndex
+    bytes <- send cbData
+
+    pure (CCallback reason routine cbObject time value index bytes)
+
+foreign import ccall "dynamic"
+  receiveRoutine :: FunPtr (Ptr CCallback -> IO CInt) -> Ptr CCallback -> IO CInt
+
+instance (UnsafeReceive extra, Received extra ~ CString) => UnsafeReceive (Callback extra) where
+  type Received (Callback extra) = CCallback
+
+  unsafeReceive CCallback{..} = do
+    reason <- unsafeReceive ccbReason
+    let routine = receiveRoutine ccbRoutine
+    time <- unsafeReceive ccbTime
+    value <- unsafeReceive ccbValue
+    let index = fromIntegral ccbIndex
+    extra <- unsafeReceive ccbData
+
+    pure (Callback reason routine ccbObject time value index extra)
+
+instance (Receive extra, Received extra ~ CString) => Receive (Callback extra) where
+  receive CCallback{..} = do
+    reason <- receive ccbReason
+    let routine = receiveRoutine ccbRoutine
+    time <- receive ccbTime
+    value <- receive ccbValue
+    let index = fromIntegral ccbIndex
+    extra <- receive ccbData
+
+    pure (Callback reason routine ccbObject time value index extra)
+
+foreign import ccall "vpi_user.h vpi_register_cb"
+  c_vpi_register_cb :: Ptr CCallback -> IO Handle
+
+foreign import ccall "vpi_user.h vpi_remove_cb"
+  c_vpi_remove_cb :: Handle -> IO Bool
+
+#ifndef IVERILOG
+foreign import ccall "vpi_user.h vpi_get_cb_info"
+  c_vpi_get_cb_info :: Handle -> Ptr CCallback -> IO ()
+#endif
+

--- a/clash-ffi/src/Clash/FFI/VPI/Callback/Reason.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Callback/Reason.hs
@@ -8,10 +8,12 @@ module Clash.FFI.VPI.Callback.Reason
   ) where
 
 import           Control.Exception (Exception)
+import qualified Control.Monad.IO.Class as IO (liftIO)
 import           Data.Maybe (fromMaybe)
 import           Foreign.C.Types (CInt)
 import           Foreign.Ptr (Ptr)
-import qualified Foreign.Storable as FFI (pokeByteOff)
+import qualified Foreign.Ptr as FFI (nullPtr)
+import qualified Foreign.Storable as FFI (peekByteOff, pokeByteOff)
 import           GHC.Stack (CallStack, callStack, prettyCallStack)
 
 import qualified Clash.FFI.Monad as Sim
@@ -21,10 +23,10 @@ import           Clash.FFI.VPI.Time
 import           Clash.FFI.VPI.Value
 
 data CallbackReason where
-  AfterValueChange :: Handle -> TimeType -> ValueFormat n -> CallbackReason
+  AfterValueChange :: Handle -> TimeType -> ValueFormat -> CallbackReason
   BeforeStatement :: Handle -> TimeType -> CallbackReason
-  AfterForce :: Maybe Handle -> TimeType -> ValueFormat n -> CallbackReason
-  AfterRelease :: Maybe Handle -> TimeType -> ValueFormat n -> CallbackReason
+  AfterForce :: Maybe Handle -> TimeType -> ValueFormat -> CallbackReason
+  AfterRelease :: Maybe Handle -> TimeType -> ValueFormat -> CallbackReason
   AtStartOfSimTime :: Maybe Handle -> Time -> CallbackReason
   ReadWriteSynch :: Maybe Handle -> Time -> CallbackReason
   ReadOnlySynch :: Maybe Handle -> Time -> CallbackReason
@@ -46,9 +48,9 @@ data CallbackReason where
   InteractiveScopeChange :: CallbackReason
   UnresolvedSysTf :: CallbackReason
 #if defined(VERILOG_2001)
-  AfterAssign :: Handle -> TimeType -> ValueFormat n -> CallbackReason
-  AfterDeassign :: Handle -> TimeType -> ValueFormat n -> CallbackReason
-  AfterDisable :: Handle -> TimeType -> ValueFormat n -> CallbackReason
+  AfterAssign :: Handle -> TimeType -> ValueFormat -> CallbackReason
+  AfterDeassign :: Handle -> TimeType -> ValueFormat -> CallbackReason
+  AfterDisable :: Handle -> TimeType -> ValueFormat -> CallbackReason
   PliError :: CallbackReason
   Signal :: CallbackReason
 #endif
@@ -64,131 +66,158 @@ instance UnsafeSend CallbackReason where
     \case
       AfterValueChange handle timeTy valueFmt -> do
         ctimeTy <- unsafeSend timeTy
-        cfmt <- unsafeSend valueFmt
+        ctime <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
 
-        ctime <- Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
-        cvalue <- Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+        cfmt <- unsafeSend valueFmt
+        cvalue <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
 
         pure (1, handle, ctime, cvalue)
 
       BeforeStatement handle timeTy -> do
         ctimeTy <- unsafeSend timeTy
-        pure (2, handle, CTime ctimeTy 0 0 0.0, 0)
+        ctime <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
+        pure (2, handle, ctime, FFI.nullPtr)
 
       AfterForce mHandle timeTy valueFmt -> do
         let handle = fromMaybe nullHandle mHandle
+
         ctimeTy <- unsafeSend timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- unsafeSend valueFmt
-        pure (3, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (3, handle, ctime, cvalue)
 
       AfterRelease mHandle timeTy valueFmt -> do
         let handle = fromMaybe nullHandle mHandle
+
         ctimeTy <- unsafeSend timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- unsafeSend valueFmt
-        pure (4, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (4, handle, ctime, cvalue)
 
       AtStartOfSimTime mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- unsafeSend time
-        pure (5, handle, ctime, 0)
+        ctime <- unsafePokeSend time
+        pure (5, handle, ctime, FFI.nullPtr)
 
       ReadWriteSynch mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- unsafeSend time
-        pure (6, handle, ctime, 0)
+        ctime <- unsafePokeSend time
+        pure (6, handle, ctime, FFI.nullPtr)
 
       ReadOnlySynch mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- unsafeSend time
-        pure (7, handle, ctime, 0)
+        ctime <- unsafePokeSend time
+        pure (7, handle, ctime, FFI.nullPtr)
 
       NextSimTime mHandle timeTy -> do
         let handle = fromMaybe nullHandle mHandle
+
         ctimeTy <- unsafeSend timeTy
-        pure (8, handle, CTime ctimeTy 0 0 0.0, 0)
+        ctime <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
+        pure (8, handle, ctime, FFI.nullPtr)
 
       AfterDelay mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- unsafeSend time
-        pure (7, handle, ctime, 0)
+        ctime <- unsafePokeSend time
+        pure (7, handle, ctime, FFI.nullPtr)
 
       EndOfCompile ->
-        pure (10, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (10, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       StartOfSimulation ->
-        pure (11, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (11, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EndOfSimulation ->
-        pure (12, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (12, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       RuntimeError ->
-        pure (13, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (13, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       TchkViolation ->
-        pure (14, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (14, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       StartOfSave ->
-        pure (15, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (15, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EndOfSave ->
-        pure (16, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (16, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       StartOfRestart ->
-        pure (17, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (17, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EndOfRestart ->
-        pure (18, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (18, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       StartOfReset ->
-        pure (19, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (19, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EndOfReset ->
-        pure (20, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (20, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EnterInteractive ->
-        pure (21, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (21, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       ExitInteractive ->
-        pure (22, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (22, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       InteractiveScopeChange ->
-        pure (23, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (23, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       UnresolvedSysTf ->
-        pure (24, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (24, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
 #if defined(VERILOG_2001)
       AfterAssign handle timeTy valueFmt -> do
         ctimeTy <- unsafeSend timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- unsafeSend valueFmt
-        pure (25, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (25, handle, ctime, cvalue)
 
       AfterDeassign handle timeTy valueFmt -> do
         ctimeTy <- unsafeSend timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- unsafeSend valueFmt
-        pure (26, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (26, handle, ctime, cvalue)
 
       AfterDisable handle timeTy valueFmt -> do
         ctimeTy <- unsafeSend timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- unsafeSend valueFmt
-        pure (27, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (27, handle, ctime, cvalue)
 
       PliError ->
-        pure (28, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (28, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       Signal ->
-        pure (29, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (29, nullHandle, FFI.nullPtr, FFI.nullPtr)
 #endif
 #if defined(VERILOG_2005)
       NbaSynch mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- unsafeSend time
-        pure (31, handle, ctime, 0)
+        ctime <- unsafePokeSend time
+        pure (31, handle, ctime, FFI.nullPtr)
 
       AtEndOfSimTime mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- unsafeSend time
-        pure (31, handle, ctime, 0)
+        ctime <- unsafePokeSend time
+        pure (31, handle, ctime, FFI.nullPtr)
 #endif
 
 instance Send CallbackReason where
@@ -196,127 +225,158 @@ instance Send CallbackReason where
     \case
       AfterValueChange handle timeTy valueFmt -> do
         ctimeTy <- send timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- send valueFmt
-        pure (1, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (1, handle, ctime, cvalue)
 
       BeforeStatement handle timeTy -> do
         ctimeTy <- send timeTy
-        pure (2, handle, CTime ctimeTy 0 0 0.0, 0)
+        ctime <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
+        pure (2, handle, ctime, FFI.nullPtr)
 
       AfterForce mHandle timeTy valueFmt -> do
         let handle = fromMaybe nullHandle mHandle
+
         ctimeTy <- send timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- send valueFmt
-        pure (3, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (3, handle, ctime, cvalue)
 
       AfterRelease mHandle timeTy valueFmt -> do
         let handle = fromMaybe nullHandle mHandle
+
         ctimeTy <- send timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- send valueFmt
-        pure (4, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (4, handle, ctime, cvalue)
 
       AtStartOfSimTime mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- send time
-        pure (5, handle, ctime, 0)
+        ctime <- pokeSend time
+        pure (5, handle, ctime, FFI.nullPtr)
 
       ReadWriteSynch mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- send time
-        pure (6, handle, ctime, 0)
+        ctime <- pokeSend time
+        pure (6, handle, ctime, FFI.nullPtr)
 
       ReadOnlySynch mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- send time
-        pure (7, handle, ctime, 0)
+        ctime <- pokeSend time
+        pure (7, handle, ctime, FFI.nullPtr)
 
       NextSimTime mHandle timeTy -> do
         let handle = fromMaybe nullHandle mHandle
+
         ctimeTy <- send timeTy
-        pure (8, handle, CTime ctimeTy 0 0 0.0, 0)
+        ctime <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
+        pure (8, handle, ctime, FFI.nullPtr)
 
       AfterDelay mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- send time
-        pure (9, handle, ctime, 0)
+        ctime <- pokeSend time
+        pure (9, handle, ctime, FFI.nullPtr)
 
       EndOfCompile ->
-        pure (10, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (10, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       StartOfSimulation ->
-        pure (11, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (11, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EndOfSimulation ->
-        pure (12, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (12, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       RuntimeError ->
-        pure (13, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (13, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       TchkViolation ->
-        pure (14, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (14, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       StartOfSave ->
-        pure (15, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (15, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EndOfSave ->
-        pure (16, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (16, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       StartOfRestart ->
-        pure (17, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (17, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EndOfRestart ->
-        pure (18, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (18, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       StartOfReset ->
-        pure (19, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (19, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EndOfReset ->
-        pure (20, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (20, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       EnterInteractive ->
-        pure (21, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (21, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       ExitInteractive ->
-        pure (22, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (22, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       InteractiveScopeChange ->
-        pure (23, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (23, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       UnresolvedSysTf ->
-        pure (24, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (24, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
 #if defined(VERILOG_2001)
       AfterAssign handle timeTy valueFmt -> do
         ctimeTy <- send timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- send valueFmt
-        pure (25, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (25, handle, ctime, cvalue)
 
       AfterDeassign handle timeTy valueFmt -> do
         ctimeTy <- send timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- send valueFmt
-        pure (26, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (26, handle, ctime, cvalue)
 
       AfterDisable handle timeTy valueFmt -> do
         ctimeTy <- send timeTy
+        ctime <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+
         cfmt <- send valueFmt
-        pure (27, handle, CTime ctimeTy 0 0 0.0, cfmt)
+        cvalue <- fst <$> Sim.withNewPtr Sim.heapPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (27, handle, ctime, cvalue)
 
       PliError ->
-        pure (28, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (28, nullHandle, FFI.nullPtr, FFI.nullPtr)
 
       Signal ->
-        pure (29, nullHandle, CTime 0 0 0 0.0, 0)
+        pure (29, nullHandle, FFI.nullPtr, FFI.nullPtr)
 #endif
 #if defined(VERILOG_2005)
       NbaSynch mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- send time
-        pure (31, handle, ctime, 0)
+        ctime <- pokeSend time
+        pure (31, handle, ctime, FFI.nullPtr)
 
       AtEndOfSimTime mHandle time -> do
         let handle = fromMaybe nullHandle mHandle
-        ctime <- send time
-        pure (31, handle, ctime, 0)
+        ctime <- pokeSend time
+        pure (31, handle, ctime, FFI.nullPtr)
 #endif
 
 data UnknownCallbackReason
@@ -332,50 +392,49 @@ instance Show UnknownCallbackReason where
       , prettyCallStack c
       ]
 
-{-
 instance UnsafeReceive CallbackReason where
-  type Received CallbackReason = (CInt, Handle, CTime, CInt)
+  type Received CallbackReason = (CInt, Handle, Ptr CTime, Ptr CValue)
 
-  unsafeReceive (creason, handle, ctime, cfmt) =
+  unsafeReceive (creason, handle, ctime, cvalue) =
     let mHandle = if isNullHandle handle then Nothing else Just handle in
     case creason of
       1 -> do
-        timeTy <- unsafeReceive (ctimeType ctime)
-        valueFmt <- unsafeReceive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= unsafeReceive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= unsafeReceive
         pure (AfterValueChange handle timeTy valueFmt)
 
       2 -> do
-        timeTy <- unsafeReceive (ctimeType ctime)
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= unsafeReceive
         pure (BeforeStatement handle timeTy)
 
       3 -> do
-        timeTy <- unsafeReceive (ctimeType ctime)
-        valueFmt <- unsafeReceive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= unsafeReceive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= unsafeReceive
         pure (AfterForce mHandle timeTy valueFmt)
 
       4 -> do
-        timeTy <- unsafeReceive (ctimeType ctime)
-        valueFmt <- unsafeReceive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= unsafeReceive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= unsafeReceive
         pure (AfterRelease mHandle timeTy valueFmt)
 
       5 -> do
-        time <- unsafeReceive ctime
+        time <- unsafePeekReceive ctime
         pure (AtStartOfSimTime mHandle time)
 
       6 -> do
-        time <- unsafeReceive ctime
+        time <- unsafePeekReceive ctime
         pure (ReadWriteSynch mHandle time)
 
       7 -> do
-        time <- unsafeReceive ctime
+        time <- unsafePeekReceive ctime
         pure (ReadOnlySynch mHandle time)
 
       8 -> do
-        timeTy <- unsafeReceive (ctimeType ctime)
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= unsafeReceive
         pure (NextSimTime mHandle timeTy)
 
       9 -> do
-        time <- unsafeReceive ctime
+        time <- unsafePeekReceive ctime
         pure (AfterDelay mHandle time)
 
       10 ->
@@ -425,18 +484,18 @@ instance UnsafeReceive CallbackReason where
 
 #if defined(VERILOG_2001)
       25 -> do
-        timeTy <- unsafeReceive (ctimeType ctime)
-        valueFmt <- unsafeReceive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= unsafeReceive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= unsafeReceive
         pure (AfterAssign handle timeTy valueFmt)
 
       26 -> do
-        timeTy <- unsafeReceive (ctimeType ctime)
-        valueFmt <- unsafeReceive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= unsafeReceive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= unsafeReceive
         pure (AfterDeassign handle timeTy valueFmt)
 
       27 -> do
-        timeTy <- unsafeReceive (ctimeType ctime)
-        valueFmt <- unsafeReceive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= unsafeReceive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= unsafeReceive
         pure (AfterDisable handle timeTy valueFmt)
 
       28 ->
@@ -447,57 +506,57 @@ instance UnsafeReceive CallbackReason where
 #endif
 #if defined(VERILOG_2005)
       30 -> do
-        time <- unsafeReceive ctime
+        time <- unsafePeekReceive ctime
         pure (NbaSynch mHandle time)
 
       31 -> do
-        time <- unsafeReceive ctime
+        time <- unsafePeekReceive ctime
         pure (AtEndOfSimTime mHandle time)
 #endif
 
       n  -> Sim.throw (UnknownCallbackReason n callStack)
 
 instance Receive CallbackReason where
-  receive (creason, handle, ctime, cfmt) =
+  receive (creason, handle, ctime, cvalue) =
     let mHandle = if isNullHandle handle then Nothing else Just handle in
     case creason of
       1 -> do
-        timeTy <- receive (ctimeType ctime)
-        valueFmt <- receive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= receive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= receive
         pure (AfterValueChange handle timeTy valueFmt)
 
       2 -> do
-        timeTy <- receive (ctimeType ctime)
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= receive
         pure (BeforeStatement handle timeTy)
 
       3 -> do
-        timeTy <- receive (ctimeType ctime)
-        valueFmt <- receive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= receive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= receive
         pure (AfterForce mHandle timeTy valueFmt)
 
       4 -> do
-        timeTy <- receive (ctimeType ctime)
-        valueFmt <- receive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= receive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= receive
         pure (AfterRelease mHandle timeTy valueFmt)
 
       5 -> do
-        time <- receive ctime
+        time <- peekReceive ctime
         pure (AtStartOfSimTime mHandle time)
 
       6 -> do
-        time <- receive ctime
+        time <- peekReceive ctime
         pure (ReadWriteSynch mHandle time)
 
       7 -> do
-        time <- receive ctime
+        time <- peekReceive ctime
         pure (ReadOnlySynch mHandle time)
 
       8 -> do
-        timeTy <- receive (ctimeType ctime)
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= receive
         pure (NextSimTime mHandle timeTy)
 
       9 -> do
-        time <- receive ctime
+        time <- peekReceive ctime
         pure (AfterDelay mHandle time)
 
       10 ->
@@ -547,18 +606,18 @@ instance Receive CallbackReason where
 
 #if defined(VERILOG_2001)
       25 -> do
-        timeTy <- receive (ctimeType ctime)
-        valueFmt <- receive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= receive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= receive
         pure (AfterAssign handle timeTy valueFmt)
 
       26 -> do
-        timeTy <- receive (ctimeType ctime)
-        valueFmt <- receive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= receive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= receive
         pure (AfterDeassign handle timeTy valueFmt)
 
       27 -> do
-        timeTy <- receive (ctimeType ctime)
-        valueFmt <- receive cfmt
+        timeTy <- IO.liftIO (FFI.peekByteOff ctime 0) >>= receive
+        valueFmt <- IO.liftIO (FFI.peekByteOff cvalue 0) >>= receive
         pure (AfterDisable handle timeTy valueFmt)
 
       28 ->
@@ -569,14 +628,13 @@ instance Receive CallbackReason where
 #endif
 #if defined(VERILOG_2005)
       30 -> do
-        time <- receive ctime
+        time <- peekReceive ctime
         pure (NbaSynch mHandle time)
 
       31 -> do
-        time <- receive ctime
+        time <- peekReceive ctime
         pure (AtEndOfSimTime mHandle time)
 #endif
 
       n  -> Sim.throw (UnknownCallbackReason n callStack)
--}
 

--- a/clash-ffi/src/Clash/FFI/VPI/Callback/Reason.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Callback/Reason.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -7,14 +8,17 @@ module Clash.FFI.VPI.Callback.Reason
   ) where
 
 import           Control.Exception (Exception)
+import           Data.Maybe (fromMaybe)
 import           Foreign.C.Types (CInt)
+import           Foreign.Ptr (Ptr)
+import qualified Foreign.Storable as FFI (pokeByteOff)
 import           GHC.Stack (CallStack, callStack, prettyCallStack)
 
-import qualified Clash.FFI.Monad as Sim (throw)
+import qualified Clash.FFI.Monad as Sim
 import           Clash.FFI.View
-import           Clash.FFI.VPI.Object (Handle)
+import           Clash.FFI.VPI.Object
 import           Clash.FFI.VPI.Time
-import           Clash.FFI.VPI.Value (ValueFormat)
+import           Clash.FFI.VPI.Value
 
 data CallbackReason where
   AfterValueChange :: Handle -> TimeType -> ValueFormat n -> CallbackReason
@@ -54,48 +58,266 @@ data CallbackReason where
 #endif
 
 instance UnsafeSend CallbackReason where
-  type Sent CallbackReason = (CInt, Handle, CTime, CInt)
+  type Sent CallbackReason = (CInt, Handle, Ptr CTime, Ptr CValue)
 
   unsafeSend =
-    pure . \case
-      ValueChange -> 1
-      Statement -> 2
-      DidForce -> 3
-      DidRelease -> 4
-      AtStartOfSimTime -> 5
-      ReadWriteSynch -> 6
-      ReadOnlySynch -> 7
-      NextSimTime -> 8
-      AfterDelay -> 9
-      EndOfCompile -> 10
-      StartOfSimulation -> 11
-      EndOfSimulation -> 12
-      DidError -> 13
-      TchkViolation -> 14
-      StartOfSave -> 15
-      EndOfSave -> 16
-      StartOfRestart -> 17
-      EndOfRestart -> 18
-      StartOfReset -> 19
-      EndOfReset -> 20
-      EnterInteractive -> 21
-      ExitInteractive -> 22
-      InteractiveScopeChange -> 23
-      UnresolvedSysTf -> 24
+    \case
+      AfterValueChange handle timeTy valueFmt -> do
+        ctimeTy <- unsafeSend timeTy
+        cfmt <- unsafeSend valueFmt
+
+        ctime <- Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 ctimeTy)
+        cvalue <- Sim.withNewPtr Sim.stackPtr (\ptr -> FFI.pokeByteOff ptr 0 cfmt)
+
+        pure (1, handle, ctime, cvalue)
+
+      BeforeStatement handle timeTy -> do
+        ctimeTy <- unsafeSend timeTy
+        pure (2, handle, CTime ctimeTy 0 0 0.0, 0)
+
+      AfterForce mHandle timeTy valueFmt -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctimeTy <- unsafeSend timeTy
+        cfmt <- unsafeSend valueFmt
+        pure (3, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      AfterRelease mHandle timeTy valueFmt -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctimeTy <- unsafeSend timeTy
+        cfmt <- unsafeSend valueFmt
+        pure (4, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      AtStartOfSimTime mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- unsafeSend time
+        pure (5, handle, ctime, 0)
+
+      ReadWriteSynch mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- unsafeSend time
+        pure (6, handle, ctime, 0)
+
+      ReadOnlySynch mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- unsafeSend time
+        pure (7, handle, ctime, 0)
+
+      NextSimTime mHandle timeTy -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctimeTy <- unsafeSend timeTy
+        pure (8, handle, CTime ctimeTy 0 0 0.0, 0)
+
+      AfterDelay mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- unsafeSend time
+        pure (7, handle, ctime, 0)
+
+      EndOfCompile ->
+        pure (10, nullHandle, CTime 0 0 0 0.0, 0)
+
+      StartOfSimulation ->
+        pure (11, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EndOfSimulation ->
+        pure (12, nullHandle, CTime 0 0 0 0.0, 0)
+
+      RuntimeError ->
+        pure (13, nullHandle, CTime 0 0 0 0.0, 0)
+
+      TchkViolation ->
+        pure (14, nullHandle, CTime 0 0 0 0.0, 0)
+
+      StartOfSave ->
+        pure (15, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EndOfSave ->
+        pure (16, nullHandle, CTime 0 0 0 0.0, 0)
+
+      StartOfRestart ->
+        pure (17, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EndOfRestart ->
+        pure (18, nullHandle, CTime 0 0 0 0.0, 0)
+
+      StartOfReset ->
+        pure (19, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EndOfReset ->
+        pure (20, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EnterInteractive ->
+        pure (21, nullHandle, CTime 0 0 0 0.0, 0)
+
+      ExitInteractive ->
+        pure (22, nullHandle, CTime 0 0 0 0.0, 0)
+
+      InteractiveScopeChange ->
+        pure (23, nullHandle, CTime 0 0 0 0.0, 0)
+
+      UnresolvedSysTf ->
+        pure (24, nullHandle, CTime 0 0 0 0.0, 0)
+
 #if defined(VERILOG_2001)
-      DidAssign -> 25
-      DidDeassign -> 26
-      DidDisable -> 27
-      DidPliError -> 28
-      DidSignal -> 29
+      AfterAssign handle timeTy valueFmt -> do
+        ctimeTy <- unsafeSend timeTy
+        cfmt <- unsafeSend valueFmt
+        pure (25, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      AfterDeassign handle timeTy valueFmt -> do
+        ctimeTy <- unsafeSend timeTy
+        cfmt <- unsafeSend valueFmt
+        pure (26, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      AfterDisable handle timeTy valueFmt -> do
+        ctimeTy <- unsafeSend timeTy
+        cfmt <- unsafeSend valueFmt
+        pure (27, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      PliError ->
+        pure (28, nullHandle, CTime 0 0 0 0.0, 0)
+
+      Signal ->
+        pure (29, nullHandle, CTime 0 0 0 0.0, 0)
 #endif
 #if defined(VERILOG_2005)
-      NbaSynch -> 30
-      AtEndOfSimTime -> 31
+      NbaSynch mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- unsafeSend time
+        pure (31, handle, ctime, 0)
+
+      AtEndOfSimTime mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- unsafeSend time
+        pure (31, handle, ctime, 0)
 #endif
 
 instance Send CallbackReason where
-  send = unsafeSend
+  send =
+    \case
+      AfterValueChange handle timeTy valueFmt -> do
+        ctimeTy <- send timeTy
+        cfmt <- send valueFmt
+        pure (1, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      BeforeStatement handle timeTy -> do
+        ctimeTy <- send timeTy
+        pure (2, handle, CTime ctimeTy 0 0 0.0, 0)
+
+      AfterForce mHandle timeTy valueFmt -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctimeTy <- send timeTy
+        cfmt <- send valueFmt
+        pure (3, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      AfterRelease mHandle timeTy valueFmt -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctimeTy <- send timeTy
+        cfmt <- send valueFmt
+        pure (4, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      AtStartOfSimTime mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- send time
+        pure (5, handle, ctime, 0)
+
+      ReadWriteSynch mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- send time
+        pure (6, handle, ctime, 0)
+
+      ReadOnlySynch mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- send time
+        pure (7, handle, ctime, 0)
+
+      NextSimTime mHandle timeTy -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctimeTy <- send timeTy
+        pure (8, handle, CTime ctimeTy 0 0 0.0, 0)
+
+      AfterDelay mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- send time
+        pure (9, handle, ctime, 0)
+
+      EndOfCompile ->
+        pure (10, nullHandle, CTime 0 0 0 0.0, 0)
+
+      StartOfSimulation ->
+        pure (11, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EndOfSimulation ->
+        pure (12, nullHandle, CTime 0 0 0 0.0, 0)
+
+      RuntimeError ->
+        pure (13, nullHandle, CTime 0 0 0 0.0, 0)
+
+      TchkViolation ->
+        pure (14, nullHandle, CTime 0 0 0 0.0, 0)
+
+      StartOfSave ->
+        pure (15, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EndOfSave ->
+        pure (16, nullHandle, CTime 0 0 0 0.0, 0)
+
+      StartOfRestart ->
+        pure (17, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EndOfRestart ->
+        pure (18, nullHandle, CTime 0 0 0 0.0, 0)
+
+      StartOfReset ->
+        pure (19, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EndOfReset ->
+        pure (20, nullHandle, CTime 0 0 0 0.0, 0)
+
+      EnterInteractive ->
+        pure (21, nullHandle, CTime 0 0 0 0.0, 0)
+
+      ExitInteractive ->
+        pure (22, nullHandle, CTime 0 0 0 0.0, 0)
+
+      InteractiveScopeChange ->
+        pure (23, nullHandle, CTime 0 0 0 0.0, 0)
+
+      UnresolvedSysTf ->
+        pure (24, nullHandle, CTime 0 0 0 0.0, 0)
+
+#if defined(VERILOG_2001)
+      AfterAssign handle timeTy valueFmt -> do
+        ctimeTy <- send timeTy
+        cfmt <- send valueFmt
+        pure (25, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      AfterDeassign handle timeTy valueFmt -> do
+        ctimeTy <- send timeTy
+        cfmt <- send valueFmt
+        pure (26, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      AfterDisable handle timeTy valueFmt -> do
+        ctimeTy <- send timeTy
+        cfmt <- send valueFmt
+        pure (27, handle, CTime ctimeTy 0 0 0.0, cfmt)
+
+      PliError ->
+        pure (28, nullHandle, CTime 0 0 0 0.0, 0)
+
+      Signal ->
+        pure (29, nullHandle, CTime 0 0 0 0.0, 0)
+#endif
+#if defined(VERILOG_2005)
+      NbaSynch mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- send time
+        pure (31, handle, ctime, 0)
+
+      AtEndOfSimTime mHandle time -> do
+        let handle = fromMaybe nullHandle mHandle
+        ctime <- send time
+        pure (31, handle, ctime, 0)
+#endif
 
 data UnknownCallbackReason
   = UnknownCallbackReason CInt CallStack
@@ -110,47 +332,251 @@ instance Show UnknownCallbackReason where
       , prettyCallStack c
       ]
 
+{-
 instance UnsafeReceive CallbackReason where
-  type Received CallbackReason = CInt
+  type Received CallbackReason = (CInt, Handle, CTime, CInt)
 
-  unsafeReceive = \case
-    1 -> pure ValueChange
-    2 -> pure Statement
-    3 -> pure DidForce
-    4 -> pure DidRelease
-    5 -> pure AtStartOfSimTime
-    6 -> pure ReadWriteSynch
-    7 -> pure ReadOnlySynch
-    8 -> pure NextSimTime
-    9 -> pure AfterDelay
-    10 -> pure EndOfCompile
-    11 -> pure StartOfSimulation
-    12 -> pure EndOfSimulation
-    13 -> pure DidError
-    14 -> pure TchkViolation
-    15 -> pure StartOfSave
-    16 -> pure EndOfSave
-    17 -> pure StartOfRestart
-    18 -> pure EndOfRestart
-    19 -> pure StartOfReset
-    20 -> pure EndOfReset
-    21 -> pure EnterInteractive
-    22 -> pure ExitInteractive
-    23 -> pure InteractiveScopeChange
-    24 -> pure UnresolvedSysTf
+  unsafeReceive (creason, handle, ctime, cfmt) =
+    let mHandle = if isNullHandle handle then Nothing else Just handle in
+    case creason of
+      1 -> do
+        timeTy <- unsafeReceive (ctimeType ctime)
+        valueFmt <- unsafeReceive cfmt
+        pure (AfterValueChange handle timeTy valueFmt)
+
+      2 -> do
+        timeTy <- unsafeReceive (ctimeType ctime)
+        pure (BeforeStatement handle timeTy)
+
+      3 -> do
+        timeTy <- unsafeReceive (ctimeType ctime)
+        valueFmt <- unsafeReceive cfmt
+        pure (AfterForce mHandle timeTy valueFmt)
+
+      4 -> do
+        timeTy <- unsafeReceive (ctimeType ctime)
+        valueFmt <- unsafeReceive cfmt
+        pure (AfterRelease mHandle timeTy valueFmt)
+
+      5 -> do
+        time <- unsafeReceive ctime
+        pure (AtStartOfSimTime mHandle time)
+
+      6 -> do
+        time <- unsafeReceive ctime
+        pure (ReadWriteSynch mHandle time)
+
+      7 -> do
+        time <- unsafeReceive ctime
+        pure (ReadOnlySynch mHandle time)
+
+      8 -> do
+        timeTy <- unsafeReceive (ctimeType ctime)
+        pure (NextSimTime mHandle timeTy)
+
+      9 -> do
+        time <- unsafeReceive ctime
+        pure (AfterDelay mHandle time)
+
+      10 ->
+        pure EndOfCompile
+
+      11 ->
+        pure StartOfSimulation
+
+      12 ->
+        pure EndOfSimulation
+
+      13 ->
+        pure RuntimeError
+
+      14 ->
+        pure TchkViolation
+
+      15 ->
+        pure StartOfSave
+
+      16 ->
+        pure EndOfSave
+
+      17 ->
+        pure StartOfRestart
+
+      18 ->
+        pure EndOfRestart
+
+      19 ->
+        pure StartOfReset
+
+      20 ->
+        pure EndOfReset
+
+      21 ->
+        pure EnterInteractive
+
+      22 ->
+        pure ExitInteractive
+
+      23 ->
+        pure InteractiveScopeChange
+
+      24 ->
+        pure UnresolvedSysTf
+
 #if defined(VERILOG_2001)
-    25 -> pure DidAssign
-    26 -> pure DidDeassign
-    27 -> pure DidDisable
-    28 -> pure DidPliError
-    29 -> pure DidSignal
+      25 -> do
+        timeTy <- unsafeReceive (ctimeType ctime)
+        valueFmt <- unsafeReceive cfmt
+        pure (AfterAssign handle timeTy valueFmt)
+
+      26 -> do
+        timeTy <- unsafeReceive (ctimeType ctime)
+        valueFmt <- unsafeReceive cfmt
+        pure (AfterDeassign handle timeTy valueFmt)
+
+      27 -> do
+        timeTy <- unsafeReceive (ctimeType ctime)
+        valueFmt <- unsafeReceive cfmt
+        pure (AfterDisable handle timeTy valueFmt)
+
+      28 ->
+        pure PliError
+
+      29 ->
+        pure Signal
 #endif
 #if defined(VERILOG_2005)
-    30 -> pure NbaSynch
-    31 -> pure AtEndOfSimTime
+      30 -> do
+        time <- unsafeReceive ctime
+        pure (NbaSynch mHandle time)
+
+      31 -> do
+        time <- unsafeReceive ctime
+        pure (AtEndOfSimTime mHandle time)
 #endif
-    n  -> Sim.throw (UnknownCallbackReason n callStack)
+
+      n  -> Sim.throw (UnknownCallbackReason n callStack)
 
 instance Receive CallbackReason where
-  receive = unsafeReceive
+  receive (creason, handle, ctime, cfmt) =
+    let mHandle = if isNullHandle handle then Nothing else Just handle in
+    case creason of
+      1 -> do
+        timeTy <- receive (ctimeType ctime)
+        valueFmt <- receive cfmt
+        pure (AfterValueChange handle timeTy valueFmt)
+
+      2 -> do
+        timeTy <- receive (ctimeType ctime)
+        pure (BeforeStatement handle timeTy)
+
+      3 -> do
+        timeTy <- receive (ctimeType ctime)
+        valueFmt <- receive cfmt
+        pure (AfterForce mHandle timeTy valueFmt)
+
+      4 -> do
+        timeTy <- receive (ctimeType ctime)
+        valueFmt <- receive cfmt
+        pure (AfterRelease mHandle timeTy valueFmt)
+
+      5 -> do
+        time <- receive ctime
+        pure (AtStartOfSimTime mHandle time)
+
+      6 -> do
+        time <- receive ctime
+        pure (ReadWriteSynch mHandle time)
+
+      7 -> do
+        time <- receive ctime
+        pure (ReadOnlySynch mHandle time)
+
+      8 -> do
+        timeTy <- receive (ctimeType ctime)
+        pure (NextSimTime mHandle timeTy)
+
+      9 -> do
+        time <- receive ctime
+        pure (AfterDelay mHandle time)
+
+      10 ->
+        pure EndOfCompile
+
+      11 ->
+        pure StartOfSimulation
+
+      12 ->
+        pure EndOfSimulation
+
+      13 ->
+        pure RuntimeError
+
+      14 ->
+        pure TchkViolation
+
+      15 ->
+        pure StartOfSave
+
+      16 ->
+        pure EndOfSave
+
+      17 ->
+        pure StartOfRestart
+
+      18 ->
+        pure EndOfRestart
+
+      19 ->
+        pure StartOfReset
+
+      20 ->
+        pure EndOfReset
+
+      21 ->
+        pure EnterInteractive
+
+      22 ->
+        pure ExitInteractive
+
+      23 ->
+        pure InteractiveScopeChange
+
+      24 ->
+        pure UnresolvedSysTf
+
+#if defined(VERILOG_2001)
+      25 -> do
+        timeTy <- receive (ctimeType ctime)
+        valueFmt <- receive cfmt
+        pure (AfterAssign handle timeTy valueFmt)
+
+      26 -> do
+        timeTy <- receive (ctimeType ctime)
+        valueFmt <- receive cfmt
+        pure (AfterDeassign handle timeTy valueFmt)
+
+      27 -> do
+        timeTy <- receive (ctimeType ctime)
+        valueFmt <- receive cfmt
+        pure (AfterDisable handle timeTy valueFmt)
+
+      28 ->
+        pure PliError
+
+      29 ->
+        pure Signal
+#endif
+#if defined(VERILOG_2005)
+      30 -> do
+        time <- receive ctime
+        pure (NbaSynch mHandle time)
+
+      31 -> do
+        time <- receive ctime
+        pure (AtEndOfSimTime mHandle time)
+#endif
+
+      n  -> Sim.throw (UnknownCallbackReason n callStack)
+-}
 

--- a/clash-ffi/src/Clash/FFI/VPI/Callback/Reason.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Callback/Reason.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Clash.FFI.VPI.Callback.Reason
   ( CallbackReason(..)
+  , UnknownCallbackReason(..)
   ) where
 
 import           Control.Exception (Exception)
@@ -22,41 +22,41 @@ import           Clash.FFI.VPI.Object
 import           Clash.FFI.VPI.Time
 import           Clash.FFI.VPI.Value
 
-data CallbackReason where
-  AfterValueChange :: Handle -> TimeType -> ValueFormat -> CallbackReason
-  BeforeStatement :: Handle -> TimeType -> CallbackReason
-  AfterForce :: Maybe Handle -> TimeType -> ValueFormat -> CallbackReason
-  AfterRelease :: Maybe Handle -> TimeType -> ValueFormat -> CallbackReason
-  AtStartOfSimTime :: Maybe Handle -> Time -> CallbackReason
-  ReadWriteSynch :: Maybe Handle -> Time -> CallbackReason
-  ReadOnlySynch :: Maybe Handle -> Time -> CallbackReason
-  NextSimTime :: Maybe Handle -> TimeType -> CallbackReason
-  AfterDelay :: Maybe Handle -> Time -> CallbackReason
-  EndOfCompile :: CallbackReason
-  StartOfSimulation :: CallbackReason
-  EndOfSimulation :: CallbackReason
-  RuntimeError :: CallbackReason
-  TchkViolation :: CallbackReason
-  StartOfSave :: CallbackReason
-  EndOfSave :: CallbackReason
-  StartOfRestart :: CallbackReason
-  EndOfRestart :: CallbackReason
-  StartOfReset :: CallbackReason
-  EndOfReset :: CallbackReason
-  EnterInteractive :: CallbackReason
-  ExitInteractive :: CallbackReason
-  InteractiveScopeChange :: CallbackReason
-  UnresolvedSysTf :: CallbackReason
+data CallbackReason
+  = AfterValueChange Handle TimeType ValueFormat
+  | BeforeStatement Handle TimeType
+  | AfterForce (Maybe Handle) TimeType ValueFormat
+  | AfterRelease (Maybe Handle) TimeType ValueFormat
+  | AtStartOfSimTime (Maybe Handle) Time
+  | ReadWriteSynch (Maybe Handle) Time
+  | ReadOnlySynch (Maybe Handle) Time
+  | NextSimTime (Maybe Handle) TimeType
+  | AfterDelay (Maybe Handle) Time
+  | EndOfCompile
+  | StartOfSimulation
+  | EndOfSimulation
+  | RuntimeError
+  | TchkViolation
+  | StartOfSave
+  | EndOfSave
+  | StartOfRestart
+  | EndOfRestart
+  | StartOfReset
+  | EndOfReset
+  | EnterInteractive
+  | ExitInteractive
+  | InteractiveScopeChange
+  | UnresolvedSysTf
 #if defined(VERILOG_2001)
-  AfterAssign :: Handle -> TimeType -> ValueFormat -> CallbackReason
-  AfterDeassign :: Handle -> TimeType -> ValueFormat -> CallbackReason
-  AfterDisable :: Handle -> TimeType -> ValueFormat -> CallbackReason
-  PliError :: CallbackReason
-  Signal :: CallbackReason
+  | AfterAssign Handle TimeType ValueFormat
+  | AfterDeassign Handle TimeType ValueFormat
+  | AfterDisable Handle TimeType ValueFormat
+  | PliError
+  | Signal
 #endif
 #if defined(VERILOG_2005)
-  NbaSynch :: Maybe Handle -> Time -> CallbackReason
-  AtEndOfSimTime :: Maybe Handle -> Time -> CallbackReason
+  | NbaSynch (Maybe Handle) Time
+  | AtEndOfSimTime (Maybe Handle) Time
 #endif
 
 instance UnsafeSend CallbackReason where
@@ -636,5 +636,5 @@ instance Receive CallbackReason where
         pure (AtEndOfSimTime mHandle time)
 #endif
 
-      n  -> Sim.throw (UnknownCallbackReason n callStack)
+      n -> Sim.throw (UnknownCallbackReason n callStack)
 

--- a/clash-ffi/src/Clash/FFI/VPI/Callback/Reason.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Callback/Reason.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.FFI.VPI.Callback.Reason
+  ( CallbackReason(..)
+  ) where
+
+import           Control.Exception (Exception)
+import           Foreign.C.Types (CInt)
+import           GHC.Stack (CallStack, callStack, prettyCallStack)
+
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.View
+import           Clash.FFI.VPI.Object (Handle)
+import           Clash.FFI.VPI.Time
+import           Clash.FFI.VPI.Value (ValueFormat)
+
+data CallbackReason where
+  AfterValueChange :: Handle -> TimeType -> ValueFormat n -> CallbackReason
+  BeforeStatement :: Handle -> TimeType -> CallbackReason
+  AfterForce :: Maybe Handle -> TimeType -> ValueFormat n -> CallbackReason
+  AfterRelease :: Maybe Handle -> TimeType -> ValueFormat n -> CallbackReason
+  AtStartOfSimTime :: Maybe Handle -> Time -> CallbackReason
+  ReadWriteSynch :: Maybe Handle -> Time -> CallbackReason
+  ReadOnlySynch :: Maybe Handle -> Time -> CallbackReason
+  NextSimTime :: Maybe Handle -> TimeType -> CallbackReason
+  AfterDelay :: Maybe Handle -> Time -> CallbackReason
+  EndOfCompile :: CallbackReason
+  StartOfSimulation :: CallbackReason
+  EndOfSimulation :: CallbackReason
+  RuntimeError :: CallbackReason
+  TchkViolation :: CallbackReason
+  StartOfSave :: CallbackReason
+  EndOfSave :: CallbackReason
+  StartOfRestart :: CallbackReason
+  EndOfRestart :: CallbackReason
+  StartOfReset :: CallbackReason
+  EndOfReset :: CallbackReason
+  EnterInteractive :: CallbackReason
+  ExitInteractive :: CallbackReason
+  InteractiveScopeChange :: CallbackReason
+  UnresolvedSysTf :: CallbackReason
+#if defined(VERILOG_2001)
+  AfterAssign :: Handle -> TimeType -> ValueFormat n -> CallbackReason
+  AfterDeassign :: Handle -> TimeType -> ValueFormat n -> CallbackReason
+  AfterDisable :: Handle -> TimeType -> ValueFormat n -> CallbackReason
+  PliError :: CallbackReason
+  Signal :: CallbackReason
+#endif
+#if defined(VERILOG_2005)
+  NbaSynch :: Maybe Handle -> Time -> CallbackReason
+  AtEndOfSimTime :: Maybe Handle -> Time -> CallbackReason
+#endif
+
+instance UnsafeSend CallbackReason where
+  type Sent CallbackReason = (CInt, Handle, CTime, CInt)
+
+  unsafeSend =
+    pure . \case
+      ValueChange -> 1
+      Statement -> 2
+      DidForce -> 3
+      DidRelease -> 4
+      AtStartOfSimTime -> 5
+      ReadWriteSynch -> 6
+      ReadOnlySynch -> 7
+      NextSimTime -> 8
+      AfterDelay -> 9
+      EndOfCompile -> 10
+      StartOfSimulation -> 11
+      EndOfSimulation -> 12
+      DidError -> 13
+      TchkViolation -> 14
+      StartOfSave -> 15
+      EndOfSave -> 16
+      StartOfRestart -> 17
+      EndOfRestart -> 18
+      StartOfReset -> 19
+      EndOfReset -> 20
+      EnterInteractive -> 21
+      ExitInteractive -> 22
+      InteractiveScopeChange -> 23
+      UnresolvedSysTf -> 24
+#if defined(VERILOG_2001)
+      DidAssign -> 25
+      DidDeassign -> 26
+      DidDisable -> 27
+      DidPliError -> 28
+      DidSignal -> 29
+#endif
+#if defined(VERILOG_2005)
+      NbaSynch -> 30
+      AtEndOfSimTime -> 31
+#endif
+
+instance Send CallbackReason where
+  send = unsafeSend
+
+data UnknownCallbackReason
+  = UnknownCallbackReason CInt CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownCallbackReason where
+  show (UnknownCallbackReason x c) =
+    mconcat
+      [ "Unknown callback reason: "
+      , show x
+      , "\n"
+      , prettyCallStack c
+      ]
+
+instance UnsafeReceive CallbackReason where
+  type Received CallbackReason = CInt
+
+  unsafeReceive = \case
+    1 -> pure ValueChange
+    2 -> pure Statement
+    3 -> pure DidForce
+    4 -> pure DidRelease
+    5 -> pure AtStartOfSimTime
+    6 -> pure ReadWriteSynch
+    7 -> pure ReadOnlySynch
+    8 -> pure NextSimTime
+    9 -> pure AfterDelay
+    10 -> pure EndOfCompile
+    11 -> pure StartOfSimulation
+    12 -> pure EndOfSimulation
+    13 -> pure DidError
+    14 -> pure TchkViolation
+    15 -> pure StartOfSave
+    16 -> pure EndOfSave
+    17 -> pure StartOfRestart
+    18 -> pure EndOfRestart
+    19 -> pure StartOfReset
+    20 -> pure EndOfReset
+    21 -> pure EnterInteractive
+    22 -> pure ExitInteractive
+    23 -> pure InteractiveScopeChange
+    24 -> pure UnresolvedSysTf
+#if defined(VERILOG_2001)
+    25 -> pure DidAssign
+    26 -> pure DidDeassign
+    27 -> pure DidDisable
+    28 -> pure DidPliError
+    29 -> pure DidSignal
+#endif
+#if defined(VERILOG_2005)
+    30 -> pure NbaSynch
+    31 -> pure AtEndOfSimTime
+#endif
+    n  -> Sim.throw (UnknownCallbackReason n callStack)
+
+instance Receive CallbackReason where
+  receive = unsafeReceive
+

--- a/clash-ffi/src/Clash/FFI/VPI/Control.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Control.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Clash.FFI.VPI.Control
+#if defined(VERILOG_2001)
+  ( Control(..)
+  , StopValue(..)
+  , DiagnosticLevel(..)
+  , controlSimulator
+  ) where
+
+import           Control.Exception (Exception)
+import qualified Control.Monad as Monad (unless)
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Foreign.C.Types (CInt(..))
+import           GHC.Stack (CallStack, callStack, prettyCallStack)
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (throw)
+
+data Control
+  = Stop DiagnosticLevel
+  | Finish DiagnosticLevel
+  | Reset StopValue (Maybe CInt) DiagnosticLevel
+  deriving stock (Show)
+
+data StopValue
+  = Interactive
+  | Batch
+  deriving stock (Show)
+
+stopValueToCInt :: StopValue -> CInt
+stopValueToCInt = \case
+  Interactive -> 0
+  Batch -> 1
+
+data DiagnosticLevel
+  = NoDiagnostics
+  | TimeAndLocation
+  | TimeLocationAndStats
+  deriving stock (Show)
+
+diagnosticLevelToCInt :: DiagnosticLevel -> CInt
+diagnosticLevelToCInt = \case
+  NoDiagnostics -> 0
+  TimeAndLocation -> 1
+  TimeLocationAndStats -> 2
+
+data CouldNotControl
+  = CouldNotControl Control CallStack
+  deriving anyclass (Exception)
+
+instance Show CouldNotControl where
+  show (CouldNotControl x c) =
+    mconcat
+      [ "Could not perform simulator control command: "
+      , show x
+      , "\n"
+      , prettyCallStack c
+      ]
+
+foreign import ccall "vpi_user.h vpi_control"
+  c_vpi_control_end :: CInt -> CInt -> IO Bool
+
+foreign import ccall "vpi_user.h vpi_control"
+  c_vpi_control_restart :: CInt -> CInt -> CInt -> CInt -> IO Bool
+
+controlSimulator :: Control -> SimCont o ()
+controlSimulator control =
+  liftOrThrow $
+    case control of
+      Stop d ->
+        c_vpi_control_end 66 (diagnosticLevelToCInt d)
+
+      Finish d ->
+        c_vpi_control_end 67 (diagnosticLevelToCInt d)
+
+      Reset s (Just r) d ->
+        c_vpi_control_restart 68 (stopValueToCInt s) r (diagnosticLevelToCInt d)
+
+      Reset s Nothing d ->
+        c_vpi_control_restart 68 (stopValueToCInt s) 0 (diagnosticLevelToCInt d)
+ where
+  liftOrThrow f =
+    IO.liftIO f >>= (`Monad.unless` Sim.throw (CouldNotControl control callStack))
+#else
+  () where
+#endif
+

--- a/clash-ffi/src/Clash/FFI/VPI/Control.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Control.hs
@@ -6,6 +6,7 @@ module Clash.FFI.VPI.Control
   ( Control(..)
   , StopValue(..)
   , DiagnosticLevel(..)
+  , CouldNotControl(..)
   , controlSimulator
   ) where
 

--- a/clash-ffi/src/Clash/FFI/VPI/Control.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Control.hs
@@ -66,7 +66,7 @@ foreign import ccall "vpi_user.h vpi_control"
 foreign import ccall "vpi_user.h vpi_control"
   c_vpi_control_restart :: CInt -> CInt -> CInt -> CInt -> IO Bool
 
-controlSimulator :: Control -> SimCont o ()
+controlSimulator :: forall o. Control -> SimCont o ()
 controlSimulator control =
   liftOrThrow $
     case control of

--- a/clash-ffi/src/Clash/FFI/VPI/Error.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Error.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- Used to improve the performance of derived instances.
@@ -9,10 +8,10 @@
 module Clash.FFI.VPI.Error
   ( CVpiError(..)
   , VpiError(..)
-  , ErrorState(..)
-  , ErrorLevel(..)
   , simulationError
   , simulationErrorLevel
+  , module Clash.FFI.VPI.Error.Level
+  , module Clash.FFI.VPI.Error.State
   ) where
 
 import           Data.ByteString (ByteString)
@@ -25,8 +24,8 @@ import           GHC.Generics (Generic)
 import           Clash.FFI.Monad (SimCont)
 import qualified Clash.FFI.Monad as Sim (stackPtr, withNewPtr)
 import           Clash.FFI.View (Receive(..), UnsafeReceive(..), receiveString)
-import           Clash.FFI.VPI.Error.Level (ErrorLevel(..))
-import           Clash.FFI.VPI.Error.State (ErrorState(..))
+import           Clash.FFI.VPI.Error.Level
+import           Clash.FFI.VPI.Error.State
 
 data CVpiError = CVpiError
   { cerrorState   :: CInt

--- a/clash-ffi/src/Clash/FFI/VPI/Error.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Error.hs
@@ -78,14 +78,17 @@ instance Receive VpiError where
 foreign import ccall "vpi_user.h vpi_chk_error"
   c_vpi_chk_error :: Ptr CVpiError -> IO CInt
 
-simulationError :: SimCont o (Ptr CVpiError) -> SimCont o (Ptr CVpiError, ErrorLevel)
+simulationError
+  :: forall o
+   . SimCont o (Ptr CVpiError)
+  -> SimCont o (Ptr CVpiError, ErrorLevel)
 simulationError alloc = do
   (ptr, clevel) <- Sim.withNewPtr alloc c_vpi_chk_error
   level <- receive clevel
 
   pure (ptr, level)
 
-simulationErrorLevel :: SimCont o ErrorLevel
+simulationErrorLevel :: forall o. SimCont o ErrorLevel
 simulationErrorLevel =
   snd <$> simulationError Sim.stackPtr
 

--- a/clash-ffi/src/Clash/FFI/VPI/Error.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Error.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- Used to improve the performance of derived instances.
+{-# OPTIONS_GHC -fplugin=Foreign.Storable.Generic.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt=Foreign.Storable.Generic.Plugin:-v0 #-}
+
+module Clash.FFI.VPI.Error
+  ( CVpiError(..)
+  , VpiError(..)
+  , ErrorState(..)
+  , ErrorLevel(..)
+  , simulationError
+  , simulationErrorLevel
+  ) where
+
+import           Data.ByteString (ByteString)
+import           Foreign.C.String (CString)
+import           Foreign.C.Types (CInt(..))
+import           Foreign.Ptr (Ptr)
+import           Foreign.Storable.Generic (GStorable)
+import           GHC.Generics (Generic)
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (stackPtr, withNewPtr)
+import           Clash.FFI.View (Receive(..), UnsafeReceive(..), receiveString)
+import           Clash.FFI.VPI.Error.Level (ErrorLevel(..))
+import           Clash.FFI.VPI.Error.State (ErrorState(..))
+
+data CVpiError = CVpiError
+  { cerrorState   :: CInt
+  , cerrorLevel   :: CInt
+  , cerrorMessage :: CString
+  , cerrorProduct :: CString
+  , cerrorCode    :: CString
+  , cerrorFile    :: CString
+  , cerrorLine    :: CInt
+  }
+  deriving stock (Generic)
+  deriving anyclass (GStorable)
+
+data VpiError = VpiError
+  { errorState    :: ErrorState
+  , errorLevel    :: ErrorLevel
+  , errorMessage  :: ByteString
+  , errorProduct  :: ByteString
+  , errorCode     :: ByteString
+  , errorFile     :: FilePath
+  , errorLine     :: Int
+  }
+
+instance UnsafeReceive VpiError where
+  type Received VpiError = CVpiError
+
+  unsafeReceive cerror = do
+    state <- unsafeReceive (cerrorState cerror)
+    level <- unsafeReceive (cerrorLevel cerror)
+    msg <- unsafeReceive (cerrorMessage cerror)
+    prod <- unsafeReceive (cerrorProduct cerror)
+    code <- unsafeReceive (cerrorCode cerror)
+    file <- receiveString (cerrorFile cerror)
+    let line = fromIntegral (cerrorLine cerror)
+
+    pure (VpiError state level msg prod code file line)
+
+instance Receive VpiError where
+  receive cerror = do
+    state <- receive (cerrorState cerror)
+    level <- receive (cerrorState cerror)
+    msg <- receive (cerrorMessage cerror)
+    prod <- receive (cerrorProduct cerror)
+    code <- receive (cerrorCode cerror)
+    file <- receiveString (cerrorFile cerror)
+    let line = fromIntegral (cerrorLine cerror)
+
+    pure (VpiError state level msg prod code file line)
+
+foreign import ccall "vpi_user.h vpi_chk_error"
+  c_vpi_chk_error :: Ptr CVpiError -> IO CInt
+
+simulationError :: SimCont o (Ptr CVpiError) -> SimCont o (Ptr CVpiError, ErrorLevel)
+simulationError alloc = do
+  (ptr, clevel) <- Sim.withNewPtr alloc c_vpi_chk_error
+  level <- receive clevel
+
+  pure (ptr, level)
+
+simulationErrorLevel :: SimCont o ErrorLevel
+simulationErrorLevel =
+  snd <$> simulationError Sim.stackPtr
+

--- a/clash-ffi/src/Clash/FFI/VPI/Error/Level.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Error/Level.hs
@@ -3,6 +3,7 @@
 
 module Clash.FFI.VPI.Error.Level
   ( ErrorLevel(..)
+  , UnknownErrorLevel(..)
   ) where
 
 import           Control.Exception (Exception)

--- a/clash-ffi/src/Clash/FFI/VPI/Error/Level.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Error/Level.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.FFI.VPI.Error.Level
+  ( ErrorLevel(..)
+  ) where
+
+import           Control.Exception (Exception)
+import           Foreign.C.Types (CInt)
+import           GHC.Stack (CallStack, callStack, prettyCallStack)
+
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.View (Receive(..), UnsafeReceive(..))
+
+data ErrorLevel
+  = Success
+  | Notice
+  | Warning
+  | Error
+  | System
+  | Internal
+  deriving stock (Show)
+
+data UnknownErrorLevel
+  = UnknownErrorLevel CInt CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownErrorLevel where
+  show (UnknownErrorLevel x c) =
+    mconcat
+      [ "Unknown error level: "
+      , show x
+      , "\n"
+      , prettyCallStack c
+      ]
+
+instance UnsafeReceive ErrorLevel where
+  type Received ErrorLevel = CInt
+
+  unsafeReceive = \case
+    0 -> pure Success
+    1 -> pure Notice
+    2 -> pure Warning
+    3 -> pure Error
+    4 -> pure System
+    5 -> pure Internal
+    n -> Sim.throw (UnknownErrorLevel n callStack)
+
+instance Receive ErrorLevel where
+  receive = unsafeReceive
+

--- a/clash-ffi/src/Clash/FFI/VPI/Error/State.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Error/State.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.FFI.VPI.Error.State
+  ( ErrorState(..)
+  ) where
+
+import           Control.Exception (Exception)
+import           Foreign.C.Types (CInt)
+import           GHC.Stack (CallStack, callStack, prettyCallStack)
+
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.View (Receive(..), UnsafeReceive(..))
+
+data ErrorState
+  = CompileError
+  | PliError
+  | RunError
+  deriving stock (Eq, Show)
+
+data UnknownErrorState
+  = UnknownErrorState CInt CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownErrorState where
+  show (UnknownErrorState x c) =
+    mconcat
+      [ "Unknown error state: "
+      , show x
+      , "\n"
+      , prettyCallStack c
+      ]
+
+instance UnsafeReceive ErrorState where
+  type Received ErrorState = CInt
+
+  unsafeReceive = \case
+    1 -> pure CompileError
+    2 -> pure PliError
+    3 -> pure RunError
+    n -> Sim.throw (UnknownErrorState n callStack)
+
+instance Receive ErrorState where
+  receive = unsafeReceive
+

--- a/clash-ffi/src/Clash/FFI/VPI/Error/State.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Error/State.hs
@@ -3,6 +3,7 @@
 
 module Clash.FFI.VPI.Error.State
   ( ErrorState(..)
+  , UnknownErrorState(..)
   ) where
 
 import           Control.Exception (Exception)

--- a/clash-ffi/src/Clash/FFI/VPI/Handle.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Handle.hs
@@ -14,6 +14,7 @@ import GHC.Stack (CallStack, prettyCallStack)
 
 import Clash.FFI.Monad (SimCont)
 
+-- | A VPI handle is a reference to some VPI object.
 class Handle a where
   nullHandle      :: a
   isNullHandle    :: a -> Bool
@@ -21,11 +22,18 @@ class Handle a where
   freeHandle      :: a -> SimCont o ()
   compareHandles  :: a -> a -> SimCont o Bool
 
+-- | Some handles allow accessing parents through the @vpiParent@ method. This
+-- class exposes that method to be implemented by specific objects, allowing
+-- them to specify the type of the parent object when the method is used.
 class Handle a => HandleParent a where
   type ParentHandle a
 
   parentHandle :: a -> SimCont o (ParentHandle a)
 
+-- | When the @vpiParent@ method is used on an object at the top of the design
+-- hierarchy, a null handle is returned. When this happens, we can throw an
+-- exception to alert authors of FFI applications that they have potentially
+-- made a mistake.
 data UnknownParent a
   = UnknownParent a CallStack
   deriving anyclass (Exception)
@@ -39,6 +47,10 @@ instance (Show a) => Show (UnknownParent a) where
       , prettyCallStack c
       ]
 
+-- | Some handles have children which can be accessed in different ways (e.g.
+-- by object type, method, name or (multi)index). This class provides a way to
+-- access child objects, allowing them to specify the type of child given the
+-- parent and index types.
 class Handle a => HandleChild i a where
   type ChildHandle i a
 

--- a/clash-ffi/src/Clash/FFI/VPI/Handle.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Handle.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.FFI.VPI.Handle
+  ( Handle(..)
+  , HandleParent(..)
+  , UnknownParent(..)
+  , HandleChild(..)
+  , UnknownChild(..)
+  ) where
+
+import Control.Exception (Exception)
+import GHC.Stack (CallStack, prettyCallStack)
+
+import Clash.FFI.Monad (SimCont)
+
+class Handle a where
+  nullHandle      :: a
+  isNullHandle    :: a -> Bool
+
+  freeHandle      :: a -> SimCont o ()
+  compareHandles  :: a -> a -> SimCont o Bool
+
+class Handle a => HandleParent a where
+  type ParentHandle a
+
+  parentHandle :: a -> SimCont o (ParentHandle a)
+
+data UnknownParent a
+  = UnknownParent a CallStack
+  deriving anyclass (Exception)
+
+instance (Show a) => Show (UnknownParent a) where
+  show (UnknownParent a c) =
+    mconcat
+      [ "Unknown parent for handle "
+      , show a
+      , "\n"
+      , prettyCallStack c
+      ]
+
+class Handle a => HandleChild i a where
+  type ChildHandle i a
+
+  childHandle :: i -> a -> SimCont o (ChildHandle i a)
+
+data UnknownChild i a
+  = UnknownChild i a CallStack
+  deriving anyclass (Exception)
+
+instance (Show i, Show a) => Show (UnknownChild i a) where
+  show (UnknownChild i a c) =
+    mconcat
+      [ "Unknown child "
+      , show i
+      , " for handle "
+      , show a
+      , "\n"
+      , prettyCallStack c
+      ]
+

--- a/clash-ffi/src/Clash/FFI/VPI/IO.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/IO.hs
@@ -1,27 +1,55 @@
 module Clash.FFI.VPI.IO
   ( simPutStr
   , simPutStrLn
+  , simFlushIO
   ) where
 
+import           Control.Exception (Exception)
 import           Control.Monad ((>=>))
-import qualified Control.Monad as Monad (void)
+import qualified Control.Monad as Monad (void, when)
 import qualified Control.Monad.IO.Class as IO (liftIO)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS (snoc)
 import           Foreign.C.String (CString)
 import           Foreign.C.Types (CInt(..))
+import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
 
 import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (throw)
 import           Clash.FFI.View (unsafeSend)
 
 foreign import ccall "vpi_user.h vpi_printf"
   c_vpi_printf :: CString -> IO CInt
 
-simPutStr :: ByteString -> SimCont o ()
+simPutStr
+  :: forall o
+   . HasCallStack
+  => ByteString
+  -> SimCont o ()
 simPutStr =
   unsafeSend >=> IO.liftIO . Monad.void . c_vpi_printf
 
-simPutStrLn :: ByteString -> SimCont o ()
+simPutStrLn :: HasCallStack => ByteString -> SimCont o ()
 simPutStrLn =
   simPutStr . (`BS.snoc` '\n')
+
+newtype CouldNotFlushIO
+  = CouldNotFlushIO CallStack
+  deriving anyclass (Exception)
+
+instance Show CouldNotFlushIO where
+  show (CouldNotFlushIO c) =
+    "Could not flush simulator output buffers\n" <> prettyCallStack c
+
+foreign import ccall "vpi_user.h vpi_flush"
+  c_vpi_flush :: IO Bool
+
+simFlushIO :: HasCallStack => SimCont o ()
+simFlushIO = do
+  failed <- IO.liftIO c_vpi_flush
+
+  Monad.when failed $
+    Sim.throw (CouldNotFlushIO callStack)
+
+  pure ()
 

--- a/clash-ffi/src/Clash/FFI/VPI/IO.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/IO.hs
@@ -1,0 +1,27 @@
+module Clash.FFI.VPI.IO
+  ( simPutStr
+  , simPutStrLn
+  ) where
+
+import           Control.Monad ((>=>))
+import qualified Control.Monad as Monad (void)
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS (snoc)
+import           Foreign.C.String (CString)
+import           Foreign.C.Types (CInt(..))
+
+import           Clash.FFI.Monad (SimCont)
+import           Clash.FFI.View (unsafeSend)
+
+foreign import ccall "vpi_user.h vpi_printf"
+  c_vpi_printf :: CString -> IO CInt
+
+simPutStr :: ByteString -> SimCont o ()
+simPutStr =
+  unsafeSend >=> IO.liftIO . Monad.void . c_vpi_printf
+
+simPutStrLn :: ByteString -> SimCont o ()
+simPutStrLn =
+  simPutStr . (`BS.snoc` '\n')
+

--- a/clash-ffi/src/Clash/FFI/VPI/Info.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Info.hs
@@ -7,6 +7,7 @@
 module Clash.FFI.VPI.Info
   ( CInfo(..)
   , Info(..)
+  , UnknownSimulator(..)
   , simulatorInfo
   ) where
 

--- a/clash-ffi/src/Clash/FFI/VPI/Info.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Info.hs
@@ -77,7 +77,11 @@ instance Show UnknownSimulator where
       , prettyCallStack c
       ]
 
-simulatorInfo :: HasCallStack => SimCont o (Ptr CInfo) -> SimCont o (Ptr CInfo)
+simulatorInfo
+  :: forall o
+   . HasCallStack
+  => SimCont o (Ptr CInfo)
+  -> SimCont o (Ptr CInfo)
 simulatorInfo alloc =
   fmap fst . Sim.withNewPtr alloc $ \ptr -> do
     isSuccess <- c_vpi_get_vlog_info ptr

--- a/clash-ffi/src/Clash/FFI/VPI/Info.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Info.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE TypeFamilies #-}
+
+-- Used to improve the performance of derived instances.
+{-# OPTIONS_GHC -fplugin=Foreign.Storable.Generic.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt=Foreign.Storable.Generic.Plugin:-v0 #-}
+
+module Clash.FFI.VPI.Info
+  ( CInfo(..)
+  , Info(..)
+  , simulatorInfo
+  ) where
+
+import           Control.Exception (Exception)
+import qualified Control.Exception as IO (throwIO)
+import qualified Control.Monad as Monad (unless)
+import           Data.ByteString (ByteString)
+import           Foreign.C.String (CString)
+import           Foreign.C.Types (CInt(..))
+import           Foreign.Ptr (Ptr)
+import qualified Foreign.Ptr as FFI (nullPtr)
+import           Foreign.Storable.Generic (GStorable)
+import           GHC.Generics (Generic)
+import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (withNewPtr)
+import           Clash.FFI.View
+
+data CInfo = CInfo
+  { cinfoArgc    :: CInt
+  , cinfoArgv    :: Ptr CString
+  , cinfoProduct :: CString
+  , cinfoVersion :: CString
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (GStorable)
+
+data Info = Info
+  { infoArgs    :: [ByteString]
+  , infoProduct :: ByteString
+  , infoVersion :: ByteString
+  }
+  deriving stock (Show)
+
+instance UnsafeReceive Info where
+  type Received Info = CInfo
+
+  unsafeReceive cinfo = do
+    -- When passing +RTS to some simulators, they may replace the whole
+    -- argument with NULL, so we check for that instead of using argc.
+    args <- unsafeReceiveArray0 FFI.nullPtr (cinfoArgv cinfo)
+    prod <- unsafeReceive (cinfoProduct cinfo)
+    ver  <- unsafeReceive (cinfoVersion cinfo)
+
+    pure (Info args prod ver)
+
+instance Receive Info where
+  receive cinfo = do
+    args <- receiveArray0 FFI.nullPtr (cinfoArgv cinfo)
+    prod <- receive (cinfoProduct cinfo)
+    ver  <- receive (cinfoVersion cinfo)
+
+    pure (Info args prod ver)
+
+foreign import ccall "vpi_user.h vpi_get_vlog_info"
+  c_vpi_get_vlog_info :: Ptr CInfo -> IO Bool
+
+data UnknownSimulator
+  = UnknownSimulator CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownSimulator where
+  show (UnknownSimulator c) =
+    mconcat
+      [ "Could not identify the running simulator\n"
+      , prettyCallStack c
+      ]
+
+simulatorInfo :: HasCallStack => SimCont o (Ptr CInfo) -> SimCont o (Ptr CInfo)
+simulatorInfo alloc =
+  fmap fst . Sim.withNewPtr alloc $ \ptr -> do
+    isSuccess <- c_vpi_get_vlog_info ptr
+
+    Monad.unless isSuccess $
+      IO.throwIO (UnknownSimulator callStack)
+
+    pure isSuccess
+

--- a/clash-ffi/src/Clash/FFI/VPI/Info.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Info.hs
@@ -9,6 +9,8 @@ module Clash.FFI.VPI.Info
   , Info(..)
   , UnknownSimulator(..)
   , simulatorInfo
+  , unsafeReceiveSimulatorInfo
+  , receiveSimulatorInfo
   ) where
 
 import           Control.Exception (Exception)
@@ -24,7 +26,7 @@ import           GHC.Generics (Generic)
 import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
 
 import           Clash.FFI.Monad (SimCont)
-import qualified Clash.FFI.Monad as Sim (withNewPtr)
+import qualified Clash.FFI.Monad as Sim (stackPtr, withNewPtr)
 import           Clash.FFI.View
 
 data CInfo = CInfo
@@ -90,4 +92,19 @@ simulatorInfo alloc =
       IO.throwIO (UnknownSimulator callStack)
 
     pure isSuccess
+
+unsafeReceiveSimulatorInfo
+  :: forall o
+   . HasCallStack
+  => SimCont o Info
+unsafeReceiveSimulatorInfo =
+  simulatorInfo Sim.stackPtr >>= unsafePeekReceive
+
+receiveSimulatorInfo
+  :: forall o
+   . HasCallStack
+  => SimCont o Info
+receiveSimulatorInfo =
+  -- This is safe, since receive will make a copy.
+  simulatorInfo Sim.stackPtr >>= peekReceive
 

--- a/clash-ffi/src/Clash/FFI/VPI/Iterator.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Iterator.hs
@@ -1,0 +1,59 @@
+module Clash.FFI.VPI.Iterator
+  ( Iterator(..)
+  , iterate
+  , iterateAll
+  , scan
+  ) where
+
+import           Prelude hiding (iterate)
+
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Data.Maybe (fromMaybe)
+import           Foreign.C.Types (CInt(..))
+import           Foreign.Storable (Storable)
+
+import           Clash.FFI.Monad (SimCont)
+import           Clash.FFI.View
+import           Clash.FFI.VPI.Object
+
+newtype Iterator
+  = Iterator { iteratorHandle :: Handle }
+  deriving stock (Show)
+  deriving newtype (Storable)
+
+foreign import ccall "vpi_user.h vpi_iterate"
+  c_vpi_iterate :: CInt -> Handle -> IO Iterator
+
+iterate :: ObjectType -> Maybe Handle -> SimCont o Iterator
+iterate objTy parent = do
+  cobjTy <- unsafeSend objTy
+  let handle = fromMaybe nullHandle parent
+
+  IO.liftIO (c_vpi_iterate cobjTy handle)
+
+foreign import ccall "vpi_user.h vpi_scan"
+  c_vpi_scan :: Iterator -> IO Handle
+
+scan :: Iterator -> SimCont o (Maybe Handle)
+scan iterator
+  | isNullHandle (iteratorHandle iterator)
+  = pure Nothing
+
+  | otherwise
+  = do next <- IO.liftIO (c_vpi_scan iterator)
+       pure (if isNullHandle next then Nothing else Just next)
+
+iterateAll :: ObjectType -> Maybe Handle -> SimCont o [Handle]
+iterateAll objTy parent = do
+  iterator <- iterate objTy parent
+  takeWhileNonNull iterator
+ where
+  -- We do not need to free the iterator here, when scan is called at the last
+  -- item the iterator is automatically deallocated (according to the spec).
+  takeWhileNonNull iterator = do
+    scanned <- scan iterator
+
+    case scanned of
+      Just next -> fmap (next :) (takeWhileNonNull iterator)
+      Nothing   -> pure []
+

--- a/clash-ffi/src/Clash/FFI/VPI/Module.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Module.hs
@@ -1,0 +1,50 @@
+module Clash.FFI.VPI.Module
+  ( Module(..)
+  , topModules
+  , moduleName
+  , moduleFullName
+  , moduleNets
+  , moduleParameters
+  , modulePorts
+  , moduleRegs
+  ) where
+
+import Data.ByteString (ByteString)
+import GHC.Stack (HasCallStack)
+
+import Clash.FFI.Monad (SimCont)
+import Clash.FFI.VPI.Object
+import Clash.FFI.VPI.Net (Net(..))
+import Clash.FFI.VPI.Parameter (Parameter(..))
+import Clash.FFI.VPI.Port (Port(..))
+import Clash.FFI.VPI.Property
+import Clash.FFI.VPI.Reg (Reg(..))
+
+newtype Module = Module { moduleHandle :: Handle }
+
+topModules :: HasCallStack => SimCont o [Module]
+topModules =
+  fmap Module <$> iterateHandle ObjModule Nothing
+
+moduleName :: HasCallStack => Module -> SimCont o ByteString
+moduleName = receiveProperty VpiName . moduleHandle
+
+moduleFullName :: HasCallStack => Module -> SimCont o ByteString
+moduleFullName = receiveProperty VpiFullName . moduleHandle
+
+moduleNets :: HasCallStack => Module -> SimCont o [Net]
+moduleNets =
+  fmap (fmap Net) . iterateHandle ObjNet . Just . moduleHandle
+
+moduleParameters :: HasCallStack => Module -> SimCont o [Parameter]
+moduleParameters =
+  fmap (fmap Parameter) . iterateHandle ObjParameter . Just . moduleHandle
+
+modulePorts :: HasCallStack => Module -> SimCont o [Port]
+modulePorts =
+  fmap (fmap Port) . iterateHandle ObjPort . Just . moduleHandle
+
+moduleRegs :: HasCallStack => Module -> SimCont o [Reg]
+moduleRegs =
+  fmap (fmap Reg) . iterateHandle ObjReg . Just . moduleHandle
+

--- a/clash-ffi/src/Clash/FFI/VPI/Module.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Module.hs
@@ -10,9 +10,11 @@ module Clash.FFI.VPI.Module
   ) where
 
 import Data.ByteString (ByteString)
+import Foreign.Storable (Storable)
 import GHC.Stack (HasCallStack)
 
 import Clash.FFI.Monad (SimCont)
+import Clash.FFI.VPI.Iterator
 import Clash.FFI.VPI.Object
 import Clash.FFI.VPI.Net (Net(..))
 import Clash.FFI.VPI.Parameter (Parameter(..))
@@ -20,31 +22,29 @@ import Clash.FFI.VPI.Port (Port(..))
 import Clash.FFI.VPI.Property
 import Clash.FFI.VPI.Reg (Reg(..))
 
-newtype Module = Module { moduleHandle :: Handle }
+newtype Module
+  = Module { moduleHandle :: Handle }
+  deriving stock (Show)
+  deriving newtype (Storable)
 
 topModules :: HasCallStack => SimCont o [Module]
-topModules =
-  fmap Module <$> iterateHandle ObjModule Nothing
+topModules = fmap Module <$> iterateAll ObjModule Nothing
 
 moduleName :: HasCallStack => Module -> SimCont o ByteString
-moduleName = receiveProperty VpiName . moduleHandle
+moduleName = receiveProperty Name . moduleHandle
 
 moduleFullName :: HasCallStack => Module -> SimCont o ByteString
-moduleFullName = receiveProperty VpiFullName . moduleHandle
+moduleFullName = receiveProperty FullName . moduleHandle
 
 moduleNets :: HasCallStack => Module -> SimCont o [Net]
-moduleNets =
-  fmap (fmap Net) . iterateHandle ObjNet . Just . moduleHandle
+moduleNets = fmap (fmap Net) . iterateAll ObjNet . Just . moduleHandle
 
 moduleParameters :: HasCallStack => Module -> SimCont o [Parameter]
-moduleParameters =
-  fmap (fmap Parameter) . iterateHandle ObjParameter . Just . moduleHandle
+moduleParameters = fmap (fmap Parameter) . iterateAll ObjParameter . Just . moduleHandle
 
 modulePorts :: HasCallStack => Module -> SimCont o [Port]
-modulePorts =
-  fmap (fmap Port) . iterateHandle ObjPort . Just . moduleHandle
+modulePorts = fmap (fmap Port) . iterateAll ObjPort . Just . moduleHandle
 
 moduleRegs :: HasCallStack => Module -> SimCont o [Reg]
-moduleRegs =
-  fmap (fmap Reg) . iterateHandle ObjReg . Just . moduleHandle
+moduleRegs = fmap (fmap Reg) . iterateAll ObjReg . Just . moduleHandle
 

--- a/clash-ffi/src/Clash/FFI/VPI/Module.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Module.hs
@@ -28,11 +28,8 @@ newtype Module
   deriving stock (Show)
   deriving newtype (Handle, Storable)
 
-instance HandleObject Module where
-  handleAsObject = moduleObject
-
 topModules :: HasCallStack => SimCont o [Module]
-topModules = iterateAll @Object ObjModule Nothing
+topModules = iterateAll @_ @Object ObjModule Nothing
 
 moduleName :: HasCallStack => Module -> SimCont o ByteString
 moduleName = receiveProperty Name

--- a/clash-ffi/src/Clash/FFI/VPI/Net.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Net.hs
@@ -52,21 +52,21 @@ netIsSigned :: HasCallStack => Net -> SimCont o Bool
 netIsSigned = getProperty VpiSigned . netHandle
 #endif
 
-netValue :: HasCallStack => Net -> SimCont o SomeValue
+netValue :: HasCallStack => Net -> SimCont o Value
 netValue net = do
   size <- netSize net
 
   case someNatVal size of
     SomeNat (proxy :: Proxy sz) ->
       case compareSNat (SNat @1) (snatProxy proxy) of
-        SNatLE -> SomeValue <$> netValueAs (ObjTypeFmt @sz) net
+        SNatLE -> netValueAs ObjTypeFmt net
         SNatGT -> Sim.throw (ZeroWidthValue callStack)
 
 netValueAs
-  :: (HasCallStack, KnownNat n, 1 <= n)
-  => ValueFormat n
+  :: HasCallStack
+  => ValueFormat
   -> Net
-  -> SimCont o (Value n)
+  -> SimCont o Value
 netValueAs fmt =
   receiveValue fmt . netHandle
 

--- a/clash-ffi/src/Clash/FFI/VPI/Net.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Net.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Clash.FFI.VPI.Net
+  ( Net(..)
+  , netName
+  , netFullName
+  , netSize
+  , netIsScalar
+  , netIsVector
+#if defined(VERILOG_2001)
+  , netIsSigned
+#endif
+  , netValue
+  , netValueAs
+  ) where
+
+import           Data.ByteString (ByteString)
+import           Data.Proxy (Proxy)
+import           GHC.Stack (HasCallStack, callStack)
+import           GHC.TypeNats
+
+import           Clash.Promoted.Nat
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.VPI.Object
+import           Clash.FFI.VPI.Property
+import           Clash.FFI.VPI.Value
+
+newtype Net = Net { netHandle :: Handle }
+
+netName :: HasCallStack => Net -> SimCont o ByteString
+netName = receiveProperty VpiName . netHandle
+
+netFullName :: HasCallStack => Net -> SimCont o ByteString
+netFullName = receiveProperty VpiFullName . netHandle
+
+netSize :: (HasCallStack, Integral n) => Net -> SimCont o n
+netSize = fmap fromIntegral . getProperty VpiSize . netHandle
+
+netIsScalar :: HasCallStack => Net -> SimCont o Bool
+netIsScalar = getProperty VpiScalar . netHandle
+
+netIsVector :: HasCallStack => Net -> SimCont o Bool
+netIsVector = getProperty VpiVector . netHandle
+
+#if defined(VERILOG_2001)
+netIsSigned :: HasCallStack => Net -> SimCont o Bool
+netIsSigned = getProperty VpiSigned . netHandle
+#endif
+
+netValue :: HasCallStack => Net -> SimCont o SomeValue
+netValue net = do
+  size <- netSize net
+
+  case someNatVal size of
+    SomeNat (proxy :: Proxy sz) ->
+      case compareSNat (SNat @1) (snatProxy proxy) of
+        SNatLE -> SomeValue <$> netValueAs (ObjTypeFmt @sz) net
+        SNatGT -> Sim.throw (ZeroWidthValue callStack)
+
+netValueAs
+  :: (HasCallStack, KnownNat n, 1 <= n)
+  => ValueFormat n
+  -> Net
+  -> SimCont o (Value n)
+netValueAs fmt =
+  receiveValue fmt . netHandle
+

--- a/clash-ffi/src/Clash/FFI/VPI/Net.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Net.hs
@@ -33,23 +33,23 @@ import           Clash.FFI.VPI.Value
 newtype Net = Net { netHandle :: Handle }
 
 netName :: HasCallStack => Net -> SimCont o ByteString
-netName = receiveProperty VpiName . netHandle
+netName = receiveProperty Name . netHandle
 
 netFullName :: HasCallStack => Net -> SimCont o ByteString
-netFullName = receiveProperty VpiFullName . netHandle
+netFullName = receiveProperty FullName . netHandle
 
 netSize :: (HasCallStack, Integral n) => Net -> SimCont o n
-netSize = fmap fromIntegral . getProperty VpiSize . netHandle
+netSize = fmap fromIntegral . getProperty Size . netHandle
 
 netIsScalar :: HasCallStack => Net -> SimCont o Bool
-netIsScalar = getProperty VpiScalar . netHandle
+netIsScalar = getProperty IsScalar . netHandle
 
 netIsVector :: HasCallStack => Net -> SimCont o Bool
-netIsVector = getProperty VpiVector . netHandle
+netIsVector = getProperty IsVector . netHandle
 
 #if defined(VERILOG_2001)
 netIsSigned :: HasCallStack => Net -> SimCont o Bool
-netIsSigned = getProperty VpiSigned . netHandle
+netIsSigned = getProperty IsSigned . netHandle
 #endif
 
 netValue :: HasCallStack => Net -> SimCont o Value

--- a/clash-ffi/src/Clash/FFI/VPI/Net.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Net.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Clash.FFI.VPI.Net
   ( Net(..)
@@ -17,28 +15,20 @@ module Clash.FFI.VPI.Net
   , netValueAs
   ) where
 
-import           Data.ByteString (ByteString)
-import           Data.Proxy (Proxy)
-import           Foreign.Storable (Storable)
-import           GHC.Stack (HasCallStack, callStack)
-import           GHC.TypeNats
+import Data.ByteString (ByteString)
+import Foreign.Storable (Storable)
+import GHC.Stack (HasCallStack)
 
-import           Clash.Promoted.Nat
-
-import           Clash.FFI.Monad (SimCont)
-import qualified Clash.FFI.Monad as Sim (throw)
-import           Clash.FFI.VPI.Handle
-import           Clash.FFI.VPI.Object
-import           Clash.FFI.VPI.Property
-import           Clash.FFI.VPI.Value
+import Clash.FFI.Monad (SimCont)
+import Clash.FFI.VPI.Handle
+import Clash.FFI.VPI.Object
+import Clash.FFI.VPI.Property
+import Clash.FFI.VPI.Value
 
 newtype Net
   = Net { netObject :: Object }
   deriving stock (Show)
   deriving newtype (Handle, Storable)
-
-instance HandleObject Net where
-  handleAsObject = netObject
 
 netName :: HasCallStack => Net -> SimCont o ByteString
 netName = receiveProperty Name
@@ -61,14 +51,7 @@ netIsSigned = getProperty IsSigned
 #endif
 
 netValue :: HasCallStack => Net -> SimCont o Value
-netValue net = do
-  size <- netSize net
-
-  case someNatVal size of
-    SomeNat (proxy :: Proxy sz) ->
-      case compareSNat (SNat @1) (snatProxy proxy) of
-        SNatLE -> netValueAs ObjTypeFmt net
-        SNatGT -> Sim.throw (ZeroWidthValue callStack)
+netValue = netValueAs ObjTypeFmt
 
 netValueAs
   :: HasCallStack
@@ -76,5 +59,5 @@ netValueAs
   -> Net
   -> SimCont o Value
 netValueAs fmt =
-  receiveValue fmt . netObject
+  receiveValue fmt
 

--- a/clash-ffi/src/Clash/FFI/VPI/Object.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Object.hs
@@ -1,0 +1,237 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Clash.FFI.VPI.Object
+  ( Handle(..)
+  , nullHandle
+  , isNullHandle
+  , freeHandle
+  , compareHandles
+  , iterateHandle
+  , HandleRef(..)
+  , UnknownHandle(..)
+  , ObjectType(..)
+  ) where
+
+import           Control.Exception (Exception)
+import qualified Control.Monad as Monad (unless, void, when)
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import qualified Data.List as List (genericLength)
+import           Data.Maybe (fromMaybe)
+import           Foreign.C.String (CString)
+import           Foreign.C.Types
+import qualified Foreign.Concurrent as FFI (newForeignPtr)
+import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
+
+#if !MIN_VERSION_base(4,15,0)
+import qualified Foreign.ForeignPtr as FFI (withForeignPtr)
+#endif
+
+import           Foreign.Ptr (Ptr)
+import qualified Foreign.Ptr as FFI (nullPtr)
+import           Foreign.Storable (Storable)
+
+#if MIN_VERSION_base(4,15,0)
+import qualified GHC.ForeignPtr as FFI (unsafeWithForeignPtr)
+#endif
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.View (unsafeSend)
+import           Clash.FFI.VPI.Object.Type
+
+newtype Handle = Handle { handleToPtr :: Ptr Handle }
+  deriving newtype (Show, Storable)
+
+nullHandle :: Handle
+nullHandle = Handle FFI.nullPtr
+
+isNullHandle :: Handle -> Bool
+isNullHandle (Handle ptr) =
+  ptr == FFI.nullPtr
+
+#if defined(VERILOG)
+foreign import ccall "vpi_user.h vpi_free_object"
+  c_vpi_free_object :: Handle -> IO CInt
+#endif
+
+#if defined(SYSTEMVERILOG)
+foreign import ccall "vpi_user.h vpi_release_handle"
+  c_vpi_release_handle :: Handle -> IO CInt
+#endif
+
+c_vpi_free :: Handle -> IO CInt
+c_vpi_free =
+#if defined(VERILOG)
+  c_vpi_free_object
+#elif defined(SYSTEMVERILOG)
+  c_vpi_release_handle
+#else
+  error "VPI: Neither VERILOG or SYSTEMVERILOG is defined"
+#endif
+
+freeHandle :: HasCallStack => Handle -> SimCont o ()
+freeHandle handle =
+  Monad.unless (isNullHandle handle) $
+    IO.liftIO $ Monad.void (c_vpi_free handle)
+
+foreign import ccall "vpi_user.h vpi_compare_objects"
+  c_vpi_compare_objects :: Handle -> Handle -> IO Bool
+
+compareHandles :: Handle -> Handle -> SimCont o Bool
+compareHandles x y =
+  IO.liftIO (c_vpi_compare_objects x y)
+
+foreign import ccall "vpi_user.h vpi_iterate"
+  c_vpi_iterate :: CInt -> Handle -> IO Handle
+
+foreign import ccall "vpi_user.h vpi_scan"
+  c_vpi_scan :: Handle -> IO Handle
+
+{-
+NOTE [ForeignPtr for iterators]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When using objects created in FFI calls, we can choose to keep them as Ptr,
+or convert them to ForeignPtr. The difference is that a ForeignPtr can have
+associated finalizers, which are run when the ForeignPtr is garbage collected
+by the Haskell RTS.
+
+An earlier design of this library used ForeignPtr for all created handles,
+however this causes a problem. Since Haskell is called from the simulator it
+is likely that any created handles are deallocated shortly after any Haskell
+callbacks complete and give control back to the simulator. For handles inside
+callbacks this is fatal, as the callback will try to access the object it acts
+on only to find it has been deallocated.
+
+For iterators, we can make the assumption that user code will not attempt to
+save and restore an iterator later. Making the iterator a ForeignPtr is
+desirable, as it means we can lazily perform the FFI calls to get items without
+having to also return a handle to the iterator to be freed later. Handles
+returned by vpiIterate still require explicit deallocation.
+-}
+
+iterateHandle :: ObjectType -> Maybe Handle -> SimCont o [Handle]
+iterateHandle ty parent = do
+  cty  <- unsafeSend ty
+
+  IO.liftIO $ do
+    iHdl <- c_vpi_iterate cty (fromMaybe nullHandle parent)
+
+    let iPtr = handleToPtr iHdl
+    iterator <- FFI.newForeignPtr iPtr (Monad.void $ c_vpi_free iHdl)
+    -- See NOTE [ForeignPtr for iterators]
+
+    go iterator
+ where
+  go iterator =
+#if MIN_VERSION_base(4,15,0)
+    FFI.unsafeWithForeignPtr iterator $ \ptr ->
+#else
+    FFI.withForeignPtr iterator $ \ptr ->
+#endif
+      if ptr == FFI.nullPtr then pure [] else do
+        nextChild <- c_vpi_scan (Handle ptr)
+
+        if isNullHandle nextChild
+          then pure []
+          else fmap (nextChild :) (go iterator)
+
+foreign import ccall "vpi_user.h vpi_handle"
+  c_vpi_handle :: CInt -> Handle -> IO Handle
+
+foreign import ccall "vpi_user.h vpi_handle_by_name"
+  c_vpi_handle_by_name :: CString -> Handle -> IO Handle
+
+foreign import ccall "vpi_user.h vpi_handle_by_index"
+  c_vpi_handle_by_index :: Handle -> CInt -> IO Handle
+
+foreign import ccall "vpi_user.h vpi_handle_by_multi_index"
+  c_vpi_handle_by_multi_index :: Handle -> CInt -> Ptr CInt -> IO Handle
+
+data UnknownHandle a
+  = UnknownHandle a Handle CallStack
+  deriving anyclass (Exception)
+
+instance (Show a) => Show (UnknownHandle a) where
+  show (UnknownHandle x h c) =
+    mconcat
+      [ "Unknown child for handle "
+      , show h
+      , " accessed via the type/name/index "
+      , show x
+      , "\n"
+      , prettyCallStack c
+      ]
+
+class HandleRef a where
+  childHandle :: HasCallStack => a -> Handle -> SimCont o Handle
+
+instance HandleRef ObjectType where
+  childHandle ty parent = do
+    cty <- unsafeSend ty
+    child <- IO.liftIO (c_vpi_handle cty parent)
+
+    Monad.when (isNullHandle child) $
+      Sim.throw (UnknownHandle ty parent callStack)
+
+    pure child
+
+instance HandleRef CString where
+  childHandle str parent = do
+    child <- IO.liftIO (c_vpi_handle_by_name str parent)
+
+    Monad.when (isNullHandle child) $
+      Sim.throw (UnknownHandle str parent callStack)
+
+    pure child
+
+instance HandleRef CInt where
+  childHandle ix parent = do
+    child <- IO.liftIO (c_vpi_handle_by_index parent ix)
+
+    Monad.when (isNullHandle child) $
+      Sim.throw (UnknownHandle ix parent callStack)
+
+    pure child
+
+instance HandleRef [CInt] where
+  childHandle ixs parent = do
+    let len = List.genericLength ixs
+    ptr <- unsafeSend ixs
+    child <- IO.liftIO (c_vpi_handle_by_multi_index parent len ptr)
+
+    Monad.when (isNullHandle child) $
+      Sim.throw (UnknownHandle ixs parent callStack)
+
+    pure child
+
+{-
+NOTE [vpi_handle_multi]
+~~~~~~~~~~~~~~~~~~~~~~~
+When traversing VPI relationships, there are different functions to use
+depending on how many objects are on the LHS or RHS:
+
+  * 1-N: vpi_iterate is used to create an iterator over the N objects, and
+         vpi_scan is used to advance the iterator
+
+  * 1-1: vpi_handle or vpi_handle_by_* are used to access the related handle
+         by something which uniquely determines it (type, name, index)
+
+  * N-1: vpi_handle_multi is used, taking all LHS handles as varargs, and
+         returning the single RHS handle
+
+Since vpi_handle_multi uses varargs instead of an array for input, it cannot
+be conveniently imported. We would need to add imports such as
+
+    foreign import ccall ...
+      c_vpi_handle_multi_2 :: VpiHandle -> VpiHandle -> IO VpiHandle
+
+    foreign import ccall ...
+      c_vpi_handle_multi_3 :: VpiHandle -> VpiHandle -> VpiHandle -> IO VpiHandle
+
+This is somewhat of a burden, so instead for the time being we leave these
+relationships inaccessible. Most relationships are 1-N or 1-1 in practice, so
+this is not a particularly large limitation.
+-}
+

--- a/clash-ffi/src/Clash/FFI/VPI/Object.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Object.hs
@@ -24,16 +24,14 @@ import           Foreign.C.Types
 import qualified Foreign.Concurrent as FFI (newForeignPtr)
 import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
 
-#if !MIN_VERSION_base(4,15,0)
-import qualified Foreign.ForeignPtr as FFI (withForeignPtr)
-#endif
-
 import           Foreign.Ptr (Ptr)
 import qualified Foreign.Ptr as FFI (nullPtr)
 import           Foreign.Storable (Storable)
 
 #if MIN_VERSION_base(4,15,0)
 import qualified GHC.ForeignPtr as FFI (unsafeWithForeignPtr)
+#else
+import qualified Foreign.ForeignPtr as FFI (withForeignPtr)
 #endif
 
 import           Clash.FFI.Monad (SimCont)

--- a/clash-ffi/src/Clash/FFI/VPI/Object.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Object.hs
@@ -6,7 +6,6 @@
 
 module Clash.FFI.VPI.Object
   ( Object(..)
-  , HandleObject(..)
   , module Clash.FFI.VPI.Object.Type
   ) where
 
@@ -26,16 +25,10 @@ import           Clash.FFI.View (unsafeSend)
 import           Clash.FFI.VPI.Handle
 import           Clash.FFI.VPI.Object.Type
 
-class Handle a => HandleObject a where
-  handleAsObject :: a -> Object
-
 newtype Object
   = Object { objectPtr :: Ptr Object }
   deriving stock (Show)
   deriving newtype (Storable)
-
-instance HandleObject Object where
-  handleAsObject = id
 
 #if defined(VERILOG)
 foreign import ccall "vpi_user.h vpi_free_object"
@@ -74,9 +67,6 @@ instance Handle Object where
 foreign import ccall "vpi_user.h vpi_handle"
   c_vpi_handle :: CInt -> Object -> IO Object
 
--- TODO Should I have another one here with Method instead of ObjectType? The
--- VPI spec seems to conflate the two but methods can only be used for
--- traversing the hierarchy from some known point *I think*
 instance HandleChild ObjectType Object where
   -- TODO Maybe we could know this if we make ObjectType a GADT
   type ChildHandle ObjectType Object = Object
@@ -108,7 +98,6 @@ foreign import ccall "vpi_user.h vpi_handle_by_index"
   c_vpi_handle_by_index :: Object -> CInt -> IO Object
 
 instance HandleChild CInt Object where
-  -- We don't know any better than "Object" here
   type ChildHandle CInt Object = Object
 
   childHandle ix parent = do

--- a/clash-ffi/src/Clash/FFI/VPI/Object.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Object.hs
@@ -8,7 +8,6 @@ module Clash.FFI.VPI.Object
   , isNullHandle
   , freeHandle
   , compareHandles
-  , iterateHandle
   , HandleRef(..)
   , UnknownHandle(..)
   , ObjectType(..)
@@ -18,21 +17,13 @@ import           Control.Exception (Exception)
 import qualified Control.Monad as Monad (unless, void, when)
 import qualified Control.Monad.IO.Class as IO (liftIO)
 import qualified Data.List as List (genericLength)
-import           Data.Maybe (fromMaybe)
 import           Foreign.C.String (CString)
 import           Foreign.C.Types
-import qualified Foreign.Concurrent as FFI (newForeignPtr)
 import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
 
 import           Foreign.Ptr (Ptr)
 import qualified Foreign.Ptr as FFI (nullPtr)
 import           Foreign.Storable (Storable)
-
-#if MIN_VERSION_base(4,15,0)
-import qualified GHC.ForeignPtr as FFI (unsafeWithForeignPtr)
-#else
-import qualified Foreign.ForeignPtr as FFI (withForeignPtr)
-#endif
 
 import           Clash.FFI.Monad (SimCont)
 import qualified Clash.FFI.Monad as Sim (throw)
@@ -80,60 +71,6 @@ foreign import ccall "vpi_user.h vpi_compare_objects"
 compareHandles :: Handle -> Handle -> SimCont o Bool
 compareHandles x y =
   IO.liftIO (c_vpi_compare_objects x y)
-
-foreign import ccall "vpi_user.h vpi_iterate"
-  c_vpi_iterate :: CInt -> Handle -> IO Handle
-
-foreign import ccall "vpi_user.h vpi_scan"
-  c_vpi_scan :: Handle -> IO Handle
-
-{-
-NOTE [ForeignPtr for iterators]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When using objects created in FFI calls, we can choose to keep them as Ptr,
-or convert them to ForeignPtr. The difference is that a ForeignPtr can have
-associated finalizers, which are run when the ForeignPtr is garbage collected
-by the Haskell RTS.
-
-An earlier design of this library used ForeignPtr for all created handles,
-however this causes a problem. Since Haskell is called from the simulator it
-is likely that any created handles are deallocated shortly after any Haskell
-callbacks complete and give control back to the simulator. For handles inside
-callbacks this is fatal, as the callback will try to access the object it acts
-on only to find it has been deallocated.
-
-For iterators, we can make the assumption that user code will not attempt to
-save and restore an iterator later. Making the iterator a ForeignPtr is
-desirable, as it means we can lazily perform the FFI calls to get items without
-having to also return a handle to the iterator to be freed later. Handles
-returned by vpiIterate still require explicit deallocation.
--}
-
-iterateHandle :: ObjectType -> Maybe Handle -> SimCont o [Handle]
-iterateHandle ty parent = do
-  cty  <- unsafeSend ty
-
-  IO.liftIO $ do
-    iHdl <- c_vpi_iterate cty (fromMaybe nullHandle parent)
-
-    let iPtr = handleToPtr iHdl
-    iterator <- FFI.newForeignPtr iPtr (Monad.void $ c_vpi_free iHdl)
-    -- See NOTE [ForeignPtr for iterators]
-
-    go iterator
- where
-  go iterator =
-#if MIN_VERSION_base(4,15,0)
-    FFI.unsafeWithForeignPtr iterator $ \ptr ->
-#else
-    FFI.withForeignPtr iterator $ \ptr ->
-#endif
-      if ptr == FFI.nullPtr then pure [] else do
-        nextChild <- c_vpi_scan (Handle ptr)
-
-        if isNullHandle nextChild
-          then pure []
-          else fmap (nextChild :) (go iterator)
 
 foreign import ccall "vpi_user.h vpi_handle"
   c_vpi_handle :: CInt -> Handle -> IO Handle

--- a/clash-ffi/src/Clash/FFI/VPI/Object/Type.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Object/Type.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Clash.FFI.VPI.Object.Type
   ( ObjectType(..)
+  , UnknownObjectType(..)
   ) where
 
 import           Control.Exception (Exception)

--- a/clash-ffi/src/Clash/FFI/VPI/Object/Type.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Object/Type.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.FFI.VPI.Object.Type
+  ( ObjectType(..)
+  ) where
+
+import           Control.Exception (Exception)
+import           Foreign.C.Types (CInt)
+import           GHC.Stack (CallStack, callStack, prettyCallStack)
+
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.View
+
+data ObjectType
+  = ObjModule
+  | ObjNet
+  | ObjParameter
+  | ObjPort
+  | ObjReg
+#if defined(VERILOG_2001)
+  | ObjCallback
+#endif
+  deriving stock (Eq, Show)
+
+instance UnsafeSend ObjectType where
+  type Sent ObjectType = CInt
+
+  unsafeSend =
+    pure . \case
+      ObjModule -> 32
+      ObjNet -> 36
+      ObjParameter -> 41
+      ObjPort -> 44
+      ObjReg -> 48
+#if defined(VERILOG_2001)
+      ObjCallback -> 107
+#endif
+
+instance Send ObjectType where
+  send = unsafeSend
+
+data UnknownObjectType
+  = UnknownObjectType CInt CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownObjectType where
+  show (UnknownObjectType x c) =
+    mconcat
+      [ "Unknown object type: "
+      , show x
+      , "\n"
+      , prettyCallStack c
+      ]
+
+instance UnsafeReceive ObjectType where
+  type Received ObjectType = CInt
+
+  unsafeReceive = \case
+    32 -> pure ObjModule
+    36 -> pure ObjNet
+    41 -> pure ObjParameter
+    44 -> pure ObjPort
+    48 -> pure ObjReg
+#if defined(VERILOG_2001)
+    107 -> pure ObjCallback
+#endif
+    ty -> Sim.throw (UnknownObjectType ty callStack)
+
+instance Receive ObjectType where
+  receive = unsafeReceive
+

--- a/clash-ffi/src/Clash/FFI/VPI/Parameter.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Parameter.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Clash.FFI.VPI.Parameter
+  ( Parameter(..)
+  , ConstantType
+      ( DecimalConst
+      , RealConst
+      , BinaryConst
+      , OctalConst
+      , HexConst
+      , StringConst
+#if defined(VERILOG_2001)
+      , IntConst
+#endif
+      , TimeConst
+      )
+  , parameterName
+  , parameterFullName
+  , parameterSize
+  , parameterType
+#if defined(VERILOG_2001)
+  , parameterIsLocal
+  , parameterIsSigned
+#endif
+  , parameterValue
+  , parameterValueAs
+  ) where
+
+import           Data.ByteString (ByteString)
+import           Data.Proxy (Proxy)
+import           Foreign.C.Types (CInt)
+import           GHC.Stack (HasCallStack, callStack)
+import           GHC.TypeNats
+
+import           Clash.Promoted.Nat
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.VPI.Object
+import           Clash.FFI.VPI.Property
+import           Clash.FFI.VPI.Value
+
+newtype Parameter = Parameter { parameterHandle :: Handle }
+
+newtype ConstantType = ConstantType CInt
+
+pattern DecimalConst :: ConstantType
+pattern DecimalConst = ConstantType 1
+
+pattern RealConst :: ConstantType
+pattern RealConst = ConstantType 2
+
+pattern BinaryConst :: ConstantType
+pattern BinaryConst = ConstantType 3
+
+pattern OctalConst :: ConstantType
+pattern OctalConst = ConstantType 4
+
+pattern HexConst :: ConstantType
+pattern HexConst = ConstantType 5
+
+pattern StringConst :: ConstantType
+pattern StringConst = ConstantType 6
+
+#if defined(VERILOG_2001)
+pattern IntConst :: ConstantType
+pattern IntConst = ConstantType 7
+#endif
+
+pattern TimeConst :: ConstantType
+pattern TimeConst = ConstantType 8
+
+parameterName :: HasCallStack => Parameter -> SimCont o ByteString
+parameterName = receiveProperty VpiName . parameterHandle
+
+parameterFullName :: HasCallStack => Parameter -> SimCont o ByteString
+parameterFullName = receiveProperty VpiFullName . parameterHandle
+
+parameterSize :: (HasCallStack, Integral n) => Parameter -> SimCont o n
+parameterSize = fmap fromIntegral . getProperty VpiSize . parameterHandle
+
+parameterType :: HasCallStack => Parameter -> SimCont o ConstantType
+parameterType = coerceProperty VpiConstType . parameterHandle
+
+#if defined(VERILOG_2001)
+parameterIsLocal :: HasCallStack => Parameter -> SimCont o Bool
+parameterIsLocal = getProperty VpiLocalParam . parameterHandle
+
+parameterIsSigned :: HasCallStack => Parameter -> SimCont o Bool
+parameterIsSigned = getProperty VpiSigned . parameterHandle
+#endif
+
+parameterValue :: HasCallStack => Parameter -> SimCont o SomeValue
+parameterValue param = do
+  size <- parameterSize param
+
+  case someNatVal size of
+    SomeNat (proxy :: Proxy sz) ->
+      case compareSNat (SNat @1) (snatProxy proxy) of
+        SNatLE -> SomeValue <$> parameterValueAs (ObjTypeFmt @sz) param
+        SNatGT -> Sim.throw (ZeroWidthValue callStack)
+
+parameterValueAs
+  :: (HasCallStack, KnownNat n, 1 <= n)
+  => ValueFormat n
+  -> Parameter
+  -> SimCont o (Value n)
+parameterValueAs fmt =
+  receiveValue fmt . parameterHandle
+

--- a/clash-ffi/src/Clash/FFI/VPI/Parameter.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Parameter.hs
@@ -46,6 +46,8 @@ import           Clash.FFI.VPI.Value
 
 newtype Parameter = Parameter { parameterHandle :: Handle }
 
+-- TODO Make this an ADT so it shows nicely.
+
 newtype ConstantType = ConstantType CInt
 
 pattern DecimalConst :: ConstantType
@@ -94,21 +96,21 @@ parameterIsSigned :: HasCallStack => Parameter -> SimCont o Bool
 parameterIsSigned = getProperty VpiSigned . parameterHandle
 #endif
 
-parameterValue :: HasCallStack => Parameter -> SimCont o SomeValue
+parameterValue :: HasCallStack => Parameter -> SimCont o Value
 parameterValue param = do
   size <- parameterSize param
 
   case someNatVal size of
     SomeNat (proxy :: Proxy sz) ->
       case compareSNat (SNat @1) (snatProxy proxy) of
-        SNatLE -> SomeValue <$> parameterValueAs (ObjTypeFmt @sz) param
+        SNatLE -> parameterValueAs ObjTypeFmt param
         SNatGT -> Sim.throw (ZeroWidthValue callStack)
 
 parameterValueAs
-  :: (HasCallStack, KnownNat n, 1 <= n)
-  => ValueFormat n
+  :: HasCallStack
+  => ValueFormat
   -> Parameter
-  -> SimCont o (Value n)
+  -> SimCont o Value
 parameterValueAs fmt =
   receiveValue fmt . parameterHandle
 

--- a/clash-ffi/src/Clash/FFI/VPI/Parameter.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Parameter.hs
@@ -17,28 +17,20 @@ module Clash.FFI.VPI.Parameter
   , parameterValueAs
   ) where
 
-import           Data.ByteString (ByteString)
-import           Data.Proxy (Proxy)
-import           Foreign.Storable (Storable)
-import           GHC.Stack (HasCallStack, callStack)
-import           GHC.TypeNats
+import Data.ByteString (ByteString)
+import Foreign.Storable (Storable)
+import GHC.Stack (HasCallStack)
 
-import           Clash.Promoted.Nat
-
-import           Clash.FFI.Monad (SimCont)
-import qualified Clash.FFI.Monad as Sim (throw)
-import           Clash.FFI.VPI.Handle
-import           Clash.FFI.VPI.Object
-import           Clash.FFI.VPI.Property
-import           Clash.FFI.VPI.Value
+import Clash.FFI.Monad (SimCont)
+import Clash.FFI.VPI.Handle
+import Clash.FFI.VPI.Object
+import Clash.FFI.VPI.Property
+import Clash.FFI.VPI.Value
 
 newtype Parameter
   = Parameter { parameterObject :: Object }
   deriving stock (Show)
   deriving newtype (Handle, Storable)
-
-instance HandleObject Parameter where
-  handleAsObject = parameterObject
 
 parameterName :: HasCallStack => Parameter -> SimCont o ByteString
 parameterName = receiveProperty Name
@@ -58,14 +50,7 @@ parameterIsSigned = getProperty IsSigned
 #endif
 
 parameterValue :: HasCallStack => Parameter -> SimCont o Value
-parameterValue param = do
-  size <- parameterSize param
-
-  case someNatVal size of
-    SomeNat (proxy :: Proxy sz) ->
-      case compareSNat (SNat @1) (snatProxy proxy) of
-        SNatLE -> parameterValueAs ObjTypeFmt param
-        SNatGT -> Sim.throw (ZeroWidthValue callStack)
+parameterValue = parameterValueAs ObjTypeFmt
 
 parameterValueAs
   :: HasCallStack
@@ -73,5 +58,5 @@ parameterValueAs
   -> Parameter
   -> SimCont o Value
 parameterValueAs fmt =
-  receiveValue fmt . parameterObject
+  receiveValue fmt
 

--- a/clash-ffi/src/Clash/FFI/VPI/Parameter.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Parameter.hs
@@ -77,23 +77,23 @@ pattern TimeConst :: ConstantType
 pattern TimeConst = ConstantType 8
 
 parameterName :: HasCallStack => Parameter -> SimCont o ByteString
-parameterName = receiveProperty VpiName . parameterHandle
+parameterName = receiveProperty Name . parameterHandle
 
 parameterFullName :: HasCallStack => Parameter -> SimCont o ByteString
-parameterFullName = receiveProperty VpiFullName . parameterHandle
+parameterFullName = receiveProperty FullName . parameterHandle
 
 parameterSize :: (HasCallStack, Integral n) => Parameter -> SimCont o n
-parameterSize = fmap fromIntegral . getProperty VpiSize . parameterHandle
+parameterSize = fmap fromIntegral . getProperty Size . parameterHandle
 
 parameterType :: HasCallStack => Parameter -> SimCont o ConstantType
-parameterType = coerceProperty VpiConstType . parameterHandle
+parameterType = coerceProperty ConstType . parameterHandle
 
 #if defined(VERILOG_2001)
 parameterIsLocal :: HasCallStack => Parameter -> SimCont o Bool
-parameterIsLocal = getProperty VpiLocalParam . parameterHandle
+parameterIsLocal = getProperty IsLocalParam . parameterHandle
 
 parameterIsSigned :: HasCallStack => Parameter -> SimCont o Bool
-parameterIsSigned = getProperty VpiSigned . parameterHandle
+parameterIsSigned = getProperty IsSigned . parameterHandle
 #endif
 
 parameterValue :: HasCallStack => Parameter -> SimCont o Value

--- a/clash-ffi/src/Clash/FFI/VPI/Port.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Port.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module Clash.FFI.VPI.Port
+  ( Port(..)
+  , Direction
+      ( VpiInput
+      , VpiOutput
+      , VpiInOut
+      , VpiMixedIO
+      , VpiNoDirection
+      )
+  , portName
+  , portDirection
+  , portIndex
+  , portSize
+  , portIsVector
+  , portIsScalar
+  ) where
+
+import Data.ByteString (ByteString)
+import Foreign.C.Types (CInt)
+import GHC.Stack (HasCallStack)
+
+import Clash.FFI.Monad (SimCont)
+import Clash.FFI.VPI.Object (Handle)
+import Clash.FFI.VPI.Property
+
+newtype Port = Port { portHandle :: Handle }
+
+portName :: Port -> SimCont o ByteString
+portName = receiveProperty VpiName . portHandle
+
+newtype Direction = Direction CInt
+
+pattern VpiInput :: Direction
+pattern VpiInput = Direction 1
+
+pattern VpiOutput :: Direction
+pattern VpiOutput = Direction 2
+
+pattern VpiInOut :: Direction
+pattern VpiInOut = Direction 3
+
+pattern VpiMixedIO :: Direction
+pattern VpiMixedIO = Direction 4
+
+pattern VpiNoDirection :: Direction
+pattern VpiNoDirection = Direction 5
+
+portDirection :: HasCallStack => Port -> SimCont o Direction
+portDirection = coerceProperty VpiDirection . portHandle
+
+portIndex :: HasCallStack => Port -> SimCont o CInt
+portIndex = getProperty VpiPortIndex . portHandle
+
+portSize :: HasCallStack => Port -> SimCont o CInt
+portSize = getProperty VpiSize . portHandle
+
+portIsVector :: HasCallStack => Port -> SimCont o Bool
+portIsVector = getProperty VpiVector . portHandle
+
+portIsScalar :: HasCallStack => Port -> SimCont o Bool
+portIsScalar = getProperty VpiScalar . portHandle
+

--- a/clash-ffi/src/Clash/FFI/VPI/Port.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Port.hs
@@ -1,64 +1,44 @@
-{-# LANGUAGE PatternSynonyms #-}
-
 module Clash.FFI.VPI.Port
   ( Port(..)
-  , Direction
-      ( VpiInput
-      , VpiOutput
-      , VpiInOut
-      , VpiMixedIO
-      , VpiNoDirection
-      )
   , portName
   , portDirection
   , portIndex
   , portSize
   , portIsVector
   , portIsScalar
+  , module Clash.FFI.VPI.Port.Direction
   ) where
 
 import Data.ByteString (ByteString)
 import Foreign.C.Types (CInt)
+import Foreign.Storable (Storable)
 import GHC.Stack (HasCallStack)
 
 import Clash.FFI.Monad (SimCont)
 import Clash.FFI.VPI.Object (Handle)
+import Clash.FFI.VPI.Port.Direction
 import Clash.FFI.VPI.Property
 
-newtype Port = Port { portHandle :: Handle }
+newtype Port
+  = Port { portHandle :: Handle }
+  deriving stock (Show)
+  deriving newtype (Storable)
 
 portName :: Port -> SimCont o ByteString
-portName = receiveProperty VpiName . portHandle
-
-newtype Direction = Direction CInt
-
-pattern VpiInput :: Direction
-pattern VpiInput = Direction 1
-
-pattern VpiOutput :: Direction
-pattern VpiOutput = Direction 2
-
-pattern VpiInOut :: Direction
-pattern VpiInOut = Direction 3
-
-pattern VpiMixedIO :: Direction
-pattern VpiMixedIO = Direction 4
-
-pattern VpiNoDirection :: Direction
-pattern VpiNoDirection = Direction 5
+portName = receiveProperty Name . portHandle
 
 portDirection :: HasCallStack => Port -> SimCont o Direction
-portDirection = coerceProperty VpiDirection . portHandle
+portDirection = receiveProperty Direction . portHandle
 
 portIndex :: HasCallStack => Port -> SimCont o CInt
-portIndex = getProperty VpiPortIndex . portHandle
+portIndex = getProperty PortIndex . portHandle
 
 portSize :: HasCallStack => Port -> SimCont o CInt
-portSize = getProperty VpiSize . portHandle
+portSize = getProperty Size . portHandle
 
 portIsVector :: HasCallStack => Port -> SimCont o Bool
-portIsVector = getProperty VpiVector . portHandle
+portIsVector = getProperty IsVector . portHandle
 
 portIsScalar :: HasCallStack => Port -> SimCont o Bool
-portIsScalar = getProperty VpiScalar . portHandle
+portIsScalar = getProperty IsScalar . portHandle
 

--- a/clash-ffi/src/Clash/FFI/VPI/Port.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Port.hs
@@ -25,9 +25,6 @@ newtype Port
   deriving stock (Show)
   deriving newtype (Handle, Storable)
 
-instance HandleObject Port where
-  handleAsObject = portObject
-
 portName :: Port -> SimCont o ByteString
 portName = receiveProperty Name
 

--- a/clash-ffi/src/Clash/FFI/VPI/Port.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Port.hs
@@ -15,30 +15,34 @@ import Foreign.Storable (Storable)
 import GHC.Stack (HasCallStack)
 
 import Clash.FFI.Monad (SimCont)
-import Clash.FFI.VPI.Object (Handle)
+import Clash.FFI.VPI.Handle
+import Clash.FFI.VPI.Object
 import Clash.FFI.VPI.Port.Direction
 import Clash.FFI.VPI.Property
 
 newtype Port
-  = Port { portHandle :: Handle }
+  = Port { portObject :: Object }
   deriving stock (Show)
-  deriving newtype (Storable)
+  deriving newtype (Handle, Storable)
+
+instance HandleObject Port where
+  handleAsObject = portObject
 
 portName :: Port -> SimCont o ByteString
-portName = receiveProperty Name . portHandle
+portName = receiveProperty Name
 
 portDirection :: HasCallStack => Port -> SimCont o Direction
-portDirection = receiveProperty Direction . portHandle
+portDirection = receiveProperty Direction
 
 portIndex :: HasCallStack => Port -> SimCont o CInt
-portIndex = getProperty PortIndex . portHandle
+portIndex = getProperty PortIndex
 
 portSize :: HasCallStack => Port -> SimCont o CInt
-portSize = getProperty Size . portHandle
+portSize = getProperty Size
 
 portIsVector :: HasCallStack => Port -> SimCont o Bool
-portIsVector = getProperty IsVector . portHandle
+portIsVector = getProperty IsVector
 
 portIsScalar :: HasCallStack => Port -> SimCont o Bool
-portIsScalar = getProperty IsScalar . portHandle
+portIsScalar = getProperty IsScalar
 

--- a/clash-ffi/src/Clash/FFI/VPI/Port/Direction.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Port/Direction.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.FFI.VPI.Port.Direction
+  ( Direction(..)
+  , UnknownDirection(..)
+  ) where
+
+import           Control.Exception (Exception)
+import           Foreign.C.Types (CInt)
+import           GHC.Stack (CallStack, callStack, prettyCallStack)
+
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.View
+
+data Direction
+  = Input
+  | Output
+  | InOut
+  | MixedIO
+  | NoDirection
+
+data UnknownDirection
+  = UnknownDirection CInt CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownDirection where
+  show (UnknownDirection d c) =
+    mconcat
+      [ "Unknown port direction: "
+      , show d
+      , "\n"
+      , prettyCallStack c
+      ]
+
+instance UnsafeReceive Direction where
+  type Received Direction = CInt
+
+  unsafeReceive = \case
+    1 -> pure Input
+    2 -> pure Output
+    3 -> pure InOut
+    4 -> pure MixedIO
+    5 -> pure NoDirection
+    n -> Sim.throw (UnknownDirection n callStack)
+
+instance Receive Direction where
+  receive = unsafeReceive
+

--- a/clash-ffi/src/Clash/FFI/VPI/Property.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Property.hs
@@ -55,6 +55,9 @@ import qualified Clash.FFI.Monad as Sim (throw)
 import           Clash.FFI.View (UnsafeReceive(..), Receive(..))
 import           Clash.FFI.VPI.Object (Handle(..), ObjectType)
 
+-- TODO Redo this to be a normal ADT with a storable instance, so we can get
+-- nice errors when a property does not belong to a handle.
+
 newtype Property value = Property CInt
   deriving newtype (Eq, Show, Storable)
 

--- a/clash-ffi/src/Clash/FFI/VPI/Property.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Property.hs
@@ -16,16 +16,15 @@ module Clash.FFI.VPI.Property
   ) where
 
 import           Control.Exception (Exception)
-import           Control.Monad ((>=>))
 import qualified Control.Monad as Monad (when)
 import qualified Control.Monad.IO.Class as IO (liftIO)
 import           Data.Coerce
+import           Data.Typeable (Typeable)
 
 #if defined(SYSTEMVERILOG)
 import           Data.Int (Int64)
 #endif
 
-import           Data.Typeable (Typeable)
 import           Foreign.C.String (CString)
 import           Foreign.C.Types (CInt(..))
 import qualified Foreign.Marshal.Utils as FFI (toBool)
@@ -36,51 +35,51 @@ import           Unsafe.Coerce
 import           Clash.FFI.Monad (SimCont)
 import qualified Clash.FFI.Monad as Sim (throw)
 import           Clash.FFI.View
-import           Clash.FFI.VPI.Object (Handle(..))
+import           Clash.FFI.VPI.Object
 import           Clash.FFI.VPI.Property.Type
 
 foreign import ccall "vpi_user.h vpi_get"
-  c_vpi_get :: CInt -> Handle -> IO CInt
+  c_vpi_get :: CInt -> Object -> IO CInt
 
 #if defined(SYSTEMVERILOG)
 foreign import ccall "vpi_user.h vpi_get64"
-  c_vpi_get64 :: CInt -> Handle -> IO Int64
+  c_vpi_get64 :: CInt -> Object -> IO Int64
 #endif
 
 foreign import ccall "vpi_user.h vpi_get_str"
-  c_vpi_get_str :: CInt -> Handle -> IO CString
+  c_vpi_get_str :: CInt -> Object -> IO CString
 
-data UndefinedProperty a
-  = UndefinedProperty (Property a) Handle CallStack
+data UndefinedProperty p a
+  = UndefinedProperty (Property p) a CallStack
   deriving anyclass (Exception)
 
-instance Show (UndefinedProperty a) where
-  show (UndefinedProperty p h c) =
+instance (Show a) => Show (UndefinedProperty p a) where
+  show (UndefinedProperty p a c) =
     mconcat
       [ "Undefined property "
       , show p
       , " for the handle "
-      , show h
+      , show a
       , "\n"
       , prettyCallStack c
       ]
 
 class PropertyType a where
-  getProperty :: HasCallStack => Property a -> Handle -> SimCont o a
+  getProperty :: (HasCallStack, Show handle, Typeable handle, HandleObject handle) => Property a -> handle -> SimCont o a
 
 getPropertyWith
-  :: (HasCallStack, Eq a, Show a, Typeable a)
-  => (CInt -> Handle -> IO a)
+  :: (HasCallStack, Show handle, Typeable handle, HandleObject handle, Eq a, Show a, Typeable a)
+  => (CInt -> Object -> IO a)
   -> a
   -> Property a
-  -> Handle
+  -> handle
   -> SimCont o a
-getPropertyWith f err prop hdl = do
+getPropertyWith f err prop handle = do
   cprop <- unsafeSend prop
-  value <- IO.liftIO (f cprop hdl)
+  value <- IO.liftIO (f cprop (handleAsObject handle))
 
   Monad.when (value == err) $
-    Sim.throw (UndefinedProperty prop hdl callStack)
+    Sim.throw (UndefinedProperty prop handle callStack)
 
   pure value
 
@@ -105,26 +104,26 @@ instance PropertyType CString where
     getPropertyWith c_vpi_get_str FFI.nullPtr
 
 coerceProperty
-  :: (HasCallStack, PropertyType a, Coercible a b)
+  :: (HasCallStack, PropertyType a, Coercible a b, Show handle, Typeable handle, HandleObject handle)
   => Property a
-  -> Handle
+  -> handle
   -> SimCont o b
 coerceProperty prop =
-  fmap coerce . getProperty prop
+  fmap coerce . getProperty prop . handleAsObject
 
 unsafeReceiveProperty
-  :: (HasCallStack, UnsafeReceive a, PropertyType (Received a))
+  :: (HasCallStack, UnsafeReceive a, PropertyType (Received a), HandleObject handle, Show handle, Typeable handle)
   => Property (Received a)
-  -> Handle
+  -> handle
   -> SimCont o a
-unsafeReceiveProperty prop =
-  getProperty prop >=> unsafeReceive
+unsafeReceiveProperty prop handle =
+  getProperty prop (handleAsObject handle) >>= unsafeReceive
 
 receiveProperty
-  :: (HasCallStack, Receive a, PropertyType (Received a))
+  :: (HasCallStack, Receive a, PropertyType (Received a), HandleObject handle, Show handle, Typeable handle)
   => Property (Received a)
-  -> Handle
+  -> handle
   -> SimCont o a
-receiveProperty prop =
-  getProperty prop >=> receive
+receiveProperty prop handle =
+  getProperty prop (handleAsObject handle) >>= receive
 

--- a/clash-ffi/src/Clash/FFI/VPI/Property.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Property.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Clash.FFI.VPI.Property
+  ( Property
+      ( VpiObjectType
+      , VpiName
+      , VpiFullName
+      , VpiSize
+      , VpiFile
+      , VpiLineNo
+      , VpiScalar
+      , VpiVector
+      , VpiDirection
+      , VpiNetType
+      , VpiPortIndex
+      , VpiConstType
+#if defined(VERILOG_2001)
+      , VpiSigned
+      , VpiLocalParam
+#endif
+      )
+  , PropertyType(..)
+  , coerceProperty
+  , unsafeReceiveProperty
+  , receiveProperty
+  , UndefinedProperty(..)
+  ) where
+
+import           Control.Exception (Exception)
+import           Control.Monad ((>=>))
+import qualified Control.Monad as Monad (when)
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Data.Coerce
+
+#if defined(SYSTEMVERILOG)
+import           Data.Int (Int64)
+#endif
+
+import           Data.Typeable (Typeable)
+import           Foreign.C.String (CString)
+import           Foreign.C.Types (CInt(..))
+import qualified Foreign.Marshal.Utils as FFI (toBool)
+import qualified Foreign.Ptr as FFI (nullPtr)
+import           Foreign.Storable (Storable)
+import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.View (UnsafeReceive(..), Receive(..))
+import           Clash.FFI.VPI.Object (Handle(..), ObjectType)
+
+newtype Property value = Property CInt
+  deriving newtype (Eq, Show, Storable)
+
+pattern VpiObjectType :: Property ObjectType
+pattern VpiObjectType = Property 1
+
+pattern VpiName :: Property CString
+pattern VpiName = Property 2
+
+pattern VpiFullName :: Property CString
+pattern VpiFullName = Property 3
+
+pattern VpiSize :: Property CInt
+pattern VpiSize = Property 4
+
+pattern VpiFile :: Property CString
+pattern VpiFile = Property 5
+
+pattern VpiLineNo :: Property CInt
+pattern VpiLineNo = Property 6
+
+pattern VpiScalar :: Property Bool
+pattern VpiScalar = Property 17
+
+pattern VpiVector :: Property Bool
+pattern VpiVector = Property 18
+
+pattern VpiDirection :: Property CInt
+pattern VpiDirection = Property 20
+
+pattern VpiNetType :: Property CInt
+pattern VpiNetType = Property 22
+
+pattern VpiPortIndex :: Property CInt
+pattern VpiPortIndex = Property 29
+
+pattern VpiConstType :: Property CInt
+pattern VpiConstType = Property 40
+
+#if defined(VERILOG_2001)
+pattern VpiSigned :: Property Bool
+pattern VpiSigned = Property 65
+
+pattern VpiLocalParam :: Property Bool
+pattern VpiLocalParam = Property 70
+#endif
+
+foreign import ccall "vpi_user.h vpi_get"
+  c_vpi_get :: Property CInt -> Handle -> IO CInt
+
+#if defined(SYSTEMVERILOG)
+foreign import ccall "vpi_user.h vpi_get64"
+  c_vpi_get64 :: Property Int64 -> Handle -> IO Int64
+#endif
+
+foreign import ccall "vpi_user.h vpi_get_str"
+  c_vpi_get_str :: Property CString -> Handle -> IO CString
+
+data UndefinedProperty a
+  = UndefinedProperty (Property a) Handle CallStack
+  deriving anyclass (Exception)
+
+instance Show (UndefinedProperty a) where
+  show (UndefinedProperty p h c) =
+    mconcat
+      [ "Undefined property "
+      , show p
+      , " for the handle "
+      , show h
+      , "\n"
+      , prettyCallStack c
+      ]
+
+class PropertyType a where
+  getProperty :: HasCallStack => Property a -> Handle -> SimCont o a
+
+getPropertyWith
+  :: (HasCallStack, Eq a, Show a, Typeable a)
+  => (Property a -> Handle -> IO a)
+  -> a
+  -> Property a
+  -> Handle
+  -> SimCont o a
+getPropertyWith f err prop hdl = do
+  value <- IO.liftIO (f prop hdl)
+
+  Monad.when (value == err) $
+    Sim.throw (UndefinedProperty prop hdl callStack)
+
+  pure value
+
+instance PropertyType CInt where
+  getProperty =
+    getPropertyWith c_vpi_get (-1)
+
+instance PropertyType Bool where
+  getProperty (Property prop) =
+    fmap FFI.toBool . getProperty @CInt (Property prop)
+
+#if defined(SYSTEMVERILOG)
+instance PropertyType Int64 where
+  getProperty =
+    getPropertyWith c_vpi_get64 (-1)
+#endif
+
+instance PropertyType CString where
+  getProperty =
+    getPropertyWith c_vpi_get_str FFI.nullPtr
+
+coerceProperty
+  :: (HasCallStack, PropertyType a, Coercible a b)
+  => Property a
+  -> Handle
+  -> SimCont o b
+coerceProperty prop =
+  fmap coerce . getProperty prop
+
+unsafeReceiveProperty
+  :: (HasCallStack, UnsafeReceive a, PropertyType (Received a))
+  => Property (Received a)
+  -> Handle
+  -> SimCont o a
+unsafeReceiveProperty prop =
+  getProperty prop >=> unsafeReceive
+
+receiveProperty
+  :: (HasCallStack, Receive a, PropertyType (Received a))
+  => Property (Received a)
+  -> Handle
+  -> SimCont o a
+receiveProperty prop =
+  getProperty prop >=> receive
+

--- a/clash-ffi/src/Clash/FFI/VPI/Property/Type.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Property/Type.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Clash.FFI.VPI.Property.Type
   ( Property(..)
@@ -6,6 +10,8 @@ module Clash.FFI.VPI.Property.Type
 
 import Foreign.C.String (CString)
 import Foreign.C.Types (CInt)
+
+import Clash.FFI.View
 
 data Property a where
   TypeOf :: Property CInt
@@ -16,4 +22,39 @@ data Property a where
   LineNo :: Property CInt
   IsScalar :: Property Bool
   IsVector :: Property Bool
+  Direction :: Property CInt
+  NetType :: Property CInt
+  PortIndex :: Property CInt
+  ConstType :: Property CInt
+#if defined(VERILOG_2001)
+  IsSigned :: Property Bool
+  IsLocalParam :: Property Bool
+#endif
+
+deriving stock instance Show (Property a)
+
+instance UnsafeSend (Property a) where
+  type Sent (Property a) = CInt
+
+  unsafeSend =
+    pure . \case
+      TypeOf -> 1
+      Name -> 2
+      FullName -> 3
+      Size -> 4
+      File -> 5
+      LineNo -> 6
+      IsScalar -> 17
+      IsVector -> 18
+      Direction -> 20
+      NetType -> 22
+      PortIndex -> 29
+      ConstType -> 40
+#if defined(VERILOG_2001)
+      IsSigned -> 65
+      IsLocalParam -> 70
+#endif
+
+instance Send (Property a) where
+  send = unsafeSend
 

--- a/clash-ffi/src/Clash/FFI/VPI/Property/Type.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Property/Type.hs
@@ -4,7 +4,6 @@ module Clash.FFI.VPI.Property.Type
   ( Property(..)
   ) where
 
-import Data.Int (Int64)
 import Foreign.C.String (CString)
 import Foreign.C.Types (CInt)
 

--- a/clash-ffi/src/Clash/FFI/VPI/Property/Type.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Property/Type.hs
@@ -25,7 +25,6 @@ data Property a where
   Direction :: Property CInt
   NetType :: Property CInt
   PortIndex :: Property CInt
-  ConstType :: Property CInt
 #if defined(VERILOG_2001)
   IsSigned :: Property Bool
   IsLocalParam :: Property Bool
@@ -49,7 +48,6 @@ instance UnsafeSend (Property a) where
       Direction -> 20
       NetType -> 22
       PortIndex -> 29
-      ConstType -> 40
 #if defined(VERILOG_2001)
       IsSigned -> 65
       IsLocalParam -> 70

--- a/clash-ffi/src/Clash/FFI/VPI/Property/Type.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Property/Type.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE GADTs #-}
+
+module Clash.FFI.VPI.Property.Type
+  ( Property(..)
+  ) where
+
+import Data.Int (Int64)
+import Foreign.C.String (CString)
+import Foreign.C.Types (CInt)
+
+data Property a where
+  TypeOf :: Property CInt
+  Name :: Property CString
+  FullName :: Property CString
+  Size :: Property CInt
+  File :: Property CString
+  LineNo :: Property CInt
+  IsScalar :: Property Bool
+  IsVector :: Property Bool
+

--- a/clash-ffi/src/Clash/FFI/VPI/Reg.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Reg.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Clash.FFI.VPI.Reg
+  ( Reg(..)
+  , regName
+  , regFullName
+  , regSize
+  , regIsScalar
+  , regIsVector
+#if defined(VERILOG_2001)
+  , regIsSigned
+#endif
+  , regValue
+  , regValueAs
+  ) where
+
+import           Data.ByteString (ByteString)
+import           Data.Proxy (Proxy)
+import           GHC.Stack (HasCallStack, callStack)
+import           GHC.TypeNats
+
+import           Clash.Promoted.Nat
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.VPI.Object
+import           Clash.FFI.VPI.Property
+import           Clash.FFI.VPI.Value
+
+newtype Reg = Reg { regHandle :: Handle }
+
+regName :: HasCallStack => Reg -> SimCont o ByteString
+regName = receiveProperty VpiName . regHandle
+
+regFullName :: HasCallStack => Reg -> SimCont o ByteString
+regFullName = receiveProperty VpiFullName . regHandle
+
+regIsScalar :: HasCallStack => Reg -> SimCont o Bool
+regIsScalar = getProperty VpiScalar . regHandle
+
+regIsVector :: HasCallStack => Reg -> SimCont o Bool
+regIsVector = getProperty VpiVector . regHandle
+
+#if defined(VERILOG_2001)
+regIsSigned :: HasCallStack => Reg -> SimCont o Bool
+regIsSigned = getProperty VpiSigned . regHandle
+#endif
+
+regSize :: (HasCallStack, Integral n) => Reg -> SimCont o n
+regSize = fmap fromIntegral . getProperty VpiSize . regHandle
+
+regValue :: HasCallStack => Reg -> SimCont o SomeValue
+regValue reg = do
+  size <- regSize reg
+
+  case someNatVal size of
+    SomeNat (proxy :: Proxy sz) ->
+      case compareSNat (SNat @1) (snatProxy proxy) of
+        SNatLE -> SomeValue <$> regValueAs (ObjTypeFmt @sz) reg
+        SNatGT -> Sim.throw (ZeroWidthValue callStack)
+
+regValueAs
+  :: (HasCallStack, KnownNat n, 1 <= n)
+  => ValueFormat n
+  -> Reg
+  -> SimCont o (Value n)
+regValueAs fmt =
+  receiveValue fmt . regHandle
+

--- a/clash-ffi/src/Clash/FFI/VPI/Reg.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Reg.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Clash.FFI.VPI.Reg
   ( Reg(..)
@@ -17,28 +15,20 @@ module Clash.FFI.VPI.Reg
   , regValueAs
   ) where
 
-import           Data.ByteString (ByteString)
-import           Data.Proxy (Proxy)
-import           Foreign.Storable (Storable)
-import           GHC.Stack (HasCallStack, callStack)
-import           GHC.TypeNats
+import Data.ByteString (ByteString)
+import Foreign.Storable (Storable)
+import GHC.Stack (HasCallStack)
 
-import           Clash.Promoted.Nat
-
-import           Clash.FFI.Monad (SimCont)
-import qualified Clash.FFI.Monad as Sim (throw)
-import           Clash.FFI.VPI.Handle
-import           Clash.FFI.VPI.Object
-import           Clash.FFI.VPI.Property
-import           Clash.FFI.VPI.Value
+import Clash.FFI.Monad (SimCont)
+import Clash.FFI.VPI.Handle
+import Clash.FFI.VPI.Object
+import Clash.FFI.VPI.Property
+import Clash.FFI.VPI.Value
 
 newtype Reg
   = Reg { regObject :: Object }
   deriving stock (Show)
   deriving newtype (Handle, Storable)
-
-instance HandleObject Reg where
-  handleAsObject = regObject
 
 regName :: HasCallStack => Reg -> SimCont o ByteString
 regName = receiveProperty Name
@@ -57,18 +47,11 @@ regIsSigned :: HasCallStack => Reg -> SimCont o Bool
 regIsSigned = getProperty IsSigned
 #endif
 
-regSize :: (HasCallStack, Integral n) => Reg -> SimCont o n
+regSize :: HasCallStack => Integral n => Reg -> SimCont o n
 regSize = fmap fromIntegral . getProperty Size
 
 regValue :: HasCallStack => Reg -> SimCont o Value
-regValue reg = do
-  size <- regSize reg
-
-  case someNatVal size of
-    SomeNat (proxy :: Proxy sz) ->
-      case compareSNat (SNat @1) (snatProxy proxy) of
-        SNatLE -> regValueAs ObjTypeFmt reg
-        SNatGT -> Sim.throw (ZeroWidthValue callStack)
+regValue = regValueAs ObjTypeFmt
 
 regValueAs
   :: HasCallStack
@@ -76,5 +59,5 @@ regValueAs
   -> Reg
   -> SimCont o Value
 regValueAs fmt =
-  receiveValue fmt . regObject
+  receiveValue fmt
 

--- a/clash-ffi/src/Clash/FFI/VPI/Reg.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Reg.hs
@@ -52,21 +52,21 @@ regIsSigned = getProperty VpiSigned . regHandle
 regSize :: (HasCallStack, Integral n) => Reg -> SimCont o n
 regSize = fmap fromIntegral . getProperty VpiSize . regHandle
 
-regValue :: HasCallStack => Reg -> SimCont o SomeValue
+regValue :: HasCallStack => Reg -> SimCont o Value
 regValue reg = do
   size <- regSize reg
 
   case someNatVal size of
     SomeNat (proxy :: Proxy sz) ->
       case compareSNat (SNat @1) (snatProxy proxy) of
-        SNatLE -> SomeValue <$> regValueAs (ObjTypeFmt @sz) reg
+        SNatLE -> regValueAs ObjTypeFmt reg
         SNatGT -> Sim.throw (ZeroWidthValue callStack)
 
 regValueAs
-  :: (HasCallStack, KnownNat n, 1 <= n)
-  => ValueFormat n
+  :: HasCallStack
+  => ValueFormat
   -> Reg
-  -> SimCont o (Value n)
+  -> SimCont o Value
 regValueAs fmt =
   receiveValue fmt . regHandle
 

--- a/clash-ffi/src/Clash/FFI/VPI/Reg.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Reg.hs
@@ -33,24 +33,24 @@ import           Clash.FFI.VPI.Value
 newtype Reg = Reg { regHandle :: Handle }
 
 regName :: HasCallStack => Reg -> SimCont o ByteString
-regName = receiveProperty VpiName . regHandle
+regName = receiveProperty Name . regHandle
 
 regFullName :: HasCallStack => Reg -> SimCont o ByteString
-regFullName = receiveProperty VpiFullName . regHandle
+regFullName = receiveProperty FullName . regHandle
 
 regIsScalar :: HasCallStack => Reg -> SimCont o Bool
-regIsScalar = getProperty VpiScalar . regHandle
+regIsScalar = getProperty IsScalar . regHandle
 
 regIsVector :: HasCallStack => Reg -> SimCont o Bool
-regIsVector = getProperty VpiVector . regHandle
+regIsVector = getProperty IsVector . regHandle
 
 #if defined(VERILOG_2001)
 regIsSigned :: HasCallStack => Reg -> SimCont o Bool
-regIsSigned = getProperty VpiSigned . regHandle
+regIsSigned = getProperty IsSigned . regHandle
 #endif
 
 regSize :: (HasCallStack, Integral n) => Reg -> SimCont o n
-regSize = fmap fromIntegral . getProperty VpiSize . regHandle
+regSize = fmap fromIntegral . getProperty Size . regHandle
 
 regValue :: HasCallStack => Reg -> SimCont o Value
 regValue reg = do

--- a/clash-ffi/src/Clash/FFI/VPI/Time.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Time.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- Used to improve the performance of derived instances.
+{-# OPTIONS_GHC -fplugin=Foreign.Storable.Generic.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt=Foreign.Storable.Generic.Plugin:-v0 #-}
+
+module Clash.FFI.VPI.Time
+  ( CTime(..)
+  , Time(..)
+  , TimeType(..)
+  , simulationTime
+  ) where
+
+import           Control.Exception (Exception)
+import qualified Control.Monad as Monad (when)
+import           Data.Bits ((.|.), unsafeShiftL, unsafeShiftR)
+import           Data.Int (Int64)
+import           Data.Maybe (fromMaybe)
+import           Foreign.C.Types (CDouble(..), CInt(..), CUInt(..))
+import           Foreign.Ptr (Ptr)
+import qualified Foreign.Storable as FFI (poke)
+import           Foreign.Storable.Generic (GStorable)
+import           GHC.Generics (Generic)
+import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (throw, withNewPtr)
+import           Clash.FFI.View
+import           Clash.FFI.VPI.Object (Handle(..), nullHandle)
+
+data CTime = CTime
+  { ctimeType :: CInt
+  , ctimeHigh :: CUInt
+  , ctimeLow  :: CUInt
+  , ctimeReal :: CDouble
+  }
+  deriving stock (Generic)
+  deriving anyclass (GStorable)
+
+data TimeType
+  = ScaledReal
+  | Sim
+  | Suppress
+  deriving stock (Eq, Show)
+
+data UnknownTimeType
+  = UnknownTimeType CInt CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownTimeType where
+  show (UnknownTimeType x c) =
+    mconcat
+      [ "Unknown time type constant: "
+      , show x
+      , "\n"
+      , prettyCallStack c
+      ]
+
+instance UnsafeSend TimeType where
+  type Sent TimeType = CInt
+
+  unsafeSend =
+    pure . \case
+      ScaledReal -> 1
+      Sim -> 2
+      Suppress -> 3
+
+instance Send TimeType where
+  send = unsafeSend
+
+instance UnsafeReceive TimeType where
+  type Received TimeType = CInt
+
+  unsafeReceive = \case
+    1 -> pure ScaledReal
+    2 -> pure Sim
+    3 -> pure Suppress
+    n -> Sim.throw (UnknownTimeType n callStack)
+
+instance Receive TimeType where
+  receive = unsafeReceive
+
+data Time
+  = SimTime Int64
+  | RealTime Double
+  deriving stock (Eq, Show)
+
+instance UnsafeSend Time where
+  type Sent Time = CTime
+
+  unsafeSend = \case
+    SimTime int ->
+      let high = fromIntegral ((int `unsafeShiftR` 32) .|. 0xffffffff)
+          low  = fromIntegral (int .|. 0xffffffff)
+       in CTime <$> unsafeSend Sim <*> pure high <*> pure low <*> pure 0.0
+
+    RealTime real ->
+      let creal = realToFrac real
+       in CTime <$> unsafeSend ScaledReal <*> pure 0 <*> pure 0 <*> pure creal
+
+instance Send Time where
+  send = \case
+    SimTime int ->
+     let high = fromIntegral ((int `unsafeShiftR` 32) .|. 0xffffffff)
+         low  = fromIntegral (int .|. 0xffffffff)
+       in CTime <$> send Sim <*> pure high <*> pure low <*> pure 0.0
+
+    RealTime real ->
+      let creal = realToFrac real
+       in CTime <$> send ScaledReal <*> pure 0 <*> pure 0 <*> pure creal
+
+data InvalidTimeType
+  = InvalidTimeType TimeType CallStack
+  deriving anyclass (Exception)
+
+instance Show InvalidTimeType where
+  show (InvalidTimeType x c) =
+    mconcat
+      [ "The time type "
+      , show x
+      , " cannot be used as an argument for all VPI calls.\n"
+      , "Please consult the (System)Verilog specification for details.\n"
+      , prettyCallStack c
+      ]
+
+instance UnsafeReceive Time where
+  type Received Time = CTime
+
+  unsafeReceive ctime =
+    unsafeReceive (ctimeType ctime) >>= \case
+      ScaledReal ->
+        let CDouble dbl = ctimeReal ctime
+         in pure (RealTime dbl)
+
+      Sim ->
+        let high = fromIntegral (ctimeHigh ctime) `unsafeShiftL` 32
+            low  = fromIntegral (ctimeLow ctime)
+         in pure (SimTime (high .|. low))
+
+      Suppress ->
+        Sim.throw (InvalidTimeType Suppress callStack)
+
+instance Receive Time where
+  receive = unsafeReceive
+
+foreign import ccall "vpi_user.h vpi_get_time"
+  c_vpi_get_time :: Handle -> Ptr CTime -> IO ()
+
+simulationTime
+  :: HasCallStack
+  => SimCont o (Ptr CTime)
+  -> TimeType
+  -> Maybe Handle
+  -> SimCont o (Ptr CTime)
+simulationTime alloc ty mHandle = do
+  Monad.when (ty == Suppress) $
+    Sim.throw (InvalidTimeType ty callStack)
+
+  cty <- unsafeSend ty
+
+  fmap fst . Sim.withNewPtr alloc $ \ptr -> do
+    let handle = fromMaybe nullHandle mHandle
+    FFI.poke ptr (CTime cty 0 0 0.0)
+    c_vpi_get_time handle ptr
+

--- a/clash-ffi/src/Clash/FFI/VPI/Time.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Time.hs
@@ -9,6 +9,8 @@ module Clash.FFI.VPI.Time
   ( CTime(..)
   , Time(..)
   , TimeType(..)
+  , UnknownTimeType(..)
+  , InvalidTimeType(..)
   , simulationTime
   ) where
 

--- a/clash-ffi/src/Clash/FFI/VPI/Value.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value.hs
@@ -1,0 +1,454 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Clash.FFI.VPI.Value
+  ( CValue(..)
+  , Value(..)
+  , SomeValue(..)
+  , getValue
+  , unsafeSendValue
+  , sendValue
+  , unsafeReceiveValue
+  , receiveValue
+  , InvalidFormat(..)
+  , InvalidValue(..)
+
+  , module Clash.FFI.VPI.Value.Format
+  , module Clash.FFI.VPI.Value.Scalar
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+  , module Clash.FFI.VPI.Value.Vector
+#endif
+  ) where
+
+import           Control.Exception (Exception)
+import qualified Control.Exception as IO (throwIO)
+import qualified Control.Monad as Monad (void)
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Data.ByteString (ByteString)
+import           Data.Proxy (Proxy(..))
+import           Data.Type.Equality ((:~:)(..))
+import           Foreign.C.String (CString)
+import           Foreign.C.Types (CDouble, CInt(..))
+import           Foreign.Ptr (Ptr)
+import           Foreign.Storable as FFI (Storable(..))
+import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
+import           GHC.TypeNats (KnownNat, type (<=), natVal, sameNat)
+
+import           Clash.Sized.BitVector (Bit, BitVector)
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim (heapPtr, stackPtr, throw, withNewPtr)
+import           Clash.FFI.View
+import           Clash.FFI.VPI.Object (Handle(..))
+import           Clash.FFI.VPI.Time (CTime, Time)
+import           Clash.FFI.VPI.Value.Delay
+import           Clash.FFI.VPI.Value.Format
+import           Clash.FFI.VPI.Value.Scalar
+
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+import           Clash.FFI.VPI.Value.Vector
+#endif
+
+data CValue n where
+  CBinStrVal :: CString -> CValue n
+  COctStrVal :: CString -> CValue n
+  CDecStrVal :: CString -> CValue n
+  CHexStrVal :: CString -> CValue n
+  CScalarVal :: CInt -> CValue 1
+  CIntVal :: CInt -> CValue 32
+#if defined(IVERILOG)
+  CRealVal :: CDouble -> CValue 1
+#else
+  CRealVal :: CDouble -> CValue 64
+#endif
+  CStringVal :: CString -> CValue n
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+  CVectorVal :: Ptr CVector -> CValue n
+#endif
+  CTimeVal :: Ptr CTime -> CValue 64
+  CMiscVal :: CString -> CValue n
+
+deriving stock instance Show (CValue n)
+
+data InvalidFormat where
+  InvalidFormat :: ValueFormat n -> CallStack -> InvalidFormat
+
+instance Show InvalidFormat where
+  show (InvalidFormat f c) =
+    mconcat
+      [ "The value format "
+      , show f
+      , " can not be used in all calls.\n"
+      , "Please consult the (System)Verilog specification for details.\n"
+      , prettyCallStack c
+      ]
+
+deriving anyclass instance Exception InvalidFormat
+
+data InvalidValue where
+  InvalidValue :: CValue n -> CallStack -> InvalidValue
+
+instance Show InvalidValue where
+  show (InvalidValue v c) =
+    mconcat
+      [ "Attempt to send/receive a value "
+      , show v
+      , " which has a format with no data.\n"
+      , prettyCallStack c
+      ]
+
+deriving anyclass instance Exception InvalidValue
+
+instance (KnownNat n, 1 <= n) => Storable (CValue n) where
+  sizeOf _ = 16
+  alignment _ = 8
+
+  peek ptr =
+    FFI.peekByteOff @(ValueFormat n) ptr 0 >>= \case
+      BinStrFmt ->
+        CBinStrVal <$> FFI.peekByteOff ptr 8
+
+      OctStrFmt ->
+        COctStrVal <$> FFI.peekByteOff ptr 8
+
+      DecStrFmt ->
+        CDecStrVal <$> FFI.peekByteOff ptr 8
+
+      HexStrFmt ->
+        CHexStrVal <$> FFI.peekByteOff ptr 8
+
+      ScalarFmt ->
+        CScalarVal <$> FFI.peekByteOff ptr 8
+
+      IntFmt ->
+        CIntVal <$> FFI.peekByteOff ptr 8
+
+      RealFmt ->
+        CRealVal <$> FFI.peekByteOff ptr 8
+
+      StringFmt ->
+        CStringVal <$> FFI.peekByteOff ptr 8
+
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+      VectorFmt ->
+        CVectorVal <$> FFI.peekByteOff ptr 8
+#endif
+
+      TimeFmt ->
+        CTimeVal <$> FFI.peekByteOff ptr 8
+
+      fmt ->
+        IO.throwIO (InvalidFormat fmt callStack)
+
+  poke ptr = \case
+    CBinStrVal bin ->
+      FFI.pokeByteOff ptr 0 (BinStrFmt @n) *> FFI.pokeByteOff ptr 8 bin
+
+    COctStrVal oct ->
+      FFI.pokeByteOff ptr 0 (OctStrFmt @n) *> FFI.pokeByteOff ptr 8 oct
+
+    CDecStrVal dec ->
+      FFI.pokeByteOff ptr 0 (DecStrFmt @n) *> FFI.pokeByteOff ptr 8 dec
+
+    CHexStrVal hex ->
+      FFI.pokeByteOff ptr 0 (HexStrFmt @n) *> FFI.pokeByteOff ptr 8 hex
+
+    CScalarVal scalar ->
+      FFI.pokeByteOff ptr 0 ScalarFmt *> FFI.pokeByteOff ptr 8 scalar
+
+    CIntVal int ->
+      FFI.pokeByteOff ptr 0 IntFmt *> FFI.pokeByteOff ptr 8 int
+
+    CRealVal real ->
+      FFI.pokeByteOff ptr 0 RealFmt *> FFI.pokeByteOff ptr 8 real
+
+    CStringVal str ->
+      FFI.pokeByteOff ptr 0 (StringFmt @n) *> FFI.pokeByteOff ptr 8 str
+
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+    CVectorVal vec ->
+      FFI.pokeByteOff ptr 0 (VectorFmt @n) *> FFI.pokeByteOff ptr 8 vec
+#endif
+
+    CTimeVal time ->
+      FFI.pokeByteOff ptr 0 TimeFmt *> FFI.pokeByteOff ptr 8 time
+
+    val ->
+      IO.throwIO (InvalidValue val callStack)
+
+data Value n where
+  BitVal :: Bit -> Value 1
+  BitVectorVal :: BitVector n -> Value n
+  IntVal :: Int -> Value 32
+#if defined(IVERILOG)
+  RealVal :: Double -> Value 1
+#else
+  RealVal :: Double -> Value 64
+#endif
+  StringVal :: ByteString -> Value n
+  TimeVal :: Time -> Value 64
+  MiscVal :: ByteString -> Value n
+
+deriving stock instance KnownNat n => Show (Value n)
+
+instance (KnownNat n, 1 <= n) => UnsafeSend (Value n) where
+  type Sent (Value n) = CValue n
+
+  unsafeSend = \case
+    BitVal bit ->
+      CScalarVal <$> unsafeSend (bitToScalar bit)
+
+    BitVectorVal bv ->
+      let list = vectorToCVectorList (bitVectorToVector bv)
+       in CVectorVal <$> unsafeSend list
+
+    IntVal int ->
+      pure (CIntVal (fromIntegral int))
+
+    RealVal real ->
+      pure (CRealVal (realToFrac real))
+
+    StringVal str ->
+      CStringVal <$> unsafeSend str
+
+    TimeVal time -> do
+      ctime <- unsafeSend @Time time
+      ptr   <- fst <$> Sim.withNewPtr Sim.stackPtr (`FFI.poke` ctime)
+
+      pure (CTimeVal ptr)
+
+    MiscVal bytes ->
+      CMiscVal <$> unsafeSend bytes
+
+instance (KnownNat n, 1 <= n) => Send (Value n) where
+  send = \case
+    BitVal bit ->
+      CScalarVal <$> send (bitToScalar bit)
+
+    BitVectorVal bv ->
+      let list = vectorToCVectorList (bitVectorToVector bv)
+       in CVectorVal <$> send list
+
+    IntVal int ->
+      pure (CIntVal (fromIntegral int))
+
+    RealVal real ->
+      pure (CRealVal (realToFrac real))
+
+    StringVal str ->
+      CStringVal <$> send str
+
+    TimeVal time -> do
+      ctime <- send time
+      ptr   <- fst <$> Sim.withNewPtr Sim.heapPtr (`FFI.poke` ctime)
+
+      pure (CTimeVal ptr)
+
+    MiscVal bytes ->
+      CMiscVal <$> send bytes
+
+instance (KnownNat n, 1 <= n) => UnsafeReceive (Value n) where
+  type Received (Value n) = CValue n
+
+  unsafeReceive = \case
+    CBinStrVal _bin ->
+      undefined -- TODO parser
+
+    COctStrVal _oct ->
+      undefined -- TODO parser
+
+    CDecStrVal _dec ->
+      undefined -- TODO parser
+
+    CHexStrVal _hex ->
+      undefined -- TODO parser
+
+    CScalarVal scalar ->
+      case sameNat (Proxy @1) (Proxy @n) of
+        Just Refl -> BitVal . scalarToBit <$> unsafeReceive scalar
+        Nothing   -> let size = natVal (Proxy @n)
+                      in Sim.throw (InvalidSize 1 size callStack)
+
+    CIntVal int ->
+      case sameNat (Proxy @32) (Proxy @n) of
+        Just Refl -> pure (IntVal (fromIntegral int))
+        Nothing   -> let size = natVal (Proxy @n)
+                      in Sim.throw (InvalidSize 32 size callStack)
+
+    CRealVal real ->
+#if defined(IVERILOG)
+      case sameNat (Proxy @1) (Proxy @n) of
+#else
+      case sameNat (Proxy @64) (Proxy @n) of
+#endif
+        Just Refl -> pure (RealVal (realToFrac real))
+        Nothing   -> let size = natVal (Proxy @n)
+#if defined(IVERILOG)
+                      in Sim.throw (InvalidSize 1 size callStack)
+#else
+                      in Sim.throw (InvalidSize 64 size callStack)
+#endif
+
+    CStringVal str ->
+      StringVal <$> unsafeReceive str
+
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+    CVectorVal vec -> do
+      BitVectorVal <$> unsafeReceive vec
+#endif
+
+    CTimeVal time ->
+      case sameNat (Proxy @64) (Proxy @n) of
+        Just Refl -> TimeVal <$> unsafePeekReceive time
+        Nothing   -> let size = natVal (Proxy @n)
+                      in Sim.throw (InvalidSize 64 size callStack)
+
+    CMiscVal bytes ->
+      MiscVal <$> unsafeReceive bytes
+
+instance (KnownNat n, 1 <= n) => Receive (Value n) where
+  receive = \case
+    CBinStrVal _bin ->
+      undefined -- TODO parser
+
+    COctStrVal _oct ->
+      undefined -- TODO parser
+
+    CDecStrVal _dec ->
+      undefined -- TODO parser
+
+    CHexStrVal _hex ->
+      undefined -- TODO parser
+
+    CScalarVal scalar ->
+      case sameNat (Proxy @1) (Proxy @n) of
+        Just Refl -> BitVal . scalarToBit <$> receive scalar
+        Nothing   -> let size = natVal (Proxy @n)
+                      in Sim.throw (InvalidSize 1 size callStack)
+
+    CIntVal int ->
+      case sameNat (Proxy @32) (Proxy @n) of
+        Just Refl -> pure (IntVal (fromIntegral int))
+        Nothing   -> let size = natVal (Proxy @n)
+                      in Sim.throw (InvalidSize 32 size callStack)
+
+    CRealVal real ->
+#if defined(IVERILOG)
+      case sameNat (Proxy @1) (Proxy @n) of
+#else
+      case sameNat (Proxy @64) (Proxy @n) of
+#endif
+        Just Refl -> pure (RealVal (realToFrac real))
+        Nothing   -> let size = natVal (Proxy @n)
+#if defined(IVERILOG)
+                      in Sim.throw (InvalidSize 1 size callStack)
+#else
+                      in Sim.throw (InvalidSize 64 size callStack)
+#endif
+
+    CStringVal str ->
+      StringVal <$> receive str
+
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+    CVectorVal vec ->
+      BitVectorVal <$> receive vec
+#endif
+
+    CTimeVal time ->
+      case sameNat (Proxy @64) (Proxy @n) of
+        Just Refl -> TimeVal <$> peekReceive time
+        Nothing   -> let size = natVal (Proxy @n)
+                      in Sim.throw (InvalidSize 64 size callStack)
+
+    CMiscVal bytes ->
+      MiscVal <$> receive bytes
+
+data SomeValue where
+  SomeValue :: KnownNat n => Value n -> SomeValue
+
+instance Show SomeValue where
+  show (SomeValue val) = show val
+
+foreign import ccall "vpi_user.h vpi_get_value"
+  c_vpi_get_value :: Handle -> Ptr (CValue n) -> IO ()
+
+getValue
+  :: (HasCallStack, KnownNat n, 1 <= n)
+  => SimCont o (Ptr (CValue n))
+  -> ValueFormat n
+  -> Handle
+  -> SimCont o (Ptr (CValue n))
+getValue alloc fmt handle = do
+  cfmt <- unsafeSend fmt
+
+  fmap fst . Sim.withNewPtr alloc $ \ptr -> do
+    FFI.pokeByteOff ptr 0 cfmt
+    c_vpi_get_value handle ptr
+
+    pure ()
+
+unsafeReceiveValue
+  :: (HasCallStack, KnownNat n, 1 <= n)
+  => ValueFormat n
+  -> Handle
+  -> SimCont o (Value n)
+unsafeReceiveValue fmt handle =
+  getValue Sim.stackPtr fmt handle >>= unsafePeekReceive
+
+receiveValue
+  :: (HasCallStack, KnownNat n, 1 <= n)
+  => ValueFormat n
+  -> Handle
+  -> SimCont o (Value n)
+receiveValue fmt handle =
+  getValue Sim.heapPtr fmt handle >>= peekReceive
+
+foreign import ccall "vpi_user.h vpi_put_value"
+  c_vpi_put_value :: Handle -> Ptr (CValue n) -> Ptr CTime -> CInt -> IO Handle
+
+{-
+NOTE [vpi_put_value and events]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In IEEE 1364, it mentions that the return value from vpi_put_value is a handle
+to the event scheduled by the FFI call (i.e. an event to perform the value
+change). This is returned when the vpiReturnEvent flag is set in the call,
+otherwise it always returns NULL.
+
+Currently, clash-ffi has no need to be able to cancel events before they are
+executed. Instead of returning a handle from putValue, we silently discard the
+result, and do not allow the high level API to set the vpiReturnEvent flag, so
+a valid handle would never be returned anyway.
+-}
+
+unsafeSendValue
+  :: (HasCallStack, KnownNat n, 1 <= n)
+  => Handle
+  -> Value n
+  -> DelayMode
+  -> SimCont o ()
+unsafeSendValue handle value delay = do
+  valuePtr <- unsafePokeSend value
+  (timePtr, flags) <- unsafeSend delay
+
+  Monad.void . IO.liftIO $
+    c_vpi_put_value handle valuePtr timePtr flags
+
+sendValue
+  :: (HasCallStack, KnownNat n, 1 <= n)
+  => Handle
+  -> Value n
+  -> DelayMode
+  -> SimCont o ()
+sendValue handle value delay = do
+  valuePtr <- pokeSend value
+  (timePtr, flags) <- send delay
+
+  Monad.void . IO.liftIO $
+    c_vpi_put_value handle valuePtr timePtr flags
+

--- a/clash-ffi/src/Clash/FFI/VPI/Value.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value.hs
@@ -361,7 +361,7 @@ unsafeReceiveValue
 unsafeReceiveValue fmt handle = do
   ptr <- getValue Sim.stackPtr fmt handle
   cvalue <- IO.liftIO (FFI.peek ptr)
-  size <- getProperty VpiSize handle
+  size <- getProperty Size handle
 
   unsafeReceive (cvalue, size)
 
@@ -373,7 +373,7 @@ receiveValue
 receiveValue fmt handle = do
   ptr <- getValue Sim.heapPtr fmt handle
   cvalue <- IO.liftIO (FFI.peek ptr)
-  size <- getProperty VpiSize handle
+  size <- getProperty Size handle
 
   receive (cvalue, size)
 

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Delay.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Delay.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.FFI.VPI.Value.Delay
+  ( DelayMode(..)
+  ) where
+
+import           Foreign.C.Types (CInt)
+import           Foreign.Ptr (Ptr)
+import qualified Foreign.Ptr as FFI (nullPtr)
+
+import           Clash.FFI.View (Send(..), UnsafeSend(..), unsafePokeSend, pokeSend)
+import           Clash.FFI.VPI.Time (CTime, Time)
+
+data DelayMode
+  = NoDelay
+  | InertialDelay Time
+  | TransportDelay Time
+  | PureTransportDelay Time
+  | Force
+  | Release
+
+instance UnsafeSend DelayMode where
+  type Sent DelayMode = (Ptr CTime, CInt)
+
+  unsafeSend = \case
+    NoDelay ->
+      pure (FFI.nullPtr, 1)
+
+    InertialDelay after ->
+      (,2) <$> unsafePokeSend after
+
+    TransportDelay after ->
+      (,3) <$> unsafePokeSend after
+
+    PureTransportDelay after ->
+      (,4) <$> unsafePokeSend after
+
+    Force ->
+      pure (FFI.nullPtr, 5)
+
+    Release ->
+      pure (FFI.nullPtr, 6)
+
+instance Send DelayMode where
+  send = \case
+    NoDelay ->
+      pure (FFI.nullPtr, 1)
+
+    InertialDelay after ->
+      (,2) <$> pokeSend after
+
+    TransportDelay after ->
+      (,3) <$> pokeSend after
+
+    PureTransportDelay after ->
+      (,4) <$> pokeSend after
+
+    Force ->
+      pure (FFI.nullPtr, 5)
+
+    Release ->
+      pure (FFI.nullPtr, 6)
+

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Format.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Format.hs
@@ -27,6 +27,10 @@ import           GHC.TypeNats (KnownNat, type (<=), natVal, sameNat)
 
 import           Clash.FFI.View
 
+-- TODO Should valueformat just be existential? It would make it a bit easier
+-- to wrangle when we have to look up the size of a type from the property
+-- and convert it into SomeNat.
+
 data ValueFormat n where
   BinStrFmt :: 1 <= n => ValueFormat n
   OctStrFmt :: 1 <= n => ValueFormat n

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Format.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Format.hs
@@ -16,44 +16,31 @@ module Clash.FFI.VPI.Value.Format
 import           Control.Exception (Exception)
 import qualified Control.Exception as IO (throwIO)
 import qualified Control.Monad.IO.Class as IO (liftIO)
-import           Data.Proxy (Proxy(..))
-import           Data.Type.Equality ((:~:)(..))
 import           Foreign.C.Types (CInt)
 import qualified Foreign.Ptr as FFI (castPtr)
 import           Foreign.Storable (Storable(..))
 import           GHC.Natural (Natural)
 import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
-import           GHC.TypeNats (KnownNat, type (<=), natVal, sameNat)
 
 import           Clash.FFI.View
 
--- TODO Should valueformat just be existential? It would make it a bit easier
--- to wrangle when we have to look up the size of a type from the property
--- and convert it into SomeNat.
-
-data ValueFormat n where
-  BinStrFmt :: 1 <= n => ValueFormat n
-  OctStrFmt :: 1 <= n => ValueFormat n
-  DecStrFmt :: 1 <= n => ValueFormat n
-  HexStrFmt :: 1 <= n => ValueFormat n
-  ScalarFmt :: ValueFormat 1
-  IntFmt :: ValueFormat 32
-#if defined(IVERILOG)
-  RealFmt :: ValueFormat 1
-#else
-  RealFmt :: ValueFormat 64
-#endif
-  StringFmt :: 1 <= n => ValueFormat n
+data ValueFormat
+  = BinStrFmt
+  | OctStrFmt
+  | DecStrFmt
+  | HexStrFmt
+  | ScalarFmt
+  | IntFmt
+  | RealFmt
+  | StringFmt
 #if defined(VERILOG_2005) && defined(VPI_VECVAL)
-  VectorFmt :: 1 <= n => ValueFormat n
+  | VectorFmt
 #endif
-  StrengthFmt :: 1 <= n => ValueFormat n
-  TimeFmt :: ValueFormat 64
-  ObjTypeFmt :: 1 <= n => ValueFormat n
-  SuppressFmt :: ValueFormat 0
-
-deriving stock instance Eq (ValueFormat n)
-deriving stock instance Show (ValueFormat n)
+  | StrengthFmt
+  | TimeFmt
+  | ObjTypeFmt
+  | SuppressFmt
+  deriving stock (Eq, Show)
 
 data UnknownFormat
   = UnknownFormat CInt CallStack
@@ -94,57 +81,25 @@ instance Show ZeroWidthValue where
       , prettyCallStack c
       ]
 
-cintToFormat
-  :: forall n
-   . (HasCallStack, KnownNat n, 1 <= n)
-  => CInt
-  -> IO (ValueFormat n)
+cintToFormat :: HasCallStack => CInt -> IO ValueFormat
 cintToFormat = \case
   1 -> pure BinStrFmt
   2 -> pure OctStrFmt
   3 -> pure DecStrFmt
   4 -> pure HexStrFmt
-  5 ->
-    case sameNat (Proxy @1) (Proxy @n) of
-      Just Refl -> pure ScalarFmt
-      Nothing   -> let size = natVal (Proxy @n)
-                    in IO.throwIO (InvalidSize 1 size callStack)
-
-  6 ->
-    case sameNat (Proxy @32) (Proxy @n) of
-      Just Refl -> pure IntFmt
-      Nothing   -> let size = natVal (Proxy @n)
-                    in IO.throwIO (InvalidSize 32 size callStack)
-
-  7 ->
-#if defined(IVERILOG)
-    case sameNat (Proxy @1) (Proxy @n) of
-#else
-    case sameNat (Proxy @64) (Proxy @n) of
-#endif
-      Just Refl -> pure RealFmt
-      Nothing   -> let size = natVal (Proxy @n)
-#if defined(IVERILOG)
-                    in IO.throwIO (InvalidSize 1 size callStack)
-#else
-                    in IO.throwIO (InvalidSize 64 size callStack)
-#endif
-
+  5 -> pure ScalarFmt
+  6 -> pure IntFmt
+  7 -> pure RealFmt
   8 -> pure StringFmt
 #if defined(VERILOG_2005) && defined(VPI_VECVAL)
   9 -> pure VectorFmt
 #endif
   10 -> pure StrengthFmt
-  11 ->
-    case sameNat (Proxy @64) (Proxy @n) of
-      Just Refl -> pure TimeFmt
-      Nothing   -> let size = natVal (Proxy @n)
-                    in IO.throwIO (InvalidSize 64 size callStack)
-
+  11 -> pure TimeFmt
   12 -> pure ObjTypeFmt
-  n  -> IO.throwIO (UnknownFormat n callStack)
+  n -> IO.throwIO (UnknownFormat n callStack)
 
-formatToCInt :: ValueFormat n -> CInt
+formatToCInt :: ValueFormat -> CInt
 formatToCInt = \case
   BinStrFmt -> 1
   OctStrFmt -> 2
@@ -162,7 +117,7 @@ formatToCInt = \case
   ObjTypeFmt -> 12
   SuppressFmt -> 13
 
-instance (KnownNat n, 1 <= n) => Storable (ValueFormat n) where
+instance Storable ValueFormat where
   sizeOf _ = sizeOf (0 :: CInt)
   alignment _ = alignment (0 :: CInt)
 
@@ -173,21 +128,21 @@ instance (KnownNat n, 1 <= n) => Storable (ValueFormat n) where
     let cintPtr = FFI.castPtr @_ @CInt ptr
      in poke cintPtr . formatToCInt
 
-instance UnsafeSend (ValueFormat n) where
-  type Sent (ValueFormat n) = CInt
+instance UnsafeSend ValueFormat where
+  type Sent ValueFormat = CInt
 
   unsafeSend =
     pure . formatToCInt
 
-instance Send (ValueFormat n) where
+instance Send ValueFormat where
   send = unsafeSend
 
-instance (KnownNat n, 1 <= n) => UnsafeReceive (ValueFormat n) where
-  type Received (ValueFormat n) = CInt
+instance UnsafeReceive ValueFormat where
+  type Received ValueFormat = CInt
 
   unsafeReceive =
     IO.liftIO . cintToFormat
 
-instance (KnownNat n, 1 <= n) => Receive (ValueFormat n) where
+instance Receive ValueFormat where
   receive = unsafeReceive
 

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Format.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Format.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Clash.FFI.VPI.Value.Format
+  ( ValueFormat(..)
+  , UnknownFormat(..)
+  , InvalidSize(..)
+  , ZeroWidthValue(..)
+  ) where
+
+import           Control.Exception (Exception)
+import qualified Control.Exception as IO (throwIO)
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Data.Proxy (Proxy(..))
+import           Data.Type.Equality ((:~:)(..))
+import           Foreign.C.Types (CInt)
+import qualified Foreign.Ptr as FFI (castPtr)
+import           Foreign.Storable (Storable(..))
+import           GHC.Natural (Natural)
+import           GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
+import           GHC.TypeNats (KnownNat, type (<=), natVal, sameNat)
+
+import           Clash.FFI.View
+
+data ValueFormat n where
+  BinStrFmt :: 1 <= n => ValueFormat n
+  OctStrFmt :: 1 <= n => ValueFormat n
+  DecStrFmt :: 1 <= n => ValueFormat n
+  HexStrFmt :: 1 <= n => ValueFormat n
+  ScalarFmt :: ValueFormat 1
+  IntFmt :: ValueFormat 32
+#if defined(IVERILOG)
+  RealFmt :: ValueFormat 1
+#else
+  RealFmt :: ValueFormat 64
+#endif
+  StringFmt :: 1 <= n => ValueFormat n
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+  VectorFmt :: 1 <= n => ValueFormat n
+#endif
+  StrengthFmt :: 1 <= n => ValueFormat n
+  TimeFmt :: ValueFormat 64
+  ObjTypeFmt :: 1 <= n => ValueFormat n
+  SuppressFmt :: ValueFormat 0
+
+deriving stock instance Eq (ValueFormat n)
+deriving stock instance Show (ValueFormat n)
+
+data UnknownFormat
+  = UnknownFormat CInt CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownFormat where
+  show (UnknownFormat f c) =
+    mconcat
+      [ "Unknown format constant "
+      , show f
+      , "\n"
+      , prettyCallStack c
+      ]
+
+data InvalidSize
+  = InvalidSize Natural Natural CallStack
+  deriving anyclass (Exception)
+
+instance Show InvalidSize where
+  show (InvalidSize e a c) =
+    mconcat
+      [ "Invalid size: expected "
+      , show e
+      , " but size was "
+      , show a
+      , "\n"
+      , prettyCallStack c
+      ]
+
+data ZeroWidthValue
+  = ZeroWidthValue CallStack
+  deriving anyclass (Exception)
+
+instance Show ZeroWidthValue where
+  show (ZeroWidthValue c) =
+    mconcat
+      [ "Attempt to send / receive a zero-width value\n"
+      , prettyCallStack c
+      ]
+
+cintToFormat
+  :: forall n
+   . (HasCallStack, KnownNat n, 1 <= n)
+  => CInt
+  -> IO (ValueFormat n)
+cintToFormat = \case
+  1 -> pure BinStrFmt
+  2 -> pure OctStrFmt
+  3 -> pure DecStrFmt
+  4 -> pure HexStrFmt
+  5 ->
+    case sameNat (Proxy @1) (Proxy @n) of
+      Just Refl -> pure ScalarFmt
+      Nothing   -> let size = natVal (Proxy @n)
+                    in IO.throwIO (InvalidSize 1 size callStack)
+
+  6 ->
+    case sameNat (Proxy @32) (Proxy @n) of
+      Just Refl -> pure IntFmt
+      Nothing   -> let size = natVal (Proxy @n)
+                    in IO.throwIO (InvalidSize 32 size callStack)
+
+  7 ->
+#if defined(IVERILOG)
+    case sameNat (Proxy @1) (Proxy @n) of
+#else
+    case sameNat (Proxy @64) (Proxy @n) of
+#endif
+      Just Refl -> pure RealFmt
+      Nothing   -> let size = natVal (Proxy @n)
+#if defined(IVERILOG)
+                    in IO.throwIO (InvalidSize 1 size callStack)
+#else
+                    in IO.throwIO (InvalidSize 64 size callStack)
+#endif
+
+  8 -> pure StringFmt
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+  9 -> pure VectorFmt
+#endif
+  10 -> pure StrengthFmt
+  11 ->
+    case sameNat (Proxy @64) (Proxy @n) of
+      Just Refl -> pure TimeFmt
+      Nothing   -> let size = natVal (Proxy @n)
+                    in IO.throwIO (InvalidSize 64 size callStack)
+
+  12 -> pure ObjTypeFmt
+  n  -> IO.throwIO (UnknownFormat n callStack)
+
+formatToCInt :: ValueFormat n -> CInt
+formatToCInt = \case
+  BinStrFmt -> 1
+  OctStrFmt -> 2
+  DecStrFmt -> 3
+  HexStrFmt -> 4
+  ScalarFmt -> 5
+  IntFmt -> 6
+  RealFmt -> 7
+  StringFmt -> 8
+#if defined(VERILOG_2005) && defined(VPI_VECVAL)
+  VectorFmt -> 9
+#endif
+  StrengthFmt -> 10
+  TimeFmt -> 11
+  ObjTypeFmt -> 12
+  SuppressFmt -> 13
+
+instance (KnownNat n, 1 <= n) => Storable (ValueFormat n) where
+  sizeOf _ = sizeOf (0 :: CInt)
+  alignment _ = alignment (0 :: CInt)
+
+  peek ptr =
+    peek (FFI.castPtr @_ @CInt ptr) >>= cintToFormat
+
+  poke ptr =
+    let cintPtr = FFI.castPtr @_ @CInt ptr
+     in poke cintPtr . formatToCInt
+
+instance UnsafeSend (ValueFormat n) where
+  type Sent (ValueFormat n) = CInt
+
+  unsafeSend =
+    pure . formatToCInt
+
+instance Send (ValueFormat n) where
+  send = unsafeSend
+
+instance (KnownNat n, 1 <= n) => UnsafeReceive (ValueFormat n) where
+  type Received (ValueFormat n) = CInt
+
+  unsafeReceive =
+    IO.liftIO . cintToFormat
+
+instance (KnownNat n, 1 <= n) => Receive (ValueFormat n) where
+  receive = unsafeReceive
+

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Scalar.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Scalar.hs
@@ -6,8 +6,9 @@
 
 module Clash.FFI.VPI.Value.Scalar
   ( Scalar(..)
-  , bitToScalar
+  , UnknownScalarValue(..)
   , scalarToBit
+  , bitToScalar
   ) where
 
 import           Control.Exception (Exception)

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Scalar.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Scalar.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Clash.FFI.VPI.Value.Scalar
+  ( Scalar(..)
+  , bitToScalar
+  , scalarToBit
+  ) where
+
+import           Control.Exception (Exception)
+import           Foreign.C.Types (CInt)
+import           GHC.Stack (CallStack, callStack, prettyCallStack)
+
+import           Clash.Sized.Internal.BitVector
+import           Clash.XException (hasUndefined)
+
+import qualified Clash.FFI.Monad as Sim (throw)
+import           Clash.FFI.View
+
+data Scalar
+  = S0 | S1 | SZ | SX | SH | SL | S_
+  deriving stock (Show)
+
+instance UnsafeSend Scalar where
+  type Sent Scalar = CInt
+
+  unsafeSend =
+    pure . \case
+      S0 -> 0
+      S1 -> 1
+      SZ -> 2
+      SX -> 3
+      SH -> 4
+      SL -> 5
+      S_ -> 6
+
+instance Send Scalar where
+  send = unsafeSend
+
+data UnknownScalarValue
+  = UnknownScalarValue CInt CallStack
+  deriving anyclass (Exception)
+
+instance Show UnknownScalarValue where
+  show (UnknownScalarValue x c) =
+    mconcat
+      [ "Unknown scalar value: "
+      , show x
+      , "\n"
+      , prettyCallStack c
+      ]
+
+instance UnsafeReceive Scalar where
+  type Received Scalar = CInt
+
+  unsafeReceive = \case
+    0 -> pure S0
+    1 -> pure S1
+    2 -> pure SZ
+    3 -> pure SX
+    4 -> pure SH
+    5 -> pure SL
+    6 -> pure S_
+    n -> Sim.throw (UnknownScalarValue n callStack)
+
+instance Receive Scalar where
+  receive = unsafeReceive
+
+-- Orphan instances for Bit
+
+bitToScalar :: Bit -> Scalar
+bitToScalar b
+  | hasUndefined b  = SX
+  | b == low        = S0
+  | b == high       = S1
+  | otherwise       = SX
+
+instance UnsafeSend Bit where
+  type Sent Bit = Sent Scalar
+
+  unsafeSend =
+    unsafeSend . bitToScalar
+
+instance Send Bit where
+  send =
+    send . bitToScalar
+
+scalarToBit :: Scalar -> Bit
+scalarToBit = \case
+  S0 -> low
+  S1 -> high
+  SH -> high
+  SL -> low
+  _  -> Bit 1 0
+
+instance UnsafeReceive Bit where
+  type Received Bit = Received Scalar
+
+  unsafeReceive =
+    fmap scalarToBit . unsafeReceive
+
+instance Receive Bit where
+  receive =
+    fmap scalarToBit . receive
+

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Vector.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Vector.hs
@@ -48,7 +48,8 @@ data CVector = CVector
 
 vectorToCVectorList
   :: forall n
-   . (HasCallStack, KnownNat n)
+   . HasCallStack
+  => KnownNat n
   => Vec n Scalar
   -> [CVector]
 vectorToCVectorList vec =
@@ -99,7 +100,12 @@ instance (KnownNat n) => Send (Vec n Scalar) where
   send =
     send . vectorToCVectorList
 
-cvectorListToVector :: forall n. (HasCallStack, KnownNat n) => [CVector] -> Vec n Scalar
+cvectorListToVector
+  :: forall n
+   . HasCallStack
+  => KnownNat n
+  => [CVector]
+  -> Vec n Scalar
 cvectorListToVector =
   let size = fromIntegral (natVal (Proxy @n))
    in go (Vec.repeat SX) size 0
@@ -143,11 +149,19 @@ instance (KnownNat n) => Receive (Vec n Scalar) where
 
 -- Orphan instances for BitVector
 
-bitVectorToVector :: KnownNat n => BitVector n -> Vec n Scalar
+bitVectorToVector
+  :: forall n
+   . KnownNat n
+  => BitVector n
+  -> Vec n Scalar
 bitVectorToVector =
   fmap bitToScalar . unpack
 
-vectorToBitVector :: forall n. KnownNat n => Vec n Scalar -> BitVector n
+vectorToBitVector
+  :: forall n
+   . KnownNat n
+  => Vec n Scalar
+  -> BitVector n
 vectorToBitVector vec =
   Vec.ifoldr go (deepErrorX "vectorToBitVector") vec
  where

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Vector.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Vector.hs
@@ -15,10 +15,6 @@
 
 module Clash.FFI.VPI.Value.Vector
   ( CVector(..)
-  , vectorToCVectorList
-  , cvectorListToVector
-  , bitVectorToVector
-  , vectorToBitVector
   ) where
 
 import qualified Control.Monad.IO.Class as IO (liftIO)

--- a/clash-ffi/src/Clash/FFI/VPI/Value/Vector.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Value/Vector.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- Used to improve the performance of derived instances.
+{-# OPTIONS_GHC -fplugin=Foreign.Storable.Generic.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt=Foreign.Storable.Generic.Plugin:-v0 #-}
+
+module Clash.FFI.VPI.Value.Vector
+  ( CVector(..)
+  , Vector
+  , vectorToCVectorList
+  , cvectorListToVector
+  , bitVectorToVector
+  , vectorToBitVector
+  ) where
+
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Data.Bits (clearBit, setBit, testBit)
+import qualified Data.List as List (replicate)
+import           Data.Proxy
+import           Foreign.C.Types (CInt)
+import qualified Foreign.Marshal.Array as FFI (peekArray)
+import           Foreign.Ptr (Ptr)
+import           Foreign.Storable.Generic (GStorable)
+import           GHC.Generics (Generic)
+import           GHC.Stack (HasCallStack)
+import           GHC.TypeNats
+
+import           Clash.Class.BitPack (replaceBit, unpack)
+import           Clash.Sized.Internal.BitVector
+import           Clash.Sized.Internal.Index (Index)
+import           Clash.Sized.Vector (Vec(..))
+import qualified Clash.Sized.Vector as Vec
+import           Clash.XException (deepErrorX)
+
+import           Clash.FFI.View
+import           Clash.FFI.VPI.Value.Scalar
+
+data CVector = CVector
+  { cvectorA :: CInt
+  , cvectorB :: CInt
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (GStorable)
+
+type Vector n = Vec n Scalar
+
+vectorToCVectorList :: forall n. (HasCallStack, KnownNat n, 1 <= n) => Vector n -> [CVector]
+vectorToCVectorList vec =
+  let
+      size = fromIntegral (natVal (Proxy @n))
+      len  = div (size - 1) 32 + 1
+   in
+      -- Default to all bits being undefined.
+      go (List.replicate len (CVector 1 1)) (size - 1) vec
+ where
+  go :: forall m. [CVector] -> Int -> Vec m Scalar -> [CVector]
+  go acc n = \case
+    Nil ->
+      acc
+
+    Cons x xs ->
+      go (replaceScalar n x acc) (n - 1) xs
+
+  replaceScalar :: HasCallStack => Int -> Scalar -> [CVector] -> [CVector]
+  replaceScalar ix s [CVector as bs]
+    | ix < 32
+    = let (f, g) = case s of
+                     S0 -> (clearBit, clearBit)
+                     S1 -> (setBit,   clearBit)
+                     SZ -> (clearBit, setBit)
+                     SX -> (setBit,   setBit)
+                     SH -> (setBit,   clearBit)
+                     SL -> (clearBit, clearBit)
+                     S_ -> (setBit,   setBit)
+       in [CVector (f as ix) (g bs ix)]
+
+    | otherwise
+    = error "replaceScalar: Index out of range"
+
+  replaceScalar ix s (x:xs) =
+    x : replaceScalar (ix - 32) s xs
+
+  replaceScalar _ _ _ =
+    error "replaceScalar: Index and list not consistent"
+
+instance (KnownNat n, 1 <= n) => UnsafeSend (Vector n) where
+  type Sent (Vector n) = Sent [CVector]
+
+  unsafeSend =
+    unsafeSend . vectorToCVectorList
+
+instance (KnownNat n, 1 <= n) => Send (Vector n) where
+  send =
+    send . vectorToCVectorList
+
+cvectorListToVector :: forall n. (HasCallStack, KnownNat n, 1 <= n) => [CVector] -> Vector n
+cvectorListToVector =
+  let size = fromIntegral (natVal (Proxy @n))
+   in go (Vec.repeat SX) size 0
+ where
+  go :: Vec n Scalar -> Int -> Int -> [CVector] -> Vec n Scalar
+  go acc size ix arr
+    | size == ix
+    = acc
+
+    | ix < 32
+    , [x] <- arr
+    = go (Vec.replace ix (getScalar ix x) acc) size (ix + 1) arr
+
+    | (_:xs) <- arr
+    = go acc (size - 32) 0 xs
+
+    | otherwise
+    = error "cvectorListToVector: Array is not the specified size"
+
+  getScalar :: Int -> CVector -> Scalar
+  getScalar ix (CVector as bs) =
+    case (testBit as ix, testBit bs ix) of
+      (False, False) -> S0
+      (True,  False) -> S1
+      (False, True)  -> SZ
+      (True,  True)  -> SX
+
+instance (KnownNat n, 1 <= n) => UnsafeReceive (Vector n) where
+  type Received (Vector n) = Ptr CVector
+
+  unsafeReceive =
+    let size = fromIntegral (natVal (Proxy @n))
+        len  = div (size - 1) 32 + 1
+     in fmap cvectorListToVector . IO.liftIO . FFI.peekArray len
+
+instance (KnownNat n, 1 <= n) => Receive (Vector n) where
+  receive =
+    let size = fromIntegral (natVal (Proxy @n))
+        len  = div (size - 1) 32 + 1
+     in fmap cvectorListToVector . IO.liftIO . FFI.peekArray len
+
+-- Orphan instances for BitVector
+
+bitVectorToVector :: KnownNat n => BitVector n -> Vector n
+bitVectorToVector =
+  fmap bitToScalar . unpack
+
+vectorToBitVector :: forall n. KnownNat n => Vector n -> BitVector n
+vectorToBitVector vec =
+  Vec.ifoldr go (deepErrorX "vectorToBitVector") vec
+ where
+  go :: Index n -> Scalar -> BitVector n -> BitVector n
+  go ix s = replaceBit ix (scalarToBit s)
+
+instance (KnownNat n, 1 <= n) => UnsafeReceive (BitVector n) where
+  type Received (BitVector n) = Received (Vector n)
+
+  unsafeReceive =
+    fmap vectorToBitVector . unsafeReceive
+
+instance (KnownNat n, 1 <= n) => Receive (BitVector n) where
+  receive =
+    fmap vectorToBitVector . receive
+

--- a/clash-ffi/src/Clash/FFI/View.hs
+++ b/clash-ffi/src/Clash/FFI/View.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Clash.FFI.View
+  ( -- * Views on Data for FFI
+    UnsafeSend(..)
+  , UnsafeReceive(..)
+  , Send(..)
+  , Receive(..)
+    -- * Pointers
+  , unsafePokeSend
+  , pokeSend
+  , unsafePeekReceive
+  , peekReceive
+    -- * Arrays
+  , unsafeSendArray
+  , sendArray
+  , unsafeReceiveArray0
+  , receiveArray0
+  , unsafeReceiveArrayN
+  , receiveArrayN
+    -- * Strings
+  , unsafeSendString
+  , sendString
+  , receiveString
+  ) where
+
+import qualified Control.Monad.IO.Class as IO (liftIO)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS (length, packCString)
+import qualified Data.ByteString.Unsafe as BS
+import           Foreign.C.String (CString)
+import qualified Foreign.C.String as FFI
+import qualified Foreign.Marshal.Alloc as FFI (mallocBytes)
+import qualified Foreign.Marshal.Array as FFI
+import qualified Foreign.Marshal.Utils as FFI (copyBytes)
+import           Foreign.Ptr (Ptr)
+import qualified Foreign.Ptr as FFI (nullPtr)
+import           Foreign.Storable (Storable)
+import qualified Foreign.Storable as FFI (peek, poke)
+import           GHC.Stack (HasCallStack)
+
+import           Clash.FFI.Monad (SimCont)
+import qualified Clash.FFI.Monad as Sim
+
+-- | A class for data with raw values which can be unsafely sent over the FFI.
+-- Any modification to this value will silently modify the original value,
+-- potentially corrupting the Haskell RTS state.
+class UnsafeSend a where
+  type Sent a
+
+  unsafeSend :: HasCallStack => a -> SimCont b (Sent a)
+
+-- | A class for data with raw values which can be safely sent over the FFI.
+-- Safely sending data involves making new copies where necessary, so the
+-- original value is not corrupted if the FFI call is impure. Memory allocated
+-- by this class must be manually deallocated.
+class UnsafeSend a => Send a where
+  send :: HasCallStack => a -> SimCont b (Sent a)
+
+instance Storable a => UnsafeSend [a] where
+  type Sent [a] = Ptr a
+
+  unsafeSend xs =
+    Sim.liftCont (FFI.withArray xs)
+
+instance Storable a => Send [a] where
+  send =
+    IO.liftIO . FFI.newArray
+
+instance (UnsafeSend a, Storable (Sent a)) => UnsafeSend (Maybe a) where
+  type Sent (Maybe a) = Ptr (Sent a)
+
+  unsafeSend =
+    maybe (pure FFI.nullPtr) unsafePokeSend
+
+instance (Send a, Storable (Sent a)) => Send (Maybe a) where
+  send =
+    maybe (pure FFI.nullPtr) pokeSend
+
+unsafePokeSend
+  :: (UnsafeSend a, Storable (Sent a))
+  => a
+  -> SimCont b (Ptr (Sent a))
+unsafePokeSend x = do
+  raw <- unsafeSend x
+  fst <$> Sim.withNewPtr Sim.stackPtr (`FFI.poke` raw)
+
+pokeSend
+  :: (Send a, Storable (Sent a))
+  => a
+  -> SimCont b (Ptr (Sent a))
+pokeSend x = do
+  raw <- send x
+  fst <$> Sim.withNewPtr Sim.heapPtr (`FFI.poke` raw)
+
+-- | Send an array by unsafely sending both the elements and the array itself.
+unsafeSendArray
+  :: (UnsafeSend a, Storable (Sent a))
+  => [a]
+  -> SimCont b (Ptr (Sent a))
+unsafeSendArray arr =
+  traverse unsafeSend arr >>= unsafeSend
+
+-- | Send an array by safely sending both the elements and the array itself.
+-- The array and elements will need to be explicitly deallocated.
+sendArray
+  :: (Send a, Storable (Sent a))
+  => [a]
+  -> SimCont b (Ptr (Sent a))
+sendArray arr =
+  traverse send arr >>= send
+
+-- | Send a string by taking a temporary view of the String as a CString.
+unsafeSendString :: String -> SimCont b CString
+unsafeSendString str =
+  Sim.liftCont (FFI.withCString str)
+
+-- | Send a string by allocating a new CString which must be explicitly freed.
+sendString :: String -> SimCont b CString
+sendString str =
+  IO.liftIO (FFI.newCString str)
+
+instance UnsafeSend ByteString where
+  type Sent ByteString = CString
+
+  unsafeSend str =
+    Sim.liftCont (BS.unsafeUseAsCString str)
+
+instance Send ByteString where
+  send str = do
+    cstr <- unsafeSend str
+    let len = BS.length str + 1
+
+    IO.liftIO $ do
+      bytes <- FFI.mallocBytes len
+      FFI.copyBytes bytes cstr len
+
+      pure bytes
+
+class UnsafeReceive a where
+  type Received a
+
+  unsafeReceive :: HasCallStack => Received a -> SimCont b a
+
+class UnsafeReceive a => Receive a where
+  receive :: HasCallStack => Received a -> SimCont b a
+
+instance (UnsafeReceive a, Storable (Received a)) => UnsafeReceive (Maybe a) where
+  type Received (Maybe a) = Ptr (Received a)
+
+  unsafeReceive ptr
+    | ptr == FFI.nullPtr
+    = pure Nothing
+
+    | otherwise
+    = Just <$> unsafePeekReceive ptr
+
+instance (Receive a, Storable (Received a)) => Receive (Maybe a) where
+  receive ptr
+    | ptr == FFI.nullPtr
+    = pure Nothing
+
+    | otherwise
+    = Just <$> peekReceive ptr
+
+instance UnsafeReceive ByteString where
+  type Received ByteString = CString
+
+  unsafeReceive =
+    IO.liftIO . BS.unsafePackCString
+
+instance Receive ByteString where
+  receive =
+    IO.liftIO . BS.packCString
+
+unsafePeekReceive
+  :: (UnsafeReceive a, Storable (Received a))
+  => Ptr (Received a)
+  -> SimCont b a
+unsafePeekReceive ptr =
+  IO.liftIO (FFI.peek ptr) >>= unsafeReceive
+
+peekReceive
+  :: (Receive a, Storable (Received a))
+  => Ptr (Received a)
+  -> SimCont b a
+peekReceive ptr =
+  IO.liftIO (FFI.peek ptr) >>= receive
+
+unsafeReceiveArray0
+  :: (UnsafeReceive a, Eq (Received a), Storable (Received a))
+  => Received a
+  -> Ptr (Received a)
+  -> SimCont b [a]
+unsafeReceiveArray0 end ptr =
+  IO.liftIO (FFI.peekArray0 end ptr) >>= traverse unsafeReceive
+
+receiveArray0
+  :: (Receive a, Eq (Received a), Storable (Received a))
+  => Received a
+  -> Ptr (Received a)
+  -> SimCont b [a]
+receiveArray0 end ptr =
+  IO.liftIO (FFI.peekArray0 end ptr) >>= traverse receive
+
+unsafeReceiveArrayN
+  :: (UnsafeReceive a, Storable (Received a))
+  => Int
+  -> Ptr (Received a)
+  -> SimCont b [a]
+unsafeReceiveArrayN len ptr =
+  IO.liftIO (FFI.peekArray len ptr) >>= traverse unsafeReceive
+
+receiveArrayN
+  :: (Receive a, Storable (Received a))
+  => Int
+  -> Ptr (Received a)
+  -> SimCont b [a]
+receiveArrayN len ptr =
+  IO.liftIO (FFI.peekArray len ptr) >>= traverse receive
+
+receiveString :: CString -> SimCont b String
+receiveString =
+  IO.liftIO . FFI.peekCString
+


### PR DESCRIPTION
This PR introduces the `clash-ffi` package, providing a means to interface with simulation tools over a standard interface (currently only VPI, the _Verilog Procedural Interface_). This package supersedes `clash-cosim`, which can be re-implemented on top of `clash-ffi` later if desired.

## Still TODO:

  - [ ] Implement parsers for reading bitstrings as `BitVector n` / `Vec n Scalar`
  - [ ] Move property, time and value under `Clash.FFI.VPI.Object`, expose operations from relevant modules with classes (similar to how VPI methods for getting child objects are already implemented)
  - [ ] Document public API
  - [ ] Add developer source notes for internal design choices
  - [ ] Integrate into CI / DevOps processes
  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
