### PR TITLE
Don't render "(end)generate" in (System)Verilog

### DIFF
--- a/changelog/2022-05-02T10_35_19+02_00_remove_generate_tags.md
+++ b/changelog/2022-05-02T10_35_19+02_00_remove_generate_tags.md
@@ -1,0 +1,2 @@
+CHANGED: Clash no longer renders the "generate" and "endgenerate" keywords in (System)Verilog, since these are purely optional.
+This means the ~GENERATE and ~ENDGENERATE blackbox tags are now noops, however for backwards compatibility they can still be parsed.

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -122,8 +122,6 @@ class HasIdentifierSet state => Backend state where
   hdlRecSel        :: HWType -> Int -> Ap (State state) Doc
   -- | Create a signal declaration from an identifier (Text) and Netlist HWType
   hdlSig           :: LT.Text -> HWType -> Ap (State state) Doc
-  -- | Create a generative block statement marker
-  genStmt          :: Bool -> State state Doc
   -- | Turn a Netlist Declaration to a HDL concurrent block
   inst             :: Declaration  -> Ap (State state) (Maybe Doc)
   -- | Turn a Netlist expression into a HDL expression

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -71,7 +71,6 @@ data SystemVerilogState =
   SystemVerilogState
     { _tyCache   :: HashSet HWType -- ^ Previously encountered  HWTypes
     , _nameCache :: HashMap HWType Identifier -- ^ Cache for previously generated product type names
-    , _genDepth  :: Int -- ^ Depth of current generative block
     , _modNm     :: ModName
     , _topNm     :: Identifier
     , _idSeen    :: IdentifierSet
@@ -104,7 +103,6 @@ instance Backend SystemVerilogState where
   initBackend opts = SystemVerilogState
     { _tyCache=HashSet.empty
     , _nameCache=HashMap.empty
-    , _genDepth=0
     , _modNm=""
     , _topNm=Id.unsafeMake ""
     , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) SystemVerilog
@@ -148,16 +146,6 @@ instance Backend SystemVerilogState where
   hdlTypeMark     = verilogTypeMark
   hdlRecSel       = verilogRecSel
   hdlSig t ty     = sigDecl (string t) ty
-  genStmt True    = do cnt <- use genDepth
-                       genDepth += 1
-                       if cnt > 0
-                          then emptyDoc
-                          else "generate"
-  genStmt False   = do genDepth -= 1
-                       cnt <- use genDepth
-                       if cnt > 0
-                          then emptyDoc
-                          else "endgenerate"
   inst            = inst_
   expr            = expr_
   iwWidth         = use intWidth

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -210,7 +210,6 @@ instance Backend VHDLState where
   hdlTypeMark     = qualTyName
   hdlRecSel       = vhdlRecSel
   hdlSig t ty     = sigDecl (pretty t) ty
-  genStmt         = const emptyDoc
   inst            = inst_
   expr            = expr_
   iwWidth         = use intWidth

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -32,7 +32,7 @@ module Clash.Backend.Verilog
 where
 
 import qualified Control.Applicative                  as A
-import           Control.Lens                         (Lens',(+=),(-=),(.=),(%=), makeLenses, use)
+import           Control.Lens                         (Lens',(.=),(%=), makeLenses, use)
 import           Control.Monad                        (forM)
 import           Control.Monad.State                  (State)
 import           Data.Bifunctor                       (first, second)
@@ -82,8 +82,7 @@ import           Clash.Util
 -- | State for the 'Clash.Backend.Verilog.VerilogM' monad:
 data VerilogState =
   VerilogState
-    { _genDepth  :: Int -- ^ Depth of current generative block
-    , _idSeen    :: IdentifierSet
+    { _idSeen    :: IdentifierSet
     , _topNm     :: Identifier
     , _srcSpan   :: SrcSpan
     , _includes  :: [(String,Doc)]
@@ -110,8 +109,7 @@ instance HasIdentifierSet VerilogState where
 
 instance Backend VerilogState where
   initBackend opts = VerilogState
-    { _genDepth=0
-    , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) Verilog
+    { _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) Verilog
     , _topNm=Id.unsafeMake ""
     , _srcSpan=noSrcSpan
     , _includes=[]
@@ -144,16 +142,6 @@ instance Backend VerilogState where
   hdlTypeMark     = verilogTypeMark
   hdlRecSel       = verilogRecSel
   hdlSig t ty     = sigDecl (string t) ty
-  genStmt True    = do cnt <- use genDepth
-                       genDepth += 1
-                       if cnt > 0
-                          then emptyDoc
-                          else "generate"
-  genStmt False   = do genDepth -= 1
-                       cnt <- use genDepth
-                       if cnt > 0
-                          then emptyDoc
-                          else "endgenerate"
   inst            = inst_
   expr            = expr_
   iwWidth         = use intWidth

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
                     2017     , Myrtle Software Ltd,
-                    2021     , QBayLogic B.V.
+                    2021-2022, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -97,8 +97,6 @@ pTagE =  Result            <$  string "~RESULT"
      <|> Depth             <$> (string "~DEPTH" *> brackets' pTagE)
      <|> MaxIndex          <$> (string "~MAXINDEX" *> brackets' pTagE)
      <|> FilePath          <$> (string "~FILE" *> brackets' pTagE)
-     <|> Gen               <$> (True <$ string "~GENERATE")
-     <|> Gen               <$> (False <$ string "~ENDGENERATE")
      <|> (`SigD` Nothing)  <$> (string "~SIGDO" *> brackets' pSigD)
      <|> SigD              <$> (string "~SIGD" *> brackets' pSigD) <*> (Just <$> (brackets' natural'))
      <|> IW64              <$  string "~IW64"
@@ -130,6 +128,10 @@ pTagE =  Result            <$  string "~RESULT"
      <|> IsInitDefined     <$> (string "~ISINITDEFINED" *> brackets' natural')
      <|> CtxName           <$  string "~CTXNAME"
      <|> LongestPeriod     <$  string "~LONGESTPERIOD"
+
+     -- Removed (parsed for backcompat):
+     <|> Text ""           <$ string "~GENERATE"
+     <|> Text ""           <$ string "~ENDGENERATE"
 
 natural' :: TokenParsing m => m Int
 natural' = fmap fromInteger natural

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -149,8 +149,6 @@ data Element
   -- ^ Hole containing a filepath for a data file
   | Template [Element] [Element]
   -- ^ Create data file <HOLE0> with contents <HOLE1>
-  | Gen !Bool
-  -- ^ Hole marking beginning (True) or end (False) of a generative construct
   | IF !Element [Element] [Element]
   | And [Element]
   | IW64

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -701,7 +701,6 @@ renderTag b (MaxIndex e) = return . Text.pack . show . vecLen $ lineToType b [e]
 
 renderTag b e@(TypElem _)   = let ty = lineToType b [e]
                               in  renderOneLine <$> getAp (hdlType Internal ty)
-renderTag _ (Gen b)         = renderOneLine <$> genStmt b
 renderTag _ (GenSym [Text t] _) = return t
 
 -- Determine variables used in argument /n/.
@@ -898,7 +897,6 @@ prettyElem (MaxIndex e) = do
 prettyElem (FilePath e) = do
   e' <- prettyElem e
   renderOneLine <$> (string "~FILE" <> brackets (string e'))
-prettyElem (Gen b) = if b then return "~GENERATE" else return "~ENDGENERATE"
 prettyElem (IF b esT esF) = do
   b' <- prettyElem b
   esT' <- prettyBlackBox esT
@@ -1031,7 +1029,6 @@ walkElement f el = maybeToList (f el) ++ walked
         Length e -> go e
         Depth e -> go e
         MaxIndex e -> go e
-        Gen _ -> []
         And es -> concatMap go es
         CmpLE e1 e2 -> go e1 ++ go e2
         IW64 -> []
@@ -1115,7 +1112,6 @@ getUsedArguments (N.BBTemplate t) = nub (concatMap (walkElement matchArg) t)
         DevNull _ -> Nothing
         Err _ -> Nothing
         FilePath _ -> Nothing
-        Gen _ -> Nothing
         GenSym _ _ -> Nothing
         HdlSyn _ -> Nothing
         IF _ _ _ -> Nothing


### PR DESCRIPTION
The `generate` and `endgenerate` pairs in (System)Verilog are not
required, and introduce an arbitrary restriction that they cannot
be nested. We can ignore this special case by simply not rendering
the keywords, as generate statements can be written as normal
concurrent statements.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
