### PR TITLE
Fix bit repr deriving for Records and Infix data types

### DIFF
--- a/changelog/2022-05-06T14_53_06+02_00_add_bitrepr_deriving_constr_support
+++ b/changelog/2022-05-06T14_53_06+02_00_add_bitrepr_deriving_constr_support
@@ -1,0 +1,1 @@
+ADDED: Added support for records and infix constructors when using `Clash.Annotations.BitRepresentation.Deriving.deriveAnnotation`.

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -1,6 +1,7 @@
 {-|
 Copyright  :  (C) 2018, Google Inc.,
                   2022, QBayLogic B.V.
+                  2022, LUMI GUIDE FIETSDETECTIE B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -183,6 +184,10 @@ resolve _nmap t = error $ "Unexpected type: " ++ show t
 resolveCon :: NameMap -> Con -> Con
 resolveCon nmap (NormalC t (unzip -> (bangs, fTypes))) =
   NormalC t $ zip bangs $ map (resolve nmap) fTypes
+resolveCon nmap (RecC t (unzip3 -> (name, bangs, fTypes))) =
+  RecC t $ zip3 name bangs $ map (resolve nmap) fTypes
+resolveCon nmap (InfixC (leftB, leftTy) t (rightB, rightTy)) =
+  InfixC (leftB, resolve nmap leftTy) t (rightB, resolve nmap rightTy)
 resolveCon _name constr =
   error $ "Unexpected constructor: " ++ show constr
 

--- a/clash-prelude/tests/Clash/Tests/DerivingDataRepr.hs
+++ b/clash-prelude/tests/Clash/Tests/DerivingDataRepr.hs
@@ -10,7 +10,7 @@ import Test.Tasty.HUnit
 import Prelude ((=<<), ($))
 import Clash.Annotations.BitRepresentation
 import Clash.Annotations.BitRepresentation.Deriving
-import Clash.Tests.DerivingDataReprTypes (Train(..), RGB(..))
+import Clash.Tests.DerivingDataReprTypes (Train(..), RGB(..), Headphones(..), EarCup(..))
 import Data.Maybe (Maybe(..))
 
 ---------------------------------------------------------
@@ -29,6 +29,29 @@ oneHotOverlapRepr' =
     , ConstrRepr 'Maintenance 64  64  []
     , ConstrRepr 'Toy         128 128 []
     ]
+
+oneHotOverlapReprRec :: DataReprAnn
+oneHotOverlapReprRec = $( (simpleDerivator OneHot OverlapL) =<< [t| Headphones |] )
+
+oneHotOverlapReprRec' :: DataReprAnn
+oneHotOverlapReprRec' =
+  DataReprAnn
+    $(liftQ [t| Headphones |])
+    4
+    [ ConstrRepr 'InEar   4  4  [0b10]
+    , ConstrRepr 'OverEar 8  8  [0b11]
+    ]
+
+oneHotOverlapReprInfix :: DataReprAnn
+oneHotOverlapReprInfix = $( (simpleDerivator OneHot OverlapL) =<< [t| EarCup |] )
+
+oneHotOverlapReprInfix' :: DataReprAnn
+oneHotOverlapReprInfix' =
+  DataReprAnn
+    $(liftQ [t| EarCup |])
+    5
+    [ ConstrRepr '(:<>:) 16  16  [0b1100,0b0011] ]
+
 
 oneHotWideRepr :: DataReprAnn
 oneHotWideRepr = $( (simpleDerivator OneHot Wide) =<< [t| Train |] )
@@ -109,10 +132,12 @@ packedMaybeRGB' =
 -- MAIN
 tests :: TestTree
 tests = testGroup "DerivingDataRepr"
-  [ testCase "OneHotOverlap" $ oneHotOverlapRepr @?= oneHotOverlapRepr'
-  , testCase "OneHotWide"    $ oneHotWideRepr    @?= oneHotWideRepr'
-  , testCase "BinaryOverlap" $ countOverlapRepr  @?= countOverlapRepr'
-  , testCase "BinaryWide"    $ countWideRepr     @?= countWideRepr'
-  , testCase "Packed"        $ packedRepr        @?= packedRepr'
-  , testCase "PackedMaybe"   $ packedMaybeRGB    @?= packedMaybeRGB'
+  [ testCase "OneHotOverlap"      $ oneHotOverlapRepr      @?= oneHotOverlapRepr'
+  , testCase "OneHotOverlapRec"   $ oneHotOverlapReprRec   @?= oneHotOverlapReprRec'
+  , testCase "OneHotOverlapInfix" $ oneHotOverlapReprInfix @?= oneHotOverlapReprInfix'
+  , testCase "OneHotWide"         $ oneHotWideRepr         @?= oneHotWideRepr'
+  , testCase "BinaryOverlap"      $ countOverlapRepr       @?= countOverlapRepr'
+  , testCase "BinaryWide"         $ countWideRepr          @?= countWideRepr'
+  , testCase "Packed"             $ packedRepr             @?= packedRepr'
+  , testCase "PackedMaybe"        $ packedMaybeRGB         @?= packedMaybeRGB'
   ]

--- a/clash-prelude/tests/Clash/Tests/DerivingDataReprTypes.hs
+++ b/clash-prelude/tests/Clash/Tests/DerivingDataReprTypes.hs
@@ -29,3 +29,11 @@ data RGB
 
 deriveDefaultAnnotation [t| RGB |]
 deriveBitPack [t| RGB |]
+
+data Headphones
+  = InEar
+      { _wireless :: Bool }
+  | OverEar
+      { _impedance :: SmallInt }
+
+data EarCup = SmallInt :<>: SmallInt


### PR DESCRIPTION
There were some missing constructors. GADT still aren't supported.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

I didn't update the copyright in the test files since it seems that test files don't have copyright notices.