### PR TITLE
Test suite: fix topEntity inclusion Ram/RMultiTop

### DIFF
--- a/tests/shouldwork/Signal/Ram/RMulti.hs
+++ b/tests/shouldwork/Signal/Ram/RMulti.hs
@@ -2,44 +2,52 @@
 --
 -- Test reading with a fast clock. Memory is initialized through the write port,
 -- but after that the write side is dormant.
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module RMulti where
 
 import Clash.Explicit.Prelude
 import Clash.Explicit.Testbench
-import qualified Prelude as P
 
 createDomain vSystem{vName="P10", vPeriod=10000}
 createDomain vSystem{vName="P20", vPeriod=20000}
 
-ram
-  :: Clock P20
+type Ram =
+     Clock P20
   -> Clock P10
   -> Signal P10 (Unsigned 1)
   -> Signal P20 (Maybe (Unsigned 1, Unsigned 2))
   -> Signal P10 (Unsigned 2)
+
+ram
+  :: Ram
 ram wClk rClk = asyncRamPow2 wClk rClk enableGen
 
 tbOutput
-  :: Clock P20
+  :: Ram
+  -> Clock P20
   -> Clock P10
   -> Signal P10 (Unsigned 2)
-tbOutput wClk rClk = output
+tbOutput top wClk rClk = output
  where
   wrM = stimuliGenerator wClk wNoReset $
           Just (0, 1) :> Just (1,2) :> Nothing :> Nil
   rd = delay rClk enableGen 0 $ rd + 1
-  output = ignoreFor rClk rNoReset enableGen d2 0 $ ram wClk rClk rd wrM
+  output = ignoreFor rClk rNoReset enableGen d2 0 $ top wClk rClk rd wrM
   wNoReset = unsafeFromHighPolarity @P20 (pure False)
   rNoReset = unsafeFromHighPolarity @P10 (pure False)
+{-# INLINE tbOutput #-}
 
 tb
   :: ( KnownNat n
      , 1 <= n)
-  => Vec n (Unsigned 2)
+  => Ram
+  -> Vec n (Unsigned 2)
   -> Signal P10 Bool
-tb expectedSamples = done
+tb top expectedSamples = done
  where
-  output = tbOutput wClk rClk
+  output = tbOutput top wClk rClk
   expectedOutput = outputVerifier' rClk noReset expectedSamples
   done = expectedOutput output
   (rClk, wClk) = biTbClockGen (not <$> done) :: (Clock P10, Clock P20)

--- a/tests/shouldwork/Signal/Ram/RMultiTop.hs
+++ b/tests/shouldwork/Signal/Ram/RMultiTop.hs
@@ -15,5 +15,6 @@ topEntity = ram
 
 testBench
   :: Signal P10 Bool
-testBench = tb $(listToVecTH $ sampleN 20 $ tbOutput clockGen clockGen)
+testBench = tb topEntity
+               $(listToVecTH $ sampleN 20 $ tbOutput ram clockGen clockGen)
 {-# NOINLINE testBench #-}


### PR DESCRIPTION
Instead of `testBench` testing `topEntity`, the former included a
functionally indentical copy of the latter.

Fixes #2192

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
