### PR TITLE
Include tasty-hedgehog >= 1.2.0 in nix builds

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -27,6 +27,9 @@ let
         doctest-parallel =
          self.callCabal2nix "doctest-parallel" sources.doctest-parallel {};
 
+        tasty-hedgehog =
+         self.callCabal2nix "tasty-hedgehog" sources.tasty-hedgehog {};
+
         # Internal overrides
         clash-lib = import ../clash-lib { inherit nixpkgs; };
         clash-ghc = import ../clash-ghc { inherit nixpkgs; };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -59,6 +59,14 @@
         "url": "https://github.com/clash-lang/ghc-typelits-natnormalise/archive/91d80e63378ac4009f0475f54c54f81eca4de0ed.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "tasty-hedgehog": {
+        "homepage": null,
+        "rev": "1.2.0.0",
+        "sha256": "sha256:0yqw2sjvfr8msqfwywssp4wyx754jvjbc9yhjz8qn5kxg7j3vzs3",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/tasty-hedgehog-1.2.0.0/tasty-hedgehog-1.2.0.0.tar.gz",
+        "url_template": "https://hackage.haskell.org/package/tasty-hedgehog-<rev>/tasty-hedgehog-<rev>.tar.gz"
+    },
     "gitignore": {
         "branch": "master",
         "description": "Nix function for filtering local git sources",


### PR DESCRIPTION
566227d30c947ebdefa11dba31dcf0f2ba7dc439 introduced a version bump for
tasty-hedgehog, but failed to make sure the nix builds continued to
work. Note that this didn't show up on CI, due to tests not being built
there. We should probably fix that at some point..