### PR TITLE
Various deriving bitrepr fixes

### DIFF
--- a/changelog/2022-05-12T18_44_42+02_00_cse_deriveAnnotation
+++ b/changelog/2022-05-12T18_44_42+02_00_cse_deriveAnnotation
@@ -1,0 +1,1 @@
+FIXED: `Clash.Annotations.BitRepresentation.Deriving.deriveAnnotation` no longer has quadratic complexity in the size of the constructors and fields.

--- a/changelog/2022-05-16T10_06_57+02_00_bitrepr_symbols
+++ b/changelog/2022-05-16T10_06_57+02_00_bitrepr_symbols
@@ -1,0 +1,1 @@
+FIXED: Added support for symbols in types while deriving bit representation.

--- a/changelog/2022-05-16T10_13_47+02_00_bitrepr_promoted
+++ b/changelog/2022-05-16T10_13_47+02_00_bitrepr_promoted
@@ -1,0 +1,1 @@
+FIXED: Added support for promoted data types while deriving bit representations.

--- a/changelog/2022-05-16T10_15_05+02_00_bitrepr_resolve_types
+++ b/changelog/2022-05-16T10_15_05+02_00_bitrepr_resolve_types
@@ -1,0 +1,1 @@
+FIXED: Fully resolve type synonyms when deriving bit representations.

--- a/clash-lib/src/Clash/Annotations/BitRepresentation/ClashLib.hs
+++ b/clash-lib/src/Clash/Annotations/BitRepresentation/ClashLib.hs
@@ -1,5 +1,6 @@
 {-|
 Copyright  :  (C) 2018, Google Inc.
+                  2022, LUMI GUIDE FIETSDETECTIE B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
@@ -15,12 +16,13 @@ module Clash.Annotations.BitRepresentation.ClashLib
   ) where
 
 import           Clash.Annotations.BitRepresentation.Internal
-  (Type'(AppTy',ConstTy',LitTy'))
+  (Type'(..))
 import qualified Clash.Annotations.BitRepresentation.Util as BitRepresentation
 import qualified Clash.Core.Type                          as C
 import           Clash.Core.Name                          (nameOcc)
 import qualified Clash.Netlist.Types                      as Netlist
 import           Clash.Util                               (curLoc)
+import qualified Data.Text as T                           (pack)
 
 -- Convert Core type to BitRepresentation type
 coreToType'
@@ -37,6 +39,8 @@ coreToType' (C.ConstTy (C.TyCon name)) =
   return $ ConstTy' (nameOcc name)
 coreToType' (C.LitTy (C.NumTy n)) =
   return $ LitTy' n
+coreToType' (C.LitTy (C.SymTy lit)) =
+  return $ SymLitTy' (T.pack lit)
 coreToType' e =
   Left $ $(curLoc) ++ "Unexpected type: " ++ show e
 

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -73,6 +73,7 @@ import           Data.Bits
   (shiftL, shiftR, complement, (.&.), (.|.), zeroBits, popCount, bit, testBit,
    Bits, setBit)
 import           Data.Data                  (Data)
+import           Data.Containers.ListUtils  (nubOrd)
 import           Data.List
   (mapAccumL, zipWith4, sortOn, partition)
 import           Data.Typeable              (Typeable)
@@ -253,11 +254,23 @@ conName c = case c of
   InfixC _ nm _ -> nm
   _ -> error $ "No GADT support"
 
-constrFieldSizes
-  :: Con
-  -> (Name, [Q Exp])
-constrFieldSizes con = do
-  (conName con, map typeSize $ fieldTypes con)
+mkLet :: String -> Q Exp -> (Q Dec, Q Exp)
+mkLet nm qe = do
+  let nm' = mkName nm
+  (valD (varP nm') (normalB qe) [], varE nm')
+
+fieldSizeLets :: [[Type]] -> ([Q Dec], [[Q Exp]])
+fieldSizeLets fieldtypess = (fieldSizeDecls, fieldSizessExps)
+  where
+    nums = map show [(0 :: Int)..]
+    uqFieldTypes = nubOrd (concat fieldtypess)
+    uqFieldSizes = map typeSize uqFieldTypes
+    (fieldSizeDecls, szVars) = unzip $ zipWith
+                                 (\i sz -> mkLet ("_f" ++ i) sz)
+                                 nums
+                                 uqFieldSizes
+    tySizeMap = Map.fromList (zip uqFieldTypes szVars)
+    fieldSizessExps = map (map (tySizeMap Map.!)) fieldtypess
 
 complementInteger :: Int -> Integer -> Integer
 complementInteger 0 _i = 0
@@ -309,59 +322,82 @@ oneHotConstructor ns = zip values values
   where
     values = [shiftL 1 n | n <- ns]
 
-overlapFieldAnnsL :: [[Q Exp]] -> [[Q Exp]]
-overlapFieldAnnsL fieldSizess = map go fieldSizess
+overlapFieldAnnsL :: [[Q Exp]] -> ([Q Dec], [[Q Exp]])
+overlapFieldAnnsL fieldSizess = ([maxDecl],  resExp)
   where
-    fieldSizess'  = listE $ map listE fieldSizess
-    constructorSizes = [| map sum $fieldSizess' |]
-    go fieldSizes =
+    (maxDecl, maxExp) = mkLet "_maxf" maxConstrSize
+    resExp = map go fieldSizess
+    fieldSizess' = listE $ map listE fieldSizess
+    constructorSizes = [| map (sum @[] @Int) $fieldSizess' |]
+    maxConstrSize = [| maximum $constructorSizes - 1 |]
+    go fieldsizes =
       snd $
       mapAccumL
         (\start size -> ([| $start - $size |], [| bitmask $start $size |]))
-        [| maximum $constructorSizes - 1 |]
-        fieldSizes
+        maxExp
+        fieldsizes
 
-overlapFieldAnnsR :: [[Q Exp]] -> [[Q Exp]]
-overlapFieldAnnsR fieldSizess = map go fieldSizess
+overlapFieldAnnsR :: [[Q Exp]] -> ([Q Dec], [[Q Exp]])
+overlapFieldAnnsR fieldSizess = (sumFieldDecl, resExp)
   where
-    fieldSizess'  = listE $ map listE fieldSizess
-    constructorSizes = [| map sum $fieldSizess' |]
-    go fieldSizes =
+    resExp = zipWith go fieldSizess sumFieldExp
+
+    nums = map show [(0 :: Int) ..]
+
+    (sumFieldDecl, sumFieldExp)
+      = unzip $ zipWith
+          (\fs i -> mkLet ("_sumf" ++ i) [|sum @[] @Int $(listE fs)|])
+          fieldSizess
+          nums
+
+    go fieldSizes sumFieldsSize =
       snd $
       mapAccumL
         (\start size -> ([| $start - $size |], [| bitmask $start $size |]))
-        [| maximum $constructorSizes - (maximum $constructorSizes - sum $(listE fieldSizes)) - 1 |]
+        [| $sumFieldsSize - 1 |]
         fieldSizes
 
-wideFieldAnns :: [[Q Exp]] -> [[Q Exp]]
-wideFieldAnns fieldSizess = zipWith id (map go constructorOffsets) fieldSizess
+wideFieldAnns :: [[Q Exp]] -> ([Q Dec], [[Q Exp]])
+wideFieldAnns fieldSizess = (decs, resExp)
   where
-    constructorSizes =
-      map (AppE (VarE 'sum) <$>) (map listE fieldSizess)
+    decs = (dataSizeDec:constrSizeDecs) ++ constrOffsetDecs
+    resExp = zipWith id (map go constrOffsetsExps) fieldSizess
+    nums = map show [(0 :: Int) ..]
 
-    constructorOffsets :: [Q Exp]
-    constructorOffsets =
-      init $
-      scanl
-        (\offset size -> [| $offset + $size |])
-        [| 0 |]
-        constructorSizes
+    constrSizeExps :: [Q Exp]
+    (constrSizeDecs, constrSizeExps)
+      = unzip $ zipWith
+          (\fs i -> mkLet ("_sumf" ++ i) [|sum @[] @Int $(listE fs)|])
+          fieldSizess
+          nums
 
-    dataSize = [| sum $(listE constructorSizes) |]
+    constrOffsetsExps :: [Q Exp]
+    (last -> constrOffsetDecs, constrOffsetsExps) =
+      unzip $ init $ scanl
+        (\(ds, offset) (size, i) ->
+          let e = [| $offset + $size |]
+              (d, ve) = mkLet ("_constroffset" ++ i) e
+          in (d:ds, ve)
+        )
+        ([], [| 0 |])
+        (zip constrSizeExps nums)
 
+    dataSizeExp :: Q Exp
+    (dataSizeDec, dataSizeExp)
+      = mkLet "_widedatasize" [| sum @[] @Int $(listE constrSizeExps) - 1 |]
     go :: Q Exp -> [Q Exp] -> [Q Exp]
     go offset fieldSizes =
       snd $
       mapAccumL
         (\start size -> ([| $start - $size |], [| bitmask $start $size |]))
-        [| $dataSize - 1 - $offset |]
+        [| $dataSizeExp - $offset |]
         fieldSizes
 
 -- | Derive DataRepr' for a specific type.
 deriveDataRepr
   :: ([Int] -> [(BitMask, Value)])
   -- ^ Constructor derivator
-  -> ([[Q Exp]] -> [[Q Exp]])
+  -> ([[Q Exp]] -> ([Q Dec], [[Q Exp]]) )
   -- ^ Field derivator
   -> Derivator
 deriveDataRepr constrDerivator fieldsDerivator typ = do
@@ -370,34 +406,52 @@ deriveDataRepr constrDerivator fieldsDerivator typ = do
     (TyConI (DataD [] _constrName vars _kind dConstructors _clauses)) ->
       let varMap = Map.fromList $ zip (map tyVarBndrName vars) typeArgs in
       let resolvedConstructors = map (resolveCon varMap) dConstructors in do
+      let nums = map show [(0 :: Int)..]
+      let fieldtypess = map fieldTypes resolvedConstructors
+
+      let (fieldSzDecs, fieldSizess) = fieldSizeLets fieldtypess
 
       -- Get sizes and names of all constructors
-      let
-        (constrNames, fieldSizess) =
-          unzip $ map constrFieldSizes resolvedConstructors
+      let constrNames = map conName resolvedConstructors
 
       let
         (constrMasks, constrValues) =
           unzip $ constrDerivator [0..length dConstructors - 1]
 
-      let constrSize    = 1 + (msb $ maximum constrMasks)
-      let fieldAnns     = fieldsDerivator fieldSizess
-      let fieldAnnsFlat = listE $ concat fieldAnns
+      let constrSize = 1 + (msb $ maximum @[] @Integer constrMasks)
+      let (fieldDecs, fieldAnns) = fieldsDerivator fieldSizess
+
+      -- extract field annotations into declarations
+      let mkAnnDecl i j an = mkLet ("_fa" ++ i ++ "_" ++ j) an
+      let
+        fieldAnnTup =
+          zipWith (\i -> zipWith (mkAnnDecl i) nums) nums fieldAnns
+
+      let
+        (fieldAnnDecs, fieldAnnVars) =
+          (concat $ map (map fst) fieldAnnTup, map (map snd) fieldAnnTup)
+
+      let fieldAnnsFlat = listE $ concat fieldAnnVars
 
       let dataSize | null $ concat fieldAnns = [| 0 |]
-                   | otherwise = [| 1 + (msb $ maximum $ $fieldAnnsFlat) |]
+                   | otherwise = [| 1 + (msb $ maximum @[] @Integer $ $fieldAnnsFlat) |]
+
+      -- Extract data size into a declaration
+      let (dataSizeDec, dataSizeExp) = mkLet "_datasize" dataSize
+
+      let decls = (dataSizeDec:fieldSzDecs) ++ fieldDecs ++ fieldAnnDecs
 
       -- Determine at which bits various fields start
       let constrReprs = zipWith4
-                          (buildConstrRepr dataSize)
+                          (buildConstrRepr dataSizeExp)
                           constrNames
-                          fieldAnns
+                          fieldAnnVars
                           constrMasks
                           constrValues
 
-      [| DataReprAnn
+      letE decls [| DataReprAnn
           $(liftQ $ return typ)
-          ($dataSize + constrSize)
+          ($dataSizeExp + constrSize)
           $(listE constrReprs) |]
     _ ->
       fail $ "Could not derive dataRepr for: " ++ show info

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -1,5 +1,6 @@
 {-|
 Copyright  :  (C) 2018, Google Inc.
+                  2022, LUMI GUIDE FIETSDETECTIE B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
@@ -44,6 +45,8 @@ data Type'
   -- ^ Qualified name of type
   | LitTy' Integer
   -- ^ Numeral literal (used in BitVector 10, for example)
+  | SymLitTy' Text.Text
+  -- ^ Symbol literal (used in for example (Signal "System" Int))
   deriving (Generic, NFData, Eq, Typeable, Hashable, Ord, Show)
 
 -- | Internal version of DataRepr
@@ -92,6 +95,7 @@ thTypeToType' ty = go ty
     go (TH.ConT name')   = ConstTy' (thToText name')
     go (TH.AppT ty1 ty2) = AppTy' (go ty1) (go ty2)
     go (TH.LitT (TH.NumTyLit n)) = LitTy' n
+    go (TH.LitT (TH.StrTyLit lit)) = SymLitTy' (Text.pack lit)
     go _ = error $ "Unsupported type: " ++ show ty
 
 -- | Convenience type for index built by buildCustomReprs

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -93,6 +93,7 @@ thTypeToType' :: TH.Type -> Type'
 thTypeToType' ty = go ty
   where
     go (TH.ConT name')   = ConstTy' (thToText name')
+    go (TH.PromotedT name') = ConstTy' (thToText name')
     go (TH.AppT ty1 ty2) = AppTy' (go ty1) (go ty2)
     go (TH.LitT (TH.NumTyLit n)) = LitTy' n
     go (TH.LitT (TH.StrTyLit lit)) = SymLitTy' (Text.pack lit)

--- a/clash-prelude/tests/Clash/Tests/DerivingDataRepr.hs
+++ b/clash-prelude/tests/Clash/Tests/DerivingDataRepr.hs
@@ -16,15 +16,29 @@ import Data.Maybe (Maybe(..))
 ---------------------------------------------------------
 ------------ DERIVING SIMPLE REPRESENTATIONS ------------
 ---------------------------------------------------------
-oneHotOverlapRepr :: DataReprAnn
-oneHotOverlapRepr = $( (simpleDerivator OneHot OverlapL) =<< [t| Train |] )
+oneHotOverlapLRepr :: DataReprAnn
+oneHotOverlapLRepr = $( (simpleDerivator OneHot OverlapL) =<< [t| Train |] )
 
-oneHotOverlapRepr' :: DataReprAnn
-oneHotOverlapRepr' =
+oneHotOverlapLRepr' :: DataReprAnn
+oneHotOverlapLRepr' =
   DataReprAnn
     $(liftQ [t| Train |])
     8
     [ ConstrRepr 'Passenger   16  16  [0b1100]
+    , ConstrRepr 'Freight     32  32  [0b1100, 0b0011]
+    , ConstrRepr 'Maintenance 64  64  []
+    , ConstrRepr 'Toy         128 128 []
+    ]
+
+oneHotOverlapRRepr :: DataReprAnn
+oneHotOverlapRRepr = $( (simpleDerivator OneHot OverlapR) =<< [t| Train |] )
+
+oneHotOverlapRRepr' :: DataReprAnn
+oneHotOverlapRRepr' =
+  DataReprAnn
+    $(liftQ [t| Train |])
+    8
+    [ ConstrRepr 'Passenger   16  16  [0b0011]
     , ConstrRepr 'Freight     32  32  [0b1100, 0b0011]
     , ConstrRepr 'Maintenance 64  64  []
     , ConstrRepr 'Toy         128 128 []
@@ -132,7 +146,8 @@ packedMaybeRGB' =
 -- MAIN
 tests :: TestTree
 tests = testGroup "DerivingDataRepr"
-  [ testCase "OneHotOverlap"      $ oneHotOverlapRepr      @?= oneHotOverlapRepr'
+  [ testCase "OneHotOverlapL"     $ oneHotOverlapLRepr     @?= oneHotOverlapLRepr'
+  , testCase "OneHotOverlapR"     $ oneHotOverlapRRepr     @?= oneHotOverlapRRepr'
   , testCase "OneHotOverlapRec"   $ oneHotOverlapReprRec   @?= oneHotOverlapReprRec'
   , testCase "OneHotOverlapInfix" $ oneHotOverlapReprInfix @?= oneHotOverlapReprInfix'
   , testCase "OneHotWide"         $ oneHotWideRepr         @?= oneHotWideRepr'


### PR DESCRIPTION
This PR fixes the following bit representation derivation issues:

### 1. Quadratic compilation time when deriving 

The process of deriving `DataReprAnn` has quadratic complexity in the size of constructors and fields.

For example this data type:

```
data ManyCons
   = ManyCons1  (Index 10) (Index 11) (Index 12)
   | ManyCons2  (Index 11) (Index 12) (Index 13)
   | ManyCons3  (Index 12) (Index 13) (Index 14)
   | ManyCons4  (Index 13) (Index 14) (Index 15)
   | ManyCons5  (Index 14) (Index 15) (Index 16)
   | ManyCons6  (Index 15) (Index 16) (Index 17)
   | ManyCons7  (Index 16) (Index 17) (Index 18)
    
$(deriveAnnotation (simpleDerivator OneHot OverlapR) [t| ManyCons |])
$(deriveBitPack [t| ManyCons |])
```

Going from 1 constructor to all 7 yields these compilation times on my machine:

- 1 constructors: 4.84 seconds
- 2 constructors: 3.31 seconds
- 3 constructors: 4.43 seconds
- 4 constructors: 7.31 seconds
- 5 constructors: 12.06 seconds
- 6 constructors: 23.03 seconds
- 7 constructors: 47.78 seconds

The reason is that the TemplateHaskell in `deriveAnnotation` creates insanely large annotations. See [this](https://gist.github.com/rowanG077/13ac329f0690b773fb8f0c87b70b758d#file-before-cse-manycons4-txt) file  where I dumbed the splice(`-ddump-splices`) for the case with 4 constructors.

This PR fixes this issue by introducing let-bindings of commonly used sub-expressions in the generated annotation. See [here](https://gist.github.com/rowanG077/13ac329f0690b773fb8f0c87b70b758d#file-after-cse-manycons4-txt) for the generated annotation after this PR. 

A quick test shows these compilation times after this PR:

- 1 constructors: 2.55 seconds
- 2 constructors: 2.61 seconds
- 3 constructors: 2.67 seconds
- 4 constructors: 2.87 seconds
- 5 constructors: 3.11 seconds
- 6 constructors: 2.85 seconds
- 7 constructors: 2.92 seconds
- 32 constructors: 5.03 seconds

### 2. Promoted data cons and symbols

Promoted data cons and symbols weren't supported at all. Which lead to issues were you used promoted data constructed as a parameter to a type you wanted to derive a bitrepresentation for. Or if you wanted to for example use the domain somewhere in your data type.

### 3. Type synonyms weren't resolved

During the process of finding types annotation exist for there could be a mismatch because the types coming via GHC core had their type synonyms resolved. While the types coming in via the annotation hadn't. The result was that if you use a type synonym somewhere in the annotation it wouldn't be able to match it with any type in the Custom representation map. Now it always fully resolves that type during the Template Haskell phase at the annotation.  