### PR TITLE
Bound tasty-hedgehog dependency

### DIFF
--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -394,7 +394,7 @@ test-suite unittests
       hint          >= 0.7      && < 0.10,
       quickcheck-classes-base >= 0.6 && < 1.0,
       tasty         >= 1.2      && < 1.5,
-      tasty-hedgehog,
+      tasty-hedgehog < 1.2,
       tasty-hunit,
       tasty-th,
       tasty-quickcheck,


### PR DESCRIPTION
CI fails because of the deprecation of `testProperty` in
`tasty-hedgehog` 1.2.0.0. Setting an upper bound allows us to add
commits to 1.4 again.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
