### PR TITLE
Add instances for `Data.Functor.*` newtypes

### DIFF
--- a/changelog/2022-05-27T11_27_11+02_00_functor_newtype_instances.md
+++ b/changelog/2022-05-27T11_27_11+02_00_functor_newtype_instances.md
@@ -1,0 +1,1 @@
+ADDED: Clash now contains instances for `ShowX`, `NFDataX` and `BitPack` on the newtypes from the Data.Functor modules (`Identity`, `Const`, `Compose`, `Product` and `Sum`) [#2218](https://github.com/clash-lang/clash-compiler/issues/2218).

--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2017, Myrtle Software Ltd,
-                  2021,      QBayLogic B.V.,
+                  2021-2022  QBayLogic B.V.,
                   2022,      Google Inc.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -31,6 +31,11 @@ import Data.Binary.IEEE754            (doubleToWord, floatToWord, wordToDouble,
                                        wordToFloat)
 
 import Data.Complex                   (Complex)
+import Data.Functor.Compose           (Compose)
+import Data.Functor.Const             (Const)
+import Data.Functor.Identity          (Identity)
+import Data.Functor.Product           (Product)
+import Data.Functor.Sum               (Sum)
 import Data.Int
 import Data.Ord                       (Down)
 import Data.Word
@@ -448,6 +453,12 @@ instance BitPack a => BitPack (Maybe a)
 
 instance BitPack a => BitPack (Complex a)
 instance BitPack a => BitPack (Down a)
+
+instance BitPack a => BitPack (Identity a)
+instance BitPack a => BitPack (Const a b)
+instance (BitPack (f a), BitPack (g a)) => BitPack (Product f g a)
+instance (BitPack (f a), BitPack (g a)) => BitPack (Sum f g a)
+instance BitPack (f (g a)) => BitPack (Compose f g a)
 
 -- | Zero-extend a 'Bool'ean value to a 'BitVector' of the appropriate size.
 --

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -53,6 +53,11 @@ import           Control.DeepSeq     (NFData, rnf)
 import           Data.Complex        (Complex)
 import           Data.Either         (isLeft)
 import           Data.Foldable       (toList)
+import           Data.Functor.Compose (Compose)
+import           Data.Functor.Const  (Const)
+import           Data.Functor.Identity (Identity)
+import           Data.Functor.Product (Product)
+import           Data.Functor.Sum    (Sum)
 import           Data.Int            (Int8, Int16, Int32, Int64)
 import           Data.Ord            (Down (Down))
 import           Data.Ratio          (Ratio, numerator, denominator)
@@ -369,6 +374,11 @@ printX :: ShowX a => a -> IO ()
 printX x = putStrLn $ showX x
 
 instance ShowX ()
+instance ShowX a => ShowX (Identity a)
+instance ShowX a => ShowX (Const a b)
+instance (ShowX (f a), ShowX (g a)) => ShowX (Product f g a)
+instance (ShowX (f a), ShowX (g a)) => ShowX (Sum f g a)
+instance (ShowX (f (g a))) => ShowX (Compose f g a)
 
 instance {-# OVERLAPPABLE #-} ShowX a => ShowX [a] where
   showsPrecX _ = showListX
@@ -532,6 +542,11 @@ instance NFDataX Bool
 instance NFDataX a => NFDataX [a]
 instance (NFDataX a, NFDataX b) => NFDataX (Either a b)
 instance NFDataX a => NFDataX (Maybe a)
+instance NFDataX a => NFDataX (Identity a)
+instance NFDataX a => NFDataX (Const a b)
+instance (NFDataX (f a), NFDataX (g a)) => NFDataX (Product f g a)
+instance (NFDataX (f a), NFDataX (g a)) => NFDataX (Sum f g a)
+instance (NFDataX (f (g a))) => NFDataX (Compose f g a)
 
 instance NFDataX Char where
   deepErrorX = errorX


### PR DESCRIPTION
Clash now contains `BitPack`, `NFDataX` and `ShowX` instances for the
newtypes exposed in the `Data.Functor.*` modules in `base`.

Fixes #2218

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
