### PR TITLE
CI: Upgrade 8.10 to 8.10.7, Haddock to 9.0.2 (copy #2201)

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -107,7 +107,7 @@ RUN git clone https://github.com/verilator/verilator verilator \
 
 FROM builder AS build-ghc
 
-ARG ghcup_version="0.1.17.4"
+ARG ghcup_version="0.1.17.7"
 
 # Must be explicitly set
 ARG ghc_version

--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -7,7 +7,7 @@ NAME="clash-ci-"
 DIR=$(dirname "$0")
 now=$(date +%F)
 
-GHC_VERSIONS=(  "9.0.2"   "8.10.2"  "8.8.4"   "8.6.5")
+GHC_VERSIONS=(  "9.0.2"   "8.10.7"  "8.8.4"   "8.6.5")
 CABAL_VERSIONS=("3.4.0.0" "3.2.0.0" "3.2.0.0" "3.0.0.0")
 
 # We want to use docker buildkit so that our layers are built in parallel. This

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -19,7 +19,7 @@
       - runner_system_failure
       - stuck_or_timeout_failure
   cache:
-    key: cabal-store-$CI_JOB_NAME.bump1
+    key: cabal-store-$CI_JOB_NAME-$CI_JOB_IMAGE
     when: always
     paths:
       - cabal-store/

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-02-02
+  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-05-10
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,5 +1,5 @@
 .common:
-  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-02-02
+  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-05-10
   timeout: 2 hours
   stage: build
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -3,7 +3,7 @@
   timeout: 2 hours
   stage: build
   variables:
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-$GHC_VERSION-3
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-$CI_JOB_IMAGE-3
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   retry:
@@ -12,7 +12,7 @@
       - runner_system_failure
       - stuck_or_timeout_failure
   cache:
-    key: $CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$GHC_VERSION
+    key: $CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_JOB_IMAGE
     when: always
     paths:
       - cache.tar.zst

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -20,7 +20,7 @@ hackage-sdist:
   interruptible: false
   stage: publish
   cache:
-    key: hackage
+    key: hackage-$CI_JOB_IMAGE
   script:
     - .ci/publish_sdist.sh clash-prelude
     - .ci/publish_sdist.sh clash-prelude-hedgehog
@@ -55,7 +55,7 @@ debian-bindist:
       files:
         - .ci/bindist/linux/debian/focal/buildinfo.json
         - .ci/bindist/linux/debian/scripts/build.py
-      prefix: ${CI_JOB_NAME}
+      prefix: ${CI_JOB_NAME}-${CI_JOB_IMAGE}
   artifacts:
     when: always
     paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
     # Run steps inside the clash CI docker image
     container:
-      image: ghcr.io/clash-lang/clash-ci-${{ matrix.ghc }}:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-${{ matrix.ghc }}:2022-05-10
 
       env:
         THREADS: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,10 +7,10 @@ include:
   - '/.ci/gitlab/publish.yml'
 #   - '/.ci/gitlab/benchmark.yml'
 
-# Default GHC / Cabal version. Used for generating Haddock and releasing to
-# Hackage.
 variables:
-  GHC_VERSION: 8.10.2
+  # Default GHC / Cabal version. Used for generating Haddock and releasing to
+  # Hackage.
+  GHC_VERSION: 8.10.7
 
 stages:
   - pre
@@ -44,7 +44,7 @@ tests-8.8:
 tests-8.10:
   extends: .common-trigger
   variables:
-    GHC_VERSION: 8.10.2
+    GHC_VERSION: 8.10.7
 
 tests-9.0:
   extends: .common-trigger
@@ -56,7 +56,7 @@ stack-build:
   needs: []
   stage: test
   variables:
-    GHC_VERSION: 8.10.2
+    GHC_VERSION: 8.10.7
   script:
     - .ci/stack_build.sh
   # Run on shared runners
@@ -84,6 +84,8 @@ haddock:
   extends: .common
   needs: []
   stage: test
+  variables:
+    GHC_VERSION: 9.0.2
   artifacts:
     paths:
       - hadocs/*/*

--- a/clash-prelude/src/Clash/Annotations/TH.hs
+++ b/clash-prelude/src/Clash/Annotations/TH.hs
@@ -151,7 +151,7 @@ failMsg s = "TopEntity generation error: " ++ s
 errorContext :: Tracked Q String
 errorContext = asks snd
 
--- | Failure message with prefix in a 'Tracked' context
+-- Failure message with prefix in a 'Tracked' context
 failMsgWithContext :: String -> Tracked Q String
 failMsgWithContext s = (++) (failMsg s) <$> errorContext
 
@@ -402,7 +402,7 @@ gatherNames
 gatherNames =
   para typeTreeToPorts . guardPorts
 
--- | Build a possible failing 'PortName' tree and unwrap the 'Naming' result.
+-- Build a possible failing 'PortName' tree and unwrap the 'Naming' result.
 buildPorts
   :: Type
   -- ^ Type to investigate

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -194,7 +194,7 @@ type role Unsigned nominal
 -- width, use the functions in the 'Clash.Class.Resize.Resize' class.
 #if MIN_VERSION_base(4,15,0)
 data Unsigned (n :: Nat) =
-    -- | The constructor, 'U', and the field, 'unsafeToInteger', are not
+    -- | The constructor, 'U', and the field, 'unsafeToNatural', are not
     -- synthesizable.
     U { unsafeToNatural :: !Natural }
 #else


### PR DESCRIPTION
PR #2201 was marked for backporting to 1.6 but Mergify didn't pick it up. So this is a manual backport instead.