### PR TITLE
Netlist track usage

### DIFF
--- a/changelog/2022-06-21T09_53_32+02_00_netlist_usage.md
+++ b/changelog/2022-06-21T09_53_32+02_00_netlist_usage.md
@@ -1,0 +1,12 @@
+CHANGED: Blackbox templates no longer have the `outputReg` key, it has been
+replaced with the more general `outputUsage` which specifies how signals are
+used in terms of whether writes are
+
+    * continuous (i.e. a concurrent context)
+    * procedural non-blocking (i.e. `signal` in a VHDL process)
+    * procedural blocking (i.e. `variable` in a VHDL process)
+
+The `~OUTPUTWIREREG` tag continues to work for backwards compatibility, but
+there is also a new `~OUTPUTUSAGE` tag which is recommended. In the future,
+the `~OUTPUTWIREREG` tag may be removed.
+

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/IO.hs
@@ -54,7 +54,7 @@ bbTemplate bbCtx = do
         , (instPort "I", In,  Bit, dOut)
         , (instPort "O", Out, Bit, Identifier dIn Nothing)
         ])
-    , Assignment result (Identifier dIn Nothing)
+    , Assignment result Cont (Identifier dIn Nothing)
     ]
  where
   [  _HasCallStack

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -91,7 +91,7 @@ sbioTemplate bbCtx = do
       , (instPort "D_IN_0", Out, Bit, Identifier dIn0 Nothing)
       , (instPort "D_IN_1", Out, Bit, Identifier dIn1 Nothing)
       ])
-    , Assignment result resultTuple
+    , Assignment result Cont resultTuple
     ]
  where
   [ _HasCallStack

--- a/clash-lib/prims/commonverilog/Clash_Explicit_SimIO.primitives.yaml
+++ b/clash-lib/prims/commonverilog/Clash_Explicit_SimIO.primitives.yaml
@@ -29,6 +29,7 @@
     name: Clash.Explicit.SimIO.writeReg
     kind: Declaration
     renderVoid: RenderVoid
+    outputUsage: Blocking
     template: ~ARG[0] = ~ARG[1];
 - BlackBox:
     name: Clash.Explicit.SimIO.openFile
@@ -51,6 +52,7 @@
 - BlackBox:
     name: Clash.Explicit.SimIO.getLine
     kind: Declaration
+    outputUsage: Blocking
     template: ~RESULT = $fgets(~ARG[2],~ARG[1]);
 - BlackBox:
     name: Clash.Explicit.SimIO.isEOF
@@ -64,10 +66,12 @@
 - BlackBox:
     name: Clash.Explicit.SimIO.seek
     kind: Declaration
+    outputUsage: Blocking
     template: ~RESULT = $fseek(~ARG[0],~ARG[1],~ARG[2]);
 - BlackBox:
     name: Clash.Explicit.SimIO.rewind
     kind: Declaration
+    outputUsage: Blocking
     template: ~RESULT = $rewind(~ARG[0]);
 - BlackBox:
     name: Clash.Explicit.SimIO.tell

--- a/clash-lib/prims/systemverilog/Clash_Explicit_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_DDR.primitives.yaml
@@ -47,6 +47,7 @@
 - BlackBox:
     name: Clash.Explicit.DDR.ddrOut#
     kind: Declaration
+    outputUsage: Blocking
     type: |-
       ddrOut# :: ( HasCallStack               -- ARG[0]
                   , Undefined a                -- ARG[1]

--- a/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.primitives.yaml
@@ -56,6 +56,7 @@
 - BlackBox:
     name: Clash.Explicit.Testbench.tbClockGen
     kind: Declaration
+    outputUsage: Blocking
     type: |-
       tbClockGen
         :: KnownDomain dom     -- ARG[0]

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.delay#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       delay#
         :: ( KnownDomain dom        -- ARG[0]
@@ -28,6 +29,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.asyncRegister#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       asyncRegister#
         :: ( KnownDomain dom        -- ARG[0]
@@ -56,6 +58,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.register#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       register#
         :: ( KnownDomain dom        -- ARG[0]
@@ -84,6 +87,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.clockGen
     kind: Declaration
+    outputUsage: Blocking
     type: |-
       clockGen
         :: KnownDomain dom     -- ARG[0]
@@ -139,6 +143,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.resetGenN
     kind: Declaration
+    outputUsage: Blocking
     type: 'resetGenN :: (KnownDomain
       dom, 1 <= n) => SNat n -> Reset dom'
     template: |-

--- a/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Internal_BitVector.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.replaceBit#
     kind: Declaration
+    outputUsage: Blocking
     type: |-
       replaceBit# :: KnownNat n  -- ARG[0]
                    => BitVector n -- ARG[1]
@@ -17,6 +18,7 @@
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.setSlice#
     kind: Declaration
+    outputUsage: Blocking
     type: |-
       setSlice# :: SNat (m + 1 + i)
                  -> BitVector (m + 1 + i) -- ARG[1]

--- a/clash-lib/prims/systemverilog/Clash_Sized_Vector.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Sized_Vector.primitives.yaml
@@ -241,6 +241,7 @@
 - BlackBox:
     name: Clash.Sized.Vector.replace_int
     kind: Declaration
+    outputUsage: Blocking
     type: 'replace_int ::
       KnownNat n => Vec n a -> Int -> a -> Vec n a'
     template: |-

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam.primitives.yaml
@@ -1,7 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.blockRam#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       blockRam#
         :: ( KnownDomain dom        ARG[0]
@@ -52,7 +52,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.blockRamU#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       blockRamU#
         :: ( KnownDomain dom        ARG[0]
@@ -95,7 +95,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.blockRam1#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       blockRam1#
         :: ( KnownDomain dom        ARG[0]

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam_Blob.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam_Blob.primitives.yaml
@@ -1,7 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.Blob.blockRamBlob#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       blockRamBlob#
         :: KnownDomain dom           --       ARG[0]

--- a/clash-lib/prims/verilog/Clash_Explicit_BlockRam_File.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_BlockRam_File.primitives.yaml
@@ -1,7 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.File.blockRamFile#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       blockRamFile#
         :: ( KnownDomain dom         --       ARG[0]

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM.primitives.yaml
@@ -1,7 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.ROM.rom#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       rom# :: ( KnownDomain dom        ARG[0]
                , KnownNat n    --       ARG[1]

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM_Blob.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM_Blob.primitives.yaml
@@ -1,7 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.ROM.Blob.romBlob#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       romBlob#
         :: KnownDomain dom  --       ARG[0]

--- a/clash-lib/prims/verilog/Clash_Explicit_ROM_File.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_ROM_File.primitives.yaml
@@ -1,7 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.ROM.File.romFile#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       romFile# :: ( KnownNat m             --       ARG[0]
                    , KnownDomain dom      ) --       ARG[1]

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.primitives.yaml
@@ -1,7 +1,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.delay#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       delay#
         :: ( KnownDomain dom        -- ARG[0]
@@ -29,7 +29,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.asyncRegister#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       asyncRegister#
         :: ( KnownDomain dom        -- ARG[0]
@@ -58,7 +58,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.register#
     kind: Declaration
-    outputReg: true
+    outputUsage: NonBlocking
     type: |-
       register#
         :: ( KnownDomain dom        -- ARG[0]

--- a/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Sized_Internal_BitVector.primitives.yaml
@@ -1,7 +1,7 @@
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.replaceBit#
     kind: Declaration
-    outputReg: true
+    outputUsage: Blocking
     type: |-
       replaceBit# :: KnownNat n  -- ARG[0]
                    => BitVector n -- ARG[1]
@@ -18,7 +18,7 @@
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.setSlice#
     kind: Declaration
-    outputReg: true
+    outputUsage: Blocking
     type: |-
       setSlice# :: SNat (m + 1 + i)
                  -> BitVector (m + 1 + i) -- ARG[1]

--- a/clash-lib/prims/verilog/Clash_Sized_Vector.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Sized_Vector.primitives.yaml
@@ -97,7 +97,7 @@
       for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]~IF~SIZE[~TYP[1]]~THEN
         wire ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];
         assign ~SYM[3] = ~VAR[vec][1][~SYM[1]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI
-        ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~GENSYM[map_out][4];
+        ~OUTPUTUSAGE[0] ~TYPEL[~TYPO] ~GENSYM[map_out][4];
         ~INST 0
           ~OUTPUT <= ~SYM[4]~ ~TYPEL[~TYPO]~
           ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
@@ -120,7 +120,7 @@
         wire [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~GENSYM[map_index][3];~IF~SIZE[~TYP[2]]~THEN
         wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];
         assign ~SYM[4] = ~VAR[vec][2][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
-        ~OUTPUTWIREREG[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
+        ~OUTPUTUSAGE[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
 
         assign ~SYM[3] = ~SIZE[~INDEXTYPE[~LIT[0]]]'d~MAXINDEX[~TYPO] - ~SYM[1][0+:~SIZE[~INDEXTYPE[~LIT[0]]]];
         ~INST 1
@@ -146,7 +146,7 @@
         wire ~TYP[0] ~GENSYM[map_index][3];~IF~SIZE[~TYP[2]]~THEN
         wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];
         assign ~SYM[4] = ~VAR[vec][2][~SYM[1]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
-        ~OUTPUTWIREREG[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
+        ~OUTPUTUSAGE[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
 
         assign ~SYM[3] = ~SIZE[~TYP[0]]'d~MAXINDEX[~TYPO] - ~SYM[1][0+:~SIZE[~TYP[0]]] + ~ARG[0];
         ~INST 1
@@ -173,7 +173,7 @@
         assign ~SYM[3] = ~VAR[vec1][1][~SYM[2]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN
         wire ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][4];
         assign ~SYM[4] = ~VAR[vec2][2][~SYM[2]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
-        ~OUTPUTWIREREG[0] ~TYPEL[~TYPO] ~SYM[5];
+        ~OUTPUTUSAGE[0] ~TYPEL[~TYPO] ~SYM[5];
         ~INST 0
           ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
           ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
@@ -200,7 +200,7 @@
         wire ~TYPEL[~TYP[2]] ~GENSYM[foldr_in1][5];
         assign ~SYM[5] = ~VAR[xs][2][(~LENGTH[~TYP[2]]-1-~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
         wire ~TYPO ~GENSYM[foldr_in2][6];
-        ~OUTPUTWIREREG[0] ~TYPO ~GENSYM[foldr_out][7];
+        ~OUTPUTUSAGE[0] ~TYPO ~GENSYM[foldr_out][7];
 
         assign ~SYM[6] = ~SYM[0][~SYM[3]+1];
         ~INST 0

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.blockRam#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       blockRam#
         :: ( KnownDomain dom        ARG[0]
@@ -56,6 +57,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.blockRamU#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       blockRamU#
         :: ( KnownDomain dom        ARG[0]
@@ -113,6 +115,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.blockRam1#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       blockRam1#
         :: ( KnownDomain dom        ARG[0]

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_Blob.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_Blob.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.Blob.blockRamBlob#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       blockRamBlob#
         :: KnownDomain dom           --       ARG[0]

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.BlockRam.File.blockRamFile#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       blockRamFile#
         :: ( KnownDomain dom        -- ARG[0]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.ROM.rom#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       rom# :: ( KnownDomain dom        ARG[0]
                , KnownNat n    --       ARG[1]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_Blob.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_Blob.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.ROM.Blob.romBlob#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       romBlob#
         :: KnownDomain dom  --       ARG[0]

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Explicit.ROM.File.romFile#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       romFile# :: ( KnownNat m           --       ARG[0]
                    , KnownDomain dom      --       ARG[1]

--- a/clash-lib/prims/vhdl/Clash_Explicit_Testbench.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_Testbench.primitives.yaml
@@ -154,6 +154,7 @@
       ModelSim and Vivado seem to round time values to an integer number of picoseconds.
               Use two half periods to prevent rounding errors from affecting the full period.
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       tbClockGen
         :: KnownDomain dom     -- ARG[0]

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.primitives.yaml
@@ -1,6 +1,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.delay#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       delay#
         :: ( KnownDomain dom        -- ARG[0]
@@ -34,6 +35,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.asyncRegister#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       asyncRegister#
         :: ( KnownDomain dom        -- ARG[0]
@@ -69,6 +71,7 @@
 - BlackBox:
     name: Clash.Signal.Internal.register#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       register#
         :: ( KnownDomain dom        -- ARG[0]
@@ -131,6 +134,7 @@
       ModelSim and Vivado seem to round time values to an integer number of picoseconds.
               Use two half periods to prevent rounding errors from affecting the full period.
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       clockGen
         :: KnownDomain dom     -- ARG[0]

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives.yaml
@@ -252,6 +252,7 @@
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.replaceBit#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       replaceBit# :: KnownNat n  -- ARG[0]
                    => BitVector n -- ARG[1]
@@ -282,6 +283,7 @@
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.setSlice#
     kind: Declaration
+    outputUsage: NonBlocking
     type: |-
       setSlice# :: SNat (m + 1 + i)
                  => BitVector (m + 1 + i) -- ARG[1]

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives.yaml
@@ -274,6 +274,7 @@
 - BlackBox:
     name: Clash.Sized.Vector.replace_int
     kind: Declaration
+    outputUsage: NonBlocking
     type: 'replace_int ::
       KnownNat n => Vec n a -> Int -> a -> Vec n a'
     template: |-

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -2,6 +2,7 @@
   Copyright  :  (C) 2015-2016, University of Twente,
                     2017     , Myrtle Software Ltd, Google Inc.,
                     2021-2022, QBayLogic B.V.
+                    2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -26,7 +27,7 @@ import SrcLoc (SrcSpan)
 #endif
 
 import Clash.Driver.Types (ClashOpts)
-import {-# SOURCE #-} Clash.Netlist.Types
+import {-# SOURCE #-} Clash.Netlist.Types hiding (Usage)
 import Clash.Netlist.BlackBox.Types
 
 import Clash.Signal.Internal                (VDomainConfiguration)
@@ -107,7 +108,7 @@ class HasIdentifierSet state => Backend state where
   extractTypes     :: state -> HashSet HWType
 
   -- | Generate HDL for a Netlist component
-  genHDL           :: ModName -> SrcSpan -> IdentifierSet -> Component -> Ap (State state) ((String, Doc),[(String,Doc)])
+  genHDL           :: ModName -> SrcSpan -> IdentifierSet -> UsageMap -> Component -> Ap (State state) ((String, Doc),[(String,Doc)])
   -- | Generate a HDL package containing type definitions for the given HWTypes
   mkTyPackage      :: ModName -> [HWType] -> Ap (State state) [(String, Doc)]
   -- | Convert a Netlist HWType to a target HDL type

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -94,6 +94,7 @@ data SystemVerilogState =
     , _aggressiveXOptBB_ :: AggressiveXOptBB
     , _renderEnums_ :: RenderEnums
     , _domainConfigurations_ :: DomainMap
+    , _usages :: UsageMap
     }
 
 makeLenses ''SystemVerilogState
@@ -123,6 +124,7 @@ instance Backend SystemVerilogState where
     , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
     , _renderEnums_=coerce (opt_renderEnums opts)
     , _domainConfigurations_=emptyDomainMap
+    , _usages=mempty
     }
   hdlKind         = const SystemVerilog
   primDirs        = const $ do root <- primsRoot
@@ -201,17 +203,20 @@ genSystemVerilog
   :: ModName
   -> SrcSpan
   -> IdentifierSet
+  -> UsageMap
   -> Component
   -> SystemVerilogM ((String, Doc), [(String, Doc)])
-genSystemVerilog _ sp seen c = do
+genSystemVerilog _ sp seen us c = do
     -- Don't have type names conflict with module names or with previously
     -- generated type names.
     --
     -- TODO: Collect all type names up front, to prevent relatively costly union.
     -- TODO: Investigate whether type names / signal names collide in the first place
-    Ap $ idSeen %= Id.union seen
+    Ap $ do
+      idSeen %= Id.union seen
+      usages .= us
+      setSrcSpan sp
 
-    Ap $ setSrcSpan sp
     v    <- verilog
     incs <- Ap $ use includes
     return ((TextS.unpack (Id.toText cName), v), incs)
@@ -525,7 +530,7 @@ module_ c =
   modEnding  = "endmodule"
 
   inPorts  = sequence [ sigPort (Nothing,isBiSignalIn ty) (i,ty) Nothing | (i,ty)  <- inputs c  ]
-  outPorts = sequence [ sigPort (Just wr,False) p iEM | (wr, p, iEM) <- outputs c ]
+  outPorts = sequence [ sigPort (Just u,False) p iEM | (u, p, iEM) <- outputs c ]
 
   -- NOTE [net types and data types]
   --
@@ -676,7 +681,7 @@ decls ds = do
       _  -> punctuate' semi (A.pure dsDoc)
 
 decl :: Declaration -> SystemVerilogM (Maybe Doc)
-decl (NetDecl' noteM _ id_ tyE iEM) =
+decl (NetDecl' noteM id_ tyE iEM) =
   Just A.<$> maybe id addNote noteM (addAttrs attrs (typ tyE))
   where
     typ ty = sigDecl (pretty id_) ty <> iE
@@ -789,7 +794,7 @@ inst_ (TickDecl {}) = return Nothing
 
 inst_ (CompDecl {}) = return Nothing
 
-inst_ (Assignment id_ e) = fmap Just $
+inst_ (Assignment id_ Cont e) = fmap Just $
   "assign" <+> pretty id_ <+> equals <+> align (expr_ False e <> semi)
 
 inst_ (CondAssignment id_ ty scrut _ [(Just (BoolLit b), l),(_,r)]) = fmap Just $ do
@@ -880,6 +885,9 @@ inst_ (NetDecl' {}) = return Nothing
 inst_ (ConditionalDecl cond ds) = Just <$>
   "`ifdef" <+> pretty cond <> line <> indent 2 (insts ds) <> line <> "`endif"
 
+inst_ d =
+  error ("inst_: " ++ show d)
+
 -- | Render a data constructor application for data constructors having a
 -- custom bit representation.
 customReprDataCon
@@ -964,8 +972,9 @@ seq_ (Branch scrut scrutTy es) =
           "end") <:> conds es'
 
 seq_ (SeqDecl sd) = case sd of
-  Assignment id_ e ->
-    pretty id_ <+> equals <+> expr_ False e <> semi
+  Assignment id_ (Proc b) e ->
+    let sym = case b of { Blocking -> equals; NonBlocking -> "<=" }
+     in pretty id_ <+> sym <+> expr_ False e <> semi
 
   BlackBoxD {} ->
     fromMaybe <$> emptyDoc <*> inst_ sd

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -2,6 +2,7 @@
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
                      2021-2022, QBayLogic B.V.
+                     2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -678,10 +679,9 @@ decl :: Declaration -> SystemVerilogM (Maybe Doc)
 decl (NetDecl' noteM _ id_ tyE iEM) =
   Just A.<$> maybe id addNote noteM (addAttrs attrs (typ tyE))
   where
-    typ (Left  ty) = stringS ty <+> pretty id_ <> iE
-    typ (Right ty) = sigDecl (pretty id_) ty <> iE
+    typ ty = sigDecl (pretty id_) ty <> iE
     addNote n = mappend ("//" <+> stringS n <> line)
-    attrs = fromMaybe [] (hwTypeAttrs A.<$> either (const Nothing) Just tyE)
+    attrs = fromMaybe [] (hwTypeAttrs A.<$> Just tyE)
     iE = maybe emptyDoc (noEmptyInit . expr_ False) iEM
 
 decl _ = return Nothing

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -2,6 +2,7 @@
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
                      2021-2022, QBayLogic B.V.
+                     2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -334,10 +335,10 @@ uselibs xs = line <>
   indent 2 (string "`uselib" <+> (hsep (mapM (\l -> ("lib=" <> string l)) xs)))
   <> line <> line
 
-wireRegFileDoc :: WireOrReg -> (Either a HWType) -> VerilogM Doc
-wireRegFileDoc _    (Right FileType) = "integer"
-wireRegFileDoc Wire _                = "wire"
-wireRegFileDoc Reg  _                = "reg"
+wireRegFileDoc :: WireOrReg -> HWType -> VerilogM Doc
+wireRegFileDoc _    FileType  = "integer"
+wireRegFileDoc Wire _         = "wire"
+wireRegFileDoc Reg  _         = "reg"
 
 verilogType :: HWType -> VerilogM Doc
 verilogType t = case t of
@@ -406,10 +407,9 @@ decl :: Declaration -> VerilogM (Maybe Doc)
 decl (NetDecl' noteM wr id_ tyE iEM) =
   Just A.<$> maybe id addNote noteM (addAttrs attrs (wireRegFileDoc wr tyE <+> tyDec tyE))
   where
-    tyDec (Left  ty) = stringS ty <+> pretty id_ <> iE
-    tyDec (Right ty) = sigDecl (pretty id_) ty <> iE
+    tyDec ty = sigDecl (pretty id_) ty <> iE
     addNote n = mappend ("//" <+> stringS n <> line)
-    attrs = fromMaybe [] (hwTypeAttrs A.<$> either (const Nothing) Just tyE)
+    attrs = fromMaybe [] (hwTypeAttrs A.<$> Just tyE)
     iE    = maybe emptyDoc (noEmptyInit . expr_ False) iEM
 
 decl _ = return Nothing

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -662,14 +662,14 @@ compilePrimitive idirs pkgDbs topDir (BlackBoxHaskell bbName wf usedArgs multiRe
       loadImportAndInterpret idirs args topDir qualMod funcName "BlackBoxFunction"
 
 compilePrimitive idirs pkgDbs topDir
-  (BlackBox pNm wf rVoid multiRes tkind () oReg libM imps fPlural incs rM riM templ) = do
+  (BlackBox pNm wf rVoid multiRes tkind () outputUsage libM imps fPlural incs rM riM templ) = do
   libM'  <- mapM parseTempl libM
   imps'  <- mapM parseTempl imps
   incs'  <- mapM (traverse parseBB) incs
   templ' <- parseBB templ
   rM'    <- traverse parseBB rM
   riM'   <- traverse parseBB riM
-  return (BlackBox pNm wf rVoid multiRes tkind () oReg libM' imps' fPlural incs' rM' riM' templ')
+  return (BlackBox pNm wf rVoid multiRes tkind () outputUsage libM' imps' fPlural incs' rM' riM' templ')
  where
   iArgs = concatMap (("-package-db":) . (:[])) pkgDbs
 
@@ -766,8 +766,8 @@ createHDL backend modName seen components domainConfs top topName = flip evalSta
   let componentsL = map snd (OMap.assocs components)
   (hdlNmDocs,incs) <-
     fmap unzip $
-      forM componentsL $ \(ComponentMeta{cmLoc, cmScope}, comp) ->
-         genHDL modName cmLoc (Id.union seen cmScope) comp
+      forM componentsL $ \(ComponentMeta{cmLoc, cmScope,cmUsage}, comp) ->
+         genHDL modName cmLoc (Id.union seen cmScope) cmUsage comp
 
   hwtys <- HashSet.toList <$> extractTypes <$> Ap get
   typesPkg <- mkTyPackage modName hwtys

--- a/clash-lib/src/Clash/Netlist.hs-boot
+++ b/clash-lib/src/Clash/Netlist.hs-boot
@@ -1,7 +1,8 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente
+                     2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 {-# LANGUAGE CPP #-}
 
@@ -39,7 +40,8 @@ mkExpr :: HasCallStack
        -> NetlistMonad (Expr,[Declaration])
 
 mkDcApplication :: HasCallStack
-                => [HWType]
+                => DeclarationType
+                -> [HWType]
                 -> NetlistId
                 -> DataCon
                 -> [Term]

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -31,6 +31,7 @@ import           Control.Monad.IO.Class        (liftIO)
 import           Data.Bifunctor                (first, second)
 import           Data.Char                     (ord)
 import           Data.Either                   (lefts, partitionEithers)
+import           Data.Foldable                 (for_)
 import qualified Data.HashMap.Lazy             as HashMap
 import qualified Data.IntMap                   as IntMap
 import           Data.List                     (elemIndex, partition)
@@ -60,7 +61,7 @@ import           Util                          (OverridingBool(..))
 import           Clash.Annotations.Primitive
   ( PrimitiveGuard(HasBlackBox, DontTranslate)
   , PrimitiveWarning(WarnNonSynthesizable, WarnAlways)
-  , extractPrim)
+  , extractPrim, HDL(VHDL))
 import           Clash.Core.DataCon            as D (dcTag)
 import           Clash.Core.FreeVars           (freeIds)
 import           Clash.Core.HasType
@@ -80,7 +81,7 @@ import           Clash.Core.TyCon              as C (TyConMap, tyConDataCons)
 import           Clash.Core.Util
   (inverseTopSortLetBindings, splitShouldSplit)
 import           Clash.Core.Var                as V
-  (Id, Var (..), mkLocalId, modifyVarName)
+  (Id, mkLocalId, modifyVarName)
 import           Clash.Core.VarEnv
   (extendInScopeSet, mkInScopeSet, lookupVarEnv, uniqAway, unitVarSet)
 import {-# SOURCE #-} Clash.Netlist
@@ -141,7 +142,7 @@ mkBlackBoxContext
 mkBlackBoxContext bbName resIds args@(lefts -> termArgs) = do
     -- Make context inputs
     let
-      resNms = map Id.unsafeFromCoreId resIds
+      resNms = fmap Id.unsafeFromCoreId resIds
       resNm = fromMaybe (error "mkBlackBoxContext: head") (listToMaybe resNms)
     resTys <- mapM (unsafeCoreTypeToHWTypeM' $(curLoc) . coreTypeOf) resIds
     (imps,impDecls) <- unzip <$> zipWithM (mkArgument bbName resNm) [0..] termArgs
@@ -205,6 +206,7 @@ prepareBlackBox _pNm templ bbCtx =
           (fmap (first BBTemplate) . setSym bbCtx)
           (\bbName bbHash bbFunc -> pure (BBFunction bbName bbHash bbFunc, []))
           templ
+      for_ decls goDecl
       return (t2,decls)
     Just err0 -> do
       (_,sp) <- Lens.use curCompNm
@@ -212,6 +214,43 @@ prepareBlackBox _pNm templ bbCtx =
                         , Data.Text.unpack (bbName bbCtx), ". Verification "
                         , "procedure reported:\n\n" ++ err0 ]
       throw (ClashException sp ($(curLoc) ++ err1) Nothing)
+ where
+  -- Right now we assume that (1) a blackbox doesn't assign to a signal
+  -- declared outside the black box template and (2) all uses of a signal
+  -- within a blackbox are correct for the targeted HDL (i.e. we don't try
+  -- to generate new signals when a signal is used incorrectly).
+  goDecl = \case
+    Assignment i u _ ->
+      declareUse u i
+
+    CondAssignment i _ _ _ _ -> do
+      -- Currently, all CondAssignment get rendered as `always @*` blocks in
+      -- (System)Verilog. This means when we target these HDL, this is _really_
+      -- a blocking procedural assignment.
+      SomeBackend b <- Lens.use backend
+      let use = case Backend.hdlKind b of { VHDL -> Cont ; _ -> Proc Blocking }
+      declareUse use i
+
+    Seq seqs -> for_ seqs goSeq
+
+    _ -> pure ()
+
+  goSeq = \case
+    AlwaysClocked _ _ seqs ->
+      for_ seqs goSeq
+
+    Initial seqs ->
+      for_ seqs goSeq
+
+    AlwaysComb seqs ->
+      for_ seqs goSeq
+
+    SeqDecl conc ->
+      goDecl conc
+
+    Branch _ _ alts ->
+      let seqs = concatMap snd alts
+       in for_ seqs goSeq
 
 -- | Determine if a term represents a literal
 isLiteral :: Term -> Bool
@@ -247,7 +286,7 @@ mkArgument bbName bndr nArg e = do
         | otherwise
         -> return ((error ($(curLoc) ++ "Forced to evaluate untranslatable type: " ++ eTyMsg), Void Nothing, False), [])
       Just hwTy -> case collectArgsTicks e of
-        (C.Var v,[],_) ->
+        (C.Var v,[],_) -> do
           return ((Identifier (Id.unsafeFromCoreId v) Nothing,hwTy,False),[])
         (C.Literal (IntegerLiteral i),[],_) ->
           return ((N.Literal (Just (Signed iw,iw)) (N.NumLit i),hwTy,True),[])
@@ -266,12 +305,12 @@ mkArgument bbName bndr nArg e = do
         (C.Literal (NaturalLiteral n), [],_) ->
           return ((N.Literal (Just (Unsigned iw,iw)) (N.NumLit n),hwTy,True),[])
         (Prim pinfo,args,ticks) -> withTicks ticks $ \tickDecls -> do
-          (e',d) <- mkPrimitive True False (NetlistId bndr ty) pinfo args tickDecls
+          (e',d) <- mkPrimitive True False Concurrent (NetlistId bndr ty) pinfo args tickDecls
           case e' of
             (Identifier _ _) -> return ((e',hwTy,False), d)
             _                -> return ((e',hwTy,isLiteral e), d)
         (Data dc, args,_) -> do
-          (exprN,dcDecls) <- mkDcApplication [hwTy] (NetlistId bndr ty) dc (lefts args)
+          (exprN,dcDecls) <- mkDcApplication Concurrent [hwTy] (NetlistId bndr ty) dc (lefts args)
           return ((exprN,hwTy,isLiteral e),dcDecls)
         (Case scrut ty' [alt],[],_) -> do
           (projection,decls) <- mkProjection False (NetlistId bndr ty) scrut ty' alt
@@ -357,6 +396,8 @@ mkPrimitive
   -- ^ Put BlackBox expression in parenthesis
   -> Bool
   -- ^ Treat BlackBox expression as declaration
+  -> DeclarationType
+  -- ^ Are we concurrent or sequential?
   -> NetlistId
   -- ^ Id to assign the result to
   -> PrimInfo
@@ -366,7 +407,7 @@ mkPrimitive
   -> [Declaration]
   -- ^ Tick declarations
   -> NetlistMonad (Expr,[Declaration])
-mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
+mkPrimitive bbEParen bbEasD declType dst pInfo args tickDecls =
   go =<< extractPrimWarnOrFail (primName pInfo)
   where
     tys = netlistTypes dst
@@ -392,7 +433,7 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
               -- Blackbox template generation successful. Rerun 'go', but this time
               -- around with a 'normal' @BlackBox@
               go (P.BlackBox
-                    bbName wf bbRenderVoid multiResult bbKind () bbOutputReg
+                    bbName wf bbRenderVoid multiResult bbKind () bbOutputUsage
                     bbLibrary bbImports bbFunctionPlurality bbIncludes
                     bbResultNames bbResultInits bbTemplate)
         -- See 'setupMultiResultPrim' in "Clash.Normalize.Transformations":
@@ -408,7 +449,7 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
           (templ, templDecl) <- prepareBlackBox name template bbCtx
           let bbDecl = N.BlackBoxD name (libraries p) (imports p) (includes p) templ bbCtx
           return (Noop, ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
-        p@P.BlackBox {template, name=pNm, kind} ->
+        p@(P.BlackBox {template, name=pNm, kind,outputUsage}) ->
           case kind of
             TDecl -> do
               resM <- resBndr1 True dst
@@ -418,6 +459,7 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   (templ,templDecl) <- prepareBlackBox pNm template bbCtx
                   let bbDecl = N.BlackBoxD pNm (libraries p) (imports p)
                                            (includes p) templ bbCtx
+                  declareUse outputUsage dstNm
                   return (Identifier dstNm Nothing,dstDecl ++ ctxDcls ++ templDecl ++ tickDecls ++ [bbDecl])
 
                 -- Render declarations as a Noop when requested
@@ -438,12 +480,12 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   resM <- resBndr1 True dst
                   case resM of
                     Just (dst',dstNm,dstDecl) -> do
-                      (bbCtx,ctxDcls)     <- mkBlackBoxContext (primName pInfo) [dst'] args
+                      (bbCtx,ctxDcls) <- mkBlackBoxContext (primName pInfo) [dst'] args
                       (bbTempl,templDecl) <- prepareBlackBox pNm template bbCtx
-                      let tmpAssgn = Assignment dstNm
-                                        (BlackBoxE pNm (libraries p) (imports p)
-                                                   (includes p) bbTempl bbCtx
-                                                   bbEParen)
+                      let bbE =  BlackBoxE pNm (libraries p) (imports p) (includes p) bbTempl bbCtx bbEParen
+                      tmpAssgn <- case declType of
+                        Concurrent -> contAssign dstNm bbE
+                        Sequential -> procAssign Blocking dstNm bbE
                       return (Identifier dstNm Nothing, dstDecl ++ ctxDcls ++ templDecl ++ [tmpAssgn])
 
                     -- Render expression as a Noop when requested
@@ -497,7 +539,7 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   tcm <- Lens.view tcCache
                   let dcs = tyConDataCons (tcm `lookupUniqMap'` tcN)
                       dc  = dcs !! fromInteger i
-                  (exprN,dcDecls) <- mkDcApplication [hwTy] dst dc []
+                  (exprN,dcDecls) <- mkDcApplication declType [hwTy] dst dc []
                   return (exprN,dcDecls)
                 [Right _, Left scrut] -> do
                   tcm     <- Lens.view tcCache
@@ -509,9 +551,9 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                     _ -> do
                       scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
                       tmpRhs <- Id.make "c$tte_rhs"
-                      let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
-                          netAssignRhs = Assignment tmpRhs scrutExpr
-                      return (DataTag hwTy (Left tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
+                      let assignTy = case declType of { Concurrent -> Cont ; Sequential -> Proc Blocking }
+                      netDecl <- N.mkInit declType assignTy tmpRhs scrutHTy scrutExpr
+                      return (DataTag hwTy (Left tmpRhs), netDecl ++ scrutDecls)
                 _ -> error $ $(curLoc) ++ "tagToEnum: " ++ show (map (either showPpr showPpr) args)
           | pNm == "GHC.Prim.dataToTag#" -> case args of
               [Right _,Left (Data dc)] -> do
@@ -527,9 +569,9 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
                   _ -> do
                     tmpRhs <- Id.make "c$dtt_rhs"
-                    let netDeclRhs   = NetDecl Nothing tmpRhs scrutHTy
-                        netAssignRhs = Assignment tmpRhs scrutExpr
-                    return (DataTag scrutHTy (Right tmpRhs),[netDeclRhs,netAssignRhs] ++ scrutDecls)
+                    let assignTy = case declType of { Concurrent -> Cont ; Sequential -> Proc Blocking }
+                    netDecl <- N.mkInit declType assignTy tmpRhs scrutHTy scrutExpr
+                    return (DataTag scrutHTy (Right tmpRhs),netDecl ++ scrutDecls)
               _ -> error $ $(curLoc) ++ "dataToTag: " ++ show (map (either showPpr showPpr) args)
 
           | pNm == "Clash.Explicit.SimIO.mealyIO" -> do
@@ -549,9 +591,10 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   Noop ->
                     return (Noop,decls)
                   _ -> case dstNms of
-                    [dstNm] ->
+                    [dstNm] -> do
+                      declareUse (Proc Blocking) dstNm
                       return ( Identifier dstNm Nothing
-                             , dstDecl ++ decls ++ [Assignment dstNm expr])
+                             , dstDecl ++ decls ++ [Assignment dstNm (Proc Blocking) expr])
                     _ -> error $ $(curLoc) ++ "bindSimIO: " ++ show resM
                 _ ->
                   return (Noop,decls)
@@ -573,9 +616,10 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                           in  substTm "mkPrimitive.fmapSimIO" subst bE
                         _ -> mkApps fun0 [Left arg1]
                   (expr,bindDecls) <- mkExpr False Sequential dst fun1
-                  let assn = case expr of
-                               Noop -> []
-                               _ -> [Assignment dstNm expr]
+                  assn <- case expr of
+                            Noop -> pure []
+                            _ -> do declareUse (Proc Blocking) dstNm
+                                    pure [Assignment dstNm (Proc Blocking) expr]
                   return (Identifier dstNm Nothing, dstDecl ++ bindDecls ++ assn)
                 Nothing -> do
                   let (_:arg0:_) = lefts args
@@ -597,9 +641,10 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   Noop ->
                     return (Noop,decls)
                   _ -> case dstNms of
-                    [dstNm] ->
+                    [dstNm] -> do
+                      declareUse (Proc Blocking) dstNm
                       return ( Identifier dstNm Nothing
-                             , dstDecl ++ decls ++ [Assignment dstNm expr])
+                             , dstDecl ++ decls ++ [Assignment dstNm (Proc Blocking) expr])
                     _ -> error "internal error"
                 _ ->
                   return (Noop,decls)
@@ -684,17 +729,18 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
         pure Nothing
       else
         case dst' of
-          NetlistId dstL _ -> case mkDec of
+          NetlistId dstL ty' -> case mkDec of
             False -> do
               -- TODO: check that it's okay to use `mkUnsafeSystemName`
               let nm' = mkUnsafeSystemName (Id.toText dstL) 0
-                  id_ = mkLocalId ty nm'
+                  id_ = mkLocalId ty' nm'
               return (Just ([id_],[dstL],[]))
             True -> do
               nm2 <- Id.suffix dstL "res"
               -- TODO: check that it's okay to use `mkUnsafeInternalName`
               let nm3 = mkUnsafeSystemName (Id.toText nm2) 0
                   id_ = mkLocalId ty nm3
+
               idDeclM <- mkNetDecl (id_, mkApps (Prim pInfo) args)
               case idDeclM of
                 [] -> return Nothing
@@ -707,10 +753,11 @@ mkPrimitive bbEParen bbEasD dst pInfo args tickDecls =
                   Multi primitive should only appear on the RHS of a
                   let-binding. Please report this as a bug.
                 |]
+
           CoreId dstR ->
-            return (Just ([dstR], [Id.unsafeMake . nameOcc . varName $ dstR], []))
+            return (Just ([dstR], [Id.unsafeFromCoreId dstR], []))
           MultiId ids ->
-            return (Just (ids, map (Id.unsafeMake . nameOcc . varName) ids, []))
+            return (Just (ids, map Id.unsafeFromCoreId ids, []))
 
     -- Like resBndr, but fails on MultiId
     resBndr1
@@ -815,37 +862,49 @@ collectMealy dstNm dst tcm (kd:clk:mealyFun:mealyInit:mealyIn:_) = do
         Letrec _ (C.Var {}) -> mkExpr False Concurrent dst (C.Var result)
         _ -> case dst of
           CoreId {} -> pure (Noop,[])
-          _ -> mkExpr False Concurrent dst (C.Var result)
-      let resAssn = case resExpr of
-            Noop -> []
-            _ -> [Seq [AlwaysComb [SeqDecl (Assignment dstNm resExpr)]]]
+          _ -> mkExpr False Sequential dst (C.Var result)
+
+      resAssn <- case resExpr of
+            Noop -> pure []
+            _ -> do
+              assign <- SeqDecl <$> procAssign Blocking dstNm resExpr
+              pure [Seq [AlwaysComb [assign]]]
 
       -- Create the declarations for the "initial state" block
       let sDst = case sBinders of
                    [] -> error "internal error: insufficient sBinders"
                    [(b,_)] -> CoreId b
                    _       -> MultiId (map fst sBinders)
+
       (exprInit,initDecls) <- mkExpr False Sequential sDst mealyInit
-      let initAssign = case exprInit of
-            Identifier _ Nothing -> []
-            Noop -> []
-            _ -> case sBinders of
-              ((b,_):_) -> [Assignment (Id.unsafeFromCoreId b) exprInit]
-              _ -> error "internal error: insufficient sBinders"
+
+      initAssign <- case exprInit of
+        Identifier _ Nothing -> pure []
+        Noop -> pure []
+        _ -> case sBinders of
+          ((b,_):_) -> do assn <- procAssign Blocking (Id.unsafeFromCoreId b) exprInit
+                          pure [assn]
+          _ -> error "internal error: insufficient sBinders"
 
       -- Create the declarations that corresponding to the input
       let iDst = case iBinders of
                    []      -> error "internal error: insufficient iBinders"
                    [(b,_)] -> CoreId b
                    _       -> MultiId (map fst iBinders)
+
       (exprArg,inpDeclsMisc) <- mkExpr False Concurrent iDst mealyIn
+
+      argAssign <- case iBinders of
+        ((i,_):_) -> do assn <- contAssign (Id.unsafeFromCoreId i) exprArg
+                        pure [assn]
+        _ -> error "internal error: insufficient iBinders"
 
       -- Split netdecl declarations and other declarations
       let (netDeclsSeqMisc,seqDeclsOther) = partition isNet (seqDecls ++ resDecls)
           (netDeclsInit,initDeclsOther)   = partition isNet initDecls
       -- All assignments happens within a sequential block, so the nets need to
       -- be of type 'reg' in Verilog nomenclature
-      let netDeclsSeq1 = map toReg (netDeclsSeq ++ netDeclsSeqMisc ++ netDeclsInit)
+      let netDeclsSeq1 = netDeclsSeq ++ netDeclsSeqMisc ++ netDeclsInit
 
       -- We run mealy block in the opposite clock edge of the the ambient system
       -- because we're basically clocked logic; so we need to have our outputs
@@ -863,20 +922,14 @@ collectMealy dstNm dst tcm (kd:clk:mealyFun:mealyInit:mealyIn:_) = do
       let netDeclsInp1 = netDeclsInp ++ inpDeclsMisc
 
       -- Collate everything
-      return (clkDecls ++ netDeclsSeq1 ++ netDeclsInp1 ++
-                [ case iBinders of
-                    ((i,_):_) -> Assignment (Id.unsafeFromCoreId i) exprArg
-                    _ -> error "internal error: insufficient iBinders"
-                , Seq [Initial (map SeqDecl (initDeclsOther ++ initAssign))]
+      return (clkDecls ++ netDeclsSeq1 ++ netDeclsInp1 ++ argAssign ++
+                [ Seq [Initial (map SeqDecl (initDeclsOther ++ initAssign))]
                 , Seq [AlwaysClocked edge clkExpr (map SeqDecl seqDeclsOther)]
                 ] ++ resAssn)
     _ -> error "internal error"
  where
   isNet NetDecl' {} = True
   isNet _ = False
-
-  toReg (NetDecl' cmM _ r ty eM) = NetDecl' cmM Reg r ty eM
-  toReg d = d
 
 collectMealy _ _ _ _ = error "internal error"
 
@@ -981,7 +1034,7 @@ mkFunInput
   -- ^ The function argument term
   -> NetlistMonad
       ((Either BlackBox (Identifier,[Declaration])
-       ,WireOrReg
+       ,Usage
        ,[BlackBoxTemplate]
        ,[BlackBoxTemplate]
        ,[((TextS.Text,TextS.Text),BlackBox)]
@@ -998,7 +1051,7 @@ mkFunInput resId e =
               bb  <- extractPrimWarnOrFail (primName p)
               case bb of
                 P.BlackBox {..} ->
-                  pure (Left (kind,outputReg,libraries,imports,includes,primName p,template))
+                  pure (Left (kind,outputUsage,libraries,imports,includes,primName p,template))
                 P.Primitive pn _ pt ->
                   error $ $(curLoc) ++ "Unexpected blackbox type: "
                                     ++ "Primitive " ++ show pn
@@ -1024,7 +1077,7 @@ mkFunInput resId e =
                                         ++ err
                     Right (BlackBoxMeta{..}, template) ->
                       pure $
-                        Left ( bbKind, bbOutputReg, bbLibrary, bbImports
+                        Left ( bbKind, bbOutputUsage, bbLibrary, bbImports
                              , bbIncludes, pName, template)
             Data dc -> do
               let eTy = inferCoreTypeOf tcm e
@@ -1039,8 +1092,8 @@ mkFunInput resId e =
                 Just (_resHTy, [areVoids@(countEq False -> 1)]) -> do
                   let nonVoidArgI = fromJust (elemIndex False areVoids)
                   let arg = Id.unsafeMake (TextS.concat ["~ARG[", showt nonVoidArgI, "]"])
-                  let assign = Assignment (Id.unsafeMake "~RESULT") (Identifier arg Nothing)
-                  return (Right ((Id.unsafeMake "", tickDecls ++ [assign]), Wire))
+                  let assign = Assignment (Id.unsafeMake "~RESULT") Cont (Identifier arg Nothing)
+                  return (Right ((Id.unsafeMake "", tickDecls ++ [assign]), Cont))
 
                 -- Because we filter void constructs, the argument indices and
                 -- the field indices don't necessarily correspond anymore. We
@@ -1054,8 +1107,8 @@ mkFunInput resId e =
                       mkArg i   = Id.unsafeMake ("~ARG[" <> showt i <> "]")
                       dcInps    = [Identifier (mkArg x) Nothing | x <- originalIndices areVoids1]
                       dcApp     = DataCon resHTy (DC (resHTy,dcI)) dcInps
-                      dcAss     = Assignment (Id.unsafeMake "~RESULT") dcApp
-                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
+                      dcAss     = Assignment (Id.unsafeMake "~RESULT") Cont dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]), Cont))
 
                 -- CustomSP the same as SP, but with a user-defined bit
                 -- level representation
@@ -1066,16 +1119,16 @@ mkFunInput resId e =
                       mkArg i   = Id.unsafeMake ("~ARG[" <> showt i <> "]")
                       dcInps    = [Identifier (mkArg x) Nothing | x <- originalIndices areVoids1]
                       dcApp     = DataCon resHTy (DC (resHTy,dcI)) dcInps
-                      dcAss     = Assignment (Id.unsafeMake "~RESULT") dcApp
-                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
+                      dcAss     = Assignment (Id.unsafeMake "~RESULT") Cont dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]), Cont))
 
                 -- Like SP, we have to retrieve the index BEFORE filtering voids
                 Just (resHTy@(Product _ _ _), areVoids1:_) -> do
                   let mkArg i    = Id.unsafeMake ("~ARG[" <> showt i <> "]")
                       dcInps    = [ Identifier (mkArg x) Nothing | x <- originalIndices areVoids1]
                       dcApp     = DataCon resHTy (DC (resHTy,0)) dcInps
-                      dcAss     = Assignment (Id.unsafeMake "~RESULT") dcApp
-                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
+                      dcAss     = Assignment (Id.unsafeMake "~RESULT") Cont dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]), Cont))
 
                 -- Vectors never have defined areVoids (or all set to False), as
                 -- it would be converted to Void otherwise. We can therefore
@@ -1084,22 +1137,22 @@ mkFunInput resId e =
                   let mkArg i = Id.unsafeMake ("~ARG[" <> showt i <> "]")
                       dcInps = [ Identifier (mkArg x) Nothing | x <- [(1::Int)..2] ]
                       dcApp  = DataCon resHTy (DC (resHTy,1)) dcInps
-                      dcAss  = Assignment (Id.unsafeMake "~RESULT") dcApp
-                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
+                      dcAss  = Assignment (Id.unsafeMake "~RESULT") Cont dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]), Cont))
 
                 -- Sum types OR a Sum type after filtering empty types:
                 Just (resHTy@(Sum _ _), _areVoids) -> do
                   let dcI   = dcTag dc - 1
                       dcApp = DataCon resHTy (DC (resHTy,dcI)) []
-                      dcAss = Assignment (Id.unsafeMake "~RESULT") dcApp
-                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
+                      dcAss = Assignment (Id.unsafeMake "~RESULT") Cont dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]), Cont))
 
                 -- Same as Sum, but with user defined bit level representation
                 Just (resHTy@(CustomSum {}), _areVoids) -> do
                   let dcI   = dcTag dc - 1
                       dcApp = DataCon resHTy (DC (resHTy,dcI)) []
-                      dcAss = Assignment (Id.unsafeMake "~RESULT") dcApp
-                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]),Wire))
+                      dcAss = Assignment (Id.unsafeMake "~RESULT") Cont dcApp
+                  return (Right ((Id.unsafeMake "",tickDecls ++ [dcAss]), Cont))
 
                 Just (Void {}, _areVoids) ->
                   return (error $ $(curLoc) ++ "Encountered Void in mkFunInput."
@@ -1133,7 +1186,7 @@ mkFunInput resId e =
                       let
                         portMap = NamedPortMap (outpAssign:inpAssigns)
                         instDecl = InstDecl Entity Nothing [] compName instLabel [] portMap
-                      return (Right ((Id.unsafeMake "",tickDecls ++ [instDecl]),Wire))
+                      return (Right ((Id.unsafeMake "",tickDecls ++ [instDecl]), Cont))
                     Nothing -> error $ $(curLoc) ++ "Cannot make function input for: " ++ showPpr e
             C.Lam {} -> do
               let is0 = mkInScopeSet (Lens.foldMapOf freeIds unitVarSet appE)
@@ -1144,27 +1197,27 @@ mkFunInput resId e =
               _ -> "__INTERNAL__"
   (bbCtx,dcls) <- mkBlackBoxContext pNm [resId] args
   case templ of
-    Left (TDecl,oreg,libs,imps,inc,_,templ') -> do
+    Left (TDecl,outputUsage,libs,imps,inc,_,templ') -> do
       (l',templDecl)
         <- onBlackBox
             (fmap (first BBTemplate) . setSym bbCtx)
             (\bbName bbHash bbFunc -> pure $ (BBFunction bbName bbHash bbFunc, []))
             templ'
-      return ((Left l',if oreg then Reg else Wire,libs,imps,inc,bbCtx),dcls ++ templDecl)
+      return ((Left l',outputUsage,libs,imps,inc,bbCtx),dcls ++ templDecl)
     Left (TExpr,_,libs,imps,inc,nm,templ') -> do
       onBlackBox
         (\t -> do t' <- getAp (prettyBlackBox t)
                   let t'' = Id.unsafeMake (Text.toStrict t')
-                      assn = Assignment (Id.unsafeMake "~RESULT") (Identifier t'' Nothing)
-                  return ((Right (Id.unsafeMake "",[assn]),Wire,libs,imps,inc,bbCtx),dcls))
+                      assn = Assignment (Id.unsafeMake "~RESULT") Cont (Identifier t'' Nothing)
+                  return ((Right (Id.unsafeMake "",[assn]),Cont,libs,imps,inc,bbCtx),dcls))
         (\bbName bbHash (TemplateFunction k g _) -> do
           let f' bbCtx' = do
-                let assn = Assignment (Id.unsafeMake "~RESULT")
+                let assn = Assignment (Id.unsafeMake "~RESULT") Cont
                             (BlackBoxE nm libs imps inc templ' bbCtx' False)
                 p <- getAp (Backend.blockDecl (Id.unsafeMake "") [assn])
                 return p
           return ((Left (BBFunction bbName bbHash (TemplateFunction k g f'))
-                  ,Wire
+                  ,Cont
                   ,[]
                   ,[]
                   ,[]
@@ -1174,8 +1227,8 @@ mkFunInput resId e =
                  )
         )
         templ'
-    Right (decl,wr) ->
-      return ((Right decl,wr,[],[],[],bbCtx),dcls)
+    Right (decl,u) ->
+      return ((Right decl,u,[],[],[],bbCtx),dcls)
   where
     goExpr app@(collectArgsTicks -> (C.Var fun,args@(_:_),ticks)) = do
       tcm <- Lens.view tcCache
@@ -1186,10 +1239,10 @@ mkFunInput resId e =
           withTicks ticks $ \tickDecls -> do
             resNm <- Id.make "result"
             appDecls <- mkFunApp resNm fun tmArgs tickDecls
-            let assn = [ Assignment (Id.unsafeMake "~RESULT") (Identifier resNm Nothing)
+            let assn = [ Assignment (Id.unsafeMake "~RESULT") Cont (Identifier resNm Nothing)
                        , NetDecl Nothing resNm resTy ]
             nm <- Id.makeBasic "block"
-            return (Right ((nm,assn++appDecls),Wire))
+            return (Right ((nm,assn++appDecls), Cont))
         else do
           (_,sp) <- Lens.use curCompNm
           throw (ClashException sp ($(curLoc) ++ "Not in normal form: Var-application with Type arguments:\n\n" ++ showPpr app) Nothing)
@@ -1197,11 +1250,11 @@ mkFunInput resId e =
       tcm <- Lens.view tcCache
       let eType = inferCoreTypeOf tcm e'
       (appExpr,appDecls) <- mkExpr False Concurrent (NetlistId (Id.unsafeMake "c$bb_res") eType) e'
-      let assn = Assignment (Id.unsafeMake "~RESULT") appExpr
+      let assn = Assignment (Id.unsafeMake "~RESULT") Cont appExpr
       nm <- if null appDecls
                then return (Id.unsafeMake "")
                else Id.makeBasic "block"
-      return (Right ((nm,appDecls ++ [assn]),Wire))
+      return (Right ((nm,appDecls ++ [assn]), Cont))
 
     go is0 n (Lam id_ e') = do
       lvl <- Lens.use curBBlvl
@@ -1214,38 +1267,30 @@ mkFunInput resId e =
       go is1 (n+(1::Int)) e''
 
     go _ _ (C.Var v) = do
-      let assn = Assignment (Id.unsafeMake "~RESULT") (Identifier (Id.unsafeFromCoreId v) Nothing)
-      return (Right ((Id.unsafeMake "",[assn]),Wire))
+      let assn = Assignment (Id.unsafeMake "~RESULT") Cont (Identifier (Id.unsafeFromCoreId v) Nothing)
+      return (Right ((Id.unsafeMake "",[assn]), Cont))
 
     go _ _ (Case scrut ty [alt]) = do
       tcm <- Lens.view tcCache
       let sTy = inferCoreTypeOf tcm scrut
       (projection,decls) <- mkProjection False (NetlistId (Id.unsafeMake "c$bb_res") sTy) scrut ty alt
-      let assn = Assignment (Id.unsafeMake "~RESULT") projection
+      let assn = Assignment (Id.unsafeMake "~RESULT") Cont projection
       nm <- if null decls
                then return (Id.unsafeMake "")
                else Id.makeBasic "projection"
-      return (Right ((nm,decls ++ [assn]),Wire))
+      return (Right ((nm,decls ++ [assn]), Cont))
 
     go _ _ (Case scrut ty alts@(_:_:_)) = do
-      tcm <- Lens.view tcCache
-      let scrutTy = inferCoreTypeOf tcm scrut
-      scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-      ite <- Lens.use backEndITE
-      let wr = case iteAlts scrutHTy alts of
-                 Just _ | ite -> Wire
-                 _ -> Reg
-
       resNm <- Id.make "result"
+      resTy <- unsafeCoreTypeToHWTypeM' $(curLoc) ty
       -- It's safe to use 'mkUnsafeSystemName' here: only the name, not the
       -- unique, will be used
       let resId'  = NetlistId resNm ty
       selectionDecls <- mkSelection Concurrent resId' scrut ty alts []
-      resTy <- unsafeCoreTypeToHWTypeM' $(curLoc) ty
-      let assn = [ NetDecl' Nothing wr resNm resTy Nothing
-                 , Assignment (Id.unsafeMake "~RESULT") (Identifier resNm Nothing) ]
+      let assn = [ NetDecl' Nothing resNm resTy Nothing
+                 , Assignment (Id.unsafeMake "~RESULT") Cont (Identifier resNm Nothing) ]
       nm <- Id.makeBasic "selection"
-      return (Right ((nm,assn++selectionDecls),Wire))
+      return (Right ((nm,assn++selectionDecls), Cont))
 
     go is0 _ e'@(Let{}) = do
       tcm <- Lens.view tcCache
@@ -1265,9 +1310,9 @@ mkFunInput resId e =
           -- tests break when reverting to the old behavior. In some cases this
           -- creates "useless" assignments. We should investigate whether we can
           -- get the old behavior back.
-          let resDecl = Assignment (Id.unsafeMake "~RESULT") (Identifier resultId Nothing)
-          return (Right ((nm,resDecl:netDecls ++ decls),Wire))
-        Nothing -> return (Right ((Id.unsafeMake "",[]),Wire))
+          let resDecl = Assignment (Id.unsafeMake "~RESULT") Cont (Identifier resultId Nothing)
+          return (Right ((nm,resDecl:netDecls ++ decls), Cont))
+        Nothing -> return (Right ((Id.unsafeMake "",[]), Cont))
 
     go is0 n (Tick _ e') = go is0 n e'
 

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -4,6 +4,7 @@
                     2016-2017, Myrtle Software Ltd,
                     2017     , Google Inc.,
                     2021-2022, QBayLogic B.V.
+                    2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -1241,7 +1242,7 @@ mkFunInput resId e =
       let resId'  = NetlistId resNm ty
       selectionDecls <- mkSelection Concurrent resId' scrut ty alts []
       resTy <- unsafeCoreTypeToHWTypeM' $(curLoc) ty
-      let assn = [ NetDecl' Nothing wr resNm (Right resTy) Nothing
+      let assn = [ NetDecl' Nothing wr resNm resTy Nothing
                  , Assignment (Id.unsafeMake "~RESULT") (Identifier resNm Nothing) ]
       nm <- Id.makeBasic "selection"
       return (Right ((nm,assn++selectionDecls),Wire))

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -2,6 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2017     , Myrtle Software Ltd,
                     2021-2022, QBayLogic B.V.
+                    2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -112,7 +113,9 @@ pTagE =  Result            <$  string "~RESULT"
      <|> IsActiveEnable    <$> (string "~ISACTIVEENABLE" *> brackets' natural')
      <|> IsUndefined       <$> (string "~ISUNDEFINED" *> brackets' natural')
      <|> StrCmp            <$> (string "~STRCMP" *> brackets' pSigD) <*> brackets' natural'
-     <|> OutputWireReg     <$> (string "~OUTPUTWIREREG" *> brackets' natural')
+     -- Parse ~OUTPUTWIREREG for backwards compatibility
+     <|> OutputUsage       <$> (string "~OUTPUTWIREREG" *> brackets' natural')
+     <|> OutputUsage       <$> (string "~OUTPUTUSAGE" *> brackets' natural')
      <|> GenSym            <$> (string "~GENSYM" *> brackets' pSigD) <*> brackets' natural'
      <|> Template          <$> (string "~TEMPLATE" *> brackets' pSigD) <*> brackets' pSigD
      <|> Repeat            <$> (string "~REPEAT" *> brackets' pSigD) <*> brackets' pSigD

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -3,6 +3,7 @@
                     2017     , Myrtle Software Ltd,
                     2021-2022, QBayLogic B.V.
                     2022     , LUMI GUIDE FIETSDETECTIE B.V.
+                    2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -34,7 +35,7 @@ import                GHC.Generics               (Generic)
 import                Clash.Core.Term            (Term)
 import                Clash.Core.Type            (Type)
 import {-# SOURCE #-} Clash.Netlist.Types
-  (BlackBox, NetlistMonad)
+  (BlackBox, NetlistMonad, Usage(Cont))
 
 import qualified      Clash.Signal.Internal      as Signal
 
@@ -55,7 +56,7 @@ data TemplateKind
 -- | See @Clash.Primitives.Types.BlackBox@ for documentation on this record's
 -- fields. (They are intentionally renamed to prevent name clashes.)
 data BlackBoxMeta =
-  BlackBoxMeta { bbOutputReg :: Bool
+  BlackBoxMeta { bbOutputUsage :: Usage
                , bbKind :: TemplateKind
                , bbLibrary :: [BlackBoxTemplate]
                , bbImports :: [BlackBoxTemplate]
@@ -69,7 +70,7 @@ data BlackBoxMeta =
 -- | Use this value in your blackbox template function if you do want to
 -- accept the defaults as documented in @Clash.Primitives.Types.BlackBox@.
 emptyBlackBoxMeta :: BlackBoxMeta
-emptyBlackBoxMeta = BlackBoxMeta False TExpr [] [] [] [] NoRenderVoid [] []
+emptyBlackBoxMeta = BlackBoxMeta Cont TExpr [] [] [] [] NoRenderVoid [] []
 
 -- | A BlackBox function generates a blackbox template, given the inputs and
 -- result type of the function it should provide a blackbox for. This is useful
@@ -192,7 +193,7 @@ data Element
   -- always return 0 (False) if `-fclash-aggressive-x-optimization-blackboxes`
   -- is NOT set.
   | StrCmp [Element] !Int
-  | OutputWireReg !Int
+  | OutputUsage !Int
   | Vars !Int
   | GenSym [Element] !Int
   | Repeat [Element] [Element]

--- a/clash-lib/src/Clash/Netlist/Id.hs
+++ b/clash-lib/src/Clash/Netlist/Id.hs
@@ -1,5 +1,6 @@
 {-|
   Copyright  :  (C) 2020, QBayLogic B.V.
+                    2022, Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -24,6 +25,7 @@ module Clash.Netlist.Id
   , Identifier
   , IdentifierType (..)
   , unsafeMake
+  , unsafeFromCoreId
   , toText
   , toLazyText
   , toList
@@ -54,7 +56,8 @@ module Clash.Netlist.Id
 where
 
 import           Clash.Annotations.Primitive (HDL (..))
-import           Clash.Core.Var (Id)
+import           Clash.Core.Name (nameOcc)
+import           Clash.Core.Var (Id, varName)
 import           Clash.Debug (debugIsOn)
 import {-# SOURCE #-} Clash.Netlist.Types
   (PreserveCase(..), HasIdentifierSet(..), IdentifierSet(..), Identifier(..),
@@ -235,3 +238,10 @@ prefix id0 prefix_ = withIdentifierSetM (\is id1 -> prefix# is id1 prefix_) id0
 -- is unique.
 fromCoreId :: (HasCallStack, IdentifierSetMonad m) => Id -> m Identifier
 fromCoreId = withIdentifierSetM fromCoreId#
+
+-- | Like 'fromCoreId, 'unsafeFromCoreId' creates an identifier that will be
+-- spliced at verbatim in the HDL. As opposed to 'fromCoreId', the resulting
+-- Identifier might be generated at a later point as it is NOT added to an
+-- IdentifierSet.
+unsafeFromCoreId :: HasCallStack => Id -> Identifier
+unsafeFromCoreId = unsafeMake . nameOcc . varName

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -3,6 +3,7 @@
                     2017     , Myrtle Software Ltd,
                     2017-2018, Google Inc.
                     2020-2022, QBayLogic B.V.
+                    2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -545,7 +546,7 @@ data Declaration
       (Maybe Comment)                -- ^ Note; will be inserted as a comment in target hdl
       WireOrReg                      -- ^ Wire or register
       !Identifier                    -- ^ Name of signal
-      (Either IdentifierText HWType) -- ^ Pointer to type of signal or type of signal
+      HWType                         -- ^ Type of signal
       (Maybe Expr)                   -- ^ Initial value
       -- ^ Signal declaration
 
@@ -602,9 +603,9 @@ pattern NetDecl
   -> HWType
   -- ^ Type of signal
   -> Declaration
-pattern NetDecl note d ty <- NetDecl' note Wire d (Right ty) _
+pattern NetDecl note d ty <- NetDecl' note Wire d ty _
   where
-    NetDecl note d ty = NetDecl' note Wire d (Right ty) Nothing
+    NetDecl note d ty = NetDecl' note Wire d ty Nothing
 
 data PortDirection = In | Out
   deriving (Eq,Ord,Show,Generic,NFData,Hashable)

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -39,6 +39,8 @@ import Control.Monad.Reader                 (ReaderT, MonadReader)
 import qualified Control.Monad.State        as Lazy (State)
 import qualified Control.Monad.State.Strict as Strict
   (State, MonadIO, MonadState, StateT)
+import Data.Aeson                           (FromJSON(..))
+import qualified Data.Aeson as Aeson
 import Data.Bits                            (testBit)
 import Data.Binary                          (Binary(..))
 import Data.Function                        (on)
@@ -49,6 +51,7 @@ import qualified Data.List                  as List
 import Data.IntMap                          (IntMap, empty)
 import Data.Map.Ordered                     (OMap)
 import Data.Map                             (Map)
+import qualified Data.Map as Map
 import Data.Maybe                           (mapMaybe)
 import Data.Monoid                          (Ap(..))
 import qualified Data.Set                   as Set
@@ -284,6 +287,7 @@ data ComponentMeta = ComponentMeta
   { cmWereVoids :: [Bool]
   , cmLoc :: SrcSpan
   , cmScope :: IdentifierSet
+  , cmUsage :: UsageMap
   } deriving (Generic, Show, NFData)
 
 type ComponentMap = OMap Unique (ComponentMeta, Component)
@@ -339,6 +343,10 @@ data NetlistState
   , _backend :: SomeBackend
   -- ^ The current HDL backend
   , _htyCache :: HWMap
+  , _usageMap :: UsageMap
+  -- ^ The current way signals are assigned in netlist. This is used to
+  -- determine how signals are rendered in HDL (i.e. wire/reg in Verilog, or
+  -- signal/variable in VHDL).
   }
 
 data ComponentPrefix
@@ -366,7 +374,7 @@ data Component
   = Component
   { componentName :: !Identifier -- ^ Name of the component
   , inputs        :: [(Identifier,HWType)] -- ^ Input ports
-  , outputs       :: [(WireOrReg,(Identifier,HWType),Maybe Expr)] -- ^ Output ports
+  , outputs       :: [(Usage,(Identifier,HWType),Maybe Expr)] -- ^ Output ports
   , declarations  :: [Declaration] -- ^ Internal declarations
   }
   deriving (Show, Generic, NFData)
@@ -504,6 +512,7 @@ data Declaration
   -- | Signal assignment
   = Assignment
       !Identifier -- ^ Signal to assign
+      !Usage      -- ^ How the signal is assigned
       !Expr       -- ^ Assigned expression
 
   -- | Conditional signal assignment:
@@ -544,7 +553,6 @@ data Declaration
   -- | Signal declaration
   | NetDecl'
       (Maybe Comment)                -- ^ Note; will be inserted as a comment in target hdl
-      WireOrReg                      -- ^ Wire or register
       !Identifier                    -- ^ Name of signal
       HWType                         -- ^ Type of signal
       (Maybe Expr)                   -- ^ Initial value
@@ -587,13 +595,110 @@ data Seq
       [(Maybe Literal,[Seq])]  -- ^ List of: (Maybe match, RHS of Alternative)
   deriving Show
 
+-- | Procedural assignment in HDL can be blocking or non-blocking. This
+-- determines when the assignment takes place in simulation. The name refers to
+-- whether evaluation of the remaining statements in a process is blocked
+-- until the assignment is performed or not.
+--
+-- See Also:
+--
+-- IEEE 1364-2001, sections 9.2.1 and 9.2.2
+-- IEEE 1076-1993, sections 8.4 and 8.5
+--
+data Blocking
+  = NonBlocking
+  -- ^ A non-blocking assignment means the new value is not observed until the
+  -- next time step in simulation. Using the signal later in the process will
+  -- continue to return the old value.
+  | Blocking
+  -- ^ A blocking assignment means the new value is observed immediately. Using
+  -- the signal later in the process will return the new value.
+  deriving (Binary, Eq, Generic, Hashable, NFData, Show)
+
+-- NOTE [`Semigroup` instances for `Blocking` and `Usage`]
+instance Semigroup Blocking where
+  NonBlocking <> y = y
+  Blocking    <> _ = Blocking
+
+-- | The usage of a signal refers to how the signal is written to in netlist.
+-- This is used to determine if the signal should be a @wire@ or @reg@ in
+-- (System)Verilog, or a @signal@ or @variable@ in VHDL.
+--
+data Usage
+  = Cont
+  -- ^ Continuous assignment, which occurs in a concurrent context.
+  | Proc Blocking
+  -- ^ Procedural assignment, which occurs in a sequential context.
+  deriving (Binary, Eq, Generic, Hashable, NFData, Show)
+
+-- NOTE [`Semigroup` instances for `Blocking` and `Usage`]
+instance Semigroup Usage where
+  Cont    <> y      = y
+  Proc x  <> Proc y = Proc (x <> y)
+  Proc x  <> _      = Proc x
+
+{-
+NOTE [`Semigroup` instances for `Blocking` and `Usage`]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Usages (and Blocking) are combined by taking the most restrictive usage, where
+most restrictive means "has the most influence over the choice of declaration".
+Clash produces three types of assignment:
+
+  * continuous
+  * prodecural non-blocking
+  * prodecural blocking
+
+Both VHDl and (System)Verilog have a type of declaration which only admits one
+type of assignment. This is the most restrictive for that HDL. However, since
+that would involve knowing the HDL type in these Semigroup instances, the
+most restrictive here is based on ordering where the most restrictive for each
+HDL is an extreme value (max for VHDL, min for Verilog). i.e.
+
+          |-------------------------------------|
+          | Continuous | NonBlocking | Blocking |
+|---------|-------------------------------------|
+|    VHDL |         signal           | variable |
+|---------|-------------------------------------|
+| Verilog |   wire     |          reg           |
+|---------|-------------------------------------|
+-}
+
+instance FromJSON Usage where
+  parseJSON = Aeson.withText "Usage" $ \case
+    "Continuous"  -> pure Cont
+    "NonBlocking" -> pure (Proc NonBlocking)
+    "Blocking"    -> pure (Proc Blocking)
+    str           -> fail $ mconcat
+      [ "Could not parse usage: "
+      , show str
+      , "\nRecognized values are 'Continuous', 'NonBlocking' and 'Blocking'"
+      ]
+
+-- See NOTE [`Text` key for `UsageMap`]
+type UsageMap = Map Text Usage
+
+lookupUsage :: Identifier -> UsageMap -> Maybe Usage
+lookupUsage i = Map.lookup (Id.toText i)
+
+{-
+NOTE [`Text` key for `UsageMap`]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We would like to use netlist identifiers as the key for the usage map, since
+concepturally it is a map from an identifier to how it is used in assignments.
+However, in practice we commonly end up with the same textual identifier
+appearing in different ways in the netlist.
+
+The most obvious example of this are identifiers that appear as both
+`UniqueIdentifier` and `RawIdentifier`. If we track the usage on the raw
+identifier, but the `NetDecl` uses the `UniqueIdentifier` then the wrong
+declaration may be used in the rendered HDL.
+
+Attempting to fix this by not generating the same textual identifier in
+different ways proved difficult, so for now the key type is `Text` instead.
+-}
+
 data EntityOrComponent = Entity | Comp | Empty
   deriving Show
-
-data WireOrReg = Wire | Reg
-  deriving (Show,Generic)
-
-instance NFData WireOrReg
 
 pattern NetDecl
   :: Maybe Comment
@@ -603,9 +708,9 @@ pattern NetDecl
   -> HWType
   -- ^ Type of signal
   -> Declaration
-pattern NetDecl note d ty <- NetDecl' note Wire d ty _
+pattern NetDecl note d ty <- NetDecl' note d ty _
   where
-    NetDecl note d ty = NetDecl' note Wire d ty Nothing
+    NetDecl note d ty = NetDecl' note d ty Nothing
 
 data PortDirection = In | Out
   deriving (Eq,Ord,Show,Generic,NFData,Hashable)
@@ -660,6 +765,24 @@ data Expr
 instance NFData Expr where
   rnf x = x `seq` ()
 
+isConstExpr :: Expr -> Bool
+isConstExpr = \case
+  Literal{} -> True
+  DataCon _ _ es -> all isConstExpr es
+  Identifier{} -> False
+  DataTag{} -> False
+  BlackBoxE nm _ _ _ _ ctx _
+    -- When using SimIO, `reg` creates (in Haskell) the mutable reference to
+    -- some value. The blackbox for this however is simply `~ARG[0]`, so if
+    -- the argument given is constant, the rendered HDL will also be constant.
+    | nm == "Clash.Explicit.SimIO.reg" ->
+        all (\(e, _, _) -> isConstExpr e) (bbInputs ctx)
+    | otherwise -> False
+  ToBv _ _ e -> isConstExpr e
+  FromBv _ _ e -> isConstExpr e
+  IfThenElse{} -> False
+  Noop -> False
+
 -- | Literals used in an expression
 data Literal
   = NumLit    !Integer          -- ^ Number literal
@@ -698,7 +821,7 @@ data BlackBoxContext
   , bbInputs :: [(Expr,HWType,Bool)]
   -- ^ Argument names, types, and whether it is a literal
   , bbFunctions :: IntMap [(Either BlackBox (Identifier,[Declaration])
-                          ,WireOrReg
+                          ,Usage
                           ,[BlackBoxTemplate]
                           ,[BlackBoxTemplate]
                           ,[((Text,Text),BlackBox)]
@@ -767,7 +890,7 @@ data NetlistId
   | MultiId [Id]
   -- ^ A split identifier (into several sub-identifiers), needed to assign
   -- expressions of types that have to be split apart (e.g. tuples of Files)
-  deriving Show
+  deriving (Eq, Show)
 
 -- | Eliminator for 'NetlistId', fails on 'MultiId'
 netlistId1
@@ -847,6 +970,9 @@ class HasIdentifierSet s where
 
 instance HasIdentifierSet IdentifierSet where
   identifierSet = ($)
+
+instance HasIdentifierSet s => HasIdentifierSet (s, a) where
+  identifierSet = Lens._1 . identifierSet
 
 -- | An "IdentifierSetMonad" supports unique name generation for Clash Netlist
 class Monad m => IdentifierSetMonad m where

--- a/clash-lib/src/Clash/Netlist/Types.hs-boot
+++ b/clash-lib/src/Clash/Netlist/Types.hs-boot
@@ -1,6 +1,7 @@
 {-|
   Copyright   :  (C) 2018, Google Inc,
                      2022, QBayLogic B.V.
+                     2022, Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -11,7 +12,11 @@ module Clash.Netlist.Types where
 
 import Control.DeepSeq (NFData)
 import Control.Lens (Lens')
-import Data.Hashable
+import Data.Aeson (FromJSON)
+import Data.Binary (Binary)
+import Data.Hashable (Hashable)
+import Data.Map (Map)
+import Data.Text (Text)
 
 data IdentifierType
 data Identifier
@@ -38,3 +43,26 @@ instance Hashable PreserveCase
 instance Eq PreserveCase
 instance Show PreserveCase
 instance NFData PreserveCase
+
+data Blocking
+  = NonBlocking
+  | Blocking
+
+instance Binary Blocking
+instance Eq Blocking
+instance Hashable Blocking
+instance NFData Blocking
+instance Show Blocking
+
+data Usage
+  = Cont
+  | Proc Blocking
+
+instance Binary Usage
+instance Eq Usage
+instance FromJSON Usage
+instance Hashable Usage
+instance NFData Usage
+instance Show Usage
+
+type UsageMap = Map Text Usage

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -3,6 +3,7 @@
                     2017     , Myrtle Software Ltd
                     2017-2018, Google Inc.
                     2021-2022, QBayLogic B.V.
+                    2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -997,10 +998,7 @@ idToPort var = do
   hwTy <- unsafeCoreTypeToHWTypeM' $(curLoc) (coreTypeOf var)
   if isVoid hwTy
     then return Nothing
-    else return (Just (id2identifier var, hwTy))
-
-id2identifier :: Id -> Identifier
-id2identifier = Id.unsafeMake . nameOcc . varName
+    else return (Just (Id.unsafeFromCoreId var, hwTy))
 
 setRepName :: Text -> Name a -> Name a
 setRepName s (Name sort' _ i loc) = Name sort' s i loc
@@ -1778,8 +1776,8 @@ expandTopEntity ihwtys (oId, ohwty) topEntityM = do
   -- TODO 2: Warn about duplicate fields
   let
     Synthesize{..} = fromMaybe (defSyn (error $(curLoc))) topEntityM
-    argHints = map (maybe "arg" (Id.toText . id2identifier) . fst) ihwtys
-    resHint = maybe "result" (Id.toText . id2identifier) oId
+    argHints = map (maybe "arg" (nameOcc . varName) . fst) ihwtys
+    resHint = maybe "result" (nameOcc . varName) oId
 
   inputs <- zipWith3M goInput argHints (map snd ihwtys) (extendPorts t_inputs)
 

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -256,7 +256,7 @@ declare'
   -- ^ Expression pointing the the new signal
 declare' decName wireOrReg ty = do
   uniqueName <- Id.makeBasic decName
-  addDeclaration (NetDecl' Nothing wireOrReg uniqueName (Right ty) Nothing)
+  addDeclaration (NetDecl' Nothing wireOrReg uniqueName ty Nothing)
   pure uniqueName
 
 -- | Declare a new signal with the given name and type.

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -213,7 +213,7 @@ declarationReturn bbCtx blockName blockBuilder =
     res <- blockBuilder
     forM_ (zip (bbResults bbCtx) res) $ \(rNm, r) -> do
       let (Identifier resultNm Nothing, _) = rNm
-      addDeclaration (Assignment resultNm (eex r))
+      addDeclaration (Assignment resultNm Cont (eex r))
 
 emptyBlockState :: backend -> BlockState backend
 emptyBlockState bck = BlockState
@@ -248,15 +248,13 @@ declare'
   :: Backend backend
   => Text
   -- ^ Name hint
-  -> WireOrReg
-  -- ^ Should signal be declared as a wire or a reg
   -> HWType
   -- ^ Type of new signal
   -> State (BlockState backend) Identifier
   -- ^ Expression pointing the the new signal
-declare' decName wireOrReg ty = do
+declare' decName ty = do
   uniqueName <- Id.makeBasic decName
-  addDeclaration (NetDecl' Nothing wireOrReg uniqueName ty Nothing)
+  addDeclaration (NetDecl' Nothing uniqueName ty Nothing)
   pure uniqueName
 
 -- | Declare a new signal with the given name and type.
@@ -264,14 +262,12 @@ declare
   :: Backend backend
   => Text
   -- ^ Name hint
-  -> WireOrReg
-  -- ^ Should signal be declared as a wire or a reg
   -> HWType
   -- ^ Type of new signal
   -> State (BlockState backend) TExpr
   -- ^ Expression pointing the the new signal
-declare decName wireOrReg ty = do
-  uniqueName <- declare' decName wireOrReg ty
+declare decName ty = do
+  uniqueName <- declare' decName ty
   pure (TExpr ty (Identifier uniqueName Nothing))
 
 -- | Assign an expression to an identifier, returns the new typed
@@ -285,8 +281,8 @@ assign
   -> State (BlockState backend) TExpr
   -- ^ the identifier of the expression that actually got assigned
 assign aName (TExpr ty aExpr) = do
-  texp@(~(TExpr _ (Identifier uniqueName Nothing))) <- declare aName Wire ty
-  addDeclaration (Assignment uniqueName aExpr)
+  texp@(~(TExpr _ (Identifier uniqueName Nothing))) <- declare aName ty
+  addDeclaration (Assignment uniqueName Cont aExpr)
   pure texp
 
 -- | Extract the elements of a vector expression and return expressions
@@ -351,8 +347,8 @@ deconstructProduct
   -- ^ Name hints for element assignments
   -> State (BlockState backend) [TExpr]
 deconstructProduct (TExpr ty@(Product _ _ tys) (Identifier resName _)) vals = do
-  newNames <- zipWithM (flip declare Wire) vals tys
-  addDeclaration $ Assignment resName $ DataCon ty (DC (ty, 0)) (fmap eex newNames)
+  newNames <- zipWithM declare vals tys
+  addDeclaration $ Assignment resName Cont $ DataCon ty (DC (ty, 0)) (fmap eex newNames)
   pure newNames
 deconstructProduct e i =
   error $ "deconstructProduct: " <> show e <> " " <> show i
@@ -412,7 +408,7 @@ boolToBit bitName = \case
   T -> pure High
   F -> pure Low
   TExpr Bool boolExpr -> do
-    texp@(~(TExpr _ (Identifier uniqueBitName Nothing))) <- declare bitName Wire Bit
+    texp@(~(TExpr _ (Identifier uniqueBitName Nothing))) <- declare bitName Bit
     addDeclaration $
       CondAssignment uniqueBitName Bit boolExpr Bool
         [ (Just (BoolLit True), Literal Nothing (BitLit H))
@@ -430,7 +426,7 @@ enableToBit
   -> State (BlockState backend) TExpr
 enableToBit bitName = \case
   TExpr ena@(Enable _) enableExpr -> do
-    texp@(~(TExpr _ (Identifier uniqueBitName Nothing))) <- declare bitName Wire Bit
+    texp@(~(TExpr _ (Identifier uniqueBitName Nothing))) <- declare bitName Bit
     addDeclaration $
       CondAssignment uniqueBitName Bit enableExpr ena
         -- Enable normalizes to Bool for all current backends
@@ -454,7 +450,7 @@ boolFromBit boolName = \case
   High -> pure T
   Low -> pure F
   TExpr Bit bitExpr -> do
-    texp@(~(TExpr _ (Identifier uniqueBoolName Nothing))) <- declare boolName Wire Bool
+    texp@(~(TExpr _ (Identifier uniqueBoolName Nothing))) <- declare boolName Bool
     addDeclaration $
       CondAssignment uniqueBoolName Bool bitExpr Bit
         [ (Just (BitLit H), Literal Nothing (BoolLit True))
@@ -525,7 +521,7 @@ outputCoerce fromType toType exprStringFn inName0 expr_
       let inName2 = Id.unsafeMake (exprStringFn (Id.toText inName1))
           exprIdent = Identifier inName2 Nothing
       addDeclaration (NetDecl Nothing inName1 fromType)
-      addDeclaration (Assignment outName exprIdent)
+      addDeclaration (Assignment outName Cont exprIdent)
       pure (TExpr fromType (Identifier inName1 Nothing))
 outputCoerce _ toType _ _ texpr = error $ "outputCoerce: the expression " <> show texpr
                                   <> " must be an Identifier with type " <> show toType
@@ -551,7 +547,7 @@ outputFn fromTypes toType exprFn inNames0 (TExpr outType (Identifier outName Not
           exprIdent = Identifier idExpr Nothing
       sequenceOf_ each [ addDeclaration (NetDecl Nothing nm t)
                        | (nm, t) <- zip inNames1 fromTypes ]
-      addDeclaration (Assignment outName exprIdent)
+      addDeclaration (Assignment outName Cont exprIdent)
       pure [ TExpr t (Identifier nm Nothing)
            | (nm,t) <- zipEqual inNames1 fromTypes ]
 outputFn _ outType _ _ texpr =
@@ -700,15 +696,8 @@ instHO bbCtx fPos (resTy, bbResTy) argsWithTypes = do
   let
     args2 = map (pure . Text . Id.toLazyText) args1
 
-    -- Create result identifier
-    -- See https://github.com/clash-lang/clash-compiler/issues/919 for info on
-    -- logic of 'resWireOrReg'
-    resWireOrReg =
-      case IntMap.lookup fPos (bbFunctions bbCtx) of
-        Just ((_,rw,_,_,_,_):_) -> rw
-        _ -> error "internal error"
   resName <- declare' (ctxName <> "_" <> "ho" <> showt fPos <> "_"
-                               <> showt fSubPos <> "_res") resWireOrReg resTy
+                               <> showt fSubPos <> "_res") resTy
   let res = ([Text (Id.toLazyText resName)], bbResTy)
 
   -- Render HO argument to plain text
@@ -828,8 +817,8 @@ viaAnnotatedSignal
 viaAnnotatedSignal sigNm (TExpr fromTy fromExpr) (TExpr toTy (Identifier outNm Nothing)) attrs
   | fromTy == toTy = do
       addDeclaration (NetDecl Nothing sigNm (Annotated attrs fromTy))
-      addDeclaration (Assignment sigNm fromExpr)
-      addDeclaration (Assignment outNm (Identifier sigNm Nothing))
+      addDeclaration (Assignment sigNm Cont fromExpr)
+      addDeclaration (Assignment outNm Cont (Identifier sigNm Nothing))
 viaAnnotatedSignal _ inTExpr outTExpr@(TExpr _ (Identifier _ _)) _ =
   error $ "viaAnnotatedSignal: The in and out expressions \"" <> show inTExpr <>
   "\" and \"" <> show outTExpr <> "\" have non-matching types."

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -91,7 +91,7 @@ alteraPllTemplate bbCtx = do
 
  getAp $ blockDecl alteraPll $ concat
   [[ NetDecl Nothing locked Bit
-   , NetDecl' Nothing Reg pllLock Bool Nothing]
+   , NetDecl Nothing pllLock Bool]
   ,[ NetDecl Nothing clkNm ty | (clkNm,ty) <- zip clocks tys]
   ,[ InstDecl Comp Nothing [] compName alteraPll_inst [] $ NamedPortMap $ concat
       [ [ (instPort "refclk", In, clkTy, clk)
@@ -101,7 +101,7 @@ alteraPllTemplate bbCtx = do
    , CondAssignment pllLock Bool (Identifier locked Nothing) Bit
       [(Just (BitLit H),Literal Nothing (BoolLit True))
       ,(Nothing        ,Literal Nothing (BoolLit False))]
-   , Assignment result (DataCon resTy (DC (resTy,0)) $ concat
+   , Assignment result Cont (DataCon resTy (DC (resTy,0)) $ concat
                           [[Identifier k Nothing | k <- clocks]
                           ,[Identifier pllLock Nothing]])
 
@@ -130,7 +130,7 @@ altpllTemplate bbCtx = do
 
  getAp $ blockDecl alteraPll
   [ NetDecl Nothing locked  Bit
-  , NetDecl' Nothing Reg pllLock Bool Nothing
+  , NetDecl Nothing pllLock Bool
   , NetDecl Nothing pllOut clkOutTy
   , InstDecl Comp Nothing [] compName alteraPll_inst [] $ NamedPortMap $
       [ (instPort "clk", In, clkTy, clk)
@@ -140,7 +140,7 @@ altpllTemplate bbCtx = do
   , CondAssignment pllLock Bool (Identifier locked Nothing) Bit
       [(Just (BitLit H),Literal Nothing (BoolLit True))
       ,(Nothing        ,Literal Nothing (BoolLit False))]
-  , Assignment result (DataCon resTy (DC (resTy,0))
+  , Assignment result Cont (DataCon resTy (DC (resTy,0))
                         [Identifier pllOut Nothing
                         ,Identifier pllLock Nothing])
 

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -1,6 +1,7 @@
 {-|
   Copyright   :  (C) 2018     , Google Inc.,
                      2021-2022, QBayLogic B.V.
+                     2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -90,7 +91,7 @@ alteraPllTemplate bbCtx = do
 
  getAp $ blockDecl alteraPll $ concat
   [[ NetDecl Nothing locked Bit
-   , NetDecl' Nothing Reg pllLock (Right Bool) Nothing]
+   , NetDecl' Nothing Reg pllLock Bool Nothing]
   ,[ NetDecl Nothing clkNm ty | (clkNm,ty) <- zip clocks tys]
   ,[ InstDecl Comp Nothing [] compName alteraPll_inst [] $ NamedPortMap $ concat
       [ [ (instPort "refclk", In, clkTy, clk)
@@ -129,7 +130,7 @@ altpllTemplate bbCtx = do
 
  getAp $ blockDecl alteraPll
   [ NetDecl Nothing locked  Bit
-  , NetDecl' Nothing Reg pllLock (Right Bool) Nothing
+  , NetDecl' Nothing Reg pllLock Bool Nothing
   , NetDecl Nothing pllOut clkOutTy
   , InstDecl Comp Nothing [] compName alteraPll_inst [] $ NamedPortMap $
       [ (instPort "clk", In, clkTy, clk)

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -1,5 +1,6 @@
 {-|
   Copyright   :  (C) 2020-2022 QBayLogic B.V.
+                     2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -230,7 +231,7 @@ foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
 
   -- Simple wire without comment
   sigDecl :: HWType -> WireOrReg -> Identifier -> Declaration
-  sigDecl typ rw nm = NetDecl' Nothing rw nm (Right typ) Nothing
+  sigDecl typ rw nm = NetDecl' Nothing rw nm typ Nothing
 
   -- Index the intermediate vector. This uses a hack in Clash: the 10th
   -- constructor of Vec doesn't exist; using it will be interpreted by the

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -17,7 +17,6 @@ import           Control.Monad                      (replicateM)
 import           Control.Monad.State                (State, zipWithM)
 import qualified Control.Lens                       as Lens
 import           Data.Either                        (rights)
-import qualified Data.IntMap                        as IntMap
 import           Data.List.Extra                    (iterateNM)
 import           Data.Maybe                         (fromMaybe)
 import           Data.Monoid                        (Ap(getAp))
@@ -43,11 +42,10 @@ import           Clash.Netlist.BlackBox.Types
   (BlackBoxFunction, BlackBoxMeta(..), TemplateKind(TExpr, TDecl),
    Element(Component, Typ, TypElem, Text), Decl(Decl), emptyBlackBoxMeta)
 import           Clash.Netlist.Types
-  (Identifier, TemplateFunction, BlackBoxContext, HWType(Vector),
+  (Identifier, TemplateFunction, BlackBoxContext, HWType(Vector), Usage(Cont),
    Declaration(..), Expr(Literal, Identifier,DataCon), Literal(NumLit),
-   BlackBox(BBTemplate, BBFunction), TemplateFunction(..), WireOrReg(Wire),
-   Modifier(Indexed, Nested, DC), HWType(..), bbInputs, bbResults, emptyBBContext, tcCache,
-   bbFunctions)
+   BlackBox(BBTemplate, BBFunction), TemplateFunction(..),
+   Modifier(Indexed, Nested, DC), HWType(..), bbInputs, bbResults, emptyBBContext, tcCache)
 import qualified Clash.Netlist.Id                   as Id
 import           Clash.Netlist.Util                 (typeSize)
 import qualified Clash.Primitives.DSL               as Prim
@@ -143,9 +141,9 @@ foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
   vecIds <- replicateM n (Id.next baseId)
 
   vecId <- Id.make "vec"
-  let vecDecl = sigDecl vecType Wire vecId
-      vecAssign = Assignment vecId vec
-      elemAssigns = zipWith Assignment vecIds (map (iIndex vecId) [0..])
+  let vecDecl = sigDecl vecType vecId
+      vecAssign = Assignment vecId Cont vec
+      elemAssigns = zipWith3 Assignment vecIds (repeat Cont) (map (iIndex vecId) [0..])
       resultId =
         case bbResults bbCtx of
           [(Identifier t _, _)] -> t
@@ -156,12 +154,8 @@ foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
   (concat -> fCalls, result) <- mkTree 1 vecIds
 
   let intermediateResultIds = concatMap (\(FCall l r _) -> [l, r]) fCalls
-      wr = case IntMap.lookup 0 (bbFunctions bbCtx) of
-             Just ((_,rw,_,_,_,_):_) -> rw
-             _ -> error "internal error"
-      sigDecls = zipWith (sigDecl aTy) (wr:replicate n Wire ++ repeat wr)
-                                       (result : intermediateResultIds)
-      resultAssign = Assignment resultId (Identifier result Nothing)
+      sigDecls = fmap (sigDecl aTy) (result : intermediateResultIds)
+      resultAssign = Assignment resultId Cont (Identifier result Nothing)
 
   callDecls <- zipWithM callDecl [0..] fCalls
   foldNm <- Id.make "fold"
@@ -230,8 +224,8 @@ foldTF' bbCtx@(bbInputs -> [_f, (vec, vecType@(Vector n aTy), _isLiteral)]) = do
     pure ([], rest)
 
   -- Simple wire without comment
-  sigDecl :: HWType -> WireOrReg -> Identifier -> Declaration
-  sigDecl typ rw nm = NetDecl' Nothing rw nm typ Nothing
+  sigDecl :: HWType -> Identifier -> Declaration
+  sigDecl typ nm = NetDecl Nothing nm typ
 
   -- Index the intermediate vector. This uses a hack in Clash: the 10th
   -- constructor of Vec doesn't exist; using it will be interpreted by the

--- a/clash-lib/src/Clash/Primitives/Util.hs
+++ b/clash-lib/src/Clash/Primitives/Util.hs
@@ -3,6 +3,7 @@
                     2017     , Myrtle Software Ltd
                     2018     , Google Inc.
                     2021     , QBayLogic B.V.
+                    2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -61,8 +62,8 @@ import           Clash.Netlist.BlackBox.Types
 hashCompiledPrimitive :: CompiledPrimitive -> Int
 hashCompiledPrimitive (Primitive {name, primSort}) = hash (name, primSort)
 hashCompiledPrimitive (BlackBoxHaskell {function}) = fst function
-hashCompiledPrimitive (BlackBox {name, kind, outputReg, libraries, imports, includes, template}) =
-  hash (name, kind, outputReg, libraries, imports, includes', hashBlackbox template)
+hashCompiledPrimitive (BlackBox {name, kind, outputUsage, libraries, imports, includes, template}) =
+  hash (name, kind, outputUsage, libraries, imports, includes', hashBlackbox template)
     where
       includes' = map (\(nms, bb) -> (nms, hashBlackbox bb)) includes
       hashBlackbox (BBTemplate bbTemplate) = hash bbTemplate
@@ -99,7 +100,7 @@ resolvePrimitive' _metaPath (Primitive name wf primType) =
   return (name, HasBlackBox [] (Primitive name wf primType))
 resolvePrimitive' metaPath BlackBox{template=t, includes=i, resultNames=r, resultInits=ri, ..} = do
   let resolveSourceM = traverse (traverse (resolveTemplateSource metaPath))
-  bb <- BlackBox name workInfo renderVoid multiResult kind () outputReg libraries imports functionPlurality
+  bb <- BlackBox name workInfo renderVoid multiResult kind () outputUsage libraries imports functionPlurality
           <$> mapM (traverse resolveSourceM) i
           <*> traverse resolveSourceM r
           <*> traverse resolveSourceM ri

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -79,7 +79,7 @@ checkBBF _isD _primName args _ty =
 
   -- Simple wire without comment
   sigDecl :: HWType -> Identifier -> Declaration
-  sigDecl typ nm = NetDecl' Nothing Wire nm (Right typ) Nothing
+  sigDecl typ nm = NetDecl' Nothing Wire nm typ Nothing
 
 checkTF
   :: [Declaration]

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -20,7 +20,7 @@ import           Clash.Core.Term                 (Term(Var), varToId)
 import           Clash.Core.TermLiteral          (termToDataError)
 import           Clash.Util                      (indexNote)
 import           Clash.Netlist                   (mkExpr)
-import           Clash.Netlist.Util              (stripVoid, id2identifier)
+import           Clash.Netlist.Util              (stripVoid)
 import qualified Clash.Netlist.Id                as Id
 import           Clash.Netlist.Types
   (BlackBox(BBFunction), TemplateFunction(..), BlackBoxContext, Identifier,
@@ -48,8 +48,8 @@ checkBBF _isD _primName args _ty =
   -- TODO: blackbox generated them.
   clk = indexNote "clk" (lefts args) 1
   clkExpr = Identifier clkId Nothing
-  (id2identifier -> clkId) = varToId clk
-  (id2identifier -> _clkId) = varToId (indexNote "rst" (lefts args) 2)
+  (Id.unsafeFromCoreId -> clkId) = varToId clk
+  (Id.unsafeFromCoreId -> _clkId) = varToId (indexNote "rst" (lefts args) 2)
 
   litArgs = do
     propName <- termToDataError (indexNote "propName" (lefts args) 3)
@@ -67,7 +67,7 @@ checkBBF _isD _primName args _ty =
     -- ^ Term to bind. Does not bind if it's already a reference to a signal
     -> NetlistMonad (Identifier, [Declaration])
     -- ^ ([new] reference to signal, [declarations need to get it in scope])
-  bindMaybe _ (Var vId) = pure (id2identifier vId, [])
+  bindMaybe _ (Var vId) = pure (Id.unsafeFromCoreId vId, [])
   bindMaybe Nothing t = bindMaybe (Just "s") t
   bindMaybe (Just nm) t = do
     tcm <- Lens.view tcCache

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -24,8 +24,8 @@ import           Clash.Netlist.Util              (stripVoid)
 import qualified Clash.Netlist.Id                as Id
 import           Clash.Netlist.Types
   (BlackBox(BBFunction), TemplateFunction(..), BlackBoxContext, Identifier,
-   NetlistMonad, Declaration(Assignment, NetDecl'),
-   HWType(Bool, KnownDomain), WireOrReg(Wire), NetlistId(..),
+   NetlistMonad, Declaration(Assignment, NetDecl), Usage(Cont),
+   HWType(Bool, KnownDomain), NetlistId(..),
    DeclarationType(Concurrent), tcCache, bbInputs, Expr(Identifier))
 import           Clash.Netlist.BlackBox.Types
   (BlackBoxFunction, BlackBoxMeta(..), TemplateKind(TDecl), RenderVoid(..),
@@ -75,11 +75,11 @@ checkBBF _isD _primName args _ty =
     (expr0, decls) <- mkExpr False Concurrent (NetlistId newId (inferCoreTypeOf tcm t)) t
     pure
       ( newId
-      , decls ++ [sigDecl Bool newId, Assignment newId expr0] )
+      , decls ++ [sigDecl Bool newId, Assignment newId Cont expr0] )
 
   -- Simple wire without comment
   sigDecl :: HWType -> Identifier -> Declaration
-  sigDecl typ nm = NetDecl' Nothing Wire nm typ Nothing
+  sigDecl typ nm = NetDecl Nothing nm typ
 
 checkTF
   :: [Declaration]

--- a/tests/shouldwork/Naming/NameHint.hs
+++ b/tests/shouldwork/Naming/NameHint.hs
@@ -39,10 +39,10 @@ assertOneDecl (Component _ _ _ ds) =
       error $ "Expected one declaration of a signal named "
            <> "\"someSignalName\", got " <> show (P.length is)
  where
-  isSigDecl (NetDecl' _ _ i@(isInfixOf "someSignalName" . Id.toText -> True) _ _) = [i]
+  isSigDecl (NetDecl' _ i@(isInfixOf "someSignalName" . Id.toText -> True) _ _) = [i]
   isSigDecl _ = []
 
-  isSigAssignment i (Assignment _ (Identifier i' _)) = i == i'
+  isSigAssignment i (Assignment _ _ (Identifier i' _)) = i == i'
   isSigAssignment _ _ = False
 
 mainVHDL :: IO ()

--- a/tests/shouldwork/Naming/T1041.hs
+++ b/tests/shouldwork/Naming/T1041.hs
@@ -71,8 +71,8 @@ assertOneVGA (Component _ _ _ ds)
   -- Multiple cases as mkUniqueIdentifier Basic
   -- in VHDL changes names to be lowercase.
   --
-  isVGADecl (NetDecl' _ Wire (Id.toText -> "vga") _ _) = True
-  isVGADecl (NetDecl' _ Wire (Id.toText -> "VGA") _ _) = True
+  isVGADecl (NetDecl' _ (Id.toText -> "vga") _ _) = True
+  isVGADecl (NetDecl' _ (Id.toText -> "VGA") _ _) = True
   isVGADecl _ = False
 
 mainVHDL :: IO ()

--- a/tests/shouldwork/Netlist/Identity.hs
+++ b/tests/shouldwork/Netlist/Identity.hs
@@ -20,9 +20,9 @@ testPath = "tests/shouldwork/Netlist/Identity.hs"
 assertAssignsInOut :: Component -> IO ()
 assertAssignsInOut (Component _ [i] [o] ds) =
   case ds of
-    [Assignment oName (Identifier iName Nothing)]
+    [Assignment oName _ (Identifier iName Nothing)]
       | Id.toText iName == Id.toText (fst i)
-      , Id.toText oName == Id.toText (fst ((\(_,x,_) -> x) o))
+      , Id.toText oName == Id.toText ((\(_,(n,_),_) -> n) o)
       -> return ()
       | otherwise -> P.error [I.i|
           Incorrect input/output names:

--- a/tests/shouldwork/Netlist/T1766.hs
+++ b/tests/shouldwork/Netlist/T1766.hs
@@ -58,7 +58,7 @@ assertNoDuplicateSignals (Component nm inps outs ds) =
         then pure ()
         else error ("Signals: " <> show signals <> ", unique names: " <> show unique)
  where
-  netName (NetDecl' _ _ i _ _) = Just i
+  netName (NetDecl' _ i _ _) = Just i
   netName _ = Nothing
 
 mainVHDL :: IO ()

--- a/tests/shouldwork/TopEntity/T1182A.hs
+++ b/tests/shouldwork/TopEntity/T1182A.hs
@@ -35,7 +35,7 @@ testPath :: FilePath
 testPath = "tests/shouldwork/TopEntity/T1182A.hs"
 
 assertInputs :: N.HWType -> N.Component -> IO ()
-assertInputs expType (N.Component _ [(clk,N.Clock _)] [(N.Wire,(ssan,actType),Nothing)] ds)
+assertInputs expType (N.Component _ [(clk,N.Clock _)] [(_,(ssan,actType),Nothing)] ds)
   | Id.toText clk == T.pack "CLK"
   , Id.toText ssan == T.pack "SS_AN"
   = pure ()

--- a/tests/shouldwork/TopEntity/T1182B.hs
+++ b/tests/shouldwork/TopEntity/T1182B.hs
@@ -41,9 +41,9 @@ testPath = "tests/shouldwork/TopEntity/T1182B.hs"
 
 assertInputs :: N.HWType-> N.HWType -> N.Component -> IO ()
 assertInputs exp1 exp2 (N.Component _ [(clk, N.Clock _)]
-  [ (N.Wire, (ssan, act1), Nothing)
-  , (N.Wire, (ssseg, act2), Nothing)
-  , (N.Wire, (ssdp, N.Bool), Nothing)
+  [ (_, (ssan, act1), Nothing)
+  , (_, (ssseg, act2), Nothing)
+  , (_, (ssdp, N.Bool), Nothing)
   ] ds)
   | Id.toText clk == T.pack "CLK"
   , Id.toText ssan == T.pack "SS_AN"


### PR DESCRIPTION
When producing sequential and concurrent code, there are restrictions for how the same declared signal can be assigned which depend on the HDL being targeted. In short, these are

  * VHDL: A `signal` can be assigned continuously, or procedurally with non-blocking assignment. A `variable` can only be assigned procedurally with blocking assignment.
  * Verilog: A `wire` can only be assigned continuously. A `reg` can only be assigned procedurally, but can be assigned both non-blocking and blocking.

When the backend produces HDL, it needs to know the type of a declaration to render it. With the `WireOrReg` type, this was easy for VHDL, but does not help differentiate between if a signal is intended to be a VHDL signal or variable. A more general type is now provided which provides the extra information to make this choice:

```haskell
data Blocking = Blocking | NonBlocking
data Usage    = Cont | Proc Blocking
```

Since a declaration can accept more than one type of assignment, the usage is not tracked with the declaration like `WireOrReg` was, but tracked in the assignments and a usage map is created for every component (tracking declared signals to their most restrictive use). When producing netlist, the current use of a signal should be checked to ensure that generated code only produces assignments that are valid for the backend being targeted.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
