### PR TITLE
Add flag rendering to 'ClashOpts'

### DIFF
--- a/Clash.hs
+++ b/Clash.hs
@@ -58,13 +58,13 @@ doHDL Proxy opts src = do
   putStrLn $ "Loading dependencies took " ++ prepStartDiff
 
   generateHDL clashEnv clashDesign (Just backend)
-    (ghcTypeToHWType (opt_intWidth opts)) ghcEvaluator evaluator Nothing startTime
+    (ghcTypeToHWType (_opt_intWidth opts)) ghcEvaluator evaluator Nothing startTime
 
 main :: IO ()
 main =
   let opts = defClashOpts
-               { opt_cachehdl = False
-               , opt_debug = debugSilent
-               , opt_clear = True
+               { _opt_cachehdl = False
+               , _opt_debug = debugSilent
+               , _opt_clear = True
                }
    in genVHDL opts "./examples/FIR.hs"

--- a/benchmark/benchmark-concurrency.hs
+++ b/benchmark/benchmark-concurrency.hs
@@ -41,5 +41,5 @@ benchFile idirs src =
       bench ("Generating HDL: " ++ src)
             (nfIO (generateHDL clashEnv clashDesign
                      (Just (initBackend @VHDLState (envOpts clashEnv)))
-                     (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                     (ghcTypeToHWType (_opt_intWidth (envOpts clashEnv)))
                      ghcEvaluator evaluator Nothing startTime))

--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -48,7 +48,7 @@ benchFile idirs src =
               (normalizeEntity
                  clashEnv
                  (designBindings clashDesign)
-                 (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                 (ghcTypeToHWType (_opt_intWidth (envOpts clashEnv)))
                  ghcEvaluator
                  evaluator
                  (fmap topId (designEntities clashDesign))

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -31,11 +31,11 @@ defaultTests =
 opts :: [FilePath] -> ClashOpts
 opts idirs =
   defClashOpts{
-      opt_cachehdl=False
-    , opt_clear=True
-    , opt_errorExtra = True
-    , opt_importPaths=idirs
-    , opt_specLimit=100 -- For "ManyEntitiesVaried"
+      _opt_cachehdl=False
+    , _opt_clear=True
+    , _opt_errorExtra = True
+    , _opt_importPaths=idirs
+    , _opt_specLimit=100 -- For "ManyEntitiesVaried"
     }
 
 hdl :: HDL
@@ -49,7 +49,7 @@ runInputStage idirs src = do
   let o = opts idirs
   let backend = initBackend @VHDLState o
   pds <- primDirs backend
-  generateBindings o (return ()) pds (opt_importPaths o) [] (hdlKind backend) src Nothing
+  generateBindings o (return ()) pds (_opt_importPaths o) [] (hdlKind backend) src Nothing
 
 runNormalisationStage
   :: [FilePath]
@@ -62,7 +62,7 @@ runNormalisationStage idirs src = do
   let topEntity = head topEntityNames
   transformedBindings <-
         normalizeEntity env (designBindings design)
-          (ghcTypeToHWType (opt_intWidth (opts idirs)))
+          (ghcTypeToHWType (_opt_intWidth (opts idirs)))
           ghcEvaluator
           evaluator
           topEntityNames supplyN topEntity

--- a/benchmark/profiling/run/profile-netlist-run.hs
+++ b/benchmark/profiling/run/profile-netlist-run.hs
@@ -57,12 +57,12 @@ benchFile idirs src = do
       topEntityMap = mkVarEnv (zip (map topId topEntities) topEntities)
       prefixM    = Nothing
       ite        = ifThenElseExpr hdlState'
-      hdlDir     = fromMaybe "." (opt_hdlDir (envOpts clashEnv)) </>
+      hdlDir     = fromMaybe "." (_opt_hdlDir (envOpts clashEnv)) </>
                          Clash.Backend.name hdlState' </>
                          takeWhile (/= '.') topEntityS
   (netlist,_,_) <-
     genNetlist clashEnv False transformedBindings topEntityMap compNames
-               (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+               (ghcTypeToHWType (_opt_intWidth (envOpts clashEnv)))
                ite (SomeBackend hdlState') seen hdlDir prefixM topEntity
   netlist `deepseq` putStrLn ".. done\n"
 

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 import           Clash.Driver
-import           Clash.Driver.Types           (ClashEnv(..), ClashOpts(opt_intWidth))
+import           Clash.Driver.Types           (ClashEnv(..), ClashOpts(_opt_intWidth))
 
 import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
@@ -44,7 +44,7 @@ benchFile idirs src = do
                    }
 
   res <- normalizeEntity clashEnv bindingsMap
-                   (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                   (ghcTypeToHWType (_opt_intWidth (envOpts clashEnv)))
                    ghcEvaluator
                    evaluator
                    topEntityNames supplyN topEntity

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -201,32 +201,37 @@ library
 
   Autogen-Modules:    Paths_clash_ghc
 
-  Exposed-Modules:    Clash.Main
+  Exposed-Modules:
+    Clash.Main
 
-                      -- exposed for use by the benchmarks
-                      Clash.GHC.Evaluator
-                      Clash.GHC.Evaluator.Primitive
-                      Clash.GHC.GenerateBindings
-                      Clash.GHC.LoadModules
-                      Clash.GHC.NetlistTypes
+    -- exposed for use by the benchmarks
+    Clash.GHC.Evaluator
+    Clash.GHC.Evaluator.Primitive
+    Clash.GHC.GenerateBindings
+    Clash.GHC.LoadModules
+    Clash.GHC.NetlistTypes
 
-                      Clash.GHC.PartialEval
-                      Clash.GHC.PartialEval.Eval
-                      Clash.GHC.PartialEval.Quote
-                      Clash.GHC.PartialEval.Primitive
+    Clash.GHC.PartialEval
+    Clash.GHC.PartialEval.Eval
+    Clash.GHC.PartialEval.Quote
+    Clash.GHC.PartialEval.Primitive
 
-                      Clash.GHCi.Common
+    Clash.GHCi.Common
 
-  Other-Modules:      Clash.GHCi.Leak
-                      Clash.GHCi.UI
-                      Clash.GHCi.UI.Info
-                      Clash.GHCi.UI.Monad
-                      Clash.GHCi.UI.Tags
+  Other-Modules:
+    Control.Lens.Extra
 
-                      Clash.GHC.ClashFlags
-                      Clash.GHC.GHC2Core
-                      Clash.GHC.LoadInterfaceFiles
-                      Clash.GHC.Util
-                      Paths_clash_ghc
+    Clash.GHCi.Leak
+    Clash.GHCi.UI
+    Clash.GHCi.UI.Info
+    Clash.GHCi.UI.Monad
+    Clash.GHCi.UI.Tags
+
+    Clash.GHC.ClashFlags
+    Clash.GHC.GHC2Core
+    Clash.GHC.LoadInterfaceFiles
+    Clash.GHC.Util
+    Paths_clash_ghc
+
   if impl(ghc >= 8.8.0)
     Other-Modules:    Clash.GHCi.Util

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -204,6 +204,10 @@ library
   Exposed-Modules:
     Clash.Main
 
+    -- exposed for tests (why don't we just export everything?)
+    Clash.GHC.ClashFlag
+    Clash.GHC.ClashFlags
+
     -- exposed for use by the benchmarks
     Clash.GHC.Evaluator
     Clash.GHC.Evaluator.Primitive
@@ -227,11 +231,35 @@ library
     Clash.GHCi.UI.Monad
     Clash.GHCi.UI.Tags
 
-    Clash.GHC.ClashFlags
     Clash.GHC.GHC2Core
     Clash.GHC.LoadInterfaceFiles
     Clash.GHC.Util
     Paths_clash_ghc
 
   if impl(ghc >= 8.8.0)
-    Other-Modules:    Clash.GHCi.Util
+    Other-Modules:
+      Clash.GHCi.Util
+
+test-suite unittests
+  import:           common-options
+  type:             exitcode-stdio-1.0
+  default-language: Haskell2010
+  main-is:          unittests.hs
+  ghc-options:      -Wall -Wcompat -threaded -with-rtsopts=-N
+  hs-source-dirs:   tests
+
+  build-depends:
+      base
+    , clash-lib
+    , clash-ghc
+    , ghc
+    , hedgehog
+    , lens
+    , tasty
+    , tasty-hunit
+    , tasty-hedgehog
+    , tasty-th
+    , text
+
+  Other-Modules:
+    Clash.Tests.GHC.ClashFlags

--- a/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-8.10/Clash/GHCi/UI.hs
@@ -2191,8 +2191,8 @@ makeHDL Proxy startAction optsRef srcs = do
   dflags <- GHC.getSessionDynFlags
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
-              let opts1  = opts0 { opt_color = useColor dflags }
-              let iw     = opt_intWidth opts1
+              let opts1  = opts0 { _opt_color = useColor dflags }
+              let iw     = _opt_intWidth opts1
                   hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2203,8 +2203,8 @@ makeHDL Proxy startAction optsRef srcs = do
                                     then Just odir
                                     else Nothing
                   idirs = importPaths dflags
-                  opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
-                                , opt_importPaths = idirs}
+                  opts2 = opts1 { _opt_hdlDir = maybe outputDir Just (_opt_hdlDir opts1)
+                                , _opt_importPaths = idirs}
                   backend = initBackend @backend opts2
 
               checkMonoLocalBinds dflags

--- a/clash-ghc/src-bin-8.10/Clash/Main.hs
+++ b/clash-ghc/src-bin-8.10/Clash/Main.hs
@@ -239,7 +239,7 @@ main' postLoadMode dflags0 args flagWarnings startAction clashOpts = do
 
   -- Propagate -Werror to Clash
   liftIO . modifyIORef' clashOpts $ \opts ->
-    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
+    opts { _opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
 
   let dflags4 = case lang of
                 HscInterpreted | not (gopt Opt_ExternalInterpreter dflags3) ->

--- a/clash-ghc/src-bin-8.10/Clash/Main.hs
+++ b/clash-ghc/src-bin-8.10/Clash/Main.hs
@@ -886,7 +886,7 @@ showOptions isInteractive = putStr . unlines . availableOptions
       availableOptions opts = concat
         [ flagsForCompletion isInteractive
         , map ('-':) (getFlagNames mode_flags)
-        , map ('-':) (getFlagNames (flagsClash opts))
+        , map ('-':) (getFlagNames (ghcClashFlags opts))
         ]
       getFlagNames opts         = map flagName opts
 

--- a/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-861/Clash/GHCi/UI.hs
@@ -2022,8 +2022,8 @@ makeHDL Proxy startAction optsRef srcs = do
   dflags <- GHC.getSessionDynFlags
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0 <- readIORef optsRef
-              let opts1  = opts0 { opt_color = useColor dflags }
-                  iw     = opt_intWidth opts1
+              let opts1  = opts0 { _opt_color = useColor dflags }
+                  iw     = _opt_intWidth opts1
                   hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2034,8 +2034,8 @@ makeHDL Proxy startAction optsRef srcs = do
                                     then Just odir
                                     else Nothing
                   idirs = importPaths dflags
-                  opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
-                                , opt_importPaths = idirs}
+                  opts2 = opts1 { _opt_hdlDir = maybe outputDir Just (_opt_hdlDir opts1)
+                                , _opt_importPaths = idirs}
                   backend = initBackend @backend opts2
 
               checkMonoLocalBinds dflags

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -238,7 +238,7 @@ main' postLoadMode dflags0 args flagWarnings startAction clashOpts = do
 
   -- Propagate -Werror to Clash
   liftIO . modifyIORef' clashOpts $ \opts ->
-    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
+    opts { _opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
 
   let dflags4 = case lang of
                 HscInterpreted | not (gopt Opt_ExternalInterpreter dflags3) ->

--- a/clash-ghc/src-bin-861/Clash/Main.hs
+++ b/clash-ghc/src-bin-861/Clash/Main.hs
@@ -848,7 +848,7 @@ showOptions isInteractive = putStr . unlines . availableOptions
       availableOptions opts = concat
         [ flagsForCompletion isInteractive
         , map ('-':) (getFlagNames mode_flags)
-        , map ('-':) (getFlagNames (flagsClash opts))
+        , map ('-':) (getFlagNames (ghcClashFlags opts))
         ]
       getFlagNames opts         = map flagName opts
 

--- a/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-881/Clash/GHCi/UI.hs
@@ -2113,8 +2113,8 @@ makeHDL Proxy startAction optsRef srcs = do
   dflags <- GHC.getSessionDynFlags
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
-              let opts1  = opts0 { opt_color = useColor dflags }
-              let iw     = opt_intWidth opts1
+              let opts1  = opts0 { _opt_color = useColor dflags }
+              let iw     = _opt_intWidth opts1
                   hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2125,8 +2125,8 @@ makeHDL Proxy startAction optsRef srcs = do
                                     then Just odir
                                     else Nothing
                   idirs = importPaths dflags
-                  opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
-                                , opt_importPaths = idirs}
+                  opts2 = opts1 { _opt_hdlDir = maybe outputDir Just (_opt_hdlDir opts1)
+                                , _opt_importPaths = idirs}
                   backend = initBackend @backend opts2
 
               checkMonoLocalBinds dflags

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -233,7 +233,7 @@ main' postLoadMode dflags0 args flagWarnings startAction clashOpts = do
 
   -- Propagate -Werror to Clash
   liftIO . modifyIORef' clashOpts $ \opts ->
-    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
+    opts { _opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
 
   let dflags4 = case lang of
                 HscInterpreted | not (gopt Opt_ExternalInterpreter dflags3) ->

--- a/clash-ghc/src-bin-881/Clash/Main.hs
+++ b/clash-ghc/src-bin-881/Clash/Main.hs
@@ -859,7 +859,7 @@ showOptions isInteractive = putStr . unlines . availableOptions
       availableOptions opts = concat
         [ flagsForCompletion isInteractive
         , map ('-':) (getFlagNames mode_flags)
-        , map ('-':) (getFlagNames (flagsClash opts))
+        , map ('-':) (getFlagNames (ghcClashFlags opts))
         ]
       getFlagNames opts         = map flagName opts
 

--- a/clash-ghc/src-bin-9.0/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.0/Clash/GHCi/UI.hs
@@ -2230,8 +2230,8 @@ makeHDL Proxy startAction optsRef srcs = do
   dflags <- GHC.getSessionDynFlags
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
-              let opts1  = opts0 { opt_color = useColor dflags }
-              let iw     = opt_intWidth opts1
+              let opts1  = opts0 { _opt_color = useColor dflags }
+              let iw     = _opt_intWidth opts1
                   hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
@@ -2242,8 +2242,8 @@ makeHDL Proxy startAction optsRef srcs = do
                                     then Just odir
                                     else Nothing
                   idirs = importPaths dflags
-                  opts2 = opts1 { opt_hdlDir = maybe outputDir Just (opt_hdlDir opts1)
-                                , opt_importPaths = idirs}
+                  opts2 = opts1 { _opt_hdlDir = maybe outputDir Just (_opt_hdlDir opts1)
+                                , _opt_importPaths = idirs}
                   backend = initBackend @backend opts2
 
               checkMonoLocalBinds dflags

--- a/clash-ghc/src-bin-9.0/Clash/Main.hs
+++ b/clash-ghc/src-bin-9.0/Clash/Main.hs
@@ -240,7 +240,7 @@ main' postLoadMode dflags0 args flagWarnings startAction clashOpts = do
 
   -- Propagate -Werror to Clash
   liftIO . modifyIORef' clashOpts $ \opts ->
-    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
+    opts { _opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
 
   let dflags4 = case lang of
                 HscInterpreted | not (gopt Opt_ExternalInterpreter dflags3) ->

--- a/clash-ghc/src-bin-9.0/Clash/Main.hs
+++ b/clash-ghc/src-bin-9.0/Clash/Main.hs
@@ -887,7 +887,7 @@ showOptions isInteractive = putStr . unlines . availableOptions
       availableOptions opts = concat [
         flagsForCompletion isInteractive,
         map ('-':) (getFlagNames mode_flags),
-        map ('-':) (getFlagNames (flagsClash opts))
+        map ('-':) (getFlagNames (ghcClashFlags opts))
         ]
       getFlagNames opts         = map flagName opts
 

--- a/clash-ghc/src-bin-common/Clash/GHCi/Common.hs
+++ b/clash-ghc/src-bin-common/Clash/GHCi/Common.hs
@@ -114,7 +114,7 @@ active :: LangExt.Extension -> GHC.DynFlags -> Bool
 active ext = GHC.member ext . GHC.extensionFlags
 
 checkImportDirs :: Foldable t => ClashOpts -> t FilePath -> IO ()
-checkImportDirs opts idirs = when (opt_checkIDir opts) $
+checkImportDirs opts idirs = when (_opt_checkIDir opts) $
   forM_ idirs $ \dir -> do
     doesDirectoryExist dir >>= \case
       False -> throwGhcException (CmdLineError $ "Missing directory: " ++ dir)

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlag.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlag.hs
@@ -1,0 +1,399 @@
+{-|
+  Copyright   :  (C) 2022, QBayLogic B.V.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Utilities to parse and render flags exposed on the Clash's command line.
+-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Clash.GHC.ClashFlag
+  ( ClashFlag(..)
+  , FlagName
+
+  -- * Simple flag builders
+  , boolFlag
+  , wordFlag
+  , intFlag
+  , readableFlag
+
+  , maybeStringFlag
+  , maybeIntFlag
+  , maybeWordFlag
+  , maybeReadableFlag
+
+  , maybeStringWithDefaultFlag
+
+  -- * Generic flag builders
+  , boolArg
+  , unsetArg
+  , wordSuffix, wordSuffixId
+  , intSuffix, intSuffixId
+  , strSuffix, strSuffixId
+
+  -- * Flag renderers
+  , renderNoArg
+  , renderSuffix
+  , renderSepSuffix
+
+  -- * Utilities
+  , deprecated
+  , isDefault
+  ) where
+
+-- base
+import Data.IORef (IORef, modifyIORef)
+
+-- ghc
+#if __GLASGOW_HASKELL__ >= 900
+import GHC.Driver.CmdLine
+#else
+import CmdLineParser
+#endif
+  (EwM, Flag (Flag, flagOptKind), liftEwM, OptKind (..), defFlag, addErr, deprecate)
+
+-- clash-lib
+import Clash.Driver.Types (ClashOpts(..), defClashOpts)
+
+-- lens
+import Control.Lens (Lens', (^.), set)
+import Text.Read (readMaybe)
+
+-- | Defines a way to parse command line flags, set their values in a 'ClashOpts',
+-- and render flags based on a 'ClashOpts'.
+data ClashFlag = ClashFlag
+  { cfFlags :: IORef ClashOpts -> [Flag IO]
+  , cfRender :: ClashOpts -> [String]
+  }
+
+type FlagName = String
+
+-- | Return two flags covering a single property: @-fclash-foo@ and @-fclash-no-foo@.
+boolFlag :: FlagName -> Lens' ClashOpts Bool -> ClashFlag
+boolFlag nm opt = ClashFlag
+  { cfFlags = \opts -> boolArg nm opts (set opt)
+  , cfRender = \opts -> if isDefault opt opts then [] else renderNoArg nm (opts ^. opt)
+  }
+
+-- | Return a flag setting a 'Word': @-fclash-foo=3@.
+wordFlag :: FlagName -> Lens' ClashOpts Word -> ClashFlag
+wordFlag nm opt = ClashFlag
+  { cfFlags = \ref -> wordSuffixId nm ref (set opt)
+  , cfRender = \opts ->
+      if isDefault opt opts then [] else renderSuffix nm (show (opts ^. opt))
+  }
+
+-- | Return a flag setting a 'Int': @-fclash-foo=3@.
+intFlag :: FlagName -> Lens' ClashOpts Int -> ClashFlag
+intFlag nm opt = ClashFlag
+  { cfFlags = \ref -> intSuffixId nm ref (set opt)
+  , cfRender = \opts ->
+      if isDefault opt opts then [] else renderSuffix nm (show (opts ^. opt))
+  }
+
+-- | Return two flags setting a 'Maybe' 'String': @-fclash-foo wibble@ and
+-- @-fclash-no-foo@.
+maybeStringFlag :: FlagName -> Lens' ClashOpts (Maybe String) -> ClashFlag
+maybeStringFlag nm opt = ClashFlag
+  { cfFlags = \opts ->
+         strSuffixId nm opts (set opt . Just)
+      ++ unsetArg nm opts (set opt)
+  , cfRender = \opts ->
+      if isDefault opt opts
+      then []
+      else case opts ^. opt of
+        Nothing -> renderNoArg nm False
+        Just s -> renderSepSuffix nm s
+  }
+
+
+-- | Return three flags setting a 'Maybe' 'String'. If no argument is supplied, a
+-- default value is set. For example, if the default is @simpleDefault@, then:
+--
+--   * @-fclash-foo@ sets the option to @Just "simpleDefault"@
+--   * @-fclash-foo=wibble@ sets the option to @Just "wibble"@
+--   * @-fclash-no-foo@ sets the option to @Nothing@
+--
+maybeStringWithDefaultFlag ::
+  FlagName ->
+  -- | Default
+  String ->
+  Lens' ClashOpts (Maybe String) ->
+  ClashFlag
+maybeStringWithDefaultFlag flagName dflt opt = ClashFlag
+  { cfFlags = \opts ->
+         anySuffix flagName opts parser (set opt)
+      ++ unsetArg flagName opts (set opt)
+  , cfRender = \opts ->
+      if isDefault opt opts
+      then []
+      else case opts ^. opt of
+        Nothing -> renderNoArg flagName False
+        Just s | s == dflt -> renderSuffix flagName ""
+        Just s -> renderSuffix flagName s
+  }
+ where
+  parser :: String -> EwM IO (Maybe (Maybe String))
+  parser ['='] = pure (Just (Just dflt))
+  parser ('=':v) = pure (Just (Just v))
+  parser s = do
+    addErr ("Could not parse: " <> s)
+    pure Nothing
+
+-- | Return two flags setting a 'Maybe' 'Int'.
+--
+--   * @-fclash-foo=3@ sets the option to @Just 3@
+--   * @-fclash-no-foo@ sets the option to @Nothing@
+--
+maybeIntFlag :: FlagName -> Lens' ClashOpts (Maybe Int) -> ClashFlag
+maybeIntFlag nm opt = ClashFlag
+  { cfFlags = \ref ->
+         intSuffixId nm ref (set opt . Just)
+      ++ unsetArg nm ref (set opt)
+
+  , cfRender = \opts ->
+      if isDefault opt opts
+      then []
+      else case opts ^. opt of
+        Nothing -> renderNoArg nm False
+        Just a -> renderSuffix nm (show a)
+  }
+
+-- | Return two flags setting a 'Maybe' 'Word'.
+--
+--   * @-fclash-foo=3@ sets the option to @Just 3@
+--   * @-fclash-no-foo@ sets the option to @Nothing@
+--
+maybeWordFlag :: FlagName -> Lens' ClashOpts (Maybe Word) -> ClashFlag
+maybeWordFlag nm opt = ClashFlag
+  { cfFlags = \ref ->
+         wordSuffixId nm ref (set opt . Just)
+      ++ unsetArg nm ref (set opt)
+
+  , cfRender = \opts ->
+      if isDefault opt opts
+      then []
+      else case opts ^. opt of
+        Nothing -> renderNoArg nm False
+        Just a -> renderSuffix nm (show a)
+  }
+
+maybeReadableFlag ::
+  forall a.
+  (Eq a, Read a, Show a) =>
+  FlagName ->
+  Lens' ClashOpts (Maybe a) ->
+  ClashFlag
+maybeReadableFlag nm opt = ClashFlag
+  { cfFlags = \ref ->
+         strSuffix nm ref parser (set opt)
+      ++ unsetArg nm ref (set opt)
+
+  , cfRender = \opts ->
+      if isDefault opt opts
+      then []
+      else case opts ^. opt of
+        Nothing -> renderNoArg nm False
+        Just a -> renderSepSuffix nm (show a)
+  }
+ where
+  parser :: String -> EwM IO (Maybe (Maybe a))
+  parser s = case readMaybe s of
+    Nothing -> do
+      addErr ("Could not parse flag argument: " <> s)
+      pure Nothing
+    a -> pure (Just a)
+
+
+readableFlag ::
+  forall a.
+  (Eq a, Read a, Show a) =>
+  FlagName ->
+  Lens' ClashOpts a ->
+  ClashFlag
+readableFlag nm opt = ClashFlag
+  { cfFlags = \ref -> strSuffix nm ref parser (set opt)
+  , cfRender = \opts ->
+      if isDefault opt opts then [] else renderSepSuffix nm (show (opts ^. opt))
+  }
+ where
+  parser :: String -> EwM IO (Maybe a)
+  parser s = case readMaybe s of
+    Nothing -> addErr ("Could not parse " <> s)  >> pure Nothing
+    a -> pure a
+
+-- | Helper function....
+validateAndSet ::
+  IORef ClashOpts ->
+  (a -> EwM IO (Maybe b)) ->
+  (b -> ClashOpts -> ClashOpts) ->
+  a ->
+  EwM IO ()
+validateAndSet ref validateFunc setFunc v0 = do
+  v1 <- validateFunc v0
+  case v1 of
+    Nothing -> pure ()
+    Just v2 -> liftEwM (modifyIORef ref (setFunc v2))
+
+-- | Build NoArg flag....
+boolArg ::
+  FlagName ->
+  IORef ClashOpts ->
+  (Bool -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+boolArg flagName ref setFunc =
+  [ defFlag ("fclash-"    <> flagName) (NoArg (wrappedSetFunc True))
+  , defFlag ("fclash-no-" <> flagName) (NoArg (wrappedSetFunc False)) ]
+ where
+  wrappedSetFunc v = liftEwM (modifyIORef ref (setFunc v))
+
+unsetArg ::
+  String ->
+  IORef ClashOpts ->
+  (Maybe a -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+unsetArg flagName ref setFunc =
+  [defFlag ("fclash-no-" <> flagName) (NoArg (unsetEwM ref))]
+ where
+  unsetEwM opts = liftEwM (modifyIORef opts (setFunc Nothing))
+
+-- | Build IntSuffix / WordSuffix flag....
+wordSuffix ::
+  FlagName ->
+  IORef ClashOpts ->
+  -- | Parser / validator
+  (Word -> EwM IO (Maybe b)) ->
+  -- | Setter
+  (b -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+wordSuffix flagName ref validateFunc setFunc =
+  -- TODO: Newer versions of GHC support 'WordSuffix'. Use with CPP.
+  -- TODO: Validate for older versions of GHC
+  [ defFlag
+      ("fclash-" <> flagName)
+      (IntSuffix (validateAndSet ref validateFunc setFunc . fromIntegral)) ]
+
+-- | Build IntSuffix / WordSuffix flag....
+wordSuffixId ::
+  FlagName ->
+  IORef ClashOpts ->
+  -- | Setter
+  (Word -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+wordSuffixId flagName ref = wordSuffix flagName ref (pure . Just)
+
+-- | Build IntSuffix flag....
+intSuffix ::
+  FlagName ->
+  IORef ClashOpts ->
+  -- | Parser / validator
+  (Int -> EwM IO (Maybe b)) ->
+  -- | Setter
+  (b -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+intSuffix flagName ref validateFunc setFunc =
+  [ defFlag
+      ("fclash-" <> flagName)
+      (IntSuffix (validateAndSet ref validateFunc setFunc)) ]
+
+-- | Build IntSuffix flag....
+intSuffixId ::
+  FlagName ->
+  IORef ClashOpts ->
+  -- | Setter
+  (Int -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+intSuffixId flagName ref = intSuffix flagName ref (pure . Just)
+
+-- | Build StrSuffix flag....
+strSuffix ::
+  FlagName ->
+  IORef ClashOpts ->
+  -- | Parser / validator
+  (String -> EwM IO (Maybe b)) ->
+  -- | Setter
+  (b -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+strSuffix flagName ref validateFunc setFunc =
+  [ defFlag
+      ("fclash-" <> flagName)
+      (SepArg (validateAndSet ref validateFunc setFunc)) ]
+
+-- | Build IntSuffix flag....
+strSuffixId ::
+  FlagName ->
+  IORef ClashOpts ->
+  -- | Setter
+  (String -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+strSuffixId flagName ref = strSuffix flagName ref (pure . Just)
+
+
+anySuffix ::
+  forall b.
+  FlagName ->
+  IORef ClashOpts ->
+  -- | Parser / validator
+  (String -> EwM IO (Maybe b)) ->
+  -- | Setter
+  (b -> ClashOpts -> ClashOpts) ->
+  [Flag IO]
+anySuffix flagName ref parser setter =
+  [ defFlag
+      ("fclash-" <> flagName)
+      (AnySuffix (validateAndSet ref validateFunc setter)) ]
+ where
+  validateFunc :: String -> EwM IO (Maybe b)
+  validateFunc = parser . drop (length ("-fclash-" <> flagName))
+
+
+-- | Render a bool flag with given name and value unconditionally
+renderNoArg :: FlagName -> Bool -> [String]
+renderNoArg flagName value
+  | value = ["-fclash-" <> flagName]
+  | otherwise = ["-fclash-no-" <> flagName]
+
+-- | Render a flag @-fclash-foo arg@. This is the default flag type for
+-- everything that's /not/ a 'Word' or 'Int'.
+renderSepSuffix :: FlagName -> String -> [String]
+renderSepSuffix flagName value = ["-fclash-" <> flagName, value]
+
+-- | Render a flag @-fclash-foo=arg@. This is the default flag type for
+-- 'Word' and 'Int'.
+renderSuffix :: FlagName -> String -> [String]
+renderSuffix flagName value = ["-fclash-" <> flagName <> "=" <> value]
+
+-- | Add a deprecation warning to a 'ClashFlag'
+deprecated :: String -> ClashFlag -> ClashFlag
+deprecated msg cf = cf{cfFlags = map go . cfFlags cf}
+ where
+  go :: Flag IO -> Flag IO
+  go flag@Flag{flagOptKind} = flag{flagOptKind = goOpKind flagOptKind}
+
+  goOpKind :: OptKind IO -> OptKind IO
+  goOpKind = \case
+    NoArg em -> NoArg (deprecate msg >> em)
+    HasArg f -> goFunc HasArg f
+    SepArg f -> goFunc SepArg f
+    Prefix f -> goFunc Prefix f
+    OptPrefix f -> goFunc OptPrefix f
+    OptIntSuffix f -> goFunc OptIntSuffix f
+    IntSuffix f -> goFunc IntSuffix f
+    FloatSuffix f -> goFunc FloatSuffix f
+    PassFlag f -> goFunc PassFlag f
+    AnySuffix f -> goFunc AnySuffix f
+#if __GLASGOW_HASKELL__ <= 806
+    PrefixPred _ _ -> error "goOpKind: unexpected constructor PrefixPred"
+    AnySuffixPred _ _ -> error "goOpKind: unexpected constructor AnySuffixPred"
+#endif
+
+  goFunc :: ((a -> EwM IO ()) -> OptKind IO) -> (a -> EwM IO ()) -> OptKind IO
+  goFunc constr f = constr (\a -> deprecate msg >> f a)
+
+-- | Given a way to retrieve a value from a 'ClashOpts', determine whether the
+-- value in the given 'ClashOpts' corresponds to the one in 'defClashOpts'.
+isDefault :: Eq a => Lens' ClashOpts a -> ClashOpts -> Bool
+isDefault opt opts = defClashOpts ^. opt == opts ^. opt

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -110,46 +110,46 @@ deprecated wrong right f a = do
 setInlineLimit :: IORef ClashOpts
                -> Int
                -> IO ()
-setInlineLimit r n = modifyIORef r (\c -> c {opt_inlineLimit = n})
+setInlineLimit r n = modifyIORef r (\c -> c {_opt_inlineLimit = n})
 
 setInlineFunctionLimit
   :: IORef ClashOpts
   -> Int
   -> IO ()
-setInlineFunctionLimit r n = modifyIORef r (\c -> c {opt_inlineFunctionLimit = toEnum n})
+setInlineFunctionLimit r n = modifyIORef r (\c -> c {_opt_inlineFunctionLimit = toEnum n})
 
 setInlineConstantLimit
   :: IORef ClashOpts
   -> Int
   -> IO ()
-setInlineConstantLimit r n = modifyIORef r (\c -> c {opt_inlineConstantLimit = toEnum n})
+setInlineConstantLimit r n = modifyIORef r (\c -> c {_opt_inlineConstantLimit = toEnum n})
 
 setEvaluatorFuelLimit
   :: IORef ClashOpts
   -> Int
   -> IO ()
-setEvaluatorFuelLimit r n = modifyIORef r (\c -> c {opt_evaluatorFuelLimit = toEnum n})
+setEvaluatorFuelLimit r n = modifyIORef r (\c -> c {_opt_evaluatorFuelLimit = toEnum n})
 
 setInlineWFLimit
   :: IORef ClashOpts
   -> Int
   -> IO ()
-setInlineWFLimit r n = modifyIORef r (\c -> c {opt_inlineWFCacheLimit = toEnum n})
+setInlineWFLimit r n = modifyIORef r (\c -> c {_opt_inlineWFCacheLimit = toEnum n})
 
 setSpecLimit :: IORef ClashOpts
              -> Int
              -> IO ()
-setSpecLimit r n = modifyIORef r (\c -> c {opt_specLimit = n})
+setSpecLimit r n = modifyIORef r (\c -> c {_opt_specLimit = n})
 
 setDebugInvariants :: IORef ClashOpts -> IO ()
 setDebugInvariants r =
   modifyIORef r $ \c ->
-    c { opt_debug = (opt_debug c) { dbg_invariants = True } }
+    c { _opt_debug = (_opt_debug c) { _dbg_invariants = True } }
 
 setDebugCountTransformations :: IORef ClashOpts -> IO ()
 setDebugCountTransformations r =
   modifyIORef r $ \c ->
-    c { opt_debug = (opt_debug c) { dbg_countTransformations = True } }
+    c { _opt_debug = (_opt_debug c) { _dbg_countTransformations = True } }
 
 setDebugTransformations :: IORef ClashOpts -> String -> EwM IO ()
 setDebugTransformations r s =
@@ -159,21 +159,21 @@ setDebugTransformations r s =
   trim = dropWhileEnd isSpace . dropWhile isSpace
 
   setTransformations xs opts =
-    opts { opt_debug = (opt_debug opts) { dbg_transformations = xs } }
+    opts { _opt_debug = (_opt_debug opts) { _dbg_transformations = xs } }
 
 setDebugTransformationsFrom :: IORef ClashOpts -> Int -> EwM IO ()
 setDebugTransformationsFrom r n =
   liftEwM (modifyIORef r (setFrom (fromIntegral n)))
  where
   setFrom from opts =
-    opts { opt_debug = (opt_debug opts) { dbg_transformationsFrom = Just from } }
+    opts { _opt_debug = (_opt_debug opts) { _dbg_transformationsFrom = Just from } }
 
 setDebugTransformationsLimit :: IORef ClashOpts -> Int -> EwM IO ()
 setDebugTransformationsLimit r n =
   liftEwM (modifyIORef r (setLimit (fromIntegral n)))
  where
   setLimit limit opts =
-    opts { opt_debug = (opt_debug opts) { dbg_transformationsLimit = Just limit } }
+    opts { _opt_debug = (_opt_debug opts) { _dbg_transformationsLimit = Just limit } }
 
 setDebugLevel :: IORef ClashOpts -> String -> EwM IO ()
 setDebugLevel r s =
@@ -212,7 +212,7 @@ setDebugLevel r s =
       addWarn (s ++ " is an invalid debug level")
  where
   setLevel lvl opts =
-    opts { opt_debug = lvl }
+    opts { _opt_debug = lvl }
 
 setDebugInfo :: IORef ClashOpts -> String -> EwM IO ()
 setDebugInfo r s =
@@ -226,50 +226,50 @@ setDebugInfo r s =
       addWarn (s ++ " is an invalid debug info")
  where
   setInfo info opts =
-    opts { opt_debug = (opt_debug opts) { dbg_transformationInfo = info } }
+    opts { _opt_debug = (_opt_debug opts) { _dbg_transformationInfo = info } }
 
 setNoCache :: IORef ClashOpts -> IO ()
-setNoCache r = modifyIORef r (\c -> c {opt_cachehdl = False})
+setNoCache r = modifyIORef r (\c -> c {_opt_cachehdl = False})
 
 setNoIDirCheck :: IORef ClashOpts -> IO ()
-setNoIDirCheck r = modifyIORef r (\c -> c {opt_checkIDir = False})
+setNoIDirCheck r = modifyIORef r (\c -> c {_opt_checkIDir = False})
 
 setNoClean :: a -> EwM IO ()
 setNoClean _ = addWarn "-fclash-no-clean has been removed"
 
 setClear :: IORef ClashOpts -> IO ()
-setClear r = modifyIORef r (\c -> c {opt_clear = True})
+setClear r = modifyIORef r (\c -> c {_opt_clear = True})
 
 setNoPrimWarn :: IORef ClashOpts -> IO ()
-setNoPrimWarn r = modifyIORef r (\c -> c {opt_primWarn = False})
+setNoPrimWarn r = modifyIORef r (\c -> c {_opt_primWarn = False})
 
 setIntWidth :: IORef ClashOpts
             -> Int
             -> EwM IO ()
 setIntWidth r n =
   if n == 32 || n == 64
-     then liftEwM $ modifyIORef r (\c -> c {opt_intWidth = n})
+     then liftEwM $ modifyIORef r (\c -> c {_opt_intWidth = n})
      else addWarn (show n ++ " is an invalid Int/Word/Integer bit-width. Allowed widths: 32, 64.")
 
 setHdlDir :: IORef ClashOpts
           -> String
           -> EwM IO ()
-setHdlDir r s = liftEwM $ modifyIORef r (\c -> c {opt_hdlDir = Just s})
+setHdlDir r s = liftEwM $ modifyIORef r (\c -> c {_opt_hdlDir = Just s})
 
 setHdlSyn :: IORef ClashOpts
           -> String
           -> EwM IO ()
 setHdlSyn r s = case readMaybe s of
-  Just hdlSyn -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = hdlSyn})
+  Just hdlSyn -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = hdlSyn})
   Nothing -> case s of
-    "Xilinx"  -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Vivado})
-    "ISE"     -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Vivado})
-    "Altera"  -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Quartus})
-    "Intel"   -> liftEwM $ modifyIORef r (\c -> c {opt_hdlSyn = Quartus})
+    "Xilinx"  -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = Vivado})
+    "ISE"     -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = Vivado})
+    "Altera"  -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = Quartus})
+    "Intel"   -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = Quartus})
     _         -> addWarn (s ++ " is an unknown hdl synthesis tool")
 
 setErrorExtra :: IORef ClashOpts -> IO ()
-setErrorExtra r = modifyIORef r (\c -> c {opt_errorExtra = True})
+setErrorExtra r = modifyIORef r (\c -> c {_opt_errorExtra = True})
 
 setFloatSupport :: IORef ClashOpts -> EwM IO ()
 setFloatSupport _ =
@@ -280,38 +280,38 @@ setComponentPrefix
   -> String
   -> IO ()
 setComponentPrefix r s =
-  modifyIORef r (\c -> c {opt_componentPrefix = Just (Text.pack s)})
+  modifyIORef r (\c -> c {_opt_componentPrefix = Just (Text.pack s)})
 
 setOldInlineStrategy :: IORef ClashOpts -> IO ()
-setOldInlineStrategy r = modifyIORef r (\c -> c {opt_newInlineStrat = False})
+setOldInlineStrategy r = modifyIORef r (\c -> c {_opt_newInlineStrat = False})
 
 setNoEscapedIds :: IORef ClashOpts -> IO ()
-setNoEscapedIds r = modifyIORef r (\c -> c {opt_escapedIds = False})
+setNoEscapedIds r = modifyIORef r (\c -> c {_opt_escapedIds = False})
 
 setLowerCaseBasicIds :: IORef ClashOpts -> IO ()
-setLowerCaseBasicIds r = modifyIORef r (\c -> c {opt_lowerCaseBasicIds = ToLower})
+setLowerCaseBasicIds r = modifyIORef r (\c -> c {_opt_lowerCaseBasicIds = ToLower})
 
 setUltra :: IORef ClashOpts -> IO ()
-setUltra r = modifyIORef r (\c -> c {opt_ultra = True})
+setUltra r = modifyIORef r (\c -> c {_opt_ultra = True})
 
 setUndefined :: IORef ClashOpts -> Maybe Int -> EwM IO ()
 setUndefined _ (Just x) | x < 0 || x > 1 =
   addWarn ("-fclash-force-undefined=" ++ show x ++ " ignored, " ++ show x ++
            " not in range [0,1]")
 setUndefined r iM =
-  liftEwM (modifyIORef r (\c -> c {opt_forceUndefined = Just iM}))
+  liftEwM (modifyIORef r (\c -> c {_opt_forceUndefined = Just iM}))
 
 setAggressiveXOpt :: IORef ClashOpts -> IO ()
 setAggressiveXOpt r = do
-  modifyIORef r (\c -> c { opt_aggressiveXOpt = True })
+  modifyIORef r (\c -> c { _opt_aggressiveXOpt = True })
   setAggressiveXOptBB r
 
 
 setAggressiveXOptBB :: IORef ClashOpts -> IO ()
-setAggressiveXOptBB r = modifyIORef r (\c -> c { opt_aggressiveXOptBB = True })
+setAggressiveXOptBB r = modifyIORef r (\c -> c { _opt_aggressiveXOptBB = True })
 
 setEdalize :: IORef ClashOpts -> IO ()
-setEdalize r = modifyIORef r (\c -> c { opt_edalize = True })
+setEdalize r = modifyIORef r (\c -> c { _opt_edalize = True })
 
 setRewriteHistoryFile :: IORef ClashOpts -> String -> IO ()
 setRewriteHistoryFile r arg = do
@@ -321,7 +321,7 @@ setRewriteHistoryFile r arg = do
   modifyIORef r (setFile fileNm)
  where
   setFile file opts =
-    opts { opt_debug = (opt_debug opts) { dbg_historyFile = Just file } }
+    opts { _opt_debug = (_opt_debug opts) { _dbg_historyFile = Just file } }
 
 setNoRenderEnums :: IORef ClashOpts -> IO ()
-setNoRenderEnums r = modifyIORef r (\c -> c { opt_renderEnums = False })
+setNoRenderEnums r = modifyIORef r (\c -> c { _opt_renderEnums = False })

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -1,327 +1,326 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2016-2017, Myrtle Software Ltd,
-                     2021,      QBayLogic B.V.
+                     2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Clash command line flag definitions.
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
 
 module Clash.GHC.ClashFlags
   ( parseClashFlags
-  , flagsClash
-  )
-where
+  , ghcClashFlags
+  , renderClashFlags
+  ) where
 
 #if MIN_VERSION_ghc(9,0,0)
-import           GHC.Driver.CmdLine
-import           GHC.Utils.Panic
-import           GHC.Types.SrcLoc
+import GHC.Driver.CmdLine
+  (addErr, errorsToGhcException, processArgs, Err(errMsg), EwM, Flag, Warn)
+import GHC.Utils.Panic (throwGhcExceptionIO)
+import GHC.Types.SrcLoc (Located, unLoc)
 #else
 import           CmdLineParser
-import           Panic
-import           SrcLoc
+  (addErr, errorsToGhcException, processArgs, Err(errMsg), EwM, Flag, Warn)
+import           Panic (throwGhcExceptionIO)
+import           SrcLoc (Located, unLoc)
 #endif
 
 import           Control.Monad
-import           Data.Char                      (isSpace)
+import           Data.Char (toLower)
 import           Data.IORef
-import           Data.List                      (dropWhileEnd)
-import           Data.List.Split                (splitOn)
-import qualified Data.Set                       as Set
-import qualified Data.Text                      as Text
-import           Text.Read                      (readMaybe)
+import           Data.List (intercalate)
+import           Text.Read (readMaybe)
+
+import qualified Data.Set as Set
+import           Data.Set (Set)
+
+import qualified Data.Text as Text
+import           Data.Text (Text)
+
+import           Control.Lens (Lens', set, (^.), lens)
+import           Control.Lens.Extra (iso')
+
+import           Data.List.Split (splitOn)
 
 import           Clash.Driver.Types
 import           Clash.Netlist.BlackBox.Types   (HdlSyn (..))
-import           Clash.Netlist.Types            (PreserveCase (ToLower))
+import           Clash.Netlist.Types            (preserveCaseToBool, boolToPreserveCase)
 
-parseClashFlags :: IORef ClashOpts -> [Located String]
-                -> IO ([Located String],[Warn])
-parseClashFlags r = parseClashFlagsFull (flagsClash r)
+import           Clash.GHC.ClashFlag
 
-parseClashFlagsFull :: [Flag IO] -> [Located String]
-                    -> IO ([Located String],[Warn])
+parseClashFlags :: IORef ClashOpts -> [Located String] -> IO ([Located String], [Warn])
+parseClashFlags r = parseClashFlagsFull (ghcClashFlags r)
+
+renderClashFlags :: ClashOpts -> [String]
+renderClashFlags opts =
+  renderedClashFlags ++ renderedWError ++ renderedColor
+ where
+  renderedClashFlags = concatMap (`cfRender` opts) clashFlags
+
+  -- -Werror and -fdiagnostics-color are flags we inherit from GHC. Still, we
+  -- should render them.
+  --
+  -- TODO: This makes testing rather awkward. I think we should move it to a
+  --       separate data structure.
+  renderedWError = if opts ^. opt_werror then ["-Werror"] else []
+  renderedColor
+    | show (opts ^. opt_color) == show (defClashOpts ^. opt_color) = []
+    | otherwise = ["-fdiagnostics-color=" <> map toLower (show (opts ^. opt_color))]
+
+parseClashFlagsFull :: [Flag IO] -> [Located String] -> IO ([Located String], [Warn])
 parseClashFlagsFull flagsAvialable args = do
-  (leftovers,errs,warns) <- processArgs flagsAvialable args
+  (leftovers, errs, warns) <- processArgs flagsAvialable args
 
   unless (null errs) $ throwGhcExceptionIO $
-    errorsToGhcException . map (("on the commandline", ) .  unLoc . errMsg)
-                         $ errs
+    errorsToGhcException . map (("on the commandline", ) .  unLoc . errMsg) $ errs
 
   return (leftovers, warns)
 
-flagsClash :: IORef ClashOpts -> [Flag IO]
-flagsClash r = [
-    defFlag "fclash-debug"                       $ SepArg (setDebugLevel r)
-  , defFlag "fclash-debug-info"                  $ SepArg (setDebugInfo r)
-  , defFlag "fclash-debug-invariants"            $ NoArg (liftEwM (setDebugInvariants r))
-  , defFlag "fclash-debug-count-transformations" $ NoArg (liftEwM (setDebugCountTransformations r))
-  , defFlag "fclash-debug-transformations"       $ SepArg (setDebugTransformations r)
-  , defFlag "fclash-debug-transformations-from"  $ IntSuffix (setDebugTransformationsFrom r)
-  , defFlag "fclash-debug-transformations-limit" $ IntSuffix (setDebugTransformationsLimit r)
-  , defFlag "fclash-debug-history"               $ AnySuffix (liftEwM . (setRewriteHistoryFile r))
-  , defFlag "fclash-hdldir"                      $ SepArg (setHdlDir r)
-  , defFlag "fclash-hdlsyn"                      $ SepArg (setHdlSyn r)
-  , defFlag "fclash-nocache"                     $ NoArg (deprecated "nocache" "no-cache" setNoCache r)
-  , defFlag "fclash-no-cache"                    $ NoArg (liftEwM (setNoCache r))
-  , defFlag "fclash-no-check-inaccessible-idirs" $ NoArg (liftEwM (setNoIDirCheck r))
-  , defFlag "fclash-no-clean"                    $ NoArg (setNoClean r)
-  , defFlag "fclash-clear"                       $ NoArg (liftEwM (setClear r))
-  , defFlag "fclash-no-prim-warn"                $ NoArg (liftEwM (setNoPrimWarn r))
-  , defFlag "fclash-spec-limit"                  $ IntSuffix (liftEwM . setSpecLimit r)
-  , defFlag "fclash-inline-limit"                $ IntSuffix (liftEwM . setInlineLimit r)
-  , defFlag "fclash-inline-function-limit"       $ IntSuffix (liftEwM . setInlineFunctionLimit r)
-  , defFlag "fclash-inline-constant-limit"       $ IntSuffix (liftEwM . setInlineConstantLimit r)
-  , defFlag "fclash-evaluator-fuel-limit"        $ IntSuffix (liftEwM . setEvaluatorFuelLimit r)
-  , defFlag "fclash-intwidth"                    $ IntSuffix (setIntWidth r)
-  , defFlag "fclash-error-extra"                 $ NoArg (liftEwM (setErrorExtra r))
-  , defFlag "fclash-float-support"               $ NoArg (setFloatSupport r)
-  , defFlag "fclash-component-prefix"            $ SepArg (liftEwM . setComponentPrefix r)
-  , defFlag "fclash-old-inline-strategy"         $ NoArg (liftEwM (setOldInlineStrategy r))
-  , defFlag "fclash-no-escaped-identifiers"      $ NoArg (liftEwM (setNoEscapedIds r))
-  , defFlag "fclash-lower-case-basic-identifiers"$ NoArg (liftEwM (setLowerCaseBasicIds r))
-  , defFlag "fclash-compile-ultra"               $ NoArg (liftEwM (setUltra r))
-  , defFlag "fclash-force-undefined"             $ OptIntSuffix (setUndefined r)
-  , defFlag "fclash-aggressive-x-optimization"   $ NoArg (liftEwM (setAggressiveXOpt r))
-  , defFlag "fclash-aggressive-x-optimization-blackboxes" $ NoArg (liftEwM (setAggressiveXOptBB r))
-  , defFlag "fclash-inline-workfree-limit"       $ IntSuffix (liftEwM . setInlineWFLimit r)
-  , defFlag "fclash-edalize"                     $ NoArg (liftEwM (setEdalize r))
-  , defFlag "fclash-no-render-enums"             $ NoArg (liftEwM (setNoRenderEnums r))
+ghcClashFlags :: IORef ClashOpts -> [Flag IO]
+ghcClashFlags ref = concatMap (`cfFlags` ref) clashFlags
+
+clashFlags :: [ClashFlag]
+clashFlags =
+  -- TODO: Depending on the type of flag, users need to specify arguments differently. That
+  --       is:
+  --
+  --          * int/word:    -fclash-foo=3
+  --          * str/enum/..: -fclash-foo s
+  --
+  --       Even worse, there's a couple of exceptions to this rule too:
+  --
+  --          * -fclash-debug-history=history.dat
+  --          * -fclash-force-undefined 1
+  --
+  --       We should be liberal in what we accept and allow both types for all flags.
+  --
+  [ debugFlag "debug"
+  , debugInfoFlag "debug-info"
+  , boolFlag "debug-invariants" (opt_debug . dbg_invariants)
+  , boolFlag "count-transformations" (opt_debug . dbg_countTransformations)
+  , debugTransformationsFlag "debug-transformations"
+  , maybeWordFlag "debug-transformations-from" (opt_debug . dbg_transformationsFrom)
+  , maybeWordFlag "debug-transformations-limit" (opt_debug . dbg_transformationsLimit)
+  , maybeStringWithDefaultFlag "debug-history" "history.dat" (opt_debug . dbg_historyFile)
+  , maybeStringFlag "hdldir" opt_hdlDir
+  , hdlSynFlag "hdlsyn"
+  , boolFlag "cache" opt_cachehdl
+  , boolFlag "check-inaccessible-idirs" opt_checkIDir
+  , boolFlag "clear" opt_clear
+  , boolFlag "prim-warn" opt_primWarn
+  , intFlag  "spec-limit" opt_specLimit
+  , intFlag  "inline-limit" opt_inlineLimit
+  , wordFlag "inline-function-limit" opt_inlineFunctionLimit
+  , wordFlag "inline-constant-limit" opt_inlineConstantLimit
+  , wordFlag "evaluator-fuel-limit" opt_evaluatorFuelLimit
+  , intWidthFlag "intwidth"
+  , boolFlag "error-extra" opt_errorExtra
+  , maybeStringFlag "component-prefix" (opt_componentPrefix . packUnpackLens)
+  , boolFlag "old-inline-strategy" (opt_newInlineStrat . iso' not not)
+  , boolFlag "escaped-identifiers" opt_escapedIds
+  , boolFlag "lower-case-basic-identifiers" lowerCaseLens
+  , boolFlag "compile-ultra" opt_ultra
+  , forceUndefinedFlag "fclash-force-undefined"
+  , aggressiveXOptFlag "aggressive-x-optimization"
+  , boolFlag "aggressive-x-optimization-blackboxes" opt_aggressiveXOptBB
+  , wordFlag "inline-workfree-limit" opt_inlineWFCacheLimit
+  , boolFlag "edalize" opt_edalize
+  , boolFlag "render-enums" opt_renderEnums
+
+  -- Deprecated/removed flags:
+  , deprecated
+      (  "-fclash-float-support is always enabled from Clash 1.6 and onwards. Passing "
+      <> "this flag will yield an error from Clash 1.10." ) $
+      boolFlag "float-support" voidLens
+
+  , deprecated
+      (  "-fclash-clean has been removed. Passing this flag will yield an error from "
+      <> "Clash 1.10." ) $
+      boolFlag "clean" voidLens
+
+  , deprecated
+      ( "-fclash-nocache deprecated in favor of -fclash-no-cache. Passing this flag "
+      <> "will yield an error from Clash 1.10." ) $
+      (boolFlag "nocache" (opt_cachehdl . iso' not not)){ cfRender = const [] }
   ]
-
--- | Print deprecated flag warning
-deprecated
-  :: String
-  -- ^ Deprecated flag
-  -> String
-  -- ^ Use X instead
-  -> (a -> IO ())
-  -> a
-  -> EwM IO ()
-deprecated wrong right f a = do
-  addWarn ("Using '-fclash-" ++ wrong
-                             ++ "' is deprecated. Use '-fclash-"
-                             ++ right
-                             ++ "' instead.")
-  liftEwM (f a)
-
-setInlineLimit :: IORef ClashOpts
-               -> Int
-               -> IO ()
-setInlineLimit r n = modifyIORef r (\c -> c {_opt_inlineLimit = n})
-
-setInlineFunctionLimit
-  :: IORef ClashOpts
-  -> Int
-  -> IO ()
-setInlineFunctionLimit r n = modifyIORef r (\c -> c {_opt_inlineFunctionLimit = toEnum n})
-
-setInlineConstantLimit
-  :: IORef ClashOpts
-  -> Int
-  -> IO ()
-setInlineConstantLimit r n = modifyIORef r (\c -> c {_opt_inlineConstantLimit = toEnum n})
-
-setEvaluatorFuelLimit
-  :: IORef ClashOpts
-  -> Int
-  -> IO ()
-setEvaluatorFuelLimit r n = modifyIORef r (\c -> c {_opt_evaluatorFuelLimit = toEnum n})
-
-setInlineWFLimit
-  :: IORef ClashOpts
-  -> Int
-  -> IO ()
-setInlineWFLimit r n = modifyIORef r (\c -> c {_opt_inlineWFCacheLimit = toEnum n})
-
-setSpecLimit :: IORef ClashOpts
-             -> Int
-             -> IO ()
-setSpecLimit r n = modifyIORef r (\c -> c {_opt_specLimit = n})
-
-setDebugInvariants :: IORef ClashOpts -> IO ()
-setDebugInvariants r =
-  modifyIORef r $ \c ->
-    c { _opt_debug = (_opt_debug c) { _dbg_invariants = True } }
-
-setDebugCountTransformations :: IORef ClashOpts -> IO ()
-setDebugCountTransformations r =
-  modifyIORef r $ \c ->
-    c { _opt_debug = (_opt_debug c) { _dbg_countTransformations = True } }
-
-setDebugTransformations :: IORef ClashOpts -> String -> EwM IO ()
-setDebugTransformations r s =
-  liftEwM (modifyIORef r (setTransformations transformations))
  where
-  transformations = Set.fromList (filter (not . null) (map trim (splitOn "," s)))
-  trim = dropWhileEnd isSpace . dropWhile isSpace
+  voidLens :: Lens' ClashOpts Bool
+  voidLens = lens (const True) const
 
-  setTransformations xs opts =
-    opts { _opt_debug = (_opt_debug opts) { _dbg_transformations = xs } }
+  lowerCaseLens :: Lens' ClashOpts Bool
+  lowerCaseLens = opt_lowerCaseBasicIds . iso' preserveCaseToBool boolToPreserveCase
 
-setDebugTransformationsFrom :: IORef ClashOpts -> Int -> EwM IO ()
-setDebugTransformationsFrom r n =
-  liftEwM (modifyIORef r (setFrom (fromIntegral n)))
+  packUnpackLens :: Lens' (Maybe Text) (Maybe String)
+  packUnpackLens = iso' (fmap Text.unpack) (fmap Text.pack)
+
+hdlSynFlag :: FlagName -> ClashFlag
+hdlSynFlag flagName = ClashFlag
+  { cfFlags = \ref -> strSuffix flagName ref parser (set opt_hdlSyn)
+  , cfRender = \opts ->
+      if isDefault opt_hdlSyn opts
+      then []
+      else renderSepSuffix flagName (show (opts ^. opt_hdlSyn))
+  }
  where
-  setFrom from opts =
-    opts { _opt_debug = (_opt_debug opts) { _dbg_transformationsFrom = Just from } }
+  parser :: String -> EwM IO (Maybe HdlSyn)
+  parser s = case readMaybe s of
+    Just hdlSyn ->
+      pure (Just hdlSyn)
 
-setDebugTransformationsLimit :: IORef ClashOpts -> Int -> EwM IO ()
-setDebugTransformationsLimit r n =
-  liftEwM (modifyIORef r (setLimit (fromIntegral n)))
+    Nothing -> case s of
+      -- TODO: Should we add a deprecation warning for these flags? We could
+      --       just use 'maybeReadableFlag' and ditch this custom impl if we
+      --       once the warning has been up long enough.
+      "Xilinx" -> pure (Just Vivado)
+      "ISE"    -> pure (Just Vivado)
+      "Altera" -> pure (Just Quartus)
+      "Intel"  -> pure (Just Quartus)
+      _ -> do
+        addErr (s ++ " is an unknown hdl synthesis tool")
+        pure Nothing
+
+debugTransformationsFlag :: FlagName -> ClashFlag
+debugTransformationsFlag flagName = ClashFlag
+  { cfFlags = \ref ->
+      strSuffix flagName ref parser (set transformations)
+  , cfRender = \opts ->
+      -- XXX: Assumes default value is the empty set
+      if Set.null (opts ^. transformations)
+      then []
+      else renderSuffix flagName (render (opts ^. transformations))
+  }
  where
-  setLimit limit opts =
-    opts { _opt_debug = (_opt_debug opts) { _dbg_transformationsLimit = Just limit } }
+  transformations :: Lens' ClashOpts (Set String)
+  transformations = opt_debug . dbg_transformations
 
-setDebugLevel :: IORef ClashOpts -> String -> EwM IO ()
-setDebugLevel r s =
-  case s of
-    "DebugNone" ->
-      liftEwM $ modifyIORef r (setLevel debugNone)
-    "DebugSilent" ->
-      liftEwM $ do
-        modifyIORef r (setLevel debugSilent)
-        setNoCache r
-    "DebugFinal" ->
-      liftEwM $ do
-        modifyIORef r (setLevel debugFinal)
-        setNoCache r
-    "DebugCount" ->
-      liftEwM $ do
-        modifyIORef r (setLevel debugCount)
-        setNoCache r
-    "DebugName" ->
-      liftEwM $ do
-        modifyIORef r (setLevel debugName)
-        setNoCache r
-    "DebugTry" ->
-      liftEwM $ do
-        modifyIORef r (setLevel debugTry)
-        setNoCache r
-    "DebugApplied" ->
-      liftEwM $ do
-        modifyIORef r (setLevel debugApplied)
-        setNoCache r
-    "DebugAll" ->
-      liftEwM $ do
-        modifyIORef r (setLevel debugAll)
-        setNoCache r
-    _ ->
-      addWarn (s ++ " is an invalid debug level")
+  render :: Set String -> String
+  render = intercalate "," . Set.elems
+
+  parser :: String -> EwM IO (Maybe (Set String))
+  parser = pure . Just . Set.fromList . splitOn ","
+
+intWidthFlag :: FlagName -> ClashFlag
+intWidthFlag flagName = ClashFlag
+  { cfFlags = \ref -> intSuffix flagName ref parser (set opt_intWidth)
+  , cfRender = \opts ->
+    if isDefault opt_intWidth opts
+    then []
+    else renderSuffix flagName (show (opts ^. opt_intWidth))
+  }
  where
-  setLevel lvl opts =
-    opts { _opt_debug = lvl }
+  parser :: Int -> EwM IO (Maybe Int)
+  parser 32 = pure (Just 32)
+  parser 64 = pure (Just 64)
+  parser n = do
+    addErr ("Invalid value: " <> show n <> ". Pick one of: 32, 64.")
+    pure Nothing
 
-setDebugInfo :: IORef ClashOpts -> String -> EwM IO ()
-setDebugInfo r s =
-  case readMaybe s of
-    Just info ->
-      liftEwM $ do
-        modifyIORef r (setInfo info)
-        when (info /= None) (setNoCache r)
+debugInfoFlag :: FlagName -> ClashFlag
+debugInfoFlag flagName = ClashFlag
+  { cfFlags = \ref ->
+      strSuffix flagName ref parser setter
 
-    Nothing ->
-      addWarn (s ++ " is an invalid debug info")
+  , cfRender = \opts ->
+      if isDefault info opts then
+        []
+      else
+        let
+          suffixFlag = renderSepSuffix flagName (show (opts ^. info))
+        in
+          suffixFlag ++ case (opts ^. info, opts ^. opt_cachehdl) of
+            -- If user explicitly enabled caching after setting a debug flag, we
+            -- need to render it too.
+            (None, _) -> []
+            (_, True) -> renderNoArg "cache" True
+            _ -> []
+  }
  where
-  setInfo info opts =
-    opts { _opt_debug = (_opt_debug opts) { _dbg_transformationInfo = info } }
+  info :: Lens' ClashOpts TransformationInfo
+  info = opt_debug . dbg_transformationInfo
 
-setNoCache :: IORef ClashOpts -> IO ()
-setNoCache r = modifyIORef r (\c -> c {_opt_cachehdl = False})
+  -- If a debug option is set, we disable HDL caching
+  setter (False, debug) opts = set info debug opts
+  setter (True, debug) opts = setter (False, debug) (set opt_cachehdl False opts)
 
-setNoIDirCheck :: IORef ClashOpts -> IO ()
-setNoIDirCheck r = modifyIORef r (\c -> c {_opt_checkIDir = False})
+  parser :: String -> EwM IO (Maybe (Bool, TransformationInfo))
+  parser s = case readMaybe s of
+    Just None -> pure (Just (False, None))
+    Just t -> pure (Just (True, t))
+    Nothing -> do
+     addErr ("Unrecognized option: " <> s)
+     pure Nothing
 
-setNoClean :: a -> EwM IO ()
-setNoClean _ = addWarn "-fclash-no-clean has been removed"
-
-setClear :: IORef ClashOpts -> IO ()
-setClear r = modifyIORef r (\c -> c {_opt_clear = True})
-
-setNoPrimWarn :: IORef ClashOpts -> IO ()
-setNoPrimWarn r = modifyIORef r (\c -> c {_opt_primWarn = False})
-
-setIntWidth :: IORef ClashOpts
-            -> Int
-            -> EwM IO ()
-setIntWidth r n =
-  if n == 32 || n == 64
-     then liftEwM $ modifyIORef r (\c -> c {_opt_intWidth = n})
-     else addWarn (show n ++ " is an invalid Int/Word/Integer bit-width. Allowed widths: 32, 64.")
-
-setHdlDir :: IORef ClashOpts
-          -> String
-          -> EwM IO ()
-setHdlDir r s = liftEwM $ modifyIORef r (\c -> c {_opt_hdlDir = Just s})
-
-setHdlSyn :: IORef ClashOpts
-          -> String
-          -> EwM IO ()
-setHdlSyn r s = case readMaybe s of
-  Just hdlSyn -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = hdlSyn})
-  Nothing -> case s of
-    "Xilinx"  -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = Vivado})
-    "ISE"     -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = Vivado})
-    "Altera"  -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = Quartus})
-    "Intel"   -> liftEwM $ modifyIORef r (\c -> c {_opt_hdlSyn = Quartus})
-    _         -> addWarn (s ++ " is an unknown hdl synthesis tool")
-
-setErrorExtra :: IORef ClashOpts -> IO ()
-setErrorExtra r = modifyIORef r (\c -> c {_opt_errorExtra = True})
-
-setFloatSupport :: IORef ClashOpts -> EwM IO ()
-setFloatSupport _ =
-  addWarn "Deprecated flag: -fclash-float-support is always enabled from Clash 1.6 and onwards"
-
-setComponentPrefix
-  :: IORef ClashOpts
-  -> String
-  -> IO ()
-setComponentPrefix r s =
-  modifyIORef r (\c -> c {_opt_componentPrefix = Just (Text.pack s)})
-
-setOldInlineStrategy :: IORef ClashOpts -> IO ()
-setOldInlineStrategy r = modifyIORef r (\c -> c {_opt_newInlineStrat = False})
-
-setNoEscapedIds :: IORef ClashOpts -> IO ()
-setNoEscapedIds r = modifyIORef r (\c -> c {_opt_escapedIds = False})
-
-setLowerCaseBasicIds :: IORef ClashOpts -> IO ()
-setLowerCaseBasicIds r = modifyIORef r (\c -> c {_opt_lowerCaseBasicIds = ToLower})
-
-setUltra :: IORef ClashOpts -> IO ()
-setUltra r = modifyIORef r (\c -> c {_opt_ultra = True})
-
-setUndefined :: IORef ClashOpts -> Maybe Int -> EwM IO ()
-setUndefined _ (Just x) | x < 0 || x > 1 =
-  addWarn ("-fclash-force-undefined=" ++ show x ++ " ignored, " ++ show x ++
-           " not in range [0,1]")
-setUndefined r iM =
-  liftEwM (modifyIORef r (\c -> c {_opt_forceUndefined = Just iM}))
-
-setAggressiveXOpt :: IORef ClashOpts -> IO ()
-setAggressiveXOpt r = do
-  modifyIORef r (\c -> c { _opt_aggressiveXOpt = True })
-  setAggressiveXOptBB r
-
-
-setAggressiveXOptBB :: IORef ClashOpts -> IO ()
-setAggressiveXOptBB r = modifyIORef r (\c -> c { _opt_aggressiveXOptBB = True })
-
-setEdalize :: IORef ClashOpts -> IO ()
-setEdalize r = modifyIORef r (\c -> c { _opt_edalize = True })
-
-setRewriteHistoryFile :: IORef ClashOpts -> String -> IO ()
-setRewriteHistoryFile r arg = do
-  let fileNm = case drop (length "-fclash-debug-history=") arg of
-                [] -> "history.dat"
-                str -> str
-  modifyIORef r (setFile fileNm)
+debugFlag :: FlagName -> ClashFlag
+debugFlag flagName = ClashFlag
+  { cfFlags = \ref -> strSuffix flagName ref parser setter
+  , cfRender = const []  -- Alias flag, all rendering handled by other flags
+  }
  where
-  setFile file opts =
-    opts { _opt_debug = (_opt_debug opts) { _dbg_historyFile = Just file } }
+  -- If a debug option is set, we disable HDL caching
+  setter (False, debug) opts = set opt_debug debug opts
+  setter (True, debug) opts = setter (False, debug) (set opt_cachehdl False opts)
 
-setNoRenderEnums :: IORef ClashOpts -> IO ()
-setNoRenderEnums r = modifyIORef r (\c -> c { _opt_renderEnums = False })
+  parser :: String -> EwM IO (Maybe (Bool, DebugOpts))
+  parser = \case
+   --                            disable cache?  debug info
+   "DebugNone"    -> pure (Just (False,          debugNone))
+   "DebugSilent"  -> pure (Just (True,           debugSilent))
+   "DebugFinal"   -> pure (Just (True,           debugFinal))
+   "DebugCount"   -> pure (Just (True,           debugCount))
+   "DebugName"    -> pure (Just (True,           debugName))
+   "DebugTry"     -> pure (Just (True,           debugTry))
+   "DebugApplied" -> pure (Just (True,           debugApplied))
+   "DebugAll"     -> pure (Just (True,           debugAll))
+   s -> do
+     addErr ("Unrecognized option: " <> s)
+     pure Nothing
+
+aggressiveXOptFlag :: FlagName -> ClashFlag
+aggressiveXOptFlag flagName = ClashFlag
+  { cfFlags = \ref -> boolArg flagName ref setBoth
+  , cfRender = \opts ->
+      if | xOpt opts == xOpt defClashOpts -> []
+         | xOpt opts && not (xOptBB opts) ->
+            -- Enabling x-optimization implies enabling blackbox x-optimization. If
+            -- this is later explicitly disabled by a user, we need to make sure to
+            -- replicate that.
+               renderNoArg flagName (xOpt opts)
+            <> renderNoArg "aggressive-x-optimization-blackboxes" (xOptBB opts)
+         | otherwise -> renderNoArg flagName (xOpt opts)
+  }
+ where
+  xOpt opts = opts ^. opt_aggressiveXOpt
+  xOptBB opts = opts ^. opt_aggressiveXOptBB
+
+  setBoth b = set opt_aggressiveXOptBB b . set opt_aggressiveXOpt b
+
+forceUndefinedFlag :: FlagName -> ClashFlag
+forceUndefinedFlag flagName = ClashFlag
+  { cfFlags = \ref ->
+         strSuffix flagName ref parser (set opt_forceUndefined)
+      ++ unsetArg flagName ref (set opt_forceUndefined)
+  , cfRender = \opts ->
+      if isDefault opt_forceUndefined opts then
+        []
+      else
+        case opts ^. opt_forceUndefined of
+          Nothing -> renderNoArg flagName False
+          Just Nothing -> renderSepSuffix flagName "c"
+          Just (Just n) -> renderSepSuffix flagName (show n)
+  }
+ where
+  parser :: String -> EwM IO (Maybe (Maybe (Maybe Int)))
+  parser = \case
+    -- TODO: Replace the maybes with a sum type
+    "0" -> pure (Just (Just (Just 0)))
+    "1" -> pure (Just (Just (Just 1)))
+    "c" -> pure (Just (Just Nothing))
+    s -> do
+      addErr ("Unrecognized option: " <> show s <> ". Options: 0, 1, c.")
+      pure Nothing

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -126,7 +126,7 @@ generateBindings opts startAction primDirs importDirs dbs hdl modName dflagsM = 
    , partitionEithers -> (unresolvedPrims, pFP)
    , customBitRepresentations
    , primGuards
-   , domainConfs ) <- loadModules startAction (opt_color opts) hdl modName dflagsM importDirs
+   , domainConfs ) <- loadModules startAction (_opt_color opts) hdl modName dflagsM importDirs
   startTime <- Clock.getCurrentTime
   primMapR <- generatePrimMap unresolvedPrims primGuards (concat [pFP, primDirs, importDirs])
   tdir <- maybe ghcLibDir (pure . GHC.topDir) dflagsM

--- a/clash-ghc/src-ghc/Clash/GHC/Util.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Util.hs
@@ -41,7 +41,7 @@ handleClashException df opts e = case fromException e of
   Just (ClashException sp s eM) -> do
     let srcInfo' | isGoodSrcSpan sp = srcInfo
                  | otherwise = empty
-    throwOneError (mkPlainErrMsg df sp (blankLine $$ textLines s $$ blankLine $$ srcInfo' $$ showExtra (opt_errorExtra opts) eM))
+    throwOneError (mkPlainErrMsg df sp (blankLine $$ textLines s $$ blankLine $$ srcInfo' $$ showExtra (_opt_errorExtra opts) eM))
   _ -> case fromException e of
     Just (ErrorCallWithLocation _ _) ->
       throwOneError (mkPlainErrMsg df noSrcSpan (text "Clash error call:" $$ textLines (show e)))

--- a/clash-ghc/src-ghc/Control/Lens/Extra.hs
+++ b/clash-ghc/src-ghc/Control/Lens/Extra.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Control.Lens.Extra where
+
+import Control.Lens (Lens', lens)
+
+iso' :: (a -> b) -> (b -> a) -> Lens' a b
+iso' ab ba = lens ab (const ba)

--- a/clash-ghc/tests/Clash/Tests/GHC/ClashFlags.hs
+++ b/clash-ghc/tests/Clash/Tests/GHC/ClashFlags.hs
@@ -1,0 +1,402 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Clash.Tests.GHC.ClashFlags where
+
+import Data.IORef (newIORef, readIORef)
+
+import GHC (GenLocated(..), noLoc, unLoc)
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Driver.CmdLine (Warn(..))
+import GHC.Utils.Misc (OverridingBool(Never, Auto))
+#else
+import CmdLineParser (Warn(..))
+import Util (OverridingBool(Never, Auto))
+#endif
+
+import Test.Tasty
+import Test.Tasty.Hedgehog (testPropertyNamed)
+import Test.Tasty.HUnit
+import Test.Tasty.Runners (TestTree(..))
+import Test.Tasty.TH
+
+import qualified Hedgehog as H
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Control.Lens (Lens', (^.))
+
+import Data.Text (Text)
+
+import Clash.Driver.Types
+
+import Clash.GHC.ClashFlags (parseClashFlags, renderClashFlags)
+
+-- Enable usage of Hedgehog operators:
+instance Show (GenLocated l e) where
+  show _ = "<GenLocated>"
+deriving instance Show Warn
+deriving instance Eq Warn
+
+-- | Parse given flags. Return leftover flags, warnings, and clash options.
+runParse :: [String] -> IO ([String], [Warn], ClashOpts)
+runParse args = do
+  optsRef <- newIORef defClashOpts
+  (leftovers, warns) <- parseClashFlags optsRef (map noLoc args)
+  opts <- readIORef optsRef
+  pure (map unLoc leftovers, warns, opts)
+
+-- | Parse given flags, fail if any flags are left unparsed or if any warnings
+-- are emitted.
+runParseClean :: [String] -> IO ClashOpts
+runParseClean args = do
+  (leftovers, warns, opts) <- runParse args
+  [] @=? leftovers
+  assertBool "" (null warns)
+  pure opts
+
+runRoundtrip :: [String] -> Assertion
+runRoundtrip args0 = do
+  (_, _, opts0) <- runParse args0
+  let args1 = renderClashFlags opts0
+  (_, _, opts1) <- runParse args1
+  opts0 @=? opts1
+
+runRoundtripClean :: [String] -> Assertion
+runRoundtripClean args0 = do
+  opts0 <- runParseClean args0
+  let args1 = renderClashFlags opts0
+  opts1 <- runParseClean args1
+  opts0 @=? opts1
+
+-- | Parser should return 'defClashOpts' if no arguments are given.
+case_parseNoArgs :: Assertion
+case_parseNoArgs = do
+  opts <- runParseClean []
+  defClashOpts @=? opts
+
+-- | Caching should be disabled through 'fclash-no-cache'
+case_cache :: Assertion
+case_cache = do
+  opts <- runParseClean ["-fclash-no-cache"]
+  defClashOpts{_opt_cachehdl=False} @=? opts
+
+-- | Caching should be disabled through 'fclash-no-cache'
+case_opposite_flags :: Assertion
+case_opposite_flags = do
+  opts <- runParseClean ["-fclash-no-cache", "-fclash-cache"]
+  defClashOpts @=? opts
+
+-- | Deprecated flags should yield a warning
+case_deprecated :: Assertion
+case_deprecated = do
+  (leftovers, warns, _opts) <- runParse ["-fclash-clean"]
+  [] @=? leftovers
+  1 @=? length warns
+
+-- | Non-existing flags should be passed through
+case_nonExisting :: Assertion
+case_nonExisting = do
+  (leftovers, warns, _opts) <- runParse ["-fclash-non-existing"]
+  ["-fclash-non-existing"] @=? leftovers
+  0 @=? length warns
+
+-- | Rendering default options should yield no flags
+case_renderDefault :: Assertion
+case_renderDefault = [] @=? renderClashFlags defClashOpts
+
+-- | Test whether -Werror (a GHC flag, not a Clash flag despite being in
+-- ClashOpts) is rendered upon setting it.
+case_werrorRender :: Assertion
+case_werrorRender = ["-Werror"] @=? renderClashFlags defClashOpts{_opt_werror=True}
+
+-- | Test whether -Wcolor (a GHC flag, not a Clash flag despite being in
+-- ClashOpts) is rendered upon setting it.
+case_colorRender :: Assertion
+case_colorRender =
+  let opts = defClashOpts{_opt_color=Never} in
+  ["-fdiagnostics-color=never"] @=? renderClashFlags opts
+
+-- | Test whether we can set some values in `ClashOpt` and do a render/parse roundtrip
+-- without losing information.
+case_roundtripEmpty :: Assertion
+case_roundtripEmpty = runRoundtripClean []
+
+-- | Test whether we can set some values in `ClashOpt` and do a render/parse roundtrip
+-- without losing information.
+case_roundtripCache :: Assertion
+case_roundtripCache = runRoundtripClean ["-fclash-cache"]
+
+-- | Test whether we can set some values in `ClashOpt` and do a render/parse roundtrip
+-- without losing information.
+case_roundtripXopt :: Assertion
+case_roundtripXopt = runRoundtripClean ["-fclash-aggressive-x-optimization"]
+
+-- | Test whether we can set some values in `ClashOpt` and do a render/parse roundtrip
+-- without losing information.
+case_roundtripXoptDisable :: Assertion
+case_roundtripXoptDisable =
+  runRoundtripClean
+    [ "-fclash-aggressive-x-optimization"
+    , "-fclash-no-aggressive-x-optimization-blackboxes" ]
+
+-- | Whether we want to generate a random value or use a default. This makes sure
+-- 'genClashOpts' shrinks towards 'defClashOpts'. Furthermore,
+data FuzzMode = Default | Fuzz
+  deriving (Show, Eq, Enum, Bounded)
+
+-- | Generate whether to fuzz or not. Shrinks towards 'Default'.
+genFuzzMode :: H.Gen FuzzMode
+genFuzzMode = Gen.enumBounded
+
+-- | Return given generator if fuzz mode is set to 'Fuzz'. Else, return a constant
+-- value retrieved with the given lens.
+genWithFuzzMode :: H.Gen a -> Lens' ClashOpts a -> FuzzMode -> H.Gen a
+genWithFuzzMode _genA opt Default = pure (defClashOpts ^. opt)
+genWithFuzzMode genA _opt Fuzz = genA
+
+genBool :: Lens' ClashOpts Bool -> FuzzMode -> H.Gen Bool
+genBool = genWithFuzzMode Gen.enumBounded
+
+genMaybe :: Lens' ClashOpts (Maybe a) -> H.Gen a -> FuzzMode -> H.Gen (Maybe a)
+genMaybe opt genA = genWithFuzzMode (Gen.maybe genA) opt
+
+genEnumBounded :: (Enum a, Bounded a) => Lens' ClashOpts a -> FuzzMode -> H.Gen a
+genEnumBounded = genWithFuzzMode Gen.enumBounded
+
+genPosInt :: Lens' ClashOpts Int -> FuzzMode -> H.Gen Int
+genPosInt = genWithFuzzMode (Gen.int (Range.linear 0 maxBound))
+
+genWord :: Lens' ClashOpts Word -> FuzzMode -> H.Gen Word
+genWord =
+  -- XXX: We currently only accept words from 0 to the max bound of Int. See
+  --      'wordSuffix'.
+  genWithFuzzMode (Gen.word (Range.linear 0 (fromIntegral (maxBound :: Int))))
+
+genElement :: Lens' ClashOpts a -> [a] -> FuzzMode -> H.Gen a
+genElement opt elements = genWithFuzzMode (Gen.element elements) opt
+
+genSimpleString :: H.Gen String
+genSimpleString = Gen.string (Range.linear 1 10) Gen.lower
+
+genSimpleText :: H.Gen Text
+genSimpleText = Gen.text (Range.linear 1 10) Gen.lower
+
+genClashOpts :: HasCallStack => _ -> H.Gen ClashOpts
+genClashOpts
+  -- Fuzz arguments are supplied externally for nicer error reporting
+  ( _opt_aggressiveXOpt_fuzz
+  , _opt_aggressiveXOptBB_fuzz
+  , _opt_cachehdl_fuzz
+  , _opt_checkIDir_fuzz
+  , _opt_clear_fuzz
+  , _opt_componentPrefix_fuzz
+  , _opt_edalize_fuzz
+  , _opt_errorExtra_fuzz
+  , _opt_escapedIds_fuzz
+  , _opt_evaluatorFuelLimit_fuzz
+  , _opt_forceUndefined_fuzz
+  , _opt_hdlDir_fuzz
+  , _opt_hdlSyn_fuzz
+  , _opt_inlineConstantLimit_fuzz
+  , _opt_inlineFunctionLimit_fuzz
+  , _opt_inlineLimit_fuzz
+  , _opt_inlineWFCacheLimit_fuzz
+  , _opt_intWidth_fuzz
+  , _opt_lowerCaseBasicIds_fuzz
+  , _opt_newInlineStrat_fuzz
+  , _opt_primWarn_fuzz
+  , _opt_renderEnums_fuzz
+  , _opt_specLimit_fuzz
+  , _opt_ultra_fuzz
+  , _dbg_countTransformations_fuzz
+  , _dbg_historyFile_fuzz
+  , _dbg_invariants_fuzz
+  , _dbg_transformationInfo_fuzz
+  , _dbg_transformations_fuzz
+  , _dbg_transformationsFrom_fuzz
+  , _dbg_transformationsLimit_fuzz ) = do
+  let
+    _opt_werror = False
+    _opt_color  = Auto
+    _opt_importPaths = []
+
+  _opt_aggressiveXOpt      <- gen_opt_aggressiveXOpt      _opt_aggressiveXOpt_fuzz
+  _opt_aggressiveXOptBB    <- gen_opt_aggressiveXOptBB    _opt_aggressiveXOptBB_fuzz
+  _opt_cachehdl            <- gen_opt_cachehdl            _opt_cachehdl_fuzz
+  _opt_checkIDir           <- gen_opt_checkIDir           _opt_checkIDir_fuzz
+  _opt_clear               <- gen_opt_clear               _opt_clear_fuzz
+  _opt_componentPrefix     <- gen_opt_componentPrefix     _opt_componentPrefix_fuzz
+  _opt_edalize             <- gen_opt_edalize             _opt_edalize_fuzz
+  _opt_errorExtra          <- gen_opt_errorExtra          _opt_errorExtra_fuzz
+  _opt_escapedIds          <- gen_opt_escapedIds          _opt_escapedIds_fuzz
+  _opt_evaluatorFuelLimit  <- gen_opt_evaluatorFuelLimit  _opt_evaluatorFuelLimit_fuzz
+  _opt_forceUndefined      <- gen_opt_forceUndefined      _opt_forceUndefined_fuzz
+  _opt_hdlDir              <- gen_opt_hdlDir              _opt_hdlDir_fuzz
+  _opt_hdlSyn              <- gen_opt_hdlSyn              _opt_hdlSyn_fuzz
+  _opt_inlineConstantLimit <- gen_opt_inlineConstantLimit _opt_inlineConstantLimit_fuzz
+  _opt_inlineFunctionLimit <- gen_opt_inlineFunctionLimit _opt_inlineFunctionLimit_fuzz
+  _opt_inlineLimit         <- gen_opt_inlineLimit         _opt_inlineLimit_fuzz
+  _opt_inlineWFCacheLimit  <- gen_opt_inlineWFCacheLimit  _opt_inlineWFCacheLimit_fuzz
+  _opt_intWidth            <- gen_opt_intWidth            _opt_intWidth_fuzz
+  _opt_lowerCaseBasicIds   <- gen_opt_lowerCaseBasicIds   _opt_lowerCaseBasicIds_fuzz
+  _opt_newInlineStrat      <- gen_opt_newInlineStrat      _opt_newInlineStrat_fuzz
+  _opt_primWarn            <- gen_opt_primWarn            _opt_primWarn_fuzz
+  _opt_renderEnums         <- gen_opt_renderEnums         _opt_renderEnums_fuzz
+  _opt_specLimit           <- gen_opt_specLimit           _opt_specLimit_fuzz
+  _opt_ultra               <- gen_opt_ultra               _opt_ultra_fuzz
+
+  _dbg_countTransformations <- gen_dbg_countTransformations _dbg_countTransformations_fuzz
+  _dbg_historyFile          <- gen_dbg_historyFile          _dbg_historyFile_fuzz
+  _dbg_invariants           <- gen_dbg_invariants           _dbg_invariants_fuzz
+  _dbg_transformationInfo   <- gen_dbg_transformationInfo   _dbg_transformationInfo_fuzz
+  _dbg_transformations      <- gen_dbg_transformations      _dbg_transformations_fuzz
+  _dbg_transformationsFrom  <- gen_dbg_transformationsFrom  _dbg_transformationsFrom_fuzz
+  _dbg_transformationsLimit <- gen_dbg_transformationsLimit _dbg_transformationsLimit_fuzz
+
+  pure ClashOpts{_opt_debug=DebugOpts{..}, ..}
+ where
+  gen_opt_aggressiveXOpt = genBool opt_aggressiveXOpt
+  gen_opt_aggressiveXOptBB = genBool opt_aggressiveXOptBB
+  gen_opt_cachehdl = genBool opt_cachehdl
+  gen_opt_checkIDir = genBool opt_checkIDir
+  gen_opt_clear = genBool opt_clear
+  gen_opt_componentPrefix = genMaybe opt_componentPrefix genSimpleText
+  gen_opt_edalize = genBool opt_edalize
+  gen_opt_errorExtra = genBool opt_errorExtra
+  gen_opt_escapedIds = genBool opt_escapedIds
+  gen_opt_evaluatorFuelLimit = genWord opt_evaluatorFuelLimit
+  gen_opt_forceUndefined = genMaybe opt_forceUndefined (Gen.maybe (Gen.element [0, 1]))
+  gen_opt_hdlDir = genMaybe opt_hdlDir genSimpleString
+  gen_opt_inlineConstantLimit = genWord opt_inlineConstantLimit
+  gen_opt_inlineFunctionLimit = genWord opt_inlineFunctionLimit
+  gen_opt_inlineLimit = genPosInt opt_inlineLimit
+  gen_opt_inlineWFCacheLimit = genWord opt_inlineWFCacheLimit
+  gen_opt_intWidth = genElement opt_intWidth [32, 64]
+  gen_opt_lowerCaseBasicIds = genEnumBounded opt_lowerCaseBasicIds
+  gen_opt_primWarn = genBool opt_primWarn
+  gen_opt_renderEnums = genBool opt_renderEnums
+  gen_opt_ultra = genBool opt_ultra
+  gen_opt_newInlineStrat = genBool opt_newInlineStrat
+  gen_opt_specLimit = genEnumBounded opt_specLimit
+  gen_opt_hdlSyn = genEnumBounded opt_hdlSyn
+
+  gen_dbg_countTransformations = genBool (opt_debug . dbg_countTransformations)
+  gen_dbg_historyFile = genMaybe (opt_debug . dbg_historyFile) genSimpleString
+  gen_dbg_invariants = genBool (opt_debug . dbg_invariants)
+  gen_dbg_transformationInfo = genEnumBounded (opt_debug . dbg_transformationInfo)
+  gen_dbg_transformationsFrom = genMaybe (opt_debug . dbg_transformationsFrom) (Gen.word Range.constantBounded)
+  gen_dbg_transformationsLimit = genMaybe (opt_debug . dbg_transformationsLimit) (Gen.word Range.constantBounded)
+
+  -- TODO
+  gen_dbg_transformations _fuzz = pure mempty
+
+-- | Generate a 'ClashOpts' structure
+hprop_parseRender :: H.Property
+hprop_parseRender = H.property $ do
+  -- We generate all fuzz modes here (instead of in 'genClashOpts') so Hedgehog
+  -- can print which properties are fuzzed. After shrinking we only expect the
+  -- "broken" flags to be set to 'Fuzz'.
+  _opt_aggressiveXOpt_fuzz      <- H.forAll genFuzzMode
+  _opt_aggressiveXOptBB_fuzz    <- H.forAll genFuzzMode
+  _opt_cachehdl_fuzz            <- H.forAll genFuzzMode
+  _opt_checkIDir_fuzz           <- H.forAll genFuzzMode
+  _opt_clear_fuzz               <- H.forAll genFuzzMode
+  _opt_componentPrefix_fuzz     <- H.forAll genFuzzMode
+  _opt_edalize_fuzz             <- H.forAll genFuzzMode
+  _opt_errorExtra_fuzz          <- H.forAll genFuzzMode
+  _opt_escapedIds_fuzz          <- H.forAll genFuzzMode
+  _opt_evaluatorFuelLimit_fuzz  <- H.forAll genFuzzMode
+  _opt_forceUndefined_fuzz      <- H.forAll genFuzzMode
+  _opt_hdlDir_fuzz              <- H.forAll genFuzzMode
+  _opt_hdlSyn_fuzz              <- H.forAll genFuzzMode
+  _opt_inlineConstantLimit_fuzz <- H.forAll genFuzzMode
+  _opt_inlineFunctionLimit_fuzz <- H.forAll genFuzzMode
+  _opt_inlineLimit_fuzz         <- H.forAll genFuzzMode
+  _opt_inlineWFCacheLimit_fuzz  <- H.forAll genFuzzMode
+  _opt_intWidth_fuzz            <- H.forAll genFuzzMode
+  _opt_lowerCaseBasicIds_fuzz   <- H.forAll genFuzzMode
+  _opt_newInlineStrat_fuzz      <- H.forAll genFuzzMode
+  _opt_primWarn_fuzz            <- H.forAll genFuzzMode
+  _opt_renderEnums_fuzz         <- H.forAll genFuzzMode
+  _opt_specLimit_fuzz           <- H.forAll genFuzzMode
+  _opt_ultra_fuzz               <- H.forAll genFuzzMode
+
+  _dbg_countTransformations_fuzz <- H.forAll genFuzzMode
+  _dbg_historyFile_fuzz          <- H.forAll genFuzzMode
+  _dbg_invariants_fuzz           <- H.forAll genFuzzMode
+  _dbg_transformationInfo_fuzz   <- H.forAll genFuzzMode
+  _dbg_transformations_fuzz      <- H.forAll genFuzzMode
+  _dbg_transformationsFrom_fuzz  <- H.forAll genFuzzMode
+  _dbg_transformationsLimit_fuzz <- H.forAll genFuzzMode
+
+  opts0 <- H.forAll $
+    genClashOpts
+      ( _opt_aggressiveXOpt_fuzz
+      , _opt_aggressiveXOptBB_fuzz
+      , _opt_cachehdl_fuzz
+      , _opt_checkIDir_fuzz
+      , _opt_clear_fuzz
+      , _opt_componentPrefix_fuzz
+      , _opt_edalize_fuzz
+      , _opt_errorExtra_fuzz
+      , _opt_escapedIds_fuzz
+      , _opt_evaluatorFuelLimit_fuzz
+      , _opt_forceUndefined_fuzz
+      , _opt_hdlDir_fuzz
+      , _opt_hdlSyn_fuzz
+      , _opt_inlineConstantLimit_fuzz
+      , _opt_inlineFunctionLimit_fuzz
+      , _opt_inlineLimit_fuzz
+      , _opt_inlineWFCacheLimit_fuzz
+      , _opt_intWidth_fuzz
+      , _opt_lowerCaseBasicIds_fuzz
+      , _opt_newInlineStrat_fuzz
+      , _opt_primWarn_fuzz
+      , _opt_renderEnums_fuzz
+      , _opt_specLimit_fuzz
+      , _opt_ultra_fuzz
+      , _dbg_countTransformations_fuzz
+      , _dbg_historyFile_fuzz
+      , _dbg_invariants_fuzz
+      , _dbg_transformationInfo_fuzz
+      , _dbg_transformations_fuzz
+      , _dbg_transformationsFrom_fuzz
+      , _dbg_transformationsLimit_fuzz )
+
+  let flags = renderClashFlags opts0
+  H.footnote ("flags: " <> show flags)
+
+  (leftovers, warns, opts1) <- H.evalIO (runParse flags)
+
+  [] H.=== leftovers
+  [] H.=== warns
+
+  H.diff opts0 (==) opts1
+
+testCases :: [TestTree]
+testCases =
+  case $(testGroupGenerator) of
+    TestGroup _ tree -> tree
+    _ -> error "Internal error"
+
+tests :: TestTree
+tests =
+  testGroup
+    "Clash.Tests.GHC.ClashFlags"
+    [ -- tasty-th doesn't account for Hedgehog tests
+      testGroup "cases" testCases
+    , testGroup "randomized"
+      [ testPropertyNamed
+          "render/parse are each others inverses"
+          "hprop_parseRender"
+          hprop_parseRender
+      ]
+    ]

--- a/clash-ghc/tests/unittests.hs
+++ b/clash-ghc/tests/unittests.hs
@@ -1,0 +1,13 @@
+module Main where
+
+import Test.Tasty
+
+import qualified Clash.Tests.GHC.ClashFlags
+
+tests :: TestTree
+tests = testGroup "Unittests"
+  [ Clash.Tests.GHC.ClashFlags.tests
+  ]
+
+main :: IO ()
+main = defaultMain tests

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -107,7 +107,7 @@ instance Backend SystemVerilogState where
     , _genDepth=0
     , _modNm=""
     , _topNm=Id.unsafeMake ""
-    , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) SystemVerilog
+    , _idSeen=Id.emptyIdentifierSet (_opt_escapedIds opts) (_opt_lowerCaseBasicIds opts) SystemVerilog
     , _oports=[]
     , _srcSpan=noSrcSpan
     , _includes=[]
@@ -116,11 +116,11 @@ instance Backend SystemVerilogState where
     , _dataFiles=[]
     , _memoryDataFiles=[]
     , _tyPkgCtx=False
-    , _intWidth=opt_intWidth opts
-    , _hdlsyn=opt_hdlSyn opts
-    , _undefValue=opt_forceUndefined opts
-    , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
-    , _renderEnums_=coerce (opt_renderEnums opts)
+    , _intWidth=_opt_intWidth opts
+    , _hdlsyn=_opt_hdlSyn opts
+    , _undefValue=_opt_forceUndefined opts
+    , _aggressiveXOptBB_=coerce (_opt_aggressiveXOptBB opts)
+    , _renderEnums_=coerce (_opt_renderEnums opts)
     , _domainConfigurations_=emptyDomainMap
     }
   hdlKind         = const SystemVerilog

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -134,15 +134,15 @@ instance Backend VHDLState where
     , _includes=[]
     , _dataFiles=[]
     , _memoryDataFiles=[]
-    , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) VHDL
+    , _idSeen=Id.emptyIdentifierSet (_opt_escapedIds opts) (_opt_lowerCaseBasicIds opts) VHDL
     , _tyPkgCtx=False
-    , _intWidth=opt_intWidth opts
-    , _hdlsyn=opt_hdlSyn opts
-    , _undefValue=opt_forceUndefined opts
+    , _intWidth=_opt_intWidth opts
+    , _hdlsyn=_opt_hdlSyn opts
+    , _undefValue=_opt_forceUndefined opts
     , _productFieldNameCache=mempty
     , _enumNameCache=mempty
-    , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
-    , _renderEnums_=coerce (opt_renderEnums opts)
+    , _aggressiveXOptBB_=coerce (_opt_aggressiveXOptBB opts)
+    , _renderEnums_=coerce (_opt_renderEnums opts)
     , _domainConfigurations_=emptyDomainMap
     }
   hdlKind         = const VHDL

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -111,7 +111,7 @@ instance HasIdentifierSet VerilogState where
 instance Backend VerilogState where
   initBackend opts = VerilogState
     { _genDepth=0
-    , _idSeen=Id.emptyIdentifierSet (opt_escapedIds opts) (opt_lowerCaseBasicIds opts) Verilog
+    , _idSeen=Id.emptyIdentifierSet (_opt_escapedIds opts) (_opt_lowerCaseBasicIds opts) Verilog
     , _topNm=Id.unsafeMake ""
     , _srcSpan=noSrcSpan
     , _includes=[]
@@ -120,10 +120,10 @@ instance Backend VerilogState where
     , _dataFiles=[]
     , _memoryDataFiles=[]
     , _customConstrs=HashMap.empty
-    , _intWidth=opt_intWidth opts
-    , _hdlsyn=opt_hdlSyn opts
-    , _undefValue=opt_forceUndefined opts
-    , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
+    , _intWidth=_opt_intWidth opts
+    , _hdlsyn=_opt_hdlSyn opts
+    , _undefValue=_opt_forceUndefined opts
+    , _aggressiveXOptBB_=coerce (_opt_aggressiveXOptBB opts)
     , _domainConfigurations_=emptyDomainMap
     }
   hdlKind         = const Verilog

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -324,9 +324,9 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
     let topEntities0 = designEntities design
     let opts = envOpts env
 
-    removeHistoryFile (dbg_historyFile (opt_debug opts))
+    removeHistoryFile (_dbg_historyFile (_opt_debug opts))
 
-    unless (opt_cachehdl opts) $
+    unless (_opt_cachehdl opts) $
       putStrLn "Clash: Ignoring previously made caches"
 
     let topEntities1 = fmap (removeForAll . splitTopEntityT tcm bindingsMap)
@@ -379,13 +379,13 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
     pure $! State.execState (Id.addRaw (Data.Text.pack modName1)) seen
 
   let topNm = lookupVarEnv' compNames topEntity
-      (modNameS, fmap Data.Text.pack -> prefixM) = prefixModuleName (hdlKind (undefined :: backend)) (opt_componentPrefix opts) annM modName1
+      (modNameS, fmap Data.Text.pack -> prefixM) = prefixModuleName (hdlKind (undefined :: backend)) (_opt_componentPrefix opts) annM modName1
       modNameT  = Data.Text.pack modNameS
       hdlState' = setDomainConfigurations domainConfs
                 $ setModName modNameT
                 $ setTopName topNm
                 $ fromMaybe (initBackend @backend opts) hdlState
-      hdlDir    = fromMaybe (Clash.Backend.name hdlState') (opt_hdlDir opts) </> topEntityS
+      hdlDir    = fromMaybe (Clash.Backend.name hdlState') (_opt_hdlDir opts) </> topEntityS
       manPath   = hdlDir </> manifestFilename
       ite       = ifThenElseExpr hdlState'
       topNmT    = Id.toText topNm
@@ -409,7 +409,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
         pure $! State.execState (mapM_ Id.addRaw (componentNames manifest0)) seen
 
       fileNames1 <- modifyMVar edamFilesV $ \edamFiles ->
-        if opt_edalize opts
+        if _opt_edalize opts
           then writeEdam hdlDir (topNm, varUniq topEntity) deps edamFiles fileNames
           else pure (edamFiles, fileNames)
 
@@ -473,7 +473,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
       -- TODO: Data files should go into their own directory
       -- FIXME: Files can silently overwrite each other
       hdlDocDigests <- mapM (writeHDL hdlDir) hdlDocs
-      dataFilesDigests <- copyDataFiles (opt_importPaths opts) hdlDir dfiles
+      dataFilesDigests <- copyDataFiles (_opt_importPaths opts) hdlDir dfiles
       memoryFilesDigests <- writeMemoryDataFiles hdlDir mfiles
 
       let
@@ -484,7 +484,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
           <> zip (map fst mfiles) memoryFilesDigests
 
       filesAndDigests1 <- modifyMVar edamFilesV $ \edamFiles ->
-        if opt_edalize opts
+        if _opt_edalize opts
           then writeEdam hdlDir (topNm, varUniq topEntity) deps edamFiles filesAndDigests0
           else pure (edamFiles, filesAndDigests0)
 
@@ -903,7 +903,7 @@ prepareDir ::
   -- | Did directory contain unexpected modifications? See 'readFreshManifest'
   Maybe [UnexpectedModification] ->
   IO ()
-prepareDir hdlDir ClashOpts{opt_clear} mods = do
+prepareDir hdlDir ClashOpts{_opt_clear} mods = do
   ifM
     (doesPathExist hdlDir)
     (ifM
@@ -934,7 +934,7 @@ prepareDir hdlDir ClashOpts{opt_clear} mods = do
       Just [] ->
         -- No unexpected changes, so no user work will get lost
         removeDirectoryRecursive hdlDir
-      _ | opt_clear ->
+      _ | _opt_clear ->
         -- Unexpected changes / non-empty directory, but @-fclash-clear@ was
         -- set, so remove directory anyway.
         removeDirectoryRecursive hdlDir

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -138,8 +138,8 @@ data Manifest
   , successFlags  :: (Int, Int)
     -- ^ Compiler flags used to achieve successful compilation:
     --
-    --   * opt_inlineLimit
-    --   * opt_specLimit
+    --   * _opt_inlineLimit
+    --   * _opt_specLimit
   , ports :: [ManifestPort]
     -- ^ Ports in the generated @TopEntity@.
   , componentNames :: [Text]
@@ -326,7 +326,7 @@ mkManifest backend domains ClashOpts{..} Component{..} components deps files top
   , componentNames = map Id.toText compNames
   , topComponent = Id.toText componentName
   , fileNames = files
-  , successFlags = (opt_inlineLimit, opt_specLimit)
+  , successFlags = (_opt_inlineLimit, _opt_specLimit)
   , domains = domains
   , transitiveDependencies = map (nameOcc . varName) deps
   }
@@ -393,7 +393,7 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
   manifestM <- readManifest path
   pure
     ( modificationsM
-    , checkManifest =<< if opt_cachehdl then manifestM else Nothing
+    , checkManifest =<< if _opt_cachehdl then manifestM else Nothing
     , topHash
     )
 
@@ -402,23 +402,23 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
       -- Ignore the following settings, they don't affect the generated HDL:
 
       -- 1. Debug
-      opt_debug = opt_debug
-        { dbg_invariants = False
-        , dbg_transformations = Set.empty
-        , dbg_historyFile = Nothing
+      _opt_debug = _opt_debug
+        { _dbg_invariants = False
+        , _dbg_transformations = Set.empty
+        , _dbg_historyFile = Nothing
         }
 
       -- 2. Caching
-    , opt_cachehdl = True
+    , _opt_cachehdl = True
 
       -- 3. Warnings
-    , opt_primWarn = True
-    , opt_color = Auto
-    , opt_errorExtra = False
-    , opt_checkIDir = True
+    , _opt_primWarn = True
+    , _opt_color = Auto
+    , _opt_errorExtra = False
+    , _opt_checkIDir = True
 
       -- 4. Optional output
-    , opt_edalize = False
+    , _opt_edalize = False
 
       -- Ignore the following settings, they don't affect the generated HDL. However,
       -- they do influence whether HDL can be generated at all.
@@ -428,13 +428,13 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
       -- to decide whether to use caching or not (see: XXXX).
       --
       -- 5. termination measures
-    , opt_inlineLimit = 20
-    , opt_specLimit = 20
+    , _opt_inlineLimit = 20
+    , _opt_specLimit = 20
 
       -- Finally, also ignore the HDL dir setting, because when a user moves the
       -- entire dir with generated HDL, they probably still want to use that as
       -- a cache
-    , opt_hdlDir = Nothing
+    , _opt_hdlDir = Nothing
     }
 
   -- TODO: Binary encoding does not account for alpha equivalence (nor should
@@ -451,8 +451,8 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
     | (cachedInline, cachedSpec) <- successFlags
 
     -- Higher limits shouldn't affect HDL
-    , cachedInline <= opt_inlineLimit
-    , cachedSpec <= opt_specLimit
+    , cachedInline <= _opt_inlineLimit
+    , cachedSpec <= _opt_specLimit
 
     -- Callgraph hashes should correspond
     , manifestHash == topHash

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -132,7 +132,7 @@ data TransformationInfo
   | TryTerm
   -- ^ Show the name and input to every transformation that is applied, and
   -- the result of every transformation that is applied.
-  deriving (Eq, Generic, Hashable, Ord, Read, Show, NFData)
+  deriving (Eq, Generic, Hashable, Ord, Read, Show, NFData, Enum, Bounded)
 
 -- | Options related to debugging. See 'ClashOpts'
 data DebugOpts = DebugOpts

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -121,14 +121,14 @@ genNetlist env isTb globals tops topNames typeTrans ite be seen0 dir prefixM top
   let reprs = envCustomReprs env
   let primMap = envPrimitives env
   let tcm = envTyConMap env
-  let iw = opt_intWidth opts
+  let iw = _opt_intWidth opts
   ((_meta, topComponent), s) <-
     runNetlistMonad isTb opts reprs globals tops primMap tcm typeTrans
                     iw ite be seen1 dir componentNames_ $ genComponent topEntity
   return (topComponent, _components s, seen1)
  where
   (componentNames_, seen1) =
-    genNames (opt_newInlineStrat (envOpts env)) prefixM seen0 topNames globals
+    genNames (_opt_newInlineStrat (envOpts env)) prefixM seen0 topNames globals
 
 -- | Run a NetlistMonad action in a given environment
 runNetlistMonad
@@ -232,9 +232,9 @@ genTopNames opts hdl tops =
     env1 <- foldlM goNonFixed env0 nonFixedTops
     pure env1
  where
-  prefixM = opt_componentPrefix opts
-  esc = opt_escapedIds opts
-  lw = opt_lowerCaseBasicIds opts
+  prefixM = _opt_componentPrefix opts
+  esc = _opt_escapedIds opts
+  lw = _opt_lowerCaseBasicIds opts
 
   fixedTops = [(topId, ann) | TopEntityT{topId, topAnnotation=Just ann} <- tops]
   nonFixedTops = [topId | TopEntityT{topId, topAnnotation=Nothing} <- tops]

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -88,7 +88,7 @@ import {-# SOURCE #-} Clash.Netlist
 import qualified Clash.Backend                 as Backend
 import           Clash.Debug                   (debugIsOn)
 import           Clash.Driver.Types
-  (ClashOpts(opt_primWarn, opt_color, opt_werror))
+  (ClashOpts(_opt_primWarn, _opt_color, _opt_werror))
 import           Clash.Netlist.BlackBox.Types  as B
 import           Clash.Netlist.BlackBox.Util   as B
 import           Clash.Netlist.Types           as N
@@ -109,14 +109,14 @@ warn
 warn opts msg = do
   -- TODO: Put in appropriate module
   useColor <-
-    case opt_color opts of
+    case _opt_color opts of
       Always -> return True
       Never  -> return False
       Auto   -> hIsTerminalDevice stderr
 
   hSetSGR stderr [SetConsoleIntensity BoldIntensity]
 
-  case opt_werror opts of
+  case _opt_werror opts of
     True -> do
       when useColor $ hSetSGR stderr [SetColor Foreground Vivid Red]
       throw (ClashException noSrcSpan msg Nothing)
@@ -328,7 +328,7 @@ extractPrimWarnOrFail nm = do
     -> NetlistMonad CompiledPrimitive
 
   go ((WarnAlways warning):ws) cp = do
-    primWarn <- opt_primWarn <$> Lens.use clashOpts
+    primWarn <- _opt_primWarn <$> Lens.use clashOpts
     seen <- Set.member nm <$> Lens.use seenPrimitives
     opts <- Lens.use clashOpts
 

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -230,4 +230,4 @@ data Decl
   deriving (Show, Generic, NFData, Binary, Eq, Hashable)
 
 data HdlSyn = Vivado | Quartus | Other
-  deriving (Eq, Show, Read, Generic, NFData, Binary, Hashable)
+  deriving (Eq, Show, Read, Generic, NFData, Binary, Hashable, Enum, Bounded)

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -139,7 +139,15 @@ type IdentifierText = Text
 data PreserveCase
   = PreserveCase
   | ToLower
-  deriving (Show, Generic, NFData, Eq, Binary, Hashable)
+  deriving (Show, Generic, NFData, Eq, Binary, Hashable, Bounded, Enum)
+
+preserveCaseToBool :: PreserveCase -> Bool
+preserveCaseToBool PreserveCase = True
+preserveCaseToBool ToLower = False
+
+boolToPreserveCase :: Bool -> PreserveCase
+boolToPreserveCase True = PreserveCase
+boolToPreserveCase False = ToLower
 
 -- See: http://vhdl.renerta.com/mobile/source/vhd00037.htm
 --      http://www.verilog.renerta.com/source/vrg00018.htm

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -212,7 +212,7 @@ normalize' nm = do
             -- (GHC-8.4 does this with tests/shouldwork/Numbers/Exp.hs)
             -- It will later be inlined by flattenCallTree.
             opts <- Lens.view debugOpts
-            traceIf (dbg_invariants opts)
+            traceIf (_dbg_invariants opts)
                     (concat [$(curLoc), "Expr belonging to bndr: ", nmS, " (:: "
                             , showPpr (coreTypeOf nm')
                             , ") has a non-representable return type."
@@ -348,7 +348,7 @@ flattenCallTree (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
 
       -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
       opts <- Lens.view debugOpts
-      let rewriteHistFile = dbg_historyFile opts
+      let rewriteHistFile = _dbg_historyFile opts
       when (Maybe.isJust rewriteHistFile) $
         let !_ = unsafePerformIO
              $ BS.appendFile (Maybe.fromJust rewriteHistFile)

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -67,7 +67,7 @@ import Clash.Core.VarEnv
   ( InScopeSet, elemVarSet, extendInScopeSet, extendInScopeSetList, mkVarSet
   , unitVarSet, uniqAway)
 import Clash.Debug (traceIf)
-import Clash.Driver.Types (DebugOpts(dbg_invariants))
+import Clash.Driver.Types (DebugOpts(_dbg_invariants))
 import Clash.Netlist.Types (FilteredHWType(..), HWType(..))
 import Clash.Netlist.Util (coreTypeToHWType, representableType)
 import qualified Clash.Normalize.Primitives as NP (undefined, undefinedX)
@@ -318,7 +318,7 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
             opts <- Lens.view debugOpts
             -- When invariants are being checked, report missing evaluation
             -- rules for the primitive evaluator.
-            traceIf (dbg_invariants opts && isConstant subj)
+            traceIf (_dbg_invariants opts && isConstant subj)
               ("Unmatchable constant as case subject: " ++ showPpr subj ++
                  "\nWHNF is: " ++ showPpr subj1)
               -- Otherwise check whether the entire case-expression has a

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -122,10 +122,10 @@ data RewriteEnv
 Lens.makeLenses ''RewriteEnv
 
 debugOpts :: Lens.Getter RewriteEnv DebugOpts
-debugOpts = clashEnv . Lens.to (opt_debug . envOpts)
+debugOpts = clashEnv . Lens.to (_opt_debug . envOpts)
 
 aggressiveXOpt :: Lens.Getter RewriteEnv Bool
-aggressiveXOpt = clashEnv . Lens.to (opt_aggressiveXOpt . envOpts)
+aggressiveXOpt = clashEnv . Lens.to (_opt_aggressiveXOpt . envOpts)
 
 tcCache :: Lens.Getter RewriteEnv TyConMap
 tcCache = clashEnv . Lens.to envTyConMap
@@ -137,31 +137,31 @@ customReprs :: Lens.Getter RewriteEnv CustomReprs
 customReprs = clashEnv . Lens.to envCustomReprs
 
 fuelLimit :: Lens.Getter RewriteEnv Word
-fuelLimit = clashEnv . Lens.to (opt_evaluatorFuelLimit . envOpts)
+fuelLimit = clashEnv . Lens.to (_opt_evaluatorFuelLimit . envOpts)
 
 primitives :: Lens.Getter RewriteEnv CompiledPrimMap
 primitives = clashEnv . Lens.to envPrimitives
 
 inlineLimit :: Lens.Getter RewriteEnv Int
-inlineLimit = clashEnv . Lens.to (opt_inlineLimit . envOpts)
+inlineLimit = clashEnv . Lens.to (_opt_inlineLimit . envOpts)
 
 inlineFunctionLimit :: Lens.Getter RewriteEnv Word
-inlineFunctionLimit = clashEnv . Lens.to (opt_inlineFunctionLimit . envOpts)
+inlineFunctionLimit = clashEnv . Lens.to (_opt_inlineFunctionLimit . envOpts)
 
 inlineConstantLimit :: Lens.Getter RewriteEnv Word
-inlineConstantLimit = clashEnv . Lens.to (opt_inlineConstantLimit . envOpts)
+inlineConstantLimit = clashEnv . Lens.to (_opt_inlineConstantLimit . envOpts)
 
 inlineWFCacheLimit :: Lens.Getter RewriteEnv Word
-inlineWFCacheLimit = clashEnv . Lens.to (opt_inlineWFCacheLimit . envOpts)
+inlineWFCacheLimit = clashEnv . Lens.to (_opt_inlineWFCacheLimit . envOpts)
 
 newInlineStrategy :: Lens.Getter RewriteEnv Bool
-newInlineStrategy = clashEnv . Lens.to (opt_newInlineStrat . envOpts)
+newInlineStrategy = clashEnv . Lens.to (_opt_newInlineStrat . envOpts)
 
 specializationLimit :: Lens.Getter RewriteEnv Int
-specializationLimit = clashEnv . Lens.to (opt_specLimit . envOpts)
+specializationLimit = clashEnv . Lens.to (_opt_specLimit . envOpts)
 
 normalizeUltra :: Lens.Getter RewriteEnv Bool
-normalizeUltra = clashEnv . Lens.to (opt_ultra . envOpts)
+normalizeUltra = clashEnv . Lens.to (_opt_ultra . envOpts)
 
 -- | Monad that keeps track how many transformations have been applied and can
 -- generate fresh variables and unique identifiers. In addition, it keeps track

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -61,7 +61,7 @@ lookupTM u tm = case HashMap.lookup u tm of
 instance Default RewriteEnv where
   def = RewriteEnv
     { _clashEnv = ClashEnv
-        { envOpts = defClashOpts { opt_debug = debugSilent }
+        { envOpts = defClashOpts { _opt_debug = debugSilent }
         , envTyConMap = emptyUniqMap
         , envTupleTyCons = IntMap.empty
         , envPrimitives = HashMap.empty

--- a/hie.yaml
+++ b/hie.yaml
@@ -11,7 +11,8 @@ cradle:
                                 ,{path: "./clash-cosim/test", component: "clash-cosim:test"}]}}
     - path: "./clash-ghc"
       config: { cradle: {cabal: [{path: "./clash-ghc/src-ghc", component: "lib:clash-ghc"}
-                                ,{path: "./clash-ghc/src-ghc-common", component: "lib:clash-ghc"}]}}
+                                ,{path: "./clash-ghc/src-ghc-common", component: "lib:clash-ghc"}
+                                ,{path: "./clash-ghc/tests", component: "clash-ghc:unittests"}]}}
     # The src-bin directories are GHC version dependant, so don't load them
     - path: "./clash-ghc/src-bin-8.10"
       config: { cradle: {none: }}

--- a/repld
+++ b/repld
@@ -22,6 +22,7 @@
 #   * `c`, `cores`, `clash-cores`
 #   * `c:tests`, `cores:tests`, `clash-cores:tests`
 #   * `g`, `ghc`, `clash-ghc`
+#   * `g:tests`, `ghc:tests`, `clash-ghc:tests`
 #   * `dev`, `clash-dev`
 #
 # That means the following will start a repl-loop for clash-lib:
@@ -56,6 +57,9 @@ elif [[ $1 == "c:tests" || $1 == "cores:tests" || $1 == "clash-cores:tests" ]]; 
 elif [[ $1 == "g" || $1 == "ghc" || $1 == "clash-ghc" ]]; then
   target="cabal v2-repl clash-ghc --repl-options=-fobject-code --repl-options=-fforce-recomp"
   watch="clash-prelude clash-lib clash-ghc/clash-ghc.cabal"
+elif [[ $1 == "g:tests" || $1 == "ghc:tests" || $1 == "clash-ghc:tests" ]]; then
+  target="cabal v2-repl clash-ghc:unittests"
+  watch="clash-prelude clash-lib clash-ghc/src-ghc clash-ghc/clash-ghc.cabal"
 elif [[ $1 == "dev" || $1 == "clash-dev" ]]; then
   target="./clash-dev"
   watch="clash-prelude clash-lib/clash-lib.cabal clash-ghc/clash-ghc.cabal"
@@ -66,6 +70,7 @@ else
   echo "  l, lib, clash-lib"                                 > /dev/stderr
   echo "  l:tests, lib:tests, clash-lib:tests"               > /dev/stderr
   echo "  g, ghc, clash-ghc"                                 > /dev/stderr
+  echo "  g:tests, ghc:tests, clash-ghc:tests"               > /dev/stderr
   echo "  c, cores, clash-cores"                             > /dev/stderr
   echo "  c:tests, cores:tests, clash-cores:tests"           > /dev/stderr
   echo "  dev, clash-dev"                                    > /dev/stderr

--- a/tests/shouldwork/XOptimization/ManyDefined.hs
+++ b/tests/shouldwork/XOptimization/ManyDefined.hs
@@ -37,7 +37,7 @@ testPath :: FilePath
 testPath = "tests/shouldwork/XOptimization/ManyDefined.hs"
 
 enableXOpt :: ClashOpts -> ClashOpts
-enableXOpt c = c { opt_aggressiveXOpt = True }
+enableXOpt c = c { _opt_aggressiveXOpt = True }
 
 mainVHDL :: IO ()
 mainVHDL = do

--- a/tests/shouldwork/XOptimization/OneDefinedDataPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedDataPat.hs
@@ -26,7 +26,7 @@ testPath :: FilePath
 testPath = "tests/shouldwork/XOptimization/OneDefinedDataPat.hs"
 
 enableXOpt :: ClashOpts -> ClashOpts
-enableXOpt c = c { opt_aggressiveXOpt = True }
+enableXOpt c = c { _opt_aggressiveXOpt = True }
 
 mainVHDL :: IO ()
 mainVHDL = do

--- a/tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs
@@ -26,7 +26,7 @@ testPath :: FilePath
 testPath = "tests/shouldwork/XOptimization/OneDefinedDefaultPat.hs"
 
 enableXOpt :: ClashOpts -> ClashOpts
-enableXOpt c = c { opt_aggressiveXOpt = True }
+enableXOpt c = c { _opt_aggressiveXOpt = True }
 
 mainVHDL :: IO ()
 mainVHDL = do

--- a/tests/shouldwork/XOptimization/OneDefinedLitPat.hs
+++ b/tests/shouldwork/XOptimization/OneDefinedLitPat.hs
@@ -26,7 +26,7 @@ testPath :: FilePath
 testPath = "tests/shouldwork/XOptimization/OneDefinedLitPat.hs"
 
 enableXOpt :: ClashOpts -> ClashOpts
-enableXOpt c = c { opt_aggressiveXOpt = True }
+enableXOpt c = c { _opt_aggressiveXOpt = True }
 
 mainVHDL :: IO ()
 mainVHDL = do

--- a/tests/src/Test/Tasty/Clash/CoreTest.hs
+++ b/tests/src/Test/Tasty/Clash/CoreTest.hs
@@ -38,8 +38,8 @@ type family TargetToState (target :: HDL) where
 
 mkClashOpts :: ClashOpts
 mkClashOpts = defClashOpts
-  { opt_cachehdl     = False
-  , opt_errorExtra   = True
+  { _opt_cachehdl     = False
+  , _opt_errorExtra   = True
   }
 
 -- Run clash as far as having access to core for all bindings. This is used
@@ -59,7 +59,7 @@ runToCoreStage
 runToCoreStage _target f src = do
   ids <- newSupply
   pds <- primDirs backend
-  (env, design) <- generateBindings opts (return ()) pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
+  (env, design) <- generateBindings opts (return ()) pds (_opt_importPaths opts) [] (hdlKind backend) src Nothing
 
   return (env, design, ids)
  where

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -49,8 +49,8 @@ import           Test.Tasty.Clash
 
 mkClashOpts :: ClashOpts
 mkClashOpts = defClashOpts
-  { opt_cachehdl     = False
-  , opt_errorExtra   = True
+  { _opt_cachehdl     = False
+  , _opt_errorExtra   = True
   }
 
 type family TargetToState (target :: HDL) where
@@ -70,7 +70,7 @@ runToNetlistStage
   -> IO [(ComponentMeta, Component)]
 runToNetlistStage target f src = do
   pds <- primDirs backend
-  (env, design) <- generateBindings opts (return ()) pds (opt_importPaths opts) [] (hdlKind backend) src Nothing
+  (env, design) <- generateBindings opts (return ()) pds (_opt_importPaths opts) [] (hdlKind backend) src Nothing
 
   let (compNames, initIs) = genTopNames opts hdl (designEntities design)
       teNames = fmap topId (designEntities design)
@@ -81,7 +81,7 @@ runToNetlistStage target f src = do
 
   transformedBindings <-
     normalizeEntity env (designBindings design)
-      (ghcTypeToHWType (opt_intWidth opts))
+      (ghcTypeToHWType (_opt_intWidth opts))
       ghcEvaluator
       evaluator
       teNames supplyN te
@@ -95,7 +95,7 @@ runToNetlistStage target f src = do
   hdl = buildTargetToHdl target
 
   netlistFrom (env, bm, tes, compNames, te, seen, domainConfs) =
-    genNetlist env False bm tes compNames (ghcTypeToHWType (opt_intWidth opts))
+    genNetlist env False bm tes compNames (ghcTypeToHWType (_opt_intWidth opts))
       ite (SomeBackend hdlSt) seen hdlDir Nothing te
    where
     teS     = Text.unpack . nameOcc $ varName te
@@ -103,6 +103,6 @@ runToNetlistStage target f src = do
     hdlSt   = setDomainConfigurations domainConfs
             $ setModName (Text.pack modN) backend
     ite     = ifThenElseExpr hdlSt
-    hdlDir  = fromMaybe "." (opt_hdlDir opts)
+    hdlDir  = fromMaybe "." (_opt_hdlDir opts)
       </> Backend.name hdlSt
       </> takeWhile (/= '.') teS


### PR DESCRIPTION
This adds a more structured way to define Clash command line flags to
`Clash.GHC.ClashFlags`. This comes with a couple of improvements over
the status quo:

  * Each boolean flag now defines two flags: `-fclash-foo` and
    `-fclash-no-foo`. This makes sure users can always unset a flag
    after setting it. This can be helpful in certain environments, and
    should help us once we'll support module-level flags.

  * Each flag backed by a `Maybe` can now be unset using `-fclash-no-foo`

Last but not least, `ClashOpts` can now be rendered to a set of flags.
This can help users of `clash-shake` to define a set of options using
`ClashOpts`, and then pass them to clash-the-binary.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
  - [ ] Document `*suffix` functions
  - [ ] Split up PR (=> lens stuff to separate one) to reduce noise?