### PR TITLE
Speed up, harmonize BitReduction

### DIFF
--- a/changelog/2022-06-17T10_37_07+02_00_bv_reduce
+++ b/changelog/2022-06-17T10_37_07+02_00_bv_reduce
@@ -1,0 +1,1 @@
+CHANGED: `reduceXor` now produces a result if the argument has undefined bits instead of throwing an `XException` (the result is an undefined bit). `reduceAnd` and `reduceOr` already always produced a result. [#2244](https://github.com/clash-lang/clash-compiler/pull/2244)


### PR DESCRIPTION
The cases for `reduceAnd` and `reduceOr` where the mask is non-zero can
also be sped up just like the cases with a zero mask.

`reduceAnd` and `reduceOr` always produce a `Bit`, but possibly with a
non-zero mask (i.e., an undefined value). `reduceXor` should also
produce such a value, which is different from throwing an `XException`
as it did.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
