### PR TITLE
Run `clash-testsuite` with 1 thread

### DIFF
--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -118,7 +118,6 @@ library
 executable clash-testsuite
   import:              basic-config
   main-is:             Main.hs
-  ghc-options:         -threaded -with-rtsopts=-N
 
   build-tool-depends:
     clash-ghc:clash


### PR DESCRIPTION
On CI the testsuite spawns 64 threads to coordinate running tests. This
induces an incredible overhead, making Clash run an order of magnitude
slower than it should. Note that `-jN` continues to work: the testsuite
will still parallelize test running.