### PR TITLE
Use `ClashEnv` in Netlist Generation

### DIFF
--- a/benchmark/profiling/run/profile-netlist-run.hs
+++ b/benchmark/profiling/run/profile-netlist-run.hs
@@ -42,7 +42,7 @@ benchFile idirs src = do
   (transformedBindings,topEntities,primMap,tcm,reprs,topEntity) <- setupEnv src
   putStrLn $ "Doing netlist generation of " ++ src
 
-  let clashEnv = ClashEnv
+  let env = ClashEnv
                    { envOpts = opts idirs
                    , envTyConMap = tcm
                    , envTupleTyCons = mempty
@@ -52,17 +52,17 @@ benchFile idirs src = do
 
       topEntityS = Text.unpack (nameOcc (varName topEntity))
       modName    = takeWhile (/= '.') topEntityS
-      hdlState'  = setModName (Text.pack modName) (initBackend @VHDLState (envOpts clashEnv))
-      (compNames, seen) = genTopNames (envOpts clashEnv) hdl topEntities
+      hdlState'  = setModName (Text.pack modName) (initBackend @VHDLState (envOpts env))
+      (compNames, seen) = genTopNames (envOpts env) hdl topEntities
       topEntityMap = mkVarEnv (zip (map topId topEntities) topEntities)
       prefixM    = Nothing
       ite        = ifThenElseExpr hdlState'
-      hdlDir     = fromMaybe "." (opt_hdlDir (envOpts clashEnv)) </>
+      hdlDir     = fromMaybe "." (opt_hdlDir (envOpts env)) </>
                          Clash.Backend.name hdlState' </>
                          takeWhile (/= '.') topEntityS
   (netlist,_,_) <-
-    genNetlist clashEnv False transformedBindings topEntityMap compNames
-               (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+    genNetlist env False transformedBindings topEntityMap compNames
+               (ghcTypeToHWType (opt_intWidth (envOpts env)))
                ite (SomeBackend hdlState') seen hdlDir prefixM topEntity
   netlist `deepseq` putStrLn ".. done\n"
 

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -59,7 +59,7 @@ import           Clash.Netlist.BlackBox.Types         (HdlSyn (..))
 import           Clash.Netlist.BlackBox.Util
   (extractLiterals, renderBlackBox, renderFilePath)
 import qualified Clash.Netlist.Id                     as Id
-import           Clash.Netlist.Types                  hiding (_intWidth, intWidth)
+import           Clash.Netlist.Types                  hiding (intWidth)
 import           Clash.Netlist.Util
 import           Clash.Signal.Internal                (ActiveEdge (..))
 import           Clash.Util

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -71,7 +71,7 @@ import           Clash.Netlist.BlackBox.Types         (HdlSyn (..))
 import           Clash.Netlist.BlackBox.Util
   (extractLiterals, renderBlackBox, renderFilePath)
 import qualified Clash.Netlist.Id                     as Id
-import           Clash.Netlist.Types                  hiding (_intWidth, intWidth)
+import           Clash.Netlist.Types                  hiding (intWidth)
 import           Clash.Netlist.Util
 import           Clash.Util
   (SrcSpan, noSrcSpan, clogBase, curLoc, makeCached, indexNote)

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -73,7 +73,7 @@ import           Clash.Netlist.BlackBox.Types         (HdlSyn)
 import           Clash.Netlist.BlackBox.Util
   (extractLiterals, renderBlackBox, renderFilePath)
 import qualified Clash.Netlist.Id                     as Id
-import           Clash.Netlist.Types                  hiding (_intWidth, intWidth)
+import           Clash.Netlist.Types                  hiding (intWidth)
 import           Clash.Netlist.Util
 import           Clash.Signal.Internal                (ActiveEdge (..))
 import           Clash.Util

--- a/clash-lib/src/Clash/Primitives/Sized/ToInteger.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/ToInteger.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright   :  (C) 2020 QBayLogic
+  Copyright   :  (C) 2020,2022 QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -70,7 +70,7 @@ toIntegerBB :: HDL -> HWType -> BlackBoxFunction
 toIntegerBB hdl hty _isD _primName args _ty = do
   case args of
     (Right (LitTy (NumTy i)):_) -> do
-      iw <- Lens.use intWidth
+      iw <- Lens.view intWidth
       let i1 = width i
       when (fromInteger i1 > iw) $ do
         (_,sp) <- Lens.use curCompNm

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright   :  (C) 2020-2021 QBayLogic
+  Copyright   :  (C) 2020-2022 QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -58,7 +58,7 @@ import           Clash.Util                         (curLoc)
 -- | Blackbox function for 'Clash.Sized.Vector.iterateI'
 iterateBBF :: HasCallStack => BlackBoxFunction
 iterateBBF _isD _primName args _resTy = do
-  tcm <- Lens.use tcCache
+  tcm <- Lens.view tcCache
   pure (Right (meta tcm, bb))
  where
   bb = BBFunction "Clash.Primitives.Sized.Vector.iterateBBF" 0 iterateTF
@@ -115,7 +115,7 @@ foldFunctionPlurality n
 -- | Blackbox function for 'Clash.Sized.Vector.fold'
 foldBBF :: HasCallStack => BlackBoxFunction
 foldBBF _isD _primName args _resTy = do
-  tcm <- Lens.use tcCache
+  tcm <- Lens.view tcCache
   pure (Right (meta tcm, bb))
  where
   bb = BBFunction "Clash.Primitives.Sized.Vector.foldTF" 0 foldTF

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -70,7 +70,7 @@ checkBBF _isD _primName args _ty =
   bindMaybe _ (Var vId) = pure (id2identifier vId, [])
   bindMaybe Nothing t = bindMaybe (Just "s") t
   bindMaybe (Just nm) t = do
-    tcm <- Lens.use tcCache
+    tcm <- Lens.view tcCache
     newId <- Id.make (Text.pack nm)
     (expr0, decls) <- mkExpr False Concurrent (NetlistId newId (inferCoreTypeOf tcm t)) t
     pure


### PR DESCRIPTION
The netlist environment in the netlist monad now re-uses `ClashEnv`
instead of extracting a lot of it into `NetlistState`. At this
point it might be worth looking into using compact regions for the
`ClashEnv` since it may be passed directly to all main parts of the
compiler without being partially unpacked into some state or
environment type in a particular step.

## Still TODO:

  - [x] ~Write a changelog entry (see changelog/README.md)~
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
