### PR TITLE
Don't terminate Verilog simulator on error in assertion functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
           - name: GHC 9.0.2, Multiple Hidden
             ghc: 9.0.2
             multiple_hidden: yes
+            workaround_ghc_mmap_crash: yes
 
           - name: GHC 9.2.5, Multiple Hidden
             ghc: 9.2.5
@@ -138,6 +139,7 @@ jobs:
       env:
         THREADS: 2
         CABAL_JOBS: 2
+        WORKAROUND_GHC_MMAP_CRASH: ${{ matrix.workaround_ghc_mmap_crash }}
         MULTIPLE_HIDDEN: ${{ matrix.multiple_hidden }}
         CI_COMMIT_BRANCH: ${{ github.base_ref }}
 

--- a/changelog/2023-05-17T13_42_59+02_00_use_stop_in_verilog
+++ b/changelog/2023-05-17T13_42_59+02_00_use_stop_in_verilog
@@ -1,0 +1,1 @@
++CHANGED: Use `$stop` in `assert` instead of `$finish`. This harmonizes VHDL and SystemVerilog simulations and will properly set an exit code. See [#2258](https://github.com/clash-lang/clash-compiler/pull/2258).

--- a/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives.yaml
@@ -17,7 +17,7 @@
       always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin
         if (~ARG[6] !== ~ARG[7]) begin
           $display("@%0tns: %s, expected: %b, actual: %b", $time, ~LIT[5], ~ARG[7], ~ARG[6]);
-          $finish;
+          $stop;
         end
       end
       // pragma translate_on
@@ -47,7 +47,7 @@
       always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin
         if (~SYM[1] !== ~SYM[2]) begin
           $display("@%0tns: %s, expected: %b, actual: %b", $time, ~LIT[4], ~ARG[6], ~ARG[5]);
-          $finish;
+          $stop;
         end
       end
       // pragma translate_on


### PR DESCRIPTION
Simulators (at least ModelSim) terminate immediately on `$finish` making it impossible to set e.g. an exit code to flag the error to the shell. I also noticed that the SystemVerilog versions of these primitives do already use `$stop` instead.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
