### PR TITLE
Add Xilinx dual clock FIFO primitive to `clash-cores`

### DIFF
--- a/.ci/build_docs.sh
+++ b/.ci/build_docs.sh
@@ -5,7 +5,7 @@ set -xueo pipefail
 if [[ "$GHC_VERSION" = "8.6.5" ]]; then
   haddock_pkgs="clash-lib clash-lib-hedgehog clash-cosim"
 else
-  haddock_pkgs="clash-prelude clash-prelude-hedgehog clash-lib clash-lib-hedgehog clash-cosim"
+  haddock_pkgs="clash-prelude clash-prelude-hedgehog clash-lib clash-lib-hedgehog clash-cosim clash-cores"
 fi
 
 mkdir -p hadocs

--- a/changelog/2022-07-26T13_16_31-05_00_reset_polarity_dsl
+++ b/changelog/2022-07-26T13_16_31-05_00_reset_polarity_dsl
@@ -1,0 +1,1 @@
+INTERNAL NEW: Added `unsafeToHighPolarity` and `unsafeToLowPolarity` to `Clash.Primitives.DSL`. [#2270](https://github.com/clash-lang/clash-compiler/pull/2270)

--- a/changelog/2022-09-12T06_00_33-04_00_derive_term_data
+++ b/changelog/2022-09-12T06_00_33-04_00_derive_term_data
@@ -1,0 +1,1 @@
+CHANGED: `deriveTermToData` now works on records [#2270](https://github.com/clash-lang/clash-compiler/pull/2270)

--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -15,6 +15,12 @@ category:            Hardware
 build-type:          Simple
 extra-source-files:  CHANGELOG.md
 
+flag doctests
+  description:
+    You can disable testing with doctests using `-f-doctests`.
+  default: True
+  manual: True
+
 flag unittests
   description:
     You can disable testing with unittests using `-f-unittests`.
@@ -33,6 +39,7 @@ common basic-config
   default-extensions:
     BinaryLiterals
     DataKinds
+    DefaultSignatures
     DeriveAnyClass
     DeriveGeneric
     DerivingStrategies
@@ -69,13 +76,19 @@ common basic-config
     ghc-typelits-knownnat     >= 0.6,
     string-interpolate        ^>= 0.3,
     QuickCheck,
-    template-haskell
+    template-haskell,
+    containers                >=0.5    && <0.7
 
 library
   import: basic-config
   hs-source-dirs: src
 
   exposed-modules:
+    Clash.Cores.Xilinx.Internal
+    Clash.Cores.Xilinx.DcFifo
+    Clash.Cores.Xilinx.DcFifo.Internal.BlackBoxes
+    Clash.Cores.Xilinx.DcFifo.Internal.Instances
+    Clash.Cores.Xilinx.DcFifo.Internal.Types
     Clash.Cores.Xilinx.Floating
     Clash.Cores.Xilinx.Floating.Annotations
     Clash.Cores.Xilinx.Floating.BlackBoxes
@@ -94,9 +107,10 @@ library
 
   build-depends:
     clash-lib,
-    mtl       >= 2.1.1 && < 2.3,
-    reducers  >= 3.12.2 && < 4.0,
-    text      >= 1.2.2 && < 1.3
+    mtl                     >= 2.1.1 && < 2.3,
+    prettyprinter           >= 1.2.0.1  && < 1.8,
+    reducers                >= 3.12.2 && < 4.0,
+    text                    >= 1.2.2 && < 1.3
 
 test-suite unittests
   import: basic-config
@@ -113,9 +127,29 @@ test-suite unittests
     Test.Cores.SPI
     Test.Cores.UART
     Test.Cores.SPI.MultiSlave
+    Test.Cores.Xilinx.DcFifo
 
   build-depends:
     clash-cores,
+    clash-lib,
     tasty        >= 1.2 && < 1.5,
     tasty-hunit,
-    tasty-quickcheck
+    tasty-quickcheck,
+    hedgehog,
+    tasty-hedgehog >= 1.2.0
+
+test-suite doctests
+  type:             exitcode-stdio-1.0
+  default-language: Haskell2010
+  main-is:          doctests.hs
+  ghc-options:      -Wall -Wcompat -threaded
+  hs-source-dirs:   test
+
+  if !flag(doctests)
+    buildable: False
+  else
+    build-depends:
+      base,
+      clash-prelude,
+      doctest-parallel >= 0.2 && < 0.3,
+      filepath

--- a/clash-cores/default.nix
+++ b/clash-cores/default.nix
@@ -3,4 +3,10 @@
 with nixpkgs.pkgs;
 with gitignore;
 
-haskellPackages.callCabal2nix "clash-cores" (gitignoreSource ./.) {}
+# We disable tests as doctests don't play nice with nix
+# (issue with ghc plugins)
+haskell.lib.dontCheck
+# We disable haddock as it doesn't play nice with nix
+# (issue with ghc plugins)
+(haskell.lib.dontHaddock
+  (haskellPackages.callCabal2nix "clash-cores" (gitignoreSource ./.) {}))

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
@@ -1,0 +1,281 @@
+{-|
+Copyright  :  (C) 2022, Google Inc,
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Support for the [FIFO Generator v13.2](https://docs.xilinx.com/v/u/en-US/pg057-fifo-generator).
+
+It is necessary to read the product guide linked above in order to effectively
+use the FIFO. The product guide also documents how to interface the FIFO
+correctly. To aid comprehension, the signals in this module also mention the
+name the product guide uses for that signal like @this@.
+
+Note that the behavior of the FIFO in Haskell simulation does not correspond
+exactly to the behavior in HDL simulation, and that neither behaviors correspond
+exactly to hardware. All the different behaviors are functionally correct and
+equivalent when the usage guidelines in the product guide are observed.
+
+Furthermore, the FIFO is configured as follows:
+
+* /Native/ interface type
+* /Independent clocks block RAM/ implementation
+* 2 synchronization stages
+* /Standard FIFO/ read mode
+* /No/ output registers
+* Reset pin /enabled/, reset synchronization /disabled/, safety circuit
+/disabled/
+
+    (Note: the GUI will still say /Asynchronous Reset/, grayed out. This might be
+    confusing: the resets are actually synchronous.)
+
+* Full flag reset value: /@0 (False)@/
+
+    (Note: this is actually not configurable for synchronous resets, it is
+    always @False@.)
+
+* No /Dout reset value/
+* Optional overflow flag: 'dcOverflow'
+* Optional underflow flag: 'dcUnderflow'
+* No other configurable status flags (no almost full, almost empty, write
+acknowledge, valid, or programmable full\/empty flags)
+* Optional write data count: 'dcWriteDataCount' (only full width is supported)
+* Optional read data count: 'dcReadDataCount' (only full width is supported)
+
+(The order of these items corresponds to Vivado's /Customize IP/ GUI dialog in
+Vivado 2022.1.)
+-}
+
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Clash.Cores.Xilinx.DcFifo
+  ( -- ** Reset sequencing
+    --
+    -- $resetSeq
+
+    -- * Instantiating IP
+    dcFifo
+  , FifoOut(..)
+
+    -- * Customizing IP
+  , DcConfig(..)
+  , defConfig
+
+    -- * Helper type aliases
+  , Full
+  , Empty
+  , DataCount
+  ) where
+
+import Clash.Explicit.Prelude
+import Clash.Signal.Internal (Clock (..), Signal (..))
+import Data.Maybe (isJust)
+import qualified Data.Sequence as Seq
+import Data.String.Interpolate (__i)
+import GHC.Stack (HasCallStack)
+import Numeric.Natural (Natural)
+
+import Clash.Annotations.Primitive (Primitive (InlineYamlPrimitive))
+
+import Clash.Cores.Xilinx.DcFifo.Internal.BlackBoxes
+import Clash.Cores.Xilinx.DcFifo.Internal.Instances ()
+import Clash.Cores.Xilinx.DcFifo.Internal.Types
+
+{- $setup
+>>> import Clash.Explicit.Prelude
+-}
+
+{- $resetSeq
+
+  The FIFO only supports synchronous resets ('Clash.Signal.Synchronous'). If the
+  read or write domain has an asynchronous reset signal, simulating the FIFO or
+  generating HDL for it will throw an error.
+
+  The FIFO does not need to be reset; it is possible to use the FIFO with its
+  reset inputs permanently deasserted. However, resetting the FIFO will flush
+  it, so resets do have a use. It is necessary to generate a proper reset
+  sequence; see the product guide for details. Read and write side need to be
+  reset together, both for at least one clock cycle. During the time where
+  either or both of the resets are asserted, do not perform write or read
+  operations to avoid unexpected behavior.
+-}
+
+-- | Default config. Read\/write data counts are enabled but over-\/underflow
+-- are not.
+--
+-- Examples using a type-level argument to specify the depth:
+--
+-- >>> fifo = dcFifo (defConfig @5)
+-- >>> fifo = dcFifo @5 defConfig
+-- >>> fifo = dcFifo (defConfig @5){dcReadDataCount=False}
+-- >>> fifo = dcFifo @5 defConfig{dcReadDataCount=False}
+defConfig :: KnownNat depth => DcConfig depth
+defConfig = DcConfig
+  { dcDepth = SNat
+  , dcReadDataCount = True
+  , dcWriteDataCount = True
+  , dcOverflow = False
+  , dcUnderflow = False
+  }
+
+-- | Xilinx dual clock FIFO
+--
+-- For an explanation about the type-level parameter @depth@, see 'DcConfig'.
+--
+-- If 'dcReadDataCount', 'dcUnderflow', 'dcOverflow', or 'dcWriteDataCount' are
+-- disabled, the relevant signals will return 'XException'.
+dcFifo ::
+  forall depth a write read .
+  ( KnownDomain write
+  , KnownDomain read
+
+  , NFDataX a
+
+  , KnownNat depth
+  -- Number of elements should be between [2**4, 2**17] ~ [16, 131072].
+  , 4 <= depth
+  , depth <= 17
+  , HasCallStack
+  ) =>
+  DcConfig depth ->
+
+  -- | Write clock, @wr_clk@
+  Clock write ->
+  -- | Synchronous write-side reset, @wr_rst@
+  Reset write ->
+  -- | Read clock, @rd_clk@
+  Clock read ->
+  -- | Synchronous read-side reset, @rd_rst@
+  Reset read ->
+
+  -- | Write data, @din@ and @wr_en@
+  Signal write (Maybe a) ->
+  -- | Read enable @rd_en@
+  Signal read Bool ->
+  FifoOut read write depth a
+dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
+  case (resetKind @write, resetKind @read) of
+    (SSynchronous, SSynchronous) ->
+      let
+        (wFull, wOver, wCnt, rEmpty, rUnder, rCnt, rData) =
+          go initState rdClkSignal wrClkSignal rstSignalR rEnable rstSignalW writeData
+      in FifoOut
+          wFull
+          (if dcOverflow
+             then register wClk wRst enableGen False wOver
+             else errorX "Overflow disabled")
+          (if dcWriteDataCount then wCnt else errorX "Write data count disabled")
+          rEmpty
+          (if dcUnderflow
+             then register rClk rRst enableGen False rUnder
+             else errorX "Underflow disabled")
+          (if dcReadDataCount then rCnt else errorX "Read data count disabled")
+          (register rClk rRst enableGen (deepErrorX "No initial value") rData)
+    _ -> error $ show 'dcFifo <> " only supports synchronous resets"
+
+ where
+  rstSignalR = unsafeToHighPolarity rRst
+  rstSignalW = unsafeToHighPolarity wRst
+
+  -- reified depth
+  maxDepth = natToNum @(2 ^ depth - 1) @Int
+
+  go ::
+    FifoState a ->
+    Signal read Natural -> -- clock
+    Signal write Natural -> -- clock
+    Signal read Bool -> -- reset
+    Signal read Bool -> -- read enabled
+    Signal write Bool -> -- reset
+    Signal write (Maybe a) -> -- write data
+    ( Signal write Full
+    , Signal write Bool
+    , Signal write (DataCount depth)
+
+    , Signal read Empty
+    , Signal read Bool
+    , Signal read (DataCount depth)
+    , Signal read a
+    )
+  go st@(FifoState _ rt) rdClk wrClk@(tWr :- _) =
+    if rt < fromIntegral tWr
+      then goRead st rdClk wrClk
+      else goWrite st rdClk wrClk
+
+  goWrite (FifoState _ rt) rdClk (tWr :- wrClk) rstR rEna (True :- rstWNext) (_ :- wData) =
+      -- The register will discard the @wOver@ sample
+      (False :- preFull, undefined :- preOver, 0 :- preWCnt, fifoEmpty, under, rCnt, rData)
+    where
+      (preFull, preOver, preWCnt, fifoEmpty, under, rCnt, rData) =
+        go (FifoState mempty (rt-fromIntegral tWr)) rdClk wrClk rstR rEna rstWNext wData
+
+  goWrite (FifoState q rt) rdClk (tWr :- wrClk) rstR rEna (_ :- rstW) (wDat :- wDats1) =
+    (full, over, wCnt, fifoEmpty, under, rCnt, rData)
+    where
+      (preFull, preOver, preWCnt, fifoEmpty, under, rCnt, rData) =
+        go (FifoState q' (rt-fromIntegral tWr)) rdClk wrClk rstR rEna rstW wDats1
+
+      wCnt = sDepth q :- preWCnt
+      full = (Seq.length q == maxDepth) :- preFull
+      (q', over) =
+        if Seq.length q < maxDepth
+          then (case wDat of { Just x -> x Seq.<| q ; _ -> q }, False :- preOver)
+          else (q, isJust wDat :- preOver)
+
+  sDepth = fromIntegral . Seq.length
+
+  goRead (FifoState _ rt) (tR :- rdClk) wrClk (True :- rstRNext) (_ :- rEnas1) rstW wData =
+    (full, over, wCnt, fifoEmpty, under, rCnt, rData)
+    where
+      -- The register will discard the sample
+      rData = undefined :- preRData
+      fifoEmpty = True :- preEmpty
+      rCnt = 0 :- preRCnt
+      -- The register will discard the sample
+      under = undefined :- preUnder
+
+      (full, over, wCnt, preEmpty, preUnder, preRCnt, preRData) =
+        go (FifoState mempty (rt+fromIntegral tR)) rdClk wrClk rstRNext rEnas1 rstW wData
+
+  goRead (FifoState q rt) (tR :- rdClk) wrClk (_ :- rstRNext) (rEna :- rEnas1) rstW wData =
+    (full, over, wCnt, fifoEmpty, under, rCnt, rData)
+    where
+      rCnt = sDepth q :- preRCnt
+      fifoEmpty = (Seq.length q == 0) :- preEmpty
+      rData = nextData :- preRData
+
+      (full, over, wCnt, preEmpty, preUnder, preRCnt, preRData) =
+        go (FifoState q' (rt+fromIntegral tR)) rdClk wrClk rstRNext rEnas1 rstW wData
+
+      (q', nextData, under) =
+        if rEna
+          then
+            case Seq.viewr q of
+              Seq.EmptyR -> (q, deepErrorX "FIFO empty", True :- preUnder)
+              qData Seq.:> qDatum -> (qData, qDatum, False :- preUnder)
+          else (q, deepErrorX "Enable off", False :- preUnder)
+
+  initState :: FifoState a
+  initState = FifoState Seq.empty 0
+
+  wrClkSignal = case wClk of
+    Clock _ (Just wrPeriods) -> wrPeriods
+    Clock _ Nothing ->
+      let SDomainConfiguration _ (snatToNum -> period) _ _ _ _ = knownDomain @write in
+        pure period
+  rdClkSignal = case rClk of
+    Clock _ (Just rdPeriods) -> rdPeriods
+    Clock _ Nothing ->
+      let SDomainConfiguration _ (snatToNum -> period) _ _ _ _ = knownDomain @read in
+        pure period
+{-# NOINLINE dcFifo #-}
+{-# ANN dcFifo (
+   let primName = 'dcFifo
+       tfName = 'dcFifoBBF
+   in InlineYamlPrimitive [minBound..] [__i|
+        BlackBoxHaskell:
+            name: #{primName}
+            templateFunction: #{tfName}
+            workInfo: Always
+        |]) #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/BlackBoxes.hs
@@ -1,0 +1,332 @@
+{-|
+  Copyright   :  (C) 2022 Google Inc
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Blackbox implementation for primitives in "Clash.Cores.Xilinx.DcFifo".
+-}
+
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Clash.Cores.Xilinx.DcFifo.Internal.BlackBoxes where
+
+import Prelude
+
+import Data.Either (lefts)
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import GHC.Stack (HasCallStack)
+
+import Clash.Core.TermLiteral (termToDataError)
+import Clash.Netlist.BlackBox.Types (BlackBoxFunction, emptyBlackBoxMeta)
+import Clash.Netlist.Types (TemplateFunction(..), BlackBox(BBFunction))
+import Clash.Netlist.Util (orNothing, stripVoid)
+import Clash.Signal.Internal (ResetKind(..))
+import Clash.Promoted.Nat (snatToNum)
+
+import qualified Clash.Primitives.DSL as DSL
+import qualified Clash.Netlist.Id as Id
+import qualified Clash.Netlist.Types as N
+import qualified Clash.Netlist.BlackBox.Types as N
+
+import Clash.Cores.Xilinx.DcFifo.Internal.Instances ()
+import Clash.Cores.Xilinx.DcFifo.Internal.Types (DcConfig(..))
+import Clash.Cores.Xilinx.Internal
+  (defIpConfig, IpConfig(properties), property, renderTcl, TclPurpose(..))
+
+-- | Blackbox function for 'Clash.Cores.Xilinx.DcFifo.dcFifo'. It parses the
+-- @DcConfig@ supplied to @dcFifo@ from its Term representation, and passes them
+-- to two template functions:
+--
+--   * 'dcFifoTclTF': renders Tcl file conforming to the /Clash\<->Tcl API/,
+--   creating the Xilinx IP with @create_ip@
+--   * 'dcFifoTF': instantiates IP generated in @dcFifoTclTF@
+dcFifoBBF :: HasCallStack => BlackBoxFunction
+dcFifoBBF _isD _primName args _resTys = do
+  let
+    [  _knownDomainWrite, _knownDomainRead
+     , _nfDataX, _knownNatDepth
+     , _constraint1, _constraint2, _hasCallStack
+     , either error id . termToDataError -> dcConfig
+     , _wClk, _wRst, _rClk, _rRst, _wData
+     , _rEnable
+
+    -- TODO: Make this blackbox return multiple results, instead of a tuple. See:
+    --       https://github.com/clash-lang/clash-compiler/pull/1560
+    --  , _, _, _, _, _, _, _
+     ] = lefts args
+
+  pure $ Right (bbMeta dcConfig, bb dcConfig)
+
+ where
+  bbMeta dcConfig = emptyBlackBoxMeta
+    { N.bbKind = N.TDecl
+    , N.bbIncludes =
+      [ ( ("dcfifo", "tcl")
+        , BBFunction (show 'dcFifoTclTF) 0 (dcFifoTclTF dcConfig))
+      ]
+    -- TODO: Make this blackbox return multiple results, instead of a tuple. See:
+    --       https://github.com/clash-lang/clash-compiler/pull/1560
+    -- , N.bbResultNames =
+    --   , N.BBTemplate [N.Text "wr_full"]
+    --   , N.BBTemplate [N.Text "wr_data_count"]
+
+    --   , N.BBTemplate [N.Text "rd_empty"]
+    --   , N.BBTemplate [N.Text "rd_data_count"]
+    --   , N.BBTemplate [N.Text "rd_dout"]
+    --   ]
+    }
+
+  bb :: DcConfig n -> BlackBox
+  bb dcConfig = BBFunction (show 'dcFifoTF) 0 (dcFifoTF dcConfig)
+
+-- | Instantiate IP generated with 'dcFifoTclTF'
+dcFifoTF :: HasCallStack => DcConfig n -> TemplateFunction
+dcFifoTF DcConfig{..} =
+  TemplateFunction
+    -- ( KnownDomain write        -- 0
+    -- , KnownDomain read         -- 1
+    -- , NFDataX a                -- 2
+    -- , KnownNat depth           -- 3
+    -- , 4 <= depth               -- 4
+    -- , depth <= 17              -- 5
+    -- , HasCallStack             -- 6
+    -- ) =>
+    -- DcConfig (SNat depth) ->   -- 7 Note: argument passed to this function
+    -- Clock write ->             -- 8
+    -- Reset write ->             -- 9
+    -- Clock read ->              -- 10
+    -- Reset read ->              -- 11
+    -- Signal write (Maybe a) ->  -- 12
+    -- Signal read Bool ->        -- 13
+    [0, 1, 7, 8, 9, 10, 11, 12, 13]
+    (const True)
+    $ \bbCtx -> do
+  let
+    depth = snatToNum dcDepth
+
+    [  knownDomainWrite, knownDomainRead
+     , _nfDataX, _knownNatDepth
+     , _constraint1, _constraint2, _hasCallStack
+     , _dcConfig
+     , wClk, wRst, rClk, rRst, wDataM
+     , rEnable
+     ] = map fst (DSL.tInputs bbCtx)
+
+    [tResult] = map DSL.ety (DSL.tResults bbCtx)
+    [dcFifoName] = N.bbQsysIncName bbCtx
+
+  dcFifoInstName <- Id.makeBasic "dcfifo_inst"
+
+  -- -1 for maybe
+  let dataTy = N.BitVector (DSL.tySize (DSL.ety wDataM) - 1)
+  let
+    compInps =
+      [ ("wr_clk", N.Bit)
+      , ("wr_rst", N.Bit)
+      , ("rd_clk", N.Bit)
+      , ("rd_rst", N.Bit)
+      , ("din", dataTy)
+      , ("wr_en", N.Bit)
+      , ("rd_en", N.Bit)
+      ]
+    compOuts = catMaybes
+      [ Just ("dout", dataTy)
+      , Just ("full", N.Bit)
+      , Just ("empty", N.Bit)
+      , dcReadDataCount `orNothing` ("rd_data_count", N.BitVector depth)
+      , dcWriteDataCount `orNothing` ("wr_data_count", N.BitVector depth)
+      , dcUnderflow `orNothing` ("underflow", N.Bit)
+      , dcOverflow `orNothing` ("overflow", N.Bit)
+      ]
+
+  DSL.declarationReturn bbCtx "dcfifo_inst_block" $ do
+
+    DSL.compInBlock dcFifoName compInps compOuts
+
+    (wEna, wData) <- DSL.deconstructMaybe wDataM ("wr_enable", "wr_din")
+
+    wrFull      <- DSL.declare "wr_full"       N.Bit
+    rdEmpty     <- DSL.declare "rd_empty"      N.Bit
+    rdDoutBV    <- DSL.declare "rd_dout_bv"    dataTy
+
+    wDataBV     <- DSL.toBV    "wr_din_bv"     wData
+
+    rdDout      <- DSL.fromBV "rd_dout" (DSL.ety wData) rdDoutBV
+
+    wrFullBool  <- DSL.boolFromBit "wr_full_bool" wrFull
+    rdEmptyBool <- DSL.boolFromBit "rd_empty_bool" rdEmpty
+    rEnableBit <- DSL.boolToBit "rd_enable" rEnable
+
+    wRstHigh <-
+      let domty = DSL.ety knownDomainWrite
+      in case stripVoid domty of
+           N.KnownDomain _ _ _ Synchronous _ _ ->
+             DSL.unsafeToHighPolarity "wr_rst_high" domty wRst
+           N.KnownDomain _ _ _ Asynchronous _ _ ->
+             error $
+               show 'dcFifoTF <> ": dcFifo only supports synchronous resets"
+           _ ->
+             error $ show 'dcFifoTF <> ": Bug: Not a KnownDomain " <>
+                     "constraint, mismatch between function and its blackbox"
+
+    rRstHigh <-
+      let domty = DSL.ety knownDomainRead
+      in case stripVoid domty of
+           N.KnownDomain _ _ _ Synchronous _ _ ->
+             DSL.unsafeToHighPolarity "rd_rst_high" domty rRst
+           N.KnownDomain _ _ _ Asynchronous _ _ ->
+             error $
+               show 'dcFifoTF <> ": dcFifo only supports synchronous resets"
+           _ ->
+             error $ show 'dcFifoTF <> ": Bug: Not a KnownDomain " <>
+                     "constraint, mismatch between function and its blackbox"
+
+    (rdDataCountUnsigned, rdDataCountPort) <-
+      if dcReadDataCount then do
+        rdDataCount <- DSL.declare "rd_data_count" (N.BitVector depth)
+        rdDataCountUnsigned <-
+          DSL.unsignedFromBitVector "rd_data_count_unsigned" rdDataCount
+        pure (rdDataCountUnsigned, Just ("rd_data_count", rdDataCount))
+      else do
+        rdDataCountUnsigned <-
+          DSL.declare "rd_data_count_unsigned" (N.Unsigned depth)
+        pure (rdDataCountUnsigned, Nothing)
+
+    (wrDataCountUnsigned, wrDataCountPort) <-
+      if dcWriteDataCount then do
+        wrDataCount <- DSL.declare "wr_data_count" (N.BitVector depth)
+        wrDataCountUnsigned <-
+          DSL.unsignedFromBitVector "wr_data_count_unsigned" wrDataCount
+        pure (wrDataCountUnsigned, Just ("wr_data_count", wrDataCount))
+      else do
+        wrDataCountUnsigned <-
+          DSL.declare "wr_data_count_unsigned" (N.Unsigned depth)
+        pure (wrDataCountUnsigned, Nothing)
+
+    (rdUnderBool, rdUnderPort) <-
+      if dcUnderflow then do
+        rdUnder <- DSL.declare "rd_underflow"   N.Bit
+        rdUnderBool <- DSL.boolFromBit "rd_under_bool" rdUnder
+        pure (rdUnderBool, Just ("underflow", rdUnder))
+      else do
+        rdUnderBool <- DSL.declare "rd_under_bool" N.Bool
+        pure (rdUnderBool, Nothing)
+
+    (wrOverBool, wrOverPort) <-
+      if dcOverflow then do
+        wrOver <- DSL.declare "wr_overflow"   N.Bit
+        wrOverBool <- DSL.boolFromBit "wr_over_bool" wrOver
+        pure (wrOverBool, Just ("overflow", wrOver))
+      else do
+        wrOverBool <- DSL.declare "wr_over_bool" N.Bool
+        pure (wrOverBool, Nothing)
+
+    let
+      inps =
+        [ ("wr_clk", wClk)
+        , ("wr_rst", wRstHigh)
+        , ("rd_clk", rClk)
+        , ("rd_rst", rRstHigh)
+        , ("din", wDataBV)
+        , ("wr_en", wEna)
+        , ("rd_en", rEnableBit)
+        ]
+
+      outs = catMaybes
+        [ Just ("full", wrFull)
+        , Just ("empty", rdEmpty)
+        , Just ("dout", rdDoutBV)
+        , rdDataCountPort
+        , wrDataCountPort
+        , rdUnderPort
+        , wrOverPort
+        ]
+
+    DSL.instDecl N.Empty (Id.unsafeMake dcFifoName) dcFifoInstName [] inps outs
+
+    pure [DSL.constructProduct
+      tResult
+      [ wrFullBool,  wrOverBool, wrDataCountUnsigned
+      , rdEmptyBool, rdUnderBool, rdDataCountUnsigned, rdDout
+      ]]
+
+-- | Renders Tcl file conforming to the /Clash\<->Tcl API/, creating the Xilinx
+-- IP with @create_ip@
+dcFifoTclTF :: HasCallStack => DcConfig n -> TemplateFunction
+dcFifoTclTF DcConfig{..} =
+  TemplateFunction
+    -- ( KnownDomain write        -- 0
+    -- , KnownDomain read         -- 1
+    -- , NFDataX a                -- 2
+    -- , KnownNat depth           -- 3
+    -- , 4 <= depth               -- 4
+    -- , depth <= 17              -- 5
+    -- , HasCallStack             -- 6
+    -- ) =>
+    -- DcConfig (SNat depth) ->   -- 7 Note: argument passed to this function
+    -- Clock write ->             -- 8
+    -- Reset write ->             -- 9
+    -- Clock read ->              -- 10
+    -- Reset read ->              -- 11
+    -- Signal write (Maybe a) ->  -- 12
+    -- Signal read Bool ->        -- 13
+    [7, 12]
+    (const True)
+    $ \bbCtx ->
+      let [dcFifoName] = N.bbQsysIncName bbCtx
+          [  _knownDomainWrite, _knownDomainRead, _nfDataX
+           , _knownNatDepth, _constraint1, _constraint2, _hasCallStack
+           , _dcConfig, _wClk, _wRst, _rClk, _rRst, wDataM, _rEnable
+           ] = map fst (DSL.tInputs bbCtx)
+          width = DSL.tySize (DSL.ety wDataM) - 1 :: Int -- (-1) cause it's Maybe
+      in  pure (renderTcl [IpConfigPurpose $ ipConfig dcFifoName width])
+ where
+  ipConfig nm width = (defIpConfig "fifo_generator" "13.2" nm){properties = props width}
+  depth = snatToNum @Int dcDepth
+
+  -- NOTE: The product guide listed the wrong default value for
+  -- "use_dout_register" (which in reality defaults to "true" for UltraScale
+  -- devices). To err on the side of caution, we list all parameters that are
+  -- valid for the selected configuration (but not listing superfluous
+  -- parameters that configure things that are irrelevant for the selected
+  -- configuration). The list is ordered as the "User Parameters" section of the
+  -- product guide.
+  props width =
+    [ property @Text "INTERFACE_TYPE"               "Native"
+    , property @Text "Fifo_Implementation"          "Independent_Clocks_Block_RAM"
+    , property @Int  "synchronization_stages"       2
+    , property @Text "Performance_Options"          "Standard_FIFO"
+    , property       "asymmetric_port_width"        False
+    , property       "Input_Data_Width"             width
+    , property @Int  "Input_Depth"                  (2 ^ depth)
+    , property       "Output_Data_Width"            width
+    , property @Int  "Output_Depth"                 (2 ^ depth)
+    , property       "enable_low_latency"           False
+    , property       "use_dout_register"            False
+    , property       "Enable_ECC"                   False
+    , property       "Use_Embedded_Registers"       False
+    , property       "Reset_Pin"                    True
+    , property       "Enable_Reset_Synchronization" False
+    , property       "Enable_Safety_Circuit"        False
+    , property @Int  "Full_Flags_Reset_Value"       0
+    , property       "Use_Dout_Reset"               False
+    , property       "Almost_Full_Flag"             False
+    , property       "Almost_Empty_Flag"            False
+    , property       "Write_Acknowledge_Flag"       False
+    , property       "Overflow_Flag"                dcOverflow
+    , property @Text "Overflow_Sense"               "Active_High"
+    , property       "Valid_Flag"                   False
+    , property       "Underflow_Flag"               dcUnderflow
+    , property @Text "Underflow_Sense"              "Active_High"
+    , property @Text "Programmable_Full_Type"       "No_Programmable_Full_Threshold"
+    , property @Text "Programmable_Empty_Type"      "No_Programmable_Empty_Threshold"
+    , property       "Write_Data_Count"             dcWriteDataCount
+    , property       "Write_Data_Count_Width"       depth
+    , property       "Read_Data_Count"              dcReadDataCount
+    , property       "Read_Data_Count_Width"        depth
+    , property       "Disable_Timing_Violations"    False
+    ]

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/Instances.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/Instances.hs
@@ -1,0 +1,21 @@
+{-|
+  Copyright   :  (C) 2022 Google Inc
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Orphan instances for types in "Clash.Cores.Xilinx.DcFifo.Internal.Types". They
+  are housed here due to TemplateHaskell stage restrictions.
+-}
+
+{-# LANGUAGE ViewPatterns #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Clash.Cores.Xilinx.DcFifo.Internal.Instances where
+
+import Clash.Core.TermLiteral (TermLiteral(..))
+import Clash.Core.TermLiteral.TH (deriveTermLiteral)
+
+import Clash.Cores.Xilinx.DcFifo.Internal.Types
+
+deriveTermLiteral ''DcConfig

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/Types.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/Types.hs
@@ -1,0 +1,102 @@
+{-|
+Copyright  :  (C) 2022, Google Inc,
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+module Clash.Cores.Xilinx.DcFifo.Internal.Types where
+
+import Clash.Prelude
+
+import qualified Data.Sequence as Seq
+
+type Full = Bool
+type Empty = Bool
+type DataCount n = Unsigned n
+
+-- | Parameters for the FIFO generator; toggle various signals.
+--
+-- The @depth@ parameter configures the number of elements the FIFO will hold,
+-- however the actual number of elements is equal to @2^depth - 1 @. So
+-- @dcDepth=d4@ will create a FIFO with an actual depth of 15 elements. The
+-- range of @depth@ is 4 through 17 inclusive: the deepest FIFO can hold 131,071
+-- elements.
+--
+-- Example:
+--
+-- @
+-- fifo = dcFifo DcConfig{ dcDepth=d5
+--                       , dcReadDataCount=False
+--                       , dcWriteDataCount=False
+--                       , dcOverflow=True
+--                       , dcUnderflow=True
+--                       }
+-- @
+data DcConfig depth = DcConfig
+  { -- | The FIFO will be able to hold @2^depth - 1@ elements.
+    dcDepth :: !(SNat depth)
+  -- | Enable @rd_data_count@ signal
+  , dcReadDataCount :: !Bool
+  -- | Enable @wr_data_count@ signal
+  , dcWriteDataCount :: !Bool
+  -- | Enable @overflow@ signal
+  , dcOverflow :: !Bool
+  -- | Enable @underflow@ signal
+  , dcUnderflow :: !Bool
+  }
+  deriving (Show, Generic)
+
+data FifoState a = FifoState
+  { hsQueue      :: Seq.Seq a
+  , relativeTime :: Int -- ^ In order to model a FIFO in two clock domains,
+                        -- we track the offset between edges in order to know
+                        -- which signals to peel off.
+  } deriving Show
+
+-- | Output of 'Clash.Cores.Xilinx.DcFifo.dcFifo'
+data FifoOut read write depth a =
+  FifoOut
+    {
+    -- | @full@. Full Flag: When asserted, this signal indicates that the FIFO
+    -- is full. Write requests are ignored when the FIFO is full, initiating a
+    -- write when the FIFO is full is not destructive to the contents of the
+    -- FIFO.
+      isFull :: Signal write Full
+    -- | @overflow@. Overflow: This signal indicates that a write request
+    -- (@wr_en@) during the prior clock cycle was rejected, because the FIFO is
+    -- full. Overflowing the FIFO is not destructive to the FIFO.
+    --
+    -- This signal will return 'XException' when 'dcOverflow' is disabled.
+    , isOverflow :: Signal write Bool
+    -- | @wr_data_count@. Write Data Count: This bus indicates the number of
+    -- words written into the FIFO. The count is guaranteed to never
+    -- under-report the number of words in the FIFO, to ensure you never
+    -- overflow the FIFO. The exception to this behavior is when a write
+    -- operation occurs at the rising edge of @wr_clk@, that write operation
+    -- will only be reflected on @wr_data_count@ at the next rising clock edge.
+    --
+    -- This signal will return 'XException' when 'dcWriteDataCount' is disabled.
+    , writeCount :: Signal write (DataCount depth)
+    -- | @empty@. Empty Flag: When asserted, this signal indicates that the FIFO
+    -- is empty. Read requests are ignored when the FIFO is empty, initiating a
+    -- read while empty is not destructive to the FIFO.
+    , isEmpty :: Signal read Empty
+    -- | @underflow@. Underflow: Indicates that read request (@rd_en@) during
+    -- the previous clock cycle was rejected because the FIFO is empty.
+    -- Underflowing the FIFO is not destructive to the FIFO.
+    --
+    -- This signal will return 'XException' when 'dcUnderflow' is disabled.
+    , isUnderflow :: Signal read Bool
+    -- | @rd_data_count@. Read Data Count: This bus indicates the number of
+    -- words available for reading in the FIFO. The count is guaranteed to never
+    -- over-report the number of words available for reading, to ensure that you
+    -- do not underflow the FIFO. The exception to this behavior is when the
+    -- read operation occurs at the rising edge of @rd_clk@, that read operation
+    -- is only reflected on @rd_data_count@ at the next rising clock edge.
+    --
+    -- This signal will return 'XException' when 'dcReadDataCount' is disabled.
+    , readCount :: Signal read (DataCount depth)
+    -- | @dout@. Data Output: The output data bus is driven in the cycle after
+    -- asserting the read enable @rd_en@.
+    , fifoData :: Signal read a
+    }

--- a/clash-cores/src/Clash/Cores/Xilinx/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Internal.hs
@@ -1,0 +1,212 @@
+{-|
+  Copyright   :  (C) 2022 Google Inc
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Common utilities for defining Xilinx IP primitives.
+-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.Xilinx.Internal where
+
+import Prelude
+import Data.Maybe (catMaybes)
+import Data.String.Interpolate (i, __i)
+import Data.Text (Text)
+import qualified Data.Text as Text
+#if MIN_VERSION_prettyprinter(1,7,0)
+import Prettyprinter
+  ((<+>), align, backslash, indent, line, pretty, rbrace, vsep)
+#else
+import Data.Text.Prettyprint.Doc
+  ((<+>), align, backslash, indent, line, pretty, rbrace, vsep)
+#endif
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import GHC.Natural (Natural)
+import GHC.Stack (HasCallStack)
+import Clash.Netlist.Types (IdentifierText)
+
+type PropName = Text
+type PropValue = Text
+data Property = Property !PropName !PropValue
+  deriving Show
+
+-- | String representation of values in Tcl
+--
+-- __WARNING__: This does not (yet?) do any escaping of special characters!
+-- Generating a proper Tcl word where needed is left to the implementation.
+class TclShow a where
+  -- | Represent the value as a Tcl string
+  --
+  -- Default: 'show'
+  tclShow :: a -> Text
+  default tclShow :: Show a => a -> Text
+  tclShow = Text.pack . show
+  -- | The method @tclShowList@ is provided to allow the programmer to give a
+  -- specialised way of showing lists of values. For example, this is used by
+  -- the @TclShow@ instance of the @Char@ type, where values of type @String@
+  -- should be a simple string rather than a list of @Char@ values.
+  --
+  -- The default implementation renders into a Tcl list of the shape
+  -- @[list X Y Z]@.
+  tclShowList :: [a] -> Text
+  tclShowList [] = "{}"
+  tclShowList [e] = tclShow e
+  tclShowList es = ("[list" <>) . shows0 es $ "]"
+   where
+    shows0 [] s = s
+    shows0 (e:es0) s = Text.cons ' ' . (tclShow e <>) . shows0 es0 $ s
+
+showLower :: Show a => a -> Text
+showLower = Text.toLower . Text.pack . show
+
+instance TclShow a => TclShow [a] where
+  tclShow = tclShowList
+
+instance TclShow Bool where
+  tclShow = showLower
+
+instance TclShow Char where
+  tclShow = Text.singleton
+  tclShowList = Text.pack
+
+instance TclShow Text where
+  tclShow = id
+
+instance TclShow Int
+instance TclShow Integer
+instance TclShow Natural
+
+newtype BraceTcl a = BraceTcl a
+  deriving (Show, Eq)
+
+instance TclShow a => TclShow (BraceTcl a) where
+  tclShow (BraceTcl x) = '{' `Text.cons` tclShow x `Text.snoc` '}'
+
+property :: TclShow a => Text -> a -> Property
+property name_ value = Property name_ (tclShow value)
+
+data TclPurpose = IpConfigPurpose !IpConfig | ReadXdcPurpose !ReadXdc
+
+data IpConfig = IpConfig
+  { name :: !Text
+  , vendor :: !Text
+  , library :: !Text
+  , version :: !Text
+  , moduleName :: !IdentifierText
+  , properties :: ![Property]
+  }
+
+data ReadXdc = ReadXdc
+  { xdcFile :: !Text
+  , order :: !Order
+  , usedIn :: !UsedIn
+  , scopeRef :: !(Maybe Text)
+  }
+
+data Order = Early | Normal | Late
+  deriving (Eq, Show)
+
+instance TclShow Order where
+  tclShow = showLower
+
+data UsedIn = Synthesis | Implementation | Both
+  deriving (Eq, Show)
+
+instance TclShow UsedIn where
+  tclShow Both = "{synthesis implementation}"
+  tclShow u = showLower u
+
+defIpConfig ::
+  -- | Name of IP core. For example: \"fifo_generator\".
+  Text ->
+  -- | Version of IP core. For example: \"13.2\".
+  Text ->
+  -- | Name of module the IP core should be generated as. For example: \"dcfifo\". This
+  -- name should be unique. See "Clash.Netlist.Id" for more information on how to
+  -- generate unique identifiers.
+  IdentifierText ->
+  -- | Configuration with sensible defaults.
+  IpConfig
+defIpConfig name_ version_ moduleName_ = IpConfig
+  { name = name_
+  , version = version_
+  , moduleName = moduleName_
+  , vendor = "xilinx.com"
+  , library = "ip"
+  , properties = []
+  }
+
+defReadXdc :: Text -> ReadXdc
+defReadXdc file = ReadXdc
+  { xdcFile = file
+  , order = Early
+  , usedIn = Both
+  , scopeRef = Nothing
+  }
+
+-- We currently have no users of the "multipleScripts" and the ReadXdc
+-- mechanisms, as it turned out that DcFifo bundled the correct constraints
+-- after all (through the 'xpm_cdc_gray' module it uses). But the Tcl code has
+-- been verified and will be useful later.
+renderTcl :: HasCallStack => [TclPurpose] -> Doc
+renderTcl = \case
+  [] ->
+    error "Tcl script needs at least one purpose"
+  [p] ->
+    rootSnippet <> line <> indent 2 (renderOne p) <> line <> rbrace
+  ps ->
+    let ms = zipWith renderMulti [1 :: Int ..] ps
+    in rootSnippet <> line <>
+       indent 2 "variable scriptPurpose multipleScripts" <> line <> rbrace <>
+       line <> vsep ms
+ where
+  rootSnippet = [__i|
+    namespace eval $tclIface {
+      variable api 1
+    |]
+
+  renderOne (IpConfigPurpose IpConfig{..}) =
+    ipSnippet <> line <> indent 4 renderedProperties <> line <>
+    indent 2 "return" <> line <> rbrace
+   where
+    -- \& is needed to prevent CPP from joining lines :-(
+    ipSnippet = [__i|
+      variable scriptPurpose createIp
+      variable ipName {#{moduleName}}
+      proc createIp {ipName0 args} {
+        create_ip \\\&
+          -name #{name} \\\&
+          -vendor #{vendor} \\\&
+          -library #{library} \\\&
+          -version #{version} \\\&
+          -module_name $ipName0 \\\&
+          {*}$args
+
+        set_property \\\&
+      |]
+    renderedProperties =
+      "-dict [list " <> align (vsep ("\\" : map prop properties)) <>
+      line <> "      ] [get_ips $ipName0]"
+    prop (Property name_ value) =
+      "CONFIG." <> pretty name_ <+> pretty value <+> backslash
+  renderOne (ReadXdcPurpose ReadXdc{..}) = vsep $ catMaybes vars
+   where
+    var :: TclShow a => Doc -> a -> Doc
+    var name_ value = "variable" <+> name_ <+> pretty (tclShow value)
+    vars :: [Maybe Doc]
+    vars = [ Just $ var @Text "scriptPurpose" "readXdc"
+           , Just $ var       "order"         order
+           , fmap ( var       "scopeRef"      . BraceTcl) scopeRef
+           , Just $ var       "usedIn"        usedIn
+           , Just $ var       "xdcFile"       $ BraceTcl xdcFile
+           ]
+
+  renderMulti n p =
+    line <> [i|namespace eval ${tclIface}::multipleScripts::script#{n} {|] <>
+    line <> indent 2 (renderOne p) <> line <> rbrace

--- a/clash-cores/test/Test/Cores/Xilinx/DcFifo.hs
+++ b/clash-cores/test/Test/Cores/Xilinx/DcFifo.hs
@@ -1,0 +1,298 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans -fno-warn-unused-top-binds #-}
+
+module Test.Cores.Xilinx.DcFifo ( tests ) where
+
+import qualified Prelude as P
+import qualified Data.List as L
+import Data.Maybe (catMaybes)
+import Data.Proxy (Proxy (..))
+
+import Clash.Explicit.Prelude
+import Clash.Cores.Xilinx.DcFifo
+import Clash.Netlist.Util (orNothing)
+
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Hedgehog (Gen, MonadGen, (===), property, forAll, Property)
+import qualified Hedgehog as H
+import Test.Tasty.Hedgehog (testPropertyNamed)
+import Test.Tasty.HUnit (testCase, assertBool)
+import Test.Tasty (testGroup, TestTree)
+
+createDomain vXilinxSystem{vName="D3", vPeriod=3}
+createDomain vXilinxSystem{vName="D5", vPeriod=5}
+createDomain vXilinxSystem{vName="D11", vPeriod=11}
+
+tests :: TestTree
+tests = testGroup "FIFO tests"
+  [ testPropertyNamed
+      "FIFO doesn't lose any data with small stalls (wrT > rdT)"
+      "prop_noloss"
+      (prop_noloss (SNat @4) (Proxy @D3) (Proxy @D5))
+  , testPropertyNamed
+      "FIFO doesn't lose any data with small stalls (rdT > wrT)"
+      "prop_noloss"
+      (prop_noloss (SNat @4) (Proxy @D5) (Proxy @D3))
+  , testPropertyNamed
+      "FIFO doesn't lose any data with small stalls (rdT = wrT)"
+      "prop_noloss"
+      (prop_noloss (SNat @4) (Proxy @D3) (Proxy @D3))
+  , testPropertyNamed
+      "Large FIFO doesn't lose any data with (rdT > wrT)"
+      "prop_noloss"
+      (prop_noloss (SNat @17) (Proxy @D11) (Proxy @D3))
+  , testPropertyNamed
+      "FIFO preserves order (wrT = rdT)"
+      "prop_fifoOrder"
+      (prop_fifoOrder (SNat @4) (Proxy @D3) (Proxy @D3) feedState takeState)
+  , testPropertyNamed
+      "FIFO preserves order (wrT > rdT)"
+      "prop_fifoOrder"
+      (prop_fifoOrder (SNat @4) (Proxy @D3) (Proxy @D11) feedState takeState)
+  , testPropertyNamed
+      "FIFO preserves order (rdT > wrT)"
+      "prop_fifoOrder"
+      (prop_fifoOrder (SNat @4) (Proxy @D11) (Proxy @D3) feedState takeState)
+  , testPropertyNamed
+      "FIFO preserves order when writes don't respect overflow (rdT > wrT)"
+      "prop_fifoOrder"
+      (prop_fifoOrder (SNat @4) (Proxy @D11) (Proxy @D3) feedClumsy takeState)
+  , testPropertyNamed
+      "FIFO doesn't throw exceptions on underflow (wrT > rdT)"
+      "prop_fifoOrder"
+      (prop_noException (SNat @4) (Proxy @D3) (Proxy @D11) feedState takeClumsy)
+  , testOverflow
+  ]
+
+-- | Must generate the same number of stalls and data
+intersperseStalls ::
+  -- | Data
+  [a] ->
+  -- | Stalls
+  [b] ->
+  [Either b a]
+intersperseStalls d s = P.concat (P.zipWith (\x y -> [Left y, Right x]) d s)
+
+genScenario ::
+  (KnownNat n) =>
+  -- | Number of elements to write and expect, @n@. For each write and read it
+  -- may generate @n@ stall cycles. Test cases can therefore expect that all elements
+  -- pass through the FIFO in @n * n * m@ cycles.
+  Gen Int ->
+  -- | Maximum stall size, @m@.
+  Gen Int ->
+  Gen ([BitVector n], [Either Int (BitVector n)], [Maybe Int])
+genScenario genN genReadWrite = do
+  n <- genN
+  xs <- Gen.list (Range.singleton n) genData
+  stallRead <- Gen.list (Range.singleton n) genReadWrite
+  stallWrite <- Gen.list (Range.singleton n) genReadWrite
+  let
+    readStalls = fmap Just stallRead
+  pure (xs, intersperseStalls xs stallWrite, L.intersperse Nothing readStalls)
+
+-- | Assert that everything in @xs@ is in @ys@ and has the same relative rank.
+orderFifo ::
+  Eq a =>
+  -- | @xs@
+  [a] ->
+  -- | @ys@
+  [a] ->
+  Bool
+orderFifo [] [] = True
+orderFifo (x:xs) (y:ys) | x == y = orderFifo xs ys
+orderFifo xs (_:ys) = orderFifo xs ys
+orderFifo _ _ = False
+
+-- | Generated stalls are large enough that we expect loss, but order should be
+-- preserved.
+prop_fifoOrder ::
+  forall (read :: Symbol) (write :: Symbol) d.
+  ( KnownDomain read
+  , KnownDomain write
+  , KnownNat d
+  , 4 <= d
+  , d <= 17
+  ) =>
+  SNat d ->
+  Proxy read ->
+  Proxy write ->
+  Feed d ->
+  Drain d 32 ->
+  Property
+prop_fifoOrder d pr pw feed drain = property $ do
+  (xs, wrIn, rdStalls) <- forAll $ genScenario (Gen.int (Range.linear 30 40)) (Gen.int (Range.linear 10 15))
+  let res = throughFifo d pr pw feed drain wrIn rdStalls
+  H.annotate (show res)
+  H.assert (orderFifo res xs)
+
+-- | If we read after underflow, we still expect that the FIFO goes on.
+prop_noException ::
+  forall (read :: Symbol) (write :: Symbol) d.
+  ( KnownDomain read
+  , KnownDomain write
+  , KnownNat d
+  , 4 <= d
+  , d <= 17
+  ) =>
+  SNat d ->
+  Proxy read ->
+  Proxy write ->
+  Feed d ->
+  Drain d 32 ->
+  Property
+prop_noException d pr pw feed drain = property $ do
+  (_, wrIn, rdStalls) <- forAll $ genScenario (Gen.int (Range.linear 7 12)) (Gen.int (Range.linear 7 8))
+  let res = throughFifo d pr pw feed drain wrIn rdStalls
+  H.annotate (show res)
+  H.assert (res `seq` True)
+
+-- | Generated stalls are small enough that we don't expect any data loss
+prop_noloss ::
+  forall (read :: Symbol) (write :: Symbol) d.
+  ( KnownDomain read
+  , KnownDomain write
+  , KnownNat d
+  , 4 <= d
+  , d <= 17
+  ) =>
+  SNat d -> Proxy read -> Proxy write -> Property
+prop_noloss d pr pw = property $ do
+  (xs, wrIn, rdStalls) <- forAll $ genScenario (Gen.int (Range.linear 7 12)) (Gen.int (Range.linear 7 8))
+  throughFifo d pr pw feedState takeState wrIn rdStalls === xs
+
+testOverflow :: TestTree
+testOverflow = testCase "Overflows appropriately" $ do
+  assertBool "Overflows if we never read" (or (sampleN 20 wrOver0))
+  assertBool "Doesn't overflow if we write exactly 15 values"
+    (not (or (sampleN 20 wrOver1)))
+ where
+  (FifoOut _ wrOver0 _ _ _ _ _) = fifo (pure (Just (1 :: Int))) (pure False)
+  (FifoOut _ wrOver1 _ _ _ _ _) = fifo drive15 (pure False)
+
+  fifo = dcFifo @4 defConfig{dcOverflow = True} clk noRst clk noRst
+  clk = clockGen @D3
+  noRst = unsafeFromHighPolarity $ pure False
+  drive15 = mealy clk noRst enableGen go 15 (pure ())
+  go 0 _ = (0 :: Int, Nothing)
+  go n _ = (n-1, Just (1 :: Int))
+
+genData :: (KnownNat n, MonadGen m) => m (BitVector n)
+genData = Gen.enumBounded
+
+type Drain depth n =
+  (Bool, [Maybe Int]) ->
+  (Empty, DataCount depth, BitVector n) ->
+  ((Bool, [Maybe Int]), (Maybe (BitVector n), Bool))
+
+-- | Mealy machine which stalls reading from the FIFO based on ['Maybe'
+-- 'Int']
+takeState ::
+  (Bool, [Maybe Int]) ->
+  (Empty, DataCount depth, BitVector n) ->
+  ((Bool, [Maybe Int]), (Maybe (BitVector n), Bool))
+takeState (readLastCycle, Just n:stalls) (_, _, d) | n > 0 =
+    ((False, Just (n-1):stalls), (nextData, False))
+  where
+    nextData = readLastCycle `orNothing` d
+takeState (readLastCycle, stalls) (fifoEmpty, _, d) =
+    ((readThisCycle, L.drop 1 stalls), (nextData, readThisCycle))
+  where
+    readThisCycle = not fifoEmpty
+    nextData = readLastCycle `orNothing` d
+
+-- | Mealy machine which stalls reading from the FIFO based on ['Maybe'
+-- 'Int']. This ignores @empty@ signals out of the FIFO.
+takeClumsy ::
+  (Bool, [Maybe Int]) ->
+  (Empty, DataCount depth, BitVector n) ->
+  ((Bool, [Maybe Int]), (Maybe (BitVector n), Bool))
+takeClumsy (readLastCycle, Just n:stalls) (_, _, d) | n > 0 =
+    ((False, Just (n-1):stalls), (nextData, False))
+  where
+    nextData = readLastCycle `orNothing` d
+takeClumsy (readLastCycle, stalls) (_, _, d) =
+    ((True, L.drop 1 stalls), (nextData, True))
+  where
+    nextData = readLastCycle `orNothing` d
+
+type Feed d =
+  SNat d ->
+  [Either Int (BitVector 32)] ->
+  (Full, DataCount d) ->
+  ([Either Int (BitVector 32)], Maybe (BitVector 32))
+
+-- | Driver for input to FIFO, takes stalls and data
+feedState ::
+  SNat d ->
+  [Either Int (BitVector 32)] ->
+  (Full, DataCount d) ->
+  ([Either Int (BitVector 32)], Maybe (BitVector 32))
+feedState _ [] _ = ([], Nothing)
+feedState _ (Left 0:xs) (_, _) = (xs, Nothing)
+feedState _ (Left i:xs) (_, _) = (Left (i-1):xs, Nothing)
+feedState _ (Right x:xs) (full, _) =
+  if full
+    then (Right x:xs, Nothing)
+    else (xs, Just x)
+
+-- | Driver for input to FIFO, takes stalls and data and ignores full signals
+-- out of the FIFO.
+feedClumsy ::
+  SNat d ->
+  [Either Int (BitVector 32)] ->
+  (Full, DataCount d) ->
+  ([Either Int (BitVector 32)], Maybe (BitVector 32))
+feedClumsy _ [] _ = ([], Nothing)
+feedClumsy _ (Left 0:xs) (_, _) = (xs, Nothing)
+feedClumsy _ (Left i:xs) (_, _) = (Left (i-1):xs, Nothing)
+feedClumsy _ (Right x:xs) (_, _) =
+    (xs, Just x)
+
+throughFifo
+  :: forall (read :: Symbol) (write :: Symbol) d.
+  ( KnownDomain read
+  , KnownDomain write
+  , KnownNat d
+  , 4 <= d
+  , d <= 17
+  ) =>
+  SNat d ->
+  Proxy read ->
+  Proxy write ->
+  -- | Driver for write domain
+  Feed d ->
+  -- | Driver for read domain
+  Drain d 32 ->
+  -- | Write data ('Left' 'Int' indicates a stall of duration @i@)
+  [Either Int (BitVector 32)] ->
+  -- | Read stalls
+  [Maybe Int] ->
+  [BitVector 32]
+throughFifo d _ _ feed drain wrDataList rdStalls = rdDataList
+  where
+
+    wrClk = clockGen @write
+    noWrRst = unsafeFromHighPolarity $ pure False
+    wrEna = enableGen @write
+
+    rdClk = clockGen @read
+    noRdRst = unsafeFromHighPolarity $ pure False
+    rdEna = enableGen @read
+
+    wrData =
+      mealyB wrClk noWrRst wrEna (feed d) wrDataList (wrFull, wrCnt)
+
+    (rdDataMaybe, rdEnaB) =
+      mealyB rdClk noRdRst rdEna drain (False, rdStalls) (rdEmpty, rdCnt, rdData)
+
+    rdDataList =
+      catMaybes
+        $ sampleN (P.length wrDataList*10)
+        $ bundle rdDataMaybe
+
+    (FifoOut wrFull _ wrCnt rdEmpty _ rdCnt rdData) =
+      dcFifo defConfig wrClk noWrRst rdClk noRdRst wrData rdEnaB

--- a/clash-cores/test/doctests.hs
+++ b/clash-cores/test/doctests.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import System.Environment (getArgs)
+import Test.DocTest (mainFromCabal)
+
+main :: IO ()
+main = mainFromCabal "clash-cores" =<< getArgs

--- a/clash-cores/test/unittests.hs
+++ b/clash-cores/test/unittests.hs
@@ -13,9 +13,10 @@ import Test.Tasty
 import qualified Test.Cores.SPI as SPI
 import qualified Test.Cores.SPI.MultiSlave as Mul
 import qualified Test.Cores.UART as UART
+import qualified Test.Cores.Xilinx.DcFifo as Fifo
 
 tests :: TestTree
-tests = testGroup "Unittests" [SPI.tests, Mul.tests, UART.tests]
+tests = testGroup "Unittests" [SPI.tests, Mul.tests, UART.tests, Fifo.tests]
 
 main :: IO ()
 main = defaultMain tests

--- a/clash-lib/src/Clash/Core/TermLiteral/TH.hs
+++ b/clash-lib/src/Clash/Core/TermLiteral/TH.hs
@@ -1,3 +1,12 @@
+{-|
+Copyright   :  (C) 2019, Myrtle Software Ltd,
+                   2021, QBayLogic B.V.
+                   2022, Google Inc
+License     :  BSD2 (see the file LICENSE)
+Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Template Haskell utilities for "Clash.Core.TermLiteral".
+-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -148,6 +157,7 @@ deriveTermToData typName = do
   pure (deriveTermToData1 (map toConstr' constrs))
  where
   toConstr' (NormalC cName fields) = (cName, length fields)
+  toConstr' (RecC cName fields) = (cName, length fields)
   toConstr' c = error $ "Unexpected constructor: " ++ show c
 
 deriveTermToData1 :: [(Name, Int)] -> Exp

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -478,6 +478,30 @@ runClashTest = defaultMain $ clashTestRoot
 --             in runTest "Floating" _opts
 --           ]
 --         ]
+      , clashTestGroup "Cores"
+        [ clashTestGroup "Xilinx"
+          [ runTest "DcFifo0" def{
+              hdlTargets=[VHDL, Verilog]
+            , hdlLoad=[]
+            , hdlSim=[Vivado]}
+          , runTest "DcFifo1" def{
+              hdlTargets=[VHDL, Verilog]
+            , hdlLoad=[]
+            , hdlSim=[Vivado]}
+          , runTest "DcFifo2" def{
+              hdlTargets=[VHDL, Verilog]
+            , hdlLoad=[]
+            , hdlSim=[Vivado]}
+          , clashTestGroup "DcFifo" [
+              let _opts =
+                    def{ hdlTargets=[VHDL, Verilog]
+                       , hdlLoad=[]
+                       , hdlSim=[Vivado]
+                       }
+              in runTest "Basic" _opts
+            ]
+          ]
+        ]
       , clashTestGroup "CSignal"
         [ runTest "MAC" def{hdlSim=[]}
         , runTest "CBlockRamTest" def{hdlSim=[]}
@@ -959,9 +983,9 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "VecOfSum" def{hdlSim=[]}
         , runTest "T452" def{hdlSim=[]}
         , runTest "T478" def{hdlSim=[]}
-        , let _opts = def { hdlSim = [], hdlTargets = [VHDL]}
+        , let _opts = def {hdlSim = [], hdlTargets = [VHDL]}
            in runTest "T895" _opts
-        , let _opts = def { hdlSim = [], hdlTargets = [VHDL], clashFlags = ["-fclash-hdlsyn", "Vivado"]}
+        , let _opts = def {hdlSim = [], hdlTargets = [VHDL]}
            in runTest "T1360" _opts
         ] -- end vector
       , clashTestGroup "Verification" [

--- a/tests/shouldwork/Cores/Xilinx/DcFifo/Abstract.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo/Abstract.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module DcFifo.Abstract where
+
+import Clash.Explicit.Prelude
+import Clash.Cores.Xilinx.DcFifo
+import Clash.Explicit.Testbench
+import Data.Maybe (isJust)
+
+type ReadLastCycle = Bool
+type Stall = Bool
+type ExpectedToRead n = BitVector n
+type UnexpectedRead = Bool
+
+createDomain vXilinxSystem{vName="Dom2", vPeriod=hzToPeriod 2e7}
+createDomain vXilinxSystem{vName="Dom3", vPeriod=hzToPeriod 3e7}
+createDomain vXilinxSystem{vName="Dom17", vPeriod=hzToPeriod 17e7}
+
+-- | Produce a 'Just' when predicate is True, else Nothing
+orNothing :: Bool -> a -> Maybe a
+orNothing True a = Just a
+orNothing False _ = Nothing
+
+lfsrF ::
+  KnownDomain dom =>
+  Clock dom -> Reset dom -> Enable dom ->
+  BitVector 16 ->
+  Signal dom Bit
+lfsrF clk rst ena seed = msb <$> r
+ where
+  r = register clk rst ena seed (lfsrF' <$> r)
+
+  lfsrF' :: BitVector 16 -> BitVector 16
+  lfsrF' s = pack lfsrFeedback ++# slice d15 d1 s
+   where
+    five, three, two, zero :: Unsigned 16
+    (five, three, two, zero) = (5, 3, 2, 0)
+    lfsrFeedback = s ! five `xor` s ! three `xor` s ! two `xor` s ! zero
+{-# NOINLINE lfsrF #-}
+
+fifoSampler ::
+  KnownDomain dom =>
+  Clock dom -> Reset dom -> Enable dom ->
+  -- | Stall circuit? For this test case, this signal comes from 'lfsrF'
+  Signal dom Stall ->
+  -- | Signals from FIFO
+  Signal dom (Empty, DataCount depth, a) ->
+  -- | Maybe output read from FIFO
+  Signal dom (Bool, Maybe a)
+fifoSampler clk rst ena stalls inps =
+  mealy clk rst ena go False (bundle (stalls, inps))
+ where
+  go ::
+    ReadLastCycle ->
+    (Stall, (Empty, DataCount depth, a)) ->
+    (ReadLastCycle, (Bool, Maybe a))
+  go readLastCycle (stall, (fifoEmpty, _dataCount, readData)) = (readNow, (readNow, maybeData))
+   where
+    maybeData = readLastCycle `orNothing` readData
+    readNow = not stall && not fifoEmpty
+{-# NOINLINE fifoSampler #-}
+
+-- | Drives Xilinx FIFO with an ascending sequence of 'BitVector's. Stalls
+-- intermittently based on stall input.
+fifoDriver ::
+  forall a dom depth .
+  ( KnownDomain dom
+  , NFDataX a
+  , Enum a
+  , Num a
+  ) =>
+  Clock dom -> Reset dom -> Enable dom ->
+  -- | Stall circuit? For this test case, this signal comes from 'lfsrF'
+  Signal dom Stall ->
+  -- | Signals from FIFO
+  Signal dom (Full, DataCount depth) ->
+  -- | Maybe write input to FIFO
+  Signal dom (Maybe a)
+fifoDriver clk rst ena stalls inps =
+  mealyB clk rst ena go 0 (stalls, inps)
+ where
+  go ::
+    a ->
+    (Stall, (Full, DataCount depth)) ->
+    (a, Maybe a)
+  go n0 (stall, (full, _dataCount)) = (n1, maybeWrite)
+   where
+    maybeWrite = willWrite `orNothing` n0
+    willWrite = not stall && not full
+    n1 = if willWrite then succ n0 else n0
+
+type ConfiguredFifo a read write =
+  Clock write ->
+  Reset write ->
+  Clock read ->
+  Reset read ->
+
+  -- | Write data
+  Signal write (Maybe a) ->
+  -- | Read enable
+  Signal read Bool ->
+  FifoOut read write 4 a
+
+mkTestBench ::
+  forall a read write.
+  ( Num a
+  , Enum a
+  , NFDataX a
+  , Ord a
+  , ShowX a
+  , KnownDomain write
+  , KnownDomain read
+  ) =>
+  ConfiguredFifo a read write ->
+  Signal read Bool
+mkTestBench cFifo = done
+ where
+  (rClk, wClk) = biTbClockGen (not <$> done)
+
+  noRRst = unsafeFromHighPolarity $ pure False
+  noWRst = unsafeFromHighPolarity $ pure False
+
+  rEna = enableGen
+  wEna = enableGen
+
+  -- Driver
+  wLfsr = bitToBool <$> lfsrF wClk noWRst wEna 0xDEAD
+  writeData = fifoDriver wClk noWRst wEna wLfsr (bundle (isFull, writeCount))
+
+  -- Sampler
+  rLfsr = bitToBool <$> lfsrF rClk noRRst rEna 0xBEEF
+  (readEnable, maybeReadData) =
+    unbundle $
+      fifoSampler rClk noRRst rEna rLfsr (bundle (isEmpty, readCount, fifoData))
+
+  FifoOut{isFull, writeCount, isEmpty, readCount, fifoData} =
+    cFifo wClk noWRst rClk noRRst writeData readEnable
+
+  done = fifoVerifier rClk noRRst rEna maybeReadData
+{-# INLINE mkTestBench #-}
+
+fifoVerifier ::
+  forall a dom .
+  ( KnownDomain dom
+  , Ord a
+  , Num a
+  , NFDataX a
+  , ShowX a
+  ) =>
+  Clock dom -> Reset dom -> Enable dom ->
+  Signal dom (Maybe a) ->
+  Signal dom Bool
+fifoVerifier clk rst ena actual = done0
+ where
+  expected = regEn clk rst ena 0 (isJust <$> actual) $ expected + 1
+  samplesDone = expected .>. 100
+  stuckCnt :: Signal dom (Index 25000)
+  stuckCnt = regEn clk rst ena 0 (not <$> stuck) $ stuckCnt + 1
+  stuck = stuckCnt .==. pure maxBound
+  -- Delay one cycle so assertion definitely triggers before stopping simulation
+  done = register clk rst ena False $ samplesDone .||. stuck
+  expected0 = liftA2 (<$) expected actual
+  done0 =
+    assert clk rst "Doesn't time out" stuck (pure False) $
+      assert clk rst "fifoVerifier" actual expected0 done
+{-# NOINLINE fifoVerifier #-}

--- a/tests/shouldwork/Cores/Xilinx/DcFifo/Basic.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo/Basic.hs
@@ -1,0 +1,137 @@
+module Basic where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+import Clash.Sized.Internal.BitVector (undefined#)
+import Clash.Cores.Xilinx.DcFifo
+
+-- Configurables
+type Overfill = 4
+type DepthParam = 4
+type ActualDepth = 15
+-- End of configurables
+
+type TotalElems = ActualDepth + Overfill
+type Elem = Index TotalElems
+
+data FSM
+  = Push (Index TotalElems)
+  | StartRead
+  | Pop (Index TotalElems)
+  | Done
+  deriving (Show, Generic, NFDataX)
+
+topEntity ::
+  Clock XilinxSystem ->
+  Reset XilinxSystem ->
+  Signal XilinxSystem (Maybe Elem) ->
+  Signal XilinxSystem Bool ->
+  ( FifoOut XilinxSystem XilinxSystem DepthParam Elem
+  , FifoOut XilinxSystem XilinxSystem DepthParam Elem
+  )
+topEntity clk rst writeData rEnable =
+  ( dcFifo minOpt clk rst clk rst writeData rEnable
+  , dcFifo maxOpt clk rst clk rst writeData rEnable
+  )
+ where
+  minOpt = DcConfig
+    { dcDepth=SNat
+    , dcReadDataCount=False
+    , dcWriteDataCount=False
+    , dcOverflow=False
+    , dcUnderflow=False
+    }
+  maxOpt = DcConfig
+    { dcDepth=SNat
+    , dcReadDataCount=True
+    , dcWriteDataCount=True
+    , dcOverflow=True
+    , dcUnderflow=True
+    }
+{-# NOINLINE topEntity #-}
+
+testBench ::
+  Signal XilinxSystem Bool
+testBench = done
+ where
+  fsmOut = let (s', o) = unbundle $ fsm <$> register clk noRst en (Push 0) s'
+           in o
+  (minOut, maxOut) =
+    topEntity clk noRst (fWriteData <$> fsmOut) (fREnable <$> fsmOut)
+  done =
+      register clk noRst en False
+    $ assertBitVector clk noRst "FIFO min full"
+        (pack <$> isFull minOut) (fExpectedFull <$> fsmOut)
+    $ assertBitVector clk noRst "FIFO max full"
+        (pack <$> isFull maxOut) (fExpectedFull <$> fsmOut)
+    $ assertBitVector clk noRst "FIFO max overflow"
+        (pack <$> isOverflow maxOut) (fExpectedOverflow <$> fsmOut)
+    $ assertBitVector clk noRst "FIFO min empty"
+        (pack <$> isEmpty minOut) (fExpectedEmpty <$> fsmOut)
+    $ assertBitVector clk noRst "FIFO max empty"
+        (pack <$> isEmpty maxOut) (fExpectedEmpty <$> fsmOut)
+    $ assertBitVector clk noRst "FIFO max underflow"
+        (pack <$> isUnderflow maxOut) (fExpectedUnderflow <$> fsmOut)
+    $ assertBitVector clk noRst "FIFO min data out"
+        (pack <$> fifoData minOut) (fExpectedData <$> fsmOut)
+    $ assertBitVector clk noRst "FIFO max data out"
+        (pack <$> fifoData maxOut) (fExpectedData <$> fsmOut)
+        (fDone <$> fsmOut)
+  clk = tbClockGen (not <$> done)
+  noRst = unsafeFromHighPolarity $ pure False
+  en = enableGen
+{-# NOINLINE testBench #-}
+
+data FsmOut = FsmOut
+  { fDone :: Bool
+  , fWriteData :: Maybe Elem
+  , fREnable :: Bool
+  , fExpectedFull :: BitVector 1
+  , fExpectedOverflow :: BitVector 1
+  , fExpectedEmpty :: BitVector 1
+  , fExpectedUnderflow :: BitVector 1
+  , fExpectedData :: BitVector (BitSize Elem)
+  }
+
+defFsmOut :: FsmOut
+defFsmOut =
+  FsmOut{ fDone=False
+        , fWriteData=Nothing
+        , fREnable=False
+        , fExpectedFull=undefined#
+        , -- Assert overflow false by default
+          fExpectedOverflow=pack False
+        , fExpectedEmpty=undefined#
+        , -- Assert underflow false by default
+          fExpectedUnderflow=pack False
+        , fExpectedData=undefined#
+        }
+
+fsm ::
+  FSM ->
+  (FSM, FsmOut)
+fsm (Push i) =
+  let s' = if (i == maxBound) then StartRead else Push (i + 1)
+      o = defFsmOut{ fWriteData=Just i
+                   , fExpectedFull=pack (i >= actualDepth)
+                   , fExpectedOverflow=pack (i > actualDepth)
+                   }
+  in (s', o)
+fsm StartRead = (Pop 0, defFsmOut{ fREnable=True
+                                 , fExpectedOverflow=pack True
+                                 })
+fsm (Pop i) =
+  let isLast = i == maxBound
+      s' = if isLast then Done else Pop (i + 1)
+      underflow = i >= actualDepth
+      o = defFsmOut{ fREnable=not isLast
+                   , fExpectedEmpty=pack (i >= actualDepth - 1)
+                   , fExpectedUnderflow=pack underflow
+                   , fExpectedData=if underflow then undefined#
+                                   else pack (resize i)
+                   }
+  in (s', o)
+fsm Done = (Done, defFsmOut{fDone=True, fExpectedEmpty=pack True})
+
+actualDepth :: Index TotalElems
+actualDepth = natToNum @ActualDepth

--- a/tests/shouldwork/Cores/Xilinx/DcFifo0.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo0.hs
@@ -1,0 +1,14 @@
+module DcFifo0 where
+
+import Clash.Cores.Xilinx.DcFifo
+import Clash.Explicit.Prelude
+
+import DcFifo.Abstract
+
+topEntity :: ConfiguredFifo (BitVector 16) Dom17 Dom2
+topEntity = dcFifo defConfig
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal Dom17 Bool
+testBench = mkTestBench topEntity
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Cores/Xilinx/DcFifo1.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo1.hs
@@ -1,0 +1,14 @@
+module DcFifo1 where
+
+import Clash.Cores.Xilinx.DcFifo
+import Clash.Explicit.Prelude
+
+import DcFifo.Abstract
+
+topEntity :: ConfiguredFifo (BitVector 16) Dom2 Dom17
+topEntity = dcFifo defConfig
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal Dom2 Bool
+testBench = mkTestBench topEntity
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Cores/Xilinx/DcFifo2.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo2.hs
@@ -1,0 +1,14 @@
+module DcFifo2 where
+
+import Clash.Cores.Xilinx.DcFifo
+import Clash.Explicit.Prelude
+
+import DcFifo.Abstract
+
+topEntity :: ConfiguredFifo (Unsigned 16) Dom2 Dom2
+topEntity = dcFifo defConfig
+{-# NOINLINE topEntity #-}
+
+testBench :: Signal Dom2 Bool
+testBench = mkTestBench topEntity
+{-# NOINLINE testBench #-}


### PR DESCRIPTION
This adds Xilinx's DcFifo to clash-cores. The Haskell model and the IP are both tested.

Past discussion is [here](https://github.com/clash-lang/clash-compiler/pull/2182#issue-1222094757); it is bit cluttered. 

It's a draft PR because it depends on https://github.com/clash-lang/clash-compiler/pull/2257 
## Still TODO:

  - [ ] ~Write a changelog entry (see changelog/README.md)~ (clash-cores isn't on Hackage)
  - [x] Check copyright notices are up to date in edited files
  - [ ] Fix `full` behavior and add a test for it
  - [ ] Fix `overflow` behavior and add a test for it
  - [x] Remove unused / obsolete code
  - [x] Test reset+full behavior
