### PR TITLE
Partially fix topological sort of files

### DIFF
--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -479,9 +479,11 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
       let
         components = map (snd . snd) (OMap.assocs netlist)
         filesAndDigests0 =
-             zip (map fst hdlDocs) hdlDocDigests
+          -- FIXME: We should track dependencies of `mfiles` and `dfiles` and
+          -- maintain the proper topological sort of all these.
+             zip (map fst mfiles) memoryFilesDigests
           <> zip (map fst dfiles) dataFilesDigests
-          <> zip (map fst mfiles) memoryFilesDigests
+          <> zip (map fst hdlDocs) hdlDocDigests
 
       filesAndDigests1 <- modifyMVar edamFilesV $ \edamFiles ->
         if opt_edalize opts

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -158,6 +158,10 @@ data Manifest
     --
     -- This list is reverse topologically sorted. I.e., a component might depend
     -- on any component listed before it, but not after it.
+    --
+    -- FIXME: Dependencies for include files and memory files are not tracked.
+    -- Instead, memory files are listed first followed by include files followed
+    -- by generated HDL. This will usually suffice.
   , domains :: HashMap Text VDomainConfiguration
     -- ^ Domains encountered in design
   , transitiveDependencies :: [Text]


### PR DESCRIPTION
We don't track dependency information for include files and memory
files. Include files are generated from
`Clash.Netlist.BlackBox.Types.bbIncludes` or YAML/JSON `includes` keys,
and memory files are generated from `~TEMPLATE` holes in the primitive
template language. We should actually track these dependencies to
maintain a proper reverse topological sort order in our manifest files.
However, this commit makes the problem less severe. We used to list
these include and memory files last in the list, but it is extremely
likely that the HDL file that caused the include/memory file to be
generated depends on it. So by listing them first instead of last, we
fix the sort order for the common case that the include/memory files
_themselves_ do not depend on anything else.

To be precise, we sort the include files after the memory files because
it is probably difficult to impossible to construct a memory file that
depends on an include file, but the reverse is easily achieved.

Additionally, experimentation showed that the note stating transitive
dependencies in the manifest file are sorted topologically (rather than
_reverse_ topologically) is incorrect: dependencies are sorted like
files and components.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
