### PR TITLE
Enable running the clash testsuite on windows

### DIFF
--- a/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives.yaml
@@ -73,7 +73,7 @@
         `ifndef VERILATOR
         #~LONGESTPERIOD0 forever begin
           if (~ ~ARG[1]) begin
-            $finish;
+            $finish(0);
           end
           ~SYM[0] = ~ ~SYM[0];
           #~SYM[1];


### PR DESCRIPTION
Assumes the Cabal store is installed in `C:\cabal\store`, which is the `ghcup` default.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
