### PR TITLE
Allow build on more recent OSX (M1 darwin 12.4)

### DIFF
--- a/clash-cosim/src/cbits/Makefile
+++ b/clash-cosim/src/cbits/Makefile
@@ -7,7 +7,7 @@ CFLAGS = -Wall -O2
 
 UNAME = $(shell uname)
 ifeq ($(UNAME),Darwin)
-  LDFLAGS = -dylib -export_dynamic -flat_namespace -undefined suppress -macosx_version_min 10.14
+  LDFLAGS = -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/ -lSystem -dylib -export_dynamic -flat_namespace -undefined suppress -macosx_version_min 10.14
 else
   LDFLAGS = -shared -E
 endif


### PR DESCRIPTION
Recent OSX development tools require you to use various framework flags, see [this blog post](https://gpanders.com/blog/exploring-mach-o-part-1/). 

## Still TODO:

  - [ ] ~Write a changelog entry (see changelog/README.md)~ not uploaded to Hackage
  - [x] Check copyright notices are up to date in edited files