### PR TITLE
Use newer bash on Nix CI builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ stack-build:
   tags:
 
 nix-build:
-  image: nixos/nix
+  image: nixos/nix:2.10.1
   needs: []
   stage: test
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,14 +73,14 @@ nix-build:
   stage: test
   before_script:
     # Circle CI needs git/ssh in /usr/bin
-    - nix-env -i git findutils gnugrep gnused coreutils openssh bash-4.4-p23 zstd
+    - nix-env -i git findutils gnugrep gnused coreutils openssh bash-5.1-p16 zstd
 
     #                                 bin         nix pkg        multiple may exist
     - ln -s $(find /nix -type f -name git  | grep libexec      | head -n1) /usr/bin
     - ln -s $(find /nix -type f -name ssh  | grep openssh      | head -n1) /usr/bin
     - ln -s $(find /nix -type f -name sed  | grep gnused       | head -n1) /usr/bin
     - ln -s $(find /nix -type f -name zstd | grep zstd         | head -n1) /usr/bin
-    - ln -s $(find /nix -type f -name bash | grep bash-4.4-p23 | head -n1) /bin
+    - ln -s $(find /nix -type f -name bash | grep bash-5.1-p16 | head -n1) /bin
 
   script:
     - nix-build -j$(./.ci/effective_cpus.sh)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,14 +73,14 @@ nix-build:
   stage: test
   before_script:
     # Circle CI needs git/ssh in /usr/bin
-    - nix-env -i git findutils gnugrep gnused coreutils openssh bash-5.1-p16 zstd
+    - nix-env -i git findutils gnugrep gnused coreutils openssh bash zstd
 
     #                                 bin         nix pkg        multiple may exist
     - ln -s $(find /nix -type f -name git  | grep libexec      | head -n1) /usr/bin
     - ln -s $(find /nix -type f -name ssh  | grep openssh      | head -n1) /usr/bin
     - ln -s $(find /nix -type f -name sed  | grep gnused       | head -n1) /usr/bin
     - ln -s $(find /nix -type f -name zstd | grep zstd         | head -n1) /usr/bin
-    - ln -s $(find /nix -type f -name bash | grep bash-5.1-p16 | head -n1) /bin
+    - ln -s $(find /nix -type f -name bash | grep 'bash-[0-9]\+\.[0-9]\+' | head -n1) /bin
 
   script:
     - nix-build -j$(./.ci/effective_cpus.sh)


### PR DESCRIPTION
The 4.4 branch no longer exist on nixpkgs 22.05 or higher
