### PR TITLE
`clash-testsuite`: Fix, improve and harmonize simulator selection

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -249,6 +249,8 @@ runClashTest = defaultMain $ clashTestRoot
         [ let n = 9 -- GHDL only has VERY basic PSL support
               _opts = def { hdlTargets=[VHDL]
                           , buildTargets=BuildSpecific ["fails" <> show i | i <- [(1::Int)..n]]
+                          , hdlLoad=[GHDL]
+                          , hdlSim=[GHDL]
                           , expectSimFail=Just (def, "psl assertion failed")
                           }
            in runTest "NonTemporalPSL" _opts
@@ -257,6 +259,7 @@ runClashTest = defaultMain $ clashTestRoot
                           , buildTargets=BuildSpecific ["fails" <> show i | i <- [(1::Int)..n]]
                           -- Only QuestaSim supports simulating SVA/PSL, but ModelSim does check
                           -- for syntax errors.
+                          , hdlLoad=[ModelSim]
                           , hdlSim=[]
                           }
            in runTest "NonTemporalPSL" _opts
@@ -266,12 +269,14 @@ runClashTest = defaultMain $ clashTestRoot
           , buildTargets=BuildSpecific ["fails" <> show i | i <- is]
           -- Only QuestaSim supports simulating SVA/PSL, but ModelSim does check
           -- for syntax errors.
+          , hdlLoad=[ModelSim]
           , hdlSim=[]
           }
         , runTest "SymbiYosys" def{
             hdlTargets=[Verilog, SystemVerilog]
           , buildTargets=BuildSpecific ["topEntity"]
-          , hdlLoad=False
+          , hdlLoad=[]
+          , hdlSim=[]
           , verificationTool=Just SymbiYosys
           , expectVerificationFail=Just (def, "Unreached cover statement at B")
           }
@@ -383,7 +388,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1254" def{hdlTargets=[VHDL,SystemVerilog],hdlSim=[]}
         , runTest "T1242" def{hdlSim=[]}
         , runTest "T1292" def{hdlTargets=[VHDL]}
-        , let _opts = def { hdlTargets = [VHDL], hdlLoad = False, hdlSim=[] }
+        , let _opts = def { hdlTargets = [VHDL], hdlLoad = [], hdlSim=[] }
            in runTest "T1304" _opts
         , let _opts = def { hdlTargets=[VHDL]
                           , hdlSim=[]
@@ -930,7 +935,8 @@ runClashTest = defaultMain $ clashTestRoot
           runTest "SymbiYosys" def{
             hdlTargets=[Verilog, SystemVerilog]
           , buildTargets=BuildSpecific ["topEntity"]
-          , hdlLoad=False
+          , hdlLoad=[]
+          , hdlSim=[]
           , verificationTool=Just SymbiYosys
           }
         ]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -160,9 +160,9 @@ runClashTest = defaultMain $ clashTestRoot
           -- see: https://github.com/clash-lang/clash-compiler/issues/2265
           let _opts = def { buildTargets = BuildSpecific ["system"]
                           , hdlTargets = [Verilog]
-                          , hdlSim = hdlSimExcludeVivado
+                          , hdlLoad = hdlLoad def \\ [Verilator, Vivado]
+                          , hdlSim = hdlSim def \\ [Verilator, Vivado]
                           , vvpStdoutNonEmptyFail = False
-                          , verilate = SimOnly
                           }
            in runTest "I2Ctest" _opts
 
@@ -663,7 +663,11 @@ runClashTest = defaultMain $ clashTestRoot
             { clashFlags=["-fconstraint-solver-iterations=15"]
             , ghcFlags=["-itests/shouldwork/Numbers"]
             }
-        , runTest "NumConstantFoldingTB_2" def{clashFlags=["-itests/shouldwork/Numbers"], verilate=SimOnly}
+        , let _opts = def { clashFlags=["-itests/shouldwork/Numbers"]
+                          , hdlLoad = hdlLoad def \\ [Verilator]
+                          , hdlSim = hdlSim def \\ [Verilator]
+                          }
+          in runTest "NumConstantFoldingTB_2" _opts
         , outputTest "NumConstantFolding_2" def
             { clashFlags=["-fconstraint-solver-iterations=15"]
             , ghcFlags=["-itests/shouldwork/Numbers"]
@@ -749,8 +753,16 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "BlockRamTest" def{hdlSim=[]}
         , runTest "Compression" def
         , runTest "DelayedReset" def
-        , runTest "DualBlockRam0" def{verilate=SimOnly, hdlSim=hdlSimExcludeVivado} -- vivado segfaults
-        , runTest "DualBlockRam1" def{verilate=SimOnly, hdlSim=hdlSimExcludeVivado} -- vivado segfaults
+        , let _opts = def { -- vivado segfaults
+                            hdlLoad = hdlLoad def \\ [Verilator, Vivado]
+                          , hdlSim = hdlSim def \\ [Verilator, Vivado]
+                          }
+          in runTest "DualBlockRam0" _opts
+        , let _opts = def { -- vivado segfaults
+                            hdlLoad = hdlLoad def \\ [Verilator, Vivado]
+                          , hdlSim = hdlSim def \\ [Verilator, Vivado]
+                          }
+          in runTest "DualBlockRam1" _opts
         , let _opts = def { buildTargets=BuildSpecific ["example"]
                           , hdlSim=[]
                           }
@@ -794,8 +806,8 @@ runClashTest = defaultMain $ clashTestRoot
         [ let _opts = def { hdlTargets=[Verilog]
                           , vvpStdoutNonEmptyFail=False
                           , buildTargets=BuildSpecific ["topEntity"]
-                          , hdlSim=hdlSimExcludeVivado
-                          , verilate=SimOnly
+                          , hdlLoad = hdlLoad def \\ [Verilator, Vivado]
+                          , hdlSim = hdlSim def \\ [Verilator, Vivado]
                           }
            in runTest "Test00" _opts
         ]
@@ -890,7 +902,10 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "IndexInt2" def{hdlSim=hdlSim def \\ [Vivado]}
         , outputTest "IndexInt2" def{hdlTargets=[Verilog]}
         , runTest "Concat" def
-        , runTest "DFold" def{verilate=SimOnly}
+        , let _opts = def { hdlLoad = hdlLoad def \\ [Verilator]
+                          , hdlSim = hdlSim def \\ [Verilator]
+                          }
+          in runTest "DFold" _opts
         , runTest "DFold2" def
         , runTest "DTFold" def
         ,

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -135,7 +135,7 @@ runClashTest = defaultMain $ clashTestRoot
       -- see: https://github.com/clash-lang/clash-compiler/issues/2264
       let _opts = def { clashFlags=["-fclash-component-prefix", "test"]
                       , buildTargets=BuildSpecific ["test_testBench"]
-                      , hdlSim=hdlSimExcludeVivado
+                      , hdlSim=hdlSim def \\ [Vivado]
                       }
        in runTest "FIR" _opts
 
@@ -360,7 +360,10 @@ runClashTest = defaultMain $ clashTestRoot
           -- tracked: https://github.com/clash-lang/clash-compiler/issues/2266
           runTest "NORX" def
 
-        , runTest "Parameters" def{hdlTargets=[VHDL], hdlSim=hdlSimExcludeVivado}
+        , let _opts = def { hdlTargets=[VHDL]
+                          , hdlSim=hdlSim def \\ [Vivado]
+                          }
+          in runTest "Parameters" _opts
         , runTest "PopCount" def
         , runTest "RecordSumOfProducts" def{hdlSim=[]}
         , runTest "Replace" def
@@ -434,13 +437,13 @@ runClashTest = defaultMain $ clashTestRoot
           , -- TODO: this also runs up against problems with BuildSpecific
             -- names, see
             -- https://github.com/clash-lang/clash-compiler/issues/2264
-            hdlSim=hdlSimExcludeVivado -- triggers error in vivado
+            hdlSim=hdlSim def \\ [Vivado] -- triggers error in vivado
           }
         , outputTest "LITrendering" def{hdlTargets=[Verilog]}
         , runTest "T2117" def{
             clashFlags=["-fclash-aggressive-x-optimization-blackboxes"]
           , hdlTargets=[VHDL]
-          , hdlSim=hdlSimExcludeVivado
+          , hdlSim=hdlSim def \\ [Vivado]
           , -- TODO: Refactor BuildSpecific so Vivado can run
             -- See https://github.com/clash-lang/clash-compiler/issues/2264
             buildTargets=BuildSpecific [ "testBenchUndefBV"
@@ -633,7 +636,10 @@ runClashTest = defaultMain $ clashTestRoot
 #if MIN_VERSION_base(4,14,0)
         , runTest "BitReverse" def
 #endif
-        , runTest "Bounds" def { hdlSim=hdlSimExcludeVivado } -- vivado segfaults
+        ,
+          -- vivado segfaults
+          runTest "Bounds" def { hdlSim=hdlSim def \\ [Vivado] }
+
         , runTest "DivideByZero" def
         , let _opts = def { clashFlags=["-fconstraint-solver-iterations=15"] }
            in runTest "ExpWithGhcCF" _opts
@@ -645,7 +651,7 @@ runClashTest = defaultMain $ clashTestRoot
         ,
           -- see https://github.com/clash-lang/clash-compiler/issues/2262,
           -- Vivado's mod misbehaves on negative dividend
-          runTest "IntegralTB" def{hdlSim=hdlSimExcludeVivado}
+          runTest "IntegralTB" def{hdlSim=hdlSim def \\ [Vivado]}
 
         , runTest "NumConstantFoldingTB_1" def{clashFlags=["-itests/shouldwork/Numbers"]}
         , outputTest "NumConstantFolding_1" def
@@ -669,7 +675,10 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "SignedProjectionTB" def
         , runTest "SignedZero" def
         , runTest "Signum" def
-        , runTest "Strict" def{hdlSim=hdlSimExcludeVivado} -- vivado segfaults
+        ,
+          -- vivado segfaults
+          runTest "Strict" def{hdlSim=hdlSim def \\ [Vivado]}
+
         , runTest "T1019" def{hdlSim=[]}
         , runTest "T1351" def
         , runTest "T2149" def
@@ -704,7 +713,7 @@ runClashTest = defaultMain $ clashTestRoot
       , clashTestGroup "Signal"
         [ runTest "AlwaysHigh" def{hdlSim=[]}
         , runTest "BangPatterns" def
-        , runTest "BlockRamFile" def{hdlSim=hdlSimExcludeVivado}
+        , runTest "BlockRamFile" def{hdlSim=hdlSim def \\ [Vivado]}
         , runTest "BlockRam0" def
         , runTest "BlockRam1" def
         , clashTestGroup "BlockRam"
@@ -715,7 +724,7 @@ runClashTest = defaultMain $ clashTestRoot
         ,
           -- TODO: Vivado is disabled because it gives different results, see
           -- https://github.com/clash-lang/clash-compiler/issues/2267
-          runTest "AndSpecificEnable" def{hdlSim=hdlSimExcludeVivado}
+          runTest "AndSpecificEnable" def{hdlSim=hdlSim def \\ [Vivado]}
 
 #endif
         , runTest "Ram" def
@@ -729,7 +738,7 @@ runClashTest = defaultMain $ clashTestRoot
           -- TODO: we do not support memory files in Vivado
           --
           -- see: https://github.com/clash-lang/clash-compiler/issues/2269
-          runTest "RomFile" def{hdlSim=hdlSimExcludeVivado}
+          runTest "RomFile" def{hdlSim=hdlSim def \\ [Vivado]}
 
         , outputTest "BlockRamLazy" def
         , runTest "BlockRamTest" def{hdlSim=[]}
@@ -761,7 +770,7 @@ runClashTest = defaultMain $ clashTestRoot
             -- TODO: Vivado is disabled because it gives different results, see
             -- https://github.com/clash-lang/clash-compiler/issues/2268
             let _opts = def { clashFlags=["-fclash-compile-ultra"]
-                            , hdlSim=hdlSimExcludeVivado
+                            , hdlSim=hdlSim def \\ [Vivado]
                             }
             in runTest "BlobVec" _opts
           ]
@@ -868,15 +877,21 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "VScan" def{hdlSim=[]}
         , runTest "VZip" def{hdlSim=[]}
         , runTest "VecConst" def{hdlSim=[]}
-        , runTest "FirOddSize" def{hdlSim=hdlSimExcludeVivado} -- vivado segfaults
+        ,
+          -- vivado segfaults
+          runTest "FirOddSize" def{hdlSim=hdlSim def \\ [Vivado]}
+
         , runTest "IndexInt" def
-        , runTest "IndexInt2" def{hdlSim=hdlSimExcludeVivado}
+        , runTest "IndexInt2" def{hdlSim=hdlSim def \\ [Vivado]}
         , outputTest "IndexInt2" def{hdlTargets=[Verilog]}
         , runTest "Concat" def
         , runTest "DFold" def{verilate=SimOnly}
         , runTest "DFold2" def
         , runTest "DTFold" def
-        , runTest "FindIndex" def{hdlSim=hdlSimExcludeVivado} -- vivado segfaults
+        ,
+          -- vivado segfaults
+          runTest "FindIndex" def{hdlSim=hdlSim def \\ [Vivado]}
+
         , runTest "Fold" def
         , runTest "FoldlFuns" def{hdlSim=[]}
         , runTest "Foldr" def
@@ -897,7 +912,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "VEmpty" def
         , runTest "VIndex" def{hdlSim=[]}
         , runTest "VIndicesI" def
-        , runTest "VFold" def{hdlSim=hdlSimExcludeVivado} -- vivado segfaults
+        , runTest "VFold" def{hdlSim=hdlSim def \\ [Vivado]} -- vivado segfaults
         , runTest "VMerge" def
         , runTest "VReplace" def
         , runTest "VReverse" def

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -96,7 +96,8 @@ data VerificationTool = SymbiYosys
 -- a test is only relevant with one type of tool.
 data Verilate = SimAndVerilate | VerilateOnly | SimOnly
 
-data Sim = Vivado | GHDL | ModelSim | Verilator deriving Eq
+data Sim = Vivado | GHDL | IVerilog | ModelSim | Verilator
+  deriving (Show, Eq, Bounded, Enum)
 
 data TestOptions =
   TestOptions
@@ -140,7 +141,7 @@ allTargets = [VHDL, Verilog, SystemVerilog]
 instance Default TestOptions where
   def =
     TestOptions
-      { hdlSim=[GHDL, ModelSim, Vivado]
+      { hdlSim=[minBound ..]
       , hdlLoad=True
       , expectClashFail=Nothing
       , expectSimFail=Nothing
@@ -153,10 +154,6 @@ instance Default TestOptions where
       , vvpStdoutNonEmptyFail=True
       , verilate=SimAndVerilate
       }
-
--- | All 'Sim's excluding Vivado
-hdlSimExcludeVivado :: [Sim]
-hdlSimExcludeVivado = [GHDL, ModelSim]
 
 -- | Directory where testbenches live.
 sourceDirectory :: String
@@ -490,7 +487,7 @@ runTest1 modName opts@TestOptions{..} path target =
       Verilog ->
         case verilate of
           VerilateOnly -> []
-          _ -> buildAndSimTests ModelSim (verilogTests opts tmpDir)
+          _ -> buildAndSimTests IVerilog (verilogTests opts tmpDir)
 
       SystemVerilog ->
         case verilate of


### PR DESCRIPTION
* Fix simulator selection
    PR #2257 caused Verilator tests to only be built rather than built and simulated.

    The new `hdlSim` list in `Test.Tasty.Clash`, also introduced in PR #2257,  turned both Icarus Verilog and ModelSim on and off with `ModelSim`; this is now split into the `IVerilog` and `ModelSim` constructors.

    Fixes #2280.
* Make `hdlLoad` a list
    This allows us finer control over which simulators to load HDL into, just like we did with `hdlSim` in PR #2257.

    The tests `shouldfail.Verification.NonTemporal{PSL,SVA}` accidentally ran Vivado and the make stage of Verilator. This no longer happens.
    This means we can remove the Vivado test filtering on `expectSimFail` since that was just an artifact of that, accidentally running a GHDL-only test in Vivado.
* Harmonize simulators, clean up
    Control execution of _all_ simulators, their load stage and their simulate stage, through `hdlLoad` and `hdlSim`.

    Verilator used to be configured through `verilate` (`SimAndVerilate`, `VerilateOnly` and `SimOnly`), but is now configured like the rest.

    At first, we had one tool for each HDL language: VHDL ran in GHDL, Verilog ran in Icarus Verilog and SystemVerilog ran in ModelSim. Then we added Verilator, which runs both Verilog and SystemVerilog, and this exception to the structure was coded with the mentioned `verilate` option. Now we also added Vivado, which runs VHDL and Verilog (and which we'll make to run SystemVerilog as well later), and it is time for a reorganization. [edit] And a TODO is added that we can also extend ModelSim to simulate VHDL and Verilog.[/edit]
* Unrelated to any of this, the function `Test.Tasty.Clash.hdlFiles` is removed because it turns out it was unused since commit 5f9dd2682 of 2018-11-26, where its use was replaced by a shell glob.


## Still TODO:

  -  ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
