### PR TITLE
Use `sequentialTestGroup` to describe dependencies in `clash-testsuite`

### DIFF
--- a/.ci/stack-8.10.7.yaml
+++ b/.ci/stack-8.10.7.yaml
@@ -18,3 +18,7 @@ extra-deps:
 - docopt-0.7.0.7@sha256:a3d2eac54cd77d8c0b306ff96fb57be55542f143d81766aa1ae51458ad790dbe,3655
 - prettyprinter-interp-0.2.0.0@sha256:45299b61bd6c27d594c1a72b5a8dd5734e791a59828725e4f4e420f3cc37232b,2016
 - infinite-list-0.1@sha256:4de250517ce75e128c766fbc1f23b5a778ea964e695e47f8e83e0f3b293091bf,2383
+- git: https://github.com/UnkindPartition/tasty.git
+  commit: e0e71bc40fcc1fa410f98a5963b9ed8eefa1e92d
+  subdirs:
+    - core

--- a/.ci/stack-8.6.5.yaml
+++ b/.ci/stack-8.6.5.yaml
@@ -30,3 +30,7 @@ extra-deps:
 - string-interpolate-0.3.1.2@sha256:4d0987f453c66040aa8e482fe28a7d3cdc9d8df01b698bc92f42a592cfb337db,4268
 - prettyprinter-interp-0.2.0.0@sha256:45299b61bd6c27d594c1a72b5a8dd5734e791a59828725e4f4e420f3cc37232b,2016
 - infinite-list-0.1@sha256:4de250517ce75e128c766fbc1f23b5a778ea964e695e47f8e83e0f3b293091bf,2383
+- git: https://github.com/UnkindPartition/tasty.git
+  commit: e0e71bc40fcc1fa410f98a5963b9ed8eefa1e92d
+  subdirs:
+    - core

--- a/.ci/stack-8.8.4.yaml
+++ b/.ci/stack-8.8.4.yaml
@@ -25,3 +25,7 @@ extra-deps:
 - string-interpolate-0.3.1.2@sha256:4d0987f453c66040aa8e482fe28a7d3cdc9d8df01b698bc92f42a592cfb337db,4268
 - prettyprinter-interp-0.2.0.0@sha256:45299b61bd6c27d594c1a72b5a8dd5734e791a59828725e4f4e420f3cc37232b,2016
 - infinite-list-0.1@sha256:4de250517ce75e128c766fbc1f23b5a778ea964e695e47f8e83e0f3b293091bf,2383
+- git: https://github.com/UnkindPartition/tasty.git
+  commit: e0e71bc40fcc1fa410f98a5963b9ed8eefa1e92d
+  subdirs:
+    - core

--- a/.ci/stack-9.0.2.yaml
+++ b/.ci/stack-9.0.2.yaml
@@ -15,3 +15,7 @@ packages:
 extra-deps:
 - prettyprinter-interp-0.2.0.0@sha256:45299b61bd6c27d594c1a72b5a8dd5734e791a59828725e4f4e420f3cc37232b,2016
 - infinite-list-0.1@sha256:4de250517ce75e128c766fbc1f23b5a778ea964e695e47f8e83e0f3b293091bf,2383
+- git: https://github.com/UnkindPartition/tasty.git
+  commit: e0e71bc40fcc1fa410f98a5963b9ed8eefa1e92d
+  subdirs:
+    - core

--- a/.ci/stack-9.2.4.yaml
+++ b/.ci/stack-9.2.4.yaml
@@ -17,3 +17,7 @@ extra-deps:
 - hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
 - prettyprinter-interp-0.2.0.0@sha256:45299b61bd6c27d594c1a72b5a8dd5734e791a59828725e4f4e420f3cc37232b,2016
 - infinite-list-0.1@sha256:4de250517ce75e128c766fbc1f23b5a778ea964e695e47f8e83e0f3b293091bf,2383
+- git: https://github.com/UnkindPartition/tasty.git
+  commit: e0e71bc40fcc1fa410f98a5963b9ed8eefa1e92d
+  subdirs:
+    - core

--- a/.ci/stack-9.4.3.yaml
+++ b/.ci/stack-9.4.3.yaml
@@ -22,3 +22,7 @@ extra-deps:
  - hashable-1.4.1.0
  - git: https://github.com/christiaanb/hint.git
    commit: 7803c34c8ae1d83c0f7c13fe6b30fcb3abd0ac51
+ - git: https://github.com/UnkindPartition/tasty.git
+   commit: e0e71bc40fcc1fa410f98a5963b9ed8eefa1e92d
+   subdirs:
+     - core

--- a/cabal.project
+++ b/cabal.project
@@ -65,9 +65,10 @@ allow-newer:
   vector-binary-instances:base,
   cryptohash-sha256:base,
   hashable,
+  haskell-src-meta:template-haskell,
   string-interpolate:template-haskell,
   string-interpolate:text,
-  haskell-src-meta:template-haskell
+  tasty-hedgehog:tasty
 
 -- Works around: https://github.com/recursion-schemes/recursion-schemes/issues/128. This
 -- shouldn't harm (runtime) performance of Clash, as we only use recursion-schemes with
@@ -82,3 +83,9 @@ source-repository-package
     type: git
     location: https://github.com/christiaanb/hint.git
     tag: 7803c34c8ae1d83c0f7c13fe6b30fcb3abd0ac51
+
+source-repository-package
+    type: git
+    location: https://github.com/UnkindPartition/tasty.git
+    tag: e0e71bc40fcc1fa410f98a5963b9ed8eefa1e92d
+    subdir: core

--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -153,7 +153,7 @@ test-suite unittests
     clash-lib,
     clash-prelude-hedgehog,
     deepseq,
-    tasty        >= 1.2 && < 1.5,
+    tasty        >= 1.2 && < 1.6,
     tasty-hunit,
     tasty-quickcheck,
     tasty-th,

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -404,7 +404,7 @@ test-suite unittests
       lens,
       pretty-show,
       quickcheck-text,
-      tasty         >= 1.2      && < 1.5,
+      tasty         >= 1.2      && < 1.6,
       tasty-hunit,
       tasty-quickcheck,
       tasty-th,

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -410,7 +410,7 @@ test-suite unittests
       hedgehog      >= 1.0.3    && < 1.3,
       hint          >= 0.7      && < 0.10,
       quickcheck-classes-base >= 0.6 && < 1.0,
-      tasty         >= 1.2      && < 1.5,
+      tasty         >= 1.2      && < 1.6,
       tasty-hedgehog >= 1.2.0,
       tasty-hunit,
       tasty-th,

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,3 +14,7 @@ extra-deps:
 - ./clash-cosim
 - prettyprinter-interp-0.2.0.0@sha256:45299b61bd6c27d594c1a72b5a8dd5734e791a59828725e4f4e420f3cc37232b,2016
 - infinite-list-0.1@sha256:4de250517ce75e128c766fbc1f23b5a778ea964e695e47f8e83e0f3b293091bf,2383
+- git: https://github.com/UnkindPartition/tasty.git
+  commit: e0e71bc40fcc1fa410f98a5963b9ed8eefa1e92d
+  subdirs:
+    - core

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -114,8 +114,8 @@ clashTestRoot testTrees =
   clashTestGroup "." testTrees []
 
 -- | `clashTestGroup` and `clashTestRoot` make sure that each test knows its
--- fully qualified test name at construction time. This is used to create
--- dependency patterns.
+-- fully qualified test name at construction time. This is used to pass -i flags
+-- to Clash as the test layout matches the layout in @shouldwork/@.
 clashTestGroup
   :: TestName
   -> [[TestName] -> TestTree]

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -63,7 +63,7 @@ common basic-config
     optparse-applicative,
     process,
     tagged,
-    tasty,
+    tasty >= 1.5,
     tasty-hunit,
     temporary,
     text,


### PR DESCRIPTION
See https://github.com/UnkindPartition/tasty/pull/343. This promises to do a few things:

* Reduce the startup time of `clash-testsuite` from ~half a minute to sub second figures
* Reduce complexity in `clash-testsuite` when specifying dependencies
* Make Tasty account for dependencies when using filters (`-p foo`) - this will make its command line suggestions upon a failing test more accurate

## Still TODO:

  - [x] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] ~~Check copyright notices are up to date in edited files~~