### PR TITLE
Make sure fromSLV doesn't cause out of bound errors in VHDL simulation

### DIFF
--- a/changelog/2022-07-19T19_23_48+02_00_fix_toEnum_OOB_errors
+++ b/changelog/2022-07-19T19_23_48+02_00_fix_toEnum_OOB_errors
@@ -1,0 +1,1 @@
+FIXED: Fix out of bound errors in toEnum/fromSLV for sum types[#2220](https://github.com/clash-lang/clash-compiler/issues/2220)

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -760,11 +760,25 @@ funDec (RenderEnums enums) _ t@(Sum _ _) | enums = Just
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> qualTyName t <+> "is" <> line <>
     "begin" <> line <>
     indent 2
-      ( "return" <+> qualTyName t <> "'val" <>
-        parens ("to_integer" <>
-          parens ("unsigned" <> parens "slv"))) <> semi <> line <>
+      (
+      translate_off (
+      "if unsigned(slv) <= " <> qualTyName t <> "'pos("<> qualTyName t <> "'high) then"
+      ) <> line <>
+        indent 2
+          ( "return" <+> qualTyName t <> "'val" <>
+            parens ("to_integer" <>
+              parens ("unsigned" <> parens "slv"))) <> semi <> line <>
+      translate_off (
+        "else" <> line <>
+        indent 2
+          ( "return" <+> qualTyName t <> "'val(0)") <> semi <> line <>
+        "end if" <> semi
+      )
+      ) <> line <>
     "end" <> semi
   )
+  where
+    translate_off body = "-- pragma translate_off" <> line <> body <> line <> "-- pragma translate_on"
 
 funDec _ syn t@(Vector _ elTy) = Just
   ( "function" <+> "toSLV" <+> parens ("value : " <+> qualTyName t) <+> "return std_logic_vector" <> semi <> line <>

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -610,6 +610,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2046C" def{hdlSim=[],clashFlags=["-Werror"],buildTargets=BuildSpecific["topEntity"]}
         , runTest "T2097" def{hdlSim=[]}
         , runTest "T2154" def{hdlTargets=[VHDL], hdlSim=[]}
+        , runTest "T2220_toEnumOOB" def{hdlTargets=[VHDL]}
         , runTest "T2272" def{hdlTargets=[VHDL], hdlSim=[]}
         ] <>
         if compiledWith == Cabal then

--- a/tests/shouldwork/Issues/T2220_toEnumOOB.hs
+++ b/tests/shouldwork/Issues/T2220_toEnumOOB.hs
@@ -1,0 +1,29 @@
+module T2220_toEnumOOB where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity :: BitVector 2 -> Maybe A_Index
+topEntity x | x == 3    = Nothing
+            | otherwise = Just $ toEnum $ fromIntegral x
+{-# NOINLINE topEntity #-}
+
+{-
+Because of the concurrent nature of the VHDL generate by clash,
+in VHDL the toEnum will be called with on 3 too.
+This toEnum is implemented in VHDL by fromSLV,
+which used to throw an exception on out-of-bound values.
+-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    testInput      = stimuliGenerator clk rst ( 0 :> 1 :> 2 :> 3 :> Nil)
+    expectedOutput = outputVerifier clk rst (Just A_0 :> Just A_1 :> Just A_2 :> Nothing :> Nil)
+    done           = expectedOutput (topEntity <$> testInput)
+    clk            = tbSystemClockGen (not <$> done)
+    rst            = systemResetGen
+
+
+data A_Index = A_0 | A_1 | A_2
+      deriving (Show,Bounded,Enum,Generic,BitPack,Eq,ShowX)


### PR DESCRIPTION
Fixes #2220

I've wrapped the extra checks in `translate_off/on` with the idea of not adding extra logic for it in hardware.
As the result shouldn't be used, because it'll throw an exception in Haskell.
But I'm not a 100% sure about this, as it (potentially) introduces differences between the resulting hardware and a VHDL simulation.

`toEnum @A_Index 3` will produce:
  * in Haskell: `Exception: toEnum{A_Index}: tag (3) is outside of enumeration's range (0,2)`
  * in VHDL simulation `A_0`
  * in hardware: ???


-----
  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

