### PR TITLE
Use -O2 with regex-tdfa

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -63,3 +63,6 @@ allow-newer:
 -- TemplateHaskell.
 package recursion-schemes
     optimization: 0
+
+package regex-tdfa
+    optimization: 2


### PR DESCRIPTION
regex-tdfa is meant to be compiled with `-O2`: https://hackage.haskell.org/package/regex-tdfa. They recommend setting it in the `cabal.project` file. 

## Still TODO:

  - ~[ ] Write a changelog entry (see changelog/README.md)~ not on Hackage
  - [x] Check copyright notices are up to date in edited files
