### PR TITLE
`clash-cores`: Not optional, tweak haddock css

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,7 @@ packages:
   ./clash-lib-hedgehog
   ./clash-prelude
   ./clash-prelude-hedgehog
+  ./clash-cores
   ./tests
 
 write-ghc-environment-files: always
@@ -44,12 +45,17 @@ package clash-lib
   ghc-options: +RTS -qn4 -A128M -RTS -j4
   flags: +debug
 
+package clash-cores
+  -- Tweak haddock stylesheet to enable word wrapping of types.
+  -- We specify the default Linuwial theme as an alnernate
+  -- so we're able to import its css file from the custom theme.
+  haddock-options: --theme=doc/linuwial-wrap-types.css --theme=Linuwial
+
 optional-packages:
   ./benchmark
   ./benchmark/profiling/prepare
   ./benchmark/profiling/run
   ./clash-cosim
-  ./clash-cores
   ./clash-term
 
 allow-newer:

--- a/clash-cores/doc/linuwial-wrap-types.css
+++ b/clash-cores/doc/linuwial-wrap-types.css
@@ -1,0 +1,1 @@
+../../clash-prelude/doc/linuwial-wrap-types.css


### PR DESCRIPTION
`clash-cores` now includes the same style sheet tweak as
`clash-prelude`, to render long lists of constraints better.

The `clash-cores` package is also moved from optional to required
packages in `cabal.project` as it is an unconditional dependency for
`clash-testsuite`.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
