### PR TITLE
DEC shouldn't care about the shape of proofs

### DIFF
--- a/changelog/2022-08-11T22_15_00+02_00_fix2289
+++ b/changelog/2022-08-11T22_15_00+02_00_fix2289
@@ -1,0 +1,1 @@
+FIXED: Netlist generation fails for certain uses of GADTs [#2289](https://github.com/clash-lang/clash-compiler/issues/2289)


### PR DESCRIPTION
Whether we have `Refl : True ~ True` or `SomeAxiom : (1 <=? 2) ~ True` it doesn't matter, since when we normalize both sides we always end up with a proof of `True ~ True`.

Since DEC only fires for applications where all the type arguments are equal, we can deduce that all equality arguments witness the same equality, hence we don't have to care about the shape of the proof.

Fixes #2289

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
