### PR TITLE
Add missing changelog entries

### DIFF
--- a/changelog/2022-08-12T10_19_40-04_00_component_decl
+++ b/changelog/2022-08-12T10_19_40-04_00_component_decl
@@ -1,0 +1,2 @@
+INTERNAL CHANGE: Add `CompDecl` to `Clash.Netlist.Types.Declaration` to
+accomodate VHDL's `component` declarations.

--- a/changelog/2022-08-12T10_32_37-04_00_conditional_usage_decl
+++ b/changelog/2022-08-12T10_32_37-04_00_conditional_usage_decl
@@ -1,0 +1,3 @@
+INTERNAL CHANGE/FIX: Black box functions declare their usage, necessary for
+implicit netlist usage analysis implemented in
+[#2230](https://github.com/clash-lang/clash-compiler/pull/2230)


### PR DESCRIPTION
I neglected to write changelogs for https://github.com/clash-lang/clash-compiler/pull/2255 and https://github.com/clash-lang/clash-compiler/pull/2259

This adds them.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files