### PR TITLE
Use `doctest-parallel` v0.2.5 with loosened Cabal bounds to mitigate CI failures

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -23,20 +23,5 @@ if [[ "$GHC_HEAD" != "yes" ]]; then
 fi
 set -u
 
-# Build compiler _libraries_, but not the executable. This makes sure the executable
-# is being built by the job that is going to use it too. In turn, this prevents
-# weird errors where executables cannot find some shared libraries.
-cabal v2-build \
-  lib:clash-prelude \
-  lib:clash-prelude-hedgehog \
-  lib:clash-lib \
-  lib:clash-lib-hedgehog \
-  lib:clash-ghc \
-  lib:clash-cores \
-  lib:clash-testsuite
-
-# Make sure all dependencies of all packages in the clash-compiler project are
-# compiled. This makes sure no future CI job is going to build it. Furthermore,
-# this command makes sure we transfer all the right dependencies as artifacts -
-# as they will end up in Cabal's 'plan.json'.
-cabal v2-build all --only-dependencies
+# Build with default constraints
+cabal v2-build all --write-ghc-environment-files=always

--- a/.ci/build_clash_dev.sh
+++ b/.ci/build_clash_dev.sh
@@ -2,7 +2,7 @@
 set -xeou pipefail
 
 # Check that clash-dev works
-cabal --write-ghc-environment-files=always v2-build lib:clash-prelude
+cabal --write-ghc-environment-files=always v2-build clash-prelude
 echo "" > clash-dev.result
 echo 'main >> writeFile "clash-dev.result" "success"' | ./clash-dev
 if [[ "$(cat clash-dev.result)" != "success" ]]; then

--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -5,11 +5,17 @@ index-state: HEAD
 package *
   documentation: False
 
+  -- Dynamic executables save oozles of space when archiving it on CI
+  executable-dynamic: True
+
 package clash-prelude
   ghc-options: -Werror
   flags: +doctests +multiple-hidden
   tests: True
   benchmarks: True
+
+  -- clash-prelude unittests fail with dynamic executables
+  executable-dynamic: False
 
 package clash-lib
   ghc-options: -Werror
@@ -22,6 +28,9 @@ package clash-ghc
 package clash-cosim
   ghc-options: -Werror
   tests: True
+
+  -- clash-cosim unittests fail with dynamic executables
+  executable-dynamic: False
 
 package clash-cores
   ghc-options: -Werror

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -5,7 +5,7 @@
   variables:
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-05-10-3-non_protected
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-06-23-3-non_protected
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   retry:

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -54,13 +54,6 @@ build-clash-dev:
   script:
     - .ci/build_clash_dev.sh
 
-# Makes sure we build everything - even if they don't have explicit tests. See
-# https://github.com/clash-lang/clash-compiler/pull/2299 for more information.
-build-all:
-  extends: .test-common
-  script:
-    - cabal v2-build all
-
 cores:unittests:
   extends: .test-common
   script:

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ write-ghc-environment-files: always
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2022-05-29T14:25:17Z
+index-state: 2022-08-17T07:55:52Z
 
 -- For some reason the `clash-testsuite` executable fails to run without
 -- this, as it cannot find the related library...


### PR DESCRIPTION
Bisecting the recent CI failures gave me the following list of fails/succeeds when setting `index-state` in `cabal.project`:

```
SUCC index: 2022-08-10T17:28:22Z
SUCC index: 2022-08-11T17:28:22Z
SUCC index: 2022-08-11T21:28:22Z
SUCC index: 2022-08-11T22:28:22Z
FAIL index: 2022-08-11T23:28:22Z
FAIL index: 2022-08-11T23:50:22Z
FAIL index: 2022-08-12T00:00:00Z
FAIL index: 2022-08-12T05:00:00Z
FAIL index: 2022-08-12T10:00:00Z
FAIL index: 2022-08-12T17:28:22Z
FAIL index: 2022-08-13T17:28:22Z
FAIL index: 2022-08-14T17:28:22Z
FAIL index: 2022-08-15T17:28:22Z
```

This indicates a "real" issue instead of a fluke: with the latter we wouldn't expect such a neat cut-off point between succeeding and failing. Next, I compared the build plans of the neighboring SUCC/FAIL:

```diff
--- plan-succ-pretty.json	2022-08-17 08:01:18.366758526 +0200
+++ plan-fail-pretty.json	2022-08-17 08:01:12.786731263 +0200
@@ -70,6 +70,45 @@
         },
         {
             "type": "configured",
+            "id": "Cabal-3.6.3.0-82b9655543bff8e44e9a837373efbeaabe7dbb18f4df4400266dff622f75d5e3",
+            "pkg-name": "Cabal",
+            "pkg-version": "3.6.3.0",
+            "flags": {
+                "bundled-binary-generic": false
+            },
+            "style": "global",
+            "pkg-src": {
+                "type": "repo-tar",
+                "repo": {
+                    "type": "secure-repo",
+                    "uri": "http://hackage.haskell.org/"
+                }
+            },
+            "pkg-cabal-sha256": "ff97c442b0c679c1c9876acd15f73ac4f602b973c45bde42b43ec28265ee48f4",
+            "pkg-src-sha256": "2fa1fe88d4a8e8ffbeb45baed5526b1267a2130026c846251ac95c656364ab77",
+            "depends": [
+                "array-0.5.3.0",
+                "base-4.12.0.0",
+                "binary-0.8.6.0",
+                "bytestring-0.10.8.2",
+                "containers-0.6.0.1",
+                "deepseq-1.4.4.0",
+                "directory-1.3.3.0",
+                "filepath-1.4.2.1",
+                "mtl-2.2.2",
+                "parsec-3.1.13.0",
+                "pretty-1.1.3.6",
+                "process-1.6.5.0",
+                "text-1.2.3.1",
+                "time-1.8.0.2",
+                "transformers-0.5.6.2",
+                "unix-2.7.2.2"
+            ],
+            "exe-depends": [],
+            "component-name": "lib"
+        },
+        {
+            "type": "configured",
             "id": "Glob-0.10.2-5536029205ada0a1691bd9e968c6e3565c25c48b106bcb0ac548eb70e71fa479",
             "pkg-name": "Glob",
             "pkg-version": "0.10.2",
@@ -1283,7 +1322,7 @@
             },
             "dist-dir": "/builds/clash-lang/clash-compiler/dist-newstyle/build/x86_64-linux/ghc-8.6.5/clash-ghc-1.7.0",
             "depends": [
-                "Cabal-2.4.0.1",
+                "Cabal-3.6.3.0-82b9655543bff8e44e9a837373efbeaabe7dbb18f4df4400266dff622f75d5e3",
                 "array-0.5.3.0",
                 "base-4.12.0.0",
                 "bytestring-0.10.8.2",
@@ -1306,7 +1345,7 @@
                 "hashable-1.4.1.0-c679d0bc203a99c705e30712ebdb8010b7a78ebdda79872e3cd9c9ba681ec725",
                 "haskeline-0.7.4.3",
                 "integer-gmp-1.0.2.0",
-                "lens-5.1.1-ea705adf240c235fd8522d2d64e871b0fb4a34cdc90fb8e34deb999222445019",
+                "lens-5.2-0fde984146e834fb35c0627fc333b5f16ec24cfb97d38520db3da949e4c6c702",
                 "mtl-2.2.2",
                 "primitive-0.7.4.0-86dfbf1c36c6dced0f09bec7790279ff68629c02c3a76d028c0ba017eeee6aa0",
                 "process-1.6.5.0",
@@ -1416,7 +1455,7 @@
                 "hint-0.9.0.6-3093a269741f7ed27822e6f3ee5cb408a7fb72012c3099aba174b89583734c8b",
                 "integer-gmp-1.0.2.0",
                 "interpolate-0.2.1-f8aa0e49d2cab3759008bcb23caef25ea9dbd6c6cdd99168e676a6bb0d966ca4",
-                "lens-5.1.1-ea705adf240c235fd8522d2d64e871b0fb4a34cdc90fb8e34deb999222445019",
+                "lens-5.2-0fde984146e834fb35c0627fc333b5f16ec24cfb97d38520db3da949e4c6c702",
                 "mtl-2.2.2",
                 "ordered-containers-0.2.2-3e79a0b10af9139df4240d724d4109824fd8308f1d6f242e1508b997096cd555",
                 "pretty-show-1.10-f39c1fcfe54d8c7d061d9ab26c4536ad6b48944607d756cf78542345e8635fc8",
@@ -1428,7 +1467,7 @@
                 "text-1.2.3.1",
                 "time-1.8.0.2",
                 "transformers-0.5.6.2",
-                "trifecta-2.1.2-9c328a2aabaf3a047da70009b3c8ece3af7b77e67ea0f64eeae819804f1b42cf",
+                "trifecta-2.1.2-f3473bed12f5eedd4026fd5bf3888392d386c0bd02d2056e93ae142b13b9301e",
                 "unordered-containers-0.2.19.1-b600372aa23b6917117488ede35b05823fd9940a1f5f7f38f11ed22b5e347218",
                 "vector-0.13.0.0-df1b37a9370d3a7c2d3dde40c75331829d8d9defc95cb8728b43995e7d44a9a1",
                 "vector-binary-instances-0.2.5.2-b539ba4ba454b651da26a2ea53b5fe88fdcc3942998746f513d7c9186014e9f7",
@@ -1467,7 +1506,7 @@
                 "ghc-8.6.5",
                 "ghc-typelits-knownnat-0.7.6-390d8372918db8c35ca2cfe246c83bc291333ab2357c6de9debe274dc295745b",
                 "haskell-src-exts-1.23.1-a11600a89c34bdbeec5d352289e5cd9ea058022d42febde3db396fdfb38d4776",
-                "lens-5.1.1-ea705adf240c235fd8522d2d64e871b0fb4a34cdc90fb8e34deb999222445019",
+                "lens-5.2-0fde984146e834fb35c0627fc333b5f16ec24cfb97d38520db3da949e4c6c702",
                 "pretty-show-1.10-f39c1fcfe54d8c7d061d9ab26c4536ad6b48944607d756cf78542345e8635fc8",
                 "quickcheck-text-0.1.2.1-52353a68793a3db84924d4011f2c62acc52d63413d536a9eb33bd34e5b4be664",
                 "tasty-1.4.2.3-434a70ce2c7b1f328efb81de01c1148bf64634520c9ca5b645d13be0d3a7dc43",
@@ -1586,7 +1625,7 @@
                 "hashable-1.4.1.0-c679d0bc203a99c705e30712ebdb8010b7a78ebdda79872e3cd9c9ba681ec725",
                 "integer-gmp-1.0.2.0",
                 "interpolate-0.2.1-f8aa0e49d2cab3759008bcb23caef25ea9dbd6c6cdd99168e676a6bb0d966ca4",
-                "lens-5.1.1-ea705adf240c235fd8522d2d64e871b0fb4a34cdc90fb8e34deb999222445019",
+                "lens-5.2-0fde984146e834fb35c0627fc333b5f16ec24cfb97d38520db3da949e4c6c702",
                 "recursion-schemes-5.2.2.2-e1487a76ab1abce314a6efbb405a026ea353fbc108875a8b0f60ed4323906560",
                 "reflection-2.1.6-ef91d1a50195a4c43f6aa843876b164a76bb73acabd653345c8f0f7a546fff47",
                 "singletons-2.5.1-6af2ec460e02f3d25289fef85f831d3d8f8c14dc119d0e19877866296d1b714e",
@@ -1659,7 +1698,7 @@
             "depends": [
                 "base-4.12.0.0",
                 "clash-prelude-1.7.0-inplace",
-                "doctest-parallel-0.2.2-ab3bfcd8db51a6ffb8d96fe74df59469bacac10dcd2bc9894306d2ee37939d96",
+                "doctest-parallel-0.2.4-9f201cbff955e8394b24447fe1989800062c4d8abe70a6ab5f1238fb05a2e5c3",
                 "filepath-1.4.2.1"
             ],
             "exe-depends": [],
@@ -2864,9 +2903,9 @@
         },
         {
             "type": "configured",
-            "id": "doctest-parallel-0.2.2-ab3bfcd8db51a6ffb8d96fe74df59469bacac10dcd2bc9894306d2ee37939d96",
+            "id": "doctest-parallel-0.2.4-27320a63addb9ec7d6be1eaffb01a1de0c47a94c6f366a456b165d3cedd85c39",
             "pkg-name": "doctest-parallel",
-            "pkg-version": "0.2.2",
+            "pkg-version": "0.2.4",
             "flags": {},
             "style": "global",
             "pkg-src": {
@@ -2876,10 +2915,34 @@
                     "uri": "http://hackage.haskell.org/"
                 }
             },
-            "pkg-cabal-sha256": "4c5787c681211dc21d3b9cecc009422f724295584700c661b5ac33b29dc031ba",
-            "pkg-src-sha256": "de3930a4fbb5ff62172bac9696af049cdec234c9a4f529100af9ec2111dcbd54",
+            "pkg-cabal-sha256": "87183137417ec2322ee640e53d918cf5cfbce3254b37cc1ee38d05c6ab15e907",
+            "pkg-src-sha256": "7792d0846c56e52e4d9c10e956b1f26a3945bf795b9b3260dd25c851d586ee3b",
             "depends": [
-                "Cabal-2.4.0.1",
+                "base-4.12.0.0",
+                "doctest-parallel-0.2.4-9f201cbff955e8394b24447fe1989800062c4d8abe70a6ab5f1238fb05a2e5c3",
+                "template-haskell-2.14.0.0"
+            ],
+            "exe-depends": [],
+            "component-name": "lib:spectests-modules"
+        },
+        {
+            "type": "configured",
+            "id": "doctest-parallel-0.2.4-9f201cbff955e8394b24447fe1989800062c4d8abe70a6ab5f1238fb05a2e5c3",
+            "pkg-name": "doctest-parallel",
+            "pkg-version": "0.2.4",
+            "flags": {},
+            "style": "global",
+            "pkg-src": {
+                "type": "repo-tar",
+                "repo": {
+                    "type": "secure-repo",
+                    "uri": "http://hackage.haskell.org/"
+                }
+            },
+            "pkg-cabal-sha256": "87183137417ec2322ee640e53d918cf5cfbce3254b37cc1ee38d05c6ab15e907",
+            "pkg-src-sha256": "7792d0846c56e52e4d9c10e956b1f26a3945bf795b9b3260dd25c851d586ee3b",
+            "depends": [
+                "Cabal-3.6.3.0-82b9655543bff8e44e9a837373efbeaabe7dbb18f4df4400266dff622f75d5e3",
                 "Glob-0.10.2-5536029205ada0a1691bd9e968c6e3565c25c48b106bcb0ac548eb70e71fa479",
                 "base-4.12.0.0",
                 "base-compat-0.12.2-1ac3dac72565672ca357bbd30ee2f914fdb7468eca53014e77e8fc7fbde43740",
@@ -2904,30 +2967,6 @@
         },
         {
             "type": "configured",
-            "id": "doctest-parallel-0.2.2-c4db59dc0f2ed46dd99e2db95aa7e20cf65541a6093dd835f968765f9488af43",
-            "pkg-name": "doctest-parallel",
-            "pkg-version": "0.2.2",
-            "flags": {},
-            "style": "global",
-            "pkg-src": {
-                "type": "repo-tar",
-                "repo": {
-                    "type": "secure-repo",
-                    "uri": "http://hackage.haskell.org/"
-                }
-            },
-            "pkg-cabal-sha256": "4c5787c681211dc21d3b9cecc009422f724295584700c661b5ac33b29dc031ba",
-            "pkg-src-sha256": "de3930a4fbb5ff62172bac9696af049cdec234c9a4f529100af9ec2111dcbd54",
-            "depends": [
-                "base-4.12.0.0",
-                "doctest-parallel-0.2.2-ab3bfcd8db51a6ffb8d96fe74df59469bacac10dcd2bc9894306d2ee37939d96",
-                "template-haskell-2.14.0.0"
-            ],
-            "exe-depends": [],
-            "component-name": "lib:spectests-modules"
-        },
-        {
-            "type": "configured",
             "id": "erf-2.0.0.0-d7569976a985122bcef3e7f12162b4fdd31b77546c5236d846df0eac3c5233f1",
             "pkg-name": "erf",
             "pkg-version": "2.0.0.0",
@@ -4056,9 +4095,9 @@
         },
         {
             "type": "configured",
-            "id": "lens-5.1.1-ea705adf240c235fd8522d2d64e871b0fb4a34cdc90fb8e34deb999222445019",
+            "id": "lens-5.2-0fde984146e834fb35c0627fc333b5f16ec24cfb97d38520db3da949e4c6c702",
             "pkg-name": "lens",
-            "pkg-version": "5.1.1",
+            "pkg-version": "5.2",
             "flags": {
                 "benchmark-uniplate": false,
                 "dump-splices": false,
@@ -4077,8 +4116,8 @@
                     "uri": "http://hackage.haskell.org/"
                 }
             },
-            "pkg-cabal-sha256": "c633a481e69bf911d9a6ed11ef156809db8b1d7c7d296fd03249b93be399e3a7",
-            "pkg-src-sha256": "cc4e99fc5d989e98ab0df7577183fe9ad5d74c63a44dc2607abcc22daba8b322",
+            "pkg-cabal-sha256": "06029d80a926c466ae7e59e7e41f114e1f437526f776d022a8d0e19a6dc14576",
+            "pkg-src-sha256": "b33e2ebede468d9e8acb79d20bb5a5947fc3bec13cc39b122aa131c5e6dcd188",
             "depends": [
                 "array-0.5.3.0",
                 "assoc-1.0.2-a3b3a4d8e11d4e8a99f20ef22cb6ec9fd41a4913a3c80ffd50331097060f10c7",
@@ -6337,7 +6376,7 @@
         },
         {
             "type": "configured",
-            "id": "trifecta-2.1.2-9c328a2aabaf3a047da70009b3c8ece3af7b77e67ea0f64eeae819804f1b42cf",
+            "id": "trifecta-2.1.2-f3473bed12f5eedd4026fd5bf3888392d386c0bd02d2056e93ae142b13b9301e",
             "pkg-name": "trifecta",
             "pkg-version": "2.1.2",
             "flags": {},
@@ -6367,7 +6406,7 @@
                 "ghc-prim-0.5.3",
                 "hashable-1.4.1.0-c679d0bc203a99c705e30712ebdb8010b7a78ebdda79872e3cd9c9ba681ec725",
                 "indexed-traversable-0.1.2-7eb6e713a08d0207daf1d150a19a3bd711334ec1908f09539cd4c2878d8d929e",
-                "lens-5.1.1-ea705adf240c235fd8522d2d64e871b0fb4a34cdc90fb8e34deb999222445019",
+                "lens-5.2-0fde984146e834fb35c0627fc333b5f16ec24cfb97d38520db3da949e4c6c702",
                 "mtl-2.2.2",
                 "parsers-0.12.11-4481fa6abe903e79882f6b5ac6e33e0f2a85d6189bb0f576ca43dbf56a7e819f",
                 "prettyprinter-1.7.1-e36e60c280ac66059ee44175bc53c5394bc78bc75390be9384b4f89e576c73d8",

```

I turns out that `doctest-parallel` forcing newer `Cabal`s was bad for older GHCs. Why? I don't know.. But [I've loosened the bounds](https://github.com/martijnbastiaan/doctest-parallel/pull/49).

PS: If this PR fails on master again like last time, it's probably due to `lens`.