### PR TITLE
Set `update_method` to `rebase` for Mergify queue action

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,4 +34,5 @@ pull_request_rules:
         ignore_conflicts: True
         branches:
           - "1.6"
-
+      queue:
+        update_method: rebase


### PR DESCRIPTION
Prevents ugly "master" => "branch" merges.