### PR TITLE
Instantiate types in component declarations with their size

### DIFF
--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1504,7 +1504,7 @@ inst_ (CompDecl nm ps0) =
   fmap Just $ "component" <+> pretty nm <+>
     ("port" <> line <> indent 2 (tupledSemi ps <> semi))
     <> line <> "end component" <> semi
-  where ps = traverse (\(t,pd,ty) -> pretty t <+> ":" <+> ppd pd <+> qualTyName ty) ps0
+  where ps = traverse (\(t,pd,ty) -> pretty t <+> ":" <+> ppd pd <+> sizedQualTyName ty) ps0
         ppd = \case { In -> "in"; Out -> "out"}
 
 inst_ (CondAssignment id_ _ scrut _ [(Just (BoolLit b), l),(_,r)]) = fmap Just $


### PR DESCRIPTION
As Peter points out, we instantiate the DcFifo differently from the Xilinx documentation: https://github.com/clash-lang/clash-compiler/pull/2270#issuecomment-1221238224

With this, component declarations attach a size to types (which conforms to the example). 

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
