### PR TITLE
Add '+>>.' and '.<<+'

### DIFF
--- a/changelog/2022-08-26T14_06_57+02_00_added_bitvector_shiftin
+++ b/changelog/2022-08-26T14_06_57+02_00_added_bitvector_shiftin
@@ -1,0 +1,1 @@
+ADDED: The prelude now exports `+>>.` and `.<<+`, which can be used to shift in a bit into a `BitVector` from the left or right respectively - similar to `+>>` and `<<+` for `Vec`s.

--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -50,9 +50,9 @@ import Clash.Annotations.Primitive    (hasBlackBox)
 import Clash.Class.BitPack.Internal.TH (deriveBitPackTuples)
 import Clash.Class.Resize             (zeroExtend, resize)
 import Clash.Promoted.Nat             (SNat(..), snatToNum)
-import Clash.Sized.BitVector          (Bit, BitVector, (++#))
 import Clash.Sized.Internal.BitVector
-  (pack#, split#, checkUnpackUndef, undefined#, unpack#, unsafeToNatural, isLike#)
+  (pack#, split#, checkUnpackUndef, undefined#, unpack#, unsafeToNatural, isLike#,
+   BitVector, Bit, (++#))
 import Clash.XException
 
 {- $setup

--- a/clash-prelude/src/Clash/Sized/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/BitVector.hs
@@ -1,5 +1,6 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente
+                  2022     , Google Inc.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
@@ -25,9 +26,43 @@ module Clash.Sized.BitVector
   , bLit
     -- ** Concatenation
   , (++#)
+    -- * Modification
+  , (+>>.)
+  , (.<<+)
     -- ** Pattern matching
   , bitPattern
   )
 where
 
 import Clash.Sized.Internal.BitVector
+import Clash.Promoted.Nat (natToNum)
+import Data.Bits (shiftL, shiftR)
+import GHC.TypeNats (KnownNat)
+
+{- $setup
+>>> :set -XNumericUnderscores
+-}
+
+infixr 4 +>>.
+-- | Shift in a bit from the MSB side of a 'BitVector'. Equal to right shifting
+-- the 'BitVector' by one and replacing the MSB with the bit to be shifted in.
+--
+-- >>> 1 +>>. 0b1111_0000 :: BitVector 8
+-- 0b1111_1000
+-- >>> 0 +>>. 0b1111_0000 :: BitVector 8
+-- 0b0111_1000
+--
+(+>>.) :: forall n. KnownNat n => Bit -> BitVector n -> BitVector n
+b +>>. bv = replaceBit# (shiftR bv 1) (natToNum @n - 1) b
+
+infixr 4 .<<+
+-- | Shift in a bit from the LSB side of a 'BitVector'. Equal to left shifting
+-- the 'BitVector' by one and replacing the LSB with the bit to be shifted in.
+--
+-- >>> 0b1111_0000 .<<+ 0 :: BitVector 8
+-- 0b1110_0000
+-- >>> 0b1111_0000 .<<+ 1 :: BitVector 8
+-- 0b1110_0001
+--
+(.<<+) :: forall n. KnownNat n => BitVector n -> Bit -> BitVector n
+bv .<<+ b = replaceBit# (shiftL bv 1) 0 b

--- a/clash-prelude/src/Clash/Sized/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Index.hs
@@ -15,11 +15,11 @@ module Clash.Sized.Index
   (Index, bv2i, fromSNat)
 where
 
-import GHC.TypeLits               (KnownNat, type (^))
-import GHC.TypeLits.Extra         (CLog) -- documentation only
+import GHC.TypeLits (KnownNat, type (^))
+import GHC.TypeLits.Extra (CLog) -- documentation only
 
-import Clash.Promoted.Nat         (SNat (..), pow2SNat)
-import Clash.Sized.BitVector      (BitVector)
+import Clash.Promoted.Nat (SNat (..), pow2SNat)
+import Clash.Sized.Internal.BitVector (BitVector)
 import Clash.Sized.Internal.Index
 
 -- | An alternative implementation of 'Clash.Class.BitPack.unpack' for the


### PR DESCRIPTION
We've got `+>>` for `Vector`. It seems natural that its `BitVector` counterpart would exist. 

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files