### PR TITLE
Disable multiple-hidden on 1.6

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -24,3 +24,16 @@ set -u
 
 # Build with default constraints
 cabal v2-build all --write-ghc-environment-files=always
+
+# `CI_COMMIT_TAG` is set when a tag has been created on GitHub. We use this to
+# trigger a release pipeline (release to Snap / Hackage).
+if [[ ${CI_COMMIT_TAG:-} != "" ]]; then
+    set +e
+    ! $(cat dist-newstyle/cache/plan.json | python3 -m json.tool | grep multiple-hidden | grep -q true)
+    if [[ $? != 0 ]]; then
+        echo "found enable multiple_hidden flag in 'dist-newstyle/cache/plan.json'"
+        echo "multiple_hidden flag should be disabled on releases!"
+        exit 1;
+    fi
+    set -e
+fi

--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -10,7 +10,7 @@ package *
 
 package clash-prelude
   ghc-options: -Werror
-  flags: +doctests +multiple-hidden
+  flags: +doctests
   tests: True
   benchmarks: True
 
@@ -47,7 +47,7 @@ package clash-lib-hedgehog
 package clash-testsuite
   ghc-options: -Werror
   -- enable cosim
-  flags: +cosim +multiple-hidden
+  flags: +cosim
 
 package clash-benchmark
   ghc-options: -Werror

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -5,7 +5,7 @@
   variables:
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-1.6-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-05-10-3-non_protected
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-1-6-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-05-10-3-non_protected
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   retry:

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -1304,6 +1304,7 @@ andEnable = \en f -> andSpecificEnable en (const f) (Proxy @dom)
 -- See Note [Going from WithSingleDomain to WithSpecificDomain]
 {-# INLINE andEnable #-}
 
+#ifdef CLASH_MULTIPLE_HIDDEN
 {- | Merge enable signal with signal of bools by applying the boolean AND
 operation.
 
@@ -1320,7 +1321,6 @@ examples for more information.
 
 <#hiddenclockandreset Click here to read more about hidden clocks, resets, and enables>
 
-#ifdef CLASH_MULTIPLE_HIDDEN
 === __Example__
 'andSpecificEnable' can only be used when it can find the specified domain
 in /r/:
@@ -1336,8 +1336,8 @@ Type variables work too, if they are in scope. For example:
 reg = 'register' @@dom 5 (reg + 1)
 f en = 'andSpecificEnable' @@dom en reg
 @
-#endif
 -}
+#endif
 andSpecificEnable
   :: forall dom r
    . ( HiddenEnable dom

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -25,7 +25,7 @@ flag multiple-hidden
     experimental feature, possibly triggering confusing error messages. By
     default, it is enabled on development versions of Clash and disabled on
     releases.
-  default: True
+  default: False
   manual: True
 
 common basic-config


### PR DESCRIPTION
This already happened during release, see:

https://github.com/clash-lang/clash-compiler/blob/4eec7d1de49618d97886f31a5e65b652612ac984/.ci/setup.sh#L65-L79

We disable multiple-hidden on 1.6 permanently to make sure PRs test the same as what would be tested on release.