### PR TITLE
GenTcl restructuring

### DIFF
--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -101,7 +101,8 @@ suite:cores:
   extends: .test-common-local
   script:
     - source /opt/tools/Xilinx/Vivado/2022.1/settings64.sh
-    - cabal v2-run -- clash-testsuite -j$THREADS -p Cores --hide-successes --no-modelsim --no-ghdl --no-iverilog --no-verilator --no-symbiyosys
+    # TODO: Change 'Vector' to 'Cores' after merging #2270
+    - cabal v2-run -- clash-testsuite -j$THREADS -p Vector --hide-successes --no-modelsim --no-ghdl --no-iverilog --no-verilator --no-symbiyosys
   tags:
     - local
     - vivado-2022.1-standard

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -215,6 +215,7 @@ Library
 
                       Clash.Driver
                       Clash.Driver.Manifest
+                      Clash.Driver.LocatedManifest
                       Clash.Driver.Types
 
                       Clash.Edalize.Edam

--- a/clash-lib/src/Clash/Driver/LocatedManifest.hs
+++ b/clash-lib/src/Clash/Driver/LocatedManifest.hs
@@ -1,0 +1,27 @@
+{-|
+Copyright  : (C) 2022, Google LLC
+License    : BSD2 (see the file LICENSE)
+Maintainer : QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+module Clash.Driver.LocatedManifest where
+
+import Clash.Driver.Manifest (Manifest)
+import System.FilePath ((</>), dropFileName)
+
+data LocatedManifest = LocatedManifest
+  { -- | Path pointing to the manifest file itself
+    lmPath :: FilePath
+
+    -- | Manifest file corresponding to the one at 'lmPath'
+  , lmManifest :: Manifest
+  }
+
+-- | Directory where all entities are stored. Probably equal to the value of
+-- @-fclash-hdldir@ passed to Clash.
+projectDirectory :: LocatedManifest -> FilePath
+projectDirectory manifest = entityDirectory manifest </> ".."
+
+-- | Directory where all HDL files are located for given entity
+entityDirectory :: LocatedManifest -> FilePath
+entityDirectory manifest = dropFileName (lmPath manifest)

--- a/clash-lib/src/Clash/Driver/LocatedManifest.hs
+++ b/clash-lib/src/Clash/Driver/LocatedManifest.hs
@@ -6,8 +6,10 @@ Maintainer : QBayLogic B.V. <devops@qbaylogic.com>
 
 module Clash.Driver.LocatedManifest where
 
-import Clash.Driver.Manifest (Manifest)
+import Clash.Driver.Manifest (Manifest, manifestFilename)
 import System.FilePath ((</>), dropFileName)
+
+import qualified Language.Haskell.TH  as TH
 
 data LocatedManifest = LocatedManifest
   { -- | Path pointing to the manifest file itself
@@ -16,6 +18,14 @@ data LocatedManifest = LocatedManifest
     -- | Manifest file corresponding to the one at 'lmPath'
   , lmManifest :: Manifest
   }
+
+-- | Get manifest location from the HDL output directory and top entity name
+manifestLocation :: FilePath -> TH.Name -> FilePath
+manifestLocation hdlDir funcName = manifestLocationFromStrName hdlDir (show funcName)
+
+-- | Get manifest location from the HDL output directory and top entity name
+manifestLocationFromStrName :: FilePath -> String -> FilePath
+manifestLocationFromStrName hdlDir funcName = hdlDir </> funcName </> manifestFilename
 
 -- | Directory where all entities are stored. Probably equal to the value of
 -- @-fclash-hdldir@ passed to Clash.

--- a/tests/src/Test/Tasty/Vivado/GenTcl.hs
+++ b/tests/src/Test/Tasty/Vivado/GenTcl.hs
@@ -84,6 +84,9 @@ simProjFromClashEntities hdlDir qualName = do
   let manifestPath = manifestLocationFromStrName hdlDir qualName
   [(_, mHdl)] <- getManifests manifestPath
   let deps = T.unpack <$> transitiveDependencies mHdl
+  -- XXX: 'transitiveDependencies' contains a flat list of the whole dependency
+  --      tree. Reinvoking 'simProjFromClashEntities' therefore risks duplicate
+  --      'HdlSource' entries.
   nextSimProj <- traverse (simProjFromClashEntities hdlDir) deps
   pure $ mconcat nextSimProj <> manifestToHdlSources (LocatedManifest manifestPath mHdl)
 

--- a/tests/src/Test/Tasty/Vivado/GenTcl.hs
+++ b/tests/src/Test/Tasty/Vivado/GenTcl.hs
@@ -152,15 +152,16 @@ launch_simulation
  where
   tclDataFile = cabalDir </> "data-files" </> "tcl" </> "clash_namespace.tcl"
   loadTclIfs =
-    concatMap (\HdlSource{..} -> case hdlType of
+    flip concatMap sp $ \HdlSource{..} ->
+      case hdlType of
         TclSource -> [i|clash::loadTclIface {#{hdlLib}} {#{hdlFile}}\n|]
         _ -> []
-      ) sp
+
   readSources =
-    concatMap (\HdlSource{..} -> case hdlType of
+    flip concatMap sp $ \HdlSource{..} ->
+      case hdlType of
         VhdlSource ->
           [i|read_vhdl -library {#{hdlLib}} {#{hdlFile}}\n|]
         VerilogSource ->
           [i|read_verilog {#{hdlFile}}\n|]
         _ -> []
-      ) sp


### PR DESCRIPTION
This PR aims to do a few things:

 * Restructure to allow functions to be reused for synthesis, instead of just simulation. (Note that this is the reason for removing references to `Sim`.)
 * Add convenience functions for external integrations such as `clash-shake`
 * Clarify functions and their docs
 * Minor refactors to prevent some ??? when reading the code.