### PR TITLE
Tweak some Stack / Stack CI settings

### DIFF
--- a/.ci/stack-8.10.7.yaml
+++ b/.ci/stack-8.10.7.yaml
@@ -1,4 +1,7 @@
-resolver: lts-18.24
+resolver: lts-18.28
+
+ghc-options:
+  "$locals": -Wall -Wcompat
 
 packages:
 - clash-prelude
@@ -12,5 +15,4 @@ packages:
 extra-deps:
 - doctest-parallel-0.2.1@sha256:c6c0d095dd6e0b8ce1bd9f6f5fc4e0cf5cf50b6895b557356ac41b8aa2947399,5631
 - fakedata-1.0.2@sha256:37c93be9a81acbc9109e2c0b300a793d9c1f5ead1d34330d869d76568191f428,24593
-- tasty-1.2.3@sha256:bba67074e5326d57e8f53fc1dabcb6841daa4dc51b053506eb7f40a6f49a0497,2517
 - docopt-0.7.0.7@sha256:a3d2eac54cd77d8c0b306ff96fb57be55542f143d81766aa1ae51458ad790dbe,3655

--- a/.ci/stack-8.6.5.yaml
+++ b/.ci/stack-8.6.5.yaml
@@ -1,5 +1,8 @@
 resolver: lts-14.27
 
+ghc-options:
+  "$locals": -Wall -Wcompat
+
 packages:
 - clash-prelude
 - clash-prelude-hedgehog

--- a/.ci/stack-8.8.4.yaml
+++ b/.ci/stack-8.8.4.yaml
@@ -1,5 +1,8 @@
 resolver: lts-16.31
 
+ghc-options:
+  "$locals": -Wall -Wcompat
+
 packages:
 - clash-prelude
 - clash-prelude-hedgehog
@@ -10,7 +13,6 @@ packages:
 - tests
 
 extra-deps:
-- tasty-1.2.3@sha256:bba67074e5326d57e8f53fc1dabcb6841daa4dc51b053506eb7f40a6f49a0497,2517
 - arrows-0.4.4.2@sha256:a260222b766da922657e302aa7c0409451913e1e503798a47a213a61ba382460,1235
 - fakedata-1.0.2@sha256:37c93be9a81acbc9109e2c0b300a793d9c1f5ead1d34330d869d76568191f428,24593
 - hedgehog-fakedata-0.0.1.4@sha256:bd826430f9fd17d4f226c917328c429add0ff410a88384d2fef2d4374382cf95,1361

--- a/.ci/stack-9.0.2.yaml
+++ b/.ci/stack-9.0.2.yaml
@@ -1,4 +1,7 @@
-resolver: nightly-2022-02-19
+resolver: lts-19.25
+
+ghc-options:
+  "$locals": -Wall -Wcompat
 
 packages:
 - clash-prelude
@@ -8,7 +11,3 @@ packages:
 - clash-ghc
 - clash-cores
 - tests
-
-extra-deps:
-- tasty-1.2.3@sha256:bba67074e5326d57e8f53fc1dabcb6841daa4dc51b053506eb7f40a6f49a0497,2517
-

--- a/.ci/stack_build.sh
+++ b/.ci/stack_build.sh
@@ -5,4 +5,7 @@ apt update
 apt install wget -y
 wget -q https://get.haskellstack.org/ -O stack_install.sh
 sh stack_install.sh
-stack build -j${THREADS}
+# Note: the --pedantic switch adds -Wall -Werror to the options passed to GHC.
+# Options specified in stack.yaml (like -Wcompat) are still passed; it is
+# cumulative. Future versions of Stack might add behavior to --pedantic.
+stack build -j${THREADS} --pedantic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           cp .ci/stack-${{ matrix.ghc }}.yaml stack.yaml
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v1
         with:
           path: |
             ${{ steps.setup-haskell.outputs.stack-root }}/snapshots
@@ -67,8 +67,12 @@ jobs:
       - name: Build happy with Stack
         run: ./.ci/retry.sh stack build happy
 
+      # Note: the --pedantic switch adds -Wall -Werror to the options passed to
+      # GHC. Options specified in stack.yaml (like -Wcompat) are still passed;
+      # it is cumulative. Future versions of Stack might add behavior to
+      # --pedantic.
       - name: Build with Stack
-        run: stack build
+        run: stack build --pedantic
 
       - name: Run Vector testsuite
         run: stack run -- clash-testsuite --hide-successes -p .Vector. --no-ghdl --no-verilator --no-modelsim --no-vivado

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,7 @@
-resolver: lts-19.21
+resolver: lts-19.25
+
+ghc-options:
+  "$locals": -Wall -Wcompat
 
 packages:
 - clash-prelude


### PR DESCRIPTION
- Pass `-Wall -Wcompat` to GHC when building with Stack (not just CI,
  also the `stack.yaml` in the root). These options only apply to the
  local packages, it will not change the GHC options for dependencies.
- Pass `--pedantic` to Stack in CI runs

    This switch adds `-Wall -Werror` to the options passed to GHC.
    Options specified in `stack.yaml` (like `-Wcompat`) are still
    passed; it is cumulative. Future versions of Stack might add
    behavior to `--pedantic`.
- Caching on GitHub Windows CI is broken in cache@v2:
  https://github.com/actions/cache/issues/666#issuecomment-1002945087
  cache@v3 exhibits the same issue, going back to cache@v1
- Drop unneeded `extra-deps`
- Use an LTS resolver for GitHub Stack CI with GHC 9.0.2, instead of a
  nightly
- While editing these files anyway, bumping all resolvers to the latest
  LTS

GitLab jobs `nix-build` and `debian-bindist` still do not have
-Wall -Werror. This could be addressed in a later PR.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
