### PR TITLE
New: `Xilinx.Floating.fromU32`

### DIFF
--- a/.ci/bindist/linux/debian/focal/buildinfo.json
+++ b/.ci/bindist/linux/debian/focal/buildinfo.json
@@ -94,6 +94,11 @@
       "src": {"type": "local", "dir": "../../../../../clash-ghc"}
     },
     {
+      "name": "clash-cores",
+      "cabal_debian_options": ["--disable-haddock", "--disable-tests"],
+      "src": {"type": "local", "dir": "../../../../../clash-cores"}
+    },
+    {
       "name": "clash-testsuite",
       "src": {"type": "local", "dir": "../../../../../tests"},
       "cabal_debian_options": [

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
@@ -1,5 +1,6 @@
 {-|
 Copyright  :  (C) 2021,      QBayLogic B.V.,
+                  2022,      Google Inc.,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -55,6 +56,9 @@ module Clash.Cores.Xilinx.Floating
   , divWith
   , div
   , E.DivDefDelay
+  , fromU32With
+  , fromU32
+  , E.FromU32DefDelay
     -- * Customizing IP
   , E.Config(..)
   , E.defConfig
@@ -172,3 +176,29 @@ div
   -> DSignal dom (n + E.DivDefDelay) Float
 div = withFrozenCallStack $ hideEnable $ hideClock E.div
 {-# INLINE div #-}
+
+-- | Customizable conversion of @Unsigned 32@ to @Float@
+--
+-- Only the delay is configurable, so this function does not take a @Config@
+-- argument.
+fromU32With
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => DSignal dom n (Unsigned 32)
+  -> DSignal dom (n + d) Float
+fromU32With = withFrozenCallStack $ hideEnable $ hideClock E.fromU32With
+{-# INLINE fromU32With #-}
+
+-- | Conversion of @Unsigned 32@ to @Float@, with default delay
+fromU32
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , HasCallStack
+     )
+  => DSignal dom n (Unsigned 32)
+  -> DSignal dom (n + E.FromU32DefDelay) Float
+fromU32 = withFrozenCallStack $ hideEnable $ hideClock E.fromU32
+{-# INLINE fromU32 #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/Annotations.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/Annotations.hs
@@ -1,14 +1,18 @@
 {-|
 Copyright  :  (C) 2021-2022, QBayLogic B.V.,
+                  2022     , Google Inc.,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Cores.Xilinx.Floating.Annotations
   ( veriBinaryPrim
   , vhdlBinaryPrim
+  , vhdlFromUPrim
+  , veriFromUPrim
   ) where
 
 import Prelude
@@ -17,6 +21,8 @@ import Data.String.Interpolate (__i)
 import Language.Haskell.TH.Syntax (Name)
 
 import Clash.Annotations.Primitive (Primitive(..), HDL(..))
+
+import Clash.Cores.Xilinx.Floating.BlackBoxes
 
 -- | The InlinePrimitive annotation for a binary function in VHDL.
 
@@ -125,4 +131,113 @@ veriBinaryPrim primName tclTFName funcName =
           name: floating_point
           format: Haskell
           templateFunction: #{tclTFName}
+    |]
+
+vhdlFromUPrim
+  :: Name
+  -> String
+  -> Primitive
+vhdlFromUPrim primName funcName =
+  let tfName = 'fromUTclTF
+      clockArg, enableArg, inputArg, blockSym, inpSlvSym, compSym,
+        clkEnStdSym :: Int
+      clockArg = 3
+      enableArg = 4
+      inputArg = 5
+      blockSym = 0
+      inpSlvSym = 1
+      compSym = 2
+      clkEnStdSym = 3
+  in InlineYamlPrimitive [VHDL] [__i|
+    BlackBox:
+      name: #{primName}
+      type: |-
+        #{primName}
+          :: ( KnownDomain dom            --            ARG[0]
+             , KnownNat d                 --            ARG[1]
+             , HasCallStack               --            ARG[2]
+             )
+          => Clock dom                    -- clockArg,  ARG[3]
+          -> Enable dom                   -- enableArg, ARG[4]
+          -> DSignal dom n (Unsigned ..)  -- inputArg , ARG[5]
+          -> DSignal dom (n + d) Float
+      kind: Declaration
+      template: |-
+        -- #{funcName} begin
+        ~GENSYM[#{funcName}][#{blockSym}] : block
+          component ~INCLUDENAME[0]
+            port (
+              aclk : in std_logic;
+        ~IF~ISACTIVEENABLE[#{enableArg}]~THEN      aclken : in std_logic;
+        ~ELSE~FI      s_axis_a_tvalid : in std_logic;
+              s_axis_a_tdata : in std_logic_vector(~SIZE[~TYP[#{inputArg}]]-1 downto 0);
+              m_axis_result_tvalid : out std_logic;
+              m_axis_result_tdata : out std_logic_vector(31 downto 0)
+            );
+          end component;
+          signal ~GENSYM[inp_slv][#{inpSlvSym}]: std_logic_vector(~SIZE[~TYP[#{inputArg}]]-1 downto 0);
+        ~IF~ISACTIVEENABLE[#{enableArg}]~THEN  signal ~GENSYM[clken_std][#{clkEnStdSym}]: std_logic;
+        begin
+          ~SYM[#{clkEnStdSym}] <= '1' when (~ARG[#{enableArg}]) else '0';
+        ~ELSEbegin
+        ~FI  ~SYM[#{inpSlvSym}] <= ~TOBV[~ARG[#{inputArg}]][~TYP[#{inputArg}]];
+          ~GENSYM[#{funcName}][#{compSym}] : ~INCLUDENAME[0]
+            port map (
+              aclk => ~ARG[#{clockArg}],
+        ~IF~ISACTIVEENABLE[#{enableArg}]~THEN      aclken => ~SYM[#{clockArg}],
+        ~ELSE~FI      s_axis_a_tvalid => '1',
+              s_axis_a_tdata => ~SYM[#{inpSlvSym}],
+              m_axis_result_tvalid => open,
+              m_axis_result_tdata => ~RESULT
+            );
+        end block;
+        -- #{funcName} end
+      includes:
+        - extension: tcl
+          name: floating_point
+          format: Haskell
+          templateFunction: #{tfName}
+    |]
+
+veriFromUPrim
+  :: Name
+  -> String
+  -> Primitive
+veriFromUPrim primName funcName =
+  let tfName = 'fromUTclTF
+      clockArg, enableArg, inputArg, instSym :: Int
+      clockArg = 3
+      enableArg = 4
+      inputArg = 5
+      instSym = 0
+  in InlineYamlPrimitive [Verilog, SystemVerilog] [__i|
+    BlackBox:
+      name: #{primName}
+      type: |-
+        #{primName}
+          :: ( KnownDomain dom            --            ARG[0]
+             , KnownNat d                 --            ARG[1]
+             , HasCallStack               --            ARG[2]
+             )
+          => Clock dom                    -- clockArg,  ARG[3]
+          -> Enable dom                   -- enableArg, ARG[4]
+          -> DSignal dom n (Unsigned ..)  -- inputArg , ARG[5]
+          -> DSignal dom (n + d) Float
+      kind: Declaration
+      template: |-
+        // #{funcName} begin
+        ~INCLUDENAME[0] ~GENSYM[#{funcName}][#{instSym}] (
+          .aclk(~ARG[#{clockArg}]),
+        ~IF~ISACTIVEENABLE[#{enableArg}]~THEN  .aclken(~ARG[#{enableArg}]),
+        ~ELSE~FI  .s_axis_a_tvalid(1'b1),
+          .s_axis_a_tdata(~ARG[#{inputArg}]),
+          .m_axis_result_tvalid(),
+          .m_axis_result_tdata(~RESULT)
+        );
+        // #{funcName} end
+      includes:
+        - extension: tcl
+          name: floating_point
+          format: Haskell
+          templateFunction: #{tfName}
     |]

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/BlackBoxes.hs
@@ -146,15 +146,23 @@ tclTemplate (HasCustom {..}) operType bbCtx = pure bbText
       ]
   prop (False, _, _) s = s
   prop (True, name, value) s =
-    replicate 25 ' ' ++ name ++ ' ': value ++ " \\\n" ++ s
+    replicate 31 ' ' ++ name ++ ' ': value ++ " \\\n" ++ s
 
-  bbText =
-    [i|create_ip -name floating_point -vendor xilinx.com -library ip \\
-          -version 7.1 -module_name {#{compName}}
-set_property -dict [list \\
-#{props}                   ] \\
-                   [get_ips {#{compName}}]
-generate_target {synthesis simulation} [get_ips {#{compName}}]|]
+  bbText = [i|proc createNamespace ns {
+  namespace eval $ns {
+    variable api 1
+    variable scriptPurpose createIp
+    variable ipName {#{compName}}
+
+    proc createIp {ipName0 args} {
+      create_ip -name floating_point -vendor xilinx.com -library ip \\
+          -version 7.1 -module_name $ipName0 {*}$args
+
+      set_property -dict [list \\
+#{props}                         ] [get_ips $ipName0]
+    }
+  }
+}|]
 
 show0 :: (Show a, IsString s) => a -> s
 show0 = fromString . show

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -468,17 +468,24 @@ runClashTest = defaultMain $ clashTestRoot
       -- run).
       -- TODO: Make these test benches compatible with our Vivado CI
       --
-      -- , clashTestGroup "Cores"
-      --   [ clashTestGroup "Xilinx"
-      --     [ runTest "Floating" def{ clashFlags=["-fclash-float-support"]
-      --                             , buildTargets=[ "addBasicTB"
-      --                                            , "addEnableTB"
-      --                                            , "addShortPLTB"
-      --                                            , "subBasicTB"
-      --                                            , "mulBasicTB"
-      --                                            , "divBasicTB"]}
-      --     ]
-      --   ]
+--       , clashTestGroup "Cores"
+--         [ clashTestGroup "Xilinx"
+--           [ let _opts = def{ hdlTargets=[VHDL, Verilog]
+--                            , hdlLoad=[Vivado]
+--                            , hdlSim=[Vivado]
+--                            , buildTargets=BuildSpecific [ "addBasicTB"
+--                                                         , "addEnableTB"
+--                                                         , "addShortPLTB"
+--                                                         , "subBasicTB"
+--                                                         , "mulBasicTB"
+--                                                         , "divBasicTB"
+--                                                         , "fromUBasicTB"
+--                                                         , "fromUEnableTB"
+--                                                         ]
+--                            }
+--             in runTest "Floating" _opts
+--           ]
+--         ]
       , clashTestGroup "CSignal"
         [ runTest "MAC" def{hdlSim=[]}
         , runTest "CBlockRamTest" def{hdlSim=[]}

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -66,6 +66,7 @@ common basic-config
     -- testsuite to compile, but we do when running it.
     -- Leaving it out will cause the testsuite to compile
     -- it anyway so we're better off doing it beforehand.
+    clash-cores,
     clash-ghc,
     clash-lib,
     clash-prelude

--- a/tests/shouldwork/Cores/Xilinx/Floating/Annotations.hs
+++ b/tests/shouldwork/Cores/Xilinx/Floating/Annotations.hs
@@ -1,5 +1,6 @@
 {-|
 Copyright  :  (C) 2021,      QBayLogic B.V.,
+                  2022,      Google Inc.,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -8,8 +9,8 @@ module Floating.Annotations where
 
 import Clash.Prelude
 
-binTopAnn :: String -> TopEntity
-binTopAnn name =
+binaryTopAnn :: String -> TopEntity
+binaryTopAnn name =
   Synthesize
     { t_name   = name
     , t_inputs =
@@ -20,8 +21,8 @@ binTopAnn name =
     , t_output = PortName "result"
     }
 
-binEnTopAnn :: String -> TopEntity
-binEnTopAnn name =
+binaryEnTopAnn :: String -> TopEntity
+binaryEnTopAnn name =
   Synthesize
     { t_name   = name
     , t_inputs =
@@ -29,6 +30,29 @@ binEnTopAnn name =
           , PortName "en"
           , PortName "x"
           , PortName "y"
+          ]
+    , t_output = PortName "result"
+    }
+
+unaryTopAnn :: String -> TopEntity
+unaryTopAnn name =
+  Synthesize
+    { t_name   = name
+    , t_inputs =
+          [ PortName "clk"
+          , PortName "x"
+          ]
+    , t_output = PortName "result"
+    }
+
+unaryEnTopAnn :: String -> TopEntity
+unaryEnTopAnn name =
+  Synthesize
+    { t_name   = name
+    , t_inputs =
+          [ PortName "clk"
+          , PortName "en"
+          , PortName "x"
           ]
     , t_output = PortName "result"
     }

--- a/tests/shouldwork/Cores/Xilinx/Floating/TH.hs
+++ b/tests/shouldwork/Cores/Xilinx/Floating/TH.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright  :  (C) 2021,      QBayLogic B.V.,
+Copyright  :  (C) 2021-2022, QBayLogic B.V.,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -8,29 +8,14 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 module Floating.TH where
 
-import Clash.Prelude (BitPack, natToNum, SNat(..), unpack)
-import Clash.Prelude.ROM.File (memFile)
+import Clash.Prelude (natToNum, unpack)
 
 import Prelude
-import Language.Haskell.TH
-  (appTypeE, conE, ExpQ, litE, litT, numTyLit, stringL, tupE)
-import Language.Haskell.TH.Syntax (qRunIO)
 import Numeric.IEEE
   (epsilon, infinity, maxFinite, minDenormal, minNormal)
 
 import Clash.Cores.Xilinx.Floating as F
 import Clash.Cores.Xilinx.Floating.Internal as F
-
-romDataFromFile
-  :: BitPack a
-  => FilePath
-  -> [a]
-  -> ExpQ
-romDataFromFile file es =
-  qRunIO (writeFile file $ memFile (Just 0) es)
-  >> tupE [ appTypeE (conE 'SNat) (litT . numTyLit . toInteger $ length es)
-          , litE $ stringL file
-          ]
 
 delayOutput
   :: Int

--- a/tests/shouldwork/Cores/Xilinx/Floating/TH.hs
+++ b/tests/shouldwork/Cores/Xilinx/Floating/TH.hs
@@ -1,5 +1,6 @@
 {-|
 Copyright  :  (C) 2021-2022, QBayLogic B.V.,
+                  2022     , Google Inc.,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -8,7 +9,7 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 module Floating.TH where
 
-import Clash.Prelude (natToNum, unpack)
+import Clash.Prelude (natToNum, unpack, Unsigned)
 
 import Prelude
 import Numeric.IEEE
@@ -520,6 +521,39 @@ nanTest =
     , (1, nan, F.xilinxNaN)
     , (nan, nan, F.xilinxNaN)
     ]
+
+fromUBasicSamples :: [(Unsigned 32, Float)]
+fromUBasicSamples = delayOutput0 (natToNum @F.FromU32DefDelay) $
+  map (\x -> (x, fromIntegral x))
+    [ 0
+    , 1
+    , maxBound
+
+      -- Patterns 0xaa and 0x55, but treating the "sign bit" separately. Floats
+      -- are stored in sign/magnitude form so signed and unsigned numbers are
+      -- not interchangeable like with two's complement. All these numbers
+      -- should be unsigned, verify that they are treated as such.
+    , 0b0010_1010_1010_1010_1010_1010_1010_1010
+    , 0b0101_0101_0101_0101_0101_0101_0101_0101
+    , 0b1010_1010_1010_1010_1010_1010_1010_1010
+    , 0b1101_0101_0101_0101_0101_0101_0101_0101
+
+    , -- Longest exactly representable
+      0b0000_0000_1111_1111_1111_1111_1111_1111
+
+    , -- Smallest with rounding
+      0b0000_0001_0000_0000_0000_0000_0000_0001
+
+      -- More rounding tests
+    , 0b0000_0001_0000_0000_0000_0000_0000_0011
+    , 0b0000_0010_0000_0000_0000_0000_0000_0001
+    ]
+ where
+  delayOutput0 d es = zip is os
+   where
+    (is0, os0) = unzip es
+    is = is0 ++ repeat (last is0)
+    os = replicate d 0 ++ os0
 
 -- Maximum subnormal value
 maxDenormal :: Float


### PR DESCRIPTION
New in `clash-cores`: convert `Unsigned 32` to `Float` with Xilinx IP.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
