### PR TITLE
Move GitLab CI to own runners

### DIFF
--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -29,6 +29,9 @@ hackage-sdist:
     - .ci/publish_sdist.sh clash-ghc
   retry:
     max: 2
+  # XXX: Temporarily on local runners
+  tags:
+   - local
 
 # Run every night, when explicitly triggered, or when tagged (release)
 .run-on-nightly-and-changes:
@@ -104,3 +107,6 @@ debian-bindist-test:
     - .ci/snap.sh publish
   retry:
     max: 2
+  # XXX: Temporarily on local runners
+  tags:
+   - local

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -30,7 +30,8 @@ stages:
 .test-common:
   extends: .test-common-local
   # Run on shared runners
-  tags:
+  # XXX: Temporarily on local runners
+  #tags:
 
 # 'build' publishes its build files as an artifact. These build files are reused
 # by 'prelude:doctests', 'prelude:unittests', 'lib:unittests'
@@ -48,6 +49,9 @@ build:
 
     # Archive all build files (from .cabal and dist-newstyle)
     - tar -cf - $(.ci/get_build_dist.sh) | zstd -T${THREADS} -15 > dist.tar.zst
+  # XXX: Temporarily on local runners
+  tags:
+   - local
 
 build-clash-dev:
   extends: .test-common

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,8 @@ nix-build:
 
   script:
     - nix-build -j$(./.ci/effective_cpus.sh)
+  tags:
+    - local
 
 haddock:
   extends: .common

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,7 +65,9 @@ stack-build:
   script:
     - .ci/stack_build.sh
   # Run on shared runners
+  # XXX: Temporarily on local runners
   tags:
+   - local
 
 nix-build:
   image: nixos/nix:2.10.1
@@ -152,6 +154,9 @@ snap-stable:
   image: curlimages/curl
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
+  # XXX: Temporarily on local runners
+  tags:
+   - local
 
 set_pending:
   extends: .github_status


### PR DESCRIPTION
We've run out of minutes on GitLab CI. I _think_ it was `nix-build` that burnt a lot of minutes.  Even with most packages coming from the NixOS cache, it still takes about 30 minutes to compile and run tests.

The first commit moves `nix-build` to a local runner; I think we should keep it as such.

The second commit temporarily moves everything on GitLab CI to local runners. This should probably later be reverted. I don't really like polluting our commit history on `master` with such housekeeping; an alternative would be to buy extra minutes as it is probably a one-time thing anyway and it's only $ 10. In that case, the first commit should probably be merged anyway.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
