### PR TITLE
CI: fix `nix-build` for newer kernels, clean up

### DIFF
--- a/.ci/effective_cpus.sh
+++ b/.ci/effective_cpus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # `nproc` doesn't account for limits set by cgroups/docker. This script tries
 # to determine the effective number of cpus we can use by inspecting the shares
 # it has been given.
@@ -14,11 +14,11 @@ elif [ -f /sys/fs/cgroup/cpu.max ]; then
   cfs_quota_us=$(cat /sys/fs/cgroup/cpu.max | awk '{ print $1 }')
   cfs_period_us=$(cat /sys/fs/cgroup/cpu.max | awk '{ print $2 }')
 else
-  echo "Could not determine number of effective CPUs"
+  echo "Could not determine number of effective CPUs" >&2
   exit 1
 fi
 
-if [[ ${cfs_quota_us} == -1 ]]; then
+if [[ ${cfs_quota_us} == @(-1|max) ]]; then
   # No limits set
   nproc
 else

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,16 +74,7 @@ nix-build:
   needs: []
   stage: test
   before_script:
-    # Circle CI needs git/ssh in /usr/bin
-    - nix-env -i git findutils gnugrep gnused coreutils openssh bash zstd
-
-    #                                 bin         nix pkg        multiple may exist
-    - ln -s $(find /nix -type f -name git  | grep libexec      | head -n1) /usr/bin
-    - ln -s $(find /nix -type f -name ssh  | grep openssh      | head -n1) /usr/bin
-    - ln -s $(find /nix -type f -name sed  | grep gnused       | head -n1) /usr/bin
-    - ln -s $(find /nix -type f -name zstd | grep zstd         | head -n1) /usr/bin
-    - ln -s $(find /nix -type f -name bash | grep 'bash-[0-9]\+\.[0-9]\+' | head -n1) /bin
-
+   - nix-env -i gawk
   script:
     - nix-build -j$(./.ci/effective_cpus.sh)
   tags:


### PR DESCRIPTION
We need to install `awk` before we can use it in `effective_cpus.sh`. `awk` is only used for newer kernels, like the one in Ubuntu 22.04. So the previous code succeeded only on older runner hosts.

The shebang line for `effective_cpus.sh` is changed to pick `bash` from the $PATH; it is pre-installed but not in /usr/bin.

An obsolete workaround for Circle CI and unneeded packages are removed.

It seems we only need to install `gawk` in the `before_script` (per above). `nix-build` will automatically fetch the following packages previously specified in the `before_script`:
findutils gnugrep gnused coreutils bash

These previously specified packages now seem unused: git ssh zstd.

I tested this PR against both `glanerbrug` (running a newer kernel) as well as `diepenheim` (running an older kernel). It all worked.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
