### PR TITLE
New: `Xilinx.Floating.fromS32`

### DIFF
--- a/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
@@ -59,6 +59,9 @@ module Clash.Cores.Xilinx.Floating
   , fromU32With
   , fromU32
   , E.FromU32DefDelay
+  , fromS32With
+  , fromS32
+  , E.FromS32DefDelay
     -- * Customizing IP
   , E.Config(..)
   , E.defConfig
@@ -202,3 +205,29 @@ fromU32
   -> DSignal dom (n + E.FromU32DefDelay) Float
 fromU32 = withFrozenCallStack $ hideEnable $ hideClock E.fromU32
 {-# INLINE fromU32 #-}
+
+-- | Customizable conversion of @Signed 32@ to @Float@
+--
+-- Only the delay is configurable, so this function does not take a @Config@
+-- argument.
+fromS32With
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => DSignal dom n (Signed 32)
+  -> DSignal dom (n + d) Float
+fromS32With = withFrozenCallStack $ hideEnable $ hideClock E.fromS32With
+{-# INLINE fromS32With #-}
+
+-- | Conversion of @Signed 32@ to @Float@, with default delay
+fromS32
+  :: ( HiddenClock dom
+     , HiddenEnable dom
+     , HasCallStack
+     )
+  => DSignal dom n (Signed 32)
+  -> DSignal dom (n + E.FromS32DefDelay) Float
+fromS32 = withFrozenCallStack $ hideEnable $ hideClock E.fromS32
+{-# INLINE fromS32 #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/BlackBoxes.hs
@@ -15,6 +15,7 @@ module Clash.Cores.Xilinx.Floating.BlackBoxes
   , mulTclTF
   , divTclTF
   , fromUTclTF
+  , fromSTclTF
   ) where
 
 import Prelude
@@ -211,6 +212,54 @@ fromUTclTemplate bbCtx = pure bbText
         return
       }
     }|]
+
+fromSTclTF :: TemplateFunction
+fromSTclTF = TemplateFunction used valid fromSTclTemplate
+ where
+  used = [1,4,5]
+  valid = const True
+
+fromSTclTemplate
+  :: Backend s
+  => BlackBoxContext
+  -> State s Doc
+fromSTclTemplate bbCtx = pure bbText
+ where
+  [compName] = bbQsysIncName bbCtx
+  (Literal _ (NumLit latency), _, _) = bbInputs bbCtx !! 1
+  tclClkEn :: String
+  tclClkEn =
+    case bbInputs bbCtx !! 4 of
+      (DataCon _ _ [Literal Nothing (BoolLit True)], _, _) -> "false"
+      _                                                    -> "true"
+  (_, Signed inpLen, _) = bbInputs bbCtx !! 5
+
+  bbText = [__i|
+    namespace eval $tclIface {
+      variable api 1
+      variable scriptPurpose createIp
+      variable ipName {#{compName}}
+
+      proc createIp {ipName0 args} {
+        create_ip -name floating_point -vendor xilinx.com -library ip \\
+            -version 7.1 -module_name $ipName0 {*}$args
+
+        set_property -dict [list \\
+                                 CONFIG.Operation_Type Fixed_to_float \\
+                                 CONFIG.A_Precision_Type Int#{inpLen} \\
+                                 CONFIG.Flow_Control NonBlocking \\
+                                 CONFIG.Has_ACLKEN #{tclClkEn} \\
+                                 CONFIG.C_A_Exponent_Width #{inpLen} \\
+                                 CONFIG.C_A_Fraction_Width 0 \\
+                                 CONFIG.Has_RESULT_TREADY false \\
+                                 CONFIG.C_Latency #{latency} \\
+                                 CONFIG.C_Rate 1 \\
+                                 CONFIG.Maximum_Latency false \\
+                           ] [get_ips $ipName0]
+        return
+      }
+    }|]
+
 
 show0 :: (Show a, IsString s) => a -> s
 show0 = fromString . show

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
@@ -62,6 +62,9 @@ module Clash.Cores.Xilinx.Floating.Explicit
   , fromU32With
   , fromU32
   , FromU32DefDelay
+  , fromS32With
+  , fromS32
+  , FromS32DefDelay
     -- * Customizing IP
   , Config(..)
   , defConfig
@@ -270,6 +273,43 @@ fromU32 = withFrozenCallStack fromU32With
 
 -- | The default delay for conversion of @Unsigned 32@ to @Float@
 type FromU32DefDelay = 5
+
+-- | Customizable conversion of @Signed 32@ to @Float@
+--
+-- Only the delay is configurable, so this function does not take a @Config@
+-- argument.
+fromS32With
+  :: forall d dom n
+   . ( KnownDomain dom
+     , KnownNat d
+     , HasCallStack
+     )
+  => Clock dom
+  -> Enable dom
+  -> DSignal dom n (Signed 32)
+  -> DSignal dom (n + d) Float
+fromS32With clk en = delayI und en clk . fmap fromIntegral
+ where
+  und = withFrozenCallStack $ errorX "Initial values of fromS32 undefined"
+{-# NOINLINE fromS32With #-}
+{-# ANN fromS32With (vhdlFromSPrim 'fromS32With "fromS32") #-}
+{-# ANN fromS32With (veriFromSPrim 'fromS32With "fromS32") #-}
+
+-- | Conversion of @Signed 32@ to @Float@, with default delay
+fromS32
+  :: forall dom n
+   . ( KnownDomain dom
+     , HasCallStack
+     )
+  => Clock dom
+  -> Enable dom
+  -> DSignal dom n (Signed 32)
+  -> DSignal dom (n + FromS32DefDelay) Float
+fromS32 = withFrozenCallStack fromS32With
+{-# INLINE fromS32 #-}
+
+-- | The default delay for conversion of @Signed 32@ to @Float@
+type FromS32DefDelay = 6
 
 -- | Default customization options.
 --

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -473,6 +473,8 @@ runClashTest = defaultMain $ clashTestRoot
 --                                                         , "divBasicTB"
 --                                                         , "fromUBasicTB"
 --                                                         , "fromUEnableTB"
+--                                                         , "fromSBasicTB"
+--                                                         , "fromSEnableTB"
 --                                                         ]
 --                            }
 --             in runTest "Floating" _opts


### PR DESCRIPTION
New in `clash-cores`: convert `Signed 32` to `Float` with Xilinx IP.

---------------

I shamelessly copied Peter's homework and I'm not really sure about `fromSBasicSamples`. How did you obtain things like "smallest with rounding" @DigitalBrains1?