### PR TITLE
Test suite: give every target its own work dir

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -440,15 +440,11 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T1786" def{
             hdlTargets=[VHDL]
           , buildTargets=BuildSpecific ["testEnableTB", "testBoolTB"]
-          , -- TODO: Enable multiple build targets for Vivado
-            hdlSim=hdlSim def \\ [Vivado] -- triggers error in vivado
           }
         , outputTest "LITrendering" def{hdlTargets=[Verilog]}
         , runTest "T2117" def{
             clashFlags=["-fclash-aggressive-x-optimization-blackboxes"]
           , hdlTargets=[VHDL]
-          , -- TODO: Enable multiple build targets for Vivado
-            hdlSim=hdlSim def \\ [Vivado]
           , buildTargets=BuildSpecific [ "testBenchUndefBV"
                                        , "testBenchUndefTup"
                                        , "testBenchPartialDefTup"]}
@@ -456,30 +452,27 @@ runClashTest = defaultMain $ clashTestRoot
       , clashTestGroup "BoxedFunctions"
         [ runTest "DeadRecursiveBoxed" def{hdlSim=[]}
         ]
-      -- The Cores.Xilinx.Floating tests require Vivado (and take much time to
-      -- run).
-      -- TODO: Enable multiple build targets for Vivado
-      --
---       , clashTestGroup "Cores"
---         [ clashTestGroup "Xilinx"
---           [ let _opts = def{ hdlTargets=[VHDL, Verilog]
---                            , hdlLoad=[Vivado]
---                            , hdlSim=[Vivado]
---                            , buildTargets=BuildSpecific [ "addBasicTB"
---                                                         , "addEnableTB"
---                                                         , "addShortPLTB"
---                                                         , "subBasicTB"
---                                                         , "mulBasicTB"
---                                                         , "divBasicTB"
---                                                         , "fromUBasicTB"
---                                                         , "fromUEnableTB"
---                                                         , "fromSBasicTB"
---                                                         , "fromSEnableTB"
---                                                         ]
---                            }
---             in runTest "Floating" _opts
---           ]
---         ]
+      , clashTestGroup "Cores"
+        [ clashTestGroup "Xilinx"
+          [ let _opts = def{ hdlTargets=[VHDL, Verilog]
+                           , hdlLoad=[Vivado]
+                           , hdlSim=[Vivado]
+                             -- addShortPLTB now segfaults :-(
+                           , buildTargets=BuildSpecific [ "addBasicTB"
+                                                        , "addEnableTB"
+                                                        -- , "addShortPLTB"
+                                                        , "subBasicTB"
+                                                        , "mulBasicTB"
+                                                        , "divBasicTB"
+                                                        , "fromUBasicTB"
+                                                        , "fromUEnableTB"
+                                                        , "fromSBasicTB"
+                                                        , "fromSEnableTB"
+                                                        ]
+                           }
+            in runTest "Floating" _opts
+          ]
+        ]
       , clashTestGroup "Cores"
         [ clashTestGroup "Xilinx"
           [ runTest "DcFifo0" def{

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -113,6 +113,7 @@ library
     Paths_clash_testsuite
 
   build-depends:
+    extra,
     deepseq,
     concurrent-extra,
     singletons,

--- a/tests/src/Test/Tasty/Common.hs
+++ b/tests/src/Test/Tasty/Common.hs
@@ -1,8 +1,12 @@
 module Test.Tasty.Common where
 
+import           Control.Monad.Extra       (forM_, ifM)
 import           Clash.Driver.Manifest     (readManifest, Manifest(..))
 import           Data.Default              (Default, def)
 import           Data.Maybe                (fromMaybe)
+import           System.Directory
+  (copyFile, createDirectory, doesDirectoryExist, listDirectory)
+import           System.FilePath           ((</>))
 import           System.FilePath.Glob      (glob)
 
 data TestExitCode
@@ -31,3 +35,23 @@ testExitCode NoTestExitCode = False
 specificExitCode :: TestExitCode -> Maybe Int
 specificExitCode (TestSpecificExitCode n) = Just n
 specificExitCode _ = Nothing
+
+buildTargetDir
+  :: IO FilePath
+  -> IO FilePath
+  -> IO ()
+buildTargetDir parentDir targetDir = do
+  hdlDir <- fmap (</> "hdl") parentDir
+  targetDir1 <- targetDir
+  copyDir hdlDir targetDir1
+ where
+  -- Note it doesn't handle symlinks as we don't have any anyway
+  copyDir src dst = do
+    createDirectory dst
+    es <- listDirectory src
+    forM_ es $ \e -> do
+      let srcE = src </> e
+          dstE = dst </> e
+      ifM (doesDirectoryExist srcE)
+        (copyDir srcE dstE)
+        (copyFile srcE dstE)

--- a/tests/src/Test/Tasty/Ghdl.hs
+++ b/tests/src/Test/Tasty/Ghdl.hs
@@ -49,13 +49,16 @@ instance IsOption Ghdl where
 -- produce @topEntity@ and @testBench@ instead.
 --
 data GhdlImportTest = GhdlImportTest
-  { gitSourceDirectory :: IO FilePath
-    -- ^ Directory containing VHDL files produced by Clash
+  { gitParentDirectory :: IO FilePath
+    -- ^ Shared temporary directory
+  , gitSourceDirectory :: IO FilePath
+    -- ^ Directory to work from
   }
 
 instance IsTest GhdlImportTest where
-  run optionSet GhdlImportTest{gitSourceDirectory} progressCallback
+  run optionSet GhdlImportTest{..} progressCallback
     | Ghdl True <- lookupOption optionSet = do
+        buildTargetDir gitParentDirectory gitSourceDirectory
         src <- gitSourceDirectory
         let workDir = src </> "work"
         createDirectory workDir

--- a/tests/src/Test/Tasty/Iverilog.hs
+++ b/tests/src/Test/Tasty/Iverilog.hs
@@ -41,15 +41,18 @@ instance IsOption Iverilog where
 -- @
 --
 data IVerilogMakeTest = IVerilogMakeTest
-  { ivmSourceDirectory :: IO FilePath
-    -- ^ Directory containing VHDL files produced by Clash
+  { ivmParentDirectory :: IO FilePath
+    -- ^ Shared temporary directory
+  , ivmSourceDirectory :: IO FilePath
+    -- ^ Directory to work from
   , ivmTop :: String
     -- ^ Entry point to be compiled
   }
 
 instance IsTest IVerilogMakeTest where
-  run optionSet IVerilogMakeTest{ivmSourceDirectory,ivmTop} progressCallback
+  run optionSet IVerilogMakeTest{..} progressCallback
     | Iverilog True <- lookupOption optionSet = do
+        buildTargetDir ivmParentDirectory ivmSourceDirectory
         src <- ivmSourceDirectory
         libs <- listDirectory src
         verilogFiles <- glob (src </> "*" </> "*.v")

--- a/tests/src/Test/Tasty/Modelsim.hs
+++ b/tests/src/Test/Tasty/Modelsim.hs
@@ -31,13 +31,16 @@ instance IsOption ModelSim where
   optionCLParser = flagCLParser Nothing (ModelSim False)
 
 data ModelsimVlibTest = ModelsimVlibTest
-  { mvtSourceDirectory :: IO FilePath
-    -- ^ Directory containing VHDL files produced by Clash
+  { mvtParentDirectory :: IO FilePath
+    -- ^ Shared temporary directory
+  , mvtSourceDirectory :: IO FilePath
+    -- ^ Directory to work from
   }
 
 instance IsTest ModelsimVlibTest where
-  run optionSet ModelsimVlibTest{mvtSourceDirectory} progressCallback
+  run optionSet ModelsimVlibTest{..} progressCallback
     | ModelSim True <- lookupOption optionSet = do
+        buildTargetDir mvtParentDirectory mvtSourceDirectory
         src <- mvtSourceDirectory
         runVlib src ["work"]
 

--- a/tests/src/Test/Tasty/SymbiYosys.hs
+++ b/tests/src/Test/Tasty/SymbiYosys.hs
@@ -31,8 +31,10 @@ instance IsOption Symbiyosys where
 data SbyVerificationTest = SbyVerificationTest
   { svtExpectFail :: Maybe (TestExitCode, T.Text)
     -- ^ Expected failure code and output (if any)
+  , svtParentDirectory :: IO FilePath
+    -- ^ Shared temporary directory
   , svtSourceDirectory :: IO FilePath
-    -- ^ Directory containing files produced by Clash
+    -- ^ Directory to work from
   , svtTop :: String
     -- ^ Entry point to be verified
   }
@@ -40,6 +42,7 @@ data SbyVerificationTest = SbyVerificationTest
 instance IsTest SbyVerificationTest where
   run optionSet SbyVerificationTest {..} progressCallback
     | Symbiyosys True <- lookupOption optionSet = do
+        buildTargetDir svtParentDirectory svtSourceDirectory
         src <- svtSourceDirectory
         [(manifestFile, Manifest {..})] <- getManifests (src </> "*" </> manifestFilename)
 

--- a/tests/src/Test/Tasty/Verilator.hs
+++ b/tests/src/Test/Tasty/Verilator.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Tasty.Verilator where
@@ -29,28 +30,30 @@ instance IsOption Verilator where
   optionCLParser = flagCLParser Nothing (Verilator False)
 
 data VerilatorMakeTest = VerilatorMakeTest
-  { vmDirectory :: IO FilePath
+  { vmParentDirectory :: IO FilePath
+  , vmDirectory :: IO FilePath
   , vmTop :: String
   }
 
 instance IsTest VerilatorMakeTest where
-  run optionSet (VerilatorMakeTest getDir top) progressCallback
+  run optionSet VerilatorMakeTest{..} progressCallback
     | Verilator True <- lookupOption optionSet = do
-        dir <- getDir
+        buildTargetDir vmParentDirectory vmDirectory
+        dir <- vmDirectory
         libs <- listDirectory dir >>= filterM doesDirectoryExist . fmap (dir </>)
 
         -- Only pass the sources for the shim and the entity to simulate. The other
         -- modules will be found in the included directories. The path to the C++
         -- shim MUST include the subdirectories below the working directory
         -- explicitly.
-        cSrc <- glob (dir </> "*" </> top <> "_shim.cpp")
-        vSrc <- fmap takeFileName <$> glob (dir </> "*" </> top <> ".v")
+        cSrc <- glob (dir </> "*" </> vmTop <> "_shim.cpp")
+        vSrc <- fmap takeFileName <$> glob (dir </> "*" </> vmTop <> ".v")
 
         -- Types modules have to be given first, or verilator will complain that
         -- they are not already declared when it sees them being imported.
         svSrc <- mappend
           <$> (fmap takeFileName <$> glob (dir </> "*" </> "*_types.sv"))
-          <*> (fmap takeFileName <$> glob (dir </> "*" </> top <> ".sv"))
+          <*> (fmap takeFileName <$> glob (dir </> "*" </> vmTop <> ".sv"))
 
         -- Clash by default will not mix HDLs in it's output. If this ever changes,
         -- and it is possible to have `clash` output both Verilog and SystemVerilog
@@ -69,7 +72,7 @@ instance IsTest VerilatorMakeTest where
            , "+1364-2001ext+v"    -- Default to Verilog 2001
            , "+1800-2005ext+sv"   -- Default to SystemVerilog 2005
            , "--top"              -- This is used to set the C++ class names
-           , top
+           , vmTop
            , "--cc"               -- Build for C++, not SystemC
            , "--build"            -- Build the verilated code immediately
            , "--exe"              -- Create an executable instead of a library


### PR DESCRIPTION
For each combination of individual targets in `BuildTargets` and individual tools in `Sim`, we create a new subdirectory and run the tool for that target in that directory. Clash generates HDL only once: the output is copied into every subdirectory.

This achieves several goals:
- Build targets run concurrently, achieving greater parallelism
- All tools now support multiple build targets
- Clean separation between tools

Before this PR, all tools ran from the same shared temporary directory, where they were exposed to each other's files. This did not cause any problems in practice, though.

It does mean that ModelSim's build stage and GHDL's import stage are no longer shared between multiple build targets, performing the work multiple times instead.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
