### PR TITLE
Consistently apply 'relativeTime' logic in DcFifo

### DIFF
--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -132,6 +132,7 @@ test-suite unittests
   build-depends:
     clash-cores,
     clash-lib,
+    deepseq,
     tasty        >= 1.2 && < 1.5,
     tasty-hunit,
     tasty-quickcheck,

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
@@ -198,8 +198,8 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
     , Signal read (DataCount depth)
     , Signal read a
     )
-  go st@(FifoState _ rt) rdClk wrClk@(tWr :- _) =
-    if rt < fromIntegral tWr
+  go st@(FifoState _ rt) rdClk wrClk =
+    if rt <= 0
       then goRead st rdClk wrClk
       else goWrite st rdClk wrClk
 


### PR DESCRIPTION
This copies the 'relativeTime' logic from 'veryUnsafeSynchronizer'. Without a consistent way of dealing with this, a feedback loop can cause a '<\<loop\>>' output in Haskell simulations.

## Still TODO:

  - [x] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

