### PR TITLE
Fix ordering issues in Manifest files (#2325, #2334)

### DIFF
--- a/changelog/2022-10-30T16_44_13+01_00_fix_2334
+++ b/changelog/2022-10-30T16_44_13+01_00_fix_2334
@@ -1,0 +1,1 @@
+FIXED: Files in `clash-manifest.json` are now (correctly) listed in reverse topological order [#2334](https://github.com/clash-lang/clash-compiler/issues/2334)

--- a/changelog/2022-10-30T17_20_09+01_00_fix_2325
+++ b/changelog/2022-10-30T17_20_09+01_00_fix_2325
@@ -1,0 +1,1 @@
+Fixed: Dependencies in `clash-manifest.json` are now listed in reverse topological ordering [#2325](https://github.com/clash-lang/clash-compiler/issues/2325)

--- a/clash-lib/data-files/tcl/clashConnector.tcl
+++ b/clash-lib/data-files/tcl/clashConnector.tcl
@@ -38,7 +38,7 @@ namespace eval clash {
         variable topEntity
 
         CheckMetadataExists
-        set libs [lreverse [dict get $metadata $topEntity dependencies]]
+        set libs [dict get $metadata $topEntity dependencies]
         lappend libs $topEntity
         foreach lib $libs {
             foreach hdlFile [dict get $metadata $lib hdlFiles] {

--- a/clash-lib/src/Clash/DataFiles.hs
+++ b/clash-lib/src/Clash/DataFiles.hs
@@ -57,15 +57,6 @@ import Paths_clash_lib (getDataFileName)
   file by invoking
 
   > cabal run clash-lib:static-files -- --tcl-connector clashConnector.tcl
-
-  The Tcl Connector is currently affected by
-  bugs [#2325](https://github.com/clash-lang/clash-compiler/issues/2325)
-  and [#2334](https://github.com/clash-lang/clash-compiler/issues/2334). The
-  result is that HDL files might be read in the wrong order. This doesn't seem
-  to affect the example script above, but simulation /is/ affected. Until these
-  bugs are fixed, an invocation of @update_compile_order@ after @clash::readHdl@
-  might be needed even in Non-project Mode, even though @update_compile_order@
-  is a Project Mode command.
 -}
 tclConnector :: IO FilePath
 tclConnector = getDataFileName $ "data-files" </> "tcl" </> "clashConnector.tcl"

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -164,10 +164,8 @@ data Manifest
     -- ^ Dependencies of this design (fully qualified binder names). Is a
     -- transitive closure of all dependencies.
     --
-    -- This list is topologically sorted. I.e., a dependency might depend
-    -- on any dependency listed after it, but not before it.
-    --
-    -- TODO: this ordered differs from `fileNames` and `componentNames`. Fix?
+    -- This list is reverse topologically sorted. I.e., a component might depend
+    -- on any component listed before it, but not after it.
   } deriving (Show,Read,Eq)
 
 instance ToJSON Manifest where

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -639,6 +639,8 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2220_toEnumOOB" def{hdlTargets=[VHDL]}
         , runTest "T2272" def{hdlTargets=[VHDL], hdlSim=[]}
         , outputTest "T2334" def{hdlTargets=[VHDL]}
+        , outputTest "T2325" def{hdlTargets=[VHDL]}
+        , outputTest "T2325f" def{hdlTargets=[VHDL]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -367,7 +367,7 @@ runClashTest = defaultMain $ clashTestRoot
           --
           -- tracked: https://github.com/clash-lang/clash-compiler/issues/2266
           let _opts = def { hdlTargets=[VHDL]
-                          , hdlSim=hdlSim def \\ [Vivado]
+                          , hdlSim=hdlSim def
                           }
           in runTest "Parameters" _opts
         , runTest "PopCount" def

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -638,6 +638,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2154" def{hdlTargets=[VHDL], hdlSim=[]}
         , runTest "T2220_toEnumOOB" def{hdlTargets=[VHDL]}
         , runTest "T2272" def{hdlTargets=[VHDL], hdlSim=[]}
+        , outputTest "T2334" def{hdlTargets=[VHDL]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2325.hs
+++ b/tests/shouldwork/Issues/T2325.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module T2325 where
+
+import qualified Prelude as P
+import Clash.Explicit.Prelude
+
+import Clash.Driver
+import Clash.Driver.Manifest
+import GHC.Stack
+import System.Environment
+import System.FilePath
+
+import qualified Control.Exception as Exception
+import qualified Data.List as L
+
+type T = Unsigned 8 -> Unsigned 8
+
+f :: T
+f = g . h
+{-# NOINLINE f #-}
+{-# ANN f (defSyn "f") #-}
+
+g :: T
+g = h . j
+{-# NOINLINE g #-}
+{-# ANN g (defSyn "g") #-}
+
+h :: T
+h = (+ 5)
+{-# NOINLINE h #-}
+{-# ANN h (defSyn "h") #-}
+
+j :: T
+j = (+ 10)
+{-# NOINLINE j #-}
+{-# ANN j (defSyn "j") #-}
+
+assertBool :: HasCallStack => Bool -> IO ()
+assertBool b = Exception.assert b pure ()
+
+assertJustTrue :: HasCallStack => Maybe Bool -> IO ()
+assertJustTrue = assertBool . (== Just True)
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  Just manifest <- readManifest (topDir </> show 'f </> "clash-manifest.json")
+  let
+    deps = transitiveDependencies manifest
+    a `before` b = do
+      aIx <- L.elemIndex a deps
+      bIx <- L.elemIndex b deps
+      Just (aIx < bIx)
+
+  assertJustTrue $ "T2325.j" `before` "T2325.g"
+  assertJustTrue $ "T2325.h" `before` "T2325.g"

--- a/tests/shouldwork/Issues/T2325f.hs
+++ b/tests/shouldwork/Issues/T2325f.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module T2325f where
+
+import qualified Prelude as P
+import Clash.Explicit.Prelude
+
+import Clash.Driver
+import Clash.Driver.Manifest
+import GHC.Stack
+import System.Environment
+import System.FilePath
+import T2325g
+import T2325h
+
+import qualified Control.Exception as Exception
+import qualified Data.List as L
+
+f :: Unsigned 8 -> Unsigned 8
+f = g . h
+{-# NOINLINE f #-}
+{-# ANN f (defSyn "f") #-}
+
+assertBool :: HasCallStack => Bool -> IO ()
+assertBool b = Exception.assert b pure ()
+
+assertJustTrue :: HasCallStack => Maybe Bool -> IO ()
+assertJustTrue = assertBool . (== Just True)
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  Just manifest <- readManifest (topDir </> show 'f </> "clash-manifest.json")
+  let
+    deps = transitiveDependencies manifest
+    a `before` b = do
+      aIx <- L.elemIndex a deps
+      bIx <- L.elemIndex b deps
+      Just (aIx < bIx)
+
+  assertJustTrue $ "T2325j.j" `before` "T2325g.g"
+  assertJustTrue $ "T2325h.h" `before` "T2325g.g"

--- a/tests/shouldwork/Issues/T2325g.hs
+++ b/tests/shouldwork/Issues/T2325g.hs
@@ -1,0 +1,11 @@
+module T2325g where
+
+import Clash.Prelude
+
+import T2325h
+import T2325j
+
+g :: Unsigned 8 -> Unsigned 8
+g = h . j
+{-# NOINLINE g #-}
+{-# ANN g (defSyn "g") #-}

--- a/tests/shouldwork/Issues/T2325h.hs
+++ b/tests/shouldwork/Issues/T2325h.hs
@@ -1,0 +1,8 @@
+module T2325h where
+
+import Clash.Prelude
+
+h :: Unsigned 8 -> Unsigned 8
+h = (+ 5)
+{-# NOINLINE h #-}
+{-# ANN h (defSyn "h") #-}

--- a/tests/shouldwork/Issues/T2325j.hs
+++ b/tests/shouldwork/Issues/T2325j.hs
@@ -1,0 +1,9 @@
+
+module T2325j where
+
+import Clash.Prelude
+
+j :: Unsigned 8 -> Unsigned 8
+j = (+ 10)
+{-# NOINLINE j #-}
+{-# ANN j (defSyn "j") #-}

--- a/tests/shouldwork/Issues/T2334.hs
+++ b/tests/shouldwork/Issues/T2334.hs
@@ -1,0 +1,36 @@
+module T2334 where
+
+import qualified Prelude as P
+import Clash.Explicit.Prelude
+
+import Clash.Driver
+import Clash.Driver.Manifest
+import GHC.Stack
+import System.Environment
+import System.FilePath
+
+import qualified Control.Exception as Exception
+
+topEntity ::
+  Clock System ->
+  Reset System ->
+  Signal System Int ->
+  Signal System Int ->
+  Signal System Int ->
+  Signal System Int
+topEntity clk rst = assert clk rst "FileOrder"
+{-# NOINLINE topEntity #-}
+
+assertBool :: HasCallStack => Bool -> IO ()
+assertBool b = Exception.assert b pure ()
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  Just manifest <- readManifest (topDir </> show 'topEntity </> "clash-manifest.json")
+  let ([sdc, slv2string, types, top], _hashes) = P.unzip (fileNames manifest)
+
+  assertBool (sdc == "topEntity.sdc")
+  assertBool (P.take 20 slv2string == "topEntity_slv2string")
+  assertBool (types == "T2334_topEntity_types.vhdl")
+  assertBool (top == "topEntity.vhdl")

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -300,6 +300,7 @@ instance IsTest ClashBinaryTest where
       [ "-package", "clash-testsuite"
       , "-main-is", cbModName <> ".main" <> show cbBuildTarget
       , "-o", oDir </> "out"
+      , "-i" <> cbSourceDirectory
       , "-outputdir", oDir
       ] <> cbExtraBuildArgs <>
       [ cbSourceDirectory </> cbModName <.> "hs"

--- a/tests/src/Test/Tasty/Vivado.hs
+++ b/tests/src/Test/Tasty/Vivado.hs
@@ -86,8 +86,6 @@ genSimTcl dir top = do
     clash::readMetadata {#{topEntityDir}}
     clash::createAndReadIp -dir ip
     clash::readHdl
-    \# Compiler doesn't topologically sort source files (bug)
-    update_compile_order -fileset [current_fileset]
     set_property TOP $clash::topEntity [current_fileset -sim]
     save_project_as sim project -force
     set_property RUNTIME all [current_fileset -sim]


### PR DESCRIPTION
Fixes #2325

Fixes #2334

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] Write tests
  - [x] Update Vivado TCL - it doesn't need to call `update_compile_order` anymore.