### PR TITLE
Refactor `relativeTime` logic to prevent divergent implementations

### DIFF
--- a/changelog/2022-11-07T14_10_14+01_00_sdomainconfiguration_record
+++ b/changelog/2022-11-07T14_10_14+01_00_sdomainconfiguration_record
@@ -1,0 +1,1 @@
+CHANGED: `SDomainConfiguration` is now a record, easing field access.

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
@@ -45,8 +45,9 @@ acknowledge, valid, or programmable full\/empty flags)
 Vivado 2022.1.)
 -}
 
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Clash.Cores.Xilinx.DcFifo
@@ -262,13 +263,16 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
   wrClkSignal = case wClk of
     Clock _ (Just wrPeriods) -> wrPeriods
     Clock _ Nothing ->
-      let SDomainConfiguration _ (snatToNum -> period) _ _ _ _ = knownDomain @write in
-        pure period
+      case knownDomain @write of
+        SDomainConfiguration{sPeriod} ->
+          pure (snatToNum sPeriod)
+
   rdClkSignal = case rClk of
     Clock _ (Just rdPeriods) -> rdPeriods
     Clock _ Nothing ->
-      let SDomainConfiguration _ (snatToNum -> period) _ _ _ _ = knownDomain @read in
-        pure period
+      case knownDomain @read of
+        SDomainConfiguration{sPeriod} ->
+          pure (snatToNum sPeriod)
 {-# NOINLINE dcFifo #-}
 {-# ANN dcFifo (
    let primName = 'dcFifo

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
@@ -70,12 +70,12 @@ module Clash.Cores.Xilinx.DcFifo
   ) where
 
 import Clash.Explicit.Prelude
-import Clash.Signal.Internal (Clock (..), Signal (..))
+import Clash.Signal.Internal (Signal (..), ClockAB (..), clockTicks)
 import Data.Maybe (isJust)
 import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
 import Data.String.Interpolate (__i)
 import GHC.Stack (HasCallStack)
-import Numeric.Natural (Natural)
 
 import Clash.Annotations.Primitive (Primitive (InlineYamlPrimitive))
 
@@ -160,7 +160,7 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
     (SSynchronous, SSynchronous) ->
       let
         (wFull, wOver, wCnt, rEmpty, rUnder, rCnt, rData) =
-          go initState rdClkSignal wrClkSignal rstSignalR rEnable rstSignalW writeData
+          go (clockTicks wClk rClk) mempty rstSignalR rEnable rstSignalW writeData
       in FifoOut
           wFull
           (if dcOverflow
@@ -183,9 +183,8 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
   maxDepth = natToNum @(2 ^ depth - 1) @Int
 
   go ::
-    FifoState a ->
-    Signal read Natural -> -- clock
-    Signal write Natural -> -- clock
+    [ClockAB] ->
+    Seq a ->
     Signal read Bool -> -- reset
     Signal read Bool -> -- read enabled
     Signal write Bool -> -- reset
@@ -199,23 +198,23 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
     , Signal read (DataCount depth)
     , Signal read a
     )
-  go st@(FifoState _ rt) rdClk wrClk =
-    if rt <= 0
-      then goRead st rdClk wrClk
-      else goWrite st rdClk wrClk
+  go (ClockA:ticks)  = goWrite ticks
+  go (ClockB:ticks)  = goRead ticks
+  go (ClockAB:ticks) = go (ClockB:ClockA:ticks)
+  go [] = error "dcFifo.go: `ticks` should have been an infinite list"
 
-  goWrite (FifoState _ rt) rdClk (tWr :- wrClk) rstR rEna (True :- rstWNext) (_ :- wData) =
+  goWrite ticks _q rstR rEna (True :- rstWNext) (_ :- wData) =
       -- The register will discard the @wOver@ sample
       (False :- preFull, undefined :- preOver, 0 :- preWCnt, fifoEmpty, under, rCnt, rData)
     where
       (preFull, preOver, preWCnt, fifoEmpty, under, rCnt, rData) =
-        go (FifoState mempty (rt-fromIntegral tWr)) rdClk wrClk rstR rEna rstWNext wData
+        go ticks mempty rstR rEna rstWNext wData
 
-  goWrite (FifoState q rt) rdClk (tWr :- wrClk) rstR rEna (_ :- rstW) (wDat :- wDats1) =
+  goWrite ticks q rstR rEna (_ :- rstW) (wDat :- wDats1) =
     (full, over, wCnt, fifoEmpty, under, rCnt, rData)
     where
       (preFull, preOver, preWCnt, fifoEmpty, under, rCnt, rData) =
-        go (FifoState q' (rt-fromIntegral tWr)) rdClk wrClk rstR rEna rstW wDats1
+        go ticks q' rstR rEna rstW wDats1
 
       wCnt = sDepth q :- preWCnt
       full = (Seq.length q == maxDepth) :- preFull
@@ -226,7 +225,7 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
 
   sDepth = fromIntegral . Seq.length
 
-  goRead (FifoState _ rt) (tR :- rdClk) wrClk (True :- rstRNext) (_ :- rEnas1) rstW wData =
+  goRead ticks _q (True :- rstRNext) (_ :- rEnas1) rstW wData =
     (full, over, wCnt, fifoEmpty, under, rCnt, rData)
     where
       -- The register will discard the sample
@@ -237,9 +236,9 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
       under = undefined :- preUnder
 
       (full, over, wCnt, preEmpty, preUnder, preRCnt, preRData) =
-        go (FifoState mempty (rt+fromIntegral tR)) rdClk wrClk rstRNext rEnas1 rstW wData
+        go ticks mempty rstRNext rEnas1 rstW wData
 
-  goRead (FifoState q rt) (tR :- rdClk) wrClk (_ :- rstRNext) (rEna :- rEnas1) rstW wData =
+  goRead ticks q (_ :- rstRNext) (rEna :- rEnas1) rstW wData =
     (full, over, wCnt, fifoEmpty, under, rCnt, rData)
     where
       rCnt = sDepth q :- preRCnt
@@ -247,7 +246,7 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
       rData = nextData :- preRData
 
       (full, over, wCnt, preEmpty, preUnder, preRCnt, preRData) =
-        go (FifoState q' (rt+fromIntegral tR)) rdClk wrClk rstRNext rEnas1 rstW wData
+        go ticks q' rstRNext rEnas1 rstW wData
 
       (q', nextData, under) =
         if rEna
@@ -256,23 +255,6 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
               Seq.EmptyR -> (q, deepErrorX "FIFO empty", True :- preUnder)
               qData Seq.:> qDatum -> (qData, qDatum, False :- preUnder)
           else (q, deepErrorX "Enable off", False :- preUnder)
-
-  initState :: FifoState a
-  initState = FifoState Seq.empty 0
-
-  wrClkSignal = case wClk of
-    Clock _ (Just wrPeriods) -> wrPeriods
-    Clock _ Nothing ->
-      case knownDomain @write of
-        SDomainConfiguration{sPeriod} ->
-          pure (snatToNum sPeriod)
-
-  rdClkSignal = case rClk of
-    Clock _ (Just rdPeriods) -> rdPeriods
-    Clock _ Nothing ->
-      case knownDomain @read of
-        SDomainConfiguration{sPeriod} ->
-          pure (snatToNum sPeriod)
 {-# NOINLINE dcFifo #-}
 {-# ANN dcFifo (
    let primName = 'dcFifo

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/Types.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/Types.hs
@@ -8,8 +8,6 @@ module Clash.Cores.Xilinx.DcFifo.Internal.Types where
 
 import Clash.Prelude
 
-import qualified Data.Sequence as Seq
-
 type Full = Bool
 type Empty = Bool
 type DataCount n = Unsigned n
@@ -45,13 +43,6 @@ data DcConfig depth = DcConfig
   , dcUnderflow :: !Bool
   }
   deriving (Show, Generic)
-
-data FifoState a = FifoState
-  { hsQueue      :: Seq.Seq a
-  , relativeTime :: Int -- ^ In order to model a FIFO in two clock domains,
-                        -- we track the offset between edges in order to know
-                        -- which signals to peel off.
-  } deriving Show
 
 -- | Output of 'Clash.Cores.Xilinx.DcFifo.dcFifo'
 data FifoOut read write depth a =

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -366,22 +366,21 @@ type DomainResetPolarity (dom :: Domain) =
 
 -- | Singleton version of 'DomainConfiguration'
 data SDomainConfiguration (dom :: Domain) (conf :: DomainConfiguration) where
-  SDomainConfiguration
-    :: SSymbol dom
-    -- Domain name ^
-    -> SNat period
-    -- Period of clock in /ps/ ^
-    -> SActiveEdge edge
-    -- Active edge of the clock (not yet
-    -- implemented) ^
-    -> SResetKind reset
-    -- Whether resets are synchronous (edge-sensitive) or asynchronous (level-sensitive) ^
-    -> SInitBehavior init
-    -- Whether the initial (or "power up") value of memory elements is
-    -- unknown/undefined, or configurable to a specific value ^
-    -> SResetPolarity polarity
-    -- Whether resets are active high or active low ^
-    -> SDomainConfiguration dom ('DomainConfiguration dom period edge reset init polarity)
+  SDomainConfiguration ::
+    { sName :: SSymbol dom
+      -- ^ Domain name
+    , sPeriod :: SNat period
+    -- ^ Period of clock in /ps/
+    , sActiveEdge :: SActiveEdge edge
+    -- ^ Active edge of the clock (not yet implemented)
+    , sResetKind :: SResetKind reset
+    -- ^ Whether resets are synchronous (edge-sensitive) or asynchronous (level-sensitive)
+    , sInitBehavior :: SInitBehavior init
+    -- ^ Whether the initial (or "power up") value of memory elements is
+    -- unknown/undefined, or configurable to a specific value
+    , sResetPolarity :: SResetPolarity polarity
+    -- ^ Whether resets are active high or active low
+    } -> SDomainConfiguration dom ('DomainConfiguration dom period edge reset init polarity)
 
 deriving instance Show (SDomainConfiguration dom conf)
 
@@ -396,13 +395,13 @@ class KnownSymbol dom => KnownDomain (dom :: Domain) where
   -- Example usage:
   --
   -- >>> knownDomain @System
-  -- SDomainConfiguration (SSymbol @"System") (SNat @10000) SRising SAsynchronous SDefined SActiveHigh
+  -- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
   knownDomain :: SDomainConfiguration dom (KnownConf dom)
 
 -- | Version of 'knownDomain' that takes a 'SSymbol'. For example:
 --
 -- >>> knownDomainByName (SSymbol @"System")
--- SDomainConfiguration (SSymbol @"System") (SNat @10000) SRising SAsynchronous SDefined SActiveHigh
+-- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
 knownDomainByName
   :: forall dom
    . KnownDomain dom

--- a/clash-prelude/src/Clash/Signal/Internal/Ambiguous.hs
+++ b/clash-prelude/src/Clash/Signal/Internal/Ambiguous.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -21,8 +22,8 @@ clockPeriod
   => SNat period
 clockPeriod =
   case knownDomain @dom of
-    SDomainConfiguration _dom period _edge _sync _init _polarity ->
-      period
+    SDomainConfiguration{sPeriod} ->
+      sPeriod
 {-# NOINLINE clockPeriod #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
@@ -41,8 +42,8 @@ activeEdge
   => SActiveEdge edge
 activeEdge =
   case knownDomain @dom of
-    SDomainConfiguration _dom _period edge _sync _init _polarity ->
-      edge
+    SDomainConfiguration{sActiveEdge} ->
+      sActiveEdge
 {-# NOINLINE activeEdge #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
@@ -61,8 +62,8 @@ resetKind
   => SResetKind sync
 resetKind =
   case knownDomain @dom of
-    SDomainConfiguration _dom _period _edge sync _init _polarity ->
-      sync
+    SDomainConfiguration{sResetKind} ->
+      sResetKind
 {-# NOINLINE resetKind #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
@@ -81,8 +82,8 @@ initBehavior
   => SInitBehavior init
 initBehavior =
   case knownDomain @dom of
-    SDomainConfiguration _dom _period _edge _sync init_ _polarity ->
-      init_
+    SDomainConfiguration{sInitBehavior} ->
+      sInitBehavior
 {-# NOINLINE initBehavior #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
@@ -101,8 +102,8 @@ resetPolarity
   => SResetPolarity polarity
 resetPolarity =
   case knownDomain @dom of
-    SDomainConfiguration _dom _period _edge _sync _init polarity ->
-      polarity
+    SDomainConfiguration{sResetPolarity} ->
+      sResetPolarity
 {-# NOINLINE resetPolarity #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -47,6 +47,7 @@ main = do
 -}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -230,9 +231,9 @@ traceSignal
   -> Signal dom a
 traceSignal traceName signal =
   case knownDomain @dom of
-    SDomainConfiguration _dom period _edge _reset _init _polarity ->
+    SDomainConfiguration{sPeriod} ->
       unsafePerformIO $
-        traceSignal# traceMap# (snatToNum period) traceName signal
+        traceSignal# traceMap# (snatToNum sPeriod) traceName signal
 {-# NOINLINE traceSignal #-}
 {-# ANN traceSignal hasBlackBox #-}
 
@@ -278,9 +279,9 @@ traceVecSignal
   -> Signal dom (Vec (n+1) a)
 traceVecSignal traceName signal =
   case knownDomain @dom of
-    SDomainConfiguration _dom period _edge _reset _init _polarity ->
+    SDomainConfiguration{sPeriod} ->
       unsafePerformIO $
-        traceVecSignal# traceMap# (snatToNum period) traceName signal
+        traceVecSignal# traceMap# (snatToNum sPeriod) traceName signal
 {-# NOINLINE traceVecSignal #-}
 {-# ANN traceVecSignal hasBlackBox #-}
 


### PR DESCRIPTION
There's also some other small cleanups piggybacked to this PR. We can split those off to a different PR if it becomes too noisy (though they're isolated in their own commits).

----------

This PR is ready now, though `trueDualPortBlockRam` will need additional care (in future PRs):

1. The prepended `ClockB` is most probably wrong (though it preserves current behavior, so as far as this PR is concerned it's okay). Will make an issue after merging this PR.
2. https://github.com/clash-lang/clash-compiler/issues/2351
3. https://github.com/clash-lang/clash-compiler/issues/2350
4. https://github.com/clash-lang/clash-compiler/issues/2352

## Still TODO:

  - [x] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Use `tA`/`domA` consistently
  - [x] Check copyright notices are up to date in edited files
  - [x] Use `clockTicks` in `asyncRam`
  - [x] Use `clockTicks` in `trueDualPortBlockRam`

