### PR TITLE
Add blackboxes for `integerToFloat#`, `integerToDouble#`

### DIFF
--- a/changelog/2022-11-09T22_23_35+01_00_add_integerTo_blackboxes.md
+++ b/changelog/2022-11-09T22_23_35+01_00_add_integerTo_blackboxes.md
@@ -1,0 +1,1 @@
+ADDED: Clash now includes backboxes for `integerToFloat#`, `integerToDouble#` [#2342](https://github.com/clash-lang/clash-compiler/issues/2342)

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -47,7 +47,8 @@ import           GHC.Integer
   (decodeDoubleInteger,encodeDoubleInteger,compareInteger,orInteger,andInteger,
    xorInteger,complementInteger,absInteger,signumInteger)
 #if MIN_VERSION_base(4,15,0)
-import           GHC.Num.Integer (Integer (..), integerEncodeFloat#)
+import           GHC.Num.Integer
+  (Integer (..), integerEncodeFloat#, integerToFloat#, integerToDouble#)
 #else
 import           GHC.Integer.GMP.Internals
   (Integer (..), BigNat (..))
@@ -1021,6 +1022,16 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
     | Just (a,b) <- integerLiterals args
     , Just c <- flogBase a b
     -> (reduce . Literal . WordLiteral . toInteger) c
+
+  "GHC.Num.Integer.integerToFloat#"
+    | [v] <- args
+    , Just i <- integerLiteral v
+    -> reduce . Literal . FloatLiteral . floatToWord $ F# (integerToFloat# i)
+
+  "GHC.Num.Integer.integerToDouble#"
+    | [v] <- args
+    , Just i <- integerLiteral v
+    -> reduce . Literal . DoubleLiteral . doubleToWord $ D# (integerToDouble# i)
 
   "GHC.Num.Natural.naturalLogBase#"
     | Just (a,b) <- naturalLiterals args

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -633,6 +633,8 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest "T2334" def{hdlTargets=[VHDL]}
         , outputTest "T2325" def{hdlTargets=[VHDL]}
         , outputTest "T2325f" def{hdlTargets=[VHDL]}
+        , runTest "T2342A" def{hdlSim=[]}
+        , runTest "T2342B" def{hdlSim=[]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2342A.hs
+++ b/tests/shouldwork/Issues/T2342A.hs
@@ -1,0 +1,11 @@
+module T2342A where
+
+import Clash.Prelude
+import Data.Proxy
+
+foo :: forall n. KnownNat n => Proxy n -> Float
+foo Proxy = natToNum @n
+{-# NOINLINE foo #-}
+
+topEntity :: Float
+topEntity = foo @10 Proxy

--- a/tests/shouldwork/Issues/T2342B.hs
+++ b/tests/shouldwork/Issues/T2342B.hs
@@ -1,0 +1,11 @@
+module T2342B where
+
+import Clash.Prelude
+import Data.Proxy
+
+foo :: forall n. KnownNat n => Proxy n -> Double
+foo Proxy = natToNum @n
+{-# NOINLINE foo #-}
+
+topEntity :: Double
+topEntity = foo @10 Proxy


### PR DESCRIPTION
Closes #2342

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
