### PR TITLE
Add Xilinx specific 'dualFlipFlopSynchronizer'

### DIFF
--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -94,6 +94,7 @@ library
     Clash.Cores.Xilinx.Floating.BlackBoxes
     Clash.Cores.Xilinx.Floating.Explicit
     Clash.Cores.Xilinx.Floating.Internal
+    Clash.Cores.Xilinx.Synchronizer
     Clash.Cores.SPI
     Clash.Cores.UART
     Clash.Cores.LatticeSemi.ICE40.IO

--- a/clash-cores/src/Clash/Cores/Xilinx/Synchronizer.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Synchronizer.hs
@@ -1,3 +1,11 @@
+{-|
+  Copyright   :  (C) 2022 Google Inc
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Xilinx specific synchronization primitives.
+-}
+
 {-# LANGUAGE QuasiQuotes #-}
 
 module Clash.Cores.Xilinx.Synchronizer where
@@ -5,7 +13,7 @@ module Clash.Cores.Xilinx.Synchronizer where
 import Clash.Annotations.Primitive
 import Clash.Explicit.Prelude
 
-import Data.String.Interpolate      (__i)
+import Data.String.Interpolate (__i)
 
 -- | See https://docs.xilinx.com/r/en-US/ug901-vivado-synthesis/ASYNC_REG
 dualFlipFlopSynchronizer ::
@@ -24,17 +32,43 @@ dualFlipFlopSynchronizer clk1 clk2 =
   . unsafeSynchronizer clk1 clk2
 {-# NOINLINE dualFlipFlopSynchronizer #-}
 {-# ANN dualFlipFlopSynchronizer hasBlackBox #-}
-{-# ANN dualFlipFlopSynchronizer (InlineYamlPrimitive [Verilog, SystemVerilog] $ [__i|
+{-# ANN dualFlipFlopSynchronizer (InlineYamlPrimitive [Verilog, SystemVerilog] [__i|
  BlackBox:
    kind: Declaration
    name: Clash.Cores.Xilinx.Synchronizer.dualFlipFlopSynchronizer
    template: |-
      // begin dualFlipFlopSynchronizer
      (* ASYNC_REG = "TRUE" *) reg ~GENSYM[sync_a][0], ~GENSYM[sync_b][1];
-     always @(posedge ~VAR[clk][5]) begin
+     always @(~IF~ACTIVEEDGE[Rising][1]~THENposedge~ELSEnegedge~FI ~ARG[5]) begin
        ~SYM[1] <= ~SYM[0];
        ~SYM[0] <= ~VAR[in][6];
      end
      assign ~RESULT = ~SYM[1];
      // end dualFlipFlopSynchronizer
+|]) #-}
+{-# ANN dualFlipFlopSynchronizer (InlineYamlPrimitive [VHDL] [__i|
+ BlackBox:
+   kind: Declaration
+   name: Clash.Cores.Xilinx.Synchronizer.dualFlipFlopSynchronizer
+   template: |-
+     -- begin dualFlipFlopSynchronizer
+     ~GENSYM[dualFlipFlopSynchronizer][2] : block
+       signal ~GENSYM[sync_a][0] : std_logic;
+       signal ~GENSYM[sync_b][1] : std_logic;
+
+       attribute ASYNC_REG : string;
+       attribute ASYNC_REG of ~SYM[0] : signal is "TRUE";
+       attribute ASYNC_REG of ~SYM[1] : signal is "TRUE";
+     begin
+       process(~ARG[5])
+       begin
+         if ~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+           ~SYM[1] <= ~SYM[0];
+           ~SYM[0] <= ~VAR[in][6];
+         end if;
+       end process;
+
+       ~RESULT <= ~SYM[1];
+     end block;
+     -- end dualFlipFlopSynchronizer
 |]) #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/Synchronizer.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Synchronizer.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Clash.Cores.Xilinx.Synchronizer where
+
+import Clash.Annotations.Primitive
+import Clash.Explicit.Prelude
+
+import Data.String.Interpolate      (__i)
+
+-- | See https://docs.xilinx.com/r/en-US/ug901-vivado-synthesis/ASYNC_REG
+dualFlipFlopSynchronizer ::
+  forall dom1 dom2 a.
+  ( KnownDomain dom1
+  , KnownDomain dom2
+  , NFDataX a
+  , BitSize a ~ 1 ) =>
+  Clock dom1 ->
+  Clock dom2 ->
+  Signal dom1 a ->
+  Signal dom2 a
+dualFlipFlopSynchronizer clk1 clk2 =
+    dflipflop clk2
+  . dflipflop clk2
+  . unsafeSynchronizer clk1 clk2
+{-# NOINLINE dualFlipFlopSynchronizer #-}
+{-# ANN dualFlipFlopSynchronizer hasBlackBox #-}
+{-# ANN dualFlipFlopSynchronizer (InlineYamlPrimitive [Verilog, SystemVerilog] $ [__i|
+ BlackBox:
+   kind: Declaration
+   name: Clash.Cores.Xilinx.Synchronizer.dualFlipFlopSynchronizer
+   template: |-
+     // begin dualFlipFlopSynchronizer
+     (* ASYNC_REG = "TRUE" *) reg ~GENSYM[sync_a][0], ~GENSYM[sync_b][1];
+     always @(posedge ~VAR[clk][5]) begin
+       ~SYM[1] <= ~SYM[0];
+       ~SYM[0] <= ~VAR[in][6];
+     end
+     assign ~RESULT = ~SYM[1];
+     // end dualFlipFlopSynchronizer
+|]) #-}

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -465,9 +465,7 @@ runClashTest = defaultMain $ clashTestRoot
                                                         ]
                            }
             in runTest "Floating" _opts
-          , runTest "Synchronizer" def{
-              hdlTargets=[Verilog, SystemVerilog]
-            }
+          , runTest "Synchronizer" def
           ]
         ]
       , clashTestGroup "Cores"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -465,6 +465,9 @@ runClashTest = defaultMain $ clashTestRoot
                                                         ]
                            }
             in runTest "Floating" _opts
+          , runTest "Synchronizer" def{
+              hdlTargets=[Verilog, SystemVerilog]
+            }
           ]
         ]
       , clashTestGroup "Cores"

--- a/tests/shouldwork/Cores/Xilinx/Synchronizer.hs
+++ b/tests/shouldwork/Cores/Xilinx/Synchronizer.hs
@@ -10,6 +10,7 @@ topEntity ::
   Signal XilinxSystem Bit ->
   Signal XilinxSystem Bit
 topEntity = X.dualFlipFlopSynchronizer
+{-# NOINLINE topEntity #-}
 
 testBench :: Signal XilinxSystem Bool
 testBench = done
@@ -20,3 +21,4 @@ testBench = done
   clk       = tbClockGen (not <$> done)
   rst       = resetGen
   ena       = enableGen
+{-# NOINLINE testBench #-}

--- a/tests/shouldwork/Cores/Xilinx/Synchronizer.hs
+++ b/tests/shouldwork/Cores/Xilinx/Synchronizer.hs
@@ -1,0 +1,22 @@
+module Synchronizer where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+import qualified Clash.Cores.Xilinx.Synchronizer as X
+
+topEntity ::
+  Clock XilinxSystem ->
+  Clock XilinxSystem ->
+  Signal XilinxSystem Bit ->
+  Signal XilinxSystem Bit
+topEntity = X.dualFlipFlopSynchronizer
+
+testBench :: Signal XilinxSystem Bool
+testBench = done
+ where
+  testInput = stimuliGenerator clk rst (1 :> 0 :> 1 :> 1 :> Nil)
+  actual    = ignoreFor clk rst ena d2 0 $ topEntity clk clk testInput
+  done      = outputVerifier' clk rst (0 :> 0 :> 1 :> 0 :> 1 :> 1 :> Nil) actual
+  clk       = tbClockGen (not <$> done)
+  rst       = resetGen
+  ena       = enableGen


### PR DESCRIPTION
Uses ASYNC_REG to instruct Vivado to pack register tightly and ignore timing checks.

--------

Even though it's a draft, I wouldn't mind a look @DigitalBrains1 

## Still TODO:

  - [ ] VHDL implementation (is this possible?)
  - [ ] More sensible test
  - [ ] Documentation
  - [x] ~~Write a changelog entry (see changelog/README.md)~~
  - [ ] Check copyright notices are up to date in edited files
