### PR TITLE
fix spi core, extra clock edge in sample trailing mode

### DIFF
--- a/clash-cores/src/Clash/Cores/SPI.hs
+++ b/clash-cores/src/Clash/Cores/SPI.hs
@@ -1,5 +1,6 @@
 {-|
   Copyright   :  (C) 2019, Foamspace corp
+                     2022, Google LLC
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -154,12 +155,10 @@ spiCommon mode ssI msI sckI dinI =
       | otherwise = dataInQ
 
     dataOutD
-      | ss        = unpack din
-      | shiftSck  = if cntOldQ
-                       then unpack din
-                       else if sampleOnTrailing mode && cntQ == 0
-                               then dataOutQ
-                               else tail @(n-1) dataOutQ :< unpack undefined#
+      | ss || (sampleOnTrailing mode && sampleSck && cntQ == maxBound) = unpack din
+      | shiftSck  = if sampleOnTrailing mode && cntQ == 0
+                    then dataOutQ
+                    else tail @(n-1) dataOutQ :< unpack undefined#
       | otherwise = dataOutQ
 
     -- The counter is updated during the capture moment
@@ -314,7 +313,6 @@ spiGen mode SNat SNat =
       _ -> 0
 
     sckD = case stQ of
-      Wait 0 | sampleOnTrailing mode -> not sckQ
       Transfer n | n == maxBound -> not sckQ
       _ -> sckQ
 

--- a/clash-cores/test/Test/Cores/SPI/MultiSlave.hs
+++ b/clash-cores/test/Test/Cores/SPI/MultiSlave.hs
@@ -97,7 +97,7 @@ tests =
  where
   threeSlaveLatch spi =
     testCase (show spi <> ", Divider 8, Slave Latch") $
-      testMasterMultiSlave d4 d1 0b0110011101 0b0110010101 spi True (3 * 84)
+      testMasterMultiSlave d4 d1 0b0110011101 0b0110010101 spi True (3 * 85)
         @?= (([0b0110011101],1),([0b0110011101],1),([0b0110011101],1),([0b0110010101],3))
 
   threeSlaveNoLatch spi =


### PR DESCRIPTION
The current implementation of the SPI core has a bug where, `SPIMode1` or `SPIMode3`, the clock would feature one too many edgeswhile SS is active, causing the idle polarity to switch after each communication. This could lead to unexpected behavior by the connected peripheral.

This problem is fixed by the change in `spiGen`.

The second problem that arose is that after fixing spiGen, the circuit would not sample the input data at the right time, causing part of the sent bits to become undefined.

This is fixed by the changes in `spiCommon`.

## Still TODO:

  - [x] ~~Write a changelog entry (see changelog/README.md)~~
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
