### PR TITLE
Tcl connector: Handle plain constraint files

### DIFF
--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/BlackBoxes.hs
@@ -65,7 +65,7 @@ dcFifoBBF _isD _primName args _resTys
   bbMeta = emptyBlackBoxMeta
     { N.bbKind = N.TDecl
     , N.bbIncludes =
-      [ ( ("dcfifo", "tcl")
+      [ ( ("dcfifo", "clash.tcl")
         , BBFunction (show 'dcFifoTclTF) 0 (dcFifoTclTF dcConfig))
       ]
     -- TODO: Make this blackbox return multiple results, instead of a tuple. See:

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
@@ -8,7 +8,7 @@ Support for the [Xilinx Floating-Point LogiCORE IP v7.1](https://www.xilinx.com/
 
 The functions in this module make it possible to use the Xilinx IP in Clash.
 Compilation will instantiate the Xilinx IP. Clash will output a TCL script
-named @floating_point@/.../@.tcl@ which needs to be executed in the Vivado
+named @floating_point@/.../@.clash.tcl@ which needs to be executed in the Vivado
 project to create the proper entity. Simulation in Clash produces bit-identical
 results to synthesis.
 

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/Annotations.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/Annotations.hs
@@ -87,7 +87,7 @@ vhdlBinaryPrim primName tclTFName funcName = InlineYamlPrimitive [VHDL] [__i|
       end block;
       -- #{funcName} end
     includes:
-      - extension: tcl
+      - extension: clash.tcl
         name: floating_point
         format: Haskell
         templateFunction: #{tclTFName}
@@ -131,7 +131,7 @@ veriBinaryPrim primName tclTFName funcName =
           .m_axis_result_tdata(~RESULT)
         );
       includes:
-        - extension: tcl
+        - extension: clash.tcl
           name: floating_point
           format: Haskell
           templateFunction: #{tclTFName}
@@ -197,7 +197,7 @@ vhdlFromUPrim primName funcName =
         end block;
         -- #{funcName} end
       includes:
-        - extension: tcl
+        - extension: clash.tcl
           name: floating_point
           format: Haskell
           templateFunction: #{tfName}
@@ -240,7 +240,7 @@ veriFromUPrim primName funcName =
         );
         // #{funcName} end
       includes:
-        - extension: tcl
+        - extension: clash.tcl
           name: floating_point
           format: Haskell
           templateFunction: #{tfName}
@@ -306,7 +306,7 @@ vhdlFromSPrim primName funcName =
         end block;
         -- #{funcName} end
       includes:
-        - extension: tcl
+        - extension: clash.tcl
           name: floating_point
           format: Haskell
           templateFunction: #{tfName}
@@ -349,7 +349,7 @@ veriFromSPrim primName funcName =
         );
         // #{funcName} end
       includes:
-        - extension: tcl
+        - extension: clash.tcl
           name: floating_point
           format: Haskell
           templateFunction: #{tfName}
@@ -401,7 +401,7 @@ vhdlComparePrim primName tclTFName funcName = InlineYamlPrimitive [VHDL] [__i|
       end block;
       -- #{funcName} end
     includes:
-      - extension: tcl
+      - extension: clash.tcl
         name: floating_point
         format: Haskell
         templateFunction: #{tclTFName}
@@ -450,7 +450,7 @@ veriComparePrim primName tclTFName funcName =
       );
       // #{funcName} end
     includes:
-      - extension: tcl
+      - extension: clash.tcl
         name: floating_point
         format: Haskell
         templateFunction: #{tclTFName}

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
@@ -8,7 +8,7 @@ Support for the [Xilinx Floating-Point LogiCORE IP v7.1](https://www.xilinx.com/
 
 The functions in this module make it possible to use the Xilinx IP in Clash.
 Compilation will instantiate the Xilinx IP. Clash will output a TCL script
-named @floating_point@/.../@.tcl@ which needs to be executed in the Vivado
+named @floating_point@/.../@.clash.tcl@ which needs to be executed in the Vivado
 project to create the proper entity. Simulation in Clash produces bit-identical
 results to synthesis.
 

--- a/clash-lib/data-files/tcl/clashConnector.tcl
+++ b/clash-lib/data-files/tcl/clashConnector.tcl
@@ -351,7 +351,7 @@ namespace eval clash {
                 dict with metadata $lib {
                     lappend constraintFiles $name
                 }
-            } elseif {[string match {*.tcl} $name]} {
+            } elseif {[string match {*.clash.tcl} $name]} {
                 Log 3 "Adding Clash<->Tcl API file: $name"
                 LoadTclIface $lib $name
             }
@@ -374,7 +374,9 @@ namespace eval clash {
     # Populate a namespace with a Clash-generated Tcl interface.
     # Namespace is clash::tclIface::${lib}::$baseName
     proc LoadTclIface {lib tclIfaceFile} {
-        set baseName [file rootname [file tail $tclIfaceFile]]
+        set fileName [file tail $tclIfaceFile]
+        # Strip all extensions
+        set baseName [string range $fileName 0 [string first . $fileName]-1]
         set tclIface [namespace current]::tclIface::${lib}::$baseName
         # Evaluate script code inside temporary throwaway namespace to
         # separate its code from ours and reduce the chance of accidentally


### PR DESCRIPTION
When the Tcl connector finds a file named `*.sdc` or `*.xdc`, and it is not handled by an accompanying Clash<->Tcl interface file, it will issue a `read_xdc` for that file. Exception: for every top component (as declared in `clash-manifest.json`), it will only load the `.sdc` file with the same file name as the top component name for the actual top entity in the design, not for subentities. Clash emits `create_clock` statements in those files, and we should only load it for the actual top entity.

Note that because all `.sdc` and `.xdc` files are loaded with an unadorned `read_xdc <file>`, they should use globally unique identifiers to match only the intended signals, entities and so on. That way, they will not unintendedly match things outside the correct entities as the statements are not scoped to any entity explicitly.

Furthermore, Clash<->Tcl interface files are now named ~~`*.tclash`~~ `*.clash.tcl`.

It's possible that you would want to pass Vivado a constraint file with the extension `.tcl`. At least in Project Mode, and maybe in Non-Project Mode, this signifies an "unmanaged" constraint file: Vivado will allow GUI edits to files named 
`.sdc` and `.xdc`. By picking our own extension for Clash<->Tcl interface files, we make it possible to name constraint
files `.tcl`. Without this change, the Tcl connector script would try to parse such a file as a Clash<->Tcl interface file and error out.

Finally, the first commit improves the coding style of the connector script.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
