### PR TITLE
Make `resetGlitchFilter` less resource intensive

### DIFF
--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -61,27 +61,27 @@ build-clash-dev:
 cores:unittests:
   extends: .test-common
   script:
-    - cabal v2-run clash-cores:unittests
+    - cabal v2-run -- clash-cores:unittests --hide-successes
 
 cosim:unittests:
   extends: .test-common
   script:
-    - cabal v2-run clash-cosim:tests
+    - cabal v2-run -- clash-cosim:tests
 
 prelude:unittests:
   extends: .test-common
   script:
-    - cabal v2-run clash-prelude:unittests
+    - cabal v2-run -- clash-prelude:unittests --hide-successes
 
 lib:doctests:
   extends: .test-common
   script:
-    - cabal v2-run clash-lib:doctests
+    - cabal v2-run -- clash-lib:doctests -j${THREADS}
 
 lib:unittests:
   extends: .test-common
   script:
-    - cabal v2-run clash-lib:unittests
+    - cabal v2-run -- clash-lib:unittests --hide-successes
 
 prelude:doctests:
   extends: .test-common

--- a/changelog/2022-12-15T11_04_34+01_00_use_counter_in_resetGlitchFilter
+++ b/changelog/2022-12-15T11_04_34+01_00_use_counter_in_resetGlitchFilter
@@ -1,0 +1,3 @@
+CHANGED: `resetGlitchFilter` now uses a counter instead of shift register, allowing glitch filtering over much larger periods.
+CHANGED: `resetGlitchFilter` now filters glitches symmetrically, only deasserting the reset after the incoming reset has stabilized. For more information, read [#2374](https://github.com/clash-lang/clash-compiler/pull/2374).
+CHANGED: `resetGlitchFilter` does not support domains with unknown initial values anymore. Its previous behavior could lead to unstable circuits. Domains not supporting initial values should consider using power-on-resets and glitch filters specifically designed for this environment.

--- a/clash-prelude/tests/Clash/Tests/Reset.hs
+++ b/clash-prelude/tests/Clash/Tests/Reset.hs
@@ -7,8 +7,6 @@
 
 module Clash.Tests.Reset where
 
-import qualified Prelude as P
-
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.TH
@@ -28,7 +26,7 @@ resetFromList = unsafeFromHighPolarity . fromList
 
 onePeriodGlitchReset :: KnownDomain dom => Reset dom
 onePeriodGlitchReset =
-  resetFromList [True,True,False,False,True,False,False,True,True,False,False]
+  resetFromList [True,True,False,False,True,False,False,True,True,False,False,False]
 
 -- | Introduce a glitch of one period, and see if it's filtered out
 case_onePeriodGlitch :: Assertion
@@ -41,14 +39,6 @@ case_onePeriodGlitch_LowPolarity :: Assertion
 case_onePeriodGlitch_LowPolarity =
       [True,True,True,True,False,False,False,False,False,True,True,False]
   @=? sampleResetN 12 (resetGlitchFilter d2 (clockGen @Low) onePeriodGlitchReset)
-
--- | Same as 'case_onePeriodGlitch' but on a domain without initial values. This
--- tests whether the 'resetGlitchFilter' can recover from an unknown initial
--- state.
-case_onePeriodGlitch_NoInit :: Assertion
-case_onePeriodGlitch_NoInit =
-      P.drop 2 [True,True,True,True,False,False,False,False,False,True,True,False]
-  @=? P.drop 2 (sampleResetN 12 (resetGlitchFilter d2 (clockGen @NoInit) onePeriodGlitchReset))
 
 tests :: TestTree
 tests = testGroup "Reset"


### PR DESCRIPTION
This PR turned out to be slightly more involved than I anticipated: the current iteration doesn't simulate without initial values.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files