### PR TITLE
Don't quote bit literals with `-fclash-force-undefined`

### DIFF
--- a/changelog/2022-12-17T15_33_33+01_00_render_force_undefined_bits_correctly.md
+++ b/changelog/2022-12-17T15_33_33+01_00_render_force_undefined_bits_correctly.md
@@ -1,0 +1,2 @@
+FIXED: Clash now renders undefined bits set via `-fclash-force-undefined`
+correctly [#2360](https://github.com/clash-lang/clash-compiler/issues/2360).

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1933,7 +1933,7 @@ bit_char U = do
   case udf of
     Nothing -> char '-'
     Just Nothing -> char '0'
-    Just (Just i) -> "'" <> int i <> "'"
+    Just (Just i) -> int i
 bit_char Z = char 'Z'
 
 toSLV :: HasCallStack => HWType -> Expr -> VHDLM Doc

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -1264,9 +1264,8 @@ bit_char k b = do
   udf <- Ap (use k)
   case (udf,b) of
     (Just Nothing,U)  -> char '0'
-    (Just (Just i),U) -> "'" <> int i <> "'"
+    (Just (Just i),U) -> int i
     _                 -> char (bit_char' b)
-
 
 dcToExpr :: HWType -> Int -> Expr
 dcToExpr ty i = Literal (Just (ty,conSize ty)) (NumLit (toInteger i))

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -635,6 +635,7 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest "T2325f" def{hdlTargets=[VHDL]}
         , runTest "T2342A" def{hdlSim=[]}
         , runTest "T2342B" def{hdlSim=[]}
+        , runTest "T2360" def{hdlSim=[],clashFlags=["-fclash-force-undefined=0"]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2360.hs
+++ b/tests/shouldwork/Issues/T2360.hs
@@ -1,0 +1,6 @@
+module T2360 where
+
+import Clash.Prelude
+
+topEntity :: (BitVector 8)
+topEntity = deepErrorX "broken"


### PR DESCRIPTION
When rendering bit literals, we use the `char` function from the prettyprinter in most cases. For undefined bits we were using the `int` function, and wrapping in single quotes. This is not the same: the `char` function prints a single Haskell `Char`, but does _not_ wrap that character in quotes.

Simply removing the quote marks solves the issue.

Fixes #2360.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] ~Check copyright notices are up to date in edited files~

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
