### PR TITLE
Relax Hedgehog bounds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ write-ghc-environment-files: always
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2022-08-17T07:55:52Z
+index-state: 2022-12-23T13:15:07Z
 
 -- For some reason the `clash-testsuite` executable fails to run without
 -- this, as it cannot find the related library...

--- a/clash-lib-hedgehog/clash-lib-hedgehog.cabal
+++ b/clash-lib-hedgehog/clash-lib-hedgehog.cabal
@@ -33,7 +33,7 @@ common basic-config
 
   build-depends:
     base      >= 4.11  && < 5,
-    hedgehog  >= 1.0.3 && < 1.1,
+    hedgehog  >= 1.0.3 && < 1.3,
 
 library
   import: basic-config

--- a/clash-prelude-hedgehog/clash-prelude-hedgehog.cabal
+++ b/clash-prelude-hedgehog/clash-prelude-hedgehog.cabal
@@ -33,7 +33,7 @@ common basic-config
 
   build-depends:
     base      >= 4.11  && < 5,
-    hedgehog  >= 1.0.3 && < 1.1,
+    hedgehog  >= 1.0.3 && < 1.3,
 
 library
   import: basic-config

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -393,7 +393,7 @@ test-suite unittests
       base,
       bytestring,
       deepseq,
-      hedgehog      >= 1.0.3    && < 1.2,
+      hedgehog      >= 1.0.3    && < 1.3,
       hint          >= 0.7      && < 0.10,
       quickcheck-classes-base >= 0.6 && < 1.0,
       tasty         >= 1.2      && < 1.5,


### PR DESCRIPTION
I'll relax the bounds on Hackage too. Constraints on `master` have already been relaxed as part of the GHC 9.2 work.