### PR TITLE
Note about fromInteger/toInteger in Concrete(ish) Fixed Types

### DIFF
--- a/clash-prelude/src/Clash/Class/Resize.hs
+++ b/clash-prelude/src/Clash/Class/Resize.hs
@@ -69,8 +69,11 @@ checkIntegral Proxy v =
 -- you "know" /a/ can't be out of bounds, but would like to have your assumptions
 -- checked.
 --
--- __N.B.__: Check only affects simulation. I.e., no checks will be inserted
+-- * __NB__: Check only affects simulation. I.e., no checks will be inserted
 -- into the generated HDL
+-- * __NB__: 'fromIntegral' is not well suited for Clash as it will go through
+-- 'Integer' which is arbitrarily bounded in HDL. Instead use
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 checkedFromIntegral ::
   forall a b.
   HasCallStack =>

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -87,7 +87,7 @@ cpu
      , (MemAddr, Maybe (MemAddr,Value), InstrAddr)
      )
 cpu regbank (memOut, instr) =
-  (regbank', (rdAddr, (,aluOut) '<$>' wrAddrM, fromIntegral ipntr))
+  (regbank', (rdAddr, (,aluOut) '<$>' wrAddrM, bitCoerce ipntr))
  where
   -- Current instruction pointer
   ipntr = regbank 'Clash.Sized.Vector.!!' PC
@@ -280,7 +280,7 @@ cpu2
      , (MemAddr, Maybe (MemAddr,Value), InstrAddr)
      )
 cpu2 (regbank, ldRegD) (memOut, instr) =
-  ((regbank', ldRegD'), (rdAddr, (,aluOut) '<$>' wrAddrM, fromIntegral ipntr))
+  ((regbank', ldRegD'), (rdAddr, (,aluOut) '<$>' wrAddrM, bitCoerce ipntr))
  where
   -- Current instruction pointer
   ipntr = regbank 'Clash.Sized.Vector.!!' PC
@@ -545,7 +545,7 @@ let cpu :: Vec 7 Value          -- ^ Register bank
         -> ( Vec 7 Value
            , (MemAddr,Maybe (MemAddr,Value),InstrAddr)
            )
-    cpu regbank (memOut,instr) = (regbank',(rdAddr,(,aluOut) <$> wrAddrM,fromIntegral ipntr))
+    cpu regbank (memOut,instr) = (regbank',(rdAddr,(,aluOut) <$> wrAddrM,bitCoerce ipntr))
       where
         -- Current instruction pointer
         ipntr = regbank C.!! PC
@@ -662,7 +662,7 @@ let cpu2 :: (Vec 7 Value,Reg)    -- ^ (Register bank, Load reg addr)
          -> ( (Vec 7 Value,Reg)
             , (MemAddr,Maybe (MemAddr,Value),InstrAddr)
             )
-    cpu2 (regbank,ldRegD) (memOut,instr) = ((regbank',ldRegD'),(rdAddr,(,aluOut) <$> wrAddrM,fromIntegral ipntr))
+    cpu2 (regbank,ldRegD) (memOut,instr) = ((regbank',ldRegD'),(rdAddr,(,aluOut) <$> wrAddrM,bitCoerce ipntr))
       where
         -- Current instruction pointer
         ipntr = regbank C.!! PC

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -86,7 +86,7 @@ cpu
      , (MemAddr, Maybe (MemAddr,Value), InstrAddr)
      )
 cpu regbank (memOut, instr) =
-  (regbank', (rdAddr, (,aluOut) 'Prelude.<$>' wrAddrM, fromIntegral ipntr))
+  (regbank', (rdAddr, (,aluOut) 'Prelude.<$>' wrAddrM, bitCoerce ipntr))
  where
   -- Current instruction pointer
   ipntr = regbank 'Clash.Sized.Vector.!!' PC
@@ -272,7 +272,7 @@ cpu2
      , (MemAddr, Maybe (MemAddr,Value), InstrAddr)
      )
 cpu2 (regbank,ldRegD) (memOut,instr) =
-  ((regbank', ldRegD'), (rdAddr, (,aluOut) 'Prelude.<$>' wrAddrM, fromIntegral ipntr))
+  ((regbank', ldRegD'), (rdAddr, (,aluOut) 'Prelude.<$>' wrAddrM, bitCoerce ipntr))
  where
   -- Current instruction pointer
   ipntr = regbank 'Clash.Sized.Vector.!!' PC
@@ -496,7 +496,7 @@ let cpu :: Vec 7 Value          -- ^ Register bank
         -> ( Vec 7 Value
            , (MemAddr,Maybe (MemAddr,Value),InstrAddr)
            )
-    cpu regbank (memOut,instr) = (regbank',(rdAddr,(,aluOut) <$> wrAddrM,fromIntegral ipntr))
+    cpu regbank (memOut,instr) = (regbank',(rdAddr,(,aluOut) <$> wrAddrM,bitCoerce ipntr))
       where
         -- Current instruction pointer
         ipntr = regbank C.!! PC
@@ -607,7 +607,7 @@ let cpu2
          , (MemAddr, Maybe (MemAddr, Value), InstrAddr)
          )
     cpu2 (regbank,ldRegD) (memOut,instr) =
-      ((regbank', ldRegD'), (rdAddr, (,aluOut) <$> wrAddrM, fromIntegral ipntr))
+      ((regbank', ldRegD'), (rdAddr, (,aluOut) <$> wrAddrM, bitCoerce ipntr))
      where
       -- Current instruction pointer
       ipntr = regbank C.!! PC

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -212,10 +212,15 @@ type role BitVector nominal
 
 -- * Type definitions
 
--- | A vector of bits.
+-- | A vector of bits
 --
 -- * Bit indices are descending
 -- * 'Num' instance performs /unsigned/ arithmetic.
+--
+-- __NB__: The usual Haskell method of converting an integral numeric type to
+-- another, 'fromIntegral', is not well suited for Clash as it will go through
+-- 'Integer' which is arbitrarily bounded in HDL. Instead use
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 --
 -- BitVector has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
@@ -223,8 +228,8 @@ type role BitVector nominal
 -- type role BitVector nominal
 -- ...
 --
--- as it is not safe to coerce between different size BitVector. To change the
--- size, use the functions in the 'Clash.Class.Resize.Resize' class.
+-- as it is not safe to coerce between different sizes of BitVector. To change
+-- the size, use the functions in the 'Resize' class.
 data BitVector (n :: Nat) =
     -- | The constructor, 'BV', and  the field, 'unsafeToNatural', are not
     -- synthesizable.
@@ -237,7 +242,12 @@ data BitVector (n :: Nat) =
 
 -- * Bit
 
--- | Bit
+-- | A single bit
+--
+-- __NB__: The usual Haskell method of converting an integral numeric type to
+-- another, 'fromIntegral', is not well suited for Clash as it will go through
+-- 'Integer' which is arbitrarily bounded in HDL. Instead use
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 data Bit =
   -- | The constructor, 'Bit', and  the field, 'unsafeToInteger#', are not
   -- synthesizable.
@@ -665,6 +675,9 @@ maxBound# = let m = 1 `shiftL` natToNum @n in BV 0 (m-1)
 {-# NOINLINE maxBound# #-}
 {-# ANN maxBound# hasBlackBox #-}
 
+-- | __NB__: 'fromInteger'/'fromIntegral' can cause unexpected truncation, as
+-- 'Integer' is arbitrarily bounded during synthesis.  Prefer
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 instance KnownNat n => Num (BitVector n) where
   (+)         = (+#)
   (-)         = (-#)
@@ -780,6 +793,9 @@ times# bv1 bv2 = undefErrorP "mul" bv1 bv2
 instance KnownNat n => Real (BitVector n) where
   toRational = toRational . toInteger#
 
+-- | __NB__: 'toInteger'/'fromIntegral' can cause unexpected truncation, as
+-- 'Integer' is arbitrarily bounded during synthesis.  Prefer
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 instance KnownNat n => Integral (BitVector n) where
   quot        = quot#
   rem         = rem#

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -120,7 +120,7 @@ import Clash.XException
 
 type role Index nominal
 
--- | Arbitrary-bounded unsigned integer represented by @ceil(log_2(n))@ bits.
+-- | Arbitrarily-bounded unsigned integer represented by @ceil(log_2(n))@ bits
 --
 -- Given an upper bound @n@, an 'Index' @n@ number has a range of: [0 .. @n@-1]
 --
@@ -144,14 +144,19 @@ type role Index nominal
 -- *** Exception: X: Clash.Sized.Index: result 8 is out of bounds: [0..7]
 -- ...
 --
+-- __NB__: The usual Haskell method of converting an integral numeric type to
+-- another, 'fromIntegral', is not well suited for Clash as it will go through
+-- 'Integer' which is arbitrarily bounded in HDL. Instead use
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
+--
 -- Index has the <https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html type role>
 --
 -- >>> :i Index
 -- type role Index nominal
 -- ...
 --
--- as it is not safe to coerce between different range Index. To change the
--- size, use the functions in the 'Clash.Class.Resize.Resize' class.
+-- as it is not safe to coerce between 'Index'es with different ranges. To
+-- change the size, use the functions in the 'Resize' class.
 #if MIN_VERSION_base(4,15,0)
 data Index (n :: Nat) =
     -- | The constructor, 'I', and the field, 'unsafeToInteger', are not
@@ -282,6 +287,10 @@ maxBound# =
 {-# ANN maxBound# hasBlackBox #-}
 
 -- | Operators report an error on overflow and underflow
+--
+-- __NB__: 'fromInteger'/'fromIntegral' can cause unexpected truncation, as
+-- 'Integer' is arbitrarily bounded during synthesis.  Prefer
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 instance KnownNat n => Num (Index n) where
   (+)         = (+#)
   (-)         = (-#)
@@ -437,6 +446,9 @@ instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
 instance KnownNat n => Real (Index n) where
   toRational = toRational . toInteger#
 
+-- | __NB__: 'toInteger'/'fromIntegral' can cause unexpected truncation, as
+-- 'Integer' is arbitrarily bounded during synthesis.  Prefer
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 instance KnownNat n => Integral (Index n) where
   quot        = quot#
   rem         = rem#

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -136,13 +136,17 @@ import Clash.XException
 type role Signed nominal
 
 -- | Arbitrary-width signed integer represented by @n@ bits, including the sign
--- bit.
+-- bit
 --
 -- Uses standard 2-complements representation. Meaning that, given @n@ bits,
 -- a 'Signed' @n@ number has a range of: [-(2^(@n@-1)) .. 2^(@n@-1)-1] for
 -- @n > 0@. When @n = 0@, both the min and max bound are 0.
 --
--- __NB__: The 'Num' operators perform @wrap-around@ on overflow. If you want
+-- * __NB__: The usual Haskell method of converting an integral numeric type to
+-- another, 'fromIntegral', is not well suited for Clash as it will go through
+-- 'Integer' which is arbitrarily bounded in HDL. Instead use
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
+-- * __NB__: The 'Num' operators perform @wrap-around@ on overflow. If you want
 -- saturation on overflow, check out the 'SaturatingNum' class.
 --
 -- >>>  maxBound :: Signed 3
@@ -365,6 +369,10 @@ maxBound# =
 {-# ANN maxBound# hasBlackBox #-}
 
 -- | Operators do @wrap-around@ on overflow
+--
+-- __NB__: 'fromInteger'/'fromIntegral' can cause unexpected truncation, as
+-- 'Integer' is arbitrarily bounded during synthesis.  Prefer
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 instance KnownNat n => Num (Signed n) where
   (+)         = (+#)
   (-)         = (-#)
@@ -471,6 +479,9 @@ times# (S a) (S b) = S (a * b)
 instance KnownNat n => Real (Signed n) where
   toRational = toRational . toInteger#
 
+-- | __NB__: 'toInteger'/'fromIntegral' can cause unexpected truncation, as
+-- 'Integer' is arbitrarily bounded during synthesis.  Prefer
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 instance KnownNat n => Integral (Signed n) where
   quot        = quot#
   rem         = rem#

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -160,7 +160,11 @@ type role Unsigned nominal
 --
 -- Given @n@ bits, an 'Unsigned' @n@ number has a range of: [0 .. 2^@n@-1]
 --
--- __NB__: The 'Num' operators perform @wrap-around@ on overflow. If you want
+-- * __NB__: The usual Haskell method of converting an integral numeric type to
+-- another, 'fromIntegral', is not well suited for Clash as it will go through
+-- 'Integer' which is arbitrarily bounded in HDL. Instead use
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
+-- * __NB__: The 'Num' operators perform @wrap-around@ on overflow. If you want
 -- saturation on overflow, check out the 'SaturatingNum' class.
 --
 -- >>> maxBound :: Unsigned 3
@@ -380,6 +384,9 @@ maxBound# = let m = 1 `shiftL` (natToNum @n) in  U (m - 1)
 {-# NOINLINE maxBound# #-}
 {-# ANN maxBound# hasBlackBox #-}
 
+-- | __NB__: 'fromInteger'/'fromIntegral' can cause unexpected truncation, as
+-- 'Integer' is arbitrarily bounded during synthesis.  Prefer
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 instance KnownNat n => Num (Unsigned n) where
   (+)         = (+#)
   (-)         = (-#)
@@ -474,6 +481,9 @@ times# (U a) (U b) = U (a * b)
 instance KnownNat n => Real (Unsigned n) where
   toRational = toRational . toInteger#
 
+-- | __NB__: 'toInteger'/'fromIntegral' can cause unexpected truncation, as
+-- 'Integer' is arbitrarily bounded during synthesis.  Prefer
+-- 'Clash.Class.BitPack.bitCoerce' and the 'Resize' class.
 instance KnownNat n => Integral (Unsigned n) where
   quot        = quot#
   rem         = rem#

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -271,7 +271,7 @@ tree-structure of adders:
 @
 populationCount :: (KnownNat (2^d), KnownNat d, KnownNat (2^d+1))
                 => BitVector (2^d) -> Index (2^d+1)
-populationCount = tfold fromIntegral (+) . v2t . bv2v
+populationCount = tfold (resize . bv2i . pack) (+) . v2t . bv2v
 @
 
 The \"problem\" with this description is that all adders have the same
@@ -293,12 +293,12 @@ type:
 We have such an adder in the form of the 'Clash.Class.Num.add' function, as
 defined in the instance 'Clash.Class.Num.ExtendingNum' instance of 'Index'.
 However, we cannot simply use 'Clash.Sized.Vector.fold' to create a tree-structure of
-'Clash.Class.Num.add'es:
+'Clash.Class.Num.add's:
 #if __GLASGOW_HASKELL__ >= 900
 >>> :{
 let populationCount' :: (KnownNat (2^d), KnownNat d, KnownNat (2^d+1))
                      => BitVector (2^d) -> Index (2^d+1)
-    populationCount' = tfold fromIntegral add . v2t . bv2v
+    populationCount' = tfold (resize . bv2i . pack) add . v2t . bv2v
 :}
 <BLANKLINE>
 <interactive>:...
@@ -310,8 +310,9 @@ let populationCount' :: (KnownNat (2^d), KnownNat d, KnownNat (2^d+1))
                 -> Index ((2 ^ d) + 1)
                 -> AResult (Index ((2 ^ d) + 1)) (Index ((2 ^ d) + 1))
     • In the second argument of ‘tfold’, namely ‘add’
-      In the first argument of ‘(.)’, namely ‘tfold fromIntegral add’
-      In the expression: tfold fromIntegral add . v2t . bv2v
+      In the first argument of ‘(.)’, namely
+        ‘tfold (resize . bv2i . pack) add’
+      In the expression: tfold (resize . bv2i . pack) add . v2t . bv2v
     • Relevant bindings include
         populationCount' :: BitVector (2 ^ d) -> Index ((2 ^ d) + 1)
           (bound at ...)
@@ -320,7 +321,7 @@ let populationCount' :: (KnownNat (2^d), KnownNat d, KnownNat (2^d+1))
 >>> :{
 let populationCount' :: (KnownNat (2^d), KnownNat d, KnownNat (2^d+1))
                      => BitVector (2^d) -> Index (2^d+1)
-    populationCount' = tfold fromIntegral add . v2t . bv2v
+    populationCount' = tfold (resize . bv2i . pack) add . v2t . bv2v
 :}
 <BLANKLINE>
 <interactive>:...
@@ -332,8 +333,9 @@ let populationCount' :: (KnownNat (2^d), KnownNat d, KnownNat (2^d+1))
                      -> Index ((2 ^ d) + 1)
                      -> AResult (Index ((2 ^ d) + 1)) (Index ((2 ^ d) + 1))
     • In the second argument of ‘tfold’, namely ‘add’
-      In the first argument of ‘(.)’, namely ‘tfold fromIntegral add’
-      In the expression: tfold fromIntegral add . v2t . bv2v
+      In the first argument of ‘(.)’, namely
+        ‘tfold (resize . bv2i . pack) add’
+      In the expression: tfold (resize . bv2i . pack) add . v2t . bv2v
     • Relevant bindings include
         populationCount' :: BitVector (2 ^ d) -> Index ((2 ^ d) + 1)
           (bound at ...)
@@ -350,7 +352,6 @@ the form of 'dtfold':
 @
 {\-\# LANGUAGE UndecidableInstances \#-\}
 import Data.Singletons
-import Data.Proxy
 
 data IIndex (f :: 'TyFun' Nat Type) :: Type
 type instance 'Apply' IIndex l = 'Index' ((2^l)+1)
@@ -358,7 +359,7 @@ type instance 'Apply' IIndex l = 'Index' ((2^l)+1)
 populationCount' :: (KnownNat k, KnownNat (2^k))
                  => BitVector (2^k) -> Index ((2^k)+1)
 populationCount' bv = 'tdfold' (Proxy @IIndex)
-                             fromIntegral
+                             (resize . bv2i . pack)
                              (\\_ x y -> 'Clash.Class.Num.add' x y)
                              ('v2t' ('Clash.Sized.Vector.bv2v' bv))
 @

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -153,6 +153,9 @@ import Clash.XException           (ShowX (..), NFDataX (..), seqX, isX)
 >>> :set -XTypeOperators
 >>> :set -XTemplateHaskell
 >>> :set -XFlexibleContexts
+>>> :set -fplugin GHC.TypeLits.Normalise
+>>> :set -fplugin GHC.TypeLits.KnownNat.Solver
+>>> :set -fplugin GHC.TypeLits.Extra.Solver
 >>> :m -Prelude
 >>> import Clash.Prelude
 >>> import qualified Clash.Sized.Vector as Vec
@@ -750,7 +753,7 @@ map f (x `Cons` xs) = f x `Cons` map f xs
 -- >>> imap (+) (2 :> 2 :> 2 :> 2 :> Nil)
 -- 2 :> 3 :> *** Exception: X: Clash.Sized.Index: result 4 is out of bounds: [0..3]
 -- ...
--- >>> imap (\i a -> fromIntegral i + a) (2 :> 2 :> 2 :> 2 :> Nil) :: Vec 4 (Unsigned 8)
+-- >>> imap (\i a -> extend (bitCoerce i) + a) (2 :> 2 :> 2 :> 2 :> Nil) :: Vec 4 (Unsigned 8)
 -- 2 :> 3 :> 4 :> 5 :> Nil
 --
 -- \"'imap' @f xs@\" corresponds to the following circuit layout:
@@ -777,7 +780,7 @@ imap f = go 0
 *** Exception: X: Clash.Sized.Index: result 3 is out of bounds: [0..1]
 ...
 #endif
->>> izipWith (\i a b -> fromIntegral i + a + b) (2 :> 2 :> Nil) (3 :> 3 :> Nil) :: Vec 2 (Unsigned 8)
+>>> izipWith (\i a b -> extend (bitCoerce i) + a + b) (2 :> 2 :> Nil) (3 :> 3 :> Nil) :: Vec 2 (Unsigned 8)
 5 :> 6 :> Nil
 
 \"'imap' @f xs@\" corresponds to the following circuit layout:


### PR DESCRIPTION
This came out of a discussion in #2384 about `fromIntegral` and how it was generally better to steer away from it (though conversion turned out not to bet the issue there).  This seemed like the places to call out the potential risks associated while very briefly touching on the reasoning.  This was my best attempt at concisely capturing the consideration and steering users towards the right places.  More than happy to make edits or close if folks feel this is unnecessary.  Cheers!

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
