### PR TITLE
Github CI: upgrade to actions/cache@v3 and fix caching on Windows

### DIFF
--- a/.ci/build_clash_dev.sh
+++ b/.ci/build_clash_dev.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -xeou pipefail
 
+# Make sure all our deps are build, and listed in the .ghc.environment file
+cabal --write-ghc-environment-files=always v2-build --only-dependencies clash-lib
+
 # Check that clash-dev works
-cabal --write-ghc-environment-files=always v2-build clash-prelude
 echo "" > clash-dev.result
 echo 'main >> writeFile "clash-dev.result" "success"' | ./clash-dev
 if [[ "$(cat clash-dev.result)" != "success" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,18 +50,25 @@ jobs:
         run: brew install icarus-verilog
 
       - name: Install IVerilog (Windows)
-        if: matrix.os == 'windows'
+        if: matrix.os == 'Windows'
         run: choco install --no-progress iverilog
 
       - name: General Setup
         run: |
           cp .ci/stack-${{ matrix.ghc }}.yaml stack.yaml
 
-      - name: Cache
-        # Note: we're stuck on v1 because of:
-        #
-        #   https://github.com/actions/cache/issues/666
-        uses: actions/cache@v1
+      - name: Cache (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        uses: actions/cache@v3
+        with:
+          # On windows we have to use "\" as a path seperator, otherwise caching fails
+          path: |
+            ${{ steps.setup-haskell.outputs.stack-root }}\snapshots
+          key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('stack.yaml', '**/*.cabal', '.github/workflows/ci.yml') }}
+          restore-keys: ${{ matrix.os }}-${{ matrix.ghc }}-
+      - name: Cache (non-Windows)
+        if: ${{ runner.os != 'Windows' }}
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.setup-haskell.outputs.stack-root }}/snapshots


### PR DESCRIPTION
With this fix in place we can upgrade to actions/cache@v3 and get rid of the deprecation warnings caused by the cache action, while keeping the cache working on Windows.

And I'll also throw in a fix for the flaky build-clash-dev job over on gitlab CI