### PR TITLE
Move small CI jobs back to shared runners

### DIFF
--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -29,9 +29,6 @@ hackage-sdist:
     - .ci/publish_sdist.sh clash-ghc
   retry:
     max: 2
-  # XXX: Temporarily on local runners
-  tags:
-   - local
 
 # Run every night, when explicitly triggered, or when tagged (release)
 .run-on-nightly-and-changes:
@@ -107,6 +104,3 @@ debian-bindist-test:
     - .ci/snap.sh publish
   retry:
     max: 2
-  # XXX: Temporarily on local runners
-  tags:
-   - local

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -29,13 +29,9 @@ stages:
 
 .test-common:
   extends: .test-common-local
-  # Run on shared runners
-  # XXX: Temporarily on local runners
-  #tags:
 
 # 'build' publishes its build files as an artifact. These build files are reused
-# by 'prelude:doctests', 'prelude:unittests', 'lib:unittests'
-# and 'suite-{verilog,vhdl}'.
+# by the tests below.
 build:
   extends: .common
   artifacts:
@@ -49,14 +45,10 @@ build:
 
     # Archive all build files (from .cabal and dist-newstyle)
     - tar -cf - $(.ci/get_build_dist.sh) | zstd -T${THREADS} -15 > dist.tar.zst
-  # XXX: Temporarily on local runners
   tags:
    - local
 
-build-clash-dev:
-  extends: .test-common
-  script:
-    - .ci/build_clash_dev.sh
+# Tests run on shared runners:
 
 cores:unittests:
   extends: .test-common
@@ -89,6 +81,16 @@ prelude:doctests:
     - cabal v2-run -- clash-prelude:doctests -j${THREADS}
 
 # Tests run on local fast machines:
+
+# Normally, this job is small. But it is flaky on GHC 9.2; it sometimes fails
+# and we don't know yet why. When it fails, it recompiles things it should have
+# picked up from the 'build' issue and then it is a larger job, so we keep it on
+# local runners for now.
+build-clash-dev:
+  extends: .test-common-local
+  script:
+    - .ci/build_clash_dev.sh
+
 suite:vhdl:
   extends: .test-common-local
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,10 +69,6 @@ stack-build:
     GHC_VERSION: 8.10.7
   script:
     - .ci/stack_build.sh
-  # Run on shared runners
-  # XXX: Temporarily on local runners
-  tags:
-   - local
 
 nix-build:
   image: nixos/nix:2.10.1
@@ -150,9 +146,6 @@ snap-stable:
   image: curlimages/curl
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-  # XXX: Temporarily on local runners
-  tags:
-   - local
 
 set_pending:
   extends: .github_status


### PR DESCRIPTION
This makes CI run quicker because shared runners are quicker to pick up jobs than our local runners.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
