### PR TITLE
GitLab CI: Use manual cache bust token

### DIFF
--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -5,7 +5,7 @@
   variables:
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-11-14-3-non_protected
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-11-14-1-3-non_protected
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   retry:
@@ -14,7 +14,7 @@
       - runner_system_failure
       - stuck_or_timeout_failure
   cache:
-    key: $CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_JOB_IMAGE
+    key: $CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_JOB_IMAGE-1
     when: always
     paths:
       - cache.tar.zst


### PR DESCRIPTION
Since we need a PR to update the cache bust token in CACHE_FALLBACK_KEY anyway, we might as well use a manual token instead.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
