### PR TITLE
CI: fix shared runners, use matrix

### DIFF
--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,6 +1,6 @@
 .common:
   image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-05-10
-  timeout: 2 hours
+  timeout: 10 minutes
   stage: build
   variables:
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
@@ -26,5 +26,15 @@
     - .ci/setup.sh
   after_script:
     - tar -cf - $(ls -d /root/.cabal /root/.stack $(pwd)/.ci/bindist/linux/debian/*/build || true) | zstd -T${THREADS} -3 > cache.tar.zst
+
+# We run tests on local machines if:
+#
+#   * A job may take more than 3 minutes to complete on public runners.
+#   * A job needs specific capabilities public runners cannot provide, e.g.
+#     more than 4GB memory of memory, proprietary synthesis tooling.
+#
+.common-local:
+  extends: .common
+  timeout: 2 hours
   tags:
     - local

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -1,5 +1,5 @@
 hackage-sdist:
-  extends: .common
+  extends: .common-local
   needs: []
   stage: pack
   script:
@@ -12,8 +12,6 @@ hackage-sdist:
     paths:
       - clash-*.tar.gz  # clash-{prelude,lib,ghc}-$version{-docs,}.tar.gz
     expire_in: 1 week
-  tags:
-    - local
 
 .hackage:
   extends: .common
@@ -45,7 +43,7 @@ hackage-sdist:
 
 # Create Debian packages.
 debian-bindist:
-  extends: .common
+  extends: .common-local
   needs: []
   image: ghcr.io/clash-lang/bindist-debian-focal:2022-01-25
   stage: pack
@@ -64,8 +62,6 @@ debian-bindist:
   script:
     - rm -rf .ci/bindist/linux/debian/focal/build/clash* || true
     - .ci/bindist/linux/debian/scripts/build.sh focal
-  tags:
-    - local
 
 # Test debian distribution. Ideally, this would be in the same stage as
 # 'debian-bindist', but we can't yet do that with GitLab CI.
@@ -84,6 +80,7 @@ debian-bindist-test:
 
 # Use binary distribution built in `snap-bindist` to build a snap package.
 .snap:
+  timeout: 10 minutes
   image: ghcr.io/clash-lang/snapcraft:2022-01-23
   stage: publish
   interruptible: false

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -29,9 +29,6 @@ hackage-sdist:
     - .ci/publish_sdist.sh clash-ghc
   retry:
     max: 2
-  # XXX: Temporarily on local runners
-  tags:
-   - local
 
 # Run every night, when explicitly triggered, or when tagged (release)
 .run-on-nightly-and-changes:
@@ -107,6 +104,3 @@ debian-bindist-test:
     - .ci/snap.sh publish
   retry:
     max: 2
-  # XXX: Temporarily on local runners
-  tags:
-   - local

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -29,13 +29,9 @@ stages:
 
 .test-common:
   extends: .test-common-local
-  # Run on shared runners
-  # XXX: Temporarily on local runners
-  #tags:
 
 # 'build' publishes its build files as an artifact. These build files are reused
-# by 'prelude:doctests', 'prelude:unittests', 'lib:unittests'
-# and 'suite-{verilog,vhdl}'.
+# by the tests below.
 build:
   extends: .common
   artifacts:
@@ -49,14 +45,10 @@ build:
 
     # Archive all build files (from .cabal and dist-newstyle)
     - tar -cf - $(.ci/get_build_dist.sh) | zstd -T${THREADS} -15 > dist.tar.zst
-  # XXX: Temporarily on local runners
   tags:
    - local
 
-build-clash-dev:
-  extends: .test-common
-  script:
-    - .ci/build_clash_dev.sh
+# Tests run on shared runners:
 
 cores:unittests:
   extends: .test-common
@@ -84,6 +76,16 @@ prelude:doctests:
     - cabal v2-run -- clash-prelude:doctests -j${THREADS}
 
 # Tests run on local fast machines:
+
+# Normally, this job is small. But it is flaky on GHC 9.2; it sometimes fails
+# and we don't know yet why. When it fails, it recompiles things it should have
+# picked up from the 'build' issue and then it is a larger job, so we keep it on
+# local runners for now.
+build-clash-dev:
+  extends: .test-common-local
+  script:
+    - .ci/build_clash_dev.sh
+
 suite:vhdl:
   extends: .test-common-local
   script:

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -61,22 +61,22 @@ build-clash-dev:
 cores:unittests:
   extends: .test-common
   script:
-    - cabal v2-run clash-cores:unittests
+    - cabal v2-run -- clash-cores:unittests --hide-successes
 
 cosim:unittests:
   extends: .test-common
   script:
-    - cabal v2-run clash-cosim:tests
+    - cabal v2-run -- clash-cosim:tests
 
 prelude:unittests:
   extends: .test-common
   script:
-    - cabal v2-run clash-prelude:unittests
+    - cabal v2-run -- clash-prelude:unittests --hide-successes
 
 lib:unittests:
   extends: .test-common
   script:
-    - cabal v2-run clash-lib:unittests
+    - cabal v2-run -- clash-lib:unittests --hide-successes
 
 prelude:doctests:
   extends: .test-common

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -5,7 +5,29 @@ stages:
   - build
   - test
 
-.test-common:
+.test-nocache:
+  extends: .common
+  needs: ["build"]
+  stage: test
+  cache:
+    paths: []
+  before_script:
+    - unset SNAPCRAFT_LOGIN_FILE
+    - unset HACKAGE_PASSWORD
+    - export THREADS=$(./.ci/effective_cpus.sh)
+    - export CABAL_JOBS=$(./.ci/effective_cpus.sh)
+    - export clash_lib_datadir=$(pwd)/clash-lib/
+    - export clash_cosim_datadir=$(pwd)/clash-cosim/
+    - export
+    - tar -xf dist.tar.zst -C /
+
+    # Not all package in cache get packed into dist.tar.zst, so we need to
+    # regenerate the package database
+    - ghc-pkg recache --package-db=$HOME/.cabal/store/ghc-$GHC_VERSION/package.db
+  after_script:
+
+.test-cache-local:
+  extends: .common-local
   needs: ["build"]
   stage: test
   before_script:
@@ -13,6 +35,8 @@ stages:
     - unset HACKAGE_PASSWORD
     - export THREADS=$(./.ci/effective_cpus.sh)
     - export CABAL_JOBS=$(./.ci/effective_cpus.sh)
+    - export clash_lib_datadir=$(pwd)/clash-lib/
+    - export clash_cosim_datadir=$(pwd)/clash-cosim/
     - export
     - tar -xf cache.tar.zst -C / || true
     - tar -xf dist.tar.zst -C /
@@ -23,16 +47,6 @@ stages:
     - ghc-pkg recache --package-db=$HOME/.cabal/store/ghc-$GHC_VERSION/package.db
   after_script:
     - tar -cf - /root/.cabal/packages | zstd -T${THREADS} -3 > cache.tar.zst
-
-.test-common-shared:
-  extends:
-    - .common
-    - .test-common
-
-.test-common-local:
-  extends:
-    - .common-local
-    - .test-common
 
 # 'build' publishes its build files as an artifact. These build files are reused
 # by the tests below.
@@ -53,29 +67,29 @@ build:
 # Tests run on shared runners:
 
 cores:unittests:
-  extends: .test-common-shared
+  extends: .test-nocache
   script:
-    - cabal v2-run -- clash-cores:unittests --hide-successes
+    - ./dist-newstyle/build/*/*/clash-cores-*/t/unittests/build/unittests/unittests --hide-successes
 
 cosim:unittests:
-  extends: .test-common-shared
+  extends: .test-nocache
   script:
-    - cabal v2-run -- clash-cosim:tests
+    - ./dist-newstyle/build/*/*/clash-cosim-*/build/test/test
 
 prelude:unittests:
-  extends: .test-common-shared
+  extends: .test-nocache
   script:
-    - cabal v2-run -- clash-prelude:unittests --hide-successes
+    - ./dist-newstyle/build/*/*/clash-prelude-*/t/unittests/build/unittests/unittests --hide-successes
 
 lib:unittests:
-  extends: .test-common-shared
+  extends: .test-nocache
   script:
-    - cabal v2-run -- clash-lib:unittests --hide-successes
+    - ./dist-newstyle/build/*/*/clash-lib-*/t/unittests/build/unittests/unittests --hide-successes
 
 prelude:doctests:
-  extends: .test-common-shared
+  extends: .test-nocache
   script:
-    - cabal v2-run -- clash-prelude:doctests -j${THREADS}
+    - ./dist-newstyle/build/*/*/clash-prelude-*/t/doctests/build/doctests/doctests -j${THREADS}
 
 # Tests run on local fast machines:
 
@@ -84,21 +98,21 @@ prelude:doctests:
 # picked up from the 'build' issue and then it is a larger job, so we keep it on
 # local runners for now.
 build-clash-dev:
-  extends: .test-common-local
+  extends: .test-cache-local
   script:
     - .ci/build_clash_dev.sh
 
 suite:vhdl:
-  extends: .test-common-local
+  extends: .test-cache-local
   script:
-    - cabal v2-run -- clash-testsuite -j$THREADS -p .VHDL --hide-successes
+    - ./dist-newstyle/build/*/*/clash-testsuite-*/x/clash-testsuite/build/clash-testsuite/clash-testsuite -j$THREADS -p .VHDL --hide-successes
 
 suite:verilog:
-  extends: .test-common-local
+  extends: .test-cache-local
   script:
-    - cabal v2-run -- clash-testsuite -j$THREADS -p .Verilog --hide-successes
+    - ./dist-newstyle/build/*/*/clash-testsuite-*/x/clash-testsuite/build/clash-testsuite/clash-testsuite -j$THREADS -p .Verilog --hide-successes
 
 suite:systemverilog:
-  extends: .test-common-local
+  extends: .test-cache-local
   script:
-    - cabal v2-run -- clash-testsuite -j$THREADS -p .SystemVerilog --hide-successes --no-modelsim
+    - ./dist-newstyle/build/*/*/clash-testsuite-*/x/clash-testsuite/build/clash-testsuite/clash-testsuite -j$THREADS -p .SystemVerilog --hide-successes --no-modelsim

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -5,8 +5,7 @@ stages:
   - build
   - test
 
-.test-common-local:
-  extends: .common
+.test-common:
   needs: ["build"]
   stage: test
   before_script:
@@ -24,16 +23,21 @@ stages:
     - ghc-pkg recache --package-db=$HOME/.cabal/store/ghc-$GHC_VERSION/package.db
   after_script:
     - tar -cf - /root/.cabal/packages | zstd -T${THREADS} -3 > cache.tar.zst
-  tags:
-    - local
 
-.test-common:
-  extends: .test-common-local
+.test-common-shared:
+  extends:
+    - .common
+    - .test-common
+
+.test-common-local:
+  extends:
+    - .common-local
+    - .test-common
 
 # 'build' publishes its build files as an artifact. These build files are reused
 # by the tests below.
 build:
-  extends: .common
+  extends: .common-local
   artifacts:
     when: always
     name: "$CI_JOB_NAME-$CI_COMMIT_SHA-$GHC_VERSION"
@@ -45,33 +49,31 @@ build:
 
     # Archive all build files (from .cabal and dist-newstyle)
     - tar -cf - $(.ci/get_build_dist.sh) | zstd -T${THREADS} -15 > dist.tar.zst
-  tags:
-   - local
 
 # Tests run on shared runners:
 
 cores:unittests:
-  extends: .test-common
+  extends: .test-common-shared
   script:
     - cabal v2-run -- clash-cores:unittests --hide-successes
 
 cosim:unittests:
-  extends: .test-common
+  extends: .test-common-shared
   script:
     - cabal v2-run -- clash-cosim:tests
 
 prelude:unittests:
-  extends: .test-common
+  extends: .test-common-shared
   script:
     - cabal v2-run -- clash-prelude:unittests --hide-successes
 
 lib:unittests:
-  extends: .test-common
+  extends: .test-common-shared
   script:
     - cabal v2-run -- clash-lib:unittests --hide-successes
 
 prelude:doctests:
-  extends: .test-common
+  extends: .test-common-shared
   script:
     - cabal v2-run -- clash-prelude:doctests -j${THREADS}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,36 +25,17 @@ stages:
   - publish
   - post
 
-# Triggers child pipelines that runs tests for various GHC and Cabal versions.
-# Should be replaced by matrix builds in the future, but currently blocking on:
-# https://gitlab.com/gitlab-org/gitlab/-/issues/270957
-.common-trigger:
+tests:
   stage: test
   needs: []
   trigger:
     include: .ci/gitlab/test.yml
     strategy: depend
-
-tests-8.6:
-  extends: .common-trigger
-  variables:
-    GHC_VERSION: 8.6.5
-    MULTIPLE_HIDDEN: "no"
-
-tests-8.8:
-  extends: .common-trigger
-  variables:
-    GHC_VERSION: 8.8.4
-
-tests-8.10:
-  extends: .common-trigger
-  variables:
-    GHC_VERSION: 8.10.7
-
-tests-9.0:
-  extends: .common-trigger
-  variables:
-    GHC_VERSION: 9.0.2
+  parallel:
+    matrix:
+      - GHC_VERSION: [8.8.4, 8.10.7, 9.0.2]
+      - GHC_VERSION: 8.6.5
+        MULTIPLE_HIDDEN: "no"
 
 stack-build:
   extends: .common-local

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,10 +64,6 @@ stack-build:
     GHC_VERSION: 8.10.7
   script:
     - .ci/stack_build.sh
-  # Run on shared runners
-  # XXX: Temporarily on local runners
-  tags:
-   - local
 
 nix-build:
   image: nixos/nix:2.9.2
@@ -145,9 +141,6 @@ snap-stable:
   image: curlimages/curl
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-  # XXX: Temporarily on local runners
-  tags:
-   - local
 
 set_pending:
   extends: .github_status

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,11 @@ variables:
   # Hackage.
   GHC_VERSION: 8.10.7
 
+  # https://docs.gitlab.com/runner/executors/custom.html#system-failure
+  GET_SOURCES_ATTEMPTS: 5
+  RESTORE_CACHE_ATTEMPTS: 5
+  ARTIFACT_DOWNLOAD_ATTEMPTS: 5
+
 stages:
   - pre
   - test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ tests-9.0:
     GHC_VERSION: 9.0.2
 
 stack-build:
-  extends: .common
+  extends: .common-local
   needs: []
   stage: test
   variables:
@@ -77,7 +77,7 @@ nix-build:
     - local
 
 haddock:
-  extends: .common
+  extends: .common-local
   needs: []
   stage: test
   variables:
@@ -88,8 +88,6 @@ haddock:
     expire_in: 1 month
   script:
     - .ci/build_docs.sh
-  tags:
-    - local
 
 # # Run benchmarks for isclashfastyet.com
 # benchmark-8.10.2:

--- a/clash-lib/tests/Clash/Tests/Netlist/Id.hs
+++ b/clash-lib/tests/Clash/Tests/Netlist/Id.hs
@@ -24,8 +24,6 @@ import qualified Data.Text as Text
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import Test.QuickCheck.Utf8
-import Text.Show.Pretty (ppShow)
-import Debug.Trace
 
 newtype NonEmptyText = NonEmptyText Text deriving (Show)
 newtype ArbitraryText = ArbitraryText Text deriving (Show)
@@ -123,7 +121,6 @@ tests =
         id0 <- Id.addRaw "LED"
         put old
         Id.add id0
-        traceM . ppShow =<< get
         id1 <- Id.toText <$> Id.make "led"
         pure [ testCase "id1 == led_0" $ id1 @?= "led_0" ]
 

--- a/clash-prelude/src/Clash/Annotations/Primitive.hs
+++ b/clash-prelude/src/Clash/Annotations/Primitive.hs
@@ -12,6 +12,7 @@ primitives.
 
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
+++ b/clash-prelude/src/Clash/Annotations/SynthesisAttributes.hs
@@ -9,6 +9,8 @@
   please report any unexpected or broken behavior to Clash's GitHub page
   (<https://github.com/clash-lang/clash-compiler/issues>).
 -}
+
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PolyKinds #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Annotations/TopEntity.hs
+++ b/clash-prelude/src/Clash/Annotations/TopEntity.hs
@@ -228,6 +228,7 @@ still need the @NOINLINE@ annotation.
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Class/BitPack.hs
+++ b/clash-prelude/src/Clash/Class/BitPack.hs
@@ -6,6 +6,8 @@ Copyright  :  (C) 2013-2016, University of Twente
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
+
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE Safe #-}
 
 module Clash.Class.BitPack

--- a/clash-prelude/src/Clash/Class/Num.hs
+++ b/clash-prelude/src/Clash/Class/Num.hs
@@ -5,6 +5,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Class/Resize.hs
+++ b/clash-prelude/src/Clash/Class/Resize.hs
@@ -5,6 +5,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}

--- a/clash-prelude/src/Clash/Explicit/Mealy.hs
+++ b/clash-prelude/src/Clash/Explicit/Mealy.hs
@@ -12,6 +12,8 @@
   requirements.
 -}
 
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+
 {-# LANGUAGE Safe #-}
 
 module Clash.Explicit.Mealy

--- a/clash-prelude/src/Clash/Explicit/Moore.hs
+++ b/clash-prelude/src/Clash/Explicit/Moore.hs
@@ -12,6 +12,8 @@
   requirements.
 -}
 
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+
 {-# LANGUAGE Safe #-}
 
 module Clash.Explicit.Moore

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -13,6 +13,7 @@ defined in "Clash.Prelude".
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -10,6 +10,7 @@ Synchronizer circuits for safe clock domain crossings
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/HaskellPrelude.hs
+++ b/clash-prelude/src/Clash/HaskellPrelude.hs
@@ -12,6 +12,8 @@ Haskell Prelude does. In addition, for the 'Clash.Class.Parity.odd' and
 'Clash.Class.Parity.Parity' is available at "Clash.Class.Parity".
 -}
 
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}

--- a/clash-prelude/src/Clash/NamedTypes.hs
+++ b/clash-prelude/src/Clash/NamedTypes.hs
@@ -33,6 +33,7 @@ fifo @System
 
 -}
 
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PolyKinds #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -377,6 +377,7 @@ This concludes the short introduction to using 'blockRam'.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/clash-prelude/src/Clash/Prelude/BlockRam/Blob.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam/Blob.hs
@@ -18,6 +18,8 @@ practically the same HDL as "Clash.Prelude.BlockRam" and is compatible with all
 tools consuming the generated HDL.
 -}
 
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}

--- a/clash-prelude/src/Clash/Prelude/DataFlow.hs
+++ b/clash-prelude/src/Clash/Prelude/DataFlow.hs
@@ -11,6 +11,7 @@ Self-synchronizing circuits based on data-flow principles.
 
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -13,6 +13,7 @@
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 
 {-# LANGUAGE Safe #-}
 

--- a/clash-prelude/src/Clash/Prelude/Moore.hs
+++ b/clash-prelude/src/Clash/Prelude/Moore.hs
@@ -13,6 +13,7 @@
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 
 {-# LANGUAGE Safe #-}
 

--- a/clash-prelude/src/Clash/Prelude/RAM.hs
+++ b/clash-prelude/src/Clash/Prelude/RAM.hs
@@ -11,6 +11,7 @@ RAM primitives with a combinational read port
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE Safe #-}

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -32,6 +32,7 @@
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 
 {-# LANGUAGE Safe #-}
 

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -9,6 +9,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 


### PR DESCRIPTION
This is mainly a backport of #2403 but some things are thrown in for good measure.

* #2403 fixes #2402; this PR includes #2402.
* The commits fe2a53daaee7957a0095fb36ae42a6a82413386c and 2012b8629747827ea5c9adc9ad6c8eade0148f18 were not backported to 1.6 yet but they also improve CI and are really small, so they are included too.
## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

(It turns out commits e3266bc8f and ad525af76 don't update the copyright notices, but they are so trivial...)