### PR TITLE
GitLab CI: Move snap publish to local

### DIFF
--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -101,3 +101,5 @@ debian-bindist-test:
     - .ci/snap.sh publish
   retry:
     max: 2
+  tags:
+    - local


### PR DESCRIPTION
It turns out this job takes nearly 20 minutes on a shared runner, so it times out since we decreased the timeout to 10 minutes.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
