### PR TITLE
GitLab CI: Increase snap publish timeout

### DIFF
--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -80,7 +80,7 @@ debian-bindist-test:
 
 # Use binary distribution built in `snap-bindist` to build a snap package.
 .snap:
-  timeout: 10 minutes
+  timeout: 2 hours
   image: ghcr.io/clash-lang/snapcraft:2022-01-23
   stage: publish
   interruptible: false


### PR DESCRIPTION
PR #2403 decreased the timeout of jobs on shared runners to 10 minutes, and PR #2415 moved the snap publish job to local runners because it is a big job. PR #2415 should have also set the timeout back to 2 hours, but I missed it.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
