### PR TITLE
GitHub CI: Use correct 8.10 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
             ghc: 8.8.4
             multiple_hidden: yes
 
-          - name: GHC 8.10.2, Multiple Hidden
-            ghc: 8.10.2
+          - name: GHC 8.10.7, Multiple Hidden
+            ghc: 8.10.7
             multiple_hidden: yes
 
           - name: GHC 9.0.2, Multiple Hidden


### PR DESCRIPTION
The full tests that are run on the `1.6` branch accidentally refer to a non-existing docker image for 8.10: PR #2201 introduces 8.10.7 as the version for the docker image, but omitted the GHC version bump for the `build_and_test` target.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
