### PR TITLE
Add Xilinx VIO Probes to `clash-cores`

### DIFF
--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -89,6 +89,8 @@ library
     Clash.Cores.Xilinx.DcFifo.Internal.BlackBoxes
     Clash.Cores.Xilinx.DcFifo.Internal.Instances
     Clash.Cores.Xilinx.DcFifo.Internal.Types
+    Clash.Cores.Xilinx.VIO
+    Clash.Cores.Xilinx.VIO.Internal.BlackBoxes
     Clash.Cores.Xilinx.Floating
     Clash.Cores.Xilinx.Floating.Annotations
     Clash.Cores.Xilinx.Floating.BlackBoxes

--- a/clash-cores/src/Clash/Cores/Xilinx/VIO.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/VIO.hs
@@ -1,0 +1,103 @@
+{-|
+Copyright  :  (C) 2022, Google Inc,
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Support for [Xilinx VIO Probes v3.0](https://docs.xilinx.com/v/u/en-US/pg159-vio).
+
+It is necessary to read the product guide linked above in order to effectively
+use the IP.
+
+Note that VIOs offers an interactive hardware debugging feature that
+lets you read from signals attached to input probes and write to
+signals attached to output probes while, running your design on an
+actual FPGA. Software offered by the IP vendor is required for using
+this debugging feature. There is no respective software equivalent
+build into Clash.
+
+Clash simulation is not applicable for this IP.
+
+The IP supports up to 256 input probes and up to 256 output probes,
+each with a maximal width of 256 bits. If these limits are exceeded,
+then Clash cannot instantiate the IP and raises an error.
+
+When using the generated VIO probes make sure you have set the correct
+JTAG clock speed:
+
+[/"For non-Versal architectures, if your design contains debug cores, ensure that the JTAG clock is 2.5 times slower than the debug hub clock."/](https://www.xilinx.com/content/dam/xilinx/support/documents/sw_manuals/xilinx2022_2/ug908-vivado-programming-debugging.pdf)
+
+-}
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Clash.Cores.Xilinx.VIO
+  ( vioProbe
+  ) where
+
+import Clash.Explicit.Prelude
+import Clash.Annotations.Primitive (Primitive (InlineYamlPrimitive))
+
+import Data.String.Interpolate (__i)
+
+import Clash.Cores.Xilinx.VIO.Internal.BlackBoxes
+
+class VIO (dom :: Domain) a res | a -> res where
+  vioX :: a
+
+-- results are virtual outputs
+instance VIO dom (Signal dom o) o where
+  vioX = pure undefined
+
+-- arguments are virtual inputs
+instance VIO dom a o => VIO dom (Signal dom i -> a) o where
+  vioX !_i = vioX @dom @a @o
+
+-- | VIO Probes are available in Clash via the polyvariadic function
+-- 'vioProbe'. If 'vioProbe' has more than one additional argument,
+-- then every argument is turned into a single input probe, where the
+-- probe's width is determined according to the argument's bit
+-- size. If 'vioProbe' has only one additional argument, which
+-- consists of multiple elements that are boxed within a vector or
+-- product type, then each of these inner elements is assigned to a
+-- single probe instead (with the probe widths matching the elements'
+-- bit sizes accordingly). In any other case, the single argument is
+-- assigned to a single probe. The output of 'vioProbe' is either
+-- assigned to a single probe, or to multiple probes if boxed within a
+-- vector or product type, similar to a single input argument.
+--
+-- Example incarnations are:
+--
+-- @
+-- someProbe :: 'KnownDomain' dom => 'Clock' dom -> 'Signal' dom 'Bit' -> 'Signal' dom ('Unsigned' 8) -> 'Signal' dom ('Bool', 'Maybe' ('Signed' 8))
+-- someProbe = 'vioProbe' ('False', 'Nothing')
+-- @
+--
+-- Creates VIO IP with two input probes of bit widths 1 and 8,
+-- and two output probes of bit widths 1 and 9, respectively. The
+-- output probes are both initialized to 0.
+--
+-- @
+-- otherProbe :: 'KnownDomain' dom => 'Clock' dom -> 'Signal' dom ('Unsigned' 4, 'Unsigned' 2, 'Bit') -> 'Signal' dom ('Vec' 3 'Bit')
+-- otherProbe = 'vioProbe' ('repeat' 'high')
+-- @
+--
+-- Creates VIO IP with three input probes of bit widths 4, 2, and 1,
+-- and three output probes, all a single bit wide. The output probes
+-- are all initialized to 1.
+vioProbe :: forall dom a o. (KnownDomain dom, VIO dom a o) => o -> Clock dom -> a
+vioProbe !_initialOutputProbeValues !_clk = vioX @dom @a @o
+{-# NOINLINE vioProbe #-}
+{-# ANN vioProbe (
+    let primName = 'vioProbe
+        tfName = 'vioProbeBBF
+    in InlineYamlPrimitive [minBound..] [__i|
+         BlackBoxHaskell:
+             name: #{primName}
+             templateFunction: #{tfName}
+             workInfo: Always
+         |]) #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/VIO/Internal/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/VIO/Internal/BlackBoxes.hs
@@ -1,0 +1,305 @@
+{-|
+  Copyright   :  (C) 2022 Google Inc
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Blackbox implementation for primitives in "Clash.Cores.Xilinx.VIO".
+-}
+
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Cores.Xilinx.VIO.Internal.BlackBoxes (vioProbeBBF) where
+
+import Prelude
+
+import GHC.Stack (HasCallStack)
+
+import Data.Foldable (fold)
+import Data.String.Interpolate (__i)
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import qualified Data.Text as T (pack, append, concat)
+
+import Control.Arrow (first)
+import Control.Monad.State (State, when, forM, zipWithM)
+import Control.Exception (assert)
+
+import qualified Clash.Netlist.Id as Id
+import qualified Clash.Primitives.DSL as DSL
+import Clash.Backend (Backend)
+import Clash.Netlist.Expr (bits, fromBits)
+import Clash.Netlist.Types
+  ( Size
+  , Expr(..)
+  , HWType(..)
+  , EntityOrComponent(..)
+  , TemplateFunction(..)
+  , BlackBoxContext(..)
+  , BlackBox(BBFunction)
+  )
+import Clash.Netlist.BlackBox.Types
+  ( TemplateKind(..)
+  , RenderVoid(..)
+  , BlackBoxFunction
+  , BlackBoxMeta(..)
+  , emptyBlackBoxMeta
+  )
+
+import Clash.Cores.Xilinx.Internal
+  ( TclPurpose(..)
+  , IpConfig(..)
+  , defIpConfig
+  , property
+  , renderTcl
+  )
+
+vioProbeBBF :: HasCallStack => BlackBoxFunction
+vioProbeBBF _isD _primName _args _resTys = pure $ Right (bbMeta, bb)
+ where
+   bbMeta :: BlackBoxMeta
+   bbMeta = emptyBlackBoxMeta
+     { bbKind = TDecl
+     , bbRenderVoid = RenderVoid
+     , bbIncludes =
+         [ ( ("vioProbe", "clash.tcl")
+           , BBFunction (show 'vioProbeTclTF) 0 vioProbeTclTF
+           )
+         ]
+     }
+
+   bb :: BlackBox
+   bb = BBFunction (show 'vioProbeTF) 0 vioProbeTF
+
+vioProbeTF :: HasCallStack => TemplateFunction
+vioProbeTF =
+  TemplateFunction
+    (
+--      0 :       -- KnownDomain dom
+--      1 :       -- VIO dom a o
+      2 :       -- initialOutputProbeValues
+      3 :       -- Clock dom
+      [4,5..]   -- input probes
+    )
+    -- 'validateVioProbeBCC' already produces string describing
+    -- failing checks, but 'TemplateFunction' cannot handle this
+    -- yet. This is prepared to get updated easily as soon as the
+    -- feature gets implemented in clash-lib.
+    (maybe True error . validateVioProbeBBC)
+    vioProbeBBTF
+
+vioProbeBBTF :: Backend s => BlackBoxContext -> State s Doc
+vioProbeBBTF bbCtx
+  | (   _knownDomainDom
+      : _vioConstraint
+      : _initialOutputProbeValues
+      : clk
+      : inputProbes
+      ) <- map fst $ DSL.tInputs bbCtx
+  , [vioProbeName] <- bbQsysIncName bbCtx
+  , Right (inTys, outTys) <- probesFromTypes bbCtx
+  , [tResult] <- map DSL.ety (DSL.tResults bbCtx)
+  = do
+      vioProbeInstName <- Id.makeBasic "vio_inst"
+
+      let
+        inPs = filter ((> (0 :: Int)) . DSL.tySize . DSL.ety) inputProbes
+        inNames = map (T.pack . ("probe_in" <>) . show) [0 :: Int, 1..]
+        outNames = map (T.pack . ("probe_out" <>) . show) [0 :: Int, 1..]
+        inBVNames = map (`T.append` "_bv") inNames
+        outBVNames = map (`T.append` "_bv") outNames
+
+      DSL.declarationReturn bbCtx "vio_inst_block" $ do
+        DSL.compInBlock vioProbeName (("clk", Bit) : zip inNames inTys)
+          $ case tResult of
+              Void{} -> []
+              _      -> [("out_probes", tResult)]
+
+        inProbesBV <- case inPs of
+          [ singleInput ] -> case DSL.ety singleInput of
+            Vector{}  -> DSL.unvec "vec" singleInput
+            Product{} -> DSL.deconstructProduct singleInput inBVNames
+            _         -> pure <$> DSL.toBV (head inBVNames) singleInput
+          _ -> zipWithM DSL.toBV inBVNames inPs
+
+        outProbesBV <-
+          forM (zip outBVNames outTys) $ \(name, ty) ->
+            DSL.declare name $ BitVector $ fromInteger $ DSL.tySize ty
+        outProbes <-
+          forM (zip (zip outNames outTys) outProbesBV)
+            $ uncurry $ uncurry DSL.fromBV
+
+        DSL.instDecl Empty (Id.unsafeMake vioProbeName) vioProbeInstName []
+          (("clk", clk) : zip inNames inProbesBV)
+          (zip outNames outProbesBV)
+
+        case tResult of
+          Vector{}  -> pure <$> DSL.vec outProbes
+          Product{} -> pure $ pure $ DSL.constructProduct tResult outProbes
+          _         -> pure outProbes
+
+  | otherwise = error $ "vioProbeBBTF, bad bbCtx: " <> show bbCtx
+
+vioProbeTclTF :: HasCallStack => TemplateFunction
+vioProbeTclTF =
+  TemplateFunction
+    (
+--      0 :       -- KnownDomain dom
+--      1 :       -- VIO dom a o
+      2 :       -- initialOutputProbeValues
+      3 :       -- Clock dom
+      [4,5..]   -- input probes
+    )
+    -- 'validateVioProbeBCC' already produces string describing
+    -- failing checks, but 'TemplateFunction' cannot handle this
+    -- yet. This is prepared to get updated easily as soon as the
+    -- feature gets implemented in clash-lib.
+    (maybe True error . validateVioProbeBBC)
+    vioProbeTclBBTF
+
+vioProbeTclBBTF ::
+  forall s.
+  (HasCallStack, Backend s) =>
+  BlackBoxContext ->
+  State s Doc
+vioProbeTclBBTF bbCtx
+  | ( _knownDomainDom
+    : _vioConstraint
+    : initialOutputProbeValues
+    : _clk
+    : _inputProbes
+    ) <- map fst $ DSL.tInputs bbCtx
+  , [vioProbeName] <- bbQsysIncName bbCtx
+  , Right (inTys, outTys) <- probesFromTypes bbCtx
+  = do
+
+    let
+      outIVals = case DSL.ety initialOutputProbeValues of
+        CustomProduct{} ->
+          -- TODO: support custom bit representations for S&P types
+          error "Custom bit representations are not supported within VIOs yet"
+        _ ->
+          constantProbeValues
+            (DSL.ety initialOutputProbeValues)
+            (DSL.eex initialOutputProbeValues)
+
+    when (length outIVals /= length outTys) $
+      error "Internal: Unexpected Structure (this should not happen)"
+
+    pure $ renderTcl $ pure $ IpConfigPurpose
+      $ (defIpConfig "vio" "3.0" vioProbeName)
+           { properties = vioProbeProperties inTys outTys outIVals
+           }
+  | otherwise = error $ "vioProbeBBTF, bad bbCtx: " <> show bbCtx
+ where
+  vioProbeProperties inTys outTys outIVals =
+    [ property @Int "C_NUM_PROBE_IN" $ length inTys
+    , property @Int "C_NUM_PROBE_OUT" $ length outTys
+    ] <>
+    [ property @Int (T.concat ["C_PROBE_IN", T.pack $ show i, "_WIDTH"]) n
+    | (i,t) <- zip [0 :: Int, 1..] inTys
+    , let n = fromInteger $ DSL.tySize t
+    ] <>
+    [ property @Int (T.concat ["C_PROBE_OUT", T.pack $ show i, "_WIDTH"]) n
+    | (i,t) <- zip [0 :: Int, 1..] outTys
+    , let n = fromInteger $ DSL.tySize t
+    ] <>
+    [ property @Int (T.concat ["C_PROBE_OUT", T.pack $ show i, "_INIT_VAL"]) v
+    | (i, v) <- zip [0 :: Int, 1..] outIVals
+    ]
+
+-- | Turns a known to be constant value 'Expr' of some known 'HWType'
+-- into a list of initial probe values, where the probe distribution
+-- is determined according to the 'HWType'.
+constantProbeValues :: HasCallStack => HWType -> Expr -> [Int]
+constantProbeValues ty expr = case bits (DSL.tySize ty) expr of
+  Left failedExpr -> error [__i|
+    Clash failed to determine a constant value for one of the expressions
+    given as the inital output probe values. The failing expression is:
+
+      #{show failedExpr}
+
+    The complete expression is:
+
+      #{show expr}
+
+    As a quick fix: it may help to leverage the template haskell function
+    $(lift ...) to get rid of this error message.
+    |]
+  Right x ->
+    let res = map fromBits $ multi ty $ fold x
+    in assert (all (<= 256) res) res
+
+ where
+  -- distributes the given bitstream to multiple probes
+  multi :: HWType -> [Bool] -> [[Bool]]
+  multi t bs = assert (length bs == DSL.tySize t) $ case t of
+    Product _ _ ts -> bs `splitAts` map DSL.tySize ts
+    Vector s t'    -> bs `splitAts` replicate s (DSL.tySize t')
+    Void _         -> []
+    _              -> [bs]
+
+  -- splits the given bitstream according to the given sizes
+  splitAts :: [Bool] -> [Size] -> [[Bool]]
+  splitAts bs =
+    reverse . fst . foldl (\(a, xs) m -> first (:a) $ splitAt m xs) ([], bs)
+
+-- | Blackbox context validation.
+validateVioProbeBBC :: BlackBoxContext -> Maybe String
+validateVioProbeBBC bbCtx = case probesFromTypes bbCtx of
+  Left err -> Just err
+  Right _  -> Nothing
+
+-- | Determines the number of specified input/output probes from the
+-- argument and result types, every argument is mapped to a single
+-- probe. See 'Clash.Cores.Xilinx.VIO' for the details on how result
+-- types are mapped to probes.
+probesFromTypes :: BlackBoxContext -> Either String ([HWType], [HWType])
+probesFromTypes Context{..} = do
+  is <- case map (\(_,x,_) -> x) bbInputs of
+    (   _knownDomainDom
+      : _VIOConstraint
+      : _clk
+      : _initialOutputProbeValues
+      : xs
+      ) -> inputProbesFromTypes xs
+    _   -> Left "Internal: Unexpected Structure (this should not happen)"
+
+  os <- case map snd bbResults of
+    [t] -> probesFromSingleOrProductType t
+    _   -> Left "Multiple result primitives are not supported"
+
+  return (is, os)
+
+ where
+  inputProbesFromTypes xs
+    | length xs > 256 = Left errProbeLimit
+    | otherwise       = case xs of
+        [t] -> probesFromSingleOrProductType t
+        _   -> mapM singleProbe $ filter ((> (0 :: Int)) . DSL.tySize) xs
+
+  probesFromSingleOrProductType = \case
+    Vector s t        -> multibleProbes $ replicate s t
+    Product _ _ xs    -> multibleProbes xs
+    BiDirectional _ t -> probesFromSingleOrProductType t
+    Annotated _ t     -> probesFromSingleOrProductType t
+    Void{}            -> return []
+    t                 -> pure <$> singleProbe t
+
+  multibleProbes ts = do
+    ps <- filter ((>= (1 :: Int)) . DSL.tySize) <$> mapM singleProbe ts
+    when (length ps > 256) $ Left errProbeLimit
+    return ps
+
+  singleProbe ty =
+    let s :: Int
+        s = DSL.tySize ty
+    in if s < 0 || s > 256
+       then Left errProbeRange
+       else return ty
+
+  errProbeLimit = "At most 256 input/output probes are supported."
+  errProbeRange = "Probe signals must be been between 1 and 256 bits wide."

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -236,6 +236,7 @@ Library
                       Clash.Netlist.BlackBox.Parser
                       Clash.Netlist.BlackBox.Types
                       Clash.Netlist.BlackBox.Util
+                      Clash.Netlist.Expr
                       Clash.Netlist.Id
                       Clash.Netlist.Id.Common
                       Clash.Netlist.Id.Internal

--- a/clash-lib/src/Clash/Netlist/Expr.hs
+++ b/clash-lib/src/Clash/Netlist/Expr.hs
@@ -1,0 +1,172 @@
+{-|
+  Copyright  :  (C) 2012-2016, University of Twente,
+                    2017     , Myrtle Software Ltd,
+                    2017-2018, Google Inc.
+                    2020-2022, QBayLogic B.V.
+                    2022     , Google Inc.
+  License    :  BSD2 (see the file LICENSE)
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Functions for expression manipulation
+-}
+
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clash.Netlist.Expr where
+
+import Control.Monad (zipWithM)
+import Control.Exception (assert)
+import Data.Set (fromList, member)
+import Data.Bits (Bits, testBit, setBit, zeroBits)
+import Data.Foldable (fold)
+import Data.Tree (Tree(..))
+import GHC.Stack (HasCallStack)
+import Data.Text (unpack)
+import Language.Haskell.TH.Quote (dataToPatQ)
+
+import qualified Clash.Sized.Vector as V (replicate)
+import qualified Clash.Sized.Internal.Index as I (fromInteger#)
+import qualified Clash.Sized.Internal.Signed as S (fromInteger#)
+import qualified Clash.Sized.Internal.Unsigned as U (fromInteger#)
+import qualified Clash.Sized.Internal.BitVector as BV
+  (high, low, fromInteger#, fromInteger##)
+import GHC.Int (Int8(I8#), Int16(I16#), Int32(I32#), Int64(I64#))
+import GHC.Word (Word8(W8#), Word16(W16#), Word32(W32#), Word64(W64#))
+
+import Clash.Primitives.DSL (tySize)
+import Clash.Netlist.Types
+  ( Size, Bit(..), Expr(..), HWType(..), Literal(..), Modifier(..)
+  , BlackBoxContext(..)
+  )
+
+-- | Turns a constant expression of known bitsize into their
+-- corresponding bitstream representation, arranged as a tree
+-- that corresponds to the structure of the expression.
+--
+-- NOTE: This conversion serves as a best effort approach and can be
+-- considered a hack. Fully featured constant expression evaluation is
+-- not available in clash yet and will replace this implementation
+-- once it is officially supported.
+bits :: HasCallStack => Size -> Expr -> Either Expr (Tree [Bool])
+bits size expr = case expr of
+  Literal _ lit -> case lit of
+    BitLit bLit   -> case bLit of
+      H -> leaf [True]
+      L -> leaf [False]
+      _ -> Left expr
+    BoolLit bLit      -> leaf [bLit]
+    NumLit nLit       -> leaf $ toBits size nLit
+    BitVecLit _ bvLit -> leaf $ toBits size bvLit
+    VecLit lits       ->
+      mapM (bits (size `div` length lits) . lit2Expr) lits >>= inner
+    StringLit{}       -> Left expr
+  DataCon ty m subs -> assert (tySize ty == size) $ case ty of
+    Vector s t      -> vecBits (tySize t) s subs
+    Product _ _ tys -> zipWithM bits (map tySize tys) subs >>= inner
+    Sum _ cs        -> spBits expr size m subs $ map (const []) cs
+    SP _ xs         -> spBits expr size m subs $ map (map tySize . snd) xs
+    _               -> case subs of
+      [e] -> bits size e
+      []  -> leaf []
+      _   -> Left expr
+  -- appears in case of complex transformations, e.g.,
+  -- >>> (bv2v 0b010) :: Vec 3 Bit
+  -- >>> (iterate (SNat @3) not True) :: Vec 3 Bool
+  -- >>> (complement <$> (True :> False :> Nil)) :: Vec 2 Bool
+  Identifier{} -> Left expr
+  DataTag{} -> Left expr
+  BlackBoxE bbName _ _ _ _ bbCtx _ -> case unpack bbName of
+    $(dataToPatQ (const Nothing) $ show 'BV.low) -> leaf [False]
+    $(dataToPatQ (const Nothing) $ show 'BV.high) -> leaf [True]
+    $(dataToPatQ (const Nothing) $ show 'V.replicate) -> case bbInputs bbCtx of
+      [ (eSize, ty, _), (eValue, _, _) ] -> do
+        bs <- bits (tySize ty) eSize
+        let s = fromBits $ fold bs
+        v <- bits (size `div` s) eValue
+        inner $ replicate s v
+      _ -> Left expr
+    _ ->
+      if unpack bbName `member` skippableBBs
+      then skippableBBBits expr bbCtx size
+      else Left expr
+  ToBv _ _ e -> bits size e
+  FromBv _ _ e -> bits size e
+  IfThenElse cond match alt -> case bits 1 cond of
+    Right (Node [True] [])  -> bits size match
+    Right (Node [False] []) -> bits size alt
+    _ -> Left expr
+  Noop -> leaf []
+
+ where
+  -- known skippable blackboxes
+  skippableBBs = fromList $ map show
+    [ 'I.fromInteger#, 'S.fromInteger#, 'U.fromInteger#
+    , 'BV.fromInteger#, 'BV.fromInteger##
+    , 'I8#, 'I16#, 'I32#, 'I64#
+    , 'W8#, 'W16#, 'W32#, 'W64#
+    ]
+
+  -- skips the blackbox conversion and obtains the constant result
+  -- directly from the last input argument instead
+  skippableBBBits e Context{..} n = case reverse bbInputs of
+    (x, _, _) : _ -> bits n x
+    _             -> Left e
+
+  -- turns sum (& product) expressions into bitstreams (preserving the
+  -- expressions' tree layout)
+  spBits :: Expr -> Size -> Modifier -> [Expr] -> [[Size]]
+         -> Either Expr (Tree [Bool])
+  spBits e n m es sizes = case m of
+    DC (_, i) -> do
+      xs <- zipWithM bits (sizes !! i) es
+      bs <- fold <$> inner xs
+      l <- leaf $ toBits (n - length bs) i
+      r <- leaf bs
+      inner [ l, r ]
+    _ -> Left e
+
+  -- turns vector expressions into bitstream (preserving the
+  -- expressions' tree layout)
+  vecBits :: Size -> Int -> [Expr] -> Either Expr (Tree [Bool])
+  vecBits elemSize elems = \case
+    []   -> assert (elems == 0) $ leaf []
+    x:xr -> assert (elems > 0) $ do
+      (processedElems, cur) <- case x of
+        DataCon t _ xs -> case t of
+          Vector subElems (tySize -> subTySize) ->
+            assert (subElems <= elems && subTySize == elemSize)
+              ((subElems,) <$> vecBits elemSize subElems xs)
+          _ -> (1,) <$> bits elemSize x
+        _ -> (1,) <$> bits elemSize x
+      sub <- vecBits elemSize (elems - processedElems) xr
+      inner [cur, sub]
+
+  -- creates a leaf node holding the leaf value
+  leaf :: [a] -> Either b (Tree [a])
+  leaf x = return $ Node x []
+
+  -- creates an inner node (holding no value) with the given
+  -- sub-trees
+  inner :: [Tree [a]] -> Either b (Tree [a])
+  inner = return . Node []
+
+  -- turns a literal into an expression
+  lit2Expr = Literal Nothing
+
+-- | Turns values into bitstreams of known length. If the bit stream
+-- requires more bits for representing the given value, then only the
+-- suffix of the corresponding bitstream gets returned.
+toBits :: Bits a => Int -> a -> [Bool]
+toBits n x =
+  map (testBit x) [n-1,n-2..0]
+
+-- | Turns bitstreams into values.
+fromBits :: Bits a => [Bool] -> a
+fromBits xs =
+  foldl setBit zeroBits $ map snd $ filter fst $ zip xs [n-1,n-2..0]
+ where
+  n = length xs

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -186,6 +186,28 @@ runClashTest = defaultMain $ clashTestRoot
           , expectClashFail=Just (def, "Template function for returned False")
           }
         ]
+      , clashTestGroup "Cores"
+        [ clashTestGroup "Xilinx"
+          [ clashTestGroup "VIO"
+            [ runTest "OutputBusWidthExceeded" def{
+                hdlTargets=[VHDL, Verilog, SystemVerilog]
+              , expectClashFail=Just (def, "Probe signals must be been between 1 and 256 bits wide.")
+              }
+            , runTest "OutputProbesExceeded" def{
+                hdlTargets=[VHDL, Verilog, SystemVerilog]
+              , expectClashFail=Just (def, "At most 256 input/output probes are supported.")
+              }
+            , runTest "InputBusWidthExceeded" def{
+                hdlTargets=[VHDL, Verilog, SystemVerilog]
+              , expectClashFail=Just (def, "Probe signals must be been between 1 and 256 bits wide.")
+              }
+            , runTest "InputProbesExceeded" def{
+                hdlTargets=[VHDL, Verilog, SystemVerilog]
+              , expectClashFail=Just (def, "At most 256 input/output probes are supported.")
+              }
+            ]
+          ]
+        ]
       , clashTestGroup "InvalidPrimitive"
         [ runTest "InvalidPrimitive" def{
             hdlTargets=[VHDL]
@@ -483,6 +505,13 @@ runClashTest = defaultMain $ clashTestRoot
                              }
               in runTest "Lfsr" _opts
             ]
+          , let _opts =
+                  def{ hdlTargets=[VHDL, Verilog, SystemVerilog]
+                     , hdlLoad=[]
+                     , hdlSim=[]
+                     , buildTargets = BuildSpecific []
+                     }
+            in runTest "VIO" _opts
           ]
         ]
       , clashTestGroup "CSignal"

--- a/tests/shouldfail/Cores/Xilinx/VIO/InputBusWidthExceeded.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/InputBusWidthExceeded.hs
@@ -1,0 +1,12 @@
+module InputBusWidthExceeded where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+
+type Dom = XilinxSystem
+
+topEntity ::
+  "clk" ::: Clock Dom ->
+  "in"  ::: Signal Dom (BitVector 257) ->
+  "out" ::: Signal Dom ()
+topEntity = vioProbe @Dom ()

--- a/tests/shouldfail/Cores/Xilinx/VIO/InputProbesExceeded.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/InputProbesExceeded.hs
@@ -1,0 +1,12 @@
+module InputProbesExceeded where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+
+type Dom = XilinxSystem
+
+topEntity ::
+  "clk" ::: Clock Dom ->
+  "in"  ::: Signal Dom (Vec 257 Bool) ->
+  "out" ::: Signal Dom ()
+topEntity = vioProbe @Dom ()

--- a/tests/shouldfail/Cores/Xilinx/VIO/OutputBusWidthExceeded.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/OutputBusWidthExceeded.hs
@@ -1,0 +1,11 @@
+module OutputBusWidthExceeded where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+
+type Dom = XilinxSystem
+
+topEntity ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (BitVector 257)
+topEntity = vioProbe @Dom 0

--- a/tests/shouldfail/Cores/Xilinx/VIO/OutputProbesExceeded.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/OutputProbesExceeded.hs
@@ -1,0 +1,11 @@
+module OutputProbesExceeded where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+
+type Dom = XilinxSystem
+
+topEntity ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (Vec 257 Bit)
+topEntity = vioProbe @Dom (replicate (SNat @257) low)

--- a/tests/shouldwork/Cores/Xilinx/VIO.hs
+++ b/tests/shouldwork/Cores/Xilinx/VIO.hs
@@ -1,0 +1,246 @@
+module VIO where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+import Clash.Annotations.TH
+import Clash.Annotations.BitRepresentation
+
+type Dom = XilinxSystem
+
+noInputTrue ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom Bool
+noInputTrue = vioProbe @Dom True
+
+makeTopEntityWithName 'noInputTrue ""
+
+
+noInputFalse ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom Bool
+noInputFalse = vioProbe @Dom False
+
+makeTopEntityWithName 'noInputFalse ""
+
+
+noInputLow ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom Bit
+noInputLow = vioProbe @Dom low
+
+makeTopEntityWithName 'noInputLow ""
+
+
+noInputHigh ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom Bit
+noInputHigh = vioProbe @Dom high
+
+makeTopEntityWithName 'noInputHigh ""
+
+
+noInputSigned ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (Signed 2)
+noInputSigned = vioProbe @Dom (-1)
+
+makeTopEntityWithName 'noInputSigned ""
+
+
+noInputUnsigned ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (Unsigned 2)
+noInputUnsigned = vioProbe @Dom 3
+
+makeTopEntityWithName 'noInputUnsigned ""
+
+
+noInputBitVector ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (BitVector 7)
+noInputBitVector = vioProbe @Dom 111
+
+makeTopEntityWithName 'noInputBitVector ""
+
+
+noInputPair ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (Bit, Bool)
+noInputPair = vioProbe @Dom (high, False)
+
+makeTopEntityWithName 'noInputPair ""
+
+
+noInputVec ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (Vec 4 (Unsigned 2))
+noInputVec = vioProbe @Dom (0 :> 1 :> 2 :> 3 :> Nil)
+
+makeTopEntityWithName 'noInputVec ""
+
+
+data D1 = D1 Bool Bit (Unsigned 2)
+
+noInputCustom ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom D1
+noInputCustom = vioProbe @Dom (D1 True high 1)
+
+makeTopEntityWithName 'noInputCustom ""
+
+
+data D2 = D2 Bool (Vec 2 D1)
+
+noInputNested ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom D2
+noInputNested = vioProbe @Dom (D2 True (D1 True high 1 :> D1 False low 0 :> Nil))
+
+makeTopEntityWithName 'noInputNested ""
+
+
+data T = R Bool Bool
+{-# ANN module (DataReprAnn
+                  $(liftQ [t|T|])
+                  3
+                  [ ConstrRepr 'R 0b111 0b000 [0b010, 0b001]
+                  ]) #-}
+{- TODO: Custom bit representations are not supported within VIOs
+   yet. See Clash.Cores.Xilinx.VIO.Internal.BlackBoxes for details.
+noInputCustomRep ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom T
+noInputCustomRep = vioProbe @Dom (R True False)
+
+makeTopEntityWithName 'noInputCustomRep ""
+-}
+
+
+singleInputBool ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom Bool ->
+  "out" ::: Signal Dom ()
+singleInputBool = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputBool ""
+
+
+singleInputBit ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom Bit ->
+  "out" ::: Signal Dom ()
+singleInputBit = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputBit ""
+
+
+singleInputSigned ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom (Signed 2) ->
+  "out" ::: Signal Dom ()
+singleInputSigned = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputSigned ""
+
+
+singleInputUnsigned ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom (Unsigned 2) ->
+  "out" ::: Signal Dom ()
+singleInputUnsigned = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputUnsigned ""
+
+
+singleInputBitVector ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom (BitVector 7) ->
+  "out" ::: Signal Dom ()
+singleInputBitVector = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputBitVector ""
+
+
+singleInputPair ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom (Bit, Bool) ->
+  "out" ::: Signal Dom ()
+singleInputPair = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputPair ""
+
+
+singleInputVec ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (Vec 4 (Unsigned 2)) ->
+  "out" ::: Signal Dom ()
+singleInputVec = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputVec ""
+
+
+singleInputCustom ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom D1 ->
+  "out" ::: Signal Dom ()
+singleInputCustom = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputCustom ""
+
+
+singleInputNested ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom D2 ->
+  "out" ::: Signal Dom ()
+singleInputNested = vioProbe @Dom ()
+
+makeTopEntityWithName 'singleInputNested ""
+
+
+multipleInputs ::
+  "clk" ::: Clock Dom ->
+  "in1" ::: Signal Dom Bit ->
+  "in2" ::: Signal Dom Bool ->
+  "in3" ::: Signal Dom (Unsigned 3) ->
+  "in4" ::: Signal Dom (Signed 4) ->
+  "in5" ::: Signal Dom (Bit, Bool, Bit) ->
+  "in6" ::: Signal Dom (Vec 3 (Unsigned 2)) ->
+  "in7" ::: Signal Dom D1 ->
+  "in8" ::: Signal Dom (BitVector 7) ->
+  "out" ::: Signal Dom (Vec 0 Bool)
+multipleInputs = vioProbe @Dom Nil
+
+makeTopEntityWithName 'multipleInputs ""
+
+
+inputsAndOutputs ::
+  "clk" ::: Clock Dom ->
+  "in1" ::: Signal Dom   Bit ->
+  "in2" ::: Signal Dom   Bool ->
+  "in3" ::: Signal Dom ( Unsigned 3 ) ->
+  "in4" ::: Signal Dom ( Signed 4 ) ->
+  "in5" ::: Signal Dom ( Bit, Bool, Bit ) ->
+  "in6" ::: Signal Dom ( Vec 3 (Unsigned 2) ) ->
+  "in7" ::: Signal Dom   D1 ->
+  "in8" ::: Signal Dom ( BitVector 7 ) ->
+  "out" ::: Signal Dom ( Bit
+                       , Bool
+                       , Unsigned 5
+                       , Signed 2
+                       , (Bool, Bit, Bool)
+                       , Vec 2 (Unsigned 3)
+                       , D1
+                       , BitVector 6
+                       )
+inputsAndOutputs = vioProbe @Dom
+  ( low
+  , True
+  , 1
+  , -1
+  , (True, low, False)
+  , 5 :> 3 :> Nil
+  , D1 False high 0
+  , 0b111000
+  )
+
+makeTopEntityWithName 'inputsAndOutputs ""


### PR DESCRIPTION
This PR adds [Xilinx Virtual IO Probes](https://www.xilinx.com/products/intellectual-property/vio.html) to [`clash-cores`](https://github.com/clash-lang/clash-compiler/tree/xilinx-vio-core/clash-cores).

VIO Probes are available in Clash via the polyvariadic function [`vioProbe`](https://github.com/clash-lang/clash-compiler/blob/xilinx-vio-core/clash-cores/src/Clash/Cores/Xilinx/VIO.hs#L42). If [`vioProbe`](https://github.com/clash-lang/clash-compiler/blob/xilinx-vio-core/clash-cores/src/Clash/Cores/Xilinx/VIO.hs#L42) has more than one argument, then every argument is turned into a single input probe, where the probe's width is determined according to the argument's bit size. If [`vioProbe`](https://github.com/clash-lang/clash-compiler/blob/xilinx-vio-core/clash-cores/src/Clash/Cores/Xilinx/VIO.hs#L42) has only one argument, which consists of multiple elements that are boxed within a vector or product type, then each of these inner elements is assigned to a single probe instead (with the probe widths matching the elements' bit sizes accordingly). In any other case, the single argument is assigned to a single probe. The output of [`vioProbe`](https://github.com/clash-lang/clash-compiler/blob/xilinx-vio-core/clash-cores/src/Clash/Cores/Xilinx/VIO.hs#L42) is either assigned to a single probe, or to multiple probes if boxed within a vector or product type, as for a single input.

Output probes are initialized to some initial value that must be set at IP creation time in Xilinx Vivado. In Clash these initial values are passed as a single argument to [`vioProbe`](https://github.com/clash-lang/clash-compiler/blob/xilinx-vio-core/clash-cores/src/Clash/Cores/Xilinx/VIO.hs#L42) and must match the output type of the probe. This passed value must be evaluated at compile time and gets currently reconstructed via static analysis of the generated Verilog code for the given expression.

Tests for the blackbox generation can be found in the [`shouldwork`](https://github.com/clash-lang/clash-compiler/blob/xilinx-vio-core/tests/shouldwork/Cores/Xilinx/VIO.hs) and [`shouldfail`](https://github.com/clash-lang/clash-compiler/tree/xilinx-vio-core/tests/shouldfail/Cores/Xilinx/VIO) folders.

--------------

## Open TODOs:
  - [x] Real Hardware Tests
  - [x] [VIO Module](https://github.com/clash-lang/clash-compiler/blob/xilinx-vio-core/clash-cores/src/Clash/Cores/Xilinx/VIO.hs) Documentation
