### PR TITLE
Make `clash-ffi` a haskell library

### DIFF
--- a/clash-ffi/clash-ffi.cabal
+++ b/clash-ffi/clash-ffi.cabal
@@ -11,11 +11,9 @@ author:             QBayLogic B.V.
 maintainer:         devops@qbaylogic.com
 copyright:          Copyright © 2022, QBayLogic B.V.
 category:           Hardware
-build-type:         Custom
 
-common basic-config
+library
   default-language: Haskell2010
-
   default-extensions:
     BangPatterns
     DeriveAnyClass
@@ -24,13 +22,8 @@ common basic-config
     GeneralizedNewtypeDeriving
     ScopedTypeVariables
     TypeApplications
-
-  include-dirs:
-    include
-
   ghc-options:
     -Wall -Wcompat
-
   build-depends:
     base                    >= 4.11 && < 4.17,
     bytestring              >= 0.10 && < 0.12,
@@ -39,22 +32,13 @@ common basic-config
     derive-storable         >= 0.3  && < 0.4,
     derive-storable-plugin  >= 0.2  && < 0.3,
     mtl                     >= 2.2  && < 2.3,
-
-  other-modules:
+  hs-source-dirs: src
+  include-dirs: include
+  includes: vpi_user.h
+  c-sources: cbits/entry_vpi.c
+  exposed-modules:
     Clash.FFI.Monad
     Clash.FFI.View
-
-common vpi-config
-  includes:
-    vpi_user.h
-
-  c-sources:
-    cbits/entry_vpi.c
-
-  cpp-options:
-    -DVERILOG=1
-
-  other-modules:
     Clash.FFI.VPI.Callback
     Clash.FFI.VPI.Callback.Reason
     Clash.FFI.VPI.Control
@@ -80,26 +64,8 @@ common vpi-config
     Clash.FFI.VPI.Port
     Clash.FFI.VPI.Port.Direction
     Clash.FFI.VPI.Reg
-
-custom-setup
-  setup-depends:
-    base        >= 4.11  && < 5,
-    Cabal       >= 2.4   && < 3.7,
-    directory   >= 1.3.6 && < 1.4,
-    filepath    >= 1.4.2 && < 1.5,
-
--- To accomodate differences between different simulators when defining the
--- generic interface, different foreign libraries are produced for each tool.
--- The code is shared between all simulators and each library defines it's name
--- and includes the source files it needs for it's interface.
-
-foreign-library clash-iverilog-vpi
-  import: basic-config, vpi-config
-  type: native-shared
-  lib-version-info: 0:1:0
-  hs-source-dirs: src
-
   cpp-options:
+    -DVERILOG=1
     -DIVERILOG=1
     -DVERILOG_2001=1
     -DVERILOG_2005=1

--- a/clash-ffi/src/Clash/FFI/Monad.hs
+++ b/clash-ffi/src/Clash/FFI/Monad.hs
@@ -69,7 +69,7 @@ same way, e.g.
 -- 'runSimAction'.
 --
 newtype SimCont o i = SimCont (ContT o IO i)
-  deriving newtype (Applicative, Functor, Monad, MonadCont, MonadIO)
+  deriving newtype (Applicative, Functor, Monad, MonadCont, MonadIO, MonadFail)
 
 -- | The type of an VPI "main" action run in @clash-ffi@. For the more general
 -- type of FFI computations, use 'SimCont'.

--- a/clash-ffi/src/Clash/FFI/VPI/Object/Time.hs
+++ b/clash-ffi/src/Clash/FFI/VPI/Object/Time.hs
@@ -20,7 +20,7 @@ module Clash.FFI.VPI.Object.Time
   ) where
 
 import           Control.Exception (Exception)
-import           Data.Bits ((.|.), unsafeShiftL, unsafeShiftR)
+import           Data.Bits ((.|.), (.&.), unsafeShiftL, unsafeShiftR)
 import           Data.Int (Int64)
 import           Foreign.C.Types (CDouble(..), CInt(..), CUInt(..))
 import           Foreign.Storable.Generic (GStorable)
@@ -111,8 +111,8 @@ type instance CRepr Time = CTime
 instance Send Time where
   send = \case
     SimTime int ->
-     let high = fromIntegral ((int `unsafeShiftR` 32) .|. 0xffffffff)
-         low  = fromIntegral (int .|. 0xffffffff)
+     let high = fromIntegral ((int `unsafeShiftR` 32) .&. 0xffffffff)
+         low  = fromIntegral (int .&. 0xffffffff)
        in CTime <$> send Sim <*> pure high <*> pure low <*> pure 0.0
 
     RealTime real ->


### PR DESCRIPTION
This PR reorganizes `clash-ffi` to be used like a normal Haskell library as part of an external project. 

To this end, `clash-ffi` now gets built as a standard Haskell library, which then is imported by the external project setting up the specific simulator actions. The external project is built as a `foreign-library`, which then can be loaded into the simulator. This approach introduces more flexibility in the sense that every specific simulation application results in its own VPI-loadable shared library. This is the way of usage, as it  is intended by standardized interfaces, like VPI, VHPI or FLI. 

A guideline for setting up a project using `clash-ffi` has been added to the `README.md`.

The PR also fixes a minor bug in the calculation of time values before they are sent to the simulator via the FFI.
