### PR TITLE
Workaround Haddock/CPP #if issues

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -30,6 +30,8 @@ package clash-prelude
   ghc-options: +RTS -qn4 -A128M -RTS -j4
   -- workaround for plugins not loading in Haddock with GHC-8.6
   haddock-options: --optghc=-fdefer-type-errors
+  -- Workaround for Haddock/CPP #if issues https://github.com/haskell/haddock/issues/1382
+  haddock-options: --optghc="-optP -P"
   -- Don't pollute docs with 1024 SNat literals
   haddock-options: --optghc=-DHADDOCK_ONLY
 


### PR DESCRIPTION
This eliminates the `# [line number]` artifacts we sometimes got in the  generated documentation in place of excluded `#if` blocks.

Fixes #2278

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

