### PR TITLE
New: `indexTuple`

### DIFF
--- a/changelog/2023-03-06T15_37_28+01_00_indexTuple
+++ b/changelog/2023-03-06T15_37_28+01_00_indexTuple
@@ -1,0 +1,2 @@
+NEW: `indexTuple`. This function can be used to bind variables to numbers
+indexing successive elements in a list-like structure.

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -298,6 +298,8 @@ Library
 
   other-modules:
                       Clash.Class.AutoReg.Instances
+                      Clash.Class.IndexTuple
+                      Clash.Class.IndexTuple.Deriving
                       Clash.CPP
                       Clash.Signal.Bundle.Internal
                       Language.Haskell.TH.Compat
@@ -327,6 +329,7 @@ Library
                       data-default-class        >= 0.1.2   && < 0.2,
                       deepseq                   >= 1.4.1.0 && < 1.5,
                       extra                     >= 1.6.17  && < 1.8,
+                      ghc,
                       ghc-prim                  >= 0.5.1.0 && < 0.9,
                       ghc-typelits-extra        >= 0.4     && < 0.5,
                       ghc-typelits-knownnat     >= 0.7.2   && < 0.8,
@@ -354,8 +357,6 @@ Library
     Build-Depends:    ghc-bignum                >= 1.0      && < 1.3
   else
     Build-Depends:    integer-gmp               >= 1.0.1.0  && < 2.0
-  if flag(large-tuples)
-    Build-Depends:    ghc
 
 test-suite doctests
   type:             exitcode-stdio-1.0

--- a/clash-prelude/src/Clash/Class/IndexTuple.hs
+++ b/clash-prelude/src/Clash/Class/IndexTuple.hs
@@ -1,0 +1,27 @@
+{-|
+Copyright  :  (C) 2023,      QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+{-# OPTIONS_GHC "-Wno-orphans" #-}
+
+{-# LANGUAGE CPP #-}
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# LANGUAGE Trustworthy #-}
+
+module Clash.Class.IndexTuple (indexTuple) where
+
+import Clash.Class.IndexTuple.Deriving
+
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Settings.Constants (mAX_TUPLE_SIZE)
+#else
+import Constants (mAX_TUPLE_SIZE)
+#endif
+
+deriveIndexTupleInstances mAX_TUPLE_SIZE

--- a/clash-prelude/src/Clash/Class/IndexTuple/Deriving.hs
+++ b/clash-prelude/src/Clash/Class/IndexTuple/Deriving.hs
@@ -1,0 +1,62 @@
+{-|
+Copyright  :  (C) 2023,      QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+{-# LANGUAGE TemplateHaskell #-}
+
+module Clash.Class.IndexTuple.Deriving
+  (IndexTuple(..), deriveIndexTupleInstances) where
+
+import Control.Monad.Extra (concatMapM)
+import Language.Haskell.TH
+
+class IndexTuple a where
+  -- | This function can be used to bind variables to numbers indexing
+  -- successive elements in a list-like structure. If the type of the indices
+  -- can be derived from context, it is enough to provide a tuple with the
+  -- variables like:
+  --
+  -- @
+  -- (a, b) = indexTuple
+  -- (a, b, c, d, e, f) = indexTuple
+  -- @
+  --
+  -- and so on. @a@ will be 0, @b@ 1, @c@ 2, etcetera. All variables will have
+  -- the same type, and specifying the type of any one of the variables is
+  -- enough. The type needs to be an instance of `Num`.
+  --
+  -- If a type needs to be specified here, you can use
+  --
+  -- @
+  -- (a :: Int, b, c) = indexTuple
+  -- @
+  --
+  -- or
+  --
+  -- @
+  -- a :: Int
+  -- (a, b, c) = indexTuple
+  -- @
+  --
+  -- depending on preference.
+  indexTuple :: a
+
+-- Derive instance for /n/-tuple
+deriveIndexTupleInstance :: Int -> DecsQ
+deriveIndexTupleInstance n = do
+  let e (i :: Int) = varT $ mkName $ "e" ++ show i
+      e0  = e 0
+      eqT i = [t| $(e i) ~ $e0 |]
+      instCxt0 = appT (tupleT n) [t| Num $e0 |]
+      instCxt1 = foldl appT instCxt0 $ map eqT [1 .. n - 1]
+      instType  = foldl appT (tupleT n) $ map e [0 .. n - 1]
+      funRHS = tupE $ map (litE . integerL) [0 .. toInteger n - 1]
+  [d| instance $instCxt1 => IndexTuple $instType where
+        indexTuple = $funRHS
+   |]
+
+-- Derive instances for up to and including to /n/-tuples
+deriveIndexTupleInstances :: Int -> DecsQ
+deriveIndexTupleInstances n = concatMapM deriveIndexTupleInstance [1..n]

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -77,6 +77,7 @@ module Clash.Explicit.Prelude
   , isFalling
   , riseEvery
   , oscillate
+  , indexTuple
     -- * Static assertions
   , clashCompileError
     -- * Testbench functions

--- a/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude/Safe.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd,
-                  2021-2022, QBayLogic B.V.
+                  2021-2023, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -64,6 +64,7 @@ module Clash.Explicit.Prelude.Safe
   , isFalling
   , riseEvery
   , oscillate
+  , indexTuple
     -- * Exported modules
     -- ** Synchronous signals
   , module Clash.Explicit.Signal
@@ -122,6 +123,7 @@ import qualified Prelude
 
 import Clash.Annotations.TopEntity
 import Clash.Class.BitPack
+import Clash.Class.IndexTuple
 import Clash.Class.Num
 import Clash.Class.Resize
 import Clash.NamedTypes

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -102,6 +102,7 @@ module Clash.Prelude
   , isFalling
   , riseEvery
   , oscillate
+  , indexTuple
     -- * Static assertions
   , clashCompileError
     -- * Tracing

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -2,7 +2,7 @@
   Copyright   :  (C) 2013-2016, University of Twente,
                      2017-2019, Myrtle Software Ltd
                      2017     , Google Inc.,
-                     2021-2022, QBayLogic B.V.
+                     2021-2023, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -80,6 +80,7 @@ module Clash.Prelude.Safe
   , isFalling
   , riseEvery
   , oscillate
+  , indexTuple
     -- * Exported modules
     -- ** Synchronous signals
   , module Clash.Signal
@@ -140,6 +141,7 @@ import           Clash.HaskellPrelude
 
 import           Clash.Annotations.TopEntity
 import           Clash.Class.BitPack
+import           Clash.Class.IndexTuple
 import           Clash.Class.Num
 import           Clash.Class.Resize
 import           Clash.Hidden


### PR DESCRIPTION
This function can be used to bind variables to numbers indexing successive elements in a list-like structure. This is really useful for writing primitives like:

```haskell
  let primName = 'Clash.Cores.Xilinx.Floating.Explicit.fromU32With
      ( _knownDomainArg :: Int
       , _knownNatArg
       , _hasCallStackArg
       , clockArg
       , enableArg
       , inputArg) = indexTuple
  in InlineYamlPrimitive [VHDL] [__i|
    BlackBox:
      name: #{primName}
      template: |-
        [...]
        ~IF~ISACTIVEENABLE[#{enableArg}]~THEN      aclken : in std_logic;
```

Before GHC 9.2, we could simply do
```haskell
a : b : c : d : _ = [0 :: Int ..]
```
but since GHC 9.2 this gives a warning:
```
Indices.hs:5:3: warning: [-Wincomplete-uni-patterns]
    Pattern match(es) are non-exhaustive
    In a pattern binding:
        Patterns of type ‘[Int]’ not matched:
            []
            [_]
            [_, _]
            [_, _, _]
  |
5 |   a : b : c : d : _ = [0 :: Int ..]
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
and we like our code to be warning-free.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
