### PR TITLE
Generalize period<->frequency conversion, use

### DIFF
--- a/changelog/2023-03-09T17_04_39+01_00_generalize_freqtools
+++ b/changelog/2023-03-09T17_04_39+01_00_generalize_freqtools
@@ -1,0 +1,6 @@
+CHANGED: Generalized the return types of `periodToHz` and `hzToPeriod`. Use a
+type application (`periodToHz @(Ratio Natural)`, `hzToPeriod @Natural`) to get
+the old behavior back, in case type errors arise.
+CHANGED: `periodToHz` and `hzToPeriod` now throw an `ErrorCall` with call stack
+when called with the argument 0 (zero), instead of a `RatioZeroDenominator ::
+ArithException`.

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -1,6 +1,6 @@
 {-|
   Copyright   :  (C) 2018     , Google Inc.,
-                     2021-2022, QBayLogic B.V.
+                     2021-2023, QBayLogic B.V.,
                      2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -19,6 +19,7 @@ import Clash.Netlist.BlackBox.Util
 import qualified Clash.Netlist.Id as Id
 import Clash.Netlist.Types
 import Clash.Netlist.Util
+import Clash.Signal (periodToHz)
 
 import Control.Monad.State
 import Data.Monoid (Ap(getAp))
@@ -166,7 +167,7 @@ altpllQsysTemplate bbCtx = case bbInputs bbCtx of
     , KnownDomain _ clkOutPeriod _ _ _ _ <- kdOut ->
     let
       clkOutFreq :: Double
-      clkOutFreq = (1.0 / (fromInteger clkOutPeriod * 1.0e-12)) / 1e6
+      clkOutFreq = periodToHz (fromIntegral clkOutPeriod) / 1e6
       clklcm = lcm clkInPeriod clkOutPeriod
       clkmult = clklcm `quot` clkOutPeriod
       clkdiv = clklcm `quot` clkInPeriod
@@ -267,7 +268,7 @@ alteraPllQsysTemplate bbCtx = case bbInputs bbCtx of
         _ -> error "internal error: not a Product or KnownDomain"
 
       cklFreq (KnownDomain _ p _ _ _ _)
-        = (1.0 / (fromInteger p * 1.0e-12 :: Double)) / 1e6
+        = periodToHz (fromIntegral p) / 1e6 :: Double
       cklFreq _ = error "internal error: not a KnownDomain"
 
       clkOuts = TextS.intercalate "\n"

--- a/clash-prelude/tests/Clash/Tests/Signal.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal.hs
@@ -1,8 +1,9 @@
 {-|
 Copyright  :  (C) 2019, Myrtle Software Ltd
                   2022, Google Inc.
+                  2023, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE CPP #-}
@@ -221,8 +222,8 @@ case_dynamicStaticEq = do
     -- We construct periods in a roundabout way (i.e., using 'hzToPeriod' instead
     -- of using 'hzToFs'), to prevent rounding errors between periods of the
     -- static clocks and the periods of the dynamic clocks.
-    fs11 = Femtoseconds (fromIntegral (1000 * hzToPeriod 11))
-    fs77 = Femtoseconds (fromIntegral (1000 * hzToPeriod 77))
+    fs11 = Femtoseconds (1000 * hzToPeriod 11)
+    fs77 = Femtoseconds (1000 * hzToPeriod 77)
 
     dclk11 = dynamicClockGen @H11 (pure fs11)
     dclk77 = dynamicClockGen @H77 (pure fs77)
@@ -249,8 +250,8 @@ case_dynamicHasEffect = do
     -- We construct periods in a roundabout way (i.e., using 'hzToPeriod' instead
     -- of using 'hzToFs'), to prevent rounding errors between periods of the
     -- static clocks and the periods of the dynamic clocks.
-    fs11 = Femtoseconds (fromIntegral (1000 * hzToPeriod 11))
-    fs77lying = Femtoseconds (fromIntegral (1000 * hzToPeriod 78))
+    fs11 = Femtoseconds (1000 * hzToPeriod 11)
+    fs77lying = Femtoseconds (1000 * hzToPeriod 78)
 
     clk11 = clockGen @H11
     clk77 = clockGen @H77


### PR DESCRIPTION
`periodToHz`, `hzToPeriod`, `fsToHz` and `hzToFs` can be generalized so
they can be more easily used in cases where we don't want `Natural` and
`Ratio Natural` as the types.

However, the common use of `vPeriod=hzToPeriod 33e6` means we want the
argument to `hzToPeriod` to be monomorphic. Making it polymorphic means
it defaults to the inferior `Double` and warns about this defaulting. So
we merely generalize the return types of these functions.

These functions used to throw exceptions without call stacks when called
with zero. By changing that to `ErrorCall` we can get a stack trace,
solving an immense frustration in debugging a Clash design.

Currently, the frequency calculation in for the Intel PLLs depends on
the unit of the period of a `KnownDomain` (picoseconds). If this unit is
to be changed internally in the future (to femtoseconds), this
calculation would produce the wrong frequency. By using `periodToHz`,
the unit of the period no longer matters and can be changed internally.
This use case is what prompted this PR.

Harmonized and slightly improved some documentation.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

(part of this commit message pilfered from a message written by Hidde)