### PR TITLE
Add flag to workaround GHC heisenbug on CI

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -10,7 +10,7 @@ package *
 
 package clash-prelude
   ghc-options: -Werror
-  flags: +doctests +multiple-hidden
+  flags: +doctests +multiple-hidden -workaround-ghc-mmap-crash
   tests: True
   benchmarks: True
 
@@ -24,6 +24,7 @@ package clash-lib
 
 package clash-ghc
   ghc-options: -Werror
+  flags: -workaround-ghc-mmap-crash
 
 package clash-cosim
   ghc-options: -Werror
@@ -47,7 +48,7 @@ package clash-lib-hedgehog
 package clash-testsuite
   ghc-options: -Werror
   -- enable cosim
-  flags: +cosim +multiple-hidden
+  flags: +cosim +multiple-hidden -workaround-ghc-mmap-crash
 
 package clash-benchmark
   ghc-options: -Werror

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -138,12 +138,13 @@ ffi:interface-tests:
   script:
     - ./dist-newstyle/build/*/*/clash-ffi-*/x/ffi-interface-tests/build/ffi-interface-tests/ffi-interface-tests --smallcheck-max-count 2000
 
-ffi:example:
-  extends: .test-cache-local
-  script:
-    - cabal build clash # ensure clash has been built (avoids some legacy cabal issue)
-    - cd clash-ffi/example && ./run-iverilog.sh
-
+# Disabled for now. The test is faulty and so is the tested code. This will be
+# fixed later.
+#ffi:example:
+#  extends: .test-cache-local
+#  script:
+#    - cabal build clash # ensure clash has been built (avoids some legacy cabal issue)
+#    - cd clash-ffi/example && ./run-iverilog.sh
 
 # Tests run on local fast machines with Vivado installed. We only run these at night
 # to save resources - as Vivado is quite slow to execute.

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -78,6 +78,10 @@ if [ ! -f cabal.project.local ]; then
   fi
 
   set +u
+  if [[ "$WORKAROUND_GHC_MMAP_CRASH" == "yes" ]]; then
+    sed -i 's/-workaround-ghc-mmap-crash/+workaround-ghc-mmap-crash/g' cabal.project.local
+  fi
+
   if [[ "$GHC_HEAD" == "yes" ]]; then
     cat .ci/cabal.project.local.append-HEAD >> cabal.project.local
   fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,9 @@ tests:
     strategy: depend
   parallel:
     matrix:
-      - GHC_VERSION: [8.8.4, 8.10.7, 9.0.2, 9.2.5]
+      - GHC_VERSION: [8.8.4, 8.10.7, 9.2.5]
+      - GHC_VERSION: 9.0.2
+        WORKAROUND_GHC_MMAP_CRASH: "yes"
       - GHC_VERSION: 8.6.5
         MULTIPLE_HIDDEN: "no"
 

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -65,12 +65,24 @@ flag use-ghc-paths
   default: False
   manual: True
 
+flag workaround-ghc-mmap-crash
+  description:
+    Only use this flag when hit by GHC bug #19421. See clash-compiler PR #2444.
+  default: False
+  manual: True
+
 executable clash
   Main-Is:            src-ghc/Batch.hs
   Build-Depends:      base, clash-ghc
-  GHC-Options:        -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-A128m
+  GHC-Options:        -Wall -Wcompat -threaded -rtsopts
   if flag(dynamic)
     GHC-Options: -dynamic
+  -- Note that multiple -with-rtsopts are not cumulative, so we can't add the
+  -- common RTS options in the unconditional GHC-Options
+  if flag(workaround-ghc-mmap-crash)
+    GHC-Options: "-with-rtsopts=-A128m -xm20000000"
+  else
+    GHC-Options: -with-rtsopts=-A128m
   extra-libraries:    pthread
   default-language:   Haskell2010
 

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -117,6 +117,12 @@ flag benchmarks
   default: True
   manual: True
 
+flag workaround-ghc-mmap-crash
+  description:
+    Only use this flag when hit by GHC bug #19421. See clash-compiler PR #2444.
+  default: False
+  manual: True
+
 common common-options
   default-language:   Haskell2010
   default-extensions: BangPatterns
@@ -372,6 +378,10 @@ test-suite doctests
       clash-prelude,
       doctest-parallel >= 0.2 && < 0.4,
       filepath
+
+  if flag(workaround-ghc-mmap-crash)
+    ghc-options:    -with-rtsopts=-xm20000000
+
 
 test-suite unittests
   import:           common-options

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -31,6 +31,12 @@ flag multiple-hidden
   default: True
   manual: True
 
+flag workaround-ghc-mmap-crash
+  description:
+    Only use this flag when hit by GHC bug #19421. See clash-compiler PR #2444.
+  default: False
+  manual: True
+
 common basic-config
   default-language: Haskell2010
   ghc-options: -Wall -Wcompat
@@ -79,6 +85,9 @@ common basic-config
 
   if flag(multiple-hidden)
     cpp-options:       -DCLASH_MULTIPLE_HIDDEN
+
+  if flag(workaround-ghc-mmap-crash)
+    cpp-options:       -DCLASH_WORKAROUND_GHC_MMAP_CRASH
 
 library
   import: basic-config

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
@@ -629,7 +630,11 @@ clashLibTest' modName target extraGhcArgs path =
   clashBuild workDir = ("clash (exec)", singleTest "clash (exec)" (ClashBinaryTest {
       cbBuildTarget=target
     , cbSourceDirectory=sourceDir
-    , cbExtraBuildArgs="-DCLASHLIBTEST" : extraGhcArgs
+    , cbExtraBuildArgs="-DCLASHLIBTEST" :
+#ifdef CLASH_WORKAROUND_GHC_MMAP_CRASH
+        "-with-rtsopts=-xm20000000" :
+#endif
+        extraGhcArgs
     , cbExtraExecArgs=[]
     , cbModName=modName
     , cbOutputDirectory=workDir


### PR DESCRIPTION
In very specific tests in GitLab CI we are affected by GHC bug #19421. We can work around the issue by passing `-with-rtsopts=-xm20000000` when compiling an affected binary. This is a stopgap measure until the real bug is fixed.

We have seen the bug:
- In `clash-testsuite` in `clashLibTest`s
- In `ffi:example` in the `clash` binary itself
- In `prelude:doctests`, probably in the `doctests` binary itself, although this is not certain.

and then only in GHC 9.0.2, although the bug should be in other versions of GHC as well.

This workaround was applied only to GHC 9.0.2 on CI and only to those cases that were observed to go wrong, although as a consequence now the `clash` binary is always built with the RTS option.

I tried to limit applying this RTS option as much as possible because of [the documentation](https://downloads.haskell.org/~ghc/9.0.2/docs/html/users_guide/runtime_control.html#rts-flag--xm%20%E2%9F%A8address%E2%9F%A9):
> ❗Warning
> This option is for working around memory allocation problems only. Do not use unless GHCi fails with a message like [...]

Our problem has nothing to do whatsoever with GHCi, but even if we ignore that, it still says "do not use unless". It would be possible to restrict the building of the `clash` binary with the option to _just_ `ffi:example`, by giving it its own special `cabal.project.local`, but I did not take it that far in this PR.

The `ffi:example` test should no longer be affected by the GHC bug, but it is a fairly useless test in its current state as it does not fail when there are issues, and the tested code is actually faulty. It is disabled to be fixed later.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - ~~Check copyright notices are up to date in edited files~~ This is a temporary CI workaround. The sooner it is removed, the better. No need for copyright messages if the code is soon to be removed again.
