### PR TITLE
Bump docker image to Ubuntu 22.04

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -6,7 +6,7 @@
 #
 # To use buildkit, you need to set DOCKER_BUILDKIT=1 in your shell
 
-ARG UBUNTU_VERSION=focal-20210416
+ARG UBUNTU_VERSION=jammy-20230308
 FROM ubuntu:$UBUNTU_VERSION AS builder
 
 LABEL vendor="QBayLogic B.V." maintainer="devops@qbaylogic.com"
@@ -18,14 +18,14 @@ RUN apt-get update \
 
 FROM builder AS build-ghdl
 
-ARG DEPS_GHDL="gnat llvm-11-dev"
+ARG DEPS_GHDL="gnat-10 llvm-13-dev"
 RUN apt-get install -y --no-install-recommends $DEPS_GHDL
 
-ARG ghdl_version="1.0.0"
+ARG ghdl_version="2.0.0"
 RUN curl -L "https://github.com/ghdl/ghdl/archive/v$ghdl_version.tar.gz" \
         | tar -xz \
  && cd ghdl-$ghdl_version \
- && ./configure --with-llvm-config=llvm-config-11 --prefix=$PREFIX \
+ && ./configure --with-llvm-config=llvm-config-13 --prefix=$PREFIX \
  && make -j$(nproc) \
  && make install
 
@@ -34,10 +34,13 @@ FROM builder AS build-iverilog
 ARG DEPS_IVERILOG="gperf"
 RUN apt-get install -y --no-install-recommends $DEPS_IVERILOG
 
-ARG iverilog_version="10_3"
-RUN curl -L "https://github.com/steveicarus/iverilog/archive/v$iverilog_version.tar.gz" \
+# At the time of writing (2023-04-14), the latest commit in 'v10-branch'. This
+# commit is needed to work around compilation issues with newer 'bison's shipped
+# with 22.04.
+ARG iverilog_version="b988543096183650979e2aae9702de3750fee798"
+RUN curl -L "https://github.com/steveicarus/iverilog/archive/${iverilog_version}.tar.gz" \
         | tar -xz \
- && cd iverilog-$iverilog_version \
+ && cd iverilog-* \
  && sh autoconf.sh \
  && ./configure --prefix=$PREFIX \
  && make -j$(nproc) \
@@ -91,7 +94,7 @@ RUN git clone https://github.com/cliffordwolf/SymbiYosys.git SymbiYosys \
 
 FROM builder AS build-verilator
 
-ARG DEPS_VERILATOR="perl python3 make autoconf g++ flex bison ccache libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlibc zlib1g zlib1g-dev"
+ARG DEPS_VERILATOR="perl python3 make autoconf g++ flex bison ccache libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g zlib1g-dev"
 RUN apt-get install -y --no-install-recommends $DEPS_VERILATOR
 
 ARG verilator_version="v4.214"
@@ -124,7 +127,7 @@ FROM ubuntu:$UBUNTU_VERSION AS run
 LABEL vendor="QBayLogic B.V." maintainer="devops@qbaylogic.com"
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH="$PATH:/opt/bin:/root/.ghcup/bin"
 
-ARG DEPS_RUNTIME="ca-certificates ccache curl g++ gcc git jq libc6-dev libgmp10-dev libgnat-9 libllvm11 libreadline8 libtinfo-dev libtcl8.6 make perl python3 ssh zlib1g-dev zlibc zstd locales libtinfo5 libx11-6"
+ARG DEPS_RUNTIME="ca-certificates ccache curl g++ gcc git jq libc6-dev libgmp10-dev libgnat-10 libllvm13 libreadline8 libtinfo-dev libtcl8.6 make perl python3 ssh zlib1g-dev zstd locales libtinfo5 libx11-6"
 RUN apt-get update \
  && apt-get install -y --no-install-recommends $DEPS_RUNTIME \
  && apt-get clean \

--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -7,6 +7,13 @@ NAME="clash-ci-"
 DIR=$(dirname "$0")
 now=$(date +%F)
 
+if [[ "$1" == "-y" ]]; then
+  push=y
+elif [[ "$1" != "" ]]; then
+  echo "Unrecognized argument: $1" >&2
+  exit 1
+fi
+
 GHC_VERSIONS=(  "9.2.5"   "9.0.2"   "8.10.7"  "8.8.4"   "8.6.5")
 CABAL_VERSIONS=("3.6.2.0" "3.4.0.0" "3.2.0.0" "3.2.0.0" "3.0.0.0")
 
@@ -27,7 +34,9 @@ do
     "$DIR"
 done
 
-read -p "Push to GitHub? (y/N) " push
+if [[ "${push}" == "" ]]; then
+  read -p "Push to GitHub? (y/N) " push
+fi
 
 if [[ $push =~ ^[Yy]$ ]]; then
   for i in "${!GHC_VERSIONS[@]}"

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-11-14
+  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-04-14
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,11 +1,11 @@
 .common:
-  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-11-14
+  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-04-14
   timeout: 10 minutes
   stage: build
   variables:
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2022-11-14-1-3-non_protected
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-04-14-1-3-non_protected
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   retry:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
 
     # Run steps inside the clash CI docker image
     container:
-      image: ghcr.io/clash-lang/clash-ci-${{ matrix.ghc }}:2022-11-14
+      image: ghcr.io/clash-lang/clash-ci-${{ matrix.ghc }}:2023-04-14
 
       env:
         THREADS: 2


### PR DESCRIPTION
LLVM versions in the Ubuntu repos were too recent for GHDL 1.0, so bumped to 2.0.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~
  - [x] Investigate `clash-cosim` failure
