### PR TITLE
Support `hashable` >= 1.4.2.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ write-ghc-environment-files: always
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2023-02-25T00:27:36Z
+index-state: 2023-04-12T11:22:22Z
 
 -- For some reason the `clash-testsuite` executable fails to run without
 -- this, as it cannot find the related library...

--- a/clash-lib/src/Data/Primitive/ByteArray/Extra.hs
+++ b/clash-lib/src/Data/Primitive/ByteArray/Extra.hs
@@ -3,13 +3,17 @@
 
 module Data.Primitive.ByteArray.Extra where
 
+import Data.Binary (Binary(..))
+import Data.Primitive.ByteArray (ByteArray)
+import GHC.Exts (IsList(..))
+
 #if !MIN_VERSION_primitive(0,7,1)
 import Control.DeepSeq (NFData(..))
 #endif
-import Data.Binary (Binary(..))
+
+#if !MIN_VERSION_hashable(1,4,2)
 import Data.Hashable (Hashable(..))
-import Data.Primitive.ByteArray (ByteArray)
-import GHC.Exts (IsList(..))
+#endif
 
 #if !MIN_VERSION_primitive(0,7,1)
 instance NFData ByteArray where
@@ -20,6 +24,7 @@ instance Binary ByteArray where
   get = fmap fromList get
   put = put . toList
 
+#if !MIN_VERSION_hashable(1,4,2)
 instance Hashable ByteArray where
   hashWithSalt salt = hashWithSalt salt . toList
-
+#endif


### PR DESCRIPTION
I've moved the CPP stuff down into their own "boxes" for readability purposes.