### PR TITLE
Expose non-`XException` bottoms in `hasX`

### DIFF
--- a/changelog/2023-04-14T16_53_05+02_00_expose_ErrorCall_in_hasX
+++ b/changelog/2023-04-14T16_53_05+02_00_expose_ErrorCall_in_hasX
@@ -1,0 +1,1 @@
+CHANGED: `hasX` now needs an `NFDataX` constraint, in addition to an `NFData` one. This API change was made to fix an issue where `hasX` would hide error calls in certain situations, see [#2450](https://github.com/clash-lang/clash-compiler/issues/2450).

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -442,6 +442,7 @@ test-suite unittests
                  Clash.Tests.TopEntityGeneration
                  Clash.Tests.Unsigned
                  Clash.Tests.Vector
+                 Clash.Tests.XException
 
                  Clash.Tests.Laws.Enum
                  Clash.Tests.Laws.SaturatingNum

--- a/clash-prelude/src/Clash/XException/MaybeX.hs
+++ b/clash-prelude/src/Clash/XException/MaybeX.hs
@@ -35,7 +35,7 @@ import Control.Applicative
 import Control.DeepSeq (NFData)
 import Control.Exception (throw)
 
-import Clash.XException (XException(..), isX, hasX)
+import Clash.XException (XException(..), NFDataX, isX, hasX)
 
 -- | Structure helping programmers to deal with 'Clash.XException.XException'
 -- values. For safety reasons it can't be constructed directly, but should be
@@ -83,7 +83,7 @@ toMaybeX = pure
 
 -- | Construct a 'MaybeX' value. If 'hasX' evaluates to 'Left', this function
 -- will return 'IsX'. Otherwise, it will return 'IsDefined'.
-hasXToMaybeX :: NFData a => a -> MaybeX a
+hasXToMaybeX :: (NFDataX a, NFData a) => a -> MaybeX a
 hasXToMaybeX = either IsX_ IsDefined_ . hasX
 
 -- | Deconstruct 'MaybeX' into an @a@ - the opposite of 'toMaybeX'. Be careful

--- a/clash-prelude/tests/Clash/Tests/Vector.hs
+++ b/clash-prelude/tests/Clash/Tests/Vector.hs
@@ -37,9 +37,7 @@ case_showVectorInList =
   "[1 :> 2 :> Nil,3 :> 4 :> Nil]" @=? show [1 :> 2 :> Nil, 3 :> i 4 :> Nil]
 
 tests :: TestTree
-tests = testGroup "All"
-  [ $(testGroupGenerator)
-  ]
+tests = $(testGroupGenerator)
 
 -- Run with:
 --

--- a/clash-prelude/tests/Clash/Tests/XException.hs
+++ b/clash-prelude/tests/Clash/Tests/XException.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Clash.Tests.XException where
+
+import Clash.XException
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.HUnit.Extra
+import Test.Tasty.TH
+
+expectLeft :: HasCallStack => Either a b -> Assertion
+expectLeft (Left _) = pure ()
+expectLeft (Right _) = assertFailure "Expected Left, got Right"
+
+expectRight :: HasCallStack => Either a b -> Assertion
+expectRight (Right _) = pure ()
+expectRight (Left _) = assertFailure "Expected Right, got Left"
+
+case_hasX :: Assertion
+case_hasX = do
+  expectRight        $ hasX @(Int, Int) (1, 2)
+  expectLeft         $ hasX @(Int, Int) (x, 2)
+  expectLeft         $ hasX @(Int, Int) (1, x)
+  expectLeft         $ hasX @(Int, Int) (x, x)
+  expectLeft         $ hasX @(Int, Int) x
+  expectExceptionNoX $ hasX @(Int, Int) (e, 2)
+  expectExceptionNoX $ hasX @(Int, Int) (1, e)
+  expectExceptionNoX $ hasX @(Int, Int) (e, e)
+  expectExceptionNoX $ hasX @(Int, Int) (x, e)
+  expectExceptionNoX $ hasX @(Int, Int) (e, x)
+  expectExceptionNoX $ hasX @(Int, Int) e
+ where
+  x = errorX "X"
+  e = error "E"
+
+tests :: TestTree
+tests = $(testGroupGenerator)
+
+-- Run with:
+--
+--    ./repld p:tests -T Clash.Tests.XException.main
+--
+-- Add -W if you want to run tests in spite of warnings
+--
+main :: IO ()
+main = defaultMain tests

--- a/clash-prelude/tests/Test/Tasty/HUnit/Extra.hs
+++ b/clash-prelude/tests/Test/Tasty/HUnit/Extra.hs
@@ -6,7 +6,6 @@ module Test.Tasty.HUnit.Extra
   , expectExceptionNoX
   ) where
 
-import Control.DeepSeq (NFData)
 import Control.Exception (SomeException, try, evaluate)
 import Test.Tasty.HUnit
 
@@ -20,14 +19,14 @@ expectXException a0 =
     Right a -> assertFailure ("Expected Exception, got: " <> show a)
 
 -- | Succeed if evaluating leads to an Exception
-expectException :: (Show a, NFData a) => a -> Assertion
+expectException :: Show a => a -> Assertion
 expectException a0 =
   try @SomeException (evaluate a0) >>= \case
     Left _ -> pure ()
     Right a -> assertFailure ("Expected Exception, got: " <> show a)
 
 -- | Succeed if evaluating leads to a non-XException Exception
-expectExceptionNoX :: (Show a, NFData a) => a -> Assertion
+expectExceptionNoX :: Show a => a -> Assertion
 expectExceptionNoX a0 =
   try @SomeException (try @XException (evaluate a0)) >>= \case
     Left _ -> pure ()

--- a/clash-prelude/tests/unittests.hs
+++ b/clash-prelude/tests/unittests.hs
@@ -24,6 +24,7 @@ import qualified Clash.Tests.Signed
 import qualified Clash.Tests.TopEntityGeneration
 import qualified Clash.Tests.Unsigned
 import qualified Clash.Tests.Vector
+import qualified Clash.Tests.XException
 
 import qualified Clash.Tests.Laws.Enum
 import qualified Clash.Tests.Laws.SaturatingNum
@@ -52,6 +53,7 @@ tests = testGroup "Unittests"
   , Clash.Tests.TopEntityGeneration.tests
   , Clash.Tests.Unsigned.tests
   , Clash.Tests.Vector.tests
+  , Clash.Tests.XException.tests
   , testGroup "Laws"
     [ Clash.Tests.Laws.Enum.tests
     , Clash.Tests.Laws.SaturatingNum.tests


### PR DESCRIPTION
Fixes #2450

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files