### PR TITLE
Add `XPM_CDC_GRAY`

### DIFF
--- a/changelog/2023-04-25T08_32_54+02_00_minimum_longest_period
+++ b/changelog/2023-04-25T08_32_54+02_00_minimum_longest_period
@@ -1,0 +1,1 @@
+CHANGED: Clock generators now wait at least 100 ns before producing their first tick. This change has been implemented to account for Xilinx's GSR in clock synchronization primitives. This change does not affect Clash simulation. See [#2455](https://github.com/clash-lang/clash-compiler/issues/2455).

--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -101,6 +101,10 @@ library
     Clash.Cores.Xilinx.Floating.BlackBoxes
     Clash.Cores.Xilinx.Floating.Explicit
     Clash.Cores.Xilinx.Floating.Internal
+    Clash.Cores.Xilinx.Xpm
+    Clash.Cores.Xilinx.Xpm.Cdc
+    Clash.Cores.Xilinx.Xpm.Cdc.Gray
+    Clash.Cores.Xilinx.Xpm.Cdc.Gray.Internal
     Clash.Cores.SPI
     Clash.Cores.UART
     Clash.Cores.LatticeSemi.ICE40.IO
@@ -116,6 +120,7 @@ library
     clash-lib,
     infinite-list           ^>= 0.1,
     mtl                     >= 2.1.1 && < 2.3,
+    pretty-show,
     prettyprinter           >= 1.2.0.1  && < 1.8,
     prettyprinter-interp    ^>= 0.2,
     reducers                >= 3.12.2 && < 4.0,
@@ -147,6 +152,7 @@ test-suite unittests
     tasty        >= 1.2 && < 1.5,
     tasty-hunit,
     tasty-quickcheck,
+    tasty-th,
     hedgehog,
     tasty-hedgehog >= 1.2.0
 

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm.hs
@@ -1,0 +1,11 @@
+{-|
+  Copyright   :  (C) 2023, Google LLC
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+module Clash.Cores.Xilinx.Xpm
+  ( module Clash.Cores.Xilinx.Xpm.Cdc
+  ) where
+
+import Clash.Cores.Xilinx.Xpm.Cdc

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc.hs
@@ -1,0 +1,11 @@
+{-|
+  Copyright   :  (C) 2023, Google LLC
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+module Clash.Cores.Xilinx.Xpm.Cdc
+  ( module Clash.Cores.Xilinx.Xpm.Cdc.Gray
+  ) where
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Gray

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Gray.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Gray.hs
@@ -1,0 +1,99 @@
+{-|
+  Copyright   :  (C) 2023, Google LLC
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.Xilinx.Xpm.Cdc.Gray
+  ( xpmCdcGray
+  , XpmCdcGrayConfig(..)
+  , xpmCdcGrayWith
+  ) where
+
+import GHC.Stack (HasCallStack)
+
+import Clash.Explicit.Prelude
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Gray.Internal (xpmCdcGray#)
+
+-- | Synchronizes an 'Unsigned' from the source clock domain to the destination
+-- clock domain using Gray code. It instantiates Xilinx's @XPM_CDC_GRAY@, so no
+-- additional constraint definitions are needed. In order to synchronize data
+-- from the source domain to the destination domain, consecutive inputs need to
+-- be unchanged, successors (+1), or predecessors (-1). Overflows are okay. That is,
+-- 'maxBound' can be followed by zero, and vice versa. If this invariant is
+-- violated, the component might not transfer data correctly until the invariant
+-- is upheld again and the source clock has sampled the input once, followed by
+-- /4/ samples in the destination domain.
+--
+-- If you need all data to be transferred from the source domain to the destination
+-- domain, make sure the destination domain samples the input domain at least
+-- twice. Alternatively, use a FIFO.
+--
+-- Read more in [PG382](https://docs.xilinx.com/r/en-US/pg382-xpm-cdc-generator/XPM_CDC_GRAY).
+--
+-- __N.B.__: The simulation model does not detect invariant violations.
+--
+-- __N.B.__: In order to simulate initial values, both the source and destination
+--           domain need to support them. If the source and destination domain
+--           disagree on this property, use of this function will fail to
+--           simulate and translate to HDL.
+--
+xpmCdcGray ::
+  forall n src dst.
+  ( 2 <= n, n <= 32
+  , KnownNat n
+  , KnownDomain src
+  , KnownDomain dst
+  , HasCallStack
+  ) =>
+  Clock src ->
+  Clock dst ->
+  Signal src (Unsigned n) ->
+  Signal dst (Unsigned n)
+xpmCdcGray = xpmCdcGrayWith XpmCdcGrayConfig{..}
+ where
+  stages = d4
+  initialValues =
+    case (initBehavior @src, initBehavior @dst) of
+      (SDefined, SDefined) -> True
+      (SUnknown, SUnknown) -> False
+      _ -> clashCompileError $ "xpmCdcGray: domains need to agree on initial value "
+                            <> "behavior. To set initial value usage explicitly, "
+                            <> "consider using 'xpmCdcGrayWith'."
+{-# INLINE xpmCdcGray #-}
+
+-- | Configuration for 'xpmCdcGrayWith'
+data XpmCdcGrayConfig stages = XpmCdcGrayConfig
+  { -- | Number of synchronization stages. I.e., number of registers in the
+    -- destination domain. Note that there is always a register in the source
+    -- domain.
+    stages :: SNat stages
+
+    -- | Initialize registers used within the primitive to /0/. Note that
+    -- 'xpmCdcGray' will set this to 'True' if both domains support initial
+    -- values, to 'False' if neither domain does, and will otherwise emit an
+    -- error.
+  , initialValues :: Bool
+  }
+
+-- | Like 'xpmCdcGray', but with a configurable number of stages. Also see
+-- 'XpmCdcGrayConfig'.
+xpmCdcGrayWith ::
+  forall stages n src dst.
+  ( 2 <= n, n <= 32
+  , 2 <= stages, stages <= 10
+  , KnownNat n
+  , KnownDomain src
+  , KnownDomain dst
+  , HasCallStack
+  ) =>
+  XpmCdcGrayConfig stages ->
+  Clock src ->
+  Clock dst ->
+  Signal src (Unsigned n) ->
+  Signal dst (Unsigned n)
+xpmCdcGrayWith XpmCdcGrayConfig{..} = xpmCdcGray# initialValues stages
+{-# INLINE xpmCdcGrayWith #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Gray/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Gray/Internal.hs
@@ -1,0 +1,178 @@
+{-|
+  Copyright   :  (C) 2023, Google LLC
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Clash.Cores.Xilinx.Xpm.Cdc.Gray.Internal where
+
+import Prelude
+import Clash.Explicit.Prelude
+  ( type (<=), KnownNat, SNat, Unsigned, Clock, KnownDomain, errorX
+  , unsafeSynchronizer )
+
+import Clash.Annotations.Primitive (Primitive(..), HDL(..), hasBlackBox)
+import Clash.Backend (Backend)
+import Clash.Netlist.Types (TemplateFunction(..), BlackBoxContext)
+import Clash.Promoted.Nat (snatToNum)
+import Clash.Signal.Internal (Signal((:-)))
+
+import Control.Monad.State (State)
+import Data.List.Infinite (Infinite(..), (...))
+import Data.String.Interpolate (__i)
+import Data.Text (Text)
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import GHC.Stack (HasCallStack)
+import Text.Show.Pretty (ppShow)
+
+import qualified Clash.Netlist.Id as Id
+import qualified Clash.Netlist.Types as N
+import qualified Clash.Primitives.DSL as DSL
+
+xpmCdcGrayTF :: TemplateFunction
+xpmCdcGrayTF =
+  TemplateFunction
+    [initBehavior, stages, clkSrc, clkDst, input]
+    (const True)
+    xpmCdcGrayTF#
+ where
+  _2LteN
+    :< _nLte32
+    :< _2LteStages
+    :< _stagesLte10
+    :< _knownNatN
+    :< _knownDomainSrc
+    :< _knownDomainDst
+    :< _hasCallStack
+    :< initBehavior
+    :< stages
+    :< clkSrc
+    :< clkDst
+    :< input
+    :< _ = (0...)
+
+xpmCdcGrayTF# :: Backend backend => BlackBoxContext -> State backend Doc
+xpmCdcGrayTF# bbCtx
+  | [ _2LteN
+    , _nLte32
+    , _2LteStages
+    , _stagesLte10
+    , _knownNatN
+    , _knownDomainSrc
+    , _knownDomainDst
+    , _hasCallStack
+    , DSL.getBool -> Just initValues
+    , DSL.tExprToInteger -> Just stages
+    , clkSrc
+    , clkDst
+    , input
+    ] <- map fst (DSL.tInputs bbCtx)
+  , [resultTy] <- map DSL.ety (DSL.tResults bbCtx)
+  = do
+
+    let
+      compName :: Text
+      compName = "xpm_cdc_gray"
+
+      width :: Integral a => a
+      width = DSL.tySize resultTy
+
+    instName <- Id.make (compName <> "_inst")
+    DSL.declarationReturn bbCtx (compName <> "_block") $ do
+      inputBv <- DSL.toBV "src_in_bin_bv" input
+      resultBv <- DSL.declare "dest_out_bin_bv" (N.BitVector width)
+      result <- DSL.fromBV "dest_out_bin" resultTy resultBv
+
+      let
+        generics :: [(Text, DSL.LitHDL)]
+        generics =
+          [ ("DEST_SYNC_FF", DSL.I stages)
+          , ("INIT_SYNC_FF", if initValues then 1 else 0)
+          , ("REG_OUTPUT", 0)
+          , ("SIM_ASSERT_CHK", 0)
+          , ("SIM_LOSSLESS_GRAY_CHK", 0)
+          , ("WIDTH", DSL.I width)
+          ]
+
+        inps :: [(Text, DSL.TExpr)]
+        inps =
+          [ ("src_clk", clkSrc)
+          , ("dest_clk", clkDst)
+          , ("src_in_bin", inputBv)
+          ]
+
+        outs :: [(Text, DSL.TExpr)]
+        outs =
+          [ ("dest_out_bin", resultBv)
+          ]
+
+      DSL.instDecl
+        N.Empty
+        (Id.unsafeMake compName)
+        instName
+        generics
+        inps
+        outs
+
+      pure [result]
+
+xpmCdcGrayTF# bbCtx = error (ppShow bbCtx)
+
+{-# NOINLINE xpmCdcGray# #-}
+{-# ANN xpmCdcGray# hasBlackBox #-}
+{-# ANN xpmCdcGray#
+  let
+    primName = show 'xpmCdcGray#
+    tfName = show 'xpmCdcGrayTF
+  in InlineYamlPrimitive [VHDL] [__i|
+    BlackBox:
+      name: #{primName}
+      kind: Declaration
+      format: Haskell
+      libraries: ["xpm"]
+      imports: ["xpm.vcomponents.all"]
+      templateFunction: #{tfName}
+  |] #-}
+{-# ANN xpmCdcGray#
+  let
+    primName = show 'xpmCdcGray#
+    tfName = show 'xpmCdcGrayTF
+  in InlineYamlPrimitive [Verilog, SystemVerilog] [__i|
+    BlackBox:
+      name: #{primName}
+      kind: Declaration
+      format: Haskell
+      templateFunction: #{tfName}
+  |] #-}
+-- | Primitive used in 'Clash.Cores.Xilinx.Xpm.Cdc.Gray.xpmCdcGray'
+xpmCdcGray# ::
+  forall stages n src dst.
+  ( 2 <= n, n <= 32
+  , 2 <= stages, stages <= 10
+  , KnownNat n
+  , KnownDomain src
+  , KnownDomain dst
+  , HasCallStack
+  ) =>
+  -- | Initial values supported
+  Bool ->
+  SNat stages ->
+  Clock src ->
+  Clock dst ->
+  Signal src (Unsigned n) ->
+  Signal dst (Unsigned n)
+xpmCdcGray# initValuesSupported stages clkSrc clkDst input =
+  go (snatToNum stages) (initVal :- input)
+ where
+  initVal
+    | initValuesSupported = 0
+    | otherwise = errorX "xpmCdcGray: initial values undefined"
+
+  go :: Word -> Signal src (Unsigned n) -> Signal dst (Unsigned n)
+  go 0 src = unsafeSynchronizer clkSrc clkDst src
+  go n src = initVal :- go (n - 1) src

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -179,7 +179,8 @@ data Element
   -- ^ Period of a domain. Errors if not applied to a @KnownDomain@ or
   -- @KnownConfiguration@.
   | LongestPeriod
-  -- ^ Longest period of all known domains
+  -- ^ Longest period of all known domains. The minimum duration returned is
+  -- 100 ns, see https://github.com/clash-lang/clash-compiler/issues/2455.
   | ActiveEdge !Signal.ActiveEdge !Int
   -- ^ Test active edge of memory elements in a certain domain. Errors if not
   -- applied to a @KnownDomain@ or @KnownConfiguration@.

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
@@ -463,7 +464,9 @@ renderElem b (Period n) = do
 
 renderElem _ LongestPeriod = do
   doms <- domainConfigurations
-  let longestPeriod = maximum [vPeriod v | v <- HashMap.elems doms]
+  -- Longest period with a minimum of 100 ns, see:
+  -- https://github.com/clash-lang/clash-compiler/issues/2455
+  let longestPeriod = maximum (100_000 : [vPeriod v | v <- HashMap.elems doms])
   return (const (Text.pack (show longestPeriod)))
 
 renderElem b (Tag n) = do

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -497,6 +497,12 @@ runClashTest = defaultMain $ clashTestRoot
                                                         ]
                            }
             in runTest "Floating" _opts
+          , runTest "XpmCdcGray" $ def
+              { hdlTargets=[VHDL, Verilog]
+              , hdlLoad=[]
+              , hdlSim=[Vivado]
+              , buildTargets=BuildSpecific ["tb" <> show n | n <- [(1::Int)..7]]
+              }
           , clashTestGroup "DcFifo"
             [ let _opts =
                     def{ hdlTargets=[VHDL, Verilog]

--- a/tests/shouldwork/Cores/Xilinx/XpmCdcGray.hs
+++ b/tests/shouldwork/Cores/Xilinx/XpmCdcGray.hs
@@ -1,0 +1,69 @@
+module XpmCdcGray where
+
+import Clash.Explicit.Prelude
+import Data.Proxy
+
+import XpmCdcGrayTypes (D3, D5, D10, D11)
+
+import qualified XpmCdcGrayTypes as Types
+
+-- | This 'topEntity' exists to make @clash-testsuite@ happy. Without it cannot
+-- find the test benches.
+topEntity :: Unsigned 1
+topEntity = 0
+
+tb0 = done
+ where
+  --                          src dst  width  stages  samples
+  done =             Types.tb @D3 @D5 @16     @4      @100     Proxy Proxy SNat expected
+  expected = $(Types.expected @D3 @D5 @16     @4      @100     Proxy Proxy SNat SNat SNat)
+{-# ANN tb0 (TestBench 'topEntity) #-}
+
+tb1 = done
+ where
+  --                          src dst  width  stages  samples
+  done =             Types.tb @D5 @D3 @16     @4      @100     Proxy Proxy SNat expected
+  expected = $(Types.expected @D5 @D3 @16     @4      @100     Proxy Proxy SNat SNat SNat)
+{-# ANN tb1 (TestBench 'topEntity) #-}
+
+tb2 = done
+ where
+  --                          src dst  width  stages  samples
+  done =             Types.tb @D3 @D5 @16     @10     @100     Proxy Proxy SNat expected
+  expected = $(Types.expected @D3 @D5 @16     @10     @100     Proxy Proxy SNat SNat SNat)
+{-# ANN tb2 (TestBench 'topEntity) #-}
+
+tb3 = done
+ where
+  --                          src dst  width  stages  samples
+  done =             Types.tb @D3 @D5 @16     @2      @100     Proxy Proxy SNat expected
+  expected = $(Types.expected @D3 @D5 @16     @2      @100     Proxy Proxy SNat SNat SNat)
+{-# ANN tb3 (TestBench 'topEntity) #-}
+
+tb4 = done
+ where
+  --                          src dst  width  stages  samples
+  done =             Types.tb @D5 @D10 @16    @2      @100     Proxy Proxy SNat expected
+  expected = $(Types.expected @D5 @D10 @16    @2      @100     Proxy Proxy SNat SNat SNat)
+{-# ANN tb4 (TestBench 'topEntity) #-}
+
+tb5 = done
+ where
+  --                          src dst  width  stages  samples
+  done =             Types.tb @D10 @D5 @16    @2      @100     Proxy Proxy SNat expected
+  expected = $(Types.expected @D10 @D5 @16    @2      @100     Proxy Proxy SNat SNat SNat)
+{-# ANN tb5 (TestBench 'topEntity) #-}
+
+tb6 = done
+ where
+  --                          src dst  width  stages  samples
+  done =             Types.tb @D5 @D11 @16    @2      @100     Proxy Proxy SNat expected
+  expected = $(Types.expected @D5 @D11 @16    @2      @100     Proxy Proxy SNat SNat SNat)
+{-# ANN tb6 (TestBench 'topEntity) #-}
+
+tb7 = done
+ where
+  --                          src  dst width  stages  samples
+  done =             Types.tb @D11 @D5 @16    @2      @100     Proxy Proxy SNat expected
+  expected = $(Types.expected @D11 @D5 @16    @2      @100     Proxy Proxy SNat SNat SNat)
+{-# ANN tb7 (TestBench 'topEntity) #-}

--- a/tests/shouldwork/Cores/Xilinx/XpmCdcGrayTypes.hs
+++ b/tests/shouldwork/Cores/Xilinx/XpmCdcGrayTypes.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE BangPatterns #-}
+
+module XpmCdcGrayTypes where
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Gray
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+import Data.Proxy
+import Language.Haskell.TH.Lib
+
+createDomain vXilinxSystem{vName="D3",  vPeriod=hzToPeriod 30e6}
+createDomain vXilinxSystem{vName="D5",  vPeriod=hzToPeriod 50e6}
+createDomain vXilinxSystem{vName="D10", vPeriod=hzToPeriod 100e6}
+createDomain vXilinxSystem{vName="D11", vPeriod=hzToPeriod 110e6}
+
+noRst :: KnownDomain dom => Reset dom
+noRst = unsafeFromHighPolarity (pure False)
+
+tb ::
+  forall a b width stages n .
+  ( KnownNat n, 1 <= n
+  , KnownNat stages, 2 <= stages, stages <= 10
+  , KnownNat width, 2 <= width, width <= 32
+  , KnownDomain a
+  , KnownDomain b
+  ) =>
+  Proxy a -> Proxy b -> SNat stages ->
+  -- | Expected data
+  Vec n (BitVector width) ->
+  Signal b Bool
+tb Proxy Proxy SNat expectedDat = done
+ where
+  counter = delay clkA enableGen 0 (counter + 1)
+
+  actual = xpmCdcGrayWith @stages @width (XpmCdcGrayConfig SNat True) clkA clkB counter
+
+  done =
+    outputVerifierWith
+      (\clk rst -> assertBitVector clk rst "outputVerifier Port A")
+      clkB clkB (noRst @b)
+      expectedDat
+      (pack <$> actual)
+
+  -- Testbench clocks
+  clkA :: Clock a
+  clkA = tbClockGen (not <$> unsafeSynchronizer clkB clkA done)
+  clkB :: Clock b
+  clkB = tbClockGen (not <$> done)
+
+expected ::
+  forall a b n stages samples .
+  ( KnownDomain a
+  , KnownDomain b
+  , 2 <= stages, stages <= 10
+  , 2 <= n, n <= 32
+  ) =>
+  Proxy a ->
+  Proxy b ->
+  SNat n ->
+  SNat stages ->
+  SNat samples ->
+  ExpQ
+expected Proxy Proxy SNat SNat SNat = listToVecTH out1
+ where
+  out0 =
+    xpmCdcGrayWith
+      @stages @n
+      (XpmCdcGrayConfig SNat True)
+      (clockGen @a)
+      (clockGen @b)
+      (fromList [0..])
+
+  out1 = pack <$> sampleN (natToNum @samples) out0

--- a/tests/src/Test/Tasty/Vivado.hs
+++ b/tests/src/Test/Tasty/Vivado.hs
@@ -87,6 +87,7 @@ genSimTcl dir top = do
     clash::createAndReadIp -dir ip
     clash::readHdl
     set_property TOP $clash::topEntity [current_fileset -sim]
+    set_property -name xsim.elaborate.xelab.more_options -value {-L xpm} -objects [current_fileset -sim]
     save_project_as sim project -force
     set_property RUNTIME all [current_fileset -sim]
     launch_simulation


### PR DESCRIPTION
## Still TODO:

  - [x] Figure out how to use XPM in combination with `launch_simulation`
    - [x] `set_property -name xsim.elaborate.xelab.more_options -value {-L xpm} -objects 
[current_fileset -sim]`
    - [x] fix weird `vl_logic` errors (https://support.xilinx.com/s/question/0D54U00006jQGuESAW/how-can-i-use-xpmcdcgray-using-launchsimulation)
  - [X] ~~Implement realistic Haskell model~~
    - [X] ~~Implement gray encoder/decoder~~
  - [x] Figure out weird start up behavior
    - [x] [Due to Xilinx's GSR](https://support.xilinx.com/s/question/0D52E00007Eu4OESAZ/gsr-usage?language=en_US) 
  - [x] Add `HasCallStack` to `xpmCdcGray#`
  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] Make initial values configurable. Only do auto-detection in non-`With` version.

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
