### PR TITLE
Enable documentation checks on all but two pkgs

### DIFF
--- a/.ci/build_docs.sh
+++ b/.ci/build_docs.sh
@@ -34,9 +34,10 @@ for pkg in ${haddock_pkgs}; do
   #   exit 1
   # fi
 
-  if [[ $pkg == "clash-prelude" ]]; then
-    # TODO: Currently just checking clash-prelude; other libraries still fail
-    # these checks.
+  if [[ "${pkg}" != "clash-lib" && "${pkg}" != "clash-lib-hedgehog" ]]; then
+    # TODO: Currently not checking `clash-lib` as it still fails these checks.
+    #       `clash-lib-hedgehog` is blocked on
+    #       https://github.com/clash-lang/clash-compiler/issues/2462
 
     out_of_scope_warn="If you qualify the identifier, haddock can try to link it anyway"
     if grep -q "${out_of_scope_warn}" haddock_log; then

--- a/clash-cores/src/Clash/Cores/UART.hs
+++ b/clash-cores/src/Clash/Cores/UART.hs
@@ -22,6 +22,14 @@ module Clash.Cores.UART
   , uartRx
   , uartNoBaudGen
   , uart
+
+  -- * Internal
+  , UartBaudGenTick
+  , UartBaudGenTick2
+  , PeriodToHz
+  , DivRound
+  , BaudGenCounterWidth
+  , Second
   ) where
 
 import Clash.Prelude

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating.hs
@@ -187,8 +187,8 @@ div = withFrozenCallStack $ hideEnable $ hideClock E.div
 
 -- | Customizable floating point comparison
 --
--- Produces 'NaN' if any of the inputs is NaN. Otherwise, it behaves like
--- Haskell's 'P.compare'.
+-- Produces 'Clash.Cores.Xilinx.Floating.NaN' if any of the inputs is NaN. Otherwise,
+-- it behaves like Haskell's 'P.compare'.
 --
 -- Only the delay is configurable, so this function does not take a @Config@
 -- argument.
@@ -207,8 +207,8 @@ compareWith = E.compareWith hasClock hasEnable
 
 -- | Floating point comparison, with default delay
 --
--- Produces 'NaN' if any of the inputs is NaN. Otherwise, it behaves like
--- Haskell's 'P.compare'.
+-- Produces 'Clash.Cores.Xilinx.Floating.NaN' if any of the inputs is NaN. Otherwise,
+-- it behaves like Haskell's 'P.compare'.
 compare
   :: forall dom n
    . ( HiddenClock dom

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
@@ -318,8 +318,8 @@ type FromS32DefDelay = 6
 
 -- | Customizable floating point comparison
 --
--- Produces 'NaN' if any of the inputs is NaN. Otherwise, it behaves like
--- Haskell's 'P.compare'.
+-- Produces 'Clash.Cores.Xilinx.Floating.Explicit.NaN' if any of the inputs is
+-- NaN. Otherwise, it behaves like Haskell's 'P.compare'.
 --
 -- Only the delay is configurable, so this function does not take a @Config@
 -- argument.
@@ -343,8 +343,8 @@ compareWith clk ena a b = delayI und ena clk (xilinxCompare <$> a <*> b)
 
 -- | Floating point comparison, with default delay
 --
--- Produces 'NaN' if any of the inputs is NaN. Otherwise, it behaves like
--- Haskell's 'P.compare'.
+-- Produces 'Clash.Cores.Xilinx.Floating.Explicit.NaN' if any of the inputs is
+-- NaN. Otherwise, it behaves like Haskell's 'P.compare'.
 compare
   :: forall dom n
    . ( KnownDomain dom

--- a/clash-cores/src/Clash/Cores/Xilinx/VIO.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/VIO.hs
@@ -37,6 +37,7 @@ JTAG clock speed:
 
 module Clash.Cores.Xilinx.VIO
   ( vioProbe
+  , VIO(..)
   ) where
 
 import Clash.Explicit.Prelude

--- a/clash-cores/test/Test/Cores/UART.hs
+++ b/clash-cores/test/Test/Cores/UART.hs
@@ -24,8 +24,6 @@ import           Clash.Cores.UART
 -- | Create a 100 MHz domain instead of relying on the default period of System.
 createDomain vSystem{vName="System100", vPeriod=10000}
 
-type Second = 1_000_000_000_000
-
 toMaybe :: Bool -> a -> Maybe a
 toMaybe True a = Just a
 toMaybe False _ = Nothing

--- a/clash-cosim/src/Clash/CoSim/DSLParser.hs
+++ b/clash-cosim/src/Clash/CoSim/DSLParser.hs
@@ -3,6 +3,10 @@ module Clash.CoSim.DSLParser
   , vars
   , clks
   , parse
+
+    -- * Internal
+  , CoSimDSL
+  , CoSimDSLToken
   ) where
 
 import Prelude

--- a/clash-cosim/src/Clash/CoSim/Simulator.hs
+++ b/clash-cosim/src/Clash/CoSim/Simulator.hs
@@ -18,6 +18,15 @@ see: <https://essay.utwente.nl/70777/>.
 module Clash.CoSim.Simulator
     ( coSimN
     , defaultSettings
+
+      -- * Internal
+    , CoSim
+    , coSim
+    , CoSimType
+    , CoSimRun
+    , SignalStream
+    , toSignalStream
+    , fromSignalStream
     ) where
 
 ---------------------------

--- a/clash-lib-hedgehog/src/Clash/Hedgehog/Core/Literal.hs
+++ b/clash-lib-hedgehog/src/Clash/Hedgehog/Core/Literal.hs
@@ -25,7 +25,7 @@ import Clash.Core.Type (Type)
 import Clash.Core.TysPrim
 
 -- | Generate a 'Literal' with the specified core type. If the type does not
--- correspond to a known 'PrimTyCon' (as defined in "Clash.Core.TysPrim") then
+-- correspond to a known @PrimTyCon@ (as defined in @Clash.Core.TysPrim@) then
 -- an error is returned.
 --
 genLiteralFrom

--- a/clash-lib-hedgehog/src/Clash/Hedgehog/Core/TyCon.hs
+++ b/clash-lib-hedgehog/src/Clash/Hedgehog/Core/TyCon.hs
@@ -74,7 +74,7 @@ arityOf = length . fst . splitFunForallTy
 
 -- | A TyConMap contains all the algebraic data types and type families that
 -- are used in a program. This is typically the first thing that should be
--- generated, as calls to other generators like 'genKind' or 'genTypeFrom' will
+-- generated, as calls to other generators like @genKind@ or @genTypeFrom@ will
 -- likely want to use the type constructors added to the TyConMap.
 --
 -- TODO It would be nice if this also included types from @clash-prelude@ like

--- a/clash-lib-hedgehog/src/Clash/Hedgehog/Core/Type.hs
+++ b/clash-lib-hedgehog/src/Clash/Hedgehog/Core/Type.hs
@@ -41,7 +41,7 @@ import Clash.Hedgehog.Unique
 
 -- | Classify a type or kind according to some criteria. The classification
 -- of a type or kind is used to determine the pre-defined types / kinds which
--- can be used in hole fills. See 'classify' and 'useTyCon'.
+-- can be used in hole fills. See @classify@ and @useTyCon@.
 --
 data Class = Class
   { cData :: !Any -- ^ Uses -XDataKinds
@@ -131,7 +131,7 @@ classify isKind tcm = go
           ConstTy _ -> error ("classify: Naked ConstTy: " <> showPpr ty)
 
 -- | Decide whether to use a type constructor based on the configuration and
--- the result of 'classifyKind'. A type constructor is not usable if it uses
+-- the result of @classifyKind@. A type constructor is not usable if it uses
 -- any features which are not included in the current configuration.
 --
 useTyCon :: Bool -> CoreGenConfig -> TyConMap -> TyCon -> Bool

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/BitVector.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/BitVector.hs
@@ -44,7 +44,7 @@ genDefinedBit :: (MonadGen m) => m Bit
 genDefinedBit = Gen.element [low, high]
 
 -- | Generate a bit which is not guaranteed to be defined.
--- This will either have the value 'low' or 'high', or throw an 'XException'.
+-- This will either have the value 'low' or 'high', or throw an @XException@.
 --
 genBit :: (MonadGen m) => m Bit
 genBit = Gen.element [low, high, errorX "X"]


### PR DESCRIPTION
Currently not checking `clash-lib` as it still fails these checks.
`clash-lib-hedgehog` is blocked on issue https://github.com/clash-lang/clash-compiler/issues/2462.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~