### PR TITLE
Correct logic when to orphan Hashable ByteArray

### DIFF
--- a/clash-lib/src/Data/Primitive/ByteArray/Extra.hs
+++ b/clash-lib/src/Data/Primitive/ByteArray/Extra.hs
@@ -11,11 +11,18 @@ import GHC.Exts (IsList(..))
 import Control.DeepSeq (NFData(..))
 #endif
 
-#if !MIN_VERSION_hashable(1,4,1)
--- Hashable <1.4.1 doesn't define hashable instances at all
+-- hashable 1.4.2 defines Hashable for Data.Array.Byte.ByteArray, either from
+-- base or from the data-array-byte compat package for GHC < 9.4.
+-- primitive 0.8.0.0 re-exports this ByteArray.
+#if !MIN_VERSION_primitive(0,8,0)
+-- In primitive < 0.8.0.0, its ByteArray is a distinct type from
+-- Data.Array.Byte.ByteArray (insofar as the latter even exists).
+#define DEFINE_HASHABLE_BYTEARRAY
+#elif !MIN_VERSION_hashable(1,4,1)
+-- hashable < 1.4.1 doesn't define a Hashable ByteArray instance at all.
 #define DEFINE_HASHABLE_BYTEARRAY
 #elif !MIN_VERSION_hashable(1,4,2)
--- Hashable 1.4.1 defines hashable for _some_ base versions
+-- hashable 1.4.1 defines hashable for the ByteArray added to base 4.17.
 #if !MIN_VERSION_base(4,17,0)
 #define DEFINE_HASHABLE_BYTEARRAY
 #endif


### PR DESCRIPTION
PR #2448 and #2449 were incomplete, missing some cases where we still needed to create an orphan instance for `Hashable ByteArray` ourselves. This should get it right, including for when we will support GHC 9.4 (which is guarded by the expression `MIN_VERSION_base(4,17,0)`).

Note that the Package Versioning Policy [has something to say](https://pvp.haskell.org/#version-numbers) about defining orphan instances like this:

> _Client defines orphan instance._ If a package defines an orphan instance, it **MUST** depend on the minor version of the packages that define the data type and the type class to be backwards compatible. For example, `build-depends: mypkg >= 2.1.1 && < 2.1.2`.

I think we used to violate this rule, but not any longer :-). Because we now switch off the orphan instance generation starting at a certain version of the dependencies, so we can freely depend in the usual only-major fashion on them again.

Why _to be backwards compatible_ though? The problem here was forwards compatibility, it seems to go both ways. Maybe a simple case of phrasing, or you're supposed to switch your view point, it's always backwards from one side ;-).

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
