### PR TITLE
Add `XPM_CDC_HANDSHAKE` to `clash-cores`

### DIFF
--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -129,6 +129,8 @@ library
     Clash.Cores.Xilinx.Xpm.Cdc.ArraySingle.Internal
     Clash.Cores.Xilinx.Xpm.Cdc.Gray
     Clash.Cores.Xilinx.Xpm.Cdc.Gray.Internal
+    Clash.Cores.Xilinx.Xpm.Cdc.Handshake
+    Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Internal
     Clash.Cores.Xilinx.Xpm.Cdc.Single
     Clash.Cores.Xilinx.Xpm.Cdc.Single.Internal
     Clash.Cores.SPI

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc.hs
@@ -18,9 +18,11 @@
 module Clash.Cores.Xilinx.Xpm.Cdc
   ( xpmCdcArraySingle
   , xpmCdcGray
+  , xpmCdcHandshake
   , xpmCdcSingle
   ) where
 
 import Clash.Cores.Xilinx.Xpm.Cdc.ArraySingle
 import Clash.Cores.Xilinx.Xpm.Cdc.Gray
+import Clash.Cores.Xilinx.Xpm.Cdc.Handshake
 import Clash.Cores.Xilinx.Xpm.Cdc.Single

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Gray/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Gray/Internal.hs
@@ -162,7 +162,7 @@ xpmCdcGray# ::
   , KnownDomain dst
   , HasCallStack
   ) =>
-  -- | Initial values supported
+  -- | Initial value usage
   Bool ->
   SNat stages ->
   Clock src ->

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Handshake.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Handshake.hs
@@ -1,0 +1,144 @@
+{-|
+  Copyright   :  (C) 2023, Google LLC
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.Xilinx.Xpm.Cdc.Handshake
+  ( xpmCdcHandshake
+  , XpmCdcHandshakeConfig(..)
+  , xpmCdcHandshakeWith
+  ) where
+
+import Clash.Explicit.Prelude
+
+import GHC.Stack (HasCallStack)
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Internal (xpmCdcHandshake#)
+
+-- | Synchronizes data from the source clock domain to the destination. For this
+-- to function correctly, a full handshake must be completed before another data
+-- transfer is initiated. The handshake is considered completed when both sides
+-- have acknowledged the transfer and the handshake signals have been reset.
+--
+-- By default, it uses four synchronization stages in both source and
+-- destination domains, and auto-detects whether to use initial values for the
+-- synchronization registers. Use 'xpmCdcHandshakeWith' to change these
+-- settings. For more information see [PG382](https://docs.xilinx.com/r/en-US/pg382-xpm-cdc-generator/XPM_CDC_HANDSHAKE).
+--
+-- __N.B.__: In order to simulate initial values, both the source and destination
+--           domain need to support them. If the source and destination domain
+--           disagree on this property, use of this function will fail to
+--           simulate and translate to HDL. You can explicitly set it using
+--           'xpmCdcHandshakeWith'.
+xpmCdcHandshake ::
+  forall a src dst.
+  ( 1 <= BitSize a, BitSize a <= 1024
+  , KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , HasCallStack
+  ) =>
+  Clock src ->
+  Clock dst ->
+  -- | Word to synchronize to destination domain. This value should not change
+  -- when @src_send@ is asserted.
+  "src_in" ::: Signal src a ->
+
+  -- | Assertion of this signal allows the @src_in@ bus to be synchronized to the
+  -- destination clock domain. This signal should only be asserted when @src_rcv@
+  -- is deasserted, indicating that the previous data transfer is complete. This
+  -- signal should only be deasserted once @src_rcv@ is asserted, acknowledging
+  -- that the @src_in@ has been received by the destination logic.
+  "src_send" ::: Signal src Bool ->
+
+  -- | Asserting this signal indicates that data on @dest_out@ has been captured
+  -- by the destination logic. This signal should be deasserted once @dest_req@ is
+  -- deasserted, completing the handshake on the destination clock domain and
+  -- indicating that the destination logic is ready for a new data transfer.
+  "dst_ack" ::: Signal dst Bool ->
+
+  -- | @dest_req@ indicates that @dest_out@ contains valid data. It can be
+  -- acknowledges by asserting @dst_ack@. @src_rcv@ indicates that the destination
+  -- domain has acknowledged a data transfer.
+  ( "dest_out" ::: Signal dst a
+  , "dest_req" ::: Signal dst Bool
+  , "src_rcv"  ::: Signal src Bool
+  )
+xpmCdcHandshake = xpmCdcHandshakeWith XpmCdcHandshakeConfig{..}
+ where
+  srcStages = d4
+  dstStages = d4
+  initialValues =
+    case (initBehavior @src, initBehavior @dst) of
+      (SDefined, SDefined) -> True
+      (SUnknown, SUnknown) -> False
+      _ -> clashCompileError $ "xpmCdcHandshake: domains need to agree on initial value "
+                            <> "behavior. To set initial value usage explicitly, "
+                            <> "consider using 'xpmCdcHandshakeWith'."
+{-# INLINE xpmCdcHandshake #-}
+
+-- | Configuration for 'xpmCdcHandshakeWith'
+data XpmCdcHandshakeConfig srcStages dstStages = XpmCdcHandshakeConfig
+  { -- | Number of synchronization stages in the source domain
+    srcStages :: SNat srcStages
+
+    -- | Number of synchronization stages in the destination domain
+  , dstStages :: SNat dstStages
+
+    -- | Initialize registers used within the primitive to /0/. Note that
+    -- 'xpmCdcHandshake' will set this to 'True' if both domains support initial
+    -- values, to 'False' if neither domain does, and will otherwise emit an
+    -- error.
+    --
+    -- This value is ignored in Clash simulation on domains configured to not
+    -- support initial values.
+  , initialValues :: Bool
+  }
+
+-- | Like 'xpmCdcHandshake', but with a configurable number of stages, initial values,
+-- and registered input. Also see 'XpmCdcHandshakeConfig'.
+xpmCdcHandshakeWith ::
+  forall srcStages dstStages a src dst.
+  ( 2 <= srcStages, srcStages <= 10
+  , 2 <= dstStages, dstStages <= 10
+  , 1 <= BitSize a, BitSize a <= 1024
+  , KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , HasCallStack
+  ) =>
+  XpmCdcHandshakeConfig srcStages dstStages ->
+  Clock src ->
+  Clock dst ->
+
+  -- | Word to synchronize to destination domain. This value should not change
+  -- when @src_send@ is asserted.
+  "src_in" ::: Signal src a ->
+
+  -- | Assertion of this signal allows the @src_in@ bus to be synchronized to the
+  -- destination clock domain. This signal should only be asserted when @src_rcv@
+  -- is deasserted, indicating that the previous data transfer is complete. This
+  -- signal should only be deasserted once @src_rcv@ is asserted, acknowledging
+  -- that the @src_in@ has been received by the destination logic.
+  "src_send" ::: Signal src Bool ->
+
+  -- | Asserting this signal indicates that data on @dest_out@ has been captured
+  -- by the destination logic. This signal should be deasserted once @dest_req@ is
+  -- deasserted, completing the handshake on the destination clock domain and
+  -- indicating that the destination logic is ready for a new data transfer.
+  "dst_ack" ::: Signal dst Bool ->
+
+  -- | @dest_req@ indicates that @dest_out@ contains valid data. It can be
+  -- acknowledges by asserting @dst_ack@. @src_rcv@ indicates that the destination
+  -- domain has acknowledged a data transfer.
+  ( "dest_out" ::: Signal dst a
+  , "dest_req" ::: Signal dst Bool
+  , "src_rcv"  ::: Signal src Bool
+  )
+xpmCdcHandshakeWith XpmCdcHandshakeConfig{..} =
+  xpmCdcHandshake# initialValues srcStages dstStages
+{-# INLINE xpmCdcHandshakeWith #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Handshake/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Handshake/Internal.hs
@@ -1,0 +1,228 @@
+{-|
+  Copyright   :  (C) 2023, Google LLC
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Internal where
+
+import Prelude
+
+import Control.Monad.State (State)
+import Data.Bifunctor (second)
+import Data.List.Infinite (Infinite(..), (...))
+import Data.String.Interpolate (__i)
+import Data.Text (Text)
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import GHC.Stack (HasCallStack)
+import Text.Show.Pretty (ppShow)
+
+import Clash.Annotations.Primitive (Primitive(..), HDL(..), hasBlackBox)
+import Clash.Backend (Backend)
+import Clash.Explicit.Prelude
+  ( type (<=), type (:::), SNat, Clock, KnownDomain, Signal, BitPack(BitSize)
+  , NFDataX, deepErrorX, unsafeSynchronizer, enableGen, delay, toEnable,
+  (.&&.), unpack )
+import Clash.Netlist.Types (TemplateFunction(..), BlackBoxContext)
+
+import qualified Clash.Netlist.Id as Id
+import qualified Clash.Netlist.Types as N
+import qualified Clash.Primitives.DSL as DSL
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Single (XpmCdcSingleConfig(..), xpmCdcSingleWith)
+
+xpmCdcHandshakeTF :: TemplateFunction
+xpmCdcHandshakeTF =
+  TemplateFunction
+    [initBehavior, srcStages0, dstStages0, clkSrc, clkDst, srcIn, srcSend, dstAck]
+    (const True)
+    xpmCdcHandshakeTF#
+ where
+  _2LteSrcStages
+    :< _srcStagesLte10
+    :< _2LteDstStages
+    :< _dstStagesLte10
+    :< _1LteBitsize
+    :< _bitsizeLte1024
+    :< _knownDomainSrc
+    :< _knownDomainDst
+    :< _bitpackA
+    :< _nfdataxA
+    :< _hasCallStack
+    :< initBehavior
+    :< srcStages0
+    :< dstStages0
+    :< clkSrc
+    :< clkDst
+    :< srcIn
+    :< srcSend
+    :< dstAck
+    :< _ = (0...)
+
+xpmCdcHandshakeTF# :: Backend backend => BlackBoxContext -> State backend Doc
+xpmCdcHandshakeTF# bbCtx
+  | [ _2LteSrcStages, _srcStagesLte10
+    , _2LteDstStages, _dstStagesLte10
+    , _1LteBitsize, _bitsizeLte1024
+    , _knownDomainSrc
+    , _knownDomainDst
+    , _bitpackA
+    , _nfdataxA
+    , _hasCallStack
+    , DSL.getBool -> Just initValues0
+    , DSL.tExprToInteger -> Just srcStages0
+    , DSL.tExprToInteger -> Just dstStages0
+    , clkSrc
+    , clkDst
+    , srcIn
+    , srcSend
+    , dstAck
+    ] <- map fst (DSL.tInputs bbCtx)
+  = do
+
+    let
+      compName :: Text
+      compName = "xpm_cdc_handshake"
+
+      width :: Integral a => a
+      width = DSL.tySize (DSL.ety srcIn)
+
+    instName <- Id.make (compName <> "_inst")
+    DSL.declarationReturn bbCtx (compName <> "_block") $ do
+      srcSendBit <- DSL.bitCoerce "src_send" N.Bit srcSend
+      dstAckBit <- DSL.bitCoerce "dst_ack" N.Bit dstAck
+
+      destOutBv <- DSL.declare "dest_out" (N.BitVector width)
+      destOut <- DSL.bitCoerce "dest_out" (DSL.ety srcIn) destOutBv
+
+      srcInBv <- DSL.bitCoerce "src_in" (N.BitVector width) srcIn
+
+      destReqBit <- DSL.declare "dest_req" N.Bit
+      destReq <- DSL.boolFromBit "dest_req" destReqBit
+
+      srcRcvBit <- DSL.declare "src_rcv" N.Bit
+      srcRcv <- DSL.boolFromBit "src_rcv" srcRcvBit
+
+      let
+        generics :: [(Text, DSL.LitHDL)]
+        generics =
+          [ ("DEST_EXT_HSK", DSL.I 0)
+          , ("DEST_SYNC_FF", DSL.I srcStages0)
+          , ("INIT_SYNC_FF", if initValues0 then 1 else 0)
+          , ("SIM_ASSERT_CHK", 0)
+          , ("SRC_SYNC_FF", DSL.I dstStages0)
+          , ("WIDTH", DSL.I width)
+          ]
+
+        inps :: [(Text, DSL.TExpr)]
+        inps =
+          [ ("src_clk", clkSrc)
+          , ("dest_clk", clkDst)
+          , ("src_in", srcInBv)
+          , ("src_send", srcSendBit)
+          , ("dest_ack", dstAckBit)
+          ]
+
+        outs :: [(Text, DSL.TExpr)]
+        outs =
+          [ ("dest_out", destOutBv)
+          , ("dest_req", destReqBit)
+          , ("src_rcv", srcRcvBit)
+          ]
+
+      DSL.instDecl
+        N.Empty
+        (Id.unsafeMake compName)
+        instName
+        (map (second DSL.litTExpr) generics)
+        inps
+        outs
+
+      pure [DSL.tuple [destOut, destReq, srcRcv]]
+
+xpmCdcHandshakeTF# bbCtx = error (ppShow bbCtx)
+
+{-# NOINLINE xpmCdcHandshake# #-}
+{-# ANN xpmCdcHandshake# hasBlackBox #-}
+{-# ANN xpmCdcHandshake#
+  let
+    primName = show 'xpmCdcHandshake#
+    tfName = show 'xpmCdcHandshakeTF
+  in InlineYamlPrimitive [VHDL] [__i|
+    BlackBox:
+      name: #{primName}
+      kind: Declaration
+      format: Haskell
+      libraries: ["xpm"]
+      imports: ["xpm.vcomponents.all"]
+      templateFunction: #{tfName}
+  |] #-}
+{-# ANN xpmCdcHandshake#
+  let
+    primName = show 'xpmCdcHandshake#
+    tfName = show 'xpmCdcHandshakeTF
+  in InlineYamlPrimitive [Verilog, SystemVerilog] [__i|
+    BlackBox:
+      name: #{primName}
+      kind: Declaration
+      format: Haskell
+      templateFunction: #{tfName}
+  |] #-}
+-- | Primitive used in 'Clash.Cores.Xilinx.Xpm.Cdc.Handshake.xpmCdcHandshake'
+xpmCdcHandshake# ::
+  forall srcStages dstStages a src dst.
+  ( 2 <= srcStages, srcStages <= 10
+  , 2 <= dstStages, dstStages <= 10
+  , 1 <= BitSize a, BitSize a <= 1024
+  , KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , HasCallStack
+  ) =>
+  -- | Initial value usage
+  Bool ->
+  SNat srcStages ->
+  SNat dstStages ->
+  Clock src ->
+  Clock dst ->
+  "src_in"   ::: Signal src a ->
+  "src_send" ::: Signal src Bool ->
+  "dst_ack"  ::: Signal dst Bool ->
+
+  ( "dest_out" ::: Signal dst a
+  , "dest_req" ::: Signal dst Bool
+  , "src_rcv"  ::: Signal src Bool
+  )
+xpmCdcHandshake# initVals srcStages dstStages clkSrc clkDst srcIn srcSend dstAck =
+  (dstOut, dstReq, srcRcv)
+ where
+  defOpts :: forall stages. SNat stages -> XpmCdcSingleConfig stages
+  defOpts nStages = XpmCdcSingleConfig
+    { stages = nStages
+    , initialValues = initVals
+    , registerInput = False }
+
+  srcSendFfSynced = xpmCdcSingleWith (defOpts srcStages) clkSrc clkDst srcSendFf
+  srcRcv = xpmCdcSingleWith (defOpts dstStages) clkDst clkSrc dstAck
+
+  srcSendFf = delay clkSrc enableGen (initVal False) srcSend
+  srcHsDataFf = delay clkSrc (toEnable (not <$> srcSendFf)) (initVal (unpack 0)) srcIn
+  dstOutEna = toEnable (srcSendFfSynced .&&. fmap not dstReq)
+
+  dstOut =
+    delay
+      clkDst dstOutEna (initVal (unpack 0))
+      (unsafeSynchronizer clkSrc clkDst srcHsDataFf)
+
+  dstReq = delay clkDst enableGen (initVal False) srcSendFfSynced
+
+  initVal :: forall x . NFDataX x => x -> x
+  initVal v
+    | initVals = v
+    | otherwise = deepErrorX "xpmCdcHandshake: initial values undefined"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -510,13 +510,13 @@ runClashTest = defaultMain $ clashTestRoot
               }
           , runTest "XpmCdcGray" $ def
               { hdlTargets=[VHDL, Verilog]
-              , hdlLoad=[]
+              , hdlLoad=[Vivado]
               , hdlSim=[Vivado]
-              , buildTargets=BuildSpecific ["tb" <> show n | n <- [(1::Int)..7]]
+              , buildTargets=BuildSpecific ["tb" <> show n | n <- [(0::Int)..7]]
               }
           , runTest "XpmCdcHandshake" $ def
               { hdlTargets=[VHDL, Verilog]
-              , hdlLoad=[]
+              , hdlLoad=[Vivado]
               , hdlSim=[Vivado]
               , buildTargets=BuildSpecific ["tb" <> show n | n <- [(0::Int)..6]]
               }
@@ -529,12 +529,12 @@ runClashTest = defaultMain $ clashTestRoot
           , clashTestGroup "DcFifo"
             [ let _opts =
                     def{ hdlTargets=[VHDL, Verilog]
-                       , hdlLoad=[]
+                       , hdlLoad=[Vivado]
                        , hdlSim=[Vivado]
                        }
               in runTest "Basic" _opts
             , let _opts = def{ hdlTargets=[VHDL, Verilog]
-                             , hdlLoad=[]
+                             , hdlLoad=[Vivado]
                              , hdlSim=[Vivado]
                              , buildTargets=BuildSpecific [ "testBench_17_2"
                                                           , "testBench_2_17"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -514,6 +514,12 @@ runClashTest = defaultMain $ clashTestRoot
               , hdlSim=[Vivado]
               , buildTargets=BuildSpecific ["tb" <> show n | n <- [(1::Int)..7]]
               }
+          , runTest "XpmCdcHandshake" $ def
+              { hdlTargets=[VHDL, Verilog]
+              , hdlLoad=[]
+              , hdlSim=[Vivado]
+              , buildTargets=BuildSpecific ["tb" <> show n | n <- [(0::Int)..6]]
+              }
           , runTest "XpmCdcSingle" $ def
               { hdlTargets=[VHDL, Verilog]
               , hdlLoad=[Vivado]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -514,12 +514,15 @@ runClashTest = defaultMain $ clashTestRoot
               , hdlSim=[Vivado]
               , buildTargets=BuildSpecific ["tb" <> show n | n <- [(0::Int)..7]]
               }
+#if !MIN_VERSION_ghc(9,6,0)
+          -- XXX: Broken on GHC 9.6. See https://github.com/clash-lang/clash-compiler/issues/2512.
           , runTest "XpmCdcHandshake" $ def
               { hdlTargets=[VHDL, Verilog]
               , hdlLoad=[Vivado]
               , hdlSim=[Vivado]
               , buildTargets=BuildSpecific ["tb" <> show n | n <- [(0::Int)..6]]
               }
+#endif
           , runTest "XpmCdcSingle" $ def
               { hdlTargets=[VHDL, Verilog]
               , hdlLoad=[Vivado]

--- a/tests/shouldwork/Cores/Xilinx/XpmCdcHandshake.hs
+++ b/tests/shouldwork/Cores/Xilinx/XpmCdcHandshake.hs
@@ -1,0 +1,82 @@
+module XpmCdcHandshake where
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Handshake
+import Clash.Explicit.Prelude
+import Data.Proxy
+
+import XpmCdcHandshakeTypes (D3, D5, D10, D11)
+
+import qualified XpmCdcHandshakeTypes as Types
+
+-- | This 'topEntity' exists to make @clash-testsuite@ happy. Without it cannot
+-- find the test benches.
+topEntity :: Unsigned 1
+topEntity = 0
+{-# NOINLINE topEntity #-}
+
+tb0 = done
+ where
+  --                          src dst srcStages dstStages samples                                               init
+  done =             Types.tb @D3 @D5 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) expected
+  expected = $(Types.expected @D3 @D5 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) SNat)
+{-# ANN tb0 (TestBench 'topEntity) #-}
+{-# NOINLINE tb0 #-}
+
+tb1 = done
+ where
+  --                          src dst srcStages dstStages samples                                               init
+  done =             Types.tb @D5 @D3 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) expected
+  expected = $(Types.expected @D5 @D3 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) SNat)
+{-# ANN tb1 (TestBench 'topEntity) #-}
+{-# NOINLINE tb1 #-}
+
+tb2 = done
+ where
+  --                          src dst srcStages dstStages samples                                               init
+  done =             Types.tb @D5 @D3 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) expected
+  expected = $(Types.expected @D5 @D3 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) SNat)
+{-# ANN tb2 (TestBench 'topEntity) #-}
+{-# NOINLINE tb2 #-}
+
+tb3 = done
+ where
+  --                          src dst  srcStages dstStages samples                                               init
+  done =             Types.tb @D5 @D10 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) expected
+  expected = $(Types.expected @D5 @D10 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) SNat)
+{-# ANN tb3 (TestBench 'topEntity) #-}
+{-# NOINLINE tb3 #-}
+
+tb4 = done
+ where
+  --                          src dst  srcStages dstStages samples                                               init
+  done =             Types.tb @D3 @D11 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) expected
+  expected = $(Types.expected @D3 @D11 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) SNat)
+{-# ANN tb4 (TestBench 'topEntity) #-}
+{-# NOINLINE tb4 #-}
+
+tb5 = done
+ where
+  --                          src dst  srcStages dstStages samples                                               init
+  done =             Types.tb @D3 @D11 @3        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) expected
+  expected = $(Types.expected @D3 @D11 @3        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) SNat)
+{-# ANN tb5 (TestBench 'topEntity) #-}
+{-# NOINLINE tb5 #-}
+
+tb6 = done
+ where
+  --                          src dst  srcStages dstStages samples                                               init
+  done =             Types.tb @D3 @D11 @2        @3        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) expected
+  expected = $(Types.expected @D3 @D11 @2        @3        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat True) SNat)
+{-# ANN tb6 (TestBench 'topEntity) #-}
+{-# NOINLINE tb6 #-}
+
+-- XXX: Test code does not handle undefined values. Given that this primitive
+--      is defined purely in terms of translatable/synthesizable constructs
+--      though, I don't think it is too bad to skip this test though.
+-- tb7 = done
+--  where
+--   --                          src dst  srcStages dstStages samples                                               init
+--   done =             Types.tb @D3 @D11 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat False) expected
+--   expected = $(Types.expected @D3 @D11 @2        @2        @100     Proxy Proxy (XpmCdcHandshakeConfig SNat SNat False) SNat)
+-- {-# ANN tb7 (TestBench 'topEntity) #-}
+-- {-# NOINLINE tb7 #-}

--- a/tests/shouldwork/Cores/Xilinx/XpmCdcHandshakeTypes.hs
+++ b/tests/shouldwork/Cores/Xilinx/XpmCdcHandshakeTypes.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+
+module XpmCdcHandshakeTypes where
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Handshake
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+import Data.Proxy
+import Language.Haskell.TH.Lib
+
+createDomain vXilinxSystem{vName="D3",  vPeriod=hzToPeriod 30e6}
+createDomain vXilinxSystem{vName="D5",  vPeriod=hzToPeriod 50e6}
+createDomain vXilinxSystem{vName="D10", vPeriod=hzToPeriod 100e6}
+createDomain vXilinxSystem{vName="D11", vPeriod=hzToPeriod 110e6}
+
+data State = WaitForDeassert | WaitForAssert deriving (Generic, NFDataX)
+
+noRst :: KnownDomain dom => Reset dom
+noRst = unsafeFromHighPolarity (pure False)
+
+-- | Transfer 1, 2, 3, ... to destination domain
+srcFsm ::
+  forall a src .
+  ( KnownDomain src
+  , Num a
+  , NFDataX a
+  ) =>
+  Clock src ->
+  Signal src Bool ->
+  Signal src (a, Bool)
+srcFsm clk = mealy clk noRst enableGen go (0, WaitForDeassert)
+ where
+  go (n, WaitForDeassert) True  = ((n,     WaitForDeassert), (n,     False))
+  go (n, WaitForDeassert) False = ((n + 1, WaitForAssert),   (n + 1, True))
+  go (n, WaitForAssert)   False = ((n,     WaitForAssert),   (n,     True))
+  go (n, WaitForAssert)   True  = ((n,     WaitForDeassert), (n,     False))
+{-# NOINLINE srcFsm #-}
+
+-- | Receives data from source domain
+dstFsm ::
+  forall a dst .
+  KnownDomain dst =>
+  Clock dst ->
+  Signal dst (Bool, a) ->
+  Signal dst (Bool, Maybe a)
+dstFsm clk = mealy clk noRst enableGen go WaitForAssert
+ where
+  go WaitForAssert   (False, _) = (WaitForAssert,   (False, Nothing))
+  go WaitForAssert   (True,  n) = (WaitForDeassert, (True,  Just n))
+  go WaitForDeassert (True,  _) = (WaitForDeassert, (True,  Nothing))
+  go WaitForDeassert (False, _) = (WaitForAssert,   (False, Nothing))
+{-# NOINLINE dstFsm #-}
+
+-- | Composition of 'srcFsm' and 'dstFsm'
+top ::
+  forall a srcStages dstStages src dst .
+  ( KnownDomain src
+  , KnownDomain dst
+  , Num a
+  , NFDataX a
+  , BitPack a
+  , 1 <= BitSize a, BitSize a <= 1024
+  , 2 <= srcStages, srcStages <= 10
+  , 2 <= dstStages, dstStages <= 10
+  ) =>
+  XpmCdcHandshakeConfig srcStages dstStages ->
+  Clock src ->
+  Clock dst ->
+  Signal dst (Maybe a)
+top opts clkSrc clkDst = maybeDat
+ where
+  (srcIn, srcSend) = unbundle $ srcFsm @a clkSrc srcRcv
+
+  (destOut, destReq, srcRcv) =
+    xpmCdcHandshakeWith opts clkSrc clkDst srcIn srcSend destAck
+
+  (destAck, maybeDat) =
+    unbundle $ dstFsm @a clkDst $ bundle (destReq, destOut)
+{-# NOINLINE top #-}
+
+tb ::
+  forall a b srcStages dstStages n .
+  ( KnownNat n, 1 <= n
+  , 2 <= srcStages, srcStages <= 10
+  , 2 <= dstStages, dstStages <= 10
+  , KnownDomain a
+  , KnownDomain b
+  ) =>
+  Proxy a -> Proxy b ->
+  XpmCdcHandshakeConfig srcStages dstStages ->
+  -- | Expected data
+  Vec n (Maybe (Unsigned 8)) ->
+  Signal b Bool
+tb Proxy Proxy opts expectedDat = done
+ where
+  actual = top @(Unsigned 8) opts clkA clkB
+
+  done = outputVerifier' clkB (noRst @b) expectedDat actual
+
+  -- Testbench clocks
+  clkA :: Clock a
+  clkA = tbClockGen (not <$> unsafeSynchronizer clkB clkA done)
+  clkB :: Clock b
+  clkB = tbClockGen (not <$> done)
+
+expected ::
+  forall a b srcStages dstStages samples .
+  ( KnownDomain a
+  , KnownDomain b
+  , 2 <= srcStages, srcStages <= 10
+  , 2 <= dstStages, dstStages <= 10
+  ) =>
+  Proxy a ->
+  Proxy b ->
+  XpmCdcHandshakeConfig srcStages dstStages ->
+  SNat samples ->
+  ExpQ
+expected Proxy Proxy opts SNat = listToVecTH out1
+ where
+  out0 = top @(Unsigned 8) opts (clockGen @a) (clockGen @b)
+  out1 = sampleN (natToNum @samples) out0


### PR DESCRIPTION
Depends on https://github.com/clash-lang/clash-compiler/pull/2459
## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] Check copyright notices are up to date in edited files
  - [x] ~~Clean up var names in Haskell model~~ They're inspired by Xilinx's. I can't think of much better names..
  - [X] ~~Randomized / non-happy path tests?~~ Upon reviewer insistence :-). The implementation of this primitive was reverse engineered from the schematic, so I consider the chance that there are any difference to be pretty small.

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
