### PR TITLE
Add SimOnly data type

### DIFF
--- a/changelog/2023-05-02T20_57_35+02_00_sim_only
+++ b/changelog/2023-05-02T20_57_35+02_00_sim_only
@@ -1,0 +1,1 @@
+ADDED: `Clash.Magic.SimOnly`, A container for data you only want to have around during simulation and is ignored during synthesis. Useful for carrying around things such as: a map of simulation/vcd traces, co-simulation state or meta-data, etc.

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -1,6 +1,6 @@
 {-|
   Copyright   :  (C) 2013-2016, University of Twente,
-                     2016-2017, Myrtle Software Ltd,
+                     2016-2023, Myrtle Software Ltd,
                      2021-2022, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -293,6 +293,9 @@ ghcTypeToHWType iw = go
         "GHC.STRef.STRef" -> case args of
           [_,aTy] -> ExceptT (MaybeT (Just <$> coreTypeToHWType go reprs m aTy))
           _ -> throwE $ $(curLoc) ++ "STRef TC has unexpected amount of arguments"
+
+        -- Anything that's wrapped in SimOnly should be elided when we generate HDL
+        "Clash.Magic.SimOnly" -> returnN (Void Nothing)
 
         _ -> ExceptT (MaybeT (pure Nothing))
 

--- a/clash-lib/prims/common/Clash_Magic.primitives.yaml
+++ b/clash-lib/prims/common/Clash_Magic.primitives.yaml
@@ -16,3 +16,9 @@
 - Primitive:
     name: Clash.Magic.setName
     primType: Function
+- BlackBox:
+    name: Clash.Magic.SimOnly
+    kind: Expression
+    type: 'SimOnly :: a -> SimOnly a'
+    template: ~ERRORO
+    workInfo: Constant

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -391,6 +391,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "TestIndex" def{hdlSim=[]}
         , runTest "Time" def
         , runTest "Shift" def{hdlSim=[]}
+        , runTest "SimOnly" def{hdlTargets=[VHDL],hdlSim=[]}
         , runTest "SimpleConstructor" def{hdlSim=[]}
         , runTest "SomeNatVal" def{hdlTargets=[VHDL],hdlSim=[]}
         , runTest "TyEqConstraints" def{

--- a/tests/shouldwork/Basic/SimOnly.hs
+++ b/tests/shouldwork/Basic/SimOnly.hs
@@ -1,0 +1,22 @@
+module SimOnly where
+
+import Clash.Explicit.Prelude
+import qualified Data.Map as Map
+
+type Ignore = SimOnly (Map.Map String [Int])
+
+unionIgnore :: Ignore -> Ignore -> Ignore
+unionIgnore (SimOnly m1) (SimOnly m2) = SimOnly (Map.unionWith (<>) m1 m2)
+
+foo :: Int -> Int -> (Int, Ignore)
+foo a b = (a+b,SimOnly (Map.fromList [("foo",[a + b])]))
+{-# NOINLINE foo #-}
+
+bar :: Int -> Int -> (Int, Ignore)
+bar a b = (a*b,SimOnly (Map.fromList [("bar",[a * b])]))
+
+topEntity :: Int -> Int -> (Int, Ignore)
+topEntity a b =
+  let (z,np1) = foo a b
+      (y,np2) = bar a b
+   in (y - z, unionIgnore np1 np2)


### PR DESCRIPTION
A container for data you only want to have around during simulation and is ignored during synthesis. Useful for carrying around things such as:

  * A map of simulation/vcd traces
  * Co-simulation state or meta-data
  * etc.

- [x] Write a changelog entry (see changelog/README.md)
- [x] Check copyright notices are up to date in edited files
