### PR TITLE
Rename `simulation` to `clashSimulation`

### DIFF
--- a/changelog/2022-12-16T12_15_46+01_00_add_Clash_Magic_simulation
+++ b/changelog/2022-12-16T12_15_46+01_00_add_Clash_Magic_simulation
@@ -1,1 +1,1 @@
-ADDED: `Clash.Magic.simulation`, a way to differentiate between simulation and generating HDL.
+ADDED: `Clash.Magic.clashSimulation`, a way to differentiate between Clash simulation and generating HDL.

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -437,7 +437,7 @@ coreToTerm primMap unlocs = term
         go "Clash.Magic.noDeDup" args
           | [_aTy,f] <- args
           = C.Tick C.NoDeDup <$> term f
-        go "Clash.Magic.simulation" _
+        go "Clash.Magic.clashSimulation" _
           = C.Data <$> coreToDataCon falseDataCon
         go "Clash.XException.xToErrorCtx" args
           -- xToErrorCtx :: forall a. String -> a -> a

--- a/clash-prelude/src/Clash/Magic.hs
+++ b/clash-prelude/src/Clash/Magic.hs
@@ -32,7 +32,7 @@ module Clash.Magic
   , noDeDup
 
   -- ** Utilities to differentiate between simulation and generating HDL
-  , simulation
+  , clashSimulation
   , SimOnly (..)
   ) where
 
@@ -239,10 +239,10 @@ noDeDup
 noDeDup = id
 {-# NOINLINE noDeDup #-}
 
--- | 'True' in Haskell simulation. Replaced by 'False' when generating HDL.
-simulation :: Bool
-simulation = True
-{-# NOINLINE simulation #-}
+-- | 'True' in Haskell/Clash simulation. Replaced by 'False' when generating HDL.
+clashSimulation :: Bool
+clashSimulation = True
+{-# NOINLINE clashSimulation #-}
 
 -- | A container for data you only want to have around during simulation and
 -- is ignored during synthesis. Useful for carrying around things such as:

--- a/tests/shouldwork/Basic/SimulationMagic.hs
+++ b/tests/shouldwork/Basic/SimulationMagic.hs
@@ -6,11 +6,11 @@ import System.Environment (getArgs)
 import System.FilePath ((</>))
 
 import Clash.Prelude
-import Clash.Magic (simulation)
+import Clash.Magic (clashSimulation)
 
 f :: Int
-f | simulation = 123
-  | otherwise  = 456
+f | clashSimulation = 123
+  | otherwise       = 456
 {-# ANN f (defSyn "f") #-}
 
 assertNotIn :: String -> String -> IO ()


### PR DESCRIPTION
Just `simulation` is ambiguous: in the future we could also differentiate between Clash simulation and target HDL simulation.

----

Note: this is not an API change, as `Clash.magic.simulation` is not in any release yet.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files