### PR TITLE
Add HDL attribute `KEEP` to `vioProbe` ports

### DIFF
--- a/clash-cores/src/Clash/Cores/Xilinx/VIO/Internal/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/VIO/Internal/BlackBoxes.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright   :  (C) 2022 Google Inc
+  Copyright   :  (C) 2022-2023, Google Inc
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -25,6 +25,7 @@ import Data.Foldable (fold)
 import Data.String.Interpolate (__i)
 import Data.Text.Prettyprint.Doc.Extra (Doc)
 import qualified Data.Text as T (pack, append, concat)
+import Text.Show.Pretty (ppShow)
 
 import Control.Arrow (first)
 import Control.Monad (when, forM, zipWithM)
@@ -223,11 +224,11 @@ constantProbeValues ty expr = case bits (DSL.tySize ty) expr of
     Clash failed to determine a constant value for one of the expressions
     given as the inital output probe values. The failing expression is:
 
-      #{show failedExpr}
+      #{ppShow failedExpr}
 
     The complete expression is:
 
-      #{show expr}
+      #{ppShow expr}
 
     As a quick fix: it may help to leverage the template haskell function
     $(lift ...) to get rid of this error message.

--- a/clash-cores/src/Clash/Cores/Xilinx/VIO/Internal/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/VIO/Internal/BlackBoxes.hs
@@ -35,6 +35,7 @@ import Control.Exception (assert)
 import qualified Clash.Netlist.Id as Id
 import qualified Clash.Primitives.DSL as DSL
 import Clash.Backend (Backend)
+import Clash.Core.Var (Attr' (StringAttr'))
 import Clash.Netlist.Expr (bits, fromBits)
 import Clash.Netlist.Types
   ( Size
@@ -115,26 +116,35 @@ vioProbeBBTF bbCtx
         outNames = map (T.pack . ("probe_out" <>) . show) [0 :: Int, 1..]
         inBVNames = map (`T.append` "_bv") inNames
         outBVNames = map (`T.append` "_bv") outNames
+        -- The HDL attribute 'KEEP' is added to the signals connected to the
+        -- probe ports so they are not optimized away by the synthesis tool.
+        attrs = [StringAttr' "KEEP" "true"]
+
+        inBVs = map (BitVector . (fromInteger . DSL.tySize)) inTys
+        outBVs = map (BitVector . (fromInteger . DSL.tySize)) outTys
 
       DSL.declarationReturn bbCtx "vio_inst_block" $ do
-        DSL.compInBlock vioProbeName (("clk", Bit) : zip inNames inTys)
+        DSL.compInBlock vioProbeName (("clk", Bit) : zip inNames inBVs)
           $ case tResult of
               Void{} -> []
-              _      -> [("out_probes", tResult)]
+              _      -> zip outNames outBVs
 
-        inProbesBV <- case inPs of
-          [ singleInput ] -> case DSL.ety singleInput of
-            Vector{}  -> DSL.unvec "vec" singleInput
-            Product{} -> DSL.deconstructProduct singleInput inBVNames
-            _         -> pure <$> DSL.toBV (head inBVNames) singleInput
-          _ -> zipWithM DSL.toBV inBVNames inPs
+        inProbes <-
+          case inPs of
+            [ singleInput ] ->
+              case DSL.ety singleInput of
+                Vector{}  -> DSL.unvec "vec" singleInput
+                Product{} -> DSL.deconstructProduct singleInput inNames
+                _         -> pure <$> DSL.assign (head inNames) singleInput
+            _ -> zipWithM DSL.assign inNames inPs
 
-        outProbesBV <-
-          forM (zip outBVNames outTys) $ \(name, ty) ->
-            DSL.declare name $ BitVector $ fromInteger $ DSL.tySize ty
         outProbes <-
-          forM (zip (zip outNames outTys) outProbesBV)
-            $ uncurry $ uncurry DSL.fromBV
+          forM (zip outNames outTys) $ uncurry DSL.declare
+        outProbesBV <-
+          forM (zip outBVNames outProbes) $ uncurry (DSL.toBvWithAttrs attrs)
+
+        inProbesBV <-
+          forM (zip inBVNames inProbes) $ uncurry (DSL.toBvWithAttrs attrs)
 
         DSL.instDecl Empty (Id.unsafeMake vioProbeName) vioProbeInstName []
           (("clk", clk) : zip inNames inProbesBV)

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -472,6 +472,13 @@ data HWType
   -- ^ File type for simulation-level I/O
   deriving (Eq, Ord, Show, Generic, NFData, Hashable)
 
+-- | Smart constructor for 'Annotated'. Wraps the given type in an 'Annotated'
+-- if the attribute list is non-empty. If it is empty, it will return the given
+-- 'HWType' unchanged.
+annotated :: [Attr'] -> HWType -> HWType
+annotated [] t = t
+annotated attrs t = Annotated attrs t
+
 hwTypeDomain :: HWType -> Maybe DomainName
 hwTypeDomain = \case
   Clock dom -> Just dom

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -539,9 +539,31 @@ runClashTest = defaultMain $ clashTestRoot
             ]
           , let _opts =
                   def{ hdlTargets=[VHDL, Verilog, SystemVerilog]
-                     , hdlLoad=[]
-                     , hdlSim=[]
-                     , buildTargets = BuildSpecific []
+                     , hdlLoad=[Vivado]
+                     , hdlSim=[Vivado]
+                     , buildTargets=BuildSpecific [ "noInputTrue"
+                                                  , "noInputFalse"
+                                                  , "noInputLow"
+                                                  , "noInputHigh"
+                                                  , "noInputSigned"
+                                                  , "noInputUnsigned"
+                                                  , "noInputBitVector"
+                                                  , "noInputPair"
+                                                  , "noInputVec"
+                                                  , "noInputCustom"
+                                                  , "noInputNested"
+                                                  , "singleInputBool"
+                                                  , "singleInputBit"
+                                                  , "singleInputSigned"
+                                                  , "singleInputUnsigned"
+                                                  , "singleInputBitVector"
+                                                  , "singleInputPair"
+                                                  , "singleInputVec"
+                                                  , "singleInputCustom"
+                                                  , "singleInputNested"
+                                                  , "multipleInputs"
+                                                  , "inputsAndOutputs"
+                                                  ]
                      }
             in runTest "VIO" _opts
           ]

--- a/tests/shouldwork/Cores/Xilinx/VIO.hs
+++ b/tests/shouldwork/Cores/Xilinx/VIO.hs
@@ -4,99 +4,117 @@ import Clash.Prelude
 import Clash.Cores.Xilinx.VIO
 import Clash.Annotations.TH
 import Clash.Annotations.BitRepresentation
+import Clash.Explicit.Testbench
 
 type Dom = XilinxSystem
 
+top :: "result" ::: Unsigned 8
+top = 0
+{-# NOINLINE top #-}
+
+makeTopEntity 'top
+
 noInputTrue ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom Bool
+  "result" ::: Signal Dom Bool
 noInputTrue = vioProbe @Dom True
+{-# ANN noInputTrue (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputTrue ""
+makeTopEntity 'noInputTrue
 
 
 noInputFalse ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom Bool
+  "result" ::: Signal Dom Bool
 noInputFalse = vioProbe @Dom False
+{-# ANN noInputFalse (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputFalse ""
+makeTopEntity 'noInputFalse
 
 
 noInputLow ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom Bit
+  "result" ::: Signal Dom Bit
 noInputLow = vioProbe @Dom low
+{-# ANN noInputLow (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputLow ""
+makeTopEntity 'noInputLow
 
 
 noInputHigh ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom Bit
+  "result" ::: Signal Dom Bit
 noInputHigh = vioProbe @Dom high
+{-# ANN noInputHigh (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputHigh ""
+makeTopEntity 'noInputHigh
 
 
 noInputSigned ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom (Signed 2)
+  "result" ::: Signal Dom (Signed 2)
 noInputSigned = vioProbe @Dom (-1)
+{-# ANN noInputSigned (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputSigned ""
+makeTopEntity 'noInputSigned
 
 
 noInputUnsigned ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom (Unsigned 2)
+  "result" ::: Signal Dom (Unsigned 2)
 noInputUnsigned = vioProbe @Dom 3
+{-# ANN noInputUnsigned (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputUnsigned ""
+makeTopEntity 'noInputUnsigned
 
 
 noInputBitVector ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom (BitVector 7)
+  "result" ::: Signal Dom (BitVector 7)
 noInputBitVector = vioProbe @Dom 111
+{-# ANN noInputBitVector (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputBitVector ""
+makeTopEntity 'noInputBitVector
 
 
 noInputPair ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom (Bit, Bool)
+  "result" ::: Signal Dom (Bit, Bool)
 noInputPair = vioProbe @Dom (high, False)
+{-# ANN noInputPair (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputPair ""
+makeTopEntity 'noInputPair
 
 
 noInputVec ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom (Vec 4 (Unsigned 2))
+  "result" ::: Signal Dom (Vec 4 (Unsigned 2))
 noInputVec = vioProbe @Dom (0 :> 1 :> 2 :> 3 :> Nil)
+{-# ANN noInputVec (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputVec ""
+makeTopEntity 'noInputVec
 
 
 data D1 = D1 Bool Bit (Unsigned 2)
 
 noInputCustom ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom D1
+  "result" ::: Signal Dom D1
 noInputCustom = vioProbe @Dom (D1 True high 1)
+{-# ANN noInputCustom (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputCustom ""
+makeTopEntity 'noInputCustom
 
 
 data D2 = D2 Bool (Vec 2 D1)
 
 noInputNested ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom D2
+  "result" ::: Signal Dom D2
 noInputNested = vioProbe @Dom (D2 True (D1 True high 1 :> D1 False low 0 :> Nil))
+{-# ANN noInputNested (TestBench 'top) #-}
 
-makeTopEntityWithName 'noInputNested ""
+makeTopEntity 'noInputNested
 
 
 data T = R Bool Bool
@@ -109,7 +127,7 @@ data T = R Bool Bool
    yet. See Clash.Cores.Xilinx.VIO.Internal.BlackBoxes for details.
 noInputCustomRep ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom T
+  "result" ::: Signal Dom T
 noInputCustomRep = vioProbe @Dom (R True False)
 
 makeTopEntityWithName 'noInputCustomRep ""
@@ -118,83 +136,92 @@ makeTopEntityWithName 'noInputCustomRep ""
 
 singleInputBool ::
   "clk" ::: Clock Dom ->
-  "in" ::: Signal Dom Bool ->
-  "out" ::: Signal Dom ()
+  "inp" ::: Signal Dom Bool ->
+  "result" ::: Signal Dom ()
 singleInputBool = vioProbe @Dom ()
+{-# ANN singleInputBool (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputBool ""
+makeTopEntity 'singleInputBool
 
 
 singleInputBit ::
   "clk" ::: Clock Dom ->
-  "in" ::: Signal Dom Bit ->
-  "out" ::: Signal Dom ()
+  "inp" ::: Signal Dom Bit ->
+  "result" ::: Signal Dom ()
 singleInputBit = vioProbe @Dom ()
+{-# ANN singleInputBit (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputBit ""
+makeTopEntity 'singleInputBit
 
 
 singleInputSigned ::
   "clk" ::: Clock Dom ->
-  "in" ::: Signal Dom (Signed 2) ->
-  "out" ::: Signal Dom ()
+  "inp" ::: Signal Dom (Signed 2) ->
+  "result" ::: Signal Dom ()
 singleInputSigned = vioProbe @Dom ()
+{-# ANN singleInputSigned (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputSigned ""
+makeTopEntity 'singleInputSigned
 
 
 singleInputUnsigned ::
   "clk" ::: Clock Dom ->
-  "in" ::: Signal Dom (Unsigned 2) ->
-  "out" ::: Signal Dom ()
+  "inp" ::: Signal Dom (Unsigned 2) ->
+  "result" ::: Signal Dom ()
 singleInputUnsigned = vioProbe @Dom ()
+{-# ANN singleInputUnsigned (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputUnsigned ""
+makeTopEntity 'singleInputUnsigned
 
 
 singleInputBitVector ::
   "clk" ::: Clock Dom ->
-  "in" ::: Signal Dom (BitVector 7) ->
-  "out" ::: Signal Dom ()
+  "inp" ::: Signal Dom (BitVector 7) ->
+  "result" ::: Signal Dom ()
 singleInputBitVector = vioProbe @Dom ()
+{-# ANN singleInputBitVector (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputBitVector ""
+makeTopEntity 'singleInputBitVector
 
 
 singleInputPair ::
   "clk" ::: Clock Dom ->
-  "in" ::: Signal Dom (Bit, Bool) ->
-  "out" ::: Signal Dom ()
+  "inp" ::: Signal Dom (Bit, Bool) ->
+  "result" ::: Signal Dom ()
 singleInputPair = vioProbe @Dom ()
+{-# ANN singleInputPair (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputPair ""
+makeTopEntity 'singleInputPair
 
 
 singleInputVec ::
   "clk" ::: Clock Dom ->
-  "out" ::: Signal Dom (Vec 4 (Unsigned 2)) ->
-  "out" ::: Signal Dom ()
+  "result" ::: Signal Dom (Vec 4 (Unsigned 2)) ->
+  "result" ::: Signal Dom ()
 singleInputVec = vioProbe @Dom ()
+{-# ANN singleInputVec (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputVec ""
+makeTopEntity 'singleInputVec
 
 
 singleInputCustom ::
   "clk" ::: Clock Dom ->
-  "in" ::: Signal Dom D1 ->
-  "out" ::: Signal Dom ()
+  "inp" ::: Signal Dom D1 ->
+  "result" ::: Signal Dom ()
 singleInputCustom = vioProbe @Dom ()
+{-# ANN singleInputCustom (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputCustom ""
+makeTopEntity 'singleInputCustom
 
 
 singleInputNested ::
   "clk" ::: Clock Dom ->
-  "in" ::: Signal Dom D2 ->
-  "out" ::: Signal Dom ()
+  "inp" ::: Signal Dom D2 ->
+  "result" ::: Signal Dom ()
 singleInputNested = vioProbe @Dom ()
+{-# ANN singleInputNested (TestBench 'top) #-}
 
-makeTopEntityWithName 'singleInputNested ""
+makeTopEntity 'singleInputNested
 
 
 multipleInputs ::
@@ -207,10 +234,11 @@ multipleInputs ::
   "in6" ::: Signal Dom (Vec 3 (Unsigned 2)) ->
   "in7" ::: Signal Dom D1 ->
   "in8" ::: Signal Dom (BitVector 7) ->
-  "out" ::: Signal Dom (Vec 0 Bool)
+  "result" ::: Signal Dom (Vec 0 Bool)
 multipleInputs = vioProbe @Dom Nil
+{-# ANN multipleInputs (TestBench 'top) #-}
 
-makeTopEntityWithName 'multipleInputs ""
+makeTopEntity 'multipleInputs
 
 
 inputsAndOutputs ::
@@ -223,7 +251,7 @@ inputsAndOutputs ::
   "in6" ::: Signal Dom ( Vec 3 (Unsigned 2) ) ->
   "in7" ::: Signal Dom   D1 ->
   "in8" ::: Signal Dom ( BitVector 7 ) ->
-  "out" ::: Signal Dom ( Bit
+  "result" ::: Signal Dom ( Bit
                        , Bool
                        , Unsigned 5
                        , Signed 2
@@ -242,5 +270,6 @@ inputsAndOutputs = vioProbe @Dom
   , D1 False high 0
   , 0b111000
   )
+{-# ANN inputsAndOutputs (TestBench 'top) #-}
 
-makeTopEntityWithName 'inputsAndOutputs ""
+makeTopEntity 'inputsAndOutputs


### PR DESCRIPTION
This PR adds the HDL attribute `KEEP` to signals connected to vioProbe ports, so the ports keep their names after synthesis. A bug in generated VHDL where the types of a vioProbe component declaration and instantiation did not match has been fixed. To make sure bugs in generated HDL do not occur, the generated designs in `shouldwork` are now loaded in Vivado. This makes sure the HDL is typechecked and has valid syntax.

## Still TODO:

  - [x] Add tests to load _shouldwork_ components in Vivado
  - [x] Check copyright notices are up to date in edited files