### PR TITLE
Add custom naming to VIO probes

### DIFF
--- a/changelog/2023-05-24T14_35_54+02_00_add_getVec
+++ b/changelog/2023-05-24T14_35_54+02_00_add_getVec
@@ -1,0 +1,1 @@
+ADDED: `getVec` tries to get all elements in a Vector from an expression

--- a/clash-cores/src/Clash/Cores/Xilinx/VIO.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/VIO.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright  :  (C) 2022, Google Inc,
+Copyright  :  (C) 2022-2023, Google Inc,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -75,7 +75,7 @@ instance VIO dom a o => VIO dom (Signal dom i -> a) o where
 --
 -- @
 -- someProbe :: 'KnownDomain' dom => 'Clock' dom -> 'Signal' dom 'Bit' -> 'Signal' dom ('Unsigned' 8) -> 'Signal' dom ('Bool', 'Maybe' ('Signed' 8))
--- someProbe = 'vioProbe' ('False', 'Nothing')
+-- someProbe = 'vioProbe' ("in_b" :> "in_u8" :> Nil) ("out_b" :> "out_mu8" :> Nil) ('False', 'Nothing')
 -- @
 --
 -- Creates VIO IP with two input probes of bit widths 1 and 8,
@@ -84,7 +84,7 @@ instance VIO dom a o => VIO dom (Signal dom i -> a) o where
 --
 -- @
 -- otherProbe :: 'KnownDomain' dom => 'Clock' dom -> 'Signal' dom ('Unsigned' 4, 'Unsigned' 2, 'Bit') -> 'Signal' dom ('Vec' 3 'Bit')
--- otherProbe = 'vioProbe' ('repeat' 'high')
+-- otherProbe = 'vioProbe' ("in_u4" :> "in_u2" :> "in_b" :> Nil) ("out_b1" :> "out_b2" :> "out_b3" :> Nil) ('repeat' 'high')
 -- @
 --
 -- Creates VIO IP with three input probes of bit widths 4, 2, and 1,
@@ -95,8 +95,15 @@ instance VIO dom a o => VIO dom (Signal dom i -> a) o where
 -- away, especially if the VIO is only used to monitor some inputs and
 -- produces no output. Utilizing 'Clash.XException.hwSeqX' may be helpful
 -- in this case to enforce the VIO to be rendered in HDL.
-vioProbe :: forall dom a o. (KnownDomain dom, VIO dom a o) => o -> Clock dom -> a
-vioProbe !_initialOutputProbeValues !_clk = vioX @dom @a @o
+vioProbe ::
+  forall dom a o n m.
+  (KnownDomain dom, VIO dom a o) =>
+  Vec n String ->
+  Vec m String ->
+  o ->
+  Clock dom ->
+  a
+vioProbe !_inputNames !_outputNames !_initialOutputProbeValues !_clk = vioX @dom @a @o
 {-# NOINLINE vioProbe #-}
 {-# ANN vioProbe (
     let primName = 'vioProbe

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -56,6 +56,7 @@ module Clash.Primitives.DSL
   , tResults
   , getStr
   , getBool
+  , getVec
   , exprToInteger
   , tExprToInteger
   , deconstructProduct
@@ -634,6 +635,17 @@ getStr (TExpr _ e) = exprToString e
 getBool :: TExpr -> Maybe Bool
 getBool (TExpr _ (Literal _ (BoolLit b))) = Just b
 getBool _ = Nothing
+
+-- | Try to get a Vector of expressions.
+getVec :: TExpr -> Maybe [TExpr]
+getVec (TExpr (Void (Just (Vector 0 _) )) _) =
+  pure []
+getVec (TExpr (Vector 1 elementTy) (DataCon _ VecAppend [e])) =
+  pure [TExpr elementTy e]
+getVec (TExpr (Vector n elementTy) (DataCon _ VecAppend [e, es0])) = do
+  es1 <- getVec (TExpr (Vector (n-1) elementTy) es0)
+  pure (TExpr elementTy e:es1)
+getVec _ = Nothing
 
 -- | Try to get the literal nat value of an expression.
 tExprToInteger :: TExpr -> Maybe Integer

--- a/tests/shouldfail/Cores/Xilinx/VIO/InputBusWidthExceeded.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/InputBusWidthExceeded.hs
@@ -5,8 +5,11 @@ import Clash.Cores.Xilinx.VIO
 
 type Dom = XilinxSystem
 
+inNames = singleton "probe_in"
+outNames = Nil
+
 topEntity ::
   "clk" ::: Clock Dom ->
   "in"  ::: Signal Dom (BitVector 257) ->
   "out" ::: Signal Dom ()
-topEntity = vioProbe @Dom ()
+topEntity = vioProbe @Dom inNames outNames ()

--- a/tests/shouldfail/Cores/Xilinx/VIO/InputProbesExceeded.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/InputProbesExceeded.hs
@@ -3,10 +3,15 @@ module InputProbesExceeded where
 import Clash.Prelude
 import Clash.Cores.Xilinx.VIO
 
+import qualified Data.List as L
+
 type Dom = XilinxSystem
+
+inNames = $(listToVecTH (L.map (("probe_in_" <>) . show) [0::Int, 1..256]))
+outNames = Nil
 
 topEntity ::
   "clk" ::: Clock Dom ->
   "in"  ::: Signal Dom (Vec 257 Bool) ->
   "out" ::: Signal Dom ()
-topEntity = vioProbe @Dom ()
+topEntity = vioProbe @Dom inNames outNames ()

--- a/tests/shouldfail/Cores/Xilinx/VIO/OutputBusWidthExceeded.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/OutputBusWidthExceeded.hs
@@ -5,7 +5,10 @@ import Clash.Cores.Xilinx.VIO
 
 type Dom = XilinxSystem
 
+inNames = Nil
+outNames = singleton "probe_out"
+
 topEntity ::
   "clk" ::: Clock Dom ->
   "out" ::: Signal Dom (BitVector 257)
-topEntity = vioProbe @Dom 0
+topEntity = vioProbe @Dom inNames outNames 0

--- a/tests/shouldfail/Cores/Xilinx/VIO/OutputProbesExceeded.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/OutputProbesExceeded.hs
@@ -3,9 +3,14 @@ module OutputProbesExceeded where
 import Clash.Prelude
 import Clash.Cores.Xilinx.VIO
 
+import qualified Data.List as L
+
 type Dom = XilinxSystem
+
+inNames = Nil
+outNames = $(listToVecTH (L.map (("probe_out_" <>) . show) [0::Int, 1..256]))
 
 topEntity ::
   "clk" ::: Clock Dom ->
   "out" ::: Signal Dom (Vec 257 Bit)
-topEntity = vioProbe @Dom (replicate (SNat @257) low)
+topEntity = vioProbe @Dom inNames outNames (replicate (SNat @257) low)

--- a/tests/shouldwork/Cores/Xilinx/VIO.hs
+++ b/tests/shouldwork/Cores/Xilinx/VIO.hs
@@ -6,6 +6,8 @@ import Clash.Annotations.TH
 import Clash.Annotations.BitRepresentation
 import Clash.Explicit.Testbench
 
+import qualified Data.List as L
+
 type Dom = XilinxSystem
 
 top :: "result" ::: Unsigned 8
@@ -17,7 +19,10 @@ makeTopEntity 'top
 noInputTrue ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom Bool
-noInputTrue = vioProbe @Dom True
+noInputTrue = vioProbe @Dom inNames outNames True
+ where
+  inNames = Nil
+  outNames = singleton "probe_out"
 {-# ANN noInputTrue (TestBench 'top) #-}
 
 makeTopEntity 'noInputTrue
@@ -26,7 +31,10 @@ makeTopEntity 'noInputTrue
 noInputFalse ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom Bool
-noInputFalse = vioProbe @Dom False
+noInputFalse = vioProbe @Dom inNames outNames False
+ where
+  inNames = Nil
+  outNames = singleton "probe_out"
 {-# ANN noInputFalse (TestBench 'top) #-}
 
 makeTopEntity 'noInputFalse
@@ -35,7 +43,10 @@ makeTopEntity 'noInputFalse
 noInputLow ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom Bit
-noInputLow = vioProbe @Dom low
+noInputLow = vioProbe @Dom inNames outNames low
+ where
+  inNames = Nil
+  outNames = singleton "probe_out"
 {-# ANN noInputLow (TestBench 'top) #-}
 
 makeTopEntity 'noInputLow
@@ -44,7 +55,10 @@ makeTopEntity 'noInputLow
 noInputHigh ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom Bit
-noInputHigh = vioProbe @Dom high
+noInputHigh = vioProbe @Dom inNames outNames high
+ where
+  inNames = Nil
+  outNames = singleton "probe_out"
 {-# ANN noInputHigh (TestBench 'top) #-}
 
 makeTopEntity 'noInputHigh
@@ -53,7 +67,10 @@ makeTopEntity 'noInputHigh
 noInputSigned ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom (Signed 2)
-noInputSigned = vioProbe @Dom (-1)
+noInputSigned = vioProbe @Dom inNames outNames (-1)
+ where
+  inNames = Nil
+  outNames = singleton "probe_out"
 {-# ANN noInputSigned (TestBench 'top) #-}
 
 makeTopEntity 'noInputSigned
@@ -62,7 +79,10 @@ makeTopEntity 'noInputSigned
 noInputUnsigned ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom (Unsigned 2)
-noInputUnsigned = vioProbe @Dom 3
+noInputUnsigned = vioProbe @Dom inNames outNames 3
+ where
+  inNames = Nil
+  outNames = singleton "probe_out"
 {-# ANN noInputUnsigned (TestBench 'top) #-}
 
 makeTopEntity 'noInputUnsigned
@@ -71,7 +91,10 @@ makeTopEntity 'noInputUnsigned
 noInputBitVector ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom (BitVector 7)
-noInputBitVector = vioProbe @Dom 111
+noInputBitVector = vioProbe @Dom inNames outNames 111
+ where
+  inNames = Nil
+  outNames = singleton "probe_out"
 {-# ANN noInputBitVector (TestBench 'top) #-}
 
 makeTopEntity 'noInputBitVector
@@ -80,7 +103,10 @@ makeTopEntity 'noInputBitVector
 noInputPair ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom (Bit, Bool)
-noInputPair = vioProbe @Dom (high, False)
+noInputPair = vioProbe @Dom inNames outNames (high, False)
+ where
+  inNames = Nil
+  outNames = $(listToVecTH (L.map (("probe_out_" <>) . show) [0,1]))
 {-# ANN noInputPair (TestBench 'top) #-}
 
 makeTopEntity 'noInputPair
@@ -89,7 +115,10 @@ makeTopEntity 'noInputPair
 noInputVec ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom (Vec 4 (Unsigned 2))
-noInputVec = vioProbe @Dom (0 :> 1 :> 2 :> 3 :> Nil)
+noInputVec = vioProbe @Dom inNames outNames (0 :> 1 :> 2 :> 3 :> Nil)
+ where
+  inNames = Nil
+  outNames = $(listToVecTH (L.map (("probe_out_" <>) . show) [0..3]))
 {-# ANN noInputVec (TestBench 'top) #-}
 
 makeTopEntity 'noInputVec
@@ -100,7 +129,10 @@ data D1 = D1 Bool Bit (Unsigned 2)
 noInputCustom ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom D1
-noInputCustom = vioProbe @Dom (D1 True high 1)
+noInputCustom = vioProbe @Dom inNames outNames (D1 True high 1)
+ where
+  inNames = Nil
+  outNames = $(listToVecTH (L.map (("probe_out_" <>) . show) [0..2]))
 {-# ANN noInputCustom (TestBench 'top) #-}
 
 makeTopEntity 'noInputCustom
@@ -111,7 +143,10 @@ data D2 = D2 Bool (Vec 2 D1)
 noInputNested ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom D2
-noInputNested = vioProbe @Dom (D2 True (D1 True high 1 :> D1 False low 0 :> Nil))
+noInputNested = vioProbe @Dom inNames outNames (D2 True (D1 True high 1 :> D1 False low 0 :> Nil))
+ where
+  inNames = Nil
+  outNames = $(listToVecTH (L.map (("probe_out_" <>) . show) [0..1]))
 {-# ANN noInputNested (TestBench 'top) #-}
 
 makeTopEntity 'noInputNested
@@ -138,7 +173,10 @@ singleInputBool ::
   "clk" ::: Clock Dom ->
   "inp" ::: Signal Dom Bool ->
   "result" ::: Signal Dom ()
-singleInputBool = vioProbe @Dom ()
+singleInputBool = vioProbe @Dom inNames outNames ()
+ where
+  inNames = singleton "probe_in"
+  outNames = Nil
 {-# ANN singleInputBool (TestBench 'top) #-}
 
 makeTopEntity 'singleInputBool
@@ -148,7 +186,10 @@ singleInputBit ::
   "clk" ::: Clock Dom ->
   "inp" ::: Signal Dom Bit ->
   "result" ::: Signal Dom ()
-singleInputBit = vioProbe @Dom ()
+singleInputBit = vioProbe @Dom inNames outNames ()
+ where
+  inNames = singleton "probe_in"
+  outNames = Nil
 {-# ANN singleInputBit (TestBench 'top) #-}
 
 makeTopEntity 'singleInputBit
@@ -158,7 +199,10 @@ singleInputSigned ::
   "clk" ::: Clock Dom ->
   "inp" ::: Signal Dom (Signed 2) ->
   "result" ::: Signal Dom ()
-singleInputSigned = vioProbe @Dom ()
+singleInputSigned = vioProbe @Dom inNames outNames ()
+ where
+  inNames = singleton "probe_in"
+  outNames = Nil
 {-# ANN singleInputSigned (TestBench 'top) #-}
 
 makeTopEntity 'singleInputSigned
@@ -168,7 +212,10 @@ singleInputUnsigned ::
   "clk" ::: Clock Dom ->
   "inp" ::: Signal Dom (Unsigned 2) ->
   "result" ::: Signal Dom ()
-singleInputUnsigned = vioProbe @Dom ()
+singleInputUnsigned = vioProbe @Dom inNames outNames ()
+ where
+  inNames = singleton "probe_in"
+  outNames = Nil
 {-# ANN singleInputUnsigned (TestBench 'top) #-}
 
 makeTopEntity 'singleInputUnsigned
@@ -178,7 +225,10 @@ singleInputBitVector ::
   "clk" ::: Clock Dom ->
   "inp" ::: Signal Dom (BitVector 7) ->
   "result" ::: Signal Dom ()
-singleInputBitVector = vioProbe @Dom ()
+singleInputBitVector = vioProbe @Dom inNames outNames ()
+ where
+  inNames = singleton "probe_in"
+  outNames = Nil
 {-# ANN singleInputBitVector (TestBench 'top) #-}
 
 makeTopEntity 'singleInputBitVector
@@ -188,7 +238,10 @@ singleInputPair ::
   "clk" ::: Clock Dom ->
   "inp" ::: Signal Dom (Bit, Bool) ->
   "result" ::: Signal Dom ()
-singleInputPair = vioProbe @Dom ()
+singleInputPair = vioProbe @Dom inNames outNames ()
+ where
+  inNames = $(listToVecTH (L.map (("probe_in_" <>) . show) [0..1]))
+  outNames = Nil
 {-# ANN singleInputPair (TestBench 'top) #-}
 
 makeTopEntity 'singleInputPair
@@ -198,7 +251,10 @@ singleInputVec ::
   "clk" ::: Clock Dom ->
   "result" ::: Signal Dom (Vec 4 (Unsigned 2)) ->
   "result" ::: Signal Dom ()
-singleInputVec = vioProbe @Dom ()
+singleInputVec = vioProbe @Dom inNames outNames ()
+ where
+  inNames = $(listToVecTH (L.map (("probe_in_" <>) . show) [0..3]))
+  outNames = Nil
 {-# ANN singleInputVec (TestBench 'top) #-}
 
 makeTopEntity 'singleInputVec
@@ -208,7 +264,10 @@ singleInputCustom ::
   "clk" ::: Clock Dom ->
   "inp" ::: Signal Dom D1 ->
   "result" ::: Signal Dom ()
-singleInputCustom = vioProbe @Dom ()
+singleInputCustom = vioProbe @Dom inNames outNames ()
+ where
+  inNames = $(listToVecTH (L.map (("probe_in_" <>) . show) [0..2]))
+  outNames = Nil
 {-# ANN singleInputCustom (TestBench 'top) #-}
 
 makeTopEntity 'singleInputCustom
@@ -218,7 +277,10 @@ singleInputNested ::
   "clk" ::: Clock Dom ->
   "inp" ::: Signal Dom D2 ->
   "result" ::: Signal Dom ()
-singleInputNested = vioProbe @Dom ()
+singleInputNested = vioProbe @Dom inNames outNames ()
+ where
+  inNames = $(listToVecTH (L.map (("probe_in_" <>) . show) [0..1]))
+  outNames = Nil
 {-# ANN singleInputNested (TestBench 'top) #-}
 
 makeTopEntity 'singleInputNested
@@ -235,7 +297,10 @@ multipleInputs ::
   "in7" ::: Signal Dom D1 ->
   "in8" ::: Signal Dom (BitVector 7) ->
   "result" ::: Signal Dom (Vec 0 Bool)
-multipleInputs = vioProbe @Dom Nil
+multipleInputs = vioProbe @Dom inNames outNames Nil
+ where
+  inNames = $(listToVecTH (L.map (("probe_in_" <>) . show) [0..7]))
+  outNames = Nil
 {-# ANN multipleInputs (TestBench 'top) #-}
 
 makeTopEntity 'multipleInputs
@@ -260,16 +325,20 @@ inputsAndOutputs ::
                        , D1
                        , BitVector 6
                        )
-inputsAndOutputs = vioProbe @Dom
-  ( low
-  , True
-  , 1
-  , -1
-  , (True, low, False)
-  , 5 :> 3 :> Nil
-  , D1 False high 0
-  , 0b111000
-  )
+inputsAndOutputs = vioProbe @Dom inNames outNames initVals
+ where
+  inNames = $(listToVecTH (L.map (("probe_in_" <>) . show) [0..7]))
+  outNames = $(listToVecTH (L.map (("probe_out_" <>) . show) [0..7]))
+  initVals =
+    ( low
+    , True
+    , 1
+    , -1
+    , (True, low, False)
+    , 5 :> 3 :> Nil
+    , D1 False high 0
+    , 0b111000
+    )
 {-# ANN inputsAndOutputs (TestBench 'top) #-}
 
 makeTopEntity 'inputsAndOutputs


### PR DESCRIPTION
A design with VIO probes is inspected (through the GUI of the synthesis tool) when programmed on an FPGA. It therefore makes sense to give each individual probe a logical name. The names of in- and output ports should be given as two `Vec`tor of `Strings`, where the length should match the number of probes.


## Known issues:
  - The custom names for probes have a lower priority for names than names generated for signals. This means your requested name gets appended `_0` if you already use a signal with an identical name in your design. See issue #2246 .

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files