### PR TITLE
Workaround GHC heisenbug on GitHub CI as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
           - name: GHC 9.0.2, Multiple Hidden
             ghc: 9.0.2
             multiple_hidden: yes
+            workaround_ghc_mmap_crash: yes
 
           - name: GHC 9.2.5, Multiple Hidden
             ghc: 9.2.5
@@ -140,6 +141,7 @@ jobs:
         CABAL_JOBS: 2
         MULTIPLE_HIDDEN: ${{ matrix.multiple_hidden }}
         CI_COMMIT_BRANCH: ${{ github.base_ref }}
+        WORKAROUND_GHC_MMAP_CRASH: ${{ matrix.workaround_ghc_mmap_crash }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
PR #2444 added a workaround for GitLab CI, but it is also needed on the GitHub CI we run for external contributions.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
