### PR TITLE
Error on unreliable name generation in VIO blackbox

### DIFF
--- a/clash-cores/src/Clash/Cores/Xilinx/VIO/Internal/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/VIO/Internal/BlackBoxes.hs
@@ -31,7 +31,7 @@ import qualified Data.List.Infinite as Infinite
 import qualified Data.Text as T (pack, concat)
 
 import Control.Arrow (first)
-import Control.Monad (when, forM, zipWithM)
+import Control.Monad (when, zipWithM)
 import Control.Monad.State (State)
 import Control.Exception (assert)
 
@@ -170,13 +170,9 @@ vioProbeBBTF bbCtx
                 _         -> pure <$> DSL.assign (head inNames) singleInput
             _ -> zipWithM DSL.assign inNames inPs
 
-        outProbes <-
-          forM (zip outNames outTys) $ uncurry DSL.declare
-        outProbesBV <-
-          forM (zip userOutputNames outProbes) $ uncurry (DSL.toBvWithAttrs attrs)
-
-        inProbesBV <-
-          forM (zip userInputNames inProbes) $ uncurry (DSL.toBvWithAttrs attrs)
+        outProbes <- zipWithM DSL.declare outNames outTys
+        outProbesBV <- zipWithM (DSL.toBvWithAttrs attrs) userOutputNames outProbes
+        inProbesBV <- zipWithM (DSL.toBvWithAttrs attrs) userInputNames inProbes
 
         DSL.instDecl Empty (Id.unsafeMake vioProbeName) vioProbeInstName []
           (("clk", clk) : zip inNames inProbesBV)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -193,7 +193,19 @@ runClashTest = defaultMain $ clashTestRoot
       , clashTestGroup "Cores"
         [ clashTestGroup "Xilinx"
           [ clashTestGroup "VIO"
-            [ runTest "OutputBusWidthExceeded" def{
+            [ runTest "DuplicateOutputNames" def{
+                hdlTargets=[VHDL]
+              , expectClashFail=Just (def, "Tried create a signal called 'a', but identifier generation returned")
+              }
+            , runTest "DuplicateInputNames" def{
+                hdlTargets=[VHDL]
+              , expectClashFail=Just (def, "Tried create a signal called 'a', but identifier generation returned")
+              }
+            , runTest "DuplicateInputOutputNames" def{
+                hdlTargets=[VHDL]
+              , expectClashFail=Just (def, "Tried create a signal called 'a', but identifier generation returned")
+              }
+            , runTest "OutputBusWidthExceeded" def{
                 hdlTargets=[VHDL, Verilog, SystemVerilog]
               , expectClashFail=Just (def, "Probe signals must be been between 1 and 256 bits wide.")
               }

--- a/tests/shouldfail/Cores/Xilinx/VIO/DuplicateInputNames.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/DuplicateInputNames.hs
@@ -1,0 +1,15 @@
+module DuplicateInputNames where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+
+type Dom = XilinxSystem
+
+inNames = "a" :> "a" :> Nil
+outNames = "b" :> Nil
+
+topEntity ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom (Bit, Bit) ->
+  "out" ::: Signal Dom Bit
+topEntity = vioProbe @Dom inNames outNames 0

--- a/tests/shouldfail/Cores/Xilinx/VIO/DuplicateInputOutputNames.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/DuplicateInputOutputNames.hs
@@ -1,0 +1,15 @@
+module DuplicateInputOutputNames where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+
+type Dom = XilinxSystem
+
+inNames = "a" :> Nil
+outNames = "a" :> Nil
+
+topEntity ::
+  "clk" ::: Clock Dom ->
+  "in" ::: Signal Dom Bit ->
+  "out" ::: Signal Dom Bit
+topEntity = vioProbe @Dom inNames outNames 0

--- a/tests/shouldfail/Cores/Xilinx/VIO/DuplicateOutputNames.hs
+++ b/tests/shouldfail/Cores/Xilinx/VIO/DuplicateOutputNames.hs
@@ -1,0 +1,14 @@
+module DuplicateOutputNames where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+
+type Dom = XilinxSystem
+
+inNames = Nil
+outNames = "a" :> "a" :> Nil
+
+topEntity ::
+  "clk" ::: Clock Dom ->
+  "out" ::: Signal Dom (Bit, Bit)
+topEntity = vioProbe @Dom inNames outNames (0, 0)


### PR DESCRIPTION
Fixes https://github.com/clash-lang/clash-compiler/issues/2497

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
  - [x] Cleanup
  - [ ] Optional error
    - [x]  ~~I'll introduce another PR that puts the VIO in its own HDL file which should fix 99% of naming collisions.~~ Impeded: https://github.com/clash-lang/clash-compiler/issues/2500.