### PR TITLE
Fix nightly rules

### DIFF
--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -7,10 +7,10 @@ stages:
 
 .nightly-rules:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"  # When schedueled (at night)
-    - if: $CI_PIPELINE_SOURCE == "trigger"   # When triggered (manual triggers)
-    - if: '$CI_COMMIT_TAG != null'           # When tags are set (releases)
-    - if: '$RUN_TESTS == "always"'           # When test matrix indicates it should always run
+    - if: $CI_PARENT_PIPELINE_SOURCE == "schedule"  # When schedueled (at night)
+    - if: $CI_PARENT_PIPELINE_SOURCE == "trigger"   # When triggered (manual triggers)
+    - if: '$CI_COMMIT_TAG != null'                  # When tags are set (releases)
+    - if: '$RUN_TESTS == "always"'                  # When test matrix indicates it should always run
 
 .test-nocache:
   extends:
@@ -184,9 +184,9 @@ ffi:example:
 .test-cache-local-nightly:
   extends: .test-cache-local
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"  # When schedueled (at night)
-    - if: $CI_PIPELINE_SOURCE == "trigger"   # When triggered (manual triggers)
-    - if: '$CI_COMMIT_TAG != null'           # When tags are set (releases)
+    - if: $CI_PARENT_PIPELINE_SOURCE == "schedule"  # When schedueled (at night)
+    - if: $CI_PARENT_PIPELINE_SOURCE == "trigger"   # When triggered (manual triggers)
+    - if: '$CI_COMMIT_TAG != null'                  # When tags are set (releases)
 
 suite:vivado:vhdl:
   extends: .test-cache-local-nightly

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,8 @@ tests:
   trigger:
     include: .ci/gitlab/test.yml
     strategy: depend
+  variables:
+    CI_PARENT_PIPELINE_SOURCE: $CI_PIPELINE_SOURCE
   parallel:
     matrix:
       - GHC_VERSION: 9.6.1


### PR DESCRIPTION
Because child pipelines do not inherit the parent pipeline source, but
rather have `CI_PIPELINE_SOURCE="parent_pipeline"`, the triggering logic
for the Vivado tests has always(?) been broken. It now also prevents
running the nightly tests split off in PR #2479.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
