### PR TITLE
Respect function's `NOINLINE` pragma when specializing

### DIFF
--- a/changelog/2023-06-17T20_55_47+02_00_fix_2502
+++ b/changelog/2023-06-17T20_55_47+02_00_fix_2502
@@ -1,0 +1,1 @@
+FIXED: Clash now preserves `NOINLINE` of functions being specialized [#2502](https://github.com/clash-lang/clash-compiler/issues/2502)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -717,6 +717,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2342A" def{hdlSim=[]}
         , runTest "T2342B" def{hdlSim=[]}
         , runTest "T2360" def{hdlSim=[],clashFlags=["-fclash-force-undefined=0"]}
+        , outputTest "T2502" def{hdlTargets=[VHDL]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2502.hs
+++ b/tests/shouldwork/Issues/T2502.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module T2502 where
+
+import qualified Prelude as P
+
+import Data.String.Interpolate (__i)
+import Clash.Explicit.Prelude
+import Clash.Annotations.Primitive
+
+import Control.Exception (AssertionFailed(..), throwIO)
+import Control.Monad (when)
+import Data.List (sort)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+import System.FilePath.Glob (globDir1)
+
+class X a where
+  x :: a
+
+instance X (Signal System Int) where
+  x = pure 3
+
+instance X a => X (Signal System Int -> a) where
+  x !_i = x
+
+bb :: X a => Int -> a
+bb !_ = x
+{-# OPAQUE bb #-}
+{-# ANN bb hasBlackBox #-}
+{-# ANN bb (
+  let bbName = show 'bb
+  in InlineYamlPrimitive [minBound..] [__i|
+    BlackBox:
+      name: "#{bbName}"
+      kind: Expression
+      template: "~ARG[2]"
+|]) #-}
+
+bbWrapper :: X a => Int -> a
+bbWrapper i = bb i
+{-# NOINLINE bbWrapper #-}
+
+topEntity :: Int -> Signal System Int -> Signal System Int
+topEntity i0 i1 = bbWrapper i0 i1
+{-# NOINLINE topEntity #-}
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+
+  -- 'bbWrapper' should get its own file, so we expect two: one for 'topEntity',
+  -- one for 'bbWrapper'.
+  --
+  -- XXX: Naming doesn't make sense. 'topEntity1' should be called 'bbWrapper'.
+  let hdlDir = topDir </> show 'topEntity
+  actual0 <- sort <$> globDir1 "*.vhdl" hdlDir
+  let
+    actual1 = P.map (P.drop (P.length hdlDir + 1)) actual0
+    expected = ["T2502_topEntity_types.vhdl", "topEntity.vhdl", "topEntity1.vhdl"]
+  when
+    (actual1 /= expected)
+    (throwIO $ AssertionFailed $ "Expected " <> show expected <> " got " <> show actual1)
+
+  pure ()


### PR DESCRIPTION
Fixes #2502

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
  - [X] ~~Investigate whether we can make Clash emit _fewer_ files again in `T2502B`. It currently also generates a separate file for the bb: `["T2502B_topEntity_types.vhdl","bb1.vhdl","topEntity.vhdl","topEntity1.vhdl"]`.~~ This is not Clash's fault, but GHCs. Some optimizations make it rename `bb`, which causes Clash to see the blackbox's internals. We should advice users to use OPAGUE - I'll report a separate issue.
  - [x] Report separate issue on weird file naming due to returning `g` here: https://github.com/clash-lang/clash-compiler/blob/26a4bc2d78eb8d544cf0a922257fddaf4a1080ab/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs#L443

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
