### PR TITLE
Combine function names when specializing

### DIFF
--- a/changelog/2024-03-04T11_17_07+01_00_fix_2508
+++ b/changelog/2024-03-04T11_17_07+01_00_fix_2508
@@ -1,0 +1,1 @@
+FIXED: Clash now generates more intuitive names for specialized binders. See [#2508](https://github.com/clash-lang/clash-compiler/issues/2508).

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -790,6 +790,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2342B" def{hdlSim=[]}
         , runTest "T2360" def{hdlSim=[],clashFlags=["-fclash-force-undefined=0"]}
         , outputTest "T2502" def{hdlTargets=[VHDL]}
+        , outputTest "T2508" def{hdlTargets=[VHDL]}
 #if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
         , runTest "T2510" def{
             hdlTargets=[VHDL]

--- a/tests/shouldwork/Cores/Xilinx/Ila.hs
+++ b/tests/shouldwork/Cores/Xilinx/Ila.hs
@@ -100,7 +100,7 @@ mainVHDL = do
 
   -- HDL content check:
   let hdlDir = dir </> show 'testWithDefaultsOne
-  [path] <- glob (hdlDir </> "Ila_testWithDefaultsOne_oneCounter*.vhdl")
+  [path] <- glob (hdlDir </> "Ila_testWithDefaultsOne_ila.vhdl")
   contents <- readFile path
   assertIn contents "attribute KEEP of foo : signal is \"true\";" -- signal name
   assertIn contents "one_counter_ila : testWithDefaultsOne_ila"   -- instantiation label

--- a/tests/shouldwork/Issues/T2508.hs
+++ b/tests/shouldwork/Issues/T2508.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module T2508 where
+
+import Clash.Explicit.Prelude
+import qualified Prelude as P
+
+import Control.Exception (AssertionFailed(..), throwIO)
+import Control.Monad (when)
+import Data.List (sort)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+import System.FilePath.Glob (globDir1)
+
+accum :: Unsigned 64 -> Unsigned 64 -> (Unsigned 64, Unsigned 64)
+accum s i = (s + i, s)
+
+opaqueAccum :: Unsigned 64 -> Unsigned 64 -> (Unsigned 64, Unsigned 64)
+opaqueAccum s i = accum s i
+{-# CLASH_OPAQUE opaqueAccum #-}
+
+noAnnotationMealy clk rst en f iS i =
+  let
+    (s', o) = unbundle $ f <$> s <*> i
+    s       = register clk rst en iS s'
+  in
+    o
+
+opaqueMealy clk rst en f iS =
+  noAnnotationMealy clk rst en f iS
+{-# CLASH_OPAQUE opaqueMealy #-}
+
+topEntity ::
+  Clock System ->
+  Reset System ->
+  Enable System ->
+  Signal System (Unsigned 64) ->
+  Signal System (Unsigned 64)
+topEntity clk rst ena i =
+    noAnnotationMealy clk rst ena accum       0 i
+  + noAnnotationMealy clk rst ena opaqueAccum 0 i
+  + opaqueMealy       clk rst ena accum       0 i
+  + opaqueMealy       clk rst ena opaqueAccum 0 i
+{-# CLASH_OPAQUE topEntity #-}
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+
+  let hdlDir = topDir </> show 'topEntity
+  actual0 <- sort <$> globDir1 "*.vhdl" hdlDir
+  let
+    actual1 = P.map (P.drop (P.length hdlDir + 1)) actual0
+    expected =
+      [ "T2508_topEntity_types.vhdl"
+      , "opaqueAccum.vhdl"
+      , "opaqueMealy.vhdl"
+      , "opaqueMealy_opaqueAccum.vhdl"
+      , "topEntity.vhdl"
+      ]
+  when
+    (actual1 /= expected)
+    (throwIO $ AssertionFailed $ "Expected " <> show expected <> " got " <> show actual1)
+
+  pure ()

--- a/tests/shouldwork/Issues/T2510.hs
+++ b/tests/shouldwork/Issues/T2510.hs
@@ -50,5 +50,5 @@ assertIn needle haystack
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
-  content <- readFile (topDir </> show 'topEntity </> "topEntity1.vhdl")
+  content <- readFile (topDir </> show 'topEntity </> "bbWrapper.vhdl")
   assertIn "this should end up in HDL with OPAQUE" content

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -207,6 +207,15 @@ data ClashGenTest = ClashGenTest
   , cgHdlDirectory :: IO FilePath
   }
 
+-- | See https://github.com/clash-lang/clash-compiler/pull/2511
+dOpaque :: String
+dOpaque =
+#if __GLASGOW_HASKELL__ >= 904
+  "-DCLASH_OPAQUE=OPAQUE"
+#else
+  "-DCLASH_OPAQUE=NOINLINE"
+#endif
+
 instance IsTest ClashGenTest where
   run optionSet ClashGenTest{..} progressCallback = do
     oDir <- cgOutputDirectory
@@ -239,13 +248,7 @@ instance IsTest ClashGenTest where
       , "-odir", oDir
       , "-hidir", oDir
       , "-fclash-debug", "DebugSilent"
-
-      -- See https://github.com/clash-lang/clash-compiler/pull/2511
-#if __GLASGOW_HASKELL__ >= 904
-      , "-DCLASH_OPAQUE=OPAQUE"
-#else
-      , "-DCLASH_OPAQUE=NOINLINE"
-#endif
+      , dOpaque
       ] <> cgExtraArgs
 
     target =
@@ -524,7 +527,7 @@ outputTest' modName target extraClashArgs extraGhcArgs path =
   clashBuild workDir = singleTest "clash (exec)" (ClashBinaryTest {
       cbBuildTarget=target
     , cbSourceDirectory=sourceDir
-    , cbExtraBuildArgs="-DOUTPUTTEST" : extraGhcArgs
+    , cbExtraBuildArgs=dOpaque : "-DOUTPUTTEST" : extraGhcArgs
     , cbExtraExecArgs=[]
     , cbModName=modName
     , cbOutputDirectory=workDir


### PR DESCRIPTION
Given a global binder `accum` and an application `f accum`, Clash
now calls the new, specialized binder `f_accum` instead of just
`accum`, provided that both are marked `NOINLINE`/`OPAQUE`. This
more accurately reflects the body of the function and will result
in more sensible file names. For example, previously Clash
would generate a separate file `accum.{v,vhdl}` that contained the
inlined bodies of both `f` and `accum`. After this patch, it will
generate `f_accum.{v,vhdl}`.

Tabulated the new behavior looks like:

| OPAQUE        | Old name for `f g` | New name for `f g` |
|---------------|--------------------|--------------------|
| `f`           | `g`                | `f`                |
| `g`           | `g`                | `g`                |
| `f` and `g`   | `g`                | `f_g`              |
| !`f` and !`g` | `g`                | `f_g`              |

Fixes #2508
## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [X] Update comments
