### PR TITLE
Warn against non-opaque primitive functions on GHC >= 9.4

### DIFF
--- a/benchmark/tests/ManyEntitiesEqual.hs
+++ b/benchmark/tests/ManyEntitiesEqual.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 
 module ManyEntitiesEqual where
@@ -34,42 +35,50 @@ type Top n =
     => Signal System (Unsigned n)
     -> Signal System (Unsigned n)
 
-{-# NOINLINE top0 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top0 #-}
 {-# ANN top0 (defSyn "top_0") #-}
 top0 :: Top 64
 top0 = entity (SNat @64)
 
-{-# NOINLINE top1 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top1 #-}
 {-# ANN top1 (defSyn "top_1") #-}
 top1 :: Top 64
 top1 = entity (SNat @64)
 
-{-# NOINLINE top2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top2 #-}
 {-# ANN top2 (defSyn "top_2") #-}
 top2 :: Top 64
 top2 = entity (SNat @64)
 
-{-# NOINLINE top3 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top3 #-}
 {-# ANN top3 (defSyn "top_3") #-}
 top3 :: Top 64
 top3 = entity (SNat @64)
 
-{-# NOINLINE top4 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top4 #-}
 {-# ANN top4 (defSyn "top_4") #-}
 top4 :: Top 64
 top4 = entity (SNat @64)
 
-{-# NOINLINE top5 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top5 #-}
 {-# ANN top5 (defSyn "top_5") #-}
 top5 :: Top 64
 top5 = entity (SNat @64)
 
-{-# NOINLINE top6 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top6 #-}
 {-# ANN top6 (defSyn "top_6") #-}
 top6 :: Top 64
 top6 = entity (SNat @64)
 
-{-# NOINLINE top7 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top7 #-}
 {-# ANN top7 (defSyn "top_7") #-}
 top7 :: Top 64
 top7 = entity (SNat @64)

--- a/benchmark/tests/ManyEntitiesVaried.hs
+++ b/benchmark/tests/ManyEntitiesVaried.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 
 module ManyEntitiesVaried where
@@ -34,27 +35,32 @@ type Top n =
     => Signal System (Unsigned n)
     -> Signal System (Unsigned n)
 
-{-# NOINLINE top0 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top0 #-}
 {-# ANN top0 (defSyn "top_0") #-}
 top0 :: Top 24
 top0 = entity (SNat @24)
 
-{-# NOINLINE top1 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top1 #-}
 {-# ANN top1 (defSyn "top_1") #-}
 top1 :: Top 32
 top1 = entity (SNat @32)
 
-{-# NOINLINE top2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top2 #-}
 {-# ANN top2 (defSyn "top_2") #-}
 top2 :: Top 48
 top2 = entity (SNat @48)
 
-{-# NOINLINE top3 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top3 #-}
 {-# ANN top3 (defSyn "top_3") #-}
 top3 :: Top 64
 top3 = entity (SNat @64)
 
-{-# NOINLINE top4 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top4 #-}
 {-# ANN top4 (defSyn "top_4") #-}
 top4 :: Top 96
 top4 = entity (SNat @96)

--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -60,6 +60,12 @@ common basic-config
     TypeFamilies
     TypeOperators
 
+  -- See https://github.com/clash-lang/clash-compiler/pull/2511
+  if impl(ghc >= 9.4)
+    CPP-Options: -DCLASH_OPAQUE=OPAQUE
+  else
+    CPP-Options: -DCLASH_OPAQUE=NOINLINE
+
   ghc-options:
     -Wall -Wcompat
 

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
@@ -7,8 +7,9 @@
   LATTICE ECP5 IO primitives. Implementations are documented in the
   <http://www.latticesemi.com/-/media/LatticeSemi/Documents/ApplicationNotes/EH/FPGA-TN-02032-1-2-ECP5-ECP5G-sysIO-Usage-Guide.ashx?document_id=50464>.
 -}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE GADTs #-}
@@ -74,7 +75,8 @@ bbECP5 _intrinsicName pkgPinIn output notOutputEnable
      toMaybe :: Bool -> a -> Maybe a
      toMaybe True a  = Just a
      toMaybe False _ = Nothing
-{-# NOINLINE bbECP5 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE bbECP5 #-}
 {-# ANN bbECP5 hasBlackBox #-}
 {-# ANN bbECP5 (InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [__i|
   BlackBox:

--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
@@ -8,11 +8,12 @@
   <http://www.latticesemi.com/~/media/LatticeSemi/Documents/TechnicalBriefs/SBTICETechnologyLibrary201504.pdf LATTICE ICE Technology Library>,
   referred to as LITL.
 -}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Clash.Cores.LatticeSemi.ICE40.IO
   ( sbio
@@ -230,7 +231,8 @@ sbio pinConf pkgPinIn latchInput dOut_0 _dOut_1 outputEnable0 =
     writeToBiSignal
       pkgPinIn
       (toMaybe <$> outputEnable1 <*> pkgPinWriteInput)
-{-# NOINLINE sbio #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE sbio #-}
 {-# ANN sbio hasBlackBox #-}
 {-# ANN sbio (InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [__i|
    BlackBox:

--- a/clash-cores/src/Clash/Cores/Xilinx/BlockRam.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/BlockRam.hs
@@ -6,6 +6,8 @@
   Xilinx block RAM primitives
 -}
 
+{-# LANGUAGE CPP #-}
+
 -- See [Note: eta port names for tdpbram]
 {-# OPTIONS_GHC -fno-do-lambda-eta-expansion #-}
 
@@ -76,4 +78,5 @@ tdpbram clkA enA addrA byteEnaA datA clkB enB addrB byteEnaB datB =
       clashCompileError "tdpbram: domain A needs a rising active edge"
     (_, SFalling) ->
       clashCompileError "tdpbram: domain B needs a rising active edge"
-{-# NOINLINE tdpbram #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tdpbram #-}

--- a/clash-cores/src/Clash/Cores/Xilinx/BlockRam/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/BlockRam/Internal.hs
@@ -7,6 +7,7 @@
 -}
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -157,7 +158,8 @@ updateRam addr (IsDefined byteEna) dat mem
   isDefinedMaxBound _        = False
 
 {-# ANN tdpbram# hasBlackBox #-}
-{-# NOINLINE tdpbram# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tdpbram# #-}
 {-# ANN tdpbram# (
    let
      primName = 'tdpbram#

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
@@ -45,6 +45,7 @@ acknowledge, valid, or programmable full\/empty flags)
 Vivado 2022.1.)
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -253,7 +254,8 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
             Seq.EmptyR -> (q, deepErrorX "FIFO empty", True :- preUnder)
             qData Seq.:> qDatum -> (qData, qDatum, False :- preUnder)
         else (q, deepErrorX "Enable off", False :- preUnder)
-{-# NOINLINE dcFifo #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE dcFifo #-}
 {-# ANN dcFifo (
    let primName = 'dcFifo
        tfName = 'dcFifoBBF

--- a/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Floating/Explicit.hs
@@ -43,6 +43,7 @@ type variable for delay annotation in circuits.
 -}
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_HADDOCK hide #-}
@@ -107,7 +108,8 @@ addWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x + y
  where
   und = withFrozenCallStack $ deepErrorX "Initial values of add undefined"
-{-# NOINLINE addWith #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE addWith #-}
 {-# ANN addWith (vhdlBinaryPrim 'addWith 'addTclTF "add") #-}
 {-# ANN addWith (veriBinaryPrim 'addWith 'addTclTF "add") #-}
 
@@ -145,7 +147,8 @@ subWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x - y
  where
   und = withFrozenCallStack $ deepErrorX "Initial values of sub undefined"
-{-# NOINLINE subWith #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE subWith #-}
 {-# ANN subWith (vhdlBinaryPrim 'subWith 'subTclTF "sub") #-}
 {-# ANN subWith (veriBinaryPrim 'subWith 'subTclTF "sub") #-}
 
@@ -184,7 +187,8 @@ mulWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x * y
  where
   und = withFrozenCallStack $ deepErrorX "Initial values of mul undefined"
-{-# NOINLINE mulWith #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE mulWith #-}
 {-# ANN mulWith (vhdlBinaryPrim 'mulWith 'mulTclTF "mul") #-}
 {-# ANN mulWith (veriBinaryPrim 'mulWith 'mulTclTF "mul") #-}
 
@@ -223,7 +227,8 @@ divWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x / y
  where
   und = withFrozenCallStack $ deepErrorX "Initial values of div undefined"
-{-# NOINLINE divWith #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE divWith #-}
 {-# ANN divWith (vhdlBinaryPrim 'divWith 'divTclTF "div") #-}
 {-# ANN divWith (veriBinaryPrim 'divWith 'divTclTF "div") #-}
 
@@ -261,7 +266,8 @@ fromU32With
 fromU32With clk en = delayI und en clk . fmap fromIntegral
  where
   und = withFrozenCallStack $ errorX "Initial values of fromU32 undefined"
-{-# NOINLINE fromU32With #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromU32With #-}
 {-# ANN fromU32With (vhdlFromUPrim 'fromU32With "fromU32") #-}
 {-# ANN fromU32With (veriFromUPrim 'fromU32With "fromU32") #-}
 
@@ -298,7 +304,8 @@ fromS32With
 fromS32With clk en = delayI und en clk . fmap fromIntegral
  where
   und = withFrozenCallStack $ errorX "Initial values of fromS32 undefined"
-{-# NOINLINE fromS32With #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromS32With #-}
 {-# ANN fromS32With (vhdlFromSPrim 'fromS32With "fromS32") #-}
 {-# ANN fromS32With (veriFromSPrim 'fromS32With "fromS32") #-}
 
@@ -339,7 +346,8 @@ compareWith
 compareWith clk ena a b = delayI und ena clk (xilinxCompare <$> a <*> b)
  where
   und = withFrozenCallStack $ errorX "Initial values of compare undefined"
-{-# NOINLINE compareWith #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE compareWith #-}
 {-# ANN compareWith (vhdlComparePrim 'compareWith 'compareTclTF "compare") #-}
 {-# ANN compareWith (veriComparePrim 'compareWith 'compareTclTF "compare") #-}
 

--- a/clash-cores/src/Clash/Cores/Xilinx/VIO.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/VIO.hs
@@ -28,11 +28,12 @@ JTAG clock speed:
 
 -}
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Clash.Cores.Xilinx.VIO
@@ -104,7 +105,8 @@ vioProbe ::
   Clock dom ->
   a
 vioProbe !_inputNames !_outputNames !_initialOutputProbeValues !_clk = vioX @dom @a @o
-{-# NOINLINE vioProbe #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE vioProbe #-}
 {-# ANN vioProbe (
     let primName = 'vioProbe
         tfName = 'vioProbeBBF

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/ArraySingle/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/ArraySingle/Internal.hs
@@ -3,6 +3,7 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -127,7 +128,8 @@ xpmCdcArraySingleTF# bbCtx
 
 xpmCdcArraySingleTF# bbCtx = error (ppShow bbCtx)
 
-{-# NOINLINE xpmCdcArraySingle# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xpmCdcArraySingle# #-}
 {-# ANN xpmCdcArraySingle# hasBlackBox #-}
 {-# ANN xpmCdcArraySingle#
   let

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Gray/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Gray/Internal.hs
@@ -3,6 +3,7 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -126,7 +127,8 @@ xpmCdcGrayTF# bbCtx
 
 xpmCdcGrayTF# bbCtx = error (ppShow bbCtx)
 
-{-# NOINLINE xpmCdcGray# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xpmCdcGray# #-}
 {-# ANN xpmCdcGray# hasBlackBox #-}
 {-# ANN xpmCdcGray#
   let

--- a/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Single/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/Xpm/Cdc/Single/Internal.hs
@@ -3,6 +3,7 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -120,7 +121,8 @@ xpmCdcSingleTF# bbCtx
 
 xpmCdcSingleTF# bbCtx = error (ppShow bbCtx)
 
-{-# NOINLINE xpmCdcSingle# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xpmCdcSingle# #-}
 {-# ANN xpmCdcSingle# hasBlackBox #-}
 {-# ANN xpmCdcSingle#
   let

--- a/clash-cosim/src/Clash/CoSim/CodeGeneration.hs
+++ b/clash-cosim/src/Clash/CoSim/CodeGeneration.hs
@@ -79,8 +79,13 @@ coSimGen' clks args = do
     -- Function declaration and body
     let coSim = FunD coSimName [Clause [] (NormalB $ VarE $ mkName "coSimN") []]
 
+#if __GLASGOW_HASKELL__ >= 904
+    -- OPAQUE pragma
+    let inline = PragmaD $ OpaqueP coSimName
+#else
     -- NOINLINE pragma
     let inline = PragmaD $ InlineP coSimName NoInline FunLike AllPhases
+#endif
 
     -- Clash blackbox pragma
     primDir        <- runIO $ getDataFileName "src/prims/verilog"

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -211,7 +211,7 @@ setNoInlineTopEntities bm tes =
   go b@Binding{bindingId}
     | bindingId `elemVarSet` ids
 #if MIN_VERSION_ghc(9,4,0)
-    = b { bindingSpec = GHC.NoInline GHC.NoSourceText }
+    = b { bindingSpec = GHC.Opaque GHC.NoSourceText }
 #else
     = b { bindingSpec = GHC.NoInline }
 #endif

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -70,7 +70,7 @@ import qualified TysWiredIn              as GHC
 import qualified Var                     as GHC
 import qualified SrcLoc                  as GHC
 #endif
-import           GHC.BasicTypes.Extra (isNoInline)
+import           GHC.BasicTypes.Extra (isOpaque)
 
 import           Clash.Annotations.BitRepresentation.Internal (buildCustomReprs)
 import           Clash.Annotations.Primitive (HDL, extractPrim)
@@ -359,8 +359,12 @@ checkPrimitive primMap v = do
             warnArgs xs
 
       unless (qName == "Clash.XException.errorX" || "GHC." `isPrefixOf` qName) $ do
-        warnIf (not (isNoInline inline))
+        warnIf (not (isOpaque inline))
+#if MIN_VERSION_ghc(9,4,0)
+          (primStr ++ "isn't marked OPAQUE."
+#else
           (primStr ++ "isn't marked NOINLINE."
+#endif
           ++ "\nThis might make Clash ignore this primitive.")
 #if MIN_VERSION_ghc(9,2,0)
         warnIf (GHC.isDeadEndAppSig strictness nrOfArgs)

--- a/clash-lib/src/GHC/BasicTypes/Extra.hs
+++ b/clash-lib/src/GHC/BasicTypes/Extra.hs
@@ -1,7 +1,8 @@
 {-|
   Copyright   :  (C) 2017, Google Inc.
+                     2023, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  Christiaan Baaij <christiaan.baaij@gmail.com>
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE CPP #-}
@@ -32,9 +33,21 @@ instance NFData SourceText
 instance Binary SourceText
 #endif
 
+-- | Determine whether given 'InlineSpec' is NOINLINE or more strict (OPAQUE)
 isNoInline :: InlineSpec -> Bool
 isNoInline NoInline{} = True
 #if MIN_VERSION_ghc(9,4,0)
 isNoInline Opaque{} = True
 #endif
 isNoInline _ = False
+
+-- | Determine whether given 'InlineSpec' is OPAQUE. If this function is used on
+-- a GHC that does not support OPAQUE yet (<9.4), it will return 'True' if given
+-- 'InlineSpec' is NOINLINE instead.
+isOpaque :: InlineSpec -> Bool
+#if MIN_VERSION_ghc(9,4,0)
+isOpaque Opaque{} = True
+#else
+isOpaque NoInline{} = True
+#endif
+isOpaque _ = False

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -155,6 +155,12 @@ Library
   ghc-options:        -Wall -Wcompat -fexpose-all-unfoldings -fno-worker-wrapper
   CPP-Options:        -DCABAL
 
+  -- See https://github.com/clash-lang/clash-compiler/pull/2511
+  if impl(ghc >= 9.4)
+    CPP-Options: -DCLASH_OPAQUE=OPAQUE
+  else
+    CPP-Options: -DCLASH_OPAQUE=NOINLINE
+
   if flag(large-tuples)
     CPP-Options: -DLARGE_TUPLES
 

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -924,7 +924,8 @@ buildPack dataRepr@(DataReprAnn _name _size constrs) = do
 -- This is used in the generated pack/unpack to not do anything in HDL.
 dontApplyInHDL :: (a -> b) -> a -> b
 dontApplyInHDL f a = f a
-{-# NOINLINE dontApplyInHDL #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE dontApplyInHDL #-}
 {-# ANN dontApplyInHDL hasBlackBox #-}
 
 buildUnpackField

--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -155,7 +155,8 @@ xToBV :: KnownNat n => BitVector n -> BitVector n
 xToBV x =
   unsafeDupablePerformIO (catch (evaluate x)
                                 (\(XException _) -> return undefined#))
-{-# NOINLINE xToBV #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xToBV #-}
 {-# ANN xToBV hasBlackBox #-}
 
 -- | Pack both arguments to a 'BitVector' and use
@@ -298,12 +299,14 @@ instance BitPack Float where
 
 packFloat# :: Float -> BitVector 32
 packFloat# = fromIntegral . floatToWord
-{-# NOINLINE packFloat# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE packFloat# #-}
 {-# ANN packFloat# hasBlackBox #-}
 
 unpackFloat# :: BitVector 32 -> Float
 unpackFloat# (unsafeToNatural -> w) = wordToFloat (fromIntegral w)
-{-# NOINLINE unpackFloat# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unpackFloat# #-}
 {-# ANN unpackFloat# hasBlackBox #-}
 
 instance BitPack Double where
@@ -313,12 +316,14 @@ instance BitPack Double where
 
 packDouble# :: Double -> BitVector 64
 packDouble# = fromIntegral . doubleToWord
-{-# NOINLINE packDouble# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE packDouble# #-}
 {-# ANN packDouble# hasBlackBox #-}
 
 unpackDouble# :: BitVector 64 -> Double
 unpackDouble# (unsafeToNatural -> w) = wordToDouble (fromIntegral w)
-{-# NOINLINE unpackDouble# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unpackDouble# #-}
 {-# ANN unpackDouble# hasBlackBox #-}
 
 instance BitPack CUShort where

--- a/clash-prelude/src/Clash/Class/Exp.hs
+++ b/clash-prelude/src/Clash/Class/Exp.hs
@@ -63,7 +63,8 @@ expIndex#
   -> Index (Max 2 (m ^ n))
 expIndex# b e@SNat =
   fromInteger (toInteger b P.^ snatToInteger e)
-{-# NOINLINE expIndex# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE expIndex# #-}
 {-# ANN expIndex# hasBlackBox #-}
 
 expSigned#
@@ -73,7 +74,8 @@ expSigned#
   -> Signed (Max 2 (m * n))
 expSigned# b e@SNat =
   fromInteger (toInteger b P.^ snatToInteger e)
-{-# NOINLINE expSigned# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE expSigned# #-}
 {-# ANN expSigned# hasBlackBox #-}
 
 expUnsigned#
@@ -83,5 +85,6 @@ expUnsigned#
   -> Unsigned (Max 1 (m * n))
 expUnsigned# b e@SNat =
   fromInteger (toInteger b P.^ snatToInteger e)
-{-# NOINLINE expUnsigned# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE expUnsigned# #-}
 {-# ANN expUnsigned# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -386,6 +386,7 @@ This concludes the short introduction to using 'blockRam'.
 
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -942,7 +943,8 @@ blockRamU# clk en SNat =
     (CV.map
       (\i -> deepErrorX $ "Initial value at index " <> show i <> " undefined.")
       (iterateI @n succ (0 :: Int)))
-{-# NOINLINE blockRamU# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE blockRamU# #-}
 {-# ANN blockRamU# hasBlackBox #-}
 
 -- | A version of 'blockRam' that is initialized with the same value on all
@@ -1031,7 +1033,8 @@ blockRam1#
 blockRam1# clk en n a =
   -- TODO: Generalize to single BRAM primitive taking an initialization function
   blockRam# clk en (replicate n a)
-{-# NOINLINE blockRam1# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE blockRam1# #-}
 {-# ANN blockRam1# hasBlackBox #-}
 
 -- | blockRAM primitive
@@ -1128,7 +1131,8 @@ blockRam# (Clock _ Nothing) gen content = \rd wen waS wd -> runST $ do
   {-# INLINE safeUpdate #-}
 blockRam# _ _ _ = error "blockRam#: dynamic clocks not supported"
 {-# ANN blockRam# hasBlackBox #-}
-{-# NOINLINE blockRam# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE blockRam# #-}
 
 -- | Create a read-after-write block RAM from a read-before-write one
 readNew
@@ -1229,9 +1233,11 @@ trueDualPortBlockRam = \clkA clkB opA opB ->
 -- into its own module / architecture.
 trueDualPortBlockRamWrapper clkA enA weA addrA datA clkB enB weB addrB datB =
   trueDualPortBlockRam# clkA enA weA addrA datA clkB enB weB addrB datB
-{-# NOINLINE trueDualPortBlockRamWrapper #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE trueDualPortBlockRamWrapper #-}
 
-{-# NOINLINE trueDualPortBlockRam# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE trueDualPortBlockRam# #-}
 {-# ANN trueDualPortBlockRam# hasBlackBox #-}
 {-# ANN trueDualPortBlockRam# (
   let

--- a/clash-prelude/src/Clash/Explicit/BlockRam/Blob.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/Blob.hs
@@ -18,6 +18,7 @@ generates practically the same HDL as "Clash.Explicit.BlockRam" and is
 compatible with all tools consuming the generated HDL.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeApplications #-}
@@ -232,7 +233,8 @@ blockRamBlob# !_ gen content@MemBlob{} = \rd wen waS wd -> runST $ do
        in forM_ [0..(szI-1)] (\j -> unsafeWriteSTArray s j d)
   {-# INLINE safeUpdate #-}
 {-# ANN blockRamBlob# hasBlackBox #-}
-{-# NOINLINE blockRamBlob# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE blockRamBlob# #-}
 
 -- | Create a 'MemBlob' binding from a list of values
 --

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -81,6 +81,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen enableGen (fromList [3..5])__
 -}
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 
 {-# LANGUAGE Unsafe #-}
@@ -426,7 +427,8 @@ blockRamFile# (Clock _ Nothing) ena sz file = \rd wen waS wd -> runST $ do
   parseBV' = fmap fst . listToMaybe . readInt 2 (`elem` "01") digitToInt
 blockRamFile# _ _ _ _ = error "blockRamFile#: dynamic clocks not supported"
 
-{-# NOINLINE blockRamFile# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE blockRamFile# #-}
 {-# ANN blockRamFile# hasBlackBox #-}
 
 -- | __NB:__ Not synthesizable
@@ -437,4 +439,5 @@ initMem = fmap (map parseBV . lines) . readFile
                   Just i  -> fromInteger i
                   Nothing -> error ("Failed to parse: " ++ s)
     parseBV' = fmap fst . listToMaybe . readInt 2 (`elem` "01") digitToInt
-{-# NOINLINE initMem #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE initMem #-}

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -135,7 +135,8 @@ ddrIn# (Clock _ Nothing) (unsafeToHighPolarity -> hRst) (fromEnable -> ena) i0 i
 
 ddrIn# _ _ _ _ _ _ =
   error "ddrIn#: dynamic clocks not supported"
-{-# NOINLINE ddrIn# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ddrIn# #-}
 {-# ANN ddrIn# hasBlackBox #-}
 
 -- | DDR output primitive
@@ -185,5 +186,6 @@ ddrOut# clk rst en i0 xs ys =
     xs' = register# clk rst en (errorX "ddrOut: unreachable error") i0 xs
     ys' = register# clk rst en (deepErrorX "ddrOut: initial value undefined") i0 ys
     zipSig (a :- as) (b :- bs) = a :- b :- zipSig as bs
-{-# NOINLINE ddrOut# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ddrOut# #-}
 {-# ANN ddrOut# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -301,7 +301,8 @@ windowD clk rst en x =
 -- descriptive.
 clashCompileError :: forall a . HasCallStack => String -> a
 clashCompileError msg = withFrozenCallStack $ error msg
-{-# NOINLINE clashCompileError #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE clashCompileError #-}
 {-# ANN clashCompileError (
   let primName = 'clashCompileError
   in InlineYamlPrimitive [minBound..] [__i|

--- a/clash-prelude/src/Clash/Explicit/RAM.hs
+++ b/clash-prelude/src/Clash/Explicit/RAM.hs
@@ -212,5 +212,6 @@ asyncRam# wClk rClk en sz rd we wr din = dout
                            " not in range [0.." ++ show szI ++ ")"))
         in d <$ s
     {-# INLINE safeUpdate #-}
-{-# NOINLINE asyncRam# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE asyncRam# #-}
 {-# ANN asyncRam# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -10,6 +10,7 @@ ROMs
 -}
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -139,5 +140,6 @@ rom# !_ en content =
         (deepErrorX ("rom: address " ++ show i ++
                      " not in range [0.." ++ show szI ++ ")"))
   {-# INLINE safeAt #-}
-{-# NOINLINE rom# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rom# #-}
 {-# ANN rom# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/ROM/Blob.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/Blob.hs
@@ -19,6 +19,7 @@ tools consuming the generated HDL.
 -}
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}
@@ -149,5 +150,6 @@ romBlob# !_ en content@MemBlob{} =
         (deepErrorX ("romBlob: address " ++ show i ++
                      " not in range [0.." ++ show szI ++ ")"))
   {-# INLINE safeAt #-}
-{-# NOINLINE romBlob# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE romBlob# #-}
 {-# ANN romBlob# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/ROM/File.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM/File.hs
@@ -77,6 +77,7 @@ __>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 @
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 {-# LANGUAGE Unsafe #-}
@@ -225,5 +226,6 @@ romFile# clk en sz file rd =
       deepErrorX ("romFile: address " ++ show i ++
                   " not in range [0.." ++ show szI ++ ")")
   {-# INLINE safeAt #-}
-{-# NOINLINE romFile# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE romFile# #-}
 {-# ANN romFile# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/Reset.hs
+++ b/clash-prelude/src/Clash/Explicit/Reset.hs
@@ -7,6 +7,7 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 Utilities to deal with resets.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -170,7 +171,8 @@ resetSynchronizer clk rst = rstOut
                          $ delay clk enableGen isActiveHigh
                          $ delay clk enableGen isActiveHigh
                          $ unsafeFromReset rst
-{-# NOINLINE resetSynchronizer #-} -- Give reset synchronizer its own HDL file
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE resetSynchronizer #-} -- Give reset synchronizer its own HDL file
 
 -- | Filter glitches from reset signals by only triggering a reset after it has
 -- been asserted for /glitchlessPeriod/ cycles. Similarly, it will stay
@@ -221,7 +223,8 @@ resetGlitchFilter SNat clk rst =
     case resetPolarity @dom of
       SActiveHigh -> True
       SActiveLow -> False
-{-# NOINLINE resetGlitchFilter #-} -- Give reset glitch filter its own HDL file
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE resetGlitchFilter #-} -- Give reset glitch filter its own HDL file
 
 -- | Hold reset for a number of cycles relative to an incoming reset signal.
 --

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -131,6 +131,7 @@ can potentially introduce situations prone to meta-stability:
 
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -460,7 +461,8 @@ unsafeSynchronizer clk1 clk2 =
       ClockA  -> go ticks as
       ClockB  -> a :- go ticks ass
       ClockAB -> go (ClockB:ClockA:ticks) ass
-{-# NOINLINE unsafeSynchronizer #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unsafeSynchronizer #-}
 {-# ANN unsafeSynchronizer hasBlackBox #-}
 
 -- | Same as 'unsafeSynchronizer', but with manually supplied clock periods.
@@ -510,7 +512,8 @@ veryUnsafeSynchronizer t1e t2e =
       ClockA  -> go ticks as
       ClockB  -> a :- go ticks ass
       ClockAB -> go (ClockB:ClockA:ticks) ass
-{-# NOINLINE veryUnsafeSynchronizer #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE veryUnsafeSynchronizer #-}
 {-# ANN veryUnsafeSynchronizer hasBlackBox #-}
 
 -- * Basic circuit functions
@@ -744,7 +747,8 @@ simulateWithReset m resetVal f as =
   clk = clockGen
   en  = enableGen
   out = simulate (f clk rst en) inp
-{-# NOINLINE simulateWithReset #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE simulateWithReset #-}
 
 -- | Same as 'simulateWithReset', but only sample the first /Int/ output values.
 simulateWithResetN
@@ -850,7 +854,8 @@ sampleWithReset
 sampleWithReset nReset f0 =
   let f1 = f0 clockGen (resetGenN @dom nReset) enableGen in
   drop (snatToNum nReset) (sample f1)
-{-# NOINLINE sampleWithReset #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE sampleWithReset #-}
 
 -- | Get a fine list of /m/ samples from a 'Signal', while asserting the reset line
 -- for /n/ clock cycles. 'sampleWithReset' does not return the first /n/ cycles,

--- a/clash-prelude/src/Clash/Explicit/SimIO.hs
+++ b/clash-prelude/src/Clash/Explicit/SimIO.hs
@@ -80,7 +80,8 @@ instance Functor SimIO where
 
 fmapSimIO# :: (a -> b) -> SimIO a -> SimIO b
 fmapSimIO# f (SimIO m) = SimIO (fmap f m)
-{-# NOINLINE fmapSimIO# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fmapSimIO# #-}
 {-# ANN fmapSimIO# hasBlackBox #-}
 
 instance Applicative SimIO where
@@ -89,12 +90,14 @@ instance Applicative SimIO where
 
 pureSimIO# :: a -> SimIO a
 pureSimIO# a = SimIO (pure a)
-{-# NOINLINE pureSimIO# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE pureSimIO# #-}
 {-# ANN pureSimIO# hasBlackBox #-}
 
 apSimIO# :: SimIO (a -> b) -> SimIO a -> SimIO b
 apSimIO# (SimIO f) (SimIO m) = SimIO (f <*> m)
-{-# NOINLINE apSimIO# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE apSimIO# #-}
 {-# ANN apSimIO# hasBlackBox #-}
 
 instance Monad SimIO where
@@ -109,7 +112,8 @@ bindSimIO# (SimIO m) k = SimIO (m >>= (\x -> x `seqX` unSimIO (k x)))
 #else
 bindSimIO# (SimIO m) k = SimIO (m >>= (\x -> x `seqX` coerce k x))
 #endif
-{-# NOINLINE bindSimIO# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE bindSimIO# #-}
 {-# ANN bindSimIO# hasBlackBox #-}
 
 -- | Display a string on /stdout/
@@ -118,7 +122,8 @@ display
   -- ^ String you want to display
   -> SimIO ()
 display s = SimIO (putStrLn s)
-{-# NOINLINE display #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE display #-}
 {-# ANN display hasBlackBox #-}
 
 -- | Finish the simulation with an exit code
@@ -127,7 +132,8 @@ finish
   -- ^ The exit code you want to return at the end of the simulation
   -> SimIO a
 finish i = return (error (show i))
-{-# NOINLINE finish #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE finish #-}
 {-# ANN finish hasBlackBox #-}
 
 -- | Mutable reference
@@ -143,13 +149,15 @@ reg
   -- ^ The starting value
   -> SimIO (Reg a)
 reg a = SimIO (Reg <$> newIORef a)
-{-# NOINLINE reg #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE reg #-}
 {-# ANN reg hasBlackBox #-}
 
 -- | Read value from a mutable reference
 readReg :: Reg a -> SimIO a
 readReg (Reg a) = SimIO (readIORef a)
-{-# NOINLINE readReg #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE readReg #-}
 {-# ANN readReg hasBlackBox #-}
 
 -- | Write new value to the mutable reference
@@ -160,7 +168,8 @@ writeReg
   -- ^ The new value
   -> SimIO ()
 writeReg (Reg r) a = SimIO (writeIORef r a)
-{-# NOINLINE writeReg #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE writeReg #-}
 {-# ANN writeReg hasBlackBox #-}
 
 -- | File handle
@@ -218,7 +227,8 @@ openFile fp "wb+" = coerce (IO.openBinaryFile fp IO.WriteMode)
 openFile fp "ab+" = coerce (IO.openBinaryFile fp IO.AppendMode)
 #endif
 openFile _  m     = error ("openFile unknown mode: " ++ show m)
-{-# NOINLINE openFile #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE openFile #-}
 {-# ANN openFile hasBlackBox #-}
 
 -- | Close a file
@@ -226,7 +236,8 @@ closeFile
   :: File
   -> SimIO ()
 closeFile (File fp) = SimIO (IO.hClose fp)
-{-# NOINLINE closeFile #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE closeFile #-}
 {-# ANN closeFile hasBlackBox #-}
 
 -- | Read one character from a file
@@ -235,7 +246,8 @@ getChar
   -- ^ File to read from
   -> SimIO Char
 getChar (File fp) = SimIO (IO.hGetChar fp)
-{-# NOINLINE getChar #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE getChar #-}
 {-# ANN getChar hasBlackBox #-}
 
 -- | Insert a character into a buffer specified by the file
@@ -246,7 +258,8 @@ putChar
   -- ^ Buffer to insert to
   -> SimIO ()
 putChar c (File fp) = SimIO (IO.hPutChar fp c)
-{-# NOINLINE putChar #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE putChar #-}
 {-# ANN putChar hasBlackBox #-}
 
 -- | Read one line from a file
@@ -269,7 +282,8 @@ getLine (File fp) (Reg r) = SimIO $ do
    rep []     vs          = vs
    rep (x:xs) (Cons _ vs) = Cons (toEnum (fromEnum x)) (rep xs vs)
    rep _      Nil         = Nil
-{-# NOINLINE getLine #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE getLine #-}
 {-# ANN getLine hasBlackBox #-}
 
 -- | Determine whether we've reached the end of the file
@@ -278,7 +292,8 @@ isEOF
   -- ^ File we want to inspect
   -> SimIO Bool
 isEOF (File fp) = SimIO (IO.hIsEOF fp)
-{-# NOINLINE isEOF #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE isEOF #-}
 {-# ANN isEOF hasBlackBox #-}
 
 -- | Set the position of the next operation on the file
@@ -295,7 +310,8 @@ seek
   -- * 2: From the end of the file
   -> SimIO Int
 seek (File fp) pos mode = SimIO (IO.hSeek fp (toEnum mode) pos >> return 0)
-{-# NOINLINE seek #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE seek #-}
 {-# ANN seek hasBlackBox #-}
 
 -- | Set the position of the next operation to the beginning of the file
@@ -303,7 +319,8 @@ rewind
   :: File
   -> SimIO Int
 rewind (File fp) = SimIO (IO.hSeek fp IO.AbsoluteSeek 0 >> return 0)
-{-# NOINLINE rewind #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rewind #-}
 {-# ANN rewind hasBlackBox #-}
 
 -- | Returns the offset from the beginning of the file (in bytes).
@@ -312,7 +329,8 @@ tell
   -- ^ File we want to inspect
   -> SimIO Integer
 tell (File fp) = SimIO (IO.hTell fp)
-{-# NOINLINE tell #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tell #-}
 {-# ANN tell hasBlackBox #-}
 
 -- | Write any buffered output to file
@@ -320,7 +338,8 @@ flush
   :: File
   -> SimIO ()
 flush (File fp) = SimIO (IO.hFlush fp)
-{-# NOINLINE flush #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE flush #-}
 {-# ANN flush hasBlackBox #-}
 
 -- | Simulation-level I/O environment that can be synthesized to HDL-level I\/O.
@@ -378,4 +397,5 @@ mealyIO !_ f (SimIO i) inp = unsafePerformIO (i >>= go inp)
  where
   go q@(~(k :- ks)) s =
     (:-) <$> unSimIO (f s k) <*> unsafeInterleaveIO ((q `seq` go ks s))
-{-# NOINLINE mealyIO #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE mealyIO #-}

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -7,6 +7,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE Unsafe #-}
@@ -112,7 +113,8 @@ assert clk (Reset _) msg checked expected returned =
   where
     eqX a b = unsafeDupablePerformIO (catch (evaluate (a == b))
                                             (\(_ :: XException) -> return False))
-{-# NOINLINE assert #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE assert #-}
 {-# ANN assert hasBlackBox #-}
 
 -- | The same as 'assert', but can handle don't care bits in its expected value.
@@ -146,7 +148,8 @@ assertBitVector clk (Reset _) msg checked expected returned =
   where
     eqX a b = unsafeDupablePerformIO (catch (evaluate (a `isLike#` b))
                                             (\(_ :: XException) -> return False))
-{-# NOINLINE assertBitVector #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE assertBitVector #-}
 {-# ANN assertBitVector hasBlackBox #-}
 
 
@@ -425,7 +428,8 @@ biTbClockGen done = (testClk, circuitClk)
 -- be optimized away.
 tbEnableGen :: Enable tag
 tbEnableGen = toEnable (pure True)
-{-# NOINLINE tbEnableGen #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tbEnableGen #-}
 {-# ANN tbEnableGen hasBlackBox #-}
 
 -- | Clock generator for the 'System' clock domain.
@@ -472,7 +476,8 @@ seClockToDiffClock ::
   -- | (Positive phase, negative phase)
   (Clock dom, Clock dom)
 seClockToDiffClock clk = (clk, clk)
-{-# NOINLINE seClockToDiffClock #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE seClockToDiffClock #-}
 {-# ANN seClockToDiffClock hasBlackBox #-}
 
 -- | Cross clock domains in a way that is unsuitable for hardware but good
@@ -493,5 +498,6 @@ unsafeSimSynchronizer
   -> Signal dom1 a
   -> Signal dom2 a
 unsafeSimSynchronizer = unsafeSynchronizer
-{-# NOINLINE unsafeSimSynchronizer #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unsafeSimSynchronizer #-}
 {-# ANN unsafeSimSynchronizer hasBlackBox #-}

--- a/clash-prelude/src/Clash/Explicit/Verification.hs
+++ b/clash-prelude/src/Clash/Explicit/Verification.hs
@@ -12,6 +12,7 @@ of PSL and an introduction to the concepts of property checking, read
 The verification API is currently experimental and subject to change.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE QuasiQuotes #-}
 
@@ -259,7 +260,8 @@ check !_clk !_rst !_propName !_renderAs !_prop =
   pure (errorX (concat [
       "Simulation for Clash.Verification not yet implemented. If you need this,"
     , " create an issue at https://github.com/clash-compiler/clash-lang/issues." ]))
-{-# NOINLINE check #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE check #-}
 {-# ANN check (InlineYamlPrimitive [Verilog, SystemVerilog, VHDL] [__i|
   BlackBoxHaskell:
     name: Clash.Explicit.Verification.check

--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -25,6 +25,7 @@ We suggest you always use a PLL even if your oscillator runs at the frequency
 you want to run your circuit at.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 module Clash.Intel.ClockGen
@@ -113,7 +114,8 @@ altpll
   -> (Clock domOut, Signal domOut Bool)
   -- ^ (Stable PLL clock, PLL lock)
 altpll !_ = knownDomain @domIn `seq` knownDomain @domOut `seq` clocks
-{-# NOINLINE altpll #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE altpll #-}
 {-# ANN altpll hasBlackBox #-}
 
 -- | A clock source that corresponds to the Intel/Quartus \"Altera PLL\"
@@ -200,5 +202,6 @@ alteraPll
   -- ^ Reset for the PLL
   -> t
 alteraPll !_ = clocks
-{-# NOINLINE alteraPll #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE alteraPll #-}
 {-# ANN alteraPll hasBlackBox #-}

--- a/clash-prelude/src/Clash/Intel/DDR.hs
+++ b/clash-prelude/src/Clash/Intel/DDR.hs
@@ -54,7 +54,8 @@ altddioIn
   -> Signal slow (BitVector m,BitVector m)
   -- ^ normal speed output pairs
 altddioIn _devFam clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
-{-# NOINLINE altddioIn #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE altddioIn #-}
 {-# ANN altddioIn hasBlackBox #-}
 
 -- | Intel specific variant of 'ddrOut' implemented using the ALTDDIO_OUT IP core.
@@ -97,5 +98,6 @@ altddioOut#
   -> Signal slow (BitVector m)
   -> Signal fast (BitVector m)
 altddioOut# _ clk rst en = ddrOut# clk rst en 0
-{-# NOINLINE altddioOut# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE altddioOut# #-}
 {-# ANN altddioOut# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Magic.hs
+++ b/clash-prelude/src/Clash/Magic.hs
@@ -16,6 +16,8 @@ Refer to "Clash.Annotations.TopEntity" for controlling naming of entities
 (VHDL) / modules ((System)Verilog) and their ports.
 -}
 
+{-# LANGUAGE CPP #-}
+
 module Clash.Magic
   (
   -- ** Functions to control names of identifiers in HDL
@@ -45,19 +47,22 @@ import Clash.Annotations.Primitive (hasBlackBox)
 prefixName
   :: forall (name :: Symbol) a . a -> name ::: a
 prefixName = id
-{-# NOINLINE prefixName #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE prefixName #-}
 
 -- | Suffix instance and register names with the given 'Symbol'
 suffixName
   :: forall (name :: Symbol) a . a -> name ::: a
 suffixName = id
-{-# NOINLINE suffixName #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE suffixName #-}
 
 -- | Suffix instance and register names with the given 'Nat'
 suffixNameFromNat
   :: forall (name :: Nat) a . a -> name ::: a
 suffixNameFromNat = id
-{-# NOINLINE suffixNameFromNat #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE suffixNameFromNat #-}
 
 -- | Suffix instance and register names with the given 'Symbol', but add it
 -- in front of other suffixes.
@@ -80,7 +85,8 @@ suffixNameFromNat = id
 suffixNameP
   :: forall (name :: Symbol) a . a -> name ::: a
 suffixNameP = id
-{-# NOINLINE suffixNameP #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE suffixNameP #-}
 
 -- | Suffix instance and register names with the given 'Nat', but add it in
 -- front of other suffixes.
@@ -103,7 +109,8 @@ suffixNameP = id
 suffixNameFromNatP
   :: forall (name :: Nat) a . a -> name ::: a
 suffixNameFromNatP = id
-{-# NOINLINE suffixNameFromNatP #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE suffixNameFromNatP #-}
 
 -- | Name the instance or register with the given 'Symbol', instead of using
 -- an auto-generated name. Pre- and suffixes annotated with 'prefixName' and
@@ -112,7 +119,8 @@ suffixNameFromNatP = id
 setName
   :: forall (name :: Symbol) a . a -> name ::: a
 setName = id
-{-# NOINLINE setName #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE setName #-}
 
 -- | Name a given term, such as one of type 'Clash.Signal.Signal', using the
 -- given 'SSymbol'. Results in a declaration with the name used as the
@@ -131,7 +139,8 @@ nameHint
   -- ^ A hint for a name
   -> a -> a
 nameHint = seq
-{-# NOINLINE nameHint #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE nameHint #-}
 {-# ANN nameHint hasBlackBox #-}
 
 -- | Force deduplication, i.e. share a function or operator between multiple
@@ -178,7 +187,8 @@ nameHint = seq
 deDup
   :: forall a . a -> a
 deDup = id
-{-# NOINLINE deDup #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE deDup #-}
 
 -- | Do not deduplicate, i.e. /keep/, an applied function inside a
 -- case-alternative; do not try to share the function between multiple
@@ -237,12 +247,14 @@ deDup = id
 noDeDup
   :: forall a . a -> a
 noDeDup = id
-{-# NOINLINE noDeDup #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE noDeDup #-}
 
 -- | 'True' in Haskell/Clash simulation. Replaced by 'False' when generating HDL.
 clashSimulation :: Bool
 clashSimulation = True
-{-# NOINLINE clashSimulation #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE clashSimulation #-}
 
 -- | A container for data you only want to have around during simulation and
 -- is ignored during synthesis. Useful for carrying around things such as:

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -9,6 +9,7 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 ROMs
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -121,7 +122,8 @@ asyncRom# content = safeAt
         withFrozenCallStack
           (deepErrorX ("asyncRom: address " ++ show i ++
                        " not in range [0.." ++ show szI ++ ")"))
-{-# NOINLINE asyncRom# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE asyncRom# #-}
 {-# ANN asyncRom# hasBlackBox #-}
 
 -- | A ROM with a synchronous read port, with space for @n@ elements

--- a/clash-prelude/src/Clash/Prelude/ROM/Blob.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/Blob.hs
@@ -18,6 +18,7 @@ the same HDL as "Clash.Prelude.ROM" and is compatible with all tools consuming
 the generated HDL.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_HADDOCK show-extensions #-}
@@ -118,7 +119,8 @@ asyncRomBlob# content@MemBlob{} = safeAt
           (deepErrorX ("asyncRom: address " ++ show i ++
                        " not in range [0.." ++ show szI ++ ")"))
 {-# ANN asyncRomBlob# hasBlackBox #-}
-{-# NOINLINE asyncRomBlob# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE asyncRomBlob# #-}
 
 -- | A ROM with a synchronous read port, with space for @n@ elements
 --

--- a/clash-prelude/src/Clash/Prelude/ROM/File.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM/File.hs
@@ -74,6 +74,7 @@ __>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 @
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 {-# LANGUAGE Unsafe #-}
@@ -255,7 +256,8 @@ asyncRomFile# sz file = (content !) -- Leave "(content !)" eta-reduced, see
     mem     = unsafePerformIO (initMem file)
     content = listArray (0,szI-1) mem
     szI     = snatToNum sz
-{-# NOINLINE asyncRomFile# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE asyncRomFile# #-}
 {-# ANN asyncRomFile# hasBlackBox #-}
 
 -- | A ROM with a synchronous read port, with space for @n@ elements

--- a/clash-prelude/src/Clash/Promoted/Nat.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat.hs
@@ -269,7 +269,8 @@ infixl 7 `mulSNat`
 -- | Power of two singleton natural numbers
 powSNat :: SNat a -> SNat b -> SNat (a^b)
 powSNat SNat SNat = SNat
-{-# NOINLINE powSNat #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE powSNat #-}
 {-# ANN powSNat hasBlackBox #-}
 infixr 8 `powSNat`
 
@@ -297,7 +298,8 @@ flogBaseSNat :: (2 <= base, 1 <= x)
              -> SNat x
              -> SNat (FLog base x)
 flogBaseSNat SNat SNat = SNat
-{-# NOINLINE flogBaseSNat #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE flogBaseSNat #-}
 {-# ANN flogBaseSNat hasBlackBox #-}
 
 -- | Ceiling of the logarithm of a natural number
@@ -306,7 +308,8 @@ clogBaseSNat :: (2 <= base, 1 <= x)
              -> SNat x
              -> SNat (CLog base x)
 clogBaseSNat SNat SNat = SNat
-{-# NOINLINE clogBaseSNat #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE clogBaseSNat #-}
 {-# ANN clogBaseSNat hasBlackBox #-}
 
 -- | Exact integer logarithm of a natural number
@@ -317,7 +320,8 @@ logBaseSNat :: (FLog base x ~ CLog base x)
             -> SNat x
             -> SNat (Log base x)
 logBaseSNat SNat SNat = SNat
-{-# NOINLINE logBaseSNat #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE logBaseSNat #-}
 {-# ANN logBaseSNat hasBlackBox #-}
 
 -- | Power of two of a singleton natural number

--- a/clash-prelude/src/Clash/Promoted/Nat/Unsafe.hs
+++ b/clash-prelude/src/Clash/Promoted/Nat/Unsafe.hs
@@ -5,6 +5,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Unsafe #-}
 
 module Clash.Promoted.Nat.Unsafe
@@ -20,5 +21,6 @@ import Clash.Promoted.Nat (SNat, snatProxy)
 -- | I hope you know what you're doing
 unsafeSNat :: Integer -> SNat k
 unsafeSNat i = reifyNat i $ (\p -> unsafeCoerce (snatProxy p))
-{-# NOINLINE unsafeSNat #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unsafeSNat #-}
 {-# ANN unsafeSNat hasBlackBox #-}

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -1800,7 +1800,8 @@ sample
   -> [a]
 sample s =
   E.sample (exposeClockResetEnable @dom s clockGen resetGen enableGen)
-{-# NOINLINE sample #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE sample #-}
 
 -- | Get a list of /n/ samples from a 'Signal'
 --
@@ -1829,7 +1830,8 @@ sampleN
 sampleN n s0 =
   let s1 = exposeClockResetEnable @dom s0 clockGen resetGen enableGen in
   E.sampleN n s1
-{-# NOINLINE sampleN #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE sampleN #-}
 
 -- | Get an infinite list of samples from a 'Signal', while asserting the reset
 -- line for /m/ clock cycles. 'sampleWithReset' does not return the first /m/
@@ -1850,7 +1852,8 @@ sampleWithReset
 sampleWithReset nReset f0 =
   let f1 = exposeClockResetEnable f0 clockGen (resetGenN @dom nReset) enableGen in
   drop (snatToNum nReset) (E.sample f1)
-{-# NOINLINE sampleWithReset #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE sampleWithReset #-}
 
 -- | Get a list of /n/ samples from a 'Signal', while asserting the reset line
 -- for /m/ clock cycles. 'sampleWithReset' does not return the first /m/ cycles,
@@ -1895,7 +1898,8 @@ sample_lazy
   -> [a]
 sample_lazy s =
   E.sample_lazy (exposeClockResetEnable @dom s clockGen resetGen enableGen)
-{-# NOINLINE sample_lazy #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE sample_lazy #-}
 
 -- | Lazily get a list of /n/ samples from a 'Signal'
 --
@@ -1920,7 +1924,8 @@ sampleN_lazy
   -> [a]
 sampleN_lazy n s =
   E.sampleN_lazy n (exposeClockResetEnable @dom s clockGen resetGen enableGen)
-{-# NOINLINE sampleN_lazy #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE sampleN_lazy #-}
 
 -- * Simulation functions
 
@@ -2038,7 +2043,8 @@ simulate_lazy
 simulate_lazy f0 =
   let f1 = exposeClockResetEnable @dom f0 clockGen resetGen enableGen in
   tail . E.simulate_lazy f1 . dup1
-{-# NOINLINE simulate_lazy #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE simulate_lazy #-}
 
 -- | Simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a list of
 -- samples of type @a@
@@ -2073,7 +2079,8 @@ simulateB f0 =
       enableGen
       (const f0)
       (Proxy @dom)
-{-# NOINLINE simulateB #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE simulateB #-}
 
 -- | /Lazily/ simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a
 -- list of samples of type @a@
@@ -2105,7 +2112,8 @@ simulateB_lazy f0 =
       enableGen
       (const f0)
       (Proxy @dom)
-{-# NOINLINE simulateB_lazy #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE simulateB_lazy #-}
 
 dup1 :: [a] -> [a]
 dup1 (x:xs) = x:x:xs
@@ -2285,4 +2293,5 @@ signalAutomaton
 signalAutomaton f0 =
   let f1 = exposeClockResetEnable @dom f0 clockGen resetGen enableGen in
   E.signalAutomaton f1
-{-# NOINLINE signalAutomaton #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE signalAutomaton #-}

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -245,7 +245,8 @@ readFromBiSignal# (BiSignalIn ds s) =
     SFloating -> fromMaybe (errorX " undefined value on BiSignalIn") <$> s
     SPullDown  -> fromMaybe minBound <$> s
     SPullUp    -> fromMaybe maxBound <$> s
-{-# NOINLINE readFromBiSignal# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE readFromBiSignal# #-}
 {-# ANN readFromBiSignal# hasBlackBox #-}
 
 -- | Read the value from an __inout__ port
@@ -265,7 +266,8 @@ mergeBiSignalOuts
   => Vec n (BiSignalOut defaultState dom m)
   -> BiSignalOut defaultState dom m
 mergeBiSignalOuts = mconcat . V.toList
-{-# NOINLINE mergeBiSignalOuts #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE mergeBiSignalOuts #-}
 {-# ANN mergeBiSignalOuts hasBlackBox #-}
 
 writeToBiSignal#
@@ -277,7 +279,8 @@ writeToBiSignal#
   -> BiSignalOut ds d n
 -- writeToBiSignal# = writeToBiSignal#
 writeToBiSignal# _ maybeSignal _ _ = BiSignalOut [maybeSignal]
-{-# NOINLINE writeToBiSignal# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE writeToBiSignal# #-}
 {-# ANN writeToBiSignal# hasBlackBox #-}
 
 -- | Write to an __inout__ port
@@ -324,5 +327,6 @@ veryUnsafeToBiSignalIn (BiSignalOut signals) = prepend# result biSignalOut'
 
     -- Recursive step
     biSignalOut' = veryUnsafeToBiSignalIn $ BiSignalOut $ map tail# signals
-{-# NOINLINE veryUnsafeToBiSignalIn #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE veryUnsafeToBiSignalIn #-}
 {-# ANN veryUnsafeToBiSignalIn hasBlackBox #-}

--- a/clash-prelude/src/Clash/Signal/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Bundle.hs
@@ -155,7 +155,8 @@ instance KnownNat n => Bundle (Vec n a) where
   bundle   = vecBundle#
   unbundle = sequenceA . fmap lazyV
 
-{-# NOINLINE vecBundle# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE vecBundle# #-}
 {-# ANN vecBundle# hasBlackBox #-}
 vecBundle# :: Vec n (Signal t a) -> Signal t (Vec n a)
 vecBundle# = traverse# id

--- a/clash-prelude/src/Clash/Signal/Internal/Ambiguous.hs
+++ b/clash-prelude/src/Clash/Signal/Internal/Ambiguous.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -24,7 +25,8 @@ clockPeriod =
   case knownDomain @dom of
     SDomainConfiguration{sPeriod} ->
       sPeriod
-{-# NOINLINE clockPeriod #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE clockPeriod #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
 -- | Get 'ActiveEdge' from a KnownDomain context. Example usage:
@@ -44,7 +46,8 @@ activeEdge =
   case knownDomain @dom of
     SDomainConfiguration{sActiveEdge} ->
       sActiveEdge
-{-# NOINLINE activeEdge #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE activeEdge #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
 -- | Get 'ResetKind' from a KnownDomain context. Example usage:
@@ -64,7 +67,8 @@ resetKind =
   case knownDomain @dom of
     SDomainConfiguration{sResetKind} ->
       sResetKind
-{-# NOINLINE resetKind #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE resetKind #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
 -- | Get 'InitBehavior' from a KnownDomain context. Example usage:
@@ -84,7 +88,8 @@ initBehavior =
   case knownDomain @dom of
     SDomainConfiguration{sInitBehavior} ->
       sInitBehavior
-{-# NOINLINE initBehavior #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE initBehavior #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
 -- | Get 'ResetPolarity' from a KnownDomain context. Example usage:
@@ -104,7 +109,8 @@ resetPolarity =
   case knownDomain @dom of
     SDomainConfiguration{sResetPolarity} ->
       sResetPolarity
-{-# NOINLINE resetPolarity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE resetPolarity #-}
 -- @NOINLINE: https://github.com/clash-lang/clash-compiler/issues/662
 
 -- | Like 'knownDomain but yields a 'VDomainConfiguration'. Should only be used

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -141,7 +141,8 @@ type TraceMap  = Map.Map String (TypeRepBS, Period, Width, [Value])
 -- | Map of traces used by the non-internal trace and dumpvcd functions.
 traceMap# :: IORef TraceMap
 traceMap# = unsafePerformIO (newIORef Map.empty)
-{-# NOINLINE traceMap# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE traceMap# #-}
 
 mkTrace
   :: HasCallStack
@@ -184,7 +185,8 @@ traceSignal# traceMap period traceName signal =
       , signal)
  where
   width = snatToNum (SNat @(BitSize a))
-{-# NOINLINE traceSignal# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE traceSignal# #-}
 
 -- | Trace a single vector signal: each element in the vector will show up as
 -- a different trace. If the trace name already exists, this function will emit
@@ -210,7 +212,8 @@ traceVecSignal# traceMap period vecTraceName (unbundle -> vecSignal) =
  where
   trace' i s = traceSignal# traceMap period (name' i) s
   name' i    = vecTraceName ++ "_" ++ show i
-{-# NOINLINE traceVecSignal# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE traceVecSignal# #-}
 
 -- | Trace a single signal. Will emit an error if a signal with the same name
 -- was previously registered.
@@ -234,7 +237,8 @@ traceSignal traceName signal =
     SDomainConfiguration{sPeriod} ->
       unsafePerformIO $
         traceSignal# traceMap# (snatToNum sPeriod) traceName signal
-{-# NOINLINE traceSignal #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE traceSignal #-}
 {-# ANN traceSignal hasBlackBox #-}
 
 -- | Trace a single signal. Will emit an error if a signal with the same name
@@ -255,7 +259,8 @@ traceSignal1
   -> Signal dom a
 traceSignal1 traceName signal =
   unsafePerformIO (traceSignal# traceMap# 1 traceName signal)
-{-# NOINLINE traceSignal1 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE traceSignal1 #-}
 {-# ANN traceSignal1 hasBlackBox #-}
 
 -- | Trace a single vector signal: each element in the vector will show up as
@@ -282,7 +287,8 @@ traceVecSignal traceName signal =
     SDomainConfiguration{sPeriod} ->
       unsafePerformIO $
         traceVecSignal# traceMap# (snatToNum sPeriod) traceName signal
-{-# NOINLINE traceVecSignal #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE traceVecSignal #-}
 {-# ANN traceVecSignal hasBlackBox #-}
 
 -- | Trace a single vector signal: each element in the vector will show up as
@@ -305,7 +311,8 @@ traceVecSignal1
   -> Signal dom (Vec (n+1) a)
 traceVecSignal1 traceName signal =
   unsafePerformIO $ traceVecSignal# traceMap# 1 traceName signal
-{-# NOINLINE traceVecSignal1 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE traceVecSignal1 #-}
 {-# ANN traceVecSignal1 hasBlackBox #-}
 
 iso8601Format :: UTCTime -> String

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -260,13 +260,15 @@ data Bit =
 
 -- * Constructions
 -- ** Initialisation
-{-# NOINLINE high #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE high #-}
 {-# ANN high hasBlackBox #-}
 -- | logic '1'
 high :: Bit
 high = Bit 0 1
 
-{-# NOINLINE low #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE low #-}
 {-# ANN low hasBlackBox #-}
 -- | logic '0'
 low :: Bit
@@ -305,12 +307,14 @@ instance Eq Bit where
 
 eq## :: Bit -> Bit -> Bool
 eq## b1 b2 = eq# (pack# b1) (pack# b2)
-{-# NOINLINE eq## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE eq## #-}
 {-# ANN eq## hasBlackBox #-}
 
 neq## :: Bit -> Bit -> Bool
 neq## b1 b2 = neq# (pack# b1) (pack# b2)
-{-# NOINLINE neq## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE neq## #-}
 {-# ANN neq## hasBlackBox #-}
 
 instance Ord Bit where
@@ -321,16 +325,20 @@ instance Ord Bit where
 
 lt##,ge##,gt##,le## :: Bit -> Bit -> Bool
 lt## b1 b2 = lt# (pack# b1) (pack# b2)
-{-# NOINLINE lt## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lt## #-}
 {-# ANN lt## hasBlackBox #-}
 ge## b1 b2 = ge# (pack# b1) (pack# b2)
-{-# NOINLINE ge## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ge## #-}
 {-# ANN ge## hasBlackBox #-}
 gt## b1 b2 = gt# (pack# b1) (pack# b2)
-{-# NOINLINE gt## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE gt## #-}
 {-# ANN gt## hasBlackBox #-}
 le## b1 b2 = le# (pack# b1) (pack# b2)
-{-# NOINLINE le## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE le## #-}
 {-# ANN le## hasBlackBox #-}
 
 instance Enum Bit where
@@ -339,7 +347,8 @@ instance Enum Bit where
 
 toEnum## :: Int -> Bit
 toEnum## = fromInteger## 0## . toInteger
-{-# NOINLINE toEnum## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toEnum## #-}
 {-# ANN toEnum## hasBlackBox #-}
 
 instance Bounded Bit where
@@ -360,7 +369,8 @@ instance Num Bit where
 
 fromInteger## :: Word# -> Integer -> Bit
 fromInteger## m# i = Bit ((W# m#) `mod` 2) (fromInteger i `mod` 2)
-{-# NOINLINE fromInteger## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromInteger## #-}
 {-# ANN fromInteger## hasBlackBox #-}
 
 instance Real Bit where
@@ -405,23 +415,27 @@ instance FiniteBits Bit where
 and##, or##, xor## :: Bit -> Bit -> Bit
 and## (Bit m1 v1) (Bit m2 v2) = Bit mask (v1 .&. v2 .&. complement mask)
   where mask = (m1.&.v2 .|. m1.&.m2 .|. m2.&.v1)
-{-# NOINLINE and## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE and## #-}
 {-# ANN and## hasBlackBox #-}
 
 or## (Bit m1 v1) (Bit m2 v2) = Bit mask ((v1 .|. v2) .&. complement mask)
   where mask = m1 .&. complement v2 .|.  m1.&.m2  .|.  m2 .&. complement v1
-{-# NOINLINE or## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE or## #-}
 {-# ANN or## hasBlackBox #-}
 
 xor## (Bit m1 v1) (Bit m2 v2) = Bit mask ((v1 `xor` v2) .&. complement mask)
   where mask = m1 .|. m2
-{-# NOINLINE xor## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xor## #-}
 {-# ANN xor## hasBlackBox #-}
 
 complement## :: Bit -> Bit
 complement## (Bit m v) = Bit m (complementB v .&. complementB m)
   where complementB (W# b#) = W# (int2Word# (eqWord# b# 0##))
-{-# NOINLINE complement## #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE complement## #-}
 {-# ANN complement## hasBlackBox #-}
 
 -- *** BitPack
@@ -431,7 +445,8 @@ pack# (Bit (W# m) (W# b)) = BV (NS m) (NS b)
 #else
 pack# (Bit (W# m) (W# b)) = BV (NatS# m) (NatS# b)
 #endif
-{-# NOINLINE pack# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE pack# #-}
 {-# ANN pack# hasBlackBox #-}
 
 unpack# :: BitVector 1 -> Bit
@@ -444,7 +459,8 @@ unpack# (BV m b) = Bit (go m) (go b)
   go (NatS# w) = W# w
   go (NatJ# w) = W# (bigNatToWord w)
 #endif
-{-# NOINLINE unpack# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unpack# #-}
 {-# ANN unpack# hasBlackBox #-}
 
 -- * Instances
@@ -542,13 +558,15 @@ instance KnownNat n => Eq (BitVector n) where
   (==) = eq#
   (/=) = neq#
 
-{-# NOINLINE eq# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE eq# #-}
 {-# ANN eq# hasBlackBox #-}
 eq# :: KnownNat n => BitVector n -> BitVector n -> Bool
 eq# (BV 0 v1) (BV 0 v2 ) = v1 == v2
 eq# bv1 bv2 = undefErrorI "==" bv1 bv2
 
-{-# NOINLINE neq# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE neq# #-}
 {-# ANN neq# hasBlackBox #-}
 neq# :: KnownNat n => BitVector n -> BitVector n -> Bool
 neq# (BV 0 v1) (BV 0 v2) = v1 /= v2
@@ -561,19 +579,23 @@ instance KnownNat n => Ord (BitVector n) where
   (<=) = le#
 
 lt#,ge#,gt#,le# :: KnownNat n => BitVector n -> BitVector n -> Bool
-{-# NOINLINE lt# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lt# #-}
 {-# ANN lt# hasBlackBox #-}
 lt# (BV 0 n) (BV 0 m) = n < m
 lt# bv1 bv2 = undefErrorI "<" bv1 bv2
-{-# NOINLINE ge# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ge# #-}
 {-# ANN ge# hasBlackBox #-}
 ge# (BV 0 n) (BV 0 m) = n >= m
 ge# bv1 bv2 = undefErrorI ">=" bv1 bv2
-{-# NOINLINE gt# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE gt# #-}
 {-# ANN gt# hasBlackBox #-}
 gt# (BV 0 n) (BV 0 m) = n > m
 gt# bv1 bv2 = undefErrorI ">" bv1 bv2
-{-# NOINLINE le# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE le# #-}
 {-# ANN le# hasBlackBox #-}
 le# (BV 0 n) (BV 0 m) = n <= m
 le#  bv1 bv2 = undefErrorI "<=" bv1 bv2
@@ -592,12 +614,14 @@ instance KnownNat n => Enum (BitVector n) where
 
 toEnum# :: forall n. KnownNat n => Int -> BitVector n
 toEnum# = fromInteger# 0 . toInteger
-{-# NOINLINE toEnum# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toEnum# #-}
 {-# ANN toEnum# hasBlackBox #-}
 
 fromEnum# :: forall n. KnownNat n => BitVector n -> Int
 fromEnum# = fromEnum . toInteger#
-{-# NOINLINE fromEnum# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromEnum# #-}
 {-# ANN fromEnum# hasBlackBox #-}
 
 enumFrom# :: forall n. KnownNat n => BitVector n -> [BitVector n]
@@ -608,7 +632,8 @@ enumFrom# (BV 0 x) = map (BV 0 . (`mod` m)) [x .. unsafeToNatural (maxBound :: B
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 enumFrom# bv = undefErrorU "enumFrom" bv
-{-# NOINLINE enumFrom# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFrom# #-}
 
 enumFromThen#
   :: forall n
@@ -627,7 +652,8 @@ enumFromThen# (BV 0 x) (BV 0 y) =
   m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 enumFromThen# bv1 bv2 = undefErrorP "enumFromThen" bv1 bv2
-{-# NOINLINE enumFromThen# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromThen# #-}
 
 enumFromTo#
   :: forall n
@@ -642,7 +668,8 @@ enumFromTo# (BV 0 x) (BV 0 y) = map (BV 0 . (`mod` m)) [x .. y]
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 enumFromTo# bv1 bv2 = undefErrorP "enumFromTo" bv1 bv2
-{-# NOINLINE enumFromTo# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromTo# #-}
 
 enumFromThenTo#
   :: forall n
@@ -658,7 +685,8 @@ enumFromThenTo# (BV 0 x1) (BV 0 x2) (BV 0 y) = map (BV 0 . (`mod` m)) [x1, x2 ..
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 enumFromThenTo# bv1 bv2 bv3 = undefErrorP3 "enumFromTo" bv1 bv2 bv3
-{-# NOINLINE enumFromThenTo# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromThenTo# #-}
 
 
 instance KnownNat n => Bounded (BitVector n) where
@@ -667,12 +695,14 @@ instance KnownNat n => Bounded (BitVector n) where
 
 minBound# :: BitVector n
 minBound# = BV 0 0
-{-# NOINLINE minBound# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE minBound# #-}
 {-# ANN minBound# hasBlackBox #-}
 
 maxBound# :: forall n. KnownNat n => BitVector n
 maxBound# = let m = 1 `shiftL` natToNum @n in BV 0 (m-1)
-{-# NOINLINE maxBound# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE maxBound# #-}
 {-# ANN maxBound# hasBlackBox #-}
 
 -- | __NB__: 'fromInteger'/'fromIntegral' can cause unexpected truncation, as
@@ -688,7 +718,8 @@ instance KnownNat n => Num (BitVector n) where
   fromInteger = fromInteger# 0
 
 (+#),(-#),(*#) :: forall n . KnownNat n => BitVector n -> BitVector n -> BitVector n
-{-# NOINLINE (+#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (+#) #-}
 {-# ANN (+#) hasBlackBox #-}
 (+#) = go
   where
@@ -701,7 +732,8 @@ instance KnownNat n => Num (BitVector n) where
     m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 
-{-# NOINLINE (-#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (-#) #-}
 {-# ANN (-#) hasBlackBox #-}
 (-#) = go
   where
@@ -714,7 +746,8 @@ instance KnownNat n => Num (BitVector n) where
     m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 
-{-# NOINLINE (*#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (*#) #-}
 {-# ANN (*#) hasBlackBox #-}
 (*#) = go
  where
@@ -727,7 +760,8 @@ instance KnownNat n => Num (BitVector n) where
   m = (1 `shiftL` fromInteger (natVal (Proxy @n))) - 1
 #endif
 
-{-# NOINLINE negate# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE negate# #-}
 {-# ANN negate# hasBlackBox #-}
 negate# :: forall n . KnownNat n => BitVector n -> BitVector n
 negate# = go
@@ -741,7 +775,8 @@ negate# = go
   m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 
-{-# NOINLINE fromInteger# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromInteger# #-}
 {-# ANN fromInteger# hasBlackBox #-}
 fromInteger# :: KnownNat n => Natural -> Integer -> BitVector n
 fromInteger# m i = sz `seq` mx
@@ -763,13 +798,15 @@ instance (KnownNat m, KnownNat n) => ExtendingNum (BitVector m) (BitVector n) wh
   type MResult (BitVector m) (BitVector n) = BitVector (m + n)
   mul = times#
 
-{-# NOINLINE plus# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE plus# #-}
 {-# ANN plus# hasBlackBox #-}
 plus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)
 plus# (BV 0 a) (BV 0 b) = BV 0 (a + b)
 plus# bv1 bv2 = undefErrorP "add" bv1 bv2
 
-{-# NOINLINE minus# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE minus# #-}
 {-# ANN minus# hasBlackBox #-}
 minus# :: forall m n . (KnownNat m, KnownNat n) => BitVector m -> BitVector n
                                                 -> BitVector (Max m n + 1)
@@ -784,7 +821,8 @@ minus# = go
   m = 1 `shiftL` fromInteger (natVal (Proxy @(Max m n + 1)))
 #endif
 
-{-# NOINLINE times# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE times# #-}
 {-# ANN times# hasBlackBox #-}
 times# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (m + n)
 times# (BV 0 a) (BV 0 b) = BV 0 (a * b)
@@ -806,16 +844,19 @@ instance KnownNat n => Integral (BitVector n) where
   toInteger   = toInteger#
 
 quot#,rem# :: KnownNat n => BitVector n -> BitVector n -> BitVector n
-{-# NOINLINE quot# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE quot# #-}
 {-# ANN quot# hasBlackBox #-}
 quot# (BV 0 i) (BV 0 j) = BV 0 (i `quot` j)
 quot# bv1 bv2 = undefErrorP "quot" bv1 bv2
-{-# NOINLINE rem# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rem# #-}
 {-# ANN rem# hasBlackBox #-}
 rem# (BV 0 i) (BV 0 j) = BV 0 (i `rem` j)
 rem# bv1 bv2 = undefErrorP "rem" bv1 bv2
 
-{-# NOINLINE toInteger# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toInteger# #-}
 {-# ANN toInteger# hasBlackBox #-}
 toInteger# :: KnownNat n => BitVector n -> Integer
 toInteger# (BV 0 i) = naturalToInteger i
@@ -854,7 +895,8 @@ countTrailingZerosBV :: KnownNat n => BitVector n -> I.Index (n+1)
 countTrailingZerosBV = V.foldl (\l r -> if eq## r low then 1 + l else 0) 0 . V.bv2v
 {-# INLINE countTrailingZerosBV #-}
 
-{-# NOINLINE reduceAnd# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE reduceAnd# #-}
 {-# ANN reduceAnd# hasBlackBox #-}
 reduceAnd# :: KnownNat n => BitVector n -> Bit
 reduceAnd# bv@(BV 0 i) = Bit 0 (W# (int2Word# (dataToTag# check)))
@@ -873,7 +915,8 @@ reduceAnd# bv@(BV m i) =
     sz    = natVal bv
     maxI  = (2 ^ sz) - 1
 
-{-# NOINLINE reduceOr# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE reduceOr# #-}
 {-# ANN reduceOr# hasBlackBox #-}
 reduceOr# :: KnownNat n => BitVector n -> Bit
 reduceOr# (BV 0 i) = Bit 0 (W# (int2Word# (dataToTag# check)))
@@ -885,7 +928,8 @@ reduceOr# bv@(BV m i) | defI /= 0 = Bit 0 1
   complementN = complementMod $ natVal bv
   defI = i .&. (complementN m)
 
-{-# NOINLINE reduceXor# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE reduceXor# #-}
 {-# ANN reduceXor# hasBlackBox #-}
 reduceXor# :: KnownNat n => BitVector n -> Bit
 reduceXor# (BV 0 i) = Bit 0 (fromIntegral (popCount i `mod` 2))
@@ -896,7 +940,8 @@ instance Default (BitVector n) where
 
 -- * Accessors
 -- ** Length information
-{-# NOINLINE size# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE size# #-}
 {-# ANN size# hasBlackBox #-}
 size# :: KnownNat n => BitVector n -> Int
 #if MIN_VERSION_base(4,15,0)
@@ -905,7 +950,8 @@ size# bv = fromIntegral (natVal bv)
 size# bv = fromInteger (natVal bv)
 #endif
 
-{-# NOINLINE maxIndex# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE maxIndex# #-}
 {-# ANN maxIndex# hasBlackBox #-}
 maxIndex# :: KnownNat n => BitVector n -> Int
 #if MIN_VERSION_base(4,15,0)
@@ -915,7 +961,8 @@ maxIndex# bv = fromInteger (natVal bv) - 1
 #endif
 
 -- ** Indexing
-{-# NOINLINE index# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE index# #-}
 {-# ANN index# hasBlackBox #-}
 index# :: KnownNat n => BitVector n -> Int -> Bit
 index# bv@(BV m v) i
@@ -935,7 +982,8 @@ index# bv@(BV m v) i
                          , "..0]"
                          ]
 
-{-# NOINLINE msb# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE msb# #-}
 {-# ANN msb# hasBlackBox #-}
 -- | MSB
 msb# :: forall n . KnownNat n => BitVector n -> Bit
@@ -961,14 +1009,16 @@ msb# (BV m v)
   msbN (NatJ# bn) = W# (bigNatToWord (shiftRBigNat bn (i# GHC.Exts.-# 1#)))
 #endif
 
-{-# NOINLINE lsb# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lsb# #-}
 {-# ANN lsb# hasBlackBox #-}
 -- | LSB
 lsb# :: BitVector n -> Bit
 lsb# (BV m v) = Bit (W# (int2Word# (dataToTag# (testBit m 0))))
                     (W# (int2Word# (dataToTag# (testBit v 0))))
 
-{-# NOINLINE slice# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE slice# #-}
 {-# ANN slice# hasBlackBox #-}
 slice# :: BitVector (m + 1 + i) -> SNat m -> SNat n -> BitVector (m + 1 - n)
 slice# (BV msk i) m n = BV (shiftR (msk .&. mask) n')
@@ -982,7 +1032,8 @@ slice# (BV msk i) m n = BV (shiftR (msk .&. mask) n')
 -- * Constructions
 
 -- ** Concatenation
-{-# NOINLINE (++#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (++#) #-}
 {-# ANN (++#) hasBlackBox #-}
 -- | Concatenate two 'BitVector's
 (++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)
@@ -999,7 +1050,8 @@ slice# (BV msk i) m n = BV (shiftR (msk .&. mask) n')
 #endif
 
 -- * Modifying BitVectors
-{-# NOINLINE replaceBit# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE replaceBit# #-}
 {-# ANN replaceBit# hasBlackBox #-}
 replaceBit# :: KnownNat n => BitVector n -> Int -> Bit -> BitVector n
 replaceBit# bv@(BV m v) i (Bit mb b)
@@ -1023,7 +1075,8 @@ replaceBit# bv@(BV m v) i (Bit mb b)
                           , "..0]"
                           ]
 
-{-# NOINLINE setSlice# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE setSlice# #-}
 {-# ANN setSlice# hasBlackBox #-}
 setSlice#
   :: forall m i n
@@ -1045,7 +1098,8 @@ setSlice# SNat =
  where
   complementN = complementMod (natVal (Proxy @(m + 1 + i)))
 
-{-# NOINLINE split# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE split# #-}
 {-# ANN split# hasBlackBox #-}
 split#
   :: forall n m
@@ -1071,7 +1125,8 @@ split# (BV m i) =
   in  (BV lMask l, BV rMask r)
 
 and#, or#, xor# :: forall n . KnownNat n => BitVector n -> BitVector n -> BitVector n
-{-# NOINLINE and# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE and# #-}
 {-# ANN and# hasBlackBox #-}
 and# =
   \(BV m1 v1) (BV m2 v2) ->
@@ -1080,7 +1135,8 @@ and# =
   where
     complementN = complementMod (natVal (Proxy @n))
 
-{-# NOINLINE or# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE or# #-}
 {-# ANN or# hasBlackBox #-}
 or# =
   \(BV m1 v1) (BV m2 v2) ->
@@ -1089,7 +1145,8 @@ or# =
   where
     complementN = complementMod (natVal (Proxy @n))
 
-{-# NOINLINE xor# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xor# #-}
 {-# ANN xor# hasBlackBox #-}
 xor# =
   \(BV m1 v1) (BV m2 v2) ->
@@ -1098,7 +1155,8 @@ xor# =
   where
     complementN = complementMod (natVal (Proxy @n))
 
-{-# NOINLINE complement# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE complement# #-}
 {-# ANN complement# hasBlackBox #-}
 complement# :: forall n . KnownNat n => BitVector n -> BitVector n
 complement# = \(BV m v) -> BV m (complementN v .&. complementN m)
@@ -1107,7 +1165,8 @@ complement# = \(BV m v) -> BV m (complementN v .&. complementN m)
 shiftL#, shiftR#, rotateL#, rotateR#
   :: forall n . KnownNat n => BitVector n -> Int -> BitVector n
 
-{-# NOINLINE shiftL# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE shiftL# #-}
 {-# ANN shiftL# hasBlackBox #-}
 shiftL# = \(BV msk v) i ->
   if | i < 0
@@ -1125,14 +1184,16 @@ shiftL# = \(BV msk v) i ->
   m = 1 `shiftL` sz
 #endif
 
-{-# NOINLINE shiftR# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE shiftR# #-}
 {-# ANN shiftR# hasBlackBox #-}
 shiftR# (BV m v) i
   | i < 0     = error
               $ "'shiftR' undefined for negative number: " ++ show i
   | otherwise = BV (shiftR m i) (shiftR v i)
 
-{-# NOINLINE rotateL# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotateL# #-}
 {-# ANN rotateL# hasBlackBox #-}
 rotateL# =
   \(BV msk v) b ->
@@ -1167,7 +1228,8 @@ rotateL# =
   m  = 1 `shiftL` sz
 #endif
 
-{-# NOINLINE rotateR# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotateR# #-}
 {-# ANN rotateR# hasBlackBox #-}
 rotateR# =
   \(BV msk v) b ->
@@ -1223,7 +1285,8 @@ truncateB# = \(BV msk i) -> BV (msk `mod` m) (i `mod` m)
 #else
   where m = 1 `shiftL` fromInteger (natVal (Proxy @a))
 #endif
-{-# NOINLINE truncateB# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE truncateB# #-}
 {-# ANN truncateB# hasBlackBox #-}
 
 instance KnownNat n => Lift (BitVector n) where
@@ -1361,7 +1424,8 @@ checkUnpackUndef _ bv = res
   where
     ty = typeOf res
     res = undefError (show ty ++ ".unpack") [bv]
-{-# NOINLINE checkUnpackUndef #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE checkUnpackUndef #-}
 {-# ANN checkUnpackUndef hasBlackBox #-}
 
 -- | Create a BitVector with all its bits undefined
@@ -1373,7 +1437,8 @@ undefined# =
   let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
   in  BV (m-1) 0
-{-# NOINLINE undefined# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE undefined# #-}
 {-# ANN undefined# hasBlackBox #-}
 
 -- | Check if one BitVector is similar to another, interpreting undefined bits
@@ -1402,7 +1467,8 @@ isLike# =
     in  e' == c' && e' == c''
  where
   complementN = complementMod (natVal (Proxy @n))
-{-# NOINLINE isLike# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE isLike# #-}
 
 fromBits :: [Bit] -> Integer
 fromBits = L.foldl (\v b -> v `shiftL` 1 .|. fromIntegral b) 0

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -172,7 +172,8 @@ newtype Index (n :: Nat) =
 
 {-# ANN I hasBlackBox #-}
 
-{-# NOINLINE size# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE size# #-}
 size# :: (KnownNat n, 1 <= n) => Index n -> Int
 size# = BV.size# . pack#
 
@@ -191,12 +192,14 @@ instance (KnownNat n, 1 <= n) => BitPack (Index n) where
 fromSNat :: (KnownNat m, n + 1 <= m) => SNat n -> Index m
 fromSNat = snatToNum
 
-{-# NOINLINE pack# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE pack# #-}
 {-# ANN pack# hasBlackBox #-}
 pack# :: Index n -> BitVector (CLog 2 n)
 pack# (I i) = BV 0 (naturalFromInteger i)
 
-{-# NOINLINE unpack# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unpack# #-}
 {-# ANN unpack# hasBlackBox #-}
 unpack# :: (KnownNat n, 1 <= n) => BitVector (CLog 2 n) -> Index n
 unpack# (BV 0 i) = fromInteger_INLINE (naturalToInteger i)
@@ -206,12 +209,14 @@ instance Eq (Index n) where
   (==) = eq#
   (/=) = neq#
 
-{-# NOINLINE eq# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE eq# #-}
 {-# ANN eq# hasBlackBox #-}
 eq# :: (Index n) -> (Index n) -> Bool
 (I n) `eq#` (I m) = n == m
 
-{-# NOINLINE neq# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE neq# #-}
 {-# ANN neq# hasBlackBox #-}
 neq# :: (Index n) -> (Index n) -> Bool
 (I n) `neq#` (I m) = n /= m
@@ -223,16 +228,20 @@ instance Ord (Index n) where
   (<=) = le#
 
 lt#,ge#,gt#,le# :: Index n -> Index n -> Bool
-{-# NOINLINE lt# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lt# #-}
 {-# ANN lt# hasBlackBox #-}
 lt# (I n) (I m) = n < m
-{-# NOINLINE ge# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ge# #-}
 {-# ANN ge# hasBlackBox #-}
 ge# (I n) (I m) = n >= m
-{-# NOINLINE gt# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE gt# #-}
 {-# ANN gt# hasBlackBox #-}
 gt# (I n) (I m) = n > m
-{-# NOINLINE le# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE le# #-}
 {-# ANN le# hasBlackBox #-}
 le# (I n) (I m) = n <= m
 
@@ -250,29 +259,35 @@ instance KnownNat n => Enum (Index n) where
 
 toEnum# :: forall n. KnownNat n => Int -> Index n
 toEnum# = fromInteger# . toInteger
-{-# NOINLINE toEnum# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toEnum# #-}
 {-# ANN toEnum# hasBlackBox #-}
 
 fromEnum# :: forall n. KnownNat n => Index n -> Int
 fromEnum# = fromEnum . toInteger#
-{-# NOINLINE fromEnum# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromEnum# #-}
 {-# ANN fromEnum# hasBlackBox #-}
 
 enumFrom# :: forall n. KnownNat n => Index n -> [Index n]
 enumFrom# x = [x .. maxBound]
-{-# NOINLINE enumFrom# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFrom# #-}
 
 enumFromThen# :: forall n. KnownNat n => Index n -> Index n -> [Index n]
 enumFromThen# x y = if x <= y then [x, y .. maxBound] else [x, y .. minBound]
-{-# NOINLINE enumFromThen# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromThen# #-}
 
 enumFromTo# :: Index n -> Index n -> [Index n]
 enumFromTo# x y = map I [unsafeToInteger x .. unsafeToInteger y]
-{-# NOINLINE enumFromTo# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromTo# #-}
 
 enumFromThenTo# :: Index n -> Index n -> Index n -> [Index n]
 enumFromThenTo# x1 x2 y = map I [unsafeToInteger x1, unsafeToInteger x2 .. unsafeToInteger y]
-{-# NOINLINE enumFromThenTo# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromThenTo# #-}
 
 instance KnownNat n => Bounded (Index n) where
   minBound = fromInteger# 0
@@ -283,7 +298,8 @@ maxBound# =
   case natToInteger @n of
     0 -> errorX "maxBound of 'Index 0' is undefined"
     n -> fromInteger_INLINE (n - 1)
-{-# NOINLINE maxBound# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE maxBound# #-}
 {-# ANN maxBound# hasBlackBox #-}
 
 -- | Operators report an error on overflow and underflow
@@ -301,15 +317,18 @@ instance KnownNat n => Num (Index n) where
   fromInteger = fromInteger#
 
 (+#),(-#),(*#) :: KnownNat n => Index n -> Index n -> Index n
-{-# NOINLINE (+#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (+#) #-}
 {-# ANN (+#) hasBlackBox #-}
 (+#) (I a) (I b) = fromInteger_INLINE $ a + b
 
-{-# NOINLINE (-#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (-#) #-}
 {-# ANN (-#) hasBlackBox #-}
 (-#) (I a) (I b) = fromInteger_INLINE $ a - b
 
-{-# NOINLINE (*#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (*#) #-}
 {-# ANN (*#) hasBlackBox #-}
 (*#) (I a) (I b) = fromInteger_INLINE $ a * b
 
@@ -318,7 +337,8 @@ negate# 0 = 0
 negate# i = maxBound -# i +# 1
 
 fromInteger# :: KnownNat n => Integer -> Index n
-{-# NOINLINE fromInteger# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromInteger# #-}
 {-# ANN fromInteger# hasBlackBox #-}
 fromInteger# = fromInteger_INLINE
 {-# INLINE fromInteger_INLINE #-}
@@ -337,11 +357,13 @@ instance ExtendingNum (Index m) (Index n) where
   mul = times#
 
 plus#, minus# :: Index m -> Index n -> Index (m + n - 1)
-{-# NOINLINE plus# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE plus# #-}
 {-# ANN plus# hasBlackBox #-}
 plus# (I a) (I b) = I (a + b)
 
-{-# NOINLINE minus# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE minus# #-}
 {-# ANN minus# hasBlackBox #-}
 minus# (I a) (I b) =
   let z   = a - b
@@ -350,7 +372,8 @@ minus# (I a) (I b) =
       res = if z < 0 then err else I z
   in  res
 
-{-# NOINLINE times# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE times# #-}
 {-# ANN times# hasBlackBox #-}
 times# :: Index m -> Index n -> Index (((m - 1) * (n - 1)) + 1)
 times# (I a) (I b) = I (a * b)
@@ -459,14 +482,17 @@ instance KnownNat n => Integral (Index n) where
   toInteger   = toInteger#
 
 quot#,rem# :: Index n -> Index n -> Index n
-{-# NOINLINE quot# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE quot# #-}
 {-# ANN quot# hasBlackBox #-}
 (I a) `quot#` (I b) = I (a `div` b)
-{-# NOINLINE rem# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rem# #-}
 {-# ANN rem# hasBlackBox #-}
 (I a) `rem#` (I b) = I (a `rem` b)
 
-{-# NOINLINE toInteger# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toInteger# #-}
 {-# ANN toInteger# hasBlackBox #-}
 toInteger# :: Index n -> Integer
 toInteger# (I n) = n
@@ -510,7 +536,8 @@ instance Resize Index where
 
 resize# :: KnownNat m => Index n -> Index m
 resize# (I i) = fromInteger_INLINE i
-{-# NOINLINE resize# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE resize# #-}
 {-# ANN resize# hasBlackBox #-}
 
 instance KnownNat n => Lift (Index n) where

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -203,7 +203,8 @@ instance NFDataX (Signed n) where
   deepErrorX = errorX
   rnfX = rwhnfX
 
-{-# NOINLINE size# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE size# #-}
 {-# ANN size# hasBlackBox #-}
 size# :: KnownNat n => Signed n -> Int
 size# bv = fromInteger (natVal bv)
@@ -230,13 +231,15 @@ instance KnownNat n => BitPack (Signed n) where
   pack   = packXWith pack#
   unpack = unpack#
 
-{-# NOINLINE pack# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE pack# #-}
 {-# ANN pack# hasBlackBox #-}
 pack# :: forall n . KnownNat n => Signed n -> BitVector n
 pack# (S i) = let m = 1 `shiftL0` fromInteger (natVal (Proxy @n))
               in  if i < 0 then BV 0 (naturalFromInteger (m + i)) else BV 0 (naturalFromInteger i)
 
-{-# NOINLINE unpack# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unpack# #-}
 {-# ANN unpack# hasBlackBox #-}
 unpack# :: forall n . KnownNat n => BitVector n -> Signed n
 unpack# (BV 0 i) =
@@ -249,12 +252,14 @@ instance Eq (Signed n) where
   (==) = eq#
   (/=) = neq#
 
-{-# NOINLINE eq# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE eq# #-}
 {-# ANN eq# hasBlackBox #-}
 eq# :: Signed n -> Signed n -> Bool
 eq# (S v1) (S v2) = v1 == v2
 
-{-# NOINLINE neq# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE neq# #-}
 {-# ANN neq# hasBlackBox #-}
 neq# :: Signed n -> Signed n -> Bool
 neq# (S v1) (S v2) = v1 /= v2
@@ -266,16 +271,20 @@ instance Ord (Signed n) where
   (<=) = le#
 
 lt#,ge#,gt#,le# :: Signed n -> Signed n -> Bool
-{-# NOINLINE lt# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lt# #-}
 {-# ANN lt# hasBlackBox #-}
 lt# (S n) (S m) = n < m
-{-# NOINLINE ge# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ge# #-}
 {-# ANN ge# hasBlackBox #-}
 ge# (S n) (S m) = n >= m
-{-# NOINLINE gt# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE gt# #-}
 {-# ANN gt# hasBlackBox #-}
 gt# (S n) (S m) = n > m
-{-# NOINLINE le# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE le# #-}
 {-# ANN le# hasBlackBox #-}
 le# (S n) (S m) = n <= m
 
@@ -307,12 +316,14 @@ instance KnownNat n => Enum (Signed n) where
 
 toEnum# :: forall n. KnownNat n => Int -> Signed n
 toEnum# = fromInteger# . toInteger
-{-# NOINLINE toEnum# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toEnum# #-}
 {-# ANN toEnum# hasBlackBox #-}
 
 fromEnum# :: forall n. KnownNat n => Signed n -> Int
 fromEnum# = fromEnum . toInteger#
-{-# NOINLINE fromEnum# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromEnum# #-}
 {-# ANN fromEnum# hasBlackBox #-}
 
 enumFrom# :: forall n. KnownNat n => Signed n -> [Signed n]
@@ -320,7 +331,8 @@ enumFrom# x = map (fromInteger_INLINE sz mB mask) [unsafeToInteger x .. unsafeTo
   where sz   = fromInteger (natVal (Proxy @n)) - 1
         mB   = 1 `shiftL` sz
         mask = mB - 1
-{-# NOINLINE enumFrom# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFrom# #-}
 
 enumFromThen# :: forall n. KnownNat n => Signed n -> Signed n -> [Signed n]
 enumFromThen# x y =
@@ -331,21 +343,24 @@ enumFromThen# x y =
   sz = fromInteger (natVal (Proxy @n)) - 1
   mB = 1 `shiftL` sz
   mask = mB - 1
-{-# NOINLINE enumFromThen# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromThen# #-}
 
 enumFromTo# :: forall n. KnownNat n => Signed n -> Signed n -> [Signed n]
 enumFromTo# x y = map (fromInteger_INLINE sz mB mask) [unsafeToInteger x .. unsafeToInteger y]
   where sz   = fromInteger (natVal (Proxy @n)) - 1
         mB   = 1 `shiftL` sz
         mask = mB - 1
-{-# NOINLINE enumFromTo# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromTo# #-}
 
 enumFromThenTo# :: forall n. KnownNat n => Signed n -> Signed n -> Signed n -> [Signed n]
 enumFromThenTo# x1 x2 y = map (fromInteger_INLINE sz mB mask) [unsafeToInteger x1, unsafeToInteger x2 .. unsafeToInteger y]
   where sz   = fromInteger (natVal (Proxy @n)) - 1
         mB   = 1 `shiftL` sz
         mask = mB - 1
-{-# NOINLINE enumFromThenTo# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromThenTo# #-}
 
 
 instance KnownNat n => Bounded (Signed n) where
@@ -357,7 +372,8 @@ minBound# =
   case natToNatural @n of
     0 -> 0
     n -> S (negate $ 2 ^ (n - 1))
-{-# NOINLINE minBound# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE minBound# #-}
 {-# ANN minBound# hasBlackBox #-}
 
 maxBound# :: forall n. KnownNat n => Signed n
@@ -365,7 +381,8 @@ maxBound# =
   case natToNatural @n of
     0 -> 0
     n -> S (2 ^ (n - 1) - 1)
-{-# NOINLINE maxBound# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE maxBound# #-}
 {-# ANN maxBound# hasBlackBox #-}
 
 -- | Operators do @wrap-around@ on overflow
@@ -384,7 +401,8 @@ instance KnownNat n => Num (Signed n) where
   fromInteger = fromInteger#
 
 (+#), (-#), (*#) :: forall n . KnownNat n => Signed n -> Signed n -> Signed n
-{-# NOINLINE (+#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (+#) #-}
 {-# ANN (+#) hasBlackBox #-}
 (+#) =
   \(S a) (S b) ->
@@ -398,7 +416,8 @@ instance KnownNat n => Num (Signed n) where
  where
   m = 1 `shiftL0` fromInteger (natVal (Proxy @n) -1)
 
-{-# NOINLINE (-#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (-#) #-}
 {-# ANN (-#) hasBlackBox #-}
 (-#) =
   \(S a) (S b) ->
@@ -412,7 +431,8 @@ instance KnownNat n => Num (Signed n) where
  where
   m  = 1 `shiftL0` fromInteger (natVal (Proxy @n) -1)
 
-{-# NOINLINE (*#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (*#) #-}
 {-# ANN (*#) hasBlackBox #-}
 (*#) = \(S a) (S b) -> fromInteger_INLINE sz mB mask (a * b)
   where sz   = fromInteger (natVal (Proxy @n)) - 1
@@ -420,7 +440,8 @@ instance KnownNat n => Num (Signed n) where
         mask = mB - 1
 
 negate#,abs# :: forall n . KnownNat n => Signed n -> Signed n
-{-# NOINLINE negate# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE negate# #-}
 {-# ANN negate# hasBlackBox #-}
 negate# =
   \(S n) ->
@@ -429,7 +450,8 @@ negate# =
  where
   m = 1 `shiftL0` fromInteger (natVal (Proxy @n) -1)
 
-{-# NOINLINE abs# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE abs# #-}
 {-# ANN abs# hasBlackBox #-}
 abs# =
   \(S n) ->
@@ -438,7 +460,8 @@ abs# =
  where
   m = 1 `shiftL0` fromInteger (natVal (Proxy @n) -1)
 
-{-# NOINLINE fromInteger# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromInteger# #-}
 {-# ANN fromInteger# hasBlackBox #-}
 fromInteger# :: forall n . KnownNat n => Integer -> Signed (n :: Nat)
 fromInteger# = fromInteger_INLINE sz mB mask
@@ -463,15 +486,18 @@ instance ExtendingNum (Signed m) (Signed n) where
   mul = times#
 
 plus#, minus# :: Signed m -> Signed n -> Signed (Max m n + 1)
-{-# NOINLINE plus# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE plus# #-}
 {-# ANN plus# hasBlackBox #-}
 plus# (S a) (S b) = S (a + b)
 
-{-# NOINLINE minus# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE minus# #-}
 {-# ANN minus# hasBlackBox #-}
 minus# (S a) (S b) = S (a - b)
 
-{-# NOINLINE times# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE times# #-}
 {-# ANN times# hasBlackBox #-}
 times# :: Signed m -> Signed n -> Signed (m + n)
 times# (S a) (S b) = S (a * b)
@@ -491,7 +517,8 @@ instance KnownNat n => Integral (Signed n) where
   divMod  n d = (n `div#`  d,n `mod#` d)
   toInteger   = toInteger#
 
-{-# NOINLINE quot# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE quot# #-}
 {-# ANN quot# hasBlackBox #-}
 quot# :: forall n. KnownNat n => Signed n -> Signed n -> Signed n
 quot# (S a) (S b)
@@ -500,12 +527,14 @@ quot# (S a) (S b)
  where
   S minB = minBound @(Signed n)
 
-{-# NOINLINE rem# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rem# #-}
 {-# ANN rem# hasBlackBox #-}
 rem# :: Signed n -> Signed n -> Signed n
 rem# (S a) (S b) = S (a `rem` b)
 
-{-# NOINLINE div# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE div# #-}
 {-# ANN div# hasBlackBox #-}
 div# :: forall n. KnownNat n => Signed n -> Signed n -> Signed n
 div# (S a) (S b)
@@ -514,12 +543,14 @@ div# (S a) (S b)
  where
   S minB = minBound @(Signed n)
 
-{-# NOINLINE mod# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE mod# #-}
 {-# ANN mod# hasBlackBox #-}
 mod# :: Signed n -> Signed n -> Signed n
 mod# (S a) (S b) = S (a `mod` b)
 
-{-# NOINLINE toInteger# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toInteger# #-}
 {-# ANN toInteger# hasBlackBox #-}
 toInteger# :: Signed n -> Integer
 toInteger# (S n) = n
@@ -552,28 +583,32 @@ instance KnownNat n => Bits (Signed n) where
   popCount s        = popCount (pack# s)
 
 and#,or#,xor# :: forall n . KnownNat n => Signed n -> Signed n -> Signed n
-{-# NOINLINE and# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE and# #-}
 {-# ANN and# hasBlackBox #-}
 and# = \(S a) (S b) -> fromInteger_INLINE sz mB mask (a .&. b)
   where sz   = fromInteger (natVal (Proxy @n)) - 1
         mB   = 1 `shiftL` sz
         mask = mB - 1
 
-{-# NOINLINE or# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE or# #-}
 {-# ANN or# hasBlackBox #-}
 or# = \(S a) (S b) -> fromInteger_INLINE sz mB mask (a .|. b)
   where sz   = fromInteger (natVal (Proxy @n)) - 1
         mB   = 1 `shiftL` sz
         mask = mB - 1
 
-{-# NOINLINE xor# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xor# #-}
 {-# ANN xor# hasBlackBox #-}
 xor# = \(S a) (S b) -> fromInteger_INLINE sz mB mask (xor a b)
   where sz   = fromInteger (natVal (Proxy @n)) - 1
         mB   = 1 `shiftL` sz
         mask = mB - 1
 
-{-# NOINLINE complement# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE complement# #-}
 {-# ANN complement# hasBlackBox #-}
 complement# :: forall n . KnownNat n => Signed n -> Signed n
 complement# = \(S a) -> fromInteger_INLINE sz mB mask (complement a)
@@ -582,7 +617,8 @@ complement# = \(S a) -> fromInteger_INLINE sz mB mask (complement a)
         mask = mB - 1
 
 shiftL#,shiftR#,rotateL#,rotateR# :: forall n . KnownNat n => Signed n -> Int -> Signed n
-{-# NOINLINE shiftL# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE shiftL# #-}
 {-# ANN shiftL# hasBlackBox #-}
 shiftL# = \(S n) b ->
   if | b < 0     -> error $ "'shiftL' undefined for negative number: " ++ show b
@@ -593,7 +629,8 @@ shiftL# = \(S n) b ->
   mB   = 1 `shiftL` sz
   mask = mB - 1
 
-{-# NOINLINE shiftR# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE shiftR# #-}
 {-# ANN shiftR# hasBlackBox #-}
 shiftR# =
   \(S n) b ->
@@ -606,7 +643,8 @@ shiftR# =
   mB   = 1 `shiftL` sz
   mask = mB - 1
 
-{-# NOINLINE rotateL# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotateL# #-}
 {-# ANN rotateL# hasBlackBox #-}
 rotateL# =
   \(S n) b ->
@@ -626,7 +664,8 @@ rotateL# =
   mB    = 1 `shiftL` sz1
   maskM = mB - 1
 
-{-# NOINLINE rotateR# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotateR# #-}
 {-# ANN rotateR# hasBlackBox #-}
 rotateR# =
   \(S n) b ->
@@ -656,7 +695,8 @@ instance Resize Signed where
   zeroExtend s = unpack# (0 ++# pack s)
   truncateB    = truncateB#
 
-{-# NOINLINE resize# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE resize# #-}
 {-# ANN resize# hasBlackBox #-}
 resize# :: forall m n . (KnownNat n, KnownNat m) => Signed n -> Signed m
 resize# s@(S i)
@@ -675,7 +715,8 @@ resize# s@(S i)
                    then S (i' - mask)
                    else S i'
 
-{-# NOINLINE truncateB# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE truncateB# #-}
 {-# ANN truncateB# hasBlackBox #-}
 truncateB# :: forall m n . KnownNat m => Signed (m + n) -> Signed m
 truncateB# = \(S n) -> fromInteger_INLINE sz mB mask n

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -215,7 +215,8 @@ newtype Unsigned (n :: Nat) =
 
 {-# ANN U hasBlackBox #-}
 
-{-# NOINLINE size# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE size# #-}
 {-# ANN size# hasBlackBox #-}
 size# :: KnownNat n => Unsigned n -> Int
 #if MIN_VERSION_base(4,15,0)
@@ -250,12 +251,14 @@ instance KnownNat n => BitPack (Unsigned n) where
   pack   = packXWith pack#
   unpack = unpack#
 
-{-# NOINLINE pack# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE pack# #-}
 {-# ANN pack# hasBlackBox #-}
 pack# :: Unsigned n -> BitVector n
 pack# (U i) = BV 0 i
 
-{-# NOINLINE unpack# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unpack# #-}
 {-# ANN unpack# hasBlackBox #-}
 unpack# :: KnownNat n => BitVector n -> Unsigned n
 unpack# (BV 0 i) = U i
@@ -265,12 +268,14 @@ instance Eq (Unsigned n) where
   (==) = eq#
   (/=) = neq#
 
-{-# NOINLINE eq# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE eq# #-}
 {-# ANN eq# hasBlackBox #-}
 eq# :: Unsigned n -> Unsigned n -> Bool
 eq# (U v1) (U v2) = v1 == v2
 
-{-# NOINLINE neq# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE neq# #-}
 {-# ANN neq# hasBlackBox #-}
 neq# :: Unsigned n -> Unsigned n -> Bool
 neq# (U v1) (U v2) = v1 /= v2
@@ -282,16 +287,20 @@ instance Ord (Unsigned n) where
   (<=) = le#
 
 lt#,ge#,gt#,le# :: Unsigned n -> Unsigned n -> Bool
-{-# NOINLINE lt# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lt# #-}
 {-# ANN lt# hasBlackBox #-}
 lt# (U n) (U m) = n < m
-{-# NOINLINE ge# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ge# #-}
 {-# ANN ge# hasBlackBox #-}
 ge# (U n) (U m) = n >= m
-{-# NOINLINE gt# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE gt# #-}
 {-# ANN gt# hasBlackBox #-}
 gt# (U n) (U m) = n > m
-{-# NOINLINE le# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE le# #-}
 {-# ANN le# hasBlackBox #-}
 le# (U n) (U m) = n <= m
 
@@ -322,12 +331,14 @@ instance KnownNat n => Enum (Unsigned n) where
 
 toEnum# :: forall n. KnownNat n => Int -> Unsigned n
 toEnum# = fromInteger# . toInteger
-{-# NOINLINE toEnum# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toEnum# #-}
 {-# ANN toEnum# hasBlackBox #-}
 
 fromEnum# :: forall n. KnownNat n => Unsigned n -> Int
 fromEnum# = fromEnum . toInteger#
-{-# NOINLINE fromEnum# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromEnum# #-}
 {-# ANN fromEnum# hasBlackBox #-}
 
 enumFrom# :: forall n. KnownNat n => Unsigned n -> [Unsigned n]
@@ -337,7 +348,8 @@ enumFrom# = \x -> map (U . (`mod` m)) [unsafeToNatural x .. unsafeToNatural (max
 #else
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
-{-# NOINLINE enumFrom# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFrom# #-}
 
 enumFromThen# :: forall n. KnownNat n => Unsigned n -> Unsigned n -> [Unsigned n]
 enumFromThen# = \x y -> toUnsigneds [unsafeToNatural x, unsafeToNatural y .. bound x y]
@@ -349,7 +361,8 @@ enumFromThen# = \x y -> toUnsigneds [unsafeToNatural x, unsafeToNatural y .. bou
 #else
   m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
-{-# NOINLINE enumFromThen# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromThen# #-}
 
 enumFromTo# :: forall n. KnownNat n => Unsigned n -> Unsigned n -> [Unsigned n]
 enumFromTo# = \x y -> map (U . (`mod` m)) [unsafeToNatural x .. unsafeToNatural y]
@@ -358,7 +371,8 @@ enumFromTo# = \x y -> map (U . (`mod` m)) [unsafeToNatural x .. unsafeToNatural 
 #else
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
-{-# NOINLINE enumFromTo# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromTo# #-}
 
 enumFromThenTo# :: forall n. KnownNat n => Unsigned n -> Unsigned n -> Unsigned n -> [Unsigned n]
 enumFromThenTo# = \x1 x2 y -> map (U . (`mod` m)) [unsafeToNatural x1, unsafeToNatural x2 .. unsafeToNatural y]
@@ -367,7 +381,8 @@ enumFromThenTo# = \x1 x2 y -> map (U . (`mod` m)) [unsafeToNatural x1, unsafeToN
 #else
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
-{-# NOINLINE enumFromThenTo# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE enumFromThenTo# #-}
 
 instance KnownNat n => Bounded (Unsigned n) where
   minBound = minBound#
@@ -375,12 +390,14 @@ instance KnownNat n => Bounded (Unsigned n) where
 
 minBound# :: Unsigned n
 minBound# = U 0
-{-# NOINLINE minBound# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE minBound# #-}
 {-# ANN minBound# hasBlackBox #-}
 
 maxBound# :: forall n. KnownNat n => Unsigned n
 maxBound# = let m = 1 `shiftL` (natToNum @n) in  U (m - 1)
-{-# NOINLINE maxBound# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE maxBound# #-}
 {-# ANN maxBound# hasBlackBox #-}
 
 -- | __NB__: 'fromInteger'/'fromIntegral' can cause unexpected truncation, as
@@ -396,7 +413,8 @@ instance KnownNat n => Num (Unsigned n) where
   fromInteger = fromInteger#
 
 (+#),(-#),(*#) :: forall n . KnownNat n => Unsigned n -> Unsigned n -> Unsigned n
-{-# NOINLINE (+#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (+#) #-}
 {-# ANN (+#) hasBlackBox #-}
 (+#) = \(U i) (U j) -> U (addMod m i j)
 #if MIN_VERSION_base(4,15,0)
@@ -405,7 +423,8 @@ instance KnownNat n => Num (Unsigned n) where
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 
-{-# NOINLINE (-#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (-#) #-}
 {-# ANN (-#) hasBlackBox #-}
 (-#) = \(U i) (U j) -> U (subMod m i j)
 #if MIN_VERSION_base(4,15,0)
@@ -414,7 +433,8 @@ instance KnownNat n => Num (Unsigned n) where
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 
-{-# NOINLINE (*#) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (*#) #-}
 {-# ANN (*#) hasBlackBox #-}
 (*#) = \(U i) (U j) -> U (mulMod2 m i j)
 #if MIN_VERSION_base(4,15,0)
@@ -423,7 +443,8 @@ instance KnownNat n => Num (Unsigned n) where
   where m = (1 `shiftL` fromInteger (natVal (Proxy @n))) - 1
 #endif
 
-{-# NOINLINE negate# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE negate# #-}
 {-# ANN negate# hasBlackBox #-}
 negate# :: forall n . KnownNat n => Unsigned n -> Unsigned n
 negate# = \(U i) -> U (negateMod m i)
@@ -433,7 +454,8 @@ negate# = \(U i) -> U (negateMod m i)
   where m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 #endif
 
-{-# NOINLINE fromInteger# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromInteger# #-}
 {-# ANN fromInteger# hasBlackBox #-}
 fromInteger# :: forall n . KnownNat n => Integer -> Unsigned n
 #if MIN_VERSION_base(4,15,0)
@@ -453,12 +475,14 @@ instance (KnownNat m, KnownNat n) => ExtendingNum (Unsigned m) (Unsigned n) wher
   type MResult (Unsigned m) (Unsigned n) = Unsigned (m + n)
   mul = times#
 
-{-# NOINLINE plus# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE plus# #-}
 {-# ANN plus# hasBlackBox #-}
 plus# :: Unsigned m -> Unsigned n -> Unsigned (Max m n + 1)
 plus# (U a) (U b) = U (a + b)
 
-{-# NOINLINE minus# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE minus# #-}
 {-# ANN minus# hasBlackBox #-}
 minus# :: forall m n . (KnownNat m, KnownNat n) => Unsigned m -> Unsigned n
                                                 -> Unsigned (Max m n + 1)
@@ -472,7 +496,8 @@ minus# = \(U a) (U b) -> U (subMod mask a b)
   mask = 1 `shiftL` sz
 #endif
 
-{-# NOINLINE times# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE times# #-}
 {-# ANN times# hasBlackBox #-}
 times# :: Unsigned m -> Unsigned n -> Unsigned (m + n)
 times# (U a) (U b) = U (a * b)
@@ -493,14 +518,17 @@ instance KnownNat n => Integral (Unsigned n) where
   toInteger   = toInteger#
 
 quot#,rem# :: Unsigned n -> Unsigned n -> Unsigned n
-{-# NOINLINE quot# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE quot# #-}
 {-# ANN quot# hasBlackBox #-}
 quot# (U i) (U j) = U (i `quot` j)
-{-# NOINLINE rem# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rem# #-}
 {-# ANN rem# hasBlackBox #-}
 rem# (U i) (U j) = U (i `rem` j)
 
-{-# NOINLINE toInteger# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE toInteger# #-}
 {-# ANN toInteger# hasBlackBox #-}
 toInteger# :: Unsigned n -> Integer
 toInteger# (U i) = naturalToInteger i
@@ -532,29 +560,34 @@ instance KnownNat n => Bits (Unsigned n) where
   rotateR v i       = rotateR# v i
   popCount u        = popCount (pack# u)
 
-{-# NOINLINE and# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE and# #-}
 {-# ANN and# hasBlackBox #-}
 and# :: Unsigned n -> Unsigned n -> Unsigned n
 and# (U v1) (U v2) = U (v1 .&. v2)
 
-{-# NOINLINE or# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE or# #-}
 {-# ANN or# hasBlackBox #-}
 or# :: Unsigned n -> Unsigned n -> Unsigned n
 or# (U v1) (U v2) = U (v1 .|. v2)
 
-{-# NOINLINE xor# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xor# #-}
 {-# ANN xor# hasBlackBox #-}
 xor# :: Unsigned n -> Unsigned n -> Unsigned n
 xor# (U v1) (U v2) = U (v1 `xor` v2)
 
-{-# NOINLINE complement# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE complement# #-}
 {-# ANN complement# hasBlackBox #-}
 complement# :: forall n . KnownNat n => Unsigned n -> Unsigned n
 complement# = \(U i) -> U (complementN i)
   where complementN = complementMod (natVal (Proxy @n))
 
 shiftL#, shiftR#, rotateL#, rotateR# :: forall n .KnownNat n => Unsigned n -> Int -> Unsigned n
-{-# NOINLINE shiftL# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE shiftL# #-}
 {-# ANN shiftL# hasBlackBox #-}
 shiftL# = \(U v) i ->
 #if MIN_VERSION_base(4,15,0)
@@ -574,7 +607,8 @@ shiftL# = \(U v) i ->
   m  = 1 `shiftL` sz
 #endif
 
-{-# NOINLINE shiftR# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE shiftR# #-}
 {-# ANN shiftR# hasBlackBox #-}
 -- shiftR# doesn't need the KnownNat constraint
 -- But having the same type signature for all shift and rotate functions
@@ -584,7 +618,8 @@ shiftR# (U v) i
               $ "'shiftR' undefined for negative number: " ++ show i
   | otherwise = U (shiftR v i)
 
-{-# NOINLINE rotateL# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotateL# #-}
 {-# ANN rotateL# hasBlackBox #-}
 rotateL# =
   \(U n) b ->
@@ -611,7 +646,8 @@ rotateL# =
     m  = 1 `shiftL` sz
 #endif
 
-{-# NOINLINE rotateR# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotateR# #-}
 {-# ANN rotateR# hasBlackBox #-}
 rotateR# =
   \(U n) b ->
@@ -649,7 +685,8 @@ instance Resize Unsigned where
   zeroExtend = extend
   truncateB  = resize#
 
-{-# NOINLINE resize# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE resize# #-}
 {-# ANN resize# hasBlackBox #-}
 resize# :: forall n m . KnownNat m => Unsigned n -> Unsigned m
 resize# = \(U i) -> if i >= m then U (i `mod` m) else U i
@@ -768,7 +805,8 @@ unsignedToWord (U (NB u#)) = bigNatToWord u#
 unsignedToWord (U (NatS# u#)) = W# u#
 unsignedToWord (U (NatJ# u#)) = W# (bigNatToWord u#)
 #endif
-{-# NOINLINE unsignedToWord #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unsignedToWord #-}
 {-# ANN unsignedToWord hasBlackBox #-}
 
 unsigned8toWord8 :: Unsigned 8 -> Word8
@@ -782,7 +820,8 @@ unsigned8toWord8 (U (NB u#)) = W8# (narrow8Word# (bigNatToWord# u#))
 unsigned8toWord8 (U (NatS# u#)) = W8# (narrow8Word# u#)
 unsigned8toWord8 (U (NatJ# u#)) = W8# (narrow8Word# (bigNatToWord u#))
 #endif
-{-# NOINLINE unsigned8toWord8 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unsigned8toWord8 #-}
 {-# ANN unsigned8toWord8 hasBlackBox #-}
 
 unsigned16toWord16 :: Unsigned 16 -> Word16
@@ -796,7 +835,8 @@ unsigned16toWord16 (U (NB u#)) = W16# (narrow16Word# (bigNatToWord# u#))
 unsigned16toWord16 (U (NatS# u#)) = W16# (narrow16Word# u#)
 unsigned16toWord16 (U (NatJ# u#)) = W16# (narrow16Word# (bigNatToWord u#))
 #endif
-{-# NOINLINE unsigned16toWord16 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unsigned16toWord16 #-}
 {-# ANN unsigned16toWord16 hasBlackBox #-}
 
 unsigned32toWord32 :: Unsigned 32 -> Word32
@@ -810,7 +850,8 @@ unsigned32toWord32 (U (NB u#)) = W32# (narrow32Word# (bigNatToWord# u#))
 unsigned32toWord32 (U (NatS# u#)) = W32# (narrow32Word# u#)
 unsigned32toWord32 (U (NatJ# u#)) = W32# (narrow32Word# (bigNatToWord u#))
 #endif
-{-# NOINLINE unsigned32toWord32 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unsigned32toWord32 #-}
 {-# ANN unsigned32toWord32 hasBlackBox #-}
 
 {-# RULES

--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -127,7 +127,8 @@ textract (RLeaf x)   = x
 #if __GLASGOW_HASKELL__ != 902
 textract (RBranch _ _) = error $ "textract: nodes hold no values"
 #endif
-{-# NOINLINE textract #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE textract #-}
 {-# ANN textract hasBlackBox #-}
 
 tsplit :: RTree (d+1) a -> (RTree d a,RTree d a)
@@ -135,7 +136,8 @@ tsplit (RBranch l r) = (l,r)
 #if __GLASGOW_HASKELL__ != 902
 tsplit (RLeaf _)   = error $ "tsplit: leaf is atomic"
 #endif
-{-# NOINLINE tsplit #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tsplit #-}
 {-# ANN tsplit hasBlackBox #-}
 
 -- | RLeaf of a perfect depth tree
@@ -388,7 +390,8 @@ tdfold _ f g = go SNat
     go _  (RLeaf a)   = f a
     go sn (RBranch l r) = let sn' = sn `subSNat` d1
                       in  g sn' (go sn' l) (go sn' r)
-{-# NOINLINE tdfold #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tdfold #-}
 {-# ANN tdfold hasBlackBox #-}
 
 data TfoldTree (a :: Type) (f :: TyFun Nat Type) :: Type
@@ -417,7 +420,8 @@ treplicate sn a = go (toUNat sn)
     go :: UNat n -> RTree n a
     go UZero      = LR a
     go (USucc un) = BR (go un) (go un)
-{-# NOINLINE treplicate #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE treplicate #-}
 {-# ANN treplicate hasBlackBox #-}
 
 -- | \"'trepeat' @a@\" creates a tree with as many copies of /a/ as demanded by

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -338,7 +338,8 @@ instance Functor (Vec n) where
 instance (KnownNat n, 1 <= n) => Traversable (Vec n) where
   traverse = traverse#
 
-{-# NOINLINE traverse# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE traverse# #-}
 {-# ANN traverse# hasBlackBox #-}
 traverse# :: forall a f b n . Applicative f => (a -> f b) -> Vec n a -> f (Vec n b)
 traverse# _ Nil           = pure Nil
@@ -373,7 +374,8 @@ instance (NFDataX a, KnownNat n) => NFDataX (Vec n a) where
 singleton :: a -> Vec 1 a
 singleton = (`Cons` Nil)
 
-{-# NOINLINE head #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE head #-}
 {-# ANN head hasBlackBox #-}
 {- | Extract the first element of a vector
 
@@ -407,7 +409,8 @@ singleton = (`Cons` Nil)
 head :: Vec (n + 1) a -> a
 head (x `Cons` _) = x
 
-{-# NOINLINE tail #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tail #-}
 {-# ANN tail hasBlackBox #-}
 {- | Extract the elements after the head of a vector
 
@@ -441,7 +444,8 @@ head (x `Cons` _) = x
 tail :: Vec (n + 1) a -> Vec n a
 tail (_ `Cons` xs) = xs
 
-{-# NOINLINE last #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE last #-}
 {-# ANN last hasBlackBox #-}
 {- | Extract the last element of a vector
 
@@ -476,7 +480,8 @@ last :: Vec (n + 1) a -> a
 last (x `Cons` Nil)         = x
 last (_ `Cons` y `Cons` ys) = last (y `Cons` ys)
 
-{-# NOINLINE init #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE init #-}
 {-# ANN init hasBlackBox #-}
 {- | Extract all the elements of a vector except the last element
 
@@ -644,7 +649,8 @@ infixr 5 ++
 (++) :: Vec n a -> Vec m a -> Vec (n + m) a
 Nil           ++ ys = ys
 (x `Cons` xs) ++ ys = x `Cons` xs ++ ys
-{-# NOINLINE (++) #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE (++) #-}
 {-# ANN (++) hasBlackBox #-}
 
 -- | Split a vector into two vectors at the given point.
@@ -655,7 +661,8 @@ Nil           ++ ys = ys
 -- (1 :> 2 :> 3 :> Nil,7 :> 8 :> Nil)
 splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)
 splitAt n xs = splitAtU (toUNat n) xs
-{-# NOINLINE splitAt #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE splitAt #-}
 {-# ANN splitAt hasBlackBox #-}
 
 splitAtU :: UNat m -> Vec (m + n) a -> (Vec m a, Vec n a)
@@ -679,7 +686,8 @@ splitAtI = withSNat splitAt
 concat :: Vec n (Vec m a) -> Vec (n * m) a
 concat Nil           = Nil
 concat (x `Cons` xs) = x ++ concat xs
-{-# NOINLINE concat #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE concat #-}
 {-# ANN concat hasBlackBox #-}
 
 -- | Map a function over all the elements of a vector and concatentate the resulting vectors.
@@ -697,7 +705,8 @@ concatMap f xs = concat (map f xs)
 -- (1 :> 2 :> 3 :> 4 :> Nil) :> (5 :> 6 :> 7 :> 8 :> Nil) :> (9 :> 10 :> 11 :> 12 :> Nil) :> Nil
 unconcat :: KnownNat n => SNat m -> Vec (n * m) a -> Vec n (Vec m a)
 unconcat n xs = unconcatU (withSNat toUNat) (toUNat n) xs
-{-# NOINLINE unconcat #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unconcat #-}
 {-# ANN unconcat hasBlackBox #-}
 
 unconcatU :: UNat n -> UNat m -> Vec (n * m) a -> Vec n (Vec m a)
@@ -729,7 +738,8 @@ merge x y = concat (transpose (x :> singleton y))
 reverse :: Vec n a -> Vec n a
 reverse Nil           = Nil
 reverse (x `Cons` xs) = reverse xs :< x
-{-# NOINLINE reverse #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE reverse #-}
 {-# ANN reverse hasBlackBox #-}
 
 -- | \"'map' @f xs@\" is the vector obtained by applying /f/ to each element
@@ -743,7 +753,8 @@ reverse (x `Cons` xs) = reverse xs :< x
 map :: (a -> b) -> Vec n a -> Vec n b
 map _ Nil           = Nil
 map f (x `Cons` xs) = f x `Cons` map f xs
-{-# NOINLINE map #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE map #-}
 {-# ANN map hasBlackBox #-}
 
 -- | Apply a function of every element of a vector and its index.
@@ -766,7 +777,8 @@ imap f = go 0
     go :: Index n -> Vec m a -> Vec m b
     go _ Nil           = Nil
     go n (x `Cons` xs) = f n x `Cons` go (n+1) xs
-{-# NOINLINE imap #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE imap #-}
 {-# ANN imap hasBlackBox #-}
 
 {- | Zip two vectors with a functions that also takes the elements' indices.
@@ -887,7 +899,8 @@ elemIndex x = findIndex (x ==)
 zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c
 zipWith _ Nil           _  = Nil
 zipWith f (x `Cons` xs) ys = f x (head ys) `Cons` zipWith f xs (tail ys)
-{-# NOINLINE zipWith #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE zipWith #-}
 {-# ANN zipWith hasBlackBox #-}
 
 -- | 'zipWith3' generalizes 'zip3' by zipping with the function given
@@ -997,7 +1010,8 @@ zipWith7 f ts us vs ws xs ys zs =
 foldr :: (a -> b -> b) -> b -> Vec n a -> b
 foldr _ z Nil           = z
 foldr f z (x `Cons` xs) = f x (foldr f z xs)
-{-# NOINLINE foldr #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE foldr #-}
 {-# ANN foldr hasBlackBox #-}
 
 -- | 'foldl', applied to a binary operator, a starting value (typically
@@ -1091,7 +1105,8 @@ fold f vs = fold' (toList vs)
     fold' xs  = fold' ys `f` fold' zs
       where
         (ys,zs) = P.splitAt (P.length xs `div` 2) xs
-{-# NOINLINE fold #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fold #-}
 {-# ANN fold (InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [I.__i|
   BlackBoxHaskell:
     name: Clash.Sized.Vector.fold
@@ -1373,7 +1388,8 @@ index_int xs i@(I# n0)
     sub (y `Cons` (!ys)) n = if isTrue# (n ==# 0#)
                                 then y
                                 else sub ys (n -# 1#)
-{-# NOINLINE index_int #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE index_int #-}
 {-# ANN index_int hasBlackBox #-}
 
 -- | \"@xs@ '!!' @n@\" returns the /n/'th element of /xs/.
@@ -1400,7 +1416,8 @@ xs !! i = index_int xs (fromEnum i)
 -- 3
 length :: KnownNat n => Vec n a -> Int
 length = fromInteger . natVal . asNatProxy
-{-# NOINLINE length #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE length #-}
 {-# ANN length hasBlackBox #-}
 
 replace_int :: KnownNat n => Vec n a -> Int -> a -> Vec n a
@@ -1417,7 +1434,8 @@ replace_int xs i@(I# n0) a
     sub (y `Cons` (!ys)) n b = if isTrue# (n ==# 0#)
                                  then b `Cons` ys
                                  else y `Cons` sub ys (n -# 1#) b
-{-# NOINLINE replace_int #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE replace_int #-}
 {-# ANN replace_int hasBlackBox #-}
 
 -- | \"'replace' @n a xs@\" returns the vector /xs/ where the /n/'th element is
@@ -1569,7 +1587,8 @@ select f s n xs = select' (toUNat n) $ drop f xs
     select' UZero      _               = Nil
     select' (USucc n') vs@(x `Cons` _) = x `Cons`
                                          select' n' (drop s (unsafeCoerce vs))
-{-# NOINLINE select #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE select #-}
 {-# ANN select hasBlackBox #-}
 
 -- | \"'selectI' @f s xs@\" selects as many elements as demanded by the context
@@ -1593,7 +1612,8 @@ selectI f s xs = withSNat (\n -> select f s n xs)
 -- 6 :> 6 :> 6 :> Nil
 replicate :: SNat n -> a -> Vec n a
 replicate n a = replicateU (toUNat n) a
-{-# NOINLINE replicate #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE replicate #-}
 {-# ANN replicate hasBlackBox #-}
 
 replicateU :: UNat n -> a -> Vec n a
@@ -1641,7 +1661,8 @@ iterateI f a = xs
   where
     xs = init (a `Cons` ws)
     ws = map f (lazyV xs)
-{-# NOINLINE iterateI #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE iterateI #-}
 {-# ANN iterateI (InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [I.__i|
   BlackBoxHaskell:
     name: Clash.Sized.Vector.iterateI
@@ -1718,7 +1739,8 @@ generateI f a = iterateI f (f a)
 -- (1 :> 3 :> 5 :> Nil) :> (2 :> 4 :> 6 :> Nil) :> Nil
 transpose :: KnownNat n => Vec m (Vec n a) -> Vec n (Vec m a)
 transpose = traverse# id
-{-# NOINLINE transpose #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE transpose #-}
 {-# ANN transpose hasBlackBox #-}
 
 -- | 1-dimensional stencil computations
@@ -1968,7 +1990,8 @@ rotateLeftS xs d = go (snatToInteger d `mod` natVal (asNatProxy xs)) xs
     go _ Nil           = Nil
     go 0 ys            = ys
     go n (y `Cons` ys) = go (n-1) (ys :< y)
-{-# NOINLINE rotateLeftS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotateLeftS #-}
 {-# ANN rotateLeftS hasBlackBox #-}
 
 -- | /Statically/ rotate a 'Vec'tor to the right:
@@ -1987,7 +2010,8 @@ rotateRightS xs d = go (snatToInteger d `mod` natVal (asNatProxy xs)) xs
     go _ Nil            = Nil
     go 0 ys             = ys
     go n ys@(Cons _ _)  = go (n-1) (last ys :> init ys)
-{-# NOINLINE rotateRightS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotateRightS #-}
 {-# ANN rotateRightS hasBlackBox #-}
 
 -- | Convert a vector to a list.
@@ -2023,7 +2047,8 @@ fromList xs
   exactLength 0 acc = null acc
   exactLength _ []  = False
   exactLength i (_:ys) = exactLength (i - 1) ys
-{-# NOINLINE fromList #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromList #-}
 {-# ANN fromList dontTranslate #-}
 
 -- | Convert a list to a vector. This function always returns a vector of the
@@ -2051,7 +2076,8 @@ unsafeFromList = unfoldr SNat go
   go [] =
     let item = error "Clash.Sized.Vector.unsafeFromList: vector larger than list"
      in (item, [])
-{-# NOINLINE unsafeFromList #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unsafeFromList #-}
 {-# ANN unsafeFromList dontTranslate #-}
 
 -- | Create a vector literal from a list literal.
@@ -2152,7 +2178,8 @@ lazyV = lazyV' (repeat ())
     lazyV' :: Vec n () -> Vec n a -> Vec n a
     lazyV' Nil           _  = Nil
     lazyV' (_ `Cons` xs) ys = head ys `Cons` lazyV' xs (tail ys)
-{-# NOINLINE lazyV #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lazyV #-}
 {-# ANN lazyV hasBlackBox #-}
 
 -- | A /dependently/ typed fold.
@@ -2256,7 +2283,8 @@ dfold _ f z xs = go (snatProxy (asNatProxy xs)) xs
     go s (y `Cons` ys) =
       let s' = s `subSNat` d1
       in  f s' y (go s' ys)
-{-# NOINLINE dfold #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE dfold #-}
 {-# ANN dfold hasBlackBox #-}
 
 {- | A combination of 'dfold' and 'fold': a /dependently/ typed fold that
@@ -2419,7 +2447,8 @@ dtfold _ f g = go (SNat :: SNat k)
           sn'       = sn `subSNat` d1
           (xsL,xsR) = splitAt (pow2SNat sn') xs
       in  g sn' (go sn' xsL) (go sn' xsR)
-{-# NOINLINE dtfold #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE dtfold #-}
 {-# ANN dtfold hasBlackBox #-}
 
 -- | To be used as the motive /p/ for 'dfold', when the /f/ in \"'dfold' @p f@\"
@@ -2496,7 +2525,8 @@ concatBitVector# = go 0
   go (BV accMsk accVal) ((BV xMsk xVal) `Cons` xs) =
     let sh = fromInteger (natVal (Proxy @m)) :: Int in
     go (BV (shiftL accMsk sh .|. xMsk) (shiftL accVal sh .|. xVal)) xs
-{-# NOINLINE concatBitVector# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE concatBitVector# #-}
 {-# ANN concatBitVector# hasBlackBox #-}
 
 unconcatBitVector#
@@ -2512,7 +2542,8 @@ unconcatBitVector# orig = snd (go (toUNat (SNat @n)))
       let (bv,xs) = go n
           (l,x) = (GHC.Magic.noinline split#) bv
       in  (l,x :> xs)
-{-# NOINLINE unconcatBitVector# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE unconcatBitVector# #-}
 {-# ANN unconcatBitVector# hasBlackBox #-}
 
 -- | Convert a 'BitVector' to a 'Vec' of 'Bit's.
@@ -2544,7 +2575,8 @@ seqV
 seqV v b =
   let s () e = seq e () in
   foldl s () v `seq` b
-{-# NOINLINE seqV #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE seqV #-}
 {-# ANN seqV hasBlackBox #-}
 infixr 0 `seqV`
 
@@ -2567,7 +2599,8 @@ seqVX
 seqVX v b =
   let s () e = seqX e () in
   foldl s () v `seqX` b
-{-# NOINLINE seqVX #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE seqVX #-}
 {-# ANN seqVX hasBlackBox #-}
 infixr 0 `seqVX`
 

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -150,7 +150,8 @@ xToErrorCtx ctx a = unsafeDupablePerformIO
   (catch (evaluate a >> return a)
          (\(XException msg) ->
            throw (ErrorCall (unlines [ctx,msg]))))
-{-# NOINLINE xToErrorCtx #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE xToErrorCtx #-}
 
 -- | Convert 'XException' to 'ErrorCall'
 --
@@ -220,7 +221,8 @@ xToError = xToErrorCtx (prettyCallStack callStack)
 seqX :: a -> b -> b
 seqX a b = unsafeDupablePerformIO
   (catch (evaluate a >> return b) (\(XException _) -> return b))
-{-# NOINLINE seqX #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE seqX #-}
 {-# ANN seqX hasBlackBox #-}
 infixr 0 `seqX`
 
@@ -236,7 +238,8 @@ seqErrorX a b = unsafeDupablePerformIO
      [ Handler (\(XException _) -> return b)
      , Handler (\(ErrorCall _) -> return b)
      ])
-{-# NOINLINE seqErrorX #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE seqErrorX #-}
 {-# ANN seqErrorX hasBlackBox #-}
 infixr 0 `seqErrorX`
 
@@ -255,7 +258,8 @@ infixr 0 `seqErrorX`
 -- uses 'Clash.Netlist.BlackBox.Types.RenderVoid'
 hwSeqX :: a -> b -> b
 hwSeqX = seqX
-{-# NOINLINE hwSeqX #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE hwSeqX #-}
 {-# ANN hwSeqX hasBlackBox #-}
 infixr 0 `hwSeqX`
 
@@ -328,7 +332,8 @@ hasX a =
     (catch
       (evaluate (rnf a) >> return (Right a))
       (\(XException msg) -> evaluate (rnfX a) >> return (Left msg)))
-{-# NOINLINE hasX #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE hasX #-}
 
 -- | Evaluate a value to WHNF, returning @'Left' msg@ if is a 'XException'.
 --
@@ -343,7 +348,8 @@ isX a =
     (catch
       (evaluate a >> return (Right a))
       (\(XException msg) -> return (Left msg)))
-{-# NOINLINE isX #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE isX #-}
 
 -- | Like the 'Show' class, but values that normally throw an 'XException' are
 -- converted to @undefined@, instead of error'ing out with an exception.
@@ -476,7 +482,8 @@ forceX x = x `deepseqX` x
 -- second. Does not propagate 'XException's.
 deepseqX :: NFDataX a => a -> b -> b
 deepseqX a b = rnfX a `seq` b
-{-# NOINLINE deepseqX #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE deepseqX #-}
 {-# ANN deepseqX hasBlackBox #-}
 infixr 0 `deepseqX`
 

--- a/clash-prelude/src/Clash/Xilinx/ClockGen.hs
+++ b/clash-prelude/src/Clash/Xilinx/ClockGen.hs
@@ -7,6 +7,7 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 PLL and other clock-related components for Xilinx FPGAs
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 
@@ -47,7 +48,8 @@ clockWizard
   -> (Clock domOut, Signal domOut Bool)
   -- ^ (Stable PLL clock, PLL lock)
 clockWizard !_ = clocks
-{-# NOINLINE clockWizard #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE clockWizard #-}
 {-# ANN clockWizard hasBlackBox #-}
 
 -- | A clock source that corresponds to the Xilinx MMCM component created
@@ -84,5 +86,6 @@ clockWizardDifferential !_ clk@(Clock _ Nothing) (Clock _ Nothing) =
   clocks clk
 clockWizardDifferential !_ _ _ =
   error "clockWizardDifferential: dynamic clocks not supported"
-{-# NOINLINE clockWizardDifferential #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE clockWizardDifferential #-}
 {-# ANN clockWizardDifferential hasBlackBox #-}

--- a/clash-prelude/src/Clash/Xilinx/DDR.hs
+++ b/clash-prelude/src/Clash/Xilinx/DDR.hs
@@ -50,7 +50,8 @@ iddr
   -> Signal slow ((BitVector m),(BitVector m))
   -- ^ normal speed output pairs
 iddr clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
-{-# NOINLINE iddr #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE iddr #-}
 {-# ANN iddr hasBlackBox #-}
 
 -- | Xilinx specific variant of 'ddrOut' implemented using the Xilinx ODDR
@@ -84,5 +85,6 @@ oddr#
   -> Signal slow (BitVector m)
   -> Signal fast (BitVector m)
 oddr# clk rst en = ddrOut# clk rst en 0
-{-# NOINLINE oddr# #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE oddr# #-}
 {-# ANN oddr# hasBlackBox #-}

--- a/examples/CHIP8.hs
+++ b/examples/CHIP8.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, DerivingStrategies #-}
 {-# LANGUAGE RecordWildCards #-}
 module CHIP8 where
@@ -11,7 +12,8 @@ import Data.Word
 import Control.Monad.RWS
 import Data.Monoid
 
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 topEntity
     :: Clock System
     -> Reset System

--- a/examples/Calculator.hs
+++ b/examples/Calculator.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Calculator where
 
 import Clash.Prelude hiding (Word)
@@ -44,7 +46,8 @@ topEntity = exposeClockResetEnable go where
     (addr,val) = (pu alu <^> (0,0,0 :: Unsigned 3)) (mem,i)
     mem        = (datamem <^> initMem) (addr,val)
     initMem    = replicate d8 0
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/examples/FIR.hs
+++ b/examples/FIR.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module FIR where
 
 import Clash.Prelude
@@ -28,7 +30,8 @@ topEntity
   -> Signal System (Signed 16)
   -> Signal System (Signed 16)
 topEntity = exposeClockResetEnable (fir (2:>3:>(-2):>8:>Nil))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/examples/MAC.hs
+++ b/examples/MAC.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module MAC where
 
 import Clash.Prelude
@@ -25,7 +27,8 @@ topEntity
 topEntity clk rst xy = r
   where
     r = exposeClockResetEnable mac clk rst xy
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/examples/MatrixVect.hs
+++ b/examples/MatrixVect.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module MatrixVect where
 
 import Clash.Prelude
@@ -16,7 +18,8 @@ matrixVector m v = map (`dotProduct` v) m
 
 topEntity :: Vec 3 (Signed 16) -> Vec 3 (Signed 16)
 topEntity = matrixVector matrix
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/examples/crc32/CRC32.hs
+++ b/examples/crc32/CRC32.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module CRC32 where
 
 import Clash.Prelude
@@ -26,7 +28,8 @@ topEntity
   -> Enable System
   -> Signal System (BitVector 8) -> Signal System (Unsigned 32)
 topEntity = exposeClockResetEnable (fmap unpack . crc32)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 -- test bench
 testBench :: Signal System Bool
@@ -38,4 +41,3 @@ testBench = done
     done           = expectedOutput (topEntity clk rst enableGen testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-

--- a/examples/i2c/I2C.hs
+++ b/examples/i2c/I2C.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module I2C where
 
 import Clash.Prelude
@@ -35,4 +37,5 @@ i2c clk arst rst ena clkCnt start stop read write ackIn din i2cI = (dout,hostAck
     (hostAck,ackOut,dout,bitCtrl) = byteMaster clk arst enableGen (rst,start,stop,read,write,ackIn,din,bitResp)
     (bitResp,busy,i2cO)           = bitMaster  clk arst enableGen (rst,ena,clkCnt,bitCtrl,i2cI)
     (cmdAck,al,dbout)             = unbundle bitResp
-{-# NOINLINE i2c #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE i2c #-}

--- a/examples/i2c/I2C/BitMaster.hs
+++ b/examples/i2c/I2C/BitMaster.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 module I2C.BitMaster (bitMaster) where
 
@@ -60,7 +61,8 @@ bitMaster
   -> Unbundled System BitMasterI
   -> Unbundled System BitMasterO
 bitMaster = exposeClockResetEnable (mealyB bitMasterT bitMasterInit)
-{-# NOINLINE bitMaster #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE bitMaster #-}
 
 bitMasterInit = BitS { _stateMachine   = stateMachineStart
                             , _busState       = busStartState

--- a/examples/i2c/I2C/BitMaster/BusCtrl.hs
+++ b/examples/i2c/I2C/BitMaster/BusCtrl.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 module I2C.BitMaster.BusCtrl where
 
@@ -40,7 +41,8 @@ busStartState
   , _cmdStop        = False              -- STOP command
   }
 
-{-# NOINLINE busStatusCtrl #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE busStatusCtrl #-}
 busStatusCtrl :: Bool
               -> Bool
               -> Unsigned 16

--- a/examples/i2c/I2C/BitMaster/StateMachine.hs
+++ b/examples/i2c/I2C/BitMaster/StateMachine.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 module I2C.BitMaster.StateMachine where
 
@@ -37,7 +38,8 @@ stateMachineStart
   , _bitStateM = Idle
   }
 
-{-# NOINLINE bitStateMachine #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE bitStateMachine #-}
 bitStateMachine :: Bool
                 -> Bool
                 -> Bool

--- a/examples/i2c/I2C/ByteMaster.hs
+++ b/examples/i2c/I2C/ByteMaster.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 module I2C.ByteMaster (byteMaster) where
 
@@ -62,7 +63,8 @@ byteMaster
   -> Unbundled System ByteMasterI
   -> Unbundled System ByteMasterO
 byteMaster = exposeClockResetEnable (mealyB byteMasterT byteMasterInit)
-{-# NOINLINE byteMaster #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE byteMaster #-}
 
 {-# INLINE byteMasterInit #-}
 byteMasterInit :: ByteMasterS

--- a/examples/i2c/I2Ctest.hs
+++ b/examples/i2c/I2Ctest.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module I2Ctest where
 
 import qualified Data.List as L
@@ -26,7 +28,8 @@ system0 clk arst = bundle (regFile,done,fault)
 
   rst = liftA2 (<) rstCounter 500
   rstCounter = register clk arst enableGen (0 :: Unsigned 18) (rstCounter + 1)
-{-# NOINLINE system0 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE system0 #-}
 
 {-# ANN system Synthesize { t_name = "system", t_inputs = [], t_output = PortName "" } #-}
 system = system0 systemClockGen resetGen

--- a/examples/i2c/I2Ctest/I2CConfig.hs
+++ b/examples/i2c/I2Ctest/I2CConfig.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module I2Ctest.I2CConfig where
 
 import Clash.Prelude
@@ -161,4 +163,5 @@ config
   -> Signal System ConfI
   -> Signal System ConfO
 config clk = mealyIO clk configT (reg confInit)
-{-# NOINLINE config #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE config #-}

--- a/examples/i2c/I2Ctest/I2CSlave.hs
+++ b/examples/i2c/I2Ctest/I2CSlave.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module I2Ctest.I2CSlave where
 
 import Clash.Prelude
@@ -109,4 +111,5 @@ i2cSlave
   -> Signal System ACConfTestI
   -> Signal System ACConfTestO
 i2cSlave clk = mealyIO clk i2cSlaveT (reg i2cSlaveInit)
-{-# NOINLINE i2cSlave #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE i2cSlave #-}

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -745,6 +745,14 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2342B" def{hdlSim=[]}
         , runTest "T2360" def{hdlSim=[],clashFlags=["-fclash-force-undefined=0"]}
         , outputTest "T2502" def{hdlTargets=[VHDL]}
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
+        , runTest "T2510" def{
+            hdlTargets=[VHDL]
+          , hdlSim=[]
+          , expectClashFail=Just (TestSpecificExitCode 0, "Warning: primitive T2510.bb isn't marked OPAQUE.")
+          }
+        , outputTest "T2510" def{hdlTargets=[VHDL], clashFlags=["-DNOINLINE=OPAQUE"]}
+#endif
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -77,6 +77,12 @@ common basic-config
     clash-lib,
     clash-prelude
 
+  -- See https://github.com/clash-lang/clash-compiler/pull/2511
+  if impl(ghc >= 9.4)
+    CPP-Options: -DCLASH_OPAQUE=OPAQUE
+  else
+    CPP-Options: -DCLASH_OPAQUE=NOINLINE
+
   if flag(cosim)
     build-depends:     clash-cosim
 

--- a/tests/shouldfail/BlackBox/T1945.hs
+++ b/tests/shouldfail/BlackBox/T1945.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module T1945 where
 
@@ -9,7 +10,8 @@ import           Data.String.Interpolate      (__i)
 
 bb :: a -> a
 bb x = x
-{-# NOINLINE bb #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE bb #-}
 {-# ANN bb hasBlackBox #-}
 {-# ANN bb (InlinePrimitive [VHDL,Verilog,SystemVerilog] [__i|
    [ { "BlackBox" :

--- a/tests/shouldfail/BlackBox/WrongReference.hs
+++ b/tests/shouldfail/BlackBox/WrongReference.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -20,7 +21,8 @@ myMultiply
   -> Signal System Int
 myMultiply a b =
   a * b
-{-# NOINLINE myMultiply #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE myMultiply #-}
 
 topEntity
   :: HiddenClockResetEnable System

--- a/tests/shouldfail/PrimitiveGuards/DontTranslate.hs
+++ b/tests/shouldfail/PrimitiveGuards/DontTranslate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module DontTranslate where
 
 import Clash.Prelude
@@ -9,7 +11,8 @@ primitive
 primitive i =
   (i+5)
 
-{-# NOINLINE primitive #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE primitive #-}
 {-# ANN primitive dontTranslate #-}
 
 topEntity = primitive

--- a/tests/shouldfail/PrimitiveGuards/HasBlackBox.hs
+++ b/tests/shouldfail/PrimitiveGuards/HasBlackBox.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module HasBlackBox where
 
 import Clash.Prelude
@@ -9,7 +11,8 @@ primitive
 primitive =
   (+5)
 
-{-# NOINLINE primitive #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE primitive #-}
 {-# ANN primitive hasBlackBox #-}
 
 topEntity = primitive

--- a/tests/shouldwork/Basic/ByteSwap32.hs
+++ b/tests/shouldwork/Basic/ByteSwap32.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
 module ByteSwap32 where
 
@@ -8,7 +9,8 @@ import Data.Bits
 
 topEntity :: Word32 -> Word32
 topEntity = byteSwap32
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/CaseOfErr.hs
+++ b/tests/shouldwork/Basic/CaseOfErr.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fno-strictness #-}
 module CaseOfErr where
 
@@ -6,7 +8,8 @@ import qualified Prelude
 
 f :: Bool -> Int
 f x = if x then 1 else 0
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 topEntity :: Int
 topEntity = f (Prelude.error "QQ")

--- a/tests/shouldwork/Basic/CharTest.hs
+++ b/tests/shouldwork/Basic/CharTest.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module CharTest where
 
 import Clash.Prelude
@@ -6,7 +8,8 @@ import Data.Char
 
 topEntity :: (Int,Char) -> (Int,Char,Char)
 topEntity (i,c) = (ord c,chr i,'λ')
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/ClassOps.hs
+++ b/tests/shouldwork/Basic/ClassOps.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ClassOps where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: (Integer,Integer) -> Integer
 topEntity = uncurry mod
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/CountTrailingZeros.hs
+++ b/tests/shouldwork/Basic/CountTrailingZeros.hs
@@ -10,7 +10,8 @@ import Data.Bits
 
 topEntity :: Word -> Int
 topEntity = countTrailingZeros
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/DivMod.hs
+++ b/tests/shouldwork/Basic/DivMod.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module DivMod where
 
 import Clash.Prelude
@@ -21,5 +23,5 @@ topEntity1 height depthInput filterHeight stride cycles = snatToNum cycles `divM
 
     rows :: Integer
     rows = ((snatToNum height - snatToNum filterHeight) `div` snatToNum stride) + 1
-{-# NOINLINE topEntity1 #-}
-
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity1 #-}

--- a/tests/shouldwork/Basic/DivZero.hs
+++ b/tests/shouldwork/Basic/DivZero.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fconstraint-solver-iterations=5 #-}
 module DivZero where
 
@@ -17,7 +19,8 @@ topEntity (b,u,s,x,i,w,nX) =
   , 4 `quot` i
   , 4 `quot` w
   , 4 `quot` nX)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 t8ToEnum :: T8 -> (BitVector 8, Unsigned 8, Signed 8, Index 8, Int, Word, Int)
 t8ToEnum (b,u,s,x,i,w,nX) = (b,u,s,x,i,w, fromEnum nX)

--- a/tests/shouldwork/Basic/LambdaDrop.hs
+++ b/tests/shouldwork/Basic/LambdaDrop.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module LambdaDrop where
 
 import Clash.Prelude
@@ -13,18 +15,22 @@ topEntity = (++#) <$> (pack <$> outport1) <*> (pack <$> outport2)
 
 core :: Signal dom (Maybe Bit) -> Signal dom Bit
 core = fmap (maybe low id)
-{-# NOINLINE core #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE core #-}
 
 ram :: Signal dom Bit -> Signal dom (Maybe Bit)
 ram = fmap pure
-{-# NOINLINE ram #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ram #-}
 
 decodeReq :: Integer -> Signal dom Bit -> Signal dom Bit
 decodeReq 0 = fmap (const low)
 decodeReq 1 = id
 decodeReq _ = fmap complement
-{-# NOINLINE decodeReq #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE decodeReq #-}
 
 gpio :: Signal dom Bit -> (Signal dom Bit,Signal dom (Maybe Bit))
 gpio i = (i,pure <$> i)
-{-# NOINLINE gpio #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE gpio #-}

--- a/tests/shouldwork/Basic/LotOfStates.hs
+++ b/tests/shouldwork/Basic/LotOfStates.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module LotOfStates where
 
 import Clash.Prelude
@@ -40,7 +42,8 @@ topEntity
   -> Signal System (Unsigned 8)
   -> Signal System (Unsigned 8)
 topEntity = exposeClockResetEnable (mealy fsm S_0)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/MultipleHidden.hs
+++ b/tests/shouldwork/Basic/MultipleHidden.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module MultipleHidden where
 
 import Clash.Prelude
@@ -30,7 +32,8 @@ topEntityI
   -> Signal domB (Unsigned 16)
   -> Signal domA (Unsigned 16)
 topEntityI a b = multiClockAdd a b
-{-# NOINLINE topEntityI #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityI #-}
 
 
 topEntity
@@ -47,7 +50,8 @@ topEntity
   -> Signal DomA (Unsigned 16)
 topEntity clkA rstA enA clkB rstB enB a b =
   withSpecificClockResetEnable clkA rstA enA $ withSpecificClockResetEnable clkB rstB enB (topEntityI a) b
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal DomA Bool
 testBench = done

--- a/tests/shouldwork/Basic/NORX.hs
+++ b/tests/shouldwork/Basic/NORX.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module NORX where
 import Data.Bits
 import Clash.Prelude
@@ -46,7 +48,8 @@ h x y = (x `xor` y) `xor` ((x .&. y) `shiftL` 1)
 
 topEntity :: Vec 16 W -> Vec 16 W
 topEntity = norx
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/NameInstance.hs
+++ b/tests/shouldwork/Basic/NameInstance.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module NameInstance where
 
 import qualified Prelude as P
@@ -12,7 +14,8 @@ topEntity = suffixName @"after" $ setName @"foo" $ prefixName @"before" f
 
 f :: Bool -> Bool -> (Bool,Bool)
 f x y = (y,x)
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 -- File content test
 assertIn :: String -> String -> IO ()

--- a/tests/shouldwork/Basic/NameOverlap.hs
+++ b/tests/shouldwork/Basic/NameOverlap.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE CPP #-}
+
 module NameOverlap where
 
 import Clash.Prelude
 
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 {-# ANN topEntity
   (Synthesize
     { t_name   = "nameoverlap"

--- a/tests/shouldwork/Basic/Parameters.hs
+++ b/tests/shouldwork/Basic/Parameters.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -135,7 +136,8 @@ myAdd
   -> Unsigned n
   -> Unsigned n
 myAdd a b = a + b
-{-# NOINLINE myAdd #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE myAdd #-}
 
 topEntity
   :: Unsigned 32

--- a/tests/shouldwork/Basic/PopCount.hs
+++ b/tests/shouldwork/Basic/PopCount.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
@@ -28,7 +29,8 @@ topEntity i =  popCount @Word j
   where
     j :: Num a => a
     j = fromInteger i
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/Replace.hs
+++ b/tests/shouldwork/Basic/Replace.hs
@@ -1,5 +1,7 @@
 
 -- See: https://github.com/clash-lang/clash-compiler/issues/365
+{-# LANGUAGE CPP #-}
+
 module Replace where
 
 import Clash.Prelude
@@ -16,7 +18,8 @@ topEntity = fmap head r
       where
         f :: Vec 1 Word8 -> Vec 1 Word8
         f regs = replace 0 (regs!!0 + 1) regs
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -25,4 +28,5 @@ testBench = done
     done           = expectedOutput (exposeClockResetEnable topEntity clk rst enableGen)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Basic/SimOnly.hs
+++ b/tests/shouldwork/Basic/SimOnly.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module SimOnly where
 
 import Clash.Explicit.Prelude
@@ -10,7 +12,8 @@ unionIgnore (SimOnly m1) (SimOnly m2) = SimOnly (Map.unionWith (<>) m1 m2)
 
 foo :: Int -> Int -> (Int, Ignore)
 foo a b = (a+b,SimOnly (Map.fromList [("foo",[a + b])]))
-{-# NOINLINE foo #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE foo #-}
 
 bar :: Int -> Int -> (Int, Ignore)
 bar a b = (a*b,SimOnly (Map.fromList [("bar",[a * b])]))

--- a/tests/shouldwork/Basic/T1292.hs
+++ b/tests/shouldwork/Basic/T1292.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1292 where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Maybe (Index 16, Unsigned 4) -> Index 16
 topEntity (Just (a,_)) = a
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/T1316.hs
+++ b/tests/shouldwork/Basic/T1316.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE CPP #-}
+
 module T1316 where
 
 import Clash.Prelude
 
 incr :: Index 2 -> Index 2
 incr i = if i == maxBound then 0 else i + 1
-{-# NOINLINE incr #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE incr #-}
 
 topEntity :: Index 10 -> Index 2
 topEntity j = case j < 1 of

--- a/tests/shouldwork/Basic/T1322.hs
+++ b/tests/shouldwork/Basic/T1322.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1322 where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 incr :: Index 3 -> Index 3
 incr i = if i == maxBound then 0 else i + 1
-{-# NOINLINE incr #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE incr #-}
 
 topEntity :: Index 10 -> Index 3
 topEntity j = case j < 1 of
@@ -25,7 +28,8 @@ topEntity j = case j < 1 of
         xs = init (Cons 2 (Cons (incr (head ys)) Nil))
         {-# NOINLINE ys #-}
     in incr (incr (head ys))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/T1556.hs
+++ b/tests/shouldwork/Basic/T1556.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1556 where
 
 import Clash.Prelude
@@ -14,7 +16,8 @@ topEntity clk rst en = o2
         o1 = withClockResetEnable clk rst enMerged $ register 1 $ succ <$> o1
         o2 = CEP.register clk rst enMerged 0 o1
         enMerged = CEP.andEnable en (pure True)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/Time.hs
+++ b/tests/shouldwork/Basic/Time.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Time where
 
 import Clash.Explicit.Prelude
@@ -10,7 +12,8 @@ topEntity
   -> Signal System Int
   -> Signal System Int
 topEntity clk rst en ps = register clk rst en 0 (ps + 1)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Basic/TyEqConstraints.hs
+++ b/tests/shouldwork/Basic/TyEqConstraints.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module TyEqConstraints where
 import GHC.Stack
 import Clash.Prelude
@@ -11,7 +13,8 @@ topEntity
 topEntity = exposeClock board
   where
     board = id
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 {-# ANN topEntity (defSyn "top1") #-}
 
 -- type equality is symmetrical so this should also work:

--- a/tests/shouldwork/BitVector/AppendZero.hs
+++ b/tests/shouldwork/BitVector/AppendZero.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module AppendZero where
 
 import Clash.Prelude
@@ -17,7 +19,8 @@ topEntity clk rst =
     , (0  :: BitVector 0)  ++# (22 :: BitVector 16)
     , (22 :: BitVector 16) ++# (22 :: BitVector 16)
     )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/BitVector/Box.hs
+++ b/tests/shouldwork/BitVector/Box.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Box where
 
 import Clash.Prelude
@@ -11,7 +13,8 @@ topEntity vec = (pack  tup
   where
     tup :: (Vec 8 Bit, Vec 8 Bit)
     tup = unpack vec
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/BitVector/BoxGrow.hs
+++ b/tests/shouldwork/BitVector/BoxGrow.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module BoxGrow where
 
 import Clash.Prelude
@@ -13,7 +15,8 @@ box0 grid =     (zeroesM :> ((zeroesN >:> grid) <:< zeroesN)) :< zeroesM
           zeroesM = replicate d8 0
 
 topEntity = box0
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/BitVector/CLZ.hs
+++ b/tests/shouldwork/BitVector/CLZ.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
 
 module CLZ where
@@ -9,7 +10,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Word -> Word -> Word
 topEntity (W# w1) (W# w2) = W# (clz# (or# w1 w2))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -18,4 +20,3 @@ testBench = done
     done           = expectedOutput (topEntity <$> pure 3 <*> pure 5)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-

--- a/tests/shouldwork/BitVector/ExtendingNumZero.hs
+++ b/tests/shouldwork/BitVector/ExtendingNumZero.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ExtendingNumZero where
 
 import Clash.Prelude
@@ -23,7 +25,8 @@ topEntity clk rst =
     , mul (n :: BitVector 16) (0 :: BitVector 0)
     , mul (0 :: BitVector 0)  (n :: BitVector 16)
     ))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -34,4 +37,5 @@ testBench = done
     done           = expectedOutput (topEntity clk rst (pure n1))
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/BitVector/GenericBitPack.hs
+++ b/tests/shouldwork/BitVector/GenericBitPack.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -39,7 +40,8 @@ topEntity (a, b, c, d, e, f, g, h, i, j, k) =
       , pack j
       , pack k
       )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/BitVector/ReduceOne.hs
+++ b/tests/shouldwork/BitVector/ReduceOne.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ReduceOne where
 
 import Clash.Prelude
@@ -11,7 +13,8 @@ topEntity
   -> Signal System (Bit, Bit, Bit)
 topEntity clk rst en =
   fmap (\a -> (reduceAnd a, reduceOr a, reduceXor a))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/BitVector/ReduceZero.hs
+++ b/tests/shouldwork/BitVector/ReduceZero.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ReduceZero where
 
 import Clash.Prelude
@@ -11,7 +13,8 @@ topEntity
   -> Signal System (Bit, Bit, Bit)
 topEntity clk rst en =
   fmap (\a -> (reduceAnd a, reduceOr a, reduceXor a))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -21,4 +24,3 @@ testBench = done
     done           = expectedOutput (topEntity clk rst enableGen testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-

--- a/tests/shouldwork/BlackBox/BlackBoxFunction.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunction.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -26,7 +27,8 @@ myMultiply
   -> Signal System Int
 myMultiply a b =
   a * b
-{-# NOINLINE myMultiply #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE myMultiply #-}
 
 topEntity
   :: SystemClockResetEnable

--- a/tests/shouldwork/BlackBox/BlackBoxFunctionHO.hs
+++ b/tests/shouldwork/BlackBox/BlackBoxFunctionHO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
@@ -33,7 +34,8 @@ myMultiply
   -> Signed 64
 myMultiply a b =
   a * b
-{-# NOINLINE myMultiply #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE myMultiply #-}
 
 topEntity
   :: Signal System (Signed 64, Vec 3 (Signed 64))

--- a/tests/shouldwork/BlackBox/DSL.hs
+++ b/tests/shouldwork/BlackBox/DSL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -35,7 +36,8 @@ funcTF = N.TemplateFunction [] (const True) $ \bbCtx -> do
 func :: Maybe a -> (Bit, a)
 func Nothing = (0, errorX "no data")
 func (Just a) = (0, a)
-{-# NOINLINE func #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE func #-}
 {-# ANN func (InlineYamlPrimitive [minBound..maxBound] [i|
 BlackBoxHaskell:
     name: DSL.func

--- a/tests/shouldwork/BlackBox/ExternalPrimitive.hs
+++ b/tests/shouldwork/BlackBox/ExternalPrimitive.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 
 module ExternalPrimitive where
@@ -12,12 +13,14 @@ import Clash.Annotations.Primitive (hasBlackBox)
 
 jsonPrim :: Int
 jsonPrim = 0
-{-# NOINLINE jsonPrim #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE jsonPrim #-}
 {-# ANN jsonPrim hasBlackBox #-}
 
 yamlPrim :: Int
 yamlPrim = 1
-{-# NOINLINE yamlPrim #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE yamlPrim #-}
 {-# ANN yamlPrim hasBlackBox #-}
 
 topEntity :: Vec _ Int

--- a/tests/shouldwork/BlackBox/LITrendering.hs
+++ b/tests/shouldwork/BlackBox/LITrendering.hs
@@ -2,6 +2,7 @@
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 module LITrendering where
 import Clash.Prelude
 import Control.Monad (when)
@@ -40,7 +41,8 @@ foo !x1
     !x17 !x18
     = False
 
-{-# NOINLINE foo #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE foo #-}
 {-# ANN foo (InlinePrimitive [Verilog] $ [I.i|
   [ { "BlackBox" :
       { "name"      : "LITrendering.foo"

--- a/tests/shouldwork/BlackBox/MultiResult.hs
+++ b/tests/shouldwork/BlackBox/MultiResult.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module MultiResult where
@@ -21,7 +22,8 @@ import System.FilePath ((</>))
 -- | Ties off sh_ddr on AWS.
 tieOffShDdr :: Clock dom -> Reset dom -> Signal dom Int -> (Signal dom Int, Signal dom Int)
 tieOffShDdr !_clk !_rst !_ = (undefined, undefined)
-{-# NOINLINE tieOffShDdr #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tieOffShDdr #-}
 {-# ANN tieOffShDdr (blackBoxHaskell 'tieOffShDdr 'tieOffShDdrBBF def{bo_multiResult=True}) #-}
 
 tieOffShDdrBBF :: BlackBoxFunction
@@ -47,7 +49,8 @@ topEntity ::
 topEntity clk rst x = bundle (a, b, pure 5)
  where
   (a, b) = tieOffShDdr @System clk rst x
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/BlackBox/T1524.hs
+++ b/tests/shouldwork/BlackBox/T1524.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1524 where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 2 (Vec 3 Int) -> Vec 2 Int
 topEntity = f @2 @(3-1)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 f :: Vec k (Vec (l+1) Int) -> Vec k Int
 f input = map g input

--- a/tests/shouldwork/BlackBox/T1786.hs
+++ b/tests/shouldwork/BlackBox/T1786.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 module T1786 where
 
 import           Clash.Prelude
@@ -10,14 +11,16 @@ import           Data.String.Interpolate (__i)
 
 testEnable :: Signal System Bool
 testEnable = testAlwaysEnabled enableGen
-{-# NOINLINE testEnable #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testEnable #-}
 
 -- Only call with always-enabled Enable if you want the model to match the HDL.
 testAlwaysEnabled
   :: Enable System
   -> Signal System Bool
 testAlwaysEnabled !_ = pure True
-{-# NOINLINE testAlwaysEnabled #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testAlwaysEnabled #-}
 {-# ANN testAlwaysEnabled (InlinePrimitive [VHDL] [__i|
   [ { "BlackBox" :
       { "name"      : "T1786.testAlwaysEnabled"
@@ -34,19 +37,22 @@ testEnableTB = done
   done = outputVerifier' clk rst (True :> Nil) testEnable
   clk  = tbSystemClockGen (not <$> done)
   rst  = systemResetGen
-{-# NOINLINE testEnableTB #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testEnableTB #-}
 {-# ANN testEnableTB (TestBench 'testEnable) #-}
 
 testBool :: Signal System Bool
 testBool = testAlwaysEnabledBool (pure True)
-{-# NOINLINE testBool #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBool #-}
 
 -- Only call with always-true input if you want the model to match the HDL.
 testAlwaysEnabledBool
   :: Signal System Bool
   -> Signal System Bool
 testAlwaysEnabledBool !_ = pure True
-{-# NOINLINE testAlwaysEnabledBool #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testAlwaysEnabledBool #-}
 {-# ANN testAlwaysEnabledBool (InlinePrimitive [VHDL] [__i|
   [ { "BlackBox" :
       { "name"      : "T1786.testAlwaysEnabledBool"
@@ -64,5 +70,6 @@ testBoolTB = done
   done = outputVerifier' clk rst (True :> Nil) testBool
   clk  = tbSystemClockGen (not <$> done)
   rst  = systemResetGen
-{-# NOINLINE testBoolTB #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBoolTB #-}
 {-# ANN testBoolTB (TestBench 'testBool) #-}

--- a/tests/shouldwork/BlackBox/T2117.hs
+++ b/tests/shouldwork/BlackBox/T2117.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 module T2117 where
 
 import Clash.Prelude
@@ -9,17 +10,20 @@ import Data.String.Interpolate (__i)
 undefBV
   :: Signal System Bool
 undefBV = testUndefined @(BitVector 8) (deepErrorX "undefined value")
-{-# NOINLINE undefBV #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE undefBV #-}
 
 undefTup
   :: Signal System Bool
 undefTup = testUndefined @(Bit, Bit) (deepErrorX "undefined value")
-{-# NOINLINE undefTup #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE undefTup #-}
 
 partialDefTup
   :: Signal System Bool
 partialDefTup = testDefined @(Bit, Bit) (errorX "undefined value", 0)
-{-# NOINLINE partialDefTup #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE partialDefTup #-}
 
 testBenchG
   :: Signal System Bool
@@ -33,17 +37,20 @@ testBenchG f = done
 
 testBenchUndefBV :: Signal System Bool
 testBenchUndefBV = testBenchG undefBV
-{-# NOINLINE testBenchUndefBV #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchUndefBV #-}
 {-# ANN testBenchUndefBV (TestBench 'undefBV) #-}
 
 testBenchUndefTup :: Signal System Bool
 testBenchUndefTup = testBenchG undefTup
-{-# NOINLINE testBenchUndefTup #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchUndefTup #-}
 {-# ANN testBenchUndefTup (TestBench 'undefTup) #-}
 
 testBenchPartialDefTup :: Signal System Bool
 testBenchPartialDefTup = testBenchG partialDefTup
-{-# NOINLINE testBenchPartialDefTup #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchPartialDefTup #-}
 {-# ANN testBenchPartialDefTup (TestBench 'partialDefTup) #-}
 
 -- Only call with XException-argument if you want the model to match the HDL.
@@ -52,7 +59,8 @@ testUndefined
   => a
   -> Signal System Bool
 testUndefined !_ = pure True
-{-# NOINLINE testUndefined #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testUndefined #-}
 {-# ANN testUndefined (InlinePrimitive [VHDL] [__i|
   [ { "BlackBox" :
       { "name"      : "T2117.testUndefined"
@@ -70,7 +78,8 @@ testDefined
   => a
   -> Signal System Bool
 testDefined !_ = pure True
-{-# NOINLINE testDefined #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testDefined #-}
 {-# ANN testDefined (InlinePrimitive [VHDL] [__i|
   [ { "BlackBox" :
       { "name"      : "T2117.testDefined"

--- a/tests/shouldwork/BlackBox/TemplateFunction.hs
+++ b/tests/shouldwork/BlackBox/TemplateFunction.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -43,7 +44,8 @@ myMultiply
   -> Signal System Int
 myMultiply a b =
   a * b
-{-# NOINLINE myMultiply #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE myMultiply #-}
 
 topEntity
   :: SystemClockResetEnable

--- a/tests/shouldwork/BlackBox/ZeroWidth.hs
+++ b/tests/shouldwork/BlackBox/ZeroWidth.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 
 module ZeroWidth where
 
@@ -22,7 +23,8 @@ answer = "A nervous wreck."
 -- | Inserts given comment in HDL. Returns "nothing".
 comment :: String -> ()
 comment !_s = ()
-{-# NOINLINE comment #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE comment #-}
 {-# ANN comment (InlinePrimitive [VHDL] [__i|
   [ { "BlackBox" :
       { "name"      : "ZeroWidth.comment"
@@ -40,7 +42,8 @@ implicitComment n =
     5 -> ()
     _ ->
       comment question
-{-# NOINLINE implicitComment #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE implicitComment #-}
 
 topEntity :: Int -> (Int, (), ())
 topEntity a = (succ a, comment luckyNumber, implicitComment a)

--- a/tests/shouldwork/CoSim/Multiply.hs
+++ b/tests/shouldwork/CoSim/Multiply.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Multiply where
 
 import Clash.CoSim
@@ -18,13 +20,15 @@ verilog_mult x y = [verilog|
 
   assign result = ${x} * ${y};
   |]
-{-# NOINLINE verilog_mult #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE verilog_mult #-}
 
 topEntity
   :: Signal System (Signed 64)
   -> Signal System (Signed 64)
 topEntity s = verilog_mult s s
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/CoSim/Register.hs
+++ b/tests/shouldwork/CoSim/Register.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 module Register where
 
@@ -27,7 +28,8 @@ verilog_register clk (unsafeToHighPolarity -> arst) x = [verilog|
       end
     end
   |]
-{-# NOINLINE verilog_register #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE verilog_register #-}
 
 topEntity
   :: Clock System

--- a/tests/shouldwork/Cores/Xilinx/DcFifo/Basic.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo/Basic.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Basic where
 
 import Clash.Explicit.Prelude
@@ -48,7 +50,8 @@ topEntity clk rst writeData rEnable =
     , dcOverflow=True
     , dcUnderflow=True
     }
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench ::
   Signal XilinxSystem Bool
@@ -80,7 +83,8 @@ testBench = done
   clk = tbClockGen (not <$> done)
   noRst = unsafeFromHighPolarity $ pure False
   en = enableGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}
 
 data FsmOut = FsmOut
   { fDone :: Bool

--- a/tests/shouldwork/Cores/Xilinx/DcFifo/Lfsr.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo/Lfsr.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Lfsr where
@@ -36,7 +37,8 @@ lfsrF clk rst ena seed = msb <$> r
     five, three, two, zero :: Unsigned 16
     (five, three, two, zero) = (5, 3, 2, 0)
     lfsrFeedback = s ! five `xor` s ! three `xor` s ! two `xor` s ! zero
-{-# NOINLINE lfsrF #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lfsrF #-}
 
 fifoSampler ::
   KnownDomain dom =>
@@ -58,7 +60,8 @@ fifoSampler clk rst ena stalls inps =
    where
     maybeData = readLastCycle `orNothing` readData
     readNow = not stall && not fifoEmpty
-{-# NOINLINE fifoSampler #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fifoSampler #-}
 
 -- | Drives Xilinx FIFO with an ascending sequence of 'BitVector's. Stalls
 -- intermittently based on stall input.
@@ -163,34 +166,41 @@ fifoVerifier clk rst ena actual = done0
   done0 =
     assert clk rst "Doesn't time out" stuck (pure False) $
       assert clk rst "fifoVerifier" actual expected0 done
-{-# NOINLINE fifoVerifier #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fifoVerifier #-}
 
 topEntity_17_2 :: ConfiguredFifo (BitVector 16) Dom17 Dom2
 topEntity_17_2 = dcFifo defConfig
-{-# NOINLINE topEntity_17_2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity_17_2 #-}
 {-# ANN topEntity_17_2 (defSyn "topEntity_17_2") #-}
 
 testBench_17_2 :: Signal Dom17 Bool
 testBench_17_2 = mkTestBench topEntity_17_2
-{-# NOINLINE testBench_17_2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench_17_2 #-}
 {-# ANN testBench_17_2 (TestBench 'topEntity_17_2) #-}
 
 topEntity_2_17 :: ConfiguredFifo (BitVector 16) Dom2 Dom17
 topEntity_2_17 = dcFifo defConfig
-{-# NOINLINE topEntity_2_17 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity_2_17 #-}
 {-# ANN topEntity_2_17 (defSyn "topEntity_2_17") #-}
 
 testBench_2_17 :: Signal Dom2 Bool
 testBench_2_17 = mkTestBench topEntity_2_17
-{-# NOINLINE testBench_2_17 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench_2_17 #-}
 {-# ANN testBench_2_17 (TestBench 'topEntity_2_17) #-}
 
 topEntity_2_2 :: ConfiguredFifo (Unsigned 16) Dom2 Dom2
 topEntity_2_2 = dcFifo defConfig
-{-# NOINLINE topEntity_2_2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity_2_2 #-}
 {-# ANN topEntity_2_2 (defSyn "topEntity_2_2") #-}
 
 testBench_2_2 :: Signal Dom2 Bool
 testBench_2_2 = mkTestBench topEntity_2_2
-{-# NOINLINE testBench_2_2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench_2_2 #-}
 {-# ANN testBench_2_2 (TestBench 'topEntity_2_2) #-}

--- a/tests/shouldwork/Cores/Xilinx/Floating.hs
+++ b/tests/shouldwork/Cores/Xilinx/Floating.hs
@@ -5,6 +5,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 -Wall -Werror #-}
 
 module Floating where
@@ -136,7 +138,8 @@ addBasic
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.AddDefDelay Float
 addBasic clk x y = withClock clk $ withEnable enableGen $ F.add x y
-{-# NOINLINE addBasic #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE addBasic #-}
 {-# ANN addBasic (binaryTopAnn "addBasic") #-}
 
 addBasicTB :: Signal XilinxSystem Bool
@@ -154,7 +157,8 @@ addEnable
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem 11 Float
 addEnable clk en x y = withClock clk $ withEnable en $ F.add x y
-{-# NOINLINE addEnable #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE addEnable #-}
 {-# ANN addEnable (binaryEnTopAnn "addEnable") #-}
 
 addEnableTB :: Signal XilinxSystem Bool
@@ -194,7 +198,8 @@ addShortPL
   -> DSignal XilinxSystem 6 Float
 addShortPL clk x y =
   withClock clk $ withEnable enableGen $ F.addWith F.defConfig x y
-{-# NOINLINE addShortPL #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE addShortPL #-}
 {-# ANN addShortPL (binaryTopAnn "addShortPL") #-}
 
 addShortPLTB :: Signal XilinxSystem Bool
@@ -212,7 +217,8 @@ subBasic
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.SubDefDelay Float
 subBasic clk x y = withClock clk $ withEnable enableGen $ F.sub x y
-{-# NOINLINE subBasic #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE subBasic #-}
 {-# ANN subBasic (binaryTopAnn "subBasic") #-}
 
 subBasicTB :: Signal XilinxSystem Bool
@@ -229,7 +235,8 @@ mulBasic
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.MulDefDelay Float
 mulBasic clk x y = withClock clk $ withEnable enableGen $ F.mul x y
-{-# NOINLINE mulBasic #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE mulBasic #-}
 {-# ANN mulBasic (binaryTopAnn "mulBasic") #-}
 
 mulBasicTB :: Signal XilinxSystem Bool
@@ -246,7 +253,8 @@ divBasic
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.DivDefDelay Float
 divBasic clk x y = withClock clk $ withEnable enableGen $ F.div x y
-{-# NOINLINE divBasic #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE divBasic #-}
 {-# ANN divBasic (binaryTopAnn "divBasic") #-}
 
 divBasicTB :: Signal XilinxSystem Bool
@@ -264,7 +272,8 @@ compareBasic
   -> DSignal XilinxSystem F.CompareDefDelay F.Ordering
 compareBasic clk x y =
   withClock clk $ withEnable enableGen $ F.compare x y
-{-# NOINLINE compareBasic #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE compareBasic #-}
 {-# ANN compareBasic (binaryTopAnn "compareBasic") #-}
 
 compareBasicTB :: Signal XilinxSystem Bool
@@ -279,7 +288,8 @@ compareEnable
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.CompareDefDelay F.Ordering
 compareEnable clk en x y = withClock clk $ withEnable en $ F.compare x y
-{-# NOINLINE compareEnable #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE compareEnable #-}
 {-# ANN compareEnable (binaryEnTopAnn "compareEnable") #-}
 
 compareEnableTB :: Signal XilinxSystem Bool
@@ -303,7 +313,8 @@ fromUBasic
   -> DSignal XilinxSystem 0 (Unsigned 32)
   -> DSignal XilinxSystem F.FromU32DefDelay Float
 fromUBasic clk x = withClock clk $ withEnable enableGen $ F.fromU32 x
-{-# NOINLINE fromUBasic #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromUBasic #-}
 {-# ANN fromUBasic (unaryTopAnn "fromUBasic") #-}
 
 fromUBasicTB :: Signal XilinxSystem Bool
@@ -328,7 +339,8 @@ fromUEnable
   -> DSignal XilinxSystem 0 (Unsigned 32)
   -> DSignal XilinxSystem 5 Float
 fromUEnable clk en x = withClock clk $ withEnable en $ F.fromU32 x
-{-# NOINLINE fromUEnable #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromUEnable #-}
 {-# ANN fromUEnable (unaryEnTopAnn "fromUEnable") #-}
 
 fromUEnableTB :: Signal XilinxSystem Bool
@@ -361,7 +373,8 @@ fromSBasic
   -> DSignal XilinxSystem 0 (Signed 32)
   -> DSignal XilinxSystem F.FromS32DefDelay Float
 fromSBasic clk x = withClock clk $ withEnable enableGen $ F.fromS32 x
-{-# NOINLINE fromSBasic #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromSBasic #-}
 {-# ANN fromSBasic (unaryTopAnn "fromSBasic") #-}
 
 fromSBasicTB :: Signal XilinxSystem Bool
@@ -386,7 +399,8 @@ fromSEnable
   -> DSignal XilinxSystem 0 (Signed 32)
   -> DSignal XilinxSystem 6 Float
 fromSEnable clk en x = withClock clk $ withEnable en $ F.fromS32 x
-{-# NOINLINE fromSEnable #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fromSEnable #-}
 {-# ANN fromSEnable (unaryEnTopAnn "fromSEnable") #-}
 
 fromSEnableTB :: Signal XilinxSystem Bool

--- a/tests/shouldwork/Cores/Xilinx/TdpBlockRam.hs
+++ b/tests/shouldwork/Cores/Xilinx/TdpBlockRam.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module TdpBlockRam where
@@ -26,7 +27,8 @@ topEntity
   tdpbram
     clkA (toEnable enA) addrA byteEnaA datA
     clkB (toEnable enB) addrB byteEnaB datB
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 noRstA :: Reset A
 noRstA = unsafeFromHighPolarity (pure False)
@@ -76,7 +78,8 @@ tb inputA expectedA inputB expectedB =
   clkB :: Clock B
   clkB = tbClockGen (not <$> doneB)
 
-{-# NOINLINE normalWritesTB #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE normalWritesTB #-}
 {-# ANN normalWritesTB (TestBench 'topEntity) #-}
 -- | Test bench doing some (non-overlapping) writes and reads on two ports, either
 -- with the byte enable fully set, or fully unset.
@@ -127,7 +130,8 @@ normalWritesTB = tb inputA expectedA inputB expectedB
     :> Nil
     ) ++ repeat @10 noOp
 
-{-# NOINLINE writeEnableWritesTB #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE writeEnableWritesTB #-}
 {-# ANN writeEnableWritesTB (TestBench 'topEntity) #-}
 -- | Test bench doing some (non-overlapping) writes and reads on two ports, with
 -- varying byte enables.

--- a/tests/shouldwork/Cores/Xilinx/VIO.hs
+++ b/tests/shouldwork/Cores/Xilinx/VIO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module VIO where
@@ -22,7 +23,8 @@ type Dom = XilinxSystem
 
 top :: "result" ::: Unsigned 8
 top = 0
-{-# NOINLINE top #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE top #-}
 
 makeTopEntity 'top
 

--- a/tests/shouldwork/CustomReprs/Deriving/BitPackDerivation.hs
+++ b/tests/shouldwork/CustomReprs/Deriving/BitPackDerivation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module BitPackDerivation where
@@ -28,7 +29,8 @@ topEntity
   => Signal System Train
   -> Signal System (BitVector 8)
 topEntity trains = pack <$> trains
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench
   :: Signal System Bool

--- a/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
+++ b/tests/shouldwork/CustomReprs/Indexed/Indexed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -18,7 +19,8 @@ topEntity
   :: Signal System WithVector
   -> Signal System Bool
 topEntity = fmap topEntity'
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
+++ b/tests/shouldwork/CustomReprs/Rotate/Rotate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
@@ -74,7 +75,8 @@ topEntity = fmap f
       case cM of
         Just c  -> rotateColor c
         Nothing -> Red
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 -- Testbench:
 testBench :: Signal System Bool

--- a/tests/shouldwork/CustomReprs/RotateC/ReprCompact.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprCompact.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ReprCompact
   ( testBench
   , topEntity
@@ -48,8 +50,10 @@ import qualified RotateC
 
 topEntity :: Top
 topEntity = RotateC.topEntity
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = tb topEntity
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/CustomReprs/RotateC/ReprCompactScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprCompactScrambled.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ReprCompactScrambled
   ( testBench
   , topEntity
@@ -48,8 +50,10 @@ import qualified RotateC
 
 topEntity :: Top
 topEntity = RotateC.topEntity
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = tb topEntity
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/CustomReprs/RotateC/ReprLastBitConstructor.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprLastBitConstructor.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ReprLastBitConstructor
   ( topEntity
   , testBench
@@ -27,8 +29,10 @@ import qualified RotateC
 
 topEntity :: Top
 topEntity = RotateC.topEntity
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = tb topEntity
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/CustomReprs/RotateC/ReprStrangeMasks.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprStrangeMasks.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ReprStrangeMasks
   ( topEntity
   , testBench
@@ -48,8 +50,10 @@ import qualified RotateC
 
 topEntity :: Top
 topEntity = RotateC.topEntity
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = tb topEntity
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/CustomReprs/RotateC/ReprWide.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/ReprWide.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ReprWide
   ( topEntity
   , testBench
@@ -32,8 +34,10 @@ import qualified RotateC
 
 topEntity :: Top
 topEntity = RotateC.topEntity
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = tb topEntity
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateC.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE RankNTypes #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
@@ -42,7 +43,8 @@ topEntity = fmap f
       case cM of
         JustC c  -> rotateColor c
         NothingC -> Red
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 -- Testbench:
 tb :: Top -> Signal System Bool
@@ -73,4 +75,5 @@ tb top = done'
 
 testBench :: Signal System Bool
 testBench = tb topEntity
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
+++ b/tests/shouldwork/CustomReprs/RotateC/RotateCScrambled.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
@@ -85,7 +86,8 @@ topEntity = fmap f
       case cM of
         NothingC -> Blue
         JustC c  -> rotateColor c
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 -- Testbench:
 testBench :: Signal System Bool

--- a/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
+++ b/tests/shouldwork/CustomReprs/RotateCNested/RotateCNested.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
@@ -79,7 +80,8 @@ topEntity = fmap f
         Just (JustC c) -> rotateColor c
         Just NothingC  -> Blue
         Nothing        -> Red
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 -- Testbench:
 testBench :: Signal System Bool

--- a/tests/shouldwork/DDR/DDRin.hs
+++ b/tests/shouldwork/DDR/DDRin.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module DDRin where
@@ -40,7 +42,8 @@ topEntityUA
   -> Signal AsyncDDR (BitVector 8)
   -> Signal AsyncReal (BitVector 8, BitVector 8)
 topEntityUA clk rst = topEntityGeneric clk rst enableGen
-{-# NOINLINE topEntityUA #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityUA #-}
 {-# ANN topEntityUA (defSyn "topEntityUA") #-}
 
 topEntityUS
@@ -49,7 +52,8 @@ topEntityUS
   -> Signal SyncDDR (BitVector 8)
   -> Signal SyncReal (BitVector 8, BitVector 8)
 topEntityUS clk rst = topEntityGeneric clk rst enableGen
-{-# NOINLINE topEntityUS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityUS #-}
 {-# ANN topEntityUS (defSyn "topEntityUS") #-}
 
 
@@ -59,7 +63,8 @@ topEntityGA
   -> Signal AsyncDDR (BitVector 8)
   -> Signal AsyncReal (BitVector 8, BitVector 8)
 topEntityGA clk rst = topEntityGeneric clk rst tbEnableGen
-{-# NOINLINE topEntityGA #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityGA #-}
 {-# ANN topEntityGA (defSyn "topEntityGA") #-}
 
 
@@ -69,7 +74,8 @@ topEntityGS
   -> Signal SyncDDR (BitVector 8)
   -> Signal SyncReal (BitVector 8, BitVector 8)
 topEntityGS clk rst = topEntityGeneric clk rst tbEnableGen
-{-# NOINLINE topEntityGS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityGS #-}
 {-# ANN topEntityGS (defSyn "topEntityGS") #-}
 
 
@@ -100,7 +106,8 @@ testBenchUS = done
     rstTest        = resetGen @TB
     rstDDR         = resetGen @SyncDDR
     rstReal        = resetGen @SyncReal
-{-# NOINLINE testBenchUS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchUS #-}
 {-# ANN testBenchUS (TestBench 'topEntityUS) #-}
 
 testBenchUA :: Signal TB Bool
@@ -116,7 +123,8 @@ testBenchUA = done
     clkReal        = tbClockGen @AsyncReal notDone
     rstDDR         = resetGen @AsyncDDR
     rstReal        = resetGen @AsyncReal
-{-# NOINLINE testBenchUA #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchUA #-}
 {-# ANN testBenchUA (TestBench 'topEntityUA) #-}
 
 testBenchGS :: Signal TB Bool
@@ -135,7 +143,8 @@ testBenchGS = done
     rstTest        = resetGen @TB
     rstDDR         = resetGen @SyncDDR
     rstReal        = resetGen @SyncReal
-{-# NOINLINE testBenchGS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchGS #-}
 {-# ANN testBenchGS (TestBench 'topEntityGS) #-}
 
 testBenchGA :: Signal TB Bool
@@ -151,5 +160,6 @@ testBenchGA = done
     clkReal        = tbClockGen @AsyncReal notDone
     rstDDR         = resetGen @AsyncDDR
     rstReal        = resetGen @AsyncReal
-{-# NOINLINE testBenchGA #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchGA #-}
 {-# ANN testBenchGA (TestBench 'topEntityGA) #-}

--- a/tests/shouldwork/DDR/DDRout.hs
+++ b/tests/shouldwork/DDR/DDRout.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module DDRout where
@@ -40,7 +42,8 @@ topEntityUA
   -> Signal AsyncReal (BitVector 8, BitVector 8)
   -> Signal AsyncDDR (BitVector 8)
 topEntityUA clk rst = topEntityGeneric clk rst enableGen
-{-# NOINLINE topEntityUA #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityUA #-}
 {-# ANN topEntityUA (defSyn "topEntityUA") #-}
 
 topEntityUS
@@ -49,7 +52,8 @@ topEntityUS
   -> Signal SyncReal (BitVector 8, BitVector 8)
   -> Signal SyncDDR (BitVector 8)
 topEntityUS clk rst = topEntityGeneric clk rst enableGen
-{-# NOINLINE topEntityUS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityUS #-}
 {-# ANN topEntityUS (defSyn "topEntityUS") #-}
 
 topEntityGA
@@ -58,7 +62,8 @@ topEntityGA
   -> Signal AsyncReal (BitVector 8, BitVector 8)
   -> Signal AsyncDDR (BitVector 8)
 topEntityGA clk rst = topEntityGeneric clk rst tbEnableGen
-{-# NOINLINE topEntityGA #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityGA #-}
 {-# ANN topEntityGA (defSyn "topEntityGA") #-}
 
 topEntityGS
@@ -67,7 +72,8 @@ topEntityGS
   -> Signal SyncReal (BitVector 8, BitVector 8)
   -> Signal SyncDDR (BitVector 8)
 topEntityGS clk rst = topEntityGeneric clk rst tbEnableGen
-{-# NOINLINE topEntityGS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityGS #-}
 {-# ANN topEntityGS (defSyn "topEntityGS") #-}
 
 input :: Vec 5 (BitVector 8, BitVector 8)
@@ -95,7 +101,8 @@ testBenchUS = done
     rstTest        = resetGen @TB
     rstDDR         = resetGen @SyncDDR
     rstReal        = resetGen @SyncReal
-{-# NOINLINE testBenchUS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchUS #-}
 {-# ANN testBenchUS (TestBench 'topEntityUS) #-}
 
 testBenchUA :: Signal TB Bool
@@ -110,7 +117,8 @@ testBenchUA = done
     clkReal        = tbClockGen @AsyncReal (unsafeSynchronizer clkDDR clkReal notDone)
     rstDDR         = resetGen @AsyncDDR
     rstReal        = resetGen @AsyncReal
-{-# NOINLINE testBenchUA #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchUA #-}
 {-# ANN testBenchUA (TestBench 'topEntityUA) #-}
 
 testBenchGA :: Signal TB Bool
@@ -125,7 +133,8 @@ testBenchGA = done
     clkReal        = tbClockGen @AsyncReal (unsafeSynchronizer clkDDR clkReal notDone)
     rstDDR         = resetGen @AsyncDDR
     rstReal        = resetGen @AsyncReal
-{-# NOINLINE testBenchGA #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchGA #-}
 {-# ANN testBenchGA (TestBench 'topEntityGA) #-}
 
 testBenchGS :: Signal TB Bool
@@ -144,5 +153,6 @@ testBenchGS = done
     rstTest        = resetGen @TB
     rstDDR         = resetGen @SyncDDR
     rstReal        = resetGen @SyncReal
-{-# NOINLINE testBenchGS #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchGS #-}
 {-# ANN testBenchGS (TestBench 'topEntityGS) #-}

--- a/tests/shouldwork/Feedback/Fib.hs
+++ b/tests/shouldwork/Feedback/Fib.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Fib where
 
 import Clash.Prelude
@@ -12,7 +14,8 @@ topEntity
   -> Enable System
   -> Signal System (Unsigned 64)
 topEntity = exposeClockResetEnable fib
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Feedback/MutuallyRecursive.hs
+++ b/tests/shouldwork/Feedback/MutuallyRecursive.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 
 module MutuallyRecursive where
@@ -34,7 +35,8 @@ hdlSimTest n topEntity testInput expectedOutput = done
         withSpecificClockResetEnable tbClk tbRst tbEn expectedOutput
 
     done = expectedOutput' (topEntity' testInput')
-{-# NOINLINE hdlSimTest #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE hdlSimTest #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Fixed/Mixer.hs
+++ b/tests/shouldwork/Fixed/Mixer.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Mixer where
 
 import Clash.Prelude
@@ -16,7 +18,8 @@ cordic angle
 
 topEntity :: SFixed 3 8 -> SFixed 3 8
 topEntity = cordic
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Fixed/SFixedTest.hs
+++ b/tests/shouldwork/Fixed/SFixedTest.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module SFixedTest where
 
 import Clash.Prelude
@@ -7,7 +9,8 @@ type SF = SFixed 4 18
 
 topEntity :: SF -> SF
 topEntity x = x * 2.56
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Fixed/ZeroInt.hs
+++ b/tests/shouldwork/Fixed/ZeroInt.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ZeroInt where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: (UFixed 0 8,UFixed 0 8) -> UFixed 0 8
 topEntity = uncurry (*)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Floating/FloatConstFolding.hs
+++ b/tests/shouldwork/Floating/FloatConstFolding.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module FloatConstFolding where
 
 import Clash.Prelude
@@ -60,7 +62,8 @@ twiddle = (+ 1e-5) -- prevent any optimiser from doing: asin . sin <=> id
 
 pi_noinline :: Floating a => a
 pi_noinline = pi
-{-# NOINLINE pi_noinline #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE pi_noinline #-}
 
 a,b,c,d,e,f :: Floating a => a
 a = 1.0

--- a/tests/shouldwork/Floating/T1803.hs
+++ b/tests/shouldwork/Floating/T1803.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NegativeLiterals #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 module T1803 where
 
@@ -21,7 +22,8 @@ topEntity clk rst =
       d :: Signal System Double
       d = stimuliGenerator clk rst (map unpack doubleData)
   in bundle (pack <$> f, pack <$> d)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench
   :: Signal System Bool
@@ -31,7 +33,8 @@ testBench = done
     done = expectOutput $ topEntity clk rst
     clk = tbSystemClockGen (not <$> done)
     rst = systemResetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}
 
 {-
  - floatData should end up in the top entity as:

--- a/tests/shouldwork/GADTs/Constrained.hs
+++ b/tests/shouldwork/GADTs/Constrained.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 
 module Constrained where
@@ -26,11 +27,13 @@ complementBus
   => Bus n
   -> Bus n
 complementBus (Bus bv) = Bus (complement bv)
-{-# NOINLINE complementBus #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE complementBus #-}
 
 topEntity :: Bus 5 -> Bus 5
 topEntity = complementBus
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/GADTs/Head.hs
+++ b/tests/shouldwork/GADTs/Head.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Head where
 
 import Clash.Prelude
@@ -5,11 +7,13 @@ import Clash.Explicit.Testbench
 
 head' :: Vec (n+1) (Signed 16) -> Signed 16
 head' (Cons x xs) = x
-{-# NOINLINE head' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE head' #-}
 
 topEntity :: Vec 3 (Signed 16) -> Signed 16
 topEntity = head'
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/GADTs/HeadM.hs
+++ b/tests/shouldwork/GADTs/HeadM.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module HeadM where
 
 import Clash.Prelude
@@ -5,11 +7,13 @@ import Clash.Explicit.Testbench
 
 head' :: Vec 3 (Signed 16) -> Signed 16
 head' (Cons x xs) = x
-{-# NOINLINE head' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE head' #-}
 
 topEntity :: Vec 3 (Signed 16) -> Signed 16
 topEntity = head'
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/GADTs/MonomorphicTopEntity.hs
+++ b/tests/shouldwork/GADTs/MonomorphicTopEntity.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 
 module MonomorphicTopEntity where
@@ -12,11 +13,13 @@ data STy ty where
 sty :: STy ty -> ty
 sty (SBool b) = not b
 sty (SInt16 i) = i + 1
-{-# NOINLINE sty #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE sty #-}
 
 topEntity :: STy (Signed 16) -> Signed 16
 topEntity = sty
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/GADTs/Record.hs
+++ b/tests/shouldwork/GADTs/Record.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -31,13 +32,15 @@ instance ShowX (Foo Int) where
 succIntChar :: Foo a -> Foo a
 succIntChar (Foo chr dt int) =
   Foo (succ chr) dt (succ int)
-{-# NOINLINE succIntChar #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE succIntChar #-}
 
 topEntity :: Foo Int -> Foo Int
 topEntity foo = Foo chr (succ <$> dt) int
   where
     Foo chr dt int = succIntChar foo
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -48,4 +51,5 @@ testBench = done
     done           = expectedOutput (topEntity <$> testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/GADTs/T1310.hs
+++ b/tests/shouldwork/GADTs/T1310.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 module T1310 where
 
@@ -8,11 +9,13 @@ data Ex where
 
 f :: Ex -> Bool
 f (Ex n y) = h (replicate n y)
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 h :: Vec n Bool -> Bool
 h xs = foldr (||) True xs
-{-# NOINLINE h #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE h #-}
 
 g :: Int -> Bool -> Ex
 g 0 b = Ex (SNat @3) b

--- a/tests/shouldwork/GADTs/Tail.hs
+++ b/tests/shouldwork/GADTs/Tail.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Tail where
 
 import Clash.Prelude
@@ -5,11 +7,13 @@ import Clash.Explicit.Testbench
 
 tail' :: Vec (n+1) (Signed 16) -> Vec n (Signed 16)
 tail' (Cons x xs) = xs
-{-# NOINLINE tail' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tail' #-}
 
 topEntity :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)
 topEntity = tail'
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/GADTs/TailM.hs
+++ b/tests/shouldwork/GADTs/TailM.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module TailM where
 
 import Clash.Prelude
@@ -5,11 +7,13 @@ import Clash.Explicit.Testbench
 
 tail' :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)
 tail' (Cons x xs) = xs
-{-# NOINLINE tail' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tail' #-}
 
 topEntity :: Vec 3 (Signed 16) -> Vec 2 (Signed 16)
 topEntity = tail'
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/GADTs/TailOfTail.hs
+++ b/tests/shouldwork/GADTs/TailOfTail.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module TailOfTail where
 
 import Clash.Prelude
@@ -5,11 +7,13 @@ import Clash.Explicit.Testbench
 
 tailOfTail :: Vec (n+2) (Signed 16) -> Vec n (Signed 16)
 tailOfTail (Cons _ (Cons _ xs)) = xs
-{-# NOINLINE tailOfTail #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE tailOfTail #-}
 
 topEntity :: Vec 4 (Signed 16) -> Vec 2 (Signed 16)
 topEntity = tailOfTail
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/HOPrim/HOImap.hs
+++ b/tests/shouldwork/HOPrim/HOImap.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module HOImap where
@@ -60,7 +61,8 @@ topEntity = exposeClockResetEnable go where
      :> f negate       -- if address == 3 negate
      :> Nil
     f xK = fmap (fmap xK)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/HOPrim/Map.hs
+++ b/tests/shouldwork/HOPrim/Map.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Map where
 
 import Clash.Prelude
@@ -21,7 +23,8 @@ topEntity
   -> Signal System (Vec 4 Bool)
 topEntity =
   bundle . fmap (go ()) . unbundle
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 
 testBench :: Signal System Bool

--- a/tests/shouldwork/HOPrim/Map2.hs
+++ b/tests/shouldwork/HOPrim/Map2.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Map2 where
 
 import Clash.Prelude
@@ -13,7 +15,8 @@ topEntity
   -> Signal System (Vec 4 Bool)
 topEntity =
   bundle . fmap go . unbundle
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 
 testBench :: SystemClockResetEnable => Signal System Bool

--- a/tests/shouldwork/HOPrim/TestMap.hs
+++ b/tests/shouldwork/HOPrim/TestMap.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module TestMap where
 
 import Clash.Explicit.Prelude
@@ -48,7 +50,8 @@ topEntity
   -> (Signal System50 Word1, Signal System50 Bool)
   -> Signal System50 Word1
 topEntity clk rst en = mf clk rst en ((romF1 :> romF2 :> Nil), d2, d8)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System50 Bool
 testBench = done

--- a/tests/shouldwork/HOPrim/Transpose.hs
+++ b/tests/shouldwork/HOPrim/Transpose.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE CPP #-}
+
 module Transpose where
 
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
 topEntity = transposeV
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 transposeV :: Vec 3 (Vec 4 Int) -> Vec 4 (Vec 3 Int)
 transposeV = sequenceA

--- a/tests/shouldwork/HOPrim/VecFun.hs
+++ b/tests/shouldwork/HOPrim/VecFun.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE CPP #-}
+
 module VecFun where
 
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
 topEntity = work
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 work :: Vec 3 Int -> Vec 3 Int
 work xs = zipWith sel xs funs where

--- a/tests/shouldwork/Issues/T1388.hs
+++ b/tests/shouldwork/Issues/T1388.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1388 where
 
 import Clash.Prelude hiding (Word)
@@ -25,13 +27,15 @@ newtype TypeA = TypeA (Bytes 4)
 newtype TypeB = TypeB (Words 4)
   deriving (Generic, NFDataX, Show, Eq)
 
-{-# NOINLINE bytesToWords #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE bytesToWords #-}
 bytesToWords :: Bytes 4 -> TypeB
 bytesToWords = TypeB . fmap (\(Byte a) -> Word $ ((unpack . resize .  pack) a))
 
 data TypeAs = Nop | TypeAS TypeA
 
-{-# NOINLINE convertTwoTypeAs #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE convertTwoTypeAs #-}
 convertTwoTypeAs :: TypeAs -> Maybe TypeB
 convertTwoTypeAs op = case op of
   TypeAS (TypeA a) -> Just $ (bytesToWords a)

--- a/tests/shouldwork/Issues/T1439.hs
+++ b/tests/shouldwork/Issues/T1439.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
 {-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module T1439 where
@@ -27,7 +28,8 @@ rotate_right
     -- ^ Result.
 rotate_right bv =
   leToPlus @1 @n (rotate_right' bv)
-{-# NOINLINE rotate_right #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotate_right #-}
 
 rotate_right'
     :: forall n . (KnownNat n)
@@ -41,7 +43,8 @@ rotate_right' bool bv
     | bool      = pack b ++# (fst $ split# bv)
     | otherwise = bv
     where b = lsb bv
-{-# NOINLINE rotate_right' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE rotate_right' #-}
 
 testPath :: FilePath
 testPath = "tests/shouldwork/Issues/T1439.hs"

--- a/tests/shouldwork/Issues/T1477.hs
+++ b/tests/shouldwork/Issues/T1477.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1477 where
 
 import Clash.Prelude
@@ -8,6 +10,7 @@ type instance QQ (Signal dom a) = a
 
 f :: forall a . Proxy a -> QQ a -> QQ a
 f Proxy = id
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 topEntity = f @(Signal System Bool)

--- a/tests/shouldwork/Issues/T1506A.hs
+++ b/tests/shouldwork/Issues/T1506A.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
@@ -27,4 +28,5 @@ topEntity xClk xRst {- 1 xRst -} xEna iClk iRst {- 1 iRst -} iEna xa xb ia ib =
   , autoReg  iClk iRst iEna      (Just Nothing) ib -- 4 iRst
   , autoReg  iClk iRst enableGen (Just Nothing) ib -- 4 iRst
   )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}

--- a/tests/shouldwork/Issues/T1606B.hs
+++ b/tests/shouldwork/Issues/T1606B.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -O0 #-}
 module T1606B where
 
@@ -6,12 +8,14 @@ import Clash.Prelude
 f :: Vec 8 (Clock System)
   -> Vec 8 (Clock System)
 f = id
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 g :: Vec 8 (Clock System)
   -> Vec 8 (Clock System)
 g = f
-{-# NOINLINE g #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE g #-}
 
 topEntity ::
      Vec 8 (Clock System)

--- a/tests/shouldwork/Issues/T1669_DEC.hs
+++ b/tests/shouldwork/Issues/T1669_DEC.hs
@@ -1,16 +1,20 @@
+{-# LANGUAGE CPP #-}
+
 module T1669_DEC where
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
 data AB = A | B
 
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 topEntity :: AB -> Int -> Int
 topEntity ab x = case ab of
     A -> f 3 x 0 1 2 3 4 5 6 7 8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64
     B -> f x x 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 0
 
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 f z0 z1 z2 z3 z4 z5 z6 z7 z8 z9 z10 z11 z12 z13 z14 z15 z16 z17 z18 z19 z20 z21 z22 z23 z24 z25 z26 z27 z28 z29 z30 z31 z32 z33 z34 z35 z36 z37 z38 z39 z40 z41 z42 z43 z44 z45 z46 z47 z48 z49 z50 z51 z52 z53 z54 z55 z56 z57 z58 z59 z60 z61 z62 z63 z64 z65 z66
   = foldl (\b (a,i) -> b - a*i) 0 $ zip args ixs
  where

--- a/tests/shouldwork/Issues/T1715.hs
+++ b/tests/shouldwork/Issues/T1715.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1715 where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: (BitVector 16,BitVector 128) -> BitVector 128
 topEntity = uncurry (setSlice d127 d112)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Issues/T1721.hs
+++ b/tests/shouldwork/Issues/T1721.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1721 where
 
 import Clash.Prelude
@@ -16,7 +18,8 @@ f :: F (T (G ()))
   -> F (T (G ()))
 f = id
 
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 topEntity :: F (T (G ()))
           -> F (T (G ()))

--- a/tests/shouldwork/Issues/T1933.hs
+++ b/tests/shouldwork/Issues/T1933.hs
@@ -11,12 +11,14 @@ data T = MkT (Unsigned 12) (Unsigned 12)
 
 f :: T -> T
 f x = x
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 p :: Unsigned 12
 p = case clockGen @System of
       Clock _ -> 4
-{-# NOINLINE p #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE p #-}
 
 q :: Natural
 #if __GLASGOW_HASKELL__ == 900
@@ -24,7 +26,8 @@ q = case p of U n -> n
 #else
 q = coerce p
 #endif
-{-# NOINLINE q #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE q #-}
 
 topEntity :: Unsigned 12 -> T
 topEntity x =

--- a/tests/shouldwork/Issues/T2040.hs
+++ b/tests/shouldwork/Issues/T2040.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2040 where
 
 import Clash.Explicit.Prelude
@@ -7,7 +9,8 @@ topEntity
   :: Signal System (Unsigned 8)
   -> Signal System (Unsigned 8)
 topEntity = id
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Issues/T2046.hs
+++ b/tests/shouldwork/Issues/T2046.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2046 where
 
 import Clash.Prelude
@@ -19,7 +21,8 @@ topBit
   -> Int
   -> Int
 topBit = topGeneric (Proxy @Bit)
-{-# NOINLINE topBit #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topBit #-}
 {-# ANN topBit (defSyn "top_bit") #-}
 
 topBitVector
@@ -27,7 +30,8 @@ topBitVector
   -> Int
   -> Int
 topBitVector = topGeneric (Proxy @(BitVector 3))
-{-# NOINLINE topBitVector #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topBitVector #-}
 {-# ANN topBitVector (defSyn "top_bitvector") #-}
 
 topIndex
@@ -35,7 +39,8 @@ topIndex
   -> Int
   -> Int
 topIndex = topGeneric (Proxy @(Index 5))
-{-# NOINLINE topIndex #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topIndex #-}
 {-# ANN topIndex (defSyn "top_index") #-}
 
 topSigned
@@ -43,7 +48,8 @@ topSigned
   -> Int
   -> Int
 topSigned = topGeneric (Proxy @(Signed 4))
-{-# NOINLINE topSigned #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topSigned #-}
 {-# ANN topSigned (defSyn "top_signed") #-}
 
 topUnsigned
@@ -51,5 +57,6 @@ topUnsigned
   -> Int
   -> Int
 topUnsigned = topGeneric (Proxy @(Unsigned 3))
-{-# NOINLINE topUnsigned #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topUnsigned #-}
 {-# ANN topUnsigned (defSyn "top_unsigned") #-}

--- a/tests/shouldwork/Issues/T2046B.hs
+++ b/tests/shouldwork/Issues/T2046B.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2046B where
 
 import Clash.Prelude
@@ -13,7 +15,8 @@ topEntity ((a, b), (c, d), (e, f), (g, h), i) =
   , (toEnum (fromEnum g), toEnum (fromEnum h))
   , toEnum (fromEnum i)
   )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Issues/T2220_toEnumOOB.hs
+++ b/tests/shouldwork/Issues/T2220_toEnumOOB.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2220_toEnumOOB where
 
 import Clash.Prelude
@@ -6,7 +8,8 @@ import Clash.Explicit.Testbench
 topEntity :: BitVector 2 -> Maybe A_Index
 topEntity x | x == 3    = Nothing
             | otherwise = Just $ toEnum $ fromIntegral x
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 {-
 Because of the concurrent nature of the VHDL generate by clash,

--- a/tests/shouldwork/Issues/T2272.hs
+++ b/tests/shouldwork/Issues/T2272.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ImpredicativeTypes, TypeApplications, GADTs #-}
 module T2272 where
 
@@ -8,7 +9,8 @@ data Ex where
 
 f :: Ex
 f = ExT (errorX @(forall b . String -> b) "qq")
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 topEntity :: Int
 topEntity = case f of

--- a/tests/shouldwork/Issues/T2325.hs
+++ b/tests/shouldwork/Issues/T2325.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module T2325 where
@@ -18,22 +19,26 @@ type T = Unsigned 8 -> Unsigned 8
 
 f :: T
 f = g . h
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 {-# ANN f (defSyn "f") #-}
 
 g :: T
 g = h . j
-{-# NOINLINE g #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE g #-}
 {-# ANN g (defSyn "g") #-}
 
 h :: T
 h = (+ 5)
-{-# NOINLINE h #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE h #-}
 {-# ANN h (defSyn "h") #-}
 
 j :: T
 j = (+ 10)
-{-# NOINLINE j #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE j #-}
 {-# ANN j (defSyn "j") #-}
 
 assertBool :: HasCallStack => Bool -> IO ()

--- a/tests/shouldwork/Issues/T2325f.hs
+++ b/tests/shouldwork/Issues/T2325f.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module T2325f where
@@ -18,7 +19,8 @@ import qualified Data.List as L
 
 f :: Unsigned 8 -> Unsigned 8
 f = g . h
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 {-# ANN f (defSyn "f") #-}
 
 assertBool :: HasCallStack => Bool -> IO ()

--- a/tests/shouldwork/Issues/T2325g.hs
+++ b/tests/shouldwork/Issues/T2325g.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2325g where
 
 import Clash.Prelude
@@ -7,5 +9,6 @@ import T2325j
 
 g :: Unsigned 8 -> Unsigned 8
 g = h . j
-{-# NOINLINE g #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE g #-}
 {-# ANN g (defSyn "g") #-}

--- a/tests/shouldwork/Issues/T2325h.hs
+++ b/tests/shouldwork/Issues/T2325h.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE CPP #-}
+
 module T2325h where
 
 import Clash.Prelude
 
 h :: Unsigned 8 -> Unsigned 8
 h = (+ 5)
-{-# NOINLINE h #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE h #-}
 {-# ANN h (defSyn "h") #-}

--- a/tests/shouldwork/Issues/T2325j.hs
+++ b/tests/shouldwork/Issues/T2325j.hs
@@ -1,9 +1,12 @@
 
+{-# LANGUAGE CPP #-}
+
 module T2325j where
 
 import Clash.Prelude
 
 j :: Unsigned 8 -> Unsigned 8
 j = (+ 10)
-{-# NOINLINE j #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE j #-}
 {-# ANN j (defSyn "j") #-}

--- a/tests/shouldwork/Issues/T2334.hs
+++ b/tests/shouldwork/Issues/T2334.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2334 where
 
 import qualified Prelude as P
@@ -19,7 +21,8 @@ topEntity ::
   Signal System Int ->
   Signal System Int
 topEntity clk rst = assert clk rst "FileOrder"
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 assertBool :: HasCallStack => Bool -> IO ()
 assertBool b = Exception.assert b pure ()

--- a/tests/shouldwork/Issues/T2342A.hs
+++ b/tests/shouldwork/Issues/T2342A.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2342A where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Data.Proxy
 
 foo :: forall n. KnownNat n => Proxy n -> Float
 foo Proxy = natToNum @n
-{-# NOINLINE foo #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE foo #-}
 
 topEntity :: Float
 topEntity = foo @10 Proxy

--- a/tests/shouldwork/Issues/T2342B.hs
+++ b/tests/shouldwork/Issues/T2342B.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2342B where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Data.Proxy
 
 foo :: forall n. KnownNat n => Proxy n -> Double
 foo Proxy = natToNum @n
-{-# NOINLINE foo #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE foo #-}
 
 topEntity :: Double
 topEntity = foo @10 Proxy

--- a/tests/shouldwork/Issues/T2510.hs
+++ b/tests/shouldwork/Issues/T2510.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+
+module T2510 where
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+import Data.String.Interpolate (__i)
+import Clash.Explicit.Prelude
+import Clash.Annotations.Primitive
+
+class X a where
+  x :: a
+
+instance X (Signal System Int) where
+  x = pure 3
+
+instance X a => X (Signal System Int -> a) where
+  x !_i = x
+
+bb :: X a => a
+bb = x
+{-# NOINLINE bb #-}
+{-# ANN bb hasBlackBox #-}
+{-# ANN bb (
+  let bbName = show 'bb
+  in InlineYamlPrimitive [minBound..] [__i|
+    BlackBox:
+      name: "#{bbName}"
+      kind: Expression
+      template: "this should end up in HDL with OPAQUE~ARG[1]"
+|]) #-}
+
+bbWrapper :: X a => a
+bbWrapper = bb
+{-# NOINLINE bbWrapper #-}
+
+topEntity :: Signal System Int -> Signal System Int
+topEntity i = bbWrapper i
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity1.vhdl")
+  assertIn "this should end up in HDL with OPAQUE" content

--- a/tests/shouldwork/Issues/T508.hs
+++ b/tests/shouldwork/Issues/T508.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module T508 where
@@ -16,10 +17,12 @@ data AB = A | B
 ab :: KnownNat n => Index n -> AB -> AB
 ab n A = if n >  0 then A else B
 ab n B = if n == 0 then B else A
-{-# NOINLINE ab #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ab #-}
 
 topEntity = ab @1
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testPath :: FilePath
 testPath = "tests/shouldwork/Issues/T508.hs"

--- a/tests/shouldwork/LoadModules/T1796.hs
+++ b/tests/shouldwork/LoadModules/T1796.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -11,7 +12,8 @@ topEntity
   :: Signal System Bool
   -> Signal System Bool
 topEntity = id
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 tb
   :: Signal System Bool
@@ -26,4 +28,5 @@ tb = done
 
 testBench :: Signal System Bool
 testBench = tb
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Netlist/NoDeDup.hs
+++ b/tests/shouldwork/Netlist/NoDeDup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -17,7 +18,8 @@ data ABCD = A | B | C | D
 
 twice :: Int -> Int
 twice a = 2 * a
-{-# NOINLINE twice #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE twice #-}
 
 -- | 'f' should have one call to twice in the netlist
 f :: Int -> ABCD -> Int
@@ -27,7 +29,8 @@ f n abcd =
     B -> 5 + n
     C -> n - 3
     D -> twice (3 + n)
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 -- | 'g' should have two calls to twice in the netlist
 g :: Int -> ABCD -> Int
@@ -37,7 +40,8 @@ g n abcd =
     B -> 5 + n
     C -> n - 3
     D -> noDeDup (twice (3 + n))
-{-# NOINLINE g #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE g #-}
 
 topEntity :: Int -> ABCD -> Int
 topEntity n abcd = (f n abcd) - (g n abcd)

--- a/tests/shouldwork/Numbers/BitInteger.hs
+++ b/tests/shouldwork/Numbers/BitInteger.hs
@@ -4,6 +4,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
+{-# LANGUAGE CPP #-}
+
 module BitInteger where
 
 import Clash.Prelude
@@ -13,7 +15,8 @@ import Data.Bits
 
 topEntity :: Int -> Integer
 topEntity = bit
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/Bounds.hs
+++ b/tests/shouldwork/Numbers/Bounds.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Bounds where
 import Clash.Prelude
 import Clash.Explicit.Testbench
@@ -24,7 +26,8 @@ topEntity
   -> Enable System
   -> Signal System () -> Signal System Integer
 topEntity = exposeClockResetEnable (mealy loop actual)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 loop :: Vec (n+2) a -> () -> (Vec (n+2) a, a)
 --loop (x:>xs) _ = (xs :< last xs, x)

--- a/tests/shouldwork/Numbers/DivideByZero.hs
+++ b/tests/shouldwork/Numbers/DivideByZero.hs
@@ -1,4 +1,6 @@
 -- Test that the compiler doesn't crash on any DivideByZero exceptions
+{-# LANGUAGE CPP #-}
+
 module DivideByZero where
 
 import Clash.Prelude
@@ -16,7 +18,8 @@ topEntity = pure @(Signal System)
   ,test @Word16
   ,test @Int32
   )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 test :: Integral a => (a,a,a,a)
 test = (div0,quot0,mod0,rem0)

--- a/tests/shouldwork/Numbers/Exp.hs
+++ b/tests/shouldwork/Numbers/Exp.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 
@@ -34,7 +35,8 @@ topEntity b =
   , resize ((fromInteger b :: Unsigned 64) ^ d2) :: Unsigned 64
   , resize ((fromInteger b :: Index (2^64)) ^ d2) :: Index (2^64)
   )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 
 -- Should be constant folded, and yield the same results as topEntity

--- a/tests/shouldwork/Numbers/ExpWithGhcCF.hs
+++ b/tests/shouldwork/Numbers/ExpWithGhcCF.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ExpWithGhcCF where
 import Clash.Prelude
 import Clash.Explicit.Testbench
@@ -8,7 +10,8 @@ expected = $(lift (map pack Exp.expectedOutputs))
 
 -- Constant folded (?) topEntity (Clash)
 topEntity = Exp.topEntity
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/Integral.hs
+++ b/tests/shouldwork/Numbers/Integral.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -45,7 +46,8 @@ topEntity (x,y) =
     , test @(Index 128) (abs x) (abs y)
     )
   )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 inputs :: Vec _ (Integer,Integer)
 inputs =
@@ -63,4 +65,3 @@ deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift 
       => Lift (a,b,c,d,e,f,g,h,i,j,k)
 deriving instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g, Lift h, Lift i, Lift j, Lift k, Lift l)
       => Lift (a,b,c,d,e,f,g,h,i,j,k,l)
-

--- a/tests/shouldwork/Numbers/IntegralTB.hs
+++ b/tests/shouldwork/Numbers/IntegralTB.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module IntegralTB where
 import Clash.Prelude
 import Clash.Explicit.Testbench
@@ -6,7 +8,8 @@ import qualified Integral
 expected = $(lift $ map Integral.topEntity $ Integral.inputs)
 
 topEntity = Integral.topEntity
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/Naturals.hs
+++ b/tests/shouldwork/Numbers/Naturals.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 module Naturals where
 
@@ -9,23 +10,28 @@ import GHC.Natural
 -- Mark NOINLINE to prevent GHC constant folding
 plusNatural' :: Natural -> Natural -> Natural
 plusNatural' = (+)
-{-# NOINLINE plusNatural' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE plusNatural' #-}
 
 timesNatural' :: Natural -> Natural -> Natural
 timesNatural' = (*)
-{-# NOINLINE timesNatural' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE timesNatural' #-}
 
 minusNatural' :: Natural -> Natural -> Natural
 minusNatural' = (-)
-{-# NOINLINE minusNatural' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE minusNatural' #-}
 
 wordToNatural' :: Word -> Natural
 wordToNatural' = wordToNatural
-{-# NOINLINE wordToNatural' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE wordToNatural' #-}
 
 naturalFromInteger' :: Integer -> Natural
 naturalFromInteger' = naturalFromInteger
-{-# NOINLINE naturalFromInteger' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE naturalFromInteger' #-}
 
 calc :: Integer -> Natural
 calc (naturalFromInteger -> n) = c + h
@@ -49,7 +55,8 @@ calc (naturalFromInteger -> n) = c + h
     -- TODO: the result of the code below is outside the range of an unsigned.
     -- lt_zero_d = minusNatural' 5 7            -- (-2)
     -- lt_zero_e = plusNatural' lt_zero_d 1000  -- 998, should NOT show after transformations
-{-# NOINLINE calc #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE calc #-}
 
 topEntity :: Integer -> Natural
 topEntity = calc

--- a/tests/shouldwork/Numbers/NumConstantFolding_1.hs
+++ b/tests/shouldwork/Numbers/NumConstantFolding_1.hs
@@ -80,5 +80,6 @@ topEntity
    , tIndex
    , tSFixed
    )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 #endif

--- a/tests/shouldwork/Numbers/NumConstantFolding_2.hs
+++ b/tests/shouldwork/Numbers/NumConstantFolding_2.hs
@@ -111,5 +111,6 @@ topEntity
    , tInt16
    , tWord16
    )
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 #endif

--- a/tests/shouldwork/Numbers/Resize.hs
+++ b/tests/shouldwork/Numbers/Resize.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Resize where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Signed 4 -> Signed 3
 topEntity = resize
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/Resize2.hs
+++ b/tests/shouldwork/Numbers/Resize2.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Resize2 where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Signed 4 -> Signed 5
 topEntity = resize
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/Resize3.hs
+++ b/tests/shouldwork/Numbers/Resize3.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Resize3 where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Signed 8
 topEntity = unpack (resize (pack (-2 :: Signed 4)))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/ShiftRotate.hs
+++ b/tests/shouldwork/Numbers/ShiftRotate.hs
@@ -5,6 +5,7 @@ by checking their results against compile-time evaluated calls to the same funct
 So it checks that the HDL implementations have the same behavior as the Haskell implementations.
 (And it assumes that the Haskell implementations are correct.)
 -}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module ShiftRotate where
@@ -15,7 +16,8 @@ import Data.Word
 import ShiftRotateBase
 
 topEntity = testall
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 expected :: Vec _ ( Vec Ops (Unsigned 8)
                   , Vec Ops (Signed 8)

--- a/tests/shouldwork/Numbers/ShiftRotateBase.hs
+++ b/tests/shouldwork/Numbers/ShiftRotateBase.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module ShiftRotateBase where
@@ -21,7 +22,8 @@ testall v i
     , testAs @(Int8)        v i
     , testAs @(Unsigned 70) v i
     )
-{-# NOINLINE testall #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testall #-}
 
 testAs
   :: (Num b, Bits b) => Integer -> Int -> Vec Ops b

--- a/tests/shouldwork/Numbers/ShiftRotateNegative.hs
+++ b/tests/shouldwork/Numbers/ShiftRotateNegative.hs
@@ -67,7 +67,8 @@ testBench = done
     , 4042322160
     ) :> Nil
 
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 topEntity
   :: (BitVector 32, Int)
   -> Vec 2

--- a/tests/shouldwork/Numbers/SignedProjectionTB.hs
+++ b/tests/shouldwork/Numbers/SignedProjectionTB.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
@@ -19,7 +20,8 @@ topEntity
   -> Signal System (Complex (Signed 3))
   -> Signal System (Signed 4)
 topEntity clk rst en = withClockResetEnable clk rst en top
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/SignedZero.hs
+++ b/tests/shouldwork/Numbers/SignedZero.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module SignedZero where
 
 import Clash.Prelude
@@ -23,7 +25,8 @@ topEntity clk rst =
     , mul (n :: Signed 16) (0 :: Signed 0)
     , mul (0 :: Signed 0)  (n :: Signed 16)
     ))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -34,4 +37,5 @@ testBench = done
     done           = expectedOutput (topEntity clk rst (pure n1))
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Numbers/Signum.hs
+++ b/tests/shouldwork/Numbers/Signum.hs
@@ -4,6 +4,8 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
+{-# LANGUAGE CPP #-}
+
 module Signum where
 
 import Clash.Prelude
@@ -13,7 +15,8 @@ topEntity
   :: (Integer, Int, Index 5, Signed 5)
   -> (Integer, Int, Index 5, Signed 5)
 topEntity (a, b, c, d) = (signum a, signum b, signum c, signum d)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/Strict.hs
+++ b/tests/shouldwork/Numbers/Strict.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 module Strict where
 import Clash.Prelude
 import Clash.Explicit.Testbench
@@ -29,12 +30,14 @@ topEntity a b = f a b
 f :: Nr -> Nr -> Vec 1 Nr
 f x y = let res = x + y
         in res `seq` res :> Nil
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 
 g :: Nr -> Nr -> Vec 1 Nr
 g x !y = x `seq` x + y :> Nil
-{-# NOINLINE g #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE g #-}
 
 
 testBench :: Signal System Bool

--- a/tests/shouldwork/Numbers/T1019.hs
+++ b/tests/shouldwork/Numbers/T1019.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1019 where
 
 import Clash.Prelude
@@ -5,6 +7,7 @@ import Clash.Prelude
 
 f :: SNat m -> Integer
 f = snatToInteger
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 topEntity = f (SNat @(LCM 733301111 742))

--- a/tests/shouldwork/Numbers/T1351.hs
+++ b/tests/shouldwork/Numbers/T1351.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1351 where
 
 import Clash.Prelude
@@ -7,7 +9,8 @@ type F = Signed 8
 
 topEntity :: HiddenClockResetEnable System => Signal System F -> Signal System F
 topEntity i = boundedAdd <$> 0 <*> (last $ generate d1 (register 0) i)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/T2149.hs
+++ b/tests/shouldwork/Numbers/T2149.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2149 where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Word -> Signed 8
 topEntity = fromIntegral
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Numbers/UnsignedZero.hs
+++ b/tests/shouldwork/Numbers/UnsignedZero.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module UnsignedZero where
 
 import Clash.Prelude
@@ -21,7 +23,8 @@ topEntity clk rst =
     , mul (n :: Unsigned 16) (0 :: Unsigned 0)
     , mul (0 :: Unsigned 0)  (n :: Unsigned 16)
     ))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -32,4 +35,5 @@ testBench = done
     done           = expectedOutput (topEntity clk rst (pure n1))
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/PartialEvaluation/EtaExpansion.hs
+++ b/tests/shouldwork/PartialEvaluation/EtaExpansion.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- Data constructor and primitives are only considered to be values when
@@ -43,7 +44,8 @@ import Clash.GHC.PartialEval
 import Test.Tasty.Clash
 import Test.Tasty.Clash.CoreTest
 
-{-# NOINLINE etaReducedData #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE etaReducedData #-}
 {-# ANN etaReducedData (Synthesize
           { t_name   = "etaReducedData"
           , t_inputs = [PortName "x"]
@@ -53,7 +55,8 @@ import Test.Tasty.Clash.CoreTest
 etaReducedData :: Integer -> Maybe Integer
 etaReducedData = Just
 
-{-# NOINLINE etaExpandedData #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE etaExpandedData #-}
 {-# ANN etaExpandedData (Synthesize
           { t_name   = "etaExpandedData"
           , t_inputs = [PortName "x"]
@@ -63,7 +66,8 @@ etaReducedData = Just
 etaExpandedData :: Integer -> Maybe Integer
 etaExpandedData x = Just x
 
-{-# NOINLINE etaReducedPrim1 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE etaReducedPrim1 #-}
 {-# ANN etaReducedPrim1 (Synthesize
           { t_name   = "etaReducedPrim1"
           , t_inputs = [PortName "x", PortName "y"]
@@ -73,7 +77,8 @@ etaExpandedData x = Just x
 etaReducedPrim1 :: Integer -> Integer -> Integer
 etaReducedPrim1 = (+)
 
-{-# NOINLINE etaReducedPrim2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE etaReducedPrim2 #-}
 {-# ANN etaReducedPrim2 (Synthesize
           { t_name   = "etaReducedPrim2"
           , t_inputs = [PortName "x", PortName "y"]
@@ -83,7 +88,8 @@ etaReducedPrim1 = (+)
 etaReducedPrim2 :: Integer -> Integer -> Integer
 etaReducedPrim2 x = (x+)
 
-{-# NOINLINE etaExpandedPrim #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE etaExpandedPrim #-}
 {-# ANN etaExpandedPrim (Synthesize
           { t_name   = "etaExpandedPrim"
           , t_inputs = [PortName "x", PortName "y"]
@@ -126,4 +132,3 @@ mainVerilog = mainCommon SVerilog
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = mainCommon SSystemVerilog
-

--- a/tests/shouldwork/PartialEvaluation/KnownCase.hs
+++ b/tests/shouldwork/PartialEvaluation/KnownCase.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- Case alternatives should be selected by the partial evalautor when they
@@ -37,7 +38,8 @@ import Test.Tasty.Clash.CoreTest
 matchedAlt :: [Integer]
 matchedAlt = [1, 1, 2, 5, 14, 42, 132, 429, 1430, 4862]
 
-{-# NOINLINE caseOfData #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE caseOfData #-}
 {-# ANN caseOfData (Synthesize
           { t_name   = "caseOfData"
           , t_inputs = []
@@ -47,7 +49,8 @@ matchedAlt = [1, 1, 2, 5, 14, 42, 132, 429, 1430, 4862]
 caseOfData :: [Integer]
 caseOfData = maybe [] (const matchedAlt) (Just 0)
 
-{-# NOINLINE caseOfLit #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE caseOfLit #-}
 {-# ANN caseOfLit (Synthesize
           { t_name   = "caseOfLit"
           , t_inputs = []
@@ -61,7 +64,8 @@ caseOfLit =
     3 -> matchedAlt
     _ -> []
 
-{-# NOINLINE caseOfDefault #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE caseOfDefault #-}
 {-# ANN caseOfDefault (Synthesize
           { t_name   = "caseOfDefault"
           , t_inputs = []
@@ -105,4 +109,3 @@ mainVerilog = mainCommon SVerilog
 
 mainSystemVerilog :: IO ()
 mainSystemVerilog = mainCommon SSystemVerilog
-

--- a/tests/shouldwork/Polymorphism/FunctionInstances.hs
+++ b/tests/shouldwork/Polymorphism/FunctionInstances.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module FunctionInstances where
 
 import Clash.Prelude
@@ -14,11 +16,13 @@ f x =
   case x + 1 of
     2 -> 3
     _ -> 5
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 topEntity :: Signal System Int -> Signal System Int
 topEntity = fmap f
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/PrimitiveGuards/WarnAlways.hs
+++ b/tests/shouldwork/PrimitiveGuards/WarnAlways.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -19,7 +20,8 @@ primitive
 primitive =
   (+5)
 
-{-# NOINLINE primitive #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE primitive #-}
 {-# ANN primitive (warnAlways "You shouldn't use 'primitive'!") #-}
 {-# ANN primitive (InlinePrimitive [VHDL] "[ { \"BlackBoxHaskell\" : { \"name\" : \"WarnAlways.primitive\", \"templateFunction\" : \"WarnAlways.primitiveTF\"}} ]") #-}
 

--- a/tests/shouldwork/PrimitiveReductions/Lambda.hs
+++ b/tests/shouldwork/PrimitiveReductions/Lambda.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Lambda where
 
 -- Test if Clash will try to reduce "myConstant" to a constant even though it
@@ -13,18 +15,21 @@ type VecSize = 32
 
 g :: Bool -> Vec (n + 1) Int -> Vec (n + 1) Int
 g b xs = (+ 1) (head xs) :> tail xs
-{-# NOINLINE g #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE g #-}
 
 myConstant :: Bool -> Vec VecSize Int
 myConstant b = g b (map (+1) (repeat 3))
-{-# NOINLINE myConstant #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE myConstant #-}
 
 topEntity
   :: SystemClockResetEnable
   => Signal System (Vec VecSize Int)
   -> Signal System (Vec VecSize Int)
 topEntity = register (myConstant True)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -34,4 +39,5 @@ testBench = done
     done           = expectedOutput (exposeClockResetEnable topEntity clk rst enableGen testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/PrimitiveReductions/ReplaceInt.hs
+++ b/tests/shouldwork/PrimitiveReductions/ReplaceInt.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ReplaceInt where
 
 import Clash.Prelude
@@ -11,7 +13,8 @@ replace_int
   -> a
   -> Vec n a
 replace_int v i a = replace i a v
-{-# NOINLINE replace_int #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE replace_int #-}
 
 
 topEntity
@@ -24,7 +27,8 @@ topEntity i = a
       register
         (replace_int (repeat 'a') 3 'c')
         (replace_int <$> a <*> i <*> pure 'x')
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -38,4 +42,5 @@ testBench = done
     done           = expectedOutput (exposeClockResetEnable topEntity clk rst enableGen testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/RTree/TRepeat2.hs
+++ b/tests/shouldwork/RTree/TRepeat2.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE CPP #-}
+
 module TRepeat2 where
 
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
 topEntity x = register @System (trepeat @2 True) x
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Shadowing/T990.hs
+++ b/tests/shouldwork/Shadowing/T990.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Arrows #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 
 module T990 (topEntity, testBench) where
@@ -42,7 +43,8 @@ topEntity
     -> Signal System Bool
     -> Signal System Bool
 topEntity = exposeClock $ runSA risingEdgeA
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/BangPatterns.hs
+++ b/tests/shouldwork/Signal/BangPatterns.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 
 module BangPatterns where
 
@@ -7,7 +8,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Signal System (BitVector 1)
 topEntity = f @System (pure False)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 f :: Signal dom Bool -> Signal dom (BitVector 1)
 f !e = fmap pack e

--- a/tests/shouldwork/Signal/BiSignal/Counter.hs
+++ b/tests/shouldwork/Signal/BiSignal/Counter.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -43,7 +44,8 @@ even :: Clock System
 even clk rst en s = writeToBiSignal s (mealy clk rst en counter (True, 0) (readFromBiSignal s))
 
 
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 topEntity :: Clock System
   -> Reset System
   -> Enable System

--- a/tests/shouldwork/Signal/BiSignal/CounterHalfTuple.hs
+++ b/tests/shouldwork/Signal/BiSignal/CounterHalfTuple.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -25,7 +26,8 @@ counter (write, prevread) i = ((write', prevread'), output)
     output    = if write then Just (succ prevread) else Nothing
     prevread' = if write then prevread else i
     write' = not write
-{-# NOINLINE counter #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE counter #-}
 
 -- | Write on odd cyles
 f :: Clock System
@@ -36,7 +38,8 @@ f :: Clock System
      , BiSignalOut 'Floating System (BitSize Int)
      )
 f clk rst en s = (6, writeToBiSignal s (mealy clk rst en counter (False, 0) (readFromBiSignal s)))
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 -- | Write on even cyles
 g :: Clock System
@@ -47,7 +50,8 @@ g :: Clock System
      , BiSignalOut 'Floating System (BitSize Int)
      )
 g clk rst en s = (7, writeToBiSignal s (mealy clk rst en counter (True, 0) (readFromBiSignal s)))
-{-# NOINLINE g #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE g #-}
 
 
 topEntity :: Clock System
@@ -65,7 +69,8 @@ topEntity clk rst en =
 
     bus  = mergeBiSignalOuts (fBus :> gBus :> Nil)
     bus' = veryUnsafeToBiSignalIn bus
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 
 main :: IO()

--- a/tests/shouldwork/Signal/BiSignal/CounterHalfTupleRev.hs
+++ b/tests/shouldwork/Signal/BiSignal/CounterHalfTupleRev.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -25,7 +26,8 @@ counter (write, prevread) i = ((write', prevread'), output)
     output    = if write then Just (succ prevread) else Nothing
     prevread' = if write then prevread else i
     write' = not write
-{-# NOINLINE counter #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE counter #-}
 
 -- | Write on odd cyles
 f :: Clock System
@@ -36,7 +38,8 @@ f :: Clock System
      , Signal System Int
      )
 f clk rst en s = (writeToBiSignal s (mealy clk rst en counter (False, 0) (readFromBiSignal s)), 6)
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 -- | Write on even cyles
 g :: Clock System
@@ -47,7 +50,8 @@ g :: Clock System
      , Signal System Int
      )
 g clk rst en s = (writeToBiSignal s (mealy clk rst en counter (True, 0) (readFromBiSignal s)), 7)
-{-# NOINLINE g #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE g #-}
 
 
 topEntity
@@ -65,7 +69,8 @@ topEntity clk rst en =
 
   bus  = mergeBiSignalOuts (fBus :> gBus :> Nil)
   bus' = veryUnsafeToBiSignalIn bus
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 
 main :: IO()

--- a/tests/shouldwork/Signal/BlockRam/Blob.hs
+++ b/tests/shouldwork/Signal/BlockRam/Blob.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
@@ -18,7 +19,8 @@ topEntity clk en rd wrM =
   let ram en0 = unpack <$> blockRamBlob clk en0 content rd wrM0
       wrM0 = fmap (fmap (\(wr, din) -> (wr, pack din))) wrM
   in bundle (ram enableGen, ram en)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 samples :: Vec _ (Unsigned 2, Maybe (Unsigned 2, Unsigned 4), Unsigned 4)
 samples =
@@ -50,4 +52,5 @@ testBench = done
     clk = tbSystemClockGen (not <$> done)
     rst = systemResetGen
     en = enableGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Signal/BlockRam0.hs
+++ b/tests/shouldwork/Signal/BlockRam0.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module BlockRam0 where
 
 import Clash.Prelude
@@ -32,7 +34,8 @@ topEntity = exposeClockResetEnable go where
         ((+22) . unpack . pack :: Index 1024 -> Unsigned 10)
         rd
         wr
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/BlockRam1.hs
+++ b/tests/shouldwork/Signal/BlockRam1.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module BlockRam1 where
 
 import Clash.Prelude
@@ -32,7 +34,8 @@ topEntity = exposeClockResetEnable go where
         (3 :: Unsigned 8)
         rd
         wr
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/BlockRamFile.hs
+++ b/tests/shouldwork/Signal/BlockRamFile.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module BlockRamFile where
 
 import Clash.Prelude
@@ -19,7 +21,8 @@ topEntity
 topEntity = exposeClockResetEnable go where
   go rd = zeroAt0 (unpack <$> dout) where
     dout = blockRamFilePow2 "memory.list" rd (pure Nothing)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/DelayedReset.hs
+++ b/tests/shouldwork/Signal/DelayedReset.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 module DelayedReset where
 
@@ -28,7 +29,8 @@ topEntity clk reset en = (cycleCount, countFromReset, newResetSig)
     cycleCount :: Signal System (Unsigned 4)
     cycleCount' = cycleCount + 1
     cycleCount = register clk reset en 0 cycleCount'
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/DualBlockRam.hs
+++ b/tests/shouldwork/Signal/DualBlockRam.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -freverse-errors #-}
 
 module DualBlockRam where
@@ -12,7 +14,8 @@ import DualBlockRamTypes
 
 topEntityAB :: TdpRam A B
 topEntityAB = tdpRam
-{-# NOINLINE topEntityAB #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityAB #-}
 {-# ANN topEntityAB (defSyn "topEntityAB") #-}
 
 testBenchAB :: Signal A Bool
@@ -39,7 +42,8 @@ testBenchAB = strictAnd <$> doneA <*> (unsafeSynchronizer clk10 clk20 doneB)
     clk20 = tbClockGen (not <$> doneA)
     clk10 :: Clock B
     clk10 = tbClockGen (not <$> doneB)
-{-# NOINLINE testBenchAB #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchAB #-}
 {-# ANN testBenchAB (TestBench 'topEntityAB) #-}
 
 topEntityBC :: TdpRam B C
@@ -73,5 +77,6 @@ testBenchBC = strictAnd <$> doneA <*> (unsafeSynchronizer clk7 clk10 doneB)
     clk10 = tbClockGen (not <$> doneA)
     clk7 :: Clock C
     clk7 = tbClockGen (not <$> doneB)
-{-# NOINLINE testBenchBC #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchBC #-}
 {-# ANN testBenchBC (TestBench 'topEntityBC) #-}

--- a/tests/shouldwork/Signal/DynamicClocks.hs
+++ b/tests/shouldwork/Signal/DynamicClocks.hs
@@ -3,6 +3,8 @@ Copyright  :  (C) 2022, Google Inc.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module DynamicClocks where
@@ -16,7 +18,8 @@ createDomain vSystem{vName="Dynamic", vPeriod=1000}
 
 counter :: KnownDomain dom => Clock dom -> Reset dom -> Enable dom -> Signal dom Int
 counter clk rst ena = let counter0 = register clk rst ena 0 (counter0 + 1) in counter0
-{-# NOINLINE counter #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE counter #-}
 
 topEntity ::
   Clock Static ->
@@ -24,7 +27,8 @@ topEntity ::
   Signal Static Int
 topEntity clkStatic clkDyn rstDyn enaDyn =
   unsafeSynchronizer clkDyn clkStatic (counter clkDyn rstDyn enaDyn)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal Static (Bit, Int)
 testBench = bundle (boolToBit <$> doneStatic, actual)
@@ -87,4 +91,5 @@ testBench = bundle (boolToBit <$> doneStatic, actual)
   rstDynamic = resetGen @"Dynamic"
 
   enaDynamic = enableGen @"Dynamic"
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Signal/NoCPR.hs
+++ b/tests/shouldwork/Signal/NoCPR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 
 module NoCPR where
@@ -19,7 +20,8 @@ import           Clash.Prelude
 example :: Signal System (BitVector 1) -> Signal System (BitVector 1, BitVector 1)
 example input = foo $ bundle (input, pure 0)
 
-{-# NOINLINE foo #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE foo #-}
 foo :: Signal dom (BitVector 1, BitVector 1)
     -> Signal dom (BitVector 1, BitVector 1)
 foo input = input

--- a/tests/shouldwork/Signal/ROM/Async.hs
+++ b/tests/shouldwork/Signal/ROM/Async.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Async where
 
 import Clash.Explicit.Prelude
@@ -8,7 +10,8 @@ topEntity
   -> Signal System (Unsigned 8)
 topEntity = fmap (asyncRomPow2 content)
  where content = $(listToVecTH [1 :: Unsigned 8 .. 16])
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -20,4 +23,5 @@ testBench = done
     clk = tbSystemClockGen (not <$> done)
     rst = systemResetGen
     en = enableGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Signal/ROM/AsyncBlob.hs
+++ b/tests/shouldwork/Signal/ROM/AsyncBlob.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module AsyncBlob where
 
 import Clash.Explicit.Prelude
@@ -9,7 +11,8 @@ topEntity
   :: Signal System (Unsigned 4)
   -> Signal System (Unsigned 8)
 topEntity = fmap (unpack . asyncRomBlobPow2 content)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -21,4 +24,5 @@ testBench = done
     clk = tbSystemClockGen (not <$> done)
     rst = systemResetGen
     en = enableGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Signal/ROM/Blob.hs
+++ b/tests/shouldwork/Signal/ROM/Blob.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Blob where
 
 import Clash.Explicit.Prelude
@@ -13,7 +15,8 @@ topEntity
 topEntity clk en rd =
   let rom0 en0 = unpack <$> romBlob clk en0 content rd
   in bundle (rom0 enableGen, rom0 en)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -26,4 +29,5 @@ testBench = done
     clk = tbSystemClockGen (not <$> done)
     rst = systemResetGen
     en = enableGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Signal/ROM/BlobVec.hs
+++ b/tests/shouldwork/Signal/ROM/BlobVec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module BlobVec where
 
 import Clash.Explicit.Prelude
@@ -14,7 +16,8 @@ topEntity clk addr = bundle $ romBlob clk enableGen <$> blobs <*> pure addr
           :> $(memBlobTH Nothing [17 :: BitVector 8 .. 31])
           :> $(memBlobTH Nothing [33 :: BitVector 8 .. 47])
           :> Nil
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -33,4 +36,5 @@ testBench = done
     clk = tbSystemClockGen (not <$> done)
     rst = systemResetGen
     en = enableGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Signal/Ram.hs
+++ b/tests/shouldwork/Signal/Ram.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Ram where
 
 import Clash.Prelude
@@ -23,7 +25,8 @@ topEntity = exposeClockResetEnable go where
   go rd = zeroAt0 dout where
     dout = asyncRamPow2 rd (Just <$> bundle (wr, bundle (wr,wr)))
     wr   = register 1 (wr + 1)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/Ram/RMultiTop.hs
+++ b/tests/shouldwork/Signal/Ram/RMultiTop.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module RMultiTop where
 
 import Clash.Explicit.Prelude
@@ -11,10 +13,12 @@ topEntity
   -> Signal P20 (Maybe (Unsigned 1, Unsigned 2))
   -> Signal P10 (Unsigned 2)
 topEntity = ram
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench
   :: Signal P10 Bool
 testBench = tb topEntity
                $(listToVecTH $ sampleN 20 $ tbOutput ram clockGen clockGen)
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Signal/Ram/RWMultiTop.hs
+++ b/tests/shouldwork/Signal/Ram/RWMultiTop.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module RWMultiTop where
 
 import Clash.Prelude
@@ -10,7 +12,8 @@ topEntity35
   -> Signal P30 (Unsigned 4)
   -> Signal P50 (Unsigned 4)
 topEntity35 = ram
-{-# NOINLINE topEntity35 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity35 #-}
 {-# ANN topEntity35 (defSyn "topEntity35") #-}
 
 testBench35
@@ -20,7 +23,8 @@ testBench35 =
                    sampleN 20 $ tbOutput (ram @P30 @P50) clockGen clockGen)
 -- testBench35 =
 --   tb topEntity35 $(listToVecTH [0 :: Unsigned 4, 1, 3, 4, 6, 8, 9, 11, 13, 14])
-{-# NOINLINE testBench35 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench35 #-}
 {-# ANN testBench35 (TestBench 'topEntity35) #-}
 
 topEntity53
@@ -29,7 +33,8 @@ topEntity53
   -> Signal P50 (Unsigned 4)
   -> Signal P30 (Unsigned 4)
 topEntity53 = ram
-{-# NOINLINE topEntity53 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity53 #-}
 {-# ANN topEntity53 (defSyn "topEntity53") #-}
 
 testBench53
@@ -40,5 +45,6 @@ testBench53 =
 -- testBench53 =
 --   tb topEntity53 $(listToVecTH [0 :: Unsigned 4, 0, 1, 1, 2, 2, 3, 4, 4, 5, 5,
 --                                 6, 7, 7, 8, 8])
-{-# NOINLINE testBench53 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench53 #-}
 {-# ANN testBench53 (TestBench 'topEntity53) #-}

--- a/tests/shouldwork/Signal/RegisterAE.hs
+++ b/tests/shouldwork/Signal/RegisterAE.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 
 module RegisterAE where
@@ -53,7 +54,8 @@ topEntityAE clk rst = topEntity clk arst en
   where
     arst = unsafeFromHighPolarity (resetInput clk rst enableGen)
     en = toEnable (enableInput clk rst enableGen)
-{-# NOINLINE topEntityAE #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityAE #-}
 
 -- | Doing this case inline trips GHC 8.4 due to dead code. We sometimes
 -- want to run our whole testsuite with a different System domain though, so

--- a/tests/shouldwork/Signal/RegisterAR.hs
+++ b/tests/shouldwork/Signal/RegisterAR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 
 module RegisterAR where
@@ -35,7 +36,8 @@ topEntity clk rst = head <$> r
 topEntityAR clk rst = topEntity clk arst
   where
     arst = unsafeFromHighPolarity (resetInput clk rst enableGen)
-{-# NOINLINE topEntityAR #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityAR #-}
 
 -- | Doing this case inline trips GHC 8.4 due to dead code. We sometimes
 -- want to run our whole testsuite with a different System domain though, so

--- a/tests/shouldwork/Signal/RegisterSE.hs
+++ b/tests/shouldwork/Signal/RegisterSE.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module RegisterSE where
 
 -- Register: Synchronous, Enabled
@@ -51,7 +53,8 @@ topEntitySE clk rst = topEntity clk arst en
   where
     arst = unsafeFromHighPolarity (resetInput clk rst enableGen)
     en = toEnable (enableInput clk rst enableGen)
-{-# NOINLINE topEntitySE #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntitySE #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/RegisterSR.hs
+++ b/tests/shouldwork/Signal/RegisterSR.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module RegisterSR where
 
 -- Register: Synchronous, Regular
@@ -33,7 +35,8 @@ topEntity clk rst = head <$> r
 topEntitySR clk rst = topEntity clk srst
   where
     srst = unsafeFromHighPolarity (resetInput clk rst enableGen)
-{-# NOINLINE topEntitySR #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntitySR #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/ResetGen.hs
+++ b/tests/shouldwork/Signal/ResetGen.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ResetGen where
 
 import Clash.Explicit.Prelude
@@ -10,7 +12,8 @@ topEntity clk = bundle (unsafeToHighPolarity r, unsafeToHighPolarity r')
   where
     r  = resetGenN (SNat @3)
     r' = holdReset clk enableGen (SNat @2) r
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/ResetLow.hs
+++ b/tests/shouldwork/Signal/ResetLow.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 
 module ResetLow where
@@ -36,7 +37,8 @@ topEntity clk rst en = head <$> r
 topEntity1 clk rst = topEntity clk arst enableGen
   where
     arst = unsafeToReset (resetInput clk rst enableGen)
-{-# NOINLINE topEntity1 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity1 #-}
 
 -- | Doing this case inline trips GHC 8.4 due to dead code. We sometimes
 -- want to run our whole testsuite with a different System domain though, so

--- a/tests/shouldwork/Signal/ResetSynchronizer.hs
+++ b/tests/shouldwork/Signal/ResetSynchronizer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 
 module ResetSynchronizer where
@@ -58,12 +59,14 @@ polyTopEntity clk asyncRst = counter
 
 topEntityAsync :: Clock System -> Reset System -> Signal System ResetCount
 topEntityAsync = polyTopEntity @System
-{-# NOINLINE topEntityAsync #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntityAsync #-}
 {-# ANN topEntityAsync (defSyn "topEntityAsync") #-}
 
 topEntitySync :: Clock XilinxSystem -> Reset XilinxSystem -> Signal XilinxSystem ResetCount
 topEntitySync = polyTopEntity @XilinxSystem
-{-# NOINLINE topEntitySync #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntitySync #-}
 {-# ANN topEntitySync (defSyn "topEntitySync") #-}
 
 -- | Doing this case inline trips GHC 8.4 due to dead code. We sometimes
@@ -91,10 +94,12 @@ polyTestBench top = (done, sampleN 20 (top cClk cRst))
 
 testBenchAsync :: Signal System Bool
 testBenchAsync = fst (polyTestBench topEntityAsync)
-{-# NOINLINE testBenchAsync #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchAsync #-}
 {-# ANN testBenchAsync (TestBench 'topEntityAsync) #-}
 
 testBenchSync :: Signal System Bool
 testBenchSync = fst (polyTestBench topEntitySync)
-{-# NOINLINE testBenchSync #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBenchSync #-}
 {-# ANN testBenchSync (TestBench 'topEntitySync) #-}

--- a/tests/shouldwork/Signal/Rom.hs
+++ b/tests/shouldwork/Signal/Rom.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Rom where
 
 import Clash.Prelude
@@ -22,7 +24,8 @@ topEntity
 topEntity = exposeClockResetEnable go where
   go rd = zeroAt0 dout where
     dout = rom $(listToVecTH $ L.map (\x -> (x,x))  [0::Unsigned 8,1,2,3,4,5,6,7,8])  rd
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/RomFile.hs
+++ b/tests/shouldwork/Signal/RomFile.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module RomFile where
 
 import Clash.Prelude
@@ -21,7 +23,8 @@ topEntity
 topEntity = exposeClockResetEnable go where
   go rd = zeroAt0 (unpack <$> dout) where
     dout = romFilePow2 "memory.list" rd
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/RomNegative.hs
+++ b/tests/shouldwork/Signal/RomNegative.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module RomNegative where
 
 import Clash.Prelude
@@ -13,7 +15,8 @@ topEntity
 topEntity = exposeClockResetEnable go
  where
   go rd = mux ((< 0) <$> rd) 0 (unpack <$> romFile d256 "memory.list" rd)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Signal/T1102A.hs
+++ b/tests/shouldwork/Signal/T1102A.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1102A where
 
 import Clash.Prelude
@@ -11,7 +13,8 @@ topEntity
   :: (Signal System Int, Signal System Int)
   -> Signal System (Int, Int)
 topEntity = bundle
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 assertIn :: String -> String -> IO ()
 assertIn needle haystack

--- a/tests/shouldwork/Signal/T2069.hs
+++ b/tests/shouldwork/Signal/T2069.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T2069 where
 
 import Clash.Explicit.BlockRam
@@ -11,7 +13,8 @@ topEntity
   -> Signal System (RamOp 1 (Unsigned 8))
   -> (Signal System (Unsigned 8), Signal System (Unsigned 8))
 topEntity = trueDualPortBlockRam
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
@@ -24,4 +27,5 @@ testBench = done
     clk = tbSystemClockGen (not <$> done)
     rst = systemResetGen
     en = enableGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/SynthesisAttributes/InstDeclAnnotations.hs
+++ b/tests/shouldwork/SynthesisAttributes/InstDeclAnnotations.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module InstDeclAnnotations where
@@ -48,7 +49,8 @@ myBlackBox
   :: Signal System Int
   -> Signal System Int
 myBlackBox _ = pure (errorX "not implemented")
-{-# NOINLINE myBlackBox #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE myBlackBox #-}
 {-# ANN myBlackBox (InlinePrimitive [VHDL,Verilog,SystemVerilog] [__i|
    [ { "BlackBox" :
         { "name" : "InstDeclAnnotations.myBlackBox",

--- a/tests/shouldwork/SynthesisAttributes/Product.hs
+++ b/tests/shouldwork/SynthesisAttributes/Product.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module Product where
@@ -40,7 +41,8 @@ topEntity
 topEntity xy = bundle (s, s)
   where
     s = mac xy
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 
 --------------- Actual tests for generated HDL -------------------

--- a/tests/shouldwork/Testbench/SyncTB.hs
+++ b/tests/shouldwork/Testbench/SyncTB.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module SyncTB where
 
 import Clash.Explicit.Testbench
@@ -43,7 +45,8 @@ topEntity clk2 clk7 clk9 i =
           clk7
           clk2
           (delay clk7 enableGen 0 i))))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench
   :: Signal Dom9 Bool

--- a/tests/shouldwork/Testbench/TB.hs
+++ b/tests/shouldwork/Testbench/TB.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module TB where
 
 import Clash.Prelude
@@ -12,7 +14,8 @@ topEntity
   -> Enable System
   -> Signal System Inp -> Signal System Outp
 topEntity = exposeClockResetEnable (transfer `mealy` initS)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 transfer s i = (i,o)
   where

--- a/tests/shouldwork/TopEntity/Multiple.hs
+++ b/tests/shouldwork/TopEntity/Multiple.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Multiple where
 
 import Prelude
@@ -12,16 +14,19 @@ import Debug.Trace
 topEntity1 :: Int
 topEntity1 = 11111111
 {-# ANN topEntity1 (defSyn "topentity1") #-}
-{-# NOINLINE topEntity1 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity1 #-}
 
 topEntity2 :: Int
 topEntity2 = topEntity1
 {-# ANN topEntity2 (defSyn "topentity2") #-}
-{-# NOINLINE topEntity2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity2 #-}
 
 topEntity3 :: Int
 topEntity3 = topEntity2
-{-# NOINLINE topEntity3 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity3 #-}
 
 -- | Make sure topEntity2 is not compiled when -main-is topEntity1
 mainSystemVerilog :: IO ()

--- a/tests/shouldwork/TopEntity/T1072.hs
+++ b/tests/shouldwork/TopEntity/T1072.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module T1072 where
 
 import Clash.Explicit.Prelude
@@ -11,7 +13,8 @@ topEntity2
   -> (Enable System, Signal System Int)
   -> Signal System Int
 topEntity2 (clk, rst) (en, a) = register clk rst en 0 a
-{-# NOINLINE topEntity2 #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity2 #-}
 
 {-# ANN topEntity
   (Synthesize

--- a/tests/shouldwork/TopEntity/T1139.hs
+++ b/tests/shouldwork/TopEntity/T1139.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE CPP #-}
+
 module T1139 where
 import Clash.Prelude
 
 topEntity, otherTopEntity :: Bool -> Bool
 topEntity = not
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 otherTopEntity = topEntity
 {-# ANN otherTopEntity (defSyn "otherTopEntity") #-}

--- a/tests/shouldwork/TopEntity/T701.hs
+++ b/tests/shouldwork/TopEntity/T701.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE CPP #-}
+
 module T701 where
 
 import Clash.Prelude
-{-# NOINLINE myNot #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE myNot #-}
 {-# ANN myNot (defSyn "mynot") #-}
 myNot = not
 

--- a/tests/shouldwork/TopEntity/TopEntHOArg.hs
+++ b/tests/shouldwork/TopEntity/TopEntHOArg.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module TopEntHOArg where
 
 import Clash.Prelude
@@ -8,7 +10,8 @@ f :: Bit
   -> (Bit,Bool,Maybe Bit,(Bit, Bool),Bool)
 f z (a,b,c) d = (z,a,c,b,d)
 {-# ANN f Synthesize {t_name = "f", t_inputs = [PortName "z",PortProduct "" []], t_output = PortProduct "" []} #-}
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 g
   :: Bit

--- a/tests/shouldwork/Types/TypeFamilyReduction.hs
+++ b/tests/shouldwork/Types/TypeFamilyReduction.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module TypeFamilyReduction where
 
 import Clash.Prelude
@@ -8,43 +10,50 @@ div'
   :: Vec (Div 4 2) Bit
   -> Vec (Div 4 2) Bit
 div' = id
-{-# NOINLINE div' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE div' #-}
 
 mod'
   :: Vec (Mod 6 4) Bit
   -> Vec (Mod 6 4) Bit
 mod' = id
-{-# NOINLINE mod' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE mod' #-}
 
 lcm'
   :: Vec (LCM 1 2) Bit
   -> Vec (LCM 1 2) Bit
 lcm' = id
-{-# NOINLINE lcm' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE lcm' #-}
 
 gcd'
   :: Vec (GCD 4 6) Bit
   -> Vec (GCD 4 6) Bit
 gcd' = id
-{-# NOINLINE gcd' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE gcd' #-}
 
 log'
   :: Vec (Log 8 64) Bit
   -> Vec (Log 8 64) Bit
 log' = id
-{-# NOINLINE log' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE log' #-}
 
 clog'
   :: Vec (CLog 8 63) Bit
   -> Vec (CLog 8 63) Bit
 clog' = id
-{-# NOINLINE clog' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE clog' #-}
 
 flog'
   :: Vec (FLog 8 65) Bit
   -> Vec (FLog 8 65) Bit
 flog' = id
-{-# NOINLINE flog' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE flog' #-}
 
 topEntity :: Vec 2 Bit -> Vec 2 Bit
 topEntity = div' . mod' . lcm' . gcd' . log' . clog' . flog'

--- a/tests/shouldwork/Unit/Imap.hs
+++ b/tests/shouldwork/Unit/Imap.hs
@@ -1,5 +1,7 @@
 -- See: https://github.com/clash-lang/clash-compiler/issues/507
 
+{-# LANGUAGE CPP #-}
+
 module Imap where
 
 import Clash.Prelude
@@ -10,11 +12,13 @@ data AB = A | B deriving (Eq, Generic, ShowX)
 ab :: KnownNat n => Index n -> AB -> AB
 ab n A = if n >  0 then A else B
 ab n B = if n == 0 then B else A
-{-# NOINLINE ab #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE ab #-}
 
 topEntity :: Vec 1 AB -> Vec 1 AB
 topEntity = imap ab
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Unit/MapConstUnit.hs
+++ b/tests/shouldwork/Unit/MapConstUnit.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module MapConstUnit where
 
 import Clash.Prelude
@@ -14,7 +16,8 @@ zeroF f a b =
 
 topEntity :: Signal System (Vec 5 Int)
 topEntity = pure (snd (mapAccumL (\acc _ -> (succ acc, acc)) 0 (map (const ()) indicesI)))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Unit/ZipWithTripleWithUnitMiddle.hs
+++ b/tests/shouldwork/Unit/ZipWithTripleWithUnitMiddle.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ZipWithTripleWithUnitMiddle where
 
 import Clash.Prelude
@@ -7,7 +9,8 @@ topEntity
   :: Vec 2 (Int,Int)
   -> Vec 2 ((Int,Int),(Int, (), Int))
 topEntity xs = zipWith (,) xs (repeat (fst (head xs), (), snd (head xs)))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Unit/ZipWithTupleWithUnitLeft.hs
+++ b/tests/shouldwork/Unit/ZipWithTupleWithUnitLeft.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ZipWithTupleWithUnitLeft where
 
 import Clash.Prelude
@@ -7,7 +9,8 @@ topEntity
   :: Vec 2 (Int,Int)
   -> Vec 2 ((Int,Int),((), Int))
 topEntity xs = zipWith (,) xs (repeat ((), fst (head xs)))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Unit/ZipWithTupleWithUnitRight.hs
+++ b/tests/shouldwork/Unit/ZipWithTupleWithUnitRight.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ZipWithTupleWithUnitRight where
 
 import Clash.Prelude
@@ -7,7 +9,8 @@ topEntity
   :: Vec 2 (Int,Int)
   -> Vec 2 ((Int,Int),(Int, ()))
 topEntity xs = zipWith (,) xs (repeat (fst (head xs), ()))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Unit/ZipWithUnitSP.hs
+++ b/tests/shouldwork/Unit/ZipWithUnitSP.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ZipWithUnitSP where
 
 import Clash.Prelude
@@ -9,7 +11,8 @@ topEntity
   :: Vec 2 PQR
   -> Vec 2 (Index 2, PQR)
 topEntity xs = zipWith (,) indicesI xs
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Unit/ZipWithUnitSP2.hs
+++ b/tests/shouldwork/Unit/ZipWithUnitSP2.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ZipWithUnitSP2 where
 
 import Clash.Prelude
@@ -9,7 +11,8 @@ topEntity
   :: Vec 2 YZA
   -> Vec 2 (Index 2, YZA)
 topEntity xs = zipWith (,) indicesI xs
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Unit/ZipWithUnitVector.hs
+++ b/tests/shouldwork/Unit/ZipWithUnitVector.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ZipWithUnitVector where
 
 import Clash.Prelude
@@ -7,7 +9,8 @@ topEntity
   :: Vec 2 (Int,Int)
   -> Vec 2 ((Int,Int),())
 topEntity xs = zipWith (,) xs (repeat ())
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/Concat.hs
+++ b/tests/shouldwork/Vector/Concat.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Concat where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 2 (Vec 3 (Unsigned 8)) -> Vec 6 (Unsigned 8)
 topEntity = concat
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/DFold.hs
+++ b/tests/shouldwork/Vector/DFold.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE KindSignatures #-}
 module DFold where
 
@@ -14,7 +15,8 @@ append' xs ys = dfold (Proxy :: Proxy (Append m a)) (const (:>)) ys xs
 
 topEntity :: (Vec 3 Int,Vec 7 Int) -> Vec 10 Int
 topEntity = uncurry append'
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/DFold2.hs
+++ b/tests/shouldwork/Vector/DFold2.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 module DFold2 where
 
@@ -7,7 +8,8 @@ import Data.Proxy
 
 topEntity :: Vec 4 (Vec 4 (Unsigned 8)) -> Vec 4 (Vec 4 (Unsigned 8))
 topEntity = smap (flip rotateRightS)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/DTFold.hs
+++ b/tests/shouldwork/Vector/DTFold.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE UndecidableInstances #-}
 module DTFold where
 
@@ -19,7 +20,8 @@ populationCount bv = dtfold (Proxy :: Proxy IIndex)
 
 topEntity :: BitVector 16 -> Index 17
 topEntity = populationCount
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/FindIndex.hs
+++ b/tests/shouldwork/Vector/FindIndex.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module FindIndex where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 7 (Unsigned 8) -> Maybe (Index 7)
 topEntity = findIndex (> 3)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/FirOddSize.hs
+++ b/tests/shouldwork/Vector/FirOddSize.hs
@@ -1,4 +1,6 @@
 -- see https://github.com/clash-lang/clash-compiler/issues/383
+{-# LANGUAGE CPP #-}
+
 module FirOddSize where
 
 import Clash.Prelude
@@ -15,7 +17,8 @@ topEntity
   -> Signal System (Signed 16)
   -> Signal System (Signed 16)
 topEntity = exposeClockResetEnable (fir (2:>3:>(-2):>8:>0:>Nil))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/Fold.hs
+++ b/tests/shouldwork/Vector/Fold.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Fold where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 8 Int -> Int
 topEntity = fold (+)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/Foldr.hs
+++ b/tests/shouldwork/Vector/Foldr.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Foldr where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 4 (Unsigned 8) -> (Unsigned 8)
 topEntity = foldr div 1
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/FoldrEmpty.hs
+++ b/tests/shouldwork/Vector/FoldrEmpty.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module FoldrEmpty where
 
 import Clash.Prelude
@@ -9,11 +11,13 @@ topEntity
   -> Signal System Int
 topEntity x =
   delayBy (SNat @0) x
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 delayBy n =
   foldr (.) id (replicate n id)
-{-# NOINLINE delayBy #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE delayBy #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/IndexInt.hs
+++ b/tests/shouldwork/Vector/IndexInt.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module IndexInt where
 
 import Clash.Prelude
@@ -11,10 +13,12 @@ index_ints
   -> (Int, Int)
 index_ints (mv, mi) (nv, ni) =
   (mv !! mi, nv !! ni)
-{-# NOINLINE index_ints #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE index_ints #-}
 
 fst' ab = fst ab
-{-# NOINLINE fst' #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE fst' #-}
 
 topEntity
   :: (Vec 3 Int, Int)
@@ -22,7 +26,8 @@ topEntity
   -> Int
 topEntity (mv, mi) (nv, ni) =
   fst' (index_ints (mv, mi) (nv, ni))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/IndexInt2.hs
+++ b/tests/shouldwork/Vector/IndexInt2.hs
@@ -1,5 +1,7 @@
 -- This tests the special, verlog only, code-path for index_int,
 -- which generates special verilog when the index is constant.
+{-# LANGUAGE CPP #-}
+
 module IndexInt2 where
 
 import qualified Prelude as P
@@ -22,7 +24,8 @@ topEntity xs ix0 =
   where
     ix1 :: Signed 8
     ix1 = fold (+) (1 :> (-1) :> 1 :> Nil)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/Indices.hs
+++ b/tests/shouldwork/Vector/Indices.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Indices where
 
 import Clash.Explicit.Prelude
@@ -7,7 +9,8 @@ topEntity
   :: Vec 2 (Index 2)
   -> Vec 2 (Index 3)
 topEntity input = liftA2 add (indices SNat) input
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/Iterate.hs
+++ b/tests/shouldwork/Vector/Iterate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Iterate where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Int -> Vec 2 Int
 topEntity = iterateI succ
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/IterateCF.hs
+++ b/tests/shouldwork/Vector/IterateCF.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module IterateCF where
 
 import qualified Prelude as P
@@ -21,7 +23,8 @@ topEntity = (a1, a2)
   a2 = case test of
     (_ :> _ :> s :> _) -> s == 257
     _ -> False
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 assertNotIn :: String -> String -> IO ()
 assertNotIn needle haystack

--- a/tests/shouldwork/Vector/Minimum.hs
+++ b/tests/shouldwork/Vector/Minimum.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Minimum where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 3 Int -> Int
 topEntity = minimum
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/Scatter.hs
+++ b/tests/shouldwork/Vector/Scatter.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Scatter where
 
 import Clash.Prelude
@@ -8,7 +10,8 @@ topEntity = scatter defvec to
   where
     defvec = replicate d5 99
     to = 0 :> 4 :> 2 :> 3 :> 1 :> Nil
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/ToList.hs
+++ b/tests/shouldwork/Vector/ToList.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module ToList where
 
 import Clash.Prelude
@@ -6,7 +8,8 @@ import qualified Data.List as L
 
 topEntity :: Vec 3 Int -> Int
 topEntity xs = L.foldr (+) 0 (toList xs)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/Unconcat.hs
+++ b/tests/shouldwork/Vector/Unconcat.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Unconcat where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 6 (Unsigned 8) -> Vec 2 (Vec 3 (Unsigned 8))
 topEntity = unconcatI
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/VEmpty.hs
+++ b/tests/shouldwork/Vector/VEmpty.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module VEmpty where
 
 import Clash.Prelude
@@ -9,11 +11,13 @@ topEntity
   -> Signal System Int
 topEntity x =
   delayBy (SNat @2) x
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 delayBy n signal =
   foldr (\_ s -> s + 10) signal (replicate n ())
-{-# NOINLINE delayBy #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE delayBy #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/VFold.hs
+++ b/tests/shouldwork/Vector/VFold.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module VFold where
 
 import Clash.Prelude
@@ -10,7 +12,8 @@ csSort = vfold (const csRow)
 
 topEntity :: Vec 4 Int -> Vec 4 Int
 topEntity = csSort
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/VIndicesI.hs
+++ b/tests/shouldwork/Vector/VIndicesI.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module VIndicesI where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Signal System (Vec 4 (Index 4))
 topEntity = pure indicesI
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/VMerge.hs
+++ b/tests/shouldwork/Vector/VMerge.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module VMerge where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: (Vec 2 Int,Vec 2 Int) -> Vec 4 Int
 topEntity (x,y) = merge x y
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/VReplace.hs
+++ b/tests/shouldwork/Vector/VReplace.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module VReplace where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: (Integer,Unsigned 4,Vec 8 (Unsigned 4)) -> Vec 8 (Vec 8 (Unsigned 4))
 topEntity (i,j,as) = zipWith (\i u -> replace i u as) (iterateI (+1) i) ((iterateI (subtract 1) j))
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/VReverse.hs
+++ b/tests/shouldwork/Vector/VReverse.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module VReverse where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 4 Int -> Vec 4 Int
 topEntity = reverse
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/VRotate.hs
+++ b/tests/shouldwork/Vector/VRotate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module VRotate where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 5 Int -> (Vec 5 Int,Vec 5 Int)
 topEntity v = (rotateLeftS v d2,rotateRightS v d2)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/Vector/VSelect.hs
+++ b/tests/shouldwork/Vector/VSelect.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module VSelect where
 
 import Clash.Prelude
@@ -5,7 +7,8 @@ import Clash.Explicit.Testbench
 
 topEntity :: Vec 8 Int -> Vec 4 Int
 topEntity x = select d1 d2 d4 x
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done

--- a/tests/shouldwork/XOptimization/Conjunction.hs
+++ b/tests/shouldwork/XOptimization/Conjunction.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fno-strictness #-}
 module Conjunction where
 
@@ -16,7 +18,8 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
 f x y = x && y
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 topEntity (x :: Bool) = f (let y :: Bool = y in y) True
 

--- a/tests/shouldwork/XOptimization/Disjunction.hs
+++ b/tests/shouldwork/XOptimization/Disjunction.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fno-strictness #-}
 module Disjunction where
 
@@ -16,7 +18,8 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
 f x y = x || y
-{-# NOINLINE f #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE f #-}
 
 topEntity (x :: Bool) = f (let y :: Bool = y in y) False
 

--- a/tests/shouldwork/Xilinx/ClockWizard.hs
+++ b/tests/shouldwork/Xilinx/ClockWizard.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -31,7 +32,8 @@ topEntity clkInN clkInP rstIn =
       o1 = f clkA rstA o1
       o2 = f clkB rstB o2
   in bundle (o1, o2)
-{-# NOINLINE topEntity #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE topEntity #-}
 
 testBench ::
   Signal DomIn Bool
@@ -45,7 +47,8 @@ testBench = done
   strictAnd !a !b = a && b
   (clkP, clkN) = seClockToDiffClock $ tbClockGen (not <$> done)
   rst = resetGen
-{-# NOINLINE testBench #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE testBench #-}
 
 -- Normally we end VHDL sim by stopping the clocks; usually simulation will
 -- notice nothing can ever change anymore and end. The @clockWizard@ simulation
@@ -61,7 +64,8 @@ endVhdlSim ::
   Bool ->
   Bool
 endVhdlSim = id
-{-# NOINLINE endVhdlSim #-}
+-- See: https://github.com/clash-lang/clash-compiler/pull/2511
+{-# CLASH_OPAQUE endVhdlSim #-}
 {-# ANN endVhdlSim (
   let primName = 'endVhdlSim
   in InlineYamlPrimitive [VHDL] [__i|

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -241,6 +241,13 @@ instance IsTest ClashGenTest where
       , "-odir", oDir
       , "-hidir", oDir
       , "-fclash-debug", "DebugSilent"
+
+      -- See https://github.com/clash-lang/clash-compiler/pull/2511
+#if __GLASGOW_HASKELL__ >= 904
+      , "-DCLASH_OPAQUE=OPAQUE"
+#else
+      , "-DCLASH_OPAQUE=NOINLINE"
+#endif
       ] <> cgExtraArgs
 
     target =


### PR DESCRIPTION
In order for Clash to work properly, some names need to remain untouched by GHC's compilation process. Examples of these names include top entities annotated with a `Synthesize` pragma, or functions having an associated black box implementation. For the longest time, we have tried to instruct GHC to do so by marking functions as "no inline":

```haskell
myFunction :: Unsigned 8 -> Unsigned 8
myFunction = (+1)
{-# NOINLINE myFunction #-}
```

While this does work in the majority of cases, GHC will still touch the name of this function in some, making Clash fail to recognize it. Hence, GHC 9.4 introduce a new pragma `OPAQUE`:


```haskell
myFunction :: Unsigned 8 -> Unsigned 8
myFunction = (+1)
{-# OPAQUE myFunction #-}
```

This PR introduces a change making Clash warn against usage of `NOINLINE` on GHCs 9.4 and newer. To remain compatible with older GHCs, Clash's code base itself defines a CPP macro that defines `CLASH_OPAQUE` as either `NOINLINE` or `OPAQUE` depending on the version of GHC the code base is compiled with. This means that you'll find the following pattern across it:

```haskell
myFunction :: Unsigned 8 -> Unsigned 8
myFunction = (+1)
{-# CLASH_OPAQUE myFunction #-} -- Expands to NOINLINE < 9.4
                                -- Expands to OPAQUE >= 9.4
```

This macro is local to Clash itself, and is not reusable within other projects. If your project suffers from similar cross-compatibility problems, consider using a similar strategy.

-----------------------------

Warn against non-opaque primitive functions on GHC >= 9.4.

Fixes #2510

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~ 9.4 / 9.6 support is not in a Hackage release yet
  - [X] Check copyright notices are up to date in edited files
  - [x] Go through all primitives and mark them `OPAQUE` with CPP :cry:. Note that we also want to mark top entities as `OPAQUE` as GHC can touch them too in some circumstances.
  - [x] Add example from issue #2510 to CI
  - [x] Extend PR cover letter in such a way that it is useful for people finding the link now scattered throughout the code base.