### PR TITLE
Disable two problematic Vivado tests in test suite

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -898,11 +898,26 @@ runClashTest = defaultMain $ clashTestRoot
                           }
            in runTest "NoCPR" _opts
         , runTest "DynamicClocks" def
-            { hdlLoad = hdlLoad def \\ [Verilator]
+            { hdlTargets = [VHDL]
+              -- Vivado often fails with "Iteration limit reached"
+            , hdlLoad = hdlLoad def \\ [Verilator, Vivado]
+            , hdlSim = hdlSim def \\ [Verilator, Vivado]
+            , clashFlags = ["-fclash-timescale-precision", "1fs"]
+            }
+        , runTest "DynamicClocks" def
+            { hdlTargets = [Verilog, SystemVerilog]
+            , hdlLoad = hdlLoad def \\ [Verilator]
             , hdlSim = hdlSim def \\ [Verilator]
             , clashFlags = ["-fclash-timescale-precision", "1fs"]
             }
         , runTest "Oversample" def
+            { hdlTargets = [VHDL]
+              -- Vivado fails "exceptional condition"
+            , hdlLoad = hdlLoad def \\ [Vivado]
+            , hdlSim = hdlSim def \\ [Vivado]
+            }
+        , runTest "Oversample" def
+            { hdlTargets = [Verilog, SystemVerilog] }
         , runTest "RegisterAR" def
         , runTest "RegisterSR" def
         , runTest "RegisterAE" def


### PR DESCRIPTION
Due to bugs in Vivado

I split off VHDL so I could disable those specifically. This makes the code less pleasant to look at, but I do like that at least the Verilog test is still run for as much coverage as we can hope for. It does change the visual layout when running the test. Before:

```
  tests
    shouldwork
      Signal
        DynamicClocks
          VHDL
            clash (gen):                  OK (7.18s)
            GHDL
              ghdl (import testBench):    OK (0.03s)
              ghdl (make testBench):      OK (2.17s)
              ghdl (sim testBench):       OK (0.09s)
            Vivado
              vivado (sim testBench): [...]
          Verilog
            clash (gen):                  OK (6.53s)
            IVerilog
              iverilog (make testBench):  OK (0.08s)
              iverilog (sim testBench):   OK (0.04s)
            Vivado
              vivado (sim testBench):     OK (25.17s)
          SystemVerilog
            clash (gen):                  OK (7.02s)
            ModelSim
              modelsim (vlib testBench):  OK (0.03s)
              modelsim (vlog testBench):  OK (0.09s)
              modelsim (sim testBench):   OK (0.84s)
```

After:
```
  tests
    shouldwork
      Signal
        DynamicClocks
          VHDL
            clash (gen):                  OK (5.24s)
            GHDL
              ghdl (import testBench):    OK (0.02s)
              ghdl (make testBench):      OK (1.51s)
              ghdl (sim testBench):       OK (0.08s)
        DynamicClocks
          Verilog
            clash (gen):                  OK (5.72s)
            IVerilog
              iverilog (make testBench):  OK (0.07s)
              iverilog (sim testBench):   OK (0.02s)
            Vivado
              vivado (sim testBench):     OK (18.73s)
          SystemVerilog
            clash (gen):                  OK (5.44s)
            ModelSim
              modelsim (vlib testBench):  OK (0.03s)
              modelsim (vlog testBench):  OK (0.07s)
              modelsim (sim testBench):   OK (0.56s)
```
## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
