### PR TITLE
Verilog `tbClockGen`: print nothing when clock stops

### DIFF
--- a/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives.yaml
@@ -73,7 +73,7 @@
         `ifndef VERILATOR
         #~LONGESTPERIOD0 forever begin
           if (~ ~ARG[1]) begin
-            $finish;
+            $finish(0);
           end
           ~SYM[0] = ~ ~SYM[0];
           #~SYM[1];


### PR DESCRIPTION
This ensures that Clash's testsuite doesn't trip up on simulation finish during normal operation. The testsuite assumes an error occured when VVP prints anything to stdout. This is needed for iverilog version 11 and later.

This commit was originally part of #2274 on `master`, but is needed in 1.6 as well.

(cherry picked from commit 07073588403ff39291447a68c7b0bf8891e10f53)

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
