### PR TITLE
Dynamically link clashLibTest generated executables on GHC 9.6+

### DIFF
--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -566,6 +566,16 @@ clashLibTest' modName target extraGhcArgs path =
       cbBuildTarget=target
     , cbSourceDirectory=sourceDir
     , cbExtraBuildArgs="-DCLASHLIBTEST" :
+#if __GLASGOW_HASKELL__ >= 906
+        "-dynamic" :
+        -- All libraries in the GHC environment file are passed to the GHC
+        -- linking stage, even when they are not used by the particular target.
+        -- The clash-ffi so-lib contains undefined references, but said library
+        -- isn't actually used in any of the clash-lib tests. So we just tell
+        -- the linker to shut up and continue producing an executable, as the
+        -- undefined references will not be an issue at run-time.
+        "-optl" : "-Wl,--allow-shlib-undefined" :
+#endif
 #ifdef CLASH_WORKAROUND_GHC_MMAP_CRASH
         "-with-rtsopts=-xm20000000" :
 #endif


### PR DESCRIPTION
Fixes #2504

On GHC 9.6.2 I now get:
```
$ time cabal v2-run clash-testsuite -- -j8 --hide-successes -p '/.VHDL/ && /clash-lib/' --no-vivado

All 16 tests passed (21.13s)

real    0m21,413s
user    2m16,543s
sys     0m14,158s
```
