### PR TITLE
GitHub CI: Enable 9.6 for external

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ "8.6.5", "9.0.2" ]
+        ghc: [ "8.6.5", "9.0.2", "9.6.1" ]
         include:
           - multiple_hidden: yes
 


### PR DESCRIPTION
This was left out of #2496 because bug #2504 made it really slow. Now that it is fixed, we can add it.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
