### PR TITLE
Use newtype for Index/(Un)Signed on GHC 9.4+

### DIFF
--- a/changelog/2023-07-11T16_01_18+02_00_fix_2525
+++ b/changelog/2023-07-11T16_01_18+02_00_fix_2525
@@ -1,0 +1,1 @@
+CHANGED: From GHC 9.4.1 onwards the following types: `BiSignalOut`, `Index`, `Signed`, `Unsigned`, `File`, `Ref`, and `SimIO` are all encoded as `newtype` instead of `data` now that [#2511](https://github.com/clash-lang/clash-compiler/pull/2511) is merged. This means you can once again use `Data.Coerce.coerce` to coerce between these types and their underlying representation.

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2017, Google Inc.
                   2019, Myrtle Software Ltd
-                  2022, QBayLogic B.V.
+                  2022-2023, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -203,7 +203,7 @@ type role BiSignalOut nominal nominal nominal
 --
 -- as it is not safe to coerce the default behaviour, synthesis domain or width
 -- of the data in the signal.
-#if MIN_VERSION_base(4,15,0)
+#if MIN_VERSION_base(4,15,0) && !MIN_VERSION_base(4,17,0)
 data BiSignalOut (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
   = BiSignalOut ![Signal dom (Maybe (BitVector n))]
 #else

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2019, Myrtle Software Ltd,
-                  2021-2022, QBayLogic B.V.
+                  2021-2023, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -157,7 +157,7 @@ type role Index nominal
 --
 -- as it is not safe to coerce between 'Index'es with different ranges. To
 -- change the size, use the functions in the 'Resize' class.
-#if MIN_VERSION_base(4,15,0)
+#if MIN_VERSION_base(4,15,0) && !MIN_VERSION_base(4,17,0)
 data Index (n :: Nat) =
     -- | The constructor, 'I', and the field, 'unsafeToInteger', are not
     -- synthesizable.

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016     , Myrtle Software Ltd,
-                  2021-2022, QBayLogic B.V.
+                  2021-2023, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -184,7 +184,7 @@ type role Signed nominal
 --
 -- as it is not safe to coerce between different width Signed. To change the
 -- width, use the functions in the 'Clash.Class.Resize.Resize' class.
-#if MIN_VERSION_base(4,15,0)
+#if MIN_VERSION_base(4,15,0) && !MIN_VERSION_base(4,17,0)
 data Signed (n :: Nat) =
     -- | The constructor, 'S', and the field, 'unsafeToInteger', are not
     -- synthesizable.

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016     , Myrtle Software Ltd,
-                  2021-2022, QBayLogic B.V.
+                  2021-2023, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -200,7 +200,7 @@ type role Unsigned nominal
 --
 -- as it is not safe to coerce between different width Unsigned. To change the
 -- width, use the functions in the 'Clash.Class.Resize.Resize' class.
-#if MIN_VERSION_base(4,15,0)
+#if MIN_VERSION_base(4,15,0) && !MIN_VERSION_base(4,17,0)
 data Unsigned (n :: Nat) =
     -- | The constructor, 'U', and the field, 'unsafeToNatural', are not
     -- synthesizable.

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -783,7 +783,7 @@ imap f = go 0
 
 {- | Zip two vectors with a functions that also takes the elements' indices.
 
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ >= 900 && __GLASGOW_HASKELL__ < 904
 >>> izipWith (\i a b -> i + a + b) (2 :> 2 :> Nil)  (3 :> 3:> Nil)
 *** Exception: X: Clash.Sized.Index: result 2 is out of bounds: [0..1]
 ...


### PR DESCRIPTION
Implements #2525

Most benchmarks were within 1-3% of each other. The outliers, in favour of newtype, were:

strict field:
```
benchmarking Signed/+ 3*WORD_SIZE_IN_BITS
time                 120.3 ns   (119.8 ns .. 120.8 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 120.8 ns   (120.4 ns .. 121.3 ns)
std dev              1.520 ns   (1.333 ns .. 1.729 ns)
variance introduced by outliers: 13% (moderately inflated)
```
newtype:
```
benchmarking Signed/+ 3*WORD_SIZE_IN_BITS
time                 106.3 ns   (106.3 ns .. 106.4 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 106.3 ns   (106.3 ns .. 106.4 ns)
std dev              133.3 ps   (107.9 ps .. 171.5 ps)
```

strict field:
```
benchmarking Signed/- 3*WORD_SIZE_IN_BITS
time                 95.15 ns   (95.11 ns .. 95.20 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 95.14 ns   (95.10 ns .. 95.19 ns)
std dev              148.2 ps   (123.6 ps .. 183.9 ps)
```
newtype:
```
benchmarking Signed/- 3*WORD_SIZE_IN_BITS
time                 89.93 ns   (89.04 ns .. 91.70 ns)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 89.35 ns   (89.05 ns .. 90.99 ns)
std dev              1.787 ns   (60.20 ps .. 4.337 ns)
variance introduced by outliers: 28% (moderately inflated)
```

strict field:
```
benchmarking Signed/.&. WORD_SIZE_IN_BITS
time                 87.26 ns   (87.24 ns .. 87.29 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 87.24 ns   (87.21 ns .. 87.27 ns)
std dev              89.59 ps   (71.91 ps .. 108.3 ps)
```
newtype:
```
benchmarking Signed/.&. WORD_SIZE_IN_BITS
time                 76.58 ns   (76.55 ns .. 76.61 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 76.60 ns   (76.57 ns .. 76.62 ns)
std dev              92.21 ps   (67.79 ps .. 137.1 ps)
```

strict field:
```
benchmarking Signed/.|. WORD_SIZE_IN_BITS
time                 89.61 ns   (89.56 ns .. 89.65 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 89.59 ns   (89.55 ns .. 89.63 ns)
std dev              147.2 ps   (109.2 ps .. 208.7 ps)
```
newtype:
```
benchmarking Signed/.|. WORD_SIZE_IN_BITS
time                 73.43 ns   (72.92 ns .. 74.35 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 73.07 ns   (72.89 ns .. 74.16 ns)
std dev              976.2 ps   (352.4 ps .. 2.453 ns)
variance introduced by outliers: 15% (moderately inflated)
```

strict field:
```
benchmarking Unsigned/.|. 3*WORD_SIZE_IN_BITS
time                 62.10 ns   (62.08 ns .. 62.12 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 62.10 ns   (62.09 ns .. 62.11 ns)
std dev              37.36 ps   (30.95 ps .. 46.13 ps)
```
newtype:
```
benchmarking Unsigned/.|. 3*WORD_SIZE_IN_BITS
time                 48.72 ns   (48.71 ns .. 48.72 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 48.72 ns   (48.71 ns .. 48.72 ns)
std dev              11.83 ps   (9.698 ps .. 14.92 ps)
```

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
