### PR TITLE
Add `unsafe{From,To}Active{Low,High}`

### DIFF
--- a/changelog/2022-07-26T13_16_31-05_00_reset_polarity_dsl
+++ b/changelog/2022-07-26T13_16_31-05_00_reset_polarity_dsl
@@ -1,1 +1,1 @@
-INTERNAL NEW: Added `unsafeToHighPolarity` and `unsafeToLowPolarity` to `Clash.Primitives.DSL`. [#2270](https://github.com/clash-lang/clash-compiler/pull/2270)
+INTERNAL NEW: Added `unsafeToActiveHigh` and `unsafeToActiveLow` to `Clash.Primitives.DSL`. [#2270](https://github.com/clash-lang/clash-compiler/pull/2270)

--- a/changelog/2023-07-13T14_49_23+02_00_rename_from_polarity
+++ b/changelog/2023-07-13T14_49_23+02_00_rename_from_polarity
@@ -1,0 +1,1 @@
+DEPRECATED: `unsafeFromLowPolarity` and `unsafeFromHighPolarity` have been replaced by `unsafeFromActiveLow` and `unsafeFromActiveHigh`. While former ones will continue to exist, a deprecation warning has been added pointing to the latter ones.

--- a/changelog/2023-07-13T14_49_23+02_00_rename_from_polarity
+++ b/changelog/2023-07-13T14_49_23+02_00_rename_from_polarity
@@ -1,1 +1,1 @@
-DEPRECATED: `unsafeFromLowPolarity` and `unsafeFromHighPolarity` have been replaced by `unsafeFromActiveLow` and `unsafeFromActiveHigh`. While former ones will continue to exist, a deprecation warning has been added pointing to the latter ones.
+DEPRECATED: `unsafeFromLowPolarity`, `unsafeFromHighPolarity`, `unsafeToLowPolarity`, `unsafeToHighPolarity` have been replaced by `unsafeFromActiveLow`, `unsafeFromActiveHigh`, `unsafeToActiveLow`, `unsafeToActiveHigh`. While former ones will continue to exist, a deprecation warning has been added pointing to the latter ones.

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo.hs
@@ -177,8 +177,8 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
     _ -> error $ show 'dcFifo <> " only supports synchronous resets"
 
  where
-  rstSignalR = unsafeToHighPolarity rRst
-  rstSignalW = unsafeToHighPolarity wRst
+  rstSignalR = unsafeToActiveHigh rRst
+  rstSignalW = unsafeToActiveHigh wRst
 
   fifoSize = natToNum @(2 ^ depth - 1) @Int
   dataCount = fromIntegral . Seq.length

--- a/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/BlackBoxes.hs
+++ b/clash-cores/src/Clash/Cores/Xilinx/DcFifo/Internal/BlackBoxes.hs
@@ -178,7 +178,7 @@ dcFifoBBTF DcConfig{..} bbCtx
       let domty = DSL.ety knownDomainWrite
       in case stripVoid domty of
            N.KnownDomain _ _ _ Synchronous _ _ ->
-             DSL.unsafeToHighPolarity "wr_rst_high" domty wRst
+             DSL.unsafeToActiveHigh "wr_rst_high" domty wRst
            N.KnownDomain _ _ _ Asynchronous _ _ ->
              error $
                show 'dcFifoTF <> ": dcFifo only supports synchronous resets"
@@ -190,7 +190,7 @@ dcFifoBBTF DcConfig{..} bbCtx
       let domty = DSL.ety knownDomainRead
       in case stripVoid domty of
            N.KnownDomain _ _ _ Synchronous _ _ ->
-             DSL.unsafeToHighPolarity "rd_rst_high" domty rRst
+             DSL.unsafeToActiveHigh "rd_rst_high" domty rRst
            N.KnownDomain _ _ _ Asynchronous _ _ ->
              error $
                show 'dcFifoTF <> ": dcFifo only supports synchronous resets"

--- a/clash-cores/test/Test/Cores/Xilinx/DcFifo.hs
+++ b/clash-cores/test/Test/Cores/Xilinx/DcFifo.hs
@@ -260,7 +260,7 @@ testOverflow = testCase "Overflows appropriately" $ do
 
   fifo = dcFifo @4 defConfig{dcOverflow = True} clk noRst clk noRst
   clk = clockGen @D3
-  noRst = unsafeFromHighPolarity $ pure False
+  noRst = unsafeFromActiveHigh $ pure False
   drive15 = mealy clk noRst enableGen go 15 (pure ())
   go 0 _ = (0 :: Int, Nothing)
   go n _ = (n-1, Just (1 :: Int))
@@ -361,11 +361,11 @@ throughFifo d _ _ feed drain wrDataList rdStalls = rdDataList
   where
 
     wrClk = clockGen @write
-    noWrRst = unsafeFromHighPolarity $ pure False
+    noWrRst = unsafeFromActiveHigh $ pure False
     wrEna = enableGen @write
 
     rdClk = clockGen @read
-    noRdRst = unsafeFromHighPolarity $ pure False
+    noRdRst = unsafeFromActiveHigh $ pure False
     rdEna = enableGen @read
 
     wrData =

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -76,8 +76,8 @@ module Clash.Primitives.DSL
   , unsignedFromBitVector
   , boolFromBits
 
-  , unsafeToHighPolarity
-  , unsafeToLowPolarity
+  , unsafeToActiveHigh
+  , unsafeToActiveLow
 
   -- ** Operations
   , andExpr
@@ -988,7 +988,7 @@ andExpr nm a b = do
   assign nm $ TExpr Bool (Identifier (Id.unsafeMake andTxt) Nothing)
 
 -- | Massage a reset to work as active-high reset.
-unsafeToHighPolarity
+unsafeToActiveHigh
   :: Backend backend
   => Text
   -- ^ Name hint
@@ -997,7 +997,7 @@ unsafeToHighPolarity
   -> TExpr
   -- ^ Reset signal
   -> State (BlockState backend) TExpr
-unsafeToHighPolarity nm dom rExpr =
+unsafeToActiveHigh nm dom rExpr =
   case extrResetPolarity dom of
     ActiveHigh -> pure rExpr
     ActiveLow -> notExpr nm rExpr
@@ -1007,7 +1007,7 @@ extrResetPolarity (Void (Just (KnownDomain _ _ _ _ _ p))) = p
 extrResetPolarity p = error ("Internal error: expected KnownDomain, got: " <> show p)
 
 -- | Massage a reset to work as active-low reset.
-unsafeToLowPolarity
+unsafeToActiveLow
   :: Backend backend
   => Text
   -- ^ Name hint
@@ -1016,7 +1016,7 @@ unsafeToLowPolarity
   -> TExpr
   -- ^ Reset signal
   -> State (BlockState backend) TExpr
-unsafeToLowPolarity nm dom rExpr =
+unsafeToActiveLow nm dom rExpr =
   case extrResetPolarity dom of
     ActiveLow -> pure rExpr
     ActiveHigh -> notExpr nm rExpr

--- a/clash-lib/src/Clash/Primitives/Xilinx/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Xilinx/ClockGen.hs
@@ -64,7 +64,7 @@ clockWizardDifferentialTemplate bbCtx
       clkWizInstName <- Id.makeBasic "clockWizardDifferential_inst"
       DSL.declarationReturn bbCtx "clockWizardDifferential" $ do
 
-        rstHigh <- DSL.unsafeToHighPolarity "reset" (DSL.ety knownDomIn) rst
+        rstHigh <- DSL.unsafeToActiveHigh "reset" (DSL.ety knownDomIn) rst
         pllOut <- DSL.declare "pllOut" Bit
         locked <- DSL.declare "locked" Bit
         pllLock <- DSL.boolFromBit "pllLock" locked

--- a/clash-prelude/src/Clash/Annotations/TopEntity.hs
+++ b/clash-prelude/src/Clash/Annotations/TopEntity.hs
@@ -84,8 +84,8 @@ topEntity clk20 rstBtn enaBtn modeBtn =
 
   -- Signal coming from the reset button is low when pressed, and high when
   -- not pressed. We convert this signal to the polarity of our domain with
-  -- /unsafeFromLowPolarity/.
-  rst = 'Clash.Signal.unsafeFromLowPolarity' ('Clash.Signal.unsafeFromReset' rstBtn)
+  -- /unsafeFromActiveLow/.
+  rst = 'Clash.Signal.unsafeFromActiveLow' ('Clash.Signal.unsafeFromReset' rstBtn)
 
   -- Instantiate a PLL: this stabilizes the incoming clock signal and indicates
   -- when the signal is stable. We're also using it to transform an incoming
@@ -99,11 +99,11 @@ topEntity clk20 rstBtn enaBtn modeBtn =
 
   -- Synchronize reset to clock signal coming from PLL. We want the reset to
   -- remain active while the PLL is NOT stable, hence the conversion with
-  -- /unsafeFromLowPolarity/
+  -- /unsafeFromActiveLow/
   rstSync =
     'Clash.Prelude.resetSynchronizer'
       clk50
-      ('Clash.Signal.unsafeFromLowPolarity' pllStable)
+      ('Clash.Signal.unsafeFromActiveLow' pllStable)
 
 blinkerT
   :: (BitVector 8, Bool, Index 16650001)

--- a/clash-prelude/src/Clash/Clocks/Deriving.hs
+++ b/clash-prelude/src/Clash/Clocks/Deriving.hs
@@ -51,7 +51,7 @@ derive' n = do
   -- Implementation of 'clocks'
   clkImpl <- [| Clock SSymbol Nothing |]
   lockImpl <- [| unsafeSynchronizer clockGen clockGen
-                   (unsafeToLowPolarity $(varE rst)) |]
+                   (unsafeToActiveLow $(varE rst)) |]
   let
     noInline  = PragmaD $ InlineP (mkName "clocks") NoInline FunLike AllPhases
     clkImpls  = replicate n clkImpl

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -92,7 +92,7 @@ ddrIn#
   -> a
   -> Signal fast a
   -> Signal slow (a,a)
-ddrIn# (Clock _ Nothing) (unsafeToHighPolarity -> hRst) (fromEnable -> ena) i0 i1 i2 =
+ddrIn# (Clock _ Nothing) (unsafeToActiveHigh -> hRst) (fromEnable -> ena) i0 i1 i2 =
   case resetKind @fast of
     SAsynchronous ->
       goAsync

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -206,10 +206,10 @@ module Clash.Explicit.Signal
   , Reset
   , unsafeToReset
   , unsafeFromReset
-  , unsafeToHighPolarity
-  , unsafeToLowPolarity
-  , unsafeFromHighPolarity
-  , unsafeFromLowPolarity
+  , unsafeToActiveHigh
+  , unsafeToActiveLow
+  , unsafeFromActiveHigh
+  , unsafeFromActiveLow
     -- * Basic circuit functions
   , andEnable
   , enable -- DEPRECATED
@@ -267,6 +267,12 @@ module Clash.Explicit.Signal
   , readFromBiSignal
   , writeToBiSignal
   , mergeBiSignalOuts
+
+  -- * Deprecated
+  , unsafeFromHighPolarity
+  , unsafeFromLowPolarity
+  , unsafeToHighPolarity
+  , unsafeToLowPolarity
   )
 where
 
@@ -813,7 +819,7 @@ simulateB_lazy f = simulate_lazy (bundle . f . unbundle)
 
 -- | Like 'fromList', but resets on reset and has a defined reset value.
 --
--- >>> let rst = unsafeFromHighPolarity (fromList [True, True, False, False, True, False])
+-- >>> let rst = unsafeFromActiveHigh (fromList [True, True, False, False, True, False])
 -- >>> let res = fromListWithReset @System rst Nothing [Just 'a', Just 'b', Just 'c']
 -- >>> sampleN 6 res
 -- [Nothing,Nothing,Just 'a',Just 'b',Nothing,Just 'a']
@@ -827,7 +833,7 @@ fromListWithReset
   -> [a]
   -> Signal dom a
 fromListWithReset rst resetValue vals =
-  go (unsafeToHighPolarity rst) vals
+  go (unsafeToActiveHigh rst) vals
  where
   go (r :- rs) _ | r = resetValue :- go rs vals
   go (_ :- rs) [] = deepErrorX "fromListWithReset: input ran out" :- go rs []

--- a/clash-prelude/src/Clash/Intel/ClockGen.hs
+++ b/clash-prelude/src/Clash/Intel/ClockGen.hs
@@ -77,13 +77,13 @@ import Clash.Signal.Internal
 --  where
 --   (clk, pllStable) =
 --     'altpll' \@'Clash.Signal.System' ('SSymbol' \@\"altpll50to100\") clkInp
---            ('Clash.Signal.unsafeFromLowPolarity' rstInp)
---   rst = 'Clash.Signal.resetSynchronizer' clk ('Clash.Signal.unsafeFromLowPolarity' pllStable)
+--            ('Clash.Signal.unsafeFromActiveLow' rstInp)
+--   rst = 'Clash.Signal.resetSynchronizer' clk ('Clash.Signal.unsafeFromActiveLow' pllStable)
 -- @
 --
 -- 'Clash.Signal.resetSynchronizer' will keep the reset asserted when
 -- @pllStable@ is 'False', hence the use of
--- @'Clash.Signal.unsafeFromLowPolarity' pllStable@. Your circuit will have
+-- @'Clash.Signal.unsafeFromActiveLow' pllStable@. Your circuit will have
 -- signals of type @'Signal' 'Clash.Signal.System'@ and all the clocks and
 -- resets of your components will be the @clk@ and @rst@ signals generated here
 -- (modulo local resets, which will be based on @rst@ or never asserted at all
@@ -179,13 +179,13 @@ altpll !_ = knownDomain @domIn `seq` knownDomain @domOut `seq` clocks
 --  where
 --   (clk :: 'Clock' 'Clash.Signal.System', pllStable :: 'Signal' 'Clash.Signal.System' 'Bool')
 --     'alteraPll' ('SSymbol' \@\"alterapll50to100\") clkInp
---               ('Clash.Signal.unsafeFromLowPolarity' rstInp)
---   rst = 'Clash.Signal.resetSynchronizer' clk ('Clash.Signal.unsafeFromLowPolarity' pllStable)
+--               ('Clash.Signal.unsafeFromActiveLow' rstInp)
+--   rst = 'Clash.Signal.resetSynchronizer' clk ('Clash.Signal.unsafeFromActiveLow' pllStable)
 -- @
 --
 -- 'Clash.Signal.resetSynchronizer' will keep the reset asserted when
 -- @pllStable@ is 'False', hence the use of
--- @'Clash.Signal.unsafeFromLowPolarity' pllStable@. Your circuit will have
+-- @'Clash.Signal.unsafeFromActiveLow' pllStable@. Your circuit will have
 -- signals of type @'Signal' 'Clash.Signal.System'@ and all the clocks and
 -- resets of your components will be the @clk@ and @rst@ signals generated here
 -- (modulo local resets, which will be based on @rst@ or never asserted at all

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -136,10 +136,10 @@ module Clash.Signal
   , Reset
   , unsafeToReset
   , unsafeFromReset
-  , unsafeToHighPolarity
-  , unsafeToLowPolarity
-  , unsafeFromHighPolarity
-  , unsafeFromLowPolarity
+  , unsafeToActiveHigh
+  , unsafeToActiveLow
+  , unsafeFromActiveHigh
+  , unsafeFromActiveLow
 #ifdef CLASH_MULTIPLE_HIDDEN
   , convertReset
 #endif
@@ -262,6 +262,12 @@ module Clash.Signal
   , HiddenClockName
   , HiddenResetName
   , HiddenEnableName
+
+    -- * Deprecated
+  , unsafeFromHighPolarity
+  , unsafeFromLowPolarity
+  , unsafeToHighPolarity
+  , unsafeToLowPolarity
   )
 where
 
@@ -417,7 +423,7 @@ topEntity
   -> Signal System (BitVector 8)
 topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol \@\"altpll50\") clk rst
-         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable)
+         rstSync            = 'resetSynchronizer' pllOut (unsafeToActiveHigh pllStable)
     in   'exposeClockResetEnable' leds pllOut rstSync enableGen
   where
     key1R  = isRising 1 key1
@@ -434,7 +440,7 @@ topEntity
   -> Signal System (BitVector 8)
 topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol \@\"altpll50\") clk rst
-         rstSync            = 'resetSynchronizer' pllOut (unsafeToHighPolarity pllStable)
+         rstSync            = 'resetSynchronizer' pllOut (unsafeToActiveHigh pllStable)
     in   'withClockResetEnable' pllOut rstSync enableGen leds
   where
     key1R  = isRising 1 key1
@@ -2234,7 +2240,7 @@ unsafeSynchronizer =
 --
 -- Example:
 --
--- >>> sampleN @System 8 (unsafeToHighPolarity (holdReset (SNat @2)))
+-- >>> sampleN @System 8 (unsafeToActiveHigh (holdReset (SNat @2)))
 -- [True,True,True,False,False,False,False,False]
 --
 -- 'holdReset' holds the reset for an additional 2 clock cycles for a total
@@ -2252,7 +2258,7 @@ holdReset m =
 
 -- | Like 'fromList', but resets on reset and has a defined reset value.
 --
--- >>> let rst = unsafeFromHighPolarity (fromList [True, True, False, False, True, False])
+-- >>> let rst = unsafeFromActiveHigh (fromList [True, True, False, False, True, False])
 -- >>> let res = withReset rst (fromListWithReset Nothing [Just 'a', Just 'b', Just 'c'])
 -- >>> sampleN @System 6 res
 -- [Nothing,Nothing,Just 'a',Just 'b',Nothing,Just 'a']

--- a/clash-prelude/src/Clash/Tutorial.hs
+++ b/clash-prelude/src/Clash/Tutorial.hs
@@ -924,8 +924,8 @@ topEntity
 topEntity clk rst =
     'exposeClockResetEnable' ('mealy' blinkerT (1,False,0) . Clash.Prelude.isRising 1) pllOut rstSync 'enableGen'
   where
-    (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' \@Dom100 (SSymbol \@\"altpll100\") clk ('Clash.Signal.unsafeFromLowPolarity' rst)
-    rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeFromLowPolarity' pllStable)
+    (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' \@Dom100 (SSymbol \@\"altpll100\") clk ('Clash.Signal.unsafeFromActiveLow' rst)
+    rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeFromActiveLow' pllStable)
 
 blinkerT (leds,mode,cntr) key1R = ((leds',mode',cntr'),leds)
   where
@@ -2505,8 +2505,8 @@ topEntity
 topEntity clk rst =
     'exposeClockResetEnable' ('mealy' blinkerT (1,False,0) . Clash.Prelude.isRising 1) pllOut rstSync 'enableGen'
   where
-    (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' \@Dom100 (SSymbol \@\"altpll100\") clk ('Clash.Signal.unsafeFromLowPolarity' rst)
-    rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeFromLowPolarity' pllStable)
+    (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' \@Dom100 (SSymbol \@\"altpll100\") clk ('Clash.Signal.unsafeFromActiveLow' rst)
+    rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeFromActiveLow' pllStable)
 
 blinkerT (leds,mode,cntr) key1R = ((leds',mode',cntr'),leds)
   where

--- a/clash-prelude/tests/Clash/Tests/AsyncFIFOSynchronizer.hs
+++ b/clash-prelude/tests/Clash/Tests/AsyncFIFOSynchronizer.hs
@@ -1053,8 +1053,8 @@ fifoOperations racts wacts = (bundle (rAllDone, rel), bundle (wAllDone, wel))
   wclk = clockGen @wdom
   -- Not resetting makes the test easier to interpret and actual proper testing
   -- of reset behaviour is a lot more involved.
-  noRRst = unsafeFromHighPolarity @rdom (pure False)
-  noWRst = unsafeFromHighPolarity @wdom (pure False)
+  noRRst = unsafeFromActiveHigh @rdom (pure False)
+  noWRst = unsafeFromActiveHigh @wdom (pure False)
   (wdone, wact) =
     unbundle $ fromList $ P.zip (P.repeat False) wacts <> P.repeat (True, WNoOp)
   (rdone, ract) =

--- a/clash-prelude/tests/Clash/Tests/Reset.hs
+++ b/clash-prelude/tests/Clash/Tests/Reset.hs
@@ -20,10 +20,10 @@ createDomain vSystem{vName="Low", vResetPolarity=ActiveLow}
 createDomain vSystem{vName="NoInit", vInitBehavior=Unknown}
 
 sampleResetN :: KnownDomain dom => Int -> Reset dom -> [Bool]
-sampleResetN n = sampleN n . unsafeToHighPolarity
+sampleResetN n = sampleN n . unsafeToActiveHigh
 
 resetFromList :: KnownDomain dom => [Bool] -> Reset dom
-resetFromList = unsafeFromHighPolarity . fromList
+resetFromList = unsafeFromActiveHigh . fromList
 
 onePeriodGlitchReset :: KnownDomain dom => Reset dom
 onePeriodGlitchReset =

--- a/clash-prelude/tests/Clash/Tests/Signal.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal.hs
@@ -113,7 +113,7 @@ tests =
         "Implicit"
         [ -- See: https://github.com/clash-lang/clash-compiler/pull/655
           let rst0 = fromList [True, True, False, False, True, True]
-              rst1 = unsafeFromHighPolarity rst0
+              rst1 = unsafeFromActiveHigh rst0
               reg  = register 'a' (pure 'b')
 #ifdef CLASH_MULTIPLE_HIDDEN
               sig = withReset rst1 reg

--- a/examples/Blinker.hs
+++ b/examples/Blinker.hs
@@ -65,8 +65,8 @@ topEntity clk20 rstBtn modeBtn =
 
   -- Signal coming from the reset button is low when pressed, and high when
   -- not pressed. We convert this signal to the polarity of our domain with
-  -- 'unsafeFromLowPolarity'.
-  rst = unsafeFromLowPolarity rstBtn
+  -- 'unsafeFromActiveLow'.
+  rst = unsafeFromActiveLow rstBtn
 
   -- Instantiate a PLL: this stabilizes the incoming clock signal and indicates
   -- when the signal is stable. We're also using it to transform an incoming
@@ -80,11 +80,11 @@ topEntity clk20 rstBtn modeBtn =
 
   -- Synchronize reset to clock signal coming from PLL. We want the reset to
   -- remain active while the PLL is NOT stable, hence the conversion with
-  -- 'unsafeFromLowPolarity'
+  -- 'unsafeFromActiveLow'
   rstSync =
     resetSynchronizer
       clk50
-      (unsafeFromLowPolarity pllStable)
+      (unsafeFromActiveLow pllStable)
 
 flipMode :: LedMode -> LedMode
 flipMode Rotate = Complement

--- a/tests/shouldwork/CoSim/Register.hs
+++ b/tests/shouldwork/CoSim/Register.hs
@@ -12,7 +12,7 @@ verilog_register
   -> Reset d
   -> Signal d (Signed 64)
   -> Signal d (Signed 64)
-verilog_register clk (unsafeToHighPolarity -> arst) x = [verilog|
+verilog_register clk (unsafeToActiveHigh -> arst) x = [verilog|
   parameter data_width = 64;
 
   input  #{clk};

--- a/tests/shouldwork/Cores/Xilinx/DcFifo/Basic.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo/Basic.hs
@@ -81,7 +81,7 @@ testBench = done
         (pack <$> fifoData maxOut) (fExpectedData <$> fsmOut)
         (fDone <$> fsmOut)
   clk = tbClockGen (not <$> done)
-  noRst = unsafeFromHighPolarity $ pure False
+  noRst = unsafeFromActiveHigh $ pure False
   en = enableGen
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE testBench #-}

--- a/tests/shouldwork/Cores/Xilinx/DcFifo/Lfsr.hs
+++ b/tests/shouldwork/Cores/Xilinx/DcFifo/Lfsr.hs
@@ -120,8 +120,8 @@ mkTestBench cFifo = done
  where
   (rClk, wClk) = biTbClockGen (not <$> done)
 
-  noRRst = unsafeFromHighPolarity $ pure False
-  noWRst = unsafeFromHighPolarity $ pure False
+  noRRst = unsafeFromActiveHigh $ pure False
+  noWRst = unsafeFromActiveHigh $ pure False
 
   rEna = enableGen
   wEna = enableGen

--- a/tests/shouldwork/Cores/Xilinx/TdpBlockRam.hs
+++ b/tests/shouldwork/Cores/Xilinx/TdpBlockRam.hs
@@ -31,10 +31,10 @@ topEntity
 {-# CLASH_OPAQUE topEntity #-}
 
 noRstA :: Reset A
-noRstA = unsafeFromHighPolarity (pure False)
+noRstA = unsafeFromActiveHigh (pure False)
 
 noRstB :: Reset B
-noRstB = unsafeFromHighPolarity (pure False)
+noRstB = unsafeFromActiveHigh (pure False)
 
 tb ::
   ( KnownNat n0, KnownNat n1, KnownNat n2, KnownNat n3

--- a/tests/shouldwork/Cores/Xilinx/XpmCdcArraySingleTypes.hs
+++ b/tests/shouldwork/Cores/Xilinx/XpmCdcArraySingleTypes.hs
@@ -14,7 +14,7 @@ createDomain vXilinxSystem{vName="D10", vPeriod=hzToPeriod 100e6}
 createDomain vXilinxSystem{vName="D11", vPeriod=hzToPeriod 110e6}
 
 noRst :: KnownDomain dom => Reset dom
-noRst = unsafeFromHighPolarity (pure False)
+noRst = unsafeFromActiveHigh (pure False)
 
 tb ::
   forall a b stages width n .

--- a/tests/shouldwork/Cores/Xilinx/XpmCdcGrayTypes.hs
+++ b/tests/shouldwork/Cores/Xilinx/XpmCdcGrayTypes.hs
@@ -14,7 +14,7 @@ createDomain vXilinxSystem{vName="D10", vPeriod=hzToPeriod 100e6}
 createDomain vXilinxSystem{vName="D11", vPeriod=hzToPeriod 110e6}
 
 noRst :: KnownDomain dom => Reset dom
-noRst = unsafeFromHighPolarity (pure False)
+noRst = unsafeFromActiveHigh (pure False)
 
 tb ::
   forall a b width stages n .

--- a/tests/shouldwork/Cores/Xilinx/XpmCdcHandshakeTypes.hs
+++ b/tests/shouldwork/Cores/Xilinx/XpmCdcHandshakeTypes.hs
@@ -18,7 +18,7 @@ createDomain vXilinxSystem{vName="D11", vPeriod=hzToPeriod 110e6}
 data State = WaitForDeassert | WaitForAssert deriving (Generic, NFDataX)
 
 noRst :: KnownDomain dom => Reset dom
-noRst = unsafeFromHighPolarity (pure False)
+noRst = unsafeFromActiveHigh (pure False)
 
 -- | Transfer 1, 2, 3, ... to destination domain
 srcFsm ::

--- a/tests/shouldwork/Cores/Xilinx/XpmCdcSingleTypes.hs
+++ b/tests/shouldwork/Cores/Xilinx/XpmCdcSingleTypes.hs
@@ -16,7 +16,7 @@ createDomain vXilinxSystem{vName="D10", vPeriod=hzToPeriod 100e6}
 createDomain vXilinxSystem{vName="D11", vPeriod=hzToPeriod 110e6}
 
 noRst :: KnownDomain dom => Reset dom
-noRst = unsafeFromHighPolarity (pure False)
+noRst = unsafeFromActiveHigh (pure False)
 
 tb ::
   forall a b stages n .

--- a/tests/shouldwork/Issues/T1742.hs
+++ b/tests/shouldwork/Issues/T1742.hs
@@ -21,7 +21,7 @@ topEntity
   -> "LED"         ::: Signal Bank2C (BitVector 4)
 topEntity clk rstnButton = exposeClockResetEnable top clk rst en where
   en = enableGen
-  rst = unsafeFromLowPolarity rstnButton
+  rst = unsafeFromActiveLow rstnButton
   rstSync = resetSynchronizer clk rst
 
 makeTopEntityWithName 'topEntity "shell"

--- a/tests/shouldwork/Netlist/T1766.hs
+++ b/tests/shouldwork/Netlist/T1766.hs
@@ -44,7 +44,7 @@ knightrider clk rst ena = pack <$> leds
 topEntity :: Clock System -> Signal System Bool -> Signal System (BitVector 8)
 topEntity clk rstBool = knightrider clk rst enableGen
  where
-  rst = unsafeFromLowPolarity rstBool
+  rst = unsafeFromActiveLow rstBool
 
 testPath :: FilePath
 testPath = "tests/shouldwork/Netlist/T1766.hs"

--- a/tests/shouldwork/Signal/BlockRam0.hs
+++ b/tests/shouldwork/Signal/BlockRam0.hs
@@ -99,6 +99,6 @@ testBench = done
 
           :> Nil)
 
-    done           = expectedOutput (topEntity clk (unsafeFromHighPolarity rst0) enableGen rd wr)
+    done           = expectedOutput (topEntity clk (unsafeFromActiveHigh rst0) enableGen rd wr)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen

--- a/tests/shouldwork/Signal/BlockRam1.hs
+++ b/tests/shouldwork/Signal/BlockRam1.hs
@@ -111,6 +111,6 @@ testBench = done
 
           :> Nil)
 
-    done           = expectedOutput (topEntity clk (unsafeFromHighPolarity rst0) enableGen rd wr)
+    done           = expectedOutput (topEntity clk (unsafeFromActiveHigh rst0) enableGen rd wr)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen

--- a/tests/shouldwork/Signal/DelayedReset.hs
+++ b/tests/shouldwork/Signal/DelayedReset.hs
@@ -15,7 +15,7 @@ topEntity clk reset en = (cycleCount, countFromReset, newResetSig)
   where
     newReset ::Reset System
     newReset
-      = unsafeFromHighPolarity newResetSig
+      = unsafeFromActiveHigh newResetSig
 
     newResetSig
       = register clk reset en True

--- a/tests/shouldwork/Signal/DualBlockRamDefinitions.hs
+++ b/tests/shouldwork/Signal/DualBlockRamDefinitions.hs
@@ -117,11 +117,11 @@ clk10TH = clockGen @B
 clk7TH = clockGen @C
 
 noRst20 :: Reset A
-noRst20 = unsafeFromHighPolarity (pure False)
+noRst20 = unsafeFromActiveHigh (pure False)
 noRst10 :: Reset B
-noRst10 = unsafeFromHighPolarity (pure False)
+noRst10 = unsafeFromActiveHigh (pure False)
 noRst7 :: Reset C
-noRst7 = unsafeFromHighPolarity (pure False)
+noRst7 = unsafeFromActiveHigh (pure False)
 
 twice = concatMap (replicate d2)
 strictAnd !a !b = (&&) a b

--- a/tests/shouldwork/Signal/Ram/RMulti.hs
+++ b/tests/shouldwork/Signal/Ram/RMulti.hs
@@ -35,8 +35,8 @@ tbOutput top wClk rClk = output
           Just (0, 1) :> Just (1,2) :> Nothing :> Nil
   rd = delay rClk enableGen 0 $ rd + 1
   output = ignoreFor rClk rNoReset enableGen d2 0 $ top wClk rClk rd wrM
-  wNoReset = unsafeFromHighPolarity @P20 (pure False)
-  rNoReset = unsafeFromHighPolarity @P10 (pure False)
+  wNoReset = unsafeFromActiveHigh @P20 (pure False)
+  rNoReset = unsafeFromActiveHigh @P10 (pure False)
 {-# INLINE tbOutput #-}
 
 tb
@@ -51,5 +51,5 @@ tb top expectedSamples = done
   expectedOutput = outputVerifier' rClk noReset expectedSamples
   done = expectedOutput output
   (rClk, wClk) = biTbClockGen (not <$> done) :: (Clock P10, Clock P20)
-  noReset = unsafeFromHighPolarity @P10 (pure False)
+  noReset = unsafeFromActiveHigh @P10 (pure False)
 {-# INLINE tb #-}

--- a/tests/shouldwork/Signal/Ram/RWMulti.hs
+++ b/tests/shouldwork/Signal/Ram/RWMulti.hs
@@ -55,7 +55,7 @@ tbOutput top wClk rClk = output
  where
   wrD = delay wClk enableGen 0 $ wrD + 1
   output = ignoreFor rClk noReset enableGen d1 0 $ top wClk rClk wrD
-  noReset = unsafeFromHighPolarity @rdom (pure False)
+  noReset = unsafeFromActiveHigh @rdom (pure False)
 {-# INLINE tbOutput #-}
 
 tb
@@ -76,5 +76,5 @@ tb top expectedSamples = done
   expectedOutput = outputVerifier' rClk noReset expectedSamples
   done = expectedOutput output
   (rClk, wClk) = biTbClockGen (not <$> done) :: (Clock rdom, Clock wdom)
-  noReset = unsafeFromHighPolarity @rdom (pure False)
+  noReset = unsafeFromActiveHigh @rdom (pure False)
 {-# INLINE tb #-}

--- a/tests/shouldwork/Signal/RegisterAE.hs
+++ b/tests/shouldwork/Signal/RegisterAE.hs
@@ -52,7 +52,7 @@ topEntity clk rst en = head <$> r
 
 topEntityAE clk rst = topEntity clk arst en
   where
-    arst = unsafeFromHighPolarity (resetInput clk rst enableGen)
+    arst = unsafeFromActiveHigh (resetInput clk rst enableGen)
     en = toEnable (enableInput clk rst enableGen)
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE topEntityAE #-}

--- a/tests/shouldwork/Signal/RegisterAR.hs
+++ b/tests/shouldwork/Signal/RegisterAR.hs
@@ -35,7 +35,7 @@ topEntity clk rst = head <$> r
 
 topEntityAR clk rst = topEntity clk arst
   where
-    arst = unsafeFromHighPolarity (resetInput clk rst enableGen)
+    arst = unsafeFromActiveHigh (resetInput clk rst enableGen)
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE topEntityAR #-}
 

--- a/tests/shouldwork/Signal/RegisterSE.hs
+++ b/tests/shouldwork/Signal/RegisterSE.hs
@@ -51,7 +51,7 @@ topEntity clk rst en = head <$> r
 
 topEntitySE clk rst = topEntity clk arst en
   where
-    arst = unsafeFromHighPolarity (resetInput clk rst enableGen)
+    arst = unsafeFromActiveHigh (resetInput clk rst enableGen)
     en = toEnable (enableInput clk rst enableGen)
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE topEntitySE #-}

--- a/tests/shouldwork/Signal/RegisterSR.hs
+++ b/tests/shouldwork/Signal/RegisterSR.hs
@@ -34,7 +34,7 @@ topEntity clk rst = head <$> r
 
 topEntitySR clk rst = topEntity clk srst
   where
-    srst = unsafeFromHighPolarity (resetInput clk rst enableGen)
+    srst = unsafeFromActiveHigh (resetInput clk rst enableGen)
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE topEntitySR #-}
 

--- a/tests/shouldwork/Signal/ResetGen.hs
+++ b/tests/shouldwork/Signal/ResetGen.hs
@@ -8,7 +8,7 @@ import Clash.Explicit.Testbench
 topEntity
   :: Clock System
   -> Signal System (Bool, Bool)
-topEntity clk = bundle (unsafeToHighPolarity r, unsafeToHighPolarity r')
+topEntity clk = bundle (unsafeToActiveHigh r, unsafeToActiveHigh r')
   where
     r  = resetGenN (SNat @3)
     r' = holdReset clk enableGen (SNat @2) r

--- a/tests/shouldwork/Signal/ResetSynchronizer.hs
+++ b/tests/shouldwork/Signal/ResetSynchronizer.hs
@@ -21,7 +21,7 @@ testReset ::
   Clock circuitDom ->
   Reset circuitDom
 testReset tbClk tbRst cClk =
-    unsafeFromHighPolarity
+    unsafeFromActiveHigh
   $ unsafeSynchronizer tbClk cClk
   $ stimuliGenerator tbClk tbRst
     ( True

--- a/tests/shouldwork/Xilinx/ClockWizard.hs
+++ b/tests/shouldwork/Xilinx/ClockWizard.hs
@@ -25,10 +25,10 @@ topEntity ::
 topEntity clkInSE clkInDiff rstIn =
   let f clk rst = register clk rst enableGen 0 . fmap (satSucc SatBound)
       (clkA, stableA) = clockWizard (SSymbol @"clk_wiz_se") clkInSE rstIn
-      rstA = unsafeFromLowPolarity stableA
+      rstA = unsafeFromActiveLow stableA
       (clkB, stableB) = clockWizardDifferential (SSymbol @"clk_wiz_diff")
                           clkInDiff rstIn
-      rstB = unsafeFromLowPolarity stableB
+      rstB = unsafeFromActiveLow stableB
       o1 = f clkA rstA o1
       o2 = f clkB rstB o2
   in bundle (o1, o2)


### PR DESCRIPTION
## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
  - [x] Update references
  - [x] Add `unsafeToActive{Low,High}`
  - [x] Change deprecation message to indicate _when_ the old functions get removed

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
