### PR TITLE
Add `KnownNat (DomainPeriod dom)` to `KnownDomain`

### DIFF
--- a/changelog/2023-07-13T20_31_20+02_00_add_knownnat_period
+++ b/changelog/2023-07-13T20_31_20+02_00_add_knownnat_period
@@ -1,0 +1,1 @@
+ADDED: `KnownNat (DomainPeriod dom)` as an implied constraint to `KnownDomain dom`. This reduces the amount of code needed to write - for example - clock speed dependent code.

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -165,7 +165,8 @@ ghcTypeToHWType iw = go
         "Clash.Signal.Internal.KnownDomain"
           -> case tyConDataCons (UniqMap.find tc m) of
                [dc] -> case substArgTys dc args of
-                 [_,tyView -> TyConApp _ [_,dom]] -> case tyView (coreView m dom) of
+                 [_knownSymbol, _knownNat, tyView -> TyConApp _ [_,dom]] ->
+                  case tyView (coreView m dom) of
                    TyConApp _ [tag0, period0, edge0, rstKind0, init0, polarity0] -> do
                      tag1      <- domTag m tag0
                      period1   <- domPeriod m period0

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -178,7 +178,7 @@ import Data.Ratio                 (Ratio)
 import Data.Type.Equality         ((:~:))
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack, withFrozenCallStack)
-import GHC.TypeLits               (KnownSymbol, Nat, Symbol, type (<=), sameSymbol)
+import GHC.TypeLits               (KnownSymbol, KnownNat, Nat, Symbol, type (<=), sameSymbol)
 import Language.Haskell.TH.Syntax -- (Lift (..), Q, Dec)
 import Language.Haskell.TH.Compat
 import Numeric.Natural            (Natural)
@@ -409,7 +409,7 @@ type KnownConfiguration dom conf = (KnownDomain dom, KnownConf dom ~ conf)
 
 -- | A 'KnownDomain' constraint indicates that a circuit's behavior depends on
 -- some properties of a domain. See 'DomainConfiguration' for more information.
-class KnownSymbol dom => KnownDomain (dom :: Domain) where
+class (KnownSymbol dom, KnownNat (DomainPeriod dom)) => KnownDomain (dom :: Domain) where
   type KnownConf dom :: DomainConfiguration
   -- | Returns 'SDomainConfiguration' corresponding to an instance's 'DomainConfiguration'.
   --


### PR DESCRIPTION
We previously needed to either:

 * Add this constraint to our functions
 * Match on the `SNat` produced by `clockPeriod @dom`

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
