### PR TITLE
Make `imap_go` eval rule lazy in index argument

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -753,6 +753,7 @@ runClashTest = defaultMain $ clashTestRoot
           }
         , outputTest "T2510" def{hdlTargets=[VHDL], clashFlags=["-DNOINLINE=OPAQUE"]}
 #endif
+        , outputTest "T2542" def{hdlTargets=[VHDL]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2542.hs
+++ b/tests/shouldwork/Issues/T2542.hs
@@ -1,0 +1,26 @@
+module T2542 where
+
+import qualified Prelude as P
+import           Data.List (isInfixOf)
+import           System.Environment (getArgs)
+import           System.FilePath ((</>), takeDirectory)
+
+import Clash.Prelude
+
+topEntity :: (Index 2, Index 2)
+topEntity = case reverse (indicesI @2) of
+  (a `Cons` b `Cons` Nil) -> (a,b)
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise = P.error $ mconcat [ "Expected:\n\n  ", needle
+                                  , "\n\nIn:\n\n", haystack ]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
+
+  assertIn "to_unsigned(1,1)" content
+  assertIn "to_unsigned(0,1)" content


### PR DESCRIPTION
Fixes #2542

The problem was that in the final recursive call, when `imap_go` would return `Nil`, the index argument was out-of-bounds. And because `imap_go` was strict in all arguments, `imap_go` would make the `Nil` undefined.

Subsequently applying `reverse` where the `Nil` is undefined, gives us a complete vector that is undefined, given that `reverse` is strict in its vector argument.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
