### PR TITLE
Make three reset glitch filter variants

### DIFF
--- a/changelog/2022-12-15T11_04_34+01_00_use_counter_in_resetGlitchFilter
+++ b/changelog/2022-12-15T11_04_34+01_00_use_counter_in_resetGlitchFilter
@@ -1,3 +1,2 @@
 CHANGED: `resetGlitchFilter` now uses a counter instead of shift register, allowing glitch filtering over much larger periods.
 CHANGED: `resetGlitchFilter` now filters glitches symmetrically, only deasserting the reset after the incoming reset has stabilized. For more information, read [#2374](https://github.com/clash-lang/clash-compiler/pull/2374).
-CHANGED: `resetGlitchFilter` does not support domains with unknown initial values anymore. Its previous behavior could lead to unstable circuits. Domains not supporting initial values should consider using power-on-resets and glitch filters specifically designed for this environment.

--- a/changelog/2023-07-14T16_45_34+02_00_safeglitch
+++ b/changelog/2023-07-14T16_45_34+02_00_safeglitch
@@ -1,0 +1,2 @@
+CHANGED: `resetGlitchFilter` does not support domains with unknown initial values anymore. Its previous behavior could lead to unstable circuits. Domains not supporting initial values should consider using `resetGlitchFilterWithReset` or `holdReset`. The previous behavior can still be attained through the new `unsafeResetGlitchFilter`.
+NEW: `resetGlitchFilterWithReset`, which accomplishes the same task as `resetGlitchFilter` in domains with unknown initial values by adding a power-on reset input to reset the glitch filter itself.

--- a/clash-prelude/src/Clash/Explicit/Synchronizer.hs
+++ b/clash-prelude/src/Clash/Explicit/Synchronizer.hs
@@ -41,10 +41,10 @@ import Clash.Class.BitPack.BitIndex (slice)
 import Clash.Explicit.Mealy        (mealyB)
 import Clash.Explicit.BlockRam     (RamOp (..), trueDualPortBlockRam)
 import Clash.Explicit.Signal
-  (Clock, Reset, Signal, Enable, register, unsafeSynchronizer, fromEnable, (.&&.))
+  (Clock, Reset, Signal, Enable, register, unsafeSynchronizer, fromEnable,
+  (.&&.), mux, KnownDomain)
 import Clash.Promoted.Nat          (SNat (..))
 import Clash.Promoted.Nat.Literals (d0)
-import Clash.Signal                (mux, KnownDomain)
 import Clash.Sized.BitVector       (BitVector, (++#))
 import Clash.XException            (NFDataX, fromJustX)
 

--- a/clash-prelude/tests/Clash/Tests/Reset.hs
+++ b/clash-prelude/tests/Clash/Tests/Reset.hs
@@ -30,16 +30,20 @@ onePeriodGlitchReset =
   resetFromList [True,True,False,False,True,False,False,True,True,False,False,False]
 
 -- | Introduce a glitch of one period, and see if it's filtered out
+--
+-- Note that since 'System' is a domain with asynchronous resets,
+-- 'resetGlitchFilter' first synchronizes the incoming reset. This leads to an
+-- additional delay of two cycles with respect to the output.
 case_onePeriodGlitch :: Assertion
 case_onePeriodGlitch =
-      [True,True,True,True,False,False,False,False,False,True,True,False]
-  @=? sampleResetN 12 (resetGlitchFilter d2 systemClockGen onePeriodGlitchReset)
+      [True,True,True,True,True,True,False,False,False,False,False,True,True,False]
+  @=? sampleResetN 14 (resetGlitchFilter d2 systemClockGen onePeriodGlitchReset)
 
 -- | Same as 'case_onePeriodGlitch' but on a domain with active low resets
 case_onePeriodGlitch_LowPolarity :: Assertion
 case_onePeriodGlitch_LowPolarity =
-      [True,True,True,True,False,False,False,False,False,True,True,False]
-  @=? sampleResetN 12 (resetGlitchFilter d2 (clockGen @Low) onePeriodGlitchReset)
+      [True,True,True,True,True,True,False,False,False,False,False,True,True,False]
+  @=? sampleResetN 14 (resetGlitchFilter d2 (clockGen @Low) onePeriodGlitchReset)
 
 -- Check that the meaning of @Reset@ is maintained when converting from
 -- active-low to active-high.


### PR DESCRIPTION
The existing code for `resetGlitchFilter` was wrong: the `error` on domains with unknown initial values rendered as an X value in HDL instead of throwing an error.

The new `unsafeResetGlitchFilter` allows to sidestep the restriction if the user is sure this works for them.

The new `resetGlitchFilterWithReset` is the better solution for domains with unknown initial values, relying on an additional power-on reset for which assertion glitches don't occur.

Both `resetSynchronizer` and `resetGlitchFilter` no longer carry a `NOINLINE`/`OPAQUE` annotation. The only reason they had one was for nicer port/signal names, there was no technical reason to put them in a separate HDL file. Furthermore, somehow the names for `resetSynchronizer` were not nice anyway, it would need `-fno-do-lambda-eta-expansion` to work correctly.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] Use new constraints #2539 will introduce