### PR TITLE
Fix `convertReset` polarity change

### DIFF
--- a/changelog/2023-07-17T18_31_48+02_00_convert_reset
+++ b/changelog/2023-07-17T18_31_48+02_00_convert_reset
@@ -1,0 +1,1 @@
+FIXED: When `convertReset` was used with two domains that had a different reset polarity, the polarity of the signal was not changed.

--- a/clash-prelude/tests/Clash/Tests/Reset.hs
+++ b/clash-prelude/tests/Clash/Tests/Reset.hs
@@ -13,11 +13,11 @@ import Test.Tasty.HUnit
 import Test.Tasty.TH
 import Clash.Explicit.Prelude
 
+import qualified Prelude as P
+
 -- Testing with explicit declaration of the Low type alias
 type Low = ("Low" :: Domain)
 createDomain vSystem{vName="Low", vResetPolarity=ActiveLow}
-
-createDomain vSystem{vName="NoInit", vInitBehavior=Unknown}
 
 sampleResetN :: KnownDomain dom => Int -> Reset dom -> [Bool]
 sampleResetN n = sampleN n . unsafeToActiveHigh
@@ -40,6 +40,16 @@ case_onePeriodGlitch_LowPolarity :: Assertion
 case_onePeriodGlitch_LowPolarity =
       [True,True,True,True,False,False,False,False,False,True,True,False]
   @=? sampleResetN 12 (resetGlitchFilter d2 (clockGen @Low) onePeriodGlitchReset)
+
+-- Check that the meaning of @Reset@ is maintained when converting from
+-- active-low to active-high.
+case_convertReset_polarity_change :: Assertion
+case_convertReset_polarity_change =
+      -- In domains with synchronous resets and defined initial values,
+      -- @resetSynchronizer@ will start with an asserted reset.
+      True : True : P.replicate 8 False
+  @=? sampleResetN 10 (convertReset (clockGen @Low) (clockGen @System)
+                                    (resetFromList $ P.repeat False))
 
 tests :: TestTree
 tests = testGroup "Reset"


### PR DESCRIPTION
The `convertReset` function did not account for the possibility that the two domains might not have the same reset polarity.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
