### PR TITLE
Allow 0-bit result for functional arguments of primitives

### DIFF
--- a/changelog/2023-07-19T20_48_35+02_00_fix_2549
+++ b/changelog/2023-07-19T20_48_35+02_00_fix_2549
@@ -1,0 +1,1 @@
+FIXED: Functional arguments of primitives cannot have 0-bit results [#2549](https://github.com/clash-lang/clash-compiler/issues/2549)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -593,6 +593,7 @@ runClashTest = defaultMain $ clashTestRoot
               hdlTargets=[VHDL]
             , buildTargets=BuildSpecific ["withSetName", "withSetNameNoResult"]
             }
+          , runTest "T2549" def{hdlTargets=[Verilog],hdlSim=[]}
           ]
         ]
       , clashTestGroup "CSignal"

--- a/tests/shouldwork/Cores/Xilinx/T2549.hs
+++ b/tests/shouldwork/Cores/Xilinx/T2549.hs
@@ -1,0 +1,17 @@
+module T2549 where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.VIO
+import GHC.Magic
+
+topEntity :: Clock System -> Signal System Bit
+topEntity c = hwSeqX probe v -- improper use of hwSeqX, the first argument of
+                             -- hwSeqX should not have a function type. When
+                             -- the first argument has a function type, it will
+                             -- not be rendered.
+  where
+    probe :: Signal System Bit -> Signal System ()
+    probe = vioProbe ("v1" :> "v2" :> Nil) Nil () c v
+    {-# INLINE probe #-}
+
+    v = pure high


### PR DESCRIPTION
Fixes #2549

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files