### PR TITLE
vioProbe uses its clock lazily

### DIFF
--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -150,6 +150,7 @@ library
   build-depends:
     clash-lib,
     infinite-list           ^>= 0.1,
+    ghc-prim                >= 0.3.1.0 && < 1.0,
     mtl                     >= 2.1.1 && < 2.4,
     pretty-show,
     prettyprinter           >= 1.2.0.1  && < 1.8,


### PR DESCRIPTION
Fixes #2532

So #2532 shows up when we have a primitive that doesn't actually use its clock argument and we use a bang-pattern on an otherwise unused argument. If we look at the demand signature of `vioProbe#` before the patch we see:
```
vioProbe#: <A><1L><1A><1A><1A><1A>
vioProbe# ::
  forall dom a o n m.
  (KnownDomain dom, VIO dom a o) =>
  Vec n String ->
  Vec m String ->
  o ->
  Clock dom ->
  a
vioProbe# !_inputNames !_outputNames !_initialOutputProbeValues !_clk = ...
```
where
```
L 	lazy. As far as the analysis could tell, the argument isn’t demanded
A 	absent == definitely unused. Indicates that the binder is certainly not used.
1*... 	used once. Not a usage but rather modifies a “used” demand denoting that the argument is used precisely once.
```
Because the `_clk` argument is both definitely evaluated and used once so there is no need to share. This in turn makes GHC want to inline the `_clk` argument in applications of `vioProbe#`.

After the patch we get the following demand signature:
```
vioProbe#: <A><1L><1A><1A><1A><L>
vioProbe# ::
  forall dom a o n m.
  (KnownDomain dom, VIO dom a o) =>
  Vec n String ->
  Vec m String ->
  o ->
  Clock dom ->
  a
vioProbe# !_inputNames !_outputNames !_initialOutputProbeValues clk = seq (lazy clk) ...
```
Now the `clk` argument is marked as evaluated lazily, and can possibly be shared. This in turn makes GHC __not__ want to inline the `clk` argument in applications of `vioProbe#`.

If we decide to merge this PR we should do two things:
1. Check all of our other primitives to see whether they use bang-patterns for unused clock arguments, and if they do, change them to use the method in this PR
2. Open up a new issue mentioning that Clash should try to undo situations like #2532 in the general case.