### PR TITLE
`convertReset`: filter synchronous reset glitches

### DIFF
--- a/changelog/2023-07-30T11_33_02+02_00_convertreset_glitch
+++ b/changelog/2023-07-30T11_33_02+02_00_convertreset_glitch
@@ -1,0 +1,3 @@
+FIXED: If `convertReset` is used to convert a synchronous reset into an
+asynchronous reset, a flip-flop in the source domain is inserted to filter
+glitches from the source reset.

--- a/clash-prelude/src/Clash/Explicit/Reset.hs
+++ b/clash-prelude/src/Clash/Explicit/Reset.hs
@@ -269,6 +269,10 @@ holdReset clk en SNat rst =
 -- | Convert between different types of reset, adding a synchronizer when
 -- the domains are not the same. See 'resetSynchronizer' for further details
 -- about reset synchronization.
+--
+-- If @domA@ has 'Synchronous' resets and @domB@ has 'Asynchronous' resets, a
+-- flip-flop is inserted in @domA@ to filter glitches. This adds one @domA@
+-- clock cycle delay.
 convertReset
   :: forall domA domB
    . ( KnownDomain domA
@@ -286,8 +290,17 @@ convertReset clkA clkB rstA0 = rstB1
       (SActiveLow, SActiveLow)   -> rstA1
       (SActiveHigh, SActiveHigh) -> rstA1
       _                          -> not <$> rstA1
-  rstB0 = unsafeToReset $ unsafeSynchronizer clkA clkB rstA2
+  rstA3 =
+    case (resetKind @domA, resetKind @domB) of
+      (SSynchronous, SAsynchronous) -> delay clkA enableGen assertedA rstA2
+      _                             -> rstA2
+  rstB0 = unsafeToReset $ unsafeSynchronizer clkA clkB rstA3
   rstB1 =
     case (sameDomain @domA @domB) of
       Just Refl -> rstA0
       Nothing   -> resetSynchronizer clkB rstB0
+  assertedA :: Bool
+  assertedA =
+    case resetPolarity @domA of
+      SActiveHigh -> True
+      SActiveLow  -> False


### PR DESCRIPTION
If `convertReset` is used to convert a synchronous reset into an asynchronous reset, a flip-flop in the source domain is inserted to filter glitches from the source reset.

A synchronous reset can safely be driven from combinatorial logic: the logic might glitch while the signals propagate, but timing analysis verified that the signals have fully propagated by the time the clock edge comes.

Asynchronous resets generally need to come from a glitch free source because glitches have a high chance of accidentally resetting logic.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
