### PR TITLE
Move `DomainMap` from `ClashDesign` to `ClashEnv`

### DIFF
--- a/benchmark/profiling/prepare/instances/SerialiseInstances.hs
+++ b/benchmark/profiling/prepare/instances/SerialiseInstances.hs
@@ -19,7 +19,7 @@ import qualified Data.HashMap.Strict                          as HM
 import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
 import           Clash.Core.Var (Id)
 import           Clash.Core.TyCon (TyConMap,TyConName)
-import           Clash.Driver.Types (BindingMap)
+import           Clash.Driver.Types (BindingMap, DomainMap)
 import           Data.IntMap.Strict (IntMap)
 
 
@@ -45,7 +45,24 @@ instance (Binary k, Binary v, Eq k, Hashable k) => Binary (HM.HashMap k v) where
   get = HM.fromList <$> get
 
 -- data that's serialised to file between profile-normalization-prepare  and profile-normalization-run
-type NormalizationInputs = (BindingMap,TyConMap,IntMap TyConName,CompiledPrimMap',CustomReprs,[Id],Id)
+type NormalizationInputs =
+  ( BindingMap
+  , TyConMap
+  , IntMap TyConName
+  , CompiledPrimMap'
+  , CustomReprs
+  , [Id]
+  , Id
+  , DomainMap
+  )
 
 -- data that's serialised to file between profile-netlist-prepare  and profile-netlist-run
-type NetlistInputs = (BindingMap,[CL.TopEntityT],CompiledPrimMap',TyConMap,CustomReprs,Id)
+type NetlistInputs =
+  ( BindingMap
+  , [CL.TopEntityT]
+  , CompiledPrimMap'
+  , TyConMap
+  , CustomReprs
+  , Id
+  , DomainMap
+  )

--- a/benchmark/profiling/prepare/profile-netlist-prepare.hs
+++ b/benchmark/profiling/prepare/profile-netlist-prepare.hs
@@ -34,8 +34,9 @@ prepareFile idirs fIn = do
                , envTyConMap clashEnv
                , envCustomReprs clashEnv
                , top
+               , envDomains clashEnv
                )
 
   putStrLn $ "Serialising to : " ++ fOut
-  B.writeFile fOut $ encode inputs
+  B.writeFile fOut $ encode (inputs :: NetlistInputs)
   putStrLn "Done"

--- a/benchmark/profiling/prepare/profile-normalization-prepare.hs
+++ b/benchmark/profiling/prepare/profile-normalization-prepare.hs
@@ -37,8 +37,9 @@ prepareFile idirs fIn = do
                , envCustomReprs clashEnv
                , topNames
                , head topNames
+               , envDomains clashEnv
                )
 
   putStrLn $ "Serialising to : " ++ fOut
-  B.writeFile fOut $ encode inputs
+  B.writeFile fOut $ encode (inputs :: NormalizationInputs)
   putStrLn "Done"

--- a/benchmark/profiling/run/profile-netlist-run.hs
+++ b/benchmark/profiling/run/profile-netlist-run.hs
@@ -39,7 +39,7 @@ main = do
 
 benchFile :: [FilePath] -> FilePath -> IO ()
 benchFile idirs src = do
-  (transformedBindings,topEntities,primMap,tcm,reprs,topEntity) <- setupEnv src
+  (transformedBindings, topEntities, primMap, tcm, reprs, topEntity, domains) <- setupEnv src
   putStrLn $ "Doing netlist generation of " ++ src
 
   let env = ClashEnv
@@ -48,6 +48,7 @@ benchFile idirs src = do
                    , envTupleTyCons = mempty
                    , envPrimitives = fmap (fmap unremoveBBfunc) primMap
                    , envCustomReprs = reprs
+                   , envDomains = domains
                    }
 
       topEntityS = Text.unpack (nameOcc (varName topEntity))

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -32,7 +32,7 @@ main = do
 benchFile :: [FilePath] -> FilePath -> IO ()
 benchFile idirs src = do
   supplyN <- Supply.newSupply
-  (bindingsMap,tcm,tupTcm,primMap,reprs,topEntityNames,topEntity) <- setupEnv src
+  (bindingsMap, tcm, tupTcm, primMap, reprs, topEntityNames, topEntity, domains) <- setupEnv src
   putStrLn $ "Doing normalization of " ++ src
 
   let clashEnv = ClashEnv
@@ -41,6 +41,7 @@ benchFile idirs src = do
                    , envTupleTyCons = tupTcm
                    , envPrimitives = fmap (fmap unremoveBBfunc) primMap
                    , envCustomReprs = reprs
+                   , envDomains = domains
                    }
 
   res <- normalizeEntity clashEnv bindingsMap

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -191,10 +191,10 @@ generateBindings opts startAction primDirs importDirs dbs hdl modName dflagsM = 
         , envTupleTyCons = tupTcCache
         , envPrimitives = primMapC
         , envCustomReprs = buildCustomReprs customBitRepresentations
+        , envDomains = domainConfs
         }
     , ClashDesign
         { designEntities = topEntities''
-        , designDomains = domainConfs
         , designBindings = allBindings'
         }
     )

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -364,7 +364,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
     -> TopEntityT
     -> IO ()
   go compNames seenV edamFilesV ioLockV deps topEntityMap (TopEntityT topEntity annM isTb) = do
-  let domainConfs = designDomains design
+  let domainConfs = envDomains env
   let bindingsMap = designBindings design
   let primMap = envPrimitives env
   let topEntities0 = designEntities design

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -74,18 +74,17 @@ data ClashEnv = ClashEnv
   , envTupleTyCons :: IntMap TyConName
   , envPrimitives  :: CompiledPrimMap
   , envCustomReprs :: CustomReprs
+  , envDomains     :: DomainMap
   } deriving (Generic, NFData)
 
 data ClashDesign = ClashDesign
   { designEntities :: [TopEntityT]
-  , designDomains  :: DomainMap
   , designBindings :: BindingMap
   }
 
 instance NFData ClashDesign where
   rnf design =
     designEntities design `seq`
-    designDomains design `deepseq`
     designBindings design `deepseq`
     ()
 

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -65,6 +65,7 @@ instance Default RewriteEnv where
         , envTupleTyCons = IntMap.empty
         , envPrimitives = HashMap.empty
         , envCustomReprs = buildCustomReprs []
+        , envDomains = HashMap.empty
         }
     , _typeTranslator=error "_typeTranslator: NYI"
     , _peEvaluator=error "_peEvaluator: NYI"

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -255,7 +255,7 @@ data ResetKind
   -- ^ Elements respond /synchronously/ to changes in their reset input. This
   -- means that changes in their reset input won't take effect until the next
   -- active clock edge. Common on Xilinx FPGA platforms.
-  deriving (Show, Read, Eq, Ord, Generic, NFData, Data, Hashable)
+  deriving (Show, Read, Eq, Ord, Generic, NFData, Data, Hashable, Binary)
 
 -- | Singleton version of 'ResetKind'
 data SResetKind (resetKind :: ResetKind) where
@@ -275,7 +275,7 @@ data ResetPolarity
   -- ^ Reset is considered active if underlying signal is 'True'.
   | ActiveLow
   -- ^ Reset is considered active if underlying signal is 'False'.
-  deriving (Eq, Ord, Show, Read, Generic, NFData, Data, Hashable)
+  deriving (Eq, Ord, Show, Read, Generic, NFData, Data, Hashable, Binary)
 
 -- | Singleton version of 'ResetPolarity'
 data SResetPolarity (polarity :: ResetPolarity) where
@@ -296,7 +296,7 @@ data InitBehavior
   -- ^ If applicable, power up value of a memory element is defined. Applies to
   -- 'Clash.Signal.register's for example, but not to
   -- 'Clash.Prelude.BlockRam.blockRam'.
-  deriving (Show, Read, Eq, Ord, Generic, NFData, Data, Hashable)
+  deriving (Show, Read, Eq, Ord, Generic, NFData, Data, Hashable, Binary)
 
 data SInitBehavior (init :: InitBehavior) where
   SUnknown :: SInitBehavior 'Unknown
@@ -579,7 +579,7 @@ data VDomainConfiguration
   , vResetPolarity :: ResetPolarity
   -- ^ Corresponds to '_resetPolarity' on 'DomainConfiguration'
   }
-  deriving (Eq, Generic, NFData, Show, Read)
+  deriving (Eq, Generic, NFData, Show, Read, Binary)
 
 -- | Convert 'SDomainConfiguration' to 'VDomainConfiguration'. Should be used in combination with
 -- 'createDomain' only.

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -88,19 +88,19 @@ runToNetlistStage target f src = do
 
   fmap (\(_,x,_) -> force (P.map snd (OMap.assocs x))) $
     netlistFrom
-      (env, transformedBindings, tes2, compNames, te, initIs, designDomains design)
+      (env, transformedBindings, tes2, compNames, te, initIs)
  where
   opts = f mkClashOpts
   backend = initBackend @(TargetToState target) opts
   hdl = buildTargetToHdl target
 
-  netlistFrom (env, bm, tes, compNames, te, seen, domainConfs) =
+  netlistFrom (env, bm, tes, compNames, te, seen) =
     genNetlist env False bm tes compNames (ghcTypeToHWType (opt_intWidth opts))
       ite (SomeBackend hdlSt) seen hdlDir Nothing te
    where
     teS     = Text.unpack . nameOcc $ varName te
     modN    = takeWhile (/= '.') teS
-    hdlSt   = setDomainConfigurations domainConfs
+    hdlSt   = setDomainConfigurations (envDomains env)
             $ setModName (Text.pack modN) backend
     ite     = ifThenElseExpr hdlSt
     hdlDir  = fromMaybe "." (opt_hdlDir opts)


### PR DESCRIPTION
I would like to have this for an upcoming `clash-cores` primitive. Given that the 1.8 release is coming up, it would be great to have it in there.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~