### PR TITLE
Drop `1 <= n` constraint from `Foldable (Vec n)` and from `Traversable (Vec n)`.

### DIFF
--- a/changelog/2023-08-16T19_26_52+02_00_vec_fold_zero
+++ b/changelog/2023-08-16T19_26_52+02_00_vec_fold_zero
@@ -1,0 +1,3 @@
+CHANGED: The `Foldable (Vec n)` instance and `Traversable (Vec n)` instance no longer have the `1 <= n` constraint. `Foldable.{foldr1,foldl1,maximum,minimum}` functions now throw an error at run-/simulation-time, and also at HDL-generation time, for vectors of length zero.
+CHANGED: The `maximum` and `minimum` functions exported by `Clash.Prelude` work on non-empty vectors, instead of the more generic version from `Data.Foldable`.
+ADDED: `1 <= n => Foldable1 (Vec n)` instance (`base-4.18+` only)

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -281,7 +281,7 @@ Library
                       Clash.Primitives.GHC.Literal
                       Clash.Primitives.GHC.Word
                       Clash.Primitives.Intel.ClockGen
-                      Clash.Primitives.Prelude
+                      Clash.Primitives.Magic
                       Clash.Primitives.Sized.ToInteger
                       Clash.Primitives.Sized.Signed
                       Clash.Primitives.Sized.Vector

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -139,7 +139,7 @@ import qualified Clash.Primitives.Sized.Vector    as P
 import qualified Clash.Primitives.GHC.Int         as P
 import qualified Clash.Primitives.GHC.Word        as P
 import qualified Clash.Primitives.Intel.ClockGen  as P
-import qualified Clash.Primitives.Prelude         as P
+import qualified Clash.Primitives.Magic           as P
 import qualified Clash.Primitives.Verification    as P
 import qualified Clash.Primitives.Xilinx.ClockGen as P
 import           Clash.Primitives.Types

--- a/clash-lib/src/Clash/Primitives/Magic.hs
+++ b/clash-lib/src/Clash/Primitives/Magic.hs
@@ -4,12 +4,12 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
-  Blackbox functions for primitives in one of the @Prelude@ modules.
+  Blackbox functions for primitives in the @Clash.Magic@ module.
 -}
 
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
-module Clash.Primitives.Prelude
+module Clash.Primitives.Magic
   ( clashCompileErrorBBF
   ) where
 

--- a/clash-prelude/src/Clash/HaskellPrelude.hs
+++ b/clash-prelude/src/Clash/HaskellPrelude.hs
@@ -26,7 +26,7 @@ import Prelude hiding
   ((++), (!!), concat, concatMap, drop, even, foldl, foldl1, foldr, foldr1, head, init,
    iterate, last, length, map, odd, repeat, replicate, reverse, scanl, scanl1,
    scanr, scanr1, splitAt, tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3, undefined,
-   (^), getChar, putChar, getLine, (&&), (||), not)
+   (^), getChar, putChar, getLine, (&&), (||), not, maximum, minimum)
 
 import qualified Prelude
 import GHC.Magic (noinline)

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -104,8 +104,6 @@ module Clash.Prelude
   , isFalling
   , riseEvery
   , oscillate
-    -- * Static assertions
-  , clashCompileError
     -- * Tracing
     -- ** Simple
   , traceSignal1
@@ -195,7 +193,6 @@ import           Clash.Class.Num
 import           Clash.Class.Parity
 import           Clash.Class.Resize
 import qualified Clash.Explicit.Prelude      as E
-import           Clash.Explicit.Prelude (clashCompileError)
 import           Clash.Hidden
 import           Clash.Magic
 import           Clash.NamedTypes

--- a/clash-prelude/src/Clash/Sized/Vector.hs-boot
+++ b/clash-prelude/src/Clash/Sized/Vector.hs-boot
@@ -13,13 +13,13 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 module Clash.Sized.Vector where
 
 import Data.Kind (Type)
-import GHC.TypeLits  (KnownNat, Nat, type (<=))
+import GHC.TypeLits  (KnownNat, Nat)
 import {-# SOURCE #-} Clash.Sized.Internal.BitVector (BitVector, Bit)
 
 type role Vec nominal representational
 data Vec :: Nat -> Type -> Type
 
-instance (KnownNat n, 1 <= n) => Foldable (Vec n)
+instance KnownNat n => Foldable (Vec n)
 
 bv2v  :: KnownNat n => BitVector n -> Vec n Bit
 map   :: (a -> b) -> Vec n a -> Vec n b


### PR DESCRIPTION
The `Foldable.{foldr1,foldl1,maximum,minimum}` functions now throw an error at run-/simulation-time, and also at HDL-generation time, for vectors of length zero.

Also moves `clashCompileError` from `Clash.Explicit.Prelude` to `Clash.Magic`.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files