### PR TITLE
Stop duplicating binders in loadLocalModule

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -518,7 +518,7 @@ loadLocalModule hdl modName = do
   localPrims <- findPrimitiveAnnotations hdl binderIds
   let loaded1 = loaded0{lbPrims=lbPrims loaded0 <> Seq.fromList localPrims}
 
-  let allBinders = concat binders ++ makeRecursiveGroups (Map.assocs (lbBinders loaded0))
+  let allBinders = makeRecursiveGroups (Map.assocs (lbBinders loaded0))
   pure (rootIds, modFamInstEnvs', rootModule, loaded1, allBinders)
 
 nameString :: Name.Name -> String


### PR DESCRIPTION
Since the refactor in c8f2bbdc1147be678c6cbda3832aec7f01a96be0 `loadLocalModule` was duplicating all (top level) binders contained in local modules.
Because `loadExternalExprs` already puts all `binders` in `loaded0`.

This led to duplicate PrimGuard warnings like seen in #2561 and possibly more duplicate work elsewhere.

Fixes #2561

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
