### PR TITLE
Enable mmap crash workaround more widely

### DIFF
--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -14,7 +14,7 @@ elif [[ "$1" != "" ]]; then
   exit 1
 fi
 
-GHC_VERSIONS=(  "9.6.1"  "9.4.3"  "9.2.5"   "9.0.2"   "8.10.7"  "8.8.4"   "8.6.5")
+GHC_VERSIONS=(  "9.6.2"  "9.4.6"  "9.2.8"   "9.0.2"   "8.10.7"  "8.8.4"   "8.6.5")
 CABAL_VERSIONS=("3.10.1.0" "3.8.1.0" "3.6.2.0" "3.4.0.0" "3.2.0.0" "3.2.0.0" "3.0.0.0")
 
 # We want to use docker buildkit so that our layers are built in parallel. This

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-05-16
+  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-08-22
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -1,11 +1,11 @@
 .common:
-  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-05-16
+  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-08-22
   timeout: 10 minutes
   stage: build
   variables:
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-05-16-1-3-non_protected
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-08-22-1-3-non_protected
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   retry:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ "8.6.5", "9.0.2", "9.6.1" ]
+        ghc: [ "8.6.5", "9.0.2", "9.6.2" ]
         include:
           - multiple_hidden: yes
 
@@ -130,7 +130,7 @@ jobs:
 
     # Run steps inside the clash CI docker image
     container:
-      image: ghcr.io/clash-lang/clash-ci-${{ matrix.ghc }}:2023-05-16
+      image: ghcr.io/clash-lang/clash-ci-${{ matrix.ghc }}:2023-08-22
 
       env:
         THREADS: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
 
           - ghc: 8.6.5
             multiple_hidden: no
+            workaround_ghc_mmap_crash: yes
 
           - ghc: 9.0.2
             workaround_ghc_mmap_crash: yes

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,17 +37,19 @@ tests:
       - GHC_VERSION: 9.6.2
         RUN_TESTS: "always"
 
-      - GHC_VERSION: [9.4.6, 9.2.8, 8.10.7]
+      - GHC_VERSION: [9.4.6, 9.2.8]
         RUN_TESTS: "nightly"
 
       - GHC_VERSION: 9.0.2
         WORKAROUND_GHC_MMAP_CRASH: "yes"
         RUN_TESTS: "always"
 
-      - GHC_VERSION: 8.8.4
+      - GHC_VERSION: [8.10.7, 8.8.4]
+        WORKAROUND_GHC_MMAP_CRASH: "yes"
         RUN_TESTS: "nightly"
 
       - GHC_VERSION: 8.6.5
+        WORKAROUND_GHC_MMAP_CRASH: "yes"
         MULTIPLE_HIDDEN: "no"
         RUN_TESTS: "always"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,10 +34,10 @@ tests:
     CI_PARENT_PIPELINE_SOURCE: $CI_PIPELINE_SOURCE
   parallel:
     matrix:
-      - GHC_VERSION: 9.6.1
+      - GHC_VERSION: 9.6.2
         RUN_TESTS: "always"
 
-      - GHC_VERSION: [9.4.3, 9.2.5, 8.10.7]
+      - GHC_VERSION: [9.4.6, 9.2.8, 8.10.7]
         RUN_TESTS: "nightly"
 
       - GHC_VERSION: 9.0.2


### PR DESCRIPTION
Lately we seem to be triggering the mmap bug a lot easier and/or on more GHC versions.

For example in [last nightly on master](https://gitlab.com/clash-lang/clash-compiler/-/pipelines/975270778)

This PR enable [the workaround](https://github.com/clash-lang/clash-compiler/pull/2444) for all jobs with GHC < 9.2.8 and additionally updates all CI images to the latest GHC minor versions.
(Including 9.2.8 which should have fixed this issue)

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

