### PR TITLE
Fix clash normalization benchmark

### DIFF
--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -44,20 +44,20 @@ benchFile idirs src =
   env (setupEnv idirs src) $
     \ ~(clashEnv, clashDesign, supplyN) -> do
       let topEntities = fmap topId (designEntities clashDesign)
-      case topEntities of
-        topEntity:_ ->
-          bench ("normalization of " ++ src)
-                (nfIO
-                  (normalizeEntity
-                    clashEnv
-                    (designBindings clashDesign)
-                    (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
-                    ghcEvaluator
-                    evaluator
-                    topEntities
-                    supplyN
-                    topEntity))
-        _ -> error "no top entities"
+          topEntity = case topEntities of
+                        t:_ -> t
+                        _ -> error "no top entities"
+      bench ("normalization of " ++ src)
+            (nfIO
+              (normalizeEntity
+                clashEnv
+                (designBindings clashDesign)
+                (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                ghcEvaluator
+                evaluator
+                topEntities
+                supplyN
+                topEntity))
 
 setupEnv
   :: [FilePath]

--- a/cabal.project
+++ b/cabal.project
@@ -53,6 +53,9 @@ package clash-cores
   -- so we're able to import its css file from the custom theme.
   haddock-options: --theme=doc/linuwial-wrap-types.css --theme=Linuwial
 
+package clash-benchmark
+  executable-dynamic: True
+
 optional-packages:
   ./benchmark
   ./benchmark/profiling/prepare


### PR DESCRIPTION
Fix fallout from GHC 9.8 upgrade and ensure the benchmark is dynamically linked to avoid very long start times.