### PR TITLE
Give evaluator acces to inscope let-bindings

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadInterfaceFiles.hs
@@ -495,7 +495,11 @@ loadExprFromTyThing :: CoreSyn.CoreBndr -> GHC.TyThing -> Maybe CoreSyn.CoreExpr
 loadExprFromTyThing bndr tyThing = case tyThing of
   GHC.AnId _id | Var.isId _id ->
     let _idInfo    = Var.idInfo _id
+#if MIN_VERSION_ghc(9,4,0)
+        unfolding  = IdInfo.realUnfoldingInfo _idInfo
+#else
         unfolding  = IdInfo.unfoldingInfo _idInfo
+#endif
     in case unfolding of
       CoreSyn.CoreUnfolding {} ->
         Just (CoreSyn.unfoldingTemplate unfolding)

--- a/clash-lib/src/Clash/Core/Evaluator/Types.hs
+++ b/clash-lib/src/Clash/Core/Evaluator/Types.hs
@@ -38,6 +38,7 @@ import Clash.Pretty (ClashPretty(..), fromPretty, showDoc)
 whnf'
   :: Evaluator
   -> BindingMap
+  -> VarEnv Term
   -> TyConMap
   -> PrimHeap
   -> Supply
@@ -45,12 +46,12 @@ whnf'
   -> Bool
   -> Term
   -> (PrimHeap, PureHeap, Term)
-whnf' eval bm tcm ph ids is isSubj e =
+whnf' eval bm lh tcm ph ids is isSubj e =
   toResult $ whnf eval tcm isSubj m
  where
   toResult x = (mHeapPrim x, mHeapLocal x, mTerm x)
 
-  m  = Machine ph gh emptyVarEnv [] ids is e
+  m  = Machine ph gh lh [] ids is e
   gh = mapVarEnv bindingTerm bm
 
 -- | Evaluate to WHNF given an existing Heap and Stack

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -455,7 +455,7 @@ pprPrecCast prec e ty1 ty2 = do
 pprPrecLetrec :: Monad m => Rational -> Bool -> [(Id, Term)] -> Term -> m ClashDoc
 pprPrecLetrec prec isRec xes body = do
   let bndrs = fst <$> xes
-  body' <- annotate (AnnContext $ LetBody bndrs) <$> pprPrec noPrec body
+  body' <- annotate (AnnContext $ LetBody xes) <$> pprPrec noPrec body
   xes'  <- mapM (\(x,e) -> do
                   x' <- pprBndr LetBind x
                   e' <- pprPrec noPrec e

--- a/clash-lib/src/Clash/Core/Term.hs
+++ b/clash-lib/src/Clash/Core/Term.hs
@@ -266,7 +266,7 @@ data CoreContext
   -- ^ Function position of a type application
   | LetBinding Id [Id]
   -- ^ RHS of a Let-binder with the sibling LHS'
-  | LetBody [Id]
+  | LetBody [LetBinding]
   -- ^ Body of a Let-binding with the bound LHS'
   | LamBody Id
   -- ^ Body of a lambda-term with the abstracted variable
@@ -303,7 +303,7 @@ instance Eq CoreContext where
     -- NB: we do not see inside the argument here
     (TyAppC,          TyAppC)            -> True
     (LetBinding i is, LetBinding i' is') -> i == i' && is == is'
-    (LetBody is,      LetBody is')       -> is == is'
+    (LetBody is,      LetBody is')       -> map fst is == map fst is'
     (LamBody i,       LamBody i')        -> i == i'
     (TyLamBody tv,    TyLamBody tv')     -> tv == tv'
     (CaseAlt p,       CaseAlt p')        -> p == p'

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -25,6 +25,7 @@ module Clash.Core.VarEnv
   , delVarEnvList
   , unionVarEnv
   , unionVarEnvWith
+  , differenceVarEnv
     -- ** Element-wise operations
     -- *** Mapping
   , mapVarEnv
@@ -226,6 +227,13 @@ unionVarEnvWith
   -> VarEnv a
   -> VarEnv a
 unionVarEnvWith = UniqMap.unionWith
+
+-- | Filter the first varenv to only contain keys which are not in the second varenv.
+differenceVarEnv
+  :: VarEnv a
+  -> VarEnv a
+  -> VarEnv a
+differenceVarEnv = UniqMap.difference
 
 -- | Create an environment given a list of var-value pairs
 mkVarEnv

--- a/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
@@ -303,7 +303,7 @@ collectGlobals' is0 substitution seen e@(collectArgsTicks -> (fun, args@(_:_), t
     let (ids1,ids2) = splitSupply ids
     uniqSupply Lens..= ids2
     gh <- Lens.use globalHeap
-    let eval = (Lens.view Lens._3) . whnf' evaluate bndrs tcm gh ids1 is0 False
+    let eval = (Lens.view Lens._3) . whnf' evaluate bndrs mempty tcm gh ids1 is0 False
     let eTy  = inferCoreTypeOf tcm e
     untran <- isUntranslatableType False eTy
     case untran of

--- a/clash-lib/src/Clash/Normalize/Transformations/EtaExpand.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/EtaExpand.hs
@@ -71,7 +71,7 @@ etaExpansionTL (TransformContext is0 ctx) (Lam bndr e) = do
   return $ Lam bndr e'
 
 etaExpansionTL (TransformContext is0 ctx) (Let (NonRec i x) e) = do
-  let ctx' = TransformContext (extendInScopeSet is0 i) (LetBody [i] : ctx)
+  let ctx' = TransformContext (extendInScopeSet is0 i) (LetBody [(i,x)] : ctx)
   e' <- etaExpansionTL ctx' e
   case stripLambda e' of
     (bs@(_:_),e2) -> do
@@ -81,7 +81,7 @@ etaExpansionTL (TransformContext is0 ctx) (Let (NonRec i x) e) = do
 
 etaExpansionTL (TransformContext is0 ctx) (Let (Rec xes) e) = do
   let bndrs = map fst xes
-      ctx' = TransformContext (extendInScopeSetList is0 bndrs) (LetBody bndrs : ctx)
+      ctx' = TransformContext (extendInScopeSetList is0 bndrs) (LetBody xes : ctx)
   e' <- etaExpansionTL ctx' e
   case stripLambda e' of
     (bs@(_:_),e2) -> do

--- a/clash-lib/src/Clash/Rewrite/Combinators.hs
+++ b/clash-lib/src/Clash/Rewrite/Combinators.hs
@@ -54,7 +54,7 @@ allR trans (TransformContext is c) (Cast e ty1 ty2) =
 
 allR trans (TransformContext is c) (Letrec xes e) = do
   xes' <- traverse rewriteBind xes
-  e'   <- trans (TransformContext is' (LetBody bndrs:c)) e
+  e'   <- trans (TransformContext is' (LetBody xes:c)) e
   return (Letrec xes' e')
  where
   bndrs              = map fst xes

--- a/clash-term/Main.hs
+++ b/clash-term/Main.hs
@@ -105,7 +105,7 @@ instance Diff Term where
         (Letrec bnds body, LetBinding i' _) ->
           Letrec (mapBindings i' bnds) body
         (Letrec bnds t, LetBody is) ->
-          if (fst <$> bnds) == is
+          if (fst <$> bnds) == (fst <$> is)
             then Letrec bnds (go t)
             else error "Ctx.LetBody: different bindings"
         (Lam i t, LamBody i') ->


### PR DESCRIPTION
Without it, Clash goes into an infinite loop on T1354A in combination with: https://github.com/clash-lang/ghc-typelits-knownnat/pull/47

There is a tiny performance regression.

Before:
```
$ cabal run clash-benchmark-normalization -- examples/Reducer.hs --time-limit 30
GHC: Setting up GHC took: 0.489s
GHC: Compiling and loading modules took: 1.125s
Clash: Parsing and compiling primitives took 0.159s
benchmarking normalization of examples/Reducer.hs
time                 684.4 ms   (674.0 ms .. 694.0 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 680.6 ms   (674.9 ms .. 684.7 ms)
std dev              8.784 ms   (4.641 ms .. 12.23 ms)
variance introduced by outliers: 11% (moderately inflated)
```
after:
```
$ cabal run clash-benchmark-normalization -- examples/Reducer.hs --time-limit 30
GHC: Setting up GHC took: 0.496s
GHC: Compiling and loading modules took: 1.135s
Clash: Parsing and compiling primitives took 0.157s
benchmarking normalization of examples/Reducer.hs
time                 696.5 ms   (689.5 ms .. 711.9 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 687.1 ms   (679.4 ms .. 692.8 ms)
std dev              11.01 ms   (8.152 ms .. 15.16 ms)
variance introduced by outliers: 11% (moderately inflated)
```