### PR TITLE
`convertReset`: always filter synchronous source

### DIFF
--- a/changelog/2023-07-30T11_33_02+02_00_convertreset_glitch
+++ b/changelog/2023-07-30T11_33_02+02_00_convertreset_glitch
@@ -1,3 +1,1 @@
-FIXED: If `convertReset` is used to convert a synchronous reset into an
-asynchronous reset, a flip-flop in the source domain is inserted to filter
-glitches from the source reset.
+FIXED: If the source reset of `convertReset` is synchronous, a flip-flop in the source domain is inserted to filter glitches from the source reset.

--- a/clash-prelude/src/Clash/Explicit/Reset.hs
+++ b/clash-prelude/src/Clash/Explicit/Reset.hs
@@ -436,9 +436,8 @@ holdReset clk en SNat rst =
 -- the domains are not the same. See 'resetSynchronizer' for further details
 -- about reset synchronization.
 --
--- If @domA@ has 'Synchronous' resets and @domB@ has 'Asynchronous' resets, a
--- flip-flop is inserted in @domA@ to filter glitches. This adds one @domA@
--- clock cycle delay.
+-- If @domA@ has 'Synchronous' resets, a flip-flop is inserted in @domA@ to
+-- filter glitches. This adds one @domA@ clock cycle delay.
 convertReset
   :: forall domA domB
    . ( KnownDomain domA
@@ -457,9 +456,9 @@ convertReset clkA clkB rstA0 = rstB1
       (SActiveHigh, SActiveHigh) -> rstA1
       _                          -> not <$> rstA1
   rstA3 =
-    case (resetKind @domA, resetKind @domB) of
-      (SSynchronous, SAsynchronous) -> delay clkA enableGen assertedA rstA2
-      _                             -> rstA2
+    case resetKind @domA of
+      SSynchronous -> delay clkA enableGen assertedA rstA2
+      _            -> rstA2
   rstB0 = unsafeToReset $ unsafeSynchronizer clkA clkB rstA3
   rstB1 =
     case (sameDomain @domA @domB) of


### PR DESCRIPTION
PR #2553 already inserted a flip-flop to filter source glitches if the target was asynchronous, but this is incomplete. The problem exists for both asynchronous and synchronous target domains. Any source glitches can actually unintendedly end up in the dual flip-flop synchronizer of a synchronous target as well.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
