### PR TITLE
Simplify Stack CI

### DIFF
--- a/.ci/stack-9.2.yaml
+++ b/.ci/stack-9.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.25
+resolver: lts-20.26
 
 ghc-options:
   "$locals": -Wall -Wcompat
@@ -13,8 +13,7 @@ packages:
 - tests
 
 extra-deps:
-- concurrent-supply-0.1.8@sha256:9373f4868ad28936a7b93781b214ef4afdeacf377ef4ac729583073491c9f9fb,1627
-- hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
-- prettyprinter-interp-0.2.0.0@sha256:45299b61bd6c27d594c1a72b5a8dd5734e791a59828725e4f4e420f3cc37232b,2016
+- concurrent-supply-0.1.8@sha256:80b658533141660818d0781b8c8fb9a8cf69b987fcfbab782dc788bfc7df4846,1627
+- prettyprinter-interp-0.2.0.0@sha256:7072e659fb902cbcab790c9cca2b0739f9f4b81b666a63f2140139950f05025d,2086
 - infinite-list-0.1@sha256:4de250517ce75e128c766fbc1f23b5a778ea964e695e47f8e83e0f3b293091bf,2383
 - tasty-1.5@sha256:c62c96da1e9d65bf61ce583e9f7085eed1daeb62a45f3106ca252bf9ef87025b,2763

--- a/.ci/stack-9.4.yaml
+++ b/.ci/stack-9.4.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-06-13
+resolver: lts-21.12
 
 ghc-options:
   "$locals": -Wall -Wcompat
@@ -12,14 +12,9 @@ packages:
 - clash-cores
 - tests
 
-allow-newer: true
-
 extra-deps:
- - concurrent-supply-0.1.8@sha256:9373f4868ad28936a7b93781b214ef4afdeacf377ef4ac729583073491c9f9fb,1627
- - string-interpolate-0.3.1.2@sha256:4d0987f453c66040aa8e482fe28a7d3cdc9d8df01b698bc92f42a592cfb337db,4268
- - prettyprinter-interp-0.2.0.0@sha256:45299b61bd6c27d594c1a72b5a8dd5734e791a59828725e4f4e420f3cc37232b,2016
- - infinite-list-0.1@sha256:4de250517ce75e128c766fbc1f23b5a778ea964e695e47f8e83e0f3b293091bf,2383
- - hashable-1.4.1.0
+ - concurrent-supply-0.1.8@sha256:80b658533141660818d0781b8c8fb9a8cf69b987fcfbab782dc788bfc7df4846,1627
+ - prettyprinter-interp-0.2.0.0@sha256:7072e659fb902cbcab790c9cca2b0739f9f4b81b666a63f2140139950f05025d,2086
  - git: https://github.com/christiaanb/hint.git
    commit: 7803c34c8ae1d83c0f7c13fe6b30fcb3abd0ac51
  - tasty-1.5@sha256:c62c96da1e9d65bf61ce583e9f7085eed1daeb62a45f3106ca252bf9ef87025b,2763

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,29 +21,29 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macOS", "windows"]
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.5"]
+        ghc: ["8.6", "8.8", "8.10", "9.0", "9.2", "9.4"]
         exclude:
           # Some tests fail with a mysterious -11 error code.
           - os: macOS
-            ghc: 8.10.7
+            ghc: 8.10
 
           # Windows gets non-deterministically gets stuck in infinite loops
           # or segfaults while running the testcase.
           - os: windows
-            ghc: 8.8.4
+            ghc: 8.8
 
-          # GHC 9.0.2 fails to compile clash-cores due to a template haskell
+          # GHC 9.0 fails to compile clash-cores due to a template haskell
           # failure
           - os: windows
-            ghc: 9.0.2
+            ghc: 9.0
 
     steps:
       - uses: actions/checkout@v3
       - uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: ${{ matrix.ghc }}
           enable-stack: true
+          stack-no-global: true
 
       - name: Install IVerilog (macOS)
         if: matrix.os == 'macOS'
@@ -56,9 +56,7 @@ jobs:
       - name: General Setup
         shell: bash
         run: |
-          declare GHC_VERSION=${{ matrix.ghc }}
-          # Rewrite an argument of the form X.Y.Z to X.Y
-          cp .ci/stack-${GHC_VERSION%.*}.yaml stack.yaml
+          cp .ci/stack-${{ matrix.ghc }}.yaml stack.yaml
           # Print out stack.yaml for debugging purposes
           cat stack.yaml
 


### PR DESCRIPTION
For Stack CI, GHC doesn't need to be installed globally; only the version installed by Stack is actually used.

Also bump to the latest LTS'es.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files