### PR TITLE
Fix `alteraPll` `qsys` generation

### DIFF
--- a/changelog/2023-10-05T16_56_51+02_00_correct_qsys
+++ b/changelog/2023-10-05T16_56_51+02_00_correct_qsys
@@ -1,0 +1,1 @@
+FIXED: Fix `alteraPll` `qsys` generation. PR [#2417](https://github.com/clash-lang/clash-compiler/pull/2417) (included in Clash v1.6.5) caused a bug in the generation of the `qsys` file: it generated a spurious extra output clock which was completely unused otherwise.

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -297,14 +297,9 @@ alteraPllQsysTemplate
 alteraPllQsysTemplate bbCtx
   |   _clocksClass
     : (_,stripVoid -> kdIn,_)
-    : (_,stripVoid -> kdOutsProd,_)
+    : (_,stripVoid -> Product _ _ (init -> kdOuts),_)
     : _ <- bbInputs bbCtx
   = let
-      kdOuts = case kdOutsProd of
-        Product _ _ ps -> ps
-        KnownDomain {} -> [kdOutsProd]
-        _ -> error "internal error: not a Product or KnownDomain"
-
       cklFreq (KnownDomain _ p _ _ _ _)
         = periodToHz (fromIntegral p) / 1e6 :: Double
       cklFreq _ = error "internal error: not a KnownDomain"


### PR DESCRIPTION
PR #2417 caused a bug in the generation of the `qsys` file: it generated a spurious extra output clock which was completely unused otherwise.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
