### PR TITLE
No more testsuite failures on questa-2023.1 and vivado-2023.1

### DIFF
--- a/changelog/2023-10-31T11_39_43+01_00_sv_compat
+++ b/changelog/2023-10-31T11_39_43+01_00_sv_compat
@@ -1,0 +1,1 @@
+FIXED: SystemVerilog backend: Assignment patterns for unpacked arrays now have an index for every element; improves QuestaSim compatibility.

--- a/clash-lib/prims/verilog/Clash_Explicit_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_DDR.primitives.yaml
@@ -63,6 +63,7 @@
       // ddrOut begin
       reg ~SIGD[~GENSYM[data_Pos][1]][7];
       reg ~SIGD[~GENSYM[data_Neg][2]][7];
+      ~IF ~VIVADO ~THENreg ~SIGDO[~GENSYM[ddrOut][3]];~ELSE~FI
       always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
         if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
           ~SYM[1] <= ~ARG[7];
@@ -78,6 +79,14 @@
         end
       end
 
-      assign ~RESULT = ~ARG[4] ? ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1] : ~SYM[2]~ELSE~SYM[2] : ~SYM[1]~FI;
+      ~IF ~VIVADO ~THENalways @(*) begin
+        if (~ARG[4]) begin
+          ~SYM[3] = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI;
+        end else begin
+          ~SYM[3] = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
+        end
+      end
+      assign ~RESULT = ~SYM[3];~ELSE
+      assign ~RESULT = ~ARG[4] ? ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1] : ~SYM[2]~ELSE~SYM[2] : ~SYM[1]~FI;~FI
 
       // ddrOut end

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -1147,10 +1147,10 @@ expr_ b (DataCon _ (DC (Void {}, -1)) [e]) =  expr_ b e
 
 expr_ _ (DataCon ty@(Vector 0 _) _ _) = verilogTypeErrValue ty
 
-expr_ _ (DataCon (Vector 1 elTy) _ [e]) = "'" <> braces (toSLV elTy e)
+expr_ _ (DataCon (Vector 1 elTy) _ [e]) = "'" <> braces (int 0 <> colon <+> toSLV elTy e)
 
 expr_ _ e@(DataCon ty@(Vector _ elTy) _ [e1,e2]) = case vectorChain e of
-  Just es -> "'" <> listBraces (mapM (toSLV elTy) es)
+  Just es -> "'" <> listBraces (zipWithM (\i e3 -> int i <> colon <+> toSLV elTy e3) [0..] es)
   Nothing -> verilogTypeMark ty <> "_cons" <> parens (expr_ False e1 <> comma <+> expr_ False e2)
 
 expr_ _ (DataCon (MemBlob n m) _ [n0, m0, _, runs, _, ends])

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -669,7 +669,20 @@ runClashTest = defaultMain $ clashTestRoot
                                                         , "testBenchUS"
                                                         , "testBenchGA"
                                                         , "testBenchGS"
-                                                        ]}
+                                                        ]
+                         , hdlLoad = hdlLoad def \\ [Vivado]
+                         , hdlSim = hdlSim def \\ [Vivado]
+                         }
+          in runTest "DDRout" _opts
+        , let _opts = def{ buildTargets = BuildSpecific [ "testBenchUA"
+                                                        , "testBenchUS"
+                                                        , "testBenchGA"
+                                                        , "testBenchGS"
+                                                        ]
+                         , hdlLoad = [Vivado]
+                         , hdlSim = [Vivado]
+                         , clashFlags=["-fclash-hdlsyn", "Vivado"]
+                         }
           in runTest "DDRout" _opts
         ]
       , clashTestGroup "DSignal"


### PR DESCRIPTION
Running:
```
cabal run clash-testsuite
```
Used to fail on the following tests:
```
BlackBox/T1524/SystemVerilog/ModelSim
DDR/DDRout/Verilog/tools/Vivado/testBenchUA;testBenchUS;techbenchGA;testbenchGS
HOPrim/Transpose/SystemVerilog/ModelSim
Vector/VMerge/SystemVerilog/ModelSim
```
On my machine, which has:
* Questa Intel FPGA Stater Edition 2023.1
* Xilinx Vivado 2023.1

With the commits in this PR, all tests pass on my machine.
