### PR TITLE
flattenLet applied in bottomup traversal 

### DIFF
--- a/benchmark/clash-benchmark.cabal
+++ b/benchmark/clash-benchmark.cabal
@@ -26,6 +26,9 @@ library
                        clash-lib,
                        clash-prelude
 
+  if impl(ghc >= 9.0.0)
+    build-depends:     ghc-boot
+
 executable clash-benchmark-normalization
   main-is:             benchmark-normalization.hs
   default-language:    Haskell2010

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeApplications #-}
 
 module BenchmarkCommon where
@@ -16,6 +17,22 @@ import Clash.GHC.GenerateBindings
 import Clash.GHC.NetlistTypes
 
 import qualified Control.Concurrent.Supply as Supply
+
+#if MIN_VERSION_ghc(9,2,0)
+import qualified GHC.Driver.Monad as GHC
+import qualified GHC.Driver.Session as GHC
+import qualified GHC.Driver.Env.Types as GHC
+import qualified GHC.LanguageExtensions as LangExt
+import qualified GHC.Settings as GHC
+import qualified GHC.Utils.Fingerprint as GHC
+#elif MIN_VERSION_ghc(9,0,0)
+import qualified GHC.Driver.Monad as GHC
+import qualified GHC.Driver.Session as GHC
+import qualified GHC.Driver.Types as GHC
+import qualified GHC.LanguageExtensions as LangExt
+import qualified GHC.Settings as GHC
+import qualified GHC.Utils.Fingerprint as GHC
+#endif
 
 defaultTests :: [FilePath]
 defaultTests =
@@ -49,7 +66,34 @@ runInputStage idirs src = do
   let o = opts idirs
   let backend = initBackend @VHDLState o
   pds <- primDirs backend
-  generateBindings o (return ()) pds (opt_importPaths o) [] (hdlKind backend) src Nothing
+  generateBindings o action pds (opt_importPaths o) [] (hdlKind backend) src Nothing
+ where
+#if MIN_VERSION_ghc(9,0,0)
+  action = do
+    env <- GHC.getSession
+    let df0 = GHC.hsc_dflags env
+#if MIN_VERSION_ghc(9,4,0)
+        df1 = addOptP "-DCLASH_OPAQUE=OPAQUE" df0
+#else
+        df1 = addOptP "-DCLASH_OPAQUE=NOINLINE" df0
+#endif
+        df2 = GHC.xopt_set df1 LangExt.Cpp
+    GHC.setSession (env {GHC.hsc_dflags = df2})
+
+  addOptP :: String -> GHC.DynFlags -> GHC.DynFlags
+  addOptP   f = alterToolSettings $ \s -> s
+            { GHC.toolSettings_opt_P   = f : GHC.toolSettings_opt_P s
+            , GHC.toolSettings_opt_P_fingerprint = fingerprintStrings (f : GHC.toolSettings_opt_P s)
+            }
+
+  alterToolSettings :: (GHC.ToolSettings -> GHC.ToolSettings) -> GHC.DynFlags -> GHC.DynFlags
+  alterToolSettings f dynFlags = dynFlags { GHC.toolSettings = f (GHC.toolSettings dynFlags) }
+
+  fingerprintStrings :: [String] -> GHC.Fingerprint
+  fingerprintStrings ss = GHC.fingerprintFingerprints $ map GHC.fingerprintString ss
+#else
+  action = return ()
+#endif
 
 runNormalisationStage
   :: [FilePath]

--- a/changelog/2023-11-06T14_40_14+01_00_fix_2598
+++ b/changelog/2023-11-06T14_40_14+01_00_fix_2598
@@ -1,0 +1,1 @@
+FIXED: Name duplication in generated Verilog involving reset synchronizer [#2598](https://github.com/clash-lang/clash-compiler/issues/2598)

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -2,7 +2,7 @@
   Copyright   :  (C) 2012-2016, University of Twente,
                      2016     , Myrtle Software Ltd,
                      2017     , Google Inc.,
-                     2021-2022, QBayLogic B.V.
+                     2021-2023, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -71,7 +71,8 @@ import           Clash.Normalize.Strategy
 import           Clash.Normalize.Transformations
 import           Clash.Normalize.Types
 import           Clash.Normalize.Util
-import           Clash.Rewrite.Combinators        ((>->),(!->),repeatR,topdownR)
+import           Clash.Rewrite.Combinators
+  ((>->), (!->), bottomupR, repeatR, topdownR)
 import           Clash.Rewrite.Types
   (RewriteEnv (..), RewriteState (..), bindings, debugOpts, extra,
    tcCache, topEntities, newInlineStrategy)
@@ -378,8 +379,8 @@ flattenCallTree (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
                  apply "caseCon" caseCon >->
                  (apply "reduceConst" reduceConst !-> apply "deadcode" deadCode) >->
                  apply "reduceNonRepPrim" reduceNonRepPrim >->
-                 apply "removeUnusedExpr" removeUnusedExpr >->
-                 apply "flattenLet" flattenLet)) !->
+                 apply "removeUnusedExpr" removeUnusedExpr) >->
+               bottomupR (apply "flattenLet" flattenLet)) !->
       topdownSucR (apply "topLet" topLet)
 
     goCheap c@(CLeaf   (nm2,(Binding _ _ inl2 _ e _)))


### PR DESCRIPTION
Ensures deeply nested let-bindings are flattened first so that let-expressions do not get inlined into argument positions in their unflattened form.

Has some minor performance effects.

Before:
```
benchmarking normalization of examples/Reducer.hs
time                 395.2 ms   (385.3 ms .. 410.2 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 401.3 ms   (396.8 ms .. 406.4 ms)
std dev              5.429 ms   (1.784 ms .. 7.434 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of tests/shouldwork/Basic/AES.hs
time                 161.3 ms   (160.1 ms .. 162.5 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 164.9 ms   (163.1 ms .. 169.4 ms)
std dev              4.042 ms   (490.2 μs .. 5.968 ms)
variance introduced by outliers: 12% (moderately inflated)
```

After:
```
benchmarking normalization of examples/Reducer.hs
time                 447.0 ms   (439.0 ms .. 451.0 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 454.4 ms   (451.0 ms .. 460.9 ms)
std dev              6.411 ms   (13.17 μs .. 7.496 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking normalization of tests/shouldwork/Basic/AES.hs
time                 182.2 ms   (180.8 ms .. 183.4 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 185.3 ms   (183.9 ms .. 188.1 ms)
std dev              2.666 ms   (490.4 μs .. 3.715 ms)
variance introduced by outliers: 14% (moderately inflated)
```

Fixes https://github.com/clash-lang/clash-compiler/issues/2598