### PR TITLE
Expire artifacts in a week by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,8 @@
 # Make all tasks interruptible by default
 default:
   interruptible: true
+  artifacts:
+    expire_in: 1 week
 
 include:
   - '/.ci/gitlab/common.yml'


### PR DESCRIPTION
We're currently using a whopping 523.5 GiB project storage on GitLab.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~

