### PR TITLE
Workaround "Pattern match has inaccessible right hand side" bug

### DIFF
--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -5,10 +5,18 @@
 
   HDL generation functionality for LATTICE ICE IO primitives.
 -}
+
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_HADDOCK hide #-}
+
+-- GHC < 9, sometimes(?) compains about the RHS of sbioTemplate being unreacheble,
+-- this explicitly turns that into an warning overriding -Werror.
+#if __GLASGOW_HASKELL__ < 900
+{-# OPTIONS_GHC -Wwarn=overlapping-patterns #-}
+#endif
 
 module Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO (sbioTF) where
 


### PR DESCRIPTION
When using GHC < 9 `.../ICE40/Blackboxes/IO.hs` sometimes(?) warns:
```
    Pattern match has inaccessible right hand side
    In a pattern binding in
         a pattern guard for
           an equation for ‘sbioTemplate’:
        [_HasCallStack,
         (clk, clkTy, _),
         (en, _enTy, _),
         (pinConfig, _pinTy, pinConfigLiteral -> ()),
         (packagePin, packagePinTy, _),
         (latchInput, Bit, _),
         (dOut0, Bit, _),
         (dOut1, Bit, _),
         (outputEnable, Bool, _)]
        <-
        ...
```
And because we run with `-Werror` on CI this causes compilation to fail. This works around that by explicitly turning it back into a warning.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files