### PR TITLE
Workaround "Pattern match has inaccessible right hand side" bug (copy #2611)

### DIFF
--- a/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/clash-cores/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -5,10 +5,18 @@
 
   HDL generation functionality for LATTICE ICE IO primitives.
 -}
+
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_HADDOCK hide #-}
+
+-- GHC < 9, sometimes(?) compains about the RHS of sbioTemplate being unreacheble,
+-- this explicitly turns that into an warning overriding -Werror.
+#if __GLASGOW_HASKELL__ < 900
+{-# OPTIONS_GHC -Wwarn=overlapping-patterns #-}
+#endif
 
 module Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO (sbioTF) where
 


### PR DESCRIPTION
Since [automatic backports were broken](https://github.com/clash-lang/clash-compiler/pull/2612) when #2611 was merged, I'm just doing the backport manually here to fix the 1.8 branch