### PR TITLE
CI: Send Slack message when nightly fails

### DIFF
--- a/.ci/report_status.sh
+++ b/.ci/report_status.sh
@@ -7,3 +7,11 @@ curl --url "https://api.github.com/repos/${username}/${repo}/statuses/${CI_COMMI
      --header 'Content-Type: application/json' \
      --header "authorization: Bearer ${GITHUB_STATUS_TOKEN}" \
      --data "{ \"state\": \"${commit_status}\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"All Gitlab pipelines\", \"context\": \"ci/gitlab/gitlab.com\" }"
+
+if [ "$CI_PIPELINE_SOURCE" = schedule -a "$commit_status" = failure ]; then
+    # Send a Slack message to #monitor
+    curl --url "https://slack.com/api/chat.postMessage" --request POST \
+        --header "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+        --data "channel=CQR9YG4CT" \
+        --data "text=Nightly for \`${CI_COMMIT_BRANCH}\` <${CI_PIPELINE_URL}|*failed*>!"
+fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,31 +111,35 @@ hackage-release:
   rules:
     - if: '$CI_COMMIT_TAG != null' # tags
 
-# Work around https://gitlab.com/gitlab-org/gitlab/-/issues/216629
+# We manually report status to GitHub to work around
+# <https://gitlab.com/gitlab-org/gitlab/-/issues/216629>.
+# The script will also send a Slack message when the nightly fails.
 #
-# If we ever remove this, we may have to rethink the use of the interruptible flag
-.github_status:
+# If we ever remove this manual GitHub reporting, we may have to rethink the
+# use of the interruptible flag: see <https://github.com/clash-lang/clash-compiler/pull/2616#discussion_r1409429185>
+.report_status:
   # interruptible: false
   image: curlimages/curl
+  dependencies: []
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
 
 set_pending:
-  extends: .github_status
+  extends: .report_status
   stage: pre
   script:
-    - .ci/set_github_status.sh pending
+    - .ci/report_status.sh pending
 
 set_success:
-  extends: .github_status
+  extends: .report_status
   stage: post
   when: on_success
   script:
-    - .ci/set_github_status.sh success
+    - .ci/report_status.sh success
 
 set_failure:
-  extends: .github_status
+  extends: .report_status
   stage: post
   when: on_failure
   script:
-    - .ci/set_github_status.sh failure
+    - .ci/report_status.sh failure


### PR DESCRIPTION
`github_status` is renamed `report_status` to reflect the expanded scope.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
