### PR TITLE
GitHub CI: Make retrying on runner failure the default

### DIFF
--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -13,11 +13,6 @@
     RUN_CLASHDEV: "no"
     RUN_TESTSUITE: "no"
     RUN_BUILD_ALL: "no"
-  retry:
-    max: 2
-    when:
-      - runner_system_failure
-      - stuck_or_timeout_failure
   cache:
     key: cabal-store-$CI_JOB_NAME-$CI_JOB_IMAGE
     when: always

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -8,11 +8,6 @@
     CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2023-08-22-2-3-non_protected
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
-  retry:
-    max: 2
-    when:
-      - runner_system_failure
-      - stuck_or_timeout_failure
   cache:
     key: $CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_JOB_IMAGE-2
     when: always

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -25,5 +25,3 @@ hackage-sdist:
     - .ci/publish_sdist.sh clash-lib
     - .ci/publish_sdist.sh clash-lib-hedgehog
     - .ci/publish_sdist.sh clash-ghc
-  retry:
-    max: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,11 @@
-# Make all tasks interruptible by default
 default:
+  # Make all tasks interruptible by default
   interruptible: true
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
 
 include:
   - '/.ci/gitlab/common.yml'


### PR DESCRIPTION
We used to specify retrying for by far most of the jobs, but it was crucially missing on `nix-build`. So when a runner is shut down during this job, it will not be retried.

To simplify matters, I just made retrying on runner failure the default.

The only jobs that were not retried before this commit were:
  - nix-build
  - set_pending
  - set_success
  - set_failure

I don't think it hurts to turn it on for those status jobs as well.

Additionally, the `.hackage` inclusion snippet redundantly specified `{retry: {max: 2}}`, which I removed. Note that GitHub's merge algorithm for inclusion would fill in the `{retry: {when: ...}}` key from `.common`, it truly was a no-op in `.hackage`.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
