### PR TITLE
CI: change nix-build log format to be less noisy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ nix-build:
   before_script:
    - nix-env -i gawk
   script:
-    - nix-build -j$(./.ci/effective_cpus.sh)
+    - nix-build -j$(./.ci/effective_cpus.sh) --log-format raw --max-silent-time 3600
   tags:
     - local
 


### PR DESCRIPTION
Change nix-build log format to be less noisy, so we don't overflow the log limit on CI anymore.

Also set max-silent-time to 1h.
This way if one of the derivations hangs, and doesn't output anything anymore for 1 hour,
 nix will detect it and report which one it was.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
