### PR TITLE
clash-prelude: Add ShowX (Proxy a) instance

### DIFF
--- a/changelog/2024-01-15T18_50_38-05_00_showx-proxy-instances
+++ b/changelog/2024-01-15T18_50_38-05_00_showx-proxy-instances
@@ -1,0 +1,1 @@
+* Add `ShowX`, `NFDataX` instances for `Proxy`

--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -63,6 +63,7 @@ import qualified Data.List.Infinite  as Inf
 import           Data.List.Infinite  (Infinite (..))
 import           Data.List.NonEmpty  (NonEmpty)
 import           Data.Ord            (Down (Down))
+import           Data.Proxy          (Proxy)
 import           Data.Ratio          (Ratio, numerator, denominator)
 import qualified Data.Semigroup      as SG
 import qualified Data.Monoid         as M
@@ -397,6 +398,8 @@ printX :: ShowX a => a -> IO ()
 printX x = putStrLn $ showX x
 
 instance ShowX ()
+-- | @since 1.8.2
+instance ShowX (Proxy a)
 instance ShowX a => ShowX (Identity a)
 instance ShowX a => ShowX (Const a b)
 instance (ShowX (f a), ShowX (g a)) => ShowX (Product f g a)
@@ -585,6 +588,8 @@ instance NFDataX a => NFDataX [a]
 instance NFDataX a => NFDataX (NonEmpty a)
 instance (NFDataX a, NFDataX b) => NFDataX (Either a b)
 instance NFDataX a => NFDataX (Maybe a)
+-- | @since 1.8.2
+instance NFDataX (Proxy a)
 instance NFDataX a => NFDataX (Identity a)
 instance NFDataX a => NFDataX (Const a b)
 instance (NFDataX (f a), NFDataX (g a)) => NFDataX (Product f g a)


### PR DESCRIPTION
Both I and `clash-protocols` have found this instance useful, leading to overlapping instances. Let's put it where it belongs.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
