### PR TITLE
Fix Clash.Primitives.DSL.tuple on GHC-9.6

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -526,15 +526,12 @@ runClashTest = defaultMain $ clashTestRoot
               , hdlSim=[Vivado]
               , buildTargets=BuildSpecific ["tb" <> show n | n <- [(0::Int)..7]]
               }
-#if !MIN_VERSION_ghc(9,6,0)
-          -- XXX: Broken on GHC 9.6. See https://github.com/clash-lang/clash-compiler/issues/2512.
           , runTest "XpmCdcHandshake" $ def
               { hdlTargets=[VHDL, Verilog]
               , hdlLoad=[Vivado]
               , hdlSim=[Vivado]
               , buildTargets=BuildSpecific ["tb" <> show n | n <- [(0::Int)..6]]
               }
-#endif
           , runTest "XpmCdcSingle" $ def
               { hdlTargets=[VHDL, Verilog]
               , hdlLoad=[Vivado]


### PR DESCRIPTION
It had the module name of tuples hardcoded to GHC.Tuple, but that changed in GHC-9.6.
This would result in type mismatches in the generated VHDL.

Fixes #2512

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files