### PR TITLE
cabal: Make workaround-ghc-mmap-crash a noop on non-x86_64

### DIFF
--- a/changelog/2024-02-04T21_34_25+01_00_x86_workaround-ghc-mmap-crash_noop
+++ b/changelog/2024-02-04T21_34_25+01_00_x86_workaround-ghc-mmap-crash_noop
@@ -1,0 +1,1 @@
+* cabal: Make `workaround-ghc-mmap-crash` a noop on non-x86_64. Fixes [#2656](https://github.com/clash-lang/clash-compiler/issues/2656)

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -79,7 +79,7 @@ executable clash
     GHC-Options: -dynamic
   -- Note that multiple -with-rtsopts are not cumulative, so we can't add the
   -- common RTS options in the unconditional GHC-Options
-  if flag(workaround-ghc-mmap-crash)
+  if arch(x86_64) && flag(workaround-ghc-mmap-crash)
     GHC-Options: "-with-rtsopts=-A128m -xm20000000"
   else
     GHC-Options: -with-rtsopts=-A128m

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -389,7 +389,7 @@ test-suite unittests
   ghc-options:      -Wall -Wcompat -threaded
   -- Note that multiple -with-rtsopts are not cumulative, so we can't add the
   -- common RTS options in the unconditional GHC-Options
-  if flag(workaround-ghc-mmap-crash)
+  if arch(x86_64) && flag(workaround-ghc-mmap-crash)
     GHC-Options: "-with-rtsopts=-N -xm20000000"
   else
     GHC-Options: -with-rtsopts=-N

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -388,7 +388,7 @@ test-suite doctests
       doctest-parallel >= 0.3.1 && < 0.4,
       filepath
 
-  if flag(workaround-ghc-mmap-crash)
+  if arch(x86_64) && flag(workaround-ghc-mmap-crash)
     ghc-options:    -with-rtsopts=-xm20000000
 
   if flag(multiple-hidden)
@@ -401,7 +401,7 @@ test-suite unittests
   main-is:          unittests.hs
   ghc-options:      -Wall -Wcompat -threaded
   -- Note that multiple -with-rtsopts are not cumulative
-  if flag(workaround-ghc-mmap-crash)
+  if arch(x86_64) && flag(workaround-ghc-mmap-crash)
     ghc-options:    "-with-rtsopts=-N -xm20000000"
   else
     ghc-options:    -with-rtsopts=-N

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -92,7 +92,7 @@ common basic-config
   if flag(multiple-hidden)
     cpp-options:       -DCLASH_MULTIPLE_HIDDEN
 
-  if flag(workaround-ghc-mmap-crash)
+  if arch(x86_64) && flag(workaround-ghc-mmap-crash)
     cpp-options:       -DCLASH_WORKAROUND_GHC_MMAP_CRASH
 
 library


### PR DESCRIPTION
Fixes [#2656](https://github.com/clash-lang/clash-compiler/issues/2656)

