### PR TITLE
Print previous errors if local module fails to load

### DIFF
--- a/changelog/2024-02-08T11_27_48+01_00_fix_2365
+++ b/changelog/2024-02-08T11_27_48+01_00_fix_2365
@@ -1,0 +1,1 @@
+FIXED: Clash no longer hides error messages if it fails to load external (precompiled) modules. Note: this fix only works from GHC 9.0 on. See [#2365](https://github.com/clash-lang/clash-compiler/issues/2365)

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -1,13 +1,14 @@
 {-|
   Copyright   :  (C) 2013-2016, University of Twente,
                      2016-2017, Myrtle Software Ltd,
-                     2017     , Google Inc.
+                     2017-2024, Google Inc.
                      2021-2023, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -38,9 +39,10 @@ import           Control.Arrow                   (first)
 import           Control.Exception               (SomeException, throw)
 import           Control.Monad                   (forM, join, when)
 import           Data.List.Extra                 (nubSort)
-import           Control.Exception               (throwIO)
+import           Control.Exception               (Exception, throwIO)
 import           Control.Monad                   (foldM)
 #if MIN_VERSION_ghc(9,0,0)
+import           Control.Monad.Catch             (catch, throwM)
 import           Control.Monad.Catch             as MC (try)
 #endif
 import           Control.Monad.IO.Class          (liftIO)
@@ -524,6 +526,26 @@ nameString = OccName.occNameString . Name.nameOccName
 varNameString :: Var.Var -> String
 varNameString = nameString . Var.varName
 
+data LoadModulesException = LoadModulesException
+  { moduleName :: String
+  , externalError :: String
+  , localError :: String
+  } deriving (Exception)
+
+instance Show LoadModulesException where
+  showsPrec :: Int -> LoadModulesException -> ShowS
+  showsPrec _ LoadModulesException{moduleName, externalError, localError} = showString [I.i|
+    Failed to load module '#{moduleName}'.
+
+    Tried to load it from precompiled sources, error was:
+
+      #{externalError}
+
+    Tried to load it from local sources, error was:
+
+      #{localError}
+  |]
+
 loadModules
   :: GHC.Ghc ()
   -- ^ Allows us to have some initial action, such as sharing a linker state
@@ -570,7 +592,21 @@ loadModules startAction useColor hdl modName dflagsM idirs = do
       -- We need to try and load external modules first, because we can't
       -- recover from errors in 'loadLocalModule'.
       loadExternalModule hdl modName >>= \case
-        Left _loadExternalErr -> loadLocalModule hdl modName
+#if MIN_VERSION_ghc(9,0,0)
+        Left loadExternalErr -> do
+          catch @_ @SomeException
+            (loadLocalModule hdl modName)
+            (\localError ->
+              throwM
+                (LoadModulesException
+                  { moduleName = modName
+                  , externalError = show loadExternalErr
+                  , localError = show localError
+                  }))
+#else
+        Left _loadExternalErr -> do
+          loadLocalModule hdl modName
+#endif
         Right res -> pure res
 
     let allBinderIds = map fst (CoreSyn.flattenBinds allBinders)


### PR DESCRIPTION
Fixes #2365

---------------------------

Example of a new-style error message:

```
<no location info>: error:
    Other error:
    Failed to load module 'Bittide.Instances.Hitl.Tcl.ExtraProbes'.
    
    Tried to load it from precompiled sources, error was:
    
      Function Clash.Cores.Xilinx.Dna.dnaPorte2 was annotated with an inline primitive for Clash.Cores.Xilinx.DnaPorte.deviceDna.dnaPorte2. These names should be the same.
      CallStack (from HasCallStack):
        error, called at src-ghc/Clash/GHC/LoadInterfaceFiles.hs:482:5 in clash-ghc-1.9.0-inplace:Clash.GHC.LoadInterfaceFiles
    
    Tried to load it from local sources, error was:
    
      module ‘Bittide.Instances.Hitl.Tcl.ExtraProbes’ cannot be found locally
```

Instead of the old:

```
<no location info>: error:
    Other error: 
      module ‘Bittide.Instances.Hitl.Tcl.ExtraProbes’ cannot be found locally
```

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
