### PR TITLE
Refactor DEC transformation

### DIFF
--- a/changelog/2024-02-23T16_56_56+01_00_fix2628
+++ b/changelog/2024-02-23T16_56_56+01_00_fix2628
@@ -1,0 +1,1 @@
+FIXED: Clash no longer errors out in the netlist generation stage when a polymorphic function is applied to type X in one alternative of a case-statement and applied to a newtype wrapper of type X in a different alternative. See [#2828](https://github.com/clash-lang/clash-compiler/issues/2628)

--- a/clash-lib/src/Data/List/Extra.hs
+++ b/clash-lib/src/Data/List/Extra.hs
@@ -4,6 +4,7 @@
 module Data.List.Extra
   ( partitionM
   , mapAccumLM
+  , mapAccumRM
   , iterateNM
   , (<:>)
   , indexMaybe
@@ -45,6 +46,19 @@ mapAccumLM f acc (x:xs) = do
   (acc',y) <- f acc x
   (acc'',ys) <- mapAccumLM f acc' xs
   return (acc'',y:ys)
+
+-- | Monadic version of 'Data.List.mapAccumR'
+mapAccumRM
+  :: Monad m
+  => (acc -> x -> m (acc,y))
+  -> acc
+  -> [x]
+  -> m (acc,[y])
+mapAccumRM _ acc [] = return (acc,[])
+mapAccumRM f acc (x:xs) = do
+  (acc1,ys) <- mapAccumRM f acc xs
+  (acc2,y) <- f acc1 x
+  return (acc2,y:ys)
 
 -- | Monadic version of 'iterate'. A carbon copy ('iterateM') would not
 -- terminate, hence the first argument.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -633,6 +633,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2593" def{hdlSim=[]}
         , runTest "T2623CaseConFVs" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         , runTest "T2781" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
+        , runTest "T2628" def{hdlTargets=[VHDL], buildTargets=BuildSpecific ["TACacheServerStep"], hdlSim=[]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2628.hs
+++ b/tests/shouldwork/Issues/T2628.hs
@@ -1,0 +1,156 @@
+module T2628 where
+
+import Clash.Prelude
+
+-- idx cacheline entries are Just(tag,Just addr) to translate idx++tag->addr
+--                       and Just(tag,Nothing) for invalidated idx++tag entry
+--                       and Nothing for no entry there
+type CacheLine m tag addr                    -- 2^m tags per line, 2^n lines
+               = Vec (2^m) (Maybe(tag,Maybe addr))
+
+{-# ANN tacache_server_step32
+  (Synthesize { t_name   = "TACacheServerStep"
+              , t_inputs = [ PortName "dx"        -- user B
+                           , PortName "d_x"       -- tlb C
+                           , PortName "dw"        -- tlb D
+                           , PortName "out2"     -- cache B
+                           , PortName "out3"     -- cache C
+                           ]
+              , t_output = PortProduct ""
+                             [ PortName "win1"   -- cache A1
+                             , PortName "win2"   -- cache A2
+                             ]
+              }) #-}
+
+{-# NOINLINE tacache_server_step32 #-}
+tacache_server_step32 = tacache_server_step'
+  where
+  tacache_server_step'
+   :: forall (m::Nat) (n::Nat) (p::Nat) (q::Nat)
+            cxdr addr idx tag cacheline
+   . ( KnownNat q, KnownNat n, KnownNat m, KnownNat p
+     , n <= p
+     , cxdr ~ Signed p
+     , addr ~ Signed q
+     , idx  ~ Signed n
+     , tag  ~ Signed (p-n)
+     , cacheline ~ CacheLine m tag addr
+     , p ~ 132
+     , q ~ 32
+     , n ~ 6
+     , m ~ 0
+     )
+   -- SNat n                         -- 2^n lines
+   -- SNat m                         -- of 2^m entries each
+   => ( Maybe cxdr        -- input frnt invalidate addr req to server
+      , Maybe cxdr        -- input back/weak invalidate req to server
+      , Maybe (cxdr,addr) -- input back/weak write req to server
+      , Maybe (idx,cacheline)
+      , Maybe (idx,cacheline)
+      )
+   -> ( Maybe(idx,cacheline)
+      , Maybe(idx,cacheline)
+      )
+  tacache_server_step' = tacache_server_step (SNat::SNat n) (SNat::SNat m)
+
+tacache_server_step
+   :: forall (m::Nat) (n::Nat) (p::Nat) (q::Nat)
+            cxdr addr idx tag cacheline
+   . ( KnownNat q, KnownNat n, KnownNat m, KnownNat p
+     , n <= p
+     , cxdr ~ Signed p
+     , addr ~ Signed q
+     , idx  ~ Signed n
+     , tag  ~ Signed (p-n)
+     , cacheline ~ CacheLine m tag addr
+--   , p ~ 132
+--   , q ~ 32
+     )
+   => SNat n                         -- 2^n lines
+   -> SNat m                         -- of 2^m entries each
+   -> ( Maybe cxdr        -- input frnt invalidate addr req to server
+      , Maybe cxdr        -- input back/weak invalidate req to server
+      , Maybe (cxdr,addr) -- input back/weak write req to server
+      , Maybe (idx,cacheline)
+      , Maybe (idx,cacheline)
+      )
+   -> ( Maybe(idx,cacheline)
+      , Maybe(idx,cacheline)
+      )
+tacache_server_step n m (dx,d_x,dw,out1,out2) = (win1,win2)
+
+  where
+      -- outs1 and outs2 are prev state
+      -- (may need to write two lines in one cycle)
+      win1,win2 :: Maybe(idx,CacheLine m tag addr)
+      (win1,win2) =
+             case (dx, d_x, dw, out1, out2) of
+
+  -- !!! FIX for HDL from here on, replace (v,_) = with v = fst $  !!! --
+
+               (Just x1,Just x2,Nothing,Just (idx1,v1),Just (idx2,v2)) ->
+                 let (idx2',tag2) = tacache_split_cxdr x2
+                 in
+                 if 1 /= idx2' then
+                      ( Just(1,v1)
+                      , Just(idx2',v2)
+                      )
+                 else
+                   let (v1',_) = tazcache_line_inval_step v1 2          -- HERE
+                       (v2',_) = tazcache_line_weak_inval_step v1' tag2 -- HERE
+                   in ( Just(idx2',v2')
+                      , Nothing
+                      )
+
+  -- !!! FIX for HDL from here, as above, and make cases top level fns !!! ---
+
+               (Nothing,Just x,Nothing,_,Just (idx,v)) ->
+                 let (v',_) = tazcache_line_weak_inval_step v 4       -- HERE
+                 in ( Nothing
+                    , Just(3,v')
+                    )
+
+               _ -> (Nothing,Nothing)
+
+   --------------------  DUMMY NOINLINE support -----------------------
+
+-- split incoming addr for translation into a cacheline index and tag
+{-# NOINLINE tacache_split_cxdr #-}
+tacache_split_cxdr
+  :: forall (n::Nat) (p::Nat) tag cxdr idx f
+   . ( KnownNat n, KnownNat p
+     , Resize f  -- might as well be just Signed
+     , n <= p, (n + (p-n)) ~ p, ((p-n) + n) ~ p
+     , BitPack cxdr, p ~    BitSize cxdr, cxdr ~ f p
+     , BitPack idx,  n ~    BitSize idx,  idx  ~ f n
+     , BitPack tag, (p-n) ~ BitSize tag,  tag  ~ f (p-n)
+     )
+  => cxdr
+  -> (idx,tag)
+tacache_split_cxdr x = (unpack 5, unpack 6)
+
+   ------------------  DUMMY NOINLINE cacheline ops ---------------------
+
+-- remove element with matching tag from cacheline, report position
+{-# NOINLINE tazcache_line_inval_step #-}
+tazcache_line_inval_step ::
+                   ( KnownNat m, KnownNat p_n, KnownNat q
+                   , BitPack tag,  p_n ~ BitSize tag,  Eq tag
+                   , BitPack addr, q ~   BitSize addr
+                   )
+                => CacheLine m tag addr
+                -> tag
+                -> (CacheLine m tag addr, Maybe(Index(2^m)))
+tazcache_line_inval_step v tag = (v,Nothing)
+
+-- add placeholder invalidated entry to cacheline, replace entry if was there
+{-# NOINLINE tazcache_line_weak_inval_step #-}
+tazcache_line_weak_inval_step ::
+                   ( KnownNat m, KnownNat p_n, KnownNat q
+                   , BitPack tag,  p_n ~ BitSize tag,  Eq tag
+                   , BitPack addr, q ~   BitSize addr
+                   )
+                => CacheLine m tag addr
+                -> tag
+                -> (CacheLine m tag addr, Maybe(Index(2^m)))
+tazcache_line_weak_inval_step v tag = (v,Nothing)


### PR DESCRIPTION
~~Create multiple selectors, one for each non-shared argument.~~
We still use one selector in order to preserve sharing.

The previous code was a big mess where we partioned arguments into shared and non-shared and then filtered the case-tree depending on whether they were part of the shared arguments or not. But then with the normalisation of type arguments, the second filter did not work properly. This then resulted in shared arguments becoming part of the tuple in the alternatives of the case-expression for the non-shared arguments.

The new code is also more robust in the sense that shared and non-shared arguments no longer need to be partioned (shared occur left-most, non-shared occur right-most). They can now be interleaved. The old code would also generate bad Core if ever type and term arguments occured interleaved, this is no longer the case for the new code.

Fixes #2628

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
