### PR TITLE
Look through annotations in tyfam solving

### DIFF
--- a/changelog/2024-02-16T16_42_52+01_00_fix2593
+++ b/changelog/2024-02-16T16_42_52+01_00_fix2593
@@ -1,0 +1,1 @@
+FIXED: HDL generation fails when using multiple-hidden feature in combination with synthesis attributes [#2593](https://github.com/clash-lang/clash-compiler/issues/2593)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -788,6 +788,7 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest "T2510" def{hdlTargets=[VHDL], clashFlags=["-DNOINLINE=OPAQUE"]}
 #endif
         , outputTest "T2542" def{hdlTargets=[VHDL]}
+        , runTest "T2593" def{hdlSim=[]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2593.hs
+++ b/tests/shouldwork/Issues/T2593.hs
@@ -1,0 +1,14 @@
+module T2593 where
+
+import Clash.Prelude
+import Clash.Annotations.SynthesisAttributes
+
+topEntity ::
+  Signal System Bit ->
+  Signal System Bit `Annotate` 'StringAttr "breaka" "me"
+topEntity dIn =
+  exposeClockResetEnable (register 0) clk rst en dIn
+ where
+   clk = clockGen
+   rst = resetGen
+   en = enableGen


### PR DESCRIPTION
1. Annotations are implemented as type synonyms.
2. GHC looks through type synonyms when matching type families
3. So Clash should do the same.

Fixes #2593

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
