### PR TITLE
Bump Verilator to v5.020

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -94,10 +94,10 @@ RUN git clone https://github.com/cliffordwolf/SymbiYosys.git SymbiYosys \
 
 FROM builder AS build-verilator
 
-ARG DEPS_VERILATOR="perl python3 make autoconf g++ flex bison ccache libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g zlib1g-dev"
+ARG DEPS_VERILATOR="perl python3 make autoconf g++ flex bison ccache libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g zlib1g-dev help2man"
 RUN apt-get install -y --no-install-recommends $DEPS_VERILATOR
 
-ARG verilator_version="v4.214"
+ARG verilator_version="v5.020"
 RUN git clone https://github.com/verilator/verilator verilator \
   && cd verilator \
   && git checkout $verilator_version \

--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -3,9 +3,9 @@
 set -xeo pipefail
 
 REPO="ghcr.io/clash-lang"
-NAME="clash-ci-"
+NAME="clash-ci"
 DIR=$(dirname "$0")
-now=$(date +%F)
+now=$(date +%Y%m%d)
 
 if [[ "$1" == "-y" ]]; then
   push=y
@@ -31,8 +31,7 @@ do
     --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
     --build-arg cabal_version=${CABAL_VERSION} \
     --build-arg ghc_version=${GHC_VERSION} \
-    -t "${REPO}/${NAME}${GHC_VERSION}:$now" \
-    -t "${REPO}/${NAME}${GHC_VERSION}:latest" \
+    -t "${REPO}/${NAME}:${GHC_VERSION}-$now" \
     "$DIR"
 done
 
@@ -44,8 +43,7 @@ if [[ $push =~ ^[Yy]$ ]]; then
   for i in "${!GHC_VERSIONS[@]}"
   do
     GHC_VERSION="${GHC_VERSIONS[i]}"
-    docker push "${REPO}/${NAME}${GHC_VERSION}:$now"
-    docker push "${REPO}/${NAME}${GHC_VERSION}:latest"
+    docker push "${REPO}/${NAME}:${GHC_VERSION}-$now"
   done
 else
   echo "Skipping push to container registry"

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2024-02-15
+  image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20240221
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -8,13 +8,13 @@ default:
       - stuck_or_timeout_failure
 
 .common:
-  image: ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2024-02-15
+  image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20240221
   timeout: 10 minutes
   stage: build
   variables:
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci-$GHC_VERSION:2024-02-15-2-3-non_protected
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20240221-2-3-non_protected
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   cache:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
     # Run steps inside the clash CI docker image
     container:
-      image: ghcr.io/clash-lang/clash-ci-${{ matrix.ghc }}:2024-02-15
+      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20240221
 
       env:
         THREADS: 2

--- a/changelog/2024-02-22T13_45_10+01_00_remove_verilator_shims
+++ b/changelog/2024-02-22T13_45_10+01_00_remove_verilator_shims
@@ -1,0 +1,1 @@
+REMOVED: Newer Verilators (> v5) can deal with delay statements, hence removing the need for Clash specific workarounds. If you relied on Clash-generated Verilator shims, consider using `verilator --build --binary` instead.

--- a/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_Testbench.primitives.yaml
@@ -17,6 +17,9 @@
       always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin
         if (~ARG[6] !== ~ARG[7]) begin
           $display("@%0tns: %s, expected: %b, actual: %b", $time, ~LIT[5], ~TOBV[~ARG[7]][~TYP[7]], ~TOBV[~ARG[6]][~TYP[6]]);
+          `ifdef VERILATOR
+            $c("std::exit(1);");
+          `endif
           $stop;
         end
       end
@@ -47,10 +50,12 @@
       always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin
         if (~SYM[1] !== ~SYM[2]) begin
           $display("@%0tns: %s, expected: %b, actual: %b", $time, ~LIT[4], ~TOBV[~ARG[6]][~TYP[6]], ~TOBV[~ARG[5]][~TYP[5]]);
+          `ifdef VERILATOR
+            $c("std::exit(1);");
+          `endif
           $stop;
         end
       end
       // pragma translate_on
       assign ~RESULT = ~ARG[7];
       // assertBitVector end
-

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.primitives.yaml
@@ -100,10 +100,12 @@
       localparam ~GENSYM[half_period][0] = (~PERIOD[0]0 / 2);
       always begin
         ~RESULT = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;
-        `ifndef VERILATOR
         #~LONGESTPERIOD0 forever begin
           ~IF~ISACTIVEENABLE[1]~THEN
           if (~ ~ARG[1]) begin
+            `ifdef VERILATOR
+              $c("std::exit(0);");
+            `endif
             $finish;
           end
           ~ELSE~FI
@@ -112,40 +114,7 @@
           ~RESULT = ~ ~RESULT;
           #~SYM[0];
         end
-        `else
-        ~RESULT = $c("this->~GENSYM[tb_clock_gen][1](",~SYM[0],",~IF~ACTIVEEDGE[Rising][0]~THENtrue~ELSEfalse~FI,",(~ ~ARG[1]),")");
-        `endif
       end
-
-      `ifdef VERILATOR
-        `systemc_interface
-        CData ~SYM[1](vluint32_t half_period, bool active_rising, bool result_rec) {
-          static vluint32_t init_wait = ~LONGESTPERIOD0;
-          static vluint32_t to_wait = 0;
-          static CData clock = active_rising ? 0 : 1;
-
-          if(init_wait == 0) {
-            if(result_rec) {
-              std::exit(0);
-            }
-            else {
-              if(to_wait == 0) {
-                to_wait = half_period - 1;
-                clock = clock == 0 ? 1 : 0;
-              }
-              else {
-                to_wait = to_wait - 1;
-              }
-            }
-          }
-          else {
-            init_wait = init_wait - 1;
-          }
-
-          return clock;
-        }
-        `verilog
-      `endif
       // pragma translate_on
       // tbClockGen end
     warning: Clash.Signal.Internal.tbClockGen is not synthesizable!
@@ -170,6 +139,9 @@
         #~LONGESTPERIOD0 forever begin
           ~IF~ISACTIVEENABLE[2]~THEN
           if (~ ~ARG[2]) begin
+            `ifdef VERILATOR
+              $c("std::exit(0);");
+            `endif
             $finish;
           end
           ~ELSE~FI
@@ -196,39 +168,10 @@
       // resetGen begin
       // pragma translate_off
       localparam ~GENSYM[reset_period][0] = ~LONGESTPERIOD0 - 10 + (~LIT[2] * ~PERIOD[0]0);
-      `ifndef VERILATOR
       initial begin
         #1 ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;
         #~SYM[0] ~RESULT = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;
       end
-      `else
-      always begin
-        // The redundant (~RESULT | ~ ~RESULT) is needed to ensure that this is
-        // calculated in every cycle by verilator. Without it, the reset will stop
-        // being updated and will be stuck as asserted forever.
-        ~RESULT =
-        $c("this->~GENSYM[reset_gen][1](",~SYM[0],",~IF~ISACTIVEHIGH[0]~THENtrue~ELSEfalse~FI)") & (~RESULT | ~ ~RESULT);
-      end
-      `systemc_interface
-      CData ~SYM[1](vluint32_t reset_period, bool active_high) {
-        static vluint32_t to_wait = reset_period;
-        static CData reset = active_high ? 1 : 0;
-        static bool finished = false;
-
-        if(!finished) {
-          if(to_wait == 0) {
-            reset = reset == 0 ? 1 : 0;
-            finished = true;
-          }
-          else {
-            to_wait = to_wait - 1;
-          }
-        }
-
-        return reset;
-      }
-      `verilog
-      `endif
       // pragma translate_on
       // resetGen end
     warning: Clash.Signal.Internal.resetGenN can not be synthesized to hardware!

--- a/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_Testbench.primitives.yaml
@@ -17,6 +17,9 @@
       always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[3]) begin
         if (~ARG[6] !== ~ARG[7]) begin
           $display("@%0tns: %s, expected: %b, actual: %b", $time, ~LIT[5], ~ARG[7], ~ARG[6]);
+          `ifdef VERILATOR
+            $c("std::exit(1);");
+          `endif
           $finish;
         end
       end
@@ -47,6 +50,9 @@
       always @(~IF~ACTIVEEDGE[Rising][0]~THENposedge~ELSEnegedge~FI ~ARG[2]) begin
         if (~SYM[1] !== ~SYM[2]) begin
           $display("@%0tns: %s, expected: %b, actual: %b", $time, ~LIT[4], ~ARG[6], ~ARG[5]);
+          `ifdef VERILATOR
+            $c("std::exit(1);");
+          `endif
           $finish;
         end
       end

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.primitives.yaml
@@ -101,10 +101,12 @@
       always begin
         // Delay of 1 mitigates race conditions (https://github.com/steveicarus/iverilog/issues/160)
         #1 ~SYM[0] = ~IF~ACTIVEEDGE[Rising][0]~THEN 0 ~ELSE 1 ~FI;
-        `ifndef VERILATOR
         #~LONGESTPERIOD0 forever begin
           ~IF~ISACTIVEENABLE[1]~THEN
           if (~ ~ARG[1]) begin
+            `ifdef VERILATOR
+              $c("std::exit(0);");
+            `endif
             $finish(0);
           end
           ~ELSE~FI
@@ -113,40 +115,7 @@
           ~SYM[0] = ~ ~SYM[0];
           #~SYM[1];
         end
-        `else
-        ~SYM[0] = $c("this->~GENSYM[tb_clock_gen][2](",~SYM[1],",~IF~ACTIVEEDGE[Rising][0]~THENtrue~ELSEfalse~FI,",(~ ~ARG[1]),")");
-        `endif
       end
-
-      `ifdef VERILATOR
-        `systemc_interface
-        CData ~SYM[2](vluint32_t half_period, bool active_rising, bool result_rec) {
-          static vluint32_t init_wait = ~LONGESTPERIOD0;
-          static vluint32_t to_wait = 0;
-          static CData clock = active_rising ? 0 : 1;
-
-          if(init_wait == 0) {
-            if(result_rec) {
-              std::exit(0);
-            }
-            else {
-              if(to_wait == 0) {
-                to_wait = half_period - 1;
-                clock = clock == 0 ? 1 : 0;
-              }
-              else {
-                to_wait = to_wait - 1;
-              }
-            }
-          }
-          else {
-            init_wait = init_wait - 1;
-          }
-
-          return clock;
-        }
-        `verilog
-      `endif
 
       assign ~RESULT = ~SYM[0];
       // pragma translate_on
@@ -173,6 +142,9 @@
         #~LONGESTPERIOD0 forever begin
           ~IF~ISACTIVEENABLE[2]~THEN
           if (~ ~ARG[2]) begin
+            `ifdef VERILATOR
+              $c("std::exit(0);");
+            `endif
             $finish(0);
           end
           ~ELSE~FI
@@ -201,38 +173,10 @@
       // pragma translate_off
       reg ~TYPO ~GENSYM[rst][0];
       localparam ~GENSYM[reset_period][1] = ~LONGESTPERIOD0 - 10 + (~LIT[2] * ~PERIOD[0]0);
-      `ifndef VERILATOR
       initial begin
         #1 ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 1 ~ELSE 0 ~FI;
         #~SYM[1] ~SYM[0] = ~IF ~ISACTIVEHIGH[0] ~THEN 0 ~ELSE 1 ~FI;
       end
-      `else
-      always begin
-        // The redundant (~SYM[0] | ~ ~SYM[0]) is needed to ensure that this is
-        // calculated in every cycle by verilator. Without it, the reset will stop
-        // being updated and will be stuck as asserted forever.
-        ~SYM[0] = $c("this->~GENSYM[reset_gen][2](",~SYM[1],",~IF~ISACTIVEHIGH[0]~THENtrue~ELSEfalse~FI)") & (~SYM[0] | ~ ~SYM[0]);
-      end
-      `systemc_interface
-      CData ~SYM[2](vluint32_t reset_period, bool active_high) {
-        static vluint32_t to_wait = reset_period;
-        static CData reset = active_high ? 1 : 0;
-        static bool finished = false;
-
-        if(!finished) {
-          if(to_wait == 0) {
-            reset = reset == 0 ? 1 : 0;
-            finished = true;
-          }
-          else {
-            to_wait = to_wait - 1;
-          }
-        }
-
-        return reset;
-      }
-      `verilog
-      `endif
       assign ~RESULT = ~SYM[0];
       // pragma translate_on
       // resetGen end

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -61,11 +61,6 @@ import           Data.Text.Lazy                   (Text)
 import qualified Data.Text.Lazy                   as Text
 import           Data.Text.Lazy.Encoding          as Text
 import qualified Data.Text.Lazy.IO                as Text
-#if MIN_VERSION_prettyprinter(1,7,0)
-import           Prettyprinter (pretty)
-#else
-import           Data.Text.Prettyprint.Doc (pretty)
-#endif
 import           Data.Text.Prettyprint.Doc.Extra
   (Doc, LayoutOptions (..), PageWidth (..) , layoutPretty, renderLazy)
 import qualified Data.Time.Clock                  as Clock
@@ -418,14 +413,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
           then writeEdam hdlDir (topNm, varUniq topEntity) deps edamFiles fileNames
           else pure (edamFiles, fileNames)
 
-      -- If we are generating (System)Verilog, we could potentially verilate
-      -- the results. Clash can output a C++ shim for doing this automatically.
-      fileNames2 <-
-        case hdlFromBackend (Proxy @backend) of
-          VHDL -> pure fileNames1
-          _ -> writeVerilatorShim hdlDir topNm fileNames1
-
-      writeManifest manPath manifest0{fileNames=fileNames2}
+      writeManifest manPath manifest0{fileNames=fileNames1}
 
       topTime <- Clock.getCurrentTime
       let topDiff = reportTimeDiff topTime prevTime
@@ -495,11 +483,6 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
           then writeEdam hdlDir (topNm, varUniq topEntity) deps edamFiles filesAndDigests0
           else pure (edamFiles, filesAndDigests0)
 
-      filesAndDigests2 <-
-        case hdlFromBackend (Proxy @backend) of
-          VHDL -> pure filesAndDigests1
-          _ -> writeVerilatorShim hdlDir topNm filesAndDigests1
-
       let
         depUniques = fromMaybe [] (HashMap.lookup (getUnique topEntity) deps)
         depBindings = mapMaybe (flip lookupVarEnvDirectly bindingsMap) depUniques
@@ -508,7 +491,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
         manifest =
           mkManifest
             hdlState' domainConfs opts topComponent components depIds
-            filesAndDigests2 topHash
+            filesAndDigests1 topHash
       writeManifest manPath manifest
 
       topTime <- hdlDocs `seq` Clock.getCurrentTime
@@ -813,48 +796,6 @@ createHDL backend opts modName seen components domainConfs top topName = flip ev
       (error $ $(curLoc) ++ "Unknown synthesis domain: " ++ show dom)
       dom
       domainConfs
-
-writeVerilatorShim
-  :: FilePath
-  -> Id.Identifier
-  -> [(FilePath, ByteString)]
-  -> IO [(FilePath, ByteString)]
-writeVerilatorShim hdlDir topNm filesAndDigests = do
-  let file = Data.Text.unpack (Id.toText topNm) <> "_shim" <.> "cpp"
-  digest <- writeHDL hdlDir (file, pprVerilatorShim topNm)
-  pure ((file, digest) : filesAndDigests)
-
--- | Create a shim for using verilator, which loads the entity and steps
--- through simulation until finished.
---
-pprVerilatorShim :: Id.Identifier -> Doc
-pprVerilatorShim (Id.toText -> topNm) =
-  -- Extra newlines are aggressively inserted so the quasiquoter doesn't wrap
-  -- the outlines lines in the file. It doesn't matter for code inside main,
-  -- but is fatal for the #include directives.
-  pretty $ Data.Text.pack [I.i|
-    \#include <cstdlib>
-
-    \#include <verilated.h>
-
-    \#include "V#{topNm}.h"
-
-    int main(int argc, char **argv) {
-      Verilated::commandArgs(argc, argv);
-
-      V#{topNm} *top = new V#{topNm};
-
-      while(!Verilated::gotFinish()) {
-        top->eval();
-      }
-
-      top->final();
-
-      delete top;
-
-      return EXIT_SUCCESS;
-    }
-  |]
 
 writeEdam ::
   FilePath ->

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -664,13 +664,23 @@ runClashTest = defaultMain $ clashTestRoot
                                                         , "testBenchUS"
                                                         ]}
           in runTest "DDRin" _opts
+
+          -- XXX: `ddrOut` contains a number of (implicit) parallel, coinciding
+          --      processes. Execution for these processes is left undefined in
+          --      the Verilog spec, nor is there a mechanism to get consistent
+          --      behavior (like in VHDL). Therefore, simulators are free to pick
+          --      any execution order they'd like. ModelSim and Verilator pick
+          --      differently, so when a test works in one, it doesn't in the
+          --      other. As a quick "fix" we disable Verilator, though we might
+          --      consider rewriting the test such that it doesn't depend or
+          --      accounts for the raciness.
         , let _opts = def{ buildTargets = BuildSpecific [ "testBenchUA"
                                                         , "testBenchUS"
                                                         , "testBenchGA"
                                                         , "testBenchGS"
                                                         ]
-                         , hdlLoad = hdlLoad def \\ [Vivado]
-                         , hdlSim = hdlSim def \\ [Vivado]
+                         , hdlLoad = hdlLoad def \\ [Vivado, Verilator]
+                         , hdlSim = hdlSim def \\ [Vivado, Verilator]
                          }
           in runTest "DDRout" _opts
         , let _opts = def{ buildTargets = BuildSpecific [ "testBenchUA"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -9,11 +9,13 @@ import           Clash.Annotations.Primitive (HDL(..))
 import qualified Data.Text                 as Text
 import           Data.Default              (def)
 import           Data.List                 ((\\), intercalate)
+import           Data.List.Extra           (trim)
 import           Data.Version              (versionBranch)
 import           System.Directory
-  (getCurrentDirectory, doesDirectoryExist, makeAbsolute)
+  (getCurrentDirectory, doesDirectoryExist, makeAbsolute, setCurrentDirectory)
 import           System.Environment
 import           System.Info
+import           System.Process            (readProcess)
 import           GHC.Conc                  (numCapabilities)
 import           GHC.Stack
 import           GHC.IO.Unsafe             (unsafePerformIO)
@@ -1195,6 +1197,8 @@ runClashTest = defaultMain $ clashTestRoot
 
 main :: IO ()
 main = do
+  projectRoot <- trim <$> readProcess "git" ["rev-parse", "--show-toplevel"] ""
+  setCurrentDirectory projectRoot
   setEnv "TASTY_NUM_THREADS" (show numCapabilities)
   setClashEnvs compiledWith
   runClashTest

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -151,7 +151,8 @@ executable clash-testsuite
 
   build-depends:
     containers,
-    clash-testsuite
+    clash-testsuite,
+    extra,
 
   if impl(ghc >= 9.0.0)
     build-depends:

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -379,7 +379,7 @@ verilatorTests opts@TestOptions{..} parentTmp =
     ]
   sim t =
     [ singleTest (simName t) $
-          VerilatorSimTest expectSimFail vvpStdoutNonEmptyFail (dir t) t
+          VerilatorSimTest expectSimFail False (dir t) t
     ]
 
 -- | Generate a test tree for running Vivado. Depending on 'hdlSim' it will be

--- a/tests/src/Test/Tasty/Verilator.hs
+++ b/tests/src/Test/Tasty/Verilator.hs
@@ -42,11 +42,6 @@ instance IsTest VerilatorMakeTest where
         dir <- vmDirectory
         libs <- listDirectory dir >>= filterM doesDirectoryExist . fmap (dir </>)
 
-        -- Only pass the sources for the shim and the entity to simulate. The other
-        -- modules will be found in the included directories. The path to the C++
-        -- shim MUST include the subdirectories below the working directory
-        -- explicitly.
-        cSrc <- glob (dir </> "*" </> vmTop <> "_shim.cpp")
         vSrc <- fmap takeFileName <$> glob (dir </> "*" </> vmTop <> ".v")
 
         -- Types modules have to be given first, or verilator will complain that
@@ -58,7 +53,7 @@ instance IsTest VerilatorMakeTest where
         -- Clash by default will not mix HDLs in it's output. If this ever changes,
         -- and it is possible to have `clash` output both Verilog and SystemVerilog
         -- then this will need to change.
-        runVerilator dir (mkArgs libs (cSrc <> vSrc <> svSrc))
+        runVerilator dir (mkArgs libs (vSrc <> svSrc))
 
     | otherwise =
         pure (testPassed "Ignoring test due to --no-verilator")
@@ -75,7 +70,7 @@ instance IsTest VerilatorMakeTest where
            , vmTop
            , "--cc"               -- Build for C++, not SystemC
            , "--build"            -- Build the verilated code immediately
-           , "--exe"              -- Create an executable instead of a library
+           , "--binary"           -- Create an binary to execute
            ]
         <> srcs
 


### PR DESCRIPTION
Verilator v5 implements its own (C++ co-routine based) scheduler, making it support delay statements. We can therefore remove all the Verilator specific code from our code base.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files