### PR TITLE
Add `Clash.Sized.Vector.ToTuple`

### DIFF
--- a/changelog/2024-02-27T20_43_27+01_00_add_vecToTuple
+++ b/changelog/2024-02-27T20_43_27+01_00_add_vecToTuple
@@ -1,0 +1,1 @@
+ADDED: Added `Clash.Sized.Vector.ToTuple.vecToTuple`: a way to safely work around @incomplete-uni-patterns@ warnings produced by GHC 9.2 and up, or @incomplete-patterns@ warnings on all GHC versions.

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -285,6 +285,8 @@ Library
                       Clash.Sized.Signed
                       Clash.Sized.Unsigned
                       Clash.Sized.Vector
+                      Clash.Sized.Vector.ToTuple
+                      Clash.Sized.Vector.ToTuple.TH
 
                       Clash.Sized.Internal.BitVector
                       Clash.Sized.Internal.Index
@@ -353,6 +355,7 @@ Library
                       reflection                >= 2       && < 2.2,
                       singletons                >= 2.0     && < 3.1,
                       string-interpolate        ^>= 0.3,
+                      tagged                    >= 0.8     && < 0.9,
                       template-haskell          >= 2.12.0.0 && < 2.22,
                       th-abstraction            >= 0.2.10 && < 0.7.0,
                       th-lift                   >= 0.7.0    && < 0.9,

--- a/clash-prelude/src/Clash/Sized/Vector/ToTuple.hs
+++ b/clash-prelude/src/Clash/Sized/Vector/ToTuple.hs
@@ -1,0 +1,98 @@
+{-|
+Copyright  :  (C) 2024, Google LLC
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Tooling to safely work around @incomplete-uni-patterns@ warnings produced by GHC
+9.2 and up, or @incomplete-patterns@ warnings on all GHC versions. See 'vecToTuple'
+for more information and examples.
+-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+
+-- Purpose of this module
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+-- For debugging:
+-- {-# OPTIONS_GHC -ddump-splices #-}
+
+module Clash.Sized.Vector.ToTuple (VecToTuple(..)) where
+
+import Clash.CPP
+import Clash.Sized.Vector
+import Clash.Sized.Vector.ToTuple.TH (vecToTupleInstances)
+
+import Data.Tagged (Tagged(..))
+
+#if MIN_VERSION_base(4,18,0)
+import Data.Tuple (Solo(MkSolo))
+#elif MIN_VERSION_base(4,16,0)
+import Data.Tuple (Solo(Solo))
+#endif
+
+{- $setup
+>>> :set -XMonoLocalBinds -XGADTs
+>>> import Clash.Sized.Vector
+-}
+
+class VecToTuple a where
+  type TupType a = r | r -> a
+
+  -- | Given a vector with three elements:
+  --
+  -- >>> myVec = (1 :> 2 :> 3 :> Nil) :: Vec 3 Int
+  --
+  -- The following would produce a warning even though we can be sure
+  -- no other pattern can ever apply:
+  --
+  -- >>> (a :> b :> c :> Nil) = myVec
+  --
+  -- 'vecToTuple' can be used to work around the warning:
+  --
+  -- >>> (a, b, c) = vecToTuple myVec
+  --
+  -- Of course, you will still get an error if you try to match a vector of the
+  -- wrong length:
+  --
+  -- >>> (a, b, c, d) = vecToTuple myVec
+  -- ...
+#if __GLASGOW_HASKELL__ > 900
+  --     • Couldn't match type: (a, b, c, d)
+  --                      with: (Int, Int, Int)
+#else
+  --     • Couldn't match type: (Int, Int, Int)
+  --                             ^
+  --                      with: (a, b, c, d)
+#endif
+  -- ...
+  --
+  vecToTuple ::  a -> TupType a
+
+instance VecToTuple (Vec 0 a) where
+  type TupType (Vec 0 a) = Tagged a ()
+  vecToTuple _ = Tagged ()
+
+#if MIN_VERSION_base(4,18,0)
+-- | Instead of using 'vecToTuple' for @Vec 1 _@, you could also consider using 'head'
+instance VecToTuple (Vec 1 a) where
+  type TupType (Vec 1 a) = Solo a
+  vecToTuple (a1 :> _) = MkSolo a1
+#elif MIN_VERSION_base(4,16,0)
+-- | Instead of using 'vecToTuple' for @Vec 1 _@, you could also consider using 'head'
+instance VecToTuple (Vec 1 a) where
+  type TupType (Vec 1 a) = Solo a
+  vecToTuple (a1 :> _) = Solo a1
+#endif
+
+-- | __NB__: The documentation only shows instances up to /3/-tuples. By
+-- default, instances up to and including /12/-tuples will exist. If the flag
+-- @large-tuples@ is set instances up to the GHC imposed limit will exist. The
+-- GHC imposed limit is either 62 or 64 depending on the GHC version.
+instance VecToTuple (Vec 2 a) where
+  type TupType (Vec 2 a) = (a, a)
+  vecToTuple (a1 :> a2 :> _) = (a1, a2)
+
+vecToTupleInstances maxTupleSize

--- a/clash-prelude/src/Clash/Sized/Vector/ToTuple/TH.hs
+++ b/clash-prelude/src/Clash/Sized/Vector/ToTuple/TH.hs
@@ -1,0 +1,50 @@
+{-# OPTIONS_HADDOCK hide #-}
+
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Clash.Sized.Vector.ToTuple.TH (vecToTupleInstance, vecToTupleInstances) where
+
+import Clash.Sized.Vector (Vec((:>)))
+import Language.Haskell.TH
+
+appTs :: Q Type -> [Q Type] -> Q Type
+appTs = foldl appT
+
+appPsInfix :: Name -> [Q Pat] -> Q Pat
+appPsInfix f = foldl1 (\l r -> uInfixP l f r)
+
+tupT :: [Q Type] -> Q Type
+tupT tyArgs = tupleT (length tyArgs) `appTs` tyArgs
+
+vecToTupleInstances :: Integer -> Q [Dec]
+vecToTupleInstances n = mapM vecToTupleInstance [3..n]
+
+vecToTupleInstance :: Integer -> Q Dec
+vecToTupleInstance n =
+  instanceD
+    -- No superclasses
+    (pure [])
+
+    -- Head
+    (vecToTupleCon `appT` vecType)
+
+    -- Implementation
+    [ tySynInstD (tySynEqn Nothing aTypeLhs aTypeRhs)
+    , funD vecToTupleFunName [clause [vecToTuplePat] (normalB vecToTupleImpl) []]
+    ]
+
+ where
+  vecToTupleCon = conT (mkName "VecToTuple")
+  vecType = conT ''Vec `appT` litT (numTyLit n) `appT` varT (mkName "a")
+
+  -- associated type
+  tupTypeCon = conT (mkName "TupType")
+  aTypeLhs = tupTypeCon `appT` vecType
+  aTypeRhs = tupT [varT (mkName "a") | _ <- [1..n]]
+
+  -- vecToTuple
+  vecToTupleFunName = mkName "vecToTuple"
+  vecToTuplePat = appPsInfix '(:>) (map varP varNames ++ [wildP])
+  vecToTupleImpl = tupE (map varE varNames)
+
+  varNames = map (mkName . ('a':) . show) [1..n]


### PR DESCRIPTION
Newer GHCs (mistakenly) emit warnings when pattern matching on `Vec`s, with neither `:>` nor `Cons` being able to prevent it. `vecToTuple` allows users to convert `Vec`s to tuples, sidestepping GHCs exhaustiveness checker while not compromising on safety.

Nested tuples were considered as an alternative implementation, simplifying implementation and removing the need for `TemplateHaskell`. This would, however, compromise on user comfort while offering no expected real-world benefits.

-------------------

This is clearly a work around. Perhaps we should write a GHC plugin to circumvent these warnings (and depending on the solution upstream)?

## Documentation
![Screenshot 2024-02-28 at 09-17-26 Clash Sized Vector ToTuple](https://github.com/clash-lang/clash-compiler/assets/5658854/14add7f8-a33e-40c6-9437-4c7b41f9fc64)



## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
