### PR TITLE
Add boundary proofs to `dfold` and `smap`

### DIFF
--- a/changelog/2024-04-08T06_51_45+00_00_smap_with_bounds
+++ b/changelog/2024-04-08T06_51_45+00_00_smap_with_bounds
@@ -1,0 +1,2 @@
+CHANGED: `dfold` now offers a proof witness for the upper bound of the vector size to the folding function. Note that this change may require additional type annotations, as solutions working in the past may complain with an untouchable type error now.
+ADDED: `smapWithBounds` extending `smap` via offering a proof witness for the upper bound of the vector size to the mapping function.

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -65,7 +65,7 @@ module Clash.Sized.Vector
   , rotateLeft, rotateRight, rotateLeftS, rotateRightS
     -- * Element-wise operations
     -- ** Mapping
-  , map, imap, smap
+  , map, imap, smap, smapWithBounds
     -- ** Zipping
   , zipWith, zipWith3, zipWith4, zipWith5, zipWith6, zipWith7
   , zip, zip3, zip4, zip5, zip6, zip7
@@ -2304,7 +2304,10 @@ lazyV = lazyV' (repeat ())
 -- >>> import Data.Singletons (Apply, Proxy (..), TyFun)
 -- >>> data Append (m :: Nat) (a :: Type) (f :: TyFun Nat Type) :: Type
 -- >>> type instance Apply (Append m a) l = Vec (l + m) a
--- >>> let append' xs ys = dfold (Proxy :: Proxy (Append m a)) (const (:>)) ys xs
+-- >>> :{
+-- >>> append' :: forall a k m. KnownNat k => Vec k a -> Vec m a -> Vec (k + m) a
+-- >>> append' xs ys = dfold (Proxy :: Proxy (Append m a)) (const ((:>) @a)) ys xs
+-- >>> :}
 --
 -- === Example usage
 --
@@ -2382,7 +2385,7 @@ lazyV = lazyV' (repeat ())
 -- fold that produces a structure with a depth of O(log_2(@'length' xs@)).
 dfold :: forall p k a . KnownNat k
       => Proxy (p :: TyFun Nat Type -> Type) -- ^ The /motive/
-      -> (forall l . SNat l -> a -> (p @@ l) -> (p @@ (l + 1)))
+      -> (forall n . n + 1 <= k => SNat n -> a -> (p @@ n) -> (p @@ (n + 1)))
       -- ^ Function to fold.
       --
       -- __NB__: The @SNat l@ is __not__ the index (see (`!!`)) to the
@@ -2393,7 +2396,7 @@ dfold :: forall p k a . KnownNat k
       -> (p @@ k)
 dfold _ f z xs = go (snatProxy (asNatProxy xs)) xs
   where
-    go :: SNat n -> Vec n a -> (p @@ n)
+    go :: n <= k => SNat n -> Vec n a -> (p @@ n)
     go _ Nil                        = z
     go s (y `Cons` ys) =
       let s' = s `subSNat` d1
@@ -2562,7 +2565,7 @@ __NB__: The depth, or delay, of the structure produced by
 dtfold :: forall p k a . KnownNat k
        => Proxy (p :: TyFun Nat Type -> Type) -- ^ The /motive/
        -> (a -> (p @@ 0)) -- ^ Function to apply to every element
-       -> (forall l . SNat l -> (p @@ l) -> (p @@ l) -> (p @@ (l + 1)))
+       -> (forall n . SNat n -> (p @@ n) -> (p @@ n) -> (p @@ (n + 1)))
        -- ^ Function to combine results.
        --
        -- __NB__: The @SNat l@ indicates the depth/height of the node in the
@@ -2621,7 +2624,7 @@ type instance Apply (VCons a) l = Vec l a
 --
 -- <<doc/csSort.svg>>
 vfold :: forall k a b . KnownNat k
-      => (forall l . SNat l -> a -> Vec l b -> Vec (l + 1) b)
+      => (forall n . SNat n -> a -> Vec n b -> Vec (n + 1) b)
       -> Vec k a
       -> Vec k b
 vfold f xs = dfold (Proxy @(VCons b)) f Nil xs
@@ -2650,12 +2653,28 @@ minimum = fold (\x y -> if x <= y then x else y)
 -- (1 :> 2 :> 3 :> Nil) :> (1 :> 2 :> 3 :> Nil) :> (1 :> 2 :> 3 :> Nil) :> Nil
 -- >>> rotateMatrix xss
 -- (1 :> 2 :> 3 :> Nil) :> (3 :> 1 :> 2 :> Nil) :> (2 :> 3 :> 1 :> Nil) :> Nil
-smap :: forall k a b . KnownNat k => (forall l . SNat l -> a -> b) -> Vec k a -> Vec k b
+smap :: forall k a b . KnownNat k => (forall n . SNat n -> a -> b) -> Vec k a -> Vec k b
 smap f xs = reverse
           $ dfold (Proxy @(VCons b))
                   (\sn x xs' -> f sn x :> xs')
                   Nil (reverse xs)
 {-# INLINE smap #-}
+
+-- | Extended version of 'smap' offering an additional boundary proof to
+-- the mapped function. Note that the type checker may need additional type
+-- annotations to resolve type ambiguity for this. Thus, if the boundary constraint
+-- is not needed it is recommended to stay with 'smap' instead.
+smapWithBounds ::
+  forall k a b .
+  KnownNat k =>
+  (forall n . n + 1 <= k => SNat n -> a -> b) ->
+  Vec k a ->
+  Vec k b
+smapWithBounds f xs = reverse
+                    $ dfold (Proxy @(VCons b))
+                            (\sn x xs' -> f sn x :> xs')
+                            Nil (reverse xs)
+{-# INLINE smapWithBounds #-}
 
 instance (KnownNat n, BitPack a) => BitPack (Vec n a) where
   type BitSize (Vec n a) = n * (BitSize a)

--- a/tests/shouldwork/Vector/DFold.hs
+++ b/tests/shouldwork/Vector/DFold.hs
@@ -11,7 +11,8 @@ import Data.Kind (Type)
 data Append (m :: Nat) (a :: Type) (f :: TyFun Nat Type) :: Type
 type instance Apply (Append m a) l = Vec (l + m) a
 
-append' xs ys = dfold (Proxy :: Proxy (Append m a)) (const (:>)) ys xs
+append' :: forall a k m. KnownNat k => Vec k a -> Vec m a -> Vec (k + m) a
+append' xs ys = dfold (Proxy :: Proxy (Append m a)) (const ((:>) @a)) ys xs
 
 topEntity :: (Vec 3 Int,Vec 7 Int) -> Vec 10 Int
 topEntity = uncurry append'


### PR DESCRIPTION
The PR extends `dfold` with a boundary proof for the folded function and introduces `smapWithBounds` offering a boundary proof as well. `smapWithBounds` is introduced in addition to `smap`, as the served proof may lead to `untouchable` errors requiring additional type annotations. While this is fine for `dfold`, which requires advanced knowledge of the type system for usage anyway, `smap` should stay intuitive for beginners, which is why we introduce an additional version instead.

The PR also renames typenat variables `l` (_small letter `L`_) to `n` to make them better distinguishable from the constant `1`.