### PR TITLE
Don't run CI on Windows with GHC 9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
           - os: windows
             ghc: 9.0
 
+          # GHC/Clash starts extremely slowly, see
+          # https://github.com/clash-lang/clash-compiler/issues/2684
+          - os: windows
+            ghc: 9.6
+
     steps:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ Note that release branches might contain non-released patches.
 | 9.0  | ✔️     | ✔️²      | ✔️     | 1.4 - 1.8        | ✔️
 | 9.2  | ⚠️¹    | ⚠️¹      | ⚠️¹    | 1.8              | ⚠️¹️
 | 9.4  | ✔️     | ✔️       | ✔️     | 1.8              | ✔️
-| 9.6  | ✔️     | ✔️       | ✔️     | 1.8              | ✔️
+| 9.6  | ✔️     | ✔️³      | ✔️     | 1.8              | ✔️
 
 ¹ GHC 9.2 contains a regression, rendering Clash error messages indecipherable. This change was reverted in 9.4.
 
 ² GHC 9.0.2 on Windows fails to compile `clash-cores`. We therefore don't run the Clash testsuite on CI for this combination.
+
+³ Clash starts extremely slowly when compiled with 9.6 on Windows. See [#2684](https://github.com/clash-lang/clash-compiler/issues/2684).
 
 ## Cabal
 To use Cabal you need both Cabal and GHC installed on your system. We recommend using [ghcup](https://www.haskell.org/ghcup/). For more information, see [https://www.haskell.org/downloads/](https://www.haskell.org/downloads/).


### PR DESCRIPTION
https://github.com/clash-lang/clash-compiler/issues/2684

Seems like a waste of time/energy.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~
