### PR TITLE
Implement `ensureSpine` for `BitVector n` as `pack`

### DIFF
--- a/changelog/2024-04-08T16_44_03+02_00_bitvector_add_ensurespine
+++ b/changelog/2024-04-08T16_44_03+02_00_bitvector_add_ensurespine
@@ -1,0 +1,1 @@
+CHANGED: `BitVector n` now has an implementation for `ensureSpine` which ensures the constructor is present.

--- a/changelog/2024-04-08T17_33_38+02_00_move_xToBV
+++ b/changelog/2024-04-08T17_33_38+02_00_move_xToBV
@@ -1,0 +1,1 @@
+CHANGED: `xToBV` is now located in `Clash.Sized.Internal.BitVector` to avoid circular dependencies.

--- a/clash-cores/clash-cores.cabal
+++ b/clash-cores/clash-cores.cabal
@@ -158,6 +158,9 @@ library
     Clash.Cores.Xilinx.Xpm.Cdc.Single
     Clash.Cores.Xilinx.Xpm.Cdc.SyncRst
 
+  other-modules:
+    Data.Text.Extra
+
   ghc-options:
     -fexpose-all-unfoldings
     -fno-worker-wrapper

--- a/clash-cores/src/Data/Text/Extra.hs
+++ b/clash-cores/src/Data/Text/Extra.hs
@@ -1,0 +1,14 @@
+module Data.Text.Extra
+  ( showt
+  , showtl
+  ) where
+
+import Prelude
+import qualified Data.Text as TS
+import qualified Data.Text.Lazy as TL
+
+showt :: (Show a) => a -> TS.Text
+showt = TS.pack . show
+
+showtl :: (Show a) => a -> TL.Text
+showtl = TL.pack . show

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -237,6 +237,7 @@ library
                       Clash.GHC.GHC2Core
                       Clash.GHC.LoadInterfaceFiles
                       Clash.GHC.Util
+                      Data.Text.Extra
                       Paths_clash_ghc
   if impl(ghc >= 8.8.0)
     Other-Modules:    Clash.GHCi.Util

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -43,6 +43,7 @@ import           Data.Proxy          (Proxy)
 import           Data.Reflection     (reifyNat)
 import           Data.Text           (Text)
 import qualified Data.Text           as Text
+import           Data.Text.Extra     (showt)
 import           GHC.Exts (IsList(..))
 import           GHC.Float
 import           GHC.Int
@@ -202,7 +203,7 @@ ghcPrimUnwind tcm p tys vs v [e] m0
                        , "Clash.Sized.Vector.replace_int"
                        , "GHC.Classes.&&"
                        , "GHC.Classes.||"
-                       , "Clash.Class.BitPack.Internal.xToBV"
+                       , showt 'BitVector.xToBV
                        , "Clash.Sized.Vector.imap_go"
                        ]
   = if isUndefinedPrimVal v then
@@ -2444,7 +2445,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
            val = unpack (toBV i :: BitVector 64)
         in reduce (mkDoubleCLit tcm val resTy)
 
-  "Clash.Class.BitPack.Internal.xToBV"
+  "Clash.Sized.Internal.BitVector.xToBV"
     | isSubj
     , Just (nTy, kn) <- extractKnownNat tcm tys
     -- The second argument to `xToBV` is always going to be suspended.

--- a/clash-ghc/src-ghc/Data/Text/Extra.hs
+++ b/clash-ghc/src-ghc/Data/Text/Extra.hs
@@ -1,0 +1,14 @@
+module Data.Text.Extra
+  ( showt
+  , showtl
+  ) where
+
+import Prelude
+import qualified Data.Text as TS
+import qualified Data.Text.Lazy as TL
+
+showt :: (Show a) => a -> TS.Text
+showt = TS.pack . show
+
+showtl :: (Show a) => a -> TL.Text
+showtl = TL.pack . show

--- a/clash-lib/prims/common/Clash_Class_BitPack.primitives.yaml
+++ b/clash-lib/prims/common/Clash_Class_BitPack.primitives.yaml
@@ -27,7 +27,7 @@
     template: ~ARG[0]
     workInfo: Never
 - BlackBox:
-    name: Clash.Class.BitPack.Internal.xToBV
+    name: Clash.Sized.Internal.BitVector.xToBV
     kind: Expression
     type: 'xToBV :: KnownNat n => BitVector n -> BitVector n'
     template: ~ARG[1]

--- a/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2022, Google Inc.,
-                    2021-2022, QBayLogic B.V.
+                    2021-2024, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -14,6 +14,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -48,7 +49,7 @@ import GHC.Stack (HasCallStack)
 import GHC.BasicTypes.Extra (isNoInline)
 
 import qualified Clash.Explicit.SimIO as SimIO
-import qualified Clash.Sized.Internal.BitVector as BV (Bit(Bit), BitVector(BV))
+import qualified Clash.Sized.Internal.BitVector as BV (Bit(Bit), BitVector(BV), xToBV)
 
 import Clash.Annotations.Primitive (extractPrim)
 import Clash.Core.DataCon (DataCon(..))
@@ -438,7 +439,8 @@ collapseRHSNoops _ (Letrec binds body) = do
     isNoopApp x (Prim PrimInfo{primWorkInfo=WorkIdentity i []},args) = do
       arg <- getTermArg (lefts args) i
       isNoopApp x (collectArgs arg)
-    isNoopApp x (Prim PrimInfo{primName="Clash.Class.BitPack.Internal.xToBV"},args) = do
+    isNoopApp x (Prim PrimInfo{primName},args)
+      | primName == Text.showt 'BV.xToBV = do
       -- We don't make 'xToBV' something of 'WorkIdentity 1 []' because we don't
       -- want 'getIdentity' to replace "naked" occurances of 'xToBV' by
       -- 'unsafeCoerce#'. We don't want that since 'xToBV' has a special evaluator

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -509,6 +509,7 @@ instance KnownNat n => NFDataX (BitVector n) where
   deepErrorX _ = undefined#
   rnfX = rwhnfX
   hasUndefined bv = isLeft (isX bv) || unsafeMask bv /= 0
+  ensureSpine = xToBV -- Converts `XException` to 'undefined#'
 
 -- | Create a binary literal
 --


### PR DESCRIPTION
This enables us to deal with undefined BitVectors using the currently derived `ensureSpine`.

To satisfy `ensureSpine (errorX "Undefined BitVector") == deepErrorX "Undefined BitVector"` 
