### PR TITLE
Fix out-of-bounds natural generation of `genBitVector`

### DIFF
--- a/changelog/2024-04-08T16_56_08+02_00_fix_genBitVector
+++ b/changelog/2024-04-08T16_56_08+02_00_fix_genBitVector
@@ -1,0 +1,1 @@
+FIXED: `genBitVector` no longer contains off-by-one error on for generated Naturals

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/BitVector.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/BitVector.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2021-2022, QBayLogic B.V.
+Copyright   : (C) 2021-2024, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -68,7 +68,7 @@ genBitVector =
     , (10, Gen.constant undefined#)
     ]
  where
-  genNatural = Gen.integral $ constant 0 (2^natToNatural @n)
+  genNatural = Gen.integral $ constant 0 (2^natToNatural @n - 1)
 
 data SomeBitVector atLeast where
   SomeBitVector :: SNat n -> BitVector (atLeast + n) -> SomeBitVector atLeast


### PR DESCRIPTION
`genBitVector` currently generates Natural numbers outside of the `BitVector`'s range.


  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
