### PR TITLE
 Detect and throw error on "broken" GHCs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ Note that release branches might contain non-released patches.
 |      | Linux | Windows | macOS | Clash (released) | Clash (development version)
 |------|-------|---------|-------|------------------|--------------------------
 | 8.6  | ✔️     | ✔️       | ✔️     | 1.0 - 1.8        | ❌
-| 8.8  | ✔️     | ❌      | ✔️     | 1.0 - 1.8        | ❌
-| 8.10 | ✔️     | ✔️       | ❌    | 1.2 - 1.8        | ✔️
+| 8.8  | ✔️     | ❌       | ✔️     | 1.0 - 1.8        | ❌
+| 8.10 | ✔️     | ✔️       | ❌     | 1.2 - 1.8        | ✔️
 | 9.0  | ✔️     | ✔️²      | ✔️     | 1.4 - 1.8        | ✔️
 | 9.2  | ⚠️¹    | ⚠️¹      | ⚠️¹    | 1.8              | ⚠️¹️
-| 9.4  | ✔️     | ✔️       | ✔️     | 1.8              | ✔️
-| 9.6  | ✔️     | ✔️³      | ✔️     | 1.8              | ✔️
+| 9.4  | ⚠️³ ️   | ⚠️³      | ️⚠️³ ️   | 1.8              | ✔️
+| 9.6  | ✔️³    | ✔️³      | ✔️³    | 1.8              | ✔️
 
 ¹ GHC 9.2 contains a regression, rendering Clash error messages indecipherable. This change was reverted in 9.4.
 
-² GHC 9.0.2 on Windows fails to compile `clash-cores`. We therefore don't run the Clash testsuite on CI for this combination.
+² GHC 9.0.2 on Windows fails to compile `clash-cores`. We therefore don't run the Clash test suite on CI for this combination.
 
-³ Clash starts extremely slowly when compiled with 9.6 on Windows. See [#2684](https://github.com/clash-lang/clash-compiler/issues/2684).
+³ Clash starts extremely slowly when compiled with 9.4.8 up to and including 9.6.2. Consider downgrading to 9.4.7 or upgrading to 9.6.3 and up.
 
 ## Cabal
 To use Cabal you need both Cabal and GHC installed on your system. We recommend using [ghcup](https://www.haskell.org/ghcup/). For more information, see [https://www.haskell.org/downloads/](https://www.haskell.org/downloads/).

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -95,6 +95,7 @@ flagsClash r = [
   , defFlag "fclash-edalize"                     $ NoArg (liftEwM (setEdalize r))
   , defFlag "fclash-no-render-enums"             $ NoArg (liftEwM (setNoRenderEnums r))
   , defFlag "fclash-timescale-precision"         $ SepArg (setTimescalePrecision r)
+  , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
   ]
 
 -- | Print deprecated flag warning
@@ -308,6 +309,9 @@ setNoEscapedIds r = modifyIORef r (\c -> c {opt_escapedIds = False})
 
 setLowerCaseBasicIds :: IORef ClashOpts -> IO ()
 setLowerCaseBasicIds r = modifyIORef r (\c -> c {opt_lowerCaseBasicIds = ToLower})
+
+setIgnoreBrokenGhcs :: IORef ClashOpts -> IO ()
+setIgnoreBrokenGhcs r = modifyIORef r (\c -> c {opt_ignoreBrokenGhcs = True})
 
 setUltra :: IORef ClashOpts -> IO ()
 setUltra r = modifyIORef r (\c -> c {opt_ultra = True})

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -164,6 +164,7 @@ Library
                       extra                   >= 1.6.17   && < 1.8,
                       filepath                >= 1.3.0.1  && < 1.6,
                       ghc                     >= 8.10.0   && < 9.9,
+                      ghc-boot,
                       ghc-boot-th,
                       ghc-prim,
                       hashable                >= 1.2.1.0  && < 1.6,
@@ -240,6 +241,7 @@ Library
                       Clash.Debug
 
                       Clash.Driver
+                      Clash.Driver.BrokenGhcs
                       Clash.Driver.Manifest
                       Clash.Driver.Types
 

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -116,6 +116,7 @@ import           Clash.Core.Var
 import           Clash.Core.VarEnv
   (elemVarEnv, emptyVarEnv, lookupVarEnv, lookupVarEnv', mkVarEnv, lookupVarEnvDirectly, eltsVarEnv, VarEnv)
 import           Clash.Debug                      (debugIsOn)
+import qualified Clash.Driver.BrokenGhcs          as BrokenGhcs
 import           Clash.Driver.Types
 import           Clash.Driver.Manifest
   (Manifest(..), readFreshManifest, UnexpectedModification, pprintUnexpectedModifications,
@@ -323,6 +324,9 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
     let tcm = envTyConMap env
     let topEntities0 = designEntities design
     let opts = envOpts env
+
+    -- Detect "broken" GHCs and throw an error (unless silenced)
+    unless (opt_ignoreBrokenGhcs opts) BrokenGhcs.assertWorking
 
     removeHistoryFile (dbg_historyFile (opt_debug opts))
 

--- a/clash-lib/src/Clash/Driver/BrokenGhcs.hs
+++ b/clash-lib/src/Clash/Driver/BrokenGhcs.hs
@@ -1,0 +1,161 @@
+{-|
+Copyright   :  (C) 2024, Martijn Bastiaan
+License     :  BSD2 (see the file LICENSE)
+Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Utilities to detect and report GHC / operating system combinations that are
+known to be buggy.
+-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Clash.Driver.BrokenGhcs where
+
+import Data.Maybe (listToMaybe)
+import Data.Version (Version(Version, versionBranch))
+import GHC.Platform (OS(..))
+
+#if __GLASGOW_HASKELL__ > 810
+import System.Info (fullCompilerVersion)
+#endif
+
+import qualified Clash.Util.Interpolate as I
+import qualified System.Info
+
+#if __GLASGOW_HASKELL__ <= 810
+fullCompilerVersion :: Version
+fullCompilerVersion = System.Info.compilerVersion
+#endif
+
+-- | Current OS. Currently only recognizes Linux, Windows, and macOS.
+os :: OS
+os = case System.Info.os of
+  "darwin" -> OSDarwin
+  "linux" -> OSLinux
+  "mingw32" -> OSMinGW32
+  _ -> OSUnknown
+
+-- | What OS GHC is broken on (or all)
+data BrokenOn = All | SomeOs OS
+
+data GhcVersion = Ghc
+  { major0 :: Int
+  , major1 :: Int
+  , patch :: Int
+  }
+  deriving (Eq, Ord)
+
+data GhcRange = GhcRange
+  { from :: GhcVersion
+  -- ^ Start of range, inclusive
+  , to :: GhcVersion
+  -- ^ End of range, exclusive
+  }
+
+-- | Check if a 'GhcVersion' is within a 'GhcRange'
+ghcInRange :: GhcVersion -> GhcRange -> Bool
+ghcInRange ghc GhcRange{from, to} = from <= ghc && ghc < to
+
+-- | Construct a range of all GHC versions matching a major version
+ghcMajor :: Int -> Int -> GhcRange
+ghcMajor major0 major1 = GhcRange
+  { from=Ghc major0 major1 0
+  , to=Ghc major0 (major1 + 1) 0
+  }
+
+data Why = Why
+  { what :: String
+    -- ^ What is broken
+  , solution :: String
+    -- ^ What can be done to work around or solve the issue
+  , issue :: String
+    -- ^ Link to issue
+  , brokenOn :: [(BrokenOn, GhcRange)]
+    -- ^ What operation systems are affected
+  }
+
+-- | Get current GHC version expressed as a triple. It probably does something
+-- non-sensible on unreleased GHCs.
+ghcVersion :: GhcVersion
+ghcVersion = Ghc{major0, major1, patch}
+ where
+  (major0, major1, patch) =
+    case fullCompilerVersion of
+      Version{versionBranch} ->
+        case versionBranch of
+          [] -> (0, 0, 1)
+          [a] -> (a, 0, 1)
+          [a, b] -> (a, b, 1)
+          [a, b, c] -> (a, b, c)
+          (a:b:c:_) -> (a, b, c)
+
+-- | Pretty print 'Why' into an error message
+whyPp :: Why -> String
+whyPp Why{what, solution, issue}= [I.i|
+  Clash has known issues on #{major0}.#{major1}.#{patch} on your current
+  OS. While not completely preventing the compiler from working, we recommend
+  switching to another GHC version. Symptoms:
+
+    #{what}
+
+  Consider the following work around or solution:
+
+    #{solution}
+
+  More information can be found at:
+
+    #{issue}
+
+  If you want to ignore this message, pass the following flag to Clash:
+
+    -fclash-ignore-broken-ghcs
+  |]
+ where
+  Ghc{major0, major1, patch} = ghcVersion
+
+-- | Which GHCs are broken and why
+brokenGhcs :: [Why]
+brokenGhcs = [brokenClashCores, brokenTypeErrors, slowStarts]
+ where
+  brokenClashCores = Why
+    { what = "GHC is known to fail compilation of libraries used by the Clash compiler test suite"
+    , solution = "Upgrade to GHC 9.4 or downgrade to GHC 8.10"
+    , issue = "<no link>"
+    , brokenOn = [(SomeOs OSMinGW32, ghcMajor 9 0)]
+    }
+
+  brokenTypeErrors = Why
+    { what = "Clash type error messages are indecipherable"
+    , solution = "Upgrade to GHC 9.4 or downgrade to GHC 9.0"
+    , issue = "<no link>"
+    , brokenOn = [(All, ghcMajor 9 2)]
+    }
+
+  slowStarts = Why
+    { what = "Clash starts really slowly from GHC 9.4.8 up to and including 9.6.2"
+    , solution = "Upgrade to GHC 9.6.3 or newer, or downgrade to GHC 9.4.7"
+    , issue = "https://github.com/clash-lang/clash-compiler/issues/2710"
+    , brokenOn = [(All, GhcRange{from=Ghc 9 4 8, to=Ghc 9 6 3})]
+    }
+
+-- | Given a 'BrokenOn', determine whether current OS matches
+matchOs :: BrokenOn -> Bool
+matchOs All = True
+matchOs (SomeOs brokenOs) = os == brokenOs
+
+-- | Given a 'BrokenOn' and 'GhcVersion', determine whether it matches current OS and GHC
+matchBroken :: (BrokenOn, GhcRange) -> Bool
+matchBroken (brokenOs, brokenRange) = matchOs brokenOs && ghcInRange ghcVersion brokenRange
+
+-- | Get first reason for GHC/OS being broken, if any
+broken :: Maybe Why
+broken = listToMaybe [why | why <- brokenGhcs, any matchBroken (brokenOn why)]
+
+-- | Throw an error if current OS / GHC version is known to be buggy
+assertWorking :: IO ()
+assertWorking = case broken of
+  Nothing -> pure ()
+  Just why -> error (whyPp why)

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -411,11 +411,12 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
       -- 2. Caching
     , opt_cachehdl = True
 
-      -- 3. Warnings
+      -- 3. Warnings / errors
     , opt_primWarn = True
     , opt_color = Auto
     , opt_errorExtra = False
     , opt_checkIDir = True
+    , opt_ignoreBrokenGhcs = False
 
       -- 4. Optional output
     , opt_edalize = False

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -400,6 +400,9 @@ data ClashOpts = ClashOpts
   , opt_timescalePrecision :: Period
   -- ^ Timescale precision set in Verilog files. E.g., setting this would sets
   -- the second part of @`timescale 100fs/100fs@.
+  , opt_ignoreBrokenGhcs :: Bool
+  -- ^ Don't error if we see a (potentially) broken GHC / platform combination.
+  -- See the project's @README.md@ for more information.
   }
   deriving (Show)
 
@@ -433,6 +436,7 @@ instance NFData ClashOpts where
     opt_edalize o `deepseq`
     opt_renderEnums o `deepseq`
     opt_timescalePrecision o `deepseq`
+    opt_ignoreBrokenGhcs o `deepseq`
     ()
 
 instance Eq ClashOpts where
@@ -464,7 +468,8 @@ instance Eq ClashOpts where
     opt_inlineWFCacheLimit s0 == opt_inlineWFCacheLimit s1 &&
     opt_edalize s0 == opt_edalize s1 &&
     opt_renderEnums s0 == opt_renderEnums s1 &&
-    opt_timescalePrecision s0 == opt_timescalePrecision s1
+    opt_timescalePrecision s0 == opt_timescalePrecision s1 &&
+    opt_ignoreBrokenGhcs s0 == opt_ignoreBrokenGhcs s1
 
    where
     eqOverridingBool :: OverridingBool -> OverridingBool -> Bool
@@ -503,7 +508,8 @@ instance Hashable ClashOpts where
     opt_inlineWFCacheLimit `hashWithSalt`
     opt_edalize `hashWithSalt`
     opt_renderEnums `hashWithSalt`
-    opt_timescalePrecision
+    opt_timescalePrecision `hashWithSalt`
+    opt_ignoreBrokenGhcs
    where
     hashOverridingBool :: Int -> OverridingBool -> Int
     hashOverridingBool s1 Auto = hashWithSalt s1 (0 :: Int)
@@ -543,6 +549,7 @@ defClashOpts
   , opt_edalize             = False
   , opt_renderEnums         = True
   , opt_timescalePrecision  = Period 100 Fs
+  , opt_ignoreBrokenGhcs    = False
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -248,6 +248,7 @@ instance IsTest ClashGenTest where
       , "-odir", oDir
       , "-hidir", oDir
       , "-fclash-debug", "DebugSilent"
+      , "-fclash-ignore-broken-ghcs"
       , dOpaque
       ] <> cgExtraArgs
 
@@ -286,6 +287,7 @@ instance IsTest ClashBinaryTest where
       , "-o", oDir </> "out"
       , "-i" <> cbSourceDirectory
       , "-outputdir", oDir
+      , "-fclash-ignore-broken-ghcs"
       ] <> cbExtraBuildArgs <>
       [ cbSourceDirectory </> cbModName <.> "hs"
       ]


### PR DESCRIPTION
We know some GHC versions interact poorly with Clash on some platforms. Rather than making everyone hunt down the right tickets on their own, this patch makes Clash emit a fat ~~warning~~ error. Because these issues don't _completely_ prevent Clash from working, we allow users to bypass the error by passing a flag `-fclash-ignore-broken-ghcs`.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
