### PR TITLE
Fix BitVector shifts

### DIFF
--- a/changelog/2024-05-31T20_14_29+02_00_fix_bitvector_shifts
+++ b/changelog/2024-05-31T20_14_29+02_00_fix_bitvector_shifts
@@ -1,0 +1,1 @@
+FIXED: (+>>.) and (.<<+) such that they are compliant with (+>>) and (<<+) for vectors of zero length in the sense that the input vector is kept unchanged.


### PR DESCRIPTION
Fixes #2730 such that `(+>>.)` and `(.<<+)` are compliant with `(+>>)` and `(<<+)` for bit vectors of zero length, respectively.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

