### PR TITLE
Improve ranges in error messages

### DIFF
--- a/changelog/2024-06-11T16_55_10+02_00_improve_range_error
+++ b/changelog/2024-06-11T16_55_10+02_00_improve_range_error
@@ -1,0 +1,1 @@
+CHANGED: The error messages that mention the valid ranges for out-of-range inputs have been improved to be more intuitive: one of `<empty range>`, `[n]` or `[n..m]`. All _n..m_ ranges are now ordered with the lower bound on the left.

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -315,6 +315,7 @@ Library
                       Clash.Clocks.Internal
                       Clash.CPP
                       Clash.Signal.Bundle.Internal
+                      Clash.Sized.Internal
                       Language.Haskell.TH.Compat
                       Paths_clash_prelude
 

--- a/clash-prelude/src/Clash/Class/BitPack/BitIndex.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/BitIndex.hs
@@ -39,7 +39,7 @@ import Clash.Sized.Internal.BitVector
 -- >>> (7 :: Unsigned 6) ! 5
 -- 0
 -- >>> (7 :: Unsigned 6) ! 6
--- *** Exception: (!): 6 is out of range [5..0]
+-- *** Exception: (!): 6 is out of range [0..5]
 -- ...
 (!) :: (BitPack a, Enum i) => a -> i -> Bit
 (!) v i = index# (pack v) (fromEnum i)
@@ -114,7 +114,7 @@ split v = split# (pack v)
 -- >>> pack (27 :: Signed 6)
 -- 0b01_1011
 -- >>> replaceBit 6 0 (-5 :: Signed 6)
--- *** Exception: replaceBit: 6 is out of range [5..0]
+-- *** Exception: replaceBit: 6 is out of range [0..5]
 -- ...
 replaceBit :: (BitPack a, Enum i) => i -> Bit -> a -> a
 replaceBit i b v = unpack (replaceBit# (pack v) (fromEnum i) b)

--- a/clash-prelude/src/Clash/Class/Resize.hs
+++ b/clash-prelude/src/Clash/Class/Resize.hs
@@ -1,6 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente
                   2020,      Myrtle Software Ltd
+                  2024,      QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -25,6 +26,8 @@ import Data.Kind (Type)
 import Data.Proxy (Proxy(Proxy))
 import GHC.Stack (HasCallStack)
 import GHC.TypeLits (Nat, KnownNat, type (+))
+
+import Clash.Sized.Internal (formatRange)
 
 -- | Coerce a value to be represented by a different number of bits
 class Resize (f :: Nat -> Type) where
@@ -61,9 +64,8 @@ checkIntegral Proxy v =
   if toInteger v > toInteger (maxBound @b)
   || toInteger v < toInteger (minBound @b) then
     error $ "Given integral " <> show (toInteger v) <> " is out of bounds for" <>
-            " target type. Bounds of target type are: [" <>
-            show (toInteger (minBound @b)) <> ".." <>
-            show (toInteger (maxBound @b)) <> "]."
+            " target type. Bounds of target type are: " <>
+            formatRange (toInteger (minBound @b)) (toInteger (maxBound @b)) <> "."
   else
     ()
 

--- a/clash-prelude/src/Clash/Sized/Internal.hs
+++ b/clash-prelude/src/Clash/Sized/Internal.hs
@@ -1,0 +1,24 @@
+{-|
+Copyright  :  (C) 2024     , QBayLogic B.V.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+module Clash.Sized.Internal where
+
+-- | Format a range of numbers for use in error messages
+--
+-- If the upper bound is below the lower bound, @"\<empty range\>"@ is returned.
+-- If the bounds are equal, @"[n]"@ is returned (for bounds equal to /n/).
+-- Otherwise, @formatRange n m@ returns @"[n..m]"@.
+formatRange ::
+  (Ord a, Show a) =>
+  -- | Lower bound
+  a ->
+  -- | Upper bound
+  a ->
+  String
+formatRange n m
+  | m < n     = "<empty range>"
+  | m == n    = '[' : shows n "]"
+  | otherwise = '[' : show n ++ ".." ++ shows m "]"

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -196,6 +196,7 @@ import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
 import Clash.Class.Resize         (Resize (..))
 import Clash.Promoted.Nat
   (SNat (..), SNatLE (..), compareSNat, snatToInteger, snatToNum, natToNum)
+import Clash.Sized.Internal (formatRange)
 import Clash.XException
   (ShowX (..), NFDataX (..), errorX, isX, showsPrecXWith, rwhnfX, XException(..))
 
@@ -1053,9 +1054,8 @@ index# bv@(BV m v) i
 #endif
     err = error $ concat [ "(!): "
                          , show i
-                         , " is out of range ["
-                         , show (sz - 1)
-                         , "..0]"
+                         , " is out of range "
+                         , formatRange 0 (sz - 1)
                          ]
 
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
@@ -1146,9 +1146,8 @@ replaceBit# bv@(BV m v) i (Bit mb b)
 #endif
     err  = error $ concat [ "replaceBit: "
                           , show i
-                          , " is out of range ["
-                          , show (sz - 1)
-                          , "..0]"
+                          , " is out of range "
+                          , formatRange 0 (sz - 1)
                           ]
 
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016-2019, Myrtle Software Ltd,
-                  2021-2023, QBayLogic B.V.
+                  2021-2024, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -108,6 +108,7 @@ import Clash.Class.Num            (ExtendingNum (..), SaturatingNum (..),
 import Clash.Class.Parity         (Parity (..))
 import Clash.Class.Resize         (Resize (..))
 import Clash.Class.BitPack.BitIndex (replaceBit)
+import Clash.Sized.Internal       (formatRange)
 import {-# SOURCE #-} Clash.Sized.Internal.BitVector (BitVector (BV), high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
 import Clash.Promoted.Nat         (SNat(..), snatToNum, natToInteger, leToPlusKN)
@@ -347,7 +348,7 @@ fromInteger_INLINE i = bound `seq` if i > (-1) && i < bound then I i else err
   where
     bound = natToInteger @n
     err   = errorX ("Clash.Sized.Index: result " ++ show i ++
-                   " is out of bounds: [0.." ++ show (bound - 1) ++ "]")
+                   " is out of bounds: " ++ formatRange 0 (bound - 1))
 
 instance ExtendingNum (Index m) (Index n) where
   type AResult (Index m) (Index n) = Index (m + n - 1)
@@ -591,5 +592,5 @@ instance (KnownNat n) => Ix (Index n) where
   range (a, b) = [a..b]
   index ab@(a, b) x
     | inRange ab x = fromIntegral $ x - a
-    | otherwise = error $ printf "Index %d out of bounds (%d, %d)" x a b
+    | otherwise = error $ printf "Index (%d) out of range ((%d, %d))" x a b
   inRange (a, b) x = a <= x && x <= b

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016     , Myrtle Software Ltd,
-                  2021-2023, QBayLogic B.V.
+                  2021-2024, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -881,7 +881,7 @@ instance (KnownNat n) => Ix (Signed n) where
   range (a, b) = [a..b]
   index ab@(a, b) x
     | inRange ab x = fromIntegral $ x - a
-    | otherwise = error $ printf "Index %d out of bounds (%d, %d) ab" x a b
+    | otherwise = error $ printf "Index (%d) out of range ((%d, %d))" x a b
   inRange (a, b) x = a <= x && x <= b
 
 -- | Shift left that ties to zero on negative shifts

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2016     , Myrtle Software Ltd,
-                  2021-2023, QBayLogic B.V.
+                  2021-2024, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -794,7 +794,7 @@ instance (KnownNat n) => Ix (Unsigned n) where
   range (a, b) = [a..b]
   index ab@(a, b) x
     | inRange ab x = fromIntegral $ x - a
-    | otherwise = error $ printf "Index %d out of bounds (%d, %d) ab" x a b
+    | otherwise = error $ printf "Index (%d) out of range ((%d, %d))" x a b
   inRange (a, b) x = a <= x && x <= b
 
 unsignedToWord :: Unsigned WORD_SIZE_IN_BITS -> Word


### PR DESCRIPTION
We sometimes mention the valid range of an out-of-range input in error messages. However, if the range is actually empty, the message is rather garbled. Additionally, we sometimes format them like [_upper bound_.._lower bound_] which probably originates from the order of bit indices (highest indices on the left), but it might be confusing.

This PR changes the messages from:
```haskell
>>> replaceBit 0 1 (0 :: BitVector 0)
*** Exception: replaceBit: 0 is out of range [-1..0]
[...]
>>> replaceBit 1 1 (0 :: BitVector 1)
*** Exception: replaceBit: 1 is out of range [0..0]
[...]
>>> replaceBit 6 0 (-5 :: Signed 6)
*** Exception: replaceBit: 6 is out of range [5..0]
[...]
>>> testBit (-5 :: Signed 6) 6
*** Exception: (!): 6 is out of range [5..0]
[...]
>>> checkedFromIntegral 1 :: Unsigned 0
*** Exception: Given integral 1 is out of bounds for target type. Bounds of target type are: [0..0].
[...]
>>> 1 :: Index 0
*** Exception: X: Clash.Sized.Index: result 1 is out of bounds: [0..-1]
[...]
```
to:
```haskell
>>> replaceBit 0 1 (0 :: BitVector 0)
*** Exception: replaceBit: 0 is out of range <empty range>
[...]
>>> replaceBit 1 1 (0 :: BitVector 1)
*** Exception: replaceBit: 1 is out of range [0]
[...]
>>> replaceBit 6 0 (-5 :: Signed 6)
*** Exception: replaceBit: 6 is out of range [0..5]
[...]
>>> testBit (-5 :: Signed 6) 6
*** Exception: (!): 6 is out of range [0..5]
[...]
>>> checkedFromIntegral 1 :: Unsigned 0
*** Exception: Given integral 1 is out of bounds for target type. Bounds of target type are: [0].
[...]
>>>  1 :: Index 0
*** Exception: X: Clash.Sized.Index: result 1 is out of bounds: <empty range>
[...]
```

I also changed these:
```haskell
>>> import qualified Data.Ix as Ix
>>> Ix.index @(Unsigned 8) (0,42) 43
*** Exception: Index 43 out of bounds (0, 42) ab
[...]
>>> Ix.index @(Signed 8) (0,42) 43
*** Exception: Index 43 out of bounds (0, 42) ab
[...]
>>> Ix.index @(Index 256) (0,42) 43
*** Exception: Index 43 out of bounds (0, 42)
[...]
```
to be the same as upstream:
```haskell
>>> Ix.index @Int (0,42) 43
*** Exception: Ix{Int}.index: Index (43) out of range ((0,42))
>>> Ix.index @(Unsigned 8) (0,42) 43
*** Exception: Index (43) out of range ((0, 42))
CallStack (from HasCallStack):
  error, called at src/Clash/Sized/Internal/Unsigned.hs:797:19 in clash-prelude-1.9.0-inplace:Clash.Sized.Internal.Unsigned
[...etcetera...]
```

I'm not completely enamoured of the double parentheses, but I do love consistency (note we have a call stack though).

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
