### PR TITLE
Make sure clashSimulation is False in HDL even with -O2

### DIFF
--- a/clash-prelude/src/Clash/Magic.hs
+++ b/clash-prelude/src/Clash/Magic.hs
@@ -44,6 +44,7 @@ module Clash.Magic
   ) where
 
 import Data.String.Interpolate     (__i)
+import GHC.Magic                   (noinline)
 import GHC.Stack                   (HasCallStack, withFrozenCallStack)
 import Clash.NamedTypes            ((:::))
 import GHC.TypeLits                (Nat,Symbol)
@@ -259,7 +260,8 @@ noDeDup = id
 
 -- | 'True' in Haskell/Clash simulation. Replaced by 'False' when generating HDL.
 clashSimulation :: Bool
-clashSimulation = True
+clashSimulation = noinline True
+-- The 'noinline' is here to prevent SpecConstr from poking through the OPAQUE, see #2736
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE clashSimulation #-}
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -387,7 +387,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "NameInstance" def{hdlSim=[]}
         , outputTest "NameInstance" def
         , outputTest "SetName" def{hdlTargets=[VHDL]}
-        , outputTest "SimulationMagic" def{hdlTargets=[VHDL]}
+        , outputTest "SimulationMagic2736" def{hdlTargets=[VHDL]}
         , runTest "PatError" def{hdlSim=[]}
         , runTest "ByteSwap32" def
         , runTest "CharTest" def

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -103,7 +103,7 @@ library
     -- Behaviour when loading modules can differ if the module is loaded from
     -- an external interface file. See
     -- https://github.com/clash-lang/clash-compiler/issues/1796 for an example.
-    shouldwork/LoadModules
+    shouldwork/LoadModules/precompiled
 
   exposed-modules:
     Test.Tasty.Common
@@ -119,8 +119,8 @@ library
     Test.Tasty.Vivado
     Test.Tasty.Clash.CollectSimResults
 
-    -- From tests/shouldwork/LoadModules
-    T1796
+    -- From tests/shouldwork/LoadModules/precompiled
+    T1796a
 
   other-modules:
     Paths_clash_testsuite

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -104,6 +104,7 @@ library
     -- an external interface file. See
     -- https://github.com/clash-lang/clash-compiler/issues/1796 for an example.
     shouldwork/LoadModules/precompiled
+    shouldwork/Basic/precompiled
 
   exposed-modules:
     Test.Tasty.Common
@@ -121,6 +122,9 @@ library
 
     -- From tests/shouldwork/LoadModules/precompiled
     T1796a
+
+    -- From tests/shouldwork/Basic/precompiled
+    SimulationMagic2736a
 
   other-modules:
     Paths_clash_testsuite

--- a/tests/shouldwork/Basic/SimulationMagic2736.hs
+++ b/tests/shouldwork/Basic/SimulationMagic2736.hs
@@ -1,4 +1,6 @@
-module SimulationMagic where
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# OPTIONS_GHC -O2 -fspec-constr #-}
+module SimulationMagic2736 where
 
 import Prelude as P
 import Data.List (isInfixOf)
@@ -6,11 +8,10 @@ import System.Environment (getArgs)
 import System.FilePath ((</>))
 
 import Clash.Prelude
-import Clash.Magic (clashSimulation)
+import SimulationMagic2736a
 
 f :: Int
-f | clashSimulation = 123
-  | otherwise       = 456
+f = f0
 {-# ANN f (defSyn "f") #-}
 
 assertNotIn :: String -> String -> IO ()

--- a/tests/shouldwork/Basic/precompiled/SimulationMagic2736a.hs
+++ b/tests/shouldwork/Basic/precompiled/SimulationMagic2736a.hs
@@ -1,0 +1,8 @@
+{-# OPTIONS_GHC -O2 -fspec-constr #-}
+module SimulationMagic2736a where
+
+import Clash.Prelude
+
+f0 :: Int
+f0 | clashSimulation = 123
+   | otherwise       = 456

--- a/tests/shouldwork/LoadModules/T1796.hs
+++ b/tests/shouldwork/LoadModules/T1796.hs
@@ -4,29 +4,6 @@
 
 module T1796 where
 
-import Clash.Prelude
+import T1796a
 
-import Clash.Explicit.Testbench
-
-topEntity
-  :: Signal System Bool
-  -> Signal System Bool
-topEntity = id
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE topEntity #-}
-
-tb
-  :: Signal System Bool
-tb = done
-  where
-    testInput = stimuliGenerator clk rst (singleton True)
-    expectOutput = outputVerifier' clk rst (singleton True)
-    done = expectOutput $ topEntity testInput
-    clk = tbClockGen @System (not <$> done)
-    rst = resetGen @System
-{-# INLINE tb #-}
-
-testBench :: Signal System Bool
-testBench = tb
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE testBench #-}
+topEntity = tb

--- a/tests/shouldwork/LoadModules/precompiled/T1796a.hs
+++ b/tests/shouldwork/LoadModules/precompiled/T1796a.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TypeApplications #-}
+
+module T1796a where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+tb :: Signal System Bool
+tb = done
+  where
+    done = register clk rst enableGen False $ id (pure True)
+    clk = tbClockGen @System (not <$> done)
+    rst = resetGen @System


### PR DESCRIPTION
Fixes #2736
Also found that the test for #1796 was broken.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
