### PR TITLE
Only domains with a positive period are valid

### DIFF
--- a/changelog/2024-07-05T14_06_50+02_00_require_positive_period
+++ b/changelog/2024-07-05T14_06_50+02_00_require_positive_period
@@ -1,0 +1,20 @@
+CHANGED: You can now only create an `SDomainConfiguration` when the `period` of the domain is at least `1`.
+Pattern matching on an `SDomainConfiguration` bring the `1 <= period` into scope.
+This in turns enables the following code to typecheck:
+```
+import Clash.Prelude
+import Data.Proxy
+
+f ::
+  forall dom .
+  KnownDomain dom =>
+  Proxy dom ->
+  SNat (PeriodToCycles dom (Milliseconds 1))
+f Proxy = case knownDomain @dom of
+    SDomainConfiguration {} -> SNat
+```
+where the `DivRU` in
+```
+type PeriodToCycles (dom :: Domain) (period :: Nat) =  period `DivRU` DomainPeriod dom
+```
+requires that the `DomainPeriod dom` is at least `1`.

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -488,6 +488,7 @@ type ClockDivider (dom :: Domain) (period :: Nat) = PeriodToCycles dom period
 -- | Singleton version of 'DomainConfiguration'
 data SDomainConfiguration (dom :: Domain) (conf :: DomainConfiguration) where
   SDomainConfiguration ::
+    1 <= period =>
     { sName :: SSymbol dom
       -- ^ Domain name
     , sPeriod :: SNat period


### PR DESCRIPTION
An alternative means to achieve https://github.com/clash-lang/clash-compiler/pull/2734#issuecomment-2182893091

```haskell
import Clash.Prelude
import Data.Proxy

f ::
  forall dom .
  KnownDomain dom =>
  Proxy dom ->
  SNat (PeriodToCycles dom (Milliseconds 1))
f Proxy = case knownDomain @dom of
    SDomainConfiguration {} -> SNat
```
now typechecks.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
