### PR TITLE
Only domains with a positive period are valid, alternative

### DIFF
--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -797,7 +797,8 @@ simulateWithReset m resetVal f as =
 
 -- | Same as 'simulateWithReset', but only sample the first /Int/ output values.
 simulateWithResetN
-  :: ( KnownDomain dom
+  :: forall dom m a b
+   . ( KnownDomain dom
      , NFDataX a
      , NFDataX b
      , 1 <= m )
@@ -817,7 +818,7 @@ simulateWithResetN
   -> [a]
   -> [b]
 simulateWithResetN nReset resetVal nSamples f as =
-  take nSamples (simulateWithReset nReset resetVal f as)
+  take nSamples (simulateWithReset @dom nReset resetVal f as)
 {-# INLINE simulateWithResetN #-}
 
 -- | Simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a list of
@@ -924,7 +925,7 @@ sampleWithResetN
   -- ^ 'Signal' to sample
   -> [a]
 sampleWithResetN nReset nSamples f =
-  take nSamples (sampleWithReset nReset f)
+  take nSamples (sampleWithReset @dom nReset f)
 
 -- | Simulate a component until it matches a condition
 --

--- a/clash-prelude/src/Clash/Prelude.hs
+++ b/clash-prelude/src/Clash/Prelude.hs
@@ -247,7 +247,8 @@ functions a type class called 'Clash.Class.Parity.Parity' is available at
 -- [1 :> 0 :> 0 :> 0 :> Nil,2 :> 1 :> 0 :> 0 :> Nil,3 :> 2 :> 1 :> 0 :> Nil,4 :> 3 :> 2 :> 1 :> Nil,5 :> 4 :> 3 :> 2 :> Nil,...
 -- ...
 window
-  :: ( HiddenClockResetEnable dom
+  :: forall dom n a
+   . ( HiddenClockResetEnable dom
      , KnownNat n
      , Default a
      , NFDataX a )
@@ -255,7 +256,7 @@ window
   -- ^ Signal to create a window over
   -> Vec (n + 1) (Signal dom a)
   -- ^ Window of at least size 1
-window = hideClockResetEnable E.window
+window = hideClockResetEnable @dom E.window
 {-# INLINE window #-}
 
 -- | Give a delayed window over a 'Signal'
@@ -270,7 +271,8 @@ window = hideClockResetEnable E.window
 -- [0 :> 0 :> 0 :> Nil,1 :> 0 :> 0 :> Nil,2 :> 1 :> 0 :> Nil,3 :> 2 :> 1 :> Nil,4 :> 3 :> 2 :> Nil,...
 -- ...
 windowD
-  :: ( HiddenClockResetEnable dom
+  :: forall dom n a
+   . ( HiddenClockResetEnable dom
      , KnownNat n
      , Default a
      , NFDataX a )
@@ -278,13 +280,14 @@ windowD
   -- ^ Signal to create a window over
   -> Vec (n + 1) (Signal dom a)
   -- ^ Window of at least size 1
-windowD = hideClockResetEnable E.windowD
+windowD = hideClockResetEnable @dom E.windowD
 {-# INLINE windowD #-}
 
 -- | Implicit version of 'Clash.Class.AutoReg.autoReg'
 autoReg
-  :: (HasCallStack, HiddenClockResetEnable dom, AutoReg a)
+  :: forall dom a
+   . (HasCallStack, HiddenClockResetEnable dom, AutoReg a)
   => a
   -> Signal dom a
   -> Signal dom a
-autoReg = hideClockResetEnable E.autoReg
+autoReg = hideClockResetEnable @dom E.autoReg

--- a/clash-prelude/src/Clash/Prelude/BlockRam.hs
+++ b/clash-prelude/src/Clash/Prelude/BlockRam.hs
@@ -757,7 +757,7 @@ blockRamU
   -- ^ Value of the BRAM at address @r@ from the previous clock cycle
 blockRamU =
   \rstStrategy cnt initF rd wrM -> withFrozenCallStack
-    (hideClockResetEnable E.blockRamU) rstStrategy cnt initF rd wrM
+    (hideClockResetEnable @dom E.blockRamU) rstStrategy cnt initF rd wrM
 {-# INLINE blockRamU #-}
 
 -- | A version of 'blockRam' that is initialized with the same value on all
@@ -786,7 +786,7 @@ blockRam1
   -- ^ Value of the BRAM at address @r@ from the previous clock cycle
 blockRam1 =
   \rstStrategy cnt initValue rd wrM -> withFrozenCallStack
-    (hideClockResetEnable E.blockRam1) rstStrategy cnt initValue rd wrM
+    (hideClockResetEnable @dom E.blockRam1) rstStrategy cnt initValue rd wrM
 {-# INLINE blockRam1 #-}
 
 -- | Create a block RAM with space for 2^@n@ elements
@@ -866,7 +866,8 @@ readNew (blockRam (0 :> 1 :> Nil))
 #endif
 -}
 readNew
-  :: ( HiddenClockResetEnable dom
+  :: forall dom addr a
+   . ( HiddenClockResetEnable dom
      , NFDataX a
      , Eq addr )
   => (Signal dom addr -> Signal dom (Maybe (addr, a)) -> Signal dom a)
@@ -877,7 +878,7 @@ readNew
   -- ^ (Write address @w@, value to write)
   -> Signal dom a
   -- ^ Value of the BRAM at address @r@ from the previous clock cycle
-readNew = hideClockResetEnable E.readNew
+readNew = hideClockResetEnable @dom E.readNew
 {-# INLINE readNew #-}
 
 -- | Produces vendor-agnostic HDL that will be inferred as a true dual-port

--- a/clash-prelude/src/Clash/Prelude/Mealy.hs
+++ b/clash-prelude/src/Clash/Prelude/Mealy.hs
@@ -120,7 +120,8 @@ delayTop = mealyS delayS initialDelayState
 --     s2 = 'mealy' macT 0 ('Clash.Signal.bundle' (b,y))
 -- @
 mealy
-  :: ( HiddenClockResetEnable dom
+  :: forall dom s i o
+   . ( HiddenClockResetEnable dom
      , NFDataX s )
   => (s -> i -> (s,o))
   -- ^ Transfer function in mealy machine form: @state -> input -> (newstate,output)@
@@ -129,7 +130,7 @@ mealy
   -> (Signal dom i -> Signal dom o)
   -- ^ Synchronous sequential function with input and output matching that
   -- of the mealy machine
-mealy = hideClockResetEnable E.mealy
+mealy = hideClockResetEnable @dom E.mealy
 {-# INLINE mealy #-}
 
 -- | A version of 'mealy' that does automatic 'Bundle'ing
@@ -159,7 +160,8 @@ mealy = hideClockResetEnable E.mealy
 --     (i2,b2) = 'mealyB' f 3 (c,i1)
 -- @
 mealyB
-  :: ( HiddenClockResetEnable dom
+  :: forall dom s i o
+   . ( HiddenClockResetEnable dom
      , NFDataX s
      , Bundle i
      , Bundle o )
@@ -170,7 +172,7 @@ mealyB
   -> (Unbundled dom i -> Unbundled dom o)
   -- ^ Synchronous sequential function with input and output matching that
   -- of the mealy machine
-mealyB = hideClockResetEnable E.mealyB
+mealyB = hideClockResetEnable @dom E.mealyB
 {-# INLINE mealyB #-}
 
 
@@ -209,7 +211,8 @@ mealyB = hideClockResetEnable E.mealyB
 -- ...
 --
 mealyS
-  :: ( HiddenClockResetEnable dom
+  :: forall dom s i o
+   . ( HiddenClockResetEnable dom
      , NFDataX s )
   => (i -> State s o)
   --  ^ Transfer function in mealy machine handling inputs using @Control.Monad.Strict.State s@.
@@ -218,12 +221,13 @@ mealyS
   -> (Signal dom i -> Signal dom o)
   -- ^ Synchronous sequential function with input and output matching that
   -- of the mealy machine
-mealyS = hideClockResetEnable E.mealyS
+mealyS = hideClockResetEnable @dom E.mealyS
 {-# INLINE mealyS #-}
 
 -- | A version of 'mealyS' that does automatic 'Bundle'ing, see 'mealyB' for details.
 mealySB
-  :: ( HiddenClockResetEnable dom
+  :: forall dom s i o
+   . ( HiddenClockResetEnable dom
      , NFDataX s
      , Bundle i
      , Bundle o  )
@@ -234,7 +238,7 @@ mealySB
   -> (Unbundled dom i -> Unbundled dom o)
   -- ^ Synchronous sequential function with input and output matching that
   -- of the mealy machine
-mealySB = hideClockResetEnable E.mealySB
+mealySB = hideClockResetEnable @dom E.mealySB
 {-# INLINE mealySB #-}
 
 -- | Infix version of 'mealyB'

--- a/clash-prelude/src/Clash/Prelude/Moore.hs
+++ b/clash-prelude/src/Clash/Prelude/Moore.hs
@@ -79,7 +79,8 @@ let macT s (x,y) = x * y + s
 --     s2 = 'moore' macT id 0 ('Clash.Signal.bundle' (b,y))
 -- @
 moore
-  :: ( HiddenClockResetEnable dom
+  :: forall dom s i o
+   . ( HiddenClockResetEnable dom
      , NFDataX s )
   => (s -> i -> s)
   -- ^ Transfer function in moore machine form: @state -> input -> newstate@
@@ -90,7 +91,7 @@ moore
   -> (Signal dom i -> Signal dom o)
   -- ^ Synchronous sequential function with input and output matching that
   -- of the moore machine
-moore = hideClockResetEnable E.moore
+moore = hideClockResetEnable @dom E.moore
 {-# INLINE moore #-}
 
 
@@ -133,7 +134,8 @@ medvedev tr st = moore tr id st
 --     (i2,b2) = 'mooreB' t o 3 (c,i1)
 -- @
 mooreB
-  :: ( HiddenClockResetEnable dom
+  :: forall dom s i o
+   . ( HiddenClockResetEnable dom
      , NFDataX s
      , Bundle i
      , Bundle o )
@@ -146,7 +148,7 @@ mooreB
   -> (Unbundled dom i -> Unbundled dom o)
    -- ^ Synchronous sequential function with input and output matching that
    -- of the moore machine
-mooreB = hideClockResetEnable E.mooreB
+mooreB = hideClockResetEnable @dom E.mooreB
 {-# INLINE mooreB #-}
 
 -- | A version of 'medvedev' that does automatic 'Bundle'ing

--- a/clash-prelude/src/Clash/Prelude/Safe.hs
+++ b/clash-prelude/src/Clash/Prelude/Safe.hs
@@ -201,19 +201,21 @@ functions a type class called 'Clash.Class.Parity.Parity' is available at
 -- [(8,8),(1,1),(2,2),(3,3)...
 -- ...
 registerB
-  :: ( HiddenClockResetEnable dom
+  :: forall dom a
+   . ( HiddenClockResetEnable dom
      , NFDataX a
      , Bundle a )
   => a
   -> Unbundled dom a
   -> Unbundled dom a
-registerB = hideClockResetEnable E.registerB
+registerB = hideClockResetEnable @dom E.registerB
 infixr 3 `registerB`
 {-# INLINE registerB #-}
 
 -- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
 isRising
-  :: ( HiddenClockResetEnable dom
+  :: forall dom a
+   . ( HiddenClockResetEnable dom
      , NFDataX a
      , Bounded a
      , Eq a )
@@ -221,12 +223,13 @@ isRising
   -- ^ Starting value
   -> Signal dom a
   -> Signal dom Bool
-isRising = hideClockResetEnable E.isRising
+isRising = hideClockResetEnable @dom E.isRising
 {-# INLINE isRising #-}
 
 -- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
 isFalling
-  :: ( HiddenClockResetEnable dom
+  :: forall dom a
+   . ( HiddenClockResetEnable dom
      , NFDataX a
      , Bounded a
      , Eq a )
@@ -234,7 +237,7 @@ isFalling
   -- ^ Starting value
   -> Signal dom a
   -> Signal dom Bool
-isFalling = hideClockResetEnable E.isFalling
+isFalling = hideClockResetEnable @dom E.isFalling
 {-# INLINE isFalling #-}
 
 -- | Give a pulse every @n@ clock cycles. This is a useful helper function when
@@ -255,10 +258,11 @@ isFalling = hideClockResetEnable E.isFalling
 -- counter = 'Clash.Signal.regEn' 0 ('riseEvery' ('SNat' :: 'SNat' 10000000)) (counter + 1)
 -- @
 riseEvery
-  :: HiddenClockResetEnable dom
+  :: forall dom n
+   . HiddenClockResetEnable dom
   => SNat n
   -> Signal dom Bool
-riseEvery = hideClockResetEnable E.riseEvery
+riseEvery = hideClockResetEnable @dom E.riseEvery
 {-# INLINE riseEvery #-}
 
 -- | Oscillate a @'Bool'@ for a given number of cycles. This is a convenient
@@ -282,9 +286,10 @@ riseEvery = hideClockResetEnable E.riseEvery
 -- >>> sampleN @System 200 (oscillate False d1) == sampleN @System 200 osc'
 -- True
 oscillate
-  :: HiddenClockResetEnable dom
+  :: forall dom n
+   . HiddenClockResetEnable dom
   => Bool
   -> SNat n
   -> Signal dom Bool
-oscillate = hideClockResetEnable E.oscillate
+oscillate = hideClockResetEnable @dom E.oscillate
 {-# INLINE oscillate #-}

--- a/clash-prelude/src/Clash/Prelude/Testbench.hs
+++ b/clash-prelude/src/Clash/Prelude/Testbench.hs
@@ -201,7 +201,8 @@ outputVerifierBitVector' = hideReset (hideClock E.outputVerifierBitVector')
 
 -- | Ignore signal for a number of cycles, while outputting a static value.
 ignoreFor
-  :: HiddenClockResetEnable dom
+  :: forall dom n a
+   . HiddenClockResetEnable dom
   => SNat n
   -- ^ Number of cycles to ignore incoming signal
   -> a
@@ -211,5 +212,5 @@ ignoreFor
   -> Signal dom a
   -- ^ Either a passthrough of the incoming signal, or the static value
   -- provided as the second argument.
-ignoreFor = hideClockResetEnable E.ignoreFor
+ignoreFor = hideClockResetEnable @dom E.ignoreFor
 {-# INLINE ignoreFor #-}

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -1928,7 +1928,7 @@ sampleWithResetN
   -- (and reset)
   -> [a]
 sampleWithResetN nReset nSamples f =
-  take nSamples (sampleWithReset nReset f)
+  take nSamples (sampleWithReset @dom nReset f)
 
 -- | /Lazily/ get an infinite list of samples from a 'Signal'
 --
@@ -2010,7 +2010,7 @@ simulate
   -- and/or enable.
   -> [a]
   -> [b]
-simulate f as = simulateWithReset (SNat @1) rval f as
+simulate f as = simulateWithReset @dom (SNat @1) rval f as
   where
     rval = maybe (error "simulate: no stimuli") fst (uncons as)
 {-# INLINE simulate #-}
@@ -2030,7 +2030,7 @@ simulateN
   -- (and reset)
   -> [a]
   -> [b]
-simulateN n f as = simulateWithResetN (SNat @1) rval n f as
+simulateN n f as = simulateWithResetN @dom (SNat @1) rval n f as
   where
     rval = maybe (error "simulate: no stimuli") fst (uncons as)
 {-# INLINE simulateN #-}
@@ -2055,7 +2055,7 @@ simulateWithReset
   -> [a]
   -> [b]
 simulateWithReset n resetVal f as =
-  E.simulateWithReset n resetVal (exposeClockResetEnable f) as
+  E.simulateWithReset @dom n resetVal (exposeClockResetEnable f) as
 {-# INLINE simulateWithReset #-}
 
 -- | Same as 'simulateWithReset', but only sample the first /Int/ output values.
@@ -2077,7 +2077,7 @@ simulateWithResetN
   -> [a]
   -> [b]
 simulateWithResetN nReset resetVal nSamples f as =
-  E.simulateWithResetN nReset resetVal nSamples (exposeClockResetEnable f) as
+  E.simulateWithResetN @dom nReset resetVal nSamples (exposeClockResetEnable f) as
 {-# INLINE simulateWithResetN #-}
 
 
@@ -2263,14 +2263,15 @@ runUntil check s =
 --
 -- __NB__: This function is not synthesizable
 testFor
-  :: KnownDomain dom
+  :: forall dom
+   . KnownDomain dom
   => Int
   -- ^ The number of cycles we want to test for
   -> (HiddenClockResetEnable dom  => Signal dom Bool)
   -- ^ 'Signal' we want to evaluate, whose source potentially has a hidden clock
   -- (and reset)
   -> Property
-testFor n s = property (and (Clash.Signal.sampleN n s))
+testFor n s = property (and (Clash.Signal.sampleN @dom n s))
 
 #ifdef CLASH_MULTIPLE_HIDDEN
 -- ** Synchronization primitive
@@ -2303,7 +2304,7 @@ holdReset
   -- signal becomes deasserted.
   -> Reset dom
 holdReset m =
-  hideClockResetEnable (\clk rst en -> E.holdReset clk en m rst)
+  hideClockResetEnable @dom (\clk rst en -> E.holdReset clk en m rst)
 
 -- | Like 'fromList', but resets on reset and has a defined reset value.
 --

--- a/clash-prelude/src/Clash/Signal/Delayed.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed.hs
@@ -80,14 +80,15 @@ import           Clash.XException              (NFDataX)
 -- >>> sampleN @System 7 (toSignal (delay3 (dfromList [0..])))
 -- [-1,-1,-1,-1,1,2,3]
 delayed
-  :: ( KnownNat d
+  :: forall d n dom a
+   . ( KnownNat d
      , HiddenClockResetEnable dom
      , NFDataX a
      )
   => Vec d a
   -> DSignal dom n a
   -> DSignal dom (n + d) a
-delayed = hideClockResetEnable E.delayed
+delayed = hideClockResetEnable @dom E.delayed
 
 {- | Delay a 'DSignal' for @d@ periods, where @d@ is derived from the context.
 
@@ -123,14 +124,15 @@ delayedI @3
 #endif
 -}
 delayedI
-  :: ( KnownNat d
+  :: forall d a dom n
+   . ( KnownNat d
      , NFDataX a
      , HiddenClockResetEnable dom  )
   => a
   -- ^ Initial value
   -> DSignal dom n a
   -> DSignal dom (n + d) a
-delayedI = hideClockResetEnable E.delayedI
+delayedI = hideClockResetEnable @dom E.delayedI
 
 -- | Delay a 'DSignal' for @d@ cycles, the value at time 0..d-1 is /a/.
 --

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -21,6 +21,7 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 {-# LANGUAGE Unsafe #-}
 
@@ -509,7 +510,7 @@ type KnownConfiguration dom conf = (KnownDomain dom, KnownConf dom ~ conf)
 
 -- | A 'KnownDomain' constraint indicates that a circuit's behavior depends on
 -- some properties of a domain. See 'DomainConfiguration' for more information.
-class (KnownSymbol dom, KnownNat (DomainPeriod dom)) => KnownDomain (dom :: Domain) where
+class (KnownSymbol dom, KnownNat (DomainPeriod dom), 1 <= DomainPeriod dom) => KnownDomain (dom :: Domain) where
   type KnownConf dom :: DomainConfiguration
   -- | Returns 'SDomainConfiguration' corresponding to an instance's 'DomainConfiguration'.
   --


### PR DESCRIPTION
An alternative means to achieve https://github.com/clash-lang/clash-compiler/pull/2734#issuecomment-2182893091
```haskell
import Clash.Prelude
import Data.Proxy

f ::
  forall dom .
  KnownDomain dom =>
  Proxy dom ->
  SNat (PeriodToCycles dom (Milliseconds 1))
f Proxy = SNat
```
now typechecks.

Though at the very high cost of needing to add `@dom` to any use of `hideClockResetEnable` which might affect user code out in the wild. https://github.com/clash-lang/clash-compiler/pull/2740 is probably a more desirable alternative.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
