### PR TITLE
Add `clash-cores:doctests` to GitLab CI

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -28,6 +28,7 @@ cabal v2-build all --write-ghc-environment-files=always
 
 # Put all the test binaries in a predictable location
 TESTS="
+clash-cores:doctests
 clash-cores:unittests
 clash-cosim:test
 clash-ffi:ffi-interface-tests

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -79,6 +79,11 @@ build:
 
 # Tests run on shared runners:
 
+cores:doctests:
+  extends: .test-nocache
+  script:
+    - bin/clash-cores:doctests -j$THREADS
+
 cores:unittests:
   extends: .test-nocache
   script:
@@ -88,6 +93,11 @@ cosim:unittests:
   extends: .test-nocache
   script:
     - bin/clash-cosim:test
+
+prelude:doctests:
+  extends: .test-nocache
+  script:
+    - bin/clash-prelude:doctests -j$THREADS
 
 prelude:unittests:
   extends: .test-nocache
@@ -103,11 +113,6 @@ lib:unittests:
   extends: .test-nocache
   script:
     - bin/clash-lib:unittests --hide-successes
-
-prelude:doctests:
-  extends: .test-nocache
-  script:
-    - bin/clash-prelude:doctests -j$THREADS
 
 ffi:interface-tests:
   extends: .test-nocache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,18 +60,20 @@ jobs:
           # Print out stack.yaml for debugging purposes
           cat stack.yaml
 
-      - name: Cache (Windows)
+      - name: Restore cache (Windows)
         if: ${{ startsWith(matrix.os, 'windows') }}
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
+        id: cache-win
         with:
           # On windows we have to use "\" as a path separator, otherwise caching fails
           path: |
             ${{ steps.setup-haskell.outputs.stack-root }}\snapshots
           key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('stack.yaml', '**/*.cabal', '.github/workflows/ci.yml') }}
           restore-keys: ${{ matrix.os }}-${{ matrix.ghc }}-
-      - name: Cache (non-Windows)
+      - name: Restore cache (non-Windows)
         if: ${{ !startsWith(matrix.os, 'windows') }}
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
+        id: cache-other
         with:
           path: |
             ${{ steps.setup-haskell.outputs.stack-root }}/snapshots
@@ -93,6 +95,29 @@ jobs:
       - name: Build happy with Stack
         shell: bash
         run: ./.ci/retry.sh stack build happy
+
+      - name: Build dependencies
+        run: stack build --only-dependencies
+
+      - name: Save cache (Windows)
+        uses: actions/cache/save@v4
+        # Trying to save over an existing cache gives distracting
+        # "Warning: Cache save failed." since they are immutable
+        if: ${{ startsWith(matrix.os, 'windows') && steps.cache-win.outputs.cache-hit != 'true' }}
+        with:
+          # On windows we have to use "\" as a path separator, otherwise caching fails
+          path: |
+            ${{ steps.setup-haskell.outputs.stack-root }}\snapshots
+          key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('stack.yaml', '**/*.cabal', '.github/workflows/ci.yml') }}
+      - name: Save cache (non-Windows)
+        uses: actions/cache/save@v4
+        # Trying to save over an existing cache gives distracting
+        # "Warning: Cache save failed." since they are immutable
+        if: ${{ !startsWith(matrix.os, 'windows') && steps.cache-other.outputs.cache-hit != 'true' }}
+        with:
+          path: |
+            ${{ steps.setup-haskell.outputs.stack-root }}/snapshots
+          key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('stack.yaml', '**/*.cabal', '.github/workflows/ci.yml') }}
 
       # Note: the --pedantic switch adds -Wall -Werror to the options passed to
       # GHC. Options specified in stack.yaml (like -Wcompat) are still passed;
@@ -148,6 +173,8 @@ jobs:
 
       - name: Setup CI
         run: |
+          # Work around dubious owner error
+          git config --global --add safe.directory "$(pwd)"
           export CABAL_DIR=$HOME/.cabal
           ./.ci/setup.sh
           cabal v2-freeze
@@ -157,13 +184,14 @@ jobs:
           mv cabal.project.freeze frozen
 
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
+        id: cache
         with:
           path: |
             dist-newstyle
             ~/.cabal/store
 
-          key: ${{ matrix.ghc }}-${{ hashFiles('frozen', 'cabal.project') }}
+          key: ${{ matrix.ghc }}-${{ hashFiles('frozen', 'cabal.project', '**/*.cabal', '.github/workflows/ci.yml') }}
           restore-keys: ${{ matrix.ghc }}-
 
       - name: Build Clash
@@ -171,14 +199,29 @@ jobs:
           export CABAL_DIR=$HOME/.cabal
           ./.ci/build.sh
 
+      - name: Save Cache
+        # Trying to save over an existing cache gives distracting
+        # "Warning: Cache save failed." since they are immutable
+        if: ${{ !cancelled() && steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            dist-newstyle
+            ~/.cabal/store
+
+          key: ${{ matrix.ghc }}-${{ hashFiles('frozen', 'cabal.project', '**/*.cabal', '.github/workflows/ci.yml') }}
+
       - name: Unit Tests
         if: github.ref != 'refs/heads/master'
         run: |
           export CABAL_DIR=$HOME/.cabal
-          cabal v2-test clash-prelude
-          cabal v2-test clash-lib
-          cabal v2-test clash-cores
-          cabal v2-test clash-cosim
+          cabal v2-run clash-prelude:doctests
+          cabal v2-run clash-prelude:unittests -- --hide-successes
+          cabal v2-run clash-lib:doctests
+          cabal v2-run clash-lib:unittests -- --hide-successes
+          cabal v2-run clash-cores:doctests
+          cabal v2-run clash-cores:unittests -- --hide-successes
+          cabal v2-run clash-cosim:test -- --hide-successes
 
       - name: Testsuite (VHDL)
         if: github.ref != 'refs/heads/master'
@@ -201,7 +244,7 @@ jobs:
 
   all:
     name: All jobs finished
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [
         build_mac_windows,
         build_and_test,

--- a/clash-cores/src/Clash/Cores/Crc.hs
+++ b/clash-cores/src/Clash/Cores/Crc.hs
@@ -52,8 +52,7 @@ deriveHardwareCrc Crc32_ethernet d8 d4
 dummy = 1
 :}
 
->>> crcEngine' = exposeClockResetEnable crcEngine systemClockGen resetGen enableGen
->>> myEngine = crcEngine' Crc32_ethernet
+>>> myEngine = crcEngine Crc32_ethernet
 
 Note how we hinted to @clashi@ that our multi-line command was a list of
 declarations by including a dummy declaration @dummy = 1@. Without this trick,
@@ -71,7 +70,7 @@ indicates how many @BitVector 8@ are valid inside the @Vec@. 0 means 1 is valid.
 >>> hwInp2 = Just (False, 0, unsafeFromList $ fmap charToBv "9___")
 >>> hwInp = [Nothing, hwInp0, hwInp1, hwInp2]
 >>> hwOut = myEngine (fromList hwInp)
->>> crcFromHardware = List.last $ sampleN (1 + List.length hwInp) hwOut
+>>> crcFromHardware = List.last $ sampleN @System (1 + List.length hwInp) hwOut
 >>> crcFromHardware == checkValue
 True
 

--- a/clash-cores/src/Clash/Cores/Crc/Internal.hs
+++ b/clash-cores/src/Clash/Cores/Crc/Internal.hs
@@ -568,7 +568,6 @@ matVecMul
             (n :: Nat)
    . KnownNat m
   => KnownNat n
-  -- ^ @n@ columns
   => Vec m (BitVector n)
   -- ^ The Matrix
   -> BitVector n


### PR DESCRIPTION
Fixed minor details in `clash-cores` CRC core.

With `multiple-hidden` enabled, the following doctest line:

`crcEngine' = exposeClockResetEnable crcEngine systemClockGen resetGen enableGen`

worked fine on GHC 9.4.8 and 9.6.{4,5}. But on GHC 8.10.7, 9.0.2 and 9.2.8, GHC wanted to check `WithSingleDomain` then and there, but could not because the `crc` term to `crcEngine` could not be inspected through `TryDomain`. The GHC's where it did work postponed this check to the `myEngine` binding in the next doctest line, where it could be resolved.

However, this `exposeClockResetEnable` is superfluous anyway as the `sampleN` function later on deals with such implicit parameters fine on its own. So the code is changed to no longer use `exposeClockResetEnable` and instead specify the domain to `sampleN`.

Additionally, a function for which no documentation was even generated had Haddock documentation on a constraint. Haddock on GHC 8.10.7 cannot handle this, breaking the doctests for clash-cores.

The documentation of that constraint has simply been removed.

With these details fixed, we can run `clash-cores:doctests` in GitLab CI. Up until now, we only ran it for external PR's in the GitHub CI _Build and Test_ job, which was an accidental disparity.

GitHub CI also received several correctness and performance tweaks.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files (did not add copyright for minuscule changes)
