### PR TITLE
Run `cabal build` in `clash-dev`

### DIFF
--- a/.ci/build_clash_dev.sh
+++ b/.ci/build_clash_dev.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -xeou pipefail
 
-# Make sure all our deps are build, and listed in the .ghc.environment file
-cabal --write-ghc-environment-files=always v2-build --only-dependencies clash-lib
-
 # Check that clash-dev works
 echo "" > clash-dev.result
 echo 'main >> writeFile "clash-dev.result" "success"' | ./clash-dev

--- a/clash-dev
+++ b/clash-dev
@@ -12,6 +12,8 @@ else
   OPAQUE="NOINLINE"
 fi
 
+cabal build clash-lib clash-ghc --only-dependencies
+
 ghci \
   -fobject-code \
   -iclash-ghc/src-bin-common/ \


### PR DESCRIPTION
This makes sure everything is in scope for `ghci` to compile everything in `clash-lib` and `clash-ghc`.

I'm not the main consumer of `clash-dev`, so I'd like @christiaanb's opinion on this. 

It's something I noticed while looking at another issue with `clash-dev`.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~
