### PR TITLE
Allow bypassing broken GHC error using an environment variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,10 @@ variables:
   RESTORE_CACHE_ATTEMPTS: 5
   ARTIFACT_DOWNLOAD_ATTEMPTS: 5
 
+  # We test all GHC version we support, so there is no use to fail if Clash
+  # detects a known-to-be-broken compiler.
+  CLASH_IGNORE_BROKEN_GHCS: "True"
+
 stages:
   - pre
   - test

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -27,6 +27,7 @@ module Clash.Core.Pretty
   , tracePprId
   , tracePpr
   , fromPpr
+  , unsafeLookupEnvBool
   )
 where
 

--- a/clash-lib/src/Clash/Driver/BrokenGhcs.hs
+++ b/clash-lib/src/Clash/Driver/BrokenGhcs.hs
@@ -112,6 +112,9 @@ whyPp Why{what, solution, issue}= [I.i|
   If you want to ignore this message, pass the following flag to Clash:
 
     -fclash-ignore-broken-ghcs
+
+  Alternatively, you can set the environment variable CLASH_IGNORE_BROKEN_GHCS
+  to 'True'.
   |]
  where
   Ghc{major0, major1, patch} = ghcVersion

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -60,6 +60,7 @@ import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
 import           Clash.Signal.Internal
 
 import           Clash.Backend.Verilog.Time     (Period(..), Unit(Fs))
+import           Clash.Core.Pretty              (unsafeLookupEnvBool)
 import           Clash.Core.Term                (Term)
 import           Clash.Core.TyCon               (TyConMap, TyConName)
 import           Clash.Core.Var                 (Id)
@@ -549,7 +550,9 @@ defClashOpts
   , opt_edalize             = False
   , opt_renderEnums         = True
   , opt_timescalePrecision  = Period 100 Fs
-  , opt_ignoreBrokenGhcs    = False
+  -- XXX: We probe environment variables until we've found a proper solution to
+  --      https://github.com/clash-lang/clash-compiler/issues/2762.
+  , opt_ignoreBrokenGhcs    = unsafeLookupEnvBool "CLASH_IGNORE_BROKEN_GHCS" False
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.


### PR DESCRIPTION
Should fix the nightlies

Related: https://github.com/clash-lang/clash-compiler/issues/2762

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
