### PR TITLE
Remove `stringsearch` dependency

### DIFF
--- a/changelog/2024-07-21T16_46_47+02_00_remove_stringsearch
+++ b/changelog/2024-07-21T16_46_47+02_00_remove_stringsearch
@@ -1,0 +1,1 @@
+FIXED: Removed `stringsearch` dependency from `v16-upgrade-primitives`. See [#2726](https://github.com/clash-lang/clash-compiler/issues/2726)

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -346,9 +346,9 @@ executable v16-upgrade-primitives
     yaml,
     bytestring,
     clash-lib,
+    text,
     containers,
     directory,
-    stringsearch,
     Glob
   GHC-Options:        -Wall -Wcompat
   default-language:   Haskell2010

--- a/clash-lib/tools/v16-upgrade-primitives.hs
+++ b/clash-lib/tools/v16-upgrade-primitives.hs
@@ -9,8 +9,9 @@ module Main where
 
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.KeyMap as Aeson
-import Data.ByteString.Lazy.Search (replace)
 import Data.String (IsString)
+import qualified Data.Text.Lazy as LazyText
+import qualified Data.Text.Lazy.Encoding as LazyText
 #endif
 
 import qualified Data.Aeson.Extra as AesonExtra
@@ -89,9 +90,10 @@ customSortOutput x = case x of
       Just val -> Aeson.insert kNew val (Aeson.delete kOld obj)
 
 removeTempKey :: ByteString -> ByteString
-removeTempKey inp = foldl go inp keySortingRenames
+removeTempKey inp =
+  LazyText.encodeUtf8 (foldl go (LazyText.decodeUtf8 inp) keySortingRenames)
  where
-  go bs (orig,temp) = replace (ByteString.toStrict temp) orig bs
+  go txt (orig,temp) = LazyText.replace temp orig txt
 #else
 -- < aeson-2.0 stores keys in HashMaps, whose order we can't possibly predict.
 removeTempKey :: ByteString -> ByteString


### PR DESCRIPTION
Fixes https://github.com/clash-lang/clash-compiler/issues/2726

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
