### PR TITLE
Fix eta-expansion in evaluator

### DIFF
--- a/changelog/2024-08-05T22_45_27+02_00_fix2781
+++ b/changelog/2024-08-05T22_45_27+02_00_fix2781
@@ -1,0 +1,1 @@
+FIXED: Bug in the compile-time evaluator [#2781](https://github.com/clash-lang/clash-compiler/issues/2781)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -632,6 +632,7 @@ runClashTest = defaultMain $ clashTestRoot
         , outputTest "T2542" def{hdlTargets=[VHDL]}
         , runTest "T2593" def{hdlSim=[]}
         , runTest "T2623CaseConFVs" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
+        , runTest "T2781" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2781.hs
+++ b/tests/shouldwork/Issues/T2781.hs
@@ -1,0 +1,35 @@
+module T2781
+  ( fullMeshSwCcTest
+  ) where
+
+import Clash.Explicit.Prelude
+import Clash.Cores.Xilinx.Ila (IlaConfig(..), Depth(..), ila, ilaConfig)
+
+fullMeshHwTestDummy ::
+  Clock System ->
+  (  Signal System Bool
+  ,  Vec 1 (Signal System Bool)
+  )
+fullMeshHwTestDummy sysClk =
+  fincFdecIla `hwSeqX`
+  ( pure False
+  , repeat (pure True)
+  )
+ where
+  fincFdecIla :: Signal System ()
+  fincFdecIla = ila
+    (ilaConfig ("trigger_0" :> Nil))
+    sysClk
+    (pure True :: Signal System Bool)
+
+-- | Top entity for this test. See module documentation for more information.
+fullMeshSwCcTest ::
+  Clock System ->
+  (Signal System Bool
+  )
+fullMeshSwCcTest sysClk = spiDone
+ where
+  (spiDone
+    , ugnsStable
+    ) = fullMeshHwTestDummy sysClk
+{-# ANN fullMeshSwCcTest (defSyn "fullMeshSwCcTest") #-}


### PR DESCRIPTION
For some eta-reduced 'e', we used to bogusly eta-expand to:
```
\x.(\y. e y) x
```
We now correctly expand to:
```
\x.\y.(e x) y
```
Fixes #2781

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
