### PR TITLE
Update mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,8 +34,6 @@ pull_request_rules:
         ignore_conflicts: True
         branches:
           - "1.6"
-      queue:
-        update_method: rebase
 
   - name: backport patches to 1.8
     conditions:
@@ -47,5 +45,6 @@ pull_request_rules:
         ignore_conflicts: True
         branches:
           - "1.8"
-      queue:
-        update_method: rebase
+
+queue_rules:
+  update_method: rebase

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -47,4 +47,5 @@ pull_request_rules:
           - "1.8"
 
 queue_rules:
-  update_method: rebase
+  - name: merge-queue
+    update_method: rebase


### PR DESCRIPTION
It was reporting:

>     The configuration uses the deprecated update_method attribute of the queue action in one or more pull_request_rules. It must now be used under the queue_rules configuration.
>     A brownout is planned on August 26th, 2024.
>     This option will be removed on September 23rd, 2024.
>     For more information: https://docs.mergify.com/configuration/file-format/#queue-rules
