### PR TITLE
Generalize delayedFold to arbitrary vectors

### DIFF
--- a/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
+++ b/clash-prelude/src/Clash/Signal/Delayed/Bundle.hs
@@ -25,7 +25,7 @@ import           GHC.TypeLits                  (KnownNat)
 import           Prelude                       hiding (head, map, tail)
 
 import           Clash.Signal.Internal         (Domain)
-import           Clash.Signal.Delayed (DSignal, toSignal, unsafeFromSignal)
+import           Clash.Signal.Delayed.Internal (DSignal, toSignal, unsafeFromSignal)
 import qualified Clash.Signal.Bundle           as B
 
 import           Clash.Sized.BitVector         (Bit, BitVector)


### PR DESCRIPTION
Previously, `delayedFold` only worked on vectors of size `2^k`. This PR relaxes that constraint.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
