### PR TITLE
Catch "divide by zero" in more places in the primitive evaluator

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -1490,7 +1490,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
          _ -> Nothing
 
   "GHC.Classes.divInt#" | Just (i,j) <- intLiterals args
-    -> reduce (integerToIntLiteral (i `div` j))
+    -> reduce $ catchDivByZero (integerToIntLiteral (i `div` j))
 
   -- modInt# :: Int# -> Int# -> Int#
   "GHC.Classes.modInt#"
@@ -2012,13 +2012,13 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
     | Just (i,j) <- naturalLiterals args
     ->
      let nTy = snd (splitFunForallTy ty) in
-     reduce (checkNaturalRange2 nTy i j quot)
+     reduce $ catchDivByZero (checkNaturalRange2 nTy i j quot)
 
   "GHC.Num.Natural.naturalRem"
     | Just (i,j) <- naturalLiterals args
     ->
      let nTy = snd (splitFunForallTy ty) in
-     reduce (checkNaturalRange2 nTy i j rem)
+     reduce $ catchDivByZero (checkNaturalRange2 nTy i j rem)
 #endif
 
 #if MIN_VERSION_base(4,15,0)
@@ -2418,26 +2418,26 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
     | [ DC intDc [Left (Literal (IntLiteral i))]
       , DC _     [Left (Literal (IntLiteral j))]
       ] <- args
-    -> reduce (App (Data intDc) (Literal (IntLiteral (i `quot` j))))
+    -> reduce $ catchDivByZero (App (Data intDc) (Literal (IntLiteral (i `quot` j))))
 
   "GHC.Base.remInt"
     | [ DC intDc [Left (Literal (IntLiteral i))]
       , DC _     [Left (Literal (IntLiteral j))]
       ] <- args
-    -> reduce (App (Data intDc) (Literal (IntLiteral (i `rem` j))))
+    -> reduce $ catchDivByZero (App (Data intDc) (Literal (IntLiteral (i `rem` j))))
 
   "GHC.Base.divInt"
     | [ DC intDc [Left (Literal (IntLiteral i))]
       , DC _     [Left (Literal (IntLiteral j))]
       ] <- args
-    -> reduce (App (Data intDc) (Literal (IntLiteral (i `div` j))))
+    -> reduce $ catchDivByZero (App (Data intDc) (Literal (IntLiteral (i `div` j))))
 
 
   "GHC.Base.modInt"
     | [ DC intDc [Left (Literal (IntLiteral i))]
       , DC _     [Left (Literal (IntLiteral j))]
       ] <- args
-    -> reduce (App (Data intDc) (Literal (IntLiteral (i `mod` j))))
+    -> reduce $ catchDivByZero (App (Data intDc) (Literal (IntLiteral (i `mod` j))))
 
   "Clash.Class.BitPack.Internal.packDouble#" -- :: Double -> BitVector 64
     | [DC _ [Left arg]] <- args


### PR DESCRIPTION
This fixes the exact problem encountered in #2815.

But there are still other places in the evaluator that still need some more work:
 * `[quot,rem][Int,Word][8,16,32,64]#`: when presented with 0 divisors these don't throw normal Haskell exception, but some lower level exception that just kills the haskell process.
    So we should just check that the divisor isn't zero instead of trying to catch exceptions, possibly for all of them.
    Also this needs a some refactoring as we currently don't have direct access to the arguments, because how the evaluation is defined via the `lift*` functions.
 * `quoteRem*`: these all output tuples with two numbers, some of them make calls to `catchDivByZero`, but per output number.
    This isn't correct, because when `catchDivByZero` catches a division by zero, it'll put in an `undefined` with the type of the full result.
 So you and up with something like `quotRemInt 3 0` evaluating to:
 `( undefined :: (Int,Int), undefined :: (Int,Int) ) :: (Int,Int)`

 
## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
