### PR TITLE
Fix unused argument warnings on writeToBiSignal#

### DIFF
--- a/changelog/2024-10-07T15_01_17+02_00_fix_writeToBiSignal_warnings
+++ b/changelog/2024-10-07T15_01_17+02_00_fix_writeToBiSignal_warnings
@@ -1,0 +1,1 @@
+FIXED: Unused argument warnings on writeToBiSignal#

--- a/clash-prelude/src/Clash/Signal/BiSignal.hs
+++ b/clash-prelude/src/Clash/Signal/BiSignal.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2017, Google Inc.
                   2019, Myrtle Software Ltd
-                  2022-2023, QBayLogic B.V.
+                  2022-2024, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -280,8 +280,7 @@ writeToBiSignal#
   -> Signal d Bool
   -> Signal d (BitVector n)
   -> BiSignalOut ds d n
--- writeToBiSignal# = writeToBiSignal#
-writeToBiSignal# _ maybeSignal _ _ = BiSignalOut [maybeSignal]
+writeToBiSignal# bIn maybeSignal wEn val = BiSignalOut [bIn `seq` wEn `seq` val `seq` maybeSignal]
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE writeToBiSignal# #-}
 {-# ANN writeToBiSignal# hasBlackBox #-}


### PR DESCRIPTION
Any usage of `writeToBiSignal` would result in:
```
Warning: The Haskell implementation of primitive Clash.Signal.BiSignal.writeToBiSignal# isn't using argument #1, but the corresponding primitive blackbox does.
This can lead to incorrect HDL output because GHC can replace these arguments by an undefined value.

Warning: The Haskell implementation of primitive Clash.Signal.BiSignal.writeToBiSignal# isn't using argument #3, but the corresponding primitive blackbox does.
This can lead to incorrect HDL output because GHC can replace these arguments by an undefined value.

Warning: The Haskell implementation of primitive Clash.Signal.BiSignal.writeToBiSignal# isn't using argument #4, but the corresponding primitive blackbox does.
This can lead to incorrect HDL output because GHC can replace these arguments by an undefined value.
```

This fixes that with some bang patterns on `writeToBiSignal#`.

I was a little afraid this might result in loops in haskell simulation.
But I've tested the manually test all three [`Counter*` tests](https://github.com/clash-lang/clash-compiler/tree/3b755b900810c727833875b1a15222d69d37029e/tests/shouldwork/Signal/BiSignal) in Haskell simulation both inside `clashi`, and when compiled to executables.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
