### PR TITLE
Fix DDR primitives

### DIFF
--- a/changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims
+++ b/changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims
@@ -2,8 +2,10 @@ FIXED: `Clash.Explicit.DDR`:
   - `ddrIn`: VHDL: Remove data input from sensitivity list of `ddrIn_neg_latch` register as it is superfluous. This should not affect functionality.
   - `ddrOut`: VHDL: Fix incorrect usage of `Enable` input when the domain is set to asynchronous resets. Deasserting the `Enable` exhibited wrong behavior before this fix.
 FIXED: `Clash.Xilinx.DDR`:
+  - These primitives only support clocks where the rising edge is the active edge. Using them in a domain with falling active edges now causes an error.
   - `oddr`: Fix VHDL and SystemVerilog erroring out during HDL generation
   - Symbols in HDL for both `iddr` and `oddr` were renamed to match their function.
 FIXED: `Clash.Intel.DDR`:
+  - These primitives only support clocks where the rising edge is the active edge. Using them in a domain with falling active edges now causes an error.
   - Fix rendering HDL. It variously errored out or generated non-working HDL.
   - Rendering HDL no longer causes Clash to issue a warning about an argument unused in Haskell but used in the primitive black box.

--- a/changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims
+++ b/changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims
@@ -1,0 +1,9 @@
+FIXED: `Clash.Explicit.DDR`:
+  - `ddrIn`: VHDL: Remove data input from sensitivity list of `ddrIn_neg_latch` register as it is superfluous. This should not affect functionality.
+  - `ddrOut`: VHDL: Fix incorrect usage of `Enable` input when the domain is set to asynchronous resets. Deasserting the `Enable` exhibited wrong behavior before this fix.
+FIXED: `Clash.Xilinx.DDR`:
+  - `oddr`: Fix VHDL and SystemVerilog erroring out during HDL generation
+  - Symbols in HDL for both `iddr` and `oddr` were renamed to match their function.
+FIXED: `Clash.Intel.DDR`:
+  - Fix rendering HDL. It variously errored out or generated non-working HDL.
+  - Rendering HDL no longer causes Clash to issue a warning about an argument unused in Haskell but used in the primitive black box.

--- a/changelog/2025-01-22T16_23_00+01_00_improve_ddr
+++ b/changelog/2025-01-22T16_23_00+01_00_improve_ddr
@@ -1,0 +1,4 @@
+CHANGED: `Clash.Explicit.DDR`, `Clash.Intel.DDR` and `Clash.Xilinx.DDR`:
+  - The constraints for the functions have been rewritten to use `DomainPeriod`, which makes them more readable and relaxes unnecessary constraints on the virtual DDR domain. The type-level variables for the domains have been renamed. `dom` is a real domain, `domDDR` is the virtual DDR domain.
+  - The Xilinx and Intel primitives only support domains where the rising edge is the active edge. This is now enforced at the type level by adding a constraint.
+  - The Xilinx and Intel primitives now directly support any data type that has a `BitPack` instance.

--- a/clash-lib/prims/commonverilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/commonverilog/Clash_Intel_DDR.primitives.yaml
@@ -5,23 +5,26 @@
     - altera_mf
     type: |-
       altddioOut#
-        :: ( HasCallStack             -- ARG[0]
-           , KnownConfi~ fast domf    -- ARG[1]
-           , KnownConfi~ slow doms    -- ARG[2]
-           , KnownNat m )             -- ARG[3]
-        => SSymbol deviceFamily       -- ARG[4]
-        -> Clock slow                 -- ARG[5]
-        -> Reset slow                 -- ARG[6]
-        -> Enable slow                -- ARG[7]
-        -> Signal slow (BitVector m)  -- ARG[8]
-        -> Signal slow (BitVector m)  -- ARG[9]
-        -> Signal fast (BitVector m)
+        :: forall deviceFamily n dom domDDR
+         . HasCallStack              -- ARG[0]
+        => KnownDomain dom           -- ARG[1]
+        => KnownDomain domDDR        -- ARG[2]
+        => DomPeriod ~ 2 * ...       -- ARG[3]
+        => DomEdge ~ Rising          -- ARG[4]
+        => KnownNat n                -- ARG[5]
+        => SSymbol deviceFamily      -- ARG[6]
+        -> Clock dom                 -- ARG[7]
+        -> Reset dom                 -- ARG[8]
+        -> Enable dom                -- ARG[9]
+        -> Signal dom (BitVector n)  -- ARG[10]
+        -> Signal dom (BitVector n)  -- ARG[11]
+        -> Signal domDDR (BitVector n)
     template: |-
       // altddioOut begin
       altddio_out
         #(
           .extend_oe_disable ("OFF"),
-          .intended_device_family (~LIT[4]),
+          .intended_device_family (~LIT[6]),
           .invert_output ("OFF"),
           .lpm_hint ("UNUSED"),
           .lpm_type ("altddio_out"),
@@ -29,15 +32,15 @@
           .power_up_high ("OFF"),
           .width (~SIZE[~TYPO])
         )
-        ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] (~IF ~ISSYNC[2] ~THEN
-          .sclr (~ARG[6]),
+        ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] (~IF ~ISSYNC[1] ~THEN
+          .sclr (~ARG[8]),
           .aclr (1'b0),~ELSE
-          .aclr (~ARG[6]),
+          .aclr (~ARG[8]),
           .sclr (1'b0),~FI
-          .datain_h (~ARG[8]),
-          .datain_l (~ARG[9]),
-          .outclock (~ARG[5]),
-          .outclocken (~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),
+          .datain_h (~ARG[10]),
+          .datain_l (~ARG[11]),
+          .outclock (~ARG[7]),
+          .outclocken (~IF ~ISACTIVEENABLE[9] ~THEN ~ARG[9] ~ELSE 1'b1 ~FI),
           .dataout (~RESULT),
           .aset (1'b0),
           .sset (1'b0),

--- a/clash-lib/prims/systemverilog/Clash_Explicit_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Explicit_DDR.primitives.yaml
@@ -2,42 +2,43 @@
     name: Clash.Explicit.DDR.ddrIn#
     kind: Declaration
     type: |-
-      ddrIn# :: forall a slow fast n pFast gated synchronous.
-                 ( HasCallStack          -- ARG[0]
-                 , NFDataX a             -- ARG[1]
-                 , KnownConfi~ fast domf -- ARG[2]
-                 , KnownConfi~ slow doms -- ARG[3]
-              => Clock slow              -- ARG[4], clk
-              -> Reset slow              -- ARG[5], rst
-              -> Enable slow             -- ARG[6], en
-              -> a                       -- ARG[7]
-              -> a                       -- ARG[8]
-              -> a                       -- ARG[9]
-              -> Signal fast a           -- ARG[10]
-              -> Signal slow (a,a)
+      ddrIn# :: forall a dom domDDR
+              . HasCallStack             -- ARG[0]
+             => NFDataX a                -- ARG[1]
+             => KnownDomain dom          -- ARG[2]
+             => KnownDomain domDDR       -- ARG[3]
+             => DomPeriod ~ 2 * ...      -- ARG[4]
+             => Clock dom                -- ARG[5]
+             -> Reset dom                -- ARG[6]
+             -> Enable dom               -- ARG[7]
+             -> a                        -- ARG[8]
+             -> a                        -- ARG[9]
+             -> a                        -- ARG[10]
+             -> Signal domDDR a          -- ARG[11]
+             -> Signal dom (a,a)
     template: |-
       // ddrIn begin
-      ~SIGD[~GENSYM[data_Pos][1]][9];
-      ~SIGD[~GENSYM[data_Neg][2]][9];
-      ~SIGD[~GENSYM[data_Neg_Latch][3]][9];
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[1] <= ~ARG[8];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-          ~SYM[1] <= ~ARG[10];
+      ~SIGD[~GENSYM[data_Pos][1]][11];
+      ~SIGD[~GENSYM[data_Neg][2]][11];
+      ~SIGD[~GENSYM[data_Neg_Latch][3]][11];
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
+          ~SYM[1] <= ~ARG[9];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
+          ~SYM[1] <= ~ARG[11];
         end
       end
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[2] <= ~ARG[9];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
           ~SYM[2] <= ~ARG[10];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
+          ~SYM[2] <= ~ARG[11];
         end
       end
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[3] <= ~ARG[7];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
+          ~SYM[3] <= ~ARG[8];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
           ~SYM[3] <= ~SYM[2];
         end
       end
@@ -49,38 +50,40 @@
     kind: Declaration
     outputUsage: Blocking
     type: |-
-      ddrOut# :: ( HasCallStack                -- ARG[0]
-                  , NFDataX a                  -- ARG[1]
-                  , KnownConfi~ fast domf      -- ARG[2]
-                  , KnownConfi~ slow doms      -- ARG[3]
-               => Clock slow                   -- ARG[4]
-               -> Reset slow                   -- ARG[5]
-               -> Enable slow                  -- ARG[6]
-               -> a                            -- ARG[7]
-               -> Signal slow a                -- ARG[8]
-               -> Signal slow a                -- ARG[9]
-               -> Signal fast a
+      ddrOut# :: forall a dom domDDR
+               . HasCallStack                 -- ARG[0]
+              => NFDataX a                    -- ARG[1]
+              => KnownDomain dom              -- ARG[2]
+              => KnownDomain domDDR           -- ARG[3]
+              => DomPeriod ~ 2 * ...          -- ARG[4]
+              => Clock dom                    -- ARG[5]
+              -> Reset dom                    -- ARG[6]
+              -> Enable dom                   -- ARG[7]
+              -> a                            -- ARG[8]
+              -> Signal dom a                 -- ARG[9]
+              -> Signal dom a                 -- ARG[10]
+              -> Signal domDDR a
     template: |-
       // ddrOut begin
-      ~SIGD[~GENSYM[data_Pos][1]][7];
-      ~SIGD[~GENSYM[data_Neg][2]][7];
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[1] <= ~ARG[7];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+      ~SIGD[~GENSYM[data_Pos][1]][8];
+      ~SIGD[~GENSYM[data_Neg][2]][8];
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
           ~SYM[1] <= ~ARG[8];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
+          ~SYM[1] <= ~ARG[9];
         end
       end
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[2] <= ~ARG[7];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-          ~SYM[2] <= ~ARG[9];
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
+          ~SYM[2] <= ~ARG[8];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
+          ~SYM[2] <= ~ARG[10];
         end
       end
 
       always @(*) begin
-        if (~ARG[4]) begin
+        if (~ARG[5]) begin
           ~RESULT = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI;
         end else begin
           ~RESULT = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;

--- a/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives.yaml
@@ -1,42 +1,45 @@
 - BlackBox:
-    name: Clash.Intel.DDR.altddioIn
+    name: Clash.Intel.DDR.altddioIn#
     kind: Declaration
     libraries:
     - altera_mf
     type: |-
-      altddioIn
-        :: ( HasCallStack               -- ARG[0]
-           , KnownConfi~ fast domf      -- ARG[1]
-           , KnownConfi~ slow doms      -- ARG[2]
-           , KnownNat m )               -- ARG[3]
-        => SSymbol deviceFamily         -- ARG[4]
-        -> Clock slow                   -- ARG[5]
-        -> Reset slow                   -- ARG[6]
-        -> Enable slow                  -- ARG[7]
-        -> Signal fast (BitVector m)    -- ARG[8]
-        -> Signal slow (BitVector m,BitVector m)
+      altddioIn#
+        :: forall deviceFamily n dom domDDR
+         . HasCallStack                 -- ARG[0]
+        => KnownDomain dom              -- ARG[1]
+        => KnownDomain domDDR           -- ARG[2]
+        => DomPeriod ~ 2 * ...          -- ARG[3]
+        => DomEdge ~ Rising             -- ARG[4]
+        => KnownNat n                   -- ARG[5]
+        => SSymbol deviceFamily         -- ARG[6]
+        -> Clock dom                    -- ARG[7]
+        -> Reset dom                    -- ARG[8]
+        -> Enable dom                   -- ARG[9]
+        -> Signal domDDR (BitVector n)  -- ARG[10]
+        -> Signal dom (BitVector n, BitVector n)
     template: |-
       // altddioIn begin
-      ~SIGD[~GENSYM[dataout_l][1]][8];
-      ~SIGD[~GENSYM[dataout_h][2]][8];
+      ~SIGD[~GENSYM[dataout_l][1]][10];
+      ~SIGD[~GENSYM[dataout_h][2]][10];
 
       altddio_in
         #(
-          .intended_device_family (~LIT[4]),
+          .intended_device_family (~LIT[6]),
           .invert_input_clocks ("OFF"),
           .lpm_hint ("UNUSED"),
           .lpm_type ("altddio_in"),
           .power_up_high ("OFF"),
-          .width (~SIZE[~TYP[8]])
+          .width (~SIZE[~TYP[10]])
         )
-        ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[2] ~THEN
-          .sclr (~ARG[6]),
+        ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[1] ~THEN
+          .sclr (~ARG[8]),
           .aclr (1'b0),~ELSE
-          .aclr (~ARG[6]),
+          .aclr (~ARG[8]),
           .sclr (1'b0),~FI
-          .datain (~ARG[8]),
-          .inclock (~ARG[5]),
-          .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN~ARG[7]~ELSE1'b1~FI),
+          .datain (~ARG[10]),
+          .inclock (~ARG[7]),
+          .inclocken (~IF ~ISACTIVEENABLE[9] ~THEN~ARG[9]~ELSE1'b1~FI),
           .dataout_h (~SYM[2]),
           .dataout_l (~SYM[1]),
           .aset (1'b0),

--- a/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives.yaml
@@ -36,7 +36,7 @@
           .sclr (1'b0),~FI
           .datain (~ARG[8]),
           .inclock (~ARG[5]),
-          .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN~ARG[7]~ELSE1'b1,~FI),
+          .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN~ARG[7]~ELSE1'b1~FI),
           .dataout_h (~SYM[2]),
           .dataout_l (~SYM[1]),
           .aset (1'b0),

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives.yaml
@@ -14,8 +14,8 @@
         -> Signal slow (BitVector m,BitVector m)
     template: |-
       // iddr begin
-      ~SIGD[~GENSYM[dataout_l][1]][7];
-      ~SIGD[~GENSYM[dataout_h][2]][7];
+      ~SIGD[~GENSYM[data_pos][1]][7];
+      ~SIGD[~GENSYM[data_neg][2]][7];
       ~SIGD[~GENSYM[d][3]][7];
       assign ~SYM[3] = ~ARG[7];
 
@@ -57,8 +57,8 @@
         -> Signal fast (BitVector m)
     template: |-
       // oddr begin
-      ~SIGD[~GENSYM[datain_l][1]][7];
-      ~SIGD[~GENSYM[datain_h][2]][7];
+      ~SIGD[~GENSYM[data_pos][1]][7];
+      ~SIGD[~GENSYM[data_neg][2]][7];
       ~SIGD[~GENSYM[q][3]][7];
 
       assign ~SYM[1] = ~ARG[6];
@@ -70,7 +70,7 @@
         ODDR #(
           .DDR_CLK_EDGE("SAME_EDGE"),
           .INIT(1'b0),
-          .SRTYPE(~IF ~ISSYNC[2] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
+          .SRTYPE(~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
         ) ~GENSYM[~COMPNAME_ODDR][9] (
           .Q(~SYM[3][~SYM[8]]),
           .C(~ARG[3]),

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives.yaml
@@ -1,39 +1,42 @@
 - BlackBox:
-    name: Clash.Xilinx.DDR.iddr
+    name: Clash.Xilinx.DDR.iddr#
     kind: Declaration
     type: |-
-      iddr
-        :: ( HasCallStack               -- ARG[0]
-           , KnownConfi~ fast domf      -- ARG[1]
-           , KnownConfi~ slow doms      -- ARG[2]
-           , KnownNat m )               -- ARG[3]
-        -> Clock slow                   -- ARG[4]
-        -> Reset slow                   -- ARG[5]
-        -> Enable slow                  -- ARG[6]
-        -> Signal fast (BitVector m)    -- ARG[7]
-        -> Signal slow (BitVector m,BitVector m)
+      iddr#
+        :: forall n dom domDDR
+         . HasCallStack                 -- ARG[0]
+        => KnownDomain dom              -- ARG[1]
+        => KnownDomain domDDR           -- ARG[2]
+        => DomPeriod ~ 2 * ...          -- ARG[3]
+        => DomEdge ~ Rising             -- ARG[4]
+        => KnownNat n                   -- ARG[5]
+        => Clock dom                    -- ARG[6]
+        -> Reset dom                    -- ARG[7]
+        -> Enable dom                   -- ARG[8]
+        -> Signal domDDR (BitVector n)  -- ARG[9]
+        -> Signal dom (BitVector n, BitVector n)
     template: |-
       // iddr begin
-      ~SIGD[~GENSYM[data_pos][1]][7];
-      ~SIGD[~GENSYM[data_neg][2]][7];
-      ~SIGD[~GENSYM[d][3]][7];
-      assign ~SYM[3] = ~ARG[7];
+      ~SIGD[~GENSYM[data_pos][1]][9];
+      ~SIGD[~GENSYM[data_neg][2]][9];
+      ~SIGD[~GENSYM[d][3]][9];
+      assign ~SYM[3] = ~ARG[9];
 
       genvar ~GENSYM[i][8];
       ~GENERATE
-      for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
+      for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[9]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
         IDDR #(
           .DDR_CLK_EDGE("SAME_EDGE"),
           .INIT_Q1(1'b0),
           .INIT_Q2(1'b0),
-          .SRTYPE(~IF ~ISSYNC[2] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
+          .SRTYPE(~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
         ) ~GENSYM[~COMPNAME_IDDR][9] (
           .Q1(~SYM[1][~SYM[8]]),
           .Q2(~SYM[2][~SYM[8]]),
-          .C(~ARG[4]),
-          .CE(~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),
+          .C(~ARG[6]),
+          .CE(~IF ~ISACTIVEENABLE[8] ~THEN ~ARG[8] ~ELSE 1'b1 ~FI),
           .D(~SYM[3][~SYM[8]]),
-          .R(~ARG[5]),
+          .R(~ARG[7]),
           .S(1'b0)
         );
       end
@@ -46,38 +49,42 @@
     kind: Declaration
     type: |-
       oddr#
-        :: ( KnownConfi~ fast domf      -- ARG[0]
-           , KnownConfi~ slow doms      -- ARG[1]
-           , KnownNat m )               -- ARG[2]
-        => Clock slow                   -- ARG[3]
-        -> Reset slow                   -- ARG[4]
-        -> Enable slow                  -- ARG[5]
-        -> Signal slow (BitVector m)    -- ARG[6]
-        -> Signal slow (BitVector m)    -- ARG[7]
-        -> Signal fast (BitVector m)
+        :: forall n dom domDDR
+         . HasCallStack              -- ARG[0]
+        => KnownDomain dom           -- ARG[1]
+        => KnownDomain domDDR        -- ARG[2]
+        => DomPeriod ~ 2 * ...       -- ARG[3]
+        => DomEdge ~ Rising          -- ARG[4]
+        => KnownNat n                -- ARG[5]
+        => Clock dom                 -- ARG[6]
+        -> Reset dom                 -- ARG[7]
+        -> Enable dom                -- ARG[8]
+        -> Signal dom (BitVector n)  -- ARG[9]
+        -> Signal dom (BitVector n)  -- ARG[10]
+        -> Signal domDDR (BitVector n)
     template: |-
       // oddr begin
-      ~SIGD[~GENSYM[data_pos][1]][7];
-      ~SIGD[~GENSYM[data_neg][2]][7];
-      ~SIGD[~GENSYM[q][3]][7];
+      ~SIGD[~GENSYM[data_pos][1]][10];
+      ~SIGD[~GENSYM[data_neg][2]][10];
+      ~SIGD[~GENSYM[q][3]][10];
 
-      assign ~SYM[1] = ~ARG[6];
-      assign ~SYM[2] = ~ARG[7];
+      assign ~SYM[1] = ~ARG[9];
+      assign ~SYM[2] = ~ARG[10];
 
       genvar ~GENSYM[i][8];
       ~GENERATE
-      for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
+      for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[10]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
         ODDR #(
           .DDR_CLK_EDGE("SAME_EDGE"),
           .INIT(1'b0),
           .SRTYPE(~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
         ) ~GENSYM[~COMPNAME_ODDR][9] (
           .Q(~SYM[3][~SYM[8]]),
-          .C(~ARG[3]),
-          .CE(~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),
+          .C(~ARG[6]),
+          .CE(~IF ~ISACTIVEENABLE[8] ~THEN ~ARG[8] ~ELSE 1'b1 ~FI),
           .D1(~SYM[1][~SYM[8]]),
           .D2(~SYM[2][~SYM[8]]),
-          .R(~ARG[4]),
+          .R(~ARG[7]),
           .S(1'b0)
         );
       end

--- a/clash-lib/prims/verilog/Clash_Explicit_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Explicit_DDR.primitives.yaml
@@ -2,42 +2,43 @@
     name: Clash.Explicit.DDR.ddrIn#
     kind: Declaration
     type: |-
-      ddrIn# :: forall a slow fast n pFast gated synchronous.
-                 ( HasCallStack          -- ARG[0]
-                 , NFDataX a             -- ARG[1]
-                 , KnownConfi~ fast domf -- ARG[2]
-                 , KnownConfi~ slow doms -- ARG[3]
-              => Clock slow              -- ARG[4]
-              -> Reset slow              -- ARG[5]
-              -> Enable slow             -- ARG[6]
-              -> a                       -- ARG[7]
-              -> a                       -- ARG[8]
-              -> a                       -- ARG[9]
-              -> Signal fast a           -- ARG[10]
-              -> Signal slow (a,a)
+      ddrIn# :: forall a dom domDDR
+              . HasCallStack             -- ARG[0]
+             => NFDataX a                -- ARG[1]
+             => KnownDomain dom          -- ARG[2]
+             => KnownDomain domDDR       -- ARG[3]
+             => DomPeriod ~ 2 * ...      -- ARG[4]
+             => Clock dom                -- ARG[5]
+             -> Reset dom                -- ARG[6]
+             -> Enable dom               -- ARG[7]
+             -> a                        -- ARG[8]
+             -> a                        -- ARG[9]
+             -> a                        -- ARG[10]
+             -> Signal domDDR a          -- ARG[11]
+             -> Signal dom (a,a)
     template: |-
       // ddrIn begin
-      reg ~SIGD[~GENSYM[data_Pos][1]][9];
-      reg ~SIGD[~GENSYM[data_Neg][2]][9];
-      reg ~SIGD[~GENSYM[data_Neg_Latch][3]][9];
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[1] <= ~ARG[8];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-          ~SYM[1] <= ~ARG[10];
+      reg ~SIGD[~GENSYM[data_Pos][1]][11];
+      reg ~SIGD[~GENSYM[data_Neg][2]][11];
+      reg ~SIGD[~GENSYM[data_Neg_Latch][3]][11];
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrIn_pos][6]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
+          ~SYM[1] <= ~ARG[9];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
+          ~SYM[1] <= ~ARG[11];
         end
       end
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[2] <= ~ARG[9];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENnegedge~ELSEposedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg][7]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
           ~SYM[2] <= ~ARG[10];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
+          ~SYM[2] <= ~ARG[11];
         end
       end
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[3] <= ~ARG[7];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrIn_neg_latch][8]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
+          ~SYM[3] <= ~ARG[8];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
           ~SYM[3] <= ~SYM[2];
         end
       end
@@ -48,45 +49,47 @@
     name: Clash.Explicit.DDR.ddrOut#
     kind: Declaration
     type: |-
-      ddrOut# :: ( HasCallStack                -- ARG[0]
-                  , NFDataX a                  -- ARG[1]
-                  , KnownConfi~ fast domf      -- ARG[2]
-                  , KnownConfi~ slow doms      -- ARG[3]
-               => Clock slow                   -- ARG[4]
-               -> Reset slow                   -- ARG[5]
-               -> Enable slow                  -- ARG[6]
-               -> a                            -- ARG[7]
-               -> Signal slow a                -- ARG[8]
-               -> Signal slow a                -- ARG[9]
-               -> Signal fast a
+      ddrOut# :: forall a dom domDDR
+               . HasCallStack                 -- ARG[0]
+              => NFDataX a                    -- ARG[1]
+              => KnownDomain dom              -- ARG[2]
+              => KnownDomain domDDR           -- ARG[3]
+              => DomPeriod ~ 2 * ...          -- ARG[4]
+              => Clock dom                    -- ARG[5]
+              -> Reset dom                    -- ARG[6]
+              -> Enable dom                   -- ARG[7]
+              -> a                            -- ARG[8]
+              -> Signal dom a                 -- ARG[9]
+              -> Signal dom a                 -- ARG[10]
+              -> Signal domDDR a
     template: |-
       // ddrOut begin
-      reg ~SIGD[~GENSYM[data_Pos][1]][7];
-      reg ~SIGD[~GENSYM[data_Neg][2]][7];
+      reg ~SIGD[~GENSYM[data_Pos][1]][8];
+      reg ~SIGD[~GENSYM[data_Neg][2]][8];
       ~IF ~VIVADO ~THENreg ~SIGDO[~GENSYM[ddrOut][3]];~ELSE~FI
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[1] <= ~ARG[7];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrOut_pos][5]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
           ~SYM[1] <= ~ARG[8];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
+          ~SYM[1] <= ~ARG[9];
         end
       end
-      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[4]~IF~ISSYNC[3]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[5])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
-        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[5]~ELSE! ~ARG[5]~FI) begin
-          ~SYM[2] <= ~ARG[7];
-        end else ~IF ~ISACTIVEENABLE[6] ~THEN if (~ARG[6]) ~ELSE ~FI begin
-          ~SYM[2] <= ~ARG[9];
+      always @(~IF~ACTIVEEDGE[Rising][2]~THENposedge~ELSEnegedge~FI ~ARG[5]~IF~ISSYNC[2]~THEN)~ELSE or ~IF~ISACTIVEHIGH[2]~THENposedge~ELSEnegedge~FI ~ARG[6])~FI begin : ~GENSYM[~COMPNAME_ddrOut_neg][6]
+        if (~IF~ISACTIVEHIGH[2]~THEN~ARG[6]~ELSE! ~ARG[6]~FI) begin
+          ~SYM[2] <= ~ARG[8];
+        end else ~IF ~ISACTIVEENABLE[7] ~THEN if (~ARG[7]) ~ELSE ~FI begin
+          ~SYM[2] <= ~ARG[10];
         end
       end
 
       ~IF ~VIVADO ~THENalways @(*) begin
-        if (~ARG[4]) begin
+        if (~ARG[5]) begin
           ~SYM[3] = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI;
         end else begin
           ~SYM[3] = ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
         end
       end
       assign ~RESULT = ~SYM[3];~ELSE
-      assign ~RESULT = ~ARG[4] ? ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1] : ~SYM[2]~ELSE~SYM[2] : ~SYM[1]~FI;~FI
+      assign ~RESULT = ~ARG[5] ? ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1] : ~SYM[2]~ELSE~SYM[2] : ~SYM[1]~FI;~FI
 
       // ddrOut end

--- a/clash-lib/prims/verilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Intel_DDR.primitives.yaml
@@ -1,42 +1,45 @@
 - BlackBox:
-    name: Clash.Intel.DDR.altddioIn
+    name: Clash.Intel.DDR.altddioIn#
     kind: Declaration
     libraries:
     - altera_mf
     type: |-
-      altddioIn
-        :: ( HasCallStack               -- ARG[0]
-           , KnownConfi~ fast domf      -- ARG[1]
-           , KnownConfi~ slow doms      -- ARG[2]
-           , KnownNat m )               -- ARG[3]
-        => SSymbol deviceFamily         -- ARG[4]
-        -> Clock slow                   -- ARG[5]
-        -> Reset slow                   -- ARG[6]
-        -> Enable slow                  -- ARG[7]
-        -> Signal fast (BitVector m)    -- ARG[8]
-        -> Signal slow (BitVector m,BitVector m)
+      altddioIn#
+        :: forall deviceFamily n dom domDDR
+         . HasCallStack                 -- ARG[0]
+        => KnownDomain dom              -- ARG[1]
+        => KnownDomain domDDR           -- ARG[2]
+        => DomPeriod ~ 2 * ...          -- ARG[3]
+        => DomEdge ~ Rising             -- ARG[4]
+        => KnownNat n                   -- ARG[5]
+        => SSymbol deviceFamily         -- ARG[6]
+        -> Clock dom                    -- ARG[7]
+        -> Reset dom                    -- ARG[8]
+        -> Enable dom                   -- ARG[9]
+        -> Signal domDDR (BitVector n)  -- ARG[10]
+        -> Signal dom (BitVector n, BitVector n)
     template: |-
       // altddioIn begin
-      wire ~SIGD[~GENSYM[dataout_l][1]][8];
-      wire ~SIGD[~GENSYM[dataout_h][2]][8];
+      wire ~SIGD[~GENSYM[dataout_l][1]][10];
+      wire ~SIGD[~GENSYM[dataout_h][2]][10];
 
       altddio_in
         #(
-          .intended_device_family (~LIT[4]),
+          .intended_device_family (~LIT[6]),
           .invert_input_clocks ("OFF"),
           .lpm_hint ("UNUSED"),
           .lpm_type ("altddio_in"),
           .power_up_high ("OFF"),
-          .width (~SIZE[~TYP[8]])
+          .width (~SIZE[~TYP[10]])
         )
-        ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[2] ~THEN
-          .sclr (~ARG[6]),
+        ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[1] ~THEN
+          .sclr (~ARG[8]),
           .aclr (1'b0),~ELSE
-          .aclr (~ARG[6]),
+          .aclr (~ARG[8]),
           .sclr (1'b0),~FI
-          .datain (~ARG[8]),
-          .inclock (~ARG[5]),
-          .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] ~ELSE 1'b1 ~FI),
+          .datain (~ARG[10]),
+          .inclock (~ARG[7]),
+          .inclocken (~IF ~ISACTIVEENABLE[9] ~THEN ~ARG[9] ~ELSE 1'b1 ~FI),
           .dataout_h (~SYM[2]),
           .dataout_l (~SYM[1]),
           .aset (1'b0),

--- a/clash-lib/prims/verilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Intel_DDR.primitives.yaml
@@ -27,7 +27,7 @@
           .lpm_hint ("UNUSED"),
           .lpm_type ("altddio_in"),
           .power_up_high ("OFF"),
-          .width (~SIZE[~TYP[7]])
+          .width (~SIZE[~TYP[8]])
         )
         ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[2] ~THEN
           .sclr (~ARG[6]),

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives.yaml
@@ -14,8 +14,8 @@
         -> Signal slow (BitVector m,BitVector m)
     template: |-
       // iddr begin
-      wire ~SIGD[~GENSYM[dataout_l][1]][7];
-      wire ~SIGD[~GENSYM[dataout_h][2]][7];
+      wire ~SIGD[~GENSYM[data_pos][1]][7];
+      wire ~SIGD[~GENSYM[data_neg][2]][7];
       wire ~SIGD[~GENSYM[d][3]][7];
       assign ~SYM[3] = ~ARG[7];
 
@@ -57,8 +57,8 @@
         -> Signal fast (BitVector m)
     template: |-
       // oddr begin
-      wire ~SIGD[~GENSYM[datain_l][1]][7];
-      wire ~SIGD[~GENSYM[datain_h][2]][7];
+      wire ~SIGD[~GENSYM[data_pos][1]][7];
+      wire ~SIGD[~GENSYM[data_neg][2]][7];
       wire ~SIGD[~GENSYM[q][3]][7];
 
       assign ~SYM[1] = ~ARG[6];

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives.yaml
@@ -1,39 +1,42 @@
 - BlackBox:
-    name: Clash.Xilinx.DDR.iddr
+    name: Clash.Xilinx.DDR.iddr#
     kind: Declaration
     type: |-
-      iddr
-        :: ( HasCallStack            -- ARG[0]
-           , KnownConfi~ fast domf   -- ARG[1]
-           , KnownConfi~ slow doms   -- ARG[2]
-           , KnownNat m )            -- ARG[3]
-        -> Clock slow                -- ARG[4]
-        -> Reset slow                -- ARG[5]
-        -> Enable slow               -- ARG[6]
-        -> Signal fast (BitVector m) -- ARG[7]
-        -> Signal slow (BitVector m,BitVector m)
+      iddr#
+        :: forall n dom domDDR
+         . HasCallStack                 -- ARG[0]
+        => KnownDomain dom              -- ARG[1]
+        => KnownDomain domDDR           -- ARG[2]
+        => DomPeriod ~ 2 * ...          -- ARG[3]
+        => DomEdge ~ Rising             -- ARG[4]
+        => KnownNat n                   -- ARG[5]
+        => Clock dom                    -- ARG[6]
+        -> Reset dom                    -- ARG[7]
+        -> Enable dom                   -- ARG[8]
+        -> Signal domDDR (BitVector n)  -- ARG[9]
+        -> Signal dom (BitVector n, BitVector n)
     template: |-
       // iddr begin
-      wire ~SIGD[~GENSYM[data_pos][1]][7];
-      wire ~SIGD[~GENSYM[data_neg][2]][7];
-      wire ~SIGD[~GENSYM[d][3]][7];
-      assign ~SYM[3] = ~ARG[7];
+      wire ~SIGD[~GENSYM[data_pos][1]][9];
+      wire ~SIGD[~GENSYM[data_neg][2]][9];
+      wire ~SIGD[~GENSYM[d][3]][9];
+      assign ~SYM[3] = ~ARG[9];
 
       genvar ~GENSYM[i][8];
       ~GENERATE
-      for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
+      for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[9]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddri_array][7]
         IDDR #(
           .DDR_CLK_EDGE("SAME_EDGE"),
           .INIT_Q1(1'b0),
           .INIT_Q2(1'b0),
-          .SRTYPE(~IF ~ISSYNC[2] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
+          .SRTYPE(~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
         ) ~GENSYM[~COMPNAME_IDDR][9] (
           .Q1(~SYM[1][~SYM[8]]),
           .Q2(~SYM[2][~SYM[8]]),
-          .C(~ARG[4]),
-          .CE(~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] ~ELSE 1'b1 ~FI),
+          .C(~ARG[6]),
+          .CE(~IF ~ISACTIVEENABLE[8] ~THEN ~ARG[8] ~ELSE 1'b1 ~FI),
           .D(~SYM[3][~SYM[8]]),
-          .R(~ARG[5]),
+          .R(~ARG[7]),
           .S(1'b0)
         );
       end
@@ -46,38 +49,42 @@
     kind: Declaration
     type: |-
       oddr#
-        :: ( KnownConfi~ fast domf    -- ARG[0]
-           , KnownConfi~ slow doms    -- ARG[1]
-           , KnownNat m )             -- ARG[2]
-        => Clock slow                 -- ARG[3]
-        -> Reset slow                 -- ARG[4]
-        -> Enable slow                -- ARG[5]
-        -> Signal slow (BitVector m)  -- ARG[6]
-        -> Signal slow (BitVector m)  -- ARG[7]
-        -> Signal fast (BitVector m)
+        :: forall n dom domDDR
+         . HasCallStack              -- ARG[0]
+        => KnownDomain dom           -- ARG[1]
+        => KnownDomain domDDR        -- ARG[2]
+        => DomPeriod ~ 2 * ...       -- ARG[3]
+        => DomEdge ~ Rising          -- ARG[4]
+        => KnownNat n                -- ARG[5]
+        => Clock dom                 -- ARG[6]
+        -> Reset dom                 -- ARG[7]
+        -> Enable dom                -- ARG[8]
+        -> Signal dom (BitVector n)  -- ARG[9]
+        -> Signal dom (BitVector n)  -- ARG[10]
+        -> Signal domDDR (BitVector n)
     template: |-
       // oddr begin
-      wire ~SIGD[~GENSYM[data_pos][1]][7];
-      wire ~SIGD[~GENSYM[data_neg][2]][7];
-      wire ~SIGD[~GENSYM[q][3]][7];
+      wire ~SIGD[~GENSYM[data_pos][1]][10];
+      wire ~SIGD[~GENSYM[data_neg][2]][10];
+      wire ~SIGD[~GENSYM[q][3]][10];
 
-      assign ~SYM[1] = ~ARG[6];
-      assign ~SYM[2] = ~ARG[7];
+      assign ~SYM[1] = ~ARG[9];
+      assign ~SYM[2] = ~ARG[10];
 
       genvar ~GENSYM[i][8];
       ~GENERATE
-      for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[7]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
+      for (~SYM[8]=0; ~SYM[8] < ~SIZE[~TYP[10]]; ~SYM[8]=~SYM[8]+1) begin : ~GENSYM[ddro_array][7]
         ODDR #(
           .DDR_CLK_EDGE("SAME_EDGE"),
           .INIT(1'b0),
           .SRTYPE(~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
         ) ~GENSYM[~COMPNAME_ODDR][9] (
           .Q(~SYM[3][~SYM[8]]),
-          .C(~ARG[3]),
-          .CE(~IF ~ISACTIVEENABLE[5] ~THEN ~ARG[5] ~ELSE 1'b1 ~FI),
+          .C(~ARG[6]),
+          .CE(~IF ~ISACTIVEENABLE[8] ~THEN ~ARG[8] ~ELSE 1'b1 ~FI),
           .D1(~SYM[1][~SYM[8]]),
           .D2(~SYM[2][~SYM[8]]),
-          .R(~ARG[4]),
+          .R(~ARG[7]),
           .S(1'b0)
         );
       end

--- a/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives.yaml
@@ -2,57 +2,58 @@
     name: Clash.Explicit.DDR.ddrIn#
     kind: Declaration
     type: |-
-      ddrIn# :: forall a slow fast n pFast enabled synchronous.
-                 ( HasCallStack           -- ARG[0]
-                 , NFDataX a              -- ARG[1]
-                 , KnownConfi~ fast domf  -- ARG[2]
-                 , KnownConfi~ slow doms  -- ARG[3]
-              => Clock slow               -- ARG[4]
-              -> Reset slow               -- ARG[5]
-              -> Enable slow              -- ARG[6]
-              -> a                        -- ARG[7]
-              -> a                        -- ARG[8]
-              -> a                        -- ARG[9]
-              -> Signal fast a            -- ARG[10]
-              -> Signal slow (a,a)
+      ddrIn# :: forall a dom domDDR
+              . HasCallStack             -- ARG[0]
+             => NFDataX a                -- ARG[1]
+             => KnownDomain dom          -- ARG[2]
+             => KnownDomain domDDR       -- ARG[3]
+             => DomPeriod ~ 2 * ...      -- ARG[4]
+             => Clock dom                -- ARG[5]
+             -> Reset dom                -- ARG[6]
+             -> Enable dom               -- ARG[7]
+             -> a                        -- ARG[8]
+             -> a                        -- ARG[9]
+             -> a                        -- ARG[10]
+             -> Signal domDDR a          -- ARG[11]
+             -> Signal dom (a,a)
     template: |-
       -- ddrIn begin
       ~GENSYM[~COMPNAME_ddrIn][0] : block
-        signal ~GENSYM[data_Pos][1]       : ~TYP[9];
-        signal ~GENSYM[data_Neg][2]       : ~TYP[9];
-        signal ~GENSYM[data_Neg_Latch][3] : ~TYP[9];
+        signal ~GENSYM[data_Pos][1]       : ~TYP[11];
+        signal ~GENSYM[data_Neg][2]       : ~TYP[11];
+        signal ~GENSYM[data_Neg_Latch][3] : ~TYP[11];
       begin
-       ~IF ~ISSYNC[3] ~THEN
+       ~IF ~ISSYNC[2] ~THEN
         -- sync
         -------------
-        ~GENSYM[~COMPNAME_ddrIn_pos][6] : process(~ARG[4])
+        ~GENSYM[~COMPNAME_ddrIn_pos][6] : process(~ARG[5])
         begin
-          if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-            if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-              ~SYM[1] <= ~ARG[8];
-            els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
-              ~SYM[1] <= ~ARG[10];
+          if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+            if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
+              ~SYM[1] <= ~ARG[9];
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+              ~SYM[1] <= ~ARG[11];
             end if;
           end if;
         end process;
 
-        ~GENSYM[~COMPNAME_ddrIn_neg][7] : process(~ARG[4])
+        ~GENSYM[~COMPNAME_ddrIn_neg][7] : process(~ARG[5])
         begin
-          if ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then
-            if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-              ~SYM[2] <= ~ARG[9];
-            els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
+          if ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[5]) then
+            if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
               ~SYM[2] <= ~ARG[10];
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+              ~SYM[2] <= ~ARG[11];
             end if;
           end if;
         end process;
 
-        ~GENSYM[~COMPNAME_ddrIn_neg_latch][8] : process(~ARG[4])
+        ~GENSYM[~COMPNAME_ddrIn_neg_latch][8] : process(~ARG[5])
         begin
-          if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-            if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-              ~SYM[3] <= ~ARG[7];
-            els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
+          if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+            if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
+              ~SYM[3] <= ~ARG[8];
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
               ~SYM[3] <= ~SYM[2];
             end if;
           end if;
@@ -60,29 +61,29 @@
        ~ELSE
         -- async
         --------------
-        ~SYM[6] : process(~ARG[4],~ARG[5])
+        ~SYM[6] : process(~ARG[5],~ARG[6])
         begin
-          if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-            ~SYM[1] <= ~ARG[8];
-          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-            ~SYM[1] <= ~ARG[10];
+          if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
+            ~SYM[1] <= ~ARG[9];
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+            ~SYM[1] <= ~ARG[11];
           end if;
         end process;
 
-        ~SYM[7] : process(~ARG[4],~ARG[5])
+        ~SYM[7] : process(~ARG[5],~ARG[6])
         begin
-          if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-            ~SYM[2] <= ~ARG[9];
-          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[4]) then
+          if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[2] <= ~ARG[10];
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[5]) then
+            ~SYM[2] <= ~ARG[11];
           end if;
         end process;
 
-        ~SYM[8] : process(~ARG[4],~ARG[5])
+        ~SYM[8] : process(~ARG[5],~ARG[6])
         begin
-          if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-            ~SYM[3] <= ~ARG[7];
-          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
+          if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
+            ~SYM[3] <= ~ARG[8];
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             ~SYM[3] <= ~SYM[2];
           end if;
         end process;
@@ -94,68 +95,70 @@
     name: Clash.Explicit.DDR.ddrOut#
     kind: Declaration
     type: |-
-      ddrOut# :: ( HasCallStack                -- ARG[0]
-                  , NFDataX a                  -- ARG[1]
-                  , KnownConfi~ fast domf      -- ARG[2]
-                  , KnownConfi~ slow doms      -- ARG[3]
-               => Clock slow                   -- ARG[4]
-               -> Reset slow                   -- ARG[5]
-               -> Enable slow                  -- ARG[6]
-               -> a                            -- ARG[7]
-               -> Signal slow a                -- ARG[8]
-               -> Signal slow a                -- ARG[9]
-               -> Signal fast a
+      ddrOut# :: forall a dom domDDR
+               . HasCallStack                 -- ARG[0]
+              => NFDataX a                    -- ARG[1]
+              => KnownDomain dom              -- ARG[2]
+              => KnownDomain domDDR           -- ARG[3]
+              => DomPeriod ~ 2 * ...          -- ARG[4]
+              => Clock dom                    -- ARG[5]
+              -> Reset dom                    -- ARG[6]
+              -> Enable dom                   -- ARG[7]
+              -> a                            -- ARG[8]
+              -> Signal dom a                 -- ARG[9]
+              -> Signal dom a                 -- ARG[10]
+              -> Signal domDDR a
     template: |-
       -- ddrOut begin
       ~GENSYM[~COMPNAME_ddrOut][0] : block
-        signal ~GENSYM[data_Pos][1] : ~TYP[7];
-        signal ~GENSYM[data_Neg][2] : ~TYP[7];
+        signal ~GENSYM[data_Pos][1] : ~TYP[8];
+        signal ~GENSYM[data_Neg][2] : ~TYP[8];
       begin
-       ~IF ~ISSYNC[3] ~THEN
+       ~IF ~ISSYNC[2] ~THEN
         -- sync
         -------------
-        ~GENSYM[~COMPNAME_ddrOut_pos][5] : process(~ARG[4])
+        ~GENSYM[~COMPNAME_ddrOut_pos][5] : process(~ARG[5])
         begin
-          if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-            if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-              ~SYM[1] <= ~ARG[7];
-            els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
+          if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+            if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
               ~SYM[1] <= ~ARG[8];
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+              ~SYM[1] <= ~ARG[9];
             end if;
           end if;
         end process;
 
-        ~GENSYM[~COMPNAME_ddrOut_neg][6] : process(~ARG[4])
+        ~GENSYM[~COMPNAME_ddrOut_neg][6] : process(~ARG[5])
         begin
-          if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-            if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-              ~SYM[2] <= ~ARG[7];
-            els~IF ~ISACTIVEENABLE[6] ~THENif ~ARG[6] then~ELSEe~FI
-              ~SYM[2] <= ~ARG[9];
+          if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+            if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
+              ~SYM[2] <= ~ARG[8];
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+              ~SYM[2] <= ~ARG[10];
             end if;
           end if;
         end process;
        ~ELSE
         -- async
         --------------
-        ~SYM[5] : process(~ARG[4],~ARG[5]~VARS[8])
+        ~SYM[5] : process(~ARG[5],~ARG[6]~VARS[9])
         begin
-          if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-            ~SYM[1] <= ~ARG[7];
-          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
+          if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[1] <= ~ARG[8];
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+            ~SYM[1] <= ~ARG[9];
           end if;
         end process;
 
-        ~SYM[6] : process(~ARG[4],~ARG[5]~VARS[9])
+        ~SYM[6] : process(~ARG[5],~ARG[6]~VARS[10])
         begin
-          if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
-            ~SYM[2] <= ~ARG[7];
-          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-            ~SYM[2] <= ~ARG[9];
+          if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
+            ~SYM[2] <= ~ARG[8];
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+            ~SYM[2] <= ~ARG[10];
           end if;
         end process;
        ~FI
-        ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1') else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
+        ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[5] = '1') else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
       end block;
       -- ddrOut end

--- a/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives.yaml
@@ -60,7 +60,7 @@
        ~ELSE
         -- async
         --------------
-        ~SYM[6] : process(~ARG[4],~ARG[5]~VARS[9])
+        ~SYM[6] : process(~ARG[4],~ARG[5])
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[1] <= ~ARG[8];
@@ -69,7 +69,7 @@
           end if;
         end process;
 
-        ~SYM[7] : process(~ARG[4],~ARG[5]~VARS[9])
+        ~SYM[7] : process(~ARG[4],~ARG[5])
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[2] <= ~ARG[9];
@@ -78,7 +78,7 @@
           end if;
         end process;
 
-        ~SYM[8] : process(~ARG[4],~ARG[5],~SYM[2])
+        ~SYM[8] : process(~ARG[4],~ARG[5])
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[3] <= ~ARG[7];
@@ -107,7 +107,7 @@
                -> Signal fast a
     template: |-
       -- ddrOut begin
-      ~GENSYM[~COMPNAME_ddrIn][0] : block
+      ~GENSYM[~COMPNAME_ddrOut][0] : block
         signal ~GENSYM[data_Pos][1] : ~TYP[7];
         signal ~GENSYM[data_Neg][2] : ~TYP[7];
       begin
@@ -142,7 +142,7 @@
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[1] <= ~ARG[7];
-          elsif ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
+          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
             ~SYM[1] <= ~ARG[8];
           end if;
         end process;
@@ -151,11 +151,11 @@
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[2] <= ~ARG[7];
-          elsif ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
+          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
             ~SYM[2] <= ~ARG[9];
           end if;
         end process;
        ~FI
-        ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1' ~IF ~ISACTIVEENABLE[6] ~THEN and ~ARG[6] ~ELSE ~FI) else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
+        ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1') else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
       end block;
       -- ddrOut end

--- a/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives.yaml
@@ -23,7 +23,7 @@
         signal ~GENSYM[dataout_l][1] : ~TYP[8];
         signal ~GENSYM[dataout_h][2] : ~TYP[8];~IF ~ISACTIVEENABLE[7] ~THEN
         signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
-      begin~IF ~ISACTIVEENABLE[5] ~THEN
+      begin~IF ~ISACTIVEENABLE[7] ~THEN
         ~SYM[4] <= '1' when (~ARG[7]) else '0';~ELSE ~FI
         ~GENSYM[~COMPNAME_ALTDDIO_IN][7] : ALTDDIO_IN
         GENERIC MAP (
@@ -37,7 +37,7 @@
         PORT MAP (~IF ~ISSYNC[6] ~THEN
           sclr      => ~ARG[6],~ELSE
           aclr      => ~ARG[6],~FI
-          datain    => ~ARG[8],~IF ~ISACTIVEENABLE[5] ~THEN
+          datain    => ~ARG[8],~IF ~ISACTIVEENABLE[7] ~THEN
           inclocken => ~SYM[4],~ELSE ~FI
           inclock   => ~ARG[5],
           dataout_h => ~SYM[2],
@@ -71,7 +71,7 @@
       ~GENSYM[~COMPNAME_ALTDDIO_OUT][0] : block ~IF ~ISACTIVEENABLE[7] ~THEN
         signal ~GENSYM[ce_logic][1] : std_logic; ~ELSE ~FI
       begin~IF ~ISACTIVEENABLE[7] ~THEN
-        ~SYM[3] <= '1' when (~ARG[7]) else '0'; ~ELSE ~FI
+        ~SYM[1] <= '1' when (~ARG[7]) else '0'; ~ELSE ~FI
         ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] : ALTDDIO_OUT
           GENERIC MAP (
             extend_oe_disable => "OFF",
@@ -88,8 +88,8 @@
             aclr       => ~ARG[6],~FI ~IF ~ISACTIVEENABLE[7] ~THEN
             outclocken => ~SYM[1],~ELSE ~FI
             outclock   => ~ARG[5],
-            datain_h   => ~ARG[7],
-            datain_l   => ~ARG[8],
+            datain_h   => ~ARG[8],
+            datain_l   => ~ARG[9],
             dataout    => ~RESULT
           );
       end block;

--- a/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives.yaml
@@ -1,45 +1,48 @@
 - BlackBox:
-    name: Clash.Intel.DDR.altddioIn
+    name: Clash.Intel.DDR.altddioIn#
     imports:
     - altera_mf.altera_mf_components.all
     kind: Declaration
     libraries:
     - altera_mf
     type: |-
-      altddioIn
-        :: ( HasCallStack               -- ARG[0]
-           , KnownConfi~ fast domf      -- ARG[1]
-           , KnownConfi~ slow doms      -- ARG[2]
-           , KnownNat m )               -- ARG[3]
-        => SSymbol deviceFamily         -- ARG[4]
-        -> Clock slow                   -- ARG[5]
-        -> Reset slow                   -- ARG[6]
-        -> Enable slow                  -- ARG[7]
-        -> Signal fast (BitVector m)    -- ARG[8]
-        -> Signal slow (BitVector m,BitVector m)
+      altddioIn#
+        :: forall deviceFamily n dom domDDR
+         . HasCallStack                 -- ARG[0]
+        => KnownDomain dom              -- ARG[1]
+        => KnownDomain domDDR           -- ARG[2]
+        => DomPeriod ~ 2 * ...          -- ARG[3]
+        => DomEdge ~ Rising             -- ARG[4]
+        => KnownNat n                   -- ARG[5]
+        => SSymbol deviceFamily         -- ARG[6]
+        -> Clock dom                    -- ARG[7]
+        -> Reset dom                    -- ARG[8]
+        -> Enable dom                   -- ARG[9]
+        -> Signal domDDR (BitVector n)  -- ARG[10]
+        -> Signal dom (BitVector n, BitVector n)
     template: |-
       -- altddioIn begin
       ~GENSYM[~COMPNAME_ALTDDIO_IN][0] : block
-        signal ~GENSYM[dataout_l][1] : ~TYP[8];
-        signal ~GENSYM[dataout_h][2] : ~TYP[8];~IF ~ISACTIVEENABLE[7] ~THEN
+        signal ~GENSYM[dataout_l][1] : ~TYP[10];
+        signal ~GENSYM[dataout_h][2] : ~TYP[10];~IF ~ISACTIVEENABLE[9] ~THEN
         signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
-      begin~IF ~ISACTIVEENABLE[7] ~THEN
-        ~SYM[4] <= '1' when (~ARG[7]) else '0';~ELSE ~FI
+      begin~IF ~ISACTIVEENABLE[9] ~THEN
+        ~SYM[4] <= '1' when (~ARG[9]) else '0';~ELSE ~FI
         ~GENSYM[~COMPNAME_ALTDDIO_IN][7] : ALTDDIO_IN
         GENERIC MAP (
-          intended_device_family => ~LIT[4],
+          intended_device_family => ~LIT[6],
           invert_input_clocks => "OFF",
           lpm_hint => "UNUSED",
           lpm_type => "altddio_in",
           power_up_high => "OFF",
-          width => ~SIZE[~TYP[8]]
+          width => ~SIZE[~TYP[10]]
         )
-        PORT MAP (~IF ~ISSYNC[6] ~THEN
-          sclr      => ~ARG[6],~ELSE
-          aclr      => ~ARG[6],~FI
-          datain    => ~ARG[8],~IF ~ISACTIVEENABLE[7] ~THEN
+        PORT MAP (~IF ~ISSYNC[1] ~THEN
+          sclr      => ~ARG[8],~ELSE
+          aclr      => ~ARG[8],~FI
+          datain    => ~ARG[10],~IF ~ISACTIVEENABLE[9] ~THEN
           inclocken => ~SYM[4],~ELSE ~FI
-          inclock   => ~ARG[5],
+          inclock   => ~ARG[7],
           dataout_h => ~SYM[2],
           dataout_l => ~SYM[1]
         );
@@ -55,27 +58,30 @@
     - altera_mf
     type: |-
       altddioOut#
-        :: ( HasCallStack             -- ARG[0]
-           , KnownConfi~ fast domf    -- ARG[1]
-           , KnownConfi~ slow doms    -- ARG[2]
-           , KnownNat m )             -- ARG[3]
-        => SSymbol deviceFamily       -- ARG[4]
-        -> Clock slow                 -- ARG[5]
-        -> Reset slow                 -- ARG[6]
-        -> Enable slow                -- ARG[7]
-        -> Signal slow (BitVector m)  -- ARG[8]
-        -> Signal slow (BitVector m)  -- ARG[9]
-        -> Signal fast (BitVector m)
+        :: forall deviceFamily n dom domDDR
+         . HasCallStack              -- ARG[0]
+        => KnownDomain dom           -- ARG[1]
+        => KnownDomain domDDR        -- ARG[2]
+        => DomPeriod ~ 2 * ...       -- ARG[3]
+        => DomEdge ~ Rising          -- ARG[4]
+        => KnownNat n                -- ARG[5]
+        => SSymbol deviceFamily      -- ARG[6]
+        -> Clock dom                 -- ARG[7]
+        -> Reset dom                 -- ARG[8]
+        -> Enable dom                -- ARG[9]
+        -> Signal dom (BitVector n)  -- ARG[10]
+        -> Signal dom (BitVector n)  -- ARG[11]
+        -> Signal domDDR (BitVector n)
     template: |-
       -- altddioOut begin
-      ~GENSYM[~COMPNAME_ALTDDIO_OUT][0] : block ~IF ~ISACTIVEENABLE[7] ~THEN
+      ~GENSYM[~COMPNAME_ALTDDIO_OUT][0] : block ~IF ~ISACTIVEENABLE[9] ~THEN
         signal ~GENSYM[ce_logic][1] : std_logic; ~ELSE ~FI
-      begin~IF ~ISACTIVEENABLE[7] ~THEN
-        ~SYM[1] <= '1' when (~ARG[7]) else '0'; ~ELSE ~FI
+      begin~IF ~ISACTIVEENABLE[9] ~THEN
+        ~SYM[1] <= '1' when (~ARG[9]) else '0'; ~ELSE ~FI
         ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] : ALTDDIO_OUT
           GENERIC MAP (
             extend_oe_disable => "OFF",
-            intended_device_family => ~LIT[4],
+            intended_device_family => ~LIT[6],
             invert_output => "OFF",
             lpm_hint => "UNUSED",
             lpm_type => "altddio_out",
@@ -83,13 +89,13 @@
             power_up_high => "OFF",
             width => ~SIZE[~TYPO]
           )
-          PORT MAP (~IF ~ISSYNC[2] ~THEN
-            sclr       => ~ARG[6],~ELSE
-            aclr       => ~ARG[6],~FI ~IF ~ISACTIVEENABLE[7] ~THEN
+          PORT MAP (~IF ~ISSYNC[1] ~THEN
+            sclr       => ~ARG[8],~ELSE
+            aclr       => ~ARG[8],~FI ~IF ~ISACTIVEENABLE[9] ~THEN
             outclocken => ~SYM[1],~ELSE ~FI
-            outclock   => ~ARG[5],
-            datain_h   => ~ARG[8],
-            datain_l   => ~ARG[9],
+            outclock   => ~ARG[7],
+            datain_h   => ~ARG[10],
+            datain_l   => ~ARG[11],
             dataout    => ~RESULT
           );
       end block;

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives.yaml
@@ -19,8 +19,8 @@
     template: |-
       -- iddr begin
       ~GENSYM[~COMPNAME_IDDR][0] : block
-        signal ~GENSYM[dataout_l][1] : ~TYP[7];
-        signal ~GENSYM[dataout_h][2] : ~TYP[7];
+        signal ~GENSYM[data_pos][1] : ~TYP[7];
+        signal ~GENSYM[data_neg][2] : ~TYP[7];
         signal ~GENSYM[d][3]         : ~TYP[7];~IF ~ISACTIVEENABLE[6] ~THEN
         signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
       begin~IF ~ISACTIVEENABLE[6] ~THEN
@@ -70,8 +70,8 @@
     template: |-
       -- oddr begin
       ~GENSYM[~COMPNAME_ODDR][0] : block
-        signal ~GENSYM[dataout_l][1] : ~TYPO;
-        signal ~GENSYM[dataout_h][2] : ~TYPO;
+        signal ~GENSYM[data_pos][1] : ~TYPO;
+        signal ~GENSYM[data_neg][2] : ~TYPO;
         signal ~GENSYM[q][3]         : ~TYPO;~IF ~ISACTIVEENABLE[5] ~THEN
         signal ~GENSYM[ce_logic][4]  : std_logic;~ELSE ~FI
       begin~IF ~ISACTIVEENABLE[5] ~THEN
@@ -79,13 +79,13 @@
         ~SYM[1] <= ~ARG[6];
         ~SYM[2] <= ~ARG[7];
 
-        ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
+        ~GENSYM[gen_oddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
         begin
           ~GENSYM[~COMPNAME_ODDR_inst][9] : ODDR
           generic map(
             DDR_CLK_EDGE => "SAME_EDGE",
             INIT => '0',
-            SRTYPE => ~IF ~ISSYNC[2] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
+            SRTYPE => ~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
           port map (
             Q  => ~SYM[3](~SYM[8]),    -- 1-bit DDR output
             C  => ~ARG[3],   -- 1-bit clock input

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives.yaml
@@ -1,31 +1,34 @@
 - BlackBox:
-    name: Clash.Xilinx.DDR.iddr
+    name: Clash.Xilinx.DDR.iddr#
     imports:
     - UNISIM.vcomponents.all
     kind: Declaration
     libraries:
     - UNISIM
     type: |-
-      iddr
-        :: ( HasCallStack             -- ARG[0]
-           , KnownConfi~ fast domf    -- ARG[1]
-           , KnownConfi~ slow doms    -- ARG[2]
-           , KnownNat m )             -- ARG[3]
-        -> Clock slow                 -- ARG[4]
-        -> Reset slow                 -- ARG[5]
-        -> Enable slow                -- ARG[6]
-        -> Signal fast (BitVector m)  -- ARG[7]
-        -> Signal slow (BitVector m,BitVector m)
+      iddr#
+        :: forall n dom domDDR
+         . HasCallStack                 -- ARG[0]
+        => KnownDomain dom              -- ARG[1]
+        => KnownDomain domDDR           -- ARG[2]
+        => DomPeriod ~ 2 * ...          -- ARG[3]
+        => DomEdge ~ Rising             -- ARG[4]
+        => KnownNat n                   -- ARG[5]
+        => Clock dom                    -- ARG[6]
+        -> Reset dom                    -- ARG[7]
+        -> Enable dom                   -- ARG[8]
+        -> Signal domDDR (BitVector n)  -- ARG[9]
+        -> Signal dom (BitVector n, BitVector n)
     template: |-
       -- iddr begin
       ~GENSYM[~COMPNAME_IDDR][0] : block
-        signal ~GENSYM[data_pos][1] : ~TYP[7];
-        signal ~GENSYM[data_neg][2] : ~TYP[7];
-        signal ~GENSYM[d][3]         : ~TYP[7];~IF ~ISACTIVEENABLE[6] ~THEN
+        signal ~GENSYM[data_pos][1] : ~TYP[9];
+        signal ~GENSYM[data_neg][2] : ~TYP[9];
+        signal ~GENSYM[d][3]         : ~TYP[9];~IF ~ISACTIVEENABLE[8] ~THEN
         signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
-      begin~IF ~ISACTIVEENABLE[6] ~THEN
-        ~SYM[4] <= '1' when (~ARG[6]) else '0';~ELSE ~FI
-        ~SYM[3] <= ~ARG[7];
+      begin~IF ~ISACTIVEENABLE[8] ~THEN
+        ~SYM[4] <= '1' when (~ARG[8]) else '0';~ELSE ~FI
+        ~SYM[3] <= ~ARG[9];
 
         ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
         begin
@@ -34,14 +37,14 @@
             DDR_CLK_EDGE => "SAME_EDGE",
             INIT_Q1      => '0',
             INIT_Q2      => '0',
-            SRTYPE       => ~IF ~ISSYNC[2] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
+            SRTYPE       => ~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
           port map (
             Q1 => ~SYM[1](~SYM[8]),   -- 1-bit output for positive edge of clock
             Q2 => ~SYM[2](~SYM[8]),   -- 1-bit output for negative edge of clock
-            C  => ~ARG[4],   -- 1-bit clock input
-            CE => ~IF ~ISACTIVEENABLE[6] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
+            C  => ~ARG[6],   -- 1-bit clock input
+            CE => ~IF ~ISACTIVEENABLE[8] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
             D  => ~SYM[3](~SYM[8]),   -- 1-bit DDR data input
-            R  => ~ARG[5],   -- 1-bit reset
+            R  => ~ARG[7],   -- 1-bit reset
             S  => '0'        -- 1-bit set
           );
         end generate;
@@ -58,26 +61,30 @@
     - UNISIM
     type: |-
       oddr#
-        :: ( KnownConfi~ fast domf     -- ARG[0]
-           , KnownConfi~ slow doms     -- ARG[1]
-           , KnownNat m )              -- ARG[2]
-        => Clock slow                  -- ARG[3]
-        -> Reset slow                  -- ARG[4]
-        -> Enable slow                 -- ARG[5]
-        -> Signal slow (BitVector m)   -- ARG[6]
-        -> Signal slow (BitVector m)   -- ARG[7]
-        -> Signal fast (BitVector m)
+        :: forall n dom domDDR
+         . HasCallStack              -- ARG[0]
+        => KnownDomain dom           -- ARG[1]
+        => KnownDomain domDDR        -- ARG[2]
+        => DomPeriod ~ 2 * ...       -- ARG[3]
+        => DomEdge ~ Rising          -- ARG[4]
+        => KnownNat n                -- ARG[5]
+        => Clock dom                 -- ARG[6]
+        -> Reset dom                 -- ARG[7]
+        -> Enable dom                -- ARG[8]
+        -> Signal dom (BitVector n)  -- ARG[9]
+        -> Signal dom (BitVector n)  -- ARG[10]
+        -> Signal domDDR (BitVector n)
     template: |-
       -- oddr begin
       ~GENSYM[~COMPNAME_ODDR][0] : block
         signal ~GENSYM[data_pos][1] : ~TYPO;
         signal ~GENSYM[data_neg][2] : ~TYPO;
-        signal ~GENSYM[q][3]         : ~TYPO;~IF ~ISACTIVEENABLE[5] ~THEN
+        signal ~GENSYM[q][3]         : ~TYPO;~IF ~ISACTIVEENABLE[8] ~THEN
         signal ~GENSYM[ce_logic][4]  : std_logic;~ELSE ~FI
-      begin~IF ~ISACTIVEENABLE[5] ~THEN
-        ~SYM[4] <= '1' when (~ARG[5]) else '0';~ELSE ~FI
-        ~SYM[1] <= ~ARG[6];
-        ~SYM[2] <= ~ARG[7];
+      begin~IF ~ISACTIVEENABLE[8] ~THEN
+        ~SYM[4] <= '1' when (~ARG[8]) else '0';~ELSE ~FI
+        ~SYM[1] <= ~ARG[9];
+        ~SYM[2] <= ~ARG[10];
 
         ~GENSYM[gen_oddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
         begin
@@ -88,11 +95,11 @@
             SRTYPE => ~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
           port map (
             Q  => ~SYM[3](~SYM[8]),    -- 1-bit DDR output
-            C  => ~ARG[3],   -- 1-bit clock input
-            CE => ~IF ~ISACTIVEENABLE[5] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
+            C  => ~ARG[6],   -- 1-bit clock input
+            CE => ~IF ~ISACTIVEENABLE[8] ~THEN ~SYM[4] ~ELSE '1' ~FI,       -- 1-bit clock enable input
             D1 => ~SYM[1](~SYM[8]),    -- 1-bit data input (positive edge)
             D2 => ~SYM[2](~SYM[8]),    -- 1-bit data input (negative edge)
-            R  => ~ARG[4],    -- 1-bit reset input
+            R  => ~ARG[7],    -- 1-bit reset input
             S  => '0'         -- 1-bit set input
           );
         end generate;

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -50,8 +50,9 @@ import Clash.Signal.Internal
 >>> import Clash.Explicit.Prelude
 >>> import Clash.Explicit.DDR
 >>> :{
-instance KnownDomain "Fast" where
-  type KnownConf "Fast" = 'DomainConfiguration "Fast" 5000 'Rising 'Asynchronous 'Defined 'ActiveHigh
+type DDR = "DDR" :: Domain
+instance KnownDomain "DDR" where
+  type KnownConf "DDR" = 'DomainConfiguration "DDR" 5000 'Rising 'Asynchronous 'Defined 'ActiveHigh
   knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
 :}
 
@@ -62,24 +63,37 @@ instance KnownDomain "Fast" where
 -- Consumes a DDR input signal and produces a regular signal containing a pair
 -- of values.
 --
--- >>> printX $ sampleN 5 $ ddrIn systemClockGen systemResetGen enableGen (-1,-2,-3) (fromList [0..10] :: Signal "Fast" Int)
+-- Data is clocked in on both edges of the clock signal. We can discern the
+-- /active edge/ of the clock and the /other edge/. When the domain has the
+-- rising edge as the active edge (which is the most common), this means that
+-- the /rising/ edge is the /active/ edge and the /falling/ edge is the /other/
+-- edge.
+--
+-- Of the output pair @(o0, o1)@, @o0@ is the data clocked in on the /other/
+-- edge and @o1@ is the data clocked in on the /active/ edge, and @o0@ comes
+-- before @o1@ in time. With a domain where the rising edge is the active edge,
+-- this means @o0@ is clocked in on the falling clock edge and @o1@ is clocked
+-- in on the rising clock edge. For a domain with the falling edge as the active
+-- edge, this is the other way around, but @o0@ still comes before @o1@ in time.
+--
+-- >>> sampleN 5 $ ddrIn @Int @System @DDR clockGen resetGen enableGen (-1,-2,-3) (fromList [0..10])
 -- [(-1,-2),(-1,-2),(-3,2),(3,4),(5,6)]
 ddrIn
-  :: ( HasCallStack
-     , NFDataX a
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
-  => Clock slow
-  -- ^ clock
-  -> Reset slow
-  -- ^ reset
-  -> Enable slow
+  :: forall a dom domDDR
+   . HasCallStack
+  => NFDataX a
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => Clock dom
+  -> Reset dom
+  -> Enable dom
   -> (a, a, a)
-  -- ^ reset values
-  -> Signal fast a
+  -- ^ Reset values
+  -> Signal domDDR a
   -- ^ DDR input signal
-  -> Signal slow (a, a)
-  -- ^ normal speed output pairs
+  -> Signal dom (a, a)
+  -- ^ Normal speed output pair @(o0, o1)@
 ddrIn clk rst en (i0,i1,i2) =
   withFrozenCallStack $ ddrIn# clk rst en i0 i1 i2
 
@@ -87,21 +101,22 @@ ddrIn clk rst en (i0,i1,i2) =
 -- For details about all the seq's en seqX's
 -- see the [Note: register strictness annotations] in Clash.Signal.Internal
 ddrIn#
-  :: forall a slow fast fPeriod polarity edge reset init
-   . ( HasCallStack
-     , NFDataX a
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
-  => Clock slow
-  -> Reset slow
-  -> Enable slow
+  :: forall a dom domDDR
+   . HasCallStack
+  => NFDataX a
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => Clock dom
+  -> Reset dom
+  -> Enable dom
   -> a
   -> a
   -> a
-  -> Signal fast a
-  -> Signal slow (a,a)
+  -> Signal domDDR a
+  -> Signal dom (a,a)
 ddrIn# (Clock _ Nothing) (unsafeToActiveHigh -> hRst) (fromEnable -> ena) i0 i1 i2 =
-  case resetKind @fast of
+  case resetKind @domDDR of
     SAsynchronous ->
       goAsync
         ( deepErrorX "ddrIn: initial value 0 undefined"
@@ -119,10 +134,10 @@ ddrIn# (Clock _ Nothing) (unsafeToActiveHigh -> hRst) (fromEnable -> ena) i0 i1 
   where
     goSync
       :: (a, a, a)
-      -> Signal slow Bool
-      -> Signal slow Bool
-      -> Signal fast a
-      -> Signal slow (a,a)
+      -> Signal dom Bool
+      -> Signal dom Bool
+      -> Signal domDDR a
+      -> Signal dom (a,a)
     goSync (o0,o1,o2) rt@(~(r :- rs)) ~(e :- es) as@(~(x0 :- x1 :- xs)) =
       let (o0',o1',o2') = if r then (i0,i1,i2) else (o2,x0,x1)
       in o0 `seqX` o1 `seqX` (o0,o1)
@@ -131,10 +146,10 @@ ddrIn# (Clock _ Nothing) (unsafeToActiveHigh -> hRst) (fromEnable -> ena) i0 i1 
 
     goAsync
       :: (a, a, a)
-      -> Signal slow Bool
-      -> Signal slow Bool
-      -> Signal fast a
-      -> Signal slow (a, a)
+      -> Signal dom Bool
+      -> Signal dom Bool
+      -> Signal domDDR a
+      -> Signal dom (a, a)
     goAsync (o0,o1,o2) ~(r :- rs) ~(e :- es) as@(~(x0 :- x1 :- xs)) =
       let (o0',o1',o2',o3',o4') = if r then (i0,i1,i0,i1,i2) else (o0,o1,o2,x0,x1)
       in o0' `seqX` o1' `seqX` (o0',o1')
@@ -151,38 +166,56 @@ ddrIn# _ _ _ _ _ _ =
 --
 -- Produces a DDR output signal from a normal signal of pairs of input.
 --
--- >>> sampleN 7 (ddrOut systemClockGen systemResetGen enableGen (-1) (fromList [(0,1),(2,3),(4,5)]) :: Signal "Fast" Int)
+-- Data is clocked out on both edges of the clock signal. We can discern the
+-- /active edge/ of the clock and the /other edge/. When the domain has the
+-- rising edge as the active edge (which is the most common), this means that
+-- the /rising/ edge is the /active/ edge and the /falling/ edge is the /other/
+-- edge.
+--
+-- Of the input pair @(i0, i1)@, @i0@ is the data clocked out on the /active/
+-- edge and @i1@ is the data clocked out on the /other/ edge, and @i0@ comes
+-- before @i1@ in time. With a domain where the rising edge is the active edge,
+-- this means @i0@ is clocked out on the rising clock edge and @i1@ is clocked
+-- out on the falling clock edge. For a domain with the falling edge as the
+-- active edge, this is the other way around, but @i0@ still comes before @i1@
+-- in time.
+--
+-- >>> sampleN 7 (ddrOut @Int @System @DDR clockGen resetGen enableGen (-1) (fromList [(0,1),(2,3),(4,5)]))
 -- [-1,-1,-1,2,3,4,5]
 ddrOut
-  :: ( HasCallStack
-     , NFDataX a
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
-  => Clock slow
-  -> Reset slow
-  -> Enable slow
+  :: forall a dom domDDR
+   . HasCallStack
+  => NFDataX a
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => Clock dom
+  -> Reset dom
+  -> Enable dom
   -> a
-  -- ^ reset value
-  -> Signal slow (a, a)
-  -- ^ Normal speed input pairs
-  -> Signal fast a
+  -- ^ Reset value
+  -> Signal dom (a, a)
+  -- ^ Normal speed input pair @(i0, i1)@
+  -> Signal domDDR a
   -- ^ DDR output signal
 ddrOut clk rst en i0 =
   uncurry (withFrozenCallStack $ ddrOut# clk rst en i0) . unbundle
 
 
 ddrOut#
-  :: ( HasCallStack
-     , NFDataX a
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity) )
-  => Clock slow
-  -> Reset slow
-  -> Enable slow
+  :: forall a dom domDDR
+   . HasCallStack
+  => NFDataX a
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => Clock dom
+  -> Reset dom
+  -> Enable dom
   -> a
-  -> Signal slow a
-  -> Signal slow a
-  -> Signal fast a
+  -> Signal dom a
+  -> Signal dom a
+  -> Signal domDDR a
 ddrOut# clk rst en i0 xs ys =
     -- We only observe one reset value, because when the mux switches on the
     -- next clock level, the second register will already be outputting its

--- a/clash-prelude/src/Clash/Intel/DDR.hs
+++ b/clash-prelude/src/Clash/Intel/DDR.hs
@@ -53,7 +53,7 @@ altddioIn
   -- ^ DDR input signal
   -> Signal slow (BitVector m,BitVector m)
   -- ^ normal speed output pairs
-altddioIn _devFam clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
+altddioIn SSymbol clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE altddioIn #-}
 {-# ANN altddioIn hasBlackBox #-}
@@ -97,7 +97,7 @@ altddioOut#
   -> Signal slow (BitVector m)
   -> Signal slow (BitVector m)
   -> Signal fast (BitVector m)
-altddioOut# _ clk rst en = ddrOut# clk rst en 0
+altddioOut# SSymbol clk rst en = ddrOut# clk rst en 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE altddioOut# #-}
 {-# ANN altddioOut# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Intel/DDR.hs
+++ b/clash-prelude/src/Clash/Intel/DDR.hs
@@ -9,7 +9,7 @@ DDR primitives for Intel FPGAs using ALTDDIO primitives.
 For general information about DDR primitives see "Clash.Explicit.DDR".
 
 Note that a reset is only available on certain devices,
-see ALTDDIO userguide for the specifics:
+see the ALTDDIO user guide for the specifics:
 <https://www.altera.com/content/dam/altera-www/global/en_US/pdfs/literature/ug/ug_altddio.pdf>
 -}
 
@@ -20,9 +20,13 @@ see ALTDDIO userguide for the specifics:
 module Clash.Intel.DDR
   ( altddioIn
   , altddioOut
+    -- * Internal
+  , altddioIn#
+  , altddioOut#
   )
 where
 
+import Data.Bifunctor
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 
 import Clash.Annotations.Primitive (hasBlackBox)
@@ -32,71 +36,105 @@ import Clash.Explicit.DDR
 -- | Intel specific variant of 'ddrIn' implemented using the ALTDDIO_IN IP core.
 --
 -- Reset values are @0@
+--
+-- Of the output pair @(o0, o1)@, @o0@ is the data clocked in on the /falling/
+-- edge and @o1@ is the data clocked in on the /rising/ edge, and @o0@ comes
+-- before @o1@ in time.
+--
+-- __NB__: This primitive only supports rising edges as the active edge.
 altddioIn
-  :: ( HasCallStack
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
-     , KnownNat m )
+  :: forall deviceFamily a dom domDDR
+   . HasCallStack
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => DomainActiveEdge dom ~ 'Rising
+  => BitPack a
   => SSymbol deviceFamily
   -- ^ The FPGA family
   --
   -- For example this can be instantiated as follows:
   --
   -- > SSymbol @"Cyclone IV GX"
-  -> Clock slow
-  -- ^ clock
-  -> Reset slow
-  -- ^ reset
-  -> Enable slow
-  -- ^ Global enable
-  -> Signal fast (BitVector m)
+  -> Clock dom
+  -> Reset dom
+  -> Enable dom
+  -> Signal domDDR a
   -- ^ DDR input signal
-  -> Signal slow (BitVector m,BitVector m)
-  -- ^ normal speed output pairs
-altddioIn SSymbol clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
+  -> Signal dom (a, a)
+  -- ^ Normal speed output pair @(o0, o1)@
+altddioIn devFam clk rst en =
+  fmap (bimap unpack unpack) .
+    withFrozenCallStack (altddioIn# devFam clk rst en) . fmap pack
+
+altddioIn#
+  :: forall deviceFamily n dom domDDR
+   . HasCallStack
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => DomainActiveEdge dom ~ 'Rising
+  => KnownNat n
+  => SSymbol deviceFamily
+  -> Clock dom
+  -> Reset dom
+  -> Enable dom
+  -> Signal domDDR (BitVector n)
+  -> Signal dom (BitVector n, BitVector n)
+altddioIn# SSymbol clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE altddioIn #-}
-{-# ANN altddioIn hasBlackBox #-}
+{-# CLASH_OPAQUE altddioIn# #-}
+{-# ANN altddioIn# hasBlackBox #-}
 
 -- | Intel specific variant of 'ddrOut' implemented using the ALTDDIO_OUT IP core.
 --
 -- Reset value is @0@
+--
+-- Of the input pair @(i0, i1)@, @i0@ is the data clocked out on the /rising/
+-- edge and @i1@ is the data clocked out on the /falling/ edge, and @i0@ comes
+-- before @i1@ in time.
+--
+-- __NB__: This primitive only supports rising edges as the active edge.
 altddioOut
-  :: ( HasCallStack
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
-     , KnownNat m )
+  :: forall deviceFamily a dom domDDR
+   . HasCallStack
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => DomainActiveEdge dom ~ 'Rising
+  => BitPack a
   => SSymbol deviceFamily
   -- ^ The FPGA family
   --
   -- For example this can be instantiated as follows:
   --
   -- > SSymbol @"Cyclone IV E"
-  -> Clock slow
-  -- ^ clock
-  -> Reset slow
-  -- ^ reset
-  -> Enable slow
-  -- ^ Global enable
-  -> Signal slow (BitVector m,BitVector m)
-  -- ^ normal speed input pair
-  -> Signal fast (BitVector m)
+  -> Clock dom
+  -> Reset dom
+  -> Enable dom
+  -> Signal dom (a, a)
+  -- ^ Normal speed input pair @(i0, i1)@
+  -> Signal domDDR a
   -- ^ DDR output signal
 altddioOut devFam clk rst en =
-  uncurry (withFrozenCallStack altddioOut# devFam clk rst en) . unbundle
+  fmap unpack . uncurry (withFrozenCallStack altddioOut# devFam clk rst en) .
+    unbundle . fmap (bimap pack pack)
 
 altddioOut#
-  :: ( HasCallStack
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
-     , KnownNat m )
+  :: forall deviceFamily n dom domDDR
+   . HasCallStack
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => DomainActiveEdge dom ~ 'Rising
+  => KnownNat n
   => SSymbol deviceFamily
-  -> Clock slow
-  -> Reset slow
-  -> Enable slow
-  -> Signal slow (BitVector m)
-  -> Signal slow (BitVector m)
-  -> Signal fast (BitVector m)
+  -> Clock dom
+  -> Reset dom
+  -> Enable dom
+  -> Signal dom (BitVector n)
+  -> Signal dom (BitVector n)
+  -> Signal domDDR (BitVector n)
 altddioOut# SSymbol clk rst en = ddrOut# clk rst en 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE altddioOut# #-}

--- a/clash-prelude/src/Clash/Xilinx/DDR.hs
+++ b/clash-prelude/src/Clash/Xilinx/DDR.hs
@@ -10,8 +10,8 @@ For general information about DDR primitives see "Clash.Explicit.DDR".
 For more information about the Xilinx DDR primitives see:
 
 * Vivado Design Suite 7 Series FPGA and Zynq-7000 All Programmable SoC
-  Libraries Guide, UG953 (v2018.3) December 5, 2018, p371-373,p481-483,
-  <https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_3/ug953-vivado-7series-libraries.pdf>
+  Libraries Guide, UG953 (v2022.2) October 19, 2022, p369-371, p477-479,
+  <https://www.xilinx.com/content/dam/xilinx/support/documents/sw_manuals/xilinx2022_2/ug953-vivado-7series-libraries.pdf>
 -}
 
 {-# LANGUAGE CPP #-}
@@ -21,9 +21,13 @@ For more information about the Xilinx DDR primitives see:
 module Clash.Xilinx.DDR
   ( iddr
   , oddr
+    -- * Internal
+  , iddr#
+  , oddr#
   )
 where
 
+import Data.Bifunctor
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 
 import Clash.Annotations.Primitive (hasBlackBox)
@@ -34,56 +38,92 @@ import Clash.Explicit.DDR
 -- primitive in @SAME_EDGE@ mode.
 --
 -- Reset values are @0@
+--
+-- Of the output pair @(o0, o1)@, @o0@ is the data clocked in on the /falling/
+-- edge and @o1@ is the data clocked in on the /rising/ edge, and @o0@ comes
+-- before @o1@ in time.
+--
+-- __NB__: This primitive only supports rising edges as the active edge.
 iddr
-  :: ( HasCallStack
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
-     , KnownNat m )
-  => Clock slow
-  -- ^ clock
-  -> Reset slow
-  -- ^ reset
-  -> Enable slow
-  -- ^ global enable
-  -> Signal fast (BitVector m)
+  :: forall a dom domDDR
+   . HasCallStack
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => DomainActiveEdge dom ~ 'Rising
+  => BitPack a
+  => Clock dom
+  -> Reset dom
+  -> Enable dom
+  -> Signal domDDR a
   -- ^ DDR input signal
-  -> Signal slow ((BitVector m),(BitVector m))
-  -- ^ normal speed output pairs
-iddr clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
+  -> Signal dom (a, a)
+  -- ^ Normal speed output pair @(o0, o1)@
+iddr clk rst en =
+  fmap (bimap unpack unpack) . withFrozenCallStack (iddr# clk rst en) .
+    fmap pack
+
+iddr#
+  :: forall n dom domDDR
+   . HasCallStack
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => DomainActiveEdge dom ~ 'Rising
+  => KnownNat n
+  => Clock dom
+  -> Reset dom
+  -> Enable dom
+  -> Signal domDDR (BitVector n)
+  -> Signal dom (BitVector n, BitVector n)
+iddr# clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE iddr #-}
-{-# ANN iddr hasBlackBox #-}
+{-# CLASH_OPAQUE iddr# #-}
+{-# ANN iddr# hasBlackBox #-}
 
 -- | Xilinx specific variant of 'ddrOut' implemented using the Xilinx ODDR
 -- primitive in @SAME_EDGE@ mode.
 --
 -- Reset value is @0@
+--
+-- Of the input pair @(i0, i1)@, @i0@ is the data clocked out on the /rising/
+-- edge and @i1@ is the data clocked out on the /falling/ edge, and @i0@ comes
+-- before @i1@ in time.
+--
+-- __NB__: This primitive only supports rising edges as the active edge.
 oddr
-  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
-     , KnownNat m )
-  => Clock slow
-  -- ^ clock
-  -> Reset slow
-  -- ^ reset
-  -> Enable slow
-  -- ^ global enable
-  -> Signal slow (BitVector m, BitVector m)
-  -- ^ normal speed input pairs
-  -> Signal fast (BitVector m)
+  :: forall a dom domDDR
+   . HasCallStack
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => DomainActiveEdge dom ~ 'Rising
+  => BitPack a
+  => Clock dom
+  -> Reset dom
+  -> Enable dom
+  -> Signal dom (a, a)
+  -- ^ Normal speed input pair @(i0, i1)@
+  -> Signal domDDR a
   -- ^ DDR output signal
-oddr clk rst en = uncurry (withFrozenCallStack oddr# clk rst en) . unbundle
+oddr clk rst en =
+  fmap unpack . uncurry (withFrozenCallStack oddr# clk rst en) . unbundle .
+    fmap (bimap pack pack)
 
 oddr#
-  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
-     , KnownNat m )
-  => Clock slow
-  -> Reset slow
-  -> Enable slow
-  -> Signal slow (BitVector m)
-  -> Signal slow (BitVector m)
-  -> Signal fast (BitVector m)
+  :: forall n dom domDDR
+   . HasCallStack
+  => KnownDomain dom
+  => KnownDomain domDDR
+  => DomainPeriod dom ~ (2 * DomainPeriod domDDR)
+  => DomainActiveEdge dom ~ 'Rising
+  => KnownNat n
+  => Clock dom
+  -> Reset dom
+  -> Enable dom
+  -> Signal dom (BitVector n)
+  -> Signal dom (BitVector n)
+  -> Signal domDDR (BitVector n)
 oddr# clk rst en = ddrOut# clk rst en 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE oddr# #-}

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -514,11 +514,17 @@ runClashTest = defaultMain
         , runTest "T694" def{hdlSim=[],hdlTargets=[VHDL]}
         ]
       , clashTestGroup "DDR"
-        [ let _opts = def{ buildTargets = BuildSpecific [ "testBenchGA"
+        [
+          -- Since the `XilinxDDR` test is more comprehensive than these tests,
+          -- we skip these tests for Vivado and only run `XilinxDDR`.
+          let _opts = def{ buildTargets = BuildSpecific [ "testBenchGA"
                                                         , "testBenchGS"
                                                         , "testBenchUA"
                                                         , "testBenchUS"
-                                                        ]}
+                                                        ]
+                         , hdlLoad = hdlLoad def \\ [Vivado]
+                         , hdlSim = hdlSim def \\ [Vivado]
+                         }
           in runTest "DDRin" _opts
 
           -- XXX: `ddrOut` contains a number of (implicit) parallel, coinciding
@@ -530,6 +536,9 @@ runClashTest = defaultMain
           --      other. As a quick "fix" we disable Verilator, though we might
           --      consider rewriting the test such that it doesn't depend or
           --      accounts for the raciness.
+          --
+          -- Since the `XilinxDDR` test is more comprehensive than these tests,
+          -- we skip these tests for Vivado and only run `XilinxDDR`.
         , let _opts = def{ buildTargets = BuildSpecific [ "testBenchUA"
                                                         , "testBenchUS"
                                                         , "testBenchGA"
@@ -539,16 +548,12 @@ runClashTest = defaultMain
                          , hdlSim = hdlSim def \\ [Vivado, Verilator]
                          }
           in runTest "DDRout" _opts
-        , let _opts = def{ buildTargets = BuildSpecific [ "testBenchUA"
-                                                        , "testBenchUS"
-                                                        , "testBenchGA"
-                                                        , "testBenchGS"
-                                                        ]
+        , let _opts = def{ buildTargets = BuildSpecific ["testBenchAll"]
                          , hdlLoad = [Vivado]
                          , hdlSim = [Vivado]
                          , clashFlags=["-fclash-hdlsyn", "Vivado"]
                          }
-          in runTest "DDRout" _opts
+          in runTest "XilinxDDR" _opts
         ]
       , clashTestGroup "DSignal"
         [ runTest "DelayedFold" def

--- a/tests/shouldwork/DDR/IntelDDR.hs
+++ b/tests/shouldwork/DDR/IntelDDR.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE CPP #-}
+
+module IntelDDR where
+
+import Clash.Annotations.TH
+import Clash.Explicit.Prelude
+import Clash.Intel.DDR
+import Data.Bifunctor
+
+import VendorDDR
+
+intelIn :: DomCxt slow fast fPeriod reset => VendorIn slow fast
+intelIn clk rst en =
+  fmap (bimap unpack unpack) .
+    altddioIn (SSymbol @"Arria II GX") clk rst en . fmap pack
+
+intelOut :: DomCxt slow fast fPeriod reset => VendorOut slow fast
+intelOut clk rst en =
+  fmap unpack .
+    altddioOut (SSymbol @"Arria II GX") clk rst en . fmap (bimap pack pack)
+
+topEntityUA :: TopEntityNoEna System DDRA
+topEntityUA clk rst = topEntityGeneric intelIn intelOut clk rst enableGen
+{-# CLASH_OPAQUE topEntityUA #-}
+{-# ANN topEntityUA (topEntityNoEnaAnn "topEntityUA") #-}
+
+expOutUA :: Vec TestLen2 D
+expOutUA = $(listToVecTH $ outAsyncReset expOut)
+
+expInUA :: Vec TestLen (D, D)
+expInUA = $(listToVecTH $ inAsyncReset expIn)
+
+testBenchUA :: TestBenchT System DDRA
+testBenchUA =
+  testBenchGeneric (noEnable topEntityUA) expInUA expOutUA expOutUA
+{-# CLASH_OPAQUE testBenchUA #-}
+{-# ANN testBenchUA (TestBench 'topEntityUA) #-}
+
+makeTopEntity 'testBenchUA
+
+topEntityUS :: TopEntityNoEna XilinxSystem DDRS
+topEntityUS clk rst = topEntityGeneric intelIn intelOut clk rst enableGen
+{-# CLASH_OPAQUE topEntityUS #-}
+{-# ANN topEntityUS (topEntityNoEnaAnn "topEntityUS") #-}
+
+expOutUS :: Vec TestLen2 D
+expOutUS = $(listToVecTH $ genOutSyncReset expOut)
+
+expInUS :: Vec TestLen (D, D)
+expInUS = $(listToVecTH $ inSyncReset expIn)
+
+testBenchUS :: TestBenchT XilinxSystem DDRS
+testBenchUS =
+  testBenchGeneric (noEnable topEntityUS) expInUS expOutUS expOutUS
+{-# CLASH_OPAQUE testBenchUS #-}
+{-# ANN testBenchUS (TestBench 'topEntityUS) #-}
+
+makeTopEntity 'testBenchUS
+
+topEntityGA :: TopEntityEna System DDRA
+topEntityGA = topEntityGeneric intelIn intelOut
+{-# CLASH_OPAQUE topEntityGA #-}
+{-# ANN topEntityGA (topEntityEnaAnn "topEntityGA") #-}
+
+expOutGA :: Vec TestLen2 D
+expOutGA = $(listToVecTH $ genOutEnable $ outAsyncReset expOut)
+
+expInGA :: Vec TestLen (D, D)
+expInGA = $(listToVecTH $ inEnable $ inAsyncReset expIn)
+
+testBenchGA :: TestBenchT System DDRA
+testBenchGA = testBenchGeneric topEntityGA expInGA expOutGA expOutGA
+{-# CLASH_OPAQUE testBenchGA #-}
+{-# ANN testBenchGA (TestBench 'topEntityGA) #-}
+
+makeTopEntity 'testBenchGA
+
+topEntityGS :: TopEntityEna XilinxSystem DDRS
+topEntityGS = topEntityGeneric intelIn intelOut
+{-# CLASH_OPAQUE topEntityGS #-}
+{-# ANN topEntityGS (topEntityEnaAnn "topEntityGS") #-}
+
+expOutGS :: Vec TestLen2 D
+expOutGS = $(listToVecTH $ genOutEnable $ genOutSyncReset expOut)
+
+expInGS :: Vec TestLen (D, D)
+expInGS = $(listToVecTH $ inEnable $ inSyncReset expIn)
+
+testBenchGS :: TestBenchT XilinxSystem DDRS
+testBenchGS = testBenchGeneric topEntityGS expInGS expOutGS expOutGS
+{-# CLASH_OPAQUE testBenchGS #-}
+{-# ANN testBenchGS (TestBench 'topEntityGS) #-}
+
+makeTopEntity 'testBenchGS
+
+-- Note that this only works correctly in HDL when all test benches are exactly
+-- equally long. Even though VHDL simulation will run until all individual
+-- clocks have stopped, 'tbClockGen' for Verilog will end the simulation when
+-- the first clock stops, cutting short the longer test bench if the lengths
+-- were to differ.
+testBenchAll :: Signal DDRA Bool
+testBenchAll = done
+ where
+   doneUA = getDone testBenchUA
+   doneUS = getDone testBenchUS
+   doneGA = getDone testBenchGA
+   doneGS = getDone testBenchGS
+   doneS = doneUS `strictAnd` doneGS
+   done =
+     doneUA `strictAnd` doneGA `strictAnd`
+     unsafeSynchronizer (clockGen @DDRS) (clockGen @DDRA) doneS
+{-# CLASH_OPAQUE testBenchAll #-}
+{-# ANN testBenchAll (defSyn "testBenchAll") #-}

--- a/tests/shouldwork/DDR/IntelDDR.hs
+++ b/tests/shouldwork/DDR/IntelDDR.hs
@@ -5,19 +5,14 @@ module IntelDDR where
 import Clash.Annotations.TH
 import Clash.Explicit.Prelude
 import Clash.Intel.DDR
-import Data.Bifunctor
 
 import VendorDDR
 
 intelIn :: DomCxt slow fast fPeriod reset => VendorIn slow fast
-intelIn clk rst en =
-  fmap (bimap unpack unpack) .
-    altddioIn (SSymbol @"Arria II GX") clk rst en . fmap pack
+intelIn = altddioIn (SSymbol @"Arria II GX")
 
 intelOut :: DomCxt slow fast fPeriod reset => VendorOut slow fast
-intelOut clk rst en =
-  fmap unpack .
-    altddioOut (SSymbol @"Arria II GX") clk rst en . fmap (bimap pack pack)
+intelOut = altddioOut (SSymbol @"Arria II GX")
 
 topEntityUA :: TopEntityNoEna System DDRA
 topEntityUA clk rst = topEntityGeneric intelIn intelOut clk rst enableGen

--- a/tests/shouldwork/DDR/VendorDDR.hs
+++ b/tests/shouldwork/DDR/VendorDDR.hs
@@ -1,0 +1,332 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module VendorDDR where
+
+import Clash.Explicit.DDR
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+import qualified Prelude as P
+
+createDomain vSystem{vName="DDRA", vPeriod=5000}
+createDomain vXilinxSystem{vName="DDRS", vPeriod=5000}
+createDomain vXilinxSystem{vName="Dom4", vPeriod=2500}
+
+type C = Unsigned 11
+type D = Unsigned 9
+
+type TestLen = 44
+type TestLen2 = 2 * TestLen - 1
+
+type DomCxt slow fast fPeriod reset =
+  ( KnownConfiguration fast ('DomainConfiguration fast fPeriod 'Rising reset 'Defined 'ActiveHigh)
+  , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) 'Rising reset 'Defined 'ActiveHigh)
+  )
+
+type VendorIn slow fast =
+  Clock slow ->
+  Reset slow ->
+  Enable slow ->
+  Signal fast D ->
+  Signal slow (D, D)
+
+type VendorOut slow fast =
+  Clock slow ->
+  Reset slow ->
+  Enable slow ->
+  Signal slow (D, D) ->
+  Signal fast D
+
+type TopEntityEna slow fast =
+  Clock slow ->
+  Reset slow ->
+  Enable slow ->
+  Signal fast D ->
+  Signal slow (D, D) ->
+  ( Signal slow ((D, D, D, D))
+  , Signal fast (D, D)
+  )
+
+type TopEntityNoEna slow fast =
+  Clock slow ->
+  Reset slow ->
+  Signal fast D ->
+  Signal slow (D, D) ->
+  ( Signal slow ((D, D, D, D))
+  , Signal fast (D, D)
+  )
+
+topEntityAnn ::
+  Bool ->
+  String ->
+  TopEntity
+topEntityAnn withEna nm =
+  Synthesize
+    { t_name = nm
+    , t_inputs =
+        [ PortName "clk"
+        , PortName "rst"
+        ] P.++
+        (if withEna then [PortName "en"] else []) P.++
+        [ PortName "in_in"
+        , PortProduct "in_out"
+            [ PortName "1"
+            , PortName "2"
+            ]
+        ]
+    , t_output =
+        PortProduct "out"
+          [ PortProduct "in"
+              [ PortName "gen1"
+              , PortName "gen2"
+              , PortName "vendor1"
+              , PortName "vendor2"
+              ]
+          , PortProduct "out"
+              [ PortName "gen"
+              , PortName "vendor"
+              ]
+          ]
+    }
+
+topEntityEnaAnn, topEntityNoEnaAnn :: String -> TopEntity
+topEntityEnaAnn = topEntityAnn True
+topEntityNoEnaAnn = topEntityAnn False
+
+type TestBenchT slow fast =
+  ( "clkSlow" ::: Clock slow
+  , "clkFast" ::: Clock fast
+  , "en" ::: Enable slow
+  , "in_in" ::: Signal fast D
+  , "out_in" ::: Signal slow
+      ( "1" ::: D
+      , "2" ::: D
+      )
+  , "in_out" ::: Signal slow
+      ( "gen1" ::: D
+      , "gen2" ::: D
+      , "vendor1" ::: D
+      , "vendor2" ::: D
+      )
+  , "out_out" ::: Signal fast
+      ( "gen" ::: D
+      , "vendor" ::: D
+      )
+  , "done" ::: Signal fast Bool
+  )
+
+topEntityGeneric ::
+  DomCxt slow fast fPeriod reset =>
+  VendorIn slow fast ->
+  VendorOut slow fast ->
+  TopEntityEna slow fast
+topEntityGeneric vendorIn vendorOut clk rst en inIn outIn =
+  ( bundle (genInOut1, genInOut2, vendorInOut1, vendorInOut2)
+  , bundle (genOutOut, vendorOutOut)
+  )
+ where
+  (genInOut1, genInOut2) = unbundle $ ddrIn clk rst en (0, 0, 0) inIn
+  (vendorInOut1, vendorInOut2) = unbundle $ vendorIn clk rst en inIn
+  genOutOut = ddrOut clk rst en 0 outIn
+  vendorOutOut = vendorOut clk rst en outIn
+
+noEnable ::
+  TopEntityNoEna slow fast ->
+  TopEntityEna slow fast
+noEnable top = top0
+ where
+  top0 clk rst _en = top clk rst
+
+expOut :: [D]
+expOut = 0 : P.concatMap (\e -> [e + 100, e + 200]) [0 .. natToNum @TestLen - 2]
+
+genOutSyncReset :: [D] -> [D]
+genOutSyncReset es =
+  let
+    es0 = P.take 51 es P.++ P.replicate 6 0 P.++ P.drop 57 es
+  in P.take 13 es0 P.++ P.replicate 6 0 P.++ P.drop 19 es0
+
+
+xilinxOutSyncReset :: [D] -> [D]
+xilinxOutSyncReset es =
+  let
+    es0 = P.take 51 es P.++ P.replicate 6 0 P.++ P.drop 57 es
+  in P.take 12 es0 P.++ P.replicate 7 0 P.++ P.drop 19 es0
+
+outAsyncReset :: [D] -> [D]
+outAsyncReset es =
+  let
+    es0 = P.take 50 es P.++ P.replicate 7 0 P.++ P.drop 57 es
+  in P.take 11 es0 P.++ P.replicate 8 0 P.++ P.drop 19 es0
+
+genOutEnable :: [D] -> [D]
+genOutEnable es =
+  let
+    es0 = P.take 69 es P.++ P.take 8 (cycle [133, 233]) P.++ P.drop 77 es
+  in P.take 31 es0 P.++ P.take 8 (cycle [114, 214]) P.++ P.drop 39 es0
+
+xilinxOutEnable :: [D] -> [D]
+xilinxOutEnable es =
+  let es0 = P.take 68 es P.++ P.replicate 9 233 P.++ P.drop 77 es
+  in P.take 30 es0 P.++ P.replicate 9 114 P.++ P.drop 39 es0
+
+expIn :: [(D, D)]
+expIn = (0,0) : (0,0) : P.zip [1, 3 .. hi] [2, 4 .. hi]
+ where
+  hi = 2 * (natToNum @TestLen - 2)
+
+inSyncReset :: [(D, D)] -> [(D, D)]
+inSyncReset es =
+  let
+    es0 = P.take 26 es P.++ P.replicate 3 (0,0) P.++ [(0, 56)] P.++ P.drop 30 es
+  in P.take 7 es0 P.++ P.replicate 3 (0, 0) P.++ P.drop 10 es0
+
+inAsyncReset :: [(D, D)] -> [(D, D)]
+inAsyncReset es =
+  let
+    es0 = P.take 25 es P.++ P.replicate 4 (0,0) P.++ [(0,56)] P.++ P.drop 30 es
+  in P.take 6 es0 P.++ P.replicate 4 (0, 0) P.++ P.drop 10 es0
+
+inEnable ::[(D, D)] ->  [(D, D)]
+inEnable es =
+  let
+    es0 =
+      P.take 35 es P.++ P.replicate 4 (65,66) P.++ [(67,76)] P.++ P.drop 40 es
+  in P.take 16 es0 P.++ P.replicate 4 (27, 28) P.++ P.drop 20 es0
+
+-- I would have liked to output @rstSlow@, but I hit a Clash bug.
+testBenchGeneric ::
+  forall slow fast .
+  ( KnownDomain slow
+  , KnownDomain fast
+  ) =>
+  TopEntityEna slow fast ->
+  Vec TestLen (D, D) ->
+  Vec TestLen2 D ->
+  Vec TestLen2 D ->
+  TestBenchT slow fast
+testBenchGeneric top expIn0 expGenOut expVendorOut =
+  ( clkSlow
+  , clkFast
+  , enSlow
+  , inIn
+  , outIn
+  , inOut
+  , outOut
+  , done
+  )
+ where
+  (inOut, outOut) = top clkSlow rstSlow enSlow inIn outIn
+  (clkSlow, clkFast, rstSlow, enSlow, inIn, outIn, done) =
+    testBenchGeneric0 expIn0 expGenOut expVendorOut inOut outOut
+{-# INLINE testBenchGeneric #-}
+
+testBenchGeneric0 ::
+  forall slow fast .
+  ( KnownDomain slow
+  , KnownDomain fast
+  ) =>
+  Vec TestLen (D, D) ->
+  Vec TestLen2 D ->
+  Vec TestLen2 D ->
+  "in_out" ::: Signal slow
+    ( "gen1" ::: D
+    , "gen2" ::: D
+    , "vendor1" ::: D
+    , "vendor2" ::: D
+    ) ->
+  "out_out" ::: Signal fast
+    ( "gen" ::: D
+    , "vendor" ::: D
+    ) ->
+  ( "clkSlow" ::: Clock slow
+  , "clkFast" ::: Clock fast
+  , "rstSlow" ::: Reset slow
+  , "en" ::: Enable slow
+  , "in_in" ::: Signal fast D
+  , "out_in" ::: Signal slow
+      ( "1" ::: D
+      , "2" ::: D
+      )
+  , "done" ::: Signal fast Bool
+  )
+testBenchGeneric0 expIn0 expGenOut expVendorOut inOut outOut =
+  (clkSlow, clkFast, rstSlow, enSlow, inIn, outIn, done)
+ where
+  (genInOut1, genInOut2, vendorInOut1, vendorInOut2) = unbundle inOut
+  (genOutOut, vendorOutOut) = unbundle outOut
+  inIn = cToDFast cntr4
+  outIn = bundle (posIn, negIn)
+  posIn = cToDSlow $ cntr4 + 402
+  negIn = cToDSlow $ cntr4 + 802
+  cToDFast = unsafeSynchronizer clk4 clkFast . fmap (truncateB . (`shiftR` 1))
+  cToDSlow = unsafeSynchronizer clk4 clkSlow . fmap (truncateB . (`shiftR` 2))
+  cntr4 :: Signal Dom4 C
+  cntr4 = register clk4 noReset enableGen 0 $ cntr4 + 1
+#ifndef INTEL_VERILOG
+  done1 = outputVerifierWith (\clk rst -> assert clk rst "genOutOut")
+    clkFast clkFast noReset expGenOut $
+      ignoreFor clkFast noReset enableGen d1 0 genOutOut
+#else
+  -- The test contains a number of (implicit) parallel, coinciding processes.
+  -- Execution for these processes is left undefined in the Verilog spec, nor is
+  -- there a mechanism to get consistent behavior (like in VHDL). Therefore,
+  -- simulators are free to pick any execution order they'd like. With Verilog
+  -- HDL, ModelSim executes the processes in an order that makes this particular
+  -- `outputVerifier` fail. SystemVerilog however is unaffected, as of course is
+  -- VHDL.
+  --
+  -- CI never runs @IntelDDR.hs@ (which imports this module), but to enable
+  -- manual verification with @IntelDDR.hs@, you can define the macro
+  -- INTEL_VERILOG when compiling. That way, you can disable this
+  -- `outputVerifier` so you can still verify the vendor primitives, which is
+  -- the main purpose of the test.
+  --
+  -- Note that @IntelDDR.hs@ still suffers from the issue described in
+  -- https://github.com/clash-lang/clash-compiler/issues/2854
+  --
+  -- The `const` is just there to prevent a @-Wunused-matches@ on @expGenOut@
+  -- and @genOutOut@.
+  done1 = pure $ const True (expGenOut, genOutOut)
+#endif
+  done2 = outputVerifierWith (\clk rst -> assert clk rst "vendorOutOut")
+    clkFast clkFast noReset expVendorOut vendorOutOut
+  done3 = outputVerifierWith (\clk rst -> assert clk rst "genInOut1")
+    clkSlow clkSlow noReset (map fst expIn0) $
+      ignoreFor clkSlow noReset enableGen d2 0 genInOut1
+  done4 = outputVerifierWith (\clk rst -> assert clk rst "genInOut2")
+    clkSlow clkSlow noReset (map snd expIn0) $
+      ignoreFor clkSlow noReset enableGen d1 0 genInOut2
+  done5 = outputVerifierWith (\clk rst -> assert clk rst "vendorInOut1")
+    clkSlow clkSlow noReset (map fst expIn0) $
+      ignoreFor clkSlow noReset enableGen d2 0 vendorInOut1
+  done6 = outputVerifierWith (\clk rst -> assert clk rst "vendorInOut2")
+    clkSlow clkSlow noReset (map snd expIn0) vendorInOut2
+  doneFast = done1 `strictAnd` done2
+  doneSlow = done3 `strictAnd` done4 `strictAnd` done5 `strictAnd` done6
+  done = doneFast `strictAnd` unsafeSynchronizer clkSlow clkFast doneSlow
+  notDone = not <$> done
+  clk4 = tbClockGen $ unsafeSynchronizer clkFast clk4 notDone
+  clkFast = tbClockGen notDone
+  clkSlow = tbClockGen $ unsafeSynchronizer clkFast clkSlow notDone
+  rstSlow =
+    unsafeFromActiveHigh $ unsafeSynchronizer clk4 clkSlow $
+      (\n -> (n >= 22 && n <= 33) || (n >= 100 && n <= 111)) <$> cntr4
+  enSlow =
+    toEnable $ unsafeSynchronizer clk4 clkSlow $
+      (\n -> (n < 58 || n > 73) && ( n < 136 || n > 151)) <$> cntr4
+{-# NOINLINE testBenchGeneric0 #-}
+
+getDone ::
+  forall slow fast .
+  TestBenchT slow fast ->
+  Signal fast Bool
+getDone tb = done
+ where
+  (_, _, _, _, _, _, _, done) = tb
+
+strictAnd :: Applicative f => f Bool -> f Bool -> f Bool
+strictAnd = liftA2 (let f !a !b = a && b in f)

--- a/tests/shouldwork/DDR/XilinxDDR.hs
+++ b/tests/shouldwork/DDR/XilinxDDR.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE CPP #-}
+
+module XilinxDDR where
+
+import Clash.Annotations.TH
+import Clash.Explicit.Prelude
+import Clash.Xilinx.DDR
+import Data.Bifunctor
+
+import VendorDDR
+
+xilinxIn :: DomCxt slow fast fPeriod reset => VendorIn slow fast
+xilinxIn clk rst en =
+  fmap (bimap unpack unpack) . iddr clk rst en . fmap pack
+
+xilinxOut :: DomCxt slow fast fPeriod reset => VendorOut slow fast
+xilinxOut clk rst en =
+  fmap unpack . oddr clk rst en . fmap (bimap pack pack)
+
+topEntityUA :: TopEntityNoEna System DDRA
+topEntityUA clk rst = topEntityGeneric xilinxIn xilinxOut clk rst enableGen
+{-# CLASH_OPAQUE topEntityUA #-}
+{-# ANN topEntityUA (topEntityNoEnaAnn "topEntityUA") #-}
+
+expGenOutUA :: Vec TestLen2 D
+expGenOutUA = $(listToVecTH $ outAsyncReset expOut)
+
+expXilinxOutUA :: Vec TestLen2 D
+expXilinxOutUA = $(listToVecTH $ outAsyncReset expOut)
+
+expInUA :: Vec TestLen (D, D)
+expInUA = $(listToVecTH $ inAsyncReset expIn)
+
+testBenchUA :: TestBenchT System DDRA
+testBenchUA =
+  testBenchGeneric (noEnable topEntityUA) expInUA expGenOutUA expXilinxOutUA
+{-# CLASH_OPAQUE testBenchUA #-}
+{-# ANN testBenchUA (TestBench 'topEntityUA) #-}
+
+makeTopEntity 'testBenchUA
+
+topEntityUS :: TopEntityNoEna XilinxSystem DDRS
+topEntityUS clk rst = topEntityGeneric xilinxIn xilinxOut clk rst enableGen
+{-# CLASH_OPAQUE topEntityUS #-}
+{-# ANN topEntityUS (topEntityNoEnaAnn "topEntityUS") #-}
+
+expGenOutUS :: Vec TestLen2 D
+expGenOutUS = $(listToVecTH $ genOutSyncReset expOut)
+
+expXilinxOutUS :: Vec TestLen2 D
+expXilinxOutUS = $(listToVecTH $ xilinxOutSyncReset expOut)
+
+expInUS :: Vec TestLen (D, D)
+expInUS = $(listToVecTH $ inSyncReset expIn)
+
+testBenchUS :: TestBenchT XilinxSystem DDRS
+testBenchUS =
+  testBenchGeneric (noEnable topEntityUS) expInUS expGenOutUS expXilinxOutUS
+{-# CLASH_OPAQUE testBenchUS #-}
+{-# ANN testBenchUS (TestBench 'topEntityUS) #-}
+
+makeTopEntity 'testBenchUS
+
+topEntityGA :: TopEntityEna System DDRA
+topEntityGA = topEntityGeneric xilinxIn xilinxOut
+{-# CLASH_OPAQUE topEntityGA #-}
+{-# ANN topEntityGA (topEntityEnaAnn "topEntityGA") #-}
+
+expGenOutGA :: Vec TestLen2 D
+expGenOutGA = $(listToVecTH $ genOutEnable $ outAsyncReset expOut)
+
+expXilinxOutGA :: Vec TestLen2 D
+expXilinxOutGA = $(listToVecTH $ xilinxOutEnable $ outAsyncReset expOut)
+
+expInGA :: Vec TestLen (D, D)
+expInGA = $(listToVecTH $ inEnable $ inAsyncReset expIn)
+
+testBenchGA :: TestBenchT System DDRA
+testBenchGA = testBenchGeneric topEntityGA expInGA expGenOutGA expXilinxOutGA
+{-# CLASH_OPAQUE testBenchGA #-}
+{-# ANN testBenchGA (TestBench 'topEntityGA) #-}
+
+makeTopEntity 'testBenchGA
+
+topEntityGS :: TopEntityEna XilinxSystem DDRS
+topEntityGS = topEntityGeneric xilinxIn xilinxOut
+{-# CLASH_OPAQUE topEntityGS #-}
+{-# ANN topEntityGS (topEntityEnaAnn "topEntityGS") #-}
+
+expGenOutGS :: Vec TestLen2 D
+expGenOutGS = $(listToVecTH $ genOutEnable $ genOutSyncReset expOut)
+
+expXilinxOutGS :: Vec TestLen2 D
+expXilinxOutGS = $(listToVecTH $ xilinxOutEnable $ xilinxOutSyncReset expOut)
+
+expInGS :: Vec TestLen (D, D)
+expInGS = $(listToVecTH $ inEnable $ inSyncReset expIn)
+
+testBenchGS :: TestBenchT XilinxSystem DDRS
+testBenchGS = testBenchGeneric topEntityGS expInGS expGenOutGS expXilinxOutGS
+{-# CLASH_OPAQUE testBenchGS #-}
+{-# ANN testBenchGS (TestBench 'topEntityGS) #-}
+
+makeTopEntity 'testBenchGS
+
+-- Note that this only works correctly in HDL when all test benches are exactly
+-- equally long. Even though VHDL simulation will run until all individual
+-- clocks have stopped, 'tbClockGen' for Verilog will end the simulation when
+-- the first clock stops, cutting short the longer test bench if the lengths
+-- were to differ.
+testBenchAll :: Signal DDRA Bool
+testBenchAll = done
+ where
+   doneUA = getDone testBenchUA
+   doneUS = getDone testBenchUS
+   doneGA = getDone testBenchGA
+   doneGS = getDone testBenchGS
+   doneS = doneUS `strictAnd` doneGS
+   done =
+     doneUA `strictAnd` doneGA `strictAnd`
+     unsafeSynchronizer (clockGen @DDRS) (clockGen @DDRA) doneS
+{-# CLASH_OPAQUE testBenchAll #-}
+{-# ANN testBenchAll (defSyn "testBenchAll") #-}

--- a/tests/shouldwork/DDR/XilinxDDR.hs
+++ b/tests/shouldwork/DDR/XilinxDDR.hs
@@ -5,17 +5,14 @@ module XilinxDDR where
 import Clash.Annotations.TH
 import Clash.Explicit.Prelude
 import Clash.Xilinx.DDR
-import Data.Bifunctor
 
 import VendorDDR
 
 xilinxIn :: DomCxt slow fast fPeriod reset => VendorIn slow fast
-xilinxIn clk rst en =
-  fmap (bimap unpack unpack) . iddr clk rst en . fmap pack
+xilinxIn = iddr
 
 xilinxOut :: DomCxt slow fast fPeriod reset => VendorOut slow fast
-xilinxOut clk rst en =
-  fmap unpack . oddr clk rst en . fmap (bimap pack pack)
+xilinxOut = oddr
 
 topEntityUA :: TopEntityNoEna System DDRA
 topEntityUA clk rst = topEntityGeneric xilinxIn xilinxOut clk rst enableGen


### PR DESCRIPTION
All of our DDR primitives turned out to have some issues. This PR initially started as fixing some issues in Xilinx `oddr` but quickly turned into fixing more bugs and extending the Haddock documentation.

* `Clash.Explicit.DDR`:
  * `ddrOut`: VHDL: Fix incorrect usage of `Enable` signal. With asynchronous resets, the `Enable` was not connected to the registers. Furthermore, the `Enable` was combinatorially(!) connected to the mux that selects the output. The mux should not be affected by the `Enable` at all (with the current Haskell simulation model).
  * `ddrIn`: VHDL: Remove bogus sensitivity list. In the initial version of this primitive, the version for asynchronous resets included the data input in its sensitivity lists for the registers. A later commit broke this, making it render the empty string for `~VARS`. But the input should not be in the sensitivity list anyway, so let's just remove the `~VARS` without actually changing the rendering in HDL.
    Additionally, the register outputting the data clocked in on the edge other than the active edge (`ddrIn_neg_latch`) also had its data input in its sensitivity list like the other two registers. This is also bogus and has been removed.
* `Clash.Xilinx.DDR`:
  * `oddr`: Verilog correctly picked one of the possible arguments to inspect for `ResetKind`, but the others picked the `KnownNat` constraint. This caused Clash to error out during HDL generation.
  * Both in and out prims: Renamed symbols that were incorrectly copy-pasted from the Intel prims.
* `Clash.Intel.DDR`:
  * `altddioIn`:
    * VHDL: Fix `~ISACTIVEENABLE` parameter reference that caused HDL generation to error out.
    * Verilog: Fix width parameter; it accidentally always rendered as 1.
    * SystemVerilog: Accidental comma generated invalid HDL.
  * `altddioOut`: VHDL: Several numeric identifiers were incorrect, referring to wrong arguments or symbols. HDL generation completed without error, but the resulting VHDL was completely broken.
  * Both prims: evaluate the `SSymbol` in Haskell to fix HDL generation warning about using an argument that is unused in Haskell.

<br>

* Add test benches for Xilinx DDR primitives
  A variant for Intel is also included, but we don't have a simulator in CI that supports Intel IP, so it can only be run manually for now. If the Verilog code is to be tested in Questa Intel FPGA Edition, one needs to define the preprocessor macro `INTEL_VERILOG`, which will skip verifying the output of the `Clash.Explicit.DDR.ddrOut` primitive as Questa trips on this: [`VendorDDR.hs` comment](https://github.com/clash-lang/clash-compiler/pull/2833/files#diff-cc19e30df0bd8ce972aaf795bf279b3ff015944190d5c5d0638f5613b6ea38c6R269-R294). SystemVerilog doesn't need this. Vivado is also fine with the Verilog code, so we actually test the Verilog variant of the vendor-neutral output DDR primitive in our nightlies now.
  The new test bench for vendor primitives tests the vendor-neutral primitives more extensively than the existing test bench did. For this reason, we also no longer run the existing test bench in Vivado, as it would not increase test coverage.
  The new test bench is very slow in generating HDL; this is due to some unfortunate GHC transformations that are hard on Clash and not easily fixed. Compensating a bit: Vivado runs all test bench configurations in parallel, saving a lot of time spent in Vivado.

<br>

* The primitives for Xilinx and Intel only support the rising edge as the active edge of the domain. This is now enforced by a constraint, instead of silently leading to a malfunctioning implementation.
* The existing constraints on the domains could be redefined in terms of `DomainPeriod`.     Since the virtual DDR domain only exists in simulation, it really doesn't matter if it doesn't match with the real domain in all its parameters, so we can drop those and make the constraints more intuitive to read.
* The primitives for Xilinx and Intel now support any data type that has a `BitPack` instance, instead of being restricted to `BitVector`.
* The Haddock for the functions is extended, explaining the purpose of the tuple elements with data.
* The internal functions for Xilinx and Intel are now exported (under the heading _Internal_) in the modules, as a general principle that we give people all the pieces so they can use them if they want to do something special.

I have written a variant for Clash 1.8 that does not change the API, but uses `clashCompileError` to prevent people instantiating the vendor primitives using a domain where the falling edge is the active edge. Once this PR has passed review, I'll open a new PR for that one (incorporating changes that are the result of review here).

Several of the bugs were introduced in 2019 in commit 0c38d6568 part of PR #527. We could not test the vendor primitives, so it went unnoticed. Now we at least test automatically in Vivado, and manually testing in Questa Intel FPGA Edition is straightforward.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files