### PR TITLE
Reduce `splitAt` to undefined in illegal contexts

### DIFF
--- a/changelog/2024-10-29T14_54_54+01_00_fix2831
+++ b/changelog/2024-10-29T14_54_54+01_00_fix2831
@@ -1,0 +1,1 @@
+FIXED: Clash errors out when `Clash.Sized.Vector.splitAt` is compile-time evaluated in an illegal context

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -634,6 +634,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2623CaseConFVs" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         , runTest "T2781" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         , runTest "T2628" def{hdlTargets=[VHDL], buildTargets=BuildSpecific ["TACacheServerStep"], hdlSim=[]}
+        , runTest "T2831" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2831.hs
+++ b/tests/shouldwork/Issues/T2831.hs
@@ -1,0 +1,14 @@
+module T2831 where
+
+import Clash.Prelude
+
+f :: forall n. SNat n -> Unsigned 4
+f n@SNat = case compareSNat n (SNat @15) of
+  SNatLE -> at @n @(16 - n - 1) SNat vec
+  SNatGT -> 0
+ where
+  vec :: Vec 16 (Unsigned 4)
+  vec = repeat 1
+
+topEntity :: Unsigned 4
+topEntity = f d17


### PR DESCRIPTION
Previously, the Clash compiler would try to reduce

```
splitAt d1 Nil
```
to something of type
```
(Vec 1 a, Vec (0-1) a)
```
by trying to project the head and the tail out of the `Nil` constructor. This of course does not work resulting in an out-of-bounds indexing error reported in:

https://github.com/clash-lang/clash-compiler/issues/2831

The compiler now reduces above expressions to:

```
undefined :: (Vec 1 a, Vec (0-1) a)
```

Which is morally equivalent to the run-time exception Haskell evaluation would have thrown if the circuit description was evaluated like a regular Haskell program.

Fixes #2831

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
