### PR TITLE
No inlining let-bound global vars with clock types (copy #2846)

### DIFF
--- a/changelog/2024-11-18T14_59_34+01_00_fix2845
+++ b/changelog/2024-11-18T14_59_34+01_00_fix2845
@@ -1,0 +1,1 @@
+FIXED: Clash generates illegal Verilog names [#2845](https://github.com/clash-lang/clash-compiler/issues/2845)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -792,6 +792,7 @@ runClashTest = defaultMain $ clashTestRoot
         , runTest "T2781" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         , runTest "T2628" def{hdlTargets=[VHDL], buildTargets=BuildSpecific ["TACacheServerStep"], hdlSim=[]}
         , runTest "T2839" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
+        , runTest "T2845" def{hdlSim=[],hdlTargets=[Verilog]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T2845.hs
+++ b/tests/shouldwork/Issues/T2845.hs
@@ -1,0 +1,13 @@
+module T2845 where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+topEntity ::
+  Signal System (Unsigned 8)
+topEntity = cntr + x
+ where
+  cntr = register clk noReset enableGen 0 0
+  x = register clk noReset enableGen 100 0
+  done = (== 100) <$> cntr
+  clk = tbClockGen $ not <$> done


### PR DESCRIPTION
The global vars are usually backed by a clock generator that are not work-free.

In addition, when these global vars are recursively defined, they can mess up the post-normalization flattening stage which then violates certain invariants of the netlist generation stage. This then causes the netlist generation stage to generate bad Verilog names.

Fixes #2845

This is a backport of #2846. The PR on master was malformed somehow, with the correct contents but missing the commit message above and an incorrect Git structure. This backport to 1.8 is reconstructed by hand.