### PR TITLE
Use hackage token when uploading documentation

### DIFF
--- a/.ci/publish_sdist.sh
+++ b/.ci/publish_sdist.sh
@@ -11,12 +11,12 @@ set +u
 if [[ "$HACKAGE_RELEASE" == "yes" ]]; then
     # Release tag set, upload as release.
     cabal upload --publish --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST}
-    cabal upload --publish --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST}
+    cabal upload --publish --documentation --token=${HACKAGE_TOKEN} ${DDIST}
 elif [[ "$HACKAGE_RELEASE" == "no" ]]; then
     # Upload as release candidate
     cabal upload --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST}
-    cabal upload --documentation --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${DDIST}
+    cabal upload --documentation --token=${HACKAGE_TOKEN} ${DDIST}
 else
-    echo "Unrecognized \$HACAKGE_RELEASE: $HACAKGE_RELEASE"
+    echo "Unrecognized \$HACKAGE_RELEASE: $HACKAGE_RELEASE"
     exit 1;
 fi


### PR DESCRIPTION
Hopefully this works around https://github.com/haskell/cabal/issues/10252
