### PR TITLE
Linear Clash.Sized.Vector.reverse

### DIFF
--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -1,7 +1,7 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017     , Myrtle Software Ltd
-                  2022-2024, QBayLogic B.V.
+                  2022-2025, QBayLogic B.V.
                   2024,      Alex Mason
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -811,8 +811,11 @@ merge x y = concat (transpose (x :> singleton y))
 -- >>> reverse (1:>2:>3:>4:>Nil)
 -- 4 :> 3 :> 2 :> 1 :> Nil
 reverse :: Vec n a -> Vec n a
-reverse Nil           = Nil
-reverse (x `Cons` xs) = reverse xs :< x
+reverse xs = go Nil xs
+ where
+  go :: i <= n => Vec (n - i) a -> Vec i a -> Vec n a
+  go a (y `Cons` ys) = go (y `Cons` a) ys
+  go a Nil = a
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE reverse #-}
 {-# ANN reverse hasBlackBox #-}


### PR DESCRIPTION
The current implementation of `Clash.Sized.Vector.reverse` has a simulation runtime that is quadratic in the input. This PR improves this to a linear version.

## Still TODO:

  - [x] ~Write a changelog entry (see changelog/README.md)~
  - [x] Check copyright notices are up to date in edited files
