### PR TITLE
Avoid warnings instead of hiding them

### DIFF
--- a/changelog/2024-11-16T11_59_31+01_00_avoid_using_unsafecoerce
+++ b/changelog/2024-11-16T11_59_31+01_00_avoid_using_unsafecoerce
@@ -1,0 +1,1 @@
+CHANGED: `select` and `selectI` now use `<=` constraints instead of `CmpNat`.

--- a/clash-prelude/src/Clash/Sized/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Index.hs
@@ -1,5 +1,6 @@
 {-|
 Copyright  :  (C) 2013-2016, University of Twente
+                  2025     , QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
@@ -18,7 +19,6 @@ where
 import GHC.TypeLits (KnownNat, type (^))
 import GHC.TypeLits.Extra (CLog) -- documentation only
 
-import Clash.Promoted.Nat (SNat (..), pow2SNat)
 import Clash.Sized.Internal.BitVector (BitVector)
 import Clash.Sized.Internal.Index
 


### PR DESCRIPTION
Certain GHC warnings are currently disabled in in `Clash.Prelude` to hide the fact some imports and bindings are not used, and that some of the patterns in `Clash.Sized.Vector` are incomplete. As this is avoidable though, and having those flags enabled may also hide problems that are easy to catch otherwise. Therefore, this PR just avoids production of the respective warnings in the first place.

The only current exception is `Clash.Tutorial`, where the unused imports are used to have shorter Haddock references. We also can avoid that one by using fully qualified imports for the references instead. I'm in favor of introducing those changes as part of this PR too, but please let me know first, whether that's of common interest, as it takes a few minutes to apply all the changes along the file.

## Requires (parts of)
* #2843 (3c1953f in particular)

## Still TODO:

  - [x] ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files