### PR TITLE
New: ddrForwardClock

### DIFF
--- a/changelog/2025-01-16T14_20_35+01_00_ddroutclock
+++ b/changelog/2025-01-16T14_20_35+01_00_ddroutclock
@@ -1,0 +1,1 @@
+NEW: The function `Clash.Explicit.DDR.ddrForwardClock`, which uses a DDR output primitive to forward a clock signal to a DDR-capable output pin.


### PR DESCRIPTION
This PR was inspired by the `clash-cores` [PR #7 Add RGMII core](https://github.com/clash-lang/clash-cores/pull/7) which uses this construction but keeps the output clock as a `Signal domDDR Bit`. With the new `ddrOutClock`, we can correctly declare the thing to be a clock.

There's a qualitative difference between `Clock` and `Signal _ Bit`. In a nutshell, a signal is relative to a clock, it has setup and hold constraints and carries data. All of these don't apply to a clock. You could say a clock leads and a signal follows. The resulting output on the pin is no different, it's just about correctly declaring what something is in the Haskell world.

The new `ddrForwardClock` function gets a DDR output primitive as an argument. If you look at `clash-prelude`, the only directly fitting one is `Clash.Explicit.DDR.ddrOut` (if you apply the reset value first). However, in a PR that I will create soon, the API for `Clash.Intel.DDR` and `Clash.Xilinx.DDR` is changed to accomodate the signature introduced in this PR. Even with the current code, it's possible to adapt the vendor primitives to fit `ddrForwardClock`, but soon it will be a natural fit.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
