### PR TITLE
Add hedgehog 1.5 support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ write-ghc-environment-files: always
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2024-07-18T12:39:16Z
+index-state: 2025-02-02T02:01:54Z
 
 -- For some reason the `clash-testsuite` executable fails to run without
 -- this, as it cannot find the related library...

--- a/clash-lib-hedgehog/clash-lib-hedgehog.cabal
+++ b/clash-lib-hedgehog/clash-lib-hedgehog.cabal
@@ -9,7 +9,7 @@ license:            BSD-2-Clause
 license-file:       LICENSE
 author:             QBayLogic B.V.
 maintainer:         devops@qbaylogic.com
-copyright:          Copyright © 2021, QBayLogic B.V.
+copyright:          Copyright © 2021-2025, QBayLogic B.V.
 category:           Hardware
 build-type:         Simple
 
@@ -30,7 +30,7 @@ common basic-config
 
   build-depends:
     base      >= 4.11  && < 5,
-    hedgehog  >= 1.0.3 && < 1.5,
+    hedgehog  >= 1.0.3 && < 1.6,
 
 library
   import: basic-config

--- a/clash-prelude-hedgehog/clash-prelude-hedgehog.cabal
+++ b/clash-prelude-hedgehog/clash-prelude-hedgehog.cabal
@@ -9,7 +9,7 @@ license:            BSD-2-Clause
 license-file:       LICENSE
 author:             QBayLogic B.V.
 maintainer:         devops@qbaylogic.com
-copyright:          Copyright © 2021, QBayLogic B.V.
+copyright:          Copyright © 2021-2025, QBayLogic B.V.
 category:           Hardware
 build-type:         Simple
 
@@ -30,7 +30,7 @@ common basic-config
 
   build-depends:
     base      >= 4.11  && < 5,
-    hedgehog  >= 1.0.3 && < 1.5,
+    hedgehog  >= 1.0.3 && < 1.6,
 
 library
   import: basic-config

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -51,7 +51,7 @@ Maintainer:           QBayLogic B.V. <devops@qbaylogic.com>
 Copyright:            Copyright © 2013-2016, University of Twente,
                                   2016-2017, Myrtle Software Ltd,
                                   2017-2019, QBayLogic B.V., Google Inc.,
-                                  2021-2023, QBayLogic B.V.
+                                  2021-2025, QBayLogic B.V.
 Category:             Hardware
 Build-type:           Simple
 
@@ -409,7 +409,7 @@ test-suite unittests
       base,
       bytestring,
       deepseq,
-      hedgehog      >= 1.0.3    && < 1.5,
+      hedgehog      >= 1.0.3    && < 1.6,
       hint          >= 0.7      && < 0.10,
       quickcheck-classes-base >= 0.6 && < 1.0,
       tasty         >= 1.2      && < 1.6,


### PR DESCRIPTION
Adds support for `hedgehog-1.5`. 

The PR also increases the index state for the new version to be selected & tested by CI, but we can revert that one to the old state if desired.

## Still TODO:
  - [x] ~Write a changelog entry (see changelog/README.md)~
  - [x] Check copyright notices are up to date in edited files
