### PR TITLE
Use sensible type arg order in `clash-prelude-hedgehog`

### DIFF
--- a/clash-cores/test/Test/Cores/Xilinx/BlockRam.hs
+++ b/clash-cores/test/Test/Cores/Xilinx/BlockRam.hs
@@ -227,7 +227,7 @@ testsCycleBoth = testGroup "cycleBoth"
   , testProperty "prop_definedOutputCycleBothWord16"
       (prop_definedOutputCycleBoth (Gen.enumBounded @_ @Word16))
   , testProperty "prop_definedOutputCycleBothBitVector16"
-      (prop_definedOutputCycleBoth (genBitVector @_ @16))
+      (prop_definedOutputCycleBoth (genBitVector @16))
   ]
  where
   cyc portA portB = showX $
@@ -286,7 +286,7 @@ testsAccessRam = testGroup "accessRam"
   , testProperty "prop_definedOutputAccessRamWord16"
       (prop_definedOutputAccessRam (Gen.enumBounded @_ @Word16))
   , testProperty "prop_definedOutputAccessRamBitVector16"
-      (prop_definedOutputAccessRam (genBitVector @_ @16))
+      (prop_definedOutputAccessRam (genBitVector @16))
   ]
  where
   access addr byteEna dat =

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Signal.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Signal.hs
@@ -24,19 +24,19 @@ import qualified Hedgehog.Gen as Gen
 
 import Clash.Signal.Internal
 
-genSignal :: (MonadGen m) => m a -> m (Signal dom a)
+genSignal :: forall a dom m. (MonadGen m) => m a -> m (Signal dom a)
 genSignal genElem = liftA2 (:-) genElem (genSignal genElem)
 
-genActiveEdge :: (MonadGen m) => m ActiveEdge
+genActiveEdge :: forall m. (MonadGen m) => m ActiveEdge
 genActiveEdge = Gen.element [Rising, Falling]
 
-genInitBehavior :: (MonadGen m) => m InitBehavior
+genInitBehavior :: forall m. (MonadGen m) => m InitBehavior
 genInitBehavior = Gen.element [Unknown, Defined]
 
-genResetKind :: (MonadGen m) => m ResetKind
+genResetKind :: forall m. (MonadGen m) => m ResetKind
 genResetKind = Gen.element [Asynchronous, Synchronous]
 
-genResetPolarity :: (MonadGen m) => m ResetPolarity
+genResetPolarity :: forall m. (MonadGen m) => m ResetPolarity
 genResetPolarity = Gen.element [ActiveHigh, ActiveLow]
 
 -- TODO Generate a full domain configuration.

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/BitVector.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/BitVector.hs
@@ -54,12 +54,12 @@ genBit = Gen.element [low, high, errorX "X"]
 
 -- | Generate a bit vector where all bits are defined.
 --
-genDefinedBitVector :: (MonadGen m, KnownNat n) => m (BitVector n)
+genDefinedBitVector :: forall n m. (MonadGen m, KnownNat n) => m (BitVector n)
 genDefinedBitVector = pack <$> genUnsigned constantBounded
 
 -- | Generate a bit vector where some bits may be undefined.
 --
-genBitVector :: forall m n . (MonadGen m, KnownNat n) => m (BitVector n)
+genBitVector :: forall n m. (MonadGen m, KnownNat n) => m (BitVector n)
 genBitVector =
   Gen.frequency
     [ (70, BV <$> genNatural <*> genNatural)
@@ -77,7 +77,7 @@ instance KnownNat atLeast => Show (SomeBitVector atLeast) where
   show (SomeBitVector SNat bv) = show bv
 
 genSomeBitVector
-  :: forall m atLeast
+  :: forall atLeast m
    . (MonadGen m, KnownNat atLeast)
   => Range Natural
   -> (forall n. KnownNat n => m (BitVector n))

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Index.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Index.hs
@@ -31,7 +31,7 @@ import qualified Hedgehog.Range as Range
 import Clash.Promoted.Nat
 import Clash.Sized.Internal.Index
 
-genIndex :: (MonadGen m, KnownNat n) => Range (Index n) -> m (Index n)
+genIndex :: forall n m. (MonadGen m, KnownNat n) => Range (Index n) -> m (Index n)
 genIndex range =
   Gen.frequency
     [ (70, Gen.integral range)
@@ -45,7 +45,8 @@ instance KnownNat atLeast => Show (SomeIndex atLeast) where
   show (SomeIndex SNat ix) = show ix
 
 genSomeIndex
-  :: (MonadGen m, KnownNat atLeast)
+  :: forall atLeast m
+  . (MonadGen m, KnownNat atLeast)
   => Range Natural
   -> m (SomeIndex atLeast)
 genSomeIndex rangeIx = do

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/RTree.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/RTree.hs
@@ -31,10 +31,10 @@ import qualified Hedgehog.Gen as Gen
 import Clash.Promoted.Nat
 import Clash.Sized.RTree
 
-genRTree :: (MonadGen m, KnownNat n) => m a -> m (RTree n a)
+genRTree :: forall n a m. (MonadGen m, KnownNat n) => m a -> m (RTree n a)
 genRTree genElem = sequenceA (trepeat genElem)
 
-genNonEmptyRTree :: (MonadGen m, KnownNat n, 1 <= n) => m a -> m (RTree n a)
+genNonEmptyRTree :: forall n a m. (MonadGen m, KnownNat n, 1 <= n) => m a -> m (RTree n a)
 genNonEmptyRTree = genRTree
 
 data SomeRTree atLeast a where
@@ -44,7 +44,8 @@ instance (KnownNat atLeast, Show a) => Show (SomeRTree atLeast a) where
   show (SomeRTree SNat x) = show x
 
 genSomeRTree
-  :: (MonadGen m, KnownNat atLeast)
+  :: forall atLeast a m
+   . (MonadGen m, KnownNat atLeast)
   => Range Natural
   -> m a
   -> m (SomeRTree atLeast a)

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Signed.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Signed.hs
@@ -31,7 +31,7 @@ import qualified Hedgehog.Range as Range
 import Clash.Promoted.Nat
 import Clash.Sized.Internal.Signed
 
-genSigned :: (MonadGen m, KnownNat n) => Range (Signed n) -> m (Signed n)
+genSigned :: forall n m. (MonadGen m, KnownNat n) => Range (Signed n) -> m (Signed n)
 genSigned range =
   Gen.frequency
     [ (60, Gen.integral range)
@@ -46,7 +46,8 @@ instance KnownNat atLeast => Show (SomeSigned atLeast) where
   show (SomeSigned SNat x) = show x
 
 genSomeSigned
-  :: (MonadGen m, KnownNat atLeast)
+  :: forall atLeast m
+   . (MonadGen m, KnownNat atLeast)
   => Range Natural
   -> m (SomeSigned atLeast)
 genSomeSigned rangeSigned = do

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Unsigned.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Unsigned.hs
@@ -31,7 +31,7 @@ import qualified Hedgehog.Range as Range
 import Clash.Promoted.Nat
 import Clash.Sized.Internal.Unsigned
 
-genUnsigned :: (MonadGen m, KnownNat n) => Range (Unsigned n) -> m (Unsigned n)
+genUnsigned :: forall n m. (MonadGen m, KnownNat n) => Range (Unsigned n) -> m (Unsigned n)
 genUnsigned range =
   Gen.frequency
     [ (70, Gen.integral range)
@@ -45,7 +45,8 @@ instance KnownNat atLeast => Show (SomeUnsigned atLeast) where
   show (SomeUnsigned SNat x) = show x
 
 genSomeUnsigned
-  :: (MonadGen m, KnownNat atLeast)
+  :: forall atLeast m
+   . (MonadGen m, KnownNat atLeast)
   => Range Natural
   -> m (SomeUnsigned atLeast)
 genSomeUnsigned rangeUnsigned = do

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Vector.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Sized/Vector.hs
@@ -37,13 +37,13 @@ import Clash.Sized.Vector
 -- | Generate a potentially empty vector, where each element is produced
 -- using the supplied generator. For a non-empty vector, see 'genNonEmptyVec'.
 --
-genVec :: (MonadGen m, KnownNat n) => m a -> m (Vec n a)
+genVec :: forall n a m. (MonadGen m, KnownNat n) => m a -> m (Vec n a)
 genVec genElem = traverse# id (repeat genElem)
 
 -- | Generate a non-empty vector, where each element is produced using the
 -- supplied generator. For a potentially empty vector, see 'genVec'.
 --
-genNonEmptyVec :: (MonadGen m, KnownNat n, 1 <= n) => m a -> m (Vec n a)
+genNonEmptyVec :: forall n a m. (MonadGen m, KnownNat n, 1 <= n) => m a -> m (Vec n a)
 genNonEmptyVec = genVec
 
 data SomeVec atLeast a where
@@ -53,7 +53,8 @@ instance (KnownNat atLeast, Show a) => Show (SomeVec atLeast a) where
   show (SomeVec SNat xs) = show xs
 
 genSomeVec
-  :: (MonadGen m, KnownNat atLeast)
+  :: forall atLeast a m
+   . (MonadGen m, KnownNat atLeast)
   => Range Natural
   -> m a
   -> m (SomeVec atLeast a)


### PR DESCRIPTION
I almost never want to type apply my `MonadGen`, but I do often want to type apply type sizes!

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] ~~Check copyright notices are up to date in edited files~~