### PR TITLE
Disable Windows CI for GHC 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,18 +24,18 @@ jobs:
         ghc: ["8.10", "9.0", "9.2", "9.4", "9.6", "9.8"]
         exclude:
           # Some tests fail with a mysterious -11 error code.
-          - os: macOS-13
-            ghc: 8.10
+          - os: "macOS-13"
+            ghc: "8.10"
 
           # GHC 9.0 fails to compile clash-cores due to a template haskell
           # failure
-          - os: windows-latest
-            ghc: 9.0
+          - os: "windows-latest"
+            ghc: "9.0"
 
           # GHC/Clash starts extremely slowly, see
           # https://github.com/clash-lang/clash-compiler/issues/2684
-          - os: windows-latest
-            ghc: 9.6
+          - os: "windows-latest"
+            ghc: "9.6"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
           - os: "windows-latest"
             ghc: "9.6"
 
+          # Vector test suite takes an _extremely_ long time to execute. Same
+          # issue as 9.6?
+          - os: "windows-latest"
+            ghc: "9.8"
+
     steps:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2


### PR DESCRIPTION
See:

* https://github.com/clash-lang/clash-compiler/actions/runs/13247987829/job/36979144736?pr=2883
* https://github.com/clash-lang/clash-compiler/actions/runs/13247987829/job/36979145097?pr=2883