### PR TITLE
CI: Downgrade Cabal for GHC 8.10.7

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -111,7 +111,7 @@ RUN git clone https://github.com/verilator/verilator verilator \
 
 FROM builder AS build-ghc
 
-ARG ghcup_version="0.1.30.0"
+ARG ghcup_version="0.1.40.0"
 
 # Must be explicitly set
 ARG ghc_version

--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -13,10 +13,9 @@ elif [[ "$1" != "" ]]; then
   echo "Unrecognized argument: $1" >&2
   exit 1
 fi
-
-UBUNTU_VERSION=jammy-20240808
+UBUNTU_VERSION=jammy-20250126
 GHC_VERSIONS=("9.10.1" "9.8.4"  "9.6.6"  "9.4.8"  "9.2.8"   "9.0.2"   "8.10.7")
-CABAL_VERSION="3.14.1.0"
+CABAL_VERSIONS=("3.14.1.1" "3.14.1.1" "3.14.1.1" "3.14.1.1" "3.14.1.1" "3.14.1.1" "3.12.1.0")
 
 # We want to use docker buildkit so that our layers are built in parallel. This
 # is ignored completely on versions of docker which don't support buildkit.
@@ -25,6 +24,7 @@ export DOCKER_BUILDKIT=1
 for i in "${!GHC_VERSIONS[@]}"
 do
   GHC_VERSION="${GHC_VERSIONS[i]}"
+  CABAL_VERSION="${CABAL_VERSIONS[i]}"
 
   docker build \
     --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20250101
+  image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20250305
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -12,7 +12,7 @@ default:
   timeout: 10 minutes
   stage: build
   variables:
-    CLASH_DOCKER_TAG: 20250101
+    CLASH_DOCKER_TAG: 20250305
     CACHE_BUST_TOKEN: 3
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
     # Run steps inside the clash CI docker image
     container:
-      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20250101
+      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20250305
 
       env:
         THREADS: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,8 +96,6 @@ haddock:
   extends: .common-local
   needs: []
   stage: test
-  variables:
-    GHC_VERSION: 9.0.2
   artifacts:
     paths:
       - hadocs/*/*


### PR DESCRIPTION
Cabal 3.14 silently ignores `haddock-options` in `cabal.project`. The change is deliberate (though not warning about it probably is not). The change is documented in some places:

https://github.com/haskell/cabal/blob/master/release-notes/cabal-install-3.14.0.0.md

https://github.com/haskell/cabal/blob/master/release-notes/WIP-Cabal-3.12.x.0.md 

https://github.com/haskell/cabal/pull/9177

(Note that the deprecation message apparently never made it to the release notes)

We should probably think about how to fix this in the future, but for now rolling back to Cabal 3.12 will allow us to build the documentation as we want to again. The mentioned `haddock-version-cpp` flag in the linked cabal PR 9177 above  to get a CPP define for `__HADDOCK_VERSION__` did not work at all for me.

PR #2201 was supposed to update our Haddock generation to 9.0.2 but accidentally picked 8.10.7 for the uploads to Hackage, which also fixed issue #2200. I'm careful about upgrading Haddock now as I've experienced several times now that there were undocumented changes going from one version to the next that broke some rendering, and carefully rereading our complete Haddock to scan for such breakage is an impossible task. One day we'll have to upgrade, when we drop GHC 8.10 from Clash.

[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
