### PR TITLE
Clarify ShowX examples

### DIFF
--- a/clash-prelude/src/Clash/XException.hs
+++ b/clash-prelude/src/Clash/XException.hs
@@ -2,17 +2,17 @@
 Copyright  :  (C) 2016,      University of Twente,
                   2017,      QBayLogic, Google Inc.
                   2017-2019, Myrtle Software Ltd,
-                  2021-2023, QBayLogic B.V.
+                  2021-2025, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 'XException': An exception for uninitialized values
 
->>> show (errorX "undefined" :: Integer, 4 :: Int)
-"(*** Exception: X: undefined
+>>> show (errorX "No value here" :: Integer, 4 :: Int)
+"(*** Exception: X: No value here
 CallStack (from HasCallStack):
 ...
->>> showX (errorX "undefined" :: Integer, 4 :: Int)
+>>> showX (errorX "No value here" :: Integer, 4 :: Int)
 "(undefined,4)"
 -}
 
@@ -358,11 +358,11 @@ isX a =
 -- | Like the 'Show' class, but values that normally throw an 'XException' are
 -- converted to @undefined@, instead of error'ing out with an exception.
 --
--- >>> show (errorX "undefined" :: Integer, 4 :: Int)
--- "(*** Exception: X: undefined
+-- >>> show (errorX "No value here" :: Integer, 4 :: Int)
+-- "(*** Exception: X: No value here
 -- CallStack (from HasCallStack):
 -- ...
--- >>> showX (errorX "undefined" :: Integer, 4 :: Int)
+-- >>> showX (errorX "No value here" :: Integer, 4 :: Int)
 -- "(undefined,4)"
 --
 -- Can be derived using 'GHC.Generics':

--- a/clash-prelude/src/Clash/XException/Internal.hs
+++ b/clash-prelude/src/Clash/XException/Internal.hs
@@ -1,17 +1,18 @@
 {-|
 Copyright  :  (C) 2016,      University of Twente,
-                  2017,      QBayLogic, Google Inc.
-                  2017-2019, Myrtle Software Ltd
+                  2017,      Google Inc.,
+                  2017-2019, Myrtle Software Ltd,
+                  2017-2025, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 'XException': An exception for uninitialized values
 
->>> show (errorX "undefined" :: Integer, 4 :: Int)
-"(*** Exception: X: undefined
+>>> show (errorX "No value here" :: Integer, 4 :: Int)
+"(*** Exception: X: No value here
 CallStack (from HasCallStack):
 ...
->>> showX (errorX "undefined" :: Integer, 4 :: Int)
+>>> showX (errorX "No value here" :: Integer, 4 :: Int)
 "(undefined,4)"
 -}
 


### PR DESCRIPTION
The fact that we used `errorX "undefined"` has the potential of misleading people into thinking `ShowX` will render the message of their `XException` rather than the literal string `undefined`. Adjust examples so this misconception is no longer possible.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
