### PR TITLE
Fix DDR primitives for 1.8 (version without API changes)

### DIFF
--- a/changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims
+++ b/changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims
@@ -2,8 +2,10 @@ FIXED: `Clash.Explicit.DDR`:
   - `ddrIn`: VHDL: Remove data input from sensitivity list of `ddrIn_neg_latch` register as it is superfluous. This should not affect functionality.
   - `ddrOut`: VHDL: Fix incorrect usage of `Enable` input when the domain is set to asynchronous resets. Deasserting the `Enable` exhibited wrong behavior before this fix.
 FIXED: `Clash.Xilinx.DDR`:
+  - These primitives only support clocks where the rising edge is the active edge. Using them in a domain with falling active edges now causes an error.
   - `oddr`: Fix VHDL and SystemVerilog erroring out during HDL generation
   - Symbols in HDL for both `iddr` and `oddr` were renamed to match their function.
 FIXED: `Clash.Intel.DDR`:
+  - These primitives only support clocks where the rising edge is the active edge. Using them in a domain with falling active edges now causes an error.
   - Fix rendering HDL. It variously errored out or generated non-working HDL.
   - Rendering HDL no longer causes Clash to issue a warning about an argument unused in Haskell but used in the primitive black box.

--- a/changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims
+++ b/changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims
@@ -1,0 +1,9 @@
+FIXED: `Clash.Explicit.DDR`:
+  - `ddrIn`: VHDL: Remove data input from sensitivity list of `ddrIn_neg_latch` register as it is superfluous. This should not affect functionality.
+  - `ddrOut`: VHDL: Fix incorrect usage of `Enable` input when the domain is set to asynchronous resets. Deasserting the `Enable` exhibited wrong behavior before this fix.
+FIXED: `Clash.Xilinx.DDR`:
+  - `oddr`: Fix VHDL and SystemVerilog erroring out during HDL generation
+  - Symbols in HDL for both `iddr` and `oddr` were renamed to match their function.
+FIXED: `Clash.Intel.DDR`:
+  - Fix rendering HDL. It variously errored out or generated non-working HDL.
+  - Rendering HDL no longer causes Clash to issue a warning about an argument unused in Haskell but used in the primitive black box.

--- a/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives.yaml
@@ -36,7 +36,7 @@
           .sclr (1'b0),~FI
           .datain (~ARG[8]),
           .inclock (~ARG[5]),
-          .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN~ARG[7]~ELSE1'b1,~FI),
+          .inclocken (~IF ~ISACTIVEENABLE[7] ~THEN~ARG[7]~ELSE1'b1~FI),
           .dataout_h (~SYM[2]),
           .dataout_l (~SYM[1]),
           .aset (1'b0),

--- a/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Intel_DDR.primitives.yaml
@@ -1,10 +1,10 @@
 - BlackBox:
-    name: Clash.Intel.DDR.altddioIn
+    name: Clash.Intel.DDR.altddioIn#
     kind: Declaration
     libraries:
     - altera_mf
     type: |-
-      altddioIn
+      altddioIn#
         :: ( HasCallStack               -- ARG[0]
            , KnownConfi~ fast domf      -- ARG[1]
            , KnownConfi~ slow doms      -- ARG[2]

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives.yaml
@@ -14,8 +14,8 @@
         -> Signal slow (BitVector m,BitVector m)
     template: |-
       // iddr begin
-      ~SIGD[~GENSYM[dataout_l][1]][7];
-      ~SIGD[~GENSYM[dataout_h][2]][7];
+      ~SIGD[~GENSYM[data_pos][1]][7];
+      ~SIGD[~GENSYM[data_neg][2]][7];
       ~SIGD[~GENSYM[d][3]][7];
       assign ~SYM[3] = ~ARG[7];
 
@@ -57,8 +57,8 @@
         -> Signal fast (BitVector m)
     template: |-
       // oddr begin
-      ~SIGD[~GENSYM[datain_l][1]][7];
-      ~SIGD[~GENSYM[datain_h][2]][7];
+      ~SIGD[~GENSYM[data_pos][1]][7];
+      ~SIGD[~GENSYM[data_neg][2]][7];
       ~SIGD[~GENSYM[q][3]][7];
 
       assign ~SYM[1] = ~ARG[6];
@@ -70,7 +70,7 @@
         ODDR #(
           .DDR_CLK_EDGE("SAME_EDGE"),
           .INIT(1'b0),
-          .SRTYPE(~IF ~ISSYNC[2] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
+          .SRTYPE(~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
         ) ~GENSYM[~COMPNAME_ODDR][9] (
           .Q(~SYM[3][~SYM[8]]),
           .C(~ARG[3]),

--- a/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Xilinx_DDR.primitives.yaml
@@ -1,8 +1,8 @@
 - BlackBox:
-    name: Clash.Xilinx.DDR.iddr
+    name: Clash.Xilinx.DDR.iddr#
     kind: Declaration
     type: |-
-      iddr
+      iddr#
         :: ( HasCallStack               -- ARG[0]
            , KnownConfi~ fast domf      -- ARG[1]
            , KnownConfi~ slow doms      -- ARG[2]

--- a/clash-lib/prims/verilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Intel_DDR.primitives.yaml
@@ -27,7 +27,7 @@
           .lpm_hint ("UNUSED"),
           .lpm_type ("altddio_in"),
           .power_up_high ("OFF"),
-          .width (~SIZE[~TYP[7]])
+          .width (~SIZE[~TYP[8]])
         )
         ~GENSYM[~COMPNAME_ALTDDIO_IN][7] (~IF ~ISSYNC[2] ~THEN
           .sclr (~ARG[6]),

--- a/clash-lib/prims/verilog/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Intel_DDR.primitives.yaml
@@ -1,10 +1,10 @@
 - BlackBox:
-    name: Clash.Intel.DDR.altddioIn
+    name: Clash.Intel.DDR.altddioIn#
     kind: Declaration
     libraries:
     - altera_mf
     type: |-
-      altddioIn
+      altddioIn#
         :: ( HasCallStack               -- ARG[0]
            , KnownConfi~ fast domf      -- ARG[1]
            , KnownConfi~ slow doms      -- ARG[2]

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives.yaml
@@ -1,8 +1,8 @@
 - BlackBox:
-    name: Clash.Xilinx.DDR.iddr
+    name: Clash.Xilinx.DDR.iddr#
     kind: Declaration
     type: |-
-      iddr
+      iddr#
         :: ( HasCallStack            -- ARG[0]
            , KnownConfi~ fast domf   -- ARG[1]
            , KnownConfi~ slow doms   -- ARG[2]

--- a/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Xilinx_DDR.primitives.yaml
@@ -14,8 +14,8 @@
         -> Signal slow (BitVector m,BitVector m)
     template: |-
       // iddr begin
-      wire ~SIGD[~GENSYM[dataout_l][1]][7];
-      wire ~SIGD[~GENSYM[dataout_h][2]][7];
+      wire ~SIGD[~GENSYM[data_pos][1]][7];
+      wire ~SIGD[~GENSYM[data_neg][2]][7];
       wire ~SIGD[~GENSYM[d][3]][7];
       assign ~SYM[3] = ~ARG[7];
 
@@ -57,8 +57,8 @@
         -> Signal fast (BitVector m)
     template: |-
       // oddr begin
-      wire ~SIGD[~GENSYM[datain_l][1]][7];
-      wire ~SIGD[~GENSYM[datain_h][2]][7];
+      wire ~SIGD[~GENSYM[data_pos][1]][7];
+      wire ~SIGD[~GENSYM[data_neg][2]][7];
       wire ~SIGD[~GENSYM[q][3]][7];
 
       assign ~SYM[1] = ~ARG[6];

--- a/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives.yaml
@@ -60,7 +60,7 @@
        ~ELSE
         -- async
         --------------
-        ~SYM[6] : process(~ARG[4],~ARG[5]~VARS[9])
+        ~SYM[6] : process(~ARG[4],~ARG[5])
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[1] <= ~ARG[8];
@@ -69,7 +69,7 @@
           end if;
         end process;
 
-        ~SYM[7] : process(~ARG[4],~ARG[5]~VARS[9])
+        ~SYM[7] : process(~ARG[4],~ARG[5])
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[2] <= ~ARG[9];
@@ -78,7 +78,7 @@
           end if;
         end process;
 
-        ~SYM[8] : process(~ARG[4],~ARG[5],~SYM[2])
+        ~SYM[8] : process(~ARG[4],~ARG[5])
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[3] <= ~ARG[7];
@@ -107,7 +107,7 @@
                -> Signal fast a
     template: |-
       -- ddrOut begin
-      ~GENSYM[~COMPNAME_ddrIn][0] : block
+      ~GENSYM[~COMPNAME_ddrOut][0] : block
         signal ~GENSYM[data_Pos][1] : ~TYP[7];
         signal ~GENSYM[data_Neg][2] : ~TYP[7];
       begin
@@ -142,7 +142,7 @@
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[1] <= ~ARG[7];
-          elsif ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
+          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
             ~SYM[1] <= ~ARG[8];
           end if;
         end process;
@@ -151,11 +151,11 @@
         begin
           if ~ARG[5] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[2] <= ~ARG[7];
-          elsif ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
+          elsif ~IF ~ISACTIVEENABLE[6] ~THEN ~ARG[6] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
             ~SYM[2] <= ~ARG[9];
           end if;
         end process;
        ~FI
-        ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1' ~IF ~ISACTIVEENABLE[6] ~THEN and ~ARG[6] ~ELSE ~FI) else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
+        ~RESULT <= ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[1]~ELSE~SYM[2]~FI when (~ARG[4] = '1') else ~IF~ACTIVEEDGE[Rising][2]~THEN~SYM[2]~ELSE~SYM[1]~FI;
       end block;
       -- ddrOut end

--- a/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives.yaml
@@ -23,7 +23,7 @@
         signal ~GENSYM[dataout_l][1] : ~TYP[8];
         signal ~GENSYM[dataout_h][2] : ~TYP[8];~IF ~ISACTIVEENABLE[7] ~THEN
         signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
-      begin~IF ~ISACTIVEENABLE[5] ~THEN
+      begin~IF ~ISACTIVEENABLE[7] ~THEN
         ~SYM[4] <= '1' when (~ARG[7]) else '0';~ELSE ~FI
         ~GENSYM[~COMPNAME_ALTDDIO_IN][7] : ALTDDIO_IN
         GENERIC MAP (
@@ -37,7 +37,7 @@
         PORT MAP (~IF ~ISSYNC[6] ~THEN
           sclr      => ~ARG[6],~ELSE
           aclr      => ~ARG[6],~FI
-          datain    => ~ARG[8],~IF ~ISACTIVEENABLE[5] ~THEN
+          datain    => ~ARG[8],~IF ~ISACTIVEENABLE[7] ~THEN
           inclocken => ~SYM[4],~ELSE ~FI
           inclock   => ~ARG[5],
           dataout_h => ~SYM[2],
@@ -71,7 +71,7 @@
       ~GENSYM[~COMPNAME_ALTDDIO_OUT][0] : block ~IF ~ISACTIVEENABLE[7] ~THEN
         signal ~GENSYM[ce_logic][1] : std_logic; ~ELSE ~FI
       begin~IF ~ISACTIVEENABLE[7] ~THEN
-        ~SYM[3] <= '1' when (~ARG[7]) else '0'; ~ELSE ~FI
+        ~SYM[1] <= '1' when (~ARG[7]) else '0'; ~ELSE ~FI
         ~GENSYM[~COMPNAME_ALTDDIO_OUT][7] : ALTDDIO_OUT
           GENERIC MAP (
             extend_oe_disable => "OFF",
@@ -88,8 +88,8 @@
             aclr       => ~ARG[6],~FI ~IF ~ISACTIVEENABLE[7] ~THEN
             outclocken => ~SYM[1],~ELSE ~FI
             outclock   => ~ARG[5],
-            datain_h   => ~ARG[7],
-            datain_l   => ~ARG[8],
+            datain_h   => ~ARG[8],
+            datain_l   => ~ARG[9],
             dataout    => ~RESULT
           );
       end block;

--- a/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Intel_DDR.primitives.yaml
@@ -1,12 +1,12 @@
 - BlackBox:
-    name: Clash.Intel.DDR.altddioIn
+    name: Clash.Intel.DDR.altddioIn#
     imports:
     - altera_mf.altera_mf_components.all
     kind: Declaration
     libraries:
     - altera_mf
     type: |-
-      altddioIn
+      altddioIn#
         :: ( HasCallStack               -- ARG[0]
            , KnownConfi~ fast domf      -- ARG[1]
            , KnownConfi~ slow doms      -- ARG[2]

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives.yaml
@@ -19,8 +19,8 @@
     template: |-
       -- iddr begin
       ~GENSYM[~COMPNAME_IDDR][0] : block
-        signal ~GENSYM[dataout_l][1] : ~TYP[7];
-        signal ~GENSYM[dataout_h][2] : ~TYP[7];
+        signal ~GENSYM[data_pos][1] : ~TYP[7];
+        signal ~GENSYM[data_neg][2] : ~TYP[7];
         signal ~GENSYM[d][3]         : ~TYP[7];~IF ~ISACTIVEENABLE[6] ~THEN
         signal ~GENSYM[ce_logic][4]: std_logic;~ELSE ~FI
       begin~IF ~ISACTIVEENABLE[6] ~THEN
@@ -70,8 +70,8 @@
     template: |-
       -- oddr begin
       ~GENSYM[~COMPNAME_ODDR][0] : block
-        signal ~GENSYM[dataout_l][1] : ~TYPO;
-        signal ~GENSYM[dataout_h][2] : ~TYPO;
+        signal ~GENSYM[data_pos][1] : ~TYPO;
+        signal ~GENSYM[data_neg][2] : ~TYPO;
         signal ~GENSYM[q][3]         : ~TYPO;~IF ~ISACTIVEENABLE[5] ~THEN
         signal ~GENSYM[ce_logic][4]  : std_logic;~ELSE ~FI
       begin~IF ~ISACTIVEENABLE[5] ~THEN
@@ -79,13 +79,13 @@
         ~SYM[1] <= ~ARG[6];
         ~SYM[2] <= ~ARG[7];
 
-        ~GENSYM[gen_iddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
+        ~GENSYM[gen_oddr][7] : for ~GENSYM[i][8] in ~SYM[3]'range generate
         begin
           ~GENSYM[~COMPNAME_ODDR_inst][9] : ODDR
           generic map(
             DDR_CLK_EDGE => "SAME_EDGE",
             INIT => '0',
-            SRTYPE => ~IF ~ISSYNC[2] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
+            SRTYPE => ~IF ~ISSYNC[1] ~THEN "SYNC" ~ELSE "ASYNC" ~FI)
           port map (
             Q  => ~SYM[3](~SYM[8]),    -- 1-bit DDR output
             C  => ~ARG[3],   -- 1-bit clock input

--- a/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Xilinx_DDR.primitives.yaml
@@ -1,12 +1,12 @@
 - BlackBox:
-    name: Clash.Xilinx.DDR.iddr
+    name: Clash.Xilinx.DDR.iddr#
     imports:
     - UNISIM.vcomponents.all
     kind: Declaration
     libraries:
     - UNISIM
     type: |-
-      iddr
+      iddr#
         :: ( HasCallStack             -- ARG[0]
            , KnownConfi~ fast domf    -- ARG[1]
            , KnownConfi~ slow doms    -- ARG[2]

--- a/clash-prelude/src/Clash/Intel/DDR.hs
+++ b/clash-prelude/src/Clash/Intel/DDR.hs
@@ -53,7 +53,7 @@ altddioIn
   -- ^ DDR input signal
   -> Signal slow (BitVector m,BitVector m)
   -- ^ normal speed output pairs
-altddioIn _devFam clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
+altddioIn SSymbol clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE altddioIn #-}
 {-# ANN altddioIn hasBlackBox #-}
@@ -97,7 +97,7 @@ altddioOut#
   -> Signal slow (BitVector m)
   -> Signal slow (BitVector m)
   -> Signal fast (BitVector m)
-altddioOut# _ clk rst en = ddrOut# clk rst en 0
+altddioOut# SSymbol clk rst en = ddrOut# clk rst en 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE altddioOut# #-}
 {-# ANN altddioOut# hasBlackBox #-}

--- a/clash-prelude/src/Clash/Intel/DDR.hs
+++ b/clash-prelude/src/Clash/Intel/DDR.hs
@@ -1,15 +1,16 @@
 {-|
 Copyright  :  (C) 2017, Google Inc
                   2019, Myrtle Software Ltd
+                  2025, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 DDR primitives for Intel FPGAs using ALTDDIO primitives.
 
 For general information about DDR primitives see "Clash.Explicit.DDR".
 
 Note that a reset is only available on certain devices,
-see ALTDDIO userguide for the specifics:
+see the ALTDDIO user guide for the specifics:
 <https://www.altera.com/content/dam/altera-www/global/en_US/pdfs/literature/ug/ug_altddio.pdf>
 -}
 
@@ -32,8 +33,17 @@ import Clash.Explicit.DDR
 -- | Intel specific variant of 'ddrIn' implemented using the ALTDDIO_IN IP core.
 --
 -- Reset values are @0@
+--
+-- Of the output pair @(o0, o1)@, @o0@ is the data clocked in on the /falling/
+-- edge and @o1@ is the data clocked in on the /rising/ edge, and @o0@ comes
+-- before @o1@ in time.
+--
+-- __NB__: This primitive only supports rising edges as the active edge. Trying
+-- to instantiate this function in a domain where falling edges are the active
+-- edge will lead to a HDL generation or Haskell simulation error.
 altddioIn
-  :: ( HasCallStack
+  :: forall fast fPeriod edge reset init polarity slow m deviceFamily
+   . ( HasCallStack
      , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
      , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
@@ -44,25 +54,50 @@ altddioIn
   --
   -- > SSymbol @"Cyclone IV GX"
   -> Clock slow
-  -- ^ clock
   -> Reset slow
-  -- ^ reset
   -> Enable slow
-  -- ^ Global enable
   -> Signal fast (BitVector m)
   -- ^ DDR input signal
   -> Signal slow (BitVector m,BitVector m)
-  -- ^ normal speed output pairs
-altddioIn SSymbol clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
+  -- ^ Normal speed output pair @(o0, o1)@
+altddioIn =
+  case activeEdge @slow of
+    SRising ->
+      withFrozenCallStack altddioIn#
+    SFalling ->
+      clashCompileError
+        "altddioIn: Primitive only supports rising active edge"
+
+altddioIn#
+  :: ( HasCallStack
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod 'Rising reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) 'Rising reset init polarity)
+     , KnownNat m )
+  => SSymbol deviceFamily
+  -> Clock slow
+  -> Reset slow
+  -> Enable slow
+  -> Signal fast (BitVector m)
+  -> Signal slow (BitVector m,BitVector m)
+altddioIn# SSymbol clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE altddioIn #-}
-{-# ANN altddioIn hasBlackBox #-}
+{-# CLASH_OPAQUE altddioIn# #-}
+{-# ANN altddioIn# hasBlackBox #-}
 
 -- | Intel specific variant of 'ddrOut' implemented using the ALTDDIO_OUT IP core.
 --
 -- Reset value is @0@
+--
+-- Of the input pair @(i0, i1)@, @i0@ is the data clocked out on the /rising/
+-- edge and @i1@ is the data clocked out on the /falling/ edge, and @i0@ comes
+-- before @i1@ in time.
+--
+-- __NB__: This primitive only supports rising edges as the active edge. Trying
+-- to instantiate this function in a domain where falling edges are the active
+-- edge will lead to a HDL generation or Haskell simulation error.
 altddioOut
-  :: ( HasCallStack
+  :: forall fast fPeriod edge reset init polarity slow m deviceFamily
+   . ( HasCallStack
      , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
      , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
@@ -73,22 +108,24 @@ altddioOut
   --
   -- > SSymbol @"Cyclone IV E"
   -> Clock slow
-  -- ^ clock
   -> Reset slow
-  -- ^ reset
   -> Enable slow
-  -- ^ Global enable
   -> Signal slow (BitVector m,BitVector m)
-  -- ^ normal speed input pair
+  -- ^ Normal speed input pair @(i0, i1)@
   -> Signal fast (BitVector m)
   -- ^ DDR output signal
 altddioOut devFam clk rst en =
-  uncurry (withFrozenCallStack altddioOut# devFam clk rst en) . unbundle
+  case activeEdge @slow of
+    SRising ->
+      uncurry (withFrozenCallStack altddioOut# devFam clk rst en) . unbundle
+    SFalling ->
+      clashCompileError
+        "altddioOut: Primitive only supports rising active edge"
 
 altddioOut#
   :: ( HasCallStack
-     , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod 'Rising reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) 'Rising reset init polarity)
      , KnownNat m )
   => SSymbol deviceFamily
   -> Clock slow

--- a/clash-prelude/src/Clash/Xilinx/DDR.hs
+++ b/clash-prelude/src/Clash/Xilinx/DDR.hs
@@ -1,7 +1,8 @@
 {-|
-Copyright  :  (C) 2017, Google Inc
+Copyright  :  (C) 2017     , Google Inc,
+                  2025     , QBayLogic B.V.,
 License    :  BSD2 (see the file LICENSE)
-Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
 DDR primitives for Xilinx FPGAs
 
@@ -10,8 +11,8 @@ For general information about DDR primitives see "Clash.Explicit.DDR".
 For more information about the Xilinx DDR primitives see:
 
 * Vivado Design Suite 7 Series FPGA and Zynq-7000 All Programmable SoC
-  Libraries Guide, UG953 (v2018.3) December 5, 2018, p371-373,p481-483,
-  <https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_3/ug953-vivado-7series-libraries.pdf>
+  Libraries Guide, UG953 (v2022.2) October 19, 2022, p369-371, p477-479,
+  <https://www.xilinx.com/content/dam/xilinx/support/documents/sw_manuals/xilinx2022_2/ug953-vivado-7series-libraries.pdf>
 -}
 
 {-# LANGUAGE CPP #-}
@@ -34,49 +35,85 @@ import Clash.Explicit.DDR
 -- primitive in @SAME_EDGE@ mode.
 --
 -- Reset values are @0@
+--
+-- Of the output pair @(o0, o1)@, @o0@ is the data clocked in on the /falling/
+-- edge and @o1@ is the data clocked in on the /rising/ edge, and @o0@ comes
+-- before @o1@ in time.
+--
+-- __NB__: This primitive only supports rising edges as the active edge. Trying
+-- to instantiate this function in a domain where falling edges are the active
+-- edge will lead to a HDL generation or Haskell simulation error.
 iddr
-  :: ( HasCallStack
+  :: forall fast fPeriod edge reset init polarity slow m
+   . ( HasCallStack
      , KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
      , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
   => Clock slow
-  -- ^ clock
   -> Reset slow
-  -- ^ reset
   -> Enable slow
-  -- ^ global enable
   -> Signal fast (BitVector m)
   -- ^ DDR input signal
   -> Signal slow ((BitVector m),(BitVector m))
-  -- ^ normal speed output pairs
-iddr clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
+  -- ^ Normal speed output pair @(o0, o1)@
+iddr =
+  case activeEdge @slow of
+    SRising ->
+      withFrozenCallStack iddr#
+    SFalling ->
+      clashCompileError
+        "iddr: Primitive only supports rising active edge"
+
+iddr#
+  :: ( HasCallStack
+     , KnownConfiguration fast ('DomainConfiguration fast fPeriod 'Rising reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) 'Rising reset init polarity)
+     , KnownNat m )
+  => Clock slow
+  -> Reset slow
+  -> Enable slow
+  -> Signal fast (BitVector m)
+  -> Signal slow ((BitVector m),(BitVector m))
+iddr# clk rst en = withFrozenCallStack ddrIn# clk rst en 0 0 0
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE iddr #-}
-{-# ANN iddr hasBlackBox #-}
+{-# CLASH_OPAQUE iddr# #-}
+{-# ANN iddr# hasBlackBox #-}
 
 -- | Xilinx specific variant of 'ddrOut' implemented using the Xilinx ODDR
 -- primitive in @SAME_EDGE@ mode.
 --
 -- Reset value is @0@
+--
+-- Of the input pair @(i0, i1)@, @i0@ is the data clocked out on the /rising/
+-- edge and @i1@ is the data clocked out on the /falling/ edge, and @i0@ comes
+-- before @i1@ in time.
+--
+-- __NB__: This primitive only supports rising edges as the active edge. Trying
+-- to instantiate this function in a domain where falling edges are the active
+-- edge will lead to a HDL generation or Haskell simulation error.
 oddr
-  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
+  :: forall fast fPeriod edge reset init polarity slow m
+   . ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
      , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
      , KnownNat m )
   => Clock slow
-  -- ^ clock
   -> Reset slow
-  -- ^ reset
   -> Enable slow
-  -- ^ global enable
   -> Signal slow (BitVector m, BitVector m)
-  -- ^ normal speed input pairs
+  -- ^ Normal speed input pair @(i0, i1)@
   -> Signal fast (BitVector m)
   -- ^ DDR output signal
-oddr clk rst en = uncurry (withFrozenCallStack oddr# clk rst en) . unbundle
+oddr clk rst en =
+  case activeEdge @slow of
+    SRising ->
+       uncurry (withFrozenCallStack oddr# clk rst en) . unbundle
+    SFalling ->
+      clashCompileError
+        "oddr: Primitive only supports rising active edge"
 
 oddr#
-  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod edge reset init polarity)
-     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) edge reset init polarity)
+  :: ( KnownConfiguration fast ('DomainConfiguration fast fPeriod 'Rising reset init polarity)
+     , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) 'Rising reset init polarity)
      , KnownNat m )
   => Clock slow
   -> Reset slow

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -680,12 +680,21 @@ runClashTest = defaultMain
         , runTest "T694" def{hdlSim=[],hdlTargets=[VHDL]}
         ]
       , clashTestGroup "DDR"
-        [ let _opts = def{ buildTargets = BuildSpecific [ "testBenchGA"
+        [
+          -- Since the `XilinxDDR` test is more comprehensive than these tests,
+          -- we skip these tests for Vivado and only run `XilinxDDR`.
+          let _opts = def{ buildTargets = BuildSpecific [ "testBenchGA"
                                                         , "testBenchGS"
                                                         , "testBenchUA"
                                                         , "testBenchUS"
-                                                        ]}
+                                                        ]
+                         , hdlLoad = hdlLoad def \\ [Vivado]
+                         , hdlSim = hdlSim def \\ [Vivado]
+                         }
           in runTest "DDRin" _opts
+
+          -- Since the `XilinxDDR` test is more comprehensive than these tests,
+          -- we skip these tests for Vivado and only run `XilinxDDR`.
         , let _opts = def{ buildTargets = BuildSpecific [ "testBenchUA"
                                                         , "testBenchUS"
                                                         , "testBenchGA"
@@ -695,16 +704,12 @@ runClashTest = defaultMain
                          , hdlSim = hdlSim def \\ [Vivado]
                          }
           in runTest "DDRout" _opts
-        , let _opts = def{ buildTargets = BuildSpecific [ "testBenchUA"
-                                                        , "testBenchUS"
-                                                        , "testBenchGA"
-                                                        , "testBenchGS"
-                                                        ]
+        , let _opts = def{ buildTargets = BuildSpecific ["testBenchAll"]
                          , hdlLoad = [Vivado]
                          , hdlSim = [Vivado]
                          , clashFlags=["-fclash-hdlsyn", "Vivado"]
                          }
-          in runTest "DDRout" _opts
+          in runTest "XilinxDDR" _opts
         ]
       , clashTestGroup "DSignal"
         [ runTest "DelayedFold" def

--- a/tests/shouldwork/DDR/IntelDDR.hs
+++ b/tests/shouldwork/DDR/IntelDDR.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE CPP #-}
+
+module IntelDDR where
+
+import Clash.Annotations.TH
+import Clash.Explicit.Prelude
+import Clash.Intel.DDR
+import Data.Bifunctor
+
+import VendorDDR
+
+intelIn :: DomCxt slow fast fPeriod reset => VendorIn slow fast
+intelIn clk rst en =
+  fmap (bimap unpack unpack) .
+    altddioIn (SSymbol @"Arria II GX") clk rst en . fmap pack
+
+intelOut :: DomCxt slow fast fPeriod reset => VendorOut slow fast
+intelOut clk rst en =
+  fmap unpack .
+    altddioOut (SSymbol @"Arria II GX") clk rst en . fmap (bimap pack pack)
+
+topEntityUA :: TopEntityNoEna System DDRA
+topEntityUA clk rst = topEntityGeneric intelIn intelOut clk rst enableGen
+{-# CLASH_OPAQUE topEntityUA #-}
+{-# ANN topEntityUA (topEntityNoEnaAnn "topEntityUA") #-}
+
+expOutUA :: Vec TestLen2 D
+expOutUA = $(listToVecTH $ outAsyncReset expOut)
+
+expInUA :: Vec TestLen (D, D)
+expInUA = $(listToVecTH $ inAsyncReset expIn)
+
+testBenchUA :: TestBenchT System DDRA
+testBenchUA =
+  testBenchGeneric (noEnable topEntityUA) expInUA expOutUA expOutUA
+{-# CLASH_OPAQUE testBenchUA #-}
+{-# ANN testBenchUA (TestBench 'topEntityUA) #-}
+
+makeTopEntity 'testBenchUA
+
+topEntityUS :: TopEntityNoEna XilinxSystem DDRS
+topEntityUS clk rst = topEntityGeneric intelIn intelOut clk rst enableGen
+{-# CLASH_OPAQUE topEntityUS #-}
+{-# ANN topEntityUS (topEntityNoEnaAnn "topEntityUS") #-}
+
+expOutUS :: Vec TestLen2 D
+expOutUS = $(listToVecTH $ genOutSyncReset expOut)
+
+expInUS :: Vec TestLen (D, D)
+expInUS = $(listToVecTH $ inSyncReset expIn)
+
+testBenchUS :: TestBenchT XilinxSystem DDRS
+testBenchUS =
+  testBenchGeneric (noEnable topEntityUS) expInUS expOutUS expOutUS
+{-# CLASH_OPAQUE testBenchUS #-}
+{-# ANN testBenchUS (TestBench 'topEntityUS) #-}
+
+makeTopEntity 'testBenchUS
+
+topEntityGA :: TopEntityEna System DDRA
+topEntityGA = topEntityGeneric intelIn intelOut
+{-# CLASH_OPAQUE topEntityGA #-}
+{-# ANN topEntityGA (topEntityEnaAnn "topEntityGA") #-}
+
+expOutGA :: Vec TestLen2 D
+expOutGA = $(listToVecTH $ genOutEnable $ outAsyncReset expOut)
+
+expInGA :: Vec TestLen (D, D)
+expInGA = $(listToVecTH $ inEnable $ inAsyncReset expIn)
+
+testBenchGA :: TestBenchT System DDRA
+testBenchGA = testBenchGeneric topEntityGA expInGA expOutGA expOutGA
+{-# CLASH_OPAQUE testBenchGA #-}
+{-# ANN testBenchGA (TestBench 'topEntityGA) #-}
+
+makeTopEntity 'testBenchGA
+
+topEntityGS :: TopEntityEna XilinxSystem DDRS
+topEntityGS = topEntityGeneric intelIn intelOut
+{-# CLASH_OPAQUE topEntityGS #-}
+{-# ANN topEntityGS (topEntityEnaAnn "topEntityGS") #-}
+
+expOutGS :: Vec TestLen2 D
+expOutGS = $(listToVecTH $ genOutEnable $ genOutSyncReset expOut)
+
+expInGS :: Vec TestLen (D, D)
+expInGS = $(listToVecTH $ inEnable $ inSyncReset expIn)
+
+testBenchGS :: TestBenchT XilinxSystem DDRS
+testBenchGS = testBenchGeneric topEntityGS expInGS expOutGS expOutGS
+{-# CLASH_OPAQUE testBenchGS #-}
+{-# ANN testBenchGS (TestBench 'topEntityGS) #-}
+
+makeTopEntity 'testBenchGS
+
+-- Note that this only works correctly in HDL when all test benches are exactly
+-- equally long. Even though VHDL simulation will run until all individual
+-- clocks have stopped, 'tbClockGen' for Verilog will end the simulation when
+-- the first clock stops, cutting short the longer test bench if the lengths
+-- were to differ.
+testBenchAll :: Signal DDRA Bool
+testBenchAll = done
+ where
+   doneUA = getDone testBenchUA
+   doneUS = getDone testBenchUS
+   doneGA = getDone testBenchGA
+   doneGS = getDone testBenchGS
+   doneS = doneUS `strictAnd` doneGS
+   done =
+     doneUA `strictAnd` doneGA `strictAnd`
+     unsafeSynchronizer (clockGen @DDRS) (clockGen @DDRA) doneS
+{-# CLASH_OPAQUE testBenchAll #-}
+{-# ANN testBenchAll (defSyn "testBenchAll") #-}

--- a/tests/shouldwork/DDR/VendorDDR.hs
+++ b/tests/shouldwork/DDR/VendorDDR.hs
@@ -1,0 +1,332 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module VendorDDR where
+
+import Clash.Explicit.DDR
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+import qualified Prelude as P
+
+createDomain vSystem{vName="DDRA", vPeriod=5000}
+createDomain vXilinxSystem{vName="DDRS", vPeriod=5000}
+createDomain vXilinxSystem{vName="Dom4", vPeriod=2500}
+
+type C = Unsigned 11
+type D = Unsigned 9
+
+type TestLen = 44
+type TestLen2 = 2 * TestLen - 1
+
+type DomCxt slow fast fPeriod reset =
+  ( KnownConfiguration fast ('DomainConfiguration fast fPeriod 'Rising reset 'Defined 'ActiveHigh)
+  , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) 'Rising reset 'Defined 'ActiveHigh)
+  )
+
+type VendorIn slow fast =
+  Clock slow ->
+  Reset slow ->
+  Enable slow ->
+  Signal fast D ->
+  Signal slow (D, D)
+
+type VendorOut slow fast =
+  Clock slow ->
+  Reset slow ->
+  Enable slow ->
+  Signal slow (D, D) ->
+  Signal fast D
+
+type TopEntityEna slow fast =
+  Clock slow ->
+  Reset slow ->
+  Enable slow ->
+  Signal fast D ->
+  Signal slow (D, D) ->
+  ( Signal slow ((D, D, D, D))
+  , Signal fast (D, D)
+  )
+
+type TopEntityNoEna slow fast =
+  Clock slow ->
+  Reset slow ->
+  Signal fast D ->
+  Signal slow (D, D) ->
+  ( Signal slow ((D, D, D, D))
+  , Signal fast (D, D)
+  )
+
+topEntityAnn ::
+  Bool ->
+  String ->
+  TopEntity
+topEntityAnn withEna nm =
+  Synthesize
+    { t_name = nm
+    , t_inputs =
+        [ PortName "clk"
+        , PortName "rst"
+        ] P.++
+        (if withEna then [PortName "en"] else []) P.++
+        [ PortName "in_in"
+        , PortProduct "in_out"
+            [ PortName "1"
+            , PortName "2"
+            ]
+        ]
+    , t_output =
+        PortProduct "out"
+          [ PortProduct "in"
+              [ PortName "gen1"
+              , PortName "gen2"
+              , PortName "vendor1"
+              , PortName "vendor2"
+              ]
+          , PortProduct "out"
+              [ PortName "gen"
+              , PortName "vendor"
+              ]
+          ]
+    }
+
+topEntityEnaAnn, topEntityNoEnaAnn :: String -> TopEntity
+topEntityEnaAnn = topEntityAnn True
+topEntityNoEnaAnn = topEntityAnn False
+
+type TestBenchT slow fast =
+  ( "clkSlow" ::: Clock slow
+  , "clkFast" ::: Clock fast
+  , "en" ::: Enable slow
+  , "in_in" ::: Signal fast D
+  , "out_in" ::: Signal slow
+      ( "1" ::: D
+      , "2" ::: D
+      )
+  , "in_out" ::: Signal slow
+      ( "gen1" ::: D
+      , "gen2" ::: D
+      , "vendor1" ::: D
+      , "vendor2" ::: D
+      )
+  , "out_out" ::: Signal fast
+      ( "gen" ::: D
+      , "vendor" ::: D
+      )
+  , "done" ::: Signal fast Bool
+  )
+
+topEntityGeneric ::
+  DomCxt slow fast fPeriod reset =>
+  VendorIn slow fast ->
+  VendorOut slow fast ->
+  TopEntityEna slow fast
+topEntityGeneric vendorIn vendorOut clk rst en inIn outIn =
+  ( bundle (genInOut1, genInOut2, vendorInOut1, vendorInOut2)
+  , bundle (genOutOut, vendorOutOut)
+  )
+ where
+  (genInOut1, genInOut2) = unbundle $ ddrIn clk rst en (0, 0, 0) inIn
+  (vendorInOut1, vendorInOut2) = unbundle $ vendorIn clk rst en inIn
+  genOutOut = ddrOut clk rst en 0 outIn
+  vendorOutOut = vendorOut clk rst en outIn
+
+noEnable ::
+  TopEntityNoEna slow fast ->
+  TopEntityEna slow fast
+noEnable top = top0
+ where
+  top0 clk rst _en = top clk rst
+
+expOut :: [D]
+expOut = 0 : P.concatMap (\e -> [e + 100, e + 200]) [0 .. natToNum @TestLen - 2]
+
+genOutSyncReset :: [D] -> [D]
+genOutSyncReset es =
+  let
+    es0 = P.take 51 es P.++ P.replicate 6 0 P.++ P.drop 57 es
+  in P.take 13 es0 P.++ P.replicate 6 0 P.++ P.drop 19 es0
+
+
+xilinxOutSyncReset :: [D] -> [D]
+xilinxOutSyncReset es =
+  let
+    es0 = P.take 51 es P.++ P.replicate 6 0 P.++ P.drop 57 es
+  in P.take 12 es0 P.++ P.replicate 7 0 P.++ P.drop 19 es0
+
+outAsyncReset :: [D] -> [D]
+outAsyncReset es =
+  let
+    es0 = P.take 50 es P.++ P.replicate 7 0 P.++ P.drop 57 es
+  in P.take 11 es0 P.++ P.replicate 8 0 P.++ P.drop 19 es0
+
+genOutEnable :: [D] -> [D]
+genOutEnable es =
+  let
+    es0 = P.take 69 es P.++ P.take 8 (cycle [133, 233]) P.++ P.drop 77 es
+  in P.take 31 es0 P.++ P.take 8 (cycle [114, 214]) P.++ P.drop 39 es0
+
+xilinxOutEnable :: [D] -> [D]
+xilinxOutEnable es =
+  let es0 = P.take 68 es P.++ P.replicate 9 233 P.++ P.drop 77 es
+  in P.take 30 es0 P.++ P.replicate 9 114 P.++ P.drop 39 es0
+
+expIn :: [(D, D)]
+expIn = (0,0) : (0,0) : P.zip [1, 3 .. hi] [2, 4 .. hi]
+ where
+  hi = 2 * (natToNum @TestLen - 2)
+
+inSyncReset :: [(D, D)] -> [(D, D)]
+inSyncReset es =
+  let
+    es0 = P.take 26 es P.++ P.replicate 3 (0,0) P.++ [(0, 56)] P.++ P.drop 30 es
+  in P.take 7 es0 P.++ P.replicate 3 (0, 0) P.++ P.drop 10 es0
+
+inAsyncReset :: [(D, D)] -> [(D, D)]
+inAsyncReset es =
+  let
+    es0 = P.take 25 es P.++ P.replicate 4 (0,0) P.++ [(0,56)] P.++ P.drop 30 es
+  in P.take 6 es0 P.++ P.replicate 4 (0, 0) P.++ P.drop 10 es0
+
+inEnable ::[(D, D)] ->  [(D, D)]
+inEnable es =
+  let
+    es0 =
+      P.take 35 es P.++ P.replicate 4 (65,66) P.++ [(67,76)] P.++ P.drop 40 es
+  in P.take 16 es0 P.++ P.replicate 4 (27, 28) P.++ P.drop 20 es0
+
+-- I would have liked to output @rstSlow@, but I hit a Clash bug.
+testBenchGeneric ::
+  forall slow fast .
+  ( KnownDomain slow
+  , KnownDomain fast
+  ) =>
+  TopEntityEna slow fast ->
+  Vec TestLen (D, D) ->
+  Vec TestLen2 D ->
+  Vec TestLen2 D ->
+  TestBenchT slow fast
+testBenchGeneric top expIn0 expGenOut expVendorOut =
+  ( clkSlow
+  , clkFast
+  , enSlow
+  , inIn
+  , outIn
+  , inOut
+  , outOut
+  , done
+  )
+ where
+  (inOut, outOut) = top clkSlow rstSlow enSlow inIn outIn
+  (clkSlow, clkFast, rstSlow, enSlow, inIn, outIn, done) =
+    testBenchGeneric0 expIn0 expGenOut expVendorOut inOut outOut
+{-# INLINE testBenchGeneric #-}
+
+testBenchGeneric0 ::
+  forall slow fast .
+  ( KnownDomain slow
+  , KnownDomain fast
+  ) =>
+  Vec TestLen (D, D) ->
+  Vec TestLen2 D ->
+  Vec TestLen2 D ->
+  "in_out" ::: Signal slow
+    ( "gen1" ::: D
+    , "gen2" ::: D
+    , "vendor1" ::: D
+    , "vendor2" ::: D
+    ) ->
+  "out_out" ::: Signal fast
+    ( "gen" ::: D
+    , "vendor" ::: D
+    ) ->
+  ( "clkSlow" ::: Clock slow
+  , "clkFast" ::: Clock fast
+  , "rstSlow" ::: Reset slow
+  , "en" ::: Enable slow
+  , "in_in" ::: Signal fast D
+  , "out_in" ::: Signal slow
+      ( "1" ::: D
+      , "2" ::: D
+      )
+  , "done" ::: Signal fast Bool
+  )
+testBenchGeneric0 expIn0 expGenOut expVendorOut inOut outOut =
+  (clkSlow, clkFast, rstSlow, enSlow, inIn, outIn, done)
+ where
+  (genInOut1, genInOut2, vendorInOut1, vendorInOut2) = unbundle inOut
+  (genOutOut, vendorOutOut) = unbundle outOut
+  inIn = cToDFast cntr4
+  outIn = bundle (posIn, negIn)
+  posIn = cToDSlow $ cntr4 + 402
+  negIn = cToDSlow $ cntr4 + 802
+  cToDFast = unsafeSynchronizer clk4 clkFast . fmap (truncateB . (`shiftR` 1))
+  cToDSlow = unsafeSynchronizer clk4 clkSlow . fmap (truncateB . (`shiftR` 2))
+  cntr4 :: Signal Dom4 C
+  cntr4 = register clk4 noReset enableGen 0 $ cntr4 + 1
+#ifndef INTEL_VERILOG
+  done1 = outputVerifierWith (\clk rst -> assert clk rst "genOutOut")
+    clkFast clkFast noReset expGenOut $
+      ignoreFor clkFast noReset enableGen d1 0 genOutOut
+#else
+  -- The test contains a number of (implicit) parallel, coinciding processes.
+  -- Execution for these processes is left undefined in the Verilog spec, nor is
+  -- there a mechanism to get consistent behavior (like in VHDL). Therefore,
+  -- simulators are free to pick any execution order they'd like. With Verilog
+  -- HDL, ModelSim executes the processes in an order that makes this particular
+  -- `outputVerifier` fail. SystemVerilog however is unaffected, as of course is
+  -- VHDL.
+  --
+  -- CI never runs @IntelDDR.hs@ (which imports this module), but to enable
+  -- manual verification with @IntelDDR.hs@, you can define the macro
+  -- INTEL_VERILOG when compiling. That way, you can disable this
+  -- `outputVerifier` so you can still verify the vendor primitives, which is
+  -- the main purpose of the test.
+  --
+  -- Note that @IntelDDR.hs@ still suffers from the issue described in
+  -- https://github.com/clash-lang/clash-compiler/issues/2854
+  --
+  -- The `const` is just there to prevent a @-Wunused-matches@ on @expGenOut@
+  -- and @genOutOut@.
+  done1 = pure $ const True (expGenOut, genOutOut)
+#endif
+  done2 = outputVerifierWith (\clk rst -> assert clk rst "vendorOutOut")
+    clkFast clkFast noReset expVendorOut vendorOutOut
+  done3 = outputVerifierWith (\clk rst -> assert clk rst "genInOut1")
+    clkSlow clkSlow noReset (map fst expIn0) $
+      ignoreFor clkSlow noReset enableGen d2 0 genInOut1
+  done4 = outputVerifierWith (\clk rst -> assert clk rst "genInOut2")
+    clkSlow clkSlow noReset (map snd expIn0) $
+      ignoreFor clkSlow noReset enableGen d1 0 genInOut2
+  done5 = outputVerifierWith (\clk rst -> assert clk rst "vendorInOut1")
+    clkSlow clkSlow noReset (map fst expIn0) $
+      ignoreFor clkSlow noReset enableGen d2 0 vendorInOut1
+  done6 = outputVerifierWith (\clk rst -> assert clk rst "vendorInOut2")
+    clkSlow clkSlow noReset (map snd expIn0) vendorInOut2
+  doneFast = done1 `strictAnd` done2
+  doneSlow = done3 `strictAnd` done4 `strictAnd` done5 `strictAnd` done6
+  done = doneFast `strictAnd` unsafeSynchronizer clkSlow clkFast doneSlow
+  notDone = not <$> done
+  clk4 = tbClockGen $ unsafeSynchronizer clkFast clk4 notDone
+  clkFast = tbClockGen notDone
+  clkSlow = tbClockGen $ unsafeSynchronizer clkFast clkSlow notDone
+  rstSlow =
+    unsafeFromActiveHigh $ unsafeSynchronizer clk4 clkSlow $
+      (\n -> (n >= 22 && n <= 33) || (n >= 100 && n <= 111)) <$> cntr4
+  enSlow =
+    toEnable $ unsafeSynchronizer clk4 clkSlow $
+      (\n -> (n < 58 || n > 73) && ( n < 136 || n > 151)) <$> cntr4
+{-# NOINLINE testBenchGeneric0 #-}
+
+getDone ::
+  forall slow fast .
+  TestBenchT slow fast ->
+  Signal fast Bool
+getDone tb = done
+ where
+  (_, _, _, _, _, _, _, done) = tb
+
+strictAnd :: Applicative f => f Bool -> f Bool -> f Bool
+strictAnd = liftA2 (let f !a !b = a && b in f)

--- a/tests/shouldwork/DDR/XilinxDDR.hs
+++ b/tests/shouldwork/DDR/XilinxDDR.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE CPP #-}
+
+module XilinxDDR where
+
+import Clash.Annotations.TH
+import Clash.Explicit.Prelude
+import Clash.Xilinx.DDR
+import Data.Bifunctor
+
+import VendorDDR
+
+xilinxIn :: DomCxt slow fast fPeriod reset => VendorIn slow fast
+xilinxIn clk rst en =
+  fmap (bimap unpack unpack) . iddr clk rst en . fmap pack
+
+xilinxOut :: DomCxt slow fast fPeriod reset => VendorOut slow fast
+xilinxOut clk rst en =
+  fmap unpack . oddr clk rst en . fmap (bimap pack pack)
+
+topEntityUA :: TopEntityNoEna System DDRA
+topEntityUA clk rst = topEntityGeneric xilinxIn xilinxOut clk rst enableGen
+{-# CLASH_OPAQUE topEntityUA #-}
+{-# ANN topEntityUA (topEntityNoEnaAnn "topEntityUA") #-}
+
+expGenOutUA :: Vec TestLen2 D
+expGenOutUA = $(listToVecTH $ outAsyncReset expOut)
+
+expXilinxOutUA :: Vec TestLen2 D
+expXilinxOutUA = $(listToVecTH $ outAsyncReset expOut)
+
+expInUA :: Vec TestLen (D, D)
+expInUA = $(listToVecTH $ inAsyncReset expIn)
+
+testBenchUA :: TestBenchT System DDRA
+testBenchUA =
+  testBenchGeneric (noEnable topEntityUA) expInUA expGenOutUA expXilinxOutUA
+{-# CLASH_OPAQUE testBenchUA #-}
+{-# ANN testBenchUA (TestBench 'topEntityUA) #-}
+
+makeTopEntity 'testBenchUA
+
+topEntityUS :: TopEntityNoEna XilinxSystem DDRS
+topEntityUS clk rst = topEntityGeneric xilinxIn xilinxOut clk rst enableGen
+{-# CLASH_OPAQUE topEntityUS #-}
+{-# ANN topEntityUS (topEntityNoEnaAnn "topEntityUS") #-}
+
+expGenOutUS :: Vec TestLen2 D
+expGenOutUS = $(listToVecTH $ genOutSyncReset expOut)
+
+expXilinxOutUS :: Vec TestLen2 D
+expXilinxOutUS = $(listToVecTH $ xilinxOutSyncReset expOut)
+
+expInUS :: Vec TestLen (D, D)
+expInUS = $(listToVecTH $ inSyncReset expIn)
+
+testBenchUS :: TestBenchT XilinxSystem DDRS
+testBenchUS =
+  testBenchGeneric (noEnable topEntityUS) expInUS expGenOutUS expXilinxOutUS
+{-# CLASH_OPAQUE testBenchUS #-}
+{-# ANN testBenchUS (TestBench 'topEntityUS) #-}
+
+makeTopEntity 'testBenchUS
+
+topEntityGA :: TopEntityEna System DDRA
+topEntityGA = topEntityGeneric xilinxIn xilinxOut
+{-# CLASH_OPAQUE topEntityGA #-}
+{-# ANN topEntityGA (topEntityEnaAnn "topEntityGA") #-}
+
+expGenOutGA :: Vec TestLen2 D
+expGenOutGA = $(listToVecTH $ genOutEnable $ outAsyncReset expOut)
+
+expXilinxOutGA :: Vec TestLen2 D
+expXilinxOutGA = $(listToVecTH $ xilinxOutEnable $ outAsyncReset expOut)
+
+expInGA :: Vec TestLen (D, D)
+expInGA = $(listToVecTH $ inEnable $ inAsyncReset expIn)
+
+testBenchGA :: TestBenchT System DDRA
+testBenchGA = testBenchGeneric topEntityGA expInGA expGenOutGA expXilinxOutGA
+{-# CLASH_OPAQUE testBenchGA #-}
+{-# ANN testBenchGA (TestBench 'topEntityGA) #-}
+
+makeTopEntity 'testBenchGA
+
+topEntityGS :: TopEntityEna XilinxSystem DDRS
+topEntityGS = topEntityGeneric xilinxIn xilinxOut
+{-# CLASH_OPAQUE topEntityGS #-}
+{-# ANN topEntityGS (topEntityEnaAnn "topEntityGS") #-}
+
+expGenOutGS :: Vec TestLen2 D
+expGenOutGS = $(listToVecTH $ genOutEnable $ genOutSyncReset expOut)
+
+expXilinxOutGS :: Vec TestLen2 D
+expXilinxOutGS = $(listToVecTH $ xilinxOutEnable $ xilinxOutSyncReset expOut)
+
+expInGS :: Vec TestLen (D, D)
+expInGS = $(listToVecTH $ inEnable $ inSyncReset expIn)
+
+testBenchGS :: TestBenchT XilinxSystem DDRS
+testBenchGS = testBenchGeneric topEntityGS expInGS expGenOutGS expXilinxOutGS
+{-# CLASH_OPAQUE testBenchGS #-}
+{-# ANN testBenchGS (TestBench 'topEntityGS) #-}
+
+makeTopEntity 'testBenchGS
+
+-- Note that this only works correctly in HDL when all test benches are exactly
+-- equally long. Even though VHDL simulation will run until all individual
+-- clocks have stopped, 'tbClockGen' for Verilog will end the simulation when
+-- the first clock stops, cutting short the longer test bench if the lengths
+-- were to differ.
+testBenchAll :: Signal DDRA Bool
+testBenchAll = done
+ where
+   doneUA = getDone testBenchUA
+   doneUS = getDone testBenchUS
+   doneGA = getDone testBenchGA
+   doneGS = getDone testBenchGS
+   doneS = doneUS `strictAnd` doneGS
+   done =
+     doneUA `strictAnd` doneGA `strictAnd`
+     unsafeSynchronizer (clockGen @DDRS) (clockGen @DDRA) doneS
+{-# CLASH_OPAQUE testBenchAll #-}
+{-# ANN testBenchAll (defSyn "testBenchAll") #-}


### PR DESCRIPTION
This is a partial backport of #2833 but with an addition. PR #2833 prevents people from instantiating the vendor IP cores in a domain where the falling edge is the active edge, but for 1.8 we need a solution that does not change the API. So instead, this PR uses `clashCompileError` to at least prevent people from generating HDL in this defective scenario, to hold the fort until 1.10 comes along to fix this properly.

I ran all the Intel tests locally (with GHC 9.10.1) and had CI run all the DDR tests, including the ones that would only run in nightly and thus wouldn't show up as a CI failure on the PR itself. I also ran all ModelSim DDR tests locally as we do not run these on CI at all. I'm pretty confident this PR is good to go :-D.

Note that there is one somewhat-issue with the Changelog files. If we release another 1.8, we should document the `clashCompileError` case, but if we don't and the next version is 1.10.0, there will never have been a stable release with the `clashCompileError` solution, so it should not appear in the Changelog. What this boils down to, is that `changelog/2024-12-14T13_35_37+01_00_fix_ddr_prims` differs between the `master` branch and the `1.8` branch after this PR is merged. If we release another 1.8, this will show up when we backport the release changes to the `master` branch as part of the release process, as Git will warn that the deleted file has been modified. The correct solution is to accept the deletion of the file despite the difference in contents. If the next version we release is 1.10.0, this situation will never occur and everything will be smooth sailing all the way through.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
