### PR TITLE
Inline global binders in `termToData`

### DIFF
--- a/changelog/2025-04-02T12_00_00+02_00_inline_global_binders_in_termToData
+++ b/changelog/2025-04-02T12_00_00+02_00_inline_global_binders_in_termToData
@@ -1,0 +1,1 @@
+INTERNAL CHANGE: `termToData` now takes an additional argument of type `BindingMap`. This allows it to inline global variables, making it handle more cases than before. The class function is now called `termToData#`. An additional function `termToDataM` has been introduced to make it easy to use in a `NetlistMonad`/`BlackBoxFunction` context.

--- a/clash-lib/src/Clash/Core/TermLiteral/TH.hs
+++ b/clash-lib/src/Clash/Core/TermLiteral/TH.hs
@@ -52,7 +52,7 @@ termToDataName :: Name
 termToDataName =
   -- Note that we can't use a fully qualified name here: GHC disallows fully
   -- qualified names in instance function declarations.
-  mkName "termToData"
+  mkName "termToData#"
 
 showsTypePrecName :: Name
 showsTypePrecName =
@@ -185,7 +185,7 @@ deriveTermToData1 constrs =
   args = zipWith (\n nm -> ValD (VarP nm) (NormalB (arg (toInteger n))) []) [0..nArgs-1] (NE.toList argNames)
   arg n = UInfixE (VarE argsName) (VarE '(!!)) (LitE (IntegerL n))
 
-  -- case nm of {"ConstrOne" -> ConstOne <$> termToData arg0; "ConstrTwo" -> ...}
+  -- case nm of {"ConstrOne" -> ConstOne <$> termToData# arg0; "ConstrTwo" -> ...}
   theCase :: Exp
   theCase =
     CaseE

--- a/clash-lib/src/Clash/Primitives/Magic.hs
+++ b/clash-lib/src/Clash/Primitives/Magic.hs
@@ -17,15 +17,15 @@ import Data.Either (lefts)
 import GHC.Stack (HasCallStack)
 import Text.Show.Pretty
 
-import Clash.Core.TermLiteral (termToDataError)
+import Clash.Core.TermLiteral (termToDataErrorM)
 import Clash.Netlist.BlackBox.Types (BlackBoxFunction)
 import Clash.Netlist.Types ()
 
 clashCompileErrorBBF :: HasCallStack => BlackBoxFunction
 clashCompileErrorBBF _isD _primName args _ty
-  |   _hasCallstack
-    : (either error id . termToDataError -> msg)
-    : _ <- lefts args
-  = pure $ Left $ "clashCompileError: " <> msg
+  | _hasCallstack : msgAsTerm : _ <- lefts args
+  = do
+      msg <- termToDataErrorM msgAsTerm
+      pure $ Left $ "clashCompileError: " <> either id id msg
   | otherwise
   = pure $ Left $ show 'clashCompileErrorBBF <> ": bad args:\n" <> ppShow args


### PR DESCRIPTION
**I've marked it as draft to prevent merges (see TODOs), but feel free to review.**

GHC sometimes decides to pull out data structures into their own global variables. For example:

    Clash.Cores.Xilinx.Xpm.Cdc.Internal.InstConfig[8214565720323807388]
      Clash.Cores.Xilinx.Unisim.DnaPortE2.Internal.dnaPortE32[8214565720323807390][GlobalId]
      Clash.Cores.Xilinx.Unisim.DnaPortE2.Internal.dnaPortE29[8214565720323807391][GlobalId]
      Clash.Cores.Xilinx.Unisim.DnaPortE2.Internal.dnaPortE26[8214565720323807392][GlobalId]
      (GHC.Maybe.Nothing[3891110078048108565]
        @Clash.Cores.Xilinx.Xpm.Cdc.Internal.XilinxWizard[8214565720323807393])

This makes it impossible for `termToData` to properly resolve it. We now pass a `BindingMap` to it, so it can inline the definition and continue working.

## Related
https://github.com/clash-lang/clash-cores/pull/28

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
  - [ ] Wait for https://github.com/clash-lang/clash-cores/pull/28 to be based on this and check that _it_ passes CI
