### PR TITLE
Add Vivado SystemVerilog to CI

### DIFF
--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -204,6 +204,15 @@ suite:vivado:verilog:
     - local
     - vivado-2022.1-standard
 
+suite:vivado:systemverilog:
+  extends: .test-cache-local-nightly
+  script:
+    - source /opt/tools/Xilinx/Vivado/2022.1/settings64.sh
+    - bin/clash-testsuite:clash-testsuite -j$THREADS -p .SystemVerilog --hide-successes --no-modelsim --no-ghdl --no-iverilog --no-verilator --no-symbiyosys
+  tags:
+    - local
+    - vivado-2022.1-standard
+
 # XXX: Vivado randomly fails with the following error message:
 #
 #          FATAL_ERROR: Vivado Simulator kernel has discovered an exceptional

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -988,8 +988,19 @@ runClashTest = defaultMain
 
         , outputTest "IndexInt2" def{hdlTargets=[Verilog]}
         , runTest "Concat" def
-        , let _opts = def { hdlLoad = hdlLoad def \\ [Verilator]
-                          , hdlSim = hdlSim def \\ [Verilator]
+        , runTest "DFold" def{hdlTargets = [VHDL, Verilog]}
+        ,
+          -- With GHC 9.0 and 9.2 specifically, Vivado doesn't compile with
+          -- error
+          --     illegal context for assignment pattern
+          -- and Verilator errors on the same line with
+          --     Assignment pattern member not underneath a supported
+          --     construct: NEQCASE
+          -- GHC 8.10 and 9.4 through 9.10 work fine, though.
+          -- https://github.com/clash-lang/clash-compiler/issues/2932
+          let _opts = def { hdlTargets = [SystemVerilog]
+                          , hdlLoad = hdlLoad def \\ [Verilator, Vivado]
+                          , hdlSim = hdlSim def \\ [Verilator, Vivado]
                           }
           in runTest "DFold" _opts
         , runTest "DFold2" def
@@ -1042,8 +1053,7 @@ runClashTest = defaultMain
           }
         ]
       , clashTestGroup "Xilinx"
-        [ let _opts = def{ hdlTargets=[VHDL, Verilog]
-                         , hdlLoad=[Vivado]
+        [ let _opts = def{ hdlLoad=[Vivado]
                          , hdlSim=[Vivado]
                          }
           in runTest "ClockWizard" _opts

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -473,6 +473,7 @@ runTest1 modName opts@TestOptions{..} path target =
       [ -- TODO: ModelSim can do VHDL and Verilog too. Add that?
         buildAndSimTests ModelSim (modelsimTests opts tmpDir)
       , buildAndSimTests Verilator (verilatorTests opts tmpDir)
+      , buildAndSimTests Vivado (vivadoTests opts tmpDir)
       ]
 
   verifTests tmpDir =


### PR DESCRIPTION
Something prevented us from adding this before, but I don't fully recall.

It works fine now, so let's add it.

One test is affected by #2932. The same test has always had Verilator excluded, but it turns out Verilator is also affected by #2932, which is SystemVerilog-specific. Verilator runs fine on the Verilog, so that test is added.

Note that ModelSim is not affected by #2932 and runs succesfully.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
