### PR TITLE
Rewrite `(+>>)` to no longer require `KnownNat`

### DIFF
--- a/changelog/2025-04-18T15_27_46+02_00_less_knownnat
+++ b/changelog/2025-04-18T15_27_46+02_00_less_knownnat
@@ -1,0 +1,1 @@
+CHANGED: Changed implementation of `(+>>)` to no longer require `KnownNat`

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -693,8 +693,8 @@ infixr 4 +>>
 -- 1 :> 3 :> 4 :> Nil
 -- >>> 1 +>> Nil
 -- Nil
-(+>>) :: KnownNat n => a -> Vec n a -> Vec n a
-s +>> xs = fst (shiftInAt0 xs (singleton s))
+(+>>) :: forall n a . a -> Vec n a -> Vec n a
+s +>> xs = init (s :> xs)
 {-# INLINE (+>>) #-}
 
 


### PR DESCRIPTION
Drops the `KnownNat` constraint from `(+>>)`, as it is not needed.


## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
    ~_(I don't see why this update should require a changelog entry, as dropping constraints is backward compatible by default.)_~
    (edited by @DigitalBrains1)
  - [x] Check copyright notices are up to date in edited files
