### PR TITLE
Test 9.10 on macOS, add to README

### DIFF
--- a/.ci/stack-9.10.yaml
+++ b/.ci/stack-9.10.yaml
@@ -1,4 +1,4 @@
-resolver: lts-23.18
+resolver: nightly-2025-04-17
 
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.ci/stack-9.4.yaml
+++ b/.ci/stack-9.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.12
+resolver: lts-21.25
 
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.ci/stack-9.6.yaml
+++ b/.ci/stack-9.6.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.9
+resolver: lts-22.43
 
 ghc-options:
   "$locals": -Wall -Wcompat
@@ -17,11 +17,3 @@ extra-deps:
 - hedgehog-fakedata-0.0.1.5@sha256:d8059e4ef9b7b4112bef9791300118f3a2d776bb191e50b41635a411af609428,1424
 - tasty-1.5@sha256:c62c96da1e9d65bf61ce583e9f7085eed1daeb62a45f3106ca252bf9ef87025b,2763
 - tasty-flaky-0.1.2.0@sha256:2f91ab9f55ae0c472474087f98bb54076aca18f8b058343479d24597a3aa181b,1858
-
-# TODO: Remove this workaround. See:
-#
-#   https://github.com/clash-lang/clash-compiler/pull/2665#issuecomment-1939044550
-- git: https://github.com/haskell/cabal.git
-  commit: a3865991986361b3a736007f620b6a8878d178e3
-  subdirs:
-  - Cabal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macOS-13", "windows-latest"]
-        ghc: ["8.10", "9.0", "9.2", "9.4", "9.6", "9.8"]
+        ghc: ["8.10", "9.0", "9.2", "9.4", "9.6", "9.8", "9.10"]
         exclude:
           # Some tests fail with a mysterious -11 error code.
           - os: "macOS-13"
@@ -36,6 +36,11 @@ jobs:
           # issue as 9.6?
           - os: "windows-latest"
             ghc: "9.8"
+
+          # Cannot build on Windows due to problem with dependency on package
+          # "Win32"
+          - os: "windows-latest"
+            ghc: "9.10"
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Note that release branches might contain non-released patches.
 | 9.4  | ⚠️³ ️   | ⚠️³      | ️⚠️³ ️   | 1.8              | ✔️
 | 9.6  | ✔️³    | ✔️³      | ✔️³    | 1.8              | ✔️
 | 9.8  | ✔️     | ✔️       | ✔️     | 1.8              | ️✔️
+| 9.10 | ✔️     | ❌       | ✔️     | 1.8              | ️✔️
 
 ¹ GHC 9.2 contains a regression, rendering Clash error messages indecipherable. This change was reverted in 9.4.
 


### PR DESCRIPTION
On Linux, Clash has been working on GHC 9.10 for a while, both `master` and 1.8. This PR verifies that the same is the case on macOS, and adds these facts to our README.

Windows is not supported at this time, due to a dependency conflict regarding the `Win32` package.

All versions of Stackage run in CI are bumped to their latest minors.

For Stackage LTS 22 (GHC 9.6) the version bump made a workaround obsolete.

We can be a bit more selective with `allow-newer` in Stackage LTS 23 (GHC 9.8).

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
