### PR TITLE
Add Windows 9.10 support to the changelog

### DIFF
--- a/changelog/2025-04-27T14_45_08+02_00_windows_910
+++ b/changelog/2025-04-27T14_45_08+02_00_windows_910
@@ -1,0 +1,1 @@
+ADDED: Support for GHC 9.10 on Windows (macOS and Linux were already supported)


### PR DESCRIPTION
PR #2939 added support for Windows. This is a noteworthy change and should have been added to the changelog.

(Originally, PR #2939 made no changes worthy of a changelog, but its scope was later broadened and this detail was missed in the process)

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
    :-)
  - [x] Check copyright notices are up to date in edited files
