### PR TITLE
Support text-2.1.2

### DIFF
--- a/clash-lib/src/Data/Text/Prettyprint/Doc/Extra.hs
+++ b/clash-lib/src/Data/Text/Prettyprint/Doc/Extra.hs
@@ -15,8 +15,8 @@ where
 
 import           Control.Applicative
 import           Data.String                           (IsString (..))
-import           Data.Text                             as T
-import           Data.Text.Lazy                        as LT
+import qualified Data.Text                             as T
+import qualified Data.Text.Lazy                        as LT
 
 #if MIN_VERSION_prettyprinter(1,7,0)
 import qualified Prettyprinter                         as PP


### PR DESCRIPTION
Only import from `text` qualified.

text-2.1.2 added a new name: `Empty`. In one file, we imported complete modules from `text` both qualified and unqualified, so this made the word `Empty` ambiguous.

I think the omission of the `qualified` keyword might have been unintended; in any case, the code compiles, so there are no unqualified references to names that are now only imported qualified. If there were, either the old version would have complained about ambiguity or the new version would have complained about missing names.

Fixes https://github.com/commercialhaskell/stackage/issues/7752

(but it will require a new 1.8 version to be released before we can actually get back in Stackage)

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
