### PR TITLE
Fix Nix and test it in CI

### DIFF
--- a/.ci/build_nix.sh
+++ b/.ci/build_nix.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -u
+
+nix \
+  --extra-experimental-features nix-command \
+  --extra-experimental-features flakes \
+  build -j$THREADS --log-format raw --max-silent-time 3600 "$@"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,8 +87,21 @@ nix-build:
   stage: test
   before_script:
    - nix-env -i gawk
+   - export THREADS=$(./.ci/effective_cpus.sh)
+   - export
   script:
-    - nix-build -j$(./.ci/effective_cpus.sh) --log-format raw --max-silent-time 3600
+    - .ci/build_nix.sh .#clash-prelude
+    - .ci/build_nix.sh .#clash-prelude-hedgehog
+    - .ci/build_nix.sh .#clash-lib
+    - .ci/build_nix.sh .#clash-lib-hedgehog
+    - .ci/build_nix.sh .#clash-ghc
+    - .ci/build_nix.sh .#clash-cosim
+    - .ci/build_nix.sh .#clash-ffi
+    - .ci/build_nix.sh .#clash-testsuite
+    - .ci/build_nix.sh .#clash-benchmark
+    - .ci/build_nix.sh .#clash-profiling-prepare
+    - .ci/build_nix.sh .#clash-profiling
+    - .ci/build_nix.sh .#clash-term
   tags:
     - local
 

--- a/nix/overlay-ghc910.nix
+++ b/nix/overlay-ghc910.nix
@@ -25,15 +25,15 @@ in
   hedgehog-fakedata = doJailbreak (markUnbroken prev.hedgehog-fakedata);
 
   # Fails on GHC 9.10 with:
-  #   library/Text/Regex/PCRE/Heavy.hs:123: failure in expression `head $ scan [re|\s*entry (\d+) (\w+)\s*&?|] (" entry 1 hello  &entry 2 hi" :: String)'                                                           
-  # expected: (" entry 1 hello  &",["1","hello"])                                                                                                                                                                 
-  #  but got: <interactive>:55:1: warning: [GHC-63394] [-Wx-partial]                                                                                                                                              
-  #           ^                                                                                                                                                                                  
-  #               In the use of ‘head’                                                                                                                                                                 
+  #   library/Text/Regex/PCRE/Heavy.hs:123: failure in expression `head $ scan [re|\s*entry (\d+) (\w+)\s*&?|] (" entry 1 hello  &entry 2 hi" :: String)'
+  # expected: (" entry 1 hello  &",["1","hello"])
+  #  but got: <interactive>:55:1: warning: [GHC-63394] [-Wx-partial]
+  #           ^
+  #               In the use of ‘head’
   #               (imported from Prelude.Compat, but defined in GHC.Internal.List):
   #               "This is a partial function, it throws an error on empty lists. Use pattern matching, 'Data.List.uncons' or 'Data.Maybe.listToMaybe' instead. Consider refactoring to use "Data.List.NonEmpty"."
   # (" entry 1 hello  &",["1","hello"])
-                                                                                                                                                                                                              
+
   pcre-heavy = dontCheck prev.pcre-heavy;
 
   # Relies on older versions of text.

--- a/nix/overlay-ghc910.nix
+++ b/nix/overlay-ghc910.nix
@@ -55,6 +55,8 @@ in
     sha256 = "sha256-irLM3aVMxpBgsM72ArulMXcoLY2glalVkG//Lrj2JBI=";
   }) {};
 
+  tasty = prev.tasty_1_5;
+
   singletons-th = prev.singletons-th_3_4;
 
   # nixplgs doesn't include revision 1, changing dependency on template-haskell.


### PR DESCRIPTION
Our dependencies for the Nix flake were not correctly declared. This could happen because our CI job for Nix actually only tries to build `clash-ghc`, but the problems are in packages that `clash-ghc` does not depend on. So change CI to actually try to build all our packages, and run any test suites they have. (Just Cabal `test-suite`s, not the executable `clash-testsuite`).

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files