### PR TITLE
Remove redundant pattern matches

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -2176,6 +2176,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
     | [i,j] <- naturalLiterals' args
     -> reduce (Literal (NaturalLiteral (i ^ j)))
 
+  -- XXX: Does it make sense to match on a @NaturalLiteral@ here?
   $(namePat 'GHC.TypeLits.natVal)
     | [Lit (NaturalLiteral n), _] <- args
     -> reduce (integerToIntegerLiteral n)
@@ -2189,11 +2190,8 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
     -> let resTy = getResultTy tcm ty tys
         in reduce (mkSomeNat tcm n resTy)
 
-  $(namePat 'GHC.TypeNats.natVal)
-    | [Lit (NaturalLiteral n), _] <- args
-    -> reduce (Literal (NaturalLiteral n))
-
-  $(namePat 'GHC.TypeNats.someNatVal)
+  -- XXX: Does it make sense to match on a @NaturalLiteral@ here?
+  $(namePat 'GHC.TypeLits.someNatVal)
     | [Lit (NaturalLiteral n)] <- args
     -> let resTy = getResultTy tcm ty tys
         in reduce (mkSomeNat tcm n resTy)


### PR DESCRIPTION
Fallout from #2973

----------

The original code mentioned:

```haskell
  "GHC.TypeNats.someNatVal"
    | [Lit (NaturalLiteral n)] <- args
    -> let resTy = getResultTy tcm ty tys
        in reduce (mkSomeNat tcm n resTy)

  [..]

  "GHC.Internal.TypeNats.someNatVal"
    | [Lit (NaturalLiteral n)] <- args
    -> let resTy = getResultTy tcm ty tys
        in reduce (mkSomeNat tcm n resTy)
```

I renamed `GHC.Internal.TypeNats.someNatVal` to `GHC.TypeNats.someNatVal`, not noticing that the same happened a few lines above. Note that only one of them is a real primitive (and with TH quotes either would resolve to the same name).

----------

I figured the `TypeNats` -> `TypeLits` change should have happened in the original code too, so that's piggy backed on here.

----------

I'm not sure why only very specific GHCs noticed this and only on the 1.8 branch..

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~
