### PR TITLE
Pin Nix GHC minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Or [use Nix](https://nixos.org/nix/download.html) to get a shell with the `clash
 nix develop .
 
 # Start a dev shell with a specific GHC version
-nix develop .#ghc961
+nix develop .#ghc9101
 ```
 
 You will need a modern version of nix with support for the new-style `nix`

--- a/flake.nix
+++ b/flake.nix
@@ -36,12 +36,12 @@
       # The versions of GHC that we want to be able to build / develop against
       # within the nix environment. Since nix is lazy, only derivations for
       # versions of GHC which are used are actually evaluated.
-      ghcVersions = [ "ghc96" "ghc98" "ghc910" ];
+      ghcVersions = [ "ghc964" "ghc982" "ghc9101" ];
 
       # We pick a single version of GHC to use by default within nix. This is
       # probably cleaner than always having N copies of each package / app and
       # being forced to refer to them by their GHC version.
-      defaultGhcVersion = "ghc910";
+      defaultGhcVersion = "ghc9101";
 
       # Overlays are not per-system, so let's only compute them once.
       # For each version of GHC we produce a `pkgs.clashPackages-ghcVER`, e.g.

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -15,7 +15,9 @@ compilerVersion:
 final: prev:
 let
   # An overlay with the things we need to change for the specified GHC version.
-  ghcOverlay = import (./. + "/overlay-${compilerVersion}.nix") {
+  # The overlays are named without the GHC minor version, so we need to strip the last character from the version
+  strippedMinorVersion = builtins.substring 0 (builtins.stringLength compilerVersion - 1) compilerVersion;
+  ghcOverlay = import (./. + "/overlay-${strippedMinorVersion}.nix") {
     pkgs = prev;
   };
 


### PR DESCRIPTION
Pins down the GHC version down to the minor version. As discussed in a PR in clash-cores
(https://github.com/clash-lang/clash-cores/pull/44#discussion_r2230178489).

Each supported GHC version is now postfixed with a minor version number. However the overlays are not. The last digit of the version number gets stripped when Nix imports an overlay. This way we can have one set of GHC version numbers pin down the right GHC version *and* import the right overlay.

I `nix build .#clash-ghc` with all three versions succesfully.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
