### PR TITLE
Expose all supported GHC versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,7 @@
       {
         # Export the variable so that other flakes can use it.
         ghcVersion = defaultGhcVersion;
+        supportedGhcVersions = ghcVersions;
 
         packages = {
           inherit (pkgs."clashPackages-${defaultGhcVersion}")


### PR DESCRIPTION
Right now the only default GHC version gets exported by the flake. This means that libraries wanting to use the clash-compiler flake realistically can only support the default GHC version. If someone wants to use any of the other supported versions, that would work fine for clash-compiler, but it wouldn't trickle down to the libraries (which are stuck with the default ghc version).

Graphs visualizing the issue:
If you want to develop with the default version (ghc9101)
```
myprogram => ghc9101
 |- clash-compiler => ghc9101
 \- clash-protocols => ghc9101
     |- clash-compiler => ghc9101
     \- circuit-notation => ghc9101
         \- clash-compiler => ghc9101
```

With a non-default, but supported version (ghc964)
```
myprogram => ghc964
 |- clash-compiler => ghc964
 \- clash-protocols => ghc9101
     |- clash-compiler => ghc9101
     \- circuit-notation => ghc9101
         \- clash-compiler => ghc9101
```

By exposing all supported libraries, clash-* libraries can be adapted to build for the same set of ghc versions.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
