### PR TITLE
Fix 3008: deduplicate filepaths in `renderFiles`

### DIFF
--- a/changelog/2025-09-19T10_26_48+02_00_deduplicate_data_files_renderFilePath
+++ b/changelog/2025-09-19T10_26_48+02_00_deduplicate_data_files_renderFilePath
@@ -1,0 +1,1 @@
+FIXED: Clash duplicates included verilog sources when component is instantiated multiple times [#3008](https://github.com/clash-lang/clash-compiler/issues/3008)


### PR DESCRIPTION
Fixes #3008 
