### PR TITLE
Add specialisation for powImpl1 over Ints

### DIFF
--- a/changelog/2025-09-20T22_46_02+02_00_fix_3011
+++ b/changelog/2025-09-20T22_46_02+02_00_fix_3011
@@ -1,0 +1,1 @@
+FIXED: Clash will no longer emit "no blackbox found for" `GHC.Real`'s exponentiation function if it is applied to constants

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -2167,6 +2167,27 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
   "GHC.Real.$wf1" -- :: Int# -> Int# -> Int#
     | [Lit (IntLiteral i), Lit (IntLiteral j)] <- args
     -> reduce (integerToIntLiteral $ i ^ j)
+  "GHC.Internal.Real.^_$s$spowImpl2" -- :: Int# -> Integer -> Integer
+    | [intLiteral -> Just j, integerLiteral -> Just i] <- args
+    -> reduce (integerToIntLiteral $ i ^ j)
+  "GHC.Internal.Real.$w$spowImpl" -- :: Integer -> Int# -> Integer
+    | [integerLiteral -> Just i, intLiteral -> Just j] <- args
+    -> reduce (integerToIntLiteral $ i ^ j)
+  "GHC.Internal.Real.$w$spowImpl1" -- :: Int# -> Int# -> Integer
+    | [intLiteral -> Just i, intLiteral -> Just j] <- args
+    -> reduce (integerToIntLiteral $ i ^ j)
+  "GHC.Real.^_$s$spowImpl2" -- :: Int# -> Integer -> Integer
+    | [intLiteral -> Just j, integerLiteral -> Just i] <- args
+    -> reduce (integerToIntLiteral $ i ^ j)
+  "GHC.Real.$w$spowImpl" -- :: Integer -> Int# -> Integer
+    | [integerLiteral -> Just i, intLiteral -> Just j] <- args
+    -> reduce (integerToIntLiteral $ i ^ j)
+  "GHC.Real.$w$spowImpl1" -- :: Int# -> Int# -> Integer
+    | [intLiteral -> Just i, intLiteral -> Just j] <- args
+    -> reduce (integerToIntLiteral $ i ^ j)
+  "GHC.Real.^_$sf2" -- :: Int# -> Integer -> Integer
+    | [intLiteral -> Just j, integerLiteral -> Just i] <- args
+    -> reduce (integerToIntLiteral $ i ^ j)
 
   -- Type level ^    -- XXX: Very fragile
   -- These is are specialized versions of ^_f, named by some combination of ghc and singletons.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -670,6 +670,7 @@ runClashTest = defaultMain
         , runTest "T2966" def{hdlSim=[],hdlTargets=[Verilog]}
         , runTest "T2988" def{hdlSim=[]}
         , outputTest "T3008" def{hdlSim=[]}
+        , outputTest "T3011" def{hdlSim=[]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T3011.hs
+++ b/tests/shouldwork/Issues/T3011.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE CPP #-}
+
+module T3011 where
+
+import Clash.Prelude hiding ((^))
+import Prelude ((^))
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+opaquePow1 :: Integer -> Integer -> Integer
+opaquePow1 a b = a ^ b
+{-# CLASH_OPAQUE opaquePow1 #-}
+
+opaquePow2 :: Integer -> Int -> Integer
+opaquePow2 a b = a ^ b
+{-# CLASH_OPAQUE opaquePow2 #-}
+
+opaquePow3 :: Int -> Int -> Int
+opaquePow3 a b = a ^ b
+{-# CLASH_OPAQUE opaquePow3 #-}
+
+
+topEntity :: (Integer, Integer, Int)
+topEntity =
+  ( opaquePow1 2 11
+  , opaquePow2 2 12
+  , opaquePow3 2 13
+  )
+{-# CLASH_OPAQUE topEntity #-}
+
+-- File content test
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+check :: FilePath -> IO ()
+check fileName = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> fileName)
+  assertIn "2048" content
+  assertIn "4096" content
+  assertIn "8192" content
+
+
+mainVHDL :: IO ()
+mainVHDL = check "topEntity.vhdl"
+
+mainVerilog :: IO ()
+mainVerilog = check "topEntity.v"
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = check "topEntity.sv"


### PR DESCRIPTION
Adds an evaluator rule to handle another GHC specialization of `(^)` for `Int` arguments, namely the worker `$w$spowImpl1`.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] Add regression test
