### PR TITLE
Use Cachix on CI

### DIFF
--- a/.ci/build_and_publish_nix.sh
+++ b/.ci/build_and_publish_nix.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -euo pipefail
+
+nix \
+  --extra-experimental-features nix-command \
+  --extra-experimental-features flakes \
+  build -j$THREADS --log-format raw --max-silent-time 3600 "$@"
+
+nix \
+  --extra-experimental-features nix-command \
+  --extra-experimental-features flakes \
+  build --no-link --print-out-paths "$@" | cachix push clash-lang

--- a/.ci/build_nix.sh
+++ b/.ci/build_nix.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -u
-
-nix \
-  --extra-experimental-features nix-command \
-  --extra-experimental-features flakes \
-  build -j$THREADS --log-format raw --max-silent-time 3600 "$@"

--- a/.ci/setup_cachix.sh
+++ b/.ci/setup_cachix.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -euo pipefail
+
+nix-env -iA cachix -f https://cachix.org/api/v1/install
+
+cachix use clash-lang

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,18 +93,20 @@ nix-build:
    - export THREADS=$(./.ci/effective_cpus.sh)
    - export
   script:
-    - .ci/build_nix.sh .#clash-prelude
-    - .ci/build_nix.sh .#clash-prelude-hedgehog
-    - .ci/build_nix.sh .#clash-lib
-    - .ci/build_nix.sh .#clash-lib-hedgehog
-    - .ci/build_nix.sh .#clash-ghc
-    - .ci/build_nix.sh .#clash-cosim
-    - .ci/build_nix.sh .#clash-ffi
-    - .ci/build_nix.sh .#clash-testsuite
-    - .ci/build_nix.sh .#clash-benchmark
-    - .ci/build_nix.sh .#clash-profiling-prepare
-    - .ci/build_nix.sh .#clash-profiling
-    - .ci/build_nix.sh .#clash-term
+    - .ci/setup_cachix.sh
+
+    - .ci/build_and_publish_nix.sh .#clash-prelude
+    - .ci/build_and_publish_nix.sh .#clash-prelude-hedgehog
+    - .ci/build_and_publish_nix.sh .#clash-lib
+    - .ci/build_and_publish_nix.sh .#clash-lib-hedgehog
+    - .ci/build_and_publish_nix.sh .#clash-ghc
+    - .ci/build_and_publish_nix.sh .#clash-cosim
+    - .ci/build_and_publish_nix.sh .#clash-ffi
+    - .ci/build_and_publish_nix.sh .#clash-testsuite
+    - .ci/build_and_publish_nix.sh .#clash-benchmark
+    - .ci/build_and_publish_nix.sh .#clash-profiling-prepare
+    - .ci/build_and_publish_nix.sh .#clash-profiling
+    - .ci/build_and_publish_nix.sh .#clash-term
   tags:
     - local
 


### PR DESCRIPTION
It still takes 15 minutes to download everything / build local packages, but at least it is better than building for 60 minutes + intermittent testsuite failures. This patch is just a temporary solution until we have local caching.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~