### PR TITLE
Make `ensureSpine` on Clash number types synthesizable

### DIFF
--- a/changelog/2025-09-30T14_03_21+02_00_fix_3021
+++ b/changelog/2025-09-30T14_03_21+02_00_fix_3021
@@ -1,0 +1,1 @@
+FIXED: Clash will no longer error out when converting `ensureSpine` on Clash number types to HDL [#3021](https://github.com/clash-lang/clash-compiler/issues/3021)

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -298,6 +298,7 @@ instance ShowX Bit where
 
 instance NFDataX Bit where
   deepErrorX = errorX
+  ensureSpine = unpack# . xToBV . pack#
   rnfX = rwhnfX
   hasUndefined bv = isLeft (isX bv) || unsafeMask# bv /= 0
 

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -557,6 +557,7 @@ instance ShowX (Index n) where
 
 instance NFDataX (Index n) where
   deepErrorX = errorX
+  ensureSpine = id
   rnfX = rwhnfX
 
 -- | None of the 'Read' class' methods are synthesizable.

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -194,6 +194,7 @@ data Signed (n :: Nat) =
 
 instance NFDataX (Signed n) where
   deepErrorX = errorX
+  ensureSpine = id
   rnfX = rwhnfX
 
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -233,6 +233,7 @@ instance ShowX (Unsigned n) where
 
 instance NFDataX (Unsigned n) where
   deepErrorX = errorX
+  ensureSpine = id
   rnfX = rwhnfX
 
 -- | None of the 'Read' class' methods are synthesizable.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -671,6 +671,8 @@ runClashTest = defaultMain
         , runTest "T2988" def{hdlSim=[]}
         , outputTest "T3008" def{hdlSim=[]}
         , outputTest "T3011" def{hdlSim=[]}
+        , let _opts = def { hdlTargets = [VHDL], hdlLoad = [], hdlSim = []}
+           in runTest "T3021" _opts
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T3021.hs
+++ b/tests/shouldwork/Issues/T3021.hs
@@ -1,0 +1,7 @@
+module T3021 where
+
+import Clash.Prelude
+
+topEntity ::
+  (Unsigned 8, Signed 8, Index 8, Bit) -> (Unsigned 8, Signed 8, Index 8, Bit)
+topEntity = ensureSpine


### PR DESCRIPTION
Fixes #3021
