### PR TITLE
Add `IsProductType` and `IsSumType`

### DIFF
--- a/changelog/2025-10-05T10_12_05+02_00_add_product_sum_info
+++ b/changelog/2025-10-05T10_12_05+02_00_add_product_sum_info
@@ -1,0 +1,1 @@
+ADDED `IsProductType` and `IsSumType` indicators to `BitPack`

--- a/clash-prelude/src/Clash/Num/Overflowing.hs
+++ b/clash-prelude/src/Clash/Num/Overflowing.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright  :  (C) 2021-2022, QBayLogic B.V.
+Copyright  :  (C) 2021-2025, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -65,6 +65,8 @@ instance (Ord a) => Ord (Overflowing a) where
 
 instance (BitPack a, KnownNat (BitSize a + 1)) => BitPack (Overflowing a) where
   type BitSize (Overflowing a) = BitSize a + 1
+  type IsProductType (Overflowing a) = IsProductType a
+  type IsSumType (Overflowing a) = IsSumType a
   -- Default instance, no explicit implementations.
 
 instance (Parity a) => Parity (Overflowing a) where

--- a/clash-prelude/src/Clash/Sized/Fixed.hs
+++ b/clash-prelude/src/Clash/Sized/Fixed.hs
@@ -549,6 +549,8 @@ instance (NumFixedC rep int frac) => Num (Fixed rep int frac) where
 
 instance (BitPack (rep (int + frac)), KnownNat (BitSize (rep (int + frac)))) => BitPack (Fixed rep int frac) where
   type BitSize (Fixed rep int frac) = BitSize (rep (int + frac))
+  type IsProductType (Fixed rep int frac) = False
+  type IsSumType (Fixed rep int frac) = False
   pack   (Fixed fRep) = pack fRep
   unpack bv           = Fixed (unpack bv)
 

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs
@@ -179,6 +179,8 @@ instance NFData (Index n) where
 
 instance (KnownNat n, 1 <= n) => BitPack (Index n) where
   type BitSize (Index n) = CLog 2 n
+  type IsProductType (Index n) = False
+  type IsSumType (Index n) = False
   pack   = packXWith pack#
   unpack = unpack#
 

--- a/clash-prelude/src/Clash/Sized/Internal/Signed.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Signed.hs
@@ -222,6 +222,8 @@ instance KnownNat n => Read (Signed n) where
 
 instance KnownNat n => BitPack (Signed n) where
   type BitSize (Signed n) = n
+  type IsProductType (Signed n) = False
+  type IsSumType (Signed n) = False
   pack   = packXWith pack#
   unpack = unpack#
 

--- a/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/Unsigned.hs
@@ -242,6 +242,8 @@ instance KnownNat n => Read (Unsigned n) where
 
 instance KnownNat n => BitPack (Unsigned n) where
   type BitSize (Unsigned n) = n
+  type IsProductType (Unsigned n) = False
+  type IsSumType (Unsigned n) = False
   pack   = packXWith pack#
   unpack = unpack#
 

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -2711,6 +2711,8 @@ smapWithBounds f xs = reverse
 
 instance (KnownNat n, BitPack a) => BitPack (Vec n a) where
   type BitSize (Vec n a) = n * (BitSize a)
+  type IsProductType (Vec n a) = True
+  type IsSumType (Vec n a) = IsSumType a
   pack   = packXWith (concatBitVector# . map pack)
   unpack = map unpack . unconcatBitVector#
 


### PR DESCRIPTION
The PR adds some type based indicators to `BitPack` that allow to check whether the instance type is a sum- or product type. This variant uses type-level `Bool`s to communicate the property.   

## Still TODO:
  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

