### PR TITLE
Prevent space leaks in `zip` family, `mapAccum{L,R}`

### DIFF
--- a/changelog/2025-10-10T23_10_18+02_00_fix_3038
+++ b/changelog/2025-10-10T23_10_18+02_00_fix_3038
@@ -1,1 +1,1 @@
-FIXED: The `unzip` family no longer retains a reference to the original input for every (unevaluated) part of the output tuple. This can help to prevent space leaks. See [#3038](https://github.com/clash-lang/clash-compiler/issues/3038).
+FIXED: The `unzip` family no longer retains a reference to the original input for every (unevaluated) part of the output tuple. Similarly, `mapAccumL` and `mapAccumR` are now also more eager to drop references. This can help to prevent space leaks. See [#3038](https://github.com/clash-lang/clash-compiler/issues/3038).

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -1335,11 +1335,10 @@ postscanr f z xs = init (scanr f z xs)
 mapAccumL :: (acc -> x -> (acc,y)) -> acc -> Vec n x -> (acc,Vec n y)
 mapAccumL f acc xs = (acc',ys)
   where
-    accs  = acc `Cons` accs'
-    ws    = zipWith (flip f) xs (init accs)
-    accs' = map fst ws
-    ys    = map snd ws
-    acc'  = last accs
+    accs        = acc `Cons` accs'
+    ws          = zipWith (flip f) xs (init accs)
+    (accs', ys) = unzip ws
+    acc'        = last accs
 {-# INLINE mapAccumL #-}
 
 -- | The 'mapAccumR' function behaves like a combination of 'map' and 'foldr';
@@ -1356,11 +1355,10 @@ mapAccumL f acc xs = (acc',ys)
 mapAccumR :: (acc -> x -> (acc,y)) -> acc -> Vec n x -> (acc, Vec n y)
 mapAccumR f acc xs = (acc',ys)
   where
-    accs  = accs' :< acc
-    ws    = zipWith (flip f) xs (tail accs)
-    accs' = map fst ws
-    ys    = map snd ws
-    acc'  = head accs
+    accs        = accs' :< acc
+    ws          = zipWith (flip f) xs (tail accs)
+    (accs', ys) = unzip ws
+    acc'        = head accs
 {-# INLINE mapAccumR #-}
 
 -- | 'zip' takes two vectors and returns a vector of corresponding pairs.


### PR DESCRIPTION
Fixes https://github.com/clash-lang/clash-compiler/issues/3038

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~