### PR TITLE
Define `iterateI` `replicate`-like, preventing space leaks

### DIFF
--- a/changelog/2025-10-15T12_07_26+02_00_fix_3042
+++ b/changelog/2025-10-15T12_07_26+02_00_fix_3042
@@ -1,0 +1,1 @@
+FIXED: individual items of `iterateI` no longer retain a reference to the whole list, preventing space leaks. See [#3042](https://github.com/clash-lang/clash-compiler/issues/3042).

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -1802,10 +1802,11 @@ iterate SNat = iterateI
 --
 -- <<doc/iterate.svg>>
 iterateI :: forall n a. KnownNat n => (a -> a) -> a -> Vec n a
-iterateI f a = xs
-  where
-    xs = init (a `Cons` ws)
-    ws = map f (lazyV xs)
+iterateI f = iterateU (toUNat (SNat @n))
+ where
+  iterateU :: forall m. UNat m -> a -> Vec m a
+  iterateU UZero _ = Nil
+  iterateU (USucc s) a = a `Cons` iterateU s (f a)
 -- See: https://github.com/clash-lang/clash-compiler/pull/2511
 {-# CLASH_OPAQUE iterateI #-}
 {-# ANN iterateI (InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [I.__i|


### PR DESCRIPTION
Fixes #3042

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
