### PR TITLE
Use newer cabal-install on CI

### DIFF
--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -14,9 +14,9 @@ elif [[ "$1" != "" ]]; then
   exit 1
 fi
 
-UBUNTU_VERSION=jammy-20250819
+UBUNTU_VERSION=jammy-20251001
 GHC_VERSIONS=("9.10.2" "9.8.4" "9.6.7" "9.4.8" "9.2.8" "9.0.2" "8.10.7" "8.8.4" "8.6.5")
-CABAL_VERSIONS=("3.14.1.1" "3.14.1.1" "3.14.1.1" "3.14.1.1" "3.14.1.1" "3.14.1.1" "3.12.1.0" "3.14.1.1" "3.14.1.1")
+CABAL_VERSIONS=("3.14.2.0" "3.14.2.0" "3.14.2.0" "3.14.2.0" "3.14.2.0" "3.14.2.0" "3.14.2.0" "3.14.2.0" "3.14.2.0")
 
 # We want to use docker buildkit so that our layers are built in parallel. This
 # is ignored completely on versions of docker which don't support buildkit.

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -8,15 +8,15 @@ default:
       - stuck_or_timeout_failure
 
 .common:
-  image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20250907
+  image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-$CLASH_DOCKER_TAG
   timeout: 10 minutes
   stage: build
   variables:
-    CLASH_DOCKER_TAG: 20250907
+    CLASH_DOCKER_TAG: 20251015
     CACHE_BUST_TOKEN: 3
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20250907-3-3-non_protected
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-1-8-ghcr.io/clash-lang/clash-ci:$GHC_VERSION-$CLASH_DOCKER_TAG-$CACHE_BUST_TOKEN-3-non_protected
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   cache:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
 
     # Run steps inside the clash CI docker image
     container:
-      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20250907
+      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20251015
 
       env:
         THREADS: 2


### PR DESCRIPTION
This fixes our documentation rendering issues due to https://github.com/haskell/cabal/issues/10782

This is a backport of #3035 for 1.8, with some housekeeping added.

Pick up the `CLASH_DOCKER_TAG` and `CACHE_BUST_TOKEN` from PR #2805 (PR #3003 already picked up the env vars).

Change the `CACHE_FALLBACK_KEY` to fall back to the 1.8 branch cache (which is built nightly) instead of the master branch cache (which will never exist because the `CLASH_DOCKER_TAG` is always different!).

We can bump the cabal-install versions for all GHC's; #3035 omitted the one for GHC 8.10 due to a misunderstanding.

Also, the Ubuntu base Docker image is bumped to the latest.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
