### PR TITLE
Run `stack build base` with a single thread on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       # https://github.com/commercialhaskell/stack/issues/5770
       - name: Initialize Stack
         shell: bash
-        run: ./.ci/retry.sh stack build base
+        run: ./.ci/retry.sh stack build base -j1 +RTS -N1
 
       # Building 'happy' sometimes fails on Windows for some obscure reason
       - name: Build happy with Stack


### PR DESCRIPTION
"Fixes" `Verification error: Invalid hash for` errors

------

I remember reading _somewhere_, _sometime_ that the intermittent errors we're seeing on CI are a symptom of a race condition. I've fired off a few jobs, and so far the "fix" seems to be working:

- https://github.com/clash-lang/clash-compiler/actions/runs/18537673876
- https://github.com/clash-lang/clash-compiler/actions/runs/18537994399
- https://github.com/clash-lang/clash-compiler/actions/runs/18538008713
- https://github.com/clash-lang/clash-compiler/actions/runs/18538010111
- https://github.com/clash-lang/clash-compiler/actions/runs/18538012033

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~