### PR TITLE
Always run `inlineCleanup` after `collapseRHSNoops`

### DIFF
--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -385,7 +385,7 @@ flattenCallTree (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
       -- See [Note] relation `collapseRHSNoops` and `inlineCleanup`
       -- Note that we do this as the very last step, after all constant propagation
       -- has been done to avoid #3036.
-      topdownSucR (apply "collapseRHSNoops" collapseRHSNoops) !->
+      topdownSucR (apply "collapseRHSNoops" collapseRHSNoops) >->
       topdownSucR (apply "inlineCleanup" inlineCleanup)
 
     goCheap c@(CLeaf   (nm2,(Binding _ _ inl2 _ e _)))


### PR DESCRIPTION
Downstream projects fail to compile without it. For example see https://github.com/bittide/bittide-hardware/actions/runs/18567116439/job/52931813121.

--------

Fallout from https://github.com/clash-lang/clash-compiler/pull/3037

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~
