### PR TITLE
Reduce type family applications

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -65,7 +65,7 @@ import           Language.Haskell.Syntax.Basic (FieldLabelString (..))
 
 -- GHC API
 #if MIN_VERSION_ghc(9,4,0)
-import GHC.Core.Reduction (Reduction(Reduction))
+import GHC.Core.Reduction (Reduction(Reduction), HetReduction(..))
 #endif
 #if MIN_VERSION_ghc(9,0,0)
 import GHC.Builtin.Types (falseDataCon)
@@ -89,7 +89,9 @@ import GHC.Core.DataCon
    dataConTyCon, dataConUnivTyVars, dataConWorkId, dataConFieldLabels, flLabel,
    HsImplBang(..), dataConImplBangs)
 import GHC.Core.FamInstEnv
-  (FamInst (..), FamInstEnvs, familyInstances, normaliseType, emptyFamInstEnvs)
+  ( FamInst (..), FamInstEnvs
+  , familyInstances, normaliseType, emptyFamInstEnvs, topReduceTyFamApp_maybe
+  )
 import GHC.Data.FastString (unpackFS, bytesFS)
 import GHC.Types.Id (isDataConId_maybe)
 import GHC.Types.Id.Info (IdDetails (..), unfoldingInfo)
@@ -121,8 +123,8 @@ import GHC.Types.Var
 import GHC.Types.Var.Set (isEmptyVarSet)
 #else
 import CoAxiom    (CoAxiom (co_ax_branches), CoAxBranch (cab_lhs,cab_rhs),
-                   fromBranches, Role (Nominal))
-import Coercion   (coercionType,coercionKind)
+                   fromBranches, Role (Nominal, Representational))
+import Coercion   (coercionType, coercionKind, mkTransCo)
 import CoreFVs    (exprSomeFreeVars)
 import CoreSyn
   (AltCon (..), Bind (..), CoreExpr, Expr (..), Unfolding (..), Tickish (..),
@@ -135,7 +137,8 @@ import DataCon    (DataCon, HsImplBang(..),
                    dataConUnivTyVars, dataConWorkId,
                    dataConFieldLabels, flLabel, dataConImplBangs)
 import FamInstEnv (FamInst (..), FamInstEnvs,
-                   familyInstances, normaliseType, emptyFamInstEnvs)
+                   familyInstances, normaliseType, emptyFamInstEnvs,
+                   normaliseTcArgs, reduceTyFamApp_maybe)
 
 import FastString (unpackFS, bytesFS)
 
@@ -982,10 +985,30 @@ coreToType
   -> C2C C.Type
 coreToType ty = ty'' >>= annotateType ty
   where
-    ty'' =
-      case coreView ty of
-        Just ty' -> coreToType ty'
-        Nothing  -> coreToType' ty
+    ty'' | Just ty' <- coreView ty = coreToType ty'
+         | TyConApp tc xs <- ty = do
+             envs <- view famInstEnvs
+             case topReduceTyFamApp_maybe envs tc xs of
+               Nothing -> coreToType' ty
+#if MIN_VERSION_ghc(9,4,0)
+               Just (HetReduction (Reduction _ ty') _) -> coreToType ty'
+#else
+               Just (_, ty', _) -> coreToType ty'
+#endif
+         | otherwise = coreToType' ty
+
+#if !MIN_VERSION_ghc(9,0,0)
+    -- taken and adapted from GHC.Core.FamInstEnv (GHC 9.0.2)
+    topReduceTyFamApp_maybe envs fam_tc arg_tys
+      | isFamilyTyCon fam_tc
+      , Just (co, rhs) <- reduceTyFamApp_maybe envs role fam_tc ntys
+      = Just (args_co `mkTransCo` co, rhs, res_co)
+      | otherwise
+      = Nothing
+      where
+        role = Representational
+        (args_co, ntys, res_co) = normaliseTcArgs envs role fam_tc arg_tys
+#endif
 
 coreToType'
   :: Type


### PR DESCRIPTION
Unevaluated type families can cause a significant compilation overhead during normalization (cf. #1977 and #3063). The PR circumvents the problem by normalizing type families of GHC core types before they are translated into their Clash core equivalent. 

This approach is sound, as Clash never is intended to handle non-resolvable type families due to monomorphization. And, even if encountering such case, the given approach will just keep the type as it is.

* Fixes #1977
* Fixes #3063

## Still TODO:
  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files
