### PR TITLE
Removed the limit on the number of traces in `dumpVCD`

### DIFF
--- a/changelog/2025-11-17T21_35_22+01_00_fixed_dumpvcd_trace_limit
+++ b/changelog/2025-11-17T21_35_22+01_00_fixed_dumpvcd_trace_limit
@@ -1,1 +1,1 @@
-FIXED: Removed the limit on the number of traces in `dumpVCD`. Also removed unnecessary newlines after 1-bit signals. [#3082](https://github.com/clash-lang/clash-compiler/issues/3082)
+FIXED: Removed the limit on the number of traces in `dumpVCD`. Also removed unnecessary double newlines after 1-bit signals. [#3082](https://github.com/clash-lang/clash-compiler/issues/3082)

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -372,7 +372,7 @@ dumpVCD## (offset, cycles) traceMap now
  where
   offensiveNames = filter (any (not . printable)) traceNames
 
-  -- Generate labels like reversed digits: 0:[1,2,01,11,21,02,12,22,001,...]
+  -- Generate labels in the pattern a,b,c,aa,ab,ac,ba,bb,bc,ca,cb,cc,aaa,...
   labels = concatMap (\s -> map (snoc s) alphabet) ([]: labels)
    where
     alphabet = map chr [33..126]


### PR DESCRIPTION
`dumpVCD` was limited to 93 traces, because it could only generate single character trace identifier codes. The codes are now generated ad infinitum, and the restriction has been removed.

Additionally, single bit traces were logged with an extra newline, causing empty lines in the VCD. This has been removed as well.

Fixes: #3082 


