### PR TITLE
Doc: `pack` should never raise `XException`

### DIFF
--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -111,6 +111,10 @@ class KnownNat (BitSize a) => BitPack a where
   type BitSize a = (CLog 2 (GConstructorCount (Rep a))) + (GFieldSize (Rep a))
   -- | Convert element of type @a@ to a 'BitVector'
   --
+  -- @pack@ will never raise @XException@; as @BitVector@ is three-valued,
+  -- @pack@ applied to an @XException@ will return a @BitVector@ filled with
+  -- undefined bits.
+  --
   -- >>> pack (-5 :: Signed 6)
   -- 0b11_1011
   pack   :: a -> BitVector (BitSize a)


### PR DESCRIPTION
It can be nice to be able to rely on `pack` never raising `XException` and it is good behavior. I have always expected this behavior, but it was not documented. Let's document it. I have checked all instances in `clash-prelude` and they all conform to the law. The same goes for deriving a `BitPack` or using `deriveBitPack`.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files

I don't think this needs a changelog entry. It is more of a clarification than a change. But if people want a changelog, that can be done.