### PR TITLE
Fix `holdReset`  glitches for async resets and add `registerSyncReset`

### DIFF
--- a/changelog/2026-01-08T16_58_32+01_00_add_registerSyncReset
+++ b/changelog/2026-01-08T16_58_32+01_00_add_registerSyncReset
@@ -1,0 +1,1 @@
+ADDED: `registerSyncReset` [#3115](https://github.com/clash-lang/clash-compiler/issues/3115)

--- a/changelog/2026-01-08T16_58_32+01_00_fix_holdreset
+++ b/changelog/2026-01-08T16_58_32+01_00_fix_holdreset
@@ -1,0 +1,1 @@
+FIXED: Fix `holdReset` glitch behaviour for asynchronous resets and wrong hold cycles for sync resets. [#3115](https://github.com/clash-lang/clash-compiler/issues/3115)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -804,6 +804,8 @@ runClashTest = defaultMain
                                                         , "testBench53"]}
             in runTest "RWMultiTop" _opts
           ]
+        , runTest "HoldResetAsync" def
+        , runTest "HoldResetSync" def
         , runTest "ResetGen" def
         ,
           -- TODO: we do not support memory files in Vivado

--- a/tests/shouldwork/Signal/HoldResetAsync.hs
+++ b/tests/shouldwork/Signal/HoldResetAsync.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE CPP #-}
+
+module HoldResetAsync where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock XilinxSystem
+  -> Signal XilinxSystem (Bool, Bool, Bool, Bool)
+topEntity clk = bundle (rBool, r0, r1, r2)
+  where
+    r = resetGenN (SNat @3)
+    rBool = unsafeToActiveHigh r
+    r0 = unsafeToActiveHigh (holdReset clk enableGen (SNat @0) r)
+    r1 = unsafeToActiveHigh (holdReset clk enableGen (SNat @1) r)
+    r2 = unsafeToActiveHigh (holdReset clk enableGen (SNat @2) r)
+{-# OPAQUE topEntity #-}
+
+testBench :: Signal XilinxSystem Bool
+testBench = done
+  where
+    expectedOutput =
+      outputVerifier'
+        clk
+        rst
+        -- Note that outputVerifier' skips first sample
+        (  (True,  True,  True,  True)
+        :> (True,  True,  True,  True)
+        :> (False, False, True,  True)
+        :> (False, False, False, True)
+        :> (False, False, False, False)
+        :> Nil )
+
+    done = expectedOutput (topEntity clk)
+    clk  = tbClockGen (not <$> done)
+    rst  = resetGen

--- a/tests/shouldwork/Signal/HoldResetSync.hs
+++ b/tests/shouldwork/Signal/HoldResetSync.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE CPP #-}
+
+module HoldResetSync where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Testbench
+
+topEntity
+  :: Clock System
+  -> Signal System (Bool, Bool, Bool, Bool)
+topEntity clk = bundle (rBool, r0, r1, r2)
+  where
+    r = resetGenN (SNat @3)
+    rBool = unsafeToActiveHigh r
+    r0 = unsafeToActiveHigh (holdReset clk enableGen (SNat @0) r)
+    r1 = unsafeToActiveHigh (holdReset clk enableGen (SNat @1) r)
+    r2 = unsafeToActiveHigh (holdReset clk enableGen (SNat @2) r)
+{-# OPAQUE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+  where
+    expectedOutput =
+      outputVerifier'
+        clk
+        rst
+        -- Note that outputVerifier' skips first sample
+        (  (True,  True,  True,  True)
+        :> (True,  True,  True,  True)
+        :> (False, False, True,  True)
+        :> (False, False, False, True)
+        :> (False, False, False, False)
+        :> Nil )
+
+    done = expectedOutput (topEntity clk)
+    clk  = tbClockGen (not <$> done)
+    rst  = resetGen

--- a/tests/shouldwork/Signal/ResetGen.hs
+++ b/tests/shouldwork/Signal/ResetGen.hs
@@ -7,11 +7,10 @@ import Clash.Explicit.Testbench
 
 topEntity
   :: Clock System
-  -> Signal System (Bool, Bool)
-topEntity clk = bundle (unsafeToActiveHigh r, unsafeToActiveHigh r')
+  -> Signal System Bool
+topEntity clk = bundle (unsafeToActiveHigh r)
   where
     r  = resetGenN (SNat @3)
-    r' = holdReset clk enableGen (SNat @2) r
 {-# OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
@@ -22,12 +21,12 @@ testBench = done
         clk
         rst
         -- Note that outputVerifier' skips first sample
-        (  (True, True)
-        :> (True, True)
-        :> (False, True)
-        :> (False, True)
-        :> (False, False)
-        :> (False, False)
+        (  True
+        :> True
+        :> False
+        :> False
+        :> False
+        :> False
         :> Nil )
 
     done = expectedOutput (topEntity clk)


### PR DESCRIPTION
Aimed to address https://github.com/clash-lang/clash-compiler/issues/3115

This updates the documentation of `holdReset` to indicate the problems it has. It also gives a new function `stretchReset` that should have the correct behaviour but has slightly different timing characteristics so it's not a drop in replacement.

I have marked the `holdReset` function with a warning, I don't like it since now we introduce warning into our own project when exposing it and using it in tests. I also thought a deprecation pragma. Both have some implication as that requires a version bump according to haskell PVP specification.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] Write test
  - [x] Adjust doctest


