### PR TITLE
GitLab CI: Fix cache fallback

### DIFF
--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -14,9 +14,13 @@ default:
   variables:
     CLASH_DOCKER_TAG: 20251007
     CACHE_BUST_TOKEN: 3
-    # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
-    # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-ghcr.io/clash-lang/clash-ci:$GHC_VERSION-$CLASH_DOCKER_TAG-$CACHE_BUST_TOKEN-3-non_protected
+    # Note that the fallback key has two cache bust tokens. `$CACHE_BUST_TOKEN`
+    # is our own, defined right above, and the `-3` at the end in the fallback
+    # key below is GitLab's cache bust token that gets incremented when the user
+    # clicks "Clear runner caches" in the GitLab web interface. We need to
+    # specify both in the fallback key specifically, but *only* our own in the
+    # `cache.key` keyword of a job.
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-$CI_JOB_IMAGE-$CACHE_BUST_TOKEN-3
     GIT_SUBMODULE_STRATEGY: recursive
     TERM: xterm-color
   cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,8 +54,6 @@ stack-build:
   image: fpco/stack-build:lts-24.32
   needs: []
   stage: test
-  variables:
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-$CI_JOB_IMAGE-$CACHE_BUST_TOKEN-3-non_protected
   before_script:
     - apt-get update
     - apt-get install -y zstd


### PR DESCRIPTION
Since GitLab 18.6.1, 18.5.3, 18.4.5, CI runs triggered by a user with at least the Maintainer role are protected:
https://docs.gitlab.com/ci/caching/#cache-key-names

This probably applies to all our CI. Our nightlies get the -protected suffix at least, so our cache fallback key was no longer correct.

Testing indicates `$CI_JOB_IMAGE` is now properly expanded by GitLab, so we can simplify the fallback key as well.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files