### PR TITLE
Suppress source location notes if `-g` is not passed to clash

### DIFF
--- a/changelog/2026-02-02T21_55_56+01_00_no_dbg_emit_srcloc
+++ b/changelog/2026-02-02T21_55_56+01_00_no_dbg_emit_srcloc
@@ -1,0 +1,1 @@
+Fixed: Do not emit source locations if `-g` is not passed to clash [#3132](https://github.com/clash-lang/clash-compiler/issues/3132).

--- a/clash-ghc/src-bin-9.10.1/Clash/Main.hs
+++ b/clash-ghc/src-bin-9.10.1/Clash/Main.hs
@@ -268,9 +268,12 @@ main' postLoadMode units dflags0 args flagWarnings startAction clashOpts = do
   (dflags3, fileish_args, dynamicFlagWarnings) <-
       GHC.parseDynamicFlags logger2 dflags2 args'
 
--- Propagate -Werror to Clash
+  -- Propagate some GHC flags to Clash
   liftIO . modifyIORef' clashOpts $ \opts ->
-    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
+    opts
+      { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3)
+      , opt_ghcDebugLevel = debugLevel dflags3
+      }
 
   let dflags4 = if backendNeedsFullWays bcknd &&
                    not (gopt Opt_ExternalInterpreter dflags3)

--- a/clash-ghc/src-bin-9.10.2/Clash/Main.hs
+++ b/clash-ghc/src-bin-9.10.2/Clash/Main.hs
@@ -268,9 +268,12 @@ main' postLoadMode units dflags0 args flagWarnings startAction clashOpts = do
   (dflags3, fileish_args, dynamicFlagWarnings) <-
       GHC.parseDynamicFlags logger2 dflags2 args'
 
-  -- Propagate -Werror to Clash
+  -- Propagate some GHC flags to Clash
   liftIO . modifyIORef' clashOpts $ \opts ->
-    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
+    opts
+      { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3)
+      , opt_ghcDebugLevel = debugLevel dflags3
+      }
 
   let dflags4 = if backendNeedsFullWays bcknd &&
                    not (gopt Opt_ExternalInterpreter dflags3)

--- a/clash-ghc/src-bin-9.6/Clash/Main.hs
+++ b/clash-ghc/src-bin-9.6/Clash/Main.hs
@@ -268,9 +268,12 @@ main' postLoadMode units dflags0 args flagWarnings startAction clashOpts = do
   (dflags3, fileish_args, dynamicFlagWarnings) <-
       GHC.parseDynamicFlags logger2 dflags2 args'
 
-  -- Propagate -Werror to Clash
+  -- Propagate some GHC flags to Clash
   liftIO . modifyIORef' clashOpts $ \opts ->
-    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
+    opts
+      { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3)
+      , opt_ghcDebugLevel = debugLevel dflags3
+      }
 
   let dflags4 = if backendNeedsFullWays bcknd &&
                    not (gopt Opt_ExternalInterpreter dflags3)

--- a/clash-ghc/src-bin-9.8/Clash/Main.hs
+++ b/clash-ghc/src-bin-9.8/Clash/Main.hs
@@ -266,9 +266,12 @@ main' postLoadMode units dflags0 args flagWarnings startAction clashOpts = do
   (dflags3, fileish_args, dynamicFlagWarnings) <-
       GHC.parseDynamicFlags logger2 dflags2 args'
 
-  -- Propagate -Werror to Clash
+  -- Propagate some GHC flags to Clash
   liftIO . modifyIORef' clashOpts $ \opts ->
-    opts { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3) }
+    opts
+      { opt_werror = EnumSet.member Opt_WarnIsError (generalFlags dflags3)
+      , opt_ghcDebugLevel = debugLevel dflags3
+      }
 
   let dflags4 = if backendNeedsFullWays bcknd &&
                    not (gopt Opt_ExternalInterpreter dflags3)

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -2,8 +2,8 @@
   Copyright  :  (C) 2013-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017     , QBayLogic, Google Inc.,
-                    2020-2022, QBayLogic,
                     2022     , Google Inc.,
+                    2020-2026, QBayLogic,
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -315,6 +315,11 @@ data ClashOpts = ClashOpts
   -- Command line flag: -fclash-evaluator-fuel-limit
   , opt_debug :: DebugOpts
   -- ^ Options which control debugging. See 'DebugOpts'.
+  , opt_ghcDebugLevel :: Int
+  -- ^ What the GHC debug level is (i.e. @-g<N>@).
+  --
+  -- Clash uses this to decide whether to emit source-location information in
+  -- generated HDL.
   , opt_cachehdl :: Bool
   -- ^ Reuse previously generated output from Clash. Only caches topentities.
   --
@@ -407,6 +412,7 @@ defClashOpts
   , opt_inlineConstantLimit = 0
   , opt_evaluatorFuelLimit  = 20
   , opt_debug               = debugNone
+  , opt_ghcDebugLevel       = 0
   , opt_cachehdl            = True
   , opt_clear               = False
   , opt_primWarn            = True

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -2,8 +2,8 @@
   Copyright   :  (C) 2012-2016, University of Twente,
                      2016-2017, Myrtle Software Ltd,
                      2017-2018, Google Inc.,
-                     2021-2024, QBayLogic B.V.
-                     2022     , Google Inc.
+                     2022     , Google Inc.,
+                     2021-2026, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -314,13 +314,25 @@ mkNetDecl (id_,tm) | (_,_,ticks) <- collectArgsTicks tm = preserveVarEnv $ withT
         Annotated attrs hty0 -> Annotated (attrs ++ lAttrs) hty0
         hty0 -> annotated lAttrs hty0
 
+  -- GHC starts including sources notes on any debug level greater than 0
+  -- we copy this behaviour here.
+  emitLocs <- (>0) . opt_ghcDebugLevel <$> Lens.view clashOpts
+  let
+    srcNote =
+      if emitLocs then
+        addSrcNote $ case tm of
+          Tick (SrcSpan s) _ -> s
+          _ -> nameLoc (varName id_)
+      else
+        Nothing
+
   if | not (shouldRenderDecl hwTy tm) -> return []
      | (Prim pInfo@PrimInfo{primMultiResult=MultiResult}, args) <- collectArgs tm ->
-          multiDecls pInfo args
-     | otherwise -> pure <$> singleDecl hwTy
+          multiDecls srcNote pInfo args
+     | otherwise -> pure <$> singleDecl srcNote hwTy
 
   where
-    multiDecls pInfo args0 = do
+    multiDecls srcNote pInfo args0 = do
       tcm <- Lens.view tcCache
       resInits0 <- getResInits (id_, tm)
       let
@@ -334,17 +346,13 @@ mkNetDecl (id_,tm) | (_,_,ticks) <- collectArgsTicks tm = preserveVarEnv $ withT
       hwTys <- mapM (unsafeCoreTypeToHWTypeM' $(curLoc)) (mpi_resultTypes mpInfo)
       pure (zipWith3 netdecl res hwTys resInits1)
 
-    singleDecl hwTy = do
+    singleDecl srcNote hwTy = do
       rIM <- listToMaybe <$> getResInits (id_, tm)
       return (NetDecl' srcNote (Id.unsafeFromCoreId id_) hwTy rIM)
 
     addSrcNote loc
       | isGoodSrcSpan loc = Just (StrictText.pack (showSDocUnsafe (ppr loc)))
       | otherwise = Nothing
-
-    srcNote = addSrcNote $ case tm of
-      Tick (SrcSpan s) _ -> s
-      _ -> nameLoc (varName id_)
 
     isMultiPrimSelect :: Term -> Bool
     isMultiPrimSelect t = case collectArgs t of

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -692,6 +692,8 @@ runClashTest = defaultMain
           , clashLibTest "NoDeDup" def{hdlTargets=[VHDL]}
           , clashLibTest "T1766" def
           , clashLibTest "T1935" def
+          , outputTest "HDLContainsLoc" def{hdlSim=[], clashFlags=["-g"]}
+          , outputTest "HDLNotContainsLoc" def{hdlSim=[]}
           ]
       , clashTestGroup "Numbers"
         [ runTest "BitInteger" def

--- a/tests/shouldwork/Netlist/HDLContainsLoc.hs
+++ b/tests/shouldwork/Netlist/HDLContainsLoc.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds #-}
+
+module HDLContainsLoc where
+
+import Clash.Prelude
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+topEntity :: Maybe Int -> Int
+topEntity x = case x of Nothing -> 0; Just x -> x
+
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
+  assertIn "HDLContainsLoc.hs:" content
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
+  assertIn "HDLContainsLoc.hs:" content
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
+  assertIn "HDLContainsLoc.hs:" content

--- a/tests/shouldwork/Netlist/HDLNotContainsLoc.hs
+++ b/tests/shouldwork/Netlist/HDLNotContainsLoc.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DataKinds #-}
+
+module HDLNotContainsLoc where
+
+import Clash.Prelude
+
+import qualified Prelude as P
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.FilePath ((</>), takeDirectory)
+
+topEntity :: Maybe Int -> Int
+topEntity x = case x of Nothing -> 0; Just x -> x
+
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | not (needle `isInfixOf` haystack)
+  = return ()
+  | otherwise
+  = P.error $ P.concat [ "Did not expect:\n\n  ", needle
+                       , "\n\nIn:\n\n", haystack ]
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
+  assertNotIn "HDLNotContainsLoc.hs:" content
+
+mainVerilog :: IO ()
+mainVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.v")
+  assertNotIn "HDLNotContainsLoc.hs:" content
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
+  assertNotIn "HDLNotContainsLoc.hs:" content


### PR DESCRIPTION
Fixes [#3132](https://github.com/clash-lang/clash-compiler/issues/3132).

First time working with this part of clash. I'm iffy about storing this in `GHC2CoreEnv` but it seems to fit the best.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

