### PR TITLE
Allow `rotate{L,R}` on zero-width `BitVector`s

### DIFF
--- a/changelog/2026-02-08T18_15_04+01_00_fix_2980
+++ b/changelog/2026-02-08T18_15_04+01_00_fix_2980
@@ -1,0 +1,1 @@
+FIXED: `rotateL` and `rotateR` no longer error when used on `BitVector 0` [#2980](https://github.com/clash-lang/clash-compiler/issues/2980)

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -1090,7 +1090,9 @@ shiftR# (BV m v) i
 {-# ANN rotateL# hasBlackBox #-}
 rotateL# =
   \(BV msk v) b ->
-    if b >= 0 then
+    if sz == 0 then
+      BV msk v
+    else if b >= 0 then
       let vl    = naturalShiftL v b'
           vr    = naturalShiftR v b''
 
@@ -1110,7 +1112,9 @@ rotateL# =
 {-# ANN rotateR# hasBlackBox #-}
 rotateR# =
   \(BV msk v) b ->
-    if b >= 0 then
+    if sz == 0 then
+      BV msk v
+    else if b >= 0 then
       let vl   = naturalShiftR v b'
           vr   = naturalShiftL v b''
           ml   = naturalShiftR msk b'

--- a/clash-prelude/tests/Clash/Tests/BitVector.hs
+++ b/clash-prelude/tests/Clash/Tests/BitVector.hs
@@ -24,7 +24,7 @@ import qualified Test.Tasty.Hedgehog.Extra as H
 import qualified Test.Tasty.QuickCheck as Q
 
 import Clash.Prelude
-  (Bit, high, low, bitPattern, type (<=), type (-), natToInteger, msb, bLit, hLit, oLit)
+  (Bit, high, low, bitPattern, type (<=), type (-), natToInteger, msb, bLit, hLit, oLit, rotateL, rotateR)
 import Clash.Sized.Internal.BitVector (BitVector (..))
 
 import Clash.Tests.SizedNum
@@ -96,6 +96,10 @@ tests = localOption (Q.QuickCheckMaxRatio 2) $ testGroup "All"
   , testGroup "Bounds"
     [ testCase "maxBound :: BitVector 0" $ maxBound @(BitVector 0) @?= 0
     , testCase "minBound :: BitVector 0" $ minBound @(BitVector 0) @?= 0
+    ]
+  , testGroup "Rotate"
+    [ testCase "rotateL BitVector 0" $ rotateL @(BitVector 0) 0 2 @?= 0
+    , testCase "rotateR BitVector 0" $ rotateR @(BitVector 0) 0 2 @?= 0
     ]
   , testGroup "MSB"
     [ H.testPropertyXXX "msb @(BitVector 1)" (msbTest @1)


### PR DESCRIPTION
Fixes #2980

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~