### PR TITLE
Yield spine in `Bit`'s `deepErrorX`

### DIFF
--- a/changelog/2026-05-08T21_02_46+02_00_fix_2978
+++ b/changelog/2026-05-08T21_02_46+02_00_fix_2978
@@ -1,0 +1,1 @@
+FIXED: `deepErrorX` and `ensureSpine` on a `Bit` no longer throws an `XException`; it now produces an undefined `Bit` (`.`), matching the behavior of `deepErrorX` on `BitVector n`. See [#2978](https://github.com/clash-lang/clash-compiler/issues/2978).

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -2576,6 +2576,8 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
     -> reduce (mkBitLit ty 0 1)
   $(namePat 'Clash.Sized.Internal.BitVector.low)
     -> reduce (mkBitLit ty 0 0)
+  $(namePat 'Clash.Sized.Internal.BitVector.undefined##)
+    -> reduce (mkBitLit ty 1 0)
 
   $(namePat 'Clash.Sized.Internal.BitVector.undefined#)
     | Just (_, kn) <- extractKnownNat tcm tys

--- a/clash-lib/prims/common/Clash_Sized_Internal_BitVector.primitives.yaml
+++ b/clash-lib/prims/common/Clash_Sized_Internal_BitVector.primitives.yaml
@@ -5,6 +5,12 @@
       n . KnownNat n => BitVector n'
     template: ~ERRORO
     workInfo: Constant
+- BlackBox:
+    name: Clash.Sized.Internal.BitVector.undefined##
+    kind: Expression
+    type: 'undefined## :: Bit'
+    template: ~ERRORO
+    workInfo: Constant
 - Primitive:
     name: Clash.Sized.Internal.BitVector.checkUnpackUndef
     primType: Function

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -30,6 +30,7 @@ module Clash.Sized.Internal.BitVector
     -- ** Construction
   , high
   , low
+  , undefined##
     -- ** Type classes
     -- *** Eq
   , eq##
@@ -261,6 +262,13 @@ high = Bit 0 1
 low :: Bit
 low = Bit 0 0
 
+-- | An 'undefined' 'Bit', i.e. a 'Bit' whose mask is set. Mirrors
+-- 'undefined#' for 'BitVector'.
+undefined## :: Bit
+undefined## = Bit 1 0
+{-# OPAQUE undefined## #-}
+{-# ANN undefined## hasBlackBox #-}
+
 -- ** Instances
 instance NFData Bit where
   rnf (Bit m i) = rnf m `seq` rnf i `seq` ()
@@ -277,7 +285,7 @@ instance ShowX Bit where
   showsPrecX = showsPrecXWith showsPrec
 
 instance NFDataX Bit where
-  deepErrorX = errorX
+  deepErrorX _ = undefined##
   ensureSpine = unpack# . xToBV . pack#
   rnfX = rwhnfX
   hasUndefined bv = isLeft (isX bv) || unsafeMask# bv /= 0

--- a/clash-prelude/tests/Clash/Tests/BitVector.hs
+++ b/clash-prelude/tests/Clash/Tests/BitVector.hs
@@ -27,7 +27,8 @@ import Data.Bits (Bits(shiftL, shiftR, rotateL, rotateR))
 
 import Clash.Prelude
   (Bit, high, low, bitPattern, type (<=), type (-), natToInteger, msb, bLit, hLit, oLit)
-import Clash.Sized.Internal.BitVector (BitVector (..), index#, replaceBit#)
+import Clash.Sized.Internal.BitVector (BitVector (..), Bit(..), index#, replaceBit#)
+import Clash.XException (ensureSpine, errorX, deepErrorX)
 
 import Test.Tasty.HUnit.Extra (expectXException)
 
@@ -162,6 +163,32 @@ tests = localOption (Q.QuickCheckMaxRatio 2) $ testGroup "All"
     , testCase "show16" $ show @(BitVector 12) $(oLit "77.4") @?= "0b1111_11.._.100"
     , testCase "show17" $ show @(BitVector 12) $(oLit "5324") @?= "0b1010_1101_0100"
     , testCase "show17" $ show @(BitVector 12) $(oLit ".324") @?= "0b...0_1101_0100"
+    ]
+  , testGroup "NFDataX"
+    [ testCase
+        "ensureSpine should yield BV constructor"
+        (case ensureSpine (errorX "" :: BitVector 2) of
+          BV m v -> do
+            m @?= 3
+            v @?= 0)
+    , testCase
+        "deepErrorX should yield BV constructor"
+        (case deepErrorX "" :: BitVector 2 of
+          BV m v -> do
+            m @?= 3
+            v @?= 0)
+    , testCase
+        "ensureSpine should yield Bit constructor"
+        (case ensureSpine (errorX "" :: Bit) of
+          Bit m v -> do
+            m @?= 1
+            v @?= 0)
+    , testCase
+        "deepErrorX should yield Bit constructor"
+        (case deepErrorX "" :: Bit of
+          Bit m v -> do
+            m @?= 1
+            v @?= 0)
     ]
   ]
 

--- a/clash-prelude/tests/Clash/Tests/NFDataX.hs
+++ b/clash-prelude/tests/Clash/Tests/NFDataX.hs
@@ -10,6 +10,7 @@ import           Test.Tasty.HUnit
 
 import           GHC.Generics         (Generic)
 import           Clash.Class.BitPack  (pack)
+import           Clash.Sized.Internal.BitVector (Bit, BitVector)
 import           Clash.Sized.Vector   (Vec(..))
 import           Clash.XException
   (NFDataX(rnfX, hasUndefined, deepErrorX), errorX, ensureSpine)
@@ -146,6 +147,15 @@ tests =
         , testCase "SP1"      $ hasUndefined (S 3 5 :: SP)                    @?= False
         , testCase "SP2"      $ hasUndefined (P 5 :: SP)                      @?= False
         , testCase "Rec2_3"   $ hasUndefined (Rec2 3 5)                       @?= False
+        ]
+    , testGroup
+        "Bit"
+        -- Regression test for #2978: 'deepErrorX' on 'Bit' should not throw
+        -- but produce an undefined 'Bit', mirroring the behavior of
+        -- 'BitVector n'.
+        [ testCase "deepErrorX-show"   $ show (deepErrorX "" :: Bit)             @?= "."
+        , testCase "deepErrorX-hasU"   $ hasUndefined (deepErrorX "" :: Bit)     @?= True
+        , testCase "deepErrorX-bv-show" $ show (deepErrorX "" :: BitVector 8)    @?= "0b...._...."
         ]
     , testGroup
         "ManualHasUndefined"


### PR DESCRIPTION
Fixes #2978

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
