### PR TITLE
Fixup "various small fixes - part 14" NFDataX deriving warnings in test

### DIFF
--- a/tests/shouldwork/Issues/T1388.hs
+++ b/tests/shouldwork/Issues/T1388.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE NoDeriveAnyClass #-}
 
 module T1388 where
 
@@ -12,21 +11,23 @@ import Test.Tasty.Clash.NetlistTest
 
 newtype Byte = Byte
   { _byte :: BitVector 8}
-  deriving (Generic, NFDataX, Show, Eq)
-
+  deriving (Generic, Show, Eq)
+  deriving anyclass (NFDataX)
 newtype Word = Word
   { _word :: BitVector 16}
-  deriving (Generic, NFDataX, Show, Eq)
+  deriving (Generic, Show, Eq)
+  deriving anyclass (NFDataX)
 
 type Bytes n = Vec n (Byte)
 
 type Words n = Vec n (Word)
 
 newtype TypeA = TypeA (Bytes 4)
-  deriving (Generic, NFDataX, Show, Eq)
-
+  deriving (Generic, Show, Eq)
+  deriving anyclass (NFDataX)
 newtype TypeB = TypeB (Words 4)
-  deriving (Generic, NFDataX, Show, Eq)
+  deriving (Generic, Show, Eq)
+  deriving anyclass (NFDataX)
 
 {-# OPAQUE bytesToWords #-}
 bytesToWords :: Bytes 4 -> TypeB


### PR DESCRIPTION
As discovery in [the backport of Various small fixes - part 14](https://github.com/clash-lang/clash-compiler/pull/3134) one of [the small fixes](https://github.com/clash-lang/clash-compiler/pull/3131/changes/4e347846d698082243f7c1e4a86baea22fdfe099) wasn't great.

This fixes that by using deriving strategies to make it explicit how NFDataX should be derived.
This fix is already in the backport.
And this PR just cherry pick from that backport, so master is in sync with the 1.8 branch
