### PR TITLE
Add CI Nix devshell dependency

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -112,6 +112,7 @@ jobs:
           ghc982,
           ghc964
         ]
+    needs: packages_common
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The current Nix developer shells require clash-ghc, clash-lib and clash-prelude as a dependency. Currently the CI will rebuild these packages twice. Adding this one makes the developer shell job wait for those packages to be built.

Thanks to @DigitalBrains1  for pointing this out to me!
