### PR TITLE
Simplify `KnownDomain`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ cabal.config
 *.bin
 *.log
 *.tar.gz
+*.agdai
 
 *~
 *.DS_Store

--- a/Clash.hs
+++ b/Clash.hs
@@ -58,7 +58,8 @@ doHDL Proxy opts src = do
   putStrLn $ "Loading dependencies took " ++ prepStartDiff
 
   generateHDL clashEnv clashDesign (Just backend)
-    (ghcTypeToHWType (opt_intWidth opts)) ghcEvaluator evaluator Nothing startTime
+    (ghcTypeToHWType (envDomainTCUs clashEnv) (opt_intWidth opts))
+    ghcEvaluator evaluator Nothing startTime
 
 main :: IO ()
 main =

--- a/benchmark/benchmark-concurrency.hs
+++ b/benchmark/benchmark-concurrency.hs
@@ -4,19 +4,19 @@ module Main (main) where
 
 import Criterion.Main
 import Data.List (isPrefixOf, partition)
-import Data.Time (getCurrentTime)
+--import Data.Time (getCurrentTime)
 import System.Environment (getArgs, withArgs)
 
-import Clash.Backend
-import Clash.Backend.VHDL (VHDLState)
-import Clash.Driver
-import Clash.Driver.Types (ClashEnv(..), ClashOpts(..))
+--import Clash.Backend
+--import Clash.Backend.VHDL (VHDLState)
+--import Clash.Driver
+--import Clash.Driver.Types (ClashEnv(..), ClashOpts(..))
 
-import Clash.GHC.PartialEval
-import Clash.GHC.Evaluator
-import Clash.GHC.NetlistTypes (ghcTypeToHWType)
+--import Clash.GHC.PartialEval
+--import Clash.GHC.Evaluator
+--import Clash.GHC.NetlistTypes (ghcTypeToHWType)
 
-import BenchmarkCommon
+--import BenchmarkCommon
 
 main :: IO ()
 main = do
@@ -35,11 +35,11 @@ main = do
     ]
 
 benchFile :: [FilePath] -> FilePath -> Benchmark
-benchFile idirs src =
-  env ((,) <$> runInputStage idirs src <*> getCurrentTime) $
+benchFile {-idirs src-} = error "TODO"
+{-  env ((,) <$> runInputStage idirs src <*> getCurrentTime) $
     \ ~((clashEnv, clashDesign),startTime) -> do
       bench ("Generating HDL: " ++ src)
             (nfIO (generateHDL clashEnv clashDesign
                      (Just (initBackend @VHDLState (envOpts clashEnv)))
-                     (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
-                     ghcEvaluator evaluator Nothing startTime))
+                     (ghcTypeToHWType (envDomainTCUs clashEnv) (opt_intWidth (envOpts clashEnv)))
+                     ghcEvaluator evaluator Nothing startTime))-}

--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -4,19 +4,19 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
-import           Clash.Driver
-import           Clash.Driver.Types
+--import           Clash.Driver
+--import           Clash.Driver.Types
 
-import           Clash.GHC.PartialEval
-import           Clash.GHC.Evaluator
-import           Clash.GHC.NetlistTypes       (ghcTypeToHWType)
+--import           Clash.GHC.PartialEval
+--import           Clash.GHC.Evaluator
+--import           Clash.GHC.NetlistTypes       (ghcTypeToHWType)
 
-import           Clash.Netlist.Types          (TopEntityT(topId))
-import qualified Clash.Util.Supply            as Supply
+--import           Clash.Netlist.Types          (TopEntityT(topId))
+--import qualified Clash.Util.Supply            as Supply
 
 import           Criterion.Main
 
-import           Control.DeepSeq              (NFData(..), rwhnf)
+--import           Control.DeepSeq              (NFData(..), rwhnf)
 import           Data.List                    (isPrefixOf, partition)
 import           System.Environment           (getArgs, withArgs)
 
@@ -40,8 +40,8 @@ main = do
   withArgs optionArgs (defaultMain $ fmap (benchFile idirs1) tests)
 
 benchFile :: [FilePath] -> FilePath -> Benchmark
-benchFile idirs src =
-  env (setupEnv idirs src) $
+benchFile {-idirs src-} = error "TODO"
+{-  env (setupEnv idirs src) $
     \ ~(clashEnv, clashDesign, supplyN) -> do
       let topEntities = fmap topId (designEntities clashDesign)
           topEntity = case topEntities of
@@ -52,7 +52,7 @@ benchFile idirs src =
               (normalizeEntity
                 clashEnv
                 (designBindings clashDesign)
-                (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                (ghcTypeToHWType (envDomainTCUs clashEnv) (opt_intWidth (envOpts clashEnv)))
                 ghcEvaluator
                 evaluator
                 topEntities
@@ -69,4 +69,4 @@ setupEnv idirs src = do
   return (clashEnv, clashDesign ,supplyN)
 
 instance NFData Supply.Supply where
-  rnf = rwhnf
+  rnf = rwhnf-}

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -60,9 +60,9 @@ runNormalisationStage idirs src = do
   let topEntityNames = fmap topId (designEntities design)
   case topEntityNames of
     topEntity:_ -> do
-      transformedBindings <-
+      (transformedBindings, _) <-
             normalizeEntity env (designBindings design)
-              (ghcTypeToHWType (opt_intWidth (opts idirs)))
+              (ghcTypeToHWType (envDomainTCUs env) (opt_intWidth (opts idirs)))
               ghcEvaluator
               evaluator
               topEntityNames supplyN topEntity

--- a/benchmark/profiling/prepare/clash-profiling-prepare.cabal
+++ b/benchmark/profiling/prepare/clash-profiling-prepare.cabal
@@ -30,8 +30,11 @@ executable clash-profile-normalization-prepare
   build-depends:       base,
                        binary,
                        bytestring,
+                       text,
+                       unordered-containers,
 
                        clash-lib,
+                       clash-prelude,
                        clash-benchmark,
                        clash-profiling-prepare
 

--- a/benchmark/profiling/prepare/profile-netlist-prepare.hs
+++ b/benchmark/profiling/prepare/profile-netlist-prepare.hs
@@ -34,7 +34,7 @@ prepareFile idirs fIn = do
                , envTyConMap clashEnv
                , envCustomReprs clashEnv
                , top
-               , envDomains clashEnv
+               , mempty --TODO --envDomains clashEnv
                )
 
   putStrLn $ "Serialising to : " ++ fOut

--- a/benchmark/profiling/prepare/profile-normalization-prepare.hs
+++ b/benchmark/profiling/prepare/profile-normalization-prepare.hs
@@ -5,9 +5,12 @@ import           System.Environment           (getArgs)
 import           Data.Binary (encode)
 import qualified Data.ByteString.Lazy as B
 import           Data.List                    (partition)
+import           Data.HashMap.Lazy            (HashMap)
+import           Data.Text                    (Text)
 
 import           Clash.Driver.Types           (ClashEnv(..), ClashDesign(..))
 import           Clash.Netlist.Types          (TopEntityT(topId))
+import           Clash.Signal.Internal        (VDomainConfiguration(..))
 
 import           SerialiseInstances
 import           BenchmarkCommon
@@ -39,7 +42,7 @@ prepareFile idirs fIn = do
                    , envCustomReprs clashEnv
                    , topNames
                    , topName
-                   , envDomains clashEnv
+                   , (mempty :: HashMap Text VDomainConfiguration) --TODO --envDomains clashEnv
                    )
 
       putStrLn $ "Serialising to : " ++ fOut

--- a/benchmark/profiling/run/profile-netlist-run.hs
+++ b/benchmark/profiling/run/profile-netlist-run.hs
@@ -40,7 +40,7 @@ main = do
 
 benchFile :: [FilePath] -> FilePath -> IO ()
 benchFile idirs src = do
-  (transformedBindings, topEntities, primMap, tcm, reprs, topEntity, domains) <- setupEnv src
+  (transformedBindings, topEntities, primMap, tcm, reprs, topEntity, _) <- setupEnv src
   putStrLn $ "Doing netlist generation of " ++ src
 
   let env = ClashEnv
@@ -49,7 +49,7 @@ benchFile idirs src = do
                    , envTupleTyCons = mempty
                    , envPrimitives = fmap (fmap unremoveBBfunc) primMap
                    , envCustomReprs = reprs
-                   , envDomains = domains
+                   , envDomainTCUs = Nothing
                    }
 
       topEntityS = Text.unpack (nameOcc (varName topEntity))
@@ -64,7 +64,7 @@ benchFile idirs src = do
                          takeWhile (/= '.') topEntityS
   (netlist,_,_) <-
     genNetlist env ghcEvaluator False transformedBindings topEntityMap compNames
-               (ghcTypeToHWType (opt_intWidth (envOpts env)))
+               (ghcTypeToHWType Nothing (opt_intWidth (envOpts env)))
                ite (SomeBackend hdlState') seen hdlDir prefixM topEntity
   netlist `deepseq` putStrLn ".. done\n"
 

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -32,7 +32,7 @@ main = do
 benchFile :: [FilePath] -> FilePath -> IO ()
 benchFile idirs src = do
   supplyN <- Supply.newSupply
-  (bindingsMap, tcm, tupTcm, primMap, reprs, topEntityNames, topEntity, domains) <- setupEnv src
+  (bindingsMap, tcm, tupTcm, primMap, reprs, topEntityNames, topEntity, _) <- setupEnv src
   putStrLn $ "Doing normalization of " ++ src
 
   let clashEnv = ClashEnv
@@ -41,11 +41,11 @@ benchFile idirs src = do
                    , envTupleTyCons = tupTcm
                    , envPrimitives = fmap (fmap unremoveBBfunc) primMap
                    , envCustomReprs = reprs
-                   , envDomains = domains
+                   , envDomainTCUs = Nothing
                    }
 
   res <- normalizeEntity clashEnv bindingsMap
-                   (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                   (ghcTypeToHWType Nothing (opt_intWidth (envOpts clashEnv)))
                    ghcEvaluator
                    evaluator
                    topEntityNames supplyN topEntity

--- a/clash-ghc/src-bin-9.10.1/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.10.1/Clash/GHCi/UI.hs
@@ -2484,7 +2484,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType (envDomainTCUs clashEnv) iw)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-bin-9.10.2/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.10.2/Clash/GHCi/UI.hs
@@ -2499,7 +2499,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType (envDomainTCUs clashEnv) iw)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-bin-9.12/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.12/Clash/GHCi/UI.hs
@@ -2477,7 +2477,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType (envDomainTCUs clashEnv) iw)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-bin-9.6/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.6/Clash/GHCi/UI.hs
@@ -2450,7 +2450,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType (envDomainTCUs clashEnv) iw)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-bin-9.8/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.8/Clash/GHCi/UI.hs
@@ -2451,7 +2451,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType (envDomainTCUs clashEnv) iw)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive/Util.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive/Util.hs
@@ -43,7 +43,7 @@ import           GHC.Word
 import           System.IO.Unsafe    (unsafeDupablePerformIO)
 
 import           GHC.Types.Basic     (Boxity (..))
-import           GHC.Types.Name      (getSrcSpan, nameOccName, occNameString)
+import           GHC.Types.Name      (getName, getSrcSpan, nameOccName, occNameString, nameStableString)
 import           GHC.Builtin.Names   (trueDataConKey, falseDataConKey)
 import qualified GHC.Core.TyCon      as TyCon
 import           GHC.Builtin.Types   (tupleTyCon)
@@ -1369,6 +1369,7 @@ ghcTyconToTyConName
   -> TyConName
 ghcTyconToTyConName tc =
     Name User n' (fromGhcUnique (TyCon.tyConUnique tc)) (getSrcSpan n)
+      (Text.pack $ nameStableString $ getName tc)
   where
     n'      = fromMaybe "_INTERNAL_" (modNameM n) `Text.append`
               ('.' `Text.cons` Text.pack occName)

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -390,32 +390,37 @@ coreToTerm primMap unlocs = term
       = term' e
       where
         -- Remove most Signal transformers
-        go "Clash.Signal.Internal.mapSignal#"  args
+        go "Clash.Signal.Internal.mapSignal#" args
           | length args == 5
           = term (App (args!!3) (args!!4))
-        go "Clash.Signal.Internal.signal#"     args
+        go "Clash.Signal.Internal.signal#" args
           | length args == 3
           = term (args!!2)
-        go "Clash.Signal.Internal.appSignal#"  args
+        go "Clash.Signal.Internal.appSignal#" args
           | length args == 5
           = term (App (args!!3) (args!!4))
         go "Clash.Signal.Internal.joinSignal#" args
           | length args == 3
           = term (args!!2)
-        go "Clash.Signal.Bundle.vecBundle#"    args
+        go "Clash.Signal.Internal.switchDomain" args
+          | length args == 13
+          = term (last args)
+        go "Clash.Signal.Bundle.vecBundle#" args
           | length args == 4
           = term (args!!3)
         --- Remove `$`
-        go "GHC.Base.$"                        args
+        go "GHC.Base.$" args
           | length args == 5
           = term (App (args!!3) (args!!4))
-        go "GHC.Magic.noinline"                args   -- noinline :: forall a. a -> a
+        go "GHC.Magic.noinline" args   -- noinline :: forall a. a -> a
           | [_ty, x] <- args
           = term x
         -- Remove most CallStack logic
-        go "GHC.Stack.Types.PushCallStack"     args = term (last args)
-        go "GHC.Stack.Types.FreezeCallStack"   args = term (last args)
-        go "GHC.Stack.withFrozenCallStack"     args
+        go "GHC.Stack.Types.PushCallStack" args
+          = term (last args)
+        go "GHC.Stack.Types.FreezeCallStack" args
+          = term (last args)
+        go "GHC.Stack.withFrozenCallStack" args
           | length args == 3
           = term (App (args!!2) (args!!1))
         go "Clash.Sized.BitVector.Internal.checkUnpackUndef" args

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -85,7 +85,7 @@ import GHC.Types.Id.Info (IdDetails (..), unfoldingInfo)
 import GHC.Types.Literal (Literal (..), LitNumType (..), literalType)
 import GHC.Unit.Module (moduleName, moduleNameString)
 import GHC.Types.Name
-  (Name, nameModule_maybe, nameOccName, nameUnique, getSrcSpan)
+  (Name, nameModule_maybe, nameOccName, nameUnique, nameStableString, getSrcSpan)
 import GHC.Builtin.Names  (integerTyConKey, naturalTyConKey)
 import GHC.Types.Name.Occurrence (occNameFS, occNameString)
 import GHC.Data.Pair (Pair (..))
@@ -1079,6 +1079,7 @@ coreToName toName toUnique toString v = do
   ns <- toString (toName v)
   let key  = fromGhcUnique (toUnique v)
       locI = getSrcSpan (toName v)
+      sn = pack (nameStableString (toName v))
       -- Is it one of [ds,ds1,ds2,..]
       isDSX = maybe False (maybe True (isDigit . fst) . Text.uncons) . Text.stripPrefix "ds"
       sort | isDSX ns || Text.isPrefixOf "$" ns
@@ -1087,7 +1088,7 @@ coreToName toName toUnique toString v = do
            = C.User
   locR <- view srcSpan
   let loc = if isGoodSrcSpan locI then locI else locR
-  return (C.Name sort ns key loc)
+  return (C.Name sort ns key loc sn)
 
 qualifiedNameString'
   :: Name

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -119,7 +119,7 @@ generateBindings opts startAction primDirs importDirs dbs hdl modName dflagsM = 
    , partitionEithers -> (unresolvedPrims, pFP)
    , customBitRepresentations
    , primGuards
-   , domainConfs ) <- loadModules startAction (toGhcOverridingBool (opt_color opts)) hdl modName dflagsM importDirs
+   , domainTCUs ) <- loadModules startAction (toGhcOverridingBool (opt_color opts)) hdl modName dflagsM importDirs
   startTime <- Clock.getCurrentTime
   primMapR <- generatePrimMap unresolvedPrims primGuards (concat [pFP, primDirs, importDirs])
   tdir <- maybe ghcLibDir (pure . GHC.topDir) dflagsM
@@ -170,7 +170,7 @@ generateBindings opts startAction primDirs importDirs dbs hdl modName dflagsM = 
         , envTupleTyCons = tupTcCache
         , envPrimitives = primMapC
         , envCustomReprs = buildCustomReprs customBitRepresentations
-        , envDomains = domainConfs
+        , envDomainTCUs = domainTCUs
         }
     , ClashDesign
         { designEntities = topEntities''

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -32,12 +32,14 @@ where
 -- External Modules
 import           Clash.Annotations.Primitive     (HDL, PrimitiveGuard(..))
 import           Clash.Annotations.TopEntity     (TopEntity (..))
+import           Clash.Driver.Types              (KnownDomainTyConUniques(..))
 import           Clash.Primitives.Types          (UnresolvedPrimitive)
+import           Clash.Unique                    (fromGhcUnique)
 import           Clash.Util                      (ClashException(..), pkgIdFromTypeable)
 import qualified Clash.Util.Interpolate          as I
 import           Control.Arrow                   (first)
 import           Control.Exception               (SomeException, throw)
-import           Control.Monad                   (forM, join, when)
+import           Control.Monad                   (forM, when)
 import           Data.List.Extra                 (nubSort)
 import           Control.Exception               (Exception, throwIO)
 import           Control.Monad                   (foldM)
@@ -49,27 +51,22 @@ import           Data.Generics.Uniplate.DataOnly (transform)
 import           Data.Data                       (Data)
 import           Data.Functor                    ((<&>))
 import           Data.Foldable                   (toList)
-import           Data.HashMap.Strict             (HashMap)
 import qualified Data.HashMap.Strict             as HashMap
 import           Data.Typeable                   (Typeable)
-import           Data.List                       (nub, find)
+import           Data.List                       (nub, find, sortOn)
 #if !MIN_VERSION_base(4,20,0)
 import           Data.List                       (foldl')
 #endif
 import qualified Data.Map                        as Map
-import           Data.Maybe
-  (catMaybes, fromMaybe, listToMaybe, mapMaybe)
+import           Data.Maybe                      (catMaybes, fromMaybe, mapMaybe)
 import qualified Data.Text                       as Text
-import qualified Data.Text.Encoding              as Text
 import qualified Data.Time.Clock                 as Clock
 import qualified Data.Set                        as Set
 import qualified Data.Sequence                   as Seq
 import           Debug.Trace
 import           Language.Haskell.TH.Syntax      (lift)
-import           GHC.Natural                     (naturalFromInteger)
 import           GHC.Stack                       (HasCallStack)
 import           System.FilePath.Posix           (dropExtension, takeDirectory)
-import           Text.Read                       (readMaybe)
 
 #ifdef USE_GHC_PATHS
 import           GHC.Paths                       (libdir)
@@ -94,6 +91,7 @@ import           GHC.Driver.Errors.Types (GhcMessage(GhcTcRnMessage))
 import           GHC.Driver.Monad (modifySession)
 import           GHC.Unit.Env (addHomeModInfoToHug)
 import           GHC.Unit.Home.ModInfo (HomeModInfo(HomeModInfo))
+import qualified GHC.Unit.Module as Module (moduleName)
 import           GHC.Unit.Module.ModSummary (findTarget)
 import qualified GHC.Driver.Env as HscTypes
 import qualified GHC.Unit.Module.ModGuts as HscTypes
@@ -105,12 +103,10 @@ import qualified GHC.Platform.Ways as Ways
 import qualified GHC.Types.Annotations as Annotations
 import qualified GHC.Core.FVs as CoreFVs
 import qualified GHC.Core as CoreSyn
-import qualified GHC.Core.DataCon as DataCon
 import qualified GHC.Data.Graph.Directed as Digraph
 import qualified GHC.Runtime.Loader as DynamicLoading
 import           GHC.Driver.Session (GeneralFlag (..))
 import qualified GHC.Driver.Session as DynFlags
-import qualified GHC.Data.FastString as FastString
 import qualified GHC
 import qualified GHC.Driver.Main as HscMain
 import qualified GHC.Iface.Load as IfaceLoad
@@ -121,8 +117,6 @@ import qualified GHC.Unit.Types as UnitTypes (unitIdString)
 import qualified GHC.Tc.Utils.Monad as TcRnMonad
 import qualified GHC.Tc.Types as TcRnTypes
 import qualified GHC.Iface.Tidy as TidyPgm
-import qualified GHC.Core.TyCon as TyCon
-import qualified GHC.Core.Type as Type
 import qualified GHC.Types.Unique as Unique
 import qualified GHC.Tc.Instance.Family as FamInst
 import qualified GHC.Core.FamInstEnv as FamInstEnv
@@ -132,6 +126,7 @@ import qualified GHC.Types.Name.Occurrence as OccName
 import           GHC.Utils.Outputable (ppr)
 import qualified GHC.Utils.Outputable as Outputable
 import qualified GHC.Types.Unique.Set as UniqSet
+import qualified GHC.Types.Unique.DSet as UniqDSet
 import qualified GHC.Types.Var as Var
 import qualified GHC.Unit.Module.Env as ModuleEnv
 import qualified GHC.Types.Name.Env as NameEnv
@@ -142,7 +137,7 @@ import           Clash.GHC.LoadInterfaceFiles
   (loadExternalExprs, getUnresolvedPrimitives, loadExternalBinders,
    LoadedBinders(..))
 import           Clash.GHCi.Common                            (checkMonoLocalBindsMod)
-import           Clash.Util                                   (curLoc, noSrcSpan, reportTimeDiff
+import           Clash.Util                                   (noSrcSpan, reportTimeDiff
                                                               ,wantedLanguageExtensions, unwantedLanguageExtensions)
 import           Clash.Annotations.BitRepresentation.Internal
   (DataRepr', dataReprAnnToDataRepr')
@@ -538,7 +533,7 @@ loadModules
         , [Either UnresolvedPrimitive FilePath]
         , [DataRepr']
         , [(Text.Text, PrimitiveGuard ())]
-        , HashMap Text.Text VDomainConfiguration -- domain names to configuration
+        , Maybe KnownDomainTyConUniques
         )
 loadModules startAction useColor hdl modName dflagsM idirs = do
   libDir <- MonadUtils.liftIO ghcLibDir
@@ -651,19 +646,46 @@ loadModules startAction useColor hdl modName dflagsM idirs = do
         allTCInsts   = FamInstEnv.famInstEnvElts (fst famInstEnvs')
                          ++ FamInstEnv.famInstEnvElts (snd famInstEnvs')
 
-        knownConfs   = filter (\x -> "KnownConf" == nameString (FamInstEnv.fi_fam x)) allTCInsts
+        qualifiedNameString name =
+          maybe "_INTERNAL_" (GHC.moduleNameString . Module.moduleName)
+                             (Name.nameModule_maybe name)
+            <> ('.' : OccName.occNameString (Name.nameOccName name))
 
-        fsToText     = Text.decodeUtf8 . FastString.bytesFS
+        knownTyCons
+          = sortOn (nameString . Name.getName)
+          $ UniqDSet.uniqDSetToList
+          $ foldl g UniqDSet.emptyUniqDSet allTCInsts
+         where
+          g s inst =
+            if qualifiedNameString (FamInstEnv.fi_fam inst) `elem`
+                 map show [ ''DomainPeriod         , ''DomainActiveEdge
+                          , ''DomainResetKind      , ''DomainInitBehavior
+                          , ''DomainResetPolarity  , ''DomainPeriodFraction
+                          , ''DomainPeriodFraction
+                          ]
+            then UniqDSet.addOneToUniqDSet s
+                   $ FamInstEnv.famInstTyCon inst
+            else s
 
-        famToDomain  = fromMaybe (error "KnownConf: Expected Symbol at LHS of type family")
-                         . join . fmap (fmap fsToText) . fmap Type.isStrLitTy
-                         . listToMaybe . FamInstEnv.fi_tys
-        famToConf    = unpackKnownConf . FamInstEnv.fi_rhs
-
-        knownConfNms = fmap famToDomain knownConfs
-        knownConfDs  = fmap famToConf knownConfs
-
-        knownConfMap = HashMap.fromList (zip knownConfNms knownConfDs)
+        mKnownDomainTyConUniques
+          | [ domainActiveEdgeTC
+             , domainInitBehaviorTC
+             , domainPeriodTC
+             , domainPeriodFractionTC
+             , domainResetKindTC
+             , domainResetPolarityTC
+             ] <- knownTyCons
+          = Just KnownDomainTyConUniques
+             { domainPeriodTCU         = fromTC domainPeriodTC
+             , domainActiveEdgeTCU     = fromTC domainActiveEdgeTC
+             , domainResetKindTCU      = fromTC domainResetKindTC
+             , domainInitBehaviorTCU   = fromTC domainInitBehaviorTC
+             , domainResetPolarityTCU  = fromTC domainResetPolarityTC
+             , domainPeriodFractionTCU = fromTC domainPeriodFractionTC
+             }
+          | otherwise = Nothing
+         where
+          fromTC = fromGhcUnique . Unique.getUnique
 
     return ( allBinders
            , Map.assocs lbClassOps
@@ -673,55 +695,8 @@ loadModules startAction useColor hdl modName dflagsM idirs = do
            , toList lbPrims
            , toList reprs1
            , primGuards
-           , knownConfMap
+           , mKnownDomainTyConUniques
            )
-
--- | Given a type that represents the RHS of a KnownConf type family instance,
--- unpack the fields of the DomainConfiguration and make a VDomainConfiguration.
---
-unpackKnownConf :: Type.Type -> VDomainConfiguration
-unpackKnownConf ty
-  | [d,p,ae,rk,ib,rp] <- Type.tyConAppArgs ty
-    -- Domain name
-  , Just dom <- fmap FastString.unpackFS (Type.isStrLitTy d)
-    -- Period
-  , Just period <- fmap naturalFromInteger (Type.isNumLitTy p)
-    -- Active Edge
-  , aeTc <- Type.tyConAppTyCon ae
-  , Just aeDc <- TyCon.isPromotedDataCon_maybe aeTc
-  , aeNm <- OccName.occNameString $ Name.nameOccName (DataCon.dataConName aeDc)
-    -- Reset Kind
-  , rkTc <- Type.tyConAppTyCon rk
-  , Just rkDc <- TyCon.isPromotedDataCon_maybe rkTc
-  , rkNm <- OccName.occNameString $ Name.nameOccName (DataCon.dataConName rkDc)
-    -- Init Behavior
-  , ibTc <- Type.tyConAppTyCon ib
-  , Just ibDc <- TyCon.isPromotedDataCon_maybe ibTc
-  , ibNm <- OccName.occNameString $ Name.nameOccName (DataCon.dataConName ibDc)
-    -- Reset Polarity
-  , rpTc <- Type.tyConAppTyCon rp
-  , Just rpDc <- TyCon.isPromotedDataCon_maybe rpTc
-  , rpNm <- OccName.occNameString $ Name.nameOccName (DataCon.dataConName rpDc)
-  = VDomainConfiguration dom period
-      (asActiveEdge aeNm)
-      (asResetKind rkNm)
-      (asInitBehavior ibNm)
-      (asResetPolarity rpNm)
-
-  | otherwise
-  = error $ $(curLoc) ++ "Could not unpack domain configuration."
- where
-  asActiveEdge :: HasCallStack => String -> ActiveEdge
-  asActiveEdge x = fromMaybe (error $ $(curLoc) ++ "Unknown active edge: " ++ show x) (readMaybe x)
-
-  asResetKind :: HasCallStack => String -> ResetKind
-  asResetKind x = fromMaybe (error $ $(curLoc) ++ "Unknown reset kind: " ++ show x) (readMaybe x)
-
-  asInitBehavior :: HasCallStack => String -> InitBehavior
-  asInitBehavior x = fromMaybe (error $ $(curLoc) ++ "Unknown init behavior: " ++ show x) (readMaybe x)
-
-  asResetPolarity :: HasCallStack => String -> ResetPolarity
-  asResetPolarity x = fromMaybe (error $ $(curLoc) ++ "Unknown reset polarity: " ++ show x) (readMaybe x)
 
 -- | Given a set of bindings, make explicit non-recursive bindings and
 -- recursive binding groups.

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -8,6 +8,7 @@
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.GHC.NetlistTypes
@@ -16,25 +17,31 @@ where
 
 import Data.Coerce                      (coerce)
 import Data.Functor.Identity            (Identity (..))
+import Data.Map                         (insert)
+import Data.Ratio                       ((%))
 import Data.Text                        (pack)
 import Data.Text.Extra                  (showt)
-import Control.Monad.State.Strict       (State)
+import Control.Arrow                    (second)
+import Control.Monad.State.Strict       (State, modify)
 import Control.Monad.Trans.Except
   (Except, ExceptT (..), mapExceptT, runExceptT, throwE)
 import Control.Monad.Trans.Maybe        (MaybeT (..))
 import Language.Haskell.TH.Syntax       (showName)
 
+import Clash.Driver.Types               (KnownDomainTyConUniques(..))
 import Clash.Core.DataCon               (DataCon (..))
 import Clash.Core.Name                  (Name (..))
-import Clash.Core.Pretty                (showPpr)
-import Clash.Core.TyCon                 (TyConMap, tyConDataCons)
+import Clash.Core.Pretty                (PrettyOptions(..), showPpr, showPpr')
+import Clash.Core.TyCon                 (TyConMap, tyConDataCons, tyConName)
 import Clash.Core.Type
-  (LitTy (..), Type (..), TypeView (..), coreView, coreView1, tyView)
+  ( LitTy (..), Type (..), TypeView (..)
+  , coreView, coreView1, tyView, mkTyConApp, normalizeType
+  )
 import Clash.Core.Util                  (tyNatSize, substArgTys)
 import qualified Clash.Data.UniqMap as UniqMap
 import Clash.Netlist.Util               (coreTypeToHWType, stripFiltered)
 import Clash.Netlist.Types
-  (HWType(..), HWMap, FilteredHWType(..), PortDirection (..))
+  (HWType(..), TTState, FilteredHWType(..), PortDirection (..))
 import Clash.Signal.Internal
   (ResetPolarity(..), ActiveEdge(..), ResetKind(..)
   ,InitBehavior(..))
@@ -42,10 +49,13 @@ import Clash.Util                       (curLoc)
 
 import Clash.Annotations.BitRepresentation.Internal
   (CustomReprs)
-import Clash.Signal.Internal (KnownDomain)
+import Clash.Signal.Internal
+  (KnownDomain, VDomainConfiguration(..), Period(..))
 
 ghcTypeToHWType
-  :: Int
+  :: Maybe KnownDomainTyConUniques
+  -- ^ TyCon uniques of the type families associated with KnownDomain
+  -> Int
   -- ^ Integer width. The width Clash assumes an Integer to be (instead of it
   -- begin an arbitrarily large, runtime sized construct).
   -> CustomReprs
@@ -54,13 +64,17 @@ ghcTypeToHWType
   -- ^ Type constructor map
   -> Type
   -- ^ Type to convert to HWType
-  -> State HWMap (Maybe (Either String FilteredHWType))
-ghcTypeToHWType iw = go
+  -> State TTState (Maybe (Either String FilteredHWType))
+ghcTypeToHWType mkdtcus iw = go
   where
     -- returnN :: HWType ->
     returnN t = return (FilteredHWType t [])
 
-    go :: CustomReprs -> TyConMap -> Type -> State HWMap (Maybe (Either String FilteredHWType))
+    go ::
+      CustomReprs ->
+      TyConMap ->
+      Type ->
+      State TTState (Maybe (Either String FilteredHWType))
     go reprs m (AnnType attrs typ) = fmap Just . runExceptT $ do
       FilteredHWType typ' areVoids <- ExceptT $ coreTypeToHWType go reprs m typ
       return (FilteredHWType (Annotated attrs typ') areVoids)
@@ -174,46 +188,29 @@ ghcTypeToHWType iw = go
                 _ -> ExceptT (MaybeT (go reprs m arg0))
 
         "Clash.Signal.Internal.KnownDomain"
-          -> case tyConDataCons (UniqMap.find tc m) of
-               [dc] -> case substArgTys dc args of
-                 [_knownSymbol, _knownNat, tyView -> TyConApp _ [_,dom]] ->
-                  case tyView (coreView m dom) of
-                   TyConApp _ [tag0, period0, edge0, rstKind0, init0, polarity0] -> do
-                     tag1      <- domTag m tag0
-                     period1   <- domPeriod m period0
-                     edge1     <- domEdge m edge0
-                     rstKind1  <- domResetKind m rstKind0
-                     init1     <- domInitBehavior m init0
-                     polarity1 <- domResetPolarity m polarity0
-                     let kd = KnownDomain (pack tag1) period1 edge1 rstKind1 init1 polarity1
-                     returnN (Void (Just kd))
-                   _ -> ExceptT (MaybeT (pure Nothing))
-                 _ -> ExceptT (MaybeT (pure Nothing))
-               _ -> ExceptT (MaybeT (pure Nothing))
+          | [dom] <- args
+          , [dc] <- tyConDataCons (UniqMap.find tc m)
+          , [ _typeable          , _knownNat           , _positiveNat
+            , _knownFraction     , _knownActiveEdge    , _knownResetKind
+            , _knownInitBehavior , _knownResetPolarity
+            ] <- substArgTys dc args
+          -> domCfg mkdtcus m dom $ Void . Just . KnownDomain
 
         "Clash.Signal.Internal.Clock"
-          | [tag0] <- args
-          -> do
-            tag1 <- domTag m tag0
-            returnN (Clock (pack tag1))
+          | [dom] <- args
+          -> domCfg mkdtcus m dom Clock
 
         "Clash.Signal.Internal.ClockN"
-          | [tag0] <- args
-          -> do
-            tag1 <- domTag m tag0
-            returnN (ClockN (pack tag1))
+          | [dom] <- args
+          -> domCfg mkdtcus m dom ClockN
 
         "Clash.Signal.Internal.Reset"
-          | [tag0] <- args
-          -> do
-            tag1 <- domTag m tag0
-            returnN (Reset (pack tag1))
+          | [dom] <- args
+          -> domCfg mkdtcus m dom Reset
 
         "Clash.Signal.Internal.Enable"
-          | [tag0] <- args
-          -> do
-            tag1 <- domTag m tag0
-            returnN (Enable (pack tag1))
+          | [dom] <- args
+          -> domCfg mkdtcus m dom Enable
 
         "Clash.Sized.Internal.BitVector.Bit" -> returnN Bit
 
@@ -332,12 +329,29 @@ liftE = mapExceptT (MaybeT . pure . Just . coerce)
 domTag :: Monad m => TyConMap -> Type -> ExceptT String (MaybeT m) String
 domTag m (coreView1 m -> Just ty) = domTag m ty
 domTag _ (LitTy (SymTy tag)) = pure tag
-domTag _ ty = throwE $ "Internal error. Cannot translate domain tag:\n" ++ showPpr ty
+domTag _ ty = pure $ showPpr' minBound { useStableNames = True } ty
 
-domPeriod :: Monad m => TyConMap -> Type -> ExceptT String (MaybeT m) Integer
+domPeriod :: Monad m => TyConMap -> Type -> ExceptT String (MaybeT m) Period
 domPeriod m (coreView1 m -> Just ty) = domPeriod m ty
-domPeriod _ (LitTy (NumTy period)) = pure period
-domPeriod _ ty = throwE $ "Internal error. Cannot translate domain period:\n" ++ showPpr ty
+domPeriod _ (LitTy (NumTy period)) = pure $ fromInteger period
+domPeriod _ ty = throwE
+  $ "Internal error. Cannot translate domain period:\n"
+ ++ showPpr ty
+
+domPeriodFraction ::
+  Monad m =>
+  TyConMap ->
+  Type ->
+  ExceptT String (MaybeT m) Period
+domPeriodFraction m (coreView1 m -> Just ty) = domPeriodFraction m ty
+domPeriodFraction _ (tyView -> TyConApp tc [_, nTy, dTy])
+  | nameOcc tc == "GHC.Internal.Real.:%"
+  , LitTy (NumTy n) <- nTy, n >= 0
+  , LitTy (NumTy d) <- dTy, d >  0
+  = pure $ Period $ fromInteger n % fromInteger d
+domPeriodFraction _ ty = throwE
+  $ "Internal error. Cannot translate domain period fraction:\n"
+ ++ show (tyView ty)
 
 fromType
   :: Monad m
@@ -364,6 +378,37 @@ fromType tyNm constrs m ty =
       go cs tcNm
   go [] _ =
     throwE $ "Can't translate " ++ tyNm ++ showPpr ty
+
+domCfg ::
+  Maybe KnownDomainTyConUniques ->
+  TyConMap ->
+  Type ->
+  (VDomainConfiguration -> HWType) ->
+   ExceptT String (MaybeT (State TTState)) FilteredHWType
+domCfg mkdTCUs m dom c
+  | Just KnownDomainTyConUniques{..} <- mkdTCUs
+  , Just periodTy   <- resolve domainPeriodTCU
+  , Just fracTy     <- resolve domainPeriodFractionTCU
+  , Just edgeTy     <- resolve domainActiveEdgeTCU
+  , Just rstKindTy  <- resolve domainResetKindTCU
+  , Just initTy     <- resolve domainInitBehaviorTCU
+  , Just polarityTy <- resolve domainResetPolarityTCU
+  = do vName          <- domTag m dom
+       period         <- domPeriod m periodTy
+       frac           <- domPeriodFraction m fracTy
+       vActiveEdge    <- domEdge m edgeTy
+       vResetKind     <- domResetKind m rstKindTy
+       vInitBehavior  <- domInitBehavior m initTy
+       vResetPolarity <- domResetPolarity m polarityTy
+       let vPeriod = period + frac
+           conf = VDomainConfiguration{..}
+       modify $ second $ insert dom conf
+       return $ FilteredHWType (c conf) []
+  | otherwise = ExceptT $ MaybeT $ pure Nothing
+ where
+  resolve u =
+    normalizeType m . (`mkTyConApp` [dom]) . tyConName
+      <$> UniqMap.lookup u m
 
 domEdge
   :: Monad m

--- a/clash-lib-hedgehog/src/Clash/Hedgehog/Core/Name.hs
+++ b/clash-lib-hedgehog/src/Clash/Hedgehog/Core/Name.hs
@@ -45,12 +45,14 @@ genOccNameWith f =
     (fmap f (Gen.fake Fake.words))
 
 genName :: forall m a. MonadGen m => m OccName -> m (Name a)
-genName genOccName =
+genName genOccName = do
+  name <- genOccName
   Name
     <$> Gen.element [User, System, Internal]
-    <*> genOccName
+    <*> pure name
     <*> genUnique
     <*> pure noSrcSpan
+    <*> pure name
 
 genKindName :: forall m. MonadGen m => m KiName
 genKindName = genName (genOccNameWith Text.toTitle)

--- a/clash-lib/prims/common/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/common/Clash_Signal_Internal.primitives.yaml
@@ -22,3 +22,7 @@
     name: Clash.Signal.Internal.joinSignal#
     primType: Function
     workInfo: Never
+- Primitive:
+    name: Clash.Signal.Internal.switchDomain
+    primType: Function
+    workInfo: Never

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -12,7 +12,6 @@
 
 module Clash.Backend where
 
-import Data.HashMap.Strict                  (HashMap, empty)
 import Data.HashSet                         (HashSet)
 import Control.Lens                         (Lens')
 import Data.Monoid                          (Ap)
@@ -23,12 +22,11 @@ import Data.Text.Prettyprint.Doc.Extra      (Doc)
 
 import GHC.Types.SrcLoc (SrcSpan)
 
-import Clash.Driver.Types (ClashOpts)
+import Clash.Driver.Types                   (ClashOpts, DomainMap)
 import {-# SOURCE #-} Clash.Netlist.Types
   (Component, Declaration, Expr, HWType, Identifier, IdentifierSet, HasIdentifierSet, UsageMap)
 import Clash.Netlist.BlackBox.Types
 
-import Clash.Signal.Internal                (VDomainConfiguration)
 import Clash.Annotations.Primitive          (HDL)
 
 #ifdef CABAL
@@ -79,11 +77,6 @@ data HWKind
   | UserType
   -- ^ User defined type that's not interchangeable with any others, even if
   -- the underlying structures are the same. Similar to an ADT in Haskell.
-
-type DomainMap = HashMap Text VDomainConfiguration
-
-emptyDomainMap :: DomainMap
-emptyDomainMap = empty
 
 class HasUsageMap s where
   usageMap :: Lens' s UsageMap

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -58,7 +58,7 @@ import           Clash.Backend
 import           Clash.Backend.Verilog
   (bits, bit_char, encodingNote, exprLit, include, noEmptyInit, uselibs)
 import           Clash.Backend.Verilog.Time           (periodToString)
-import           Clash.Driver.Types                   (ClashOpts(..))
+import           Clash.Driver.Types                   (ClashOpts(..), DomainMap)
 import           Clash.Explicit.BlockRam.Internal     (unpackNats)
 import           Clash.Netlist.BlackBox.Types         (HdlSyn (..))
 import           Clash.Netlist.BlackBox.Util
@@ -135,7 +135,7 @@ instance Backend SystemVerilogState where
     , _undefValue=opt_forceUndefined opts
     , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
     , _renderEnums_=coerce (opt_renderEnums opts)
-    , _domainConfigurations_=emptyDomainMap
+    , _domainConfigurations_=mempty
     , _usages=mempty
     }
   hdlKind         = const SystemVerilog

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -68,7 +68,7 @@ import           Clash.Annotations.BitRepresentation.Util
 import           Clash.Annotations.SynthesisAttributes (Attr(..))
 import           Clash.Backend
 import           Clash.Debug                          (traceIf)
-import           Clash.Driver.Types                   (ClashOpts(..))
+import           Clash.Driver.Types                   (ClashOpts(..), DomainMap)
 import           Clash.Explicit.BlockRam.Internal     (unpackNats)
 import           Clash.Netlist.BlackBox.Types         (HdlSyn (..))
 import           Clash.Netlist.BlackBox.Util
@@ -76,6 +76,7 @@ import           Clash.Netlist.BlackBox.Util
 import qualified Clash.Netlist.Id                     as Id
 import           Clash.Netlist.Types                  hiding (intWidth, usages, _usages)
 import           Clash.Netlist.Util
+import           Clash.Signal.Internal                (VDomainConfiguration(..))
 import           Clash.Util
   (SrcSpan, noSrcSpan, clogBase, curLoc, makeCached, indexNote)
 import qualified Clash.Util.Interpolate               as I
@@ -155,7 +156,7 @@ instance Backend VHDLState where
     , _enumNameCache=mempty
     , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
     , _renderEnums_=coerce (opt_renderEnums opts)
-    , _domainConfigurations_=emptyDomainMap
+    , _domainConfigurations_=mempty
     , _usages=mempty
     }
   hdlKind         = const VHDL
@@ -1227,18 +1228,18 @@ tyName' rec0 (filterTransparent -> t) = do
     -- TODO: nice formatting for Index. I.e., 2000 = 2e3, 1024 = 2pow10
     Index n ->
       return ("index_" `TextS.append` showt n)
-    Clock nm0 ->
-      let nm1 = "clk_" `TextS.append` nm0 in
-      Ap $ makeCached (t, False) nameCache (userTyName "clk" nm1 t)
-    ClockN nm0 ->
-      let nm1 = "clk_n_" `TextS.append` nm0 in
-      Ap $ makeCached (t, False) nameCache (userTyName "clk" nm1 t)
-    Reset nm0 ->
-      let nm1 = "rst_" `TextS.append` nm0 in
-      Ap $ makeCached (t, False) nameCache (userTyName "rst" nm1 t)
-    Enable nm0 ->
-      let nm1 = "en_" `TextS.append` nm0 in
-      Ap $ makeCached (t, False) nameCache (userTyName "en" nm1 t)
+    Clock dom ->
+      let nm = "clk_" `withDomSuffix` dom
+       in Ap $ makeCached (t, False) nameCache (userTyName "clk" nm t)
+    ClockN dom ->
+      let nm = "clk_n_" `withDomSuffix` dom
+       in Ap $ makeCached (t, False) nameCache (userTyName "clk" nm t)
+    Reset dom ->
+      let nm = "rst_" `withDomSuffix` dom
+       in Ap $ makeCached (t, False) nameCache (userTyName "rst" nm t)
+    Enable dom ->
+      let nm = "en_" `withDomSuffix` dom
+       in Ap $ makeCached (t, False) nameCache (userTyName "en" nm t)
     Sum nm _  ->
       Ap $ makeCached (t, False) nameCache (userTyName "sum" nm t)
     CustomSum nm _ _ _ ->
@@ -1258,6 +1259,10 @@ tyName' rec0 (filterTransparent -> t) = do
     FileType -> return "file"
     ty -> return (error ($(curLoc) ++  show ty ++
                          " not filtered by filterTransparent"))
+ where
+  withDomSuffix nm = TextS.pack . (nm <>) . concatMap suffix . words . vName
+   where
+    suffix = reverse . takeWhile (/= '$') . reverse
 
 -- | Returns underlying type of given HWType. That is, the type by which it
 -- eventually will be represented in VHDL.

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -75,7 +75,7 @@ import           Clash.Annotations.SynthesisAttributes (Attr(..))
 import           Clash.Backend
 import           Clash.Backend.Verilog.Time           (periodToString)
 import           Clash.Debug                          (traceIf)
-import           Clash.Driver.Types                   (ClashOpts(..))
+import           Clash.Driver.Types                   (ClashOpts(..), DomainMap)
 import           Clash.Explicit.BlockRam.Internal     (unpackNats)
 import           Clash.Netlist.BlackBox.Types         (HdlSyn)
 import           Clash.Netlist.BlackBox.Util
@@ -141,7 +141,7 @@ instance Backend VerilogState where
     , _hdlsyn=opt_hdlSyn opts
     , _undefValue=opt_forceUndefined opts
     , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
-    , _domainConfigurations_=emptyDomainMap
+    , _domainConfigurations_=mempty
     , _usages=mempty
     }
   hdlKind         = const Verilog

--- a/clash-lib/src/Clash/Core/Name.hs
+++ b/clash-lib/src/Clash/Core/Name.hs
@@ -33,10 +33,11 @@ import           Clash.Unique
 
 data Name a
   = Name
-  { nameSort :: NameSort
-  , nameOcc  :: !OccName
-  , nameUniq :: {-# UNPACK #-} !Unique
-  , nameLoc  :: !SrcSpan
+  { nameSort   :: NameSort
+  , nameOcc    :: !OccName
+  , nameUniq   :: {-# UNPACK #-} !Unique
+  , nameLoc    :: !SrcSpan
+  , nameStable :: Text
   }
   deriving (Show,Generic,NFData,Binary)
 
@@ -87,22 +88,24 @@ mkUnsafeName
   -> Text
   -> Unique
   -> Name a
-mkUnsafeName ns s i = Name ns s i noSrcSpan
+mkUnsafeName ns s i = Name ns s i noSrcSpan ("$unsafe" `append` s)
 
 mkUnsafeSystemName
   :: Text
   -> Unique
   -> Name a
-mkUnsafeSystemName s i = Name System s i noSrcSpan
+mkUnsafeSystemName s i = Name System s i noSrcSpan ("$unsafe" `append` s)
 
 mkUnsafeInternalName
   :: Text
   -> Unique
   -> Name a
-mkUnsafeInternalName s i = Name Internal ("c$" `append` s) i noSrcSpan
+mkUnsafeInternalName s i =
+  Name Internal ("c$" `append` s) i noSrcSpan ("$unsafe" `append` s)
 
 appendToName :: Name a -> Text -> Name a
-appendToName (Name sort nm uniq loc) s = Name Internal nm2 uniq loc
+appendToName (Name sort nm uniq loc sn) s = Name Internal nm2 uniq loc sn1
   where
     nm1 = case sort of {Internal -> nm; _ -> "c$" `append` nm}
     nm2 = nm1 `append` s
+    sn1 = sn `append` s

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -89,7 +89,9 @@ data PrettyOptions = PrettyOptions
   -- ^ whether to display module qualifiers
   , displayTicks      :: Bool
   -- ^ whether to display ticks
-  }
+  , useStableNames    :: Bool
+  -- ^ whether to stable names
+  } deriving (Bounded)
 
 instance Default PrettyOptions where
   def = PrettyOptions
@@ -97,6 +99,7 @@ instance Default PrettyOptions where
     , displayTypes      = unsafeLookupEnvBool "CLASH_PPR_TYPES" True
     , displayQualifiers = unsafeLookupEnvBool "CLASH_PPR_QUALIFIERS" True
     , displayTicks      = unsafeLookupEnvBool "CLASH_PPR_TICKS" True
+    , useStableNames    = unsafeLookupEnvBool "CLASH_PPR_STABLE" False
     }
 
 -- | Annotations carried on pretty-printed code.
@@ -105,6 +108,9 @@ data ClashAnnotation
   -- ^ marking navigation to a different context
   | AnnSyntax  SyntaxElement
   -- ^ marking a specific sort of syntax
+  | AnnStableAlternative Text
+  -- ^ a plain text alternative (not allowed to contain any
+  -- newlines)
   deriving Eq
 
 -- | Specific places in the program syntax.
@@ -133,6 +139,8 @@ class PrettyPrec p where
         Column f             -> Column (hide . f)
         WithPageWidth f      -> WithPageWidth (hide . f)
         Nesting f            -> Nesting (hide . f)
+        Annotated (AnnStableAlternative t) _ | useStableNames opts
+                             -> unsafeTextWithoutNewlines t
         Annotated ann d'     ->
           if not (displayTypes opts)      && ann == AnnSyntax Type
           || not (displayUniques opts)    && ann == AnnSyntax Unique
@@ -195,11 +203,12 @@ viewName n = (qual, occ, T.pack $ show $ nameUniq n)
   where (qual, occ) = T.breakOnEnd "." $ nameOcc n
 
 instance PrettyPrec (Name a) where
-  pprPrec p (viewName -> (qual, occ, uniq)) = do
+  pprPrec p name@(viewName -> (qual, occ, uniq)) = do
     qual' <- annotate (AnnSyntax Qualifier) <$> pprPrec p qual
     occ'  <- pprPrec p occ
     uniq' <- annotate (AnnSyntax Unique) . brackets <$> (pprPrec p uniq)
-    return $ qual' <> occ' <> uniq'
+    return $ annotate (AnnStableAlternative $ nameStable name)
+           $ qual' <> occ' <> uniq'
 
 instance ClashPretty (Name a) where
   clashPretty = fromPpr

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -68,7 +68,7 @@ import           Data.List              (foldl')
 #endif
 import           Data.List.Extra        (splitAtList)
 import           Data.Maybe             (isJust, mapMaybe)
-import           Data.Text              (Text)
+import           Data.Text              (Text, pack)
 import           GHC.Base               (isTrue#,(==#))
 import           GHC.Generics           (Generic(..))
 import           GHC.Integer            (smallInteger)
@@ -86,8 +86,10 @@ import           GHC.Builtin.Names
   (integerTyConKey, typeNatAddTyFamNameKey, typeNatExpTyFamNameKey,
    typeNatMulTyFamNameKey, typeNatSubTyFamNameKey,
    typeNatCmpTyFamNameKey, ordLTDataConKey, ordEQDataConKey, ordGTDataConKey,
+   ordLTDataConName, ordEQDataConName, ordGTDataConName,
    typeSymbolAppendFamNameKey, typeSymbolCmpTyFamNameKey,
    typeNatDivTyFamNameKey, typeNatModTyFamNameKey)
+import           GHC.Types.Name         (nameStableString)
 import           GHC.Types.SrcLoc       (wiredInSrcSpan)
 
 -- Local imports
@@ -520,10 +522,13 @@ reduceTypeFamily tcm (tyView -> TyConApp tc tys)
           case compare i1 i2 of
             LT -> Name User "GHC.Types.LT"
                     (fromGhcUnique ordLTDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordLTDataConName)
             EQ -> Name User "GHC.Types.EQ"
                     (fromGhcUnique ordEQDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordEQDataConName)
             GT -> Name User "GHC.Types.GT"
                     (fromGhcUnique ordGTDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordGTDataConName)
       _ -> Nothing
 
   | nameUniq tc == fromGhcUnique typeSymbolCmpTyFamNameKey -- "GHC.TypeNats.CmpSymbol"
@@ -533,10 +538,13 @@ reduceTypeFamily tcm (tyView -> TyConApp tc tys)
           case compare s1 s2 of
             LT -> Name User "GHC.Types.LT"
                     (fromGhcUnique ordLTDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordLTDataConName)
             EQ -> Name User "GHC.Types.EQ"
                     (fromGhcUnique ordEQDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordEQDataConName)
             GT -> Name User "GHC.Types.GT"
                     (fromGhcUnique ordGTDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordGTDataConName)
       _ -> Nothing
 
   | nameUniq tc == fromGhcUnique typeCharCmpTyFamNameKey -- "GHC.TypeNats.CmpSymbol"
@@ -546,10 +554,13 @@ reduceTypeFamily tcm (tyView -> TyConApp tc tys)
           case compare s1 s2 of
             LT -> Name User (showt 'LT)
                     (fromGhcUnique ordLTDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordLTDataConName)
             EQ -> Name User (showt 'EQ)
                     (fromGhcUnique ordEQDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordEQDataConName)
             GT -> Name User (showt 'GT)
                     (fromGhcUnique ordGTDataConKey) wiredInSrcSpan
+                    (pack $ nameStableString ordGTDataConName)
       _ -> Nothing
 
   | nameUniq tc == fromGhcUnique typeConsSymbolTyFamNameKey -- ConsSymbol

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -120,7 +120,7 @@ import           Clash.Netlist.BlackBox.Parser    (runParse)
 import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate, BlackBoxFunction)
 import qualified Clash.Netlist.Id                 as Id
 import           Clash.Netlist.Types
-  (IdentifierText, BlackBox (..), Component (..), FilteredHWType, HWMap, SomeBackend (..),
+  (IdentifierText, BlackBox (..), Component (..), FilteredHWType, TTState, SomeBackend (..),
    TopEntityT(..), TemplateFunction, ComponentMap, findClocks, ComponentMeta(..))
 import           Clash.Netlist.Util               (checkTopEntityPorts)
 import           Clash.Normalize                  (checkNonRecursive, cleanupGraph,
@@ -136,7 +136,7 @@ import qualified Clash.Primitives.Magic           as P
 import qualified Clash.Primitives.Verification    as P
 import qualified Clash.Primitives.Xilinx.ClockGen as P
 import           Clash.Primitives.Types
-import           Clash.Signal.Internal
+import           Clash.Rewrite.Types              (RewriteState(..))
 import           Clash.Unique                     (Unique, getUnique, fromGhcUnique)
 import           Clash.Util
   (ClashException(..), reportTimeDiff,
@@ -188,7 +188,7 @@ splitTopAnn tcm sp typ@(tyView -> FunTy {}) t@Synthesize{t_inputs} =
               to a malformed Synthesize annotation. All clocks, resets, and
               enables should be given a unique port name. Type to be split:
 
-                #{showPpr' (PrettyOptions False True False False) a}
+                #{showPpr' minBound{displayTypes=True\} a}
 
               Given port annotation: #{p}. You might want to use the
               following instead: PortProduct #{show nm} []. This allows Clash to
@@ -303,7 +303,7 @@ generateHDL
   -> ClashDesign
   -> Maybe backend
   -> (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
   -> PE.Evaluator
   -- ^ Hardcoded evaluator for partial evaluation
@@ -366,7 +366,6 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
     -> TopEntityT
     -> IO ()
   go compNames seenV edamFilesV ioLockV deps topEntityMap (TopEntityT topEntity annM isTb) = do
-  let domainConfs = envDomains env
   let bindingsMap = designBindings design
   let primMap = envPrimitives env
   let topEntities0 = designEntities design
@@ -385,13 +384,12 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
   let topNm = lookupVarEnv' compNames topEntity
       (modNameS, fmap Data.Text.pack -> prefixM) = prefixModuleName (hdlKind (undefined :: backend)) (opt_componentPrefix opts) annM modName1
       modNameT  = Data.Text.pack modNameS
-      hdlState' = setDomainConfigurations domainConfs
-                $ setModName modNameT
+      hdlState0 = setModName modNameT
                 $ setTopName topNm
                 $ fromMaybe (initBackend @backend opts) hdlState
-      hdlDir    = fromMaybe (Clash.Backend.name hdlState') (opt_hdlDir opts) </> topEntityS
+      hdlDir    = fromMaybe (Clash.Backend.name hdlState0) (opt_hdlDir opts) </> topEntityS
       manPath   = hdlDir </> manifestFilename
-      ite       = ifThenElseExpr hdlState'
+      ite       = ifThenElseExpr hdlState0
       topNmT    = Id.toText topNm
 
   -- Get manifest file if cache is not stale and caching is enabled. This is used
@@ -454,8 +452,9 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
 
       -- 3. Normalize topEntity
       supplyN <- Supply.newSupply
-      transformedBindings <- normalizeEntity env bindingsMap typeTrans peEval
-                               eval topEntityNames supplyN topEntity
+      (transformedBindings, domains) <-
+        normalizeEntity env bindingsMap typeTrans peEval
+                        eval topEntityNames supplyN topEntity
 
       normTime <- transformedBindings `deepseq` Clock.getCurrentTime
       let prepNormDiff = reportTimeDiff normTime prevTime
@@ -463,12 +462,14 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
       withMVar ioLockV . const $
         putStrLn ("Clash: Normalization took " ++ prepNormDiff)
 
+      let hdlState1 = setDomainConfigurations domains hdlState0
+
       -- 4. Generate netlist for topEntity
       (topComponent, netlist) <- modifyMVar seenV $ \seen -> do
         (topComponent, netlist, seen') <-
           -- TODO My word, this has far too many arguments.
           genNetlist env peEval isTb transformedBindings topEntityMap compNames
-            typeTrans ite (SomeBackend hdlState') seen hdlDir prefixM topEntity
+            typeTrans ite (SomeBackend hdlState1) seen hdlDir prefixM topEntity
 
         pure (seen', (topComponent, netlist))
 
@@ -480,7 +481,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
 
       -- 5. Generate topEntity wrapper
       (hdlDocs, dfiles, mfiles) <- withMVar seenV $ \seen ->
-        pure $! createHDL hdlState' opts modNameT seen netlist domainConfs topComponent topNmT
+        pure $! createHDL hdlState1 opts modNameT seen netlist topComponent topNmT
 
       -- TODO: Data files should go into their own directory
       -- FIXME: Files can silently overwrite each other
@@ -507,10 +508,8 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
         depBindings = mapMaybe (flip lookupVarEnvDirectly bindingsMap) depUniques
         depIds = map bindingId depBindings
 
-        manifest =
-          mkManifest
-            hdlState' domainConfs opts topComponent components depIds
-            filesAndDigests1 topHashWithSubHashes
+        manifest = mkManifest hdlState1 opts topComponent components depIds
+                              filesAndDigests1 topHashWithSubHashes
       writeManifest manPath manifest
 
       topTime <- hdlDocs `seq` Clock.getCurrentTime
@@ -913,8 +912,6 @@ createHDL
   -- ^ Component names
   -> ComponentMap
   -- ^ List of components
-  -> HashMap Data.Text.Text VDomainConfiguration
-  -- ^ Known domains to configurations
   -> Component
   -- ^ Top component
   -> IdentifierText
@@ -922,7 +919,7 @@ createHDL
   -> ([(String,Doc)],[(String,FilePath)],[(String,String)])
   -- ^ The pretty-printed HDL documents
   -- + The data files that need to be copied
-createHDL backend opts modName seen components domainConfs top topName = flip evalState backend $ getAp $ do
+createHDL backend opts modName seen components top topName = flip evalState backend $ getAp $ do
   let componentsL = map snd (OMap.assocs components)
   (hdlNmDocs0,incs) <-
     fmap unzip $
@@ -938,19 +935,12 @@ createHDL backend opts modName seen components domainConfs top topName = flip ev
     hdlNmDocs1 = map (first (<.> Clash.Backend.extension backend)) hdlNmDocs0
     topFiles = concat incs ++ typesPkg1 ++ hdlNmDocs1
 
-    topClks = findClocks top
-    sdcInfo = fmap findDomainConfig <$> topClks
+    sdcInfo = findClocks top
     sdcFile = Data.Text.unpack topName <.> "sdc"
     sdcDoc  = (sdcFile, pprSDC (SdcInfo sdcInfo))
     sdc = if null sdcInfo then Nothing else Just sdcDoc
 
   return (maybeToList sdc <> topFiles, dataFiles, memFiles)
- where
-  findDomainConfig dom =
-    HashMap.lookupDefault
-      (error $ $(curLoc) ++ "Unknown synthesis domain: " ++ show dom)
-      dom
-      domainConfs
 
 writeEdam ::
   FilePath ->
@@ -1153,7 +1143,7 @@ normalizeEntity
   -> BindingMap
   -- ^ All bindings
   -> (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
   -> PE.Evaluator
   -- ^ Hardcoded evaluator for partial evaluation
@@ -1165,13 +1155,14 @@ normalizeEntity
   -- ^ Unique supply
   -> Id
   -- ^ root of the hierarchy
-  -> IO BindingMap
+  -> IO (BindingMap, DomainMap)
 normalizeEntity env bindingsMap typeTrans peEval eval topEntities supply tm = transformedBindings
   where
     doNorm = do norm <- normalize [tm]
                 let normChecked = checkNonRecursive norm
                 cleaned <- cleanupGraph tm normChecked
-                return cleaned
+                doms <- State.gets _domains
+                return (cleaned, doms)
     transformedBindings = runNormalization env supply bindingsMap
                             typeTrans peEval eval emptyVarEnv
                             topEntities doNorm

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -32,8 +32,7 @@ import           Data.Char (toLower)
 import           Data.Either (fromRight)
 #endif
 import           Data.Hashable (hash)
-import           Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes)
 import           Data.Monoid (Ap(getAp))
 import qualified Data.Text as Text
@@ -52,7 +51,7 @@ import           System.Directory (listDirectory, doesFileExist)
 import           Text.Read (readMaybe)
 
 import           Clash.Annotations.TopEntity.Extra ()
-import           Clash.Backend (Backend (hdlType), Usage (External))
+import           Clash.Backend (Backend(..), Usage (External))
 import           Clash.Core.Name (nameOcc)
 import           Clash.Driver.Bool (OverridingBool(..))
 import           Clash.Driver.Types
@@ -177,7 +176,7 @@ data Manifest
     --
     -- This list is reverse topologically sorted. I.e., a component might depend
     -- on any component listed before it, but not after it.
-  , domains :: HashMap Text VDomainConfiguration
+  , domains :: [VDomainConfiguration]
     -- ^ Domains encountered in design
   , transitiveDependencies :: [Text]
     -- ^ Dependencies of this design (fully qualified binder names). Is a
@@ -230,8 +229,8 @@ instance ToJSON Manifest where
             -- TODO: Add Edam like fields
           ]
         | (fName, fHash) <- fileNames]
-      , "domains" .= HashMap.fromList
-        [ ( domNm
+      , "domains" .= Map.fromList
+        [ ( vName
           , Aeson.object
             [ "period" .= ((\(Period p) -> p) vPeriod)
             , "active_edge" .= show vActiveEdge
@@ -240,7 +239,7 @@ instance ToJSON Manifest where
             , "reset_polarity" .= show vResetPolarity
             ]
           )
-        | (domNm, VDomainConfiguration{..}) <- HashMap.toList domains ]
+        | VDomainConfiguration{..} <- domains ]
       , "dependencies" .= Aeson.object
         [ "transitive" .= transitiveDependencies ]
       ]
@@ -290,7 +289,7 @@ instance FromJSON Manifest where
         <*> v .: "components"
         <*> (topComponent >>= (.: "name"))
         <*> parseFiles v
-        <*> (v .: "domains" >>= HashMap.traverseWithKey parseDomain)
+        <*> (Map.elems <$> (v .: "domains" >>= Map.traverseWithKey parseDomain))
         <*> (v .: "dependencies" >>= (.: "transitive"))
    where
     parseDomain :: Text -> Aeson.Object -> Parser VDomainConfiguration
@@ -334,7 +333,7 @@ mkManifestPort backend portId portType portDir = ManifestPort{..}
   mpWidth = typeSize portType
   mpDirection = portDir
   mpIsClock = case portType of {Clock _ -> True; ClockN _ -> True; _ -> False}
-  mpDomain = hwTypeDomain portType
+  mpDomain = Text.pack . vName <$> hwTypeDomain portType
   mpTypeName = flip evalState backend $ getAp $ do
      LText.toStrict . renderOneLine <$> hdlType (External mpName) portType
 
@@ -346,8 +345,6 @@ mkManifest ::
   Backend backend =>
   -- | Backend used to lookup port type names
   backend ->
-  -- | Domains encountered in design
-  HashMap Text VDomainConfiguration ->
   -- | Options Clash was run with
   ClashOpts ->
   -- | Component of top entity
@@ -362,7 +359,7 @@ mkManifest ::
   (ByteString, DebugSubHashes) ->
   -- | New manifest
   Manifest
-mkManifest backend domains ClashOpts{..} Component{..} components deps files (topHash, subHashes) = Manifest
+mkManifest backend ClashOpts{..} Component{..} components deps files (topHash, subHashes) = Manifest
   { manifestHash = topHash
   , manifestDebugSubHashes = if opt_debugManifestHash then Just subHashes else Nothing
   , ports = inPorts <> inOutPorts <> outPorts
@@ -370,7 +367,7 @@ mkManifest backend domains ClashOpts{..} Component{..} components deps files (to
   , topComponent = Id.toText componentName
   , fileNames = files
   , successFlags = (opt_inlineLimit, opt_specLimit)
-  , domains = domains
+  , domains = Map.elems $ evalState domainConfigurations backend
   , transitiveDependencies = map (nameOcc . varName) deps
   }
  where

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -64,7 +64,7 @@ import qualified Clash.Netlist.Types as Netlist
 import qualified Clash.Netlist.Id as Id
 import           Clash.Netlist.Util (typeSize)
 import           Clash.Primitives.Util (hashCompiledPrimMap)
-import           Clash.Signal (VDomainConfiguration(..))
+import           Clash.Signal (VDomainConfiguration(..), Period(..))
 import           Clash.Util.Graph (callGraphBindings)
 
 data PortDirection
@@ -233,7 +233,7 @@ instance ToJSON Manifest where
       , "domains" .= HashMap.fromList
         [ ( domNm
           , Aeson.object
-            [ "period" .= vPeriod
+            [ "period" .= ((\(Period p) -> p) vPeriod)
             , "active_edge" .= show vActiveEdge
             , "reset_kind" .= show vResetKind
             , "init_behavior" .= show vInitBehavior
@@ -297,7 +297,7 @@ instance FromJSON Manifest where
     parseDomain nm v =
       VDomainConfiguration
         <$> pure (Text.unpack nm)
-        <*> (v .: "period")
+        <*> (Period <$> (v .: "period"))
         <*> parseWithRead "active_edge" v
         <*> parseWithRead "reset_kind" v
         <*> parseWithRead "init_behavior" v

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -26,8 +26,8 @@ import           Control.DeepSeq                (NFData(rnf), deepseq)
 import           Data.Binary                    (Binary)
 import           Data.Fixed
 import           Data.Hashable
-import           Data.HashMap.Strict            (HashMap)
 import           Data.IntMap.Strict             (IntMap)
+import           Data.Map.Strict                (Map)
 import           Data.Maybe                     (isJust)
 import           Data.Set                       (Set)
 import qualified Data.Set                       as Set
@@ -51,6 +51,7 @@ import           Clash.Signal.Internal          (VDomainConfiguration(..))
 import           Clash.Backend.Verilog.Time     (Period(..), Unit(Fs))
 import           Clash.Core.Pretty              (unsafeLookupEnvBool)
 import           Clash.Core.Term                (Term)
+import           Clash.Core.Type                (Type)
 import           Clash.Core.TyCon               (TyConMap, TyConName)
 import           Clash.Core.Var                 (Id)
 import           Clash.Core.VarEnv              (VarEnv)
@@ -58,6 +59,7 @@ import           Clash.Driver.Bool              (OverridingBool(..))
 import           Clash.Netlist.BlackBox.Types   (HdlSyn (..))
 import {-# SOURCE #-} Clash.Netlist.Types       (PreserveCase(..), TopEntityT)
 import           Clash.Primitives.Types         (CompiledPrimMap)
+import           Clash.Unique                   (Unique)
 
 data ClashEnv = ClashEnv
   { envOpts        :: ClashOpts
@@ -65,8 +67,17 @@ data ClashEnv = ClashEnv
   , envTupleTyCons :: IntMap TyConName
   , envPrimitives  :: CompiledPrimMap
   , envCustomReprs :: CustomReprs
-  , envDomains     :: DomainMap
-  } deriving (Generic, NFData)
+  , envDomainTCUs  :: Maybe KnownDomainTyConUniques
+  }
+
+data KnownDomainTyConUniques = KnownDomainTyConUniques
+  { domainPeriodTCU         :: Unique
+  , domainActiveEdgeTCU     :: Unique
+  , domainResetKindTCU      :: Unique
+  , domainInitBehaviorTCU   :: Unique
+  , domainResetPolarityTCU  :: Unique
+  , domainPeriodFractionTCU :: Unique
+  }
 
 data ClashDesign = ClashDesign
   { designEntities :: [TopEntityT]
@@ -114,7 +125,11 @@ data Binding a = Binding
 --
 -- Global functions cannot be mutually recursive, only self-recursive.
 type BindingMap = VarEnv (Binding Term)
-type DomainMap = HashMap Text VDomainConfiguration
+
+-- | Maps core types with a 'Clash.Signal.Internal.KnownDomain'
+-- instance that appear in the design to their corresponding
+-- 'VDomainConfiguration'.
+type DomainMap = Map Type VDomainConfiguration
 
 -- | Information to show about transformations during compilation.
 --

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -46,7 +46,7 @@ import           GHC.Types.Basic                (InlineSpec)
 import           GHC.Types.SrcLoc               (SrcSpan)
 
 import           Clash.Annotations.BitRepresentation.Internal (CustomReprs)
-import           Clash.Signal.Internal
+import           Clash.Signal.Internal          (VDomainConfiguration(..))
 
 import           Clash.Backend.Verilog.Time     (Period(..), Unit(Fs))
 import           Clash.Core.Pretty              (unsafeLookupEnvBool)

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -72,7 +72,8 @@ import           Clash.Core.Var                   (Id, Var (..), isGlobalId)
 import           Clash.Core.VarEnv
   (VarEnv, emptyInScopeSet, emptyVarEnv, extendVarEnv, lookupVarEnv,
    lookupVarEnv')
-import           Clash.Driver.Types               (BindingMap, Binding(..), ClashEnv(..), ClashOpts (..))
+import           Clash.Driver.Types
+  (BindingMap, Binding(..), ClashEnv(..), ClashOpts (..))
 import           Clash.Netlist.BlackBox
 import qualified Clash.Netlist.Id                 as Id
 import           Clash.Netlist.Types              as HW
@@ -96,7 +97,7 @@ genNetlist
   -> VarEnv Identifier
   -- ^ Top entity names
   -> (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded Type -> HWType translator
   -> Bool
   -- ^ Whether the backend supports ifThenElse expressions
@@ -131,7 +132,7 @@ runNetlistMonad
   -> VarEnv TopEntityT
   -- ^ TopEntity annotations
   -> (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -- ^ Hardcode Type -> HWType translator
   -> Bool
   -- ^ Whether the backend supports ifThenElse expressions

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -101,7 +101,8 @@ import           Clash.Netlist.Util            as N
 import           Clash.Normalize.Primitives    (removedArg)
 import           Clash.Primitives.Types        as P
 import qualified Clash.Primitives.Util         as P
-import           Clash.Signal.Internal         (ActiveEdge (..))
+import           Clash.Signal.Internal
+  ( ActiveEdge(..), VDomainConfiguration(..) )
 import           Clash.Util
 import qualified Clash.Util.Interpolate        as I
 
@@ -958,8 +959,9 @@ collectMealy dstNm dst tcm (kd:clk:mealyFun:mealyInit:mealyIn:_) = do
       -- ensures that the "opposite" edge always comes first.
       kdTy <- unsafeCoreTypeToHWTypeM $(curLoc) (inferCoreTypeOf tcm kd)
       let edge = case stripVoid (stripFiltered kdTy) of
-                   KnownDomain _ _ Rising _ _ _  -> Falling
-                   KnownDomain _ _ Falling _ _ _ -> Rising
+                   KnownDomain dom -> case vActiveEdge dom of
+                     Rising -> Falling
+                     Falling -> Rising
                    _ -> error "internal error"
       (clkExpr,clkDecls) <-
         mkExpr False Concurrent (NetlistId (Id.unsafeMake "__MEALY_CLK__") (inferCoreTypeOf tcm clk)) clk

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
@@ -82,12 +83,12 @@ import           Text.Read                       (readEither)
 import           Text.Trifecta.Result            hiding (Err)
 
 import           Clash.Backend
-  (Backend (..), DomainMap, Usage (..), AggressiveXOptBB(..), RenderEnums(..))
+  (Backend (..), Usage (..), AggressiveXOptBB(..), RenderEnums(..))
 import           Clash.Netlist.BlackBox.Parser
 import           Clash.Netlist.BlackBox.Types
 import           Clash.Netlist.Types
   (BlackBoxContext (..), Expr (..), HWType (..), Literal (..), Modifier (..),
-   Declaration(BlackBoxD))
+   Declaration(BlackBoxD), hwTypeDomain)
 import qualified Clash.Netlist.Id                as Id
 import qualified Clash.Netlist.Types             as N
 import           Clash.Netlist.Util              (typeSize, isVoid, stripAttributes, stripVoid)
@@ -588,8 +589,12 @@ renderElem b (SigD e m) = do
 renderElem b (Period n) = do
   let (_, ty, _) = bbInputs b !! n
   case stripVoid ty of
-    KnownDomain _ period _ _ _ _ ->
-      return $ const $ Text.pack $ show period
+    KnownDomain dom ->
+      -- TODO: better utilize the fact that periods are of type
+      -- rational now. We should not rely on blindly appending `0`s in
+      -- the primitive files for creating a multiple of the period any
+      -- more, but use more precise numbers instead.
+      return $ const $ Text.pack $ show $ toInteger $ vPeriod dom
     _ ->
       error $ $(curLoc) ++ "Period: Expected `KnownDomain` or `KnownConfiguration`, not: " ++ show ty
 
@@ -597,25 +602,16 @@ renderElem _ LongestPeriod = do
   doms <- domainConfigurations
   -- Longest period with a minimum of 100 ns, see:
   -- https://github.com/clash-lang/clash-compiler/issues/2455
-  let longestPeriod = maximum (100_000 : [vPeriod v | v <- HashMap.elems doms])
-  return (const (Text.pack (show longestPeriod)))
+  let longestPeriod = maximum (100_000 : fmap (ceiling . vPeriod) (Map.elems doms))
+  return (const (Text.pack (show @Integer longestPeriod)))
 
 renderElem b (Tag n) = do
   let (_, ty, _) = bbInputs b !! n
-  case stripVoid ty of
-    KnownDomain dom _ _ _ _ _ ->
-      return (const (Text.pack (Data.Text.unpack dom)))
-    Clock dom ->
-      return (const (Text.pack (Data.Text.unpack dom)))
-    ClockN dom ->
-      return (const (Text.pack (Data.Text.unpack dom)))
-    Reset dom ->
-      return (const (Text.pack (Data.Text.unpack dom)))
-    Enable dom ->
-      return (const (Text.pack (Data.Text.unpack dom)))
-    _ ->
-      error $ $(curLoc) ++ "Tag: Expected `KnownDomain` or `KnownConfiguration`, not: " ++ show ty
-
+  case hwTypeDomain $ stripVoid ty of
+    Just dom -> return $ const $ Text.pack $ vName dom
+    Nothing -> error $ $(curLoc)
+            <> "Tag: Expected `KnownDomain` or `KnownConfiguration`, not: "
+            <> show ty
 
 renderElem b (IF c t f) = do
   iw <- iwWidth
@@ -717,31 +713,29 @@ renderElem b (IF c t f) = do
 
       (ActiveEdge edgeRequested n) -> do
         let (_, ty, _) = bbInputs b !! n
-        domConf <- getDomainConf ty
-        case domConf of
-          VDomainConfiguration _ _ edgeActual _ _ _ -> pure $
-            if edgeRequested == edgeActual then 1 else 0
+            domConf = getDomainConf ty
+        pure $ if edgeRequested == domConf.vActiveEdge then 1 else 0
 
       (IsSync n) -> do
         let (_, ty, _) = bbInputs b !! n
-        domConf <- getDomainConf ty
-        case domConf of
-          VDomainConfiguration _ _ _ Synchronous _ _ -> pure 1
-          VDomainConfiguration _ _ _ Asynchronous _ _ -> pure 0
+            domConf = getDomainConf ty
+        pure $ case domConf.vResetKind of
+          Synchronous -> 1
+          Asynchronous -> 0
 
       (IsInitDefined n) -> do
         let (_, ty, _) = bbInputs b !! n
-        domConf <- getDomainConf ty
-        case domConf of
-          VDomainConfiguration _ _ _ _ Defined _ -> pure 1
-          VDomainConfiguration _ _ _ _ Unknown _ -> pure 0
+            domConf = getDomainConf ty
+        pure $ case domConf.vInitBehavior of
+          Defined -> 1
+          Unknown -> 0
 
       (IsActiveHigh n) -> do
         let (_, ty, _) = bbInputs b !! n
-        domConf <- getDomainConf ty
-        case domConf of
-          VDomainConfiguration _ _ _ _ _ ActiveHigh -> pure 1
-          VDomainConfiguration _ _ _ _ _ ActiveLow  -> pure 0
+            domConf = getDomainConf ty
+        pure $ case domConf.vResetPolarity of
+          ActiveHigh -> 1
+          ActiveLow  -> 0
 
       (StrCmp [Text t1] n) -> pure $
         let (e,_,_) = bbInputs b !! n
@@ -765,30 +759,15 @@ renderElem b (IF c t f) = do
                              ++ "\nGot: " ++ show c'
 renderElem b e = fmap const (renderTag b e)
 
-getDomainConf :: (Backend backend, HasCallStack) => HWType -> State backend VDomainConfiguration
-getDomainConf = generalGetDomainConf domainConfigurations
-
-generalGetDomainConf
-  :: forall m. (Monad m, HasCallStack)
-  => (m DomainMap) -- ^ a way to get the `DomainMap`
-  -> HWType -> m VDomainConfiguration
-generalGetDomainConf getDomainMap ty = case (snd . stripAttributes . stripVoid) ty of
-  KnownDomain dom period activeEdge resetKind initBehavior resetPolarity ->
-    pure $ VDomainConfiguration (Data.Text.unpack dom) (fromIntegral period) activeEdge resetKind initBehavior resetPolarity
-
-  Clock dom -> go dom
-  ClockN dom -> go dom
-  Reset dom  -> go dom
-  Enable dom -> go dom
-  Product _DiffClock _ [Clock dom,_clkN] -> go dom
+getDomainConf :: HasCallStack => HWType -> VDomainConfiguration
+getDomainConf ty = case snd $ stripAttributes $ stripVoid ty of
+  KnownDomain dom -> dom
+  Clock dom -> dom
+  ClockN dom -> dom
+  Reset dom -> dom
+  Enable dom -> dom
+  Product _DiffClock _ [Clock dom,_clkN] -> dom
   t -> error $ "Don't know how to get a Domain out of HWType: " <> show t
- where
-  go :: HasCallStack => N.DomainName -> m VDomainConfiguration
-  go dom = do
-    doms <- getDomainMap
-    case HashMap.lookup dom doms of
-      Nothing -> error $ "Can't find domain " <> show dom <> ". Please report an issue at https://github.com/clash-lang/clash-compiler/issues."
-      Just conf -> pure conf
 
 parseFail :: BlackBoxContext -> Text -> BlackBoxTemplate
 parseFail b t = case runParse t of

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -76,11 +76,10 @@ import Clash.Core.Var                       (Id)
 import Clash.Core.TyCon                     (TyConMap)
 import Clash.Core.VarEnv                    (VarEnv)
 import Clash.Driver.Types
-  (BindingMap, ClashEnv(..), ClashOpts(..))
+  (BindingMap, ClashEnv(..), ClashOpts(..), DomainMap)
 import Clash.Netlist.BlackBox.Types         (BlackBoxTemplate)
 import Clash.Primitives.Types               (CompiledPrimMap)
-import Clash.Signal.Internal
-  (ResetPolarity, ActiveEdge, ResetKind, InitBehavior)
+import Clash.Signal.Internal                (ActiveEdge, VDomainConfiguration(..))
 import Clash.Unique                         (Unique)
 
 import Clash.Annotations.BitRepresentation.Internal
@@ -130,6 +129,7 @@ newtype NetlistMonad a =
                     Strict.MonadState NetlistState, Strict.MonadIO, MonadFail)
 
 type HWMap = Map Type (Either String FilteredHWType)
+type TTState = (HWMap, DomainMap)
 
 -- | See 'is_freshCache'
 type FreshCache = HashMap Text (IntMap Word)
@@ -304,7 +304,7 @@ data NetlistState
   -- ^ Cached components. Is an insertion ordered map to preserve a topologically
   -- sorted component list for the manifest file.
   , _typeTranslator :: CustomReprs -> TyConMap -> Type
-                    -> Strict.State HWMap (Maybe (Either String FilteredHWType))
+                    -> Strict.State TTState (Maybe (Either String FilteredHWType))
   -- ^ Hardcoded Type -> HWType translator
   , _curCompNm      :: !(Identifier,SrcSpan)
   , _seenIds        :: IdentifierSet
@@ -401,7 +401,7 @@ isBiDirectional = go . snd
 --
 -- This will not consider @ClockN@ to be a clock argument, which means only the
 -- positive phase of a differential pair will be added to @sdcClock@.
-findClocks :: Component -> [(Text, Text)]
+findClocks :: Component -> [(Text, VDomainConfiguration)]
 findClocks (Component _ is _ _) =
   mapMaybe isClock is
  where
@@ -420,8 +420,6 @@ type IsVoid = Bool
 data FilteredHWType =
   FilteredHWType HWType [[(IsVoid, FilteredHWType)]]
     deriving (Eq, Show)
-
-type DomainName = Text
 
 -- | Representable hardware types
 data HWType
@@ -458,14 +456,14 @@ data HWType
   -- populated when using records.
   | SP !Text [(Text, [HWType])]
   -- ^ Sum-of-Product type: Name and Constructor names + field types
-  | Clock !DomainName
-  -- ^ Clock type corresponding to domain /DomainName/
-  | ClockN !DomainName
-  -- ^ ClockN type corresponding to domain /DomainName/
-  | Reset !DomainName
-  -- ^ Reset type corresponding to domain /DomainName/
-  | Enable !DomainName
-  -- ^ Enable type corresponding to domain /DomainName/
+  | Clock !VDomainConfiguration
+  -- ^ Clock type corresponding to the attached domain configuration
+  | ClockN !VDomainConfiguration
+  -- ^ ClockN type corresponding to the attached domain configuration
+  | Reset !VDomainConfiguration
+  -- ^ Reset type corresponding to the attached domain configuration
+  | Enable !VDomainConfiguration
+  -- ^ Enable type corresponding to the attached domain configuration
   | BiDirectional !PortDirection !HWType
   -- ^ Tagging type indicating a bidirectional (inout) port
   | CustomSP !Text !DataRepr' !Size [(ConstrRepr', Text, [HWType])]
@@ -479,8 +477,8 @@ data HWType
   -- info, see: Clash.Annotations.BitRepresentations.
   | Annotated [Attr Text] !HWType
   -- ^ Annotated with HDL attributes
-  | KnownDomain !DomainName !Integer !ActiveEdge !ResetKind !InitBehavior !ResetPolarity
-  -- ^ Domain name, period, active edge, reset kind, initial value behavior
+  | KnownDomain !VDomainConfiguration
+  -- ^ Known Domain Configuration
   | FileType
   -- ^ File type for simulation-level I/O
   deriving (Eq, Ord, Show, Generic, NFData, Hashable)
@@ -492,13 +490,13 @@ annotated :: [Attr Text] -> HWType -> HWType
 annotated [] t = t
 annotated attrs t = Annotated attrs t
 
-hwTypeDomain :: HWType -> Maybe DomainName
+hwTypeDomain :: HWType -> Maybe VDomainConfiguration
 hwTypeDomain = \case
   Clock dom -> Just dom
   ClockN dom -> Just dom
   Reset dom -> Just dom
   Enable dom -> Just dom
-  KnownDomain dom _ _ _ _ _ -> Just dom
+  KnownDomain dom -> Just dom
   _ -> Nothing
 
 -- | Extract hardware attributes from Annotated. Returns an empty list if

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -24,6 +24,7 @@
 module Clash.Netlist.Util where
 
 import           Data.Coerce             (coerce)
+import           Control.Arrow           (first)
 import           Control.Exception       (throw)
 import           Control.Lens            ((.=), (%=))
 import qualified Control.Lens            as Lens
@@ -32,7 +33,7 @@ import           Control.Monad.Extra     (concatMapM)
 import           Control.Monad.Reader    (ask, local)
 import qualified Control.Monad.State as State
 import           Control.Monad.State.Strict
-  (State, evalState, get, modify, runState)
+  (State, evalState, gets, modify, runState)
 import           Control.Monad.Trans.Except
   (ExceptT (..), runExcept, runExceptT, throwE)
 import           Data.Bifunctor          (second)
@@ -49,7 +50,6 @@ import           Data.List               (unzip4, partition)
 import qualified Data.List               as List
 import           Data.List.NonEmpty      (NonEmpty((:|)))
 import qualified Data.Map                as Map
-import           Data.Map                (Map)
 import           Data.Maybe
   (catMaybes, fromMaybe, isNothing, mapMaybe, isJust, listToMaybe, maybeToList)
 import           Text.Printf             (printf)
@@ -78,7 +78,10 @@ import           Clash.Annotations.BitRepresentation.Internal
    uncheckedGetConstrRepr)
 import           Clash.Annotations.SynthesisAttributes (Attr)
 import           Clash.Annotations.Primitive (HDL(VHDL))
-import           Clash.Backend           (HasUsageMap (..), HWKind(..), hdlHWTypeKind, hdlKind)
+import           Clash.Backend
+  ( HasUsageMap (..), HWKind(..), hdlHWTypeKind, hdlKind
+  , domainConfigurations, setDomainConfigurations
+  )
 import           Clash.Core.DataCon      (DataCon (..))
 import           Clash.Core.EqSolver     (typeEq)
 import           Clash.Core.FreeVars     (typeFreeVars, typeFreeVars')
@@ -109,6 +112,7 @@ import           Clash.Core.Var
 import           Clash.Core.VarEnv
   (InScopeSet, extendInScopeSetList, uniqAway, lookupVarEnv, emptyInScopeSet)
 import qualified Clash.Data.UniqMap as UniqMap
+import           Clash.Driver.Types      (DomainMap)
 import {-# SOURCE #-} Clash.Netlist.BlackBox
 import {-# SOURCE #-} Clash.Netlist.BlackBox.Util
 import           Clash.Netlist.BlackBox.Types
@@ -199,11 +203,11 @@ unsafeCoreTypeToHWType
   -- ^ Approximate location in original source file
   -> String
   -> (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -> CustomReprs
   -> TyConMap
   -> Type
-  -> State HWMap FilteredHWType
+  -> State TTState FilteredHWType
 unsafeCoreTypeToHWType sp loc builtInTranslation reprs m ty =
   either (\msg -> throw (ClashException sp (loc ++ msg) Nothing)) id <$>
     coreTypeToHWType builtInTranslation reprs m ty
@@ -221,13 +225,17 @@ unsafeCoreTypeToHWTypeM
   -> Type
   -> NetlistMonad FilteredHWType
 unsafeCoreTypeToHWTypeM loc ty = do
-  (_,cmpNm) <- Lens.use curCompNm
-  tt        <- Lens.use typeTranslator
-  reprs     <- Lens.view customReprs
-  tcm       <- Lens.view tcCache
-  htm0      <- Lens.use htyCache
-  let (hty,htm1) = runState (unsafeCoreTypeToHWType cmpNm loc tt reprs tcm ty) htm0
+  (_,cmpNm)     <- Lens.use curCompNm
+  tt            <- Lens.use typeTranslator
+  reprs         <- Lens.view customReprs
+  tcm           <- Lens.view tcCache
+  htm0          <- Lens.use htyCache
+  SomeBackend b <- Lens.use backend
+  let doms0  = State.evalState domainConfigurations b
+      action = unsafeCoreTypeToHWType cmpNm loc tt reprs tcm ty
+      (hty, (htm1, doms1)) = runState action (htm0, doms0)
   htyCache Lens..= htm1
+  backend  Lens..= SomeBackend (setDomainConfigurations doms1 b)
   return hty
 
 -- | Same as @coreTypeToHWTypeM@, but discards void filter information
@@ -238,20 +246,23 @@ coreTypeToHWTypeM'
 coreTypeToHWTypeM' ty =
   fmap stripFiltered <$> coreTypeToHWTypeM ty
 
-
 -- | Converts a Core type to a HWType within the NetlistMonad; 'Nothing' on failure
 coreTypeToHWTypeM
   :: Type
   -- ^ Type to convert to HWType
   -> NetlistMonad (Maybe FilteredHWType)
 coreTypeToHWTypeM ty = do
-  tt    <- Lens.use typeTranslator
-  reprs <- Lens.view customReprs
-  tcm   <- Lens.view tcCache
-  htm0  <- Lens.use htyCache
-  let (hty,htm1) = runState (coreTypeToHWType tt reprs tcm ty) htm0
+  tt            <- Lens.use typeTranslator
+  reprs         <- Lens.view customReprs
+  tcm           <- Lens.view tcCache
+  htm0          <- Lens.use htyCache
+  SomeBackend b <- Lens.use backend
+  let doms0  = State.evalState domainConfigurations b
+      action = coreTypeToHWType tt reprs tcm ty
+      (hty, (htm1, doms1)) = runState action (htm0, doms0)
   htyCache Lens..= htm1
-  return (either (const Nothing) Just hty)
+  backend  Lens..= SomeBackend (setDomainConfigurations doms1 b)
+  return $ either (const Nothing) Just hty
 
 -- | Constructs error message for unexpected projections out of a type annotated
 -- with a custom bit representation.
@@ -356,42 +367,40 @@ maybeConvertToCustomRepr _reprs _ty hwTy = hwTy
 -- | Same as @coreTypeToHWType@, but discards void filter information
 coreTypeToHWType'
   :: (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -> CustomReprs
   -> TyConMap
   -> Type
   -- ^ Type to convert to HWType
-  -> State HWMap (Either String HWType)
+  -> State TTState (Either String HWType)
 coreTypeToHWType' builtInTranslation reprs m ty =
   fmap stripFiltered <$> coreTypeToHWType builtInTranslation reprs m ty
-
 
 -- | Converts a Core type to a HWType given a function that translates certain
 -- builtin types. Returns a string containing the error message when the Core
 -- type is not translatable.
 coreTypeToHWType
   :: (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -> CustomReprs
   -> TyConMap
   -> Type
   -- ^ Type to convert to HWType
-  -> State HWMap (Either String FilteredHWType)
+  -> State TTState (Either String FilteredHWType)
 coreTypeToHWType builtInTranslation reprs m ty = do
-  htyM <- Map.lookup ty <$> get
-  case htyM of
+  hwm <- gets fst
+  case Map.lookup ty hwm of
     Just hty -> return hty
     _ -> do
       hty0M <- builtInTranslation reprs m ty
       hty1  <- go hty0M ty
-      modify (Map.insert ty hty1)
+      modify $ first $ Map.insert ty hty1
       return hty1
  where
   -- Try builtin translation; for now this is hardcoded to be the one in ghcTypeToHWType
   go :: Maybe (Either String FilteredHWType)
      -> Type
-     -> State (Map Type (Either String FilteredHWType))
-              (Either String FilteredHWType)
+     -> State TTState (Either String FilteredHWType)
   go (Just hwtyE) _ = pure $ maybeConvertToCustomRepr reprs ty <$> hwtyE
   -- Strip transparant types:
   go _ (coreView1 m -> Just ty') =
@@ -419,7 +428,7 @@ originalIndices wereVoids =
 -- | Converts an algebraic Core type (split into a TyCon and its argument) to a HWType.
 mkADT
   :: (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded Type -> HWType translator
   -> CustomReprs
   -> TyConMap
@@ -430,7 +439,7 @@ mkADT
   -- ^ The TyCon
   -> [Type]
   -- ^ Its applied arguments
-  -> ExceptT String (State HWMap) FilteredHWType
+  -> ExceptT String (State TTState) FilteredHWType
   -- ^ An error string or a tuple with the type and possibly a list of
   -- removed arguments.
 mkADT _ _ m tyString tc _
@@ -645,31 +654,33 @@ isRecursiveTy m tc = case tyConDataCons (UniqMap.find tc m) of
 -- translates certain builtin types.
 representableType
   :: (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
+  -> DomainMap
   -> CustomReprs
   -> Bool
   -- ^ String considered representable
   -> TyConMap
   -> Type
-  -> Bool
-representableType builtInTranslation reprs stringRepresentable m =
-    flip evalState mempty .
+  -> (Bool, DomainMap)
+representableType builtInTranslation doms0 reprs stringRepresentable m =
+    flip evalState (mempty, doms0) .
     representableTypeState builtInTranslation reprs stringRepresentable m
 
 -- | Like 'representableType', but memoizes the Core-type to HWType
 -- translation in the given state.
 representableTypeState
   :: (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -> CustomReprs
   -> Bool
   -- ^ String considered representable
   -> TyConMap
   -> Type
-  -> State HWMap Bool
-representableTypeState builtInTranslation reprs stringRepresentable m =
-    fmap (either (const False) isRepresentable) .
-    coreTypeToHWType' builtInTranslation reprs m
+  -> State TTState (Bool, DomainMap)
+representableTypeState builtInTranslation reprs stringRepresentable m ty = do
+  eshty <- coreTypeToHWType' builtInTranslation reprs m ty
+  doms1 <- gets snd
+  return $ (, doms1) $ either (const False) isRepresentable eshty
   where
     isRepresentable hty = case hty of
       String            -> stringRepresentable
@@ -678,7 +689,7 @@ representableTypeState builtInTranslation reprs stringRepresentable m =
       Product _ _ elTys -> all isRepresentable elTys
       SP _ elTyss       -> all (all isRepresentable . snd) elTyss
       BiDirectional _ t -> isRepresentable t
-      Annotated _ ty    -> isRepresentable ty
+      Annotated _ ty1   -> isRepresentable ty1
       _                 -> True
 
 -- | Determines the bitsize of a type. For types that don't get turned
@@ -1030,7 +1041,7 @@ idToPort var = do
     else return (Just (Id.unsafeFromCoreId var, hwTy))
 
 setRepName :: Text -> Name a -> Name a
-setRepName s (Name sort' _ i loc) = Name sort' s i loc
+setRepName s name = name { nameOcc = s }
 
 -- | Make a set of IDs unique; also returns a substitution from old ID to new
 -- updated unique ID.
@@ -2023,7 +2034,7 @@ expandTopEntityOrErr ihwtys ohwty topM =
 checkTopEntityPorts
   :: HasCallStack
   => (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded 'Type' -> 'HWType' translator
   -> CustomReprs
   -> TyConMap

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -67,7 +67,7 @@ import           Clash.Debug                      (traceIf)
 import           Clash.Driver.Types
   (BindingMap, Binding(..), DebugOpts(..), ClashEnv(..))
 import           Clash.Netlist.Types
-  (HWMap, FilteredHWType(..))
+  (TTState, FilteredHWType(..))
 import           Clash.Netlist.Util
   (splitNormalized)
 import           Clash.Normalize.Strategy
@@ -100,7 +100,7 @@ runNormalization
   -> BindingMap
   -- ^ Global Binders
   -> (CustomReprs -> TyConMap -> Type ->
-      State HWMap (Maybe (Either String FilteredHWType)))
+      State TTState (Maybe (Either String FilteredHWType)))
   -- ^ Hardcoded Type -> HWType translator
   -> PE.Evaluator
   -- ^ Hardcoded evaluator for partial evaluation
@@ -128,6 +128,7 @@ runNormalization env supply globals typeTrans peEval eval rcsMap topEnts =
                   0
                   mempty       -- transformAppliedCounters Map
                   mempty       -- transformTriedCounters Map
+                  mempty       -- known domains Map
                   globals
                   supply
                   (error $ $(curLoc) ++ "Report as bug: no curFun",noSrcSpan)

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -53,12 +53,16 @@ import qualified Data.List.NonEmpty               as NE
 #endif
 import qualified Data.Maybe                       as Maybe
 import           Data.Semigroup                   (sconcat)
+import           Data.Text                        (pack)
 import           Data.Text.Extra                  (showt)
 import           GHC.Stack                        (HasCallStack)
 
 import           GHC.Builtin.Names
   (boolTyConKey, typeNatAddTyFamNameKey, typeNatMulTyFamNameKey,
    typeNatSubTyFamNameKey)
+import           GHC.Builtin.Types.Literals
+  (typeNatAddTyCon, typeNatMulTyCon, typeNatSubTyCon)
+import           GHC.Types.Name                   (getName, nameStableString)
 import           GHC.Types.SrcLoc                 (wiredInSrcSpan)
 
 import           Clash.Core.DataCon               (DataCon)
@@ -102,14 +106,17 @@ import qualified Clash.Util.Interpolate           as I
 typeNatAdd :: TyConName
 typeNatAdd =
   Name User "GHC.TypeNats.+" (fromGhcUnique typeNatAddTyFamNameKey) wiredInSrcSpan
+    (pack $ nameStableString $ getName typeNatAddTyCon)
 
 typeNatMul :: TyConName
 typeNatMul =
   Name User "GHC.TypeNats.*" (fromGhcUnique typeNatMulTyFamNameKey) wiredInSrcSpan
+    (pack $ nameStableString $ getName typeNatMulTyCon)
 
 typeNatSub :: TyConName
 typeNatSub =
   Name User "GHC.TypeNats.-" (fromGhcUnique typeNatSubTyFamNameKey) wiredInSrcSpan
+    (pack $ nameStableString $ getName typeNatSubTyCon)
 
 vecHeadPrim
   :: TyConName

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -30,7 +30,6 @@ module Clash.Normalize.Transformations.Case
 import Control.Exception.Base (patError)
 import GHC.Prim.Panic (absentError)
 import qualified Control.Lens as Lens
-
 import Data.Bifunctor (second)
 import Data.Coerce (coerce)
 import qualified Data.Either as Either
@@ -87,11 +86,11 @@ import Clash.XException (errorX)
 -- alternatives
 caseCase :: HasCallStack => NormRewrite
 caseCase (TransformContext is0 _) e@(Case (stripTicks -> Case scrut alts1Ty alts1) alts2Ty alts2) = do
-  ty1Rep <- not <$> isUntranslatableType False alts1Ty
+  ty1NonRep <- isUntranslatableType False alts1Ty
 
   -- This is only worth doing if the inner case-expression has a
   -- non-representable alternative type.
-  if ty1Rep then return e else
+  if ty1NonRep then
     -- Deshadow to prevent accidental capture of free variables of inner
     -- case. Imagine:
     --
@@ -115,6 +114,8 @@ caseCase (TransformContext is0 _) e@(Case (stripTicks -> Case scrut alts1Ty alts
     let newAlts = fmap (second (\altE -> Case altE alts2Ty alts2))
                       (fmap (deShadowAlt is0) alts1)
      in changed $ Case scrut alts2Ty newAlts
+  else
+    return e
 
 caseCase _ e = return e
 {-# SCC caseCase #-}

--- a/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
@@ -535,7 +535,6 @@ inlineNonRepWorker e@(Case scrut altsTy alts)
       notClassTy = not (isClassTy tcm scrutTy)
       overLimit = notClassTy && (Maybe.fromMaybe 0 isInlined) > limit
 
-
     bodyMaybe   <- lookupVarEnv f <$> Lens.use bindings
     nonRepScrut <- isUntranslatableType False scrutTy
     case (nonRepScrut, bodyMaybe) of

--- a/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
@@ -34,7 +34,7 @@ module Clash.Normalize.Transformations.Inline
 
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
-import Control.Monad ((>=>))
+import Control.Monad ((>=>), filterM)
 import Control.Monad.Extra (anyM)
 import Control.Monad.Trans.Maybe (MaybeT(..))
 import Control.Monad.Writer (lift,listen)
@@ -756,8 +756,16 @@ inlineWorkFree _ e@(collectTicks -> (Var f, ticks))
                       if termSizeSmallerThan sizeLimit topB then
                         changed (mkTicks topB ticks)
                       else do
-                        b <- normalizeTopLvlBndr False f top
-                        changed (mkTicks (bindingTerm b) ticks)
+                        e0 <- bindingTerm <$> normalizeTopLvlBndr False f top
+                        case e0 of
+                          Let (Term.NonRec i0 e1) (Var i1) | i0 == i1 -> changed e1
+                          Let (Term.Rec xs) (Var i1) ->
+                            case filter ((== i1) . fst) xs of
+                              [] -> changed e0
+                              ys -> filterM (fmap not . isRecursiveBndr . fst) ys >>= \case
+                                []          -> changed e0
+                                (_, e1) : _ -> changed e1
+                          _ -> changed (mkTicks e0 ticks)
                 _ -> return e
 
 inlineWorkFree _ e = return e

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -205,17 +205,6 @@ instance Backend backend => HasIdentifierSet (BlockState backend) where
 instance HasUsageMap backend => HasUsageMap (BlockState backend) where
   usageMap = bsBackend.usageMap
 
-liftToBlockState
-  :: forall backend a. Backend backend
-   => State backend a -> State (BlockState backend) a
-liftToBlockState (StateT f) = StateT g
- where
-  g :: BlockState backend -> Identity (a, BlockState backend)
-  g sbsIn = do
-    let sIn = _bsBackend sbsIn
-    (res,sOut) <- f sIn
-    pure (res, sbsIn{_bsBackend = sOut})
-
 -- | A typed expression.
 data TExpr = TExpr
   { ety :: HWType
@@ -1051,7 +1040,7 @@ unsafeToActiveHigh
   -- ^ Reset signal
   -> State (BlockState backend) TExpr
 unsafeToActiveHigh nm rExpr = do
-  resetLevel <- vResetPolarity <$> liftToBlockState (getDomainConf (ety rExpr))
+  let resetLevel = vResetPolarity $ getDomainConf $ ety rExpr
   case resetLevel of
     ActiveHigh -> pure rExpr
     ActiveLow -> notExpr nm rExpr
@@ -1065,7 +1054,7 @@ unsafeToActiveLow
   -- ^ Reset signal
   -> State (BlockState backend) TExpr
 unsafeToActiveLow nm rExpr = do
-  resetLevel <- vResetPolarity <$> liftToBlockState (getDomainConf (ety rExpr))
+  let resetLevel = vResetPolarity $ getDomainConf $ ety rExpr
   case resetLevel of
     ActiveLow -> pure rExpr
     ActiveHigh -> notExpr nm rExpr

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -26,7 +26,7 @@ import qualified Clash.Netlist.Id as Id
 import Clash.Netlist.Types
 import Clash.Netlist.Util
 import qualified Clash.Primitives.DSL as DSL
-import Clash.Signal (periodToHz)
+import Clash.Signal (periodToHz, vPeriod)
 import Data.Text.Extra (showt)
 
 import qualified Data.String.Interpolate as I
@@ -142,12 +142,12 @@ altpllQsysTemplate
   => BlackBoxContext
   -> State s Doc
 altpllQsysTemplate bbCtx
-  |   (_,stripVoid -> (KnownDomain _ clkInPeriod _ _ _ _),_)
+  |   (_,stripVoid -> KnownDomain (vPeriod -> clkInPeriod),_)
     : _clocksClass
     : (_,stripVoid -> Product _ _ (init -> kdOuts),_)
     : _ <- bbInputs bbCtx
   = let
-    clkPeriod (KnownDomain _ p _ _ _ _) = p
+    clkPeriod (KnownDomain (vPeriod -> p)) = p
     clkPeriod _ =
       error $ "Internal error: not a KnownDomain\n" <> ppShow bbCtx
 
@@ -280,7 +280,7 @@ alteraPllQsysTemplate bbCtx
     : (_,stripVoid -> Product _ _ (init -> kdOuts),_)
     : _ <- bbInputs bbCtx
   = let
-    clkFreq (KnownDomain _ p _ _ _ _) = periodToHz p / 1e6 :: Double
+    clkFreq (KnownDomain (vPeriod -> p)) = periodToHz p / 1e6 :: Double
     clkFreq _ =
       error $ "Internal error: not a KnownDomain\n" <> ppShow bbCtx
 

--- a/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Intel/ClockGen.hs
@@ -151,7 +151,7 @@ altpllQsysTemplate bbCtx
     clkPeriod _ =
       error $ "Internal error: not a KnownDomain\n" <> ppShow bbCtx
 
-    clkFreq p = periodToHz (fromInteger p) / 1e6 :: Double
+    clkFreq p = periodToHz p / 1e6 :: Double
 
     clkOutPeriods = map clkPeriod kdOuts
     clkLcms = map (lcm clkInPeriod) clkOutPeriods
@@ -280,8 +280,7 @@ alteraPllQsysTemplate bbCtx
     : (_,stripVoid -> Product _ _ (init -> kdOuts),_)
     : _ <- bbInputs bbCtx
   = let
-    clkFreq (KnownDomain _ p _ _ _ _)
-      = periodToHz (fromIntegral p) / 1e6 :: Double
+    clkFreq (KnownDomain _ p _ _ _ _) = periodToHz p / 1e6 :: Double
     clkFreq _ =
       error $ "Internal error: not a KnownDomain\n" <> ppShow bbCtx
 

--- a/clash-lib/src/Clash/Primitives/Verification.hs
+++ b/clash-lib/src/Clash/Primitives/Verification.hs
@@ -40,6 +40,7 @@ import           Clash.Netlist.Types
 import           Clash.Netlist.BlackBox.Types
   (BlackBoxFunction, BlackBoxMeta(..), TemplateKind(TDecl), RenderVoid(..),
    emptyBlackBoxMeta)
+import           Clash.Signal.Internal           (VDomainConfiguration(..))
 
 import           Clash.Verification.Internal
 import           Clash.Verification.Pretty
@@ -129,7 +130,7 @@ checkTF' decls (clkId, clkDecls) propName renderAs prop bbCtx = do
 
   edge =
     case bbInputs bbCtx of
-      (_, stripVoid -> KnownDomain _nm _period e _rst _init _polarity, _):_ -> e
+      (_, stripVoid -> KnownDomain dom, _):_ -> vActiveEdge dom
       _ -> error $ "Unexpected first argument: " ++ show (listToMaybe (bbInputs bbCtx))
 
   renderedPslProperty = case renderAs of

--- a/clash-lib/src/Clash/Primitives/Xilinx/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Xilinx/ClockGen.hs
@@ -26,7 +26,7 @@ import qualified Data.Text as T
 import Prettyprinter.Interpolate (__di)
 import Text.Show.Pretty (ppShow)
 
-import Clash.Signal (periodToHz)
+import Clash.Signal (periodToHz, vPeriod)
 
 import Clash.Backend (Backend)
 import qualified Clash.Netlist.Id as Id
@@ -142,7 +142,7 @@ clockWizardTclTemplate isDifferential bbCtx
     : _ <- bbInputs bbCtx
   , [compName] <- bbQsysIncName bbCtx
   = let
-    clkFreq (KnownDomain _ p _ _ _ _) = periodToHz p / 1e6 :: Double
+    clkFreq (KnownDomain (vPeriod -> p)) = periodToHz p / 1e6 :: Double
     clkFreq _ =
       error $ "Internal error: not a KnownDomain\n" <> ppShow bbCtx
 

--- a/clash-lib/src/Clash/Primitives/Xilinx/ClockGen.hs
+++ b/clash-lib/src/Clash/Primitives/Xilinx/ClockGen.hs
@@ -142,8 +142,7 @@ clockWizardTclTemplate isDifferential bbCtx
     : _ <- bbInputs bbCtx
   , [compName] <- bbQsysIncName bbCtx
   = let
-    clkFreq (KnownDomain _ p _ _ _ _) =
-      periodToHz (fromInteger p) / 1e6 :: Double
+    clkFreq (KnownDomain _ p _ _ _ _) = periodToHz p / 1e6 :: Double
     clkFreq _ =
       error $ "Internal error: not a KnownDomain\n" <> ppShow bbCtx
 

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -47,8 +47,9 @@ import Clash.Core.Type           (Type)
 import Clash.Core.TyCon          (TyConMap, TyConName)
 import Clash.Core.Var            (Id)
 import Clash.Core.VarEnv         (InScopeSet, VarSet, VarEnv)
-import Clash.Driver.Types        (ClashEnv(..), ClashOpts(..), BindingMap, DebugOpts)
-import Clash.Netlist.Types       (FilteredHWType, HWMap)
+import Clash.Driver.Types
+  (ClashEnv(..), ClashOpts(..), BindingMap, DebugOpts, DomainMap)
+import Clash.Netlist.Types       (FilteredHWType, HWMap, TTState)
 import Clash.Primitives.Types    (CompiledPrimMap)
 import Clash.Rewrite.WorkFree    (isWorkFree)
 import Clash.Util
@@ -82,6 +83,8 @@ data RewriteState extra
   -- ^ Map that tracks how many times each transformation is applied
   , _transformTriedCounters :: HashMap Text Word
   -- ^ Map that tracks how many times each transformation has been tried
+  , _domains          :: DomainMap
+  -- ^ Domain information
   , _bindings         :: !BindingMap
   -- ^ Global binders
   , _uniqSupply       :: !Supply
@@ -113,7 +116,7 @@ data RewriteEnv
   , _typeTranslator :: CustomReprs
                     -> TyConMap
                     -> Type
-                    -> State HWMap (Maybe (Either String FilteredHWType))
+                    -> State TTState (Maybe (Either String FilteredHWType))
   -- ^ Hardcode Type -> FilteredHWType translator
   , _peEvaluator    :: PE.Evaluator
   -- ^ Hardcoded evaluator for partial evaluation

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -79,7 +79,7 @@ import           Clash.Debug
 import           Clash.Driver.Types
   (TransformationInfo(..), DebugOpts(..), BindingMap, Binding(..), IsPrim(..),
   ClashEnv(..), ClashOpts(..), hasDebugInfo, isDebugging)
-import           Clash.Netlist.Types         (HWMap)
+import           Clash.Netlist.Types         (TTState)
 import           Clash.Netlist.Util          (representableTypeState)
 import           Clash.Pretty                (clashPretty, showDoc)
 import           Clash.Rewrite.Types
@@ -712,11 +712,13 @@ cloneNameWithBindingMap binders nm = do
 {-# INLINE isUntranslatable #-}
 -- | Run a Core-type to HWType translation action against the session-wide
 -- translation cache ('hwTypeCache').
-runWithHWTypeCache :: State.State HWMap a -> RewriteMonad extra a
+runWithHWTypeCache :: State.State TTState a -> RewriteMonad extra a
 runWithHWTypeCache m = do
   cache0 <- Lens.use hwTypeCache
-  let (a, !cache1) = State.runState m cache0
+  doms0 <- Lens.use domains
+  let (a, (!cache1, !doms1)) = State.runState m (cache0, doms0)
   hwTypeCache Lens..= cache1
+  domains Lens..= doms1
   pure a
 
 -- | Determine if a term cannot be represented in hardware
@@ -740,7 +742,11 @@ isUntranslatableType stringRepresentable ty = do
   tt <- Lens.view typeTranslator
   reprs <- Lens.view customReprs
   tcm <- Lens.view tcCache
-  not <$> runWithHWTypeCache (representableTypeState tt reprs stringRepresentable tcm ty)
+--  doms0 <- State.gets _domains
+  (representable, doms1) <-
+    runWithHWTypeCache (representableTypeState tt reprs stringRepresentable tcm ty)
+  State.modify $ Lens.set domains doms1
+  return $ not representable
 
 normalizeTermTypes :: TyConMap -> Term -> Term
 normalizeTermTypes tcm e = case e of

--- a/clash-lib/tests/Clash/Tests/Core/FreeVars.hs
+++ b/clash-lib/tests/Clash/Tests/Core/FreeVars.hs
@@ -23,6 +23,7 @@ fakeName =
     , nameOcc="fake"
     , nameUniq=0
     , nameLoc=noSrcSpan
+    , nameStable="fake"
     }
 
 f :: IdScope -> Var Term
@@ -31,7 +32,8 @@ f scope =
   Id { varName = Name { nameSort=User
                       , nameOcc="f"
                       , nameUniq=unique
-                      , nameLoc=noSrcSpan }
+                      , nameLoc=noSrcSpan
+                      , nameStable="f" }
      , varUniq = unique
      , varType = ConstTy (TyCon fakeName)
      , idScope = scope }

--- a/clash-lib/tests/Clash/Tests/Core/Subst.hs
+++ b/clash-lib/tests/Clash/Tests/Core/Subst.hs
@@ -27,6 +27,7 @@ fakeName =
     , nameOcc="fake"
     , nameUniq=0
     , nameLoc=noSrcSpan
+    , nameStable="fake"
     }
 
 unique :: Unique

--- a/clash-lib/tests/Clash/Tests/Driver/Manifest.hs
+++ b/clash-lib/tests/Clash/Tests/Driver/Manifest.hs
@@ -9,7 +9,6 @@ import qualified Data.ByteString.Base16 as Base16
 import Data.Coerce (coerce)
 import Data.Either (fromRight)
 import Data.Text (Text)
-import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
@@ -38,19 +37,16 @@ genDigest = Base16.encode . Text.encodeUtf8 . coerce @ArbitraryText <$> Q.arbitr
 genString :: Q.Gen FilePath
 genString = Text.unpack . coerce @ArbitraryText <$> Q.arbitrary
 
-genDomain :: Q.Gen (Text, VDomainConfiguration)
+genDomain :: Q.Gen VDomainConfiguration
 genDomain = do
   nm <- coerce @(Q.Gen ArbitraryText) Q.arbitrary
-  dom <-
-    VDomainConfiguration
-      <$> pure (Text.unpack nm)
-      <*> (fromIntegral @Int . abs <$> Q.arbitraryBoundedIntegral)
-      <*> Q.elements [Rising, Falling]
-      <*> Q.elements [Synchronous, Asynchronous]
-      <*> Q.elements [Defined, Unknown]
-      <*> Q.elements [ActiveHigh, ActiveLow]
-
-  pure (nm, dom)
+  VDomainConfiguration
+    <$> pure (Text.unpack nm)
+    <*> (fromIntegral @Int . abs <$> Q.arbitraryBoundedIntegral)
+    <*> Q.elements [Rising, Falling]
+    <*> Q.elements [Synchronous, Asynchronous]
+    <*> Q.elements [Defined, Unknown]
+    <*> Q.elements [ActiveHigh, ActiveLow]
 
 genPort :: Q.Gen ManifestPort
 genPort =
@@ -81,7 +77,7 @@ genManifest =
     <*> coerce @(Q.Gen [ArbitraryText]) @(Q.Gen [Text]) Q.arbitrary -- comp names
     <*> coerce @(Q.Gen ArbitraryText)   @(Q.Gen Text)   Q.arbitrary -- top name
     <*> Q.listOf ((,) <$> genString <*> genDigest) -- files
-    <*> (HashMap.fromList <$> Q.listOf genDomain) -- domains
+    <*> Q.listOf genDomain -- domains
     <*> coerce @(Q.Gen [ArbitraryText]) @(Q.Gen [Text]) Q.arbitrary -- dependencies
 
 tests :: TestTree

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -77,7 +77,7 @@ instance Default RewriteEnv where
         , envTupleTyCons = IntMap.empty
         , envPrimitives = HashMap.empty
         , envCustomReprs = buildCustomReprs []
-        , envDomains = HashMap.empty
+        , envDomainTCUs = Nothing
         }
     , _typeTranslator=error "_typeTranslator: NYI"
     , _peEvaluator=error "_peEvaluator: NYI"
@@ -90,6 +90,7 @@ instance Default extra => Default (RewriteState extra) where
     { _transformCounter=0
     , _transformAppliedCounters=mempty
     , _transformTriedCounters=mempty
+    , _domains=mempty
     , _bindings=emptyVarEnv
     , _uniqSupply=unsafePerformIO newSupply
     , _curFun=error "_curFun: NYI"
@@ -291,7 +292,7 @@ parseId typs nm0 = C.Id nm1 uniq (lookupTM uniq typs) scope
 -- declared, see 'parsePats'.
 freeVarType :: C.Type
 freeVarType =
-  C.ConstTy (C.TyCon (C.Name C.Internal (Text.pack "FreeVar") 0 C.noSrcSpan))
+  C.ConstTy (C.TyCon (C.Name C.Internal (Text.pack "FreeVar") 0 C.noSrcSpan (Text.pack "FreeVar")))
 
 -- | Parse a reference to a variable, looking its type up in the given 'TypeMap'.
 -- References that aren't in it are free variables, and get 'freeVarType'.
@@ -548,7 +549,7 @@ parseToTermQQ = TH.QuasiQuoter{
 parseTyConTy :: HasCallStack => String -> C.Type
 parseTyConTy nm =
   C.ConstTy
-    (C.TyCon (C.Name C.User (Text.pack nm) (nameToUnique nm) C.noSrcSpan))
+    (C.TyCon (C.Name C.User (Text.pack nm) (nameToUnique nm) C.noSrcSpan (Text.pack nm)))
 
 -- | The type 'parseType' produces for the type constructor @Int@
 intTy :: C.Type
@@ -747,7 +748,7 @@ tests = testGroup "Test.Clash.Rewrite"
                 C.AppTy
                   (C.ConstTy
                     (C.TyCon
-                      (C.Name C.User (Text.pack "Maybe") 9 C.noSrcSpan)))
+                      (C.Name C.User (Text.pack "Maybe") 9 C.noSrcSpan (Text.pack "Maybe"))))
                   intTy
           in assertStructurallyEqual
                (C.Lam

--- a/clash-prelude/src/Clash/Clocks/Internal.hs
+++ b/clash-prelude/src/Clash/Clocks/Internal.hs
@@ -27,7 +27,6 @@ import Clash.CPP (haddockOnly)
 import Clash.Explicit.Reset (resetSynchronizer)
 import Clash.Explicit.Signal (unsafeSynchronizer)
 import Clash.Magic (setName)
-import Clash.Promoted.Symbol (SSymbol(..))
 import Clash.Signal.Internal
   (clockGen, Clock(..), Domain, KnownDomain, Reset, Signal, unsafeFromActiveLow,
    unsafeToActiveLow)
@@ -51,7 +50,7 @@ deriveClocksInstance n =
         type ClocksCxt $instType = $cxtType
         type NumOutClocks $instType = $numOutClocks
 
-        clocks (Clock _ Nothing) $(varP rst) = $funcImpl
+        clocks (Clock Nothing) $(varP rst) = $funcImpl
         clocks _ _ = error "clocks: dynamic clocks unsupported"
         {-# OPAQUE clocks #-}
     |]
@@ -73,7 +72,7 @@ deriveClocksInstance n =
   lockImpl = [|
     unsafeSynchronizer clockGen clockGen (unsafeToActiveLow $(varE rst))
     |]
-  clkImpls = replicate n [| Clock SSymbol Nothing |]
+  clkImpls = replicate n [| Clock Nothing |]
   funcImpl = tupE $ clkImpls <> [lockImpl]
 
 -- Derive instances for up to and including 18 clocks, except when we are

--- a/clash-prelude/src/Clash/Examples.hs
+++ b/clash-prelude/src/Clash/Examples.hs
@@ -166,7 +166,7 @@ upDownCounter upDown = s
 
 The following property holds:
 
-prop> \en -> en ==> testFor 1000 (upCounter (pure en) .==. upDownCounter (pure en) :: Signal "System" Bool)
+prop> \en -> en ==> testFor 1000 (upCounter (pure en) .==. upDownCounter (pure en) :: Signal System Bool)
 
 = LFSR
 
@@ -207,7 +207,7 @@ lfsrG seed = 'last' ('unbundle' r)
 
 The following property holds:
 
-prop> testFor 100 (lfsrF 0xACE1 .==. lfsrG 0x4645 :: Signal "System" Bool)
+prop> testFor 100 (lfsrF 0xACE1 .==. lfsrG 0x4645 :: Signal System Bool)
 
 = Gray counter
 

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -1065,7 +1065,7 @@ blockRam#
   -- ^ Value to write (at address @w@)
   -> Signal dom a
   -- ^ Value of the BRAM at address @r@ from the previous clock cycle
-blockRam# (Clock _ Nothing) gen content = \rd wen waS wd -> runST $ do
+blockRam# (Clock Nothing) gen content = \rd wen waS wd -> runST $ do
   ramStart <- newListArray (0,szI-1) contentL
   -- start benchmark only
   -- ramStart <- unsafeThawSTArray ramArr

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -1068,7 +1068,7 @@ blockRam#
   -- ^ Value to write (at address @w@)
   -> Signal dom a
   -- ^ Value of the BRAM at address @r@ from the previous clock cycle
-blockRam# (Clock _ Nothing) gen content = \rd wen waS wd -> runST $ do
+blockRam# (Clock Nothing) gen content = \rd wen waS wd -> runST $ do
   ramStart <- newListArray (0,szI-1) contentL
   -- start benchmark only
   -- ramStart <- unsafeThawSTArray ramArr

--- a/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam/File.hs
@@ -333,7 +333,7 @@ blockRamFile#
   -- ^ Value to write (at address @w@)
   -> Signal dom (BitVector m)
   -- ^ Value of the BRAM at address @r@ from the previous clock cycle
-blockRamFile# (Clock _ Nothing) ena sz file = \rd wen waS wd -> runST $ do
+blockRamFile# (Clock Nothing) ena sz file = \rd wen waS wd -> runST $ do
   ramStart <- newArray_ (0,szI)
   unsafeIOToST (withFile file ReadMode (\h ->
     forM_ [0..(szI-1)] (\i -> do

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -51,9 +51,12 @@ import Clash.Signal.Internal
 >>> import Clash.Explicit.DDR
 >>> :{
 type DDR = "DDR" :: Domain
-instance KnownDomain "DDR" where
-  type KnownConf "DDR" = 'DomainConfiguration "DDR" 5000 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+instance KnownDomain DDR where
+  type DomainPeriod DDR        = 5000
+  type DomainActiveEdge DDR    = 'Rising
+  type DomainResetKind DDR     = 'Asynchronous
+  type DomainInitBehavior DDR  = 'Defined
+  type DomainResetPolarity DDR = 'ActiveHigh
 :}
 
 -}

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -118,7 +118,7 @@ ddrIn#
   -> a
   -> Signal domDDR a
   -> Signal dom (a,a)
-ddrIn# (Clock _ Nothing) (unsafeToActiveHigh -> hRst) (fromEnable -> ena) i0 i1 i2 =
+ddrIn# (Clock Nothing) (unsafeToActiveHigh -> hRst) (fromEnable -> ena) i0 i1 i2 =
   case resetKind @domDDR of
     SAsynchronous ->
       goAsync
@@ -308,8 +308,8 @@ ddrForwardClock#
   => Clock domIn
   -> Signal domDDR Bit
   -> Clock domOut
-ddrForwardClock# (Clock SSymbol periods) ddrSignal =
-  Clock (ddrSignal `seq` SSymbol) (unsafeCoerce periods)
+ddrForwardClock# (Clock periods) ddrSignal =
+  Clock (ddrSignal `seq` unsafeCoerce periods)
 {-# OPAQUE ddrForwardClock# #-}
 {-# ANN ddrForwardClock# (
   let

--- a/clash-prelude/src/Clash/Explicit/DDR.hs
+++ b/clash-prelude/src/Clash/Explicit/DDR.hs
@@ -50,7 +50,7 @@ import Clash.Signal.Internal
 >>> import Clash.Explicit.Prelude
 >>> import Clash.Explicit.DDR
 >>> :{
-type DDR = "DDR" :: Domain
+data DDR :: Domain
 instance KnownDomain DDR where
   type DomainPeriod DDR        = 5000
   type DomainActiveEdge DDR    = 'Rising

--- a/clash-prelude/src/Clash/Explicit/Prelude.hs
+++ b/clash-prelude/src/Clash/Explicit/Prelude.hs
@@ -16,6 +16,7 @@ defined in "Clash.Prelude".
 
 {-# LANGUAGE Unsafe #-}
 
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_HADDOCK show-extensions, not-home #-}
 

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -46,9 +46,12 @@ made. Clash provides a standard implementation, called 'System', that is
 configured as follows:
 
 @
-instance KnownDomain 'System' where
-  type KnownConf 'System' = 'DomainConfiguration 'System' 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = 'SDomainConfiguration' SSymbol SNat 'SRising' 'SAsynchronous' 'SDefined' 'SActiveHigh'
+instance KnownDomain System where
+  type DomainPeriod System        = 10000
+  type DomainActiveEdge System    = 'Rising
+  type DomainResetKind System     = 'Asynchronous
+  type DomainInitBehavior System  = 'Defined
+  type DomainResetPolarity System = 'ActiveHigh
 @
 
 In words, \"System\" is a synthesis domain with a clock running with a period
@@ -166,12 +169,6 @@ module Clash.Explicit.Signal
   , SResetPolarity(..)
   , DomainConfiguration(..)
   , SDomainConfiguration(..)
-  -- ** Configuration type families
-  , DomainPeriod
-  , DomainActiveEdge
-  , DomainResetKind
-  , DomainInitBehavior
-  , DomainResetPolarity
     -- *** Convenience types #conveniencetypes#
     -- $conveniencetypes
 
@@ -200,6 +197,7 @@ module Clash.Explicit.Signal
     -- ** Domain utilities
   , VDomainConfiguration(..)
   , vDomain
+  , knownDomain
   , createDomain
   , knownVDomain
   , clockPeriod
@@ -320,14 +318,20 @@ import           Clash.XException
 >>> import qualified Data.List as L
 >>> :{
 instance KnownDomain "Dom2" where
-  type KnownConf "Dom2" = 'DomainConfiguration "Dom2" 2 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+  type DomainPeriod "Dom2"        = 2
+  type DomainActiveEdge "Dom2"    = 'Rising
+  type DomainResetKind "Dom2"     = 'Asynchronous
+  type DomainInitBehavior "Dom2"  = 'Defined
+  type DomainResetPolarity "Dom2" = 'ActiveHigh
 :}
 
 >>> :{
 instance KnownDomain "Dom7" where
-  type KnownConf "Dom7" = 'DomainConfiguration "Dom7" 7 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+  type DomainPeriod "Dom7"        = 7
+  type DomainActiveEdge "Dom7"    = 'Rising
+  type DomainResetKind "Dom7"     = 'Asynchronous
+  type DomainInitBehavior "Dom7"  = 'Defined
+  type DomainResetPolarity "Dom7" = 'ActiveHigh
 :}
 
 >>> type Dom2 = "Dom2"

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -46,9 +46,12 @@ made. Clash provides a standard implementation, called 'System', that is
 configured as follows:
 
 @
-instance KnownDomain 'System' where
-  type KnownConf 'System' = 'DomainConfiguration 'System' 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = 'SDomainConfiguration' SSymbol SNat 'SRising' 'SAsynchronous' 'SDefined' 'SActiveHigh'
+instance KnownDomain System where
+  type DomainPeriod System        = 10000
+  type DomainActiveEdge System    = 'Rising
+  type DomainResetKind System     = 'Asynchronous
+  type DomainInitBehavior System  = 'Defined
+  type DomainResetPolarity System = 'ActiveHigh
 @
 
 In words, \"System\" is a synthesis domain with a clock running with a period
@@ -166,12 +169,6 @@ module Clash.Explicit.Signal
   , SResetPolarity(..)
   , DomainConfiguration(..)
   , SDomainConfiguration(..)
-  -- ** Configuration type families
-  , DomainPeriod
-  , DomainActiveEdge
-  , DomainResetKind
-  , DomainInitBehavior
-  , DomainResetPolarity
     -- *** Convenience types #conveniencetypes#
     -- $conveniencetypes
 
@@ -200,6 +197,7 @@ module Clash.Explicit.Signal
     -- ** Domain utilities
   , VDomainConfiguration(..)
   , vDomain
+  , knownDomain
   , createDomain
   , knownVDomain
   , clockPeriod
@@ -323,14 +321,20 @@ import           Clash.XException
 >>> import qualified Data.List as L
 >>> :{
 instance KnownDomain "Dom2" where
-  type KnownConf "Dom2" = 'DomainConfiguration "Dom2" 2 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+  type DomainPeriod "Dom2"        = 2
+  type DomainActiveEdge "Dom2"    = 'Rising
+  type DomainResetKind "Dom2"     = 'Asynchronous
+  type DomainInitBehavior "Dom2"  = 'Defined
+  type DomainResetPolarity "Dom2" = 'ActiveHigh
 :}
 
 >>> :{
 instance KnownDomain "Dom7" where
-  type KnownConf "Dom7" = 'DomainConfiguration "Dom7" 7 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+  type DomainPeriod "Dom7"        = 7
+  type DomainActiveEdge "Dom7"    = 'Rising
+  type DomainResetKind "Dom7"     = 'Asynchronous
+  type DomainInitBehavior "Dom7"  = 'Defined
+  type DomainResetPolarity "Dom7" = 'ActiveHigh
 :}
 
 >>> type Dom2 = "Dom2"

--- a/clash-prelude/src/Clash/Explicit/Signal.hs
+++ b/clash-prelude/src/Clash/Explicit/Signal.hs
@@ -320,25 +320,25 @@ import           Clash.XException
 >>> import Clash.Promoted.Nat (SNat(..))
 >>> import qualified Data.List as L
 >>> :{
-instance KnownDomain "Dom2" where
-  type DomainPeriod "Dom2"        = 2
-  type DomainActiveEdge "Dom2"    = 'Rising
-  type DomainResetKind "Dom2"     = 'Asynchronous
-  type DomainInitBehavior "Dom2"  = 'Defined
-  type DomainResetPolarity "Dom2" = 'ActiveHigh
+data Dom2 :: Domain
+instance KnownDomain Dom2 where
+  type DomainPeriod Dom2        = 2
+  type DomainActiveEdge Dom2    = 'Rising
+  type DomainResetKind Dom2     = 'Asynchronous
+  type DomainInitBehavior Dom2  = 'Defined
+  type DomainResetPolarity Dom2 = 'ActiveHigh
 :}
 
 >>> :{
-instance KnownDomain "Dom7" where
-  type DomainPeriod "Dom7"        = 7
-  type DomainActiveEdge "Dom7"    = 'Rising
-  type DomainResetKind "Dom7"     = 'Asynchronous
-  type DomainInitBehavior "Dom7"  = 'Defined
-  type DomainResetPolarity "Dom7" = 'ActiveHigh
+data Dom7 :: Domain
+instance KnownDomain Dom7 where
+  type DomainPeriod Dom7        = 7
+  type DomainActiveEdge Dom7    = 'Rising
+  type DomainResetKind Dom7     = 'Asynchronous
+  type DomainInitBehavior Dom7  = 'Defined
+  type DomainResetPolarity Dom7 = 'ActiveHigh
 :}
 
->>> type Dom2 = "Dom2"
->>> type Dom7 = "Dom7"
 >>> let clk2 = clockGen @Dom2
 >>> let clk7 = clockGen @Dom7
 >>> let en2 = enableGen @Dom2

--- a/clash-prelude/src/Clash/Explicit/Testbench.hs
+++ b/clash-prelude/src/Clash/Explicit/Testbench.hs
@@ -41,6 +41,7 @@ where
 
 import Control.Exception     (catch, evaluate)
 import Debug.Trace           (trace)
+import Data.Proxy            (Proxy(..))
 import GHC.TypeLits          (KnownNat, type (+), type (<=))
 import Prelude               hiding ((!!), length)
 import System.IO.Unsafe      (unsafeDupablePerformIO)
@@ -48,7 +49,6 @@ import System.IO.Unsafe      (unsafeDupablePerformIO)
 import Clash.Annotations.Primitive (hasBlackBox)
 import Clash.Class.Num       (satSucc, SaturationMode(SatBound))
 import Clash.Promoted.Nat    (SNat(..))
-import Clash.Promoted.Symbol (SSymbol(..))
 import Clash.Explicit.Signal
   (Clock, Reset, System, Signal, toEnable, fromList, register,
   unbundle, unsafeSynchronizer)
@@ -475,7 +475,7 @@ clockToDiffClock ::
   Clock dom ->
   -- | Differential output
   DiffClock dom
-clockToDiffClock clk = DiffClock clk (ClockN SSymbol)
+clockToDiffClock clk = DiffClock clk (ClockN Proxy)
 {-# OPAQUE clockToDiffClock #-}
 {-# ANN clockToDiffClock hasBlackBox #-}
 

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -45,9 +45,12 @@ made. Clash provides an implementation 'System' with some common options
 chosen:
 
 @
-instance KnownDomain 'System' where
-  type KnownConf 'System' = 'DomainConfiguration 'System' 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+instance KnownDomain System where
+  type DomainPeriod System        = 10000
+  type DomainActiveEdge System    = 'Rising
+  type DomainResetKind System     = 'Asynchronous
+  type DomainInitBehavior System  = 'Defined
+  type DomainResetPolarity System = 'ActiveHigh
 @
 
 In words, \"System\" is a synthesis domain with a clock running with a period
@@ -100,12 +103,6 @@ module Clash.Signal
   , SResetPolarity(..)
   , DomainConfiguration(..)
   , SDomainConfiguration(..)
-  -- ** Configuration type families
-  , DomainPeriod
-  , DomainActiveEdge
-  , DomainResetKind
-  , DomainInitBehavior
-  , DomainResetPolarity
     -- *** Convenience types
     -- $conveniencetypes
 
@@ -134,6 +131,7 @@ module Clash.Signal
     -- ** Domain utilities
   , VDomainConfiguration(..)
   , vDomain
+  , knownDomain
   , createDomain
   , knownVDomain
   , clockPeriod

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -91,6 +91,10 @@ module Clash.Signal
     -- * Domain
   , Domain
   , sameDomain
+  , switchDomain
+  , switchClockDomain
+  , switchResetDomain
+  , switchEnableDomain
   , KnownDomain(..)
   , KnownConfiguration
   , ActiveEdge(..)
@@ -103,6 +107,8 @@ module Clash.Signal
   , SResetPolarity(..)
   , DomainConfiguration(..)
   , SDomainConfiguration(..)
+  , SupportsSwitchingTo
+  , EligibleDomainSwitch
     -- *** Convenience types
     -- $conveniencetypes
 
@@ -174,23 +180,27 @@ module Clash.Signal
   , exposeClock
   , withClock
   , hasClock
+  , switchHiddenClockDomain
     -- ** Hidden reset
   , HiddenReset
   , hideReset
   , exposeReset
   , withReset
   , hasReset
+  , switchHiddenResetDomain
     -- ** Hidden enable
   , HiddenEnable
   , hideEnable
   , exposeEnable
   , withEnable
   , hasEnable
+  , switchHiddenEnableDomain
     -- ** Hidden clock, reset, and enable
   , HiddenClockResetEnable
   , hideClockResetEnable
   , exposeClockResetEnable
   , withClockResetEnable
+  , switchHiddenClockResetEnableDomain
   , SystemClockResetEnable
     -- * Basic circuit functions
   , andEnable
@@ -698,6 +708,14 @@ hasClock
 hasClock = fromLabel @(HiddenClockName dom)
 {-# INLINE hasClock #-}
 
+-- | Switches the domain of a hidden clock. See 'switchDomain' for further
+-- details on domain switching in particular.
+switchHiddenClockDomain ::
+  (EligibleDomainSwitch domA domB, HiddenClock domA) =>
+  (HiddenClock domB => r) -> r
+switchHiddenClockDomain = withClock $ switchClockDomain hasClock
+{-# INLINE switchHiddenClockDomain #-}
+
 {- | Expose a hidden 'Reset' argument of a component, so it can be applied
 explicitly.
 
@@ -778,6 +796,14 @@ hasReset
   => Reset dom
 hasReset = fromLabel @(HiddenResetName dom)
 {-# INLINE hasReset #-}
+
+-- | Switches the domain of a hidden reset. See 'switchDomain' for further
+-- details on domain switching in particular.
+switchHiddenResetDomain ::
+  (EligibleDomainSwitch domA domB, HiddenReset domA) =>
+  (HiddenReset domB => r) -> r
+switchHiddenResetDomain = withReset $ switchResetDomain hasReset
+{-# INLINE switchHiddenResetDomain #-}
 
 {- | Expose a hidden 'Enable' argument of a component, so it can be applied
 explicitly.
@@ -862,6 +888,14 @@ hasEnable
   => Enable dom
 hasEnable = fromLabel @(HiddenEnableName dom)
 {-# INLINE hasEnable #-}
+
+-- | Switches the domain of a hidden enable. See 'switchDomain' for
+-- further details on domain switching in particular.
+switchHiddenEnableDomain ::
+  (EligibleDomainSwitch domA domB, HiddenEnable domA) =>
+  (HiddenEnable domB => r) -> r
+switchHiddenEnableDomain = withEnable $ switchEnableDomain hasEnable
+{-# INLINE switchHiddenEnableDomain #-}
 
 {- | Merge enable signal with signal of bools by applying the boolean AND
 operation.
@@ -1015,6 +1049,18 @@ withClockResetEnable
 withClockResetEnable =
   \clk rst en f -> withClock clk (withReset rst (withEnable en f))
 {-# INLINE withClockResetEnable #-}
+
+-- | Switches the domain of a hidden clock, reset, and enable. See
+-- 'switchDomain' for further details on domain switching in
+-- particular.
+switchHiddenClockResetEnableDomain ::
+  (EligibleDomainSwitch domA domB, HiddenClockResetEnable domA) =>
+  (HiddenClockResetEnable domB => r) -> r
+switchHiddenClockResetEnableDomain =
+  withClockResetEnable (switchClockDomain hasClock)
+                       (switchResetDomain hasReset)
+                       (switchEnableDomain hasEnable)
+{-# INLINE switchHiddenClockResetEnableDomain #-}
 
 -- * Basic circuit functions
 

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -115,6 +115,7 @@ module Clash.Signal
   , Microseconds
   , Nanoseconds
   , Picoseconds
+  , Period(..)
   -- **** Time conversions
   , DomainToHz
   , HzToPeriod

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -44,7 +44,9 @@ module Clash.Signal.Internal
   , Domain
   , sameDomain
   , KnownDomain(..)
+  , KnownConf
   , KnownConfiguration
+  , knownDomain
   , knownDomainByName
   , ActiveEdge(..)
   , SActiveEdge(..)
@@ -57,18 +59,11 @@ module Clash.Signal.Internal
   , DomainConfiguration(..)
   , SDomainConfiguration(..)
   -- ** Configuration type families
-  , DomainPeriod
-  , DomainActiveEdge
-  , DomainResetKind
-  , DomainInitBehavior
-  , DomainResetPolarity
-
   , DomainConfigurationPeriod
   , DomainConfigurationActiveEdge
   , DomainConfigurationResetKind
   , DomainConfigurationInitBehavior
   , DomainConfigurationResetPolarity
-
   -- *** Convenience types
   , HasSynchronousReset
   , HasAsynchronousReset
@@ -201,7 +196,7 @@ import Data.Type.Equality         ((:~:))
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits
-  (Div, KnownSymbol, KnownNat, Nat, Symbol, type (<=), type (*), sameSymbol)
+  (Div, KnownSymbol, KnownNat, Nat, Symbol, type (<=), type (*), type (-), sameSymbol)
 import GHC.TypeLits.Extra         (DivRU)
 import GHC.Records                (HasField(getField))
 import Language.Haskell.TH.Syntax -- (Lift (..), Q, Dec)
@@ -366,32 +361,6 @@ type family DomainConfigurationInitBehavior (config :: DomainConfiguration) :: I
 type family DomainConfigurationResetPolarity (config :: DomainConfiguration) :: ResetPolarity where
   DomainConfigurationResetPolarity ('DomainConfiguration name period edge reset init polarity) = polarity
 
--- | Convenience type to help to extract a period from a domain. Example usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainPeriod dom ~ 6000) => ...
--- @
-type DomainPeriod (dom :: Domain) =
-  DomainConfigurationPeriod (KnownConf dom)
-
--- | Convenience type to help to extract the active edge from a domain. Example
--- usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainActiveEdge dom ~ 'Rising) => ...
--- @
-type DomainActiveEdge (dom :: Domain) =
-  DomainConfigurationActiveEdge (KnownConf dom)
-
--- | Convenience type to help to extract the reset synchronicity from a
--- domain. Example usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainResetKind dom ~ 'Synchronous) => ...
--- @
-type DomainResetKind (dom :: Domain) =
-  DomainConfigurationResetKind (KnownConf dom)
-
 -- | Convenience type to constrain a domain to have synchronous resets. Example
 -- usage:
 --
@@ -418,15 +387,6 @@ type HasSynchronousReset (dom :: Domain) =
 type HasAsynchronousReset (dom :: Domain) =
   (KnownDomain dom, DomainResetKind dom ~ 'Asynchronous)
 
--- | Convenience type to help to extract the initial value behavior from a
--- domain. Example usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainInitBehavior dom ~ 'Defined) => ...
--- @
-type DomainInitBehavior (dom :: Domain) =
-  DomainConfigurationInitBehavior (KnownConf dom)
-
 -- | Convenience type to constrain a domain to have initial values. Example
 -- usage:
 --
@@ -442,15 +402,6 @@ type DomainInitBehavior (dom :: Domain) =
 -- [Click here for usage hints]("Clash.Explicit.Signal#g:conveniencetypes")
 type HasDefinedInitialValues (dom :: Domain) =
   (KnownDomain dom, DomainInitBehavior dom ~ 'Defined)
-
--- | Convenience type to help to extract the reset polarity from a domain.
--- Example usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainResetPolarity dom ~ 'ActiveHigh) => ...
--- @
-type DomainResetPolarity (dom :: Domain) =
-  DomainConfigurationResetPolarity (KnownConf dom)
 
 -- * Time representation
 
@@ -508,17 +459,73 @@ deriving instance Show (SDomainConfiguration dom conf)
 
 type KnownConfiguration dom conf = (KnownDomain dom, KnownConf dom ~ conf)
 
+-- | Evidence for the active edge to be known.
+class KnownActiveEdge (edge :: ActiveEdge) where
+  knownActiveEdge :: SActiveEdge edge
+instance KnownActiveEdge Rising  where knownActiveEdge = SRising
+instance KnownActiveEdge Falling where knownActiveEdge = SFalling
+
+-- | Evidence for the reset kind to be known.
+class KnownResetKind (resetKind :: ResetKind) where
+  knownResetKind :: SResetKind resetKind
+instance KnownResetKind Asynchronous where knownResetKind = SAsynchronous
+instance KnownResetKind Synchronous  where knownResetKind = SSynchronous
+
+-- | Evidence for the init behavior to be known.
+class KnownInitBehavior (init :: InitBehavior) where
+  knownInitBehavior :: SInitBehavior init
+instance KnownInitBehavior Unknown where knownInitBehavior = SUnknown
+instance KnownInitBehavior Defined where knownInitBehavior = SDefined
+
+-- | Evidence for the reset polarity to be known.
+class KnownResetPolarity (polarity :: ResetPolarity) where
+  knownResetPolarity :: SResetPolarity polarity
+instance KnownResetPolarity ActiveLow  where knownResetPolarity = SActiveLow
+instance KnownResetPolarity ActiveHigh where knownResetPolarity = SActiveHigh
+
+-- | The configuration parameters of a known domain given as a
+-- 'DomainConfiguration'.
+type KnownConf dom = 'DomainConfiguration dom
+  (DomainPeriod dom)
+  (DomainActiveEdge dom)
+  (DomainResetKind dom)
+  (DomainInitBehavior dom)
+  (DomainResetPolarity dom)
+
 -- | A 'KnownDomain' constraint indicates that a circuit's behavior depends on
 -- some properties of a domain. See 'DomainConfiguration' for more information.
-class (KnownSymbol dom, KnownNat (DomainPeriod dom)) => KnownDomain (dom :: Domain) where
-  type KnownConf dom :: DomainConfiguration
-  -- | Returns 'SDomainConfiguration' corresponding to an instance's 'DomainConfiguration'.
-  --
-  -- Example usage:
-  --
-  -- >>> knownDomain @System
-  -- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
-  knownDomain :: SDomainConfiguration dom (KnownConf dom)
+class
+  ( KnownSymbol dom
+  , KnownNat (DomainPeriod dom)
+  , KnownNat (DomainPeriod dom - 1)
+  , KnownActiveEdge (DomainActiveEdge dom)
+  , KnownResetKind (DomainResetKind dom)
+  , KnownInitBehavior (DomainInitBehavior dom)
+  , KnownResetPolarity (DomainResetPolarity dom)
+  ) =>
+  KnownDomain (dom :: Domain)
+ where
+  type DomainPeriod dom :: Nat
+  type DomainActiveEdge dom :: ActiveEdge
+  type DomainResetKind dom :: ResetKind
+  type DomainInitBehavior dom :: InitBehavior
+  type DomainResetPolarity dom :: ResetPolarity
+
+-- | Returns 'SDomainConfiguration' corresponding to an instance's 'KnownDomain'.
+--
+-- Example usage:
+--
+-- >>> knownDomain @System
+-- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
+knownDomain :: KnownDomain dom => SDomainConfiguration dom (KnownConf dom)
+knownDomain = SDomainConfiguration
+  { sName          = SSymbol
+  , sPeriod        = SNat
+  , sActiveEdge    = knownActiveEdge
+  , sResetKind     = knownResetKind
+  , sInitBehavior  = knownInitBehavior
+  , sResetPolarity = knownResetPolarity
+  }
 
 -- | Version of 'knownDomain' that takes a 'SSymbol'. For example:
 --
@@ -535,18 +542,27 @@ knownDomainByName =
 
 -- | A /clock/ (and /reset/) dom with clocks running at 100 MHz
 instance KnownDomain System where
-  type KnownConf System = 'DomainConfiguration System 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+  type DomainPeriod System        = 10000
+  type DomainActiveEdge System    = 'Rising
+  type DomainResetKind System     = 'Asynchronous
+  type DomainInitBehavior System  = 'Defined
+  type DomainResetPolarity System = 'ActiveHigh
 
 -- | System instance with defaults set for Xilinx FPGAs
 instance KnownDomain XilinxSystem where
-  type KnownConf XilinxSystem = 'DomainConfiguration XilinxSystem 10000 'Rising 'Synchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SSynchronous SDefined SActiveHigh
+  type DomainPeriod XilinxSystem        = 10000
+  type DomainActiveEdge XilinxSystem    = 'Rising
+  type DomainResetKind XilinxSystem     = 'Synchronous
+  type DomainInitBehavior XilinxSystem  = 'Defined
+  type DomainResetPolarity XilinxSystem = 'ActiveHigh
 
 -- | System instance with defaults set for Intel FPGAs
 instance KnownDomain IntelSystem where
-  type KnownConf IntelSystem = 'DomainConfiguration IntelSystem 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+  type DomainPeriod IntelSystem        = 10000
+  type DomainActiveEdge IntelSystem    = 'Rising
+  type DomainResetKind IntelSystem     = 'Asynchronous
+  type DomainInitBehavior IntelSystem  = 'Defined
+  type DomainResetPolarity IntelSystem = 'ActiveHigh
 
 -- | Convenience value to allow easy "subclassing" of System domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
@@ -679,12 +695,18 @@ createDomain :: VDomainConfiguration -> Q [Dec]
 createDomain (VDomainConfiguration name period edge reset init_ polarity) =
   if isValidDomainName name then do
     kdType <- [t| KnownDomain $nameT |]
-    kcType <- [t| ('DomainConfiguration $nameT $periodT $edgeT $resetKindT $initT $polarityT) |]
-    sDom <- [| SDomainConfiguration SSymbol SNat $edgeE $resetKindE $initE $polarityE |]
+    kpType <- [t| $periodT |]
+    keType <- [t| $edgeT |]
+    krType <- [t| $resetKindT |]
+    kiType <- [t| $initT |]
+    koType <- [t| $polarityT |]
 
     let vNameImpl = AppE (VarE 'vDomain) (AppTypeE (VarE 'knownDomain) (LitT (StrTyLit name)))
-        kdImpl = FunD 'knownDomain [Clause [] (NormalB sDom) []]
-        kcImpl = mkTySynInstD ''KnownConf [LitT (StrTyLit name)] kcType
+        kpImpl = mkTySynInstD ''DomainPeriod [LitT (StrTyLit name)] kpType
+        keImpl = mkTySynInstD ''DomainActiveEdge [LitT (StrTyLit name)] keType
+        krImpl = mkTySynInstD ''DomainResetKind [LitT (StrTyLit name)] krType
+        kiImpl = mkTySynInstD ''DomainInitBehavior [LitT (StrTyLit name)] kiType
+        koImpl = mkTySynInstD ''DomainResetPolarity [LitT (StrTyLit name)] koType
         vName' = mkName ('v':name)
 
     tySynExists <- isJust <$> lookupTypeName name
@@ -705,37 +727,13 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
         | not vHelperExists
         ]
       , [ -- KnownDomain instance (ex: instance KnownDomain "System" where ...)
-          InstanceD Nothing [] kdType [kcImpl, kdImpl]
+          InstanceD Nothing [] kdType [kpImpl, keImpl, krImpl, kiImpl, koImpl]
         ]
       ]
 
   else
     error ("Domain names should be a valid Haskell type name, not: " ++ name)
  where
-
-  edgeE =
-    pure $
-    case edge of
-      Rising -> ConE 'SRising
-      Falling -> ConE 'SFalling
-
-  resetKindE =
-    pure $
-    case reset of
-      Asynchronous -> ConE 'SAsynchronous
-      Synchronous -> ConE 'SSynchronous
-
-  initE =
-    pure $
-    case init_ of
-      Unknown -> ConE 'SUnknown
-      Defined -> ConE 'SDefined
-
-  polarityE =
-    pure $
-    case polarity of
-      ActiveHigh -> ConE 'SActiveHigh
-      ActiveLow -> ConE 'SActiveLow
 
   nameT   = pure (LitT (StrTyLit name))
   periodT = pure (LitT (NumTyLit (toInteger period)))

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -177,7 +177,7 @@ module Clash.Signal.Internal
 where
 
 import Data.IORef                 (IORef, atomicModifyIORef, newIORef, readIORef)
-import Type.Reflection            (Typeable)
+import Type.Reflection            (Typeable, typeRep)
 import Control.Arrow.Transformer.Automaton
 import Control.Applicative        (liftA3)
 import Control.DeepSeq            (NFData)
@@ -192,14 +192,14 @@ import Data.Int                   (Int64)
 import Data.Maybe                 (isJust)
 import Data.Proxy                 (Proxy(..))
 import Data.Ratio                 (Ratio)
-import Data.Type.Equality         ((:~:))
+import Data.Type.Equality         ((:~:), testEquality)
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack, withFrozenCallStack)
-import GHC.TypeLits
-  (Div, KnownSymbol, KnownNat, Nat, Symbol, type (<=), type (*), type (-), sameSymbol)
+import GHC.Types                  (Type)
+import GHC.TypeLits               (Div, KnownNat, Nat, type (<=), type (*), type (-))
 import GHC.TypeLits.Extra         (DivRU)
 import GHC.Records                (HasField(getField))
-import Language.Haskell.TH.Syntax -- (Lift (..), Q, Dec)
+import Language.Haskell.TH.Syntax hiding (Type) -- (Lift (..), Q, Dec)
 import Language.Haskell.TH.Compat
 import Numeric.Natural            (Natural)
 import System.IO.Unsafe           (unsafeInterleaveIO, unsafePerformIO)
@@ -210,7 +210,6 @@ import Clash.Class.Num            (SaturatingNum(..))
 import Clash.CPP                  (fStrictMapSignal)
 import Clash.NamedTypes
 import Clash.Promoted.Nat         (SNat (..), snatToNum, snatToNatural)
-import Clash.Promoted.Symbol      (SSymbol (..), ssymbolToString)
 import Clash.XException
   (NFDataX(..), errorX, isX, deepseqX, defaultSeqX, seqX)
 
@@ -440,9 +439,7 @@ type ClockDivider (dom :: Domain) (period :: Nat) = PeriodToCycles dom period
 data SDomainConfiguration (dom :: Domain) (conf :: DomainConfiguration) where
   SDomainConfiguration ::
     1 <= period =>
-    { sName :: SSymbol dom
-      -- ^ Domain name
-    , sPeriod :: SNat period
+    { sPeriod :: SNat period
     -- ^ Period of clock in /ps/
     , sActiveEdge :: SActiveEdge edge
     -- ^ Active edge of the clock (not yet implemented)
@@ -495,7 +492,7 @@ type KnownConf dom = 'DomainConfiguration dom
 -- | A 'KnownDomain' constraint indicates that a circuit's behavior depends on
 -- some properties of a domain. See 'DomainConfiguration' for more information.
 class
-  ( KnownSymbol dom
+  ( Typeable dom
   , KnownNat (DomainPeriod dom)
   , KnownNat (DomainPeriod dom - 1)
   , KnownActiveEdge (DomainActiveEdge dom)
@@ -519,8 +516,7 @@ class
 -- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
 knownDomain :: KnownDomain dom => SDomainConfiguration dom (KnownConf dom)
 knownDomain = SDomainConfiguration
-  { sName          = SSymbol
-  , sPeriod        = SNat
+  { sPeriod        = SNat
   , sActiveEdge    = knownActiveEdge
   , sResetKind     = knownResetKind
   , sInitBehavior  = knownInitBehavior
@@ -534,7 +530,7 @@ knownDomain = SDomainConfiguration
 knownDomainByName
   :: forall dom
    . KnownDomain dom
-  => SSymbol dom
+  => Proxy dom
   -> SDomainConfiguration dom (KnownConf dom)
 knownDomainByName =
   const knownDomain
@@ -579,8 +575,7 @@ vSystem = vDomain (knownDomain @System)
 --
 -- See module documentation of "Clash.Explicit.Signal" for more information on
 -- how to create custom synthesis domains.
-type System = ("System" :: Domain)
-
+data System
 
 -- | Convenience value to allow easy "subclassing" of IntelSystem domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
@@ -597,7 +592,7 @@ vIntelSystem = vDomain (knownDomain @IntelSystem)
 --
 -- See module documentation of "Clash.Explicit.Signal" for more information on
 -- how to create custom synthesis domains.
-type IntelSystem = ("IntelSystem" :: Domain)
+data IntelSystem
 
 -- | Convenience value to allow easy "subclassing" of XilinxSystem domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
@@ -614,7 +609,7 @@ vXilinxSystem = vDomain (knownDomain @XilinxSystem)
 --
 -- See module documentation of "Clash.Explicit.Signal" for more information on
 -- how to create custom synthesis domains.
-type XilinxSystem = ("XilinxSystem" :: Domain)
+data XilinxSystem
 
 -- | Same as SDomainConfiguration but allows for easy updates through record update syntax.
 -- Should be used in combination with 'vDomain' and 'createDomain'. Example:
@@ -646,10 +641,14 @@ data VDomainConfiguration
 
 -- | Convert 'SDomainConfiguration' to 'VDomainConfiguration'. Should be used in combination with
 -- 'createDomain' only.
-vDomain :: SDomainConfiguration dom conf -> VDomainConfiguration
-vDomain (SDomainConfiguration dom period edge reset init_ polarity) =
+vDomain ::
+  forall dom conf.
+  Typeable dom =>
+  SDomainConfiguration dom conf ->
   VDomainConfiguration
-    (ssymbolToString dom)
+vDomain (SDomainConfiguration period edge reset init_ polarity) =
+  VDomainConfiguration
+    (show (typeRep @dom))
     (snatToNatural period)
     (case edge of {SRising -> Rising; SFalling -> Falling})
     (case reset of {SAsynchronous -> Asynchronous; SSynchronous -> Synchronous})
@@ -701,12 +700,12 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
     kiType <- [t| $initT |]
     koType <- [t| $polarityT |]
 
-    let vNameImpl = AppE (VarE 'vDomain) (AppTypeE (VarE 'knownDomain) (LitT (StrTyLit name)))
-        kpImpl = mkTySynInstD ''DomainPeriod [LitT (StrTyLit name)] kpType
-        keImpl = mkTySynInstD ''DomainActiveEdge [LitT (StrTyLit name)] keType
-        krImpl = mkTySynInstD ''DomainResetKind [LitT (StrTyLit name)] krType
-        kiImpl = mkTySynInstD ''DomainInitBehavior [LitT (StrTyLit name)] kiType
-        koImpl = mkTySynInstD ''DomainResetPolarity [LitT (StrTyLit name)] koType
+    let vNameImpl = AppE (VarE 'vDomain) (AppTypeE (VarE 'knownDomain) (ConT name'))
+        kpImpl = mkTySynInstD ''DomainPeriod [ConT name'] kpType
+        keImpl = mkTySynInstD ''DomainActiveEdge [ConT name'] keType
+        krImpl = mkTySynInstD ''DomainResetKind [ConT name'] krType
+        kiImpl = mkTySynInstD ''DomainInitBehavior [ConT name'] kiType
+        koImpl = mkTySynInstD ''DomainResetPolarity [ConT name'] koType
         vName' = mkName ('v':name)
 
     tySynExists <- isJust <$> lookupTypeName name
@@ -714,8 +713,8 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
 
     pure $ concat
       [
-        [ -- Type synonym (ex: type System = "System")
-          TySynD (mkName name) [] (LitT (StrTyLit name)  `SigT`  ConT ''Domain)
+        [ -- Type declaration (ex: data System :: Domain)
+          DataD [] name' [] (Just (ConT ''Domain)) [] []
         | not tySynExists
         ]
 
@@ -734,8 +733,8 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
   else
     error ("Domain names should be a valid Haskell type name, not: " ++ name)
  where
-
-  nameT   = pure (LitT (StrTyLit name))
+  name' = mkName name
+  nameT   = pure (ConT name')
   periodT = pure (LitT (NumTyLit (toInteger period)))
 
   edgeT =
@@ -763,7 +762,7 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
       ActiveLow -> PromotedT 'ActiveLow
 
 
-type Domain = Symbol
+type Domain = Type
 
 -- | We either get evidence that this function was instantiated with the same
 -- domains, or Nothing.
@@ -771,7 +770,7 @@ sameDomain
   :: forall (domA :: Domain) (domB :: Domain)
    . (KnownDomain domA, KnownDomain domB)
   => Maybe (domA :~: domB)
-sameDomain = sameSymbol (Proxy @domA) (Proxy @domB)
+sameDomain = testEquality (typeRep @domA) (typeRep @domB)
 
 infixr 5 :-
 {- | Clash has synchronous 'Signal's in the form of:
@@ -972,26 +971,23 @@ enableGen = toEnable (pure True)
 
 -- | A clock signal belonging to a domain named /dom/.
 data Clock (dom :: Domain) = Clock
-  { -- | Domain associated with the clock
-    clockTag :: SSymbol dom
-
-    -- | Periods of the clock. This is an experimental feature used to simulate
+  { -- | Periods of the clock. This is an experimental feature used to simulate
     -- clock frequency correction mechanisms. Currently, all ways to contruct
     -- such a clock are hidden from the public API.
-  , clockPeriods :: Maybe (Signal dom Femtoseconds)
+    clockPeriods :: Maybe (Signal dom Femtoseconds)
   }
 
-instance Show (Clock dom) where
-  show (Clock dom Nothing) = "<Clock: " ++ ssymbolToString dom ++ ">"
-  show (Clock dom _) = "<Dynamic clock: " ++ ssymbolToString dom ++ ">"
+instance Typeable dom => Show (Clock dom) where
+  show (Clock Nothing) = "<Clock: " ++ show (typeRep @dom) ++ ">"
+  show (Clock _) = "<Dynamic clock: " ++ show (typeRep @dom) ++ ">"
 
 -- | The negative or inverted phase of a differential clock signal. HDL
 -- generation will treat it the same as 'Clock', except that no @create_clock@
 -- command is issued in the SDC file for 'ClockN'. Used in 'DiffClock'.
-newtype ClockN (dom :: Domain) = ClockN { clockNTag :: SSymbol dom }
+newtype ClockN (dom :: Domain) = ClockN { clockNTag :: Proxy dom }
 
-instance Show (ClockN dom) where
-  show (ClockN dom) = "<ClockN: " ++ ssymbolToString dom ++ ">"
+instance Typeable dom => Show (ClockN dom) where
+  show (ClockN _) = "<ClockN: " ++ show (typeRep @dom) ++ ">"
 
 -- | A differential clock signal belonging to a domain named /dom/. The clock
 -- input of a design with such an input has two ports which are in antiphase.
@@ -1004,11 +1000,11 @@ instance Show (ClockN dom) where
 data DiffClock (dom :: Domain) =
   DiffClock ("p" ::: Clock dom) ("n" ::: ClockN dom)
 
-instance Show (DiffClock dom) where
-  show (DiffClock (Clock dom Nothing) _) =
-    "<DiffClock: " ++ ssymbolToString dom ++ ">"
-  show (DiffClock (Clock dom _) _) =
-    "<Dynamic DiffClock: " ++ ssymbolToString dom ++ ">"
+instance Typeable dom => Show (DiffClock dom) where
+  show (DiffClock (Clock Nothing) _) =
+    "<DiffClock: " ++ show (typeRep @dom) ++ ">"
+  show (DiffClock (Clock _) _) =
+    "<Dynamic DiffClock: " ++ show (typeRep @dom) ++ ">"
 
 -- | Clock generator for simulations. Do __not__ use this clock generator for
 -- the /testBench/ function, use 'tbClockGen' instead.
@@ -1076,7 +1072,7 @@ tbClockGen
   :: KnownDomain testDom
   => Signal testDom Bool
   -> Clock testDom
-tbClockGen done = Clock (done `seq` SSymbol) Nothing
+tbClockGen done = Clock (done `seq` Nothing)
 {-# OPAQUE tbClockGen #-}
 {-# ANN tbClockGen hasBlackBox #-}
 
@@ -1154,7 +1150,7 @@ tbDynamicClockGen ::
   Signal dom Bool ->
   Clock dom
 tbDynamicClockGen periods ena =
-  Clock (ena `seq` periods `seq` SSymbol) (Just periods)
+  Clock (ena `seq` periods `seq` Just periods)
 {-# OPAQUE tbDynamicClockGen #-}
 {-# ANN tbDynamicClockGen hasBlackBox #-}
 
@@ -1221,7 +1217,7 @@ resetPolarityProxy
   -> SResetPolarity polarity
 resetPolarityProxy _proxy =
   case knownDomain @dom of
-    SDomainConfiguration _dom _period _edge _sync _init polarity ->
+    SDomainConfiguration _period _edge _sync _init polarity ->
       polarity
 
 -- | Convert a reset to an active high reset. Has no effect if reset is already
@@ -1506,16 +1502,16 @@ delay#
   -> a
   -> Signal dom a
   -> Signal dom a
-delay# (Clock dom _) (fromEnable -> en) powerUpVal0 =
+delay# (Clock _) (fromEnable -> en) powerUpVal0 =
     go powerUpVal1 en
   where
     powerUpVal1 :: a
     powerUpVal1 =
-      case knownDomainByName dom of
-        SDomainConfiguration _dom _period _edge _sync SDefined _polarity ->
+      case knownDomainByName (Proxy @dom) of
+        SDomainConfiguration _period _edge _sync SDefined _polarity ->
           powerUpVal0
-        SDomainConfiguration _dom _period _edge _sync SUnknown _polarity ->
-          deepErrorX ("First value of `delay` unknown on domain " ++ show dom)
+        SDomainConfiguration _period _edge _sync SUnknown _polarity ->
+          deepErrorX ("First value of `delay` unknown on domain " ++ show (typeRep @dom))
 
     go o (e :- es) as@(~(x :- xs)) =
       let o' = if e then x else o
@@ -1548,11 +1544,11 @@ register#
   -- ^ Reset value
   -> Signal dom a
   -> Signal dom a
-register# clk@(Clock dom _) rst ena powerUpVal resetVal =
-  case knownDomainByName dom of
-    SDomainConfiguration _name _period _edge SSynchronous _init _polarity ->
+register# clk@(Clock _) rst ena powerUpVal resetVal =
+  case knownDomainByName (Proxy @dom) of
+    SDomainConfiguration _period _edge SSynchronous _init _polarity ->
       syncRegister# clk rst ena powerUpVal resetVal
-    SDomainConfiguration _name _period _edge SAsynchronous _init _polarity ->
+    SDomainConfiguration _period _edge SAsynchronous _init _polarity ->
       asyncRegister# clk rst ena powerUpVal resetVal
 {-# OPAQUE register# #-}
 {-# ANN register# hasBlackBox #-}
@@ -1567,11 +1563,11 @@ registerPowerup#
   => Clock dom
   -> a
   -> a
-registerPowerup# (Clock dom _) a =
-  case knownDomainByName dom of
-    SDomainConfiguration _dom _period _edge _sync SDefined _polarity -> a
-    SDomainConfiguration _dom _period _edge _sync SUnknown _polarity ->
-      deepErrorX ("First value of register undefined on domain " ++ show dom)
+registerPowerup# (Clock _) a =
+  case knownDomainByName (Proxy @dom) of
+    SDomainConfiguration _period _edge _sync SDefined _polarity -> a
+    SDomainConfiguration _period _edge _sync SUnknown _polarity ->
+      deepErrorX ("First value of register undefined on domain " ++ show (typeRep @dom))
 
 -- | Version of 'register#' that simulates a register on an asynchronous
 -- domain. Is synthesizable.
@@ -2147,7 +2143,7 @@ clockTicks clkA clkB = clockTicksEither (toEither clkA) (toEither clkB)
     KnownDomain dom =>
     Clock dom ->
     Either Int64 (Signal dom Int64)
-  toEither (Clock _ maybePeriods)
+  toEither (Clock maybePeriods)
     | Just periods <- maybePeriods =
         Right (unFemtosecondsSignal periods)
     | SDomainConfiguration{sPeriod} <- knownDomain @dom =

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -231,14 +231,13 @@ import Clash.XException
 >>> :set -XDataKinds
 >>> :set -XMagicHash
 >>> :set -XTypeApplications
->>> import Clash.Prelude (SSymbol(..))
 >>> import Clash.Signal.Internal
 >>> import Clash.Promoted.Nat
 >>> import Clash.Promoted.Nat.Literals
 >>> import Clash.XException
+>>> import Data.Proxy (Proxy(..))
 >>> import Data.Ratio (Ratio)
 >>> import Numeric.Natural (Natural)
->>> type System = "System"
 >>> let systemClockGen = clockGen @System
 >>> let systemResetGen = resetGen @System
 >>> import Clash.Explicit.Signal (register)
@@ -529,7 +528,7 @@ class
 -- Example usage:
 --
 -- >>> knownDomain @System
--- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
+-- SDomainConfiguration {sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
 knownDomain :: KnownDomain dom => SDomainConfiguration dom (KnownConf dom)
 knownDomain = SDomainConfiguration
   { sPeriod        = SNat
@@ -541,8 +540,8 @@ knownDomain = SDomainConfiguration
 
 -- | Version of 'knownDomain' that takes a 'SSymbol'. For example:
 --
--- >>> knownDomainByName (SSymbol @"System")
--- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
+-- >>> knownDomainByName (Proxy @System)
+-- SDomainConfiguration {sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
 knownDomainByName
   :: forall dom
    . KnownDomain dom

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -46,6 +46,10 @@ module Clash.Signal.Internal
     -- * Domains
   , Domain
   , sameDomain
+  , switchDomain
+  , switchClockDomain
+  , switchResetDomain
+  , switchEnableDomain
   , KnownDomain(..)
   , KnownConf
   , KnownConfiguration
@@ -60,6 +64,8 @@ module Clash.Signal.Internal
   , SResetPolarity(..)
   , DomainConfiguration(..)
   , SDomainConfiguration(..)
+  , SupportsSwitchingTo
+  , EligibleDomainSwitch
   -- ** Configuration type families
   , DomainConfigurationPeriod
   , DomainConfigurationPeriodFraction
@@ -200,6 +206,7 @@ import Data.Type.Equality         ((:~:), testEquality)
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack, withFrozenCallStack)
 import GHC.Types                  (Type)
+import GHC.TypeError              (Assert, TypeError, ErrorMessage(..))
 import GHC.TypeLits               (Div, KnownNat, Nat, type (<=), type (*), type (-))
 import GHC.TypeLits.Extra         (DivRU)
 import GHC.Real                   (Ratio(..), (%))
@@ -925,6 +932,67 @@ sameDomain
    . (KnownDomain domA, KnownDomain domB)
   => Maybe (domA :~: domB)
 sameDomain = testEquality (typeRep @domA) (typeRep @domB)
+
+-- | An open type family for keeping track of the supported domain
+-- switches. Instantiating this type family with a 'True' value is a
+-- strict requirement for enabling domain switching via
+-- 'switchDomain'. Setting the value to 'False' instead actively
+-- forbids such switching behavior. The direction of domain switching
+-- is unidirectional.
+type family (domA :: Domain) `SupportsSwitchingTo` (domB :: Domain) :: Bool
+
+-- | The constraints to be satisfied for switching from @domA@ to @domB@.
+type EligibleDomainSwitch domA domB =
+  ( KnownDomain domA          , KnownDomain domB
+  , DomainPeriod domA         ~ DomainPeriod domB
+  , DomainActiveEdge domA     ~ DomainActiveEdge domB
+  , DomainResetKind domA      ~ DomainResetKind domB
+  , DomainInitBehavior domA   ~ DomainInitBehavior domB
+  , DomainResetPolarity domA  ~ DomainResetPolarity domB
+  , DomainPeriodFraction domA ~ DomainPeriodFraction domB
+  , Assert (domA `SupportsSwitchingTo` domB)
+      (TypeError (    Text "Forbidden domain switch:" :$$: Text "  "
+                 :<>: ShowType domA :<>: Text "  ⟶  " :<>: ShowType domB
+                 )
+      )
+  )
+
+-- | Switches the domain of a signal, given that the corresponding two
+-- domains are hardware compatible. Furthermore, switching needs to be
+-- enabled through the open 'SupportsSwitchingTo' type family for the
+-- selected domain pair .
+--
+-- This function is intended to be used for domain switching inside
+-- physical clock domains, which enjoy some further virtual
+-- partitioning according to some additionally given context. It will
+-- not introduce any additional logic in hardware.
+switchDomain ::
+  EligibleDomainSwitch domA domB =>
+  Signal domA a -> Signal domB a
+switchDomain ~(x :- xr) = x :- switchDomain xr
+{-# OPAQUE switchDomain #-}
+{-# ANN switchDomain hasBlackBox #-}
+
+-- | Switches the domain of a clock. See 'switchDomain' for further
+-- details on domain switching in particular.
+switchClockDomain ::
+  EligibleDomainSwitch domA domB =>
+  Clock domA -> Clock domB
+switchClockDomain (Clock c) = Clock $ fmap switchDomain c
+
+-- | Switches the domain of a reset. See 'switchDomain' for further
+-- details on domain switching in particular.
+switchResetDomain ::
+  EligibleDomainSwitch domA domB =>
+  Reset domA -> Reset domB
+switchResetDomain (Reset r) = Reset $ switchDomain r
+
+-- | Switches the domain of an enable. See 'switchDomain' for further
+-- details on domain switching in particular.
+switchEnableDomain ::
+  EligibleDomainSwitch domA domB =>
+  Enable domA -> Enable domB
+switchEnableDomain (Enable e) = Enable $ switchDomain e
 
 infixr 5 :-
 {- | Clash has synchronous 'Signal's in the form of:

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -14,9 +14,11 @@ Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -48,7 +50,6 @@ module Clash.Signal.Internal
   , KnownConf
   , KnownConfiguration
   , knownDomain
-  , knownDomainByName
   , ActiveEdge(..)
   , SActiveEdge(..)
   , InitBehavior(..)
@@ -61,6 +62,7 @@ module Clash.Signal.Internal
   , SDomainConfiguration(..)
   -- ** Configuration type families
   , DomainConfigurationPeriod
+  , DomainConfigurationPeriodFraction
   , DomainConfigurationActiveEdge
   , DomainConfigurationResetKind
   , DomainConfigurationInitBehavior
@@ -75,6 +77,7 @@ module Clash.Signal.Internal
   , Microseconds
   , Nanoseconds
   , Picoseconds
+  , Period(..)
   -- **** Time conversions
   , DomainToHz
   , HzToPeriod
@@ -179,11 +182,7 @@ module Clash.Signal.Internal
 where
 
 import Data.IORef                 (IORef, atomicModifyIORef, newIORef, readIORef)
-#if __GLASGOW_HASKELL__ < 912
 import Type.Reflection            (Typeable, typeRep)
-#else
-import Type.Reflection            (typeRep)
-#endif
 import Control.Arrow.Transformer.Automaton
 import Control.Applicative        (liftA3)
 import Control.DeepSeq            (NFData)
@@ -197,13 +196,13 @@ import Data.Hashable              (Hashable)
 import Data.Int                   (Int64)
 import Data.Maybe                 (isJust)
 import Data.Proxy                 (Proxy(..))
-import Data.Ratio                 (Ratio)
 import Data.Type.Equality         ((:~:), testEquality)
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack, withFrozenCallStack)
 import GHC.Types                  (Type)
 import GHC.TypeLits               (Div, KnownNat, Nat, type (<=), type (*), type (-))
 import GHC.TypeLits.Extra         (DivRU)
+import GHC.Real                   (Ratio(..), (%))
 import GHC.Records                (HasField(getField))
 import Language.Haskell.TH.Syntax hiding (Type) -- (Lift (..), Q, Dec)
 import Language.Haskell.TH.Compat
@@ -223,9 +222,9 @@ import Test.QuickCheck            (Arbitrary (..), CoArbitrary(..), Property,
 import Clash.Class.Num            (SaturatingNum(..))
 import Clash.CPP                  (fStrictMapSignal)
 import Clash.NamedTypes
-import Clash.Promoted.Nat         (SNat (..), snatToNum, snatToNatural)
+import Clash.Promoted.Nat         (SNat(..), natToNatural, snatToNum)
 import Clash.XException
-  (NFDataX(..), errorX, isX, deepseqX, defaultSeqX, seqX)
+  (NFDataX(..), ShowX, errorX, isX, deepseqX, defaultSeqX, seqX)
 
 {- $setup
 >>> :set -XDataKinds
@@ -341,6 +340,8 @@ data DomainConfiguration
   -- ^ Domain name
   , _period :: Nat
   -- ^ Period of clock in /ps/
+  , _periodFraction :: Ratio Nat
+  -- ^ Rational fraction of the period (always smaller than one)
   , _activeEdge :: ActiveEdge
   -- ^ Active edge of the clock
   , _resetKind :: ResetKind
@@ -357,23 +358,33 @@ data DomainConfiguration
 
 -- | Helper type family for 'DomainPeriod'
 type family DomainConfigurationPeriod (config :: DomainConfiguration) :: Nat where
-  DomainConfigurationPeriod ('DomainConfiguration name period edge reset init polarity) = period
+  DomainConfigurationPeriod
+    ('DomainConfiguration name period fraction edge reset init polarity) = period
+
+-- | Helper type family for 'DomainPeriodFraction'
+type family DomainConfigurationPeriodFraction (config :: DomainConfiguration) :: Ratio Nat where
+  DomainConfigurationPeriodFraction
+    ('DomainConfiguration name period fraction edge reset init polarity) = fraction
 
 -- | Helper type family for 'DomainActiveEdge'
 type family DomainConfigurationActiveEdge (config :: DomainConfiguration) :: ActiveEdge where
-  DomainConfigurationActiveEdge ('DomainConfiguration name period edge reset init polarity) = edge
+  DomainConfigurationActiveEdge
+    ('DomainConfiguration name period fraction edge reset init polarity) = edge
 
 -- | Helper type family for 'DomainResetKind'
 type family DomainConfigurationResetKind (config :: DomainConfiguration) :: ResetKind where
-  DomainConfigurationResetKind ('DomainConfiguration name period edge reset init polarity) = reset
+  DomainConfigurationResetKind
+    ('DomainConfiguration name period fraction edge reset init polarity) = reset
 
 -- | Helper type family for 'DomainInitBehavior'
 type family DomainConfigurationInitBehavior (config :: DomainConfiguration) :: InitBehavior where
-  DomainConfigurationInitBehavior ('DomainConfiguration name period edge reset init polarity) = init
+  DomainConfigurationInitBehavior
+    ('DomainConfiguration name period fraction edge reset init polarity) = init
 
 -- | Helper type family for 'DomainResetPolarity'
 type family DomainConfigurationResetPolarity (config :: DomainConfiguration) :: ResetPolarity where
-  DomainConfigurationResetPolarity ('DomainConfiguration name period edge reset init polarity) = polarity
+  DomainConfigurationResetPolarity
+    ('DomainConfiguration name period fraction edge reset init polarity) = polarity
 
 -- | Convenience type to constrain a domain to have synchronous resets. Example
 -- usage:
@@ -450,12 +461,34 @@ type PeriodToHz (period :: Nat) = (Seconds 1) `Div` period
 -- @period@ has passed. The same as 'PeriodToCycles'.
 type ClockDivider (dom :: Domain) (period :: Nat) = PeriodToCycles dom period
 
+-- | Helper type family for accessing the numerator of type-level ratios.
+type family Numerator (r :: Ratio a) :: a where
+  Numerator (x :% _) = x
+
+-- | Helper type family for accessing the denominator of type-level ratios.
+type family Denominator (r :: Ratio a) :: a where
+  Denominator (_ :% x) = x
+
+-- | A value-level witness for a type-level ratio over natural numbers.
+data SRatioNat (r :: Ratio Nat) where
+  SRatioNat ::
+    (KnownNat numerator, KnownNat denominator, 1 <= denominator) =>
+    SRatioNat (numerator :% denominator)
+
+instance Show (SRatioNat r) where
+  show SRatioNat = "type "
+    <> show (natToNatural @(Numerator r))
+    <> " % "
+    <> show (natToNatural @(Denominator r))
+
 -- | Singleton version of 'DomainConfiguration'
 data SDomainConfiguration (dom :: Domain) (conf :: DomainConfiguration) where
   SDomainConfiguration ::
     1 <= period =>
     { sPeriod :: SNat period
     -- ^ Period of clock in /ps/
+    , sPeriodFraction :: SRatioNat fraction
+    -- ^ Rational fraction of the period (always smaller than one)
     , sActiveEdge :: SActiveEdge edge
     -- ^ Active edge of the clock (not yet implemented)
     , sResetKind :: SResetKind reset
@@ -465,11 +498,23 @@ data SDomainConfiguration (dom :: Domain) (conf :: DomainConfiguration) where
     -- unknown/undefined, or configurable to a specific value
     , sResetPolarity :: SResetPolarity polarity
     -- ^ Whether resets are active high or active low
-    } -> SDomainConfiguration dom ('DomainConfiguration dom period edge reset init polarity)
+    } -> SDomainConfiguration dom
+      ( 'DomainConfiguration dom
+           period fraction edge reset init polarity
+      )
 
 deriving instance Show (SDomainConfiguration dom conf)
 
 type KnownConfiguration dom conf = (KnownDomain dom, KnownConf dom ~ conf)
+
+-- | Evidence for the period fraction to be known.
+class KnownFraction (fraction :: Ratio Nat) where
+  knownFraction :: SRatioNat fraction
+instance
+  (KnownNat numerator, KnownNat denominator, 1 <= denominator) =>
+  KnownFraction (numerator :% denominator)
+ where
+  knownFraction = SRatioNat
 
 -- | Evidence for the active edge to be known.
 class KnownActiveEdge (edge :: ActiveEdge) where
@@ -499,6 +544,7 @@ instance KnownResetPolarity ActiveHigh where knownResetPolarity = SActiveHigh
 -- 'DomainConfiguration'.
 type KnownConf dom = 'DomainConfiguration dom
   (DomainPeriod dom)
+  (DomainPeriodFraction dom)
   (DomainActiveEdge dom)
   (DomainResetKind dom)
   (DomainInitBehavior dom)
@@ -510,6 +556,7 @@ class
   ( Typeable dom
   , KnownNat (DomainPeriod dom)
   , KnownNat (DomainPeriod dom - 1)
+  , KnownFraction (DomainPeriodFraction dom)
   , KnownActiveEdge (DomainActiveEdge dom)
   , KnownResetKind (DomainResetKind dom)
   , KnownInitBehavior (DomainInitBehavior dom)
@@ -522,34 +569,24 @@ class
   type DomainResetKind dom :: ResetKind
   type DomainInitBehavior dom :: InitBehavior
   type DomainResetPolarity dom :: ResetPolarity
+  type DomainPeriodFraction dom :: Ratio Nat
+  type DomainPeriodFraction dom = 0 :% 1
 
 -- | Returns 'SDomainConfiguration' corresponding to an instance's 'KnownDomain'.
 --
 -- Example usage:
 --
 -- >>> knownDomain @System
--- SDomainConfiguration {sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
+-- SDomainConfiguration {sPeriod = SNat @10000, sPeriodFraction = type 0 % 1, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
 knownDomain :: KnownDomain dom => SDomainConfiguration dom (KnownConf dom)
 knownDomain = SDomainConfiguration
-  { sPeriod        = SNat
-  , sActiveEdge    = knownActiveEdge
-  , sResetKind     = knownResetKind
-  , sInitBehavior  = knownInitBehavior
-  , sResetPolarity = knownResetPolarity
+  { sPeriod         = SNat
+  , sPeriodFraction = knownFraction
+  , sActiveEdge     = knownActiveEdge
+  , sResetKind      = knownResetKind
+  , sInitBehavior   = knownInitBehavior
+  , sResetPolarity  = knownResetPolarity
   }
-
--- | Version of 'knownDomain' that takes a 'SSymbol'. For example:
---
--- >>> knownDomainByName (Proxy @System)
--- SDomainConfiguration {sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
-knownDomainByName
-  :: forall dom
-   . KnownDomain dom
-  => Proxy dom
-  -> SDomainConfiguration dom (KnownConf dom)
-knownDomainByName =
-  const knownDomain
-{-# INLINE knownDomainByName #-}
 
 -- | A /clock/ (and /reset/) dom with clocks running at 100 MHz
 instance KnownDomain System where
@@ -626,6 +663,96 @@ vXilinxSystem = vDomain (knownDomain @XilinxSystem)
 -- how to create custom synthesis domains.
 data XilinxSystem
 
+-- | A precise period given in picoseconds.
+newtype Period = Period (Ratio Nat)
+  deriving stock   ( Lift )
+  deriving newtype ( NFDataX, NFData, ShowX, Eq, Ord, Read, Binary
+                   , Enum, Num, Real, RealFrac, Fractional, Hashable
+                   )
+
+instance Show Period where
+  show (Period (n :% m))
+    | n `mod` m == 0 = show (n `div` m) <> " ps"
+    | n `div` m == 0 = show n <> "/" <> show m <> " ps"
+    | otherwise      = show (n `div` m) <> " + "
+                    <> show (n `mod` m) <> "/" <> show m <> " ps"
+
+-- Some notes on the `Integral Period` instance given below:
+--
+--  1. The instance satisfies:
+--
+--        (x `quot` y) * y + (x `rem` y) == x
+--     && (x `div`  y) * y + (x `mod` y) == x
+--
+--     It further ensures that the quotient is always an integer and that
+--     @rem x y < y && rem x y >= 0 @, which are the desired properties for
+--     splitting rationals into their corresponding integer and fractional
+--     parts.
+--
+--     Machine checkable proofs for the aforementioned properties are given in
+--     `clash-prelude/src/Clash/Signal/Internal/IntegralPeriodProperties.agda`.
+--     The proof are only given for `quot` and `rem`, as for rationals over the
+--     naturals `quot` / `rem` and `div` / `mod` always coincide.
+--
+--  2. One may consider to use of the following alternative definition for the
+--     reminder:
+--
+--     rem x y = let Period (n :% m) = x / y
+--                in Period ((n `mod` m) :% (denominator x * denominator y))
+--
+--     However, this definition will break the aforementioned laws due to
+--     @x / y@ returning a normalized fraction. It is crucial here that the
+--     intermediate result is not normalized to satisfy the aforementioned
+--     laws. Study the result of @quot (3 / 4) (6 / 5)@ to see the particular
+--     difference.
+--
+--  3. While the aforementioned properties do hold, they are no sufficient
+--     condition for 'Period' to be an Euclidean domain. Due to the infinite
+--     density of the rationals it is considered impossible to define them as
+--     such. In this particular case, the proof sketch below can be used to
+--     disproof the instance being Euclidean. This is no strong limitation
+--     though, as the properties of (1) are still sufficient for our purposes.
+--
+--     Proof sketch:
+--
+--     To be an Euclidean domain, there must exist an Euclidean function
+--
+--        f :: Period -> Positive Natural
+--
+--     such that if `rem x y /= 0` then `f y > f (rem x y)`. For the sake of
+--     contradiction assume such f would exist. Then
+--
+--     * Pick (i / n) s.t. f (i / n) is minimal with i > 1 and n /= 0,
+--       i.e., there are no i' and n' with i' > 1 and n' /= 0 s.t.
+--       f (i' / n') < f (i / n). Such i and n must exist, since f is total
+--       and maps to the positive integers.
+--     * Pick j s.t. abs j is a prime and j > i (hence: gcd i j == 1)
+--     * Then: `rem (j / n) (i / n) /= 0`
+--         => Proof by contraction, assume the opposite:
+--            -> rem (j / n) (i / n) == 0
+--            -> ((j * n) `mod` (i * n)) / (n * n) == 0
+--            -> (j * n) `mod` (i * n) == 0
+--            -> exists k s.t. j * n == k * i * n
+--            -> exists k s.t. j == k * i
+--            -> gcd i j is a multiple of i
+--            -> gcd i j /= 1
+--     * Since `rem (j / n) (i / n) /= 0` it must hold
+--       f (i / n) > f (rem (j / n) (i / n)) which contradicts minimality
+--       of the chosen (i / n). Consequently, such function f cannot exist.
+--     * QED
+--
+instance Integral Period where
+  quotRem (Period (a :% b)) (Period (c :% d)) =
+    ( Period $ (a * d `div` b * c) :% 1
+    , Period $ (a * d `mod` b * c) :% (b * c)
+    )
+  quot x y = fst $ quotRem x y
+  rem x y = snd $ quotRem x y
+  div = quot
+  mod = rem
+  divMod = quotRem
+  toInteger (Period (n :% m)) = toInteger $ n `div` m
+
 -- | Same as SDomainConfiguration but allows for easy updates through record update syntax.
 -- Should be used in combination with 'vDomain' and 'createDomain'. Example:
 --
@@ -640,35 +767,47 @@ data XilinxSystem
 data VDomainConfiguration
   = VDomainConfiguration
   { vName :: String
-  -- ^ Corresponds to '_name' on 'DomainConfiguration'
-  , vPeriod :: Natural
-  -- ^ Corresponds to '_period' on 'DomainConfiguration'
+  -- ^ Corresponds to '_name' of 'DomainConfiguration'
+  , vPeriod :: Period
+  -- ^ Corresponds to '_period' and '_periodFraction' of 'DomainConfiguration'
   , vActiveEdge :: ActiveEdge
-  -- ^ Corresponds to '_activeEdge' on 'DomainConfiguration'
+  -- ^ Corresponds to '_activeEdge' of 'DomainConfiguration'
   , vResetKind :: ResetKind
-  -- ^ Corresponds to '_resetKind' on 'DomainConfiguration'
+  -- ^ Corresponds to '_resetKind' of 'DomainConfiguration'
   , vInitBehavior :: InitBehavior
-  -- ^ Corresponds to '_initBehavior' on 'DomainConfiguration'
+  -- ^ Corresponds to '_initBehavior' of 'DomainConfiguration'
   , vResetPolarity :: ResetPolarity
-  -- ^ Corresponds to '_resetPolarity' on 'DomainConfiguration'
+  -- ^ Corresponds to '_resetPolarity' of 'DomainConfiguration'
   }
-  deriving (Eq, Generic, NFData, Show, Read, Binary)
+  deriving (Eq, Ord, Generic, NFData, Show, Read, Binary, Hashable)
 
--- | Convert 'SDomainConfiguration' to 'VDomainConfiguration'. Should be used in combination with
--- 'createDomain' only.
+-- | Convert 'SDomainConfiguration' to 'VDomainConfiguration'.
+-- Should be used in combination with 'createDomain' only.
 vDomain ::
   forall dom conf.
   Typeable dom =>
   SDomainConfiguration dom conf ->
   VDomainConfiguration
-vDomain (SDomainConfiguration period edge reset init_ polarity) =
-  VDomainConfiguration
-    (show (typeRep @dom))
-    (snatToNatural period)
-    (case edge of {SRising -> Rising; SFalling -> Falling})
-    (case reset of {SAsynchronous -> Asynchronous; SSynchronous -> Synchronous})
-    (case init_ of {SDefined -> Defined; SUnknown -> Unknown})
-    (case polarity of {SActiveHigh -> ActiveHigh; SActiveLow -> ActiveLow})
+vDomain cfg@SDomainConfiguration{} = VDomainConfiguration
+  { vName = show $ typeRep @dom
+  , vPeriod = snatToNum cfg.sPeriod + periodFraction cfg.sPeriodFraction
+  , vActiveEdge = case cfg.sActiveEdge of
+      SRising -> Rising
+      SFalling -> Falling
+  , vResetKind = case cfg.sResetKind of
+      SAsynchronous -> Asynchronous
+      SSynchronous -> Synchronous
+  , vInitBehavior = case cfg.sInitBehavior of
+      SDefined -> Defined
+      SUnknown -> Unknown
+  , vResetPolarity = case cfg.sResetPolarity of
+      SActiveHigh -> ActiveHigh
+      SActiveLow -> ActiveLow
+  }
+ where
+  periodFraction :: forall (srn :: Ratio Nat). SRatioNat srn -> Period
+  periodFraction SRatioNat = Period
+    $ natToNatural @(Numerator srn) % natToNatural @(Denominator srn)
 
 -- TODO: Function might reject valid type names. Figure out what's allowed.
 isValidDomainName :: String -> Bool
@@ -687,11 +826,11 @@ isValidDomainName _ = False
 --
 -- The function will create two extra identifiers. The first:
 --
--- > type System10 = ..
+-- > data System10 :: Domain
 --
 -- You can use that as the dom to Clocks\/Resets\/Enables\/Signals. For example:
--- @Signal System10 Int@. Additionally, it will create a 'VDomainConfiguration' that you can
--- use in later calls to 'createDomain':
+-- @Signal System10 Int@. Additionally, it will create a 'VDomainConfiguration'
+-- that you can use in later calls to 'createDomain':
 --
 -- > vSystem10 = knownVDomain @System10
 --
@@ -701,81 +840,81 @@ isValidDomainName _ = False
 -- Note: This can be useful for example when documenting a new domain:
 --
 -- > -- | Here is some documentation for CustomDomain
--- > type CustomDomain = ("CustomDomain" :: Domain)
+-- > data CustomDomain :: Domain
 -- >
 -- > -- | Here is some documentation for vCustomDomain
 -- > createDomain vSystem{vName="CustomDomain"}
 createDomain :: VDomainConfiguration -> Q [Dec]
-createDomain (VDomainConfiguration name period edge reset init_ polarity) =
-  if isValidDomainName name then do
+createDomain cfg@VDomainConfiguration{} =
+  if isValidDomainName cfg.vName then do
     kdType <- [t| KnownDomain $nameT |]
     kpType <- [t| $periodT |]
+    kfType <- [t| $numeratorT :% $denominatorT |]
     keType <- [t| $edgeT |]
     krType <- [t| $resetKindT |]
     kiType <- [t| $initT |]
     koType <- [t| $polarityT |]
 
-    let vNameImpl = AppE (VarE 'vDomain) (AppTypeE (VarE 'knownDomain) (ConT name'))
-        kpImpl = mkTySynInstD ''DomainPeriod [ConT name'] kpType
-        keImpl = mkTySynInstD ''DomainActiveEdge [ConT name'] keType
-        krImpl = mkTySynInstD ''DomainResetKind [ConT name'] krType
-        kiImpl = mkTySynInstD ''DomainInitBehavior [ConT name'] kiType
-        koImpl = mkTySynInstD ''DomainResetPolarity [ConT name'] koType
-        vName' = mkName ('v':name)
+    let vNameImpl = AppE (VarE 'vDomain) (AppTypeE (VarE 'knownDomain) (ConT name))
+        kpImpl = mkTySynInstD ''DomainPeriod         [ConT name] kpType
+        kfImpl = mkTySynInstD ''DomainPeriodFraction [ConT name] kfType
+        keImpl = mkTySynInstD ''DomainActiveEdge     [ConT name] keType
+        krImpl = mkTySynInstD ''DomainResetKind      [ConT name] krType
+        kiImpl = mkTySynInstD ''DomainInitBehavior   [ConT name] kiType
+        koImpl = mkTySynInstD ''DomainResetPolarity  [ConT name] koType
+        vname = mkName ('v' : cfg.vName)
 
-    tySynExists <- isJust <$> lookupTypeName name
-    vHelperExists <- isJust <$> lookupValueName ('v':name)
+    tySynExists <- isJust <$> lookupTypeName cfg.vName
+    vHelperExists <- isJust <$> lookupValueName ('v' : cfg.vName)
 
     pure $ concat
       [
         [ -- Type declaration (ex: data System :: Domain)
-          DataD [] name' [] (Just (ConT ''Domain)) [] []
+          DataD [] name [] (Just (ConT ''Domain)) [] []
         | not tySynExists
         ]
 
       , concat
         [ -- vDomain helper (ex: vSystem = vDomain (knownDomain @System))
-          [ SigD vName' (ConT ''VDomainConfiguration)
-          , FunD vName' [Clause [] (NormalB vNameImpl) []]
+          [ SigD vname (ConT ''VDomainConfiguration)
+          , FunD vname [Clause [] (NormalB vNameImpl) []]
           ]
         | not vHelperExists
         ]
       , [ -- KnownDomain instance (ex: instance KnownDomain "System" where ...)
-          InstanceD Nothing [] kdType [kpImpl, keImpl, krImpl, kiImpl, koImpl]
+          InstanceD Nothing [] kdType
+            [kpImpl, kfImpl, keImpl, krImpl, kiImpl, koImpl]
         ]
       ]
 
   else
-    error ("Domain names should be a valid Haskell type name, not: " ++ name)
+    error $ "Domain names should be a valid Haskell type name, not: "
+         <> cfg.vName
  where
-  name' = mkName name
-  nameT   = pure (ConT name')
-  periodT = pure (LitT (NumTyLit (toInteger period)))
+  name = mkName cfg.vName
+  nameT = pure $ ConT name
+  periodT = pure $ LitT $ NumTyLit $ toInteger cfg.vPeriod
+  (numeratorT, denominatorT) =
+    let Period (n :% m) = cfg.vPeriod
+    in ( pure $ LitT $ NumTyLit $ toInteger $ n `mod` m
+       , pure $ LitT $ NumTyLit $ toInteger m
+       )
 
-  edgeT =
-    pure $
-    case edge of
-      Rising -> PromotedT 'Rising
-      Falling -> PromotedT 'Falling
+  edgeT = pure $ case cfg.vActiveEdge of
+    Rising -> PromotedT 'Rising
+    Falling -> PromotedT 'Falling
 
-  resetKindT =
-    pure $
-    case reset of
-      Asynchronous -> PromotedT 'Asynchronous
-      Synchronous -> PromotedT 'Synchronous
+  resetKindT = pure $ case cfg.vResetKind of
+    Asynchronous -> PromotedT 'Asynchronous
+    Synchronous -> PromotedT 'Synchronous
 
-  initT =
-    pure $
-    case init_ of
-      Unknown -> PromotedT 'Unknown
-      Defined -> PromotedT 'Defined
+  initT = pure $ case cfg.vInitBehavior of
+    Unknown -> PromotedT 'Unknown
+    Defined -> PromotedT 'Defined
 
-  polarityT =
-    pure $
-    case polarity of
-      ActiveHigh -> PromotedT 'ActiveHigh
-      ActiveLow -> PromotedT 'ActiveLow
-
+  polarityT = pure $ case cfg.vResetPolarity of
+    ActiveHigh -> PromotedT 'ActiveHigh
+    ActiveLow -> PromotedT 'ActiveLow
 
 type Domain = Type
 
@@ -1112,7 +1251,8 @@ tbClockGen done = Clock (done `seq` Nothing)
 --
 newtype Femtoseconds = Femtoseconds Int64
   -- No 'Integral' instance to prevent accidental picoseconds / femtoseconds mixup
-  deriving (Show, Eq, Generic, NFDataX, NFData, Lift, Ord)
+  deriving stock    (Show, Eq, Ord, Generic, Lift)
+  deriving anyclass (NFDataX, NFData)
 
 -- | Strip newtype wrapper 'Femtoseconds'
 unFemtoseconds :: Femtoseconds -> Int64
@@ -1246,10 +1386,8 @@ resetPolarityProxy
    . (KnownDomain dom, DomainResetPolarity dom ~ polarity)
   => proxy dom
   -> SResetPolarity polarity
-resetPolarityProxy _proxy =
-  case knownDomain @dom of
-    SDomainConfiguration _period _edge _sync _init polarity ->
-      polarity
+resetPolarityProxy _proxy = case knownDomain @dom of
+  cfg@SDomainConfiguration{} -> cfg.sResetPolarity
 
 -- | Convert a reset to an active high reset. Has no effect if reset is already
 -- an active high reset. Is unsafe because it can introduce:
@@ -1537,12 +1675,12 @@ delay# (Clock _) (fromEnable -> en) powerUpVal0 =
     go powerUpVal1 en
   where
     powerUpVal1 :: a
-    powerUpVal1 =
-      case knownDomainByName (Proxy @dom) of
-        SDomainConfiguration _period _edge _sync SDefined _polarity ->
-          powerUpVal0
-        SDomainConfiguration _period _edge _sync SUnknown _polarity ->
-          deepErrorX ("First value of `delay` unknown on domain " ++ show (typeRep @dom))
+    powerUpVal1 = case knownDomain @dom of
+      cfg@SDomainConfiguration{} -> case cfg.sInitBehavior of
+        SDefined -> powerUpVal0
+        SUnknown -> deepErrorX
+                  $ "First value of `delay` unknown on domain "
+                 <> show (typeRep @dom)
 
     go o (e :- es) as@(~(x :- xs)) =
       let o' = if e then x else o
@@ -1576,11 +1714,10 @@ register#
   -> Signal dom a
   -> Signal dom a
 register# clk@(Clock _) rst ena powerUpVal resetVal =
-  case knownDomainByName (Proxy @dom) of
-    SDomainConfiguration _period _edge SSynchronous _init _polarity ->
-      syncRegister# clk rst ena powerUpVal resetVal
-    SDomainConfiguration _period _edge SAsynchronous _init _polarity ->
-      asyncRegister# clk rst ena powerUpVal resetVal
+  case knownDomain @dom of
+    cfg@SDomainConfiguration{} -> case cfg.sResetKind of
+      SSynchronous -> syncRegister# clk rst ena powerUpVal resetVal
+      SAsynchronous -> asyncRegister# clk rst ena powerUpVal resetVal
 {-# OPAQUE register# #-}
 {-# ANN register# hasBlackBox #-}
 
@@ -1595,10 +1732,12 @@ registerPowerup#
   -> a
   -> a
 registerPowerup# (Clock _) a =
-  case knownDomainByName (Proxy @dom) of
-    SDomainConfiguration _period _edge _sync SDefined _polarity -> a
-    SDomainConfiguration _period _edge _sync SUnknown _polarity ->
-      deepErrorX ("First value of register undefined on domain " ++ show (typeRep @dom))
+  case knownDomain @dom of
+    cfg@SDomainConfiguration{} -> case cfg.sInitBehavior of
+      SDefined -> a
+      SUnknown -> deepErrorX
+                $ "First value of register undefined on domain "
+               <> show (typeRep @dom)
 
 -- | Version of 'register#' that simulates a register on an asynchronous
 -- domain. Is synthesizable.
@@ -2037,8 +2176,13 @@ simulate_lazy f = sample_lazy . f . fromList_lazy
 --
 -- I.e., to calculate the clock period for a circuit to run at 240 MHz we get
 --
--- >>> hzToPeriod 240e6
--- 4166
+-- >>> hzToPeriod @Period 240e6
+-- 4166 + 2/3 ps
+--
+-- The 'Period' type application is optional, but recommended if no other type
+-- is enforced by the context. Otherwise, GHC most likely will default to
+-- 'GHC.Types.Double', which is imprecise in comparison to @Period@ being
+-- defined as a newtype over @Ratio Natural@ instead.
 --
 -- If the value @hzToPeriod@ is applied to is not of the type 'Ratio'
 -- 'Natural', you can use @hzToPeriod ('realToFrac' f)@. Note that if @f@ is
@@ -2046,17 +2190,24 @@ simulate_lazy f = sample_lazy . f . fromList_lazy
 -- t'Control.Exception.ArithException'@ without a call stack, making debugging
 -- cumbersome.
 --
--- Before Clash 1.8, this function always returned a 'Natural'. To get the old
--- behavior of this function, use a type application:
+-- Before Clash 1.12, this function always returned an 'Integral' type with
+-- the result being rounded down. To get back this behavior of the function
+-- combine it with 'floor':
 --
--- >>> hzToPeriod @Natural 240e6
+-- >>> floor (hzToPeriod @Period 240e6)
+-- 4166
+--
+-- Before Clash 1.8, this function always returned a 'Natural'. To get back
+-- this behavior of the function combine it with 'floor' and use a type
+-- application:
+--
+-- >>> floor @_ @Natural (hzToPeriod @Period 240e6)
 -- 4166
 --
 -- * __NB__: This function is not synthesizable
--- * __NB__: This function is lossy. I.e., @periodToHz . hzToPeriod /= id@.
-hzToPeriod :: (HasCallStack, Integral a) => Ratio Natural -> a
+hzToPeriod :: (HasCallStack, Fractional a) => Ratio Natural -> a
 hzToPeriod freq
-  | freq > 0  = floor ((1.0 / freq) / 1e-12)
+  | freq > 0  = fromRational $ toRational $ (1.0 / freq) / 1e-12
   | otherwise = withFrozenCallStack $ error "Zero frequency"
 
 -- | Calculate the period in __fs__, given a frequency in __Hz__
@@ -2091,16 +2242,23 @@ hzToFs freq
 -- t'Control.Exception.ArithException'@ without a call stack, making debugging
 -- cumbersome.
 --
--- Before Clash 1.8, this function always returned a 'Ratio'
--- 'Natural'. To get the old behavior of this function, use a type application:
+-- Before Clash 1.12, this function always received a 'Natural'. To get the
+-- old behavior of the function use a type application:
 --
--- >>> periodToHz @(Ratio Natural) 5000
+-- >>> periodToHz @Natural 5000
+-- 2.0e8
+--
+-- Before Clash 1.8, this function always received a 'Natural' and returned a
+-- 'Ratio' 'Natural'. To get the old behavior of the function use type
+-- applications:
+--
+-- >>> periodToHz @Natural @(Ratio Natural) 5000
 -- 200000000 % 1
 --
 -- __NB__: This function is not synthesizable
-periodToHz :: (HasCallStack, Fractional a) => Natural -> a
+periodToHz :: (HasCallStack, Real a, Fractional b) => a -> b
 periodToHz period
-  | period > 0 = fromRational $ 1.0 / (fromIntegral period * 1e-12)
+  | period > 0 = fromRational $ 1.0 / (toRational period * 1e-12)
   | otherwise  = withFrozenCallStack $ error "Zero period"
 
 -- | Calculate the frequency in __Hz__, given the period in __fs__

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -180,7 +180,9 @@ where
 
 import Data.IORef                 (IORef, atomicModifyIORef, newIORef, readIORef)
 #if __GLASGOW_HASKELL__ < 912
-import Type.Reflection            (Typeable)
+import Type.Reflection            (Typeable, typeRep)
+#else
+import Type.Reflection            (typeRep)
 #endif
 import Control.Arrow.Transformer.Automaton
 import Control.Applicative        (liftA3)
@@ -196,14 +198,14 @@ import Data.Int                   (Int64)
 import Data.Maybe                 (isJust)
 import Data.Proxy                 (Proxy(..))
 import Data.Ratio                 (Ratio)
-import Data.Type.Equality         ((:~:))
+import Data.Type.Equality         ((:~:), testEquality)
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack, withFrozenCallStack)
-import GHC.TypeLits
-  (Div, KnownSymbol, KnownNat, Nat, Symbol, type (<=), type (*), type (-), sameSymbol)
+import GHC.Types                  (Type)
+import GHC.TypeLits               (Div, KnownNat, Nat, type (<=), type (*), type (-))
 import GHC.TypeLits.Extra         (DivRU)
 import GHC.Records                (HasField(getField))
-import Language.Haskell.TH.Syntax -- (Lift (..), Q, Dec)
+import Language.Haskell.TH.Syntax hiding (Type) -- (Lift (..), Q, Dec)
 import Language.Haskell.TH.Compat
 import Numeric.Natural            (Natural)
 import CheckedLiterals.Class.Integer
@@ -222,7 +224,6 @@ import Clash.Class.Num            (SaturatingNum(..))
 import Clash.CPP                  (fStrictMapSignal)
 import Clash.NamedTypes
 import Clash.Promoted.Nat         (SNat (..), snatToNum, snatToNatural)
-import Clash.Promoted.Symbol      (SSymbol (..), ssymbolToString)
 import Clash.XException
   (NFDataX(..), errorX, isX, deepseqX, defaultSeqX, seqX)
 
@@ -454,9 +455,7 @@ type ClockDivider (dom :: Domain) (period :: Nat) = PeriodToCycles dom period
 data SDomainConfiguration (dom :: Domain) (conf :: DomainConfiguration) where
   SDomainConfiguration ::
     1 <= period =>
-    { sName :: SSymbol dom
-      -- ^ Domain name
-    , sPeriod :: SNat period
+    { sPeriod :: SNat period
     -- ^ Period of clock in /ps/
     , sActiveEdge :: SActiveEdge edge
     -- ^ Active edge of the clock (not yet implemented)
@@ -509,7 +508,7 @@ type KnownConf dom = 'DomainConfiguration dom
 -- | A 'KnownDomain' constraint indicates that a circuit's behavior depends on
 -- some properties of a domain. See 'DomainConfiguration' for more information.
 class
-  ( KnownSymbol dom
+  ( Typeable dom
   , KnownNat (DomainPeriod dom)
   , KnownNat (DomainPeriod dom - 1)
   , KnownActiveEdge (DomainActiveEdge dom)
@@ -533,8 +532,7 @@ class
 -- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
 knownDomain :: KnownDomain dom => SDomainConfiguration dom (KnownConf dom)
 knownDomain = SDomainConfiguration
-  { sName          = SSymbol
-  , sPeriod        = SNat
+  { sPeriod        = SNat
   , sActiveEdge    = knownActiveEdge
   , sResetKind     = knownResetKind
   , sInitBehavior  = knownInitBehavior
@@ -548,7 +546,7 @@ knownDomain = SDomainConfiguration
 knownDomainByName
   :: forall dom
    . KnownDomain dom
-  => SSymbol dom
+  => Proxy dom
   -> SDomainConfiguration dom (KnownConf dom)
 knownDomainByName =
   const knownDomain
@@ -593,8 +591,7 @@ vSystem = vDomain (knownDomain @System)
 --
 -- See module documentation of "Clash.Explicit.Signal" for more information on
 -- how to create custom synthesis domains.
-type System = ("System" :: Domain)
-
+data System
 
 -- | Convenience value to allow easy "subclassing" of IntelSystem domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
@@ -611,7 +608,7 @@ vIntelSystem = vDomain (knownDomain @IntelSystem)
 --
 -- See module documentation of "Clash.Explicit.Signal" for more information on
 -- how to create custom synthesis domains.
-type IntelSystem = ("IntelSystem" :: Domain)
+data IntelSystem
 
 -- | Convenience value to allow easy "subclassing" of XilinxSystem domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
@@ -628,7 +625,7 @@ vXilinxSystem = vDomain (knownDomain @XilinxSystem)
 --
 -- See module documentation of "Clash.Explicit.Signal" for more information on
 -- how to create custom synthesis domains.
-type XilinxSystem = ("XilinxSystem" :: Domain)
+data XilinxSystem
 
 -- | Same as SDomainConfiguration but allows for easy updates through record update syntax.
 -- Should be used in combination with 'vDomain' and 'createDomain'. Example:
@@ -660,10 +657,14 @@ data VDomainConfiguration
 
 -- | Convert 'SDomainConfiguration' to 'VDomainConfiguration'. Should be used in combination with
 -- 'createDomain' only.
-vDomain :: SDomainConfiguration dom conf -> VDomainConfiguration
-vDomain (SDomainConfiguration dom period edge reset init_ polarity) =
+vDomain ::
+  forall dom conf.
+  Typeable dom =>
+  SDomainConfiguration dom conf ->
   VDomainConfiguration
-    (ssymbolToString dom)
+vDomain (SDomainConfiguration period edge reset init_ polarity) =
+  VDomainConfiguration
+    (show (typeRep @dom))
     (snatToNatural period)
     (case edge of {SRising -> Rising; SFalling -> Falling})
     (case reset of {SAsynchronous -> Asynchronous; SSynchronous -> Synchronous})
@@ -715,12 +716,12 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
     kiType <- [t| $initT |]
     koType <- [t| $polarityT |]
 
-    let vNameImpl = AppE (VarE 'vDomain) (AppTypeE (VarE 'knownDomain) (LitT (StrTyLit name)))
-        kpImpl = mkTySynInstD ''DomainPeriod [LitT (StrTyLit name)] kpType
-        keImpl = mkTySynInstD ''DomainActiveEdge [LitT (StrTyLit name)] keType
-        krImpl = mkTySynInstD ''DomainResetKind [LitT (StrTyLit name)] krType
-        kiImpl = mkTySynInstD ''DomainInitBehavior [LitT (StrTyLit name)] kiType
-        koImpl = mkTySynInstD ''DomainResetPolarity [LitT (StrTyLit name)] koType
+    let vNameImpl = AppE (VarE 'vDomain) (AppTypeE (VarE 'knownDomain) (ConT name'))
+        kpImpl = mkTySynInstD ''DomainPeriod [ConT name'] kpType
+        keImpl = mkTySynInstD ''DomainActiveEdge [ConT name'] keType
+        krImpl = mkTySynInstD ''DomainResetKind [ConT name'] krType
+        kiImpl = mkTySynInstD ''DomainInitBehavior [ConT name'] kiType
+        koImpl = mkTySynInstD ''DomainResetPolarity [ConT name'] koType
         vName' = mkName ('v':name)
 
     tySynExists <- isJust <$> lookupTypeName name
@@ -728,8 +729,8 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
 
     pure $ concat
       [
-        [ -- Type synonym (ex: type System = "System")
-          TySynD (mkName name) [] (LitT (StrTyLit name)  `SigT`  ConT ''Domain)
+        [ -- Type declaration (ex: data System :: Domain)
+          DataD [] name' [] (Just (ConT ''Domain)) [] []
         | not tySynExists
         ]
 
@@ -748,8 +749,8 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
   else
     error ("Domain names should be a valid Haskell type name, not: " ++ name)
  where
-
-  nameT   = pure (LitT (StrTyLit name))
+  name' = mkName name
+  nameT   = pure (ConT name')
   periodT = pure (LitT (NumTyLit (toInteger period)))
 
   edgeT =
@@ -777,7 +778,7 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
       ActiveLow -> PromotedT 'ActiveLow
 
 
-type Domain = Symbol
+type Domain = Type
 
 -- | We either get evidence that this function was instantiated with the same
 -- domains, or Nothing.
@@ -785,7 +786,7 @@ sameDomain
   :: forall (domA :: Domain) (domB :: Domain)
    . (KnownDomain domA, KnownDomain domB)
   => Maybe (domA :~: domB)
-sameDomain = sameSymbol (Proxy @domA) (Proxy @domB)
+sameDomain = testEquality (typeRep @domA) (typeRep @domB)
 
 infixr 5 :-
 {- | Clash has synchronous 'Signal's in the form of:
@@ -1002,26 +1003,23 @@ enableGen = toEnable (pure True)
 
 -- | A clock signal belonging to a domain named /dom/.
 data Clock (dom :: Domain) = Clock
-  { -- | Domain associated with the clock
-    clockTag :: SSymbol dom
-
-    -- | Periods of the clock. This is an experimental feature used to simulate
+  { -- | Periods of the clock. This is an experimental feature used to simulate
     -- clock frequency correction mechanisms. Currently, all ways to contruct
     -- such a clock are hidden from the public API.
-  , clockPeriods :: Maybe (Signal dom Femtoseconds)
+    clockPeriods :: Maybe (Signal dom Femtoseconds)
   }
 
-instance Show (Clock dom) where
-  show (Clock dom Nothing) = "<Clock: " ++ ssymbolToString dom ++ ">"
-  show (Clock dom _) = "<Dynamic clock: " ++ ssymbolToString dom ++ ">"
+instance Typeable dom => Show (Clock dom) where
+  show (Clock Nothing) = "<Clock: " ++ show (typeRep @dom) ++ ">"
+  show (Clock _) = "<Dynamic clock: " ++ show (typeRep @dom) ++ ">"
 
 -- | The negative or inverted phase of a differential clock signal. HDL
 -- generation will treat it the same as 'Clock', except that no @create_clock@
 -- command is issued in the SDC file for 'ClockN'. Used in 'DiffClock'.
-newtype ClockN (dom :: Domain) = ClockN { clockNTag :: SSymbol dom }
+newtype ClockN (dom :: Domain) = ClockN { clockNTag :: Proxy dom }
 
-instance Show (ClockN dom) where
-  show (ClockN dom) = "<ClockN: " ++ ssymbolToString dom ++ ">"
+instance Typeable dom => Show (ClockN dom) where
+  show (ClockN _) = "<ClockN: " ++ show (typeRep @dom) ++ ">"
 
 -- | A differential clock signal belonging to a domain named /dom/. The clock
 -- input of a design with such an input has two ports which are in antiphase.
@@ -1034,11 +1032,11 @@ instance Show (ClockN dom) where
 data DiffClock (dom :: Domain) =
   DiffClock ("p" ::: Clock dom) ("n" ::: ClockN dom)
 
-instance Show (DiffClock dom) where
-  show (DiffClock (Clock dom Nothing) _) =
-    "<DiffClock: " ++ ssymbolToString dom ++ ">"
-  show (DiffClock (Clock dom _) _) =
-    "<Dynamic DiffClock: " ++ ssymbolToString dom ++ ">"
+instance Typeable dom => Show (DiffClock dom) where
+  show (DiffClock (Clock Nothing) _) =
+    "<DiffClock: " ++ show (typeRep @dom) ++ ">"
+  show (DiffClock (Clock _) _) =
+    "<Dynamic DiffClock: " ++ show (typeRep @dom) ++ ">"
 
 -- | Clock generator for simulations. Do __not__ use this clock generator for
 -- the /testBench/ function, use 'tbClockGen' instead.
@@ -1106,7 +1104,7 @@ tbClockGen
   :: KnownDomain testDom
   => Signal testDom Bool
   -> Clock testDom
-tbClockGen done = Clock (done `seq` SSymbol) Nothing
+tbClockGen done = Clock (done `seq` Nothing)
 {-# OPAQUE tbClockGen #-}
 {-# ANN tbClockGen hasBlackBox #-}
 
@@ -1184,7 +1182,7 @@ tbDynamicClockGen ::
   Signal dom Bool ->
   Clock dom
 tbDynamicClockGen periods ena =
-  Clock (ena `seq` periods `seq` SSymbol) (Just periods)
+  Clock (ena `seq` periods `seq` Just periods)
 {-# OPAQUE tbDynamicClockGen #-}
 {-# ANN tbDynamicClockGen hasBlackBox #-}
 
@@ -1251,7 +1249,7 @@ resetPolarityProxy
   -> SResetPolarity polarity
 resetPolarityProxy _proxy =
   case knownDomain @dom of
-    SDomainConfiguration _dom _period _edge _sync _init polarity ->
+    SDomainConfiguration _period _edge _sync _init polarity ->
       polarity
 
 -- | Convert a reset to an active high reset. Has no effect if reset is already
@@ -1536,16 +1534,16 @@ delay#
   -> a
   -> Signal dom a
   -> Signal dom a
-delay# (Clock dom _) (fromEnable -> en) powerUpVal0 =
+delay# (Clock _) (fromEnable -> en) powerUpVal0 =
     go powerUpVal1 en
   where
     powerUpVal1 :: a
     powerUpVal1 =
-      case knownDomainByName dom of
-        SDomainConfiguration _dom _period _edge _sync SDefined _polarity ->
+      case knownDomainByName (Proxy @dom) of
+        SDomainConfiguration _period _edge _sync SDefined _polarity ->
           powerUpVal0
-        SDomainConfiguration _dom _period _edge _sync SUnknown _polarity ->
-          deepErrorX ("First value of `delay` unknown on domain " ++ show dom)
+        SDomainConfiguration _period _edge _sync SUnknown _polarity ->
+          deepErrorX ("First value of `delay` unknown on domain " ++ show (typeRep @dom))
 
     go o (e :- es) as@(~(x :- xs)) =
       let o' = if e then x else o
@@ -1578,11 +1576,11 @@ register#
   -- ^ Reset value
   -> Signal dom a
   -> Signal dom a
-register# clk@(Clock dom _) rst ena powerUpVal resetVal =
-  case knownDomainByName dom of
-    SDomainConfiguration _name _period _edge SSynchronous _init _polarity ->
+register# clk@(Clock _) rst ena powerUpVal resetVal =
+  case knownDomainByName (Proxy @dom) of
+    SDomainConfiguration _period _edge SSynchronous _init _polarity ->
       syncRegister# clk rst ena powerUpVal resetVal
-    SDomainConfiguration _name _period _edge SAsynchronous _init _polarity ->
+    SDomainConfiguration _period _edge SAsynchronous _init _polarity ->
       asyncRegister# clk rst ena powerUpVal resetVal
 {-# OPAQUE register# #-}
 {-# ANN register# hasBlackBox #-}
@@ -1597,11 +1595,11 @@ registerPowerup#
   => Clock dom
   -> a
   -> a
-registerPowerup# (Clock dom _) a =
-  case knownDomainByName dom of
-    SDomainConfiguration _dom _period _edge _sync SDefined _polarity -> a
-    SDomainConfiguration _dom _period _edge _sync SUnknown _polarity ->
-      deepErrorX ("First value of register undefined on domain " ++ show dom)
+registerPowerup# (Clock _) a =
+  case knownDomainByName (Proxy @dom) of
+    SDomainConfiguration _period _edge _sync SDefined _polarity -> a
+    SDomainConfiguration _period _edge _sync SUnknown _polarity ->
+      deepErrorX ("First value of register undefined on domain " ++ show (typeRep @dom))
 
 -- | Version of 'register#' that simulates a register on an asynchronous
 -- domain. Is synthesizable.
@@ -2186,7 +2184,7 @@ clockTicks clkA clkB = clockTicksEither (toEither clkA) (toEither clkB)
     KnownDomain dom =>
     Clock dom ->
     Either Int64 (Signal dom Int64)
-  toEither (Clock _ maybePeriods)
+  toEither (Clock maybePeriods)
     | Just periods <- maybePeriods =
         Right (unFemtosecondsSignal periods)
     | SDomainConfiguration{sPeriod} <- knownDomain @dom =

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -45,7 +45,9 @@ module Clash.Signal.Internal
   , Domain
   , sameDomain
   , KnownDomain(..)
+  , KnownConf
   , KnownConfiguration
+  , knownDomain
   , knownDomainByName
   , ActiveEdge(..)
   , SActiveEdge(..)
@@ -58,18 +60,11 @@ module Clash.Signal.Internal
   , DomainConfiguration(..)
   , SDomainConfiguration(..)
   -- ** Configuration type families
-  , DomainPeriod
-  , DomainActiveEdge
-  , DomainResetKind
-  , DomainInitBehavior
-  , DomainResetPolarity
-
   , DomainConfigurationPeriod
   , DomainConfigurationActiveEdge
   , DomainConfigurationResetKind
   , DomainConfigurationInitBehavior
   , DomainConfigurationResetPolarity
-
   -- *** Convenience types
   , HasSynchronousReset
   , HasAsynchronousReset
@@ -205,7 +200,7 @@ import Data.Type.Equality         ((:~:))
 import GHC.Generics               (Generic)
 import GHC.Stack                  (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits
-  (Div, KnownSymbol, KnownNat, Nat, Symbol, type (<=), type (*), sameSymbol)
+  (Div, KnownSymbol, KnownNat, Nat, Symbol, type (<=), type (*), type (-), sameSymbol)
 import GHC.TypeLits.Extra         (DivRU)
 import GHC.Records                (HasField(getField))
 import Language.Haskell.TH.Syntax -- (Lift (..), Q, Dec)
@@ -380,32 +375,6 @@ type family DomainConfigurationInitBehavior (config :: DomainConfiguration) :: I
 type family DomainConfigurationResetPolarity (config :: DomainConfiguration) :: ResetPolarity where
   DomainConfigurationResetPolarity ('DomainConfiguration name period edge reset init polarity) = polarity
 
--- | Convenience type to help to extract a period from a domain. Example usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainPeriod dom ~ 6000) => ...
--- @
-type DomainPeriod (dom :: Domain) =
-  DomainConfigurationPeriod (KnownConf dom)
-
--- | Convenience type to help to extract the active edge from a domain. Example
--- usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainActiveEdge dom ~ 'Rising) => ...
--- @
-type DomainActiveEdge (dom :: Domain) =
-  DomainConfigurationActiveEdge (KnownConf dom)
-
--- | Convenience type to help to extract the reset synchronicity from a
--- domain. Example usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainResetKind dom ~ 'Synchronous) => ...
--- @
-type DomainResetKind (dom :: Domain) =
-  DomainConfigurationResetKind (KnownConf dom)
-
 -- | Convenience type to constrain a domain to have synchronous resets. Example
 -- usage:
 --
@@ -432,15 +401,6 @@ type HasSynchronousReset (dom :: Domain) =
 type HasAsynchronousReset (dom :: Domain) =
   (KnownDomain dom, DomainResetKind dom ~ 'Asynchronous)
 
--- | Convenience type to help to extract the initial value behavior from a
--- domain. Example usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainInitBehavior dom ~ 'Defined) => ...
--- @
-type DomainInitBehavior (dom :: Domain) =
-  DomainConfigurationInitBehavior (KnownConf dom)
-
 -- | Convenience type to constrain a domain to have initial values. Example
 -- usage:
 --
@@ -456,15 +416,6 @@ type DomainInitBehavior (dom :: Domain) =
 -- [Click here for usage hints]("Clash.Explicit.Signal#g:conveniencetypes")
 type HasDefinedInitialValues (dom :: Domain) =
   (KnownDomain dom, DomainInitBehavior dom ~ 'Defined)
-
--- | Convenience type to help to extract the reset polarity from a domain.
--- Example usage:
---
--- @
--- myFunc :: (KnownDomain dom, DomainResetPolarity dom ~ 'ActiveHigh) => ...
--- @
-type DomainResetPolarity (dom :: Domain) =
-  DomainConfigurationResetPolarity (KnownConf dom)
 
 -- * Time representation
 
@@ -522,17 +473,73 @@ deriving instance Show (SDomainConfiguration dom conf)
 
 type KnownConfiguration dom conf = (KnownDomain dom, KnownConf dom ~ conf)
 
+-- | Evidence for the active edge to be known.
+class KnownActiveEdge (edge :: ActiveEdge) where
+  knownActiveEdge :: SActiveEdge edge
+instance KnownActiveEdge Rising  where knownActiveEdge = SRising
+instance KnownActiveEdge Falling where knownActiveEdge = SFalling
+
+-- | Evidence for the reset kind to be known.
+class KnownResetKind (resetKind :: ResetKind) where
+  knownResetKind :: SResetKind resetKind
+instance KnownResetKind Asynchronous where knownResetKind = SAsynchronous
+instance KnownResetKind Synchronous  where knownResetKind = SSynchronous
+
+-- | Evidence for the init behavior to be known.
+class KnownInitBehavior (init :: InitBehavior) where
+  knownInitBehavior :: SInitBehavior init
+instance KnownInitBehavior Unknown where knownInitBehavior = SUnknown
+instance KnownInitBehavior Defined where knownInitBehavior = SDefined
+
+-- | Evidence for the reset polarity to be known.
+class KnownResetPolarity (polarity :: ResetPolarity) where
+  knownResetPolarity :: SResetPolarity polarity
+instance KnownResetPolarity ActiveLow  where knownResetPolarity = SActiveLow
+instance KnownResetPolarity ActiveHigh where knownResetPolarity = SActiveHigh
+
+-- | The configuration parameters of a known domain given as a
+-- 'DomainConfiguration'.
+type KnownConf dom = 'DomainConfiguration dom
+  (DomainPeriod dom)
+  (DomainActiveEdge dom)
+  (DomainResetKind dom)
+  (DomainInitBehavior dom)
+  (DomainResetPolarity dom)
+
 -- | A 'KnownDomain' constraint indicates that a circuit's behavior depends on
 -- some properties of a domain. See 'DomainConfiguration' for more information.
-class (KnownSymbol dom, KnownNat (DomainPeriod dom)) => KnownDomain (dom :: Domain) where
-  type KnownConf dom :: DomainConfiguration
-  -- | Returns 'SDomainConfiguration' corresponding to an instance's 'DomainConfiguration'.
-  --
-  -- Example usage:
-  --
-  -- >>> knownDomain @System
-  -- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
-  knownDomain :: SDomainConfiguration dom (KnownConf dom)
+class
+  ( KnownSymbol dom
+  , KnownNat (DomainPeriod dom)
+  , KnownNat (DomainPeriod dom - 1)
+  , KnownActiveEdge (DomainActiveEdge dom)
+  , KnownResetKind (DomainResetKind dom)
+  , KnownInitBehavior (DomainInitBehavior dom)
+  , KnownResetPolarity (DomainResetPolarity dom)
+  ) =>
+  KnownDomain (dom :: Domain)
+ where
+  type DomainPeriod dom :: Nat
+  type DomainActiveEdge dom :: ActiveEdge
+  type DomainResetKind dom :: ResetKind
+  type DomainInitBehavior dom :: InitBehavior
+  type DomainResetPolarity dom :: ResetPolarity
+
+-- | Returns 'SDomainConfiguration' corresponding to an instance's 'KnownDomain'.
+--
+-- Example usage:
+--
+-- >>> knownDomain @System
+-- SDomainConfiguration {sName = SSymbol @"System", sPeriod = SNat @10000, sActiveEdge = SRising, sResetKind = SAsynchronous, sInitBehavior = SDefined, sResetPolarity = SActiveHigh}
+knownDomain :: KnownDomain dom => SDomainConfiguration dom (KnownConf dom)
+knownDomain = SDomainConfiguration
+  { sName          = SSymbol
+  , sPeriod        = SNat
+  , sActiveEdge    = knownActiveEdge
+  , sResetKind     = knownResetKind
+  , sInitBehavior  = knownInitBehavior
+  , sResetPolarity = knownResetPolarity
+  }
 
 -- | Version of 'knownDomain' that takes a 'SSymbol'. For example:
 --
@@ -549,18 +556,27 @@ knownDomainByName =
 
 -- | A /clock/ (and /reset/) dom with clocks running at 100 MHz
 instance KnownDomain System where
-  type KnownConf System = 'DomainConfiguration System 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+  type DomainPeriod System        = 10000
+  type DomainActiveEdge System    = 'Rising
+  type DomainResetKind System     = 'Asynchronous
+  type DomainInitBehavior System  = 'Defined
+  type DomainResetPolarity System = 'ActiveHigh
 
 -- | System instance with defaults set for Xilinx FPGAs
 instance KnownDomain XilinxSystem where
-  type KnownConf XilinxSystem = 'DomainConfiguration XilinxSystem 10000 'Rising 'Synchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SSynchronous SDefined SActiveHigh
+  type DomainPeriod XilinxSystem        = 10000
+  type DomainActiveEdge XilinxSystem    = 'Rising
+  type DomainResetKind XilinxSystem     = 'Synchronous
+  type DomainInitBehavior XilinxSystem  = 'Defined
+  type DomainResetPolarity XilinxSystem = 'ActiveHigh
 
 -- | System instance with defaults set for Intel FPGAs
 instance KnownDomain IntelSystem where
-  type KnownConf IntelSystem = 'DomainConfiguration IntelSystem 10000 'Rising 'Asynchronous 'Defined 'ActiveHigh
-  knownDomain = SDomainConfiguration SSymbol SNat SRising SAsynchronous SDefined SActiveHigh
+  type DomainPeriod IntelSystem        = 10000
+  type DomainActiveEdge IntelSystem    = 'Rising
+  type DomainResetKind IntelSystem     = 'Asynchronous
+  type DomainInitBehavior IntelSystem  = 'Defined
+  type DomainResetPolarity IntelSystem = 'ActiveHigh
 
 -- | Convenience value to allow easy "subclassing" of System domain. Should
 -- be used in combination with 'createDomain'. For example, if you just want to
@@ -693,12 +709,18 @@ createDomain :: VDomainConfiguration -> Q [Dec]
 createDomain (VDomainConfiguration name period edge reset init_ polarity) =
   if isValidDomainName name then do
     kdType <- [t| KnownDomain $nameT |]
-    kcType <- [t| ('DomainConfiguration $nameT $periodT $edgeT $resetKindT $initT $polarityT) |]
-    sDom <- [| SDomainConfiguration SSymbol SNat $edgeE $resetKindE $initE $polarityE |]
+    kpType <- [t| $periodT |]
+    keType <- [t| $edgeT |]
+    krType <- [t| $resetKindT |]
+    kiType <- [t| $initT |]
+    koType <- [t| $polarityT |]
 
     let vNameImpl = AppE (VarE 'vDomain) (AppTypeE (VarE 'knownDomain) (LitT (StrTyLit name)))
-        kdImpl = FunD 'knownDomain [Clause [] (NormalB sDom) []]
-        kcImpl = mkTySynInstD ''KnownConf [LitT (StrTyLit name)] kcType
+        kpImpl = mkTySynInstD ''DomainPeriod [LitT (StrTyLit name)] kpType
+        keImpl = mkTySynInstD ''DomainActiveEdge [LitT (StrTyLit name)] keType
+        krImpl = mkTySynInstD ''DomainResetKind [LitT (StrTyLit name)] krType
+        kiImpl = mkTySynInstD ''DomainInitBehavior [LitT (StrTyLit name)] kiType
+        koImpl = mkTySynInstD ''DomainResetPolarity [LitT (StrTyLit name)] koType
         vName' = mkName ('v':name)
 
     tySynExists <- isJust <$> lookupTypeName name
@@ -719,37 +741,13 @@ createDomain (VDomainConfiguration name period edge reset init_ polarity) =
         | not vHelperExists
         ]
       , [ -- KnownDomain instance (ex: instance KnownDomain "System" where ...)
-          InstanceD Nothing [] kdType [kcImpl, kdImpl]
+          InstanceD Nothing [] kdType [kpImpl, keImpl, krImpl, kiImpl, koImpl]
         ]
       ]
 
   else
     error ("Domain names should be a valid Haskell type name, not: " ++ name)
  where
-
-  edgeE =
-    pure $
-    case edge of
-      Rising -> ConE 'SRising
-      Falling -> ConE 'SFalling
-
-  resetKindE =
-    pure $
-    case reset of
-      Asynchronous -> ConE 'SAsynchronous
-      Synchronous -> ConE 'SSynchronous
-
-  initE =
-    pure $
-    case init_ of
-      Unknown -> ConE 'SUnknown
-      Defined -> ConE 'SDefined
-
-  polarityE =
-    pure $
-    case polarity of
-      ActiveHigh -> ConE 'SActiveHigh
-      ActiveLow -> ConE 'SActiveLow
 
   nameT   = pure (LitT (StrTyLit name))
   periodT = pure (LitT (NumTyLit (toInteger period)))

--- a/clash-prelude/src/Clash/Signal/Internal/IntegralPeriodProperties.agda
+++ b/clash-prelude/src/Clash/Signal/Internal/IntegralPeriodProperties.agda
@@ -1,0 +1,529 @@
+-------------------------------------------------------------------------------
+-- Copyright  :  © 2026, Felix Klein
+-- License    :  BSD2 (see the file LICENSE)
+-- Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+--
+-- Proven properties of the `Integral Period` instance in
+-- `Clash.Signal.Internal`.
+-------------------------------------------------------------------------------
+
+open import Function.Base using (_$_)
+open import Data.Sum.Base using (inj₂)
+open import Data.Sign.Base as Sign using ()
+open import Data.Nat.Base as ℕ using (ℕ; suc)
+open import Data.Nat.Properties as ℕ using ()
+open import Data.Nat.GCD as ℕ using ()
+open import Data.Nat.DivMod as ℕ using (/-congʳ; /-congˡ; m*n/m*o≡n/o)
+open import Data.Integer.Base as ℤ using (ℤ; 1ℤ; +_; -[1+_]; +[1+_]; +0; ∣_∣)
+open import Data.Integer.Properties as ℤ using ()
+open import Data.Integer.GCD as ℤ using (gcd; gcd-zeroʳ)
+open import Data.Integer.DivMod using (a≡a%ℕn+[a/ℕn]*n; div-neg-is-neg-/ℕ; n%d<d)
+open import Data.Rational as ℚ hiding (∣_∣)
+open import Data.Rational.Properties
+open import Relation.Binary.PropositionalEquality.Core using (_≡_)
+open import Relation.Binary.PropositionalEquality
+
+-------------------------------------------------------------------------------
+-- Common Properties of Rationals
+-------------------------------------------------------------------------------
+--
+--  The following are common properties over rationals, which however are
+--  not part of the used `agda-stdlib` v2.3. A PR to add them has been
+--  accepted upstream (https://github.com/agda/agda-stdlib/pull/2996), which
+--  is why they can be assumed obsolete when using `agda-stlib` > v2.4.
+--
+-------------------------------------------------------------------------------
+
+↥[i/1]≡i : (i : ℤ) → ↥ (i / 1) ≡ i
+↥[i/1]≡i i = begin
+    ↥ (i / 1)              ≡⟨ ℤ.*-identityʳ (↥ (i / 1)) ⟨
+    ↥ (i / 1) ℤ.* 1ℤ       ≡⟨ cong (↥ (i / 1) ℤ.*_) $ gcd-zeroʳ i ⟨
+    ↥ (i / 1) ℤ.* gcd i 1ℤ ≡⟨ ↥-/ i 1 ⟩
+    i                      ∎
+  where open ≡-Reasoning
+
+
+↧ₙ[i/1]≡1 : (i : ℤ) → ↧ₙ (i / 1) ≡ 1
+↧ₙ[i/1]≡1 i = ℤ.+-injective $ begin
+    ↧ (i / 1)               ≡⟨ ℤ.*-identityʳ (↧ (i / 1)) ⟨
+    ↧ (i / 1) ℤ.* 1ℤ        ≡⟨ cong (↧ (i / 1) ℤ.*_) $ gcd-zeroʳ i ⟨
+    ↧ (i / 1) ℤ.* gcd i 1ℤ  ≡⟨ ↧-/ i 1 ⟩
+    1ℤ                      ∎
+  where open ≡-Reasoning
+
+n/n≡1 : ∀ (n : ℕ) .{{_ : ℕ.NonZero n}} → + n / n ≡ 1ℚ
+n/n≡1 n {{nz}} = mkℚ+-cong n/gcd[n,n]≡1 n/gcd[n,n]≡1
+  where
+  instance g≢0   = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 n n (inj₂ (ℕ.≢-nonZero⁻¹ n)))
+           n/g≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 n n {{gcd≢0 = g≢0}})
+
+  gcd[n,n]≡n : ∀ n → ℕ.gcd n n ≡ n
+  gcd[n,n]≡n n = begin
+    ℕ.gcd n n                 ≡⟨ cong₂ ℕ.gcd n*1≡n n*1≡n ⟨
+    ℕ.gcd (n ℕ.* 1) (n ℕ.* 1) ≡⟨ ℕ.c*gcd[m,n]≡gcd[cm,cn] n 1 1 ⟨
+    n ℕ.* ℕ.gcd 1 1           ≡⟨ n*1≡n ⟩
+    n                         ∎
+    where
+    open ≡-Reasoning
+    n*1≡n = ℕ.*-identityʳ n
+
+  n/gcd[n,n]≡1
+    = trans (ℕ./-congʳ {ℕ.gcd n n} (gcd[n,n]≡n n)) (ℕ.n/n≡1 n {{nz}})
+
+-i/n≡-[i/n] : ∀ (i : ℤ) (n : ℕ) .{{_ : ℕ.NonZero n}} →
+              ℤ.- i / n ≡ - (i / n)
+-i/n≡-[i/n] +0       n = trans (0/n≡0 n) (cong -_ (sym (0/n≡0 n)))
+-i/n≡-[i/n] +[1+ m ] n = refl
+-i/n≡-[i/n] -[1+ m ] n
+  with +[1+ m ] / n
+... | mkℚ -[1+ a ] d prf = refl
+... | mkℚ +0       d prf = refl
+... | mkℚ +[1+ a ] d prf = refl
+
+*-cancelˡ-/ : ∀ p {q r} .{{_ : ℕ.NonZero r}} .{{_ : ℕ.NonZero (p ℕ.* r)}} →
+              (+ p ℤ.* q) / (p ℕ.* r) ≡ q / r
+*-cancelˡ-/ p {q} {r} = proof q
+  where
+  open ≡-Reasoning
+
+  *-cancelˡ-/-helper : ∀ qₙ → normalize (p ℕ.* qₙ) (p ℕ.* r) ≡ + qₙ / r
+  *-cancelˡ-/-helper qₙ = mkℚ+-cong (lemma qₙ) (lemma r)
+    where
+    instance
+      p≢0    = ℕ.m*n≢0⇒m≢0 p
+      g≢0    = ℕ.≢-nonZero $ ℕ.gcd[m,n]≢0 (p ℕ.* qₙ) (p ℕ.* r) $ inj₂
+                           $ ℕ.≢-nonZero⁻¹ $ p ℕ.* r
+      n/g≢0  = ℕ.≢-nonZero $ ℕ.n/gcd[m,n]≢0 (p ℕ.* qₙ) (p ℕ.* r) {{gcd≢0 = g≢0}}
+      g≢0'   = ℕ.≢-nonZero $ ℕ.gcd[m,n]≢0 qₙ r $ inj₂ $ ℕ.≢-nonZero⁻¹ r
+      n/g≢0' = ℕ.≢-nonZero $ ℕ.n/gcd[m,n]≢0 qₙ r {{gcd≢0 = g≢0'}}
+      p*g≢0  = ℕ.m*n≢0 p (ℕ.gcd qₙ r)
+
+    lemma : ∀ n → (p ℕ.* n) ℕ./ ℕ.gcd (p ℕ.* qₙ) (p ℕ.* r) ≡ n ℕ./ ℕ.gcd qₙ r
+    lemma n = begin
+      p ℕ.* n ℕ./ ℕ.gcd (p ℕ.* qₙ) (p ℕ.* r)
+        ≡⟨ ℕ./-congʳ $ ℕ.c*gcd[m,n]≡gcd[cm,cn] p qₙ r ⟨
+      p ℕ.* n ℕ./ (p ℕ.* ℕ.gcd qₙ r)
+        ≡⟨ ℕ.m*n/m*o≡n/o p n $ ℕ.gcd qₙ r ⟩
+      n ℕ./ ℕ.gcd qₙ r
+        ∎
+
+  proof : ∀ q → (+ p ℤ.* q) / (p ℕ.* r) ≡ q / r
+  proof (+ qₙ) = begin
+    + p ℤ.* + qₙ / (p ℕ.* r) ≡⟨ /-cong (ℤ.pos-* p qₙ) refl ⟨
+    + (p ℕ.* qₙ) / (p ℕ.* r) ≡⟨ *-cancelˡ-/-helper qₙ ⟩
+    + qₙ / r                 ∎
+  proof -[1+ qₙ ] = begin
+    + p ℤ.* -[1+ qₙ ] / (p ℕ.* r)
+      ≡⟨ /-cong (ℤ.neg-distribʳ-* (+ p) +[1+ qₙ ]) refl ⟨
+    ℤ.- (Sign.+ ℤ.◃ p ℕ.* suc qₙ) / (p ℕ.* r)
+      ≡⟨ /-cong (cong (ℤ.-_) (ℤ.pos-* p (suc qₙ))) refl ⟨
+    ℤ.- + (p ℕ.* suc qₙ) / (p ℕ.* r)
+      ≡⟨ -i/n≡-[i/n] (+ (p ℕ.* suc qₙ)) (p ℕ.* r) ⟩
+    - (+ (p ℕ.* suc qₙ) / (p ℕ.* r))
+      ≡⟨ cong (-_) $ *-cancelˡ-/-helper $ suc qₙ ⟩
+    -[1+ qₙ ] / r
+      ∎
+
+*-cancelʳ-/ : ∀ p {q r} .{{_ : ℕ.NonZero r}} .{{_ : ℕ.NonZero (r ℕ.* p)}} →
+              (q ℤ.* + p) / (r ℕ.* p) ≡ q / r
+*-cancelʳ-/ p {q} {r} = begin
+   q ℤ.* + p / (r ℕ.* p) ≡⟨ /-cong {q ℤ.* + p} refl (ℕ.*-comm r p) ⟩
+   q ℤ.* + p / (p ℕ.* r) ≡⟨ /-cong (ℤ.*-comm q (+ p)) refl ⟩
+   + p ℤ.* q / (p ℕ.* r) ≡⟨ *-cancelˡ-/ p ⟩
+   q / r                 ∎
+   where
+   open ≡-Reasoning
+   instance p≢0 : ℕ.NonZero p
+            p≢0 = ℕ.m*n≢0⇒n≢0 r
+            p*r≢0 : ℕ.NonZero (p ℕ.* r)
+            p*r≢0 = ℕ.m*n≢0 p r
+
+i/n+j/n≡[i+j]/n : ∀ (i j : ℤ) (n : ℕ) .{{_ : ℕ.NonZero n }} →
+                  i / n + j / n ≡ (i ℤ.+ j) / n
+i/n+j/n≡[i+j]/n i j n = begin
+  i / n + j / n
+    ≡⟨ +-def ⟩
+  (↥ pᵢ ℤ.* ↧ qⱼ ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ) / (↧ₙ pᵢ ℕ.* ↧ₙ qⱼ)
+    ≡⟨ *-cancelʳ-/ gcd[j,n]ₙ
+                   {↥ pᵢ ℤ.* ↧ qⱼ ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ}
+                   { ↧ₙ pᵢ ℕ.* ↧ₙ qⱼ }
+     ⟨
+  (↥ pᵢ ℤ.* ↧ qⱼ ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ) ℤ.* gcd[j,n]
+    / (↧ₙ pᵢ ℕ.* ↧ₙ qⱼ ℕ.* gcd[j,n]ₙ)
+    ≡⟨ *-cancelʳ-/ gcd[i,n]ₙ
+                   { (↥ pᵢ ℤ.* ↧ qⱼ ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ) ℤ.* gcd[j,n] }
+                   { ↧ₙ pᵢ ℕ.* ↧ₙ qⱼ ℕ.* gcd[j,n]ₙ }
+     ⟨
+  (↥ pᵢ ℤ.* ↧ qⱼ ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ) ℤ.* gcd[j,n] ℤ.* gcd[i,n]
+    / (↧ₙ pᵢ ℕ.* ↧ₙ qⱼ ℕ.* gcd[j,n]ₙ ℕ.* gcd[i,n]ₙ)
+    ≡⟨ /-cong ↥≡ ↧≡ ⟩
+  (i ℤ.+ j) ℤ.* + n / (n ℕ.* n)
+    ≡⟨ *-cancelʳ-/ n {i ℤ.+ j} {n} ⟩
+  (i ℤ.+ j) / n
+    ∎
+  where
+  open ≡-Reasoning
+
+  pᵢ = i / n
+  qⱼ = j / n
+  gcd[i,n]ₙ = ℕ.gcd ℤ.∣ i ∣ n
+  gcd[i,n]  = + gcd[i,n]ₙ
+  gcd[j,n]ₙ = ℕ.gcd ℤ.∣ j ∣ n
+  gcd[j,n]  = + gcd[j,n]ₙ
+
+  instance
+    _ = ℕ.≢-nonZero $ ℕ.gcd[m,n]≢0 ℤ.∣ i ∣ n $ inj₂ $ ℕ.≢-nonZero⁻¹ n
+    _ = ℕ.≢-nonZero $ ℕ.gcd[m,n]≢0 ℤ.∣ j ∣ n $ inj₂ $ ℕ.≢-nonZero⁻¹ n
+    _ = ℕ.m*n≢0 (↧ₙ pᵢ ℕ.* ↧ₙ qⱼ) gcd[j,n]ₙ
+    _ = ℕ.m*n≢0 (↧ₙ pᵢ ℕ.* ↧ₙ qⱼ ℕ.* gcd[j,n]ₙ) gcd[i,n]ₙ
+    _ = ℕ.m*n≢0 n n
+
+  +-def : pᵢ + qⱼ ≡ (↥ pᵢ ℤ.* ↧ qⱼ ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ) / (↧ₙ pᵢ ℕ.* ↧ₙ qⱼ)
+  +-def with record{} ← pᵢ with record{} ← qⱼ = refl
+
+  ↥≡ : (↥ pᵢ ℤ.* ↧ qⱼ ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ) ℤ.* gcd[j,n] ℤ.* gcd[i,n]
+     ≡ (i ℤ.+ j) ℤ.* + n
+  ↥≡ = begin
+    (↥ pᵢ ℤ.* ↧ qⱼ ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ) ℤ.* gcd[j,n] ℤ.* gcd[i,n]
+      ≡⟨ cong (ℤ._* gcd[i,n])
+       $ ℤ.*-distribʳ-+ gcd[j,n]
+           (↥ pᵢ ℤ.* ↧ qⱼ)
+           (↥ qⱼ ℤ.* ↧ pᵢ)
+       ⟩
+    (↥ pᵢ ℤ.* ↧ qⱼ ℤ.* gcd[j,n] ℤ.+ ↥ qⱼ ℤ.* ↧ pᵢ ℤ.* gcd[j,n]) ℤ.* gcd[i,n]
+      ≡⟨ ℤ.*-distribʳ-+ gcd[i,n]
+           (↥ pᵢ ℤ.* ↧ qⱼ ℤ.* gcd[j,n])
+           (↥ qⱼ ℤ.* ↧ pᵢ ℤ.* gcd[j,n])
+       ⟩
+    ↥ pᵢ ℤ.* ↧ qⱼ ℤ.* gcd[j,n] ℤ.* gcd[i,n] ℤ.+
+    ↥ qⱼ ℤ.* ↧ pᵢ ℤ.* gcd[j,n] ℤ.* gcd[i,n]
+      ≡⟨ cong (ℤ._+ ↥ qⱼ ℤ.* ↧ pᵢ ℤ.* gcd[j,n] ℤ.* gcd[i,n])
+       $ cong (ℤ._* gcd[i,n])
+       $ ℤ.*-assoc (↥ pᵢ) (↧ qⱼ) gcd[j,n]
+       ⟩
+    ↥ pᵢ ℤ.* (↧ qⱼ ℤ.* gcd[j,n]) ℤ.* gcd[i,n] ℤ.+
+    ↥ qⱼ ℤ.* ↧ pᵢ ℤ.* gcd[j,n] ℤ.* gcd[i,n]
+      ≡⟨ cong (ℤ._+ (↥ qⱼ ℤ.* ↧ pᵢ ℤ.* gcd[j,n] ℤ.* gcd[i,n]))
+       $ cong (ℤ._* gcd[i,n])
+       $ cong (↥ pᵢ ℤ.*_)
+       $ ↧-/ j n
+       ⟩
+    ↥ pᵢ ℤ.* + n ℤ.* gcd[i,n] ℤ.+
+    ↥ qⱼ ℤ.* ↧ pᵢ ℤ.* gcd[j,n] ℤ.* gcd[i,n]
+      ≡⟨ cong (ℤ._+_ (↥ pᵢ ℤ.* + n ℤ.* gcd[i,n]))
+       $ cong (ℤ._* gcd[i,n])
+       $ ℤ.*-assoc (↥ qⱼ) (↧ pᵢ) gcd[j,n]
+       ⟩
+    ↥ pᵢ ℤ.* + n ℤ.* gcd[i,n] ℤ.+
+    ↥ qⱼ ℤ.* (↧ pᵢ ℤ.* gcd[j,n]) ℤ.* gcd[i,n]
+      ≡⟨ cong (ℤ._+_ (↥ pᵢ ℤ.* + n ℤ.* gcd[i,n]))
+       $ cong (ℤ._* gcd[i,n])
+       $ cong (↥ qⱼ ℤ.*_)
+       $ ℤ.*-comm (↧ pᵢ) gcd[j,n]
+       ⟩
+    ↥ pᵢ ℤ.* + n ℤ.* gcd[i,n] ℤ.+
+    ↥ qⱼ ℤ.* (gcd[j,n] ℤ.* ↧ pᵢ) ℤ.* gcd[i,n]
+      ≡⟨ cong (ℤ._+_ (↥ pᵢ ℤ.* + n ℤ.* gcd[i,n]))
+       $ cong (ℤ._* gcd[i,n])
+       $ ℤ.*-assoc (↥ qⱼ) gcd[j,n] (↧ pᵢ)
+       ⟨
+    ↥ pᵢ ℤ.* + n ℤ.* gcd[i,n] ℤ.+
+    ↥ qⱼ ℤ.* gcd[j,n] ℤ.* ↧ pᵢ ℤ.* gcd[i,n]
+      ≡⟨ cong (ℤ._+_ (↥ pᵢ ℤ.* + n ℤ.* gcd[i,n]))
+       $ cong (ℤ._* gcd[i,n])
+       $ cong (ℤ._* ↧ pᵢ)
+       $ ↥-/ j n
+       ⟩
+    ↥ pᵢ ℤ.* + n ℤ.* gcd[i,n] ℤ.+ j ℤ.* ↧ pᵢ ℤ.* gcd[i,n]
+      ≡⟨ cong (ℤ._+_ (↥ pᵢ ℤ.* + n ℤ.* gcd[i,n]))
+       $ ℤ.*-assoc j (↧ pᵢ) gcd[i,n]
+       ⟩
+    ↥ pᵢ ℤ.* + n ℤ.* gcd[i,n] ℤ.+ j ℤ.* (↧ pᵢ ℤ.* gcd[i,n])
+      ≡⟨ cong (ℤ._+_ (↥ pᵢ ℤ.* + n ℤ.* gcd[i,n]))
+       $ cong (j ℤ.*_)
+       $ ↧-/ i n
+       ⟩
+    ↥ pᵢ ℤ.* + n ℤ.* gcd[i,n] ℤ.+ j ℤ.* + n
+      ≡⟨ cong (ℤ._+ j ℤ.* + n)
+       $ cong (ℤ._* gcd[i,n])
+       $ ℤ.*-comm (↥ pᵢ) (+ n)
+       ⟩
+    + n ℤ.* ↥ pᵢ ℤ.* gcd[i,n] ℤ.+ j ℤ.* + n
+      ≡⟨ cong (ℤ._+ j ℤ.* + n)
+       $ ℤ.*-assoc (+ n) (↥ pᵢ) gcd[i,n]
+       ⟩
+    + n ℤ.* (↥ pᵢ ℤ.* gcd[i,n]) ℤ.+ j ℤ.* + n
+      ≡⟨ cong (ℤ._+ j ℤ.* + n)
+       $ cong (+ n ℤ.*_)
+       $ ↥-/ i n
+       ⟩
+    + n ℤ.* i ℤ.+ j ℤ.* + n
+      ≡⟨ cong (ℤ._+ j ℤ.* + n)
+       $ ℤ.*-comm (+ n) i
+       ⟩
+    i ℤ.* + n ℤ.+ j ℤ.* + n
+      ≡⟨ ℤ.*-distribʳ-+ (+ n) i j ⟨
+    (i ℤ.+ j) ℤ.* + n
+      ∎
+
+  ↧≡ : ↧ₙ pᵢ ℕ.* ↧ₙ qⱼ ℕ.* gcd[j,n]ₙ ℕ.* gcd[i,n]ₙ ≡ n ℕ.* n
+  ↧≡ = begin
+    ↧ₙ pᵢ ℕ.* ↧ₙ qⱼ ℕ.* gcd[j,n]ₙ ℕ.* gcd[i,n]ₙ
+      ≡⟨ cong (ℕ._* gcd[i,n]ₙ)
+       $ ℕ.*-assoc (↧ₙ pᵢ) (↧ₙ qⱼ) gcd[j,n]ₙ
+       ⟩
+    ↧ₙ pᵢ ℕ.* (↧ₙ qⱼ ℕ.* gcd[j,n]ₙ) ℕ.* gcd[i,n]ₙ
+      ≡⟨ cong (ℕ._* gcd[i,n]ₙ)
+       $ cong (↧ₙ pᵢ ℕ.*_)
+       $ ℤ.abs-* (↧ qⱼ) (gcd j (+ n))
+       ⟨
+    ↧ₙ pᵢ ℕ.* ℤ.∣ (+ ↧ₙ qⱼ) ℤ.* gcd j (+ n) ∣ ℕ.* gcd[i,n]ₙ
+      ≡⟨ cong (ℕ._* gcd[i,n]ₙ)
+       $ cong (↧ₙ pᵢ ℕ.*_)
+       $ cong ℤ.∣_∣
+       $ ↧-/ j n
+       ⟩
+    ↧ₙ pᵢ ℕ.* n ℕ.* gcd[i,n]ₙ
+      ≡⟨ cong (ℕ._* gcd[i,n]ₙ)
+       $ ℕ.*-comm (↧ₙ pᵢ) n
+       ⟩
+    n ℕ.* ↧ₙ pᵢ ℕ.* gcd[i,n]ₙ
+      ≡⟨ ℕ.*-assoc n (↧ₙ pᵢ) gcd[i,n]ₙ ⟩
+    n ℕ.* (↧ₙ pᵢ ℕ.* gcd[i,n]ₙ)
+      ≡⟨ cong (n ℕ.*_)
+       $ ℤ.abs-* (↧ pᵢ) (gcd i (+ n))
+       ⟨
+    n ℕ.* ℤ.∣ + ↧ₙ pᵢ ℤ.* gcd i (+ n) ∣
+      ≡⟨ cong (n ℕ.*_)
+       $ cong ℤ.∣_∣
+       $ ↧-/ i n
+       ⟩
+    n ℕ.* n
+      ∎
+
+-------------------------------------------------------------------------------
+-- Definitions
+-------------------------------------------------------------------------------
+
+quot : (p q : ℚ) .{{ _ : NonZero q }} → ℚ
+quot p q@record{} = (↥ p ℤ.* ↧ q) ℤ./ (↧ p ℤ.* ↥ q) / 1
+  where instance _ = ℤ.i*j≢0 (↧ p) (↥ q)
+
+rem : (p q : ℚ) .{{ _ : NonZero q }} → ℚ
+rem p q@record{} = + ((↥ p ℤ.* ↧ q) ℤ.% (↧ p ℤ.* ↥ q)) / (↧ₙ p ℕ.* ↧ₙ q)
+  where instance _ = ℤ.i*j≢0 (↧ p) (↥ q)
+
+-------------------------------------------------------------------------------
+-- Proofs
+-------------------------------------------------------------------------------
+
+↧ₙquot≡1 : ∀ (p q : ℚ) .{{_ : NonZero q }} → ↧ₙ (quot p q) ≡ 1
+↧ₙquot≡1 p q@record{} = ↧ₙ[i/1]≡1 ((↥ p ℤ.* ↧ q) ℤ./ (↧ p ℤ.* ↥ q))
+  where instance _ = ℤ.i*j≢0 (↧ p) (↥ q)
+
+theorem₀ : ∀ (p q : ℚ) .{{_ : NonZero q }} → NonNegative (rem p q)
+theorem₀ p q@record{} = mkℚ+-nonNeg (m ℕ./ ℕ.gcd m n) (n ℕ./ ℕ.gcd m n)
+  where
+  m = (↥ p ℤ.* ↧ q) ℤ.% (↧ p ℤ.* ↥ q)
+  n = ↧ₙ p ℕ.* ↧ₙ q
+
+  instance
+    ↧p*↥q≢0 = ℤ.i*j≢0 (↧ p) (↥ q)
+    g≢0     = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ (ℕ.≢-nonZero⁻¹ n)))
+    n/g≢0   = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 m n {{gcd≢0 = g≢0}})
+
+theorem₁ : ∀ (p q : ℚ) .{{_ : NonZero q }} → rem p q < ℚ.∣ q ∣
+theorem₁ p@record{} q@record{}
+  = *<* $ ℤ.*-cancelʳ-<-nonNeg gcd[m,n]
+  $ begin-strict
+    ↥ rem p q ℤ.* d ℤ.* gcd[m,n]     ≡⟨ cong (ℤ._* gcd[m,n])
+                                      $ ℤ.*-comm d $ ↥ rem p q
+                                      ⟨
+    d ℤ.* ↥ rem p q ℤ.* gcd[m,n]     ≡⟨ ℤ.*-assoc d (↥ rem p q) gcd[m,n] ⟩
+    d ℤ.* (↥ rem p q ℤ.* gcd[m,n])   ≡⟨ cong (d ℤ.*_) $ ↥-/ (+ m) n ⟩
+    d ℤ.* + m                        <⟨ ℤ.*-monoˡ-<-pos d $ ℤ.+<+
+                                      $ n%d<d (a ℤ.* d) (b ℤ.* c)
+                                      ⟩
+    d ℤ.* + ∣ b ℤ.* c ∣              ≡⟨ cong (d ℤ.*_) $ cong (+_) $ ℤ.abs-* b c ⟩
+    d ℤ.* + (∣ b ∣ ℕ.* ∣ c ∣)        ≡⟨ cong (d ℤ.*_) $ ℤ.pos-* (↧ₙ p) ∣ c ∣ ⟩
+    d ℤ.* (b ℤ.* ∣c∣)                ≡⟨ ℤ.*-assoc d b ∣c∣ ⟨
+    d ℤ.* b ℤ.* ∣c∣                  ≡⟨ cong (ℤ._* ∣c∣) $ ℤ.*-comm d b ⟩
+    b ℤ.* d ℤ.* ∣c∣                  ≡⟨ ℤ.*-comm (b ℤ.* d) ∣c∣ ⟩
+    ∣c∣ ℤ.* (b ℤ.* d)                ≡⟨ cong (∣c∣ ℤ.*_) $ ↧-/ (+ m) n ⟨
+    ∣c∣ ℤ.* (↧ rem p q ℤ.* gcd[m,n]) ≡⟨ ℤ.*-assoc ∣c∣ (↧ rem p q) gcd[m,n] ⟨
+    ∣c∣ ℤ.* ↧ rem p q ℤ.* gcd[m,n]   ∎
+  where
+  open ℤ.≤-Reasoning
+
+  a = ↥ p
+  b = ↧ p
+  c = ↥ q
+  d = ↧ q
+  ∣c∣ = + ∣ c ∣
+
+  m = (a ℤ.* d) ℤ.% (b ℤ.* c)
+  n = ∣ b ∣ ℕ.* ∣ d ∣
+
+  instance
+    b*c≢0 = ℤ.i*j≢0 b c
+    g≢0   = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ (ℕ.≢-nonZero⁻¹ n)))
+    n/g≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 m n {{gcd≢0 = g≢0}})
+
+  gcd[m,n] = ℤ.gcd (+ m) (+ n)
+
+theorem₂ : (p q : ℚ) .{{_ : NonZero q }} → quot p q * q + rem p q ≡ p
+theorem₂ p@record{} q@record{} {{ nz }}
+  = let open ≡-Reasoning in begin
+      quot p q * q + rem p q
+
+        ≡⟨ cong (_+ rem p q)
+         $ *-def (quot p q) q
+         ⟩
+
+      (↥ quot p q ℤ.* c) / (↧ₙ (quot p q) ℕ.* dₙ) + rem p q
+
+        ≡⟨ cong (_+ rem p q)
+         $ /-cong { ↥ quot p q ℤ.* ↥ q } refl
+         $ cong (ℕ._* ↧ₙ q)
+         $ ↧ₙquot≡1 p q
+         ⟩
+
+      (↥ quot p q ℤ.* c) / (1 ℕ.* dₙ) + rem p q
+
+        ≡⟨ cong (_+ rem p q)
+         $ /-cong { ↥ quot p q ℤ.* ↥ q } refl
+         $  ℕ.*-identityˡ (↧ₙ q)
+         ⟩
+
+      (↥ quot p q ℤ.* c) / dₙ + rem p q
+
+        ≡⟨ cong (_+ rem p q)
+         $ /-cong (cong (ℤ._* c) $ ↥[i/1]≡i $ n ℤ./ m) refl
+         ⟩
+
+      (n ℤ./ m ℤ.* c) / dₙ + rem p q
+
+        ≡⟨ cong (_+ rem p q)
+         $ *-cancelˡ-/ bₙ {(n ℤ./ m) ℤ.* c}
+         ⟨
+
+      (b ℤ.* (n ℤ./ m ℤ.* c)) / (bₙ ℕ.* dₙ) + + (n ℤ.% m) / (bₙ ℕ.* dₙ)
+
+        ≡⟨ i/n+j/n≡[i+j]/n
+             (b ℤ.* (n ℤ./ m ℤ.* c))
+             (+ (n ℤ.% m))
+             (bₙ ℕ.* dₙ)
+         ⟩
+
+      (b ℤ.* (n ℤ./ m ℤ.* c) ℤ.+ + (n ℤ.% m)) / (bₙ ℕ.* dₙ)
+
+        ≡⟨ /-cong
+             ( cong (ℤ._+ + (n ℤ.% m))
+             $ cong (b ℤ.*_)
+             $ ℤ.*-comm (n ℤ./ m) c
+             ) refl
+         ⟩
+
+      (b ℤ.* (c ℤ.* (n ℤ./ m)) ℤ.+ + (n ℤ.% m)) / (bₙ ℕ.* dₙ)
+
+        ≡⟨ /-cong
+             ( cong (ℤ._+ + (n ℤ.% m))
+             $ ℤ.*-assoc b c (n ℤ./ m)
+             ) refl
+         ⟨
+
+      (m ℤ.* (n ℤ./ m) ℤ.+ + (n ℤ.% m)) / (bₙ ℕ.* dₙ)
+
+        ≡⟨ /-cong
+             ( cong (ℤ._+ + (n ℤ.% m))
+             $ ℤ.*-comm m (n ℤ./ m)
+             ) refl
+         ⟩
+
+      (n ℤ./ m ℤ.* m ℤ.+ + (n ℤ.% m)) / (bₙ ℕ.* dₙ)
+
+        ≡⟨ /-cong (ℤ.+-comm (n ℤ./ m ℤ.* m) (+ (n ℤ.% m))) refl ⟩
+
+      (+ (n ℤ.% m) ℤ.+ (n ℤ./ m ℤ.* m)) / (bₙ ℕ.* dₙ)
+
+        ≡⟨ /-cong lemma₁ refl ⟩
+
+      (+ (n ℤ.%ℕ ∣ m ∣) ℤ.+ (n ℤ./ℕ ∣ m ∣) ℤ.* + ∣ m ∣) / (bₙ ℕ.* dₙ)
+
+        ≡⟨ /-cong (a≡a%ℕn+[a/ℕn]*n n ∣ m ∣) refl ⟨
+
+      n / (bₙ ℕ.* dₙ)
+
+        ≡⟨ *-cancelʳ-/ dₙ {a} {bₙ} ⟩
+
+      a / bₙ
+
+        ≡⟨ ↥p/↧p≡p p ⟩
+
+      p
+
+    ∎
+ where
+  a = ↥ p
+  b = ↧ p
+  c = ↥ q
+  d = ↧ q
+  bₙ = ↧ₙ p
+  dₙ = ↧ₙ q
+  n = a ℤ.* d
+  m = b ℤ.* c
+
+  instance
+    _ = ℤ.i*j≢0 (↧ p) (↥ q)
+
+  *-def : ∀ p q → p * q ≡ (↥ p ℤ.* ↥ q) / (↧ₙ p ℕ.* ↧ₙ q)
+  *-def record{} record{} = refl
+
+  lemma₀ : ∀ n m .{{ _ : ℕ.NonZero ∣ m ∣ }} →
+          n ℤ./ m ℤ.* m ≡ n ℤ./ℕ ∣ m ∣ ℤ.* + ∣ m ∣
+  lemma₀ n (-[1+ m ])
+    = let open ≡-Reasoning in begin
+
+       ℤ.-1ℤ ℤ.* (n ℤ./ℕ suc m) ℤ.* -[1+ m ]
+
+    ≡⟨ ℤ.*-assoc ℤ.-1ℤ (n ℤ./ℕ suc m) -[1+ m ] ⟩
+
+       ℤ.-1ℤ ℤ.* ((n ℤ./ℕ suc m) ℤ.* -[1+ m ])
+
+    ≡⟨ cong (ℤ.-1ℤ ℤ.*_) $ ℤ.*-comm (n ℤ./ℕ suc m) (-[1+ m ]) ⟩
+
+       ℤ.-1ℤ ℤ.* (-[1+ m ] ℤ.* (n ℤ./ℕ suc m))
+
+    ≡⟨ ℤ.*-assoc ℤ.-1ℤ (-[1+ m ]) (n ℤ./ℕ suc m) ⟨
+
+       + (1 ℕ.* suc m) ℤ.* (n ℤ./ℕ suc m)
+
+    ≡⟨ ( cong (ℤ._* (n ℤ./ℕ suc m)) $ cong (+_) $ ℕ.*-identityˡ (suc m)) ⟩
+
+       + (suc m) ℤ.* (n ℤ./ℕ suc m)
+
+    ≡⟨ ℤ.*-comm (+ (suc m)) (n ℤ./ℕ suc m) ⟩
+
+       n ℤ./ℕ (suc m) ℤ.* + (suc m)
+
+    ∎
+  lemma₀ (-[1+ n ]) (+ m) with suc n ℕ.% m
+  ... | ℕ.zero
+    = cong (ℤ._* + m)
+    $ ℤ.*-identityˡ (ℤ.- (+ (suc n ℕ./ m)))
+  ... | suc _
+    = cong (Sign.- ℤ.◃_)
+    $ cong (m ℕ.+_)
+    $ cong (ℕ._* m)
+    $ ℕ.+-identityʳ (suc n ℕ./ m)
+  lemma₀ (+ n) (+ m)
+    = cong (ℤ._* + m)
+    $ ℤ.*-identityˡ (+ (n ℕ./ m))
+
+  lemma₁ : + (n ℤ.% m) ℤ.+ (n ℤ./ m ℤ.* m) ≡
+           + (n ℤ.%ℕ ∣ m ∣) ℤ.+ (n ℤ./ℕ ∣ m ∣ ℤ.* + ∣ m ∣)
+  lemma₁ rewrite lemma₀ n m {{_}} with n
+  ... | + _      = refl
+  ... | -[1+ _ ] = refl
+
+-------------------------------------------------------------------------------

--- a/clash-prelude/src/Clash/Signal/Trace.hs
+++ b/clash-prelude/src/Clash/Signal/Trace.hs
@@ -102,7 +102,7 @@ module Clash.Signal.Trace
 import           Clash.Annotations.Primitive (hasBlackBox)
 import           Clash.Signal.Internal (fromList)
 import           Clash.Signal
-  (KnownDomain(..), SDomainConfiguration(..), Signal, bundle, unbundle)
+  (KnownDomain, SDomainConfiguration(..), Signal, knownDomain, bundle, unbundle)
 import           Clash.Sized.Vector    (Vec, iterateI)
 import qualified Clash.Sized.Vector    as Vector
 import           Clash.Class.BitPack   (BitPack, BitSize, pack, unpack)

--- a/clash-prelude/tests/Clash/Tests/AsyncFIFOSynchronizer.hs
+++ b/clash-prelude/tests/Clash/Tests/AsyncFIFOSynchronizer.hs
@@ -9,6 +9,7 @@ module Clash.Tests.AsyncFIFOSynchronizer (tests) where
 
 import Data.Maybe (isJust, catMaybes)
 import qualified Prelude as P
+import Type.Reflection (typeRep)
 
 import Hedgehog as H
 import qualified Hedgehog.Range as Range
@@ -983,8 +984,8 @@ data DomProxy (dom :: Domain) where
 
 -- A more useful Show instance than the one for 'Proxy'
 instance Show (DomProxy dom) where
-  showsPrec d dom@DomProxy =
-    showParen (d > app_prec) $ ("DomProxy @" <>) . (symbolVal dom <>)
+  showsPrec d DomProxy =
+    showParen (d > app_prec) $ ("DomProxy @" <>) . (show (typeRep @dom) <>)
    where app_prec = 10
 
 data NamedTest a = NamedTest

--- a/clash-prelude/tests/Clash/Tests/Reset.hs
+++ b/clash-prelude/tests/Clash/Tests/Reset.hs
@@ -15,7 +15,6 @@ import Clash.Explicit.Prelude
 import qualified Prelude as P
 
 -- Testing with explicit declaration of the Low type alias
-type Low = ("Low" :: Domain)
 createDomain vSystem{vName="Low", vResetPolarity=ActiveLow}
 
 sampleResetN :: KnownDomain dom => Int -> Reset dom -> [Bool]

--- a/clash-prelude/tests/Clash/Tests/Signal.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal.hs
@@ -94,8 +94,8 @@ case_dynamicStaticEq = do
     -- We construct periods in a roundabout way (i.e., using 'hzToPeriod' instead
     -- of using 'hzToFs'), to prevent rounding errors between periods of the
     -- static clocks and the periods of the dynamic clocks.
-    fs11 = Femtoseconds (1000 * hzToPeriod 11)
-    fs77 = Femtoseconds (1000 * hzToPeriod 77)
+    fs11 = Femtoseconds (1000 * floor (hzToPeriod @Rational 11))
+    fs77 = Femtoseconds (1000 * floor (hzToPeriod @Rational 77))
 
     dclk11 = dynamicClockGen @H11 (pure fs11)
     dclk77 = dynamicClockGen @H77 (pure fs77)
@@ -150,8 +150,8 @@ case_dynamicHasEffect = do
     -- We construct periods in a roundabout way (i.e., using 'hzToPeriod' instead
     -- of using 'hzToFs'), to prevent rounding errors between periods of the
     -- static clocks and the periods of the dynamic clocks.
-    fs11 = Femtoseconds (1000 * hzToPeriod 11)
-    fs77lying = Femtoseconds (1000 * hzToPeriod 78)
+    fs11 = Femtoseconds (1000 * floor (hzToPeriod @Rational 11))
+    fs77lying = Femtoseconds (1000 * floor (hzToPeriod @Rational 78))
 
     clk11 = clockGen @H11
     clk77 = clockGen @H77

--- a/clash-term/Main.hs
+++ b/clash-term/Main.hs
@@ -82,7 +82,7 @@ instance Diff Term where
   ppr' = Pr.ppr'
 
   initOptions :: PrettyOptions
-  initOptions = PrettyOptions True True True True
+  initOptions = PrettyOptions True True True True False
 
   flagFields :: [(PrettyOptions -> Bool, PrettyOptions -> Bool -> PrettyOptions, String)]
   flagFields =

--- a/tests/shouldwork/DDR/VendorDDR.hs
+++ b/tests/shouldwork/DDR/VendorDDR.hs
@@ -5,6 +5,7 @@
 
 module VendorDDR where
 
+import GHC.Real
 import Clash.Explicit.DDR
 import Clash.Explicit.Prelude
 import Clash.Explicit.Testbench
@@ -22,8 +23,16 @@ type TestLen = 44
 type TestLen2 = 2 * TestLen - 1
 
 type DomCxt slow fast fPeriod reset =
-  ( KnownConfiguration fast ('DomainConfiguration fast fPeriod 'Rising reset 'Defined 'ActiveHigh)
-  , KnownConfiguration slow ('DomainConfiguration slow (2*fPeriod) 'Rising reset 'Defined 'ActiveHigh)
+  ( KnownConfiguration fast
+      ( 'DomainConfiguration fast
+           fPeriod (0 :% 1)
+           'Rising reset 'Defined 'ActiveHigh
+      )
+  , KnownConfiguration slow
+      ( 'DomainConfiguration slow
+           (2*fPeriod) (0 :% 1)
+           'Rising reset 'Defined 'ActiveHigh
+      )
   )
 
 type VendorIn slow fast =

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -81,28 +81,29 @@ runToNetlistStage target f src = do
 
   supplyN <- Supply.newSupply
 
-  transformedBindings <-
+  (transformedBindings, domains) <-
     normalizeEntity env (designBindings design)
-      (ghcTypeToHWType (opt_intWidth opts))
+      (ghcTypeToHWType (envDomainTCUs env) (opt_intWidth opts))
       ghcEvaluator
       evaluator
       teNames supplyN te
 
   fmap (\(_,x,_) -> force (P.map snd (OMap.assocs x))) $
     netlistFrom
-      (env, transformedBindings, tes2, compNames, te, initIs)
+      (env, domains, transformedBindings, tes2, compNames, te, initIs)
  where
   opts = f mkClashOpts
   backend = initBackend @(TargetToState target) opts
   hdl = buildTargetToHdl target
 
-  netlistFrom (env, bm, tes, compNames, te, seen) =
-    genNetlist env ghcEvaluator False bm tes compNames (ghcTypeToHWType (opt_intWidth opts))
+  netlistFrom (env, doms, bm, tes, compNames, te, seen) =
+    genNetlist env ghcEvaluator False bm tes compNames
+      (ghcTypeToHWType (envDomainTCUs env) (opt_intWidth opts))
       ite (SomeBackend hdlSt) seen hdlDir Nothing te
    where
     teS     = Text.unpack . nameOcc $ varName te
     modN    = takeWhile (/= '.') teS
-    hdlSt   = setDomainConfigurations (envDomains env)
+    hdlSt   = setDomainConfigurations doms
             $ setModName (Text.pack modN) backend
     ite     = ifThenElseExpr hdlSt
     hdlDir  = fromMaybe "." (opt_hdlDir opts)


### PR DESCRIPTION
The PR implements the suggestions of #3178, except for the clock periods, where it instead keeps the exiting integer period for backward compatibility, while just adding the period fraction that may result from conversion imprecision. This fraction then can be used to recover the precise frequency, if needed.

## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [ ] Check copyright notices are up to date in edited files

---

Approved for public release. This work has been supported by funding from the _Agentur für Innovation in der Cybersicherheit GmbH ([Cyberagentur](https://www.cyberagentur.de))_ as part of the [Clash Formal](https://clash-formal.org) project.