### PR TITLE
Fix RTree doctest for GHC 8.8.4 and 8.10.7

### DIFF
--- a/clash-prelude/src/Clash/Sized/RTree.hs
+++ b/clash-prelude/src/Clash/Sized/RTree.hs
@@ -357,8 +357,7 @@ let populationCount' :: (KnownNat (2^d), KnownNat d, KnownNat (2^d+1))
 :}
 <BLANKLINE>
 <interactive>:...
-    • Couldn't match type ‘(((2 ^ d) + 1) + ((2 ^ d) + 1)) - 1’
-                     with ‘(2 ^ d) + 1’
+...
       Expected type: Index ((2 ^ d) + 1)
                      -> Index ((2 ^ d) + 1) -> Index ((2 ^ d) + 1)
         Actual type: Index ((2 ^ d) + 1)


### PR DESCRIPTION
PR #3112 (backport: #3165) fixed the doctest already for GHC 9.0 and later. GHC 8.6.5 was unaffected. But 8.8.4 and 8.10.7 remained unchanged initially. We don't test these versions in the CI for a PR, but we do test them in the nightly runs, where it turned out these versions also need the ellipsis in the doctest because of the changed error message from GHC.

The change in the error message is due to newer type checking plugin(s). GHC 8.6.5 doesn't need a change because it doesn't support the newer plugins.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
    Actually, the incomplete change from PR #3112 didn't update the copyright date. To stay consistent with master, I'm also not doing it here now.
