### PR TITLE
Add `SomeBoundedSNat` and Hedgehog generator

### DIFF
--- a/changelog/2026-04-13T09_23_22+02_00_add_someboundedsnat_generator
+++ b/changelog/2026-04-13T09_23_22+02_00_add_someboundedsnat_generator
@@ -1,0 +1,1 @@
+ADDED: `SomeBoundedSNat` and Hedgehog generators

--- a/clash-prelude-hedgehog/clash-prelude-hedgehog.cabal
+++ b/clash-prelude-hedgehog/clash-prelude-hedgehog.cabal
@@ -9,7 +9,7 @@ license:            BSD-2-Clause
 license-file:       LICENSE
 author:             QBayLogic B.V.
 maintainer:         devops@qbaylogic.com
-copyright:          Copyright © 2021-2025, QBayLogic B.V.
+copyright:          Copyright © 2021-2026, QBayLogic B.V.
 category:           Hardware
 build-type:         Simple
 
@@ -40,6 +40,7 @@ library
 
   exposed-modules:
     Clash.Hedgehog.Annotations.SynthesisAttributes
+    Clash.Hedgehog.Promoted.Nat
     Clash.Hedgehog.Signal
     Clash.Hedgehog.Sized.BitVector
     Clash.Hedgehog.Sized.Index
@@ -52,5 +53,6 @@ library
     ghc-typelits-knownnat     >= 0.7.2   && < 0.9,
     ghc-typelits-natnormalise >= 0.7.2   && < 0.10,
     text                      >= 1.2.2   && < 2.2,
+    string-interpolate        ^>= 0.3,
 
     clash-prelude             == 1.9.0,

--- a/clash-prelude-hedgehog/src/Clash/Hedgehog/Promoted/Nat.hs
+++ b/clash-prelude-hedgehog/src/Clash/Hedgehog/Promoted/Nat.hs
@@ -1,0 +1,79 @@
+{-|
+Copyright   : (C) 2026, QBayLogic B.V.
+License     : BSD2 (see the file LICENSE)
+Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
+
+Random generation of SNat.
+-}
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Clash.Hedgehog.Promoted.Nat where
+
+import Clash.Prelude
+import Hedgehog (Gen)
+import qualified Data.String.Interpolate as I
+import qualified GHC.TypeNats as TypeNats
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+-- | Like @SomeSNat@, but with bounds.
+data SomeBoundedSNat lower upperInclusive where
+  SomeBoundedSNat
+    :: forall n lower upperInclusive
+     . (lower <= n, n <= upperInclusive)
+    => SNat n
+    -> SomeBoundedSNat lower upperInclusive
+
+instance Show (SomeBoundedSNat lower upperInclusive) where
+  show (SomeBoundedSNat sn@SNat) = show ''SomeBoundedSNat <> " " <> show sn
+
+{- | Generate a v'SomeBoundedSNat' between the given bounds (inclusive).
+Uses 'Hedgehog.Range.linear' and shrinks to @lower@.
+
+For example, to bring into scope the constraints @(KnownNat n, 1 <= n, n <= 8)@:
+
+> SomeBoundedSNat (SNat :: SNat n) <- forAll (genSomeBoundedSNat @1 @8)
+-}
+genSomeBoundedSNat
+  :: (KnownNat lower, KnownNat upperInclusive, lower <= upperInclusive)
+  => Gen (SomeBoundedSNat lower upperInclusive)
+genSomeBoundedSNat = genSomeBoundedSNat# (\l -> Gen.integral . Range.linear l)
+
+-- | Like 'genSomeBoundedSNat' but does /not/ shrink.
+genSomeBoundedSNat_
+  :: (KnownNat lower, KnownNat upperInclusive, lower <= upperInclusive)
+  => Gen (SomeBoundedSNat lower upperInclusive)
+genSomeBoundedSNat_ = genSomeBoundedSNat# (\l -> Gen.integral_ . Range.linear l)
+
+{- | Generate a v'SomeBoundedSNat' between the given bounds (inclusive).
+To do so, uses a given term level generator.
+
+__NB__: Make sure the given generator respects the bounds that it is passed at
+the term level.
+-}
+genSomeBoundedSNat#
+  :: forall lower upperInclusive
+   . (KnownNat lower, KnownNat upperInclusive, lower <= upperInclusive)
+  => (Natural -> Natural -> Gen Natural)
+  -> Gen (SomeBoundedSNat lower upperInclusive)
+genSomeBoundedSNat# gen = do
+  n <- gen (natToNatural @lower) (natToNatural @upperInclusive)
+  case TypeNats.someNatVal n of
+    SomeNat p ->
+      case (SNat @lower `compareSNat` sn, sn `compareSNat` SNat @upperInclusive) of
+        (SNatLE, SNatLE) -> pure (SomeBoundedSNat sn)
+        _ ->
+          error
+            [I.__i|
+            genSomeBoundedSNat: internal error: generated number out of bounds
+
+            lower bound:             #{natToNatural @lower}
+            upper bound (inclusive): #{natToNatural @upperInclusive}
+            generated number:        #{n}
+            |]
+       where
+        sn = snatProxy p


### PR DESCRIPTION
[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

Useful to generate type level natural numbers in Hedgehog property-based tests, e.g. for DUT type variables. For instance, the following brings into scope the constraints `(KnownNat n, 1 <= n, n <= 8)`.
``` haskell
property $ do
  SomeBoundedSNat @n SNat <- forAll $ genSomeBoundedSNat @1 @8
  ...
```

A user might want to use e.g. `Range.constant` instead of the currently hardcoded `Range.linear`, but there's currently no `Range` argument as I'm not convinced it'd be an improvement.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files