### PR TITLE
Add `-fclash-no-concurrent-topentity-compilation`

### DIFF
--- a/changelog/2026-04-12T15_50_45+02_00_no_concurrent_topentity_compilation
+++ b/changelog/2026-04-12T15_50_45+02_00_no_concurrent_topentity_compilation
@@ -1,0 +1,1 @@
+ADDED: `-fclash-no-concurrent-topentity-compilation` flag to disable concurrent compilation of top entities. This is mostly useful to get a consistent debug output.

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -86,6 +86,7 @@ flagsClash r = [
   , defFlag "fclash-no-render-enums"             $ NoArg (liftEwM (setNoRenderEnums r))
   , defFlag "fclash-timescale-precision"         $ SepArg (setTimescalePrecision r)
   , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
+  , defFlag "fclash-no-concurrent-topentity-compilation" $ NoArg (liftEwM (setNoConcurrentTopEntities r))
   ]
 
 -- | Print deprecated flag warning
@@ -337,3 +338,6 @@ setRewriteHistoryFile r arg = do
 
 setNoRenderEnums :: IORef ClashOpts -> IO ()
 setNoRenderEnums r = modifyIORef r (\c -> c { opt_renderEnums = False })
+
+setNoConcurrentTopEntities :: IORef ClashOpts -> IO ()
+setNoConcurrentTopEntities r = modifyIORef r (\c -> c { opt_concurrentTopEntities = False })

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -342,7 +342,12 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
     edamFiles <- newMVar HashMap.empty
     ioLock <- newMVar ()
 
-    mapConcurrently_ (go compNames idSet edamFiles ioLock deps topEntityMap) tes
+    let
+      maybeMapConcurrently_
+        | opt_concurrentTopEntities opts = mapConcurrently_
+        | otherwise = mapM_
+
+    maybeMapConcurrently_ (go compNames idSet edamFiles ioLock deps topEntityMap) tes
 
     time <- Clock.getCurrentTime
     let diff = reportTimeDiff time startTime

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -399,6 +399,11 @@ data ClashOpts = ClashOpts
   , opt_ignoreBrokenGhcs :: Bool
   -- ^ Don't error if we see a (potentially) broken GHC / platform combination.
   -- See the project's @README.md@ for more information.
+  , opt_concurrentTopEntities :: Bool
+  -- ^ Compile top entities concurrently. Disabling this is useful when
+  -- investigating bugs, because it will make log output deterministic.
+  --
+  -- Command line flag: -fclash-no-concurrent-topentity-compilation
   }
   deriving (Show, Eq, NFData, Generic, Hashable)
 
@@ -438,6 +443,7 @@ defClashOpts
   -- XXX: We probe environment variables until we've found a proper solution to
   --      https://github.com/clash-lang/clash-compiler/issues/2762.
   , opt_ignoreBrokenGhcs    = unsafeLookupEnvBool "CLASH_IGNORE_BROKEN_GHCS" False
+  , opt_concurrentTopEntities = True
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.


### PR DESCRIPTION
ADDED: `-fclash-no-concurrent-topentity-compilation` flag to disable concurrent compilation of top entities. This is mostly useful to get a consistent debug output.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
