### PR TITLE
CI: No Hackage candidate for published version

### DIFF
--- a/.ci/functions.sh
+++ b/.ci/functions.sh
@@ -1,0 +1,10 @@
+exit_trap() {
+  local REAL_EXIT=$?
+
+  if [ "$REAL_EXIT" -eq 64 ]; then
+    echo "Process exited with status code 64, which we reserve to indicate" >&2
+    echo "allowed-to-fail in CI. Replacing with exit code 65!" >&2
+    exit 65
+  fi
+  exit $REAL_EXIT
+}

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -20,8 +20,10 @@ hackage-sdist:
   cache:
     key: hackage-$CI_JOB_IMAGE
   script:
-    - .ci/publish_sdist.sh clash-prelude
-    - .ci/publish_sdist.sh clash-prelude-hedgehog
-    - .ci/publish_sdist.sh clash-lib
-    - .ci/publish_sdist.sh clash-lib-hedgehog
-    - .ci/publish_sdist.sh clash-ghc
+    # Currently, GitLab runners do not propagate the error code, but we need to
+    # match on it for allowed-to-fail
+    - .ci/publish_sdist.sh clash-prelude || exit $?
+    - .ci/publish_sdist.sh clash-prelude-hedgehog || exit $?
+    - .ci/publish_sdist.sh clash-lib || exit $?
+    - .ci/publish_sdist.sh clash-lib-hedgehog || exit $?
+    - .ci/publish_sdist.sh clash-ghc || exit $?

--- a/.ci/publish_sdist.sh
+++ b/.ci/publish_sdist.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eu -o pipefail
 
+. .ci/functions.sh
+
+trap exit_trap EXIT
+
 PASSWORD=$(echo $HACKAGE_PASSWORD | base64 --decode --ignore-garbage)
 
 SDIST=$(find . -type f -regex "\./$1-[0-9\.]+\.tar\.gz")
@@ -14,6 +18,16 @@ if [[ "$HACKAGE_RELEASE" == "yes" ]]; then
     cabal upload --publish --documentation --token=${HACKAGE_TOKEN} ${DDIST}
 elif [[ "$HACKAGE_RELEASE" == "no" ]]; then
     # Upload as release candidate
+
+    version=$(grep "^[vV]ersion" "$1/$1.cabal" | grep -Eo '[0-9]+(\.[0-9]+)+')
+
+    if cabal list --simple-output "$1" | grep -q "^$1 $version$"; then
+      echo "$1 v$version has been published, cannot upload to Hackage" >&2
+      trap - EXIT
+      # Signals allowed-to-fail to CI
+      exit 64
+    fi
+
     cabal upload --username=${HACKAGE_USERNAME} --password=${PASSWORD} ${SDIST}
     cabal upload --documentation --token=${HACKAGE_TOKEN} ${DDIST}
 else

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -xou pipefail
 
+. .ci/functions.sh
+
+trap exit_trap EXIT
+
 grep -E ' $' -n -r . --include=*.{hs,hs-boot,sh} --exclude-dir=dist-newstyle
 if [[ $? == 0 ]]; then
     echo "EOL whitespace detected. See ^"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,12 @@ hackage-release-candidate:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "trigger"
 
+  allow_failure:
+    # .ci/publish_sdist.sh uses this magic exit code to signal allowed-to-fail.
+    # .ci/functions.sh defines a wrapper to prevent accidentally emitting this
+    # code.
+    exit_codes: 64
+
 # Release new version of Clash to Hackage
 hackage-release:
   extends: .hackage


### PR DESCRIPTION
Since https://github.com/haskell/hackage-server/pull/1469 (Check candidate uploads against main index), Hackage no longer allows candidates for published versions.

But we use the `.ci/publish_sdist.sh` script from our stable branches to publish a candidate before we do the final release, so we do want it to run for nightlies on our stable branch. But we need to differentiate between runs that do not contain a new version and runs that do contain a new version.

So we do this check in the CI job, and exit with a special exit code to flag when we did not upload a candidate. This means normal nightlies will have an exclamation mark in an orange circle next to the `hackage-release-candidate`, indicating a failure that does not cause the pipeline as a whole to fail.

When the "special" nightly before a release is run, the developer inspecting the result should verify a candidate was published (check mark in green circle). In the usual case, where only one candidate will be uploaded before release, they will also necessarily notice that the candidate is simply not on Hackage if they forget to check the CI job's result.

Because we don't have control over the exit codes of any binaries we invoke, a trap handler is added in `.ci/functions.sh` that makes sure no other exits will have the exit code we reserve for allowed-to-fail. Currently, GitLab runners will not actually propagate the exit code of a failing step in the script, but this might very well change in an update. So we also proof our `.ci/setup.sh` script against such exits so they don't trigger unwantedly in the `hackage-release-candidate` job.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
