### PR TITLE
Run `flattenLet` after `caseCon` to prevent ANF violations

### DIFF
--- a/changelog/2026-04-12T20_12_45+02_00_fix_3188
+++ b/changelog/2026-04-12T20_12_45+02_00_fix_3188
@@ -1,0 +1,1 @@
+FIXED: Failure to generate binder assignments in very specific cases [#3185](https://github.com/clash-lang/clash-compiler/issues/3185)

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -400,7 +400,9 @@ flattenCallTree (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
       -- has been done to avoid #3036.
       topdownSucR (apply "collapseRHSNoops" collapseRHSNoops) >->
       topdownSucR (apply "inlineCleanup" inlineCleanup) >->
-      topdownSucR (apply "caseCon" caseCon)
+      topdownSucR (apply "caseCon" caseCon) >-> -- https://github.com/clash-lang/clash-compiler/issues/3159
+      bottomupR (apply "flattenLet" flattenLet) >-> -- https://github.com/clash-lang/clash-compiler/issues/3185
+      topdownSucR (apply "topLet" topLet)
 
     goCheap c@(CLeaf   (nm2,(Binding _ _ inl2 _ e _)))
       | isNoInline inl2  = (Nothing     ,[c])

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -672,6 +672,7 @@ runClashTest = defaultMain
            in runTest "T3084" _opts
         , runTest "T3141" def{hdlSim=[], hdlLoad=[], clashFlags=["-itests/shouldwork/Issues/T3141", "-itests/shouldwork/Issues/T3141"]}
         , runTest "T3159" def{hdlSim=[], hdlLoad=[] }
+        , runTest "T3185" def
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T3185.hs
+++ b/tests/shouldwork/Issues/T3185.hs
@@ -1,0 +1,87 @@
+{-|
+Copyright  :  (C) 2021-2022, QBayLogic B.V.,
+                  2022     , Google Inc.,
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 -Wall -Werror #-}
+
+module T3185 where
+
+import Clash.Prelude hiding (Ordering(..))
+import Clash.Explicit.Testbench
+
+import T3185.Annotations
+import T3185.TH
+import T3185.Types
+
+import qualified Clash.Explicit.Prelude as CEP
+
+topEntity :: Bool
+topEntity = False
+
+playSampleRom
+  :: forall n a dom
+   . ( KnownDomain dom
+     , KnownNat n
+     , BitPack a
+     , 1 <= n
+     )
+  => Clock dom
+  -> Reset dom
+  -> MemBlob n (BitSize a)
+  -> (Signal dom Bool, Signal dom a)
+playSampleRom clk rst content = (done, out)
+ where
+  out = unpack . asyncRomBlob content <$> cnt
+  done = CEP.register clk rst enableGen False $ (== maxBound) <$> cnt
+  cnt :: Signal dom (Index n)
+  cnt = CEP.register clk rst enableGen 0 $ satSucc SatBound <$> cnt
+
+basicRomTB
+  :: forall d n x y z
+   . ( KnownNat n
+     , KnownNat d
+     , BitPack x
+     , BitPack y
+     , Eq z, ShowX z, BitPack z
+     , 1 <= n
+     )
+  => (   Clock XilinxSystem
+      -> DSignal XilinxSystem 0 x
+      -> DSignal XilinxSystem 0 y
+      -> DSignal XilinxSystem d z
+     )
+  -> z
+  -> MemBlob n (BitSize (x, y, z))
+  -> Signal XilinxSystem Bool
+basicRomTB comp resDef sampleBlob = done
+ where
+  (done0, samples) = playSampleRom clk rst sampleBlob
+  (inputX, inputY, expectedOutput) = unbundle samples
+  -- Only assert while not finished
+  done = mux done0 done0
+    $ assert clk rst "basicRomTB" out expectedOutput
+             done0
+  out =
+      ignoreFor clk rst en (SNat @d) resDef
+    . toSignal $ comp clk (fromSignal inputX) (fromSignal inputY)
+  clk = tbClockGen (not <$> done)
+  rst = resetGen
+  en = enableGen
+{-# INLINE basicRomTB #-}
+
+compareBasic
+  :: Clock XilinxSystem
+  -> DSignal XilinxSystem 0 Float
+  -> DSignal XilinxSystem 0 Float
+  -> DSignal XilinxSystem 2 Ordering
+compareBasic !_clk !_x !_y = pure LT
+{-# OPAQUE compareBasic #-}
+{-# ANN compareBasic (binaryTopAnn "compareBasic") #-}
+
+testBench  :: Signal XilinxSystem Bool
+testBench  =
+  basicRomTB compareBasic LT $(memBlobTH Nothing compareBasicSamples)
+{-# ANN testBench (TestBench 'compareBasic) #-}

--- a/tests/shouldwork/Issues/T3185/Annotations.hs
+++ b/tests/shouldwork/Issues/T3185/Annotations.hs
@@ -1,0 +1,22 @@
+{-|
+Copyright  :  (C) 2021,      QBayLogic B.V.,
+                  2022,      Google Inc.,
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+module T3185.Annotations where
+
+import Clash.Prelude
+
+binaryTopAnn :: String -> TopEntity
+binaryTopAnn name =
+  Synthesize
+    { t_name   = name
+    , t_inputs =
+          [ PortName "clk"
+          , PortName "x"
+          , PortName "y"
+          ]
+    , t_output = PortName "result"
+    }

--- a/tests/shouldwork/Issues/T3185/TH.hs
+++ b/tests/shouldwork/Issues/T3185/TH.hs
@@ -1,0 +1,21 @@
+{-|
+Copyright  :  (C) 2021-2022, QBayLogic B.V.,
+                  2022     , Google Inc.,
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+-}
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module T3185.TH where
+
+import Prelude hiding (Ordering(..))
+import T3185.Types (Ordering(..))
+
+compareBasicSamples :: [(Float, Float, Ordering)]
+compareBasicSamples =
+  [ (1.0, 2.0, LT)
+  , (1.0, 2.0, LT)
+  , (1.0, 2.0, LT)
+  , (1.0, 2.0, LT)
+  ]

--- a/tests/shouldwork/Issues/T3185/Types.hs
+++ b/tests/shouldwork/Issues/T3185/Types.hs
@@ -1,0 +1,16 @@
+module T3185.Types where
+
+import Clash.Prelude hiding (Ordering(..))
+
+import Clash.Annotations.BitRepresentation.Deriving
+  ( deriveAnnotation, simpleDerivator, ConstructorType(OneHot), FieldsType(Wide)
+  , deriveBitPack )
+
+data Ordering
+  = EQ
+  | LT
+  | GT
+  | NaN
+  deriving (Generic, NFDataX, Eq, ShowX, Show, Lift)
+deriveAnnotation (simpleDerivator OneHot Wide) [t| Ordering |]
+deriveBitPack [t| Ordering |]


### PR DESCRIPTION
Fixes #3185

To state the perhaps obvious; I wrote the regression tests without the patch applied and verified that it triggered the issue.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~ The test files were copied from `clash-cores` and stripped.
  - [ ] Simplify regression test? I'm not too bothered with the status quo.

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
