### PR TITLE
nix: dontCheck row-types due to test being flaky

### DIFF
--- a/nix/overlay-ghc910.nix
+++ b/nix/overlay-ghc910.nix
@@ -33,4 +33,7 @@ in
 
   # Randomly GHC panics with heap overflows during testing
   row-types = dontCheck prev.row-types;
+
+  # Randomly fails a single test -- cannot reproduce locally
+  attoparsec = dontCheck prev.attoparsec;
 }

--- a/nix/overlay-ghc910.nix
+++ b/nix/overlay-ghc910.nix
@@ -30,4 +30,7 @@ in
 
   # Criterion test fails with tasty 1.5.4
   criterion = dontCheck prev.criterion;
+
+  # Randomly GHC panics with heap overflows during testing
+  row-types = dontCheck prev.row-types;
 }

--- a/nix/overlay-ghc96.nix
+++ b/nix/overlay-ghc96.nix
@@ -41,4 +41,7 @@ in
 
   # Randomly GHC panics with heap overflows during testing
   row-types = dontCheck prev.row-types;
+
+  # Randomly fails a single test -- cannot reproduce locally
+  attoparsec = dontCheck prev.attoparsec;
 }

--- a/nix/overlay-ghc96.nix
+++ b/nix/overlay-ghc96.nix
@@ -38,4 +38,7 @@ in
 
   # Criterion test fails with tasty 1.5.4
   criterion = dontCheck prev.criterion;
+
+  # Randomly GHC panics with heap overflows during testing
+  row-types = dontCheck prev.row-types;
 }

--- a/nix/overlay-ghc98.nix
+++ b/nix/overlay-ghc98.nix
@@ -39,4 +39,7 @@ in
 
   # Randomly GHC panics with heap overflows during testing
   row-types = dontCheck prev.row-types;
+
+  # Randomly fails a single test -- cannot reproduce locally
+  attoparsec = dontCheck prev.attoparsec;
 }

--- a/nix/overlay-ghc98.nix
+++ b/nix/overlay-ghc98.nix
@@ -36,4 +36,7 @@ in
   clash-ffi = overrideCabal prev.clash-ffi (drv: {
     broken = true;
   });
+
+  # Randomly GHC panics with heap overflows during testing
+  row-types = dontCheck prev.row-types;
 }


### PR DESCRIPTION
Randomly flakes on all GHC version.

See:

- https://github.com/clash-lang/clash-compiler/actions/runs/24314290905/job/70994182100
- https://github.com/clash-lang/clash-compiler/actions/runs/24308500177/job/70976823615
- https://github.com/clash-lang/clash-compiler/actions/runs/24308500177/job/70976823604
- https://github.com/clash-lang/clash-compiler/actions/runs/24308500177/job/70976823622
