### PR TITLE
Add SaturatingNum instances for Clash.Num types

### DIFF
--- a/changelog/2026-04-14T07_25_34+02_00_saturatingnum_for_saturating_num_wrappers
+++ b/changelog/2026-04-14T07_25_34+02_00_saturatingnum_for_saturating_num_wrappers
@@ -1,0 +1,1 @@
+ADDED: `SaturatingNum` instances for `Erroring`, `Overflowing`, `Saturating`, `Wrapping`, and `Zeroing`.

--- a/clash-prelude/src/Clash/Num/Erroring.hs
+++ b/clash-prelude/src/Clash/Num/Erroring.hs
@@ -1,5 +1,5 @@
-{-
-Copyright   : (C) 2021, QBayLogic B.V.
+{-|
+Copyright   : (C) 2021-2026, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -110,6 +110,22 @@ instance (Bounded a, Ord a, SaturatingNum a) => Num (Erroring a) where
   -- is not in range (typically wrapping). It would be better if this also
   -- threw an XException, but in a way which remained synthesizable.
   fromInteger = coerce (fromInteger @a)
+
+instance (Ord a, SaturatingNum a) => SaturatingNum (Erroring a) where
+  {-# INLINE satAdd #-}
+  satAdd mode (Erroring a) (Erroring b) = Erroring $ satAdd mode a b
+
+  {-# INLINE satSub #-}
+  satSub mode (Erroring a) (Erroring b) = Erroring $ satSub mode a b
+
+  {-# INLINE satMul #-}
+  satMul mode (Erroring a) (Erroring b) = Erroring $ satMul mode a b
+
+  {-# INLINE satSucc #-}
+  satSucc mode (Erroring a) = Erroring $ satSucc mode a
+
+  {-# INLINE satPred #-}
+  satPred mode (Erroring a) = Erroring $ satPred mode a
 
 instance (Enum a, SaturatingNum a) => Enum (Erroring a) where
   {-# INLINE succ #-}

--- a/clash-prelude/src/Clash/Num/Overflowing.hs
+++ b/clash-prelude/src/Clash/Num/Overflowing.hs
@@ -157,7 +157,9 @@ instance (Ord a, SaturatingNum a) => SaturatingNum (Overflowing a) where
     | otherwise
     = withOverflow (a || b)
    where
-    withOverflow = Overflowing $ satAdd mode x y
+    withOverflow =
+      let r = satAdd mode x y
+       in seq r $ Overflowing r
 
   {-# INLINE satSub #-}
   satSub mode (Overflowing x a) (Overflowing y b)
@@ -172,7 +174,9 @@ instance (Ord a, SaturatingNum a) => SaturatingNum (Overflowing a) where
     | otherwise
     = withOverflow (a || b)
    where
-    withOverflow = Overflowing (satSub mode x y)
+    withOverflow =
+      let r = satSub mode x y
+       in seq r $ Overflowing r
 
   {-# INLINE satMul #-}
   satMul mode (Overflowing x a) (Overflowing y b)
@@ -184,15 +188,21 @@ instance (Ord a, SaturatingNum a) => SaturatingNum (Overflowing a) where
     | otherwise
     = withOverflow (a || b)
    where
-    withOverflow = Overflowing (satMul mode x y)
+    withOverflow =
+      let r = satMul mode x y
+       in seq r $ Overflowing r
 
   {-# INLINE satSucc #-}
   satSucc mode (Overflowing x a) =
-    Overflowing (satSucc mode x) (a || x == maxBound)
+    let xSucc = satSucc mode x
+     in seq xSucc
+      $ Overflowing xSucc (a || x == maxBound)
 
   {-# INLINE satPred #-}
   satPred mode (Overflowing x a) =
-    Overflowing (satPred mode x) (a || x == minBound)
+    let xPred = satPred mode x
+     in seq xPred
+      $ Overflowing (satPred mode x) (a || x == minBound)
 
 instance (Enum a, Eq a, SaturatingNum a) => Enum (Overflowing a) where
   succ (Overflowing x a)

--- a/clash-prelude/src/Clash/Num/Overflowing.hs
+++ b/clash-prelude/src/Clash/Num/Overflowing.hs
@@ -143,6 +143,10 @@ instance (Bounded a) => Bounded (Overflowing a) where
 -- for the overflow check (depending on the utilized 'SaturationMode'
 -- or inner type), which is not guaranteed to be optimized away at a
 -- later synthesis stage.
+--
+-- The 'hasOverflowed' flag still will be set even when the 'SaturatingNum'
+-- operation has prevented the overflow:
+-- @hasOverflowed (satSucc SatBound maxBound) == True@
 instance (Ord a, SaturatingNum a) => SaturatingNum (Overflowing a) where
   {-# INLINE satAdd #-}
   satAdd mode (Overflowing x a) (Overflowing y b)

--- a/clash-prelude/src/Clash/Num/Overflowing.hs
+++ b/clash-prelude/src/Clash/Num/Overflowing.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright  :  (C) 2021-2022, QBayLogic B.V.
+Copyright  :  (C) 2021-2026, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -138,6 +138,61 @@ instance (Bounded a, Ord a, SaturatingNum a) => Num (Overflowing a) where
 instance (Bounded a) => Bounded (Overflowing a) where
   minBound = Overflowing minBound False
   maxBound = Overflowing maxBound False
+
+-- | NOTE: Usage of this instance might introduce redundant circuitry
+-- for the overflow check (depending on the utilized 'SaturationMode'
+-- or inner type), which is not guaranteed to be optimized away at a
+-- later synthesis stage.
+instance (Ord a, SaturatingNum a) => SaturatingNum (Overflowing a) where
+  {-# INLINE satAdd #-}
+  satAdd mode (Overflowing x a) (Overflowing y b)
+    | y > 0
+    , x > satSub SatWrap maxBound y
+    = withOverflow True
+
+    | y < 0
+    , x < satSub SatWrap minBound y
+    = withOverflow True
+
+    | otherwise
+    = withOverflow (a || b)
+   where
+    withOverflow = Overflowing $ satAdd mode x y
+
+  {-# INLINE satSub #-}
+  satSub mode (Overflowing x a) (Overflowing y b)
+    | y < 0
+    , x > satAdd SatWrap maxBound y
+    = withOverflow True
+
+    | y > 0
+    , x < satAdd SatWrap minBound y
+    = withOverflow True
+
+    | otherwise
+    = withOverflow (a || b)
+   where
+    withOverflow = Overflowing (satSub mode x y)
+
+  {-# INLINE satMul #-}
+  satMul mode (Overflowing x a) (Overflowing y b)
+    | x /= 0
+    , y /= 0
+    , satMul SatZero x y == 0
+    = withOverflow True
+
+    | otherwise
+    = withOverflow (a || b)
+   where
+    withOverflow = Overflowing (satMul mode x y)
+
+  {-# INLINE satSucc #-}
+  satSucc mode (Overflowing x a) =
+    Overflowing (satSucc mode x) (a || x == maxBound)
+
+  {-# INLINE satPred #-}
+  satPred mode (Overflowing x a) =
+    Overflowing (satPred mode x) (a || x == minBound)
 
 instance (Enum a, Eq a, SaturatingNum a) => Enum (Overflowing a) where
   succ (Overflowing x a)

--- a/clash-prelude/src/Clash/Num/Saturating.hs
+++ b/clash-prelude/src/Clash/Num/Saturating.hs
@@ -1,5 +1,5 @@
-{-
-Copyright   : (C) 2021, QBayLogic B.V.
+{-|
+Copyright   : (C) 2021-2026, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -109,6 +109,22 @@ instance (Ord a, SaturatingNum a) => Num (Saturating a) where
   -- is not in range (typically wrapping). It would be better if this also
   -- saturated, but in a way which remained synthesizable.
   fromInteger = coerce (fromInteger @a)
+
+instance (Ord a, SaturatingNum a) => SaturatingNum (Saturating a) where
+  {-# INLINE satAdd #-}
+  satAdd mode (Saturating a) (Saturating b) = Saturating $ satAdd mode a b
+
+  {-# INLINE satSub #-}
+  satSub mode (Saturating a) (Saturating b) = Saturating $ satSub mode a b
+
+  {-# INLINE satMul #-}
+  satMul mode (Saturating a) (Saturating b) = Saturating $ satMul mode a b
+
+  {-# INLINE satSucc #-}
+  satSucc mode (Saturating a) = Saturating $ satSucc mode a
+
+  {-# INLINE satPred #-}
+  satPred mode (Saturating a) = Saturating $ satPred mode a
 
 instance (Enum a, SaturatingNum a) => Enum (Saturating a) where
   {-# INLINE succ #-}

--- a/clash-prelude/src/Clash/Num/Wrapping.hs
+++ b/clash-prelude/src/Clash/Num/Wrapping.hs
@@ -108,6 +108,22 @@ instance (SaturatingNum a) => Num (Wrapping a) where
   -- definitely wrapped, but in a way which remained synthesizable.
   fromInteger = coerce (fromInteger @a)
 
+instance (Bounded a, SaturatingNum a) => SaturatingNum (Wrapping a) where
+  {-# INLINE satAdd #-}
+  satAdd mode (Wrapping a) (Wrapping b) = Wrapping $ satAdd mode a b
+
+  {-# INLINE satSub #-}
+  satSub mode (Wrapping a) (Wrapping b) = Wrapping $ satSub mode a b
+
+  {-# INLINE satMul #-}
+  satMul mode (Wrapping a) (Wrapping b) = Wrapping $ satMul mode a b
+
+  {-# INLINE satSucc #-}
+  satSucc mode (Wrapping a) = Wrapping $ satSucc mode a
+
+  {-# INLINE satPred #-}
+  satPred mode (Wrapping a) = Wrapping $ satPred mode a
+
 instance (Enum a, SaturatingNum a) => Enum (Wrapping a) where
   {-# INLINE succ #-}
   -- Deliberately breaks the Enum law that succ maxBound ~> error

--- a/clash-prelude/src/Clash/Num/Zeroing.hs
+++ b/clash-prelude/src/Clash/Num/Zeroing.hs
@@ -1,5 +1,5 @@
-{-
-Copyright   : (C) 2021, QBayLogic B.V.
+{-|
+Copyright   : (C) 2021-2026, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -108,6 +108,22 @@ instance (Bounded a, Ord a, SaturatingNum a) => Num (Zeroing a) where
   -- is not in range (typically wrapping). It would be better if this also
   -- returned zero, but in a way which remained synthesizable.
   fromInteger = coerce (fromInteger @a)
+
+instance (Ord a, SaturatingNum a) => SaturatingNum (Zeroing a) where
+  {-# INLINE satAdd #-}
+  satAdd mode (Zeroing a) (Zeroing b) = Zeroing $ satAdd mode a b
+
+  {-# INLINE satSub #-}
+  satSub mode (Zeroing a) (Zeroing b) = Zeroing $ satSub mode a b
+
+  {-# INLINE satMul #-}
+  satMul mode (Zeroing a) (Zeroing b) = Zeroing $ satMul mode a b
+
+  {-# INLINE satSucc #-}
+  satSucc mode (Zeroing a) = Zeroing $ satSucc mode a
+
+  {-# INLINE satPred #-}
+  satPred mode (Zeroing a) = Zeroing $ satPred mode a
 
 instance (Enum a, SaturatingNum a) => Enum (Zeroing a) where
   {-# INLINE succ #-}

--- a/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
+++ b/clash-prelude/tests/Clash/Tests/Laws/SaturatingNum.hs
@@ -21,6 +21,7 @@ import Test.Tasty.HUnit
 import Test.Tasty.HUnit.Extra
 
 import Clash.Class.Num
+import Clash.Num.Overflowing (Overflowing, toOverflowing)
 import Clash.Sized.Index (Index)
 import Clash.Sized.Signed (Signed)
 import Clash.Sized.Fixed (SFixed, UFixed)
@@ -151,11 +152,20 @@ genBoundedIntegral = Gen.frequency
 genIndex :: forall n. KnownNat n => Gen (Index n)
 genIndex = genBoundedIntegral
 
+genOIndex :: forall n. KnownNat n => Gen (Overflowing (Index n))
+genOIndex = toOverflowing <$> genIndex
+
 genUnsigned :: forall n. KnownNat n => Gen (Unsigned n)
 genUnsigned = genBoundedIntegral
 
+genOUnsigned :: forall n. KnownNat n => Gen (Overflowing (Unsigned n))
+genOUnsigned = toOverflowing <$> genUnsigned
+
 genSigned :: forall n. KnownNat n => Gen (Signed n)
 genSigned = genBoundedIntegral
+
+genOSigned :: forall n. KnownNat n => Gen (Overflowing (Signed n))
+genOSigned = toOverflowing <$> genSigned
 
 -- | Generates a bounded fractional with a bias towards extreme values:
 --
@@ -179,8 +189,14 @@ genBoundedFractional = Gen.frequency
 genSFixed :: forall a b. (KnownNat a, KnownNat b) => Gen (SFixed a b)
 genSFixed = genBoundedFractional
 
+genOSFixed :: forall a b. (KnownNat a, KnownNat b) => Gen (Overflowing (SFixed a b))
+genOSFixed = toOverflowing <$> genSFixed
+
 genUFixed :: forall a b. (KnownNat a, KnownNat b) => Gen (UFixed a b)
 genUFixed = genBoundedFractional
+
+genOUFixed :: forall a b. (KnownNat a, KnownNat b) => Gen (Overflowing (UFixed a b))
+genOUFixed = toOverflowing <$> genUFixed
 
 tests :: TestTree
 tests = testGroup "SaturatingNum"
@@ -225,4 +241,20 @@ tests = testGroup "SaturatingNum"
   , testSaturationLaws False "UFixed 7 7" (genUFixed @7 @7)
   , testSaturationLaws False "UFixed 121 121" (genUFixed @121 @121)
   , testSaturationLaws False "UFixed 128 128" (genUFixed @128 @128)
+
+  , testSaturationLaws True "Overflowing (Index 1)" (genOIndex @1)
+  , testSaturationLaws True "Overflowing (Index 10)" (genOIndex @10)
+  , testSaturationLaws True "Overflowing (Signed 0)" (genOSigned @0)
+  , testSaturationLaws True "Overflowing (Signed 8)" (genOSigned @8)
+  , testSaturationLaws True "Overflowing (Unsigned 0)" (genOUnsigned @0)
+  , testSaturationLaws True "Overflowing (Unsigned 8)" (genOUnsigned @8)
+  , testSaturationLaws False "Overflowing (UFixed 7 7)" (genOUFixed @7 @7)
+  , testSaturationLaws False "Overflowing (SFixed 0 0)" (genOSFixed @0 @0)
+  , testSaturationLaws False "Overflowing (SFixed 0 1)" (genOSFixed @0 @1)
+  , testSaturationLaws False "Overflowing (SFixed 1 0)" (genOSFixed @1 @0)
+  , testSaturationLaws False "Overflowing (SFixed 7 7)" (genOSFixed @7 @7)
+  , testSaturationLaws False "Overflowing (UFixed 0 0)" (genOUFixed @0 @0)
+  , testSaturationLaws False "Overflowing (UFixed 0 1)" (genOUFixed @0 @1)
+  , testSaturationLaws False "Overflowing (UFixed 1 0)" (genOUFixed @1 @0)
+  , testSaturationLaws False "Overflowing (UFixed 7 7)" (genOUFixed @7 @7)
   ]


### PR DESCRIPTION
The PR adds the missing `SaturatingNum` instances for `Erroring`, `Overflowing`, `Saturating`, `Wrapping`, and `Zeroing`.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files