### PR TITLE
Add concurrent normalization

### DIFF
--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -16,6 +16,7 @@ import Clash.GHC.Evaluator
 import Clash.GHC.GenerateBindings
 import Clash.GHC.NetlistTypes
 
+import qualified Control.Concurrent.MVar as MVar
 defaultTests :: [FilePath]
 defaultTests =
   [ "examples/FIR.hs"
@@ -56,6 +57,7 @@ runNormalisationStage
   -> IO (ClashEnv, ClashDesign, Id)
 runNormalisationStage idirs src = do
   supplyN <- Supply.newSupply
+  lock <- MVar.newMVar ()
   (env, design) <- runInputStage idirs src
   let topEntityNames = fmap topId (designEntities design)
   case topEntityNames of
@@ -65,6 +67,7 @@ runNormalisationStage idirs src = do
               (ghcTypeToHWType (opt_intWidth (opts idirs)))
               ghcEvaluator
               evaluator
+              lock
               topEntityNames supplyN topEntity
       return (env, design{designBindings=transformedBindings},topEntity)
     _ -> error "no top entities"

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -8,6 +8,7 @@ import           Clash.GHC.PartialEval
 import           Clash.GHC.Evaluator
 import           Clash.GHC.NetlistTypes       (ghcTypeToHWType)
 
+import qualified Control.Concurrent.MVar      as MVar
 import           Control.DeepSeq              (deepseq)
 import           Data.Binary                  (decode)
 import           Data.List                    (partition)
@@ -32,6 +33,7 @@ main = do
 benchFile :: [FilePath] -> FilePath -> IO ()
 benchFile idirs src = do
   supplyN <- Supply.newSupply
+  lock <- MVar.newMVar ()
   (bindingsMap, tcm, tupTcm, primMap, reprs, topEntityNames, topEntity, domains) <- setupEnv src
   putStrLn $ "Doing normalization of " ++ src
 
@@ -48,6 +50,7 @@ benchFile idirs src = do
                    (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
                    ghcEvaluator
                    evaluator
+                   lock
                    topEntityNames supplyN topEntity
   res `deepseq` putStrLn ".. done\n"
 

--- a/changelog/2022-03-21T11_09_46-05_00_concurrent_normalization
+++ b/changelog/2022-03-21T11_09_46-05_00_concurrent_normalization
@@ -1,0 +1,1 @@
+CHANGED: Add concurrent normalization flag [#2074](https://github.com/clash-lang/clash-compiler/pull/2074)

--- a/changelog/2022-03-21T11_09_46-05_00_concurrent_normalization
+++ b/changelog/2022-03-21T11_09_46-05_00_concurrent_normalization
@@ -1,1 +1,0 @@
-CHANGED: Add concurrent normalization flag [#2074](https://github.com/clash-lang/clash-compiler/pull/2074)

--- a/changelog/2026-05-06T09_20_49+02_00_concurrent_normalization
+++ b/changelog/2026-05-06T09_20_49+02_00_concurrent_normalization
@@ -1,0 +1,1 @@
+ADDED: `-fclash-concurrent-normalization`, a flag enabling concurrent normalization. [#3196](https://github.com/clash-lang/clash-compiler/pull/3196).

--- a/changelog/2026-05-06T09_20_49+02_00_concurrent_normalization
+++ b/changelog/2026-05-06T09_20_49+02_00_concurrent_normalization
@@ -1,0 +1,1 @@
+ADDED: Concurrent normalization, enabled by default. It can be disabled with `-fclash-no-concurrent-normalization`. [#3196](https://github.com/clash-lang/clash-compiler/pull/3196).

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -89,7 +89,7 @@ executable clash
 executable clashi
   Main-Is:            src-ghc/Interactive.hs
   Build-Depends:      base, clash-ghc
-  GHC-Options:        -Wall -Wcompat -rtsopts -with-rtsopts=-A128m
+  GHC-Options:        -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-A128m
   if flag(dynamic)
     GHC-Options: -dynamic
   extra-libraries:    pthread

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -94,7 +94,7 @@ executable clash
 executable clashi
   Main-Is:            src-ghc/Interactive.hs
   Build-Depends:      base, clash-ghc
-  GHC-Options:        -Wall -Wcompat -rtsopts -with-rtsopts=-A128m
+  GHC-Options:        -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-A128m
   if flag(dynamic)
     GHC-Options: -dynamic
   extra-libraries:    pthread

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -88,7 +88,10 @@ executable clash
     --
     -- -H and -K512M: Trade slight memory increase for better performance in
     -- large designs.
-    "-with-rtsopts=-K512M -H -I5 -T"
+    --
+    -- -N: auto set number of capabilities ("number of threads") for Haskell
+    -- runtime.
+    "-with-rtsopts=-K512M -H -I5 -T -N -qn4"
     -Wall
     -Wcompat
     -threaded
@@ -96,18 +99,18 @@ executable clash
   if flag(dynamic)
     GHC-Options: -dynamic
   if arch(x86_64) && flag(workaround-ghc-mmap-crash)
-    GHC-Options: "-with-rtsopts=-K512M -H -I5 -T -xm20000000"
+    GHC-Options: "-with-rtsopts=-K512M -H -I5 -T -N -qn4 -xm20000000"
   extra-libraries:    pthread
   default-language:   Haskell2010
 
 executable clashi
   Main-Is:            src-ghc/Interactive.hs
   Build-Depends:      base, clash-ghc
-  GHC-Options:        -Wall -Wcompat -threaded -rtsopts "-with-rtsopts=-K512M -H -I5 -T"
+  GHC-Options:        -Wall -Wcompat -threaded -rtsopts "-with-rtsopts=-K512M -H -I5 -T -N -qn4"
   if flag(dynamic)
     GHC-Options: -dynamic
   if arch(x86_64) && flag(workaround-ghc-mmap-crash)
-    GHC-Options: "-with-rtsopts=-K512M -H -I5 -T -xm20000000"
+    GHC-Options: "-with-rtsopts=-K512M -H -I5 -T -N -qn4 -xm20000000"
   extra-libraries:    pthread
   default-language:   Haskell2010
 

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -103,7 +103,7 @@ executable clash
 executable clashi
   Main-Is:            src-ghc/Interactive.hs
   Build-Depends:      base, clash-ghc
-  GHC-Options:        -Wall -Wcompat -rtsopts "-with-rtsopts=-K512M -H -I5 -T"
+  GHC-Options:        -Wall -Wcompat -threaded -rtsopts "-with-rtsopts=-K512M -H -I5 -T"
   if flag(dynamic)
     GHC-Options: -dynamic
   if arch(x86_64) && flag(workaround-ghc-mmap-crash)

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -87,6 +87,7 @@ flagsClash r = [
   , defFlag "fclash-timescale-precision"         $ SepArg (setTimescalePrecision r)
   , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
   , defFlag "fclash-no-concurrent-topentity-compilation" $ NoArg (liftEwM (setNoConcurrentTopEntities r))
+  , defFlag "fclash-concurrent-normalization"    $ NoArg (liftEwM (setConcurrentNormalization r))
   ]
 
 -- | Print deprecated flag warning
@@ -325,6 +326,9 @@ setAggressiveXOptBB r = modifyIORef r (\c -> c { opt_aggressiveXOptBB = True })
 
 setEdalize :: IORef ClashOpts -> IO ()
 setEdalize r = modifyIORef r (\c -> c { opt_edalize = True })
+
+setConcurrentNormalization :: IORef ClashOpts -> IO ()
+setConcurrentNormalization r = modifyIORef r (\c -> c { opt_concurrentNormalization = True })
 
 setRewriteHistoryFile :: IORef ClashOpts -> String -> IO ()
 setRewriteHistoryFile r arg = do

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -88,6 +88,8 @@ flagsClash r = [
   , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
   , defFlag "fclash-no-concurrent-topentity-compilation" $ NoArg (liftEwM (setNoConcurrentTopEntities r))
   , defFlag "fclash-debug-manifest-hash"         $ NoArg (liftEwM (setDebugManifestHash r))
+  , defFlag "fclash-concurrent-normalization"    $ NoArg (liftEwM (setConcurrentNormalization r))
+  , defFlag "fclash-no-concurrent-normalization" $ NoArg (liftEwM (setNoConcurrentNormalization r))
   ]
 
 -- | Print deprecated flag warning
@@ -326,6 +328,12 @@ setAggressiveXOptBB r = modifyIORef r (\c -> c { opt_aggressiveXOptBB = True })
 
 setEdalize :: IORef ClashOpts -> IO ()
 setEdalize r = modifyIORef r (\c -> c { opt_edalize = True })
+
+setConcurrentNormalization :: IORef ClashOpts -> IO ()
+setConcurrentNormalization r = modifyIORef r (\c -> c { opt_concurrentNormalization = True })
+
+setNoConcurrentNormalization :: IORef ClashOpts -> IO ()
+setNoConcurrentNormalization r = modifyIORef r (\c -> c { opt_concurrentNormalization = False })
 
 setRewriteHistoryFile :: IORef ClashOpts -> String -> IO ()
 setRewriteHistoryFile r arg = do

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -145,7 +145,6 @@ Library
                       aeson-pretty            >= 0.8      && < 0.9,
                       ansi-terminal           >= 0.8.0.0  && < 1.2,
                       array,
-                      async                   >= 2.2.0    && < 2.3,
                       attoparsec              >= 0.10.4.0 && < 0.15,
                       base                    >= 4.18     && < 5,
                       base16-bytestring       >= 0.1.1    && < 1.1,
@@ -173,6 +172,9 @@ Library
                       infinite-list           ^>= 0.1,
                       lens                    >= 4.10     && < 5.4,
                       mtl                     >= 2.3.1    && < 2.4,
+                      lifted-async            >=0.10      && <0.12,
+                      lifted-base             >=0.2       && <0.3,
+                      monad-control           >=1.0       && <1.1,
                       ordered-containers      >= 0.2      && < 0.3,
                       prettyprinter           >= 1.2.0.1  && < 1.8,
                       prettyprinter-interp    ^>= 0.2,
@@ -185,6 +187,7 @@ Library
                       text                    >= 1.2.2    && < 2.2,
                       time                    >= 1.4.0.1  && < 1.15,
                       transformers            >= 0.6.1.0  && < 0.7,
+                      transformers-base,
                       trifecta                >= 1.7.1.1  && < 2.2,
                       vector                  >= 0.11     && < 1.0,
                       vector-binary-instances >= 0.2.3.5  && < 0.3,
@@ -259,6 +262,7 @@ Library
                       Clash.Normalize.PrimitiveReductions
                       Clash.Normalize.Primitives
                       Clash.Normalize.Strategy
+                      Clash.Normalize.TracedMVar
                       Clash.Normalize.Transformations
                       Clash.Normalize.Transformations.ANF
                       Clash.Normalize.Transformations.Case
@@ -317,6 +321,7 @@ Library
                       GHC.BasicTypes.Extra
 
   Other-Modules:      Clash.Annotations.TopEntity.Extra
+                      Control.Concurrent.Async.Lifted.Extra
                       Data.List.Extra
                       Data.Map.Ordered.Extra
                       Data.Monoid.Extra

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -150,7 +150,6 @@ Library
                       aeson-pretty            >= 0.8      && < 0.9,
                       ansi-terminal           >= 0.8.0.0  && < 1.2,
                       array,
-                      async                   >= 2.2.0    && < 2.3,
                       attoparsec              >= 0.10.4.0 && < 0.15,
                       base                    >= 4.18     && < 5,
                       base16-bytestring       >= 0.1.1    && < 1.1,
@@ -178,6 +177,9 @@ Library
                       infinite-list           ^>= 0.1,
                       lens                    >= 4.10     && < 5.4,
                       mtl                     >= 2.3.1    && < 2.4,
+                      lifted-async            >=0.10      && <0.12,
+                      lifted-base             >=0.2       && <0.3,
+                      monad-control           >=1.0       && <1.1,
                       ordered-containers      >= 0.2      && < 0.3,
                       prettyprinter           >= 1.2.0.1  && < 1.8,
                       prettyprinter-interp    ^>= 0.2,
@@ -190,6 +192,7 @@ Library
                       text                    >= 1.2.2    && < 2.2,
                       time                    >= 1.4.0.1  && < 1.15,
                       transformers            >= 0.6.1.0  && < 0.7,
+                      transformers-base,
                       trifecta                >= 1.7.1.1  && < 2.2,
                       vector                  >= 0.11     && < 1.0,
                       vector-binary-instances >= 0.2.3.5  && < 0.3,
@@ -264,6 +267,7 @@ Library
                       Clash.Normalize.PrimitiveReductions
                       Clash.Normalize.Primitives
                       Clash.Normalize.Strategy
+                      Clash.Normalize.TracedMVar
                       Clash.Normalize.Transformations
                       Clash.Normalize.Transformations.ANF
                       Clash.Normalize.Transformations.Case
@@ -322,6 +326,7 @@ Library
                       GHC.BasicTypes.Extra
 
   Other-Modules:      Clash.Annotations.TopEntity.Extra
+                      Control.Concurrent.Async.Lifted.Extra
                       Data.List.Extra
                       Data.Map.Ordered.Extra
                       Data.Monoid.Extra

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -234,6 +234,7 @@ Library
                       Clash.Core.Var
                       Clash.Core.VarEnv
 
+                      Clash.Data.RwVar
                       Clash.Data.UniqMap
 
                       Clash.DataFiles

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -150,7 +150,6 @@ Library
                       aeson-pretty            >= 0.8      && < 0.9,
                       ansi-terminal           >= 0.8.0.0  && < 1.2,
                       array,
-                      async                   >= 2.2.0    && < 2.3,
                       attoparsec              >= 0.10.4.0 && < 0.15,
                       base                    >= 4.18     && < 5,
                       base16-bytestring       >= 0.1.1    && < 1.1,
@@ -178,6 +177,9 @@ Library
                       infinite-list           ^>= 0.1,
                       lens                    >= 4.10     && < 5.4,
                       mtl                     >= 2.3.1    && < 2.4,
+                      lifted-async            >=0.10      && <0.12,
+                      lifted-base             >=0.2       && <0.3,
+                      monad-control           >=1.0       && <1.1,
                       ordered-containers      >= 0.2      && < 0.3,
                       prettyprinter           >= 1.2.0.1  && < 1.8,
                       prettyprinter-interp    ^>= 0.2,
@@ -190,6 +192,7 @@ Library
                       text                    >= 1.2.2    && < 2.2,
                       time                    >= 1.4.0.1  && < 1.17,
                       transformers            >= 0.6.1.0  && < 0.7,
+                      transformers-base,
                       trifecta                >= 1.7.1.1  && < 2.2,
                       vector                  >= 0.11     && < 1.0,
                       vector-binary-instances >= 0.2.3.5  && < 0.3,
@@ -264,6 +267,7 @@ Library
                       Clash.Normalize.PrimitiveReductions
                       Clash.Normalize.Primitives
                       Clash.Normalize.Strategy
+                      Clash.Normalize.TracedMVar
                       Clash.Normalize.Transformations
                       Clash.Normalize.Transformations.ANF
                       Clash.Normalize.Transformations.Case
@@ -323,6 +327,7 @@ Library
                       GHC.Data.FastString.Extra
 
   Other-Modules:      Clash.Annotations.TopEntity.Extra
+                      Control.Concurrent.Async.Lifted.Extra
                       Data.List.Extra
                       Data.Map.Ordered.Extra
                       Data.Monoid.Extra

--- a/clash-lib/src/Clash/Core/PartialEval/Monad.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/Monad.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2020-2021, QBayLogic B.V.
+Copyright   : (C) 2020-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -79,7 +79,7 @@ import           Clash.Core.Util (mkUniqSystemId, mkUniqSystemTyVar)
 import           Clash.Core.Var (Id, TyVar, Var)
 import           Clash.Core.VarEnv
 import           Clash.Driver.Types (Binding(..))
-import           Clash.Rewrite.WorkFree (isWorkFree)
+import           Clash.Rewrite.WorkFree (isWorkFreePure)
 import           Clash.Util.Supply (Supply)
 
 {-
@@ -307,7 +307,11 @@ workFreeValue :: Value -> Eval Bool
 workFreeValue = \case
   VNeutral _ -> pure False
   VThunk x _ -> do
-    bindings <- fmap (fmap asTerm) . genvBindings <$> getGlobalEnv
-    isWorkFree workFreeCache bindings x
+    env <- getGlobalEnv
+    let bindings = fmap (fmap asTerm) (genvBindings env)
+    let (cache, wf) = isWorkFreePure (genvWorkCache env) bindings x
+
+    modifyGlobalEnv (\genv -> genv { genvWorkCache = cache })
+    pure wf
 
   _ -> pure True

--- a/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
+++ b/clash-lib/src/Clash/Core/PartialEval/NormalForm.hs
@@ -1,6 +1,5 @@
 {-|
-Copyright   : (C) 2020-2021, QBayLogic B.V.,
-                  2022     , Google Inc.
+Copyright   : (C) 2020-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -27,10 +26,8 @@ module Clash.Core.PartialEval.NormalForm
   , Normal(..)
   , LocalEnv(..)
   , GlobalEnv(..)
-  , workFreeCache
   ) where
 
-import Control.Lens (Lens', lens)
 import Data.IntMap.Strict (IntMap)
 import Data.Map.Strict (Map)
 
@@ -199,6 +196,3 @@ data GlobalEnv = GlobalEnv
     -- ^ Cache for the results of isWorkFree. This is required to use
     -- Clash.Rewrite.WorkFree.isWorkFree.
   }
-
-workFreeCache :: Lens' GlobalEnv (VarEnv Bool)
-workFreeCache = lens genvWorkCache (\env x -> env { genvWorkCache = x })

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -39,12 +39,15 @@ module Clash.Core.VarEnv
     -- ** Conversions
     -- *** Lists
   , eltsVarEnv
+  , toListVarEnv
+  , listToVarEnv
     -- * Sets of variables
   , VarSet
     -- ** Construction
   , emptyVarSet
   , unitVarSet
     -- ** Modification
+  , extendVarSet
   , delVarSetByKey
   , unionVarSet
   , differenceVarSet
@@ -277,6 +280,15 @@ eltsVarEnv
   :: VarEnv a
   -> [a]
 eltsVarEnv = UniqMap.elems
+
+toListVarEnv :: VarEnv a -> [(Unique, a)]
+toListVarEnv = UniqMap.toList
+
+listToVarEnv
+  :: Uniquable a
+  => [(a, b)]
+  -> VarEnv b
+listToVarEnv = UniqMap.fromList
 
 -- | Does the variable exist in the environment
 elemVarEnv

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -9,6 +9,7 @@ module Clash.Core.VarEnv
     -- ** Accessors
     -- *** Size information
   , nullVarEnv
+  , sizeVarEnv
     -- ** Indexing
   , lookupVarEnv
   , lookupVarEnv'
@@ -206,6 +207,12 @@ nullVarEnv
   :: VarEnv a
   -> Bool
 nullVarEnv = UniqMap.null
+
+-- | The number of elements in a 'VarEnv'
+sizeVarEnv
+  :: VarEnv a
+  -> Int
+sizeVarEnv = UniqMap.size
 
 -- | Get the (left-biased) union of two environments
 unionVarEnv

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -39,6 +39,8 @@ module Clash.Core.VarEnv
     -- ** Conversions
     -- *** Lists
   , eltsVarEnv
+  , toListVarEnv
+  , listToVarEnv
     -- * Sets of variables
   , VarSet
     -- ** Construction
@@ -263,6 +265,15 @@ eltsVarEnv
   :: VarEnv a
   -> [a]
 eltsVarEnv = UniqMap.elems
+
+toListVarEnv :: VarEnv a -> [(Unique, a)]
+toListVarEnv = UniqMap.toList
+
+listToVarEnv
+  :: Uniquable a
+  => [(a, b)]
+  -> VarEnv b
+listToVarEnv = UniqMap.fromList
 
 -- | Does the variable exist in the environment
 elemVarEnv

--- a/clash-lib/src/Clash/Data/RwVar.hs
+++ b/clash-lib/src/Clash/Data/RwVar.hs
@@ -1,0 +1,68 @@
+{-|
+  Copyright   :  (C) 2026, QBayLogic B.V.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  A mutable variable for read-mostly state: reads are lock-free, writes are
+  serialized against each other.
+
+  Normalization state such as the global binding map is read orders of
+  magnitude more often than it is written (on a large design, ~1.5M reads
+  against ~9k writes). Holding a single 'Control.Concurrent.MVar.MVar' for
+  those reads makes every reader queue behind every other reader, which is
+  what a 'RwVar' avoids: 'readRwVar' never blocks, and only the writers in
+  'modifyRwVar' take the lock.
+-}
+
+{-# LANGUAGE FlexibleContexts #-}
+
+module Clash.Data.RwVar
+  ( RwVar
+  , newRwVar
+  , readRwVar
+  , modifyRwVar
+  , modifyRwVar_
+  ) where
+
+import Control.Concurrent.MVar (MVar)
+import Control.Monad.Base (MonadBase, liftBase)
+import Control.Monad.Trans.Control (MonadBaseControl)
+import Data.IORef (IORef)
+
+import qualified Control.Concurrent.MVar.Lifted as MVar
+import qualified Data.IORef as IORef
+
+-- | A variable holding read-mostly state.
+--
+-- The 'IORef' holds the current value; the 'MVar' serializes writers so that a
+-- read-modify-write in 'modifyRwVar' is atomic with respect to other writers.
+-- Readers ignore the lock entirely, so a reader can observe the value from
+-- before a write that is in progress — exactly as it could when a writer had
+-- not yet started.
+data RwVar a = RwVar (IORef a) (MVar ())
+
+-- | Create a 'RwVar' holding the given value.
+newRwVar :: MonadBase IO m => a -> m (RwVar a)
+newRwVar a = liftBase (RwVar <$> IORef.newIORef a <*> MVar.newMVar ())
+
+-- | Read the current value. Never blocks.
+readRwVar :: MonadBase IO m => RwVar a -> m a
+readRwVar (RwVar ref _) = liftBase (IORef.readIORef ref)
+{-# INLINE readRwVar #-}
+
+-- | Atomically update the value, and return a result computed alongside it.
+--
+-- The update runs with the write lock held, so it sees a value no other writer
+-- can be modifying. Keep it short: readers are unaffected, but other writers
+-- are not.
+modifyRwVar :: MonadBaseControl IO m => RwVar a -> (a -> m (a, b)) -> m b
+modifyRwVar (RwVar ref lock) f =
+  MVar.withMVar lock $ \() -> do
+    a0 <- liftBase (IORef.readIORef ref)
+    (a1, b) <- f a0
+    liftBase (IORef.writeIORef ref a1)
+    pure b
+
+-- | 'modifyRwVar' for updates with no result.
+modifyRwVar_ :: MonadBaseControl IO m => RwVar a -> (a -> m a) -> m ()
+modifyRwVar_ var f = modifyRwVar var (fmap (, ()) . f)

--- a/clash-lib/src/Clash/Data/UniqMap.hs
+++ b/clash-lib/src/Clash/Data/UniqMap.hs
@@ -15,6 +15,7 @@ module Clash.Data.UniqMap
   , singleton
   , singletonUnique
   , null
+  , size
   , insert
   , insertUnique
   , insertWith
@@ -122,6 +123,11 @@ singletonUnique v =
 null :: UniqMap a -> Bool
 null =
   IntMap.null . uniqMapToIntMap
+
+-- | The number of elements in the map.
+size :: UniqMap a -> Int
+size =
+  IntMap.size . uniqMapToIntMap
 
 {-# SPECIALIZE insert :: Unique -> b -> UniqMap b -> UniqMap b #-}
 -- | Insert a new key-value pair into the map.

--- a/clash-lib/src/Clash/Debug.hs
+++ b/clash-lib/src/Clash/Debug.hs
@@ -3,6 +3,7 @@
 module Clash.Debug
   ( debugIsOn
   , traceIf
+  , traceWhen
   , module Debug.Trace
   ) where
 
@@ -19,4 +20,8 @@ debugIsOn = False
 traceIf :: Bool -> String -> a -> a
 traceIf True  msg = trace msg
 traceIf False _   = id
-{-# INLINE traceIf #-}
+
+traceWhen :: Monad m => Bool -> String -> m ()
+traceWhen True = traceM
+traceWhen False = const (pure ())
+

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -23,7 +23,7 @@
 module Clash.Driver where
 
 import           Control.Concurrent               (MVar, modifyMVar, modifyMVar_, newMVar, withMVar)
-import           Control.Concurrent.Async         (mapConcurrently_)
+import           Control.Concurrent.Async.Lifted  (mapConcurrently_)
 import           Control.DeepSeq
 import           Control.Exception                (throw, Exception)
 import qualified Control.Monad                    as Monad
@@ -437,7 +437,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
       -- 2. Normalize topEntity
       supplyN <- Supply.newSupply
       transformedBindings <- normalizeEntity env bindingsMap typeTrans peEval
-                               eval topEntityNames supplyN topEntity
+                               eval ioLockV topEntityNames supplyN topEntity
 
       normTime <- transformedBindings `deepseq` Clock.getCurrentTime
       let prepNormDiff = reportTimeDiff normTime prevTime
@@ -1005,6 +1005,8 @@ normalizeEntity
   -- ^ Hardcoded evaluator for partial evaluation
   -> WHNF.Evaluator
   -- ^ Hardcoded evaluator for WHNF (old evaluator)
+  -> MVar ()
+  -- ^ Synchronization for stdout
   -> [Id]
   -- ^ TopEntities
   -> Supply.Supply
@@ -1012,14 +1014,14 @@ normalizeEntity
   -> Id
   -- ^ root of the hierarchy
   -> IO BindingMap
-normalizeEntity env bindingsMap typeTrans peEval eval topEntities supply tm = transformedBindings
+normalizeEntity env bindingsMap typeTrans peEval eval lock topEntities supply tm = transformedBindings
   where
     doNorm = do norm <- normalize [tm]
                 let normChecked = checkNonRecursive norm
                 cleaned <- cleanupGraph tm normChecked
                 return cleaned
     transformedBindings = runNormalization env supply bindingsMap
-                            typeTrans peEval eval emptyVarEnv
+                            typeTrans peEval eval emptyVarEnv lock
                             topEntities doNorm
 
 -- | Reverse topologically sort given top entities. Also returns a mapping that

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -24,7 +24,7 @@
 module Clash.Driver where
 
 import           Control.Concurrent               (MVar, modifyMVar, modifyMVar_, newMVar, withMVar)
-import           Control.Concurrent.Async         (mapConcurrently_)
+import           Control.Concurrent.Async.Lifted  (mapConcurrently_)
 import           Control.DeepSeq
 import           Control.Exception                (evaluate, throw, Exception)
 import qualified Control.Monad                    as Monad
@@ -455,7 +455,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
       -- 3. Normalize topEntity
       supplyN <- Supply.newSupply
       transformedBindings <- normalizeEntity env bindingsMap typeTrans peEval
-                               eval topEntityNames supplyN topEntity
+                               eval ioLockV topEntityNames supplyN topEntity
 
       normTime <- transformedBindings `deepseq` Clock.getCurrentTime
       let prepNormDiff = reportTimeDiff normTime prevTime
@@ -1159,6 +1159,8 @@ normalizeEntity
   -- ^ Hardcoded evaluator for partial evaluation
   -> WHNF.Evaluator
   -- ^ Hardcoded evaluator for WHNF (old evaluator)
+  -> MVar ()
+  -- ^ Synchronization for stdout
   -> [Id]
   -- ^ TopEntities
   -> Supply.Supply
@@ -1166,14 +1168,14 @@ normalizeEntity
   -> Id
   -- ^ root of the hierarchy
   -> IO BindingMap
-normalizeEntity env bindingsMap typeTrans peEval eval topEntities supply tm = transformedBindings
+normalizeEntity env bindingsMap typeTrans peEval eval lock topEntities supply tm = transformedBindings
   where
     doNorm = do norm <- normalize [tm]
                 let normChecked = checkNonRecursive norm
                 cleaned <- cleanupGraph tm normChecked
                 return cleaned
     transformedBindings = runNormalization env supply bindingsMap
-                            typeTrans peEval eval emptyVarEnv
+                            typeTrans peEval eval emptyVarEnv lock
                             topEntities doNorm
 
 -- | Reverse topologically sort given top entities. Also returns a mapping that

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -404,6 +404,8 @@ data ClashOpts = ClashOpts
   -- investigating bugs, because it will make log output deterministic.
   --
   -- Command line flag: -fclash-no-concurrent-topentity-compilation
+  , opt_concurrentNormalization :: Bool
+  -- ^ Toggle concurrent normalization (usually slower, faster on large designs)
   }
   deriving (Show, Eq, NFData, Generic, Hashable)
 
@@ -444,6 +446,7 @@ defClashOpts
   --      https://github.com/clash-lang/clash-compiler/issues/2762.
   , opt_ignoreBrokenGhcs    = unsafeLookupEnvBool "CLASH_IGNORE_BROKEN_GHCS" False
   , opt_concurrentTopEntities = True
+  , opt_concurrentNormalization = False
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -412,6 +412,10 @@ data ClashOpts = ClashOpts
   -- /which/ input changed.
   --
   -- Command line flag: -fclash-debug-manifest-hash
+  , opt_concurrentNormalization :: Bool
+  -- ^ Toggle concurrent normalization (usually slower, faster on large designs)
+  --
+  -- Command line flag: -fclash-no-concurrent-normalization
   }
   deriving (Show, Eq, NFData, Generic, Hashable)
 
@@ -453,6 +457,7 @@ defClashOpts
   , opt_ignoreBrokenGhcs    = unsafeLookupEnvBool "CLASH_IGNORE_BROKEN_GHCS" False
   , opt_concurrentTopEntities = True
   , opt_debugManifestHash   = False
+  , opt_concurrentNormalization = True
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -415,6 +415,10 @@ data ClashOpts = ClashOpts
   , opt_concurrentNormalization :: Bool
   -- ^ Toggle concurrent normalization (usually slower, faster on large designs)
   --
+  -- Has no effect when the RTS runs on a single capability: normalization then
+  -- runs sequentially rather than paying for synchronization it cannot use.
+  -- Pass @+RTS -N -RTS@ to give it capabilities to work with.
+  --
   -- Command line flag: -fclash-no-concurrent-normalization
   }
   deriving (Show, Eq, NFData, Generic, Hashable)

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -69,9 +69,10 @@ import           Clash.Core.TyCon                 (TyConMap)
 import           Clash.Core.TysPrim               (integerPrimTy, naturalPrimTy)
 import           Clash.Core.Util                  (splitShouldSplit)
 import           Clash.Core.Var                   (Id, Var (..), isGlobalId)
+import           Clash.Core.FreeVars              (globalIds)
 import           Clash.Core.VarEnv
-  (VarEnv, emptyInScopeSet, emptyVarEnv, extendVarEnv, lookupVarEnv,
-   lookupVarEnv')
+  (VarEnv, eltsVarEnv, elemVarSet, emptyInScopeSet, emptyVarEnv, emptyVarSet,
+   extendVarEnv, extendVarSet, lookupVarEnv, lookupVarEnv')
 import           Clash.Driver.Types               (BindingMap, Binding(..), ClashEnv(..), ClashOpts (..))
 import           Clash.Netlist.BlackBox
 import qualified Clash.Netlist.Id                 as Id
@@ -118,7 +119,7 @@ genNetlist env eval isTb globals tops topNames typeTrans ite be seen0 dir prefix
   return (topComponent, _components s, seen1)
  where
   (componentNames_, seen1) =
-    genNames (opt_newInlineStrat (envOpts env)) prefixM seen0 topNames globals
+    genNames (opt_newInlineStrat (envOpts env)) prefixM topEntity seen0 topNames globals
 
 -- | Run a NetlistMonad action in a given environment
 runNetlistMonad
@@ -173,21 +174,46 @@ runNetlistMonad env eval isTb s tops typeTrans ite be seenIds_ dir componentName
 
 -- | Generate names for all binders in "BindingMap", except for the ones already
 -- present in given identifier varenv.
+--
+-- Binders are named following a depth-first walk of the call graph rooted at
+-- the top entity, so the name a binder gets (in particular which of several
+-- same-named binders gets the bare name and which get @_N@ suffixes) depends
+-- only on the structure of the normalized terms — not on the unique each
+-- binder happens to carry, which varies with normalization order and, when
+-- normalizing concurrently (the default), with the thread schedule.
 genNames
   :: Bool
   -- ^ New inline strategy enabled?
   -> Maybe StrictText.Text
   -- ^ Prefix
+  -> Id
+  -- ^ Top entity, the root of the call-graph walk that determines the
+  -- naming order
   -> IdentifierSet
   -- ^ Identifier set to extend
   -> VarEnv Identifier
   -- ^ Pre-generated names
   -> BindingMap
   -> (VarEnv Identifier, IdentifierSet)
-genNames newInlineStrat prefixM is env bndrs =
-  runState (foldlM go env bndrs) is
+genNames newInlineStrat prefixM topEntity is env bndrs =
+  runState (foldlM go env orderedIds) is
  where
-  go env_ (bindingId -> id_) =
+  -- All binders reachable from the top entity in depth-first call-graph
+  -- order, followed by any unreachable leftovers (which never end up in the
+  -- generated HDL, so their relative order cannot influence it).
+  orderedIds = reachable ++ map bindingId (eltsVarEnv bndrs)
+
+  reachable = dfs emptyVarSet [topEntity]
+
+  dfs _ [] = []
+  dfs seen (i:rest)
+    | i `elemVarSet` seen = dfs seen rest
+    | Just b <- lookupVarEnv i bndrs =
+        i : dfs (extendVarSet seen i)
+                (Lens.toListOf globalIds (bindingTerm b) ++ rest)
+    | otherwise = dfs seen rest
+
+  go env_ id_ =
     case lookupVarEnv id_ env_ of
       Just _ -> pure env_
       Nothing -> do

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -10,19 +10,24 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Normalize where
 
+import           Control.Concurrent.MVar.Lifted   (MVar)
+import qualified Clash.Normalize.TracedMVar       as MVar
 import           Control.Exception                (throw)
 import qualified Control.Lens                     as Lens
-import           Control.Monad                    ((>=>), when)
+import           Control.Monad                    (when)
+import qualified Control.Monad.IO.Class as Monad  (liftIO)
 import           Control.Monad.State.Strict       (State)
+import           Data.Bifunctor                   (second)
 import           Data.Default                     (def)
 import           Data.Either                      (lefts,partitionEithers)
-import qualified Data.IntMap                      as IntMap
+import qualified Data.HashMap.Strict              as HashMap
 import           Data.List
   (intersect, mapAccumL)
 import qualified Data.Map                         as Map
@@ -56,9 +61,9 @@ import           Clash.Core.TyCon (TyConMap)
 import           Clash.Core.Type                  (isPolyTy)
 import           Clash.Core.Var                   (Id, varName, varType)
 import           Clash.Core.VarEnv
-  (VarEnv, elemVarSet, eltsVarEnv, emptyInScopeSet, emptyVarEnv,
-   extendVarEnv, lookupVarEnv, mapVarEnv, mapMaybeVarEnv,
-   mkVarEnv, mkVarSet, notElemVarEnv, notElemVarSet, nullVarEnv, unionVarEnv)
+  (VarEnv, VarSet, elemVarSet, eltsVarEnv, emptyInScopeSet, emptyVarEnv, emptyVarSet,
+   extendVarSet, lookupVarEnv, mapMaybeVarEnv,
+   mkVarEnv, mkVarSet, nullVarEnv)
 import           Clash.Debug                      (traceIf)
 import           Clash.Driver.Types
   (BindingMap, Binding(..), DebugOpts(..), ClashEnv(..))
@@ -73,21 +78,20 @@ import           Clash.Normalize.Util
 import           Clash.Rewrite.Combinators
   ((>->), (!->), bottomupR, repeatR, topdownR)
 import           Clash.Rewrite.Types
-  (RewriteEnv (..), RewriteState (..), bindings, debugOpts, extra,
-   tcCache, topEntities, newInlineStrategy)
+  (RewriteEnv (..), RewriteState (..), bindings, debugOpts, uniqSupply,
+   tcCache, topEntities, newInlineStrategy, ioLock)
 import           Clash.Rewrite.Util
   (apply, isUntranslatableType, runRewriteSession)
 import           Clash.Util
 import           Clash.Util.Interpolate           (i)
-import           Clash.Util.Supply                (Supply)
+import           Clash.Util.Supply                (Supply, splitSupply)
 
 import           Data.Binary                      (encode)
 import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Lazy             as BL
 
-import           System.IO.Unsafe                 (unsafePerformIO)
 import           Clash.Rewrite.Types (RewriteStep(..))
-
+import Control.Concurrent.Async.Lifted (mapConcurrently_)
 
 -- | Run a NormalizeSession in a given environment
 runNormalization
@@ -105,66 +109,79 @@ runNormalization
   -- ^ Hardcoded evaluator for WHNF (old evaluator)
   -> VarEnv Bool
   -- ^ Map telling whether a components is part of a recursive group
+  -> MVar ()
+  -- ^ Synchronization on stdout
   -> [Id]
   -- ^ topEntities
   -> NormalizeSession a
   -- ^ NormalizeSession to run
   -> IO a
-runNormalization env supply globals typeTrans peEval eval rcsMap topEnts =
-  runRewriteSession rwEnv rwState
-  where
-    -- TODO The RewriteEnv should just take ClashOpts.
-    rwEnv     = RewriteEnv
-                  env
-                  typeTrans
-                  peEval
-                  eval
-                  (mkVarSet topEnts)
+runNormalization env supply globals typeTrans peEval eval rcsMap lock entities session = do
+  normState <- NormalizeState
+    <$> MVar.newMVar "normalized" emptyVarEnv
+    <*> MVar.newMVar "specialisationCache" Map.empty
+    <*> MVar.newMVar "specialisationHistory" emptyVarEnv
+    <*> MVar.newMVar "inlineHistory" emptyVarEnv
+    <*> MVar.newMVar "primitiveArgs" Map.empty
+    <*> MVar.newMVar "recursiveComponents" rcsMap
 
-    rwState   = RewriteState
-                  0
-                  mempty       -- transformCounters Map
-                  globals
-                  supply
-                  (error $ $(curLoc) ++ "Report as bug: no curFun",noSrcSpan)
-                  0
-                  (IntMap.empty, 0)
-                  emptyVarEnv
-                  normState
+  rwState <- RewriteState
+    <$> MVar.newMVar "transformCounters" mempty
+    <*> MVar.newMVar "bindings" globals
+    <*> pure supply
+    <*> MVar.newMVar "curFun" HashMap.empty
+    <*> MVar.newMVar "nameCounter" 0
+    <*> MVar.newMVar "globalHeap" (mempty, 0)
+    <*> MVar.newMVar "workFreeBinders" mempty
+    <*> pure lock
+    <*> pure normState
 
-    normState = NormalizeState
-                  emptyVarEnv
-                  Map.empty
-                  emptyVarEnv
-                  emptyVarEnv
-                  Map.empty
-                  rcsMap
-
-normalize
-  :: [Id]
-  -> NormalizeSession BindingMap
-normalize = go >=> unionWithCache
+  runRewriteSession rwEnv rwState session
  where
-  go []  = return emptyVarEnv
-  go top = do
-    (new,topNormalized) <- unzip <$> mapM normalize' top
-    newNormalized <- normalize (concat new)
-    return (unionVarEnv (mkVarEnv topNormalized) newNormalized)
+  rwEnv = RewriteEnv
+    { _clashEnv = env
+    , _typeTranslator = typeTrans
+    , _peEvaluator = peEval
+    , _evaluator = eval
+    , _topEntities = mkVarSet entities
+    }
 
-  unionWithCache :: BindingMap -> NormalizeSession BindingMap
-  unionWithCache env = do
-    cache <- Lens.use (extra.normalized)
-    -- We need to include the cache in our final result, forgetting to do so
-    -- leads to https://github.com/clash-lang/clash-compiler/issues/3109
-    --
-    -- On the other hand, just returning the cache as our final result could
-    -- not be enough, because normalize' might return a non-normalized binder
-    -- that is later picked up and cleaned up by flattenCallTree.
-    return (unionVarEnv cache env)
+supplies :: Int -> Supply -> [Supply]
+supplies 0 _ = []
+supplies n s = let (s0', s1') = splitSupply s in s0' : supplies (n-1) s1'
 
-normalize' :: Id -> NormalizeSession ([Id], (Id, Binding Term))
+normalize :: [Id] -> NormalizeSession BindingMap
+normalize tops = do
+  binds <- MVar.newMVar "normalizeBinds" (emptyVarSet, [])
+  uniq0 <- Lens.use uniqSupply
+  let ss = supplies (length tops) uniq0
+  mapConcurrently_ (normalizeStep binds) (zip tops ss)
+  mkVarEnv . snd <$> MVar.readMVar "normalizeBinds" binds
+
+normalizeStep
+    :: MVar (VarSet, [(Id, Binding Term)])
+    -> (Id, Supply)
+    -> NormalizeSession ()
+normalizeStep binds (id', s) = do
+  uniqSupply Lens..= s
+  work <- MVar.modifyMVar "normalizeBinds" binds $ \(orig@(bound, pairs)) ->
+    if id' `elemVarSet` bound
+    then pure (orig, pure [])
+    else pure
+      ( (bound `extendVarSet` id', pairs)
+      , do
+          (pair, new) <- normalize' id'
+          MVar.modifyMVar_ "normalizeBinds" binds (pure . second (pair:))
+          pure new
+      )
+
+  new <- work
+  mapConcurrently_ (normalizeStep binds) new
+
+normalize' :: Id -> NormalizeSession ((Id, Binding Term), [(Id, Supply)])
 normalize' nm = do
-  exprM <- lookupVarEnv nm <$> Lens.use bindings
+  bndrsV <- Lens.use bindings
+  exprM <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv nm)
   let nmS = showPpr (varName nm)
   case exprM of
     Just (Binding nm' sp inl pr tm r) -> do
@@ -202,10 +219,10 @@ normalize' nm = do
                             , ") remains recursive after normalization:\n"
                             , showPpr (bindingTerm tmNorm) ])
                     (return ())
-            prevNorm <- mapVarEnv bindingId <$> Lens.use (extra.normalized)
-            let toNormalize = filter (`notElemVarSet` topEnts)
-                            $ filter (`notElemVarEnv` (extendVarEnv nm nm prevNorm)) usedBndrs
-            return (toNormalize,(nm,tmNorm))
+
+            s <- Lens.use uniqSupply
+            let ss = supplies (length usedBndrs) s
+            pure ((nm, tmNorm), zip usedBndrs ss)
          else
            do
             -- Throw an error for unrepresentable topEntities and functions
@@ -227,7 +244,7 @@ normalize' nm = do
                             , showPpr (coreTypeOf nm')
                             , ") has a non-representable return type."
                             , " Not normalising:\n", showPpr tm] )
-                    (return ([],(nm,(Binding nm' sp inl pr tm r))))
+                    (return ((nm,(Binding nm' sp inl pr tm r)), []))
 
 
     Nothing -> error $ $(curLoc) ++ "Expr belonging to bndr: " ++ nmS ++ " not found"
@@ -359,18 +376,22 @@ flattenCallTree (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
       -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
       opts <- Lens.view debugOpts
       let rewriteHistFile = dbg_historyFile opts
-      when (Maybe.isJust rewriteHistFile) $
-        let !_ = unsafePerformIO
-             $ BS.appendFile (Maybe.fromJust rewriteHistFile)
-             $ BL.toStrict
-             $ encode RewriteStep
-                 { t_ctx    = []
-                 , t_name   = "INLINE"
-                 , t_bndrS  = showPpr (varName nm')
-                 , t_before = tm
-                 , t_after  = tm1
-                 }
-        in pure ()
+
+      when (Maybe.isJust rewriteHistFile) $ do
+        lock <- Lens.use ioLock
+
+        MVar.withMVar "ioLock" lock $ \() ->
+          Monad.liftIO
+            . BS.appendFile (Maybe.fromJust rewriteHistFile)
+            . BL.toStrict
+            $ encode RewriteStep
+                { t_ctx    = []
+                , t_name   = "INLINE"
+                , t_bndrS  = showPpr (varName nm')
+                , t_before = tm
+                , t_after  = tm1
+                }
+
       rewriteExpr ("flattenExpr",flatten) (showPpr nm, tm1) (nm', sp)
   let allUsed = newUsed ++ concat il_used
   -- inline all components when the resulting expression after flattening

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -70,7 +70,7 @@ import           Clash.Core.VarEnv
    mkVarEnv, mkVarSet, nullVarEnv)
 import           Clash.Debug                      (traceIf)
 import           Clash.Driver.Types
-  (BindingMap, Binding(..), DebugOpts(..), ClashEnv(..))
+  (BindingMap, Binding(..), ClashEnv(..), ClashOpts(..), DebugOpts(..))
 import           Clash.Netlist.Types
   (HWMap, FilteredHWType(..))
 import           Clash.Netlist.Util
@@ -82,7 +82,7 @@ import           Clash.Normalize.Util
 import           Clash.Rewrite.Combinators
   ((>->), (!->), bottomupR, repeatR, topdownR)
 import           Clash.Rewrite.Types
-  (RewriteEnv (..), RewriteState (..), bindings, debugOpts, uniqSupply,
+  (RewriteEnv (..), RewriteState (..), bindings, clashEnv, debugOpts, uniqSupply,
    tcCache, topEntities, newInlineStrategy, ioLock)
 import           Clash.Rewrite.Util
   (apply, isUntranslatableType, runRewriteSession)
@@ -157,16 +157,22 @@ supplies n s = let (s0', s1') = splitSupply s in s0' : supplies (n-1) s1'
 normalize :: [Id] -> NormalizeSession BindingMap
 normalize tops = do
   binds <- MVar.newMVar "normalizeBinds" (emptyVarSet, [])
+  concurrent <- Lens.view (clashEnv . Lens.to (opt_concurrentNormalization . envOpts))
   uniq0 <- Lens.use uniqSupply
   let ss = supplies (length tops) uniq0
-  mapConcurrently_ (normalizeStep binds) (zip tops ss)
+  normalizeMany concurrent (normalizeStep concurrent binds) (zip tops ss)
   mkVarEnv . snd <$> MVar.readMVar "normalizeBinds" binds
 
+normalizeMany :: Bool -> (a -> NormalizeSession ()) -> [a] -> NormalizeSession ()
+normalizeMany True = mapConcurrently_
+normalizeMany False = mapM_
+
 normalizeStep
-    :: MVar (VarSet, [(Id, Binding Term)])
+    :: Bool
+    -> MVar (VarSet, [(Id, Binding Term)])
     -> (Id, Supply)
     -> NormalizeSession ()
-normalizeStep binds (id', s) = do
+normalizeStep concurrent binds (id', s) = do
   uniqSupply Lens..= s
   work <- MVar.modifyMVar "normalizeBinds" binds $ \(orig@(bound, pairs)) ->
     if id' `elemVarSet` bound
@@ -180,7 +186,7 @@ normalizeStep binds (id', s) = do
       )
 
   new <- work
-  mapConcurrently_ (normalizeStep binds) new
+  normalizeMany concurrent (normalizeStep concurrent binds) new
 
 normalize' :: Id -> NormalizeSession ((Id, Binding Term), [(Id, Supply)])
 normalize' nm = do

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -10,23 +10,28 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Normalize where
 
+import           Control.Concurrent.MVar.Lifted   (MVar)
+import qualified Clash.Normalize.TracedMVar       as MVar
 import           Control.Exception                (throw)
 import qualified Control.Lens                     as Lens
 import           Control.Monad                    ((>=>), when)
 import           Control.Monad.IO.Class           (liftIO)
 import           Control.Monad.State.Strict       (State)
+import           Data.Bifunctor                   (second)
 import           Data.Default                     (def)
 import           Data.Either                      (lefts,partitionEithers)
 import qualified Data.IntMap                      as IntMap
 import qualified Data.IORef                       as IORef
 import           Clash.Data.UniqMap               (UniqMap)
 import qualified Clash.Data.UniqMap               as UniqMap
+import qualified Data.HashMap.Strict              as HashMap
 import           Data.List
   (intersect, mapAccumL)
 import qualified Data.Map                         as Map
@@ -60,9 +65,9 @@ import           Clash.Core.TyCon (TyConMap)
 import           Clash.Core.Type                  (isPolyTy)
 import           Clash.Core.Var                   (Id, varName, varType)
 import           Clash.Core.VarEnv
-  (VarEnv, elemVarSet, eltsVarEnv, emptyInScopeSet, emptyVarEnv,
-   extendVarEnv, lookupVarEnv, mapVarEnv, mapMaybeVarEnv,
-   mkVarEnv, mkVarSet, notElemVarEnv, notElemVarSet, nullVarEnv, unionVarEnv)
+  (VarEnv, VarSet, elemVarSet, eltsVarEnv, emptyInScopeSet, emptyVarEnv, emptyVarSet,
+   extendVarSet, lookupVarEnv, mapMaybeVarEnv,
+   mkVarEnv, mkVarSet, nullVarEnv)
 import           Clash.Debug                      (traceIf)
 import           Clash.Driver.Types
   (BindingMap, Binding(..), DebugOpts(..), ClashEnv(..))
@@ -77,20 +82,20 @@ import           Clash.Normalize.Util
 import           Clash.Rewrite.Combinators
   ((>->), (!->), bottomupR, repeatR, topdownR)
 import           Clash.Rewrite.Types
-  (RewriteEnv (..), RewriteState (..), bindings, debugOpts, extra,
-   tcCache, topEntities, newInlineStrategy)
+  (RewriteEnv (..), RewriteState (..), bindings, debugOpts, uniqSupply,
+   tcCache, topEntities, newInlineStrategy, ioLock)
 import           Clash.Rewrite.Util
   (apply, isUntranslatableType, runRewriteSession)
 import           Clash.Util
 import           Clash.Util.Interpolate           (i)
-import           Clash.Util.Supply                (Supply)
+import           Clash.Util.Supply                (Supply, splitSupply)
 
 import           Data.Binary                      (encode)
 import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Lazy             as BL
 
 import           Clash.Rewrite.Types (RewriteStep(..))
-
+import Control.Concurrent.Async.Lifted (mapConcurrently_)
 
 -- | Run a NormalizeSession in a given environment
 runNormalization
@@ -108,66 +113,79 @@ runNormalization
   -- ^ Hardcoded evaluator for WHNF (old evaluator)
   -> VarEnv Bool
   -- ^ Map telling whether a components is part of a recursive group
+  -> MVar ()
+  -- ^ Synchronization on stdout
   -> [Id]
   -- ^ topEntities
   -> NormalizeSession a
   -- ^ NormalizeSession to run
   -> IO a
-runNormalization env supply globals typeTrans peEval eval rcsMap topEnts =
-  runRewriteSession rwEnv rwState
-  where
-    -- TODO The RewriteEnv should just take ClashOpts.
-    rwEnv     = RewriteEnv
-                  env
-                  typeTrans
-                  peEval
-                  eval
-                  (mkVarSet topEnts)
+runNormalization env supply globals typeTrans peEval eval rcsMap lock entities session = do
+  normState <- NormalizeState
+    <$> MVar.newMVar "normalized" emptyVarEnv
+    <*> MVar.newMVar "specialisationCache" Map.empty
+    <*> MVar.newMVar "specialisationHistory" emptyVarEnv
+    <*> MVar.newMVar "inlineHistory" emptyVarEnv
+    <*> MVar.newMVar "primitiveArgs" Map.empty
+    <*> MVar.newMVar "recursiveComponents" rcsMap
 
-    rwState   = RewriteState
-                  0
-                  mempty       -- transformCounters Map
-                  globals
-                  supply
-                  (error $ $(curLoc) ++ "Report as bug: no curFun",noSrcSpan)
-                  0
-                  (IntMap.empty, 0)
-                  emptyVarEnv
-                  normState
+  rwState <- RewriteState
+    <$> MVar.newMVar "transformCounters" mempty
+    <*> MVar.newMVar "bindings" globals
+    <*> pure supply
+    <*> MVar.newMVar "curFun" HashMap.empty
+    <*> MVar.newMVar "nameCounter" 0
+    <*> MVar.newMVar "globalHeap" (mempty, 0)
+    <*> MVar.newMVar "workFreeBinders" mempty
+    <*> pure lock
+    <*> pure normState
 
-    normState = NormalizeState
-                  emptyVarEnv
-                  Map.empty
-                  emptyVarEnv
-                  emptyVarEnv
-                  Map.empty
-                  rcsMap
-
-normalize
-  :: [Id]
-  -> NormalizeSession BindingMap
-normalize = go >=> unionWithCache
+  runRewriteSession rwEnv rwState session
  where
-  go []  = return emptyVarEnv
-  go top = do
-    (new,topNormalized) <- unzip <$> mapM normalize' top
-    newNormalized <- normalize (concat new)
-    return (unionVarEnv (mkVarEnv topNormalized) newNormalized)
+  rwEnv = RewriteEnv
+    { _clashEnv = env
+    , _typeTranslator = typeTrans
+    , _peEvaluator = peEval
+    , _evaluator = eval
+    , _topEntities = mkVarSet entities
+    }
 
-  unionWithCache :: BindingMap -> NormalizeSession BindingMap
-  unionWithCache env = do
-    cache <- Lens.use (extra.normalized)
-    -- We need to include the cache in our final result, forgetting to do so
-    -- leads to https://github.com/clash-lang/clash-compiler/issues/3109
-    --
-    -- On the other hand, just returning the cache as our final result could
-    -- not be enough, because normalize' might return a non-normalized binder
-    -- that is later picked up and cleaned up by flattenCallTree.
-    return (unionVarEnv cache env)
+supplies :: Int -> Supply -> [Supply]
+supplies 0 _ = []
+supplies n s = let (s0', s1') = splitSupply s in s0' : supplies (n-1) s1'
 
-normalize' :: Id -> NormalizeSession ([Id], (Id, Binding Term))
+normalize :: [Id] -> NormalizeSession BindingMap
+normalize tops = do
+  binds <- MVar.newMVar "normalizeBinds" (emptyVarSet, [])
+  uniq0 <- Lens.use uniqSupply
+  let ss = supplies (length tops) uniq0
+  mapConcurrently_ (normalizeStep binds) (zip tops ss)
+  mkVarEnv . snd <$> MVar.readMVar "normalizeBinds" binds
+
+normalizeStep
+    :: MVar (VarSet, [(Id, Binding Term)])
+    -> (Id, Supply)
+    -> NormalizeSession ()
+normalizeStep binds (id', s) = do
+  uniqSupply Lens..= s
+  work <- MVar.modifyMVar "normalizeBinds" binds $ \(orig@(bound, pairs)) ->
+    if id' `elemVarSet` bound
+    then pure (orig, pure [])
+    else pure
+      ( (bound `extendVarSet` id', pairs)
+      , do
+          (pair, new) <- normalize' id'
+          MVar.modifyMVar_ "normalizeBinds" binds (pure . second (pair:))
+          pure new
+      )
+
+  new <- work
+  mapConcurrently_ (normalizeStep binds) new
+
+normalize' :: Id -> NormalizeSession ((Id, Binding Term), [(Id, Supply)])
 normalize' nm = do
-  exprM <- lookupVarEnv nm <$> Lens.use bindings
+  bndrsV <- Lens.use bindings
+  exprM <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv nm)
   let nmS = showPpr (varName nm)
   case exprM of
     Just (Binding nm' sp inl pr tm r) -> do
@@ -205,10 +223,10 @@ normalize' nm = do
                             , ") remains recursive after normalization:\n"
                             , showPpr (bindingTerm tmNorm) ])
                     (return ())
-            prevNorm <- mapVarEnv bindingId <$> Lens.use (extra.normalized)
-            let toNormalize = filter (`notElemVarSet` topEnts)
-                            $ filter (`notElemVarEnv` (extendVarEnv nm nm prevNorm)) usedBndrs
-            return (toNormalize,(nm,tmNorm))
+
+            s <- Lens.use uniqSupply
+            let ss = supplies (length usedBndrs) s
+            pure ((nm, tmNorm), zip usedBndrs ss)
          else
            do
             -- Throw an error for unrepresentable topEntities and functions
@@ -230,7 +248,7 @@ normalize' nm = do
                             , showPpr (coreTypeOf nm')
                             , ") has a non-representable return type."
                             , " Not normalising:\n", showPpr tm] )
-                    (return ([],(nm,(Binding nm' sp inl pr tm r))))
+                    (return ((nm,(Binding nm' sp inl pr tm r)), []))
 
 
     Nothing -> error $ $(curLoc) ++ "Expr belonging to bndr: " ++ nmS ++ " not found"
@@ -379,17 +397,19 @@ flattenCallTree cache (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
        -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
        opts <- Lens.view debugOpts
        let rewriteHistFile = dbg_historyFile opts
-       when (Maybe.isJust rewriteHistFile) $
-         liftIO
-           $ BS.appendFile (Maybe.fromJust rewriteHistFile)
-           $ BL.toStrict
-           $ encode RewriteStep
-               { t_ctx    = []
-               , t_name   = "INLINE"
-               , t_bndrS  = showPpr (varName nm')
-               , t_before = tm
-               , t_after  = tm1
-               }
+       when (Maybe.isJust rewriteHistFile) $ do
+         lock <- Lens.use ioLock
+         MVar.withMVar "ioLock" lock $ \() ->
+           liftIO
+             $ BS.appendFile (Maybe.fromJust rewriteHistFile)
+             $ BL.toStrict
+             $ encode RewriteStep
+                 { t_ctx    = []
+                 , t_name   = "INLINE"
+                 , t_bndrS  = showPpr (varName nm')
+                 , t_before = tm
+                 , t_after  = tm1
+                 }
        rewriteExpr ("flattenExpr",flatten) (showPpr nm, tm1) (nm', sp)
    let allUsed = newUsed ++ concat il_used
    -- inline all components when the resulting expression after flattening

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -18,6 +18,7 @@
 module Clash.Normalize where
 
 import           Control.Concurrent.MVar.Lifted   (MVar)
+import qualified Clash.Data.RwVar                as RwVar
 import qualified Clash.Normalize.TracedMVar       as MVar
 import           Control.Exception                (throw)
 import qualified Control.Lens                     as Lens
@@ -84,7 +85,7 @@ import           Clash.Rewrite.Types
   (RewriteEnv (..), RewriteState (..), bindings, clashEnv, debugOpts, uniqSupply,
    tcCache, topEntities, newInlineStrategy, ioLock)
 import           Clash.Rewrite.Util
-  (apply, isUntranslatableType, runRewriteSession)
+  (apply, isUntranslatableType, runRewriteSession, withSharedHWTypeCache)
 import           Clash.Util
 import           Clash.Util.Interpolate           (i)
 import           Clash.Util.Supply                (Supply, splitSupply)
@@ -125,19 +126,20 @@ runNormalization env supply globals typeTrans peEval eval rcsMap lock entities s
     <*> MVar.newMVar "specialisationCache" Map.empty
     <*> MVar.newMVar "specialisationHistory" emptyVarEnv
     <*> MVar.newMVar "inlineHistory" emptyVarEnv
-    <*> MVar.newMVar "primitiveArgs" Map.empty
-    <*> MVar.newMVar "recursiveComponents" rcsMap
+    <*> RwVar.newRwVar Map.empty
+    <*> RwVar.newRwVar rcsMap
 
   rwState <- RewriteState
     <$> MVar.newMVar "transformAppliedCounters" mempty
     <*> MVar.newMVar "transformTriedCounters" mempty
-    <*> MVar.newMVar "bindings" globals
+    <*> RwVar.newRwVar globals
     <*> pure supply
     <*> MVar.newMVar "curFun" HashMap.empty
     <*> MVar.newMVar "nameCounter" 0
     <*> MVar.newMVar "globalHeap" (mempty, 0)
-    <*> MVar.newMVar "workFreeBinders" mempty
-    <*> pure Map.empty  -- hwTypeCache
+    <*> RwVar.newRwVar mempty
+    <*> pure Map.empty  -- hwTypeCache (task-local)
+    <*> RwVar.newRwVar Map.empty  -- sharedHwTypeCache
     <*> pure lock
     <*> pure normState
 
@@ -181,18 +183,23 @@ normalizeStep concurrent binds (id', s) = do
     else pure
       ( (bound `extendVarSet` id', pairs)
       , do
-          (pair, new) <- normalize' id'
+          -- This task runs with its own copy of the state, so the type
+          -- translations it performs would be lost without this.
+          (pair, new) <- shareCache (normalize' id')
           MVar.modifyMVar_ "normalizeBinds" binds (pure . second (pair:))
           pure new
       )
 
   new <- work
   normalizeMany concurrent (normalizeStep concurrent binds) new
+ where
+  shareCache | concurrent = withSharedHWTypeCache
+             | otherwise = id
 
 normalize' :: Id -> NormalizeSession ((Id, Binding Term), [(Id, Supply)])
 normalize' nm = do
   bndrsV <- Lens.use bindings
-  exprM <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv nm)
+  exprM <- lookupVarEnv nm <$> RwVar.readRwVar bndrsV
   let nmS = showPpr (varName nm)
   case exprM of
     Just (Binding nm' sp inl pr tm r) -> do
@@ -405,6 +412,14 @@ If you touch code related to this, please make sure to run benchmarks.
 -- | Flatten a 'CallTree', memoizing results by binder Id within one cleanup
 -- pass. Without the cache, every binder reachable from the root is flattened
 -- as many times as it appears in the (un-deduplicated) call tree.
+-- Note [flattening is a chain, not a fan-out]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- Flattening sibling branches concurrently was measured on wireDemoTest and
+-- gained nothing: of the 1016 nodes in that call tree, 415 have exactly one
+-- child, and the root's flattening spans the entire phase because every level
+-- has to wait for the child whose flattened body it substitutes. The phase is
+-- a dependency chain; the way to make it faster is to make each node's rewrite
+-- cheaper, not to run nodes at the same time.
 flattenCallTree
   :: IORef.IORef (UniqMap CallTree)
   -- ^ Memo cache, keyed by binder Id. Local to one 'cleanupGraph' call.
@@ -412,8 +427,6 @@ flattenCallTree
   -> NormalizeSession CallTree
 flattenCallTree _ c@(CLeaf _) = return c
 flattenCallTree cache (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
-  -- XXX: Careful! If you ever add concurrency, this will have to be changed to
-  --      account for multiple workers.
   cached <- liftIO (UniqMap.lookup nm <$> IORef.readIORef cache)
   case cached of
     Just ct -> pure ct

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -10,23 +10,27 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Normalize where
 
+import           Control.Concurrent.MVar.Lifted   (MVar)
+import qualified Clash.Normalize.TracedMVar       as MVar
 import           Control.Exception                (throw)
 import qualified Control.Lens                     as Lens
-import           Control.Monad                    ((>=>), when)
+import           Control.Monad                    (when)
 import           Control.Monad.IO.Class           (liftIO)
 import           Control.Monad.State.Strict       (State)
+import           Data.Bifunctor                   (second)
 import           Data.Default                     (def)
 import           Data.Either                      (lefts,partitionEithers)
-import qualified Data.IntMap                      as IntMap
 import qualified Data.IORef                       as IORef
 import           Clash.Data.UniqMap               (UniqMap)
 import qualified Clash.Data.UniqMap               as UniqMap
+import qualified Data.HashMap.Strict              as HashMap
 import           Data.List
   (intersect, mapAccumL)
 import qualified Data.Map                         as Map
@@ -60,12 +64,12 @@ import           Clash.Core.TyCon (TyConMap)
 import           Clash.Core.Type                  (isPolyTy)
 import           Clash.Core.Var                   (Id, varName, varType)
 import           Clash.Core.VarEnv
-  (VarEnv, elemVarSet, eltsVarEnv, emptyInScopeSet, emptyVarEnv,
-   extendVarEnv, lookupVarEnv, mapVarEnv, mapMaybeVarEnv,
-   mkVarEnv, mkVarSet, notElemVarEnv, notElemVarSet, nullVarEnv, unionVarEnv)
+  (VarEnv, VarSet, elemVarSet, eltsVarEnv, emptyInScopeSet, emptyVarEnv, emptyVarSet,
+   extendVarSet, lookupVarEnv, mapMaybeVarEnv,
+   mkVarEnv, mkVarSet, nullVarEnv)
 import           Clash.Debug                      (traceIf)
 import           Clash.Driver.Types
-  (BindingMap, Binding(..), DebugOpts(..), ClashEnv(..))
+  (BindingMap, Binding(..), ClashEnv(..), ClashOpts(..), DebugOpts(..))
 import           Clash.Netlist.Types
   (HWMap, FilteredHWType(..))
 import           Clash.Netlist.Util
@@ -77,20 +81,20 @@ import           Clash.Normalize.Util
 import           Clash.Rewrite.Combinators
   ((>->), (!->), bottomupR, repeatR, topdownFixR)
 import           Clash.Rewrite.Types
-  (RewriteEnv (..), RewriteState (..), bindings, debugOpts, extra,
-   tcCache, topEntities, newInlineStrategy)
+  (RewriteEnv (..), RewriteState (..), bindings, clashEnv, debugOpts, uniqSupply,
+   tcCache, topEntities, newInlineStrategy, ioLock)
 import           Clash.Rewrite.Util
   (apply, isUntranslatableType, runRewriteSession)
 import           Clash.Util
 import           Clash.Util.Interpolate           (i)
-import           Clash.Util.Supply                (Supply)
+import           Clash.Util.Supply                (Supply, splitSupply)
 
 import           Data.Binary                      (encode)
 import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Lazy             as BL
 
 import           Clash.Rewrite.Types (RewriteStep(..))
-
+import Control.Concurrent.Async.Lifted (mapConcurrently_)
 
 -- | Run a NormalizeSession in a given environment
 runNormalization
@@ -108,68 +112,87 @@ runNormalization
   -- ^ Hardcoded evaluator for WHNF (old evaluator)
   -> VarEnv Bool
   -- ^ Map telling whether a components is part of a recursive group
+  -> MVar ()
+  -- ^ Synchronization on stdout
   -> [Id]
   -- ^ topEntities
   -> NormalizeSession a
   -- ^ NormalizeSession to run
   -> IO a
-runNormalization env supply globals typeTrans peEval eval rcsMap topEnts =
-  runRewriteSession rwEnv rwState
-  where
-    -- TODO The RewriteEnv should just take ClashOpts.
-    rwEnv     = RewriteEnv
-                  env
-                  typeTrans
-                  peEval
-                  eval
-                  (mkVarSet topEnts)
+runNormalization env supply globals typeTrans peEval eval rcsMap lock entities session = do
+  normState <- NormalizeState
+    <$> MVar.newMVar "normalized" emptyVarEnv
+    <*> MVar.newMVar "specialisationCache" Map.empty
+    <*> MVar.newMVar "specialisationHistory" emptyVarEnv
+    <*> MVar.newMVar "inlineHistory" emptyVarEnv
+    <*> MVar.newMVar "primitiveArgs" Map.empty
+    <*> MVar.newMVar "recursiveComponents" rcsMap
 
-    rwState   = RewriteState
-                  0
-                  mempty       -- transformAppliedCounters Map
-                  mempty       -- transformTriedCounters Map
-                  globals
-                  supply
-                  (error $ $(curLoc) ++ "Report as bug: no curFun",noSrcSpan)
-                  0
-                  (IntMap.empty, 0)
-                  emptyVarEnv
-                  Map.empty    -- hwTypeCache
-                  normState
+  rwState <- RewriteState
+    <$> MVar.newMVar "transformAppliedCounters" mempty
+    <*> MVar.newMVar "transformTriedCounters" mempty
+    <*> MVar.newMVar "bindings" globals
+    <*> pure supply
+    <*> MVar.newMVar "curFun" HashMap.empty
+    <*> MVar.newMVar "nameCounter" 0
+    <*> MVar.newMVar "globalHeap" (mempty, 0)
+    <*> MVar.newMVar "workFreeBinders" mempty
+    <*> pure Map.empty  -- hwTypeCache
+    <*> pure lock
+    <*> pure normState
 
-    normState = NormalizeState
-                  emptyVarEnv
-                  Map.empty
-                  emptyVarEnv
-                  emptyVarEnv
-                  Map.empty
-                  rcsMap
-
-normalize
-  :: [Id]
-  -> NormalizeSession BindingMap
-normalize = go >=> unionWithCache
+  runRewriteSession rwEnv rwState session
  where
-  go []  = return emptyVarEnv
-  go top = do
-    (new,topNormalized) <- unzip <$> mapM normalize' top
-    newNormalized <- normalize (concat new)
-    return (unionVarEnv (mkVarEnv topNormalized) newNormalized)
+  rwEnv = RewriteEnv
+    { _clashEnv = env
+    , _typeTranslator = typeTrans
+    , _peEvaluator = peEval
+    , _evaluator = eval
+    , _topEntities = mkVarSet entities
+    }
 
-  unionWithCache :: BindingMap -> NormalizeSession BindingMap
-  unionWithCache env = do
-    cache <- Lens.use (extra.normalized)
-    -- We need to include the cache in our final result, forgetting to do so
-    -- leads to https://github.com/clash-lang/clash-compiler/issues/3109
-    --
-    -- On the other hand, just returning the cache as our final result could
-    -- not be enough, because normalize' might return a non-normalized binder
-    -- that is later picked up and cleaned up by flattenCallTree.
-    return (unionVarEnv cache env)
+supplies :: Int -> Supply -> [Supply]
+supplies 0 _ = []
+supplies n s = let (s0', s1') = splitSupply s in s0' : supplies (n-1) s1'
 
-normalize' :: Id -> NormalizeSession ([Id], (Id, Binding Term))
+normalize :: [Id] -> NormalizeSession BindingMap
+normalize tops = do
+  binds <- MVar.newMVar "normalizeBinds" (emptyVarSet, [])
+  concurrent <- Lens.view (clashEnv . Lens.to (opt_concurrentNormalization . envOpts))
+  uniq0 <- Lens.use uniqSupply
+  let ss = supplies (length tops) uniq0
+  normalizeMany concurrent (normalizeStep concurrent binds) (zip tops ss)
+  mkVarEnv . snd <$> MVar.readMVar "normalizeBinds" binds
+
+normalizeMany :: Bool -> (a -> NormalizeSession ()) -> [a] -> NormalizeSession ()
+normalizeMany True = mapConcurrently_
+normalizeMany False = mapM_
+
+normalizeStep
+    :: Bool
+    -> MVar (VarSet, [(Id, Binding Term)])
+    -> (Id, Supply)
+    -> NormalizeSession ()
+normalizeStep concurrent binds (id', s) = do
+  uniqSupply Lens..= s
+  work <- MVar.modifyMVar "normalizeBinds" binds $ \(orig@(bound, pairs)) ->
+    if id' `elemVarSet` bound
+    then pure (orig, pure [])
+    else pure
+      ( (bound `extendVarSet` id', pairs)
+      , do
+          (pair, new) <- normalize' id'
+          MVar.modifyMVar_ "normalizeBinds" binds (pure . second (pair:))
+          pure new
+      )
+
+  new <- work
+  normalizeMany concurrent (normalizeStep concurrent binds) new
+
+normalize' :: Id -> NormalizeSession ((Id, Binding Term), [(Id, Supply)])
 normalize' nm = do
-  exprM <- lookupVarEnv nm <$> Lens.use bindings
+  bndrsV <- Lens.use bindings
+  exprM <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv nm)
   let nmS = showPpr (varName nm)
   case exprM of
     Just (Binding nm' sp inl pr tm r) -> do
@@ -207,10 +230,10 @@ normalize' nm = do
                             , ") remains recursive after normalization:\n"
                             , showPpr (bindingTerm tmNorm) ])
                     (return ())
-            prevNorm <- mapVarEnv bindingId <$> Lens.use (extra.normalized)
-            let toNormalize = filter (`notElemVarSet` topEnts)
-                            $ filter (`notElemVarEnv` (extendVarEnv nm nm prevNorm)) usedBndrs
-            return (toNormalize,(nm,tmNorm))
+
+            s <- Lens.use uniqSupply
+            let ss = supplies (length usedBndrs) s
+            pure ((nm, tmNorm), zip usedBndrs ss)
          else
            do
             -- Throw an error for unrepresentable topEntities and functions
@@ -232,7 +255,7 @@ normalize' nm = do
                             , showPpr (coreTypeOf nm')
                             , ") has a non-representable return type."
                             , " Not normalising:\n", showPpr tm] )
-                    (return ([],(nm,(Binding nm' sp inl pr tm r))))
+                    (return ((nm,(Binding nm' sp inl pr tm r)), []))
 
 
     Nothing -> error $ $(curLoc) ++ "Expr belonging to bndr: " ++ nmS ++ " not found"
@@ -412,17 +435,19 @@ flattenCallTree cache (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
        -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
        opts <- Lens.view debugOpts
        let rewriteHistFile = dbg_historyFile opts
-       when (Maybe.isJust rewriteHistFile) $
-         liftIO
-           $ BS.appendFile (Maybe.fromJust rewriteHistFile)
-           $ BL.toStrict
-           $ encode RewriteStep
-               { t_ctx    = []
-               , t_name   = "INLINE"
-               , t_bndrS  = showPpr (varName nm')
-               , t_before = tm
-               , t_after  = tm1
-               }
+       when (Maybe.isJust rewriteHistFile) $ do
+         lock <- Lens.use ioLock
+         MVar.withMVar "ioLock" lock $ \() ->
+           liftIO
+             $ BS.appendFile (Maybe.fromJust rewriteHistFile)
+             $ BL.toStrict
+             $ encode RewriteStep
+                 { t_ctx    = []
+                 , t_name   = "INLINE"
+                 , t_bndrS  = showPpr (varName nm')
+                 , t_before = tm
+                 , t_after  = tm1
+                 }
        rewriteExpr ("flattenExpr",flatten) (showPpr nm, tm1) (nm', sp)
    let allUsed = newUsed ++ concat il_used
    -- inline all components when the resulting expression after flattening

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -20,6 +20,7 @@ module Clash.Normalize where
 import           Control.Concurrent.MVar.Lifted   (MVar)
 import qualified Clash.Data.RwVar                as RwVar
 import qualified Clash.Normalize.TracedMVar       as MVar
+import qualified Control.Concurrent               as Concurrent
 import           Control.Exception                (throw)
 import qualified Control.Lens                     as Lens
 import           Control.Monad                    (when)
@@ -157,10 +158,18 @@ supplies :: Int -> Supply -> [Supply]
 supplies 0 _ = []
 supplies n s = let (s0', s1') = splitSupply s in s0' : supplies (n-1) s1'
 
+-- | Whether to normalize concurrently: requested by the user and if there is more
+-- than one thread available to the runtime.
+useConcurrency :: NormalizeSession Bool
+useConcurrency = do
+  requested <- Lens.view (clashEnv . Lens.to (opt_concurrentNormalization . envOpts))
+  capabilities <- liftIO Concurrent.getNumCapabilities
+  pure (requested && capabilities > 1)
+
 normalize :: [Id] -> NormalizeSession BindingMap
 normalize tops = do
   binds <- MVar.newMVar "normalizeBinds" (emptyVarSet, [])
-  concurrent <- Lens.view (clashEnv . Lens.to (opt_concurrentNormalization . envOpts))
+  concurrent <- useConcurrency
   uniq0 <- Lens.use uniqSupply
   let ss = supplies (length tops) uniq0
   normalizeMany concurrent (normalizeStep concurrent binds) (zip tops ss)

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -1,7 +1,8 @@
 {-|
   Copyright  :  (C) 2015-2016, University of Twente,
                     2016     , Myrtle Software Ltd,
-                    2021-2024, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
+                    2021     , QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -438,7 +439,6 @@ reduceIterateI n aTy vTy _kn f0 a (TransformContext is0 ctx) = do
   tcm <- Lens.view tcCache
   f1 <- constantPropagation (TransformContext is0 (AppArg Nothing:ctx)) f0
 
-  -- Generate uniq ids for element assignments.
   uniqs0 <- Lens.use uniqSupply
   let
     is1 = extendInScopeSetList is0 (collectTermIds f1)
@@ -955,6 +955,7 @@ reduceUnconcat unconcatPrimInfo n m aTy _kn sm arg (TransformContext inScope _ct
             (uniqs1,(vars,headsAndTails)) =
               second (second sconcat . NE.unzip)
                      (extractElems uniqs0 inScope consCon aTy 'U' (n*m) arg)
+
             -- Build a vector out of the first m elements
             mvec = mkVec nilCon consCon aTy m (NE.take (fromInteger m) vars)
             -- Get the vector representing the next ((n-1)*m) elements

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -1,7 +1,8 @@
 {-|
   Copyright  :  (C) 2015-2016, University of Twente,
                     2016     , Myrtle Software Ltd,
-                    2021-2024, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
+                    2021     , QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -440,7 +441,6 @@ reduceIterateI n aTy vTy _kn f0 a (TransformContext is0 ctx) = do
   tcm <- Lens.view tcCache
   f1 <- constantPropagation (TransformContext is0 (AppArg Nothing:ctx)) f0
 
-  -- Generate uniq ids for element assignments.
   uniqs0 <- Lens.use uniqSupply
   let
     is1 = extendInScopeSetList is0 (collectTermIds f1)
@@ -961,6 +961,7 @@ reduceUnconcat unconcatPrimInfo n m aTy _kn sm arg (TransformContext inScope _ct
             (uniqs1,(vars,headsAndTails)) =
               second (second sconcat . NE.unzip)
                      (extractElems uniqs0 inScope consCon aTy 'U' (n*m) arg)
+
             -- Build a vector out of the first m elements
             mvec = mkVec nilCon consCon aTy m (NE.take (fromInteger m) vars)
             -- Get the vector representing the next ((n-1)*m) elements

--- a/clash-lib/src/Clash/Normalize/TracedMVar.hs
+++ b/clash-lib/src/Clash/Normalize/TracedMVar.hs
@@ -1,0 +1,142 @@
+{-|
+Copyright  :  (C) 2025 Martijn Bastiaan
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Traced wrappers around Control.Concurrent.MVar operations.
+Each function takes an extra String argument for context and uses HasCallStack
+to provide detailed tracing information about MVar operations.
+-}
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Clash.Normalize.TracedMVar
+  ( MVar
+  , newEmptyMVar
+  , newMVar
+  , takeMVar
+  , putMVar
+  , readMVar
+  , modifyMVar
+  , modifyMVar_
+  , withMVar
+  ) where
+
+import Control.Concurrent.MVar (MVar)
+import Control.Exception.Lifted (finally)
+import Control.Monad (when)
+import Control.Monad.Base (MonadBase, liftBase)
+import Control.Monad.Trans.Control (MonadBaseControl)
+import GHC.Stack (HasCallStack, callStack, getCallStack, SrcLoc(..), withFrozenCallStack)
+import System.IO (hPutStrLn, stderr)
+
+import Clash.Core.Pretty (unsafeLookupEnvBool)
+
+import qualified Control.Concurrent.Lifted as Concurrent
+import qualified Control.Concurrent.MVar.Lifted as MVar
+import qualified Clash.Util.Interpolate as I
+
+-- | Check if MVar tracing is enabled via CLASH_DEBUG_MVAR environment variable.
+-- Defaults to False if not set.
+traceEnabled :: Bool
+traceEnabled = unsafeLookupEnvBool "CLASH_DEBUG_MVAR" False
+{-# NOINLINE traceEnabled #-}
+
+-- | Get the immediate callsite location (filename:lineno)
+callSite :: HasCallStack => String
+callSite = withFrozenCallStack $
+  case getCallStack callStack of
+    ((_,loc):_) -> srcLocFile loc ++ ":" ++ show (srcLocStartLine loc)
+    [] -> "<no-callstack>"
+
+-- | Trace a lock event with lock name and call stack
+trace :: (HasCallStack, MonadBase IO m) => String -> String -> m ()
+trace lockName event = do
+  when traceEnabled $ do
+    threadId <- Concurrent.myThreadId
+    liftBase $ hPutStrLn stderr [I.i|[TracedMVar][#{threadId}][#{lockName}] #{event} #{callSite}|]
+
+-- | Trace when trying to acquire a lock
+traceTry :: (HasCallStack, MonadBase IO m) => String -> m ()
+traceTry lockName = withFrozenCallStack $ trace lockName "try"
+
+-- | Trace when a lock has been acquired
+traceAcquire :: (HasCallStack, MonadBase IO m) => String -> m ()
+traceAcquire lockName = withFrozenCallStack $ trace lockName "acq"
+
+-- | Trace when a lock has been returned
+traceReturn :: (HasCallStack, MonadBase IO m) => String -> m ()
+traceReturn lockName = withFrozenCallStack $ trace lockName "ret"
+
+-- | Wrap an MVar operation with optional tracing based on traceEnabled.
+-- If tracing is disabled, just runs the action directly.
+-- If tracing is enabled, runs the provided tracing action.
+wrap :: (HasCallStack, Monad m) => m a -> m a -> m a
+wrap action tracedAction = if traceEnabled then tracedAction else action
+
+-- | Create an empty MVar
+newEmptyMVar :: (HasCallStack, MonadBaseControl IO m) => String -> m (MVar a)
+newEmptyMVar lockName = withFrozenCallStack $ wrap MVar.newEmptyMVar $ do
+  traceTry lockName
+  mvar <- MVar.newEmptyMVar
+  traceReturn lockName
+  return mvar
+
+-- | Create a new MVar with an initial value
+newMVar :: (HasCallStack, MonadBaseControl IO m) => String -> a -> m (MVar a)
+newMVar lockName val = withFrozenCallStack $ wrap (MVar.newMVar val) $ do
+  traceTry lockName
+  mvar <- MVar.newMVar val
+  traceReturn lockName
+  return mvar
+
+-- | Take a value from an MVar
+takeMVar :: (HasCallStack, MonadBaseControl IO m) => String -> MVar a -> m a
+takeMVar lockName mvar = withFrozenCallStack $ wrap (MVar.takeMVar mvar) $ do
+  traceTry lockName
+  val <- MVar.takeMVar mvar
+  traceAcquire lockName
+  return val
+
+-- | Put a value into an MVar
+putMVar :: (HasCallStack, MonadBaseControl IO m) => String -> MVar a -> a -> m ()
+putMVar lockName mvar val = withFrozenCallStack $ wrap (MVar.putMVar mvar val) $ do
+  traceTry lockName
+  MVar.putMVar mvar val
+  traceReturn lockName
+
+-- | Read a value from an MVar without taking it
+readMVar :: (HasCallStack, MonadBaseControl IO m) => String -> MVar a -> m a
+readMVar lockName mvar = withFrozenCallStack $ wrap (MVar.readMVar mvar) $ do
+  traceTry lockName
+  val <- MVar.readMVar mvar
+  traceAcquire lockName
+  traceReturn lockName
+  return val
+
+-- | Modify the contents of an MVar
+modifyMVar :: (HasCallStack, MonadBaseControl IO m) => String -> MVar a -> (a -> m (a, b)) -> m b
+modifyMVar lockName mvar f = withFrozenCallStack $ wrap (MVar.modifyMVar mvar f) $ do
+  traceTry lockName
+  result <- MVar.modifyMVar mvar $ \a -> do
+    traceAcquire lockName
+    f a `finally` traceReturn lockName
+  return result
+
+-- | Modify the contents of an MVar (discarding result)
+modifyMVar_ :: (HasCallStack, MonadBaseControl IO m) => String -> MVar a -> (a -> m a) -> m ()
+modifyMVar_ lockName mvar f = withFrozenCallStack $ wrap (MVar.modifyMVar_ mvar f) $ do
+  traceTry lockName
+  MVar.modifyMVar_ mvar $ \a -> do
+    traceAcquire lockName
+    f a `finally` traceReturn lockName
+
+-- | Perform an action with the value from an MVar
+withMVar :: (HasCallStack, MonadBaseControl IO m) => String -> MVar a -> (a -> m b) -> m b
+withMVar lockName mvar f = withFrozenCallStack $ wrap (MVar.withMVar mvar f) $ do
+  traceTry lockName
+  result <- MVar.withMVar mvar $ \a -> do
+    traceAcquire lockName
+    f a `finally` traceReturn lockName
+  return result

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -26,9 +26,10 @@ module Clash.Normalize.Transformations.Case
   , elimExistentials
   ) where
 
+import qualified Clash.Normalize.TracedMVar as MVar
+import qualified Control.Lens as Lens
 import Control.Exception.Base (patError)
 import GHC.Prim.Panic (absentError)
-import qualified Control.Lens as Lens
 import Control.Monad.State.Strict (evalState)
 import Data.Bifunctor (second)
 import Data.Coerce (coerce)
@@ -64,7 +65,7 @@ import Clash.Core.Util (listToLets, mkInternalVar)
 import Clash.Core.VarEnv
   ( InScopeSet, elemVarSet, extendInScopeSet, extendInScopeSetList, mkVarSet
   , unitVarSet, uniqAway)
-import Clash.Debug (traceIf)
+import Clash.Debug (traceM)
 import Clash.Driver.Types (DebugOpts(dbg_invariants))
 import Clash.Netlist.Types (FilteredHWType(..), HWType(..))
 import Clash.Netlist.Util (coreTypeToHWType, representableType)
@@ -73,7 +74,7 @@ import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Rewrite.Combinators ((>-!))
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, customReprs, debugOpts, tcCache
-  , typeTranslator, workFreeBinders)
+  , typeTranslator, workFreeBinders, ioLock)
 import Clash.Rewrite.Util (changed, isFromInt, whnfRW)
 import Clash.Rewrite.WorkFree
 import Clash.Util (curLoc)
@@ -237,8 +238,9 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
       -- based on the fact on whether the argument has the potential to make
       -- the circuit larger than needed if we were to duplicate that argument.
       newBinder (isN0, substN) (x, arg) = do
-        bndrs <- Lens.use bindings
-        isWorkFree workFreeBinders bndrs arg >>= \case
+        bindingsV <- Lens.use bindings
+        wf <- MVar.withMVar "bindings" bindingsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+        case wf of
           True -> pure ((isN0, (x, arg):substN), Nothing)
           False ->
             let
@@ -316,14 +318,21 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
             -> caseCon ctx1 (Case (Literal (IntegerLiteral 0)) ty alts)
           _ -> do
             opts <- Lens.view debugOpts
+            ioLockV <- Lens.use ioLock
             -- When invariants are being checked, report missing evaluation
             -- rules for the primitive evaluator.
-            traceIf (dbg_invariants opts && isConstant subj)
-              ("Unmatchable constant as case subject: " ++ showPpr subj ++
-                 "\nWHNF is: " ++ showPpr subj1)
+            let shouldTrace = dbg_invariants opts && isConstant subj
+            if shouldTrace then do
+              MVar.withMVar "ioLock" ioLockV $ \() ->
+                traceM ("Unmatchable constant as case subject: " ++ showPpr subj ++
+                       "\nWHNF is: " ++ showPpr subj1)
               -- Otherwise check whether the entire case-expression has a
               -- single alternative, and pick that one.
-              (caseOneAlt e)
+              caseOneAlt e
+            else
+              -- Otherwise check whether the entire case-expression has a
+              -- single alternative, and pick that one.
+              caseOneAlt e
 
   -- The subject is a variable
   (Var v, [], _) | isNum0 (coreTypeOf v) ->

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -27,9 +27,10 @@ module Clash.Normalize.Transformations.Case
   , elimCaseBigNumInternals
   ) where
 
+import qualified Clash.Normalize.TracedMVar as MVar
+import qualified Control.Lens as Lens
 import Control.Exception.Base (patError)
 import GHC.Prim.Panic (absentError)
-import qualified Control.Lens as Lens
 import Control.Monad.State.Strict (evalState)
 import Data.Bifunctor (second)
 import Data.Coerce (coerce)
@@ -66,7 +67,7 @@ import Clash.Core.Util (listToLets, mkInternalVar)
 import Clash.Core.VarEnv
   ( InScopeSet, elemVarSet, extendInScopeSet, extendInScopeSetList, mkVarSet
   , unitVarSet, uniqAway)
-import Clash.Debug (traceIf)
+import Clash.Debug (traceM)
 import Clash.Driver.Types (DebugOpts(dbg_invariants))
 import Clash.Netlist.Types (FilteredHWType(..), HWType(..))
 import Clash.Netlist.Util (coreTypeToHWType, representableType)
@@ -75,7 +76,7 @@ import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Rewrite.Combinators ((>-!))
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, customReprs, debugOpts, tcCache
-  , typeTranslator, workFreeBinders)
+  , typeTranslator, workFreeBinders, ioLock)
 import Clash.Rewrite.Util (changed, isFromInt, whnfRW)
 import Clash.Rewrite.WorkFree
 import Clash.Util (curLoc)
@@ -239,8 +240,9 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
       -- based on the fact on whether the argument has the potential to make
       -- the circuit larger than needed if we were to duplicate that argument.
       newBinder (isN0, substN) (x, arg) = do
-        bndrs <- Lens.use bindings
-        isWorkFree workFreeBinders bndrs arg >>= \case
+        bindingsV <- Lens.use bindings
+        wf <- MVar.withMVar "bindings" bindingsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+        case wf of
           True -> pure ((isN0, (x, arg):substN), Nothing)
           False ->
             let
@@ -318,14 +320,21 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
             -> caseCon ctx1 (Case (Literal (IntegerLiteral 0)) ty alts)
           _ -> do
             opts <- Lens.view debugOpts
+            ioLockV <- Lens.use ioLock
             -- When invariants are being checked, report missing evaluation
             -- rules for the primitive evaluator.
-            traceIf (dbg_invariants opts && isConstant subj)
-              ("Unmatchable constant as case subject: " ++ showPpr subj ++
-                 "\nWHNF is: " ++ showPpr subj1)
+            let shouldTrace = dbg_invariants opts && isConstant subj
+            if shouldTrace then do
+              MVar.withMVar "ioLock" ioLockV $ \() ->
+                traceM ("Unmatchable constant as case subject: " ++ showPpr subj ++
+                       "\nWHNF is: " ++ showPpr subj1)
               -- Otherwise check whether the entire case-expression has a
               -- single alternative, and pick that one.
-              (caseOneAlt e)
+              caseOneAlt e
+            else
+              -- Otherwise check whether the entire case-expression has a
+              -- single alternative, and pick that one.
+              caseOneAlt e
 
   -- The subject is a variable
   (Var v, [], _) | isNum0 (coreTypeOf v) ->

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -27,6 +27,7 @@ module Clash.Normalize.Transformations.Case
   , elimCaseBigNumInternals
   ) where
 
+import qualified Clash.Data.RwVar as RwVar
 import qualified Clash.Normalize.TracedMVar as MVar
 import qualified Control.Lens as Lens
 import Control.Exception.Base (patError)
@@ -236,7 +237,7 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
       -- the circuit larger than needed if we were to duplicate that argument.
       newBinder (isN0, substN) (x, arg) = do
         bindingsV <- Lens.use bindings
-        wf <- MVar.withMVar "bindings" bindingsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+        wf <- (\bndrs -> isWorkFree workFreeBinders bndrs arg) =<< RwVar.readRwVar bindingsV
         case wf of
           True -> pure ((isN0, (x, arg):substN), Nothing)
           False ->

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -27,10 +27,10 @@ module Clash.Normalize.Transformations.Case
   , elimCaseBigNumInternals
   ) where
 
+import qualified Clash.Normalize.TracedMVar as MVar
+import qualified Control.Lens as Lens
 import Control.Exception.Base (patError)
 import GHC.Prim.Panic (absentError)
-import qualified Control.Lens as Lens
-
 import Data.Bifunctor (second)
 import Data.Coerce (coerce)
 import qualified Data.Either as Either
@@ -66,7 +66,7 @@ import Clash.Core.Util (listToLets, mkInternalVar)
 import Clash.Core.VarEnv
   ( InScopeSet, elemVarSet, extendInScopeSet, extendInScopeSetList, mkVarSet
   , unitVarSet, uniqAway)
-import Clash.Debug (traceIf)
+import Clash.Debug (traceM)
 import Clash.Driver.Types (DebugOpts(dbg_invariants))
 import Clash.Netlist.Types (FilteredHWType(..), HWType(..))
 import Clash.Netlist.Util (coreTypeToHWType)
@@ -75,7 +75,7 @@ import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Rewrite.Combinators ((>-!))
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, customReprs, debugOpts, tcCache
-  , typeTranslator, workFreeBinders)
+  , typeTranslator, workFreeBinders, ioLock)
 import Clash.Rewrite.Util
   (changed, isFromInt, isUntranslatableType, runWithHWTypeCache, whnfRW)
 import Clash.Rewrite.WorkFree
@@ -235,8 +235,9 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
       -- based on the fact on whether the argument has the potential to make
       -- the circuit larger than needed if we were to duplicate that argument.
       newBinder (isN0, substN) (x, arg) = do
-        bndrs <- Lens.use bindings
-        isWorkFree workFreeBinders bndrs arg >>= \case
+        bindingsV <- Lens.use bindings
+        wf <- MVar.withMVar "bindings" bindingsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+        case wf of
           True -> pure ((isN0, (x, arg):substN), Nothing)
           False ->
             let
@@ -315,14 +316,21 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
             -> caseCon ctx1 (Case (Literal (IntegerLiteral 0)) ty alts)
           _ -> do
             opts <- Lens.view debugOpts
+            ioLockV <- Lens.use ioLock
             -- When invariants are being checked, report missing evaluation
             -- rules for the primitive evaluator.
-            traceIf (dbg_invariants opts && isConstant subj)
-              ("Unmatchable constant as case subject: " ++ showPpr subj ++
-                 "\nWHNF is: " ++ showPpr subj1)
+            let shouldTrace = dbg_invariants opts && isConstant subj
+            if shouldTrace then do
+              MVar.withMVar "ioLock" ioLockV $ \() ->
+                traceM ("Unmatchable constant as case subject: " ++ showPpr subj ++
+                       "\nWHNF is: " ++ showPpr subj1)
               -- Otherwise check whether the entire case-expression has a
               -- single alternative, and pick that one.
-              (caseOneAlt e)
+              caseOneAlt e
+            else
+              -- Otherwise check whether the entire case-expression has a
+              -- single alternative, and pick that one.
+              caseOneAlt e
 
   -- The subject is a variable
   (Var v, [], _) | isNum0 (coreTypeOf v) ->

--- a/clash-lib/src/Clash/Normalize/Transformations/Cast.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Cast.hs
@@ -9,9 +9,13 @@ module Clash.Normalize.Transformations.Cast
   , splitCastWork
   ) where
 
+import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import Control.Exception (throw)
 import qualified Control.Lens as Lens
+import qualified Control.Monad as Monad (when)
 import Control.Monad.Writer (listen)
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Monoid as Monoid (Any(..))
 import GHC.Stack (HasCallStack)
 
@@ -22,11 +26,11 @@ import Clash.Core.TermInfo (isCast)
 import Clash.Core.Type (normalizeType)
 import Clash.Core.Var (isGlobalId, varName)
 import Clash.Core.VarEnv (InScopeSet)
-import Clash.Debug (trace)
+import Clash.Debug (traceM)
 import Clash.Normalize.Transformations.Specialize (specialize)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Rewrite.Types
-  (TransformContext(..), bindings, curFun, tcCache, workFreeBinders)
+  (TransformContext(..), bindings, curFun, tcCache, workFreeBinders, ioLock)
 import Clash.Rewrite.Util (changed, mkDerivedName, mkTmBinderFor)
 import Clash.Rewrite.WorkFree (isWorkFree)
 import Clash.Util (ClashException(..), curLoc)
@@ -58,18 +62,23 @@ argCastSpec ctx e@(App f (stripTicks -> Cast e' _ _))
  -- We can only push casts into global binders
  , (Var g, _) <- collectArgs f
  , isGlobalId g = do
-  bndrs <- Lens.use bindings
-  isWorkFree workFreeBinders bndrs e' >>= \case
-    True -> go
-    False -> warn go
+  bndrsV <- Lens.use bindings
+  wf <- MVar.withMVar "bindings" bndrsV (\bndrs -> isWorkFree workFreeBinders bndrs e')
+
+  ioLockV <- Lens.use ioLock
+
+  Monad.when (not wf) $
+    MVar.withMVar "ioLock" ioLockV $ \() -> traceM warn
+
+  specialize ctx e
  where
-  go = specialize ctx e
-  warn = trace (unwords
+  warn = unwords
     [ "WARNING:", $(curLoc), "specializing a function on a non work-free"
     , "cast. Generated HDL implementation might contain duplicate work."
     , "Please report this as a bug.", "\n\nExpression where this occured:"
     , "\n\n" ++ showPpr e
-    ])
+    ]
+
 argCastSpec _ e = return e
 {-# SCC argCastSpec #-}
 
@@ -96,7 +105,9 @@ elimCastCast _ c@(Cast (stripTicks -> Cast e tyA tyB) tyB' tyC) = do
   if ntyB == ntyB' && ntyA == ntyC then changed e
                                    else throwError
   where throwError = do
-          (nm,sp) <- Lens.use curFun
+          curFunsV <- Lens.use curFun
+          thread <- myThreadId
+          Just (nm,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
           throw (ClashException sp ($(curLoc) ++ showPpr nm
                   ++ ": Found 2 nested casts whose types don't line up:\n"
                   ++ showPpr c)

--- a/clash-lib/src/Clash/Normalize/Transformations/Cast.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Cast.hs
@@ -10,6 +10,7 @@ module Clash.Normalize.Transformations.Cast
   ) where
 
 import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Data.RwVar as RwVar
 import qualified Clash.Normalize.TracedMVar as MVar
 import Control.Exception (throw)
 import qualified Control.Lens as Lens
@@ -63,7 +64,7 @@ argCastSpec ctx e@(App f (stripTicks -> Cast e' _ _))
  , (Var g, _) <- collectArgs f
  , isGlobalId g = do
   bndrsV <- Lens.use bindings
-  wf <- MVar.withMVar "bindings" bndrsV (\bndrs -> isWorkFree workFreeBinders bndrs e')
+  wf <- (\bndrs -> isWorkFree workFreeBinders bndrs e') =<< RwVar.readRwVar bndrsV
 
   ioLockV <- Lens.use ioLock
 

--- a/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
@@ -37,7 +37,8 @@ module Clash.Normalize.Transformations.DEC
   ( disjointExpressionConsolidation
   ) where
 
-import Control.Lens ((^.), _1)
+import qualified Clash.Normalize.TracedMVar as MVar
+import           Control.Lens ((^.), _1)
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import Data.Bifunctor (first, second)
@@ -317,13 +318,19 @@ collectGlobals is0 substitution seen (Case scrut ty alts) = do
 collectGlobals is0 substitution seen e@(collectArgsTicks -> (fun, args@(_:_), ticks))
   | not (isConstant e) = do
     tcm <- Lens.view tcCache
-    bndrs <- Lens.use bindings
+    bndrsV <- Lens.use bindings
     evaluate <- Lens.view evaluator
     ids <- Lens.use uniqSupply
     let (ids1,ids2) = splitSupply ids
     uniqSupply Lens..= ids2
-    gh <- Lens.use globalHeap
-    let eval = (Lens.view Lens._3) . whnf' evaluate bndrs mempty tcm gh ids1 is0 False
+
+    ghV <- Lens.use globalHeap
+
+    eval <-
+      MVar.withMVar "bindings" bndrsV $ \bndrs ->
+        MVar.withMVar "globalHeap" ghV $ \gh ->
+          pure $ (Lens.view Lens._3) . whnf' evaluate bndrs mempty tcm gh ids1 is0 False
+
     let eTy  = inferCoreTypeOf tcm e
     untran <- isUntranslatableType False eTy
     case untran of

--- a/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
@@ -37,7 +37,8 @@ module Clash.Normalize.Transformations.DEC
   ( disjointExpressionConsolidation
   ) where
 
-import Control.Lens ((^.), _1)
+import qualified Clash.Normalize.TracedMVar as MVar
+import           Control.Lens ((^.), _1)
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import Data.Bifunctor (first, second)
@@ -320,13 +321,19 @@ collectGlobals is0 substitution seen (Case scrut ty alts) = do
 collectGlobals is0 substitution seen e@(collectArgsTicks -> (fun, args@(_:_), ticks))
   | not (isConstant e) = do
     tcm <- Lens.view tcCache
-    bndrs <- Lens.use bindings
+    bndrsV <- Lens.use bindings
     evaluate <- Lens.view evaluator
     ids <- Lens.use uniqSupply
     let (ids1,ids2) = splitSupply ids
     uniqSupply Lens..= ids2
-    gh <- Lens.use globalHeap
-    let eval = (Lens.view Lens._3) . whnf' evaluate bndrs mempty tcm gh ids1 is0 False
+
+    ghV <- Lens.use globalHeap
+
+    eval <-
+      MVar.withMVar "bindings" bndrsV $ \bndrs ->
+        MVar.withMVar "globalHeap" ghV $ \gh ->
+          pure $ (Lens.view Lens._3) . whnf' evaluate bndrs mempty tcm gh ids1 is0 False
+
     let eTy  = inferCoreTypeOf tcm e
     untran <- isUntranslatableType False eTy
     case untran of

--- a/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
@@ -37,6 +37,7 @@ module Clash.Normalize.Transformations.DEC
   ( disjointExpressionConsolidation
   ) where
 
+import qualified Clash.Data.RwVar as RwVar
 import qualified Clash.Normalize.TracedMVar as MVar
 import           Control.Lens ((^.), _1)
 import qualified Control.Lens as Lens
@@ -329,10 +330,10 @@ collectGlobals is0 substitution seen e@(collectArgsTicks -> (fun, args@(_:_), ti
 
     ghV <- Lens.use globalHeap
 
+    bndrs <- RwVar.readRwVar bndrsV
     eval <-
-      MVar.withMVar "bindings" bndrsV $ \bndrs ->
-        MVar.withMVar "globalHeap" ghV $ \gh ->
-          pure $ (Lens.view Lens._3) . whnf' evaluate bndrs mempty tcm gh ids1 is0 False
+      MVar.withMVar "globalHeap" ghV $ \gh ->
+        pure $ (Lens.view Lens._3) . whnf' evaluate bndrs mempty tcm gh ids1 is0 False
 
     let eTy  = inferCoreTypeOf tcm e
     untran <- isUntranslatableType False eTy

--- a/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
@@ -32,6 +32,8 @@ module Clash.Normalize.Transformations.Inline
   , inlineWorkFree
   ) where
 
+import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import Control.Monad ((>=>))
@@ -40,6 +42,7 @@ import Control.Monad.Writer (lift,listen)
 import Data.Default (Default(..))
 import Data.Either  (lefts)
 import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.HashMap.Strict as HashMapS
 import qualified Data.List as List
 import qualified Data.Maybe as Maybe
 import qualified Data.Monoid as Monoid (Any(..))
@@ -74,7 +77,7 @@ import Clash.Core.VarEnv
   , eltsVarEnv, emptyVarEnv, extendInScopeSetList, extendVarEnv
   , foldlWithUniqueVarEnv', lookupVarEnv, lookupVarEnvDirectly, mkVarEnv
   , notElemVarSet, unionVarEnv, unionVarEnvWith, unitVarSet)
-import Clash.Debug (trace)
+import Clash.Debug (traceM)
 import Clash.Driver.Types (Binding(..))
 import Clash.Netlist.Util (representableType)
 import Clash.Primitives.Types
@@ -83,7 +86,7 @@ import Clash.Rewrite.Combinators (allR)
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, curFun, customReprs, tcCache, topEntities
   , typeTranslator, inlineConstantLimit, inlineFunctionLimit, inlineLimit
-  , inlineWFCacheLimit, primitives)
+  , inlineWFCacheLimit, primitives, ioLock)
 import Clash.Rewrite.Util
   ( changed, inlineBinders, inlineOrLiftBinders, isJoinPointIn
   , isUntranslatable, isUntranslatableType, isVoidWrapper, zoomExtra)
@@ -121,7 +124,9 @@ bindConstantVar = inlineBinders test
       True -> return (i `notElemFreeVars` e)
       _    -> do
         tcm <- Lens.view tcCache
-        (fn,_) <- Lens.use curFun
+        curFunsV <- Lens.use curFun
+        thread <- myThreadId
+        Just (fn,_) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
         -- Don't inline things that perform work, it increases the circuit size.
         --
         -- Also don't inline globally recursive calls, it prevents the
@@ -399,8 +404,11 @@ simply a variable reference. See issue #779 -}
 -- on functions that might be inlined later. See #3036.
 collapseRHSNoops :: HasCallStack => NormRewrite
 collapseRHSNoops _ letrec@(Let letBind body) = do
-  (curFunId, _) <- Lens.use curFun
-  curBinding <- lookupVarEnv curFunId <$> Lens.use bindings
+  curFunsV <- Lens.use curFun
+  thread <- myThreadId
+  Just (curFunId, _) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
+  bindingsV <- Lens.use bindings
+  curBinding <- MVar.withMVar "bindings" bindingsV (pure . lookupVarEnv curFunId)
   case curBinding of
     Just binding | isNoInline (bindingSpec binding) -> do
       -- Explicitly match on Let instead of using LetRec, because we need to
@@ -417,32 +425,40 @@ collapseRHSNoops _ letrec@(Let letBind body) = do
     runCollapseNoop orig =
       runMaybeT (collapseNoop orig) >>= Maybe.maybe (return orig) changed
 
-    collapseNoop (iD,term) = do
+    collapseNoop :: (Id, Term) -> MaybeT NormalizeSession (Id, Term)
+    collapseNoop (iD, term) = do
       (Prim info,args) <- return $ collectArgs term
       identity         <- getIdentity info $ lefts args
       collapsed        <- collapseToIdentity iD identity
       return (iD,collapsed)
 
+    collapseToIdentity :: Id -> Term -> MaybeT NormalizeSession Term
     collapseToIdentity iD identity = do
       tcm <- Lens.view tcCache
       let aTy = inferCoreTypeOf tcm identity
           bTy = coreTypeOf iD
       return $ primUCo `TyApp` aTy `TyApp` bTy `App` identity
 
+    getIdentity :: PrimInfo -> [Term] -> MaybeT NormalizeSession Term
     getIdentity primInfo termArgs = do
       WorkIdentity idIdx noopIdxs <- return $ primWorkInfo primInfo
       mapM_ (getTermArg termArgs >=> isNoop >=> Monad.guard) noopIdxs
       getTermArg termArgs idIdx
 
+    getTermArg :: [Term] -> Int -> MaybeT NormalizeSession Term
     getTermArg args i = do
       Monad.guard $ i <= length args - 1
       return $ args !! i
 
+    isNoop :: Term -> MaybeT NormalizeSession Bool
     isNoop (Var i) = do
-      binding     <- MaybeT $ lookupVarEnv i <$> Lens.use bindings
-      isRecursive <- lift $ isRecursiveBndr $ bindingId binding
+      bindingsV <- Lens.use bindings
+      binding <- MVar.withMVar "bindings" bindingsV (MaybeT . pure . lookupVarEnv i)
+      isRecursive <- lift $ isRecursiveBndr (bindingId binding)
+
       Monad.guard $ not isRecursive
       isNoop $ bindingTerm binding
+
     isNoop (Prim PrimInfo{primWorkInfo=WorkIdentity _ []}) = return True
     isNoop (Lam x e) = isNoopApp x (collectArgs e)
     isNoop _ = return False
@@ -522,7 +538,9 @@ inlineNonRepWorker e@(Case scrut altsTy alts)
   | (Var f, args,ticks) <- collectArgsTicks scrut
   , isGlobalId f
   = do
-    (cf,_)    <- Lens.use curFun
+    curFunsV <- Lens.use curFun
+    thread <- myThreadId
+    Just (cf,_) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
     isInlined <- zoomExtra (alreadyInlined f cf)
     limit     <- Lens.view inlineLimit
     tcm       <- Lens.view tcCache
@@ -535,7 +553,8 @@ inlineNonRepWorker e@(Case scrut altsTy alts)
       overLimit = notClassTy && (Maybe.fromMaybe 0 isInlined) > limit
 
 
-    bodyMaybe   <- lookupVarEnv f <$> Lens.use bindings
+    bindingsV <- Lens.use bindings
+    bodyMaybe <- MVar.withMVar "bindings" bindingsV (pure . lookupVarEnv f)
     nonRepScrut <- not <$> (representableType <$> Lens.view typeTranslator
                                               <*> Lens.view customReprs
                                               <*> pure False
@@ -543,19 +562,24 @@ inlineNonRepWorker e@(Case scrut altsTy alts)
                                               <*> pure scrutTy)
     case (nonRepScrut, bodyMaybe) of
       (True, Just b) -> do
-        if overLimit then
-          trace ($(curLoc) ++ [I.i|
-            InlineNonRep: #{showPpr (varName f)} already inlined
-            #{limit} times in: #{showPpr (varName cf)}. The type of the subject
-            is:
+        if overLimit then do
+          ioLockV <- Lens.use ioLock
 
-              #{showPpr' def{displayTypes=True\} scrutTy}
+          MVar.withMVar "ioLock" ioLockV $ \() ->
+            traceM ($(curLoc) ++ [I.i|
+              InlineNonRep: #{showPpr (varName f)} already inlined
+              #{limit} times in: #{showPpr (varName cf)}. The type of the subject
+              is:
 
-            Function #{showPpr (varName cf)} will not reach a normal form and
-            compilation might fail.
+                #{showPpr' def{displayTypes=True\} scrutTy}
 
-            Run with '-fclash-inline-limit=N' to increase the inline limit to N.
-          |]) (return e)
+              Function #{showPpr (varName cf)} will not reach a normal form and
+              compilation might fail.
+
+              Run with '-fclash-inline-limit=N' to increase the inline limit to N.
+             |])
+
+          return e
         else do
           Monad.when notClassTy (zoomExtra (addNewInline f cf))
 
@@ -620,9 +644,11 @@ inlineSmall _ e@(collectArgsTicks -> (Var f,args,ticks)) = do
   if untranslatable || f `elemVarSet` topEnts || lv
     then return e
     else do
-      bndrs <- Lens.use bindings
       sizeLimit <- Lens.view inlineFunctionLimit
-      case lookupVarEnv f bndrs of
+      bndrsV <- Lens.use bindings
+      mBind <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+
+      case mBind of
         -- Don't inline recursive expressions
         Just b -> do
           isRecBndr <- isRecursiveBndr f
@@ -655,8 +681,9 @@ inlineWorkFree _ e@(collectArgsTicks -> (Var f,args@(_:_),ticks))
     if untranslatable || isSignal || argsHaveWork || lv || isTopEnt
       then return e
       else do
-        bndrs <- Lens.use bindings
-        case lookupVarEnv f bndrs of
+        bndrsV <- Lens.use bindings
+        bndr <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+        case bndr of
           -- Don't inline recursive expressions
           Just b -> do
             isRecBndr <- isRecursiveBndr f
@@ -688,8 +715,9 @@ inlineWorkFree _ e@(Var f) = do
   let gv = isGlobalId f
   if closed && f `notElemVarSet` topEnts && not untranslatable && not isSignal && gv
     then do
-      bndrs <- Lens.use bindings
-      case lookupVarEnv f bndrs of
+      bndrsV <- Lens.use bindings
+      bndr <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+      case bndr of
         -- Don't inline recursive expressions
         Just top -> do
           isRecBndr <- isRecursiveBndr f
@@ -706,7 +734,7 @@ inlineWorkFree _ e@(Var f) = do
                 b <- normalizeTopLvlBndr False f top
                 changed (bindingTerm b)
         _ -> return e
-    else return e
+  else return e
 
 inlineWorkFree _ e = return e
 {-# SCC inlineWorkFree #-}

--- a/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
@@ -33,6 +33,7 @@ module Clash.Normalize.Transformations.Inline
   ) where
 
 import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Data.RwVar as RwVar
 import qualified Clash.Normalize.TracedMVar as MVar
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
@@ -409,7 +410,7 @@ collapseRHSNoops _ letrec@(Let letBind body) = do
   thread <- myThreadId
   Just (curFunId, _) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
   bindingsV <- Lens.use bindings
-  curBinding <- MVar.withMVar "bindings" bindingsV (pure . lookupVarEnv curFunId)
+  curBinding <- lookupVarEnv curFunId <$> RwVar.readRwVar bindingsV
   case curBinding of
     Just binding | isNoInline (bindingSpec binding) -> do
       -- Explicitly match on Let instead of using LetRec, because we need to
@@ -454,7 +455,7 @@ collapseRHSNoops _ letrec@(Let letBind body) = do
     isNoop :: Term -> MaybeT NormalizeSession Bool
     isNoop (Var i) = do
       bindingsV <- Lens.use bindings
-      binding <- MVar.withMVar "bindings" bindingsV (MaybeT . pure . lookupVarEnv i)
+      binding <- MaybeT (lookupVarEnv i <$> RwVar.readRwVar bindingsV)
       isRecursive <- lift $ isRecursiveBndr (bindingId binding)
 
       Monad.guard $ not isRecursive
@@ -555,7 +556,7 @@ inlineNonRepWorker e@(Case scrut altsTy alts)
 
 
     bindingsV <- Lens.use bindings
-    bodyMaybe <- MVar.withMVar "bindings" bindingsV (pure . lookupVarEnv f)
+    bodyMaybe <- lookupVarEnv f <$> RwVar.readRwVar bindingsV
     nonRepScrut <- isUntranslatableType False scrutTy
     case (nonRepScrut, bodyMaybe) of
       (True, Just b) -> do
@@ -677,7 +678,7 @@ inlineSmall _ e@(collectArgsTicks -> (Var f,args,ticks))
         else do
           sizeLimit <- Lens.view inlineFunctionLimit
           bndrsV <- Lens.use bindings
-          mBind <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+          mBind <- lookupVarEnv f <$> RwVar.readRwVar bndrsV
           case mBind of
             Just b
               | not (isNoInline (bindingSpec b))
@@ -717,7 +718,7 @@ inlineWorkFree _ e@(collectArgsTicks -> (Var f,args@(_:_),ticks))
       then return e
       else do
         bndrsV <- Lens.use bindings
-        bndr <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+        bndr <- lookupVarEnv f <$> RwVar.readRwVar bndrsV
         case bndr of
           Just b -> do
             tcm <- Lens.view tcCache
@@ -769,7 +770,7 @@ inlineWorkFree _ e@(collectTicks -> (Var f, ticks))
             then return e
             else do
               bndrsV <- Lens.use bindings
-              bndr <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+              bndr <- lookupVarEnv f <$> RwVar.readRwVar bndrsV
               case bndr of
                 -- Don't inline recursive expressions
                 Just top -> do

--- a/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
@@ -32,6 +32,8 @@ module Clash.Normalize.Transformations.Inline
   , inlineWorkFree
   ) where
 
+import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import Control.Monad ((>=>))
@@ -41,6 +43,7 @@ import Control.Monad.Writer (lift,listen)
 import Data.Default (Default(..))
 import Data.Either  (lefts)
 import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.HashMap.Strict as HashMapS
 import qualified Data.List as List
 import qualified Data.Maybe as Maybe
 import qualified Data.Monoid as Monoid (Any(..))
@@ -75,7 +78,7 @@ import Clash.Core.VarEnv
   , eltsVarEnv, emptyVarEnv, extendInScopeSetList, extendVarEnv
   , foldlWithUniqueVarEnv', lookupVarEnv, lookupVarEnvDirectly, mkVarEnv
   , notElemVarSet, unionVarEnv, unionVarEnvWith, unitVarSet)
-import Clash.Debug (trace)
+import Clash.Debug (traceM)
 import Clash.Driver.Types (Binding(..))
 import Clash.Primitives.Types
   (CompiledPrimMap, Primitive(..), TemplateKind(..))
@@ -83,7 +86,7 @@ import Clash.Rewrite.Combinators (allR)
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, curFun, tcCache, topEntities
   , inlineConstantLimit, inlineFunctionLimit, inlineLimit
-  , inlineWFCacheLimit, primitives)
+  , inlineWFCacheLimit, primitives, ioLock)
 import Clash.Rewrite.Util
   ( changed, inlineBinders, inlineOrLiftBinders, isJoinPointIn
   , isUntranslatable, isUntranslatableType, isVoidWrapper, zoomExtra)
@@ -120,7 +123,9 @@ bindConstantVar = inlineBinders test
       -- Don't inline `let x = x in x`, it throws  us in an infinite loop
       True -> return (i `notElemFreeVars` e)
       _    -> do
-        (fn,_) <- Lens.use curFun
+        curFunsV <- Lens.use curFun
+        thread <- myThreadId
+        Just (fn,_) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
         -- Don't inline globally recursive calls, it prevents the
         -- recToLetRec transformation from transforming global recursion to
         -- local recursion.
@@ -400,8 +405,11 @@ simply a variable reference. See issue #779 -}
 -- on functions that might be inlined later. See #3036.
 collapseRHSNoops :: HasCallStack => NormRewrite
 collapseRHSNoops _ letrec@(Let letBind body) = do
-  (curFunId, _) <- Lens.use curFun
-  curBinding <- lookupVarEnv curFunId <$> Lens.use bindings
+  curFunsV <- Lens.use curFun
+  thread <- myThreadId
+  Just (curFunId, _) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
+  bindingsV <- Lens.use bindings
+  curBinding <- MVar.withMVar "bindings" bindingsV (pure . lookupVarEnv curFunId)
   case curBinding of
     Just binding | isNoInline (bindingSpec binding) -> do
       -- Explicitly match on Let instead of using LetRec, because we need to
@@ -418,32 +426,40 @@ collapseRHSNoops _ letrec@(Let letBind body) = do
     runCollapseNoop orig =
       runMaybeT (collapseNoop orig) >>= Maybe.maybe (return orig) changed
 
-    collapseNoop (iD,term) = do
+    collapseNoop :: (Id, Term) -> MaybeT NormalizeSession (Id, Term)
+    collapseNoop (iD, term) = do
       (Prim info,args) <- return $ collectArgs term
       identity         <- getIdentity info $ lefts args
       collapsed        <- collapseToIdentity iD identity
       return (iD,collapsed)
 
+    collapseToIdentity :: Id -> Term -> MaybeT NormalizeSession Term
     collapseToIdentity iD identity = do
       tcm <- Lens.view tcCache
       let aTy = inferCoreTypeOf tcm identity
           bTy = coreTypeOf iD
       return $ primUCo `TyApp` aTy `TyApp` bTy `App` identity
 
+    getIdentity :: PrimInfo -> [Term] -> MaybeT NormalizeSession Term
     getIdentity primInfo termArgs = do
       WorkIdentity idIdx noopIdxs <- return $ primWorkInfo primInfo
       mapM_ (getTermArg termArgs >=> isNoop >=> Monad.guard) noopIdxs
       getTermArg termArgs idIdx
 
+    getTermArg :: [Term] -> Int -> MaybeT NormalizeSession Term
     getTermArg args i = do
       Monad.guard $ i <= length args - 1
       return $ args !! i
 
+    isNoop :: Term -> MaybeT NormalizeSession Bool
     isNoop (Var i) = do
-      binding     <- MaybeT $ lookupVarEnv i <$> Lens.use bindings
-      isRecursive <- lift $ isRecursiveBndr $ bindingId binding
+      bindingsV <- Lens.use bindings
+      binding <- MVar.withMVar "bindings" bindingsV (MaybeT . pure . lookupVarEnv i)
+      isRecursive <- lift $ isRecursiveBndr (bindingId binding)
+
       Monad.guard $ not isRecursive
       isNoop $ bindingTerm binding
+
     isNoop (Prim PrimInfo{primWorkInfo=WorkIdentity _ []}) = return True
     isNoop (Lam x e) = isNoopApp x (collectArgs e)
     isNoop _ = return False
@@ -523,7 +539,9 @@ inlineNonRepWorker e@(Case scrut altsTy alts)
   | (Var f, args,ticks) <- collectArgsTicks scrut
   , isGlobalId f
   = do
-    (cf,_)    <- Lens.use curFun
+    curFunsV <- Lens.use curFun
+    thread <- myThreadId
+    Just (cf,_) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
     isInlined <- zoomExtra (alreadyInlined f cf)
     limit     <- Lens.view inlineLimit
     tcm       <- Lens.view tcCache
@@ -536,23 +554,29 @@ inlineNonRepWorker e@(Case scrut altsTy alts)
       overLimit = notClassTy && (Maybe.fromMaybe 0 isInlined) > limit
 
 
-    bodyMaybe   <- lookupVarEnv f <$> Lens.use bindings
+    bindingsV <- Lens.use bindings
+    bodyMaybe <- MVar.withMVar "bindings" bindingsV (pure . lookupVarEnv f)
     nonRepScrut <- isUntranslatableType False scrutTy
     case (nonRepScrut, bodyMaybe) of
       (True, Just b) -> do
-        if overLimit then
-          trace ($(curLoc) ++ [I.i|
-            InlineNonRep: #{showPpr (varName f)} already inlined
-            #{limit} times in: #{showPpr (varName cf)}. The type of the subject
-            is:
+        if overLimit then do
+          ioLockV <- Lens.use ioLock
 
-              #{showPpr' def{displayTypes=True\} scrutTy}
+          MVar.withMVar "ioLock" ioLockV $ \() ->
+            traceM ($(curLoc) ++ [I.i|
+              InlineNonRep: #{showPpr (varName f)} already inlined
+              #{limit} times in: #{showPpr (varName cf)}. The type of the subject
+              is:
 
-            Function #{showPpr (varName cf)} will not reach a normal form and
-            compilation might fail.
+                #{showPpr' def{displayTypes=True\} scrutTy}
 
-            Run with '-fclash-inline-limit=N' to increase the inline limit to N.
-          |]) (return e)
+              Function #{showPpr (varName cf)} will not reach a normal form and
+              compilation might fail.
+
+              Run with '-fclash-inline-limit=N' to increase the inline limit to N.
+             |])
+
+          return e
         else do
           Monad.when notClassTy (zoomExtra (addNewInline f cf))
 
@@ -651,9 +675,10 @@ inlineSmall _ e@(collectArgsTicks -> (Var f,args,ticks))
       if f `elemVarSet` topEnts
         then return e
         else do
-          bndrs <- Lens.use bindings
           sizeLimit <- Lens.view inlineFunctionLimit
-          case lookupVarEnv f bndrs of
+          bndrsV <- Lens.use bindings
+          mBind <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+          case mBind of
             Just b
               | not (isNoInline (bindingSpec b))
               , termSizeSmallerThan sizeLimit (bindingTerm b)
@@ -691,8 +716,9 @@ inlineWorkFree _ e@(collectArgsTicks -> (Var f,args@(_:_),ticks))
     if f `elemVarSet` topEnts
       then return e
       else do
-        bndrs <- Lens.use bindings
-        case lookupVarEnv f bndrs of
+        bndrsV <- Lens.use bindings
+        bndr <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+        case bndr of
           Just b -> do
             tcm <- Lens.view tcCache
             let eTy = inferCoreTypeOf tcm e
@@ -742,8 +768,9 @@ inlineWorkFree _ e@(collectTicks -> (Var f, ticks))
           if untranslatable
             then return e
             else do
-              bndrs <- Lens.use bindings
-              case lookupVarEnv f bndrs of
+              bndrsV <- Lens.use bindings
+              bndr <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+              case bndr of
                 -- Don't inline recursive expressions
                 Just top -> do
                   isRecBndr <- isRecursiveBndr f

--- a/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
@@ -23,6 +23,8 @@ module Clash.Normalize.Transformations.Letrec
   , topLet
   ) where
 
+import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import Control.Monad.Trans.Except (runExcept)
@@ -30,6 +32,7 @@ import Control.Monad.Writer (listen)
 import Data.Bifunctor (second)
 import qualified Data.Either as Either
 import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.HashMap.Strict as HashMapS
 import Data.List ((\\))
 import qualified Data.List as List
 import qualified Data.List.Extra as List
@@ -196,11 +199,15 @@ flattenLet (TransformContext is0 _) (Letrec binds body) = do
                    emptyVarEnv (`unitVarEnv` (1 :: Int))
                    body
   (is2,binds1) <- second concat <$> List.mapAccumLM go is1 binds
-  bndrs <- Lens.use bindings
+
   e1WorkFree <-
     case binds1 of
-      [(_,e1)] -> isWorkFree workFreeBinders bndrs e1
+      [(_,e1)] -> do
+        bndrsV <- Lens.use bindings
+        MVar.withMVar "bindings" bndrsV (\bndrs ->isWorkFree workFreeBinders bndrs e1)
+
       _ -> pure (error "flattenLet: unreachable")
+
   case binds1 of
     -- inline binders into the body when there's only a single binder, and only
     -- if that binder doesn't perform any work or is only used once in the body
@@ -209,7 +216,7 @@ flattenLet (TransformContext is0 _) (Letrec binds body) = do
          -- Except when the binder is recursive!
          then return (Letrec binds1 body)
          else let subst = extendIdSubst (mkSubst is2) id1 e1
-              in changed (substTm "flattenLet" subst body)
+               in changed (substTm "flattenLet" subst body)
     _ -> return (Letrec binds1 body)
   where
     go :: InScopeSet -> LetBinding -> NormalizeSession (InScopeSet,[LetBinding])
@@ -236,11 +243,15 @@ flattenLet (TransformContext is0 _) (Letrec binds body) = do
                        emptyVarEnv (`unitVarEnv` (1 :: Int))
                        body2
           (srcTicks,nmTicks) = partitionTicks ticks
-      bndrs <- Lens.use bindings
+
       e2WorkFree <-
         case binds2 of
-          [(_,e2)] -> isWorkFree workFreeBinders bndrs e2
+          [(_,e2)] -> do
+            bndrsV <- Lens.use bindings
+            MVar.withMVar "bindings" bndrsV (\bndrs ->isWorkFree workFreeBinders bndrs e2)
+
           _ -> pure (error "flattenLet: unreachable")
+
       -- Distribute the name ticks of the let-expression over all the bindings
       (isN1,) . map (second (`mkTicks` nmTicks)) <$> case binds2 of
         -- inline binders into the body when there's only a single binder, and
@@ -269,7 +280,9 @@ flattenLet _ e = return e
 -- found in the body of the top-level let-expression.
 recToLetRec :: HasCallStack => NormRewrite
 recToLetRec (TransformContext is0 []) e = do
-  (fn,_) <- Lens.use curFun
+  curFunsV <- Lens.use curFun
+  thread <- myThreadId
+  Just (fn,_) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
   tcm    <- Lens.view tcCache
   case splitNormalized tcm e of
     Right (args,bndrs,res) -> do

--- a/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
@@ -24,6 +24,7 @@ module Clash.Normalize.Transformations.Letrec
   ) where
 
 import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Data.RwVar as RwVar
 import qualified Clash.Normalize.TracedMVar as MVar
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
@@ -238,7 +239,7 @@ flattenLet (TransformContext is0 _) (Letrec binds body) = do
     case binds1 of
       [(_,e1)] -> do
         bndrsV <- Lens.use bindings
-        MVar.withMVar "bindings" bndrsV (\bndrs ->isWorkFree workFreeBinders bndrs e1)
+        (\bndrs -> isWorkFree workFreeBinders bndrs e1) =<< RwVar.readRwVar bndrsV
 
       _ -> pure (error "flattenLet: unreachable")
 
@@ -282,7 +283,7 @@ flattenLet (TransformContext is0 _) (Letrec binds body) = do
         case binds2 of
           [(_,e2)] -> do
             bndrsV <- Lens.use bindings
-            MVar.withMVar "bindings" bndrsV (\bndrs ->isWorkFree workFreeBinders bndrs e2)
+            (\bndrs -> isWorkFree workFreeBinders bndrs e2) =<< RwVar.readRwVar bndrsV
 
           _ -> pure (error "flattenLet: unreachable")
 

--- a/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
@@ -23,6 +23,8 @@ module Clash.Normalize.Transformations.Letrec
   , topLet
   ) where
 
+import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import Control.Monad.Trans.Except (runExcept)
@@ -30,6 +32,7 @@ import Control.Monad.Writer (listen)
 import Data.Bifunctor (second)
 import qualified Data.Either as Either
 import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.HashMap.Strict as HashMapS
 import Data.List ((\\))
 import qualified Data.List as List
 import qualified Data.List.Extra as List
@@ -230,11 +233,15 @@ flattenLet (TransformContext is0 _) (Letrec binds body) = do
                    emptyVarEnv (`unitVarEnv` (1 :: Int))
                    body
   (is2,binds1) <- second concat <$> List.mapAccumLM go is1 binds
-  bndrs <- Lens.use bindings
+
   e1WorkFree <-
     case binds1 of
-      [(_,e1)] -> isWorkFree workFreeBinders bndrs e1
+      [(_,e1)] -> do
+        bndrsV <- Lens.use bindings
+        MVar.withMVar "bindings" bndrsV (\bndrs ->isWorkFree workFreeBinders bndrs e1)
+
       _ -> pure (error "flattenLet: unreachable")
+
   case binds1 of
     -- inline binders into the body when there's only a single binder, and only
     -- if that binder doesn't perform any work or is only used once in the body
@@ -243,7 +250,7 @@ flattenLet (TransformContext is0 _) (Letrec binds body) = do
          -- Except when the binder is recursive!
          then return (Letrec binds1 body)
          else let subst = extendIdSubst (mkSubst is2) id1 e1
-              in changed (substTm "flattenLet" subst body)
+               in changed (substTm "flattenLet" subst body)
     _ -> return (Letrec binds1 body)
   where
     go :: InScopeSet -> LetBinding -> NormalizeSession (InScopeSet,[LetBinding])
@@ -270,11 +277,15 @@ flattenLet (TransformContext is0 _) (Letrec binds body) = do
                        emptyVarEnv (`unitVarEnv` (1 :: Int))
                        body2
           (srcTicks,nmTicks) = partitionTicks ticks
-      bndrs <- Lens.use bindings
+
       e2WorkFree <-
         case binds2 of
-          [(_,e2)] -> isWorkFree workFreeBinders bndrs e2
+          [(_,e2)] -> do
+            bndrsV <- Lens.use bindings
+            MVar.withMVar "bindings" bndrsV (\bndrs ->isWorkFree workFreeBinders bndrs e2)
+
           _ -> pure (error "flattenLet: unreachable")
+
       -- Distribute the name ticks of the let-expression over all the bindings
       (isN1,) . map (second (`mkTicks` nmTicks)) <$> case binds2 of
         -- inline binders into the body when there's only a single binder, and
@@ -303,7 +314,9 @@ flattenLet _ e = return e
 -- found in the body of the top-level let-expression.
 recToLetRec :: HasCallStack => NormRewrite
 recToLetRec (TransformContext is0 []) e = do
-  (fn,_) <- Lens.use curFun
+  curFunsV <- Lens.use curFun
+  thread <- myThreadId
+  Just (fn,_) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
   tcm    <- Lens.view tcCache
   case splitNormalized tcm e of
     Right (args,bndrs,res) -> do

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -28,17 +28,18 @@ module Clash.Normalize.Transformations.Specialize
   ) where
 
 import Control.Arrow ((***), (&&&))
+import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import Control.DeepSeq (deepseq)
 import Control.Exception (throw)
-import Control.Lens ((%=))
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
-import Control.Monad.Extra (orM)
 import qualified Control.Monad.Writer as Writer (listen)
 import Data.Bifunctor (bimap)
 import Data.Coerce (coerce)
 import qualified Data.Either as Either
 import Data.Functor.Const (Const(..))
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map.Strict as Map
 import qualified Data.Monoid as Monoid (getAny)
 import qualified Data.Set.Ordered as OSet
@@ -74,17 +75,17 @@ import Clash.Core.Type
 import Clash.Core.TysPrim
 import Clash.Core.Util (listToLets)
 import Clash.Core.Var (Var(..), Id, TyVar, mkTyVar)
-import Clash.Core.VarEnv
+import           Clash.Core.VarEnv
   ( InScopeSet, extendInScopeSet, extendInScopeSetList, lookupVarEnv
   , mkInScopeSet, mkVarSet, unionInScope, elemVarSet)
 import qualified Clash.Data.UniqMap as UniqMap
-import Clash.Debug (traceIf, traceM)
-import Clash.Driver.Types (Binding(..), TransformationInfo(..), hasTransformationInfo)
+import           Clash.Debug (traceIf, traceM)
+import           Clash.Driver.Types (Binding(..), TransformationInfo(..), hasTransformationInfo)
 import Clash.Netlist.Util (representableType)
 import Clash.Rewrite.Combinators (topdownR)
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, censor, curFun, customReprs, extra, tcCache
-  , typeTranslator, workFreeBinders, debugOpts, topEntities, specializationLimit)
+  , typeTranslator, workFreeBinders, debugOpts, topEntities, specializationLimit, ioLock)
 import Clash.Rewrite.Util
   ( mkBinderFor, mkDerivedName, mkFunction, mkTmBinderFor, setChanged, changed
   , normalizeTermTypes, normalizeId, whnfRW)
@@ -201,8 +202,10 @@ appProp ctx@(TransformContext is _) = \case
 
   go is0 (Lam v e) (Left arg:args) ticks = do
     setChanged
-    bndrs <- Lens.use bindings
-    orM [pure (isVar arg), isWorkFree workFreeBinders bndrs arg] >>= \case
+    bndrsV <- Lens.use bindings
+    wf <- MVar.withMVar "bindings" bndrsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+
+    case isVar arg || wf of
       True ->
         let subst = extendIdSubst (mkSubst is0) v arg in
         (`mkTicks` ticks) <$> go is0 (substTm "appProp.AppLam" subst e) args []
@@ -264,10 +267,12 @@ appProp ctx@(TransformContext is _) = \case
 
   goCaseArg isA0 ty0 ls0 (Left arg:args0) = do
     tcm <- Lens.view tcCache
-    bndrs <- Lens.use bindings
     let argTy = inferCoreTypeOf tcm arg
         ty1   = applyFunTy tcm ty0 argTy
-    orM [pure (isVar arg), isWorkFree workFreeBinders bndrs arg] >>= \case
+    bndrsV <- Lens.use bindings
+    wf <- MVar.withMVar "bindings" bndrsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+
+    case isVar arg || wf of
       True -> do
         (ty2,ls1,args1) <- goCaseArg isA0 ty1 ls0 args0
         return (ty2,ls1,Left arg:args1)
@@ -376,24 +381,29 @@ specialize'
 specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
   opts <- Lens.view debugOpts
   tcm <- Lens.view tcCache
+  ioLockV <- Lens.use ioLock
 
   -- Don't specialize TopEntities
   topEnts <- Lens.view topEntities
   if f `elemVarSet` topEnts
-  then do
+  then
     case specArgIn of
       Left _ -> do
-        traceM ("Not specializing TopEntity: " ++ showPpr (varName f))
+        MVar.withMVar "ioLock" ioLockV $ \() ->
+          traceM ("Not specializing TopEntity: " ++ showPpr (varName f))
+
         return e
-      Right tyArg ->
-        traceIf (hasTransformationInfo AppliedTerm opts) ("Dropping type application on TopEntity: " ++ showPpr (varName f) ++ "\ntype:\n" ++ showPpr tyArg) $
+      Right tyArg -> do
+        Monad.when (hasTransformationInfo AppliedTerm opts) $
+          MVar.withMVar "ioLock" ioLockV $ \() ->
+            traceM ("Dropping type application on TopEntity: " ++ showPpr (varName f) ++ "\ntype:\n" ++ showPpr tyArg)
         -- TopEntities aren't allowed to be semantically polymorphic.
         -- But using type equality constraints they may be syntactically polymorphic.
         -- > topEntity :: forall dom . (dom ~ "System") => Signal dom Bool -> Signal dom Bool
         -- The TyLam's in the body will have been removed by 'Clash.Normalize.Util.substWithTyEq'.
         -- So we drop the TyApp ("specializing" on it) and change the varType to match.
         let newVarTy = piResultTy tcm (coreTypeOf f) tyArg
-        in  changed (mkApps (mkTicks (Var f{varType = newVarTy}) ticks) args)
+        changed (mkApps (mkTicks (Var f{varType = newVarTy}) ticks) args)
   else do -- NondecreasingIndentation
 
   let specArg = bimap (normalizeTermTypes tcm) (normalizeType tcm) specArgIn
@@ -408,7 +418,8 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
       specAbs :: Either Term Type
       specAbs = either (Left . stripAllTicks . (`mkAbstraction` specBndrs)) (Right . id) specArg
   -- Determine if 'f' has already been specialized on (a type-normalized) 'specArg'
-  specM <- Map.lookup (f,argLen,specAbs) <$> Lens.use (extra.specialisationCache)
+  cacheV <- Lens.use (extra.specialisationCache)
+  specM <- MVar.withMVar "specialisationCache" cacheV $ \cache -> pure $ Map.lookup (f,argLen,specAbs) cache
   case specM of
     -- Use previously specialized function
     Just f' ->
@@ -419,11 +430,13 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
     -- Create new specialized function
     Nothing -> do
       -- Determine if we can specialize f
-      bodyMaybe <- fmap (UniqMap.lookup f) $ Lens.use bindings
+      bndrsV <- Lens.use bindings
+      bodyMaybe <- MVar.withMVar "bindings" bndrsV $ \bndrs -> pure $ UniqMap.lookup f bndrs
       case bodyMaybe of
         Just (Binding _ sp inl _ bodyTm _) -> do
           -- Determine if we see a sequence of specializations on a growing argument
-          specHistM <- UniqMap.lookup f <$> Lens.use (extra.specialisationHistory)
+          histV <- Lens.use (extra.specialisationHistory)
+          specHistM <- MVar.withMVar "specialisationHistory" histV $ \hist -> pure $ UniqMap.lookup f hist
           specLim   <- Lens.view specializationLimit
           if maybe False (> specLim) specHistM
             then throw (ClashException
@@ -476,7 +489,8 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
                       -- Finally, we must make sure we do not inline the bodies
                       -- of functions with a Synthesize annotation, as that would
                       -- duplicate Clash compiler work. See also issue #3024
-                      gTmM <- fmap (UniqMap.lookup g) $ Lens.use bindings
+                      bndrsV2 <- Lens.use bindings
+                      gTmM <- MVar.withMVar "bindings" bndrsV2 $ \bndrs -> pure $ UniqMap.lookup g bndrs
                       let gBody = if g `elemVarSet` topEnts then
                                     Nothing
                                   else
@@ -492,8 +506,8 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
               let newBody = mkAbstraction (mkApps bodyTm (argVars ++ [specArg'])) (boundArgs ++ specBndrs)
               newf <- mkFunction newName sp inl' newBody
               -- Remember specialization
-              (extra.specialisationHistory) %= UniqMap.insertWith (+) f 1
-              (extra.specialisationCache)  %= Map.insert (f,argLen,specAbs) newf
+              MVar.modifyMVar_ "specialisationHistory" histV $ \hist -> pure $ UniqMap.insertWith (+) f 1 hist
+              MVar.modifyMVar_ "specialisationCache" cacheV $ \cache -> pure $ Map.insert (f,argLen,specAbs) newf cache
               -- use specialized function
               let newExpr = mkApps (mkTicks (Var newf) ticks) (args ++ specVars)
               newf `deepseq` changed newExpr
@@ -536,10 +550,13 @@ specialize' _ctx _ (appE,args,ticks) (Left specArg) = do
       newBody = mkAbstraction specArg specBndrs
   -- See if there's an existing binder that's alpha-equivalent to the
   -- specialized function
-  existing <- UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) <$> Lens.use bindings
+  bndrsV3 <- Lens.use bindings
+  existing <- MVar.withMVar "bindings" bndrsV3 $ \bndrs -> pure $ UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) bndrs
   -- Create a new function if an alpha-equivalent binder doesn't exist
   newf <- case UniqMap.elems existing of
-    [] -> do (cf,sp) <- Lens.use curFun
+    [] -> do curFunsV <- Lens.use curFun
+             thread <- myThreadId
+             Just (cf,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
              mkFunction (appendToName (varName cf) "_specF") sp NoUserInlinePrag newBody
     (b:_) -> return (bindingId b)
   -- Create specialized argument
@@ -632,7 +649,8 @@ nonRepSpec ctx e@(App e1 e2)
     inlineInternalSpecialisationArgument app
       | (Var f,fArgs,ticks) <- collectArgsTicks app
       = do
-        fTmM <- lookupVarEnv f <$> Lens.use bindings
+        bndrsV <- Lens.use bindings
+        fTmM <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
         case fTmM of
           Just b
             | nameSort (varName (bindingId b)) == Internal

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -417,37 +417,58 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
       -- See Note [ticks and specialization]
       specAbs :: Either Term Type
       specAbs = either (Left . stripAllTicks . (`mkAbstraction` specBndrs)) (Right . id) specArg
-  -- Determine if 'f' has already been specialized on (a type-normalized) 'specArg'
+  -- Determine if 'f' has already been specialized on (a type-normalized) 'specArg'.
+  --
+  -- With concurrent normalization, multiple threads may try to specialize the
+  -- same function simultaneously. We use a "future" pattern: atomically check
+  -- the cache and, if absent, insert an empty MVar as a placeholder. The first
+  -- thread to arrive creates the specialization and fills the MVar; any other
+  -- thread that arrives for the same key will find the placeholder and wait on
+  -- it. This prevents duplicate specializations and duplicate history counter
+  -- increments.
   cacheV <- Lens.use (extra.specialisationCache)
-  specM <- MVar.withMVar "specialisationCache" cacheV $ \cache -> pure $ Map.lookup (f,argLen,specAbs) cache
-  case specM of
-    -- Use previously specialized function
-    Just f' ->
+  resultMVar <- MVar.newEmptyMVar "specResult"
+  specDecision <- MVar.modifyMVar "specialisationCache" cacheV $ \cache ->
+    case Map.lookup (f,argLen,specAbs) cache of
+      Just existingMVar ->
+        -- Already cached or in progress; return the existing future
+        pure (cache, Left existingMVar)
+      Nothing ->
+        -- Not cached; insert our empty MVar as a placeholder so other threads wait
+        pure (Map.insert (f,argLen,specAbs) resultMVar cache, Right resultMVar)
+
+  case specDecision of
+    Left existingMVar -> do
+      -- Use previously (or concurrently) specialized function
+      f' <- MVar.readMVar "specCacheResult" existingMVar
       traceIf (hasTransformationInfo AppliedTerm opts)
         ("Using previous specialization of " ++ showPpr (varName f) ++ " on " ++
           (either showPpr showPpr) specAbs ++ ": " ++ showPpr (varName f')) $
         changed $ mkApps (mkTicks (Var f') ticks) (args ++ specVars)
-    -- Create new specialized function
-    Nothing -> do
-      -- Determine if we can specialize f
+    Right myMVar -> do
+      -- We're responsible for creating the specialization
       bndrsV <- Lens.use bindings
       bodyMaybe <- MVar.withMVar "bindings" bndrsV $ \bndrs -> pure $ UniqMap.lookup f bndrs
       case bodyMaybe of
         Just (Binding _ sp inl _ bodyTm _) -> do
           -- Determine if we see a sequence of specializations on a growing argument
           histV <- Lens.use (extra.specialisationHistory)
+          specLim <- Lens.view specializationLimit
           specHistM <- MVar.withMVar "specialisationHistory" histV $ \hist -> pure $ UniqMap.lookup f hist
-          specLim   <- Lens.view specializationLimit
           if maybe False (> specLim) specHistM
-            then throw (ClashException
-                        sp
-                        (unlines [ "Hit specialization limit " ++ show specLim ++ " on function `" ++ showPpr (varName f) ++ "'.\n"
-                                 , "The function `" ++ showPpr f ++ "' is most likely recursive, and looks like it is being indefinitely specialized on a growing argument.\n"
-                                 , "Body of `" ++ showPpr f ++ "':\n" ++ showPpr bodyTm ++ "\n"
-                                 , "Argument (in position: " ++ show argLen ++ ") that triggered termination:\n" ++ (either showPpr showPpr) specArg
-                                 , "Run with '-fclash-spec-limit=N' to increase the specialization limit to N."
-                                 ])
-                        Nothing)
+            then do
+              -- Remove our placeholder from the cache before throwing
+              MVar.modifyMVar_ "specialisationCache" cacheV $ \cache ->
+                pure $ Map.delete (f,argLen,specAbs) cache
+              throw (ClashException
+                      sp
+                      (unlines [ "Hit specialization limit " ++ show specLim ++ " on function `" ++ showPpr (varName f) ++ "'.\n"
+                               , "The function `" ++ showPpr f ++ "' is most likely recursive, and looks like it is being indefinitely specialized on a growing argument.\n"
+                               , "Body of `" ++ showPpr f ++ "':\n" ++ showPpr bodyTm ++ "\n"
+                               , "Argument (in position: " ++ show argLen ++ ") that triggered termination:\n" ++ (either showPpr showPpr) specArg
+                               , "Run with '-fclash-spec-limit=N' to increase the specialization limit to N."
+                               ])
+                      Nothing)
             else do
               let existingNames = collectBndrsMinusApps bodyTm
                   newNames      = [ mkUnsafeInternalName ("pTS" `Text.append` Text.pack (show n)) n
@@ -507,11 +528,16 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
               newf <- mkFunction newName sp inl' newBody
               -- Remember specialization
               MVar.modifyMVar_ "specialisationHistory" histV $ \hist -> pure $ UniqMap.insertWith (+) f 1 hist
-              MVar.modifyMVar_ "specialisationCache" cacheV $ \cache -> pure $ Map.insert (f,argLen,specAbs) newf cache
+              -- Fill the future so waiting threads can proceed
+              MVar.putMVar "specCacheResult" myMVar newf
               -- use specialized function
               let newExpr = mkApps (mkTicks (Var newf) ticks) (args ++ specVars)
               newf `deepseq` changed newExpr
-        Nothing -> return e
+        Nothing -> do
+          -- Remove placeholder; no specialization possible
+          MVar.modifyMVar_ "specialisationCache" cacheV $ \cache ->
+            pure $ Map.delete (f,argLen,specAbs) cache
+          return e
   where
     noUserInline :: InlineSpec
     noUserInline = NoUserInlinePrag

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -32,6 +32,7 @@ import Control.Concurrent.Lifted (myThreadId)
 import qualified Clash.Normalize.TracedMVar as MVar
 import Control.DeepSeq (deepseq)
 import Control.Exception (throw)
+import qualified Control.Exception.Lifted as Exception
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Writer as Writer (listen)
@@ -425,7 +426,8 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
   -- thread to arrive creates the specialization and fills the MVar; any other
   -- thread that arrives for the same key will find the placeholder and wait on
   -- it. This prevents duplicate specializations and duplicate history counter
-  -- increments.
+  -- increments. The future stores failures too, so waiting threads cannot get
+  -- stranded on an exception path.
   cacheV <- Lens.use (extra.specialisationCache)
   resultMVar <- MVar.newEmptyMVar "specResult"
   specDecision <- MVar.modifyMVar "specialisationCache" cacheV $ \cache ->
@@ -440,35 +442,63 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
   case specDecision of
     Left existingMVar -> do
       -- Use previously (or concurrently) specialized function
-      f' <- MVar.readMVar "specCacheResult" existingMVar
-      traceIf (hasTransformationInfo AppliedTerm opts)
-        ("Using previous specialization of " ++ showPpr (varName f) ++ " on " ++
-          (either showPpr showPpr) specAbs ++ ": " ++ showPpr (varName f')) $
-        changed $ mkApps (mkTicks (Var f') ticks) (args ++ specVars)
+      MVar.readMVar "specCacheResult" existingMVar >>= \case
+        Left err ->
+          Exception.throwIO err
+
+        Right Nothing ->
+          return e
+
+        Right (Just f') ->
+          traceIf (hasTransformationInfo AppliedTerm opts)
+            ("Using previous specialization of " ++ showPpr (varName f) ++ " on " ++
+              (either showPpr showPpr) specAbs ++ ": " ++ showPpr (varName f')) $
+            changed $ mkApps (mkTicks (Var f') ticks) (args ++ specVars)
+
     Right myMVar -> do
       -- We're responsible for creating the specialization
+      Exception.mask $ \restore -> do
+        result <-
+          Exception.try (restore (createSpecialization tcm topEnts specArg specBndrs specVars argLen))
+        case result of
+          Left err -> do
+            MVar.modifyMVar_ "specialisationCache" cacheV $ \cache ->
+              pure $ Map.delete (f,argLen,specAbs) cache
+            MVar.putMVar "specCacheResult" myMVar (Left err)
+            Exception.throwIO err
+
+          Right Nothing -> do
+            MVar.modifyMVar_ "specialisationCache" cacheV $ \cache ->
+              pure $ Map.delete (f,argLen,specAbs) cache
+            MVar.putMVar "specCacheResult" myMVar (Right Nothing)
+            return e
+
+          Right (Just (newf, newExpr)) -> do
+            MVar.putMVar "specCacheResult" myMVar (Right (Just newf))
+            restore (newf `deepseq` changed newExpr)
+  where
+    createSpecialization tcm topEnts specArg specBndrs specVars argLen = do
       bndrsV <- Lens.use bindings
       bodyMaybe <- MVar.withMVar "bindings" bndrsV $ \bndrs -> pure $ UniqMap.lookup f bndrs
       case bodyMaybe of
+        Nothing ->
+          pure Nothing
+
         Just (Binding _ sp inl _ bodyTm _) -> do
           -- Determine if we see a sequence of specializations on a growing argument
           histV <- Lens.use (extra.specialisationHistory)
           specLim <- Lens.view specializationLimit
           specHistM <- MVar.withMVar "specialisationHistory" histV $ \hist -> pure $ UniqMap.lookup f hist
           if maybe False (> specLim) specHistM
-            then do
-              -- Remove our placeholder from the cache before throwing
-              MVar.modifyMVar_ "specialisationCache" cacheV $ \cache ->
-                pure $ Map.delete (f,argLen,specAbs) cache
-              throw (ClashException
-                      sp
-                      (unlines [ "Hit specialization limit " ++ show specLim ++ " on function `" ++ showPpr (varName f) ++ "'.\n"
-                               , "The function `" ++ showPpr f ++ "' is most likely recursive, and looks like it is being indefinitely specialized on a growing argument.\n"
-                               , "Body of `" ++ showPpr f ++ "':\n" ++ showPpr bodyTm ++ "\n"
-                               , "Argument (in position: " ++ show argLen ++ ") that triggered termination:\n" ++ (either showPpr showPpr) specArg
-                               , "Run with '-fclash-spec-limit=N' to increase the specialization limit to N."
-                               ])
-                      Nothing)
+            then throw (ClashException
+                    sp
+                    (unlines [ "Hit specialization limit " ++ show specLim ++ " on function `" ++ showPpr (varName f) ++ "'.\n"
+                             , "The function `" ++ showPpr f ++ "' is most likely recursive, and looks like it is being indefinitely specialized on a growing argument.\n"
+                             , "Body of `" ++ showPpr f ++ "':\n" ++ showPpr bodyTm ++ "\n"
+                             , "Argument (in position: " ++ show argLen ++ ") that triggered termination:\n" ++ (either showPpr showPpr) specArg
+                             , "Run with '-fclash-spec-limit=N' to increase the specialization limit to N."
+                             ])
+                    Nothing)
             else do
               let existingNames = collectBndrsMinusApps bodyTm
                   newNames      = [ mkUnsafeInternalName ("pTS" `Text.append` Text.pack (show n)) n
@@ -528,17 +558,10 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
               newf <- mkFunction newName sp inl' newBody
               -- Remember specialization
               MVar.modifyMVar_ "specialisationHistory" histV $ \hist -> pure $ UniqMap.insertWith (+) f 1 hist
-              -- Fill the future so waiting threads can proceed
-              MVar.putMVar "specCacheResult" myMVar newf
               -- use specialized function
               let newExpr = mkApps (mkTicks (Var newf) ticks) (args ++ specVars)
-              newf `deepseq` changed newExpr
-        Nothing -> do
-          -- Remove placeholder; no specialization possible
-          MVar.modifyMVar_ "specialisationCache" cacheV $ \cache ->
-            pure $ Map.delete (f,argLen,specAbs) cache
-          return e
-  where
+              pure (Just (newf, newExpr))
+
     noUserInline :: InlineSpec
     noUserInline = NoUserInlinePrag
 

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -29,6 +29,7 @@ module Clash.Normalize.Transformations.Specialize
 
 import Control.Arrow ((***), (&&&))
 import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Data.RwVar as RwVar
 import qualified Clash.Normalize.TracedMVar as MVar
 import Control.DeepSeq (deepseq)
 import Control.Exception (throw)
@@ -203,7 +204,7 @@ appProp ctx@(TransformContext is _) = \case
   go is0 (Lam v e) (Left arg:args) ticks = do
     setChanged
     bndrsV <- Lens.use bindings
-    wf <- MVar.withMVar "bindings" bndrsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+    wf <- (\bndrs -> isWorkFree workFreeBinders bndrs arg) =<< RwVar.readRwVar bndrsV
 
     case isVar arg || wf of
       True ->
@@ -276,7 +277,7 @@ appProp ctx@(TransformContext is _) = \case
     let argTy = inferCoreTypeOf tcm arg
         ty1   = applyFunTy tcm ty0 argTy
     bndrsV <- Lens.use bindings
-    wf <- MVar.withMVar "bindings" bndrsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+    wf <- (\bndrs -> isWorkFree workFreeBinders bndrs arg) =<< RwVar.readRwVar bndrsV
 
     case isVar arg || wf of
       True -> do
@@ -484,7 +485,7 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
   where
     createSpecialization tcm topEnts specArg specBndrs specVars argLen = do
       bndrsV <- Lens.use bindings
-      bodyMaybe <- MVar.withMVar "bindings" bndrsV $ \bndrs -> pure $ UniqMap.lookup f bndrs
+      bodyMaybe <- UniqMap.lookup f <$> RwVar.readRwVar bndrsV
       case bodyMaybe of
         Nothing ->
           pure Nothing
@@ -546,7 +547,7 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
                       -- of functions with a Synthesize annotation, as that would
                       -- duplicate Clash compiler work. See also issue #3024
                       bndrsV2 <- Lens.use bindings
-                      gTmM <- MVar.withMVar "bindings" bndrsV2 $ \bndrs -> pure $ UniqMap.lookup g bndrs
+                      gTmM <- UniqMap.lookup g <$> RwVar.readRwVar bndrsV2
                       let gBody = if g `elemVarSet` topEnts then
                                     Nothing
                                   else
@@ -605,7 +606,7 @@ specialize' _ctx _ (appE,args,ticks) (Left specArg) = do
   -- See if there's an existing binder that's alpha-equivalent to the
   -- specialized function
   bndrsV3 <- Lens.use bindings
-  existing <- MVar.withMVar "bindings" bndrsV3 $ \bndrs -> pure $ UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) bndrs
+  existing <- UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) <$> RwVar.readRwVar bndrsV3
   -- Create a new function if an alpha-equivalent binder doesn't exist
   newf <- case UniqMap.elems existing of
     [] -> do curFunsV <- Lens.use curFun
@@ -700,7 +701,7 @@ nonRepSpec ctx e@(App e1 e2)
       | (Var f,fArgs,ticks) <- collectArgsTicks app
       = do
         bndrsV <- Lens.use bindings
-        fTmM <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
+        fTmM <- lookupVarEnv f <$> RwVar.readRwVar bndrsV
         case fTmM of
           Just b
             | nameSort (varName (bindingId b)) == Internal

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -28,17 +28,19 @@ module Clash.Normalize.Transformations.Specialize
   ) where
 
 import Control.Arrow ((***), (&&&))
+import Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import Control.DeepSeq (deepseq)
 import Control.Exception (throw)
-import Control.Lens ((%=))
+import qualified Control.Exception.Lifted as Exception
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
-import Control.Monad.Extra (orM)
 import qualified Control.Monad.Writer as Writer (listen)
 import Data.Bifunctor (bimap)
 import Data.Coerce (coerce)
 import qualified Data.Either as Either
 import Data.Functor.Const (Const(..))
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map.Strict as Map
 import qualified Data.Monoid as Monoid (getAny)
 import qualified Data.Set.Ordered as OSet
@@ -83,7 +85,7 @@ import Clash.Driver.Types (Binding(..), TransformationInfo(..), hasTransformatio
 import Clash.Rewrite.Combinators (topdownR)
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, censor, curFun, extra, tcCache
-  , workFreeBinders, debugOpts, topEntities, specializationLimit)
+  , workFreeBinders, debugOpts, topEntities, specializationLimit, ioLock)
 import Clash.Rewrite.Util
   ( mkBinderFor, mkDerivedName, mkFunction, mkTmBinderFor, setChanged, changed
   , isUntranslatableType, normalizeTermTypes, normalizeId, whnfRW)
@@ -200,8 +202,10 @@ appProp ctx@(TransformContext is _) = \case
 
   go is0 (Lam v e) (Left arg:args) ticks = do
     setChanged
-    bndrs <- Lens.use bindings
-    orM [pure (isVar arg), isWorkFree workFreeBinders bndrs arg] >>= \case
+    bndrsV <- Lens.use bindings
+    wf <- MVar.withMVar "bindings" bndrsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+
+    case isVar arg || wf of
       True ->
         -- 'e' is deshadowed w.r.t. an in-scope set that contains the free
         -- variables of 'arg': 'appProp' deshadows the function expression
@@ -269,10 +273,12 @@ appProp ctx@(TransformContext is _) = \case
 
   goCaseArg isA0 ty0 ls0 (Left arg:args0) = do
     tcm <- Lens.view tcCache
-    bndrs <- Lens.use bindings
     let argTy = inferCoreTypeOf tcm arg
         ty1   = applyFunTy tcm ty0 argTy
-    orM [pure (isVar arg), isWorkFree workFreeBinders bndrs arg] >>= \case
+    bndrsV <- Lens.use bindings
+    wf <- MVar.withMVar "bindings" bndrsV (\bndrs -> isWorkFree workFreeBinders bndrs arg)
+
+    case isVar arg || wf of
       True -> do
         (ty2,ls1,args1) <- goCaseArg isA0 ty1 ls0 args0
         return (ty2,ls1,Left arg:args1)
@@ -381,24 +387,29 @@ specialize'
 specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
   opts <- Lens.view debugOpts
   tcm <- Lens.view tcCache
+  ioLockV <- Lens.use ioLock
 
   -- Don't specialize TopEntities
   topEnts <- Lens.view topEntities
   if f `elemVarSet` topEnts
-  then do
+  then
     case specArgIn of
       Left _ -> do
-        traceM ("Not specializing TopEntity: " ++ showPpr (varName f))
+        MVar.withMVar "ioLock" ioLockV $ \() ->
+          traceM ("Not specializing TopEntity: " ++ showPpr (varName f))
+
         return e
-      Right tyArg ->
-        traceIf (hasTransformationInfo AppliedTerm opts) ("Dropping type application on TopEntity: " ++ showPpr (varName f) ++ "\ntype:\n" ++ showPpr tyArg) $
+      Right tyArg -> do
+        Monad.when (hasTransformationInfo AppliedTerm opts) $
+          MVar.withMVar "ioLock" ioLockV $ \() ->
+            traceM ("Dropping type application on TopEntity: " ++ showPpr (varName f) ++ "\ntype:\n" ++ showPpr tyArg)
         -- TopEntities aren't allowed to be semantically polymorphic.
         -- But using type equality constraints they may be syntactically polymorphic.
         -- > topEntity :: forall dom . (dom ~ "System") => Signal dom Bool -> Signal dom Bool
         -- The TyLam's in the body will have been removed by 'Clash.Normalize.Util.substWithTyEq'.
         -- So we drop the TyApp ("specializing" on it) and change the varType to match.
         let newVarTy = piResultTy tcm (coreTypeOf f) tyArg
-        in  changed (mkApps (mkTicks (Var f{varType = newVarTy}) ticks) args)
+        changed (mkApps (mkTicks (Var f{varType = newVarTy}) ticks) args)
   else do -- NondecreasingIndentation
 
   let specArg = bimap (normalizeTermTypes tcm) (normalizeType tcm) specArgIn
@@ -412,34 +423,87 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
       -- See Note [ticks and specialization]
       specAbs :: Either Term Type
       specAbs = either (Left . stripAllTicks . (`mkAbstraction` specBndrs)) (Right . id) specArg
-  -- Determine if 'f' has already been specialized on (a type-normalized) 'specArg'
-  specM <- Map.lookup (f,argLen,specAbs) <$> Lens.use (extra.specialisationCache)
-  case specM of
-    -- Use previously specialized function
-    Just f' ->
-      traceIf (hasTransformationInfo AppliedTerm opts)
-        ("Using previous specialization of " ++ showPpr (varName f) ++ " on " ++
-          (either showPpr showPpr) specAbs ++ ": " ++ showPpr (varName f')) $
-        changed $ mkApps (mkTicks (Var f') ticks) (args ++ specVars)
-    -- Create new specialized function
-    Nothing -> do
-      -- Determine if we can specialize f
-      bodyMaybe <- fmap (UniqMap.lookup f) $ Lens.use bindings
+  -- Determine if 'f' has already been specialized on (a type-normalized) 'specArg'.
+  --
+  -- With concurrent normalization, multiple threads may try to specialize the
+  -- same function simultaneously. We use a "future" pattern: atomically check
+  -- the cache and, if absent, insert an empty MVar as a placeholder. The first
+  -- thread to arrive creates the specialization and fills the MVar; any other
+  -- thread that arrives for the same key will find the placeholder and wait on
+  -- it. This prevents duplicate specializations and duplicate history counter
+  -- increments. The future stores failures too, so waiting threads cannot get
+  -- stranded on an exception path.
+  cacheV <- Lens.use (extra.specialisationCache)
+  resultMVar <- MVar.newEmptyMVar "specResult"
+  specDecision <- MVar.modifyMVar "specialisationCache" cacheV $ \cache ->
+    case Map.lookup (f,argLen,specAbs) cache of
+      Just existingMVar ->
+        -- Already cached or in progress; return the existing future
+        pure (cache, Left existingMVar)
+      Nothing ->
+        -- Not cached; insert our empty MVar as a placeholder so other threads wait
+        pure (Map.insert (f,argLen,specAbs) resultMVar cache, Right resultMVar)
+
+  case specDecision of
+    Left existingMVar -> do
+      -- Use previously (or concurrently) specialized function
+      MVar.readMVar "specCacheResult" existingMVar >>= \case
+        Left err ->
+          Exception.throwIO err
+
+        Right Nothing ->
+          return e
+
+        Right (Just f') ->
+          traceIf (hasTransformationInfo AppliedTerm opts)
+            ("Using previous specialization of " ++ showPpr (varName f) ++ " on " ++
+              (either showPpr showPpr) specAbs ++ ": " ++ showPpr (varName f')) $
+            changed $ mkApps (mkTicks (Var f') ticks) (args ++ specVars)
+
+    Right myMVar -> do
+      -- We're responsible for creating the specialization
+      Exception.mask $ \restore -> do
+        result <-
+          Exception.try (restore (createSpecialization tcm topEnts specArg specBndrs specVars argLen))
+        case result of
+          Left err -> do
+            MVar.modifyMVar_ "specialisationCache" cacheV $ \cache ->
+              pure $ Map.delete (f,argLen,specAbs) cache
+            MVar.putMVar "specCacheResult" myMVar (Left err)
+            Exception.throwIO err
+
+          Right Nothing -> do
+            MVar.modifyMVar_ "specialisationCache" cacheV $ \cache ->
+              pure $ Map.delete (f,argLen,specAbs) cache
+            MVar.putMVar "specCacheResult" myMVar (Right Nothing)
+            return e
+
+          Right (Just (newf, newExpr)) -> do
+            MVar.putMVar "specCacheResult" myMVar (Right (Just newf))
+            restore (newf `deepseq` changed newExpr)
+  where
+    createSpecialization tcm topEnts specArg specBndrs specVars argLen = do
+      bndrsV <- Lens.use bindings
+      bodyMaybe <- MVar.withMVar "bindings" bndrsV $ \bndrs -> pure $ UniqMap.lookup f bndrs
       case bodyMaybe of
+        Nothing ->
+          pure Nothing
+
         Just (Binding _ sp inl _ bodyTm _) -> do
           -- Determine if we see a sequence of specializations on a growing argument
-          specHistM <- UniqMap.lookup f <$> Lens.use (extra.specialisationHistory)
-          specLim   <- Lens.view specializationLimit
+          histV <- Lens.use (extra.specialisationHistory)
+          specLim <- Lens.view specializationLimit
+          specHistM <- MVar.withMVar "specialisationHistory" histV $ \hist -> pure $ UniqMap.lookup f hist
           if maybe False (> specLim) specHistM
             then throw (ClashException
-                        sp
-                        (unlines [ "Hit specialization limit " ++ show specLim ++ " on function `" ++ showPpr (varName f) ++ "'.\n"
-                                 , "The function `" ++ showPpr f ++ "' is most likely recursive, and looks like it is being indefinitely specialized on a growing argument.\n"
-                                 , "Body of `" ++ showPpr f ++ "':\n" ++ showPpr bodyTm ++ "\n"
-                                 , "Argument (in position: " ++ show argLen ++ ") that triggered termination:\n" ++ (either showPpr showPpr) specArg
-                                 , "Run with '-fclash-spec-limit=N' to increase the specialization limit to N."
-                                 ])
-                        Nothing)
+                    sp
+                    (unlines [ "Hit specialization limit " ++ show specLim ++ " on function `" ++ showPpr (varName f) ++ "'.\n"
+                             , "The function `" ++ showPpr f ++ "' is most likely recursive, and looks like it is being indefinitely specialized on a growing argument.\n"
+                             , "Body of `" ++ showPpr f ++ "':\n" ++ showPpr bodyTm ++ "\n"
+                             , "Argument (in position: " ++ show argLen ++ ") that triggered termination:\n" ++ (either showPpr showPpr) specArg
+                             , "Run with '-fclash-spec-limit=N' to increase the specialization limit to N."
+                             ])
+                    Nothing)
             else do
               let existingNames = collectBndrsMinusApps bodyTm
                   newNames      = [ mkUnsafeInternalName ("pTS" `Text.append` Text.pack (show n)) n
@@ -481,7 +545,8 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
                       -- Finally, we must make sure we do not inline the bodies
                       -- of functions with a Synthesize annotation, as that would
                       -- duplicate Clash compiler work. See also issue #3024
-                      gTmM <- fmap (UniqMap.lookup g) $ Lens.use bindings
+                      bndrsV2 <- Lens.use bindings
+                      gTmM <- MVar.withMVar "bindings" bndrsV2 $ \bndrs -> pure $ UniqMap.lookup g bndrs
                       let gBody = if g `elemVarSet` topEnts then
                                     Nothing
                                   else
@@ -497,13 +562,11 @@ specialize' (TransformContext is0 _) e (Var f, args, ticks) specArgIn = do
               let newBody = mkAbstraction (mkApps bodyTm (argVars ++ [specArg'])) (boundArgs ++ specBndrs)
               newf <- mkFunction newName sp inl' newBody
               -- Remember specialization
-              (extra.specialisationHistory) %= UniqMap.insertWith (+) f 1
-              (extra.specialisationCache)  %= Map.insert (f,argLen,specAbs) newf
+              MVar.modifyMVar_ "specialisationHistory" histV $ \hist -> pure $ UniqMap.insertWith (+) f 1 hist
               -- use specialized function
               let newExpr = mkApps (mkTicks (Var newf) ticks) (args ++ specVars)
-              newf `deepseq` changed newExpr
-        Nothing -> return e
-  where
+              pure (Just (newf, newExpr))
+
     noUserInline :: InlineSpec
     noUserInline = NoUserInlinePrag
 
@@ -541,10 +604,13 @@ specialize' _ctx _ (appE,args,ticks) (Left specArg) = do
       newBody = mkAbstraction specArg specBndrs
   -- See if there's an existing binder that's alpha-equivalent to the
   -- specialized function
-  existing <- UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) <$> Lens.use bindings
+  bndrsV3 <- Lens.use bindings
+  existing <- MVar.withMVar "bindings" bndrsV3 $ \bndrs -> pure $ UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) bndrs
   -- Create a new function if an alpha-equivalent binder doesn't exist
   newf <- case UniqMap.elems existing of
-    [] -> do (cf,sp) <- Lens.use curFun
+    [] -> do curFunsV <- Lens.use curFun
+             thread <- myThreadId
+             Just (cf,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
              mkFunction (appendToName (varName cf) "_specF") sp NoUserInlinePrag newBody
     (b:_) -> return (bindingId b)
   -- Create specialized argument
@@ -633,7 +699,8 @@ nonRepSpec ctx e@(App e1 e2)
     inlineInternalSpecialisationArgument app
       | (Var f,fArgs,ticks) <- collectArgsTicks app
       = do
-        fTmM <- lookupVarEnv f <$> Lens.use bindings
+        bndrsV <- Lens.use bindings
+        fTmM <- MVar.withMVar "bindings" bndrsV (pure . lookupVarEnv f)
         case fTmM of
           Just b
             | nameSort (varName (bindingId b)) == Internal

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -12,8 +12,9 @@
 
 module Clash.Normalize.Types where
 
+import Control.Concurrent.MVar    (MVar)
 import qualified Control.Lens as Lens
-import Control.Monad.State.Strict (State)
+import Control.Monad.State.Strict (StateT)
 import Data.Map                   (Map)
 import Data.Set                   (Set)
 import Data.Text                  (Text)
@@ -22,31 +23,31 @@ import Clash.Core.Term        (Term)
 import Clash.Core.Type        (Type)
 import Clash.Core.Var         (Id)
 import Clash.Core.VarEnv      (VarEnv)
-import Clash.Driver.Types     (BindingMap)
+import Clash.Driver.Types     (Binding)
 import Clash.Rewrite.Types    (Rewrite, RewriteMonad)
 
 -- | State of the 'NormalizeMonad'
 data NormalizeState
   = NormalizeState
-  { _normalized          :: BindingMap
+  { _normalized          :: MVar (VarEnv (MVar (Binding Term)))
   -- ^ Global binders
-  , _specialisationCache :: Map (Id,Int,Either Term Type) Id
+  , _specialisationCache :: MVar (Map (Id,Int,Either Term Type) Id)
   -- ^ Cache of previously specialized functions:
   --
   -- * Key: (name of the original function, argument position, specialized term/type)
   --
   -- * Elem: (name of specialized function,type of specialized function)
-  , _specialisationHistory :: VarEnv Int
+  , _specialisationHistory :: MVar (VarEnv Int)
   -- ^ Cache of how many times a function was specialized
-  , _inlineHistory   :: VarEnv (VarEnv Int)
+  , _inlineHistory   :: MVar (VarEnv (VarEnv Int))
   -- ^ Cache of function where inlining took place:
   --
   -- * Key: function where inlining took place
   --
   -- * Elem: (functions which were inlined, number of times inlined)
-  , _primitiveArgs :: Map Text (Set Int)
+  , _primitiveArgs :: MVar (Map Text (Set Int))
   -- ^ Cache for looking up constantness of blackbox arguments
-  , _recursiveComponents :: VarEnv Bool
+  , _recursiveComponents :: MVar (VarEnv Bool)
   -- ^ Map telling whether a components is recursively defined.
   --
   -- NB: there are only no mutually-recursive component, only self-recursive
@@ -56,7 +57,7 @@ data NormalizeState
 Lens.makeLenses ''NormalizeState
 
 -- | State monad that stores specialisation and inlining information
-type NormalizeMonad = State NormalizeState
+type NormalizeMonad = StateT NormalizeState IO
 
 -- | RewriteSession with extra Normalisation information
 type NormalizeSession = RewriteMonad NormalizeState

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -31,12 +31,13 @@ data NormalizeState
   = NormalizeState
   { _normalized          :: MVar (VarEnv (MVar (Binding Term)))
   -- ^ Global binders
-  , _specialisationCache :: MVar (Map (Id,Int,Either Term Type) Id)
+  , _specialisationCache :: MVar (Map (Id,Int,Either Term Type) (MVar Id))
   -- ^ Cache of previously specialized functions:
   --
   -- * Key: (name of the original function, argument position, specialized term/type)
   --
-  -- * Elem: (name of specialized function,type of specialized function)
+  -- * Elem: MVar containing the name of the specialized function. An empty
+  -- MVar indicates a specialization is in progress by another thread.
   , _specialisationHistory :: MVar (VarEnv Int)
   -- ^ Cache of how many times a function was specialized
   , _inlineHistory   :: MVar (VarEnv (VarEnv Int))

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -13,6 +13,7 @@
 module Clash.Normalize.Types where
 
 import Control.Concurrent.MVar    (MVar)
+import Control.Exception          (SomeException)
 import qualified Control.Lens as Lens
 import Control.Monad.State.Strict (StateT)
 import Data.Map                   (Map)
@@ -31,12 +32,13 @@ data NormalizeState
   = NormalizeState
   { _normalized          :: MVar (VarEnv (MVar (Binding Term)))
   -- ^ Global binders
-  , _specialisationCache :: MVar (Map (Id,Int,Either Term Type) (MVar Id))
+  , _specialisationCache ::
+      MVar (Map (Id,Int,Either Term Type) (MVar (Either SomeException (Maybe Id))))
   -- ^ Cache of previously specialized functions:
   --
   -- * Key: (name of the original function, argument position, specialized term/type)
   --
-  -- * Elem: MVar containing the name of the specialized function. An empty
+  -- * Elem: MVar containing the result of a specialization attempt. An empty
   -- MVar indicates a specialization is in progress by another thread.
   , _specialisationHistory :: MVar (VarEnv Int)
   -- ^ Cache of how many times a function was specialized

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -12,8 +12,10 @@
 
 module Clash.Normalize.Types where
 
+import Control.Concurrent.MVar    (MVar)
+import Control.Exception          (SomeException)
 import qualified Control.Lens as Lens
-import Control.Monad.State.Strict (State)
+import Control.Monad.State.Strict (StateT)
 import Data.Map                   (Map)
 import Data.Set                   (Set)
 import Data.Text                  (Text)
@@ -22,31 +24,33 @@ import Clash.Core.Term        (Term)
 import Clash.Core.Type        (Type)
 import Clash.Core.Var         (Id)
 import Clash.Core.VarEnv      (VarEnv)
-import Clash.Driver.Types     (BindingMap)
+import Clash.Driver.Types     (Binding)
 import Clash.Rewrite.Types    (Rewrite, RewriteMonad)
 
 -- | State of the 'NormalizeMonad'
 data NormalizeState
   = NormalizeState
-  { _normalized          :: BindingMap
+  { _normalized          :: MVar (VarEnv (MVar (Binding Term)))
   -- ^ Global binders
-  , _specialisationCache :: Map (Id,Int,Either Term Type) Id
+  , _specialisationCache ::
+      MVar (Map (Id,Int,Either Term Type) (MVar (Either SomeException (Maybe Id))))
   -- ^ Cache of previously specialized functions:
   --
   -- * Key: (name of the original function, argument position, specialized term/type)
   --
-  -- * Elem: (name of specialized function,type of specialized function)
-  , _specialisationHistory :: VarEnv Int
+  -- * Elem: MVar containing the result of a specialization attempt. An empty
+  -- MVar indicates a specialization is in progress by another thread.
+  , _specialisationHistory :: MVar (VarEnv Int)
   -- ^ Cache of how many times a function was specialized
-  , _inlineHistory   :: VarEnv (VarEnv Int)
+  , _inlineHistory   :: MVar (VarEnv (VarEnv Int))
   -- ^ Cache of function where inlining took place:
   --
   -- * Key: function where inlining took place
   --
   -- * Elem: (functions which were inlined, number of times inlined)
-  , _primitiveArgs :: Map Text (Set Int)
+  , _primitiveArgs :: MVar (Map Text (Set Int))
   -- ^ Cache for looking up constantness of blackbox arguments
-  , _recursiveComponents :: VarEnv Bool
+  , _recursiveComponents :: MVar (VarEnv Bool)
   -- ^ Map telling whether a components is recursively defined.
   --
   -- NB: there are only no mutually-recursive component, only self-recursive
@@ -56,7 +60,7 @@ data NormalizeState
 Lens.makeLenses ''NormalizeState
 
 -- | State monad that stores specialisation and inlining information
-type NormalizeMonad = State NormalizeState
+type NormalizeMonad = StateT NormalizeState IO
 
 -- | RewriteSession with extra Normalisation information
 type NormalizeSession = RewriteMonad NormalizeState

--- a/clash-lib/src/Clash/Normalize/Types.hs
+++ b/clash-lib/src/Clash/Normalize/Types.hs
@@ -24,6 +24,7 @@ import Clash.Core.Term        (Term)
 import Clash.Core.Type        (Type)
 import Clash.Core.Var         (Id)
 import Clash.Core.VarEnv      (VarEnv)
+import Clash.Data.RwVar       (RwVar)
 import Clash.Driver.Types     (Binding)
 import Clash.Rewrite.Types    (Rewrite, RewriteMonad)
 
@@ -48,9 +49,9 @@ data NormalizeState
   -- * Key: function where inlining took place
   --
   -- * Elem: (functions which were inlined, number of times inlined)
-  , _primitiveArgs :: MVar (Map Text (Set Int))
+  , _primitiveArgs :: RwVar (Map Text (Set Int))
   -- ^ Cache for looking up constantness of blackbox arguments
-  , _recursiveComponents :: MVar (VarEnv Bool)
+  , _recursiveComponents :: RwVar (VarEnv Bool)
   -- ^ Map telling whether a components is recursively defined.
   --
   -- NB: there are only no mutually-recursive component, only self-recursive

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Normalize.Util
  ( ConstantSpecInfo(..)
@@ -33,13 +33,17 @@ module Clash.Normalize.Util
  )
  where
 
-import           Control.Lens            ((&),(+~),(%=),(.=))
+import           Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
+import           Control.Lens            ((&),(+~))
 import qualified Control.Lens            as Lens
+import           Control.Monad           (when)
 import           Data.Bifunctor          (bimap)
 import           Data.Either             (lefts,rights)
 import qualified Data.List               as List
 import qualified Data.List.Extra         as List
 import qualified Data.Map                as Map
+import           Data.Maybe              (fromMaybe)
 import qualified Data.HashMap.Strict     as HashMapS
 import qualified Data.HashSet            as HashSet
 import           Data.Text               (Text)
@@ -69,7 +73,7 @@ import           Clash.Core.VarEnv
   (VarEnv, emptyInScopeSet, emptyVarEnv, extendVarEnv, extendVarEnvWith,
    lookupVarEnv, unionVarEnvWith, unitVarEnv, extendInScopeSetList, mkInScopeSet, mkVarSet)
 import qualified Clash.Data.UniqMap as UniqMap
-import           Clash.Debug             (traceIf)
+import           Clash.Debug             (traceM)
 import           Clash.Driver.Types
   (BindingMap, Binding(..), TransformationInfo(FinalTerm), hasTransformationInfo)
 import           Clash.Normalize.Primitives (removedArg)
@@ -78,11 +82,11 @@ import           Clash.Normalize.Types
 import           Clash.Primitives.Util   (constantArgs)
 import           Clash.Rewrite.Types
   (RewriteMonad, TransformContext(..), bindings, curFun, debugOpts, extra,
-   tcCache, primitives)
+   tcCache, primitives, ioLock)
 import           Clash.Rewrite.Util
   (runRewrite, mkTmBinderFor, mkDerivedName)
 import           Clash.Unique
-import           Clash.Util              (SrcSpan, makeCachedU)
+import           Clash.Util              (SrcSpan, curLoc, noSrcSpan)
 
 -- | Determine if argument should reduce to a constant given a primitive and
 -- an argument number. Caches results.
@@ -97,23 +101,26 @@ isConstantArg
   -- blackbox.
 isConstantArg "Clash.Explicit.SimIO.mealyIO" i = pure (i == 2 || i == 3)
 isConstantArg nm i = do
-  argMap <- Lens.use (extra.primitiveArgs)
-  case Map.lookup nm argMap of
-    Nothing -> do
-      -- Constant args not yet calculated, or primitive does not exist
-      prims <- Lens.view primitives
-      case extractPrim =<< HashMapS.lookup nm prims of
-        Nothing ->
-          -- Primitive does not exist:
-          pure False
-        Just p -> do
-          -- Calculate constant arguments:
-          let m = constantArgs nm p
-          (extra.primitiveArgs) Lens.%= Map.insert nm m
-          pure (i `elem` m)
-    Just m ->
-      -- Cached version found
-      pure (i `elem` m)
+  argMapV <- Lens.use (extra.primitiveArgs)
+
+  MVar.modifyMVar "primitiveArgs" argMapV $ \argMap ->
+    case Map.lookup nm argMap of
+      Nothing -> do
+        prims <- Lens.view primitives
+        -- Constant args not yet calculated, or primitive does not exist
+        case extractPrim =<< HashMapS.lookup nm prims of
+          Nothing ->
+            -- Primitive does not exist:
+            pure (argMap, False)
+
+          Just p ->
+            -- Calculate constant arguments:
+            let m = constantArgs nm p
+             in pure (Map.insert nm m argMap, i `elem` m)
+
+      Just m ->
+        -- Cached version found
+        pure (argMap, i `elem` m)
 
 -- | Given a list of transformation contexts, determine if any of the contexts
 -- indicates that the current arg is to be reduced to a constant / literal.
@@ -134,10 +141,12 @@ alreadyInlined
   -- ^ Function in which we want to perform the inlining
   -> NormalizeMonad (Maybe Int)
 alreadyInlined f cf = do
-  inlinedHM <- Lens.use inlineHistory
-  case lookupVarEnv cf inlinedHM of
-    Nothing       -> return Nothing
-    Just inlined' -> return (lookupVarEnv f inlined')
+  inlinedHMV <- Lens.use inlineHistory
+
+  MVar.withMVar "inlineHistory" inlinedHMV $ \inlinedHM ->
+    case lookupVarEnv cf inlinedHM of
+      Nothing       -> return Nothing
+      Just inlined' -> return (lookupVarEnv f inlined')
 
 -- | Record a new inlining in the `inlineHistory`
 addNewInline
@@ -146,11 +155,11 @@ addNewInline
   -> Id
   -- ^ Function in which we're inlining it
   -> NormalizeMonad ()
-addNewInline f cf =
-  inlineHistory %= extendVarEnvWith
-                     cf
-                     (unitVarEnv f 1)
-                     (\_ hm -> extendVarEnvWith f 1 (+) hm)
+addNewInline f cf = do
+  inlineHistV <- Lens.use inlineHistory
+
+  MVar.modifyMVar_ "inlineHistory" inlineHistV $
+    pure . extendVarEnvWith cf (unitVarEnv f 1) (\_ hm -> extendVarEnvWith f 1 (+) hm)
 
 -- | Test whether a given term represents a non-recursive global variable
 isNonRecursiveGlobalVar
@@ -167,20 +176,23 @@ isRecursiveBndr
   :: Id
   -> NormalizeSession Bool
 isRecursiveBndr f = do
-  cg <- Lens.use (extra.recursiveComponents)
-  case lookupVarEnv f cg of
-    Just isR -> return isR
-    Nothing -> do
-      fBodyM <- lookupVarEnv f <$> Lens.use bindings
-      case fBodyM of
-        Nothing -> return False
-        Just b -> do
-          -- There are no global mutually-recursive functions, only self-recursive
-          -- ones, so checking whether 'f' is part of the free variables of the
-          -- body of 'f' is sufficient.
-          let isR = f `globalIdOccursIn` bindingTerm b
-          (extra.recursiveComponents) %= extendVarEnv f isR
-          return isR
+  cgV <- Lens.use (extra.recursiveComponents)
+
+  MVar.modifyMVar "recursiveComponents" cgV $ \cg ->
+    case lookupVarEnv f cg of
+      Just isR -> pure (cg, isR)
+      Nothing -> do
+        bindingsV <- Lens.use bindings
+        mBind <- MVar.withMVar "bindings" bindingsV (pure . lookupVarEnv f)
+
+        case mBind of
+          Nothing -> pure (cg, False)
+          Just b ->
+            -- There are no global mutually-recursive functions, only self-recursive
+            -- ones, so checking whether 'f' is part of the free variables of the
+            -- body of 'f' is sufficient.
+            let isR = f `globalIdOccursIn` bindingTerm b
+             in pure (extendVarEnv f isR cg, isR)
 
 data ConstantSpecInfo =
   ConstantSpecInfo
@@ -318,7 +330,9 @@ constantSpecInfo ctx e = do
           pure (constantCsr e)
 
       (var@(Var f), args, ticks) -> do
-        (curF, _) <- Lens.use curFun
+        curFunsV <- Lens.use curFun
+        thread <- myThreadId
+        Just (curF, _) <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
         isNonRecGlobVar <- isNonRecursiveGlobalVar e
         if isNonRecGlobVar && f /= curF then do
           csr <- mergeCsrs ctx ticks e (mkApps var) args
@@ -403,22 +417,44 @@ normalizeTopLvlBndr
   -> Id
   -> Binding Term
   -> NormalizeSession (Binding Term)
-normalizeTopLvlBndr isTop nm (Binding nm' sp inl pr tm _) = makeCachedU nm (extra.normalized) $ do
-  tcm <- Lens.view tcCache
-  let nmS = showPpr (varName nm)
-  -- We deshadow the term because sometimes GHC gives us
-  -- code where a local binder has the same unique as a
-  -- global binder, sometimes causing the inliner to go
-  -- into a loop. Deshadowing freshens all the bindings
-  -- to avoid this.
-  let tm1 = deShadowTerm emptyInScopeSet tm
-      tm2 = if isTop then substWithTyEq tm1 else tm1
-  old <- Lens.use curFun
-  tm3 <- rewriteExpr ("normalization",normalization) (nmS,tm2) (nm',sp)
-  curFun .= old
-  let ty' = inferCoreTypeOf tcm tm3
-  let r' = nm' `globalIdOccursIn` tm3
-  return (Binding nm'{varType = ty'} sp inl pr tm3 r')
+normalizeTopLvlBndr isTop nm (Binding nm' sp inl pr tm _) = do
+  normalizedV <- Lens.use (extra.normalized)
+
+  -- TODO This was a call to makeCachedU, but since there was no variation
+  -- for MVar, I unrolled everything. Maybe there should be MVar versions of
+  -- the makeCachedX functions needed in normalization.
+
+  cache <- MVar.takeMVar "normalized" normalizedV
+  case lookupVarEnv nm cache of
+    Just vMVar -> do
+      MVar.putMVar "normalized" normalizedV cache
+      MVar.readMVar "normalizedBinding" vMVar
+    Nothing -> do
+      tmp <- MVar.newEmptyMVar "normalizedTmp"
+      MVar.putMVar "normalized" normalizedV (extendVarEnv nm tmp cache)
+
+      tcm <- Lens.view tcCache
+      let nmS = showPpr (varName nm)
+      -- We deshadow the term because sometimes GHC gives us
+      -- code where a local binder has the same unique as a
+      -- global binder, sometimes causing the inliner to go
+      -- into a loop. Deshadowing freshens all the bindings
+      -- to avoid this.
+      let tm1 = deShadowTerm emptyInScopeSet tm
+          tm2 = if isTop then substWithTyEq tm1 else tm1
+      -- TODO Should tm3 be done async / added to the job queue when it's made?
+      curFunsV <- Lens.use curFun
+      thread <- myThreadId
+      old <- MVar.withMVar "curFun" curFunsV (pure . HashMapS.lookup thread)
+      tm3 <- rewriteExpr ("normalization",normalization) (nmS,tm2) (nm',sp)
+      MVar.modifyMVar_ "curFun" curFunsV $
+        pure . HashMapS.insert thread (fromMaybe (error $ $(curLoc) ++ "Report as bug: no curFun", noSrcSpan) old)
+      let ty' = inferCoreTypeOf tcm tm3
+      let r' = nm' `globalIdOccursIn` tm3
+      let value = Binding nm'{varType = ty'} sp inl pr tm3 r'
+
+      MVar.putMVar "normalizedTmp" tmp value
+      pure value
 
 -- | Turn type equality constraints into substitutions and apply them.
 --
@@ -489,17 +525,23 @@ rewriteExpr :: (String,NormRewrite) -- ^ Transformation to apply
             -> (Id, SrcSpan)        -- ^ Renew current function being rewritten
             -> NormalizeSession Term
 rewriteExpr (nrwS,nrw) (bndrS,expr) (nm, sp) = do
-  curFun .= (nm, sp)
+  curFunsV <- Lens.use curFun
+  thread <- myThreadId
+  MVar.modifyMVar_ "curFun" curFunsV (pure . HashMapS.insert thread (nm, sp))
   opts <- Lens.view debugOpts
-  let before = showPpr expr
-  let expr' = traceIf (hasTransformationInfo FinalTerm opts)
-                (bndrS ++ " before " ++ nrwS ++ ":\n\n" ++ before ++ "\n")
-                expr
-  rewritten <- runRewrite nrwS emptyInScopeSet nrw expr'
-  let after = showPpr rewritten
-  traceIf (hasTransformationInfo FinalTerm opts)
-    (bndrS ++ " after " ++ nrwS ++ ":\n\n" ++ after ++ "\n") $
-    return rewritten
+  ioLockV <- Lens.use ioLock
+
+  when (hasTransformationInfo FinalTerm opts) $
+    MVar.withMVar "ioLock" ioLockV $ \() ->
+      traceM (bndrS ++ " before " ++ nrwS ++ ":\n\n" ++ showPpr expr ++ "\n")
+
+  rewritten <- runRewrite nrwS emptyInScopeSet nrw expr
+
+  when (hasTransformationInfo FinalTerm opts) $
+    MVar.withMVar "ioLock" ioLockV $ \() ->
+      traceM (bndrS ++ " after " ++ nrwS ++ ":\n\n" ++ showPpr rewritten ++ "\n")
+
+  return rewritten
 
 -- | A tick to prefix an inlined expression with it's original name.
 -- For example, given

--- a/clash-lib/src/Clash/Normalize/Util.hs
+++ b/clash-lib/src/Clash/Normalize/Util.hs
@@ -34,6 +34,7 @@ module Clash.Normalize.Util
  where
 
 import           Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Data.RwVar as RwVar
 import qualified Clash.Normalize.TracedMVar as MVar
 import           Control.Lens            ((&),(+~))
 import qualified Control.Lens            as Lens
@@ -102,25 +103,27 @@ isConstantArg
 isConstantArg "Clash.Explicit.SimIO.mealyIO" i = pure (i == 2 || i == 3)
 isConstantArg nm i = do
   argMapV <- Lens.use (extra.primitiveArgs)
+  argMap <- RwVar.readRwVar argMapV
 
-  MVar.modifyMVar "primitiveArgs" argMapV $ \argMap ->
-    case Map.lookup nm argMap of
-      Nothing -> do
-        prims <- Lens.view primitives
-        -- Constant args not yet calculated, or primitive does not exist
-        case extractPrim =<< HashMapS.lookup nm prims of
-          Nothing ->
-            -- Primitive does not exist:
-            pure (argMap, False)
+  case Map.lookup nm argMap of
+    Nothing -> do
+      prims <- Lens.view primitives
+      -- Constant args not yet calculated, or primitive does not exist
+      case extractPrim =<< HashMapS.lookup nm prims of
+        Nothing ->
+          -- Primitive does not exist:
+          pure False
 
-          Just p ->
-            -- Calculate constant arguments:
-            let m = constantArgs nm p
-             in pure (Map.insert nm m argMap, i `elem` m)
+        Just p -> do
+          -- Calculate constant arguments. Depends only on the primitive
+          -- definition, so it is computed outside the lock.
+          let m = constantArgs nm p
+          RwVar.modifyRwVar_ argMapV (pure . Map.insert nm m)
+          pure (i `elem` m)
 
-      Just m ->
-        -- Cached version found
-        pure (argMap, i `elem` m)
+    Just m ->
+      -- Cached version found
+      pure (i `elem` m)
 
 -- | Given a list of transformation contexts, determine if any of the contexts
 -- indicates that the current arg is to be reduced to a constant / literal.
@@ -177,22 +180,27 @@ isRecursiveBndr
   -> NormalizeSession Bool
 isRecursiveBndr f = do
   cgV <- Lens.use (extra.recursiveComponents)
+  cg <- RwVar.readRwVar cgV
 
-  MVar.modifyMVar "recursiveComponents" cgV $ \cg ->
-    case lookupVarEnv f cg of
-      Just isR -> pure (cg, isR)
-      Nothing -> do
-        bindingsV <- Lens.use bindings
-        mBind <- MVar.withMVar "bindings" bindingsV (pure . lookupVarEnv f)
+  case lookupVarEnv f cg of
+    Just isR -> pure isR
+    Nothing -> do
+      bindingsV <- Lens.use bindings
+      mBind <- lookupVarEnv f <$> RwVar.readRwVar bindingsV
 
-        case mBind of
-          Nothing -> pure (cg, False)
-          Just b ->
-            -- There are no global mutually-recursive functions, only self-recursive
-            -- ones, so checking whether 'f' is part of the free variables of the
-            -- body of 'f' is sufficient.
-            let isR = f `globalIdOccursIn` bindingTerm b
-             in pure (extendVarEnv f isR cg, isR)
+      case mBind of
+        Nothing -> pure False
+        Just b -> do
+          -- There are no global mutually-recursive functions, only self-recursive
+          -- ones, so checking whether 'f' is part of the free variables of the
+          -- body of 'f' is sufficient.
+          --
+          -- The answer only depends on the (immutable) body of 'f', so it is
+          -- computed outside the lock: two threads racing on the same binder
+          -- compute the same value.
+          let isR = f `globalIdOccursIn` bindingTerm b
+          RwVar.modifyRwVar_ cgV (pure . extendVarEnv f isR)
+          pure isR
 
 data ConstantSpecInfo =
   ConstantSpecInfo

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -18,16 +18,34 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+#if MIN_VERSION_transformers(0,5,6)
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+#endif
 
 module Clash.Rewrite.Types where
 
-import Control.DeepSeq                       (NFData)
+import           Control.Applicative                   (Alternative)
+import           Control.Concurrent                    (MVar, ThreadId)
+import           Clash.Util.Supply                     (Supply, freshId)
+import           Control.DeepSeq                       (NFData)
 import Control.Lens                          (Lens', use, (.=))
 import qualified Control.Lens as Lens
+import Control.Monad.Base
+#if !MIN_VERSION_base(4,13,0)
+import Control.Monad.Fail                    (MonadFail)
+#endif
 import Control.Monad.Fix                     (MonadFix)
+import Control.Monad.IO.Class                (MonadIO)
 import Control.Monad.State.Strict            (State)
 import Control.Monad.Reader                  (MonadReader (..))
 import Control.Monad.State                   (MonadState (..))
+import Control.Monad.Trans.Control
+  ( ComposeSt, MonadBaseControl(..), MonadTransControl(..)
+  , defaultLiftBaseWith, defaultRestoreM)
 import Control.Monad.Trans.RWS.CPS           (RWST)
 import qualified Control.Monad.Trans.RWS.CPS as RWS
 import Control.Monad.Writer                  (MonadWriter (..))
@@ -51,7 +69,7 @@ import Clash.Netlist.Types       (FilteredHWType, HWMap)
 import Clash.Primitives.Types    (CompiledPrimMap)
 import Clash.Rewrite.WorkFree    (isWorkFree)
 import Clash.Util
-import Clash.Util.Supply         (Supply, freshId)
+import Clash.Util.Supply         ()
 
 import Clash.Annotations.BitRepresentation.Internal (CustomReprs)
 
@@ -70,27 +88,40 @@ data RewriteStep
   -- ^ Term after `apply`
   } deriving (Show, Generic, NFData, Binary)
 
+{-
+Note [strictness in RewriteState]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Prior to concurrent normalization, the _bindings and _nameCounter
+all had strictness marked in the fields. However, since they are now MVar, it
+is not the field itself that needs to be strict but the contents of the MVar.
+When these are updated in rewriting, it is necessary to use `seq` or bang
+patterns to ensure that they are always forced to WHNF.
+
+Since the transform count was replaced in it's entirity with the map of
+counters, operations on the map are always forced completely with `deepseq`.
+This prevents thunks being built up on map updates, since counting the number
+of transformations applied is common when debugging.
+-}
+
 -- | State of a rewriting session
 data RewriteState extra
   = RewriteState
-    -- TODO Given we now keep transformCounters, this should just be 'fold'
-    -- over that map, otherwise the two counts could fall out of sync.
-  { _transformCounter :: {-# UNPACK #-} !Word
-  -- ^ Total number of applied transformations
-  , _transformCounters :: HashMap Text Word
+  { _transformCounters :: MVar (HashMap Text Word)
   -- ^ Map that tracks how many times each transformation is applied
-  , _bindings         :: !BindingMap
+  , _bindings         :: MVar BindingMap
   -- ^ Global binders
   , _uniqSupply       :: !Supply
   -- ^ Supply of unique numbers
-  , _curFun           :: (Id,SrcSpan) -- Initially set to undefined: no strictness annotation
-  -- ^ Function which is currently normalized
-  , _nameCounter      :: {-# UNPACK #-} !Int
+  , _curFun           :: MVar (HashMap ThreadId (Id,SrcSpan))
+  -- ^ Function which is currently normalized for each thread
+  , _nameCounter      :: MVar Int
   -- ^ Used for 'Fresh'
-  , _globalHeap       :: PrimHeap
+  , _globalHeap       :: MVar PrimHeap
   -- ^ Used as a heap for compile-time evaluation of primitives that live in I/O
-  , _workFreeBinders  :: VarEnv Bool
+  , _workFreeBinders  :: MVar (VarEnv Bool)
   -- ^ Map telling whether a binder's definition is work-free
+  , _ioLock           :: MVar ()
+  -- ^ Synchronization for logging to stdout
   , _extra            :: !extra
   -- ^ Additional state
   }
@@ -165,10 +196,15 @@ normalizeUltra = clashEnv . Lens.to (opt_ultra . envOpts)
 newtype RewriteMonad extra a = R
   { unR :: RWST RewriteEnv Any (RewriteState extra) IO a }
   deriving newtype
-    ( Applicative
+    ( Alternative
+    , Applicative
     , Functor
     , Monad
+    , MonadBase IO
+    , MonadBaseControl IO
+    , MonadFail
     , MonadFix
+    , MonadIO
     , MonadState (RewriteState extra)
     , MonadWriter Any
     , MonadReader RewriteEnv
@@ -181,6 +217,34 @@ runR
   -> RewriteState extra
   -> IO (a, RewriteState extra, Any)
 runR m = RWS.runRWST (unR m)
+
+
+#if !MIN_VERSION_transformers_base(0,4,6)
+instance (Monoid w, MonadBase b m) => MonadBase b (RWST r w s m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
+#endif
+
+-- For Control.Monad.Trans.RWS.Strict these are already defined, however
+-- the CPS version of RWS is not included in `monad-control` yet.
+
+instance (Monoid w) => MonadTransControl (RWST r w s) where
+  type StT (RWST r w s) a = (a, s, w)
+
+  liftWith f = RWS.rwsT $ \r s ->
+    fmap (\x -> (x, s, mempty)) (f (\t -> RWS.runRWST t r s))
+  {-# INLINE liftWith #-}
+
+  restoreT m = RWS.rwsT $ \_ _ -> m
+  {-# INLINE restoreT #-}
+
+instance (Monoid w, MonadBaseControl b m) => MonadBaseControl b (RWST r w s m) where
+  type StM (RWST r w s m) a = ComposeSt (RWST r w s) m a
+
+  liftBaseWith = defaultLiftBaseWith
+  {-# INLINE liftBaseWith #-}
+  restoreM = defaultRestoreM
+  {-# INLINE restoreM #-}
 
 instance MonadUnique (RewriteMonad extra) where
   getUniqueM = do
@@ -207,7 +271,7 @@ type Rewrite extra = Transform (RewriteMonad extra)
 
 -- Moved into Clash.Rewrite.WorkFree
 {-# SPECIALIZE isWorkFree
-      :: Lens' (RewriteState extra) (VarEnv Bool)
+      :: Lens' (RewriteState extra) (MVar (VarEnv Bool))
       -> BindingMap
       -> Term
       -> RewriteMonad extra Bool

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -18,17 +18,34 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+#if MIN_VERSION_transformers(0,5,6)
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+#endif
 
 module Clash.Rewrite.Types where
 
-import Control.DeepSeq                       (NFData)
+import           Control.Applicative                   (Alternative)
+import           Control.Concurrent                    (MVar, ThreadId)
+import           Clash.Util.Supply                     (Supply, freshId)
+import           Control.DeepSeq                       (NFData)
 import Control.Lens                          (Lens', use, (.=))
 import qualified Control.Lens as Lens
+import Control.Monad.Base
+#if !MIN_VERSION_base(4,13,0)
+import Control.Monad.Fail                    (MonadFail)
+#endif
 import Control.Monad.Fix                     (MonadFix)
 import Control.Monad.IO.Class                (MonadIO)
 import Control.Monad.State.Strict            (State)
 import Control.Monad.Reader                  (MonadReader (..))
 import Control.Monad.State                   (MonadState (..))
+import Control.Monad.Trans.Control
+  ( ComposeSt, MonadBaseControl(..), MonadTransControl(..)
+  , defaultLiftBaseWith, defaultRestoreM)
 import Control.Monad.Trans.RWS.CPS           (RWST)
 import qualified Control.Monad.Trans.RWS.CPS as RWS
 import Control.Monad.Writer                  (MonadWriter (..))
@@ -52,7 +69,7 @@ import Clash.Netlist.Types       (FilteredHWType, HWMap)
 import Clash.Primitives.Types    (CompiledPrimMap)
 import Clash.Rewrite.WorkFree    (isWorkFree)
 import Clash.Util
-import Clash.Util.Supply         (Supply, freshId)
+import Clash.Util.Supply         ()
 
 import Clash.Annotations.BitRepresentation.Internal (CustomReprs)
 
@@ -71,27 +88,40 @@ data RewriteStep
   -- ^ Term after `apply`
   } deriving (Show, Generic, NFData, Binary)
 
+{-
+Note [strictness in RewriteState]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Prior to concurrent normalization, the _bindings and _nameCounter
+all had strictness marked in the fields. However, since they are now MVar, it
+is not the field itself that needs to be strict but the contents of the MVar.
+When these are updated in rewriting, it is necessary to use `seq` or bang
+patterns to ensure that they are always forced to WHNF.
+
+Since the transform count was replaced in it's entirity with the map of
+counters, operations on the map are always forced completely with `deepseq`.
+This prevents thunks being built up on map updates, since counting the number
+of transformations applied is common when debugging.
+-}
+
 -- | State of a rewriting session
 data RewriteState extra
   = RewriteState
-    -- TODO Given we now keep transformCounters, this should just be 'fold'
-    -- over that map, otherwise the two counts could fall out of sync.
-  { _transformCounter :: {-# UNPACK #-} !Word
-  -- ^ Total number of applied transformations
-  , _transformCounters :: HashMap Text Word
+  { _transformCounters :: MVar (HashMap Text Word)
   -- ^ Map that tracks how many times each transformation is applied
-  , _bindings         :: !BindingMap
+  , _bindings         :: MVar BindingMap
   -- ^ Global binders
   , _uniqSupply       :: !Supply
   -- ^ Supply of unique numbers
-  , _curFun           :: (Id,SrcSpan) -- Initially set to undefined: no strictness annotation
-  -- ^ Function which is currently normalized
-  , _nameCounter      :: {-# UNPACK #-} !Int
+  , _curFun           :: MVar (HashMap ThreadId (Id,SrcSpan))
+  -- ^ Function which is currently normalized for each thread
+  , _nameCounter      :: MVar Int
   -- ^ Used for 'Fresh'
-  , _globalHeap       :: PrimHeap
+  , _globalHeap       :: MVar PrimHeap
   -- ^ Used as a heap for compile-time evaluation of primitives that live in I/O
-  , _workFreeBinders  :: VarEnv Bool
+  , _workFreeBinders  :: MVar (VarEnv Bool)
   -- ^ Map telling whether a binder's definition is work-free
+  , _ioLock           :: MVar ()
+  -- ^ Synchronization for logging to stdout
   , _extra            :: !extra
   -- ^ Additional state
   }
@@ -166,9 +196,13 @@ normalizeUltra = clashEnv . Lens.to (opt_ultra . envOpts)
 newtype RewriteMonad extra a = R
   { unR :: RWST RewriteEnv Any (RewriteState extra) IO a }
   deriving newtype
-    ( Applicative
+    ( Alternative
+    , Applicative
     , Functor
     , Monad
+    , MonadBase IO
+    , MonadBaseControl IO
+    , MonadFail
     , MonadFix
     , MonadIO
     , MonadState (RewriteState extra)
@@ -183,6 +217,34 @@ runR
   -> RewriteState extra
   -> IO (a, RewriteState extra, Any)
 runR m = RWS.runRWST (unR m)
+
+
+#if !MIN_VERSION_transformers_base(0,4,6)
+instance (Monoid w, MonadBase b m) => MonadBase b (RWST r w s m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
+#endif
+
+-- For Control.Monad.Trans.RWS.Strict these are already defined, however
+-- the CPS version of RWS is not included in `monad-control` yet.
+
+instance (Monoid w) => MonadTransControl (RWST r w s) where
+  type StT (RWST r w s) a = (a, s, w)
+
+  liftWith f = RWS.rwsT $ \r s ->
+    fmap (\x -> (x, s, mempty)) (f (\t -> RWS.runRWST t r s))
+  {-# INLINE liftWith #-}
+
+  restoreT m = RWS.rwsT $ \_ _ -> m
+  {-# INLINE restoreT #-}
+
+instance (Monoid w, MonadBaseControl b m) => MonadBaseControl b (RWST r w s m) where
+  type StM (RWST r w s m) a = ComposeSt (RWST r w s) m a
+
+  liftBaseWith = defaultLiftBaseWith
+  {-# INLINE liftBaseWith #-}
+  restoreM = defaultRestoreM
+  {-# INLINE restoreM #-}
 
 instance MonadUnique (RewriteMonad extra) where
   getUniqueM = do
@@ -209,7 +271,7 @@ type Rewrite extra = Transform (RewriteMonad extra)
 
 -- Moved into Clash.Rewrite.WorkFree
 {-# SPECIALIZE isWorkFree
-      :: Lens' (RewriteState extra) (VarEnv Bool)
+      :: Lens' (RewriteState extra) (MVar (VarEnv Bool))
       -> BindingMap
       -> Term
       -> RewriteMonad extra Bool

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -64,6 +64,7 @@ import Clash.Core.Type           (Type)
 import Clash.Core.TyCon          (TyConMap, TyConName)
 import Clash.Core.Var            (Id)
 import Clash.Core.VarEnv         (InScopeSet, VarSet, VarEnv)
+import Clash.Data.RwVar          (RwVar)
 import Clash.Driver.Types        (ClashEnv(..), ClashOpts(..), BindingMap, DebugOpts)
 import Clash.Netlist.Types       (FilteredHWType, HWMap)
 import Clash.Primitives.Types    (CompiledPrimMap)
@@ -111,8 +112,9 @@ data RewriteState extra
   -- number of applied transformations is the 'sum' of this map.
   , _transformTriedCounters :: MVar (HashMap Text Word)
   -- ^ Map that tracks how many times each transformation has been tried
-  , _bindings         :: MVar BindingMap
-  -- ^ Global binders
+  , _bindings         :: RwVar BindingMap
+  -- ^ Global binders. Read on nearly every rewrite and written only when a
+  -- binder is created or updated, hence a 'RwVar' rather than an 'MVar'.
   , _uniqSupply       :: !Supply
   -- ^ Supply of unique numbers
   , _curFun           :: MVar (HashMap ThreadId (Id,SrcSpan))
@@ -121,13 +123,22 @@ data RewriteState extra
   -- ^ Used for 'Fresh'
   , _globalHeap       :: MVar PrimHeap
   -- ^ Used as a heap for compile-time evaluation of primitives that live in I/O
-  , _workFreeBinders  :: MVar (VarEnv Bool)
+  , _workFreeBinders  :: RwVar (VarEnv Bool)
   -- ^ Map telling whether a binder's definition is work-free
   , _hwTypeCache      :: HWMap
   -- ^ Cache for the Core-type to HWType translation. The translation only
   -- depends on environment that is constant for the whole rewrite session
   -- (the type translator, custom representations, and the TyConMap), so the
   -- cache never has to be invalidated.
+  --
+  -- Updated on nearly every type translation, so this stays a plain field: it
+  -- is far too hot to synchronize per update. It is task-local, and exchanged
+  -- with '_sharedHwTypeCache' at task boundaries.
+  , _sharedHwTypeCache :: RwVar HWMap
+  -- ^ Translations learned by tasks that have finished. A normalization task
+  -- starts from this cache and merges its own entries back when it is done, so
+  -- that what one task translated is not re-translated by every task after it.
+  -- See 'Clash.Rewrite.Util.withSharedHWTypeCache'.
   , _ioLock           :: MVar ()
   -- ^ Synchronization for logging to stdout
   , _extra            :: !extra
@@ -279,7 +290,7 @@ type Rewrite extra = Transform (RewriteMonad extra)
 
 -- Moved into Clash.Rewrite.WorkFree
 {-# SPECIALIZE isWorkFree
-      :: Lens' (RewriteState extra) (MVar (VarEnv Bool))
+      :: Lens' (RewriteState extra) (RwVar (VarEnv Bool))
       -> BindingMap
       -> Term
       -> RewriteMonad extra Bool

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -18,17 +18,34 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+#if MIN_VERSION_transformers(0,5,6)
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+#endif
 
 module Clash.Rewrite.Types where
 
-import Control.DeepSeq                       (NFData)
+import           Control.Applicative                   (Alternative)
+import           Control.Concurrent                    (MVar, ThreadId)
+import           Clash.Util.Supply                     (Supply, freshId)
+import           Control.DeepSeq                       (NFData)
 import Control.Lens                          (Lens', use, (.=))
 import qualified Control.Lens as Lens
+import Control.Monad.Base
+#if !MIN_VERSION_base(4,13,0)
+import Control.Monad.Fail                    (MonadFail)
+#endif
 import Control.Monad.Fix                     (MonadFix)
 import Control.Monad.IO.Class                (MonadIO)
 import Control.Monad.State.Strict            (State)
 import Control.Monad.Reader                  (MonadReader (..))
 import Control.Monad.State                   (MonadState (..))
+import Control.Monad.Trans.Control
+  ( ComposeSt, MonadBaseControl(..), MonadTransControl(..)
+  , defaultLiftBaseWith, defaultRestoreM)
 import Control.Monad.Trans.RWS.CPS           (RWST)
 import qualified Control.Monad.Trans.RWS.CPS as RWS
 import Control.Monad.Writer                  (MonadWriter (..))
@@ -52,7 +69,7 @@ import Clash.Netlist.Types       (FilteredHWType, HWMap)
 import Clash.Primitives.Types    (CompiledPrimMap)
 import Clash.Rewrite.WorkFree    (isWorkFree)
 import Clash.Util
-import Clash.Util.Supply         (Supply, freshId)
+import Clash.Util.Supply         ()
 
 import Clash.Annotations.BitRepresentation.Internal (CustomReprs)
 
@@ -71,34 +88,48 @@ data RewriteStep
   -- ^ Term after `apply`
   } deriving (Show, Generic, NFData, Binary)
 
+{-
+Note [strictness in RewriteState]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Prior to concurrent normalization, the _bindings and _nameCounter
+all had strictness marked in the fields. However, since they are now MVar, it
+is not the field itself that needs to be strict but the contents of the MVar.
+When these are updated in rewriting, it is necessary to use `seq` or bang
+patterns to ensure that they are always forced to WHNF.
+
+Since the transform count was replaced in it's entirity with the map of
+counters, operations on the map are always forced completely with `deepseq`.
+This prevents thunks being built up on map updates, since counting the number
+of transformations applied is common when debugging.
+-}
+
 -- | State of a rewriting session
 data RewriteState extra
   = RewriteState
-    -- TODO Given we now keep transformCounter, this should just be 'fold'
-    -- over that map, otherwise the two counts could fall out of sync.
-  { _transformCounter :: {-# UNPACK #-} !Word
-  -- ^ Total number of applied transformations
-  , _transformAppliedCounters :: HashMap Text Word
-  -- ^ Map that tracks how many times each transformation is applied
-  , _transformTriedCounters :: HashMap Text Word
+  { _transformAppliedCounters :: MVar (HashMap Text Word)
+  -- ^ Map that tracks how many times each transformation is applied. The total
+  -- number of applied transformations is the 'sum' of this map.
+  , _transformTriedCounters :: MVar (HashMap Text Word)
   -- ^ Map that tracks how many times each transformation has been tried
-  , _bindings         :: !BindingMap
+  , _bindings         :: MVar BindingMap
   -- ^ Global binders
   , _uniqSupply       :: !Supply
   -- ^ Supply of unique numbers
-  , _curFun           :: (Id,SrcSpan) -- Initially set to undefined: no strictness annotation
-  -- ^ Function which is currently normalized
-  , _nameCounter      :: {-# UNPACK #-} !Int
+  , _curFun           :: MVar (HashMap ThreadId (Id,SrcSpan))
+  -- ^ Function which is currently normalized for each thread
+  , _nameCounter      :: MVar Int
   -- ^ Used for 'Fresh'
-  , _globalHeap       :: PrimHeap
+  , _globalHeap       :: MVar PrimHeap
   -- ^ Used as a heap for compile-time evaluation of primitives that live in I/O
-  , _workFreeBinders  :: VarEnv Bool
+  , _workFreeBinders  :: MVar (VarEnv Bool)
   -- ^ Map telling whether a binder's definition is work-free
   , _hwTypeCache      :: HWMap
   -- ^ Cache for the Core-type to HWType translation. The translation only
   -- depends on environment that is constant for the whole rewrite session
   -- (the type translator, custom representations, and the TyConMap), so the
   -- cache never has to be invalidated.
+  , _ioLock           :: MVar ()
+  -- ^ Synchronization for logging to stdout
   , _extra            :: !extra
   -- ^ Additional state
   }
@@ -173,9 +204,13 @@ normalizeUltra = clashEnv . Lens.to (opt_ultra . envOpts)
 newtype RewriteMonad extra a = R
   { unR :: RWST RewriteEnv Any (RewriteState extra) IO a }
   deriving newtype
-    ( Applicative
+    ( Alternative
+    , Applicative
     , Functor
     , Monad
+    , MonadBase IO
+    , MonadBaseControl IO
+    , MonadFail
     , MonadFix
     , MonadIO
     , MonadState (RewriteState extra)
@@ -190,6 +225,34 @@ runR
   -> RewriteState extra
   -> IO (a, RewriteState extra, Any)
 runR m = RWS.runRWST (unR m)
+
+
+#if !MIN_VERSION_transformers_base(0,4,6)
+instance (Monoid w, MonadBase b m) => MonadBase b (RWST r w s m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
+#endif
+
+-- For Control.Monad.Trans.RWS.Strict these are already defined, however
+-- the CPS version of RWS is not included in `monad-control` yet.
+
+instance (Monoid w) => MonadTransControl (RWST r w s) where
+  type StT (RWST r w s) a = (a, s, w)
+
+  liftWith f = RWS.rwsT $ \r s ->
+    fmap (\x -> (x, s, mempty)) (f (\t -> RWS.runRWST t r s))
+  {-# INLINE liftWith #-}
+
+  restoreT m = RWS.rwsT $ \_ _ -> m
+  {-# INLINE restoreT #-}
+
+instance (Monoid w, MonadBaseControl b m) => MonadBaseControl b (RWST r w s m) where
+  type StM (RWST r w s m) a = ComposeSt (RWST r w s) m a
+
+  liftBaseWith = defaultLiftBaseWith
+  {-# INLINE liftBaseWith #-}
+  restoreM = defaultRestoreM
+  {-# INLINE restoreM #-}
 
 instance MonadUnique (RewriteMonad extra) where
   getUniqueM = do
@@ -216,7 +279,7 @@ type Rewrite extra = Transform (RewriteMonad extra)
 
 -- Moved into Clash.Rewrite.WorkFree
 {-# SPECIALIZE isWorkFree
-      :: Lens' (RewriteState extra) (VarEnv Bool)
+      :: Lens' (RewriteState extra) (MVar (VarEnv Bool))
       -> BindingMap
       -> Term
       -> RewriteMonad extra Bool

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -24,11 +24,14 @@ module Clash.Rewrite.Util
   , module Clash.Rewrite.WorkFree
   ) where
 
+import           Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import           Control.DeepSeq
 import           Control.Exception           (throw)
-import           Control.Lens ((%=), (+=), (^.))
+import           Control.Lens ((^.))
 import qualified Control.Lens                as Lens
 import qualified Control.Monad               as Monad
+import qualified Control.Monad.IO.Class      as Monad
 import qualified Control.Monad.State.Strict  as State
 import qualified Control.Monad.Trans.RWS.CPS as RWS
 import qualified Control.Monad.Writer        as Writer
@@ -46,7 +49,6 @@ import qualified Data.Set                    as Set
 import qualified Data.Set.Lens               as Lens
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
-import           System.IO.Unsafe            (unsafePerformIO)
 import           Data.Binary                 (encode)
 import qualified Data.ByteString             as BS
 import qualified Data.ByteString.Lazy        as BL
@@ -89,10 +91,10 @@ import qualified Clash.Util.Interpolate as I
 import           Clash.Util.Supply           (splitSupply)
 
 -- | Lift an action working in the '_extra' state to the 'RewriteMonad'
-zoomExtra :: State.State extra a -> RewriteMonad extra a
-zoomExtra m = R . RWS.rwsT $ \_ s ->
-  let (a, st') = State.runState m (_extra s)
-   in pure (a, s { _extra = st' }, mempty)
+zoomExtra :: State.StateT extra IO a -> RewriteMonad extra a
+zoomExtra m = R . RWS.rwsT $ \_ s -> do
+  (a, st') <- State.runStateT m (_extra s)
+  pure (a, s { _extra = st' }, mempty)
 
 -- | Some transformations might erroneously introduce shadowing. For example,
 -- a transformation might result in:
@@ -142,30 +144,51 @@ apply
   -> Rewrite extra
 apply = \s rewrite ctx expr0 -> do
   opts <- Lens.view debugOpts
-  traceIf (hasDebugInfo TryName s opts) ("Trying: " <> s) (pure ())
+  ioLockV <- Lens.use ioLock
+
+  Monad.when (hasDebugInfo TryName s opts) $
+    MVar.withMVar "ioLock" ioLockV $ \() ->
+      traceM ("Trying: " <> s)
 
   (!expr1,anyChanged) <- Writer.listen (rewrite ctx expr0)
   let hasChanged = Monoid.getAny anyChanged
-  Monad.when hasChanged (transformCounter += 1)
+
+  Monad.when hasChanged $ do
+    countersV <- Lens.use transformCounters
+    MVar.modifyMVar_ "transformCounters" countersV (pure . force . HashMap.insertWith (const succ) (Text.pack s) 1)
 
   -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
   let rewriteHistFile = dbg_historyFile opts
   Monad.when (isJust rewriteHistFile && hasChanged) $ do
-    (curBndr, _) <- Lens.use curFun
-    let !_ = unsafePerformIO
-             $ BS.appendFile (fromJust rewriteHistFile)
-             $ BL.toStrict
-             $ encode RewriteStep
-                 { t_ctx    = tfContext ctx
-                 , t_name   = s
-                 , t_bndrS  = showPpr (varName curBndr)
-                 , t_before = expr0
-                 , t_after  = expr1
-                 }
-    return ()
+    thread <- myThreadId
+    curFunsV <- Lens.use curFun
+
+    MVar.withMVar "curFun" curFunsV $ \curFuns ->
+      case fst <$> HashMap.lookup thread curFuns of
+        Just curBndr ->
+          -- TODO Although we're locking access to the history file, entries
+          -- may still be written to it interleaved by entity. I'm not sure if
+          -- clash-term can handle this correctly...
+          MVar.withMVar "ioLock" ioLockV $ \() ->
+            Monad.liftIO
+              . BS.appendFile (fromJust rewriteHistFile)
+              . BL.toStrict
+              $ encode RewriteStep
+                         { t_ctx    = tfContext ctx
+                         , t_name   = s
+                         , t_bndrS  = showPpr (varName curBndr)
+                         , t_before = expr0
+                         , t_after  = expr1
+                         }
+
+        Nothing ->
+          error "apply: Normalizing from an unknown thread"
 
   if isDebugging opts
-    then applyDebug ctx s expr0 hasChanged expr1
+    then do
+      countersV <- Lens.use transformCounters
+      nTrans <- sum <$> MVar.readMVar "transformCounters" countersV
+      applyDebug ctx s expr0 hasChanged expr1 nTrans
     else return expr1
 {-# INLINE apply #-}
 
@@ -179,26 +202,27 @@ applyDebug
   -- ^ Whether the rewrite indicated change
   -> Term
   -- ^ New expression
+  -> Word
   -> RewriteMonad extra Term
-applyDebug ctx name exprOld hasChanged exprNew = do
-  nTrans <- Lens.use transformCounter
+applyDebug ctx name exprOld hasChanged exprNew nTrans = do
   opts <- Lens.view debugOpts
 
   let from = fromMaybe 0 (dbg_transformationsFrom opts)
   let limit = fromMaybe maxBound (dbg_transformationsLimit opts)
 
-  if | nTrans - from > limit ->
+  if | nTrans - from > limit -> do
          error "-fclash-debug-transformations-limit exceeded"
-     | nTrans <= from ->
+     | nTrans <= from -> do
          pure exprNew
      | otherwise ->
-         go opts
+         go (pred nTrans) opts
  where
-  go opts = traceIf (hasDebugInfo TryTerm name opts) ("Tried: " ++ name ++ " on:\n" ++ before) $ do
-    nTrans <- pred <$> Lens.use transformCounter
+  go nTrans' opts = do
+    ioLockV <- Lens.use ioLock
 
-    Monad.when (dbg_countTransformations opts && hasChanged) $ do
-      transformCounters %= HashMap.insertWith (const succ) (Text.pack name) 1
+    Monad.when (hasDebugInfo TryTerm name opts) $
+      MVar.withMVar "ioLock" ioLockV $ \() ->
+        traceM ("Tried: " ++ name ++ " on:\n" ++ before)
 
     Monad.when (dbg_invariants opts && hasChanged) $ do
       tcm                  <- Lens.view tcCache
@@ -254,12 +278,20 @@ applyDebug ctx name exprOld hasChanged exprNew = do
       error $ $(curLoc) ++ "Expression changed without notice(" ++ name ++  "): before"
                         ++ before ++ "\nafter:\n" ++ after
 
-    traceIf (hasDebugInfo AppliedName name opts && hasChanged) (name <> " {" <> show nTrans <> "}") $
-      traceIf (hasDebugInfo AppliedTerm name opts && hasChanged) ("Changes when applying rewrite to:\n"
-                        ++ before ++ "\nResult:\n" ++ after ++ "\n") $
-        traceIf (hasDebugInfo TryTerm name opts && not hasChanged) ("No changes when applying rewrite "
-                          ++ name ++ " to:\n" ++ after ++ "\n") $
-          return exprNew
+    let traceName = hasDebugInfo AppliedName name opts && hasChanged
+        traceTerm = hasDebugInfo AppliedTerm name opts && hasChanged
+        traceTryTerm = hasDebugInfo TryTerm name opts && not hasChanged
+        shouldTrace = traceName || traceTerm || traceTryTerm
+
+    Monad.when shouldTrace $
+      MVar.withMVar "ioLock" ioLockV $ \() -> do
+        traceWhen traceName (name <> " {" <> show nTrans' <> "}")
+        traceWhen traceTerm
+          ("Changes when applying rewrite to:\n" ++ before ++ "\nResult:\n" ++ after ++ "\n")
+        traceWhen traceTryTerm
+          ("No changes when applying rewrite " ++ name ++ " to:\n" ++ after ++ "\n")
+
+    return exprNew
    where
     before = showPpr exprOld
     after  = showPpr exprNew
@@ -292,13 +324,20 @@ runRewriteSession :: RewriteEnv
                   -> RewriteState extra
                   -> RewriteMonad extra a
                   -> IO a
-runRewriteSession r s m = do
-  (a, s', _) <- runR m r s
-  traceIf (dbg_countTransformations (opt_debug (envOpts (_clashEnv r))))
-    ("Clash: Transformations:\n" ++ Text.unpack (showCounters (s' ^. transformCounters))) $
-    traceIf (None < dbg_transformationInfo (opt_debug (envOpts (_clashEnv r))))
-      ("Clash: Applied " ++ show (s' ^. transformCounter) ++ " transformations")
-      pure a
+runRewriteSession rwEnv rwState session = do
+  (a, session1, _) <- runR session rwEnv rwState
+  MVar.withMVar "transformCounters" (session1 ^. transformCounters) $ \counters -> do
+    let opts = opt_debug (envOpts (_clashEnv rwEnv))
+        shouldTrace = dbg_countTransformations opts || None < dbg_transformationInfo opts
+
+    Monad.when shouldTrace $
+      MVar.withMVar "ioLock" (session1 ^. ioLock) $ \() -> do
+        traceWhen (dbg_countTransformations opts)
+          ("Clash: Transformations:\n" ++ Text.unpack (showCounters counters))
+        traceWhen (None < dbg_transformationInfo opts)
+          ("Clash: Applied " ++ show (sum counters) ++ " transformations")
+
+    pure a
   where
     showCounters =
       Text.unlines
@@ -504,7 +543,9 @@ liftAndSubsituteBinders inScope toLift toKeep body = do
                                                 (substTmEnv subst) }
         subst2 = extendIdSubst subst1 x e2
     if x `elemFreeVars` e2 then do
-      (_,sp) <- Lens.use curFun
+      curFunsV <- Lens.use curFun
+      thread <- myThreadId
+      Just (_,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
       throw (ClashException sp [I.i|
         Internal error: inlineOrLiftBInders failed on:
 
@@ -583,8 +624,11 @@ liftBinding (var@Id {varName = idName} ,e) = do
   -- Make a new global ID
   tcm       <- Lens.view tcCache
   let newBodyTy = inferCoreTypeOf tcm $ mkTyLams (mkLams e boundFVs) boundFTVs
-  (cf,sp)   <- Lens.use curFun
-  binders <- Lens.use bindings
+  curFunsV <- Lens.use curFun
+  thread <- myThreadId
+  Just (cf,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
+  bindersV <- Lens.use bindings
+  binders <- MVar.takeMVar "bindings" bindersV
   newBodyNm <-
     cloneNameWithBindingMap
       binders
@@ -606,30 +650,31 @@ liftBinding (var@Id {varName = idName} ,e) = do
       newBody = mkTyLams (mkLams e' boundFVs) boundFTVs
 
   -- Check if an alpha-equivalent global binder already exists
-  aeqExisting <- (UniqMap.elems . UniqMap.filter ((`aeqTerm` newBody) . bindingTerm)) <$> Lens.use bindings
+  let aeqExisting = UniqMap.elems . UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) $ binders
   case aeqExisting of
     -- If it doesn't, create a new binder
     [] -> do -- Add the created function to the list of global bindings
              let r = newBodyId `globalIdOccursIn` newBody
-             bindings %= UniqMap.insert newBodyNm
-                                    -- We mark this function as internal so that
-                                    -- it can be inlined at the very end of
-                                    -- the normalisation pipeline as part of the
-                                    -- flattening pass. We don't inline
-                                    -- right away because we are lifting this
-                                    -- function at this moment for a reason!
-                                    -- (termination, CSE and DEC oppertunities,
-                                    -- ,etc.)
-                                    (Binding newBodyId sp NoUserInlinePrag IsFun newBody r)
-             -- Return the new binder
+             MVar.putMVar "bindings" bindersV $
+               UniqMap.insert
+                 newBodyNm
+                 -- We mark this function as internal so that it can be inlined
+                 -- at the very end of the normalization pipeline as part of the
+                 -- flattening pass. We don't inline right away because we are
+                 -- lifting this function at this moment for a reason!
+                 -- (termination, CSE and DEC opportunities, etc.)
+                 (Binding newBodyId sp NoUserInlinePrag IsFun newBody r)
+                 binders
+
              return (var, newExpr)
     -- If it does, use the existing binder
-    (b:_) ->
+    (b:_) -> do
       let newExpr' = mkTmApps
                       (mkTyApps (Var $ bindingId b)
                                 (map VarTy boundFTVs))
                       (map Var boundFVs)
-      in  return (var, newExpr')
+      MVar.putMVar "bindings" bindersV binders
+      return (var, newExpr')
 
 liftBinding _ = error $ $(curLoc) ++ "liftBinding: invalid core, expr bound to tyvar"
 
@@ -646,23 +691,16 @@ mkFunction
 mkFunction bndrNm sp inl body = do
   tcm <- Lens.view tcCache
   let bodyTy = inferCoreTypeOf tcm body
-  binders <- Lens.use bindings
-  bodyNm <- cloneNameWithBindingMap binders bndrNm
-  addGlobalBind bodyNm bodyTy sp inl body
-  return (mkGlobalId bodyTy bodyNm)
+  bindersV <- Lens.use bindings
 
--- | Add a function to the set of global binders
-addGlobalBind
-  :: TmName
-  -> Type
-  -> SrcSpan
-  -> InlineSpec
-  -> Term
-  -> RewriteMonad extra ()
-addGlobalBind vNm ty sp inl body = do
-  let vId = mkGlobalId ty vNm
-      r = vId `globalIdOccursIn` body
-  (ty,body) `deepseq` bindings %= UniqMap.insert vNm (Binding vId sp inl IsFun body r)
+  MVar.modifyMVar "bindings" bindersV $ \binders -> do
+    bodyNm <- cloneNameWithBindingMap binders bndrNm
+    let vId = mkGlobalId bodyTy bodyNm
+        r = vId `globalIdOccursIn` body
+        bind = Binding vId sp inl IsFun body r
+        binders' = UniqMap.insert vId bind binders
+
+    bodyTy `deepseq` body `deepseq` binders' `seq` pure (binders', vId)
 
 -- | Create a new name out of the given name, but with another unique. Resulting
 -- unique is guaranteed to not be in the given InScopeSet.
@@ -729,84 +767,89 @@ normalizeId _   tyvar     = tyvar
 -- | Evaluate an expression to weak-head normal form (WHNF), and apply a
 -- transformation on the expression in WHNF.
 whnfRW
-  :: Bool
+  :: forall extra
+   . Bool
   -- ^ Whether the expression we're reducing to WHNF is the subject of a
   -- case expression.
   -> TransformContext
   -> Term
   -> Rewrite extra
   -> RewriteMonad extra Term
-whnfRW isSubj ctx@(TransformContext is0 hist) e rw = do
+whnfRW isSubj (TransformContext is0 hist) e0 rw = do
   tcm <- Lens.view tcCache
-  bndrs <- Lens.use bindings
   eval <- Lens.view evaluator
+
+  bndrsV <- Lens.use bindings
   ids <- Lens.use uniqSupply
+  ghV <- Lens.use globalHeap
+
+  bndrs <- MVar.takeMVar "bindings" bndrsV
+  gh <- MVar.takeMVar "globalHeap" ghV
+
   let (ids1,ids2) = splitSupply ids
   uniqSupply Lens..= ids2
-  gh <- Lens.use globalHeap
   let lh = localBinders mempty hist
 
-  case whnf' eval bndrs lh tcm gh ids1 is0 isSubj e of
+  case whnf' eval bndrs lh tcm gh ids1 is0 isSubj e0 of
     (!gh1,ph,v) -> do
-      globalHeap Lens..= gh1
-      bindPureHeap tcm (ph `differenceVarEnv` lh) rw ctx v
+      let result = bindPureHeap tcm bndrs (ph `differenceVarEnv` lh) v
+      MVar.putMVar "bindings" bndrsV bndrs
+      MVar.putMVar "globalHeap" ghV gh1
+      result
  where
   localBinders acc [] = acc
   localBinders !acc (h:hs) = case h of
     LetBody ls -> localBinders (acc <> mkVarEnv ls) hs
     _ -> localBinders acc hs
 
-{-# SCC whnfRW #-}
-
--- | Binds variables on the PureHeap over the result of the rewrite
---
--- To prevent unnecessary rewrites only do this when rewrite changed something.
-bindPureHeap
-  :: TyConMap
-  -> PureHeap
-  -> Rewrite extra
-  -> Rewrite extra
-bindPureHeap tcm heap rw ctx0@(TransformContext is0 hist) e = do
-  (e1, Monoid.getAny -> hasChanged) <- Writer.listen $ rw ctx e
-  if hasChanged && not (null bndrs) then do
-    -- The evaluator results are post-processed with two operations:
-    --
-    --   1. Inline work free binders. We've seen cases in the wild† where the
-    --      evaluator (or rather, 'bindPureHeap') would let-bind work-free
-    --      binders that were crucial for eliminating case constructs. If these
-    --      case constructs were used in a self-referential (but terminating)
-    --      manner, Clash would get stuck in an infinite loop. The proper
-    --      solution would be to use 'isWorkFree', instead of 'isWorkFreeIsh',
-    --      in 'bindConstantVar' such that these work free constructs would get
-    --      inlined again. However, this incurs a great performance penalty so
-    --      we opt to prevent the evaluator from introducing this situation in
-    --      the first place.
-    --
-    --      I'd like to stress that this is not a proper solution though, as GHC
-    --      might produce a similar situation. We plan on properly solving this
-    --      by eliminating the current lift/bind/eval strategy, instead replacing
-    --      it by a partial evaluator‡.
-    --
-    --   2. Remove any unused let-bindings. Similar to (1), we risk Clash getting
-    --      stuck in an infinite loop if we don't remove unused (eliminated by
-    --      evaluation!) binders.
-    --
-    -- † https://github.com/clash-lang/clash-compiler/pull/1354#issuecomment-635430374
-    -- ‡ https://www.microsoft.com/en-us/research/wp-content/uploads/2016/07/supercomp-by-eval.pdf
-    bs <- Lens.use bindings
-    inlineBinders (inlineTest bs) ctx0 (Letrec bndrs e1) >>= \case
-      e2@(Let bnders1 e3) ->
-        pure (fromMaybe e2 (removeUnusedBinders bnders1 e3))
-      e2 ->
-        pure e2
-  else
-    return e1
-  where
-    heapIds = map fst bndrs
+  -- | Binds variables on the PureHeap over the result of the rewrite
+  -- To prevent unnecessary rewrites only do this when rewrite changed something.
+  bindPureHeap
+    :: TyConMap
+    -> BindingMap
+    -> PureHeap
+    -> Term
+    -> RewriteMonad extra Term
+  bindPureHeap tcm bs heap e1 = do
+    (e2, Monoid.getAny -> hasChanged) <- Writer.listen $ rw ctx e1
+    if hasChanged && not (null letBndrs) then do
+      -- The evaluator results are post-processed with two operations:
+      --
+      --   1. Inline work free binders. We've seen cases in the wild† where the
+      --      evaluator (or rather, 'bindPureHeap') would let-bind work-free
+      --      binders that were crucial for eliminating case constructs. If these
+      --      case constructs were used in a self-referential (but terminating)
+      --      manner, Clash would get stuck in an infinite loop. The proper
+      --      solution would be to use 'isWorkFree', instead of 'isWorkFreeIsh',
+      --      in 'bindConstantVar' such that these work free constructs would get
+      --      inlined again. However, this incurs a great performance penalty so
+      --      we opt to prevent the evaluator from introducing this situation in
+      --      the first place.
+      --
+      --      I'd like to stress that this is not a proper solution though, as GHC
+      --      might produce a similar situation. We plan on properly solving this
+      --      by eliminating the current lift/bind/eval strategy, instead replacing
+      --      it by a partial evaluator‡.
+      --
+      --   2. Remove any unused let-bindings. Similar to (1), we risk Clash getting
+      --      stuck in an infinite loop if we don't remove unused (eliminated by
+      --      evaluation!) binders.
+      --
+      -- † https://github.com/clash-lang/clash-compiler/pull/1354#issuecomment-635430374
+      -- ‡ https://www.microsoft.com/en-us/research/wp-content/uploads/2016/07/supercomp-by-eval.pdf
+      inlineBinders inlineTest ctx (Letrec letBndrs e2) >>= \case
+        e3@(Let bnders1 e4) ->
+          pure (fromMaybe e3 (removeUnusedBinders bnders1 e4))
+        e3 ->
+          pure e3
+    else
+      return e2
+   where
+    heapIds = map fst letBndrs
     is1 = extendInScopeSetList is0 heapIds
-    ctx = TransformContext is1 (LetBody bndrs : hist)
+    ctx = TransformContext is1 (LetBody letBndrs : hist)
 
-    bndrs = map toLetBinding $ UniqMap.toList heap
+    letBndrs = map toLetBinding $ UniqMap.toList heap
 
     toLetBinding :: (Unique,Term) -> LetBinding
     toLetBinding (uniq,term) = (nm, term)
@@ -814,7 +857,8 @@ bindPureHeap tcm heap rw ctx0@(TransformContext is0 hist) e = do
         ty = inferCoreTypeOf tcm term
         nm = mkLocalId ty (mkUnsafeSystemName "x" uniq) -- See [Note: Name re-creation]
 
-    inlineTest bs _ (_, stripTicks -> e_) = isWorkFree workFreeBinders bs e_
+    inlineTest _ (_, stripTicks -> e_) = isWorkFree workFreeBinders bs e_
+{-# SCC whnfRW #-}
 
 -- | Remove unused binders in given let-binding. Returns /Nothing/ if no unused
 -- binders were found.

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -24,12 +24,14 @@ module Clash.Rewrite.Util
   , module Clash.Rewrite.WorkFree
   ) where
 
+import           Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import           Control.DeepSeq
 import           Control.Exception           (throw)
-import           Control.Lens ((%=), (+=), (^.))
+import           Control.Lens ((^.))
 import qualified Control.Lens                as Lens
 import qualified Control.Monad               as Monad
-import           Control.Monad.IO.Class      (liftIO)
+import qualified Control.Monad.IO.Class      as Monad
 import qualified Control.Monad.State.Strict  as State
 import qualified Control.Monad.Trans.RWS.CPS as RWS
 import qualified Control.Monad.Writer        as Writer
@@ -89,10 +91,10 @@ import qualified Clash.Util.Interpolate as I
 import           Clash.Util.Supply           (splitSupply)
 
 -- | Lift an action working in the '_extra' state to the 'RewriteMonad'
-zoomExtra :: State.State extra a -> RewriteMonad extra a
-zoomExtra m = R . RWS.rwsT $ \_ s ->
-  let (a, st') = State.runState m (_extra s)
-   in pure (a, s { _extra = st' }, mempty)
+zoomExtra :: State.StateT extra IO a -> RewriteMonad extra a
+zoomExtra m = R . RWS.rwsT $ \_ s -> do
+  (a, st') <- State.runStateT m (_extra s)
+  pure (a, s { _extra = st' }, mempty)
 
 -- | Some transformations might erroneously introduce shadowing. For example,
 -- a transformation might result in:
@@ -142,29 +144,51 @@ apply
   -> Rewrite extra
 apply = \s rewrite ctx expr0 -> do
   opts <- Lens.view debugOpts
-  traceIf (hasDebugInfo TryName s opts) ("Trying: " <> s) (pure ())
+  ioLockV <- Lens.use ioLock
+
+  Monad.when (hasDebugInfo TryName s opts) $
+    MVar.withMVar "ioLock" ioLockV $ \() ->
+      traceM ("Trying: " <> s)
 
   (!expr1,anyChanged) <- Writer.listen (rewrite ctx expr0)
   let hasChanged = Monoid.getAny anyChanged
-  Monad.when hasChanged (transformCounter += 1)
+
+  Monad.when hasChanged $ do
+    countersV <- Lens.use transformCounters
+    MVar.modifyMVar_ "transformCounters" countersV (pure . force . HashMap.insertWith (const succ) (Text.pack s) 1)
 
   -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
   let rewriteHistFile = dbg_historyFile opts
   Monad.when (isJust rewriteHistFile && hasChanged) $ do
-    (curBndr, _) <- Lens.use curFun
-    liftIO
-      $ BS.appendFile (fromJust rewriteHistFile)
-      $ BL.toStrict
-      $ encode RewriteStep
-          { t_ctx    = tfContext ctx
-          , t_name   = s
-          , t_bndrS  = showPpr (varName curBndr)
-          , t_before = expr0
-          , t_after  = expr1
-          }
+    thread <- myThreadId
+    curFunsV <- Lens.use curFun
+
+    MVar.withMVar "curFun" curFunsV $ \curFuns ->
+      case fst <$> HashMap.lookup thread curFuns of
+        Just curBndr ->
+          -- TODO Although we're locking access to the history file, entries
+          -- may still be written to it interleaved by entity. I'm not sure if
+          -- clash-term can handle this correctly...
+          MVar.withMVar "ioLock" ioLockV $ \() ->
+            Monad.liftIO
+              . BS.appendFile (fromJust rewriteHistFile)
+              . BL.toStrict
+              $ encode RewriteStep
+                         { t_ctx    = tfContext ctx
+                         , t_name   = s
+                         , t_bndrS  = showPpr (varName curBndr)
+                         , t_before = expr0
+                         , t_after  = expr1
+                         }
+
+        Nothing ->
+          error "apply: Normalizing from an unknown thread"
 
   if isDebugging opts
-    then applyDebug ctx s expr0 hasChanged expr1
+    then do
+      countersV <- Lens.use transformCounters
+      nTrans <- sum <$> MVar.readMVar "transformCounters" countersV
+      applyDebug ctx s expr0 hasChanged expr1 nTrans
     else return expr1
 {-# INLINE apply #-}
 
@@ -178,26 +202,27 @@ applyDebug
   -- ^ Whether the rewrite indicated change
   -> Term
   -- ^ New expression
+  -> Word
   -> RewriteMonad extra Term
-applyDebug ctx name exprOld hasChanged exprNew = do
-  nTrans <- Lens.use transformCounter
+applyDebug ctx name exprOld hasChanged exprNew nTrans = do
   opts <- Lens.view debugOpts
 
   let from = fromMaybe 0 (dbg_transformationsFrom opts)
   let limit = fromMaybe maxBound (dbg_transformationsLimit opts)
 
-  if | nTrans - from > limit ->
+  if | nTrans - from > limit -> do
          error "-fclash-debug-transformations-limit exceeded"
-     | nTrans <= from ->
+     | nTrans <= from -> do
          pure exprNew
      | otherwise ->
-         go opts
+         go (pred nTrans) opts
  where
-  go opts = traceIf (hasDebugInfo TryTerm name opts) ("Tried: " ++ name ++ " on:\n" ++ before) $ do
-    nTrans <- pred <$> Lens.use transformCounter
+  go nTrans' opts = do
+    ioLockV <- Lens.use ioLock
 
-    Monad.when (dbg_countTransformations opts && hasChanged) $ do
-      transformCounters %= HashMap.insertWith (const succ) (Text.pack name) 1
+    Monad.when (hasDebugInfo TryTerm name opts) $
+      MVar.withMVar "ioLock" ioLockV $ \() ->
+        traceM ("Tried: " ++ name ++ " on:\n" ++ before)
 
     Monad.when (dbg_invariants opts && hasChanged) $ do
       tcm                  <- Lens.view tcCache
@@ -253,12 +278,20 @@ applyDebug ctx name exprOld hasChanged exprNew = do
       error $ $(curLoc) ++ "Expression changed without notice(" ++ name ++  "): before"
                         ++ before ++ "\nafter:\n" ++ after
 
-    traceIf (hasDebugInfo AppliedName name opts && hasChanged) (name <> " {" <> show nTrans <> "}") $
-      traceIf (hasDebugInfo AppliedTerm name opts && hasChanged) ("Changes when applying rewrite to:\n"
-                        ++ before ++ "\nResult:\n" ++ after ++ "\n") $
-        traceIf (hasDebugInfo TryTerm name opts && not hasChanged) ("No changes when applying rewrite "
-                          ++ name ++ " to:\n" ++ after ++ "\n") $
-          return exprNew
+    let traceName = hasDebugInfo AppliedName name opts && hasChanged
+        traceTerm = hasDebugInfo AppliedTerm name opts && hasChanged
+        traceTryTerm = hasDebugInfo TryTerm name opts && not hasChanged
+        shouldTrace = traceName || traceTerm || traceTryTerm
+
+    Monad.when shouldTrace $
+      MVar.withMVar "ioLock" ioLockV $ \() -> do
+        traceWhen traceName (name <> " {" <> show nTrans' <> "}")
+        traceWhen traceTerm
+          ("Changes when applying rewrite to:\n" ++ before ++ "\nResult:\n" ++ after ++ "\n")
+        traceWhen traceTryTerm
+          ("No changes when applying rewrite " ++ name ++ " to:\n" ++ after ++ "\n")
+
+    return exprNew
    where
     before = showPpr exprOld
     after  = showPpr exprNew
@@ -290,13 +323,20 @@ runRewriteSession :: RewriteEnv
                   -> RewriteState extra
                   -> RewriteMonad extra a
                   -> IO a
-runRewriteSession r s m = do
-  (a, s', _) <- runR m r s
-  traceIf (dbg_countTransformations (opt_debug (envOpts (_clashEnv r))))
-    ("Clash: Transformations:\n" ++ Text.unpack (showCounters (s' ^. transformCounters))) $
-    traceIf (None < dbg_transformationInfo (opt_debug (envOpts (_clashEnv r))))
-      ("Clash: Applied " ++ show (s' ^. transformCounter) ++ " transformations")
-      pure a
+runRewriteSession rwEnv rwState session = do
+  (a, session1, _) <- runR session rwEnv rwState
+  MVar.withMVar "transformCounters" (session1 ^. transformCounters) $ \counters -> do
+    let opts = opt_debug (envOpts (_clashEnv rwEnv))
+        shouldTrace = dbg_countTransformations opts || None < dbg_transformationInfo opts
+
+    Monad.when shouldTrace $
+      MVar.withMVar "ioLock" (session1 ^. ioLock) $ \() -> do
+        traceWhen (dbg_countTransformations opts)
+          ("Clash: Transformations:\n" ++ Text.unpack (showCounters counters))
+        traceWhen (None < dbg_transformationInfo opts)
+          ("Clash: Applied " ++ show (sum counters) ++ " transformations")
+
+    pure a
   where
     showCounters =
       Text.unlines
@@ -502,7 +542,9 @@ liftAndSubsituteBinders inScope toLift toKeep body = do
                                                 (substTmEnv subst) }
         subst2 = extendIdSubst subst1 x e2
     if x `elemFreeVars` e2 then do
-      (_,sp) <- Lens.use curFun
+      curFunsV <- Lens.use curFun
+      thread <- myThreadId
+      Just (_,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
       throw (ClashException sp [I.i|
         Internal error: inlineOrLiftBInders failed on:
 
@@ -581,8 +623,11 @@ liftBinding (var@Id {varName = idName} ,e) = do
   -- Make a new global ID
   tcm       <- Lens.view tcCache
   let newBodyTy = inferCoreTypeOf tcm $ mkTyLams (mkLams e boundFVs) boundFTVs
-  (cf,sp)   <- Lens.use curFun
-  binders <- Lens.use bindings
+  curFunsV <- Lens.use curFun
+  thread <- myThreadId
+  Just (cf,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
+  bindersV <- Lens.use bindings
+  binders <- MVar.takeMVar "bindings" bindersV
   newBodyNm <-
     cloneNameWithBindingMap
       binders
@@ -604,30 +649,31 @@ liftBinding (var@Id {varName = idName} ,e) = do
       newBody = mkTyLams (mkLams e' boundFVs) boundFTVs
 
   -- Check if an alpha-equivalent global binder already exists
-  aeqExisting <- (UniqMap.elems . UniqMap.filter ((`aeqTerm` newBody) . bindingTerm)) <$> Lens.use bindings
+  let aeqExisting = UniqMap.elems . UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) $ binders
   case aeqExisting of
     -- If it doesn't, create a new binder
     [] -> do -- Add the created function to the list of global bindings
              let r = newBodyId `globalIdOccursIn` newBody
-             bindings %= UniqMap.insert newBodyNm
-                                    -- We mark this function as internal so that
-                                    -- it can be inlined at the very end of
-                                    -- the normalisation pipeline as part of the
-                                    -- flattening pass. We don't inline
-                                    -- right away because we are lifting this
-                                    -- function at this moment for a reason!
-                                    -- (termination, CSE and DEC oppertunities,
-                                    -- ,etc.)
-                                    (Binding newBodyId sp NoUserInlinePrag IsFun newBody r)
-             -- Return the new binder
+             MVar.putMVar "bindings" bindersV $
+               UniqMap.insert
+                 newBodyNm
+                 -- We mark this function as internal so that it can be inlined
+                 -- at the very end of the normalization pipeline as part of the
+                 -- flattening pass. We don't inline right away because we are
+                 -- lifting this function at this moment for a reason!
+                 -- (termination, CSE and DEC opportunities, etc.)
+                 (Binding newBodyId sp NoUserInlinePrag IsFun newBody r)
+                 binders
+
              return (var, newExpr)
     -- If it does, use the existing binder
-    (b:_) ->
+    (b:_) -> do
       let newExpr' = mkTmApps
                       (mkTyApps (Var $ bindingId b)
                                 (map VarTy boundFTVs))
                       (map Var boundFVs)
-      in  return (var, newExpr')
+      MVar.putMVar "bindings" bindersV binders
+      return (var, newExpr')
 
 liftBinding _ = error $ $(curLoc) ++ "liftBinding: invalid core, expr bound to tyvar"
 
@@ -644,23 +690,16 @@ mkFunction
 mkFunction bndrNm sp inl body = do
   tcm <- Lens.view tcCache
   let bodyTy = inferCoreTypeOf tcm body
-  binders <- Lens.use bindings
-  bodyNm <- cloneNameWithBindingMap binders bndrNm
-  addGlobalBind bodyNm bodyTy sp inl body
-  return (mkGlobalId bodyTy bodyNm)
+  bindersV <- Lens.use bindings
 
--- | Add a function to the set of global binders
-addGlobalBind
-  :: TmName
-  -> Type
-  -> SrcSpan
-  -> InlineSpec
-  -> Term
-  -> RewriteMonad extra ()
-addGlobalBind vNm ty sp inl body = do
-  let vId = mkGlobalId ty vNm
-      r = vId `globalIdOccursIn` body
-  (ty,body) `deepseq` bindings %= UniqMap.insert vNm (Binding vId sp inl IsFun body r)
+  MVar.modifyMVar "bindings" bindersV $ \binders -> do
+    bodyNm <- cloneNameWithBindingMap binders bndrNm
+    let vId = mkGlobalId bodyTy bodyNm
+        r = vId `globalIdOccursIn` body
+        bind = Binding vId sp inl IsFun body r
+        binders' = UniqMap.insert vId bind binders
+
+    bodyTy `deepseq` body `deepseq` binders' `seq` pure (binders', vId)
 
 -- | Create a new name out of the given name, but with another unique. Resulting
 -- unique is guaranteed to not be in the given InScopeSet.
@@ -727,84 +766,89 @@ normalizeId _   tyvar     = tyvar
 -- | Evaluate an expression to weak-head normal form (WHNF), and apply a
 -- transformation on the expression in WHNF.
 whnfRW
-  :: Bool
+  :: forall extra
+   . Bool
   -- ^ Whether the expression we're reducing to WHNF is the subject of a
   -- case expression.
   -> TransformContext
   -> Term
   -> Rewrite extra
   -> RewriteMonad extra Term
-whnfRW isSubj ctx@(TransformContext is0 hist) e rw = do
+whnfRW isSubj (TransformContext is0 hist) e0 rw = do
   tcm <- Lens.view tcCache
-  bndrs <- Lens.use bindings
   eval <- Lens.view evaluator
+
+  bndrsV <- Lens.use bindings
   ids <- Lens.use uniqSupply
+  ghV <- Lens.use globalHeap
+
+  bndrs <- MVar.takeMVar "bindings" bndrsV
+  gh <- MVar.takeMVar "globalHeap" ghV
+
   let (ids1,ids2) = splitSupply ids
   uniqSupply Lens..= ids2
-  gh <- Lens.use globalHeap
   let lh = localBinders mempty hist
 
-  case whnf' eval bndrs lh tcm gh ids1 is0 isSubj e of
+  case whnf' eval bndrs lh tcm gh ids1 is0 isSubj e0 of
     (!gh1,ph,v) -> do
-      globalHeap Lens..= gh1
-      bindPureHeap tcm (ph `differenceVarEnv` lh) rw ctx v
+      let result = bindPureHeap tcm bndrs (ph `differenceVarEnv` lh) v
+      MVar.putMVar "bindings" bndrsV bndrs
+      MVar.putMVar "globalHeap" ghV gh1
+      result
  where
   localBinders acc [] = acc
   localBinders !acc (h:hs) = case h of
     LetBody ls -> localBinders (acc <> mkVarEnv ls) hs
     _ -> localBinders acc hs
 
-{-# SCC whnfRW #-}
-
--- | Binds variables on the PureHeap over the result of the rewrite
---
--- To prevent unnecessary rewrites only do this when rewrite changed something.
-bindPureHeap
-  :: TyConMap
-  -> PureHeap
-  -> Rewrite extra
-  -> Rewrite extra
-bindPureHeap tcm heap rw ctx0@(TransformContext is0 hist) e = do
-  (e1, Monoid.getAny -> hasChanged) <- Writer.listen $ rw ctx e
-  if hasChanged && not (null bndrs) then do
-    -- The evaluator results are post-processed with two operations:
-    --
-    --   1. Inline work free binders. We've seen cases in the wild† where the
-    --      evaluator (or rather, 'bindPureHeap') would let-bind work-free
-    --      binders that were crucial for eliminating case constructs. If these
-    --      case constructs were used in a self-referential (but terminating)
-    --      manner, Clash would get stuck in an infinite loop. The proper
-    --      solution would be to use 'isWorkFree', instead of 'isWorkFreeIsh',
-    --      in 'bindConstantVar' such that these work free constructs would get
-    --      inlined again. However, this incurs a great performance penalty so
-    --      we opt to prevent the evaluator from introducing this situation in
-    --      the first place.
-    --
-    --      I'd like to stress that this is not a proper solution though, as GHC
-    --      might produce a similar situation. We plan on properly solving this
-    --      by eliminating the current lift/bind/eval strategy, instead replacing
-    --      it by a partial evaluator‡.
-    --
-    --   2. Remove any unused let-bindings. Similar to (1), we risk Clash getting
-    --      stuck in an infinite loop if we don't remove unused (eliminated by
-    --      evaluation!) binders.
-    --
-    -- † https://github.com/clash-lang/clash-compiler/pull/1354#issuecomment-635430374
-    -- ‡ https://www.microsoft.com/en-us/research/wp-content/uploads/2016/07/supercomp-by-eval.pdf
-    bs <- Lens.use bindings
-    inlineBinders (inlineTest bs) ctx0 (Letrec bndrs e1) >>= \case
-      e2@(Let bnders1 e3) ->
-        pure (fromMaybe e2 (removeUnusedBinders bnders1 e3))
-      e2 ->
-        pure e2
-  else
-    return e1
-  where
-    heapIds = map fst bndrs
+  -- | Binds variables on the PureHeap over the result of the rewrite
+  -- To prevent unnecessary rewrites only do this when rewrite changed something.
+  bindPureHeap
+    :: TyConMap
+    -> BindingMap
+    -> PureHeap
+    -> Term
+    -> RewriteMonad extra Term
+  bindPureHeap tcm bs heap e1 = do
+    (e2, Monoid.getAny -> hasChanged) <- Writer.listen $ rw ctx e1
+    if hasChanged && not (null letBndrs) then do
+      -- The evaluator results are post-processed with two operations:
+      --
+      --   1. Inline work free binders. We've seen cases in the wild† where the
+      --      evaluator (or rather, 'bindPureHeap') would let-bind work-free
+      --      binders that were crucial for eliminating case constructs. If these
+      --      case constructs were used in a self-referential (but terminating)
+      --      manner, Clash would get stuck in an infinite loop. The proper
+      --      solution would be to use 'isWorkFree', instead of 'isWorkFreeIsh',
+      --      in 'bindConstantVar' such that these work free constructs would get
+      --      inlined again. However, this incurs a great performance penalty so
+      --      we opt to prevent the evaluator from introducing this situation in
+      --      the first place.
+      --
+      --      I'd like to stress that this is not a proper solution though, as GHC
+      --      might produce a similar situation. We plan on properly solving this
+      --      by eliminating the current lift/bind/eval strategy, instead replacing
+      --      it by a partial evaluator‡.
+      --
+      --   2. Remove any unused let-bindings. Similar to (1), we risk Clash getting
+      --      stuck in an infinite loop if we don't remove unused (eliminated by
+      --      evaluation!) binders.
+      --
+      -- † https://github.com/clash-lang/clash-compiler/pull/1354#issuecomment-635430374
+      -- ‡ https://www.microsoft.com/en-us/research/wp-content/uploads/2016/07/supercomp-by-eval.pdf
+      inlineBinders inlineTest ctx (Letrec letBndrs e2) >>= \case
+        e3@(Let bnders1 e4) ->
+          pure (fromMaybe e3 (removeUnusedBinders bnders1 e4))
+        e3 ->
+          pure e3
+    else
+      return e2
+   where
+    heapIds = map fst letBndrs
     is1 = extendInScopeSetList is0 heapIds
-    ctx = TransformContext is1 (LetBody bndrs : hist)
+    ctx = TransformContext is1 (LetBody letBndrs : hist)
 
-    bndrs = map toLetBinding $ UniqMap.toList heap
+    letBndrs = map toLetBinding $ UniqMap.toList heap
 
     toLetBinding :: (Unique,Term) -> LetBinding
     toLetBinding (uniq,term) = (nm, term)
@@ -812,7 +856,8 @@ bindPureHeap tcm heap rw ctx0@(TransformContext is0 hist) e = do
         ty = inferCoreTypeOf tcm term
         nm = mkLocalId ty (mkUnsafeSystemName "x" uniq) -- See [Note: Name re-creation]
 
-    inlineTest bs _ (_, stripTicks -> e_) = isWorkFree workFreeBinders bs e_
+    inlineTest _ (_, stripTicks -> e_) = isWorkFree workFreeBinders bs e_
+{-# SCC whnfRW #-}
 
 -- | Remove unused binders in given let-binding. Returns /Nothing/ if no unused
 -- binders were found.

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -24,12 +24,14 @@ module Clash.Rewrite.Util
   , module Clash.Rewrite.WorkFree
   ) where
 
+import           Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Normalize.TracedMVar as MVar
 import           Control.DeepSeq
 import           Control.Exception           (throw)
-import           Control.Lens                ((%=), (+=), (^.), Lens')
+import           Control.Lens ((^.), Lens')
 import qualified Control.Lens                as Lens
 import qualified Control.Monad               as Monad
-import           Control.Monad.IO.Class      (liftIO)
+import qualified Control.Monad.IO.Class      as Monad
 import qualified Control.Monad.State.Strict  as State
 import qualified Control.Monad.Trans.RWS.CPS as RWS
 import qualified Control.Monad.Writer        as Writer
@@ -91,10 +93,10 @@ import qualified Clash.Util.Interpolate as I
 import           Clash.Util.Supply           (splitSupply)
 
 -- | Lift an action working in the '_extra' state to the 'RewriteMonad'
-zoomExtra :: State.State extra a -> RewriteMonad extra a
-zoomExtra m = R . RWS.rwsT $ \_ s ->
-  let (a, st') = State.runState m (_extra s)
-   in pure (a, s { _extra = st' }, mempty)
+zoomExtra :: State.StateT extra IO a -> RewriteMonad extra a
+zoomExtra m = R . RWS.rwsT $ \_ s -> do
+  (a, st') <- State.runStateT m (_extra s)
+  pure (a, s { _extra = st' }, mempty)
 
 -- | Some transformations might erroneously introduce shadowing. For example,
 -- a transformation might result in:
@@ -138,12 +140,16 @@ findAccidentialShadows =
 -- or 'transformAppliedCounters'.
 bumpCounter
   :: String
-  -> Lens' (RewriteState extra) (HashMap Text Word)
+  -- ^ Name of the 'MVar', used for lock tracing
+  -> String
+  -- ^ Name of the transformation
+  -> Lens' (RewriteState extra) (MVar.MVar (HashMap Text Word))
   -> RewriteMonad extra ()
-bumpCounter name l = do
-  counters <- Lens.use l
-  -- Note: Using $! to force thunks to prevent a gigantic pile of +1s in memory
-  Lens.assign l $! HashMap.insertWith (+) (Text.pack name) 1 counters
+bumpCounter mvarName name l = do
+  countersV <- Lens.use l
+  -- Note: Forcing the map to prevent a gigantic pile of +1s in memory
+  MVar.modifyMVar_ mvarName countersV
+    (pure . force . HashMap.insertWith (+) (Text.pack name) 1)
 
 -- | Record if a transformation is successfully applied
 apply
@@ -154,29 +160,50 @@ apply
   -> Rewrite extra
 apply = \s rewrite ctx expr0 -> do
   opts <- Lens.view debugOpts
-  traceIf (hasDebugInfo TryName s opts) ("Trying: " <> s) (pure ())
+  ioLockV <- Lens.use ioLock
+
+  Monad.when (hasDebugInfo TryName s opts) $
+    MVar.withMVar "ioLock" ioLockV $ \() ->
+      traceM ("Trying: " <> s)
 
   (!expr1,anyChanged) <- Writer.listen (rewrite ctx expr0)
   let hasChanged = Monoid.getAny anyChanged
-  Monad.when hasChanged (transformCounter += 1)
+
+  Monad.when hasChanged $
+    bumpCounter "transformAppliedCounters" s transformAppliedCounters
 
   -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
   let rewriteHistFile = dbg_historyFile opts
   Monad.when (isJust rewriteHistFile && hasChanged) $ do
-    (curBndr, _) <- Lens.use curFun
-    liftIO
-      $ BS.appendFile (fromJust rewriteHistFile)
-      $ BL.toStrict
-      $ encode RewriteStep
-          { t_ctx    = tfContext ctx
-          , t_name   = s
-          , t_bndrS  = showPpr (varName curBndr)
-          , t_before = expr0
-          , t_after  = expr1
-          }
+    thread <- myThreadId
+    curFunsV <- Lens.use curFun
+
+    MVar.withMVar "curFun" curFunsV $ \curFuns ->
+      case fst <$> HashMap.lookup thread curFuns of
+        Just curBndr ->
+          -- TODO Although we're locking access to the history file, entries
+          -- may still be written to it interleaved by entity. I'm not sure if
+          -- clash-term can handle this correctly...
+          MVar.withMVar "ioLock" ioLockV $ \() ->
+            Monad.liftIO
+              . BS.appendFile (fromJust rewriteHistFile)
+              . BL.toStrict
+              $ encode RewriteStep
+                         { t_ctx    = tfContext ctx
+                         , t_name   = s
+                         , t_bndrS  = showPpr (varName curBndr)
+                         , t_before = expr0
+                         , t_after  = expr1
+                         }
+
+        Nothing ->
+          error "apply: Normalizing from an unknown thread"
 
   if isDebugging opts
-    then applyDebug ctx s expr0 hasChanged expr1
+    then do
+      countersV <- Lens.use transformAppliedCounters
+      nTrans <- sum <$> MVar.readMVar "transformAppliedCounters" countersV
+      applyDebug ctx s expr0 hasChanged expr1 nTrans
     else return expr1
 {-# INLINE apply #-}
 
@@ -190,28 +217,32 @@ applyDebug
   -- ^ Whether the rewrite indicated change
   -> Term
   -- ^ New expression
+  -> Word
   -> RewriteMonad extra Term
-applyDebug ctx name exprOld hasChanged exprNew = do
-  nTrans <- Lens.use transformCounter
+applyDebug ctx name exprOld hasChanged exprNew nTrans = do
   opts <- Lens.view debugOpts
 
   let from = fromMaybe 0 (dbg_transformationsFrom opts)
   let limit = fromMaybe maxBound (dbg_transformationsLimit opts)
 
-  if | nTrans - from > limit ->
+  if | nTrans - from > limit -> do
          error "-fclash-debug-transformations-limit exceeded"
-     | nTrans <= from ->
+     | nTrans <= from -> do
          pure exprNew
      | otherwise ->
-         go opts
+         go (pred nTrans) opts
  where
-  go opts = traceIf (hasDebugInfo TryTerm name opts) ("Tried: " ++ name ++ " on:\n" ++ before) $ do
-    nTrans <- pred <$> Lens.use transformCounter
+  go nTrans' opts = do
+    ioLockV <- Lens.use ioLock
 
-    Monad.when (dbg_countTransformations opts) $ do
-      bumpCounter name transformTriedCounters
-      Monad.when hasChanged $
-        bumpCounter name transformAppliedCounters
+    Monad.when (hasDebugInfo TryTerm name opts) $
+      MVar.withMVar "ioLock" ioLockV $ \() ->
+        traceM ("Tried: " ++ name ++ " on:\n" ++ before)
+
+    -- NB: 'transformAppliedCounters' is bumped unconditionally in 'apply', as
+    -- the total transformation count is derived from it.
+    Monad.when (dbg_countTransformations opts) $
+      bumpCounter "transformTriedCounters" name transformTriedCounters
 
     Monad.when (dbg_invariants opts && hasChanged) $ do
       tcm                  <- Lens.view tcCache
@@ -267,12 +298,20 @@ applyDebug ctx name exprOld hasChanged exprNew = do
       error $ $(curLoc) ++ "Expression changed without notice(" ++ name ++  "): before"
                         ++ before ++ "\nafter:\n" ++ after
 
-    traceIf (hasDebugInfo AppliedName name opts && hasChanged) (name <> " {" <> show nTrans <> "}") $
-      traceIf (hasDebugInfo AppliedTerm name opts && hasChanged) ("Changes when applying rewrite to:\n"
-                        ++ before ++ "\nResult:\n" ++ after ++ "\n") $
-        traceIf (hasDebugInfo TryTerm name opts && not hasChanged) ("No changes when applying rewrite "
-                          ++ name ++ " to:\n" ++ after ++ "\n") $
-          return exprNew
+    let traceName = hasDebugInfo AppliedName name opts && hasChanged
+        traceTerm = hasDebugInfo AppliedTerm name opts && hasChanged
+        traceTryTerm = hasDebugInfo TryTerm name opts && not hasChanged
+        shouldTrace = traceName || traceTerm || traceTryTerm
+
+    Monad.when shouldTrace $
+      MVar.withMVar "ioLock" ioLockV $ \() -> do
+        traceWhen traceName (name <> " {" <> show nTrans' <> "}")
+        traceWhen traceTerm
+          ("Changes when applying rewrite to:\n" ++ before ++ "\nResult:\n" ++ after ++ "\n")
+        traceWhen traceTryTerm
+          ("No changes when applying rewrite " ++ name ++ " to:\n" ++ after ++ "\n")
+
+    return exprNew
    where
     before = showPpr exprOld
     after  = showPpr exprNew
@@ -304,20 +343,23 @@ runRewriteSession :: RewriteEnv
                   -> RewriteState extra
                   -> RewriteMonad extra a
                   -> IO a
-runRewriteSession r s m = do
-  (a, s', _) <- runR m r s
+runRewriteSession rwEnv rwState session = do
+  (a, session1, _) <- runR session rwEnv rwState
+  tried <- MVar.readMVar "transformTriedCounters" (session1 ^. transformTriedCounters)
+  applied <- MVar.readMVar "transformAppliedCounters" (session1 ^. transformAppliedCounters)
 
-  let
-    triedTransformationsMessage =
-      ("Clash: Tried transformations:\n" ++ Text.unpack (showCounters (s' ^. transformTriedCounters)))
-    appliedTransformationsMessage =
-      ("Clash: Applied transformations:\n" ++ Text.unpack (showCounters (s' ^. transformAppliedCounters)))
+  let opts = opt_debug (envOpts (_clashEnv rwEnv))
+      shouldTrace = dbg_countTransformations opts || None < dbg_transformationInfo opts
 
-  traceIf (dbg_countTransformations (opt_debug (envOpts (_clashEnv r))))
-    (triedTransformationsMessage ++ "\n" ++ appliedTransformationsMessage) $
-    traceIf (None < dbg_transformationInfo (opt_debug (envOpts (_clashEnv r))))
-      ("Clash: Applied " ++ show (s' ^. transformCounter) ++ " transformations")
-      pure a
+  Monad.when shouldTrace $
+    MVar.withMVar "ioLock" (session1 ^. ioLock) $ \() -> do
+      traceWhen (dbg_countTransformations opts) $
+        "Clash: Tried transformations:\n" ++ Text.unpack (showCounters tried) ++
+        "\nClash: Applied transformations:\n" ++ Text.unpack (showCounters applied)
+      traceWhen (None < dbg_transformationInfo opts)
+        ("Clash: Applied " ++ show (sum applied) ++ " transformations")
+
+  pure a
   where
     showCounters =
       Text.unlines
@@ -527,7 +569,9 @@ liftAndSubsituteBinders inScope toLift toKeep body = do
                                                 (substTmEnv subst) }
         subst2 = extendIdSubst subst1 x e2
     if x `elemFreeVars` e2 then do
-      (_,sp) <- Lens.use curFun
+      curFunsV <- Lens.use curFun
+      thread <- myThreadId
+      Just (_,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
       throw (ClashException sp [I.i|
         Internal error: inlineOrLiftBInders failed on:
 
@@ -606,8 +650,11 @@ liftBinding (var@Id {varName = idName} ,e) = do
   -- Make a new global ID
   tcm       <- Lens.view tcCache
   let newBodyTy = inferCoreTypeOf tcm $ mkTyLams (mkLams e boundFVs) boundFTVs
-  (cf,sp)   <- Lens.use curFun
-  binders <- Lens.use bindings
+  curFunsV <- Lens.use curFun
+  thread <- myThreadId
+  Just (cf,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
+  bindersV <- Lens.use bindings
+  binders <- MVar.takeMVar "bindings" bindersV
   newBodyNm <-
     cloneNameWithBindingMap
       binders
@@ -629,30 +676,31 @@ liftBinding (var@Id {varName = idName} ,e) = do
       newBody = mkTyLams (mkLams e' boundFVs) boundFTVs
 
   -- Check if an alpha-equivalent global binder already exists
-  aeqExisting <- (UniqMap.elems . UniqMap.filter ((`aeqTerm` newBody) . bindingTerm)) <$> Lens.use bindings
+  let aeqExisting = UniqMap.elems . UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) $ binders
   case aeqExisting of
     -- If it doesn't, create a new binder
     [] -> do -- Add the created function to the list of global bindings
              let r = newBodyId `globalIdOccursIn` newBody
-             bindings %= UniqMap.insert newBodyNm
-                                    -- We mark this function as internal so that
-                                    -- it can be inlined at the very end of
-                                    -- the normalisation pipeline as part of the
-                                    -- flattening pass. We don't inline
-                                    -- right away because we are lifting this
-                                    -- function at this moment for a reason!
-                                    -- (termination, CSE and DEC oppertunities,
-                                    -- ,etc.)
-                                    (Binding newBodyId sp NoUserInlinePrag IsFun newBody r)
-             -- Return the new binder
+             MVar.putMVar "bindings" bindersV $
+               UniqMap.insert
+                 newBodyNm
+                 -- We mark this function as internal so that it can be inlined
+                 -- at the very end of the normalization pipeline as part of the
+                 -- flattening pass. We don't inline right away because we are
+                 -- lifting this function at this moment for a reason!
+                 -- (termination, CSE and DEC opportunities, etc.)
+                 (Binding newBodyId sp NoUserInlinePrag IsFun newBody r)
+                 binders
+
              return (var, newExpr)
     -- If it does, use the existing binder
-    (b:_) ->
+    (b:_) -> do
       let newExpr' = mkTmApps
                       (mkTyApps (Var $ bindingId b)
                                 (map VarTy boundFTVs))
                       (map Var boundFVs)
-      in  return (var, newExpr')
+      MVar.putMVar "bindings" bindersV binders
+      return (var, newExpr')
 
 liftBinding _ = error $ $(curLoc) ++ "liftBinding: invalid core, expr bound to tyvar"
 
@@ -669,23 +717,16 @@ mkFunction
 mkFunction bndrNm sp inl body = do
   tcm <- Lens.view tcCache
   let bodyTy = inferCoreTypeOf tcm body
-  binders <- Lens.use bindings
-  bodyNm <- cloneNameWithBindingMap binders bndrNm
-  addGlobalBind bodyNm bodyTy sp inl body
-  return (mkGlobalId bodyTy bodyNm)
+  bindersV <- Lens.use bindings
 
--- | Add a function to the set of global binders
-addGlobalBind
-  :: TmName
-  -> Type
-  -> SrcSpan
-  -> InlineSpec
-  -> Term
-  -> RewriteMonad extra ()
-addGlobalBind vNm ty sp inl body = do
-  let vId = mkGlobalId ty vNm
-      r = vId `globalIdOccursIn` body
-  (ty,body) `deepseq` bindings %= UniqMap.insert vNm (Binding vId sp inl IsFun body r)
+  MVar.modifyMVar "bindings" bindersV $ \binders -> do
+    bodyNm <- cloneNameWithBindingMap binders bndrNm
+    let vId = mkGlobalId bodyTy bodyNm
+        r = vId `globalIdOccursIn` body
+        bind = Binding vId sp inl IsFun body r
+        binders' = UniqMap.insert vId bind binders
+
+    bodyTy `deepseq` body `deepseq` binders' `seq` pure (binders', vId)
 
 -- | Create a new name out of the given name, but with another unique. Resulting
 -- unique is guaranteed to not be in the given InScopeSet.
@@ -756,84 +797,89 @@ normalizeId _   tyvar     = tyvar
 -- | Evaluate an expression to weak-head normal form (WHNF), and apply a
 -- transformation on the expression in WHNF.
 whnfRW
-  :: Bool
+  :: forall extra
+   . Bool
   -- ^ Whether the expression we're reducing to WHNF is the subject of a
   -- case expression.
   -> TransformContext
   -> Term
   -> Rewrite extra
   -> RewriteMonad extra Term
-whnfRW isSubj ctx@(TransformContext is0 hist) e rw = do
+whnfRW isSubj (TransformContext is0 hist) e0 rw = do
   tcm <- Lens.view tcCache
-  bndrs <- Lens.use bindings
   eval <- Lens.view evaluator
+
+  bndrsV <- Lens.use bindings
   ids <- Lens.use uniqSupply
+  ghV <- Lens.use globalHeap
+
+  bndrs <- MVar.takeMVar "bindings" bndrsV
+  gh <- MVar.takeMVar "globalHeap" ghV
+
   let (ids1,ids2) = splitSupply ids
   uniqSupply Lens..= ids2
-  gh <- Lens.use globalHeap
   let lh = localBinders mempty hist
 
-  case whnf' eval bndrs lh tcm gh ids1 is0 isSubj e of
+  case whnf' eval bndrs lh tcm gh ids1 is0 isSubj e0 of
     (!gh1,ph,v) -> do
-      globalHeap Lens..= gh1
-      bindPureHeap tcm (ph `differenceVarEnv` lh) rw ctx v
+      let result = bindPureHeap tcm bndrs (ph `differenceVarEnv` lh) v
+      MVar.putMVar "bindings" bndrsV bndrs
+      MVar.putMVar "globalHeap" ghV gh1
+      result
  where
   localBinders acc [] = acc
   localBinders !acc (h:hs) = case h of
     LetBody ls -> localBinders (acc <> mkVarEnv ls) hs
     _ -> localBinders acc hs
 
-{-# SCC whnfRW #-}
-
--- | Binds variables on the PureHeap over the result of the rewrite
---
--- To prevent unnecessary rewrites only do this when rewrite changed something.
-bindPureHeap
-  :: TyConMap
-  -> PureHeap
-  -> Rewrite extra
-  -> Rewrite extra
-bindPureHeap tcm heap rw ctx0@(TransformContext is0 hist) e = do
-  (e1, Monoid.getAny -> hasChanged) <- Writer.listen $ rw ctx e
-  if hasChanged && not (null bndrs) then do
-    -- The evaluator results are post-processed with two operations:
-    --
-    --   1. Inline work free binders. We've seen cases in the wild† where the
-    --      evaluator (or rather, 'bindPureHeap') would let-bind work-free
-    --      binders that were crucial for eliminating case constructs. If these
-    --      case constructs were used in a self-referential (but terminating)
-    --      manner, Clash would get stuck in an infinite loop. The proper
-    --      solution would be to use 'isWorkFree', instead of 'isWorkFreeIsh',
-    --      in 'bindConstantVar' such that these work free constructs would get
-    --      inlined again. However, this incurs a great performance penalty so
-    --      we opt to prevent the evaluator from introducing this situation in
-    --      the first place.
-    --
-    --      I'd like to stress that this is not a proper solution though, as GHC
-    --      might produce a similar situation. We plan on properly solving this
-    --      by eliminating the current lift/bind/eval strategy, instead replacing
-    --      it by a partial evaluator‡.
-    --
-    --   2. Remove any unused let-bindings. Similar to (1), we risk Clash getting
-    --      stuck in an infinite loop if we don't remove unused (eliminated by
-    --      evaluation!) binders.
-    --
-    -- † https://github.com/clash-lang/clash-compiler/pull/1354#issuecomment-635430374
-    -- ‡ https://www.microsoft.com/en-us/research/wp-content/uploads/2016/07/supercomp-by-eval.pdf
-    bs <- Lens.use bindings
-    inlineBinders (inlineTest bs) ctx0 (Letrec bndrs e1) >>= \case
-      e2@(Let bnders1 e3) ->
-        pure (fromMaybe e2 (removeUnusedBinders bnders1 e3))
-      e2 ->
-        pure e2
-  else
-    return e1
-  where
-    heapIds = map fst bndrs
+  -- | Binds variables on the PureHeap over the result of the rewrite
+  -- To prevent unnecessary rewrites only do this when rewrite changed something.
+  bindPureHeap
+    :: TyConMap
+    -> BindingMap
+    -> PureHeap
+    -> Term
+    -> RewriteMonad extra Term
+  bindPureHeap tcm bs heap e1 = do
+    (e2, Monoid.getAny -> hasChanged) <- Writer.listen $ rw ctx e1
+    if hasChanged && not (null letBndrs) then do
+      -- The evaluator results are post-processed with two operations:
+      --
+      --   1. Inline work free binders. We've seen cases in the wild† where the
+      --      evaluator (or rather, 'bindPureHeap') would let-bind work-free
+      --      binders that were crucial for eliminating case constructs. If these
+      --      case constructs were used in a self-referential (but terminating)
+      --      manner, Clash would get stuck in an infinite loop. The proper
+      --      solution would be to use 'isWorkFree', instead of 'isWorkFreeIsh',
+      --      in 'bindConstantVar' such that these work free constructs would get
+      --      inlined again. However, this incurs a great performance penalty so
+      --      we opt to prevent the evaluator from introducing this situation in
+      --      the first place.
+      --
+      --      I'd like to stress that this is not a proper solution though, as GHC
+      --      might produce a similar situation. We plan on properly solving this
+      --      by eliminating the current lift/bind/eval strategy, instead replacing
+      --      it by a partial evaluator‡.
+      --
+      --   2. Remove any unused let-bindings. Similar to (1), we risk Clash getting
+      --      stuck in an infinite loop if we don't remove unused (eliminated by
+      --      evaluation!) binders.
+      --
+      -- † https://github.com/clash-lang/clash-compiler/pull/1354#issuecomment-635430374
+      -- ‡ https://www.microsoft.com/en-us/research/wp-content/uploads/2016/07/supercomp-by-eval.pdf
+      inlineBinders inlineTest ctx (Letrec letBndrs e2) >>= \case
+        e3@(Let bnders1 e4) ->
+          pure (fromMaybe e3 (removeUnusedBinders bnders1 e4))
+        e3 ->
+          pure e3
+    else
+      return e2
+   where
+    heapIds = map fst letBndrs
     is1 = extendInScopeSetList is0 heapIds
-    ctx = TransformContext is1 (LetBody bndrs : hist)
+    ctx = TransformContext is1 (LetBody letBndrs : hist)
 
-    bndrs = map toLetBinding $ UniqMap.toList heap
+    letBndrs = map toLetBinding $ UniqMap.toList heap
 
     toLetBinding :: (Unique,Term) -> LetBinding
     toLetBinding (uniq,term) = (nm, term)
@@ -841,7 +887,8 @@ bindPureHeap tcm heap rw ctx0@(TransformContext is0 hist) e = do
         ty = inferCoreTypeOf tcm term
         nm = mkLocalId ty (mkUnsafeSystemName "x" uniq) -- See [Note: Name re-creation]
 
-    inlineTest bs _ (_, stripTicks -> e_) = isWorkFree workFreeBinders bs e_
+    inlineTest _ (_, stripTicks -> e_) = isWorkFree workFreeBinders bs e_
+{-# SCC whnfRW #-}
 
 -- | Remove unused binders in given let-binding. Returns /Nothing/ if no unused
 -- binders were found.

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -25,6 +25,7 @@ module Clash.Rewrite.Util
   ) where
 
 import           Control.Concurrent.Lifted (myThreadId)
+import qualified Clash.Data.RwVar as RwVar
 import qualified Clash.Normalize.TracedMVar as MVar
 import           Control.DeepSeq
 import           Control.Exception           (throw)
@@ -35,6 +36,7 @@ import qualified Control.Monad.IO.Class      as Monad
 import qualified Control.Monad.State.Strict  as State
 import qualified Control.Monad.Trans.RWS.CPS as RWS
 import qualified Control.Monad.Writer        as Writer
+import qualified Data.Map                    as Map
 import           Data.Bifunctor              (second)
 import           Data.Coerce                 (coerce)
 import           Data.Functor.Const          (Const (..))
@@ -654,53 +656,55 @@ liftBinding (var@Id {varName = idName} ,e) = do
   thread <- myThreadId
   Just (cf,sp) <- MVar.withMVar "curFun" curFunsV (pure . HashMap.lookup thread)
   bindersV <- Lens.use bindings
-  binders <- MVar.takeMVar "bindings" bindersV
-  newBodyNm <-
-    cloneNameWithBindingMap
-      binders
-      (appendToName (varName cf) ("_" `Text.append` nameOcc idName))
-  let newBodyId = mkGlobalId newBodyTy newBodyNm {nameSort = Internal}
+  -- Deriving the new name from the binding map, and checking whether an
+  -- alpha-equivalent binder already exists, both have to see the same map the
+  -- new binder is inserted into, so this whole section is one write.
+  RwVar.modifyRwVar bindersV $ \binders -> do
+    newBodyNm <-
+      cloneNameWithBindingMap
+        binders
+        (appendToName (varName cf) ("_" `Text.append` nameOcc idName))
+    let newBodyId = mkGlobalId newBodyTy newBodyNm {nameSort = Internal}
 
-  -- Make a new expression, consisting of the the lifted function applied to
-  -- its free variables
-  let newExpr = mkTmApps
-                  (mkTyApps (Var newBodyId)
-                            (map VarTy boundFTVs))
-                  (map Var boundFVs)
-      inScope0 = mkInScopeSet (coerce boundFVsSet)
-      inScope1 = extendInScopeSetList inScope0 [var,newBodyId]
-  let subst    = extendIdSubst (mkSubst inScope1) var newExpr
-      -- Substitute the recursive calls by the new expression
-      e' = substTm "liftBinding" subst e
-      -- Create a new body that abstracts over the free variables
-      newBody = mkTyLams (mkLams e' boundFVs) boundFTVs
+    -- Make a new expression, consisting of the the lifted function applied to
+    -- its free variables
+    let newExpr = mkTmApps
+                    (mkTyApps (Var newBodyId)
+                              (map VarTy boundFTVs))
+                    (map Var boundFVs)
+        inScope0 = mkInScopeSet (coerce boundFVsSet)
+        inScope1 = extendInScopeSetList inScope0 [var,newBodyId]
+    let subst    = extendIdSubst (mkSubst inScope1) var newExpr
+        -- Substitute the recursive calls by the new expression
+        e' = substTm "liftBinding" subst e
+        -- Create a new body that abstracts over the free variables
+        newBody = mkTyLams (mkLams e' boundFVs) boundFTVs
 
-  -- Check if an alpha-equivalent global binder already exists
-  let aeqExisting = UniqMap.elems . UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) $ binders
-  case aeqExisting of
-    -- If it doesn't, create a new binder
-    [] -> do -- Add the created function to the list of global bindings
-             let r = newBodyId `globalIdOccursIn` newBody
-             MVar.putMVar "bindings" bindersV $
-               UniqMap.insert
-                 newBodyNm
-                 -- We mark this function as internal so that it can be inlined
-                 -- at the very end of the normalization pipeline as part of the
-                 -- flattening pass. We don't inline right away because we are
-                 -- lifting this function at this moment for a reason!
-                 -- (termination, CSE and DEC opportunities, etc.)
-                 (Binding newBodyId sp NoUserInlinePrag IsFun newBody r)
-                 binders
+    -- Check if an alpha-equivalent global binder already exists
+    let aeqExisting = UniqMap.elems . UniqMap.filter ((`aeqTerm` newBody) . bindingTerm) $ binders
+    case aeqExisting of
+      -- If it doesn't, create a new binder
+      [] -> do -- Add the created function to the list of global bindings
+               let r = newBodyId `globalIdOccursIn` newBody
+               let binders1 =
+                     UniqMap.insert
+                       newBodyNm
+                       -- We mark this function as internal so that it can be inlined
+                       -- at the very end of the normalization pipeline as part of the
+                       -- flattening pass. We don't inline right away because we are
+                       -- lifting this function at this moment for a reason!
+                       -- (termination, CSE and DEC opportunities, etc.)
+                       (Binding newBodyId sp NoUserInlinePrag IsFun newBody r)
+                       binders
 
-             return (var, newExpr)
-    -- If it does, use the existing binder
-    (b:_) -> do
-      let newExpr' = mkTmApps
-                      (mkTyApps (Var $ bindingId b)
-                                (map VarTy boundFTVs))
-                      (map Var boundFVs)
-      MVar.putMVar "bindings" bindersV binders
-      return (var, newExpr')
+               return (binders1, (var, newExpr))
+      -- If it does, use the existing binder
+      (b:_) -> do
+        let newExpr' = mkTmApps
+                        (mkTyApps (Var $ bindingId b)
+                                  (map VarTy boundFTVs))
+                        (map Var boundFVs)
+        return (binders, (var, newExpr'))
 
 liftBinding _ = error $ $(curLoc) ++ "liftBinding: invalid core, expr bound to tyvar"
 
@@ -719,7 +723,7 @@ mkFunction bndrNm sp inl body = do
   let bodyTy = inferCoreTypeOf tcm body
   bindersV <- Lens.use bindings
 
-  MVar.modifyMVar "bindings" bindersV $ \binders -> do
+  RwVar.modifyRwVar bindersV $ \binders -> do
     bodyNm <- cloneNameWithBindingMap binders bndrNm
     let vId = mkGlobalId bodyTy bodyNm
         r = vId `globalIdOccursIn` body
@@ -760,6 +764,34 @@ runWithHWTypeCache m = do
   hwTypeCache Lens..= cache1
   pure a
 
+-- | Seed this task's HWType cache from the shared one, and publish what the
+-- task learned when it finishes.
+--
+-- The cache is a plain (task-local) field because it is updated on nearly every
+-- type translation — millions of times per compilation — which is far too hot
+-- to synchronize per update. Sharing it at task boundaries instead keeps the
+-- translations one task performed available to the tasks that start after it,
+-- rather than discarding them when the task's state copy dies.
+withSharedHWTypeCache :: RewriteMonad extra a -> RewriteMonad extra a
+withSharedHWTypeCache m = do
+  var <- Lens.use sharedHwTypeCache
+  shared0 <- RwVar.readRwVar var
+  hwTypeCache Lens..= shared0
+  a <- m
+  cache1 <- Lens.use hwTypeCache
+  Monad.when (Map.size cache1 > Map.size shared0) $
+    RwVar.modifyRwVar_ var (pure . Map.union cache1)
+  pure a
+
+-- Note [rewriting a let's bindings concurrently]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- The bindings of a let are independent, so rewriting them on separate threads
+-- looks like free parallelism inside a single binder. It was measured on
+-- wireDemoTest (fork above 32 bindings) and made normalization 2.8x slower:
+-- 2m39s against 57.6s. The settle loop traverses the same let on every
+-- iteration, so each traversal pays for forking again, against rewrites that
+-- cost microseconds per node.
+--
 -- | Determine if a term cannot be represented in hardware
 isUntranslatable
   :: Bool
@@ -813,7 +845,7 @@ whnfRW isSubj (TransformContext is0 hist) e0 rw = do
   ids <- Lens.use uniqSupply
   ghV <- Lens.use globalHeap
 
-  bndrs <- MVar.takeMVar "bindings" bndrsV
+  bndrs <- RwVar.readRwVar bndrsV
   gh <- MVar.takeMVar "globalHeap" ghV
 
   let (ids1,ids2) = splitSupply ids
@@ -823,7 +855,6 @@ whnfRW isSubj (TransformContext is0 hist) e0 rw = do
   case whnf' eval bndrs lh tcm gh ids1 is0 isSubj e0 of
     (!gh1,ph,v) -> do
       let result = bindPureHeap tcm bndrs (ph `differenceVarEnv` lh) v
-      MVar.putMVar "bindings" bndrsV bndrs
       MVar.putMVar "globalHeap" ghV gh1
       result
  where

--- a/clash-lib/src/Clash/Rewrite/WorkFree.hs
+++ b/clash-lib/src/Clash/Rewrite/WorkFree.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (C) 2020-2021, QBayLogic B.V.
+Copyright   : (C) 2020-2022, QBayLogic B.V.
 License     : BSD2 (see the file LICENSE)
 Maintainer  : QBayLogic B.V. <devops@qaylogic.com>
 
@@ -8,21 +8,25 @@ evaluation to check whether it is possible to perform changes without
 duplicating work in the result, e.g. inlining.
 -}
 
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 module Clash.Rewrite.WorkFree
   ( isWorkFree
+  , isWorkFreePure
   , isWorkFreeClockOrResetOrEnable
   , isWorkFreeIsh
   , isConstant
   , isConstantNotClockReset
   ) where
 
-import Control.Lens (Lens')
-import Control.Monad.Extra (allM, andM, eitherM)
+import Control.Concurrent.MVar (MVar)
+import qualified Clash.Normalize.TracedMVar as MVar
+import Control.Lens as Lens (Lens', use)
 import Control.Monad.State.Class (MonadState)
+import Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Data.Text.Extra as Text
 import GHC.Stack (HasCallStack)
 
@@ -35,41 +39,59 @@ import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (isPolyFunTy)
 import Clash.Core.Util
 import Clash.Core.Var (Id, isLocalId)
-import Clash.Core.VarEnv (VarEnv, lookupVarEnv)
+import Clash.Core.VarEnv (VarEnv, extendVarEnv, lookupVarEnv, unionVarEnv)
 import Clash.Driver.Types (BindingMap, Binding(..))
 import Clash.Normalize.Primitives (removedArg)
-import Clash.Util (makeCachedU)
+
+-- TODO I think isWorkFree only needs to exist within the rewriting monad, and
+-- this extra polymorphism is probably unnecessary. Needs checking. -- Alex
+
+{-# INLINABLE isWorkFree #-}
+isWorkFree
+  :: (HasCallStack, MonadState s m, MonadBaseControl IO m)
+  => Lens' s (MVar (VarEnv Bool))
+  -> BindingMap
+  -> Term
+  -> m Bool
+isWorkFree cacheL bndrs bndr = do
+  lock <- Lens.use cacheL
+  MVar.modifyMVar "workFreeBinders" lock (\cache -> pure (isWorkFreePure cache bndrs bndr))
 
 -- | Determines whether a global binder is work free. Errors if binder does
 -- not exist.
 isWorkFreeBinder
-  :: (HasCallStack, MonadState s m)
-  => Lens' s (VarEnv Bool)
+  :: HasCallStack
+  => VarEnv Bool
   -> BindingMap
   -> Id
-  -> m Bool
+  -> (VarEnv Bool, Bool)
 isWorkFreeBinder cache bndrs bndr =
-  makeCachedU bndr cache $
-    case lookupVarEnv bndr bndrs of
-      Nothing -> error ("isWorkFreeBinder: couldn't find binder: " ++ showPpr bndr)
-      Just (bindingTerm -> t) ->
-        if bndr `globalIdOccursIn` t
-        then pure False
-        else isWorkFree cache bndrs t
+  case lookupVarEnv bndr cache of
+    Just value ->
+      (cache, value)
 
-{-# INLINABLE isWorkFree #-}
+    Nothing ->
+      case lookupVarEnv bndr bndrs of
+        Nothing ->
+          error ("isWorkFreeBinder: couldn't find binder: " ++ showPpr bndr)
+
+        Just (bindingTerm -> t) ->
+          if bndr `globalIdOccursIn` t
+            then (extendVarEnv bndr False cache, False)
+            else isWorkFreePure cache bndrs t
+
+{-# INLINABLE isWorkFreePure #-}
 -- | Determine whether a term does any work, i.e. adds to the size of the
 -- circuit. This function requires a cache (specified as a lens) to store the
 -- result for querying work info of global binders.
 --
-isWorkFree
-  :: forall s m
-   . (HasCallStack, MonadState s m)
-  => Lens' s (VarEnv Bool)
+isWorkFreePure
+  :: HasCallStack
+  => VarEnv Bool
   -> BindingMap
   -> Term
-  -> m Bool
-isWorkFree cache bndrs = go True
+  -> (VarEnv Bool, Bool)
+isWorkFreePure cache bndrs = go True
  where
   -- If we are in the outermost level of a term (i.e. not checking a subterm)
   -- then a term is work free if it simply refers to a local variable. This
@@ -79,7 +101,7 @@ isWorkFree cache bndrs = go True
   --
   -- as being work free, as the term bound to f may introduce work.
   --
-  go :: HasCallStack => Bool -> Term -> m Bool
+  go :: HasCallStack => Bool -> Term -> (VarEnv Bool, Bool)
   go isOutermost (collectArgs -> (fun, args)) =
     case fun of
       Var i
@@ -91,38 +113,79 @@ isWorkFree cache bndrs = go True
         -- would need to be changed to know the FVs of global binders first.
         --
         | isPolyFunTy (coreTypeOf i) ->
-            pure (isLocalId i && isOutermost && null args)
+            (cache, isLocalId i && isOutermost && null args)
         | isLocalId i ->
-            pure True
+          (cache, True)
         | otherwise ->
-            andM [isWorkFreeBinder cache bndrs i, allM goArg args]
+            let (cache', wf) = isWorkFreeBinder cache bndrs i
+                (caches, wfs) = unzip (fmap goArg args)
+             in (foldr unionVarEnv cache' caches, and (wf : wfs))
 
-      Data _ -> allM goArg args
-      Literal _ -> pure True
+      Data _ ->
+        let (caches, wfs) = unzip (fmap goArg args)
+         in (foldr unionVarEnv mempty caches, and wfs)
+
+      Literal _ ->
+        (cache, True)
+
       Prim pr ->
         case primWorkInfo pr of
           -- We can ignore arguments because the primitive outputs a constant
           -- regardless of their values.
-          WorkConstant -> pure True
-          WorkNever -> allM goArg args
-          WorkIdentity _ _ -> allM goArg args
-          WorkVariable -> pure (all isConstantArg args)
-          WorkAlways -> pure False
+          WorkConstant -> (cache, True)
+          WorkNever ->
+            let (caches, wfs) = unzip (fmap goArg args)
+             in (foldr unionVarEnv mempty caches, and wfs)
+          WorkIdentity _ _ ->
+            let (caches, wfs) = unzip (fmap goArg args)
+             in (foldr unionVarEnv mempty caches, and wfs)
+          WorkVariable -> (cache, all isConstantArg args)
+          WorkAlways -> (cache, False)
 
-      Lam _ e -> andM [go False e, allM goArg args]
-      TyLam _ e -> andM [go False e, allM goArg args]
-      Let (NonRec _ x) e -> andM [go False e, go False x, allM goArg args]
-      Let (Rec bs) e -> andM [go False e, allM (go False . snd) bs, allM goArg args]
-      Case s _ [(_, a)] -> andM [go False s, go False a, allM goArg args]
-      Case e _ _ -> andM [go False e, allM goArg args]
-      Cast e _ _ -> andM [go False e, allM goArg args]
+      Lam _ e ->
+        let (cache', wf) = go False e
+            (caches, wfs) = unzip (fmap goArg args)
+         in (foldr unionVarEnv cache' caches, and (wf : wfs))
+
+      TyLam _ e ->
+        let (cache', wf) = go False e
+            (caches, wfs) = unzip (fmap goArg args)
+         in (foldr unionVarEnv cache' caches, and (wf : wfs))
+
+      Let (NonRec _ x) e ->
+        let (cacheE, wfE) = go False e
+            (cacheX, wfX) = go False x
+            (caches, wfs) = unzip (fmap goArg args)
+         in (foldr unionVarEnv cacheE (cacheX : caches), and (wfE : wfX : wfs))
+
+      Let (Rec bs) e ->
+        let (cacheE, wfE) = go False e
+            (cacheBs, wfBs) = unzip (fmap (go False . snd) bs)
+            (caches, wfs) = unzip (fmap goArg args)
+         in (foldr unionVarEnv cacheE (cacheBs <> caches), and (wfE : (wfBs <> wfs)))
+
+      Case s _ [(_, a)] ->
+        let (cacheS, wfS) = go False s
+            (cacheA, wfA) = go False a
+            (caches, wfs) = unzip (fmap goArg args)
+         in (foldr unionVarEnv cacheS (cacheA : caches), and (wfS : wfA : wfs))
+
+      Case e _ _ ->
+        let (cache', wf) = go False e
+            (caches, wfs) = unzip (fmap goArg args)
+         in (foldr unionVarEnv cache' caches, and (wf : wfs))
+
+      Cast e _ _ ->
+        let (cache', wf) = go False e
+            (caches, wfs) = unzip (fmap goArg args)
+         in (foldr unionVarEnv cache' caches, and (wf : wfs))
 
       -- (Ty)App's and  Ticks are removed by collectArgs
       Tick _ _ -> error "isWorkFree: unexpected Tick"
       App {}   -> error "isWorkFree: unexpected App"
       TyApp {} -> error "isWorkFree: unexpected TyApp"
 
-  goArg e = eitherM (go False) (pure . const True) (pure e)
+  goArg e = either (go False) (const (cache, True)) e
   isConstantArg = either isConstant (const True)
 
 -- | Determine if a term represents a constant

--- a/clash-lib/src/Clash/Rewrite/WorkFree.hs
+++ b/clash-lib/src/Clash/Rewrite/WorkFree.hs
@@ -22,9 +22,8 @@ module Clash.Rewrite.WorkFree
   , isConstantNotClockReset
   ) where
 
-import Control.Concurrent.MVar (MVar)
-import qualified Clash.Normalize.TracedMVar as MVar
 import Control.Lens as Lens (Lens', use)
+import Control.Monad (when)
 import Control.Monad.State.Class (MonadState)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Data.Text.Extra as Text
@@ -39,7 +38,10 @@ import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (isPolyFunTy)
 import Clash.Core.Util
 import Clash.Core.Var (Id, isLocalId)
-import Clash.Core.VarEnv (VarEnv, extendVarEnv, lookupVarEnv, unionVarEnv)
+import Clash.Core.VarEnv
+  (VarEnv, extendVarEnv, lookupVarEnv, sizeVarEnv, unionVarEnv)
+import Clash.Data.RwVar (RwVar)
+import qualified Clash.Data.RwVar as RwVar
 import Clash.Driver.Types (BindingMap, Binding(..))
 import Clash.Normalize.Primitives (removedArg)
 
@@ -49,13 +51,20 @@ import Clash.Normalize.Primitives (removedArg)
 {-# INLINABLE isWorkFree #-}
 isWorkFree
   :: (HasCallStack, MonadState s m, MonadBaseControl IO m)
-  => Lens' s (MVar (VarEnv Bool))
+  => Lens' s (RwVar (VarEnv Bool))
   -> BindingMap
   -> Term
   -> m Bool
 isWorkFree cacheL bndrs bndr = do
-  lock <- Lens.use cacheL
-  MVar.modifyMVar "workFreeBinders" lock (\cache -> pure (isWorkFreePure cache bndrs bndr))
+  var <- Lens.use cacheL
+  cache0 <- RwVar.readRwVar var
+  let (cache1, res) = isWorkFreePure cache0 bndrs bndr
+  -- The traversal is the expensive part and depends only on immutable data, so
+  -- it runs outside the lock. Entries other threads added in the meantime are
+  -- kept: every entry for a given binder has the same value.
+  when (sizeVarEnv cache1 /= sizeVarEnv cache0) $
+    RwVar.modifyRwVar_ var (pure . unionVarEnv cache1)
+  pure res
 
 -- | Determines whether a global binder is work free. Errors if binder does
 -- not exist.

--- a/clash-lib/src/Control/Concurrent/Async/Lifted/Extra.hs
+++ b/clash-lib/src/Control/Concurrent/Async/Lifted/Extra.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Control.Concurrent.Async.Lifted.Extra where
+
+import Control.Concurrent.Async.Lifted (mapConcurrently, mapConcurrently_)
+import Control.Monad.Base (MonadBase)
+import Control.Monad.Trans.Control (MonadBaseControl)
+
+zipWithConcurrently ::
+  (MonadBaseControl IO m, MonadBase IO m) =>
+  (a -> b -> m c) ->
+  [a] ->
+  [b] ->
+  m [c]
+zipWithConcurrently f xs ys = mapConcurrently (uncurry f) (zip xs ys)
+
+zipWithConcurrently_ ::
+  (MonadBaseControl IO m, MonadBase IO m) =>
+  (a -> b -> m c) ->
+  [a] ->
+  [b] ->
+    m ()
+zipWithConcurrently_ f xs ys = mapConcurrently_ (uncurry f) (zip xs ys)

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -32,6 +32,7 @@ import Clash.Util.Supply (newSupply)
 import Clash.Unique (Unique)
 
 import Control.Applicative ((<|>))
+import Control.Concurrent.MVar (newMVar)
 import Control.DeepSeq (NFData, force)
 import Control.Exception (ErrorCall (..), evaluate, try)
 import Data.Char (isAscii, ord)
@@ -41,7 +42,6 @@ import Language.Haskell.Exts.Syntax
 import Language.Haskell.Exts.Extension (Extension (..), KnownExtension (..))
 import Language.Haskell.Exts.Parser
   (ParseMode (..), defaultParseMode, fromParseResult, parseExpWithMode)
-import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertEqual, assertFailure, testCase)
 import Text.Read (readMaybe)
@@ -85,30 +85,28 @@ instance Default RewriteEnv where
     , _topEntities=emptyVarSet
     }
 
-instance Default extra => Default (RewriteState extra) where
-  def = RewriteState
-    { _transformCounter=0
-    , _transformAppliedCounters=mempty
-    , _transformTriedCounters=mempty
-    , _bindings=emptyVarEnv
-    , _uniqSupply=unsafePerformIO newSupply
-    , _curFun=error "_curFun: NYI"
-    , _nameCounter=2
-    , _workFreeBinders=emptyVarEnv
-    , _hwTypeCache=mempty
-    , _globalHeap=error "_globalHeap: NYI"
-    , _extra=def
-    }
+defRewriteState :: IO (RewriteState NormalizeState)
+defRewriteState = do
+  normState <- NormalizeState
+    <$> newMVar emptyVarEnv
+    <*> newMVar Map.empty
+    <*> newMVar emptyVarEnv
+    <*> newMVar emptyVarEnv
+    <*> newMVar Map.empty
+    <*> newMVar emptyVarEnv
 
-instance Default NormalizeState where
-  def = NormalizeState
-    { _normalized=emptyVarEnv
-    , _specialisationCache=Map.empty
-    , _specialisationHistory=emptyVarEnv
-    , _inlineHistory=emptyVarEnv
-    , _primitiveArgs=Map.empty
-    , _recursiveComponents=emptyVarEnv
-    }
+  RewriteState
+    <$> newMVar mempty
+    <*> newMVar mempty
+    <*> newMVar emptyVarEnv
+    <*> newSupply
+    <*> pure (error "_curFun: NYI")
+    <*> newMVar 2
+    <*> newMVar (error "_globalHeap: NYI")
+    <*> newMVar emptyVarEnv
+    <*> pure mempty
+    <*> newMVar ()
+    <*> pure normState
 
 instance Default InScopeSet where
   def = emptyInScopeSet
@@ -138,8 +136,10 @@ runSingleTransformation rwEnv rwState is trans term = do
 -- include a type translator, evaluator, current function, or global heap. Maps,
 -- like the primitive and tycon map, are also empty. If the transformation under
 -- test needs these definitions, you should add them manually.
-runSingleTransformationDef :: Default extra => Rewrite extra -> C.Term -> IO C.Term
-runSingleTransformationDef = runSingleTransformation def def def
+runSingleTransformationDef :: Rewrite NormalizeState -> C.Term -> IO C.Term
+runSingleTransformationDef rewrite term = do
+  st <- defRewriteState
+  runSingleTransformation def st def rewrite term
 
 
 parseType :: (HasCallStack, Show l) => Type l -> C.Type

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -24,6 +24,7 @@ import qualified Clash.Core.TysPrim as C
 import qualified Clash.Core.Var as C
 import Clash.Core.VarEnv (InScopeSet, emptyVarSet, emptyVarEnv, emptyInScopeSet)
 import Clash.Driver.Types (ClashEnv(..), ClashOpts(..), defClashOpts, debugSilent)
+import qualified Clash.Data.RwVar as RwVar
 import Clash.Rewrite.Types
 import Clash.Rewrite.Util (runRewrite)
 import Clash.Normalize.Types
@@ -92,19 +93,20 @@ defRewriteState = do
     <*> newMVar Map.empty
     <*> newMVar emptyVarEnv
     <*> newMVar emptyVarEnv
-    <*> newMVar Map.empty
-    <*> newMVar emptyVarEnv
+    <*> RwVar.newRwVar Map.empty
+    <*> RwVar.newRwVar emptyVarEnv
 
   RewriteState
     <$> newMVar mempty
     <*> newMVar mempty
-    <*> newMVar emptyVarEnv
+    <*> RwVar.newRwVar emptyVarEnv
     <*> newSupply
     <*> pure (error "_curFun: NYI")
     <*> newMVar 2
     <*> newMVar (error "_globalHeap: NYI")
-    <*> newMVar emptyVarEnv
+    <*> RwVar.newRwVar emptyVarEnv
     <*> pure mempty
+    <*> RwVar.newRwVar mempty
     <*> newMVar ()
     <*> pure normState
 

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -283,6 +283,11 @@ instance IsTest ClashBinaryTest where
       , "-o", oDir </> "out"
       , "-i" <> cbSourceDirectory
       , "-outputdir", oDir
+      -- We want to test concurrent normalization, but Tasty already spawns a bunch
+      -- of threads. We therefore only make normalization run with 2, to prevent
+      -- massive oversubscription.
+      , "-fclash-concurrent-normalization"
+      , "+RTS", "-N2", "-RTS"
       ] <> commonArgs
         <> cbExtraBuildArgs
         <> [cbSourceDirectory </> cbModName <.> "hs"]

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -285,6 +285,10 @@ instance IsTest ClashBinaryTest where
       , "-o", oDir </> "out"
       , "-i" <> cbSourceDirectory
       , "-outputdir", oDir
+      -- Concurrent normalization is on by default, but Tasty already spawns a
+      -- bunch of threads. We therefore only make normalization run with 2, to
+      -- prevent massive oversubscription.
+      , "+RTS", "-N2", "-RTS"
       ] <> commonArgs
         <> cbExtraBuildArgs
         <> [cbSourceDirectory </> cbModName <.> "hs"]

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -39,6 +39,7 @@ import           Clash.Netlist
 import           Clash.Netlist.Types hiding (backend, hdlDir)
 import qualified Clash.Util.Supply as Supply
 
+import qualified Control.Concurrent.MVar as MVar
 import           Control.DeepSeq (force)
 import           Data.Maybe
 import qualified Data.Map.Ordered as OMap
@@ -80,12 +81,14 @@ runToNetlistStage target f src = do
       tes2    = mkVarEnv (P.zip (P.map topId (designEntities design)) (designEntities design))
 
   supplyN <- Supply.newSupply
+  lock <- MVar.newMVar ()
 
   transformedBindings <-
     normalizeEntity env (designBindings design)
       (ghcTypeToHWType (opt_intWidth opts))
       ghcEvaluator
       evaluator
+      lock
       teNames supplyN te
 
   fmap (\(_,x,_) -> force (P.map snd (OMap.assocs x))) $


### PR DESCRIPTION
This adds concurrent normalization by wrapping all state (fields) in `MVar`s. Earlier patches used STM, but this didn't yield a performance benefit due to excessive contention/rollbacks. Explicit locks have all the usual drawbacks of potential deadlocks, which is why `TracedMVar` has been added. This can be enabled by `CLASH_DEBUG_MVAR`.

The feature is enabled by default, but can be disabled using `-fclash-no-concurrent-normalization`.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
  - [x] Rebase on `master`
  - [x] Actually listen to `-fclash-concurrent-normalization`
  - [X] Check on `bittide-hardware`
  - [x] Investigate ``Hit specialization limit 20 on function `Clash.Explicit.Testbench.outputVerifierWith[454934]'.``. This can be triggered semi-reliably by executing `cabal run clash-testsuite -- -j8 -p clash --hide-successes -p XilinxDDR`.
  - [X] Wait for benchmarks: https://clash-lang.github.io/clash-benchmarks/?machine=oele&branch=clash-lang%2Fclash-compiler%40martijn%2Fconcurrent-normalization

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
