### PR TITLE
ci: use macos-26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "windows-latest"]
+        os: ["macos-26", "windows-latest"]
         ghc: ["9.6", "9.8", "9.10"]
         exclude:
           # GHC/Clash starts extremely slowly, see


### PR DESCRIPTION
Should actually have been done by: https://github.com/clash-lang/clash-compiler/pull/3195

But `macos-latest` is not actually "latest", as that still refers to macos-15...