### PR TITLE
Derive instances for `RamOp`

### DIFF
--- a/changelog/2026-04-14T15_56_13+02_00_derive_ramop_instances
+++ b/changelog/2026-04-14T15_56_13+02_00_derive_ramop_instances
@@ -1,0 +1,1 @@
+ADDED: `Eq`, `NFData`, `ShowX` and `BitPack` instances for `RamOp`.

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -429,6 +429,7 @@ where
 
 import Clash.HaskellPrelude
 
+import Control.DeepSeq (NFData)
 import Control.Exception (catch, throw)
 import Control.Monad (forM_)
 import Control.Monad.ST (ST, runST)
@@ -460,7 +461,7 @@ import Clash.Sized.Index (Index)
 import Clash.Sized.Unsigned (Unsigned)
 import Clash.Sized.Vector (Vec, replicate, iterateI)
 import Clash.XException
- (maybeIsX, NFDataX(deepErrorX), defaultSeqX, fromJustX, undefined,
+ (ShowX, maybeIsX, NFDataX(deepErrorX), defaultSeqX, fromJustX, undefined,
  XException (..), seqX, errorX)
 import Clash.XException.MaybeX (MaybeX(..), andX)
 
@@ -1169,7 +1170,7 @@ data RamOp n a
   -- ^ Write data to address
   | RamNoOp
   -- ^ No operation
-  deriving (Generic, NFDataX, Show)
+  deriving (Eq, Generic, NFData, NFDataX, Show, ShowX)
 
 instance (AutoReg a, KnownNat n) => AutoReg (RamOp n a) where
   autoReg clk rst en initVal input =


### PR DESCRIPTION
Derive `Eq`, `NFData`, `ShowX` and `BitPack` for `RamOp`

[comment]: # (Thank you for contributing to Clash. Please fill out this template to describe your contribution and any outstanding tasks / questions.)
[comment]: # (External PRs will not automatically run on CI, this requires approval from a trusted contributer.)

[comment]: # (Add a line of the form "Fixes: #xxxx" for each related issue closed by this pull request, where #xxxx is an issue number.)

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
