### PR TITLE
inline `localparam` in higher Vec higher order blackboxes

### DIFF
--- a/changelog/2026-04-14T17_33_09+02_00_inline_localparams
+++ b/changelog/2026-04-14T17_33_09+02_00_inline_localparams
@@ -1,0 +1,1 @@
+FIXES: Bug where localparams introduced by higher order function blackboxes would cause vivado to segfault

--- a/clash-lib/prims/verilog/Clash_Sized_Vector.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Sized_Vector.primitives.yaml
@@ -86,16 +86,15 @@
       // map begin
       genvar ~GENSYM[i][1];
       ~GENERATE
-      for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]
-        localparam ~GENSYM[vec_index][5] = ~MAXINDEX[~TYPO] - ~SYM[1];~IF~SIZE[~TYP[1]]~THEN
+      for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[map][2]~IF~SIZE[~TYP[1]]~THEN
         wire ~TYPEL[~TYP[1]] ~GENSYM[map_in][3];
-        assign ~SYM[3] = ~VAR[vec][1][~SYM[5]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI
+        assign ~SYM[3] = ~VAR[vec][1][(~MAXINDEX[~TYPO] - ~SYM[1])*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI
         ~OUTPUTUSAGE[0] ~TYPEL[~TYPO] ~GENSYM[map_out][4];
         ~INST 0
           ~OUTPUT <= ~SYM[4]~ ~TYPEL[~TYPO]~
           ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
         ~INST
-        assign ~RESULT[~SYM[5]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[4];
+        assign ~RESULT[(~MAXINDEX[~TYPO] - ~SYM[1])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[4];
       end
       ~ENDGENERATE
       // map end
@@ -109,10 +108,9 @@
       genvar ~GENSYM[i][1];
       ~GENERATE
       for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap][2]
-        localparam ~GENSYM[vec_index][6] = ~MAXINDEX[~TYPO] - ~SYM[1];
         wire [~SIZE[~INDEXTYPE[~LIT[0]]]-1:0] ~GENSYM[map_index][3];~IF~SIZE[~TYP[2]]~THEN
         wire ~TYPEL[~TYP[2]] ~GENSYM[map_in][4];
-        assign ~SYM[4] = ~VAR[vec][2][~SYM[6]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
+        assign ~SYM[4] = ~VAR[vec][2][(~MAXINDEX[~TYPO] - ~SYM[1])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
         ~OUTPUTUSAGE[1] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
 
         assign ~SYM[3] = ~SYM[1][0+:~SIZE[~INDEXTYPE[~LIT[0]]]];
@@ -121,7 +119,7 @@
           ~INPUT  <= ~SYM[3]~ ~INDEXTYPE[~LIT[0]]~
           ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
         ~INST
-        assign ~RESULT[~SYM[6]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
+        assign ~RESULT[(~MAXINDEX[~TYPO] - ~SYM[1])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
       end
       ~ENDGENERATE
       // imap end
@@ -135,10 +133,9 @@
       genvar ~GENSYM[i][1];
       ~GENERATE
       for (~SYM[1]=0; ~SYM[1] < ~LENGTH[~TYPO]; ~SYM[1] = ~SYM[1] + 1) begin : ~GENSYM[imap_go][2]
-        localparam ~GENSYM[vec_index][6] = ~MAXINDEX[~TYPO] - ~SYM[1];
         wire ~TYP[2] ~GENSYM[map_index][3];~IF~SIZE[~TYP[1]]~THEN
         wire ~TYPEL[~TYP[1]] ~GENSYM[map_in][4];
-        assign ~SYM[4] = ~VAR[vec][1][~SYM[6]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI
+        assign ~SYM[4] = ~VAR[vec][1][(~MAXINDEX[~TYPO] - ~SYM[1])*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI
         ~OUTPUTUSAGE[0] ~TYPEL[~TYPO] ~GENSYM[map_out][5];
 
         assign ~SYM[3] = ~SYM[1][0+:~SIZE[~TYP[2]]] + ~ARG[2];
@@ -147,7 +144,7 @@
           ~INPUT  <= ~SYM[3]~ ~TYP[2]~
           ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[1]]~
         ~INST
-        assign ~RESULT[~SYM[6]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
+        assign ~RESULT[(~MAXINDEX[~TYPO] - ~SYM[1])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
       end
       ~ENDGENERATE
       // imap_go end
@@ -160,19 +157,18 @@
       // zipWith start
       genvar ~GENSYM[i][2];
       ~GENERATE
-      for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][6]
-        localparam ~GENSYM[vec_index][7] = ~MAXINDEX[~TYPO] - ~SYM[2];~IF~SIZE[~TYP[1]]~THEN
+      for (~SYM[2] = 0; ~SYM[2] < ~LENGTH[~TYPO]; ~SYM[2] = ~SYM[2] + 1) begin : ~GENSYM[zipWith][6]~IF~SIZE[~TYP[1]]~THEN
         wire ~TYPEL[~TYP[1]] ~GENSYM[zipWith_in1][3];
-        assign ~SYM[3] = ~VAR[vec1][1][~SYM[7]*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN
+        assign ~SYM[3] = ~VAR[vec1][1][(~MAXINDEX[~TYPO] - ~SYM[2])*~SIZE[~TYPEL[~TYP[1]]]+:~SIZE[~TYPEL[~TYP[1]]]];~ELSE ~FI~IF~SIZE[~TYP[2]]~THEN
         wire ~TYPEL[~TYP[2]] ~GENSYM[zipWith_in2][4];
-        assign ~SYM[4] = ~VAR[vec2][2][~SYM[7]*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
+        assign ~SYM[4] = ~VAR[vec2][2][(~MAXINDEX[~TYPO] - ~SYM[2])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
         ~OUTPUTUSAGE[0] ~TYPEL[~TYPO] ~GENSYM[zip_out][5];
         ~INST 0
           ~OUTPUT <= ~SYM[5]~ ~TYPEL[~TYPO]~
           ~INPUT  <= ~SYM[3]~ ~TYPEL[~TYP[1]]~
           ~INPUT  <= ~SYM[4]~ ~TYPEL[~TYP[2]]~
         ~INST
-        assign ~RESULT[~SYM[7]*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
+        assign ~RESULT[(~MAXINDEX[~TYPO] - ~SYM[2])*~SIZE[~TYPEL[~TYPO]]+:~SIZE[~TYPEL[~TYPO]]] = ~SYM[5];
       end
       ~ENDGENERATE
       // zipWith end
@@ -189,9 +185,8 @@
       genvar ~GENSYM[i][3];
       ~GENERATE
       for (~SYM[3]=0; ~SYM[3] < ~LENGTH[~TYP[2]]; ~SYM[3]=~SYM[3]+1) begin : ~GENSYM[foldr][4]~IF~SIZE[~TYP[2]]~THEN
-        localparam ~GENSYM[vec_index][8] = ~MAXINDEX[~TYP[2]] - ~SYM[3];
         wire ~TYPEL[~TYP[2]] ~GENSYM[foldr_in1][5];
-        assign ~SYM[5] = ~VAR[xs][2][(~SYM[8])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
+        assign ~SYM[5] = ~VAR[xs][2][(~MAXINDEX[~TYP[2]] - ~SYM[3])*~SIZE[~TYPEL[~TYP[2]]]+:~SIZE[~TYPEL[~TYP[2]]]];~ELSE ~FI
         wire ~TYPO ~GENSYM[foldr_in2][6];
         ~OUTPUTUSAGE[0] ~TYPO ~GENSYM[foldr_out][7];
 


### PR DESCRIPTION
What:
I inlined the `localparam` declarations in the higher order function blackboxes for Vectors.

Why:
The `localparam` usage causes problems where Vivado runs out of memory, takes ages to synthesize and straight up segfaults. We've found that with this patch vivado passes on the development branch of clash-compiler.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
