### PR TITLE
Fix clash-testsuite nix packaging

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -49,14 +49,14 @@ RUN curl -L "https://github.com/steveicarus/iverilog/archive/${iverilog_version}
 
 FROM builder AS build-symbiyosys
 
-ARG DEPS_YOSYS="libffi-dev libreadline-dev pkg-config tcl-dev"
+ARG DEPS_YOSYS="libffi-dev libfl-dev libreadline-dev pkg-config tcl-dev"
 ARG DEPS_Z3="python3 python3-distutils"
 RUN apt-get install -y --no-install-recommends $DEPS_YOSYS $DEPS_Z3
 
-ARG yosys_version="8cfed1a97957e4c096d1e0a0304d978bcb27e116"
-RUN git clone https://github.com/YosysHQ/yosys.git yosys \
+ARG yosys_version="v0.64"
+RUN git clone --branch $yosys_version --depth 1 https://github.com/YosysHQ/yosys.git yosys \
  && cd yosys \
- && git checkout $yosys_version \
+ && git submodule update --init --recursive \
  && make PREFIX=$PREFIX -j$(nproc) \
  && make PREFIX=$PREFIX install \
  && cd .. \
@@ -85,10 +85,9 @@ RUN curl -L "https://github.com/Boolector/boolector/archive/refs/tags/$boolector
  && cd .. \
  && rm -Rf boolector-$boolector_version
 
-ARG symbiyosys_version="66a458958dc93f8e12418d425e4c31848889937b"
-RUN git clone https://github.com/cliffordwolf/SymbiYosys.git SymbiYosys \
+ARG symbiyosys_version="v0.64"
+RUN git clone --branch $symbiyosys_version --depth 1 https://github.com/cliffordwolf/SymbiYosys.git SymbiYosys \
  && cd SymbiYosys \
- && git checkout $symbiyosys_version \
  && make PREFIX=$PREFIX -j$(nproc) install \
  && cd .. \
  && rm -Rf SymbiYosys
@@ -128,7 +127,7 @@ FROM ubuntu:$UBUNTU_VERSION AS run
 LABEL vendor="QBayLogic B.V." maintainer="devops@qbaylogic.com"
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH="$PATH:/opt/bin:/root/.ghcup/bin"
 
-ARG DEPS_RUNTIME="ca-certificates ccache curl g++ gcc git jq libc6-dev libgmp10-dev libgnat-10 libllvm13 libreadline8 libtinfo-dev libtcl8.6 make perl python3 ssh zlib1g-dev zstd locales libtinfo5 libx11-6"
+ARG DEPS_RUNTIME="ca-certificates ccache curl g++ gcc git jq libc6-dev libgmp10-dev libgnat-10 libllvm13 libreadline8 libtinfo-dev libtcl8.6 make perl python3 python3-click ssh zlib1g-dev zstd locales libtinfo5 libx11-6"
 RUN apt-get update \
  && apt-get install -y --no-install-recommends $DEPS_RUNTIME \
  && apt-get clean \

--- a/.ci/gitlab/benchmark.yml
+++ b/.ci/gitlab/benchmark.yml
@@ -1,5 +1,5 @@
 .benchmark:
-  image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20260331
+  image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-20260417
   stage: test
   timeout: 2 hours
   variables:

--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -12,7 +12,7 @@ default:
   timeout: 2 hours
   stage: build
   variables:
-    CLASH_DOCKER_TAG: 20260331
+    CLASH_DOCKER_TAG: 20260417
     CACHE_BUST_TOKEN: 3
     # Note that the fallback key has two cache bust tokens. `$CACHE_BUST_TOKEN`
     # is our own, defined right above, and the `-3` at the end in the fallback

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
 
     # Run steps inside the clash CI docker image
     container:
-      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20260331
+      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20260417
 
       env:
         THREADS: 2

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -107,6 +107,26 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#clashPackages-${{matrix.ghc}}.${{matrix.package}} | cachix push clash-lang
 
+  testsuite:
+    name: Run Testsuite (${{matrix.ghc}})
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [
+          ghc9124,
+          ghc9103,
+          ghc984,
+          ghc967
+        ]
+
+    needs: packages_other
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run clash-testsuite
+        run: nix run -L .#clashPackages-${{matrix.ghc}}.clash-testsuite
+
   developer_shells:
     name: Build Developer Shells (${{matrix.ghc}})
     runs-on: self-hosted

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -261,7 +261,7 @@ let
                 prev.gcc
                 final.ghdl-llvm
                 prev.sby
-                prev.verilator
+                final.verilator
                 prev.iverilog
                 prev.yosys
                 prev.z3
@@ -282,6 +282,12 @@ let
     ];
 in
 {
+  verilator = prev.verilator.overrideAttrs (old: {
+    patches = prev.lib.unique ((old.patches or [ ]) ++ [
+      ./verilator-fix-side-effect-loss-when-slicing-astexprstmt-array-expressions.patch
+    ]);
+  });
+
   # gnat13 which si the default as of 11.03.2026 does not support aarch64
   # but ghdl-llvm works fine with gnat14 sos witch to it.
   ghdl-llvm = prev.ghdl-llvm.override { gnat = prev.gnat14; };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -232,20 +232,42 @@ let
           ];
 
           postInstall = (old.postInstall or "") + ''
+            ghcBinDir=${dirOf "${old.passthru.env.NIX_GHC}"}
+            ghcLibDir="${old.passthru.env.NIX_GHC_LIBDIR}"
+            globalPackageDb="$ghcLibDir/package.conf.d"
+            testsuitePackageDb="$out/lib/''${ghcLibDir#*/lib/}/package.conf.d"
+            wrapperDir="$out/libexec/clash-testsuite-wrappers"
+
+            mkdir -p "$wrapperDir"
+
+            cat > "$wrapperDir/clash" <<EOF
+            #!${prev.runtimeShell}
+            exec ${hfinal.clash-ghc}/bin/clash \
+              -package-db "$globalPackageDb" \
+              -package-db "$testsuitePackageDb" \
+              "\$@"
+            EOF
+            chmod +x "$wrapperDir/clash"
+
+            "$ghcBinDir/ghc-pkg" recache --package-db="$testsuitePackageDb"
+
             wrapProgram $out/bin/clash-testsuite \
               --add-flags "--no-modelsim --no-vivado" \
-              --prefix PATH : ${dirOf "${old.passthru.env.NIX_GHC}"} \
-              --set GHC_PACKAGE_PATH "${old.passthru.env.NIX_GHC_LIBDIR}/package.conf.d:" \
+              --prefix PATH : "$ghcBinDir" \
+              --prefix PATH : "$wrapperDir" \
+              --set GHC_PACKAGE_PATH "$testsuitePackageDb:$globalPackageDb:" \
+              --set USE_GLOBAL_CLASH 1 \
               --prefix PATH : ${prev.lib.makeBinPath [
                 prev.gcc
-                prev.ghdl-llvm
+                final.ghdl-llvm
                 prev.sby
                 prev.verilator
                 prev.iverilog
                 prev.yosys
+                prev.z3
               ]} \
               --set LIBRARY_PATH ${prev.lib.makeLibraryPath [
-                prev.ghdl-llvm
+                final.ghdl-llvm
                 prev.zlib.static
               ]}
           '';

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -258,7 +258,7 @@ let
                 prev.gcc
                 final.ghdl-llvm
                 prev.sby
-                prev.verilator
+                final.verilator
                 prev.iverilog
                 prev.yosys
                 prev.z3
@@ -279,6 +279,12 @@ let
     ];
 in
 {
+  verilator = prev.verilator.overrideAttrs (old: {
+    patches = prev.lib.unique ((old.patches or [ ]) ++ [
+      ./verilator-fix-side-effect-loss-when-slicing-astexprstmt-array-expressions.patch
+    ]);
+  });
+
   # gnat13 which si the default as of 11.03.2026 does not support aarch64
   # but ghdl-llvm works fine with gnat14 sos witch to it.
   ghdl-llvm = prev.ghdl-llvm.override { gnat = prev.gnat14; };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -229,20 +229,42 @@ let
           ];
 
           postInstall = (old.postInstall or "") + ''
+            ghcBinDir=${dirOf "${old.passthru.env.NIX_GHC}"}
+            ghcLibDir="${old.passthru.env.NIX_GHC_LIBDIR}"
+            globalPackageDb="$ghcLibDir/package.conf.d"
+            testsuitePackageDb="$out/lib/''${ghcLibDir#*/lib/}/package.conf.d"
+            wrapperDir="$out/libexec/clash-testsuite-wrappers"
+
+            mkdir -p "$wrapperDir"
+
+            cat > "$wrapperDir/clash" <<EOF
+            #!${prev.runtimeShell}
+            exec ${hfinal.clash-ghc}/bin/clash \
+              -package-db "$globalPackageDb" \
+              -package-db "$testsuitePackageDb" \
+              "\$@"
+            EOF
+            chmod +x "$wrapperDir/clash"
+
+            "$ghcBinDir/ghc-pkg" recache --package-db="$testsuitePackageDb"
+
             wrapProgram $out/bin/clash-testsuite \
               --add-flags "--no-modelsim --no-vivado" \
-              --prefix PATH : ${dirOf "${old.passthru.env.NIX_GHC}"} \
-              --set GHC_PACKAGE_PATH "${old.passthru.env.NIX_GHC_LIBDIR}/package.conf.d:" \
+              --prefix PATH : "$ghcBinDir" \
+              --prefix PATH : "$wrapperDir" \
+              --set GHC_PACKAGE_PATH "$testsuitePackageDb:$globalPackageDb:" \
+              --set USE_GLOBAL_CLASH 1 \
               --prefix PATH : ${prev.lib.makeBinPath [
                 prev.gcc
-                prev.ghdl-llvm
+                final.ghdl-llvm
                 prev.sby
                 prev.verilator
                 prev.iverilog
                 prev.yosys
+                prev.z3
               ]} \
               --set LIBRARY_PATH ${prev.lib.makeLibraryPath [
-                prev.ghdl-llvm
+                final.ghdl-llvm
                 prev.zlib.static
               ]}
           '';

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -249,13 +249,15 @@ let
             "$ghcBinDir/ghc-pkg" recache --package-db="$testsuitePackageDb"
 
             wrapProgram $out/bin/clash-testsuite \
-              --add-flags "--no-modelsim --no-vivado" \
               --prefix PATH : "$ghcBinDir" \
               --prefix PATH : "$wrapperDir" \
               --set GHC_PACKAGE_PATH "$testsuitePackageDb:$globalPackageDb:" \
               --set USE_GLOBAL_CLASH 1 \
               --prefix PATH : ${prev.lib.makeBinPath [
                 prev.gcc
+                # make and python3 are used in verilator invocations
+                prev.gnumake
+                prev.python3
                 final.ghdl-llvm
                 prev.sby
                 final.verilator
@@ -279,6 +281,7 @@ let
     ];
 in
 {
+  # This patch can be removed once verilator 5.048 has reached nixpkgs.
   verilator = prev.verilator.overrideAttrs (old: {
     patches = prev.lib.unique ((old.patches or [ ]) ++ [
       ./verilator-fix-side-effect-loss-when-slicing-astexprstmt-array-expressions.patch

--- a/nix/verilator-fix-side-effect-loss-when-slicing-astexprstmt-array-expressions.patch
+++ b/nix/verilator-fix-side-effect-loss-when-slicing-astexprstmt-array-expressions.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rowan Goemans <rowan@example.com>
+Date: Wed, 15 Apr 2026 00:00:00 +0200
+Subject: [PATCH] Fix side-effect loss when slicing AstExprStmt array
+ expressions
+
+diff --git a/src/V3Slice.cpp b/src/V3Slice.cpp
+index 81e622ee2..092f7ba24 100644
+--- a/src/V3Slice.cpp
++++ b/src/V3Slice.cpp
+@@ -283,16 +283,6 @@ class SliceVisitor final : public VNVisitor {
+             AstNodeAssign* const newp
+                 = nodep->cloneType(cloneAndSel(nodep->lhsp(), elements, elemIdx, elemIdx != 0),
+                                    cloneAndSel(nodep->rhsp(), elements, elemIdx, elemIdx != 0));
+-            if (elemIdx == 0) {
+-                nodep->foreach([this](AstExprStmt* const exprp) {
+-                    // Result expression is always evaluated to the same value, so the statements
+-                    // can be removed once they were included in the expression created for the 1st
+-                    // element.
+-                    AstNodeExpr* const resultp = exprp->resultp()->unlinkFrBack();
+-                    exprp->replaceWith(resultp);
+-                    VL_DO_DANGLING(pushDeletep(exprp), exprp);
+-                });
+-            }
+             UINFOTREE(9, newp, "", "new");
+             newlistp = AstNode::addNext(newlistp, newp);
+         }
+@@ -356,17 +346,6 @@ class SliceVisitor final : public VNVisitor {
+                 T_NodeBiop* const clonep = new T_NodeBiop{
+                     nodep->fileline(), cloneAndSel(nodep->lhsp(), elements, elemIdx, elemIdx != 0),
+                     cloneAndSel(nodep->rhsp(), elements, elemIdx, elemIdx != 0)};
+-                if (elemIdx == 0) {
+-                    nodep->foreach([this](AstExprStmt* const exprp) {
+-                        // Result expression is always evaluated to the same value, so the
+-                        // statements can be removed once they were included in the expression
+-                        // created for the 1st element.
+-                        AstNodeExpr* const resultp = exprp->resultp()->unlinkFrBack();
+-                        exprp->replaceWith(resultp);
+-                        VL_DO_DANGLING(pushDeletep(exprp), exprp);
+-                    });
+-                }
+-
+                 if (!logp) {
+                     logp = clonep;
+                 } else {
+-- 
+2.49.0
+

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -305,7 +305,7 @@ runClashTest = defaultMain
           , hdlLoad=[]
           , hdlSim=[]
           , verificationTool=Just SymbiYosys
-          , expectVerificationFail=Just (def, "Unreached cover statement at B")
+          , expectVerificationFail=Just (def, "Unreached cover statement at topEntity: B")
           }
         ]
       , clashTestGroup "ZeroWidth"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -311,7 +311,7 @@ runClashTest = defaultMain
           , hdlLoad=[]
           , hdlSim=[]
           , verificationTool=Just SymbiYosys
-          , expectVerificationFail=Just (def, "Unreached cover statement at B")
+          , expectVerificationFail=Just (def, "Unreached cover statement at topEntity: B")
           }
         ]
       , clashTestGroup "ZeroWidth"


### PR DESCRIPTION
This will allows running the clash-testsuite via the flake. Which is currently FUBAR.

TODO:

- [x] Look into why verilator output is different.