### PR TITLE
Run post-normalization `caseCon` as `bottomupR`

### DIFF
--- a/changelog/2026-04-16T16_15_15+02_00_fix_3204
+++ b/changelog/2026-04-16T16_15_15+02_00_fix_3204
@@ -1,0 +1,1 @@
+FIXED: Post-normalization flattening could leave a `Just` constructor as the scrutinee of a `case` after simplifying tuple projections [#3204](https://github.com/clash-lang/clash-compiler/issues/3204)

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -400,8 +400,8 @@ flattenCallTree (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
       -- has been done to avoid #3036.
       topdownSucR (apply "collapseRHSNoops" collapseRHSNoops) >->
       topdownSucR (apply "inlineCleanup" inlineCleanup) >->
-      topdownSucR (apply "caseCon" caseCon) >-> -- https://github.com/clash-lang/clash-compiler/issues/3159
-      bottomupR (apply "flattenLet" flattenLet) >-> -- https://github.com/clash-lang/clash-compiler/issues/3185
+      bottomupR (apply "caseCon" caseCon) >-> -- https://github.com/clash-lang/clash-compiler/issues/3159
+      bottomupR (apply "flattenLet" flattenLet) >-> -- https://github.com/clash-lang/clash-compiler/issues/3185 / #3204
       topdownSucR (apply "topLet" topLet)
 
     goCheap c@(CLeaf   (nm2,(Binding _ _ inl2 _ e _)))

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -674,6 +674,7 @@ runClashTest = defaultMain
         , outputTest "T3147" def{hdlTargets=[Verilog], hdlSim=[]}
         , runTest "T3159" def{hdlSim=[], hdlLoad=[] }
         , runTest "T3185" def
+        , runTest "T3204" def{hdlSim=[], hdlLoad=[], hdlTargets=[Verilog]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T3204.hs
+++ b/tests/shouldwork/Issues/T3204.hs
@@ -1,0 +1,9 @@
+module T3204 where
+
+import Clash.Prelude
+
+topEntity :: Clock System -> Reset System -> Signal System Bool
+topEntity clk rst = withClockResetEnable clk rst enableGen (maybe False id <$> snd foo)
+
+foo :: HiddenClockResetEnable dom => ((), Signal dom (Maybe Bool))
+foo = ((), Just <$> register False (pure False))


### PR DESCRIPTION
Perhaps this is a too brutish of a solution :)

Fixes https://github.com/clash-lang/clash-compiler/issues/3204

## Stil TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] Test bittide
  - [x] Synthesize some working bittide instances before/after this PR to see if this introduces a performance regression 

