### PR TITLE
Remove GHC mmap crash workaround from Nix

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -132,10 +132,9 @@ let
       clash-ghc =
         let
           unmodified =
-            hprev.callCabal2nixWithOptions
+            hprev.callCabal2nix
               "clash-ghc"
-              ../clash-ghc
-              "--flag workaround-ghc-mmap-crash" {
+              ../clash-ghc {
               inherit (hfinal) clash-lib clash-prelude;
             };
         in
@@ -167,10 +166,9 @@ let
         };
 
       clash-prelude =
-        hprev.callCabal2nixWithOptions
+        hprev.callCabal2nix
           "clash-prelude"
           ../clash-prelude
-          "--flag workaround-ghc-mmap-crash"
           { };
 
       clash-prelude-hedgehog =
@@ -219,10 +217,9 @@ let
       clash-testsuite =
         let
           unmodified =
-            hprev.callCabal2nixWithOptions
+            hprev.callCabal2nix
               "clash-testsuite"
-              ../tests
-              "--flag workaround-ghc-mmap-crash" {
+              ../tests {
               inherit (hfinal) clash-ghc clash-lib clash-prelude;
             };
         in


### PR DESCRIPTION
GHC 9.6 and newer should no longer be affected by this. In CI, only the Nix jobs still carry this option. Let's remove it and once some time has passed without the bug happening, we can remove all the plumbing for it.

I did see this error pop up not too long ago, but most likely that was in Clash 1.8.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
