### PR TITLE
Account for custom bit representations in `dataToTag`

### DIFF
--- a/changelog/2026-04-26T20_02_28+02_00_fix_2724
+++ b/changelog/2026-04-26T20_02_28+02_00_fix_2724
@@ -1,0 +1,1 @@
+FIXED: Clash no longer produces an error when using `dataToTag` in combination with custom bit representations. See [#2724](https://github.com/clash-lang/clash-compiler/issues/2724).

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -553,18 +553,7 @@ mkPrimitive bbEParen bbEasD declType dst pInfo args tickDecls =
               [Right _,Left (Data dc)] -> do
                 iw <- Lens.view intWidth
                 return (N.Literal (Just (Signed iw,iw)) (NumLit $ toInteger $ dcTag dc - 1),[])
-              [Right _,Left scrut] -> do
-                tcm      <- Lens.view tcCache
-                let scrutTy = inferCoreTypeOf tcm scrut
-                scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-                (scrutExpr,scrutDecls) <-
-                  mkExpr False declType (NetlistId (Id.unsafeMake "c$dtt_rhs") scrutTy) scrut
-                case scrutExpr of
-                  Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
-                  _ -> do
-                    tmpRhs <- Id.make "c$dtt_rhs"
-                    netDecl <- N.mkInit declType assignTy tmpRhs scrutHTy scrutExpr
-                    return (DataTag scrutHTy (Right tmpRhs),netDecl ++ scrutDecls)
+              [Right _,Left scrut] -> mkDataToTag declType assignTy scrut
               _ -> error $ $(curLoc) ++ "dataToTag: " ++ show (map (either showPpr showPpr) args)
 
           | pNm `elem`
@@ -572,18 +561,7 @@ mkPrimitive bbEParen bbEasD declType dst pInfo args tickDecls =
               [Right _, Right _,Left (Data dc)] -> do
                 iw <- Lens.view intWidth
                 return (N.Literal (Just (Signed iw,iw)) (NumLit $ toInteger $ dcTag dc - 1),[])
-              [Right _, Right _,Left scrut] -> do
-                tcm      <- Lens.view tcCache
-                let scrutTy = inferCoreTypeOf tcm scrut
-                scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
-                (scrutExpr,scrutDecls) <-
-                  mkExpr False declType (NetlistId (Id.unsafeMake "c$dtt_rhs") scrutTy) scrut
-                case scrutExpr of
-                  Identifier id_ Nothing -> return (DataTag scrutHTy (Right id_),scrutDecls)
-                  _ -> do
-                    tmpRhs <- Id.make "c$dtt_rhs"
-                    netDecl <- N.mkInit declType assignTy tmpRhs scrutHTy scrutExpr
-                    return (DataTag scrutHTy (Right tmpRhs),netDecl ++ scrutDecls)
+              [Right _, Right _,Left scrut] -> mkDataToTag declType assignTy scrut
               _ -> error $ $(curLoc) ++ "dataToTag: " ++ show (map (either showPpr showPpr) args)
 
           | pNm == "Clash.Explicit.SimIO.mealyIO" -> do
@@ -789,6 +767,58 @@ mkPrimitive bbEParen bbEasD declType dst pInfo args tickDecls =
       Nothing -> pure Nothing
       Just ([id_],[nm_],decls) -> pure (Just (id_,nm_,decls))
       _ -> error "internal error"
+
+-- | Lower a non-constant @dataToTag# scrut@ to netlist. For plain @Sum@/@SP@
+-- types, the bits stored in @scrut@ /are/ the GHC tag, so a 'DataTag' netlist
+-- expression that the backend renders as a bit-extract is sufficient. For
+-- types with a user-defined bit representation (@CustomSum@, @CustomSP@,
+-- @CustomProduct@) the stored bits are arbitrary, so we lower to a
+-- 'CondAssignment' that maps each constructor's custom bit pattern back to
+-- its GHC tag (@dcTag - 1@). See issue #2724.
+mkDataToTag
+  :: HasCallStack
+  => DeclarationType
+  -> Usage
+  -> Term
+  -> NetlistMonad (Expr, [Declaration])
+mkDataToTag declType assignTy scrut = do
+  tcm      <- Lens.view tcCache
+  let scrutTy = inferCoreTypeOf tcm scrut
+  scrutHTy <- unsafeCoreTypeToHWTypeM' $(curLoc) scrutTy
+  (scrutExpr, scrutDecls) <-
+    mkExpr False declType (NetlistId (Id.unsafeMake "c$dtt_rhs") scrutTy) scrut
+  (scrutId, scrutDecls') <- case scrutExpr of
+    Identifier id_ Nothing -> pure (id_, scrutDecls)
+    _ -> do
+      tmpRhs <- Id.make "c$dtt_rhs"
+      netDecl <- N.mkInit declType assignTy tmpRhs scrutHTy scrutExpr
+      pure (tmpRhs, netDecl ++ scrutDecls)
+  let nReprs = case scrutHTy of
+        CustomSum _ _ _ reprs -> Just (length reprs)
+        CustomSP  _ _ _ reprs -> Just (length reprs)
+        CustomProduct {}      -> Just 1
+        _                     -> Nothing
+  case nReprs of
+    Nothing -> pure (DataTag scrutHTy (Right scrutId), scrutDecls')
+    Just k -> do
+      iw <- Lens.view intWidth
+      let sIw = Signed iw
+      if k <= 1
+        then pure ( N.Literal (Just (sIw, iw)) (NumLit 0)
+                  , scrutDecls' )
+        else do
+          tag <- Id.make "c$dtt_tag"
+          let alts = [ ( Just (NumLit (toInteger i))
+                       , N.Literal (Just (sIw, iw)) (NumLit (toInteger i)))
+                     | i <- [0 .. k - 1] ]
+              tagDecl = NetDecl' Nothing tag sIw Nothing
+          assn <- N.condAssign tag sIw (Identifier scrutId Nothing) scrutHTy alts
+          -- Wrap the tag identifier in an identity 'DataCon' so the caller's
+          -- catch-all assignment fires (an 'Identifier _ Nothing' would be
+          -- skipped, leaving the destination unassigned). All backends render
+          -- 'DataCon _ (DC (Void {}, -1)) [e]' as 'e' verbatim.
+          pure ( N.DataCon sIw (DC (Void Nothing, -1)) [Identifier tag Nothing]
+               , tagDecl : assn : scrutDecls' )
 
 -- | Turn a 'mealyIO' expression into a two sequential processes, one "initial"
 -- process for the starting state, and one clocked sequential process.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -657,6 +657,8 @@ runClashTest = defaultMain
         , runTest "T2593" def{hdlSim=[]}
         , runTest "T2623CaseConFVs" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         , runTest "T2628" def{hdlTargets=[VHDL], buildTargets=BuildSpecific ["TACacheServerStep"], hdlSim=[]}
+        , runTest "T2724" def
+        , runTest "T2724B" def
         , runTest "T2729" def
         , runTest "T2831" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         , runTest "T2839" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}

--- a/tests/shouldwork/Issues/T2724.hs
+++ b/tests/shouldwork/Issues/T2724.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module T2724 where
+
+import Clash.Annotations.BitRepresentation
+import Clash.Explicit.Testbench
+import Clash.Prelude
+
+-- From #2724: DataTag on a CustomSum type crashes the Verilog backend.
+data Animal = Turtle | Wombat | Bear
+    deriving (Generic, NFDataX, ShowX, Eq)
+
+{-# ANN module (DataReprAnn
+                $(liftQ [t|Animal|])
+                2
+                [ ConstrRepr 'Turtle 0b11 0b00 []
+                , ConstrRepr 'Wombat 0b11 0b01 []
+                , ConstrRepr 'Bear   0b11 0b10 []
+                ]) #-}
+
+topEntity :: Signal System Animal -> Signal System Bool
+topEntity = fmap (== Bear)
+{-# OPAQUE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+ where
+  testInputs = stimuliGenerator clk rst (Turtle :> Wombat :> Bear :> Nil)
+  expectedOutputs =
+    outputVerifier' clk rst (False :> False :> True :> Nil)
+  done = expectedOutputs (topEntity testInputs)
+  clk = tbSystemClockGen (not <$> done)
+  rst = systemResetGen
+{-# OPAQUE testBench #-}

--- a/tests/shouldwork/Issues/T2724B.hs
+++ b/tests/shouldwork/Issues/T2724B.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module T2724B where
+
+import Clash.Annotations.BitRepresentation
+import Clash.Explicit.Testbench
+import Clash.Prelude
+
+-- Non-monotone variant of T2724: the user-defined bit patterns do not match
+-- the GHC tag order, so a naive bit-slice fix would silently produce wrong
+-- results.
+data Animal = Turtle | Wombat | Bear
+    deriving (Generic, NFDataX, ShowX, Eq)
+
+{-# ANN module (DataReprAnn
+                $(liftQ [t|Animal|])
+                2
+                [ ConstrRepr 'Turtle 0b11 0b10 []
+                , ConstrRepr 'Wombat 0b11 0b00 []
+                , ConstrRepr 'Bear   0b11 0b01 []
+                ]) #-}
+
+topEntity :: Signal System Animal -> Signal System Bool
+topEntity = fmap (== Bear)
+{-# OPAQUE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+ where
+  testInputs = stimuliGenerator clk rst (Turtle :> Wombat :> Bear :> Nil)
+  expectedOutputs =
+    outputVerifier' clk rst (False :> False :> True :> Nil)
+  done = expectedOutputs (topEntity testInputs)
+  clk = tbSystemClockGen (not <$> done)
+  rst = systemResetGen
+{-# OPAQUE testBench #-}


### PR DESCRIPTION
A common codepath, `mkDataToTag`, now generates a case statement that essentially amounts to:

    case x of
      C0 {} -> 0
      C1 {} -> 1
      _  {} -> 2

This case expression will be picked up by the netlist backend and will account for custom bit representations. To keep the HDL readable, the case will only be emitted for types with a custom bit representation.

Fixes #2724

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
