### PR TITLE
Prevent duplicate `attribute`s in VHDL backend

### DIFF
--- a/changelog/2026-04-26T20_19_52+02_00_fix_3218
+++ b/changelog/2026-04-26T20_19_52+02_00_fix_3218
@@ -1,0 +1,1 @@
+FIXED: Clash will no longer generate duplicate `attribute` when they're both used for top entity ports and internal signals. See [#3218](https://github.com/clash-lang/clash-compiler/issues/3218). The VHDL backend now also reports a clearer error when a synthesis attribute is declared with conflicting types in the same design.

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -970,14 +970,18 @@ entity c = do
 architecture :: Component -> VHDLM Doc
 architecture c = do {
   ; syn <- Ap hdlSyn
-  ; let attrs = case syn of
+  -- The entity declarative region is implicitly visible inside the
+  -- architecture, so re-declaring `attribute X : T;` here for an `X` already
+  -- declared by the entity produces a duplicate declaration that GHDL rejects.
+  -- Skip declarations for any (name, type) pair already emitted by the entity.
+  ; let (entityDeclared, attrs) = case syn of
                   -- See: [Note] Hack entity attributes in architecture
-                  Other -> declAttrs
-                  _     -> inputAttrs ++ outputAttrs ++ declAttrs
+                  Other -> (entityDeclaredAttrTypes c, declAttrs)
+                  _     -> (mempty, inputAttrs ++ outputAttrs ++ declAttrs)
   ; nest 2
       (("architecture structural of" <+> pretty (componentName c) <+> "is" <> line <>
        decls (declarations c)) <> line <>
-       if null attrs then emptyDoc else line <> line <> renderAttrs (TextS.pack "signal") attrs) <> line <>
+       if null attrs then emptyDoc else line <> line <> renderAttrsSkippingDecls (TextS.pack "signal") entityDeclared attrs) <> line <>
     nest 2
       ("begin" <> line <>
        insts (declarations c)) <> line <>
@@ -993,6 +997,14 @@ architecture c = do {
    isNetDecl NetDecl'{} = True
    isNetDecl _          = False
 
+-- | The (name, type) pairs of attribute declarations emitted by 'entity' for a
+-- given component. Only for input and output ports, not for any internal signals.
+entityDeclaredAttrTypes :: Component -> HashMap TextS.Text TextS.Text
+entityDeclaredAttrTypes c = attrTypes (map snd (inputAttrs ++ outputAttrs))
+ where
+  inputAttrs  = [(id_, attr) | (id_, hwtype) <- inputs c, attr <- hwTypeAttrs hwtype]
+  outputAttrs = [(id_, attr) | (_, (id_, hwtype), _) <- outputs c, attr <- hwTypeAttrs hwtype]
+
 attrType ::
   HashMap TextS.Text TextS.Text ->
   Attr TextS.Text ->
@@ -1001,10 +1013,11 @@ attrType types attr =
   case HashMap.lookup name' types of
     Nothing    -> HashMap.insert name' type' types
     Just type'' | type'' == type' -> types
-                | otherwise -> error $
-                      $(curLoc) ++ unwords [ TextS.unpack name', "already assigned"
-                                           , TextS.unpack type'', "while we tried to"
-                                           , "add", TextS.unpack type' ]
+                | otherwise -> error $ [I.i|
+                    Synthesis attribute '#{TextS.unpack name'}' was declared with
+                    conflicting types '#{TextS.unpack type''}' and '#{TextS.unpack type'}'.
+                    An attribute must have a single type across the entire design.
+                  |]
  where
   name' = attrName attr
   type' = case attr of
@@ -1054,15 +1067,28 @@ renderAttrs
   :: TextS.Text
   -> [(Identifier, Attr TextS.Text)]
   -> VHDLM Doc
-renderAttrs what (attrMap -> attrs) =
+renderAttrs what = renderAttrsSkippingDecls what HashMap.empty
+
+-- | Like 'renderAttrs', but skip emitting the @attribute X : T;@ declaration
+-- line for any name that appears in the supplied @name -> type@ map with the
+-- same type.
+renderAttrsSkippingDecls
+  :: TextS.Text
+  -> HashMap TextS.Text TextS.Text
+  -> [(Identifier, Attr TextS.Text)]
+  -> VHDLM Doc
+renderAttrsSkippingDecls what skipDecls (attrMap -> attrs) =
   vcat $ sequence $ intersperse " " $ map renderAttrGroup (HashMap.toList attrs)
  where
   renderAttrGroup
     :: (TextS.Text, (TextS.Text, [(TextS.Text, TextS.Text)]))
     -> VHDLM Doc
   renderAttrGroup (attrname, (typ, elems)) =
-    ("attribute" <+> stringS attrname <+> colon <+> stringS typ <> semi)
-    <> line <>
+    (if HashMap.lookup attrname skipDecls == Just typ
+       then emptyDoc
+       else ("attribute" <+> stringS attrname <+> colon <+> stringS typ <> semi)
+            <> line)
+    <>
     (vcat $ sequence $ map (renderAttrDecl attrname) elems)
 
   renderAttrDecl

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -258,6 +258,10 @@ runClashTest = defaultMain
             hdlTargets=[VHDL]
           , expectClashFail=Just (def, "Cannot use attribute annotations on product types of top entities")
           }
+        , runTest "ConflictingAttrTypes" def{
+            hdlTargets=[VHDL]
+          , expectClashFail=Just (def, "Synthesis attribute 'foo' was declared with conflicting types")
+          }
         ]
       , clashTestGroup "Testbench"
         [ runTest "UnsafeOutputVerifier" def{
@@ -682,6 +686,7 @@ runClashTest = defaultMain
         , runTest "T3159" def{hdlSim=[], hdlLoad=[] }
         , runTest "T3185" def
         , runTest "T3204" def{hdlSim=[], hdlLoad=[], hdlTargets=[Verilog]}
+        , runTest "T3218" def{hdlTargets=[VHDL], hdlSim=[]}
         , outputTest "T3232" def{hdlTargets=[Verilog], hdlSim=[]}
         , outputTest "T3224" def{hdlTargets=[VHDL], hdlSim=[], hdlLoad=[]}
         ] <>

--- a/tests/shouldfail/SynthesisAttributes/ConflictingAttrTypes.hs
+++ b/tests/shouldfail/SynthesisAttributes/ConflictingAttrTypes.hs
@@ -1,0 +1,25 @@
+{-# OPTIONS_GHC -O0 #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module ConflictingAttrTypes where
+
+import Clash.Prelude
+import Clash.Annotations.SynthesisAttributes
+
+topEntity ::
+  Clock System ->
+  Reset System ->
+  Enable System ->
+  Signal System (BitVector 8) ->
+  ( Signal System (BitVector 8) `Annotate` 'StringAttr "foo" "B1"
+  , Signal System (BitVector 8)
+  )
+topEntity clk rst ena i = (leds, leds2)
+ where
+  leds = withClockResetEnable clk rst ena $ register 0 (liftA2 xor i next)
+
+  leds2 = withClockResetEnable clk rst ena $ register 0 (liftA2 xor i next)
+
+  next :: Signal System (BitVector 8) `Annotate` 'BoolAttr "foo" True
+  next = withClockResetEnable clk rst ena $ register 0 leds
+{-# OPAQUE topEntity #-}

--- a/tests/shouldwork/Issues/T3218.hs
+++ b/tests/shouldwork/Issues/T3218.hs
@@ -1,0 +1,21 @@
+{-# OPTIONS_GHC -O0 #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module T3218 where
+
+import Clash.Prelude
+import Clash.Annotations.SynthesisAttributes
+
+topEntity ::
+  Clock System ->
+  Reset System ->
+  Enable System ->
+  Signal System (BitVector 8) ->
+  Signal System (BitVector 8) `Annotate` 'StringAttr "foo" "B1"
+topEntity clk rst ena i = leds
+ where
+  leds :: Signal System (BitVector 8) `Annotate` 'StringAttr "foo" "B2"
+  leds = withClockResetEnable clk rst ena $ register 0 (liftA2 xor i next)
+
+  next = withClockResetEnable clk rst ena $ register 0 leds
+{-# OPAQUE topEntity #-}


### PR DESCRIPTION
Fixes #3218

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~