### PR TITLE
Do not duplicate synthesis attributes in `mkUniqueNormalized`

### DIFF
--- a/changelog/2026-04-26T19_59_07+00_00_fix_3224
+++ b/changelog/2026-04-26T19_59_07+00_00_fix_3224
@@ -1,0 +1,1 @@
+FIXED: Due to HDL standards, when the result of a top entity is read by another binder Clash is forced to introduce an internal indirection signal. Clash no longer attaches the top entity's `Annotate` synthesis attributes to that internal signal, preventing duplicate synthesis attributes in the generated HDL. See [#3224](https://github.com/clash-lang/clash-compiler/issues/3224).

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -54,6 +54,7 @@ module Clash.Core.Type
   , normalizeType
   , varAttrs
   , typeAttrs
+  , stripAnnTypes
   )
 where
 
@@ -364,6 +365,12 @@ isPolyFunCoreTy _ ty = case tyView ty of
 typeAttrs :: Type -> [Attr Text]
 typeAttrs (AnnType attrs _typ) = attrs
 typeAttrs _                    = []
+
+-- | Remove all 'AnnType' wrappers from a type, returning the underlying type
+-- without any synthesis attributes.
+stripAnnTypes :: Type -> Type
+stripAnnTypes (AnnType _ typ) = stripAnnTypes typ
+stripAnnTypes typ             = typ
 
 -- | Is a type a function type?
 isFunTy :: TyConMap

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -101,7 +101,7 @@ import           Clash.Core.TyCon
   (TyCon (FunTyCon), TyConName, TyConMap, tyConDataCons)
 import           Clash.Core.Type
   (LitTy (..), Type (..), TyVar, TypeView (..), coreView, coreView1, normalizeType,
-   splitTyConAppM, tyView)
+   splitTyConAppM, stripAnnTypes, tyView)
 import           Clash.Core.Util
   (substArgTys, tyLitShow)
 import           Clash.Core.Var
@@ -815,8 +815,12 @@ mkUniqueNormalized is0 topMM (args, binds, res) = do
             pure (res1, Nothing, subst0)
           Just (_, newName0) -> do
             -- Result binder was renamed. We cannot rename 'res1', so we need
-            -- to create an indirection.
-            ([newName1], s) <- mkUnique subst0 [newName0]
+            -- to create an indirection. The indirection binder is an internal
+            -- signal, so it must not inherit any 'AnnType' synthesis attributes
+            -- attached to the top entity's return type; those belong on the
+            -- output port only. See #3224.
+            let newName0' = newName0 { varType = stripAnnTypes (coreTypeOf newName0) }
+            ([newName1], s) <- mkUnique subst0 [newName0']
             pure (newName1, Just (res1, Var newName1), s)
 
       let

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -683,6 +683,7 @@ runClashTest = defaultMain
         , runTest "T3185" def
         , runTest "T3204" def{hdlSim=[], hdlLoad=[], hdlTargets=[Verilog]}
         , outputTest "T3232" def{hdlTargets=[Verilog], hdlSim=[]}
+        , outputTest "T3224" def{hdlTargets=[VHDL], hdlSim=[], hdlLoad=[]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T3224.hs
+++ b/tests/shouldwork/Issues/T3224.hs
@@ -1,0 +1,42 @@
+{-# OPTIONS_GHC -O0 #-}
+
+module T3224 where
+
+import qualified Prelude as P
+
+import Clash.Prelude
+import Clash.Annotations.SynthesisAttributes
+
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+topEntity ::
+  Clock System ->
+  Reset System ->
+  Enable System ->
+  Signal System (BitVector 8) ->
+  Signal System (BitVector 8) `Annotate` StringAttr "foo" "B2"
+topEntity clk rst ena i = leds
+ where
+  leds = liftA2 xor i regOut
+  regOut = withClockResetEnable clk rst ena $ register 0 leds
+{-# OPAQUE topEntity #-}
+
+countOccurrences :: String -> String -> Int
+countOccurrences needle = go
+ where
+  n = P.length needle
+  go [] = 0
+  go s@(_:rest)
+    | needle == P.take n s = 1 + go rest
+    | otherwise = go rest
+
+mainVHDL :: IO ()
+mainVHDL = do
+  [topDir] <- getArgs
+  content <- P.readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
+
+  let n = countOccurrences "\"B2\"" content
+  if n == 1
+    then return ()
+    else P.error (P.concat ["Expected exactly 1 occurrence of \"B2\", found ", P.show n, ":\n\n", content])


### PR DESCRIPTION
Fixes #3224

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~

