### PR TITLE
Memoize results in `flattenCallTree`

### DIFF
--- a/changelog/2026-05-01T17_12_57+02_00_cache_flattenCallTree
+++ b/changelog/2026-05-01T17_12_57+02_00_cache_flattenCallTree
@@ -1,0 +1,1 @@
+FIXED: `flattenCallTree` now caches intermediate results, reducing Clash normalization by 10% for realistic designs. Fixes #[3246](https://github.com/clash-lang/clash-compiler/issues/3246).

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -24,6 +24,9 @@ import           Control.Monad.State.Strict       (State)
 import           Data.Default                     (def)
 import           Data.Either                      (lefts,partitionEithers)
 import qualified Data.IntMap                      as IntMap
+import qualified Data.IORef                       as IORef
+import           Clash.Data.UniqMap               (UniqMap)
+import qualified Clash.Data.UniqMap               as UniqMap
 import           Data.List
   (intersect, mapAccumL)
 import qualified Data.Map                         as Map
@@ -258,7 +261,8 @@ cleanupGraph
   -> NormalizeSession BindingMap
 cleanupGraph topEntity norm
   | Just ct <- mkCallTree [] norm topEntity
-  = do ctFlat <- flattenCallTree ct
+  = do cache <- liftIO (IORef.newIORef UniqMap.empty)
+       ctFlat <- flattenCallTree cache ct
        return (mkVarEnv $ snd $ callTreeToList [] ctFlat)
 cleanupGraph _ norm = return norm
 
@@ -342,74 +346,90 @@ flattenNode b@(CBranch (nm,(Binding _ _ _ _ e _)) us) = do
            then return (Right ((nm,e),us))
            else return (Left b)
 
+-- | Flatten a 'CallTree', memoizing results by binder Id within one cleanup
+-- pass. Without the cache, every binder reachable from the root is flattened
+-- as many times as it appears in the (un-deduplicated) call tree.
 flattenCallTree
-  :: CallTree
+  :: IORef.IORef (UniqMap CallTree)
+  -- ^ Memo cache, keyed by binder Id. Local to one 'cleanupGraph' call.
+  -> CallTree
   -> NormalizeSession CallTree
-flattenCallTree c@(CLeaf _) = return c
-flattenCallTree (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
-  flattenedUsed   <- mapM flattenCallTree used
-  (newUsed,il_ct) <- partitionEithers <$> mapM flattenNode flattenedUsed
-  let (toInline,il_used) = unzip il_ct
-      subst = extendGblSubstList (mkSubst emptyInScopeSet) toInline
-  newExpr <- case toInline of
-    [] -> return tm
-    _  -> do
-      let tm1 = substTm "flattenCallTree.flattenExpr" subst tm
+flattenCallTree _ c@(CLeaf _) = return c
+flattenCallTree cache (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
+  -- XXX: Careful! If you ever add concurrency, this will have to be changed to
+  --      account for multiple workers.
+  cached <- liftIO (UniqMap.lookup nm <$> IORef.readIORef cache)
+  case cached of
+    Just ct -> pure ct
+    Nothing -> do
+      ct <- doFlatten
+      liftIO (IORef.modifyIORef' cache (UniqMap.insert nm ct))
+      pure ct
+ where
+  doFlatten = do
+   flattenedUsed   <- mapM (flattenCallTree cache) used
+   (newUsed,il_ct) <- partitionEithers <$> mapM flattenNode flattenedUsed
+   let (toInline,il_used) = unzip il_ct
+       subst = extendGblSubstList (mkSubst emptyInScopeSet) toInline
+   newExpr <- case toInline of
+     [] -> return tm
+     _  -> do
+       let tm1 = substTm "flattenCallTree.flattenExpr" subst tm
 
-      -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
-      opts <- Lens.view debugOpts
-      let rewriteHistFile = dbg_historyFile opts
-      when (Maybe.isJust rewriteHistFile) $
-        liftIO
-          $ BS.appendFile (Maybe.fromJust rewriteHistFile)
-          $ BL.toStrict
-          $ encode RewriteStep
-              { t_ctx    = []
-              , t_name   = "INLINE"
-              , t_bndrS  = showPpr (varName nm')
-              , t_before = tm
-              , t_after  = tm1
-              }
-      rewriteExpr ("flattenExpr",flatten) (showPpr nm, tm1) (nm', sp)
-  let allUsed = newUsed ++ concat il_used
-  -- inline all components when the resulting expression after flattening
-  -- is still considered "cheap". This happens often at the topEntity which
-  -- wraps another functions and has some selectors and data-constructors.
-  if not (isNoInline inl) && isCheapFunction newExpr
-     then do
-        let (toInline',allUsed') = unzip (map goCheap allUsed)
-            subst' = extendGblSubstList (mkSubst emptyInScopeSet)
-                                        (Maybe.catMaybes toInline')
-        let tm1 = substTm "flattenCallTree.flattenCheap" subst' newExpr
-        newExpr' <- rewriteExpr ("flattenCheap",flatten) (showPpr nm, tm1) (nm', sp)
-        return (CBranch (nm,(Binding nm' sp inl pr newExpr' r)) (concat allUsed'))
-     else return (CBranch (nm,(Binding nm' sp inl pr newExpr r)) allUsed)
-  where
-    flatten =
-      repeatR (topdownR (apply "appProp" appProp >->
-                 apply "bindConstantVar" bindConstantVar >->
-                 apply "caseCon" caseCon >->
-                 (apply "reduceConst" reduceConst !-> apply "deadcode" deadCode) >->
-                 apply "reduceNonRepPrim" reduceNonRepPrim >->
-                 apply "removeUnusedExpr" removeUnusedExpr) >->
-               bottomupR (apply "flattenLet" flattenLet)) !->
-      topdownSucR (apply "topLet" topLet) >->
-      -- See [Note] relation `collapseRHSNoops` and `inlineCleanup`
-      -- Note that we do this as the very last step, after all constant propagation
-      -- has been done to avoid #3036.
-      topdownSucR (apply "collapseRHSNoops" collapseRHSNoops) >->
-      topdownSucR (apply "inlineCleanup" inlineCleanup) >->
-      bottomupR (apply "caseCon" caseCon) >-> -- https://github.com/clash-lang/clash-compiler/issues/3159 / #3204
-      bottomupR (apply "flattenLet" flattenLet) >-> -- https://github.com/clash-lang/clash-compiler/issues/3185
-      bottomupR (apply "bindConstantVar" bindConstantVar) >-> -- https://github.com/clash-lang/clash-compiler/issues/3041
-      topdownSucR (apply "topLet" topLet)
+       -- NB: When -fclash-debug-history is on, emit binary data holding the recorded rewrite steps
+       opts <- Lens.view debugOpts
+       let rewriteHistFile = dbg_historyFile opts
+       when (Maybe.isJust rewriteHistFile) $
+         liftIO
+           $ BS.appendFile (Maybe.fromJust rewriteHistFile)
+           $ BL.toStrict
+           $ encode RewriteStep
+               { t_ctx    = []
+               , t_name   = "INLINE"
+               , t_bndrS  = showPpr (varName nm')
+               , t_before = tm
+               , t_after  = tm1
+               }
+       rewriteExpr ("flattenExpr",flatten) (showPpr nm, tm1) (nm', sp)
+   let allUsed = newUsed ++ concat il_used
+   -- inline all components when the resulting expression after flattening
+   -- is still considered "cheap". This happens often at the topEntity which
+   -- wraps another functions and has some selectors and data-constructors.
+   if not (isNoInline inl) && isCheapFunction newExpr
+      then do
+         let (toInline',allUsed') = unzip (map goCheap allUsed)
+             subst' = extendGblSubstList (mkSubst emptyInScopeSet)
+                                         (Maybe.catMaybes toInline')
+         let tm1 = substTm "flattenCallTree.flattenCheap" subst' newExpr
+         newExpr' <- rewriteExpr ("flattenCheap",flatten) (showPpr nm, tm1) (nm', sp)
+         return (CBranch (nm,(Binding nm' sp inl pr newExpr' r)) (concat allUsed'))
+      else return (CBranch (nm,(Binding nm' sp inl pr newExpr r)) allUsed)
 
-    goCheap c@(CLeaf   (nm2,(Binding _ _ inl2 _ e _)))
-      | isNoInline inl2  = (Nothing     ,[c])
-      | otherwise        = (Just (nm2,e),[])
-    goCheap c@(CBranch (nm2,(Binding _ _ inl2 _ e _)) us)
-      | isNoInline inl2  = (Nothing, [c])
-      | otherwise        = (Just (nm2,e),us)
+  flatten =
+    repeatR (topdownR (apply "appProp" appProp >->
+               apply "bindConstantVar" bindConstantVar >->
+               apply "caseCon" caseCon >->
+               (apply "reduceConst" reduceConst !-> apply "deadcode" deadCode) >->
+               apply "reduceNonRepPrim" reduceNonRepPrim >->
+               apply "removeUnusedExpr" removeUnusedExpr) >->
+             bottomupR (apply "flattenLet" flattenLet)) !->
+    topdownSucR (apply "topLet" topLet) >->
+    -- See [Note] relation `collapseRHSNoops` and `inlineCleanup`
+    -- Note that we do this as the very last step, after all constant propagation
+    -- has been done to avoid #3036.
+    topdownSucR (apply "collapseRHSNoops" collapseRHSNoops) >->
+    topdownSucR (apply "inlineCleanup" inlineCleanup) >->
+    bottomupR (apply "caseCon" caseCon) >-> -- https://github.com/clash-lang/clash-compiler/issues/3159 / #3204
+    bottomupR (apply "flattenLet" flattenLet) >-> -- https://github.com/clash-lang/clash-compiler/issues/3185
+    bottomupR (apply "bindConstantVar" bindConstantVar) >-> -- https://github.com/clash-lang/clash-compiler/issues/3041
+    topdownSucR (apply "topLet" topLet)
+
+  goCheap c@(CLeaf   (nm2,(Binding _ _ inl2 _ e _)))
+    | isNoInline inl2  = (Nothing     ,[c])
+    | otherwise        = (Just (nm2,e),[])
+  goCheap c@(CBranch (nm2,(Binding _ _ inl2 _ e _)) us)
+    | isNoInline inl2  = (Nothing, [c])
+    | otherwise        = (Just (nm2,e),us)
 
 callTreeToList :: [Id] -> CallTree -> ([Id], [(Id, Binding Term)])
 callTreeToList visited (CLeaf (nm,bndr))

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -19,6 +19,7 @@ module Clash.Normalize where
 import           Control.Exception                (throw)
 import qualified Control.Lens                     as Lens
 import           Control.Monad                    ((>=>), when)
+import           Control.Monad.IO.Class           (liftIO)
 import           Control.Monad.State.Strict       (State)
 import           Data.Default                     (def)
 import           Data.Either                      (lefts,partitionEithers)
@@ -85,7 +86,6 @@ import           Data.Binary                      (encode)
 import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Lazy             as BL
 
-import           System.IO.Unsafe                 (unsafePerformIO)
 import           Clash.Rewrite.Types (RewriteStep(..))
 
 
@@ -360,17 +360,16 @@ flattenCallTree (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
       opts <- Lens.view debugOpts
       let rewriteHistFile = dbg_historyFile opts
       when (Maybe.isJust rewriteHistFile) $
-        let !_ = unsafePerformIO
-             $ BS.appendFile (Maybe.fromJust rewriteHistFile)
-             $ BL.toStrict
-             $ encode RewriteStep
-                 { t_ctx    = []
-                 , t_name   = "INLINE"
-                 , t_bndrS  = showPpr (varName nm')
-                 , t_before = tm
-                 , t_after  = tm1
-                 }
-        in pure ()
+        liftIO
+          $ BS.appendFile (Maybe.fromJust rewriteHistFile)
+          $ BL.toStrict
+          $ encode RewriteStep
+              { t_ctx    = []
+              , t_name   = "INLINE"
+              , t_bndrS  = showPpr (varName nm')
+              , t_before = tm
+              , t_after  = tm1
+              }
       rewriteExpr ("flattenExpr",flatten) (showPpr nm, tm1) (nm', sp)
   let allUsed = newUsed ++ concat il_used
   -- inline all components when the resulting expression after flattening

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -25,6 +25,7 @@ import Control.DeepSeq                       (NFData)
 import Control.Lens                          (Lens', use, (.=))
 import qualified Control.Lens as Lens
 import Control.Monad.Fix                     (MonadFix)
+import Control.Monad.IO.Class                (MonadIO)
 import Control.Monad.State.Strict            (State)
 import Control.Monad.Reader                  (MonadReader (..))
 import Control.Monad.State                   (MonadState (..))
@@ -169,6 +170,7 @@ newtype RewriteMonad extra a = R
     , Functor
     , Monad
     , MonadFix
+    , MonadIO
     , MonadState (RewriteState extra)
     , MonadWriter Any
     , MonadReader RewriteEnv

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -29,6 +29,7 @@ import           Control.Exception           (throw)
 import           Control.Lens ((%=), (+=), (^.))
 import qualified Control.Lens                as Lens
 import qualified Control.Monad               as Monad
+import           Control.Monad.IO.Class      (liftIO)
 import qualified Control.Monad.State.Strict  as State
 import qualified Control.Monad.Trans.RWS.CPS as RWS
 import qualified Control.Monad.Writer        as Writer
@@ -46,7 +47,6 @@ import qualified Data.Set                    as Set
 import qualified Data.Set.Lens               as Lens
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
-import           System.IO.Unsafe            (unsafePerformIO)
 import           Data.Binary                 (encode)
 import qualified Data.ByteString             as BS
 import qualified Data.ByteString.Lazy        as BL
@@ -152,17 +152,16 @@ apply = \s rewrite ctx expr0 -> do
   let rewriteHistFile = dbg_historyFile opts
   Monad.when (isJust rewriteHistFile && hasChanged) $ do
     (curBndr, _) <- Lens.use curFun
-    let !_ = unsafePerformIO
-             $ BS.appendFile (fromJust rewriteHistFile)
-             $ BL.toStrict
-             $ encode RewriteStep
-                 { t_ctx    = tfContext ctx
-                 , t_name   = s
-                 , t_bndrS  = showPpr (varName curBndr)
-                 , t_before = expr0
-                 , t_after  = expr1
-                 }
-    return ()
+    liftIO
+      $ BS.appendFile (fromJust rewriteHistFile)
+      $ BL.toStrict
+      $ encode RewriteStep
+          { t_ctx    = tfContext ctx
+          , t_name   = s
+          , t_bndrS  = showPpr (varName curBndr)
+          , t_before = expr0
+          , t_after  = expr1
+          }
 
   if isDebugging opts
     then applyDebug ctx s expr0 hasChanged expr1


### PR DESCRIPTION
Before this patch, `flatten` would get called many times on the same binder. Having a cache reduces duplicate work considerably. I've tested this on `bittide`, the generated HDL is byte-for-byte equal when compared to pre-patch and yields about a 10% speedup (18m16s -> 16m35s).

Fixes #3246

## Still TODO:
  - [x] Write up issue
  - [x] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
