### PR TITLE
Implement specialized `topdownFixR` that avoids redundant root restarts

### DIFF
--- a/changelog/2026-05-06T11_22_25+02_00_topdown_fixr
+++ b/changelog/2026-05-06T11_22_25+02_00_topdown_fixr
@@ -1,0 +1,1 @@
+CHANGED: Improved normalization performance for repeated top-down rewrite loops by avoiding full root restarts after every successful rewrite. This gives a ~17% performance improvements on larger designs [#3249](https://github.com/clash-lang/clash-compiler/issues/3249)

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -75,7 +75,7 @@ import           Clash.Normalize.Transformations
 import           Clash.Normalize.Types
 import           Clash.Normalize.Util
 import           Clash.Rewrite.Combinators
-  ((>->), (!->), bottomupR, repeatR, topdownR)
+  ((>->), (!->), bottomupR, repeatR, topdownFixR)
 import           Clash.Rewrite.Types
   (RewriteEnv (..), RewriteState (..), bindings, debugOpts, extra,
    tcCache, topEntities, newInlineStrategy)
@@ -406,7 +406,10 @@ flattenCallTree cache (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
       else return (CBranch (nm,(Binding nm' sp inl pr newExpr r)) allUsed)
 
   flatten =
-    repeatR (topdownR (apply "appProp" appProp >->
+    -- topdownFixR reaches a fixpoint for the top-down propagation bundle.
+    -- Keep flattenLet in the outer fixed-point loop: flattening can expose
+    -- fresh propagation redexes for the next top-down pass.
+    repeatR (topdownFixR (apply "appProp" appProp >->
                apply "bindConstantVar" bindConstantVar >->
                apply "caseCon" caseCon >->
                (apply "reduceConst" reduceConst !-> apply "deadcode" deadCode) >->

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -74,10 +74,13 @@ constantPropagation =
   conSpec
   where
     etaTL              = apply "etaTL" etaExpansionTL !-> topdownR (apply "applicationPropagation" appProp)
-    inlineAndPropagate = repeatR (topdownR (applyMany transPropagateAndInline) >-> inlineNR)
+    -- The outer repeatR is still needed: inlineNR is a full traversal whose
+    -- results can only be processed by re-running the top-down bundle from the
+    -- new root.
+    inlineAndPropagate = repeatR (topdownFixR (applyMany transPropagateAndInline) >-> inlineNR)
     spec               = bottomupR (applyMany specTransformations)
-    caseFlattening     = repeatR (topdownR (apply "caseFlat" caseFlat))
-    dec                = repeatR (topdownR (apply "DEC" disjointExpressionConsolidation))
+    caseFlattening     = topdownFixR (apply "caseFlat" caseFlat)
+    dec                = topdownFixR (apply "DEC" disjointExpressionConsolidation)
     conSpec            = bottomupR  ((apply "appPropCS" appProp !->
                                      bottomupR (apply "constantSpec" constantSpec)) >-!
                                      apply "constantSpec" constantSpec)

--- a/clash-lib/src/Clash/Rewrite/Combinators.hs
+++ b/clash-lib/src/Clash/Rewrite/Combinators.hs
@@ -1,6 +1,6 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente
-                         2021, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -16,6 +16,7 @@ module Clash.Rewrite.Combinators
   , bottomupR
   , repeatR
   , topdownR
+  , topdownFixR
   ) where
 
 import           Control.DeepSeq             (deepseq)
@@ -117,6 +118,69 @@ Then we must repeat the transformation to let it also inline y.
 topdownR :: Rewrite m -> Rewrite m
 -- See Note [topdown repeatR]
 topdownR r = repeatR r >-> allR (topdownR r)
+
+{-
+Note [topdownFixR]
+~~~~~~~~~~~~~~~~~~
+'topdownFixR r' is an optimized alternative to some uses of
+'repeatR (topdownR r)'. It repeats 'r' top-down, but when a child changes it
+only rechecks the ancestors of that child instead of restarting traversal from
+the root.
+
+For example, suppose 'r' can rewrite both:
+
+> let x = True in x
+
+to:
+
+> True
+
+and:
+
+> case True of { True -> a; False -> b }
+
+to:
+
+> a
+
+When traversing:
+
+> h (case (let x = True in x) of { True -> a; False -> b })
+
+'topdownFixR r' first cannot rewrite the 'case', so it descends into the
+scrutinee. Rewriting the scrutinee exposes a new redex at the parent 'case', so
+the parent is checked again immediately and rewritten to 'a'. That change then
+bubbles up to 'h a'. With 'repeatR (topdownR r)' the same result is reached by
+starting another complete traversal from 'h'.
+
+Only use 'topdownFixR' as a replacement for 'repeatR (topdownR r)' when 'r' is
+local and context-stable: it should fire or fail based on the current node, and
+the relevant parts of 'TransformContext' should not change when sibling
+subtrees are rewritten. Rewrites that inspect let-bound context whose binding
+terms may have changed, for example through 'whnfRW', still need an outer
+repeat or a normal repeated top-down traversal.
+-}
+
+-- | Apply a transformation in a repeated top-down traversal.
+--
+-- Optimized for local, context-stable transformations. See Note [topdownFixR].
+topdownFixR :: Rewrite m -> Rewrite m
+topdownFixR r = go True
+ where
+  go tryParent ctx term = do
+    term1 <-
+      if tryParent
+        then repeatR r ctx term
+        else pure term
+    (term2, Monoid.getAny -> childChanged) <- Writer.listen (allR (go True) ctx term1)
+    if childChanged
+      then do
+        (term3, Monoid.getAny -> parentChanged) <- Writer.listen (repeatR r ctx term2)
+        if parentChanged
+          then go False ctx term3
+          else return term3
+      else return term2
+{-# INLINE topdownFixR #-}
 
 -- | Apply a transformation in a bottomup traversal
 bottomupR :: Monad m => Transform m -> Transform m


### PR DESCRIPTION
With Bittide `softUgnDemoTest` it gives a 17% improvement, less than the reported issue because I still had a bug when reporting that number.

Before: Clash: Compiling Bittide.Instances.Hitl.SoftUgnDemo.TopEntity.softUgnDemoTest took 9m7s
After: Clash: Compiling Bittide.Instances.Hitl.SoftUgnDemo.TopEntity.softUgnDemoTest took 7m34s

Fixes https://github.com/clash-lang/clash-compiler/issues/3249

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
