### PR TITLE
Don't emit a trailing empty line when reflowing paragraphs

### DIFF
--- a/changelog/2026-05-08T20_51_55+02_00_fix_2753
+++ b/changelog/2026-05-08T20_51_55+02_00_fix_2753
@@ -1,0 +1,1 @@
+FIXED: `Clash.Util.Interpolate.i` no longer inserts an extra blank line after a paragraph that gets reflowed onto multiple lines. See [#2753](https://github.com/clash-lang/clash-compiler/issues/2753).

--- a/clash-lib/src/Clash/Util/Interpolate.hs
+++ b/clash-lib/src/Clash/Util/Interpolate.hs
@@ -140,7 +140,9 @@ nodesToLines =
     maxLength = 80
 
     go :: Int -> [Node] -> [Node] -> [[Node]]
-    go accLen acc goNodes | accLen > maxLength = reverse acc : go 0 [] goNodes
+    -- Only break when there's still content to put on the next line; otherwise
+    -- we'd emit a trailing empty line. See issue #2753.
+    go accLen acc goNodes@(_:_) | accLen > maxLength = reverse acc : go 0 [] goNodes
     go accLen acc (l@(Literal s):goNodes) = go (accLen + length s) (l:acc) goNodes
     go accLen acc (e@(Expression s):goNodes) = go (accLen + length s) (e:acc) goNodes
     go _accLen acc [] = [reverse acc]

--- a/clash-lib/tests/Clash/Tests/Util/Interpolate.hs
+++ b/clash-lib/tests/Clash/Tests/Util/Interpolate.hs
@@ -12,7 +12,7 @@ import qualified Clash.Util.Interpolate as I
 import Test.Tasty
 import Test.Tasty.HUnit
 
-test1, test2, test3, test4, test5, test6, test7, test8, test9 :: String
+test1, test2, test3, test4, test5, test6, test7, test8, test9, test10 :: String
 test1 = [I.i| Simple |]
 test2 = [I.i|
   Single line
@@ -46,6 +46,14 @@ test8 = [I.i|
   looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong word
 |]
 
+-- Regression test for issue #2753: a paragraph that wraps onto multiple lines
+-- followed by a blank line was emitting an extra blank line.
+test10 = [I.i|
+  Clash has known issues on 9.4.8 on your current OS. While not completely preventing the compiler from working, we recommend switching to another GHC version. Symptoms:
+
+  After.
+|]
+
 data SomeRecord = SomeRecord { getField :: Int }
 someRecord :: SomeRecord
 someRecord = SomeRecord 5
@@ -69,4 +77,9 @@ tests =
     , testCase "test7" $ test7 @?= ("The big test:\n\n" ++ test5)
     , testCase "test8" $ test8 @?= "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong \nword"
     , testCase "test9" $ test9 @?= "\\42"
+    , testCase "test10" $ test10 @?=
+        "Clash has known issues on 9.4.8 on your current OS. While not completely preventing \n\
+        \the compiler from working, we recommend switching to another GHC version. Symptoms:\n\
+        \\n\
+        \After."
     ]


### PR DESCRIPTION
Fixes #2753

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] ~~Check copyright notices are up to date in edited files~~
