### PR TITLE
GitLab CI: Move nearly everything to local runners

### DIFF
--- a/.ci/gitlab/common.yml
+++ b/.ci/gitlab/common.yml
@@ -9,7 +9,7 @@ default:
 
 .common:
   image: ghcr.io/clash-lang/clash-ci:$GHC_VERSION-$CLASH_DOCKER_TAG
-  timeout: 10 minutes
+  timeout: 2 hours
   stage: build
   variables:
     CLASH_DOCKER_TAG: 20260331
@@ -38,15 +38,5 @@ default:
   after_script:
     - export THREADS=$(./.ci/effective_cpus.sh)
     - tar -cf - /root/.cabal | zstd -T$THREADS -3 > cache.tar.zst
-
-# We run tests on local machines if:
-#
-#   * A job may take more than 3 minutes to complete on public runners.
-#   * A job needs specific capabilities public runners cannot provide, e.g.
-#     more than 4GB memory of memory, proprietary synthesis tooling.
-#
-.common-local:
-  extends: .common
-  timeout: 2 hours
   tags:
     - local

--- a/.ci/gitlab/publish.yml
+++ b/.ci/gitlab/publish.yml
@@ -1,5 +1,5 @@
 hackage-sdist:
-  extends: .common-local
+  extends: .common
   needs: []
   stage: pack
   script:

--- a/.ci/gitlab/test.yml
+++ b/.ci/gitlab/test.yml
@@ -42,9 +42,9 @@ stages:
       fi
   after_script:
 
-.test-cache-local:
+.test-cache:
   extends:
-    - .common-local
+    - .common
     - .nightly-rules
   needs: ["build"]
   stage: test
@@ -76,7 +76,7 @@ stages:
 # 'build' publishes its build files as an artifact. These build files are reused
 # by the tests below.
 build:
-  extends: .common-local
+  extends: .common
   artifacts:
     when: always
     name: "$CI_JOB_NAME-$CI_COMMIT_SHA-$GHC_VERSION"
@@ -89,7 +89,6 @@ build:
     # Archive all build files (from .cabal and dist-newstyle)
     - tar -cf - $(.ci/get_build_dist.sh) | zstd -T${THREADS} -15 > dist.tar.zst
 
-# Tests run on shared runners:
 cosim:unittests:
   extends: .test-nocache
   script:
@@ -123,35 +122,32 @@ ffi:interface-tests:
   script:
     - bin/clash-ffi:ffi-interface-tests --smallcheck-max-count 2000
 
-# Tests run on local fast machines:
-
-# Normally, this job is small. But it is flaky on GHC 9.2; it sometimes fails
+# Normally, this job is small. But it was flaky on GHC 9.2; it sometimes fails
 # and we don't know yet why. When it fails, it recompiles things it should have
-# picked up from the 'build' issue and then it is a larger job, so we keep it on
-# local runners for now.
+# picked up from the 'build' issue and then it is a larger job.
 build-clash-dev:
-  extends: .test-cache-local
+  extends: .test-cache
   script:
     - .ci/build_clash_dev.sh
 
 suite:vhdl:
-  extends: .test-cache-local
+  extends: .test-cache
   script:
     - bin/clash-testsuite:clash-testsuite -j$THREADS -p .VHDL --hide-successes --no-vivado
 
 suite:verilog:
-  extends: .test-cache-local
+  extends: .test-cache
   script:
     - bin/clash-testsuite:clash-testsuite -j$THREADS -p .Verilog --hide-successes --no-vivado
 
 suite:systemverilog:
-  extends: .test-cache-local
+  extends: .test-cache
   script:
     - bin/clash-testsuite:clash-testsuite -j$THREADS -p .SystemVerilog --hide-successes --no-modelsim --no-vivado
 
 ffi:example:
   extends:
-    - .common-local
+    - .common
     - .nightly-rules
   # GHC 9.8.3, 9.8.4 and 9.10.2 have issues, see https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12264#note_602406
   rules:
@@ -185,8 +181,8 @@ ffi:example:
 
 # Tests run on local fast machines with Vivado installed. We only run these at night
 # to save resources - as Vivado is quite slow to execute.
-.test-cache-local-nightly:
-  extends: .test-cache-local
+.test-cache-nightly:
+  extends: .test-cache
   rules:
     - if: $CI_PARENT_PIPELINE_SOURCE == "schedule"  # When schedueled (at night)
     - if: $CI_PARENT_PIPELINE_SOURCE == "trigger"   # When triggered (manual triggers)
@@ -194,7 +190,7 @@ ffi:example:
 
 
 suite:vivado:verilog:
-  extends: .test-cache-local-nightly
+  extends: .test-cache-nightly
   script:
     - source /opt/tools/Xilinx/Vivado/2022.1/settings64.sh
     - bin/clash-testsuite:clash-testsuite -j$THREADS -p .Verilog --hide-successes --no-modelsim --no-ghdl --no-iverilog --no-verilator --no-symbiyosys
@@ -203,7 +199,7 @@ suite:vivado:verilog:
     - vivado-2022.1-standard
 
 suite:vivado:systemverilog:
-  extends: .test-cache-local-nightly
+  extends: .test-cache-nightly
   script:
     - source /opt/tools/Xilinx/Vivado/2022.1/settings64.sh
     - bin/clash-testsuite:clash-testsuite -j$THREADS -p .SystemVerilog --hide-successes --no-modelsim --no-ghdl --no-iverilog --no-verilator --no-symbiyosys
@@ -223,7 +219,7 @@ suite:vivado:systemverilog:
 #      wolf" situtation.
 #
 # suite:vivado:vhdl:
-#   extends: .test-cache-local-nightly
+#   extends: .test-cache-nightly
 #   script:
 #     - source /opt/tools/Xilinx/Vivado/2022.1/settings64.sh
 #     - bin/clash-testsuite:clash-testsuite -j$THREADS -p .VHDL --hide-successes --no-modelsim --no-ghdl --no-iverilog --no-verilator --no-symbiyosys

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ tests:
         RUN_TESTS: "always"
 
 stack-build:
-  extends: .common-local
+  extends: .common
   image: fpco/stack-build:lts-24.32
   needs: []
   stage: test
@@ -71,7 +71,7 @@ stack-build:
     - tar -cf - /root/.stack | zstd -T$THREADS -3 > cache.tar.zst
 
 haddock:
-  extends: .common-local
+  extends: .common
   needs: []
   stage: test
   artifacts:


### PR DESCRIPTION
Only the "report status" jobs are kept on shared runners as they are truly tiny.

Our use of the shared runners has increased a lot lately. It's probably just a high number of PR's causing this. Moving these jobs to local runners will slow things down a bit because more jobs contend for the same limited set of runners, but the current excessive use of shared runners justifies this.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
