### PR TITLE
Migrate on-push PR jobs from Gitlab over to Github

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -27,11 +27,9 @@ jobs:
           9.6.7
         ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - name: Setup cache
-        run: mkdir .cache
-      - uses: tespkg/actions-cache@v1
+      - uses: tespkg/actions-cache/restore@v1
         with:
           endpoint: "192.168.102.136"
           port: 9000
@@ -42,8 +40,12 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-checkout-cabal
-          path: .cache
+          # The cabal.project file contains the index state & hashes
+          # Since we only cache the dependencies, and this is what determines what dependencies are grabbed
+          # hashing the cabal.project file should suffice in determining if the dependencies changed
+          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles("cabal.project") }
+          restore-keys: ${{ runner.os }}-${ matrix.ghc }-cabal-
+          path: ~/.cabal
 
       # Perhaps we should preinstall these on the container?
       # This step always takes a minute...
@@ -58,6 +60,36 @@ jobs:
         run:
           cabal --version
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install libtinfo-dev -y
+          sudo apt-get install tree -y
+          sudo apt-get install iverilog -y
+
+      - name: Build dependencies
+        run: |
+          cabal v2-build all --dependencies-only
+
+      - uses: tespkg/actions-cache/save@v1
+        with:
+          endpoint: "192.168.102.136"
+          port: 9000
+          insecure: true
+          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
+          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles("cabal.project") }
+          path: ~/.cabal
+
+      - name: Build
+        run: |
+          # clash-cosim really wants to be built first
+          cabal v2-build clash-cosim
+          cabal v2-build all
+
   stack:
     name: Stack compilation test
     runs-on: self-hosted
@@ -71,23 +103,7 @@ jobs:
           9.6.7
         ]
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup cache
-        run: mkdir .cache
-      - uses: tespkg/actions-cache@v1
-        with:
-          endpoint: "192.168.102.136"
-          port: 9000
-          insecure: true
-          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
-          secretKey: "${{ secrets.S3_SECRET_KEY }}"
-          bucket: runner
-          region: local
-          use-fallback: false
-          retry: false
-          key: ${{ runner.os }}-checkout-stack
-          path: ~/.stack
+      - uses: actions/checkout@v6
 
       # Perhaps we should preinstall these on the container?
       # This step always takes a minute...
@@ -99,9 +115,20 @@ jobs:
           enable-stack: true
           stack-version: latest
 
+
       - name: Version information
         run:
           stack --version
+
+      - name: Install system dependencies
+        run: sudo apt-get install libtinfo-dev -y
+
+      # From what I read online, stack is difficult to cache and also generates huge build artifacts
+      # So maybe it's better not to cache the stack builds? The current Gitlab runners don't either
+      - name: Build
+        run:
+          stack build -j$(nproc) --pedantic
+
 
   packages_common:
     name: Build Common (${{matrix.ghc}})
@@ -117,7 +144,7 @@ jobs:
           ghc967
         ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Authenticate cache
         env:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,4 +1,4 @@
-name: Nix Packaging
+name: On push CI
 
 on:
   push:
@@ -10,6 +10,99 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Nix by default runs tests, meaning that there's not much point in re-running tests in Cabal/Stack
+  # So for these we do a simple compilation test instead, checking that they still compile with
+  # whatever changes got made
+
+  cabal:
+    name: Cabal compilation test
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [
+          9.12.4,
+          9.10.3,
+          9.8.4,
+          9.6.7
+        ]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup cache
+        run: mkdir .cache
+      - uses: tespkg/actions-cache@v1
+        with:
+          endpoint: "192.168.102.136"
+          port: 9000
+          insecure: true
+          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
+          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-checkout-cabal
+          path: .cache
+
+      # Perhaps we should preinstall these on the container?
+      # This step always takes a minute...
+      # We'd lose the ability to select the version of cabal inside of the runner though
+      - name: Install GHC
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+
+      - name: Version information
+        run:
+          cabal --version
+
+  stack:
+    name: Stack compilation test
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [
+          9.12.4,
+          9.10.3,
+          9.8.4,
+          9.6.7
+        ]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup cache
+        run: mkdir .cache
+      - uses: tespkg/actions-cache@v1
+        with:
+          endpoint: "192.168.102.136"
+          port: 9000
+          insecure: true
+          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
+          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-checkout-stack
+          path: ~/.stack
+
+      # Perhaps we should preinstall these on the container?
+      # This step always takes a minute...
+      # We'd lose the ability to select the version of cabal inside of the runner though
+      - name: Install GHC
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          enable-stack: true
+          stack-version: latest
+
+      - name: Version information
+        run:
+          stack --version
+
   packages_common:
     name: Build Common (${{matrix.ghc}})
     runs-on: self-hosted
@@ -24,7 +117,7 @@ jobs:
           ghc967
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate cache
         env:
@@ -42,7 +135,6 @@ jobs:
       - run: |
           nix build -L .#clashPackages-${{matrix.ghc}}.clash-prelude
           attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-prelude)
-
       - run: |
           nix build -L .#clashPackages-${{matrix.ghc}}.clash-lib
           attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-lib)
@@ -88,7 +180,7 @@ jobs:
 
     needs: packages_common
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate cache
         env:
@@ -121,7 +213,7 @@ jobs:
         ]
     needs: packages_common
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate cache
         env:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -18,7 +18,6 @@ jobs:
     name: Cabal compilation test
     runs-on: self-hosted
     strategy:
-      fail-fast: false
       matrix:
         ghc: [
           9.12.4,
@@ -94,7 +93,6 @@ jobs:
     name: Stack compilation test
     runs-on: self-hosted
     strategy:
-      fail-fast: false
       matrix:
         ghc: [
           9.12.4,
@@ -198,8 +196,7 @@ jobs:
             "clash-prelude-hedgehog",
             "clash-profiling",
             "clash-profiling-prepare",
-            "clash-term",
-            "clash-testsuite"
+            "clash-term"
         ]
         exclude:
           - ghc: ghc984
@@ -207,7 +204,7 @@ jobs:
 
     needs: packages_common
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Authenticate cache
         env:
@@ -240,7 +237,7 @@ jobs:
         ]
     needs: packages_common
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Authenticate cache
         env:
@@ -258,3 +255,66 @@ jobs:
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#devShells.x86_64-linux.${{matrix.ghc}} | cachix push clash-lang
+
+  packages_testsuite:
+    name: Packaging clash-testsuite (${{matrix.ghc}})
+    runs-on: self-hosted
+    strategy:
+      # If caching fails for one package, then we are still interested in caching other packages
+      fail-fast: false
+      matrix:
+        ghc: [
+          ghc9124,
+          ghc9103,
+          ghc984,
+          ghc967
+        ]
+    needs: packages_common
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Authenticate cache
+        env:
+          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
+        run: .ci/attic-auth.sh
+
+      - name: Build clash-testsuite
+        run: |
+          nix build -L .#clashPackages-${{matrix.ghc}}.clash-testsuite
+          attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-prelude)
+
+      - name: Cachix
+        if: github.ref == 'refs/heads/master'
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
+        run: |
+          nix path-info .#clashPackages-${{matrix.ghc}}.clash-testsuite | cachix push clash-lang
+
+  running_testsuite:
+    name: Running clash-testsuite (${{matrix.ghc}}, ${{matrix.hdl}})
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        hdl: [
+          "VHDL",
+          "Verilog",
+          "SystemVerilog"
+        ]
+        ghc: [
+          ghc9124,
+          ghc9103,
+          ghc984,
+          ghc967
+        ]
+    needs: packages_testsuite
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Authenticate cache
+        env:
+          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
+        run: .ci/attic-auth.sh
+
+      - name: Run clash-testsuite
+        run: |
+          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(nproc) --hide-successes -p .${{matrix.hdl}} --no-vivado --no-modelsim


### PR DESCRIPTION
We have self-hosted Github runners, however we still mirror the repository to Gitlab to run jobs on PRs. This migrates over the jobs that the Gitlab runners do over to Github. In specific; only the jobs performed on push are copied over. This includes the following set of jobs:

 - Testing if all clash-* projects successfully compile against all supported GHC versions in Cabal and Stack
 - Package & cache all clash-* projects using Nix (this also runs tests for those packages) for all supported GHC versions
 - Run the clash testsuite for VHDL, Verilog and SystemVerilog in all supported GHC versions

Nix automatically caches whatever it builds to our local cache, pushes to the master branch also get cached in Cachix.
Cabal caches only the clash dependencies (the key is the hash of the cabal.project file, I think this should be correct as its the only thing that changes the dependencies(?). If not, let me know and I will change it to something else. Maybe the `.cabal` files should be part of the key too?) It uses the local minio cache. 
Stack does not utilize caching.

## TODO:
 - [ ] Run clash-ffi tests(?)
 - [ ] Add `.cabal` to the key to the Cabal cache