### PR TITLE
Add flag to en/disable the translation of  Integers and Naturals

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -15,12 +15,12 @@ package clash-prelude
   benchmarks: True
 
 package clash-lib
-  ghc-options: -Werror
+  -- ghc-options: -Werror
   tests: True
   flags: +debug -workaround-ghc-mmap-crash
 
 package clash-ghc
-  ghc-options: -Werror
+  -- ghc-options: -Werror
   flags: -workaround-ghc-mmap-crash
 
 package clash-cosim

--- a/Clash.hs
+++ b/Clash.hs
@@ -58,7 +58,7 @@ doHDL Proxy opts src = do
   putStrLn $ "Loading dependencies took " ++ prepStartDiff
 
   generateHDL clashEnv clashDesign (Just backend)
-    (ghcTypeToHWType (opt_intWidth opts)) ghcEvaluator evaluator Nothing startTime
+    (ghcTypeToHWType opts) ghcEvaluator evaluator Nothing startTime
 
 main :: IO ()
 main =

--- a/benchmark/benchmark-concurrency.hs
+++ b/benchmark/benchmark-concurrency.hs
@@ -10,7 +10,7 @@ import System.Environment (getArgs, withArgs)
 import Clash.Backend
 import Clash.Backend.VHDL (VHDLState)
 import Clash.Driver
-import Clash.Driver.Types (ClashEnv(..), ClashOpts(..))
+import Clash.Driver.Types (ClashEnv(..))
 
 import Clash.GHC.PartialEval
 import Clash.GHC.Evaluator
@@ -41,5 +41,5 @@ benchFile idirs src =
       bench ("Generating HDL: " ++ src)
             (nfIO (generateHDL clashEnv clashDesign
                      (Just (initBackend @VHDLState (envOpts clashEnv)))
-                     (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                     (ghcTypeToHWType (envOpts clashEnv))
                      ghcEvaluator evaluator Nothing startTime))

--- a/benchmark/benchmark-normalization.hs
+++ b/benchmark/benchmark-normalization.hs
@@ -52,7 +52,7 @@ benchFile idirs src =
               (normalizeEntity
                 clashEnv
                 (designBindings clashDesign)
-                (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                (ghcTypeToHWType (envOpts clashEnv))
                 ghcEvaluator
                 evaluator
                 topEntities

--- a/benchmark/common/BenchmarkCommon.hs
+++ b/benchmark/common/BenchmarkCommon.hs
@@ -62,7 +62,7 @@ runNormalisationStage idirs src = do
     topEntity:_ -> do
       transformedBindings <-
             normalizeEntity env (designBindings design)
-              (ghcTypeToHWType (opt_intWidth (opts idirs)))
+              (ghcTypeToHWType (opts idirs))
               ghcEvaluator
               evaluator
               topEntityNames supplyN topEntity

--- a/benchmark/profiling/run/profile-netlist-run.hs
+++ b/benchmark/profiling/run/profile-netlist-run.hs
@@ -64,7 +64,7 @@ benchFile idirs src = do
                          takeWhile (/= '.') topEntityS
   (netlist,_,_) <-
     genNetlist env ghcEvaluator False transformedBindings topEntityMap compNames
-               (ghcTypeToHWType (opt_intWidth (envOpts env)))
+               (ghcTypeToHWType (envOpts env))
                ite (SomeBackend hdlState') seen hdlDir prefixM topEntity
   netlist `deepseq` putStrLn ".. done\n"
 

--- a/benchmark/profiling/run/profile-normalization-run.hs
+++ b/benchmark/profiling/run/profile-normalization-run.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 import           Clash.Driver
-import           Clash.Driver.Types           (ClashEnv(..), ClashOpts(opt_intWidth))
+import           Clash.Driver.Types           (ClashEnv(..))
 import qualified Clash.Util.Supply            as Supply
 
 import           Clash.GHC.PartialEval
@@ -45,7 +45,7 @@ benchFile idirs src = do
                    }
 
   res <- normalizeEntity clashEnv bindingsMap
-                   (ghcTypeToHWType (opt_intWidth (envOpts clashEnv)))
+                   (ghcTypeToHWType (envOpts clashEnv))
                    ghcEvaluator
                    evaluator
                    topEntityNames supplyN topEntity

--- a/clash-ghc/src-bin-9.10.1/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.10.1/Clash/GHCi/UI.hs
@@ -2448,8 +2448,7 @@ makeHDL Proxy startAction optsRef srcs = do
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
               let opts1  = opts0 { opt_color = fromGhcOverridingBool (useColor dflags) }
-              let iw     = opt_intWidth opts1
-                  hdl    = hdlKind backend
+              let hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
                                  hidir <- hiDir dflags
@@ -2484,7 +2483,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType opts2)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-bin-9.10.2/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.10.2/Clash/GHCi/UI.hs
@@ -2463,8 +2463,7 @@ makeHDL Proxy startAction optsRef srcs = do
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
               let opts1  = opts0 { opt_color = fromGhcOverridingBool (useColor dflags) }
-              let iw     = opt_intWidth opts1
-                  hdl    = hdlKind backend
+              let hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
                                  hidir <- hiDir dflags
@@ -2499,7 +2498,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType opts2)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-bin-9.12/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.12/Clash/GHCi/UI.hs
@@ -2441,8 +2441,7 @@ makeHDL Proxy startAction optsRef srcs = do
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
               let opts1  = opts0 { opt_color = fromGhcOverridingBool (useColor dflags) }
-              let iw     = opt_intWidth opts1
-                  hdl    = hdlKind backend
+              let hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
                                  hidir <- hiDir dflags
@@ -2477,7 +2476,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType opts2)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-bin-9.6/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.6/Clash/GHCi/UI.hs
@@ -2414,8 +2414,7 @@ makeHDL Proxy startAction optsRef srcs = do
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
               let opts1  = opts0 { opt_color = fromGhcOverridingBool (useColor dflags) }
-              let iw     = opt_intWidth opts1
-                  hdl    = hdlKind backend
+              let hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
                                  hidir <- hiDir dflags
@@ -2450,7 +2449,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType opts2)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-bin-9.8/Clash/GHCi/UI.hs
+++ b/clash-ghc/src-bin-9.8/Clash/GHCi/UI.hs
@@ -2415,8 +2415,7 @@ makeHDL Proxy startAction optsRef srcs = do
   liftIO $ do startTime <- Clock.getCurrentTime
               opts0  <- readIORef optsRef
               let opts1  = opts0 { opt_color = fromGhcOverridingBool (useColor dflags) }
-              let iw     = opt_intWidth opts1
-                  hdl    = hdlKind backend
+              let hdl    = hdlKind backend
                   -- determine whether `-outputdir` was used
                   outputDir = do odir <- objectDir dflags
                                  hidir <- hiDir dflags
@@ -2451,7 +2450,7 @@ makeHDL Proxy startAction optsRef srcs = do
                   clashEnv
                   clashDesign
                   (Just backend)
-                  (ghcTypeToHWType iw)
+                  (ghcTypeToHWType opts2)
                   ghcEvaluator
                   evaluator
                   mainTopEntity

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2016-2017, Myrtle Software Ltd,
-                     2021,      QBayLogic B.V.,
+                     2021-2026, QBayLogic B.V.,
                      2022,      Google Inc.,
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -88,6 +88,8 @@ flagsClash r = [
   , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
   , defFlag "fclash-no-concurrent-topentity-compilation" $ NoArg (liftEwM (setNoConcurrentTopEntities r))
   , defFlag "fclash-debug-manifest-hash"         $ NoArg (liftEwM (setDebugManifestHash r))
+  , defFlag "fclash-translate-bignums" $ NoArg (liftEwM (setTranslateBigNums r True))
+  , defFlag "fclash-no-translate-bignums" $ NoArg (liftEwM (setTranslateBigNums r False))
   ]
 
 -- | Print deprecated flag warning
@@ -249,6 +251,9 @@ setIntWidth r n =
   if n == 32 || n == 64
      then liftEwM $ modifyIORef r (\c -> c {opt_intWidth = n})
      else addWarn (show n ++ " is an invalid Int/Word/Integer bit-width. Allowed widths: 32, 64.")
+
+setTranslateBigNums :: IORef ClashOpts -> Bool -> IO ()
+setTranslateBigNums r b = modifyIORef r (\c -> c {opt_translateBigNums = b})
 
 setHdlDir :: IORef ClashOpts
           -> String

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -88,7 +88,7 @@ flagsClash r = [
   , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
   , defFlag "fclash-no-concurrent-topentity-compilation" $ NoArg (liftEwM (setNoConcurrentTopEntities r))
   , defFlag "fclash-debug-manifest-hash"         $ NoArg (liftEwM (setDebugManifestHash r))
-  , defFlag "fclash-translate-bignums" $ OptPrefix (liftEwM . (setTranslateBigNums r))
+  , defFlag "fclash-translate-bignums" $ OptPrefix (setTranslateBigNums r)
   ]
 
 -- | Print deprecated flag warning
@@ -251,17 +251,19 @@ setIntWidth r n =
      then liftEwM $ modifyIORef r (\c -> c {opt_intWidth = n})
      else addWarn (show n ++ " is an invalid Int/Word/Integer bit-width. Allowed widths: 32, 64.")
 
-setTranslateBigNums :: IORef ClashOpts -> String -> IO ()
-setTranslateBigNums r arg = modifyIORef r (\c -> c {opt_translateBigNums = val})
+setTranslateBigNums :: IORef ClashOpts -> String -> EwM IO ()
+setTranslateBigNums r arg = case valM of
+  Just val -> liftEwM $ modifyIORef r (\c -> c {opt_translateBigNums = val})
+  Nothing -> addWarn ("invalid flag: -fclash-translate-bignums=" <> arg)
  where
-  val = case map toLower arg of
-      ""       -> BigNumWarn  -- or Silent?
-      "yes"    -> BigNumWarn  -- or Silent?
-      "no"     -> BigNumError
-      "error"  -> BigNumError
-      "warn"   -> BigNumWarn
-      "silent" -> BigNumSilent
-      _ -> error ("invalid flag: -fclash-translate-bignums=" <> arg)
+  valM = case map toLower arg of
+      ""       -> Just BigNumWarn  -- or Silent?
+      "yes"    -> Just BigNumWarn  -- or Silent?
+      "no"     -> Just BigNumError
+      "error"  -> Just BigNumError
+      "warn"   -> Just BigNumWarn
+      "silent" -> Just BigNumSilent
+      _ -> Nothing
 
 setHdlDir :: IORef ClashOpts
           -> String

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -18,7 +18,7 @@ import           GHC.Utils.Panic
 import           GHC.Types.SrcLoc
 
 import           Control.Monad
-import           Data.Char                      (isSpace)
+import           Data.Char                      (isSpace,toLower)
 import           Data.IORef
 import           Data.List                      (dropWhileEnd)
 import           Data.List.Split                (splitOn)
@@ -88,8 +88,7 @@ flagsClash r = [
   , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
   , defFlag "fclash-no-concurrent-topentity-compilation" $ NoArg (liftEwM (setNoConcurrentTopEntities r))
   , defFlag "fclash-debug-manifest-hash"         $ NoArg (liftEwM (setDebugManifestHash r))
-  , defFlag "fclash-translate-bignums" $ NoArg (liftEwM (setTranslateBigNums r True))
-  , defFlag "fclash-no-translate-bignums" $ NoArg (liftEwM (setTranslateBigNums r False))
+  , defFlag "fclash-translate-bignums" $ OptPrefix (liftEwM . (setTranslateBigNums r))
   ]
 
 -- | Print deprecated flag warning
@@ -252,8 +251,17 @@ setIntWidth r n =
      then liftEwM $ modifyIORef r (\c -> c {opt_intWidth = n})
      else addWarn (show n ++ " is an invalid Int/Word/Integer bit-width. Allowed widths: 32, 64.")
 
-setTranslateBigNums :: IORef ClashOpts -> Bool -> IO ()
-setTranslateBigNums r b = modifyIORef r (\c -> c {opt_translateBigNums = b})
+setTranslateBigNums :: IORef ClashOpts -> String -> IO ()
+setTranslateBigNums r arg = modifyIORef r (\c -> c {opt_translateBigNums = val})
+ where
+  val = case map toLower arg of
+      ""       -> BigNumWarn  -- or Silent?
+      "yes"    -> BigNumWarn  -- or Silent?
+      "no"     -> BigNumError
+      "error"  -> BigNumError
+      "warn"   -> BigNumWarn
+      "silent" -> BigNumSilent
+      _ -> error ("invalid flag: -fclash-translate-bignums=" <> arg)
 
 setHdlDir :: IORef ClashOpts
           -> String

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -7,6 +7,7 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -39,11 +40,29 @@ import Clash.Netlist.Types
 import Clash.Signal.Internal
   (ResetPolarity(..), ActiveEdge(..), ResetKind(..)
   ,InitBehavior(..))
-import Clash.Util                       (curLoc)
+import Clash.Util                       (curLoc, namePat)
+#if MIN_VERSION_ghc_prim(0,12,0)
+import Clash.Util                       (fromTHName)
+#endif
 
 import Clash.Annotations.BitRepresentation.Internal
   (CustomReprs)
 import Clash.Signal.Internal (KnownDomain)
+
+
+import Data.Int
+import Data.STRef (STRef)
+import Data.Word
+import Numeric.Natural
+#if MIN_VERSION_ghc_prim(0,12,0)
+import qualified GHC.Classes
+#endif
+import qualified GHC.Prim
+import qualified GHC.Types
+import GHC.Stack
+import qualified Clash.Prelude as C
+import qualified Clash.Signal.Internal as C
+import qualified Clash.Explicit.SimIO
 
 ghcTypeToHWType
   :: ClashOpts
@@ -67,14 +86,15 @@ ghcTypeToHWType opts = go
 
     go reprs m ty@(tyView -> TyConApp tc args) = runMaybeT . runExceptT $
       case nameOcc tc of
-        "GHC.Int.Int8"                  -> returnN (Signed 8)
-        "GHC.Int.Int16"                 -> returnN (Signed 16)
-        "GHC.Int.Int32"                 -> returnN (Signed 32)
-        "GHC.Int.Int64"                 ->
+        $(namePat ''Int8)                  -> returnN (Signed 8)
+        $(namePat ''Int16)                 -> returnN (Signed 16)
+        $(namePat ''Int32)                 -> returnN (Signed 32)
+        $(namePat ''Int64)                 ->
           if iw < 64
              then case tyConDataCons (UniqMap.find tc m) of
                     [dc] -> case dcArgTys dc of
                       [tyView -> TyConApp nm _]
+                        -- TODO de-stringify
                         | nameOcc nm == "GHC.Prim.Int#"   ->
                             throwE $ unlines ["Int64 not supported in forced 32-bit mode on a 64-bit machine."
                                              ,"Run Clash with `-fclash-intwidth=64`."
@@ -84,14 +104,15 @@ ghcTypeToHWType opts = go
                       _  -> throwE $ $(curLoc) ++ "Int64 DC has unexpected amount of arguments"
                     _    -> throwE $ $(curLoc) ++ "Int64 TC has unexpected amount of DCs"
              else returnN (Signed 64)
-        "GHC.Word.Word8"                -> returnN (Unsigned 8)
-        "GHC.Word.Word16"               -> returnN (Unsigned 16)
-        "GHC.Word.Word32"               -> returnN (Unsigned 32)
-        "GHC.Word.Word64"               ->
+        $(namePat ''Word8)                -> returnN (Unsigned 8)
+        $(namePat ''Word16)               -> returnN (Unsigned 16)
+        $(namePat ''Word32)               -> returnN (Unsigned 32)
+        $(namePat ''Word64)               ->
           if iw < 64
              then case tyConDataCons (UniqMap.find tc m) of
                     [dc] -> case dcArgTys dc of
                       [tyView -> TyConApp nm _]
+                        -- TODO de-stringify
                         | nameOcc nm == "GHC.Prim.Word#"   ->
                             throwE $ unlines ["Word64 not supported in forced 32-bit mode on a 64-bit machine."
                                              ,"Run Clash with `-fclash-intwidth=64`."
@@ -101,33 +122,33 @@ ghcTypeToHWType opts = go
                       _  -> throwE $ $(curLoc) ++ "Word64 DC has unexpected amount of arguments"
                     _    -> throwE $ $(curLoc) ++ "Word64 TC has unexpected amount of DCs"
              else returnN (Unsigned 64)
-        "GHC.Num.Integer.Integer"       -> returnN (Signed iw)
-        "GHC.Num.Natural.Natural"       -> returnN (Unsigned iw)
-        "GHC.Prim.Char#"                -> returnN (Unsigned 21)
-        "GHC.Prim.Int#"                 -> returnN (Signed iw)
-        "GHC.Prim.Word#"                -> returnN (Unsigned iw)
-        "GHC.Prim.Int8#"                -> returnN (Signed 8)
-        "GHC.Prim.Int16#"               -> returnN (Signed 16)
-        "GHC.Prim.Int32#"               -> returnN (Signed 32)
-        "GHC.Prim.Int64#"               -> returnN (Signed 64)
-        "GHC.Prim.Word8#"               -> returnN (Unsigned 8)
-        "GHC.Prim.Word16#"              -> returnN (Unsigned 16)
-        "GHC.Prim.Word32#"              -> returnN (Unsigned 32)
-        "GHC.Prim.Word64#"              -> returnN (Unsigned 64)
-        "GHC.Prim.Float#"               -> returnN (BitVector 32)
-        "GHC.Prim.Double#"              -> returnN (BitVector 64)
-        "GHC.Prim.ByteArray#"           ->
+        $(namePat ''Integer)                       -> returnN (Signed iw)
+        $(namePat ''Natural)                       -> returnN (Unsigned iw)
+        $(namePat ''GHC.Prim.Char#)                -> returnN (Unsigned 21)
+        $(namePat ''GHC.Prim.Int#)                 -> returnN (Signed iw)
+        $(namePat ''GHC.Prim.Word#)                -> returnN (Unsigned iw)
+        $(namePat ''GHC.Prim.Int8#)                -> returnN (Signed 8)
+        $(namePat ''GHC.Prim.Int16#)               -> returnN (Signed 16)
+        $(namePat ''GHC.Prim.Int32#)               -> returnN (Signed 32)
+        $(namePat ''GHC.Prim.Int64#)               -> returnN (Signed 64)
+        $(namePat ''GHC.Prim.Word8#)               -> returnN (Unsigned 8)
+        $(namePat ''GHC.Prim.Word16#)              -> returnN (Unsigned 16)
+        $(namePat ''GHC.Prim.Word32#)              -> returnN (Unsigned 32)
+        $(namePat ''GHC.Prim.Word64#)              -> returnN (Unsigned 64)
+        $(namePat ''GHC.Prim.Float#)               -> returnN (BitVector 32)
+        $(namePat ''GHC.Prim.Double#)              -> returnN (BitVector 64)
+        $(namePat ''GHC.Prim.ByteArray#)           ->
           throwE $ "Can't translate type: " ++ showPpr ty
 
-        "GHC.Types.Bool"                -> returnN Bool
-        "GHC.Types.Float"               -> returnN (BitVector 32)
-        "GHC.Types.Double"              -> returnN (BitVector 64)
+        $(namePat ''Bool)               -> returnN Bool
+        $(namePat ''Float)              -> returnN (BitVector 32)
+        $(namePat ''Double)             -> returnN (BitVector 64)
         "GHC.Prim.~#"                   -> returnN (Void Nothing)
 
-        "Clash.Signal.Internal.Signal" ->
+        $(namePat ''C.Signal) ->
           ExceptT $ MaybeT $ Just <$> coreTypeToHWType go reprs m (args !! 1)
 
-        "Clash.Signal.BiSignal.BiSignalIn" -> do
+        $(namePat ''C.BiSignalIn) -> do
           szTy <- case args of
             [_, _, szTy] -> pure szTy
             _ -> throwE $ $(curLoc) ++ "BiSignalIn TC has unexpected amount of arguments"
@@ -135,7 +156,7 @@ ghcTypeToHWType opts = go
           (fType . BiDirectional In . BitVector . fromInteger) <$>
             liftE (tyNatSize m szTy)
 
-        "Clash.Signal.BiSignal.BiSignalOut" -> do
+        $(namePat ''C.BiSignalOut) -> do
           szTy <- case args of
             [_, _, szTy] -> pure szTy
             _ -> throwE $ $(curLoc) ++ "BiSignalOut TC has unexpected amount of arguments"
@@ -144,7 +165,15 @@ ghcTypeToHWType opts = go
             liftE (tyNatSize m szTy)
 
         -- XXX: this is a hack to get a KnownDomain from a KnownConfiguration
-        "GHC.Classes.(%,%)"
+-- TODO hackage shows ghc-prim 0.11.0 should be ok, but somehow it it doesn't work??
+#if MIN_VERSION_ghc_prim(0,12,0)
+#define CONSTRAINT_TUP2_PAT $(namePat ''GHC.Classes.CTuple2)
+#define CONSTRAINT_TUP2_EXPR (fromTHName ''GHC.Classes.CTuple2)
+#else
+#define CONSTRAINT_TUP2_PAT "GHC.Classes.(%,%)"
+#define CONSTRAINT_TUP2_EXPR "GHC.Classes.(%,%)"
+#endif
+        CONSTRAINT_TUP2_PAT
           | [arg0@(tyView -> TyConApp kdNm _), arg1] <- args
           , nameOcc kdNm == showt ''KnownDomain
           -> case tyView arg1 of
@@ -152,28 +181,13 @@ ghcTypeToHWType opts = go
                   | nameOcc kdNm1 == showt ''KnownDomain
                   -> do k1 <- (stripVoid . stripFiltered) <$> ExceptT (MaybeT (go reprs m arg0))
                         k2 <- (stripVoid . stripFiltered) <$> ExceptT (MaybeT (go reprs m arg1))
-                        returnN (Void (Just (Product "GHC.Classes.(%,%)" Nothing [k1,k2])))
+                        returnN (Void (Just (Product CONSTRAINT_TUP2_EXPR Nothing [k1,k2])))
                   where
                     stripVoid (Void (Just t)) = t
                     stripVoid t = t
                 _ -> ExceptT (MaybeT (go reprs m arg0))
 
-        -- XXX: this is a hack to get a KnownDomain from a KnownConfiguration
-        "GHC.Classes.CTuple2"
-          | [arg0@(tyView -> TyConApp kdNm _), arg1] <- args
-          , nameOcc kdNm == showt ''KnownDomain
-          -> case tyView arg1 of
-                TyConApp kdNm1 _
-                  | nameOcc kdNm1 == showt ''KnownDomain
-                  -> do k1 <- (stripVoid . stripFiltered) <$> ExceptT (MaybeT (go reprs m arg0))
-                        k2 <- (stripVoid . stripFiltered) <$> ExceptT (MaybeT (go reprs m arg1))
-                        returnN (Void (Just (Product "GHC.Classes.CTuple2" Nothing [k1,k2])))
-                  where
-                    stripVoid (Void (Just t)) = t
-                    stripVoid t = t
-                _ -> ExceptT (MaybeT (go reprs m arg0))
-
-        "Clash.Signal.Internal.KnownDomain"
+        $(namePat ''C.KnownDomain)
           -> case tyConDataCons (UniqMap.find tc m) of
                [dc] -> case substArgTys dc args of
                  [_knownSymbol, _knownNat, tyView -> TyConApp _ [_,dom]] ->
@@ -191,57 +205,57 @@ ghcTypeToHWType opts = go
                  _ -> ExceptT (MaybeT (pure Nothing))
                _ -> ExceptT (MaybeT (pure Nothing))
 
-        "Clash.Signal.Internal.Clock"
+        $(namePat ''C.Clock)
           | [tag0] <- args
           -> do
             tag1 <- domTag m tag0
             returnN (Clock (pack tag1))
 
-        "Clash.Signal.Internal.ClockN"
+        $(namePat ''C.ClockN)
           | [tag0] <- args
           -> do
             tag1 <- domTag m tag0
             returnN (ClockN (pack tag1))
 
-        "Clash.Signal.Internal.Reset"
+        $(namePat ''C.Reset)
           | [tag0] <- args
           -> do
             tag1 <- domTag m tag0
             returnN (Reset (pack tag1))
 
-        "Clash.Signal.Internal.Enable"
+        $(namePat ''C.Enable)
           | [tag0] <- args
           -> do
             tag1 <- domTag m tag0
             returnN (Enable (pack tag1))
 
-        "Clash.Sized.Internal.BitVector.Bit" -> returnN Bit
+        $(namePat ''C.Bit) -> returnN Bit
 
-        "Clash.Sized.Internal.BitVector.BitVector" | n0:_ <- args -> do
+        $(namePat ''C.BitVector) | n0:_ <- args -> do
           n <- liftE (tyNatSize m n0)
           case n of
             0 -> returnN (Void (Just (BitVector (fromInteger n))))
             _ -> returnN (BitVector (fromInteger n))
 
-        "Clash.Sized.Internal.Index.Index" | n0:_ <- args -> do
+        $(namePat ''C.Index) | n0:_ <- args -> do
           n <- liftE (tyNatSize m n0)
           if n < 2
              then returnN (Void (Just (Index (fromInteger n))))
              else returnN (Index (fromInteger n))
 
-        "Clash.Sized.Internal.Signed.Signed" | n0:_ <- args -> do
+        $(namePat ''C.Signed) | n0:_ <- args -> do
           n <- liftE (tyNatSize m n0)
           if n == 0
              then returnN (Void (Just (Signed (fromInteger n))))
              else returnN (Signed (fromInteger n))
 
-        "Clash.Sized.Internal.Unsigned.Unsigned" | n0:_ <- args -> do
+        $(namePat ''C.Unsigned) | n0:_ <- args -> do
           n <- liftE (tyNatSize m n0)
           if n == 0
              then returnN (Void (Just (Unsigned (fromInteger n))))
              else returnN (Unsigned (fromInteger n))
 
-        "Clash.Sized.Vector.Vec" -> case args of
+        $(namePat ''C.Vec) -> case args of
           [szTy,elTy] -> do
             sz0     <- liftE (tyNatSize m szTy)
             fElHWTy <- ExceptT $ MaybeT $ Just <$> coreTypeToHWType go reprs m elTy
@@ -262,14 +276,14 @@ ghcTypeToHWType opts = go
             return (FilteredHWType vecHWTy filtered)
           _ -> throwE $ $(curLoc) ++ "Vec TC has unexpected amount of arguments"
 
-        "Clash.Explicit.BlockRam.Internal.MemBlob" -> case args of
+        $(namePat ''C.MemBlob) -> case args of
           [nTy,mTy] -> do
             n0 <- liftE (tyNatSize m nTy)
             m0 <- liftE (tyNatSize m mTy)
             returnN (MemBlob (fromInteger n0) (fromInteger m0))
           _ -> throwE $ $(curLoc) ++ "MemBlob TC has unexpected amount of arguments"
 
-        "Clash.Sized.RTree.RTree" -> case args of
+        $(namePat ''C.RTree) -> case args of
           [szTy,elTy] -> do
             sz0     <- liftE (tyNatSize m szTy)
             fElHWTy <- ExceptT $ MaybeT $ Just <$> coreTypeToHWType go reprs m elTy
@@ -289,35 +303,34 @@ ghcTypeToHWType opts = go
             return (FilteredHWType vecHWTy filtered)
           _ -> throwE $ $(curLoc) ++ "RTree TC has unexpected amount of arguments"
 
-        "String" -> returnN String
-        "GHC.Prim.Addr#" -> returnN String
-        "GHC.Types.[]" | a0:_ <- args -> case tyView a0 of
-          (TyConApp (nameOcc -> "GHC.Types.Char") []) -> returnN String
+        "String" -> returnN String -- ???
+        $(namePat ''GHC.Prim.Addr#) -> returnN String
+        $(namePat '[]) | a0:_ <- args -> case tyView a0 of
+          (TyConApp (nameOcc -> $(namePat ''Char)) []) -> returnN String
           _ -> throwE $ "Can't translate type: " ++ showPpr ty
-        "GHC.Types.List" | a0:_ <- args -> case tyView a0 of
-          (TyConApp (nameOcc -> "GHC.Types.Char") []) -> returnN String
+        $(namePat ''GHC.Types.List) | a0:_ <- args -> case tyView a0 of
+          (TyConApp (nameOcc -> $(namePat ''Char)) []) -> returnN String
           _ -> throwE $ "Can't translate type: " ++ showPpr ty
 
         -- To ensure that Clash doesn't get stuck working away callstacks that
         -- never end up being used in the generated HDL.
-        "GHC.Stack.Types.CallStack" -> returnN (Void Nothing)
-        "GHC.Internal.Stack.Types.CallStack" -> returnN (Void Nothing)
+        $(namePat ''CallStack) -> returnN (Void Nothing)
 
-        "Clash.Explicit.SimIO.SimIO" | a0:_ <- args ->
+        $(namePat ''Clash.Explicit.SimIO.SimIO) | a0:_ <- args ->
           ExceptT $ MaybeT $ Just <$> coreTypeToHWType go reprs m a0
 
-        "Clash.Explicit.SimIO.File" -> returnN FileType
+        $(namePat ''Clash.Explicit.SimIO.File) -> returnN FileType
 
-        "Clash.Explicit.SimIO.Reg" -> case args of
+        $(namePat ''Clash.Explicit.SimIO.Reg) -> case args of
           [aTy] -> ExceptT (MaybeT (Just <$> coreTypeToHWType go reprs m aTy))
           _ -> throwE $ $(curLoc) ++ "Reg TC has unexpected amount of arguments"
 
-        "GHC.STRef.STRef" -> case args of
+        $(namePat ''STRef) -> case args of
           [_,aTy] -> ExceptT (MaybeT (Just <$> coreTypeToHWType go reprs m aTy))
           _ -> throwE $ $(curLoc) ++ "STRef TC has unexpected amount of arguments"
 
         -- Anything that's wrapped in SimOnly should be elided when we generate HDL
-        "Clash.Magic.SimOnly" -> returnN (Void Nothing)
+        $(namePat ''C.SimOnly) -> returnN (Void Nothing)
 
         _ -> ExceptT (MaybeT (pure Nothing))
 

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2013-2016, University of Twente,
                      2016-2023, Myrtle Software Ltd,
-                     2021-2024, QBayLogic B.V.
+                     2021-2026, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -122,8 +122,12 @@ ghcTypeToHWType opts = go
                       _  -> throwE $ $(curLoc) ++ "Word64 DC has unexpected amount of arguments"
                     _    -> throwE $ $(curLoc) ++ "Word64 TC has unexpected amount of DCs"
              else returnN (Unsigned 64)
-        $(namePat ''Integer)                       -> returnN (Signed iw)
-        $(namePat ''Natural)                       -> returnN (Unsigned iw)
+        $(namePat ''Integer)
+          | opt_translateBigNums opts -> returnN (Signed iw)
+          | otherwise -> returnN Integer
+        $(namePat ''Natural)
+          | opt_translateBigNums opts -> returnN (Unsigned iw)
+          | otherwise -> returnN Natural
         $(namePat ''GHC.Prim.Char#)                -> returnN (Unsigned 21)
         $(namePat ''GHC.Prim.Int#)                 -> returnN (Signed iw)
         $(namePat ''GHC.Prim.Word#)                -> returnN (Unsigned iw)

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -32,6 +32,7 @@ import Clash.Core.Type
   (LitTy (..), Type (..), TypeView (..), coreView, coreView1, tyView)
 import Clash.Core.Util                  (tyNatSize, substArgTys)
 import qualified Clash.Data.UniqMap as UniqMap
+import Clash.Driver.Types               (ClashOpts(..))
 import Clash.Netlist.Util               (coreTypeToHWType, stripFiltered)
 import Clash.Netlist.Types
   (HWType(..), HWMap, FilteredHWType(..), PortDirection (..))
@@ -45,9 +46,7 @@ import Clash.Annotations.BitRepresentation.Internal
 import Clash.Signal.Internal (KnownDomain)
 
 ghcTypeToHWType
-  :: Int
-  -- ^ Integer width. The width Clash assumes an Integer to be (instead of it
-  -- begin an arbitrarily large, runtime sized construct).
+  :: ClashOpts
   -> CustomReprs
   -- ^ Custom bit representations
   -> TyConMap
@@ -55,8 +54,9 @@ ghcTypeToHWType
   -> Type
   -- ^ Type to convert to HWType
   -> State HWMap (Maybe (Either String FilteredHWType))
-ghcTypeToHWType iw = go
+ghcTypeToHWType opts = go
   where
+    iw = opt_intWidth opts
     -- returnN :: HWType ->
     returnN t = return (FilteredHWType t [])
 

--- a/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/NetlistTypes.hs
@@ -122,12 +122,15 @@ ghcTypeToHWType opts = go
                       _  -> throwE $ $(curLoc) ++ "Word64 DC has unexpected amount of arguments"
                     _    -> throwE $ $(curLoc) ++ "Word64 TC has unexpected amount of DCs"
              else returnN (Unsigned 64)
-        $(namePat ''Integer)
-          | opt_translateBigNums opts -> returnN (Signed iw)
-          | otherwise -> returnN Integer
-        $(namePat ''Natural)
-          | opt_translateBigNums opts -> returnN (Unsigned iw)
-          | otherwise -> returnN Natural
+
+        -- NOTE that we keep Integer and Natural here as a tag
+        -- Later we'll do a pass over the whole netlist with 'Clash.Netlist.filterBigNums',
+        -- that finds all of them and transforms them to Signed/Unsigned
+        -- and optionally reports them as warnings or errors.
+        $(namePat ''Integer) -> returnN Integer
+        $(namePat ''Natural) -> returnN Natural
+
+
         $(namePat ''GHC.Prim.Char#)                -> returnN (Unsigned 21)
         $(namePat ''GHC.Prim.Int#)                 -> returnN (Signed iw)
         $(namePat ''GHC.Prim.Word#)                -> returnN (Unsigned iw)

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -43,6 +43,7 @@ import qualified Data.Text                            as TextS
 import           Data.Text.Prettyprint.Doc.Extra
 import qualified Data.Text.Prettyprint.Doc.Extra      as PP
 import           Data.Tuple                           (swap)
+import           GHC.Stack                            (HasCallStack)
 import qualified System.FilePath
 
 import           Clash.Annotations.Primitive          (HDL (..))
@@ -618,7 +619,14 @@ verilogType t_ = do
     Bool          -> "logic"
     String        -> "string"
     FileType      -> "integer"
+    Integer       -> integerTyError
+    Natural       -> naturalTyError
     _ -> logicOrWire <+> brackets (int (typeSize t -1) <> colon <> int 0)
+
+integerTyError, naturalTyError :: HasCallStack => a
+integerTyError = error "Verilog backend processing a Integer, this shouldn't have happened :'("
+naturalTyError = error "Verilog backend processing a Natural, this shouldn't have happened :'("
+
 
 sigDecl :: SystemVerilogM Doc -> HWType -> SystemVerilogM Doc
 sigDecl d t = verilogType t <+> d

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
-                     2021-2024, QBayLogic B.V.,
+                     2021-2026, QBayLogic B.V.,
                      2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -56,7 +56,7 @@ import           Clash.Annotations.SynthesisAttributes (Attr(..))
 import           Clash.Debug                          (traceIf)
 import           Clash.Backend
 import           Clash.Backend.Verilog
-  (bits, bit_char, encodingNote, exprLit, include, noEmptyInit, uselibs)
+  (altTy, bits, bit_char, encodingNote, exprLit, include, noEmptyInit, uselibs)
 import           Clash.Backend.Verilog.Time           (periodToString)
 import           Clash.Driver.Types                   (ClashOpts(..))
 import           Clash.Explicit.BlockRam.Internal     (unpackNats)
@@ -68,7 +68,7 @@ import           Clash.Netlist.Types                  hiding (intWidth, usages, 
 import           Clash.Netlist.Util
 import           Clash.Signal.Internal                (ActiveEdge (..))
 import           Clash.Util
-  (SrcSpan, clogBase, noSrcSpan, curLoc, makeCached, indexNote)
+  (SrcSpan, noSrcSpan, curLoc, makeCached, indexNote)
 import           Clash.Util.Graph                     (reverseTopSort)
 
 -- | State for the 'Clash.Backend.SystemVerilog.SystemVerilogM' monad:
@@ -879,7 +879,7 @@ inst_ (CondAssignment id_ ty scrut scrutTy es) = fmap Just $ do
     conds _ []                = return []
     conds i [(_,e)]           = ("default" <+> colon <+> pretty i <+> equals <+> expr_ False e) <:> return []
     conds i ((Nothing,e):_)   = ("default" <+> colon <+> pretty i <+> equals <+> expr_ False e) <:> return []
-    conds i ((Just c ,e):es') = (exprLitSV (Just (scrutTy,conSize scrutTy)) c <+> colon <+> pretty i <+> equals <+> expr_ False e) <:> conds i es'
+    conds i ((Just c ,e):es') = (exprLitSV (Just (altTy scrutTy)) c <+> colon <+> pretty i <+> equals <+> expr_ False e) <:> conds i es'
 
 inst_ (InstDecl _ _ attrs nm lbl ps pms0) = fmap Just $
     attrs' <> nest 2 (pretty nm <> params <> pretty lbl <> line <> pms2 <> semi)
@@ -990,7 +990,7 @@ seq_ (Branch scrut scrutTy es) =
             indent 2 (seqs sq) <> line <>
           "end") <:> return []
         conds ((Just c ,sq):es') =
-          (exprLitSV (Just (scrutTy,conSize scrutTy)) c <+> colon <+> "begin" <> line <>
+          (exprLitSV (Just (altTy scrutTy)) c <+> colon <+> "begin" <> line <>
             indent 2 (seqs sq) <> line <>
           "end") <:> conds es'
 
@@ -1017,7 +1017,7 @@ seqs (d:ds) = seq_ d <> line <> line <> seqs ds
 expr_ :: Bool -- ^ Enclose in parentheses?
       -> Expr -- ^ Expr to convert
       -> SystemVerilogM Doc
-expr_ _ (Literal sizeM lit) = exprLitSV sizeM lit
+expr_ _ (Literal htyM lit) = exprLitSV htyM lit
 expr_ _ (Identifier id_ Nothing) = pretty id_
 expr_ _ (Identifier id_ (Just (Indexed (CustomSP _id dataRepr _size args,dcI,fI)))) =
   case fieldTy of
@@ -1174,7 +1174,7 @@ expr_ _ (DataCon (MemBlob n m) _ [n0, m0, _, runs, _, ends])
   , Literal Nothing (StringLit runs0) <- runs
   , Literal Nothing (StringLit ends0) <- ends
   , es <- unpackNats n m (B8.pack runs0) (B8.pack ends0) =
-    let el val = exprLitSV (Just (BitVector m, m))
+    let el val = exprLitSV (Just (BitVector m))
                            (BitVecLit 0 $ toInteger val)
     in "'" <> listBraces (mapM el es)
 
@@ -1219,31 +1219,29 @@ expr_ _ (DataCon (Enable _) _ [e]) =
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Signed.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  = exprLitSV (Just (Signed (fromInteger n),fromInteger n)) i
+  = exprLitSV (Just (Signed (fromInteger n))) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Unsigned.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  = exprLitSV (Just (Unsigned (fromInteger n),fromInteger n)) i
+  = exprLitSV (Just (Unsigned (fromInteger n))) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.BitVector.fromInteger#"
   , [Literal _ (NumLit n), Literal _ (NumLit m), Literal _ (NumLit i)] <- extractLiterals bbCtx
-  = exprLitSV (Just (BitVector (fromInteger n),fromInteger n)) (BitVecLit m i)
+  = exprLitSV (Just (BitVector (fromInteger n))) (BitVecLit m i)
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.BitVector.fromInteger##"
   , [Literal _ m, Literal _ i] <- extractLiterals bbCtx
   , NumLit m' <- m
   , NumLit i' <- i
-  = exprLitSV (Just (Bit,1)) (BitLit $ toBit m' i')
+  = exprLitSV (Just Bit) (BitLit $ toBit m' i')
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Index.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  , Just k <- clogBase 2 n
-  , let k' = max 1 k
-  = exprLitSV (Just (Index (fromInteger n),k')) i
+  = exprLitSV (Just (Index (fromInteger n))) i
 
 expr_ b (BlackBoxE _ libs imps inc bs bbCtx b') =
   parenIf (b || b') (Ap (renderBlackBox libs imps inc bs bbCtx <*> pure 0))
@@ -1316,7 +1314,7 @@ expr_ b (IfThenElse c t e) =
 
 expr_ _ e = error $ $(curLoc) ++ (show e) -- empty
 
-exprLitSV :: Maybe (HWType,Size) -> Literal -> SystemVerilogM Doc
+exprLitSV :: Maybe HWType -> Literal -> SystemVerilogM Doc
 exprLitSV = exprLit undefValue
 
 otherSize :: [HWType] -> Int -> Int
@@ -1364,7 +1362,7 @@ expFromSLV (Signed _) exp_ = "$signed" <> parens exp_
 expFromSLV _ exp_ = exp_
 
 dcToExpr :: HWType -> Int -> Expr
-dcToExpr ty i = Literal (Just (ty,conSize ty)) (NumLit (toInteger i))
+dcToExpr ty i = Literal (Just (altTy ty)) (NumLit (toInteger i))
 
 listBraces :: Monad m => m [Doc] -> m Doc
 listBraces = align . encloseSep lbrace rbrace comma

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -199,8 +199,8 @@ instance Backend VHDLState where
     Unsigned {} -> pure PrimitiveType
     Signed {} -> pure PrimitiveType
     String -> pure PrimitiveType
-    Integer -> pure PrimitiveType
-    Natural -> pure PrimitiveType  -- TODO natural is a primitive type, but we don't ever want to generate it
+    Integer -> integerTyError
+    Natural -> naturalTyError
     FileType -> pure PrimitiveType
 
     -- Transparent types:
@@ -619,8 +619,8 @@ tyDec hwty = do
     Unsigned _  -> emptyDoc
     Signed _    -> emptyDoc
     String      -> emptyDoc
-    Integer     -> emptyDoc
-    Natural     -> emptyDoc
+    Integer     -> integerTyError
+    Natural     -> naturalTyError
     FileType    -> emptyDoc
 
     -- Transparent types:
@@ -635,7 +635,9 @@ tyDec hwty = do
       Unexpected Product with fewer than 2 fields: #{hwty}
     |]
 
-
+integerTyError, naturalTyError :: HasCallStack => a
+integerTyError = error "VHDL backend processing a Integer, this shouldn't have happened :'("
+naturalTyError = error "VHDL backend processing a Natural, this shouldn't have happened :'("
 
 
 funDec :: RenderEnums -> HdlSyn -> HWType -> Maybe (VHDLM Doc,VHDLM Doc)
@@ -1212,8 +1214,8 @@ tyName' rec0 (filterTransparent -> t) = do
       let app = if rec0 then ["_", showt n] else [] in
       return $ TextS.concat $ "std_logic_vector" : app
     String        -> return "string"
-    Integer       -> return "integer"
-    -- Natural       -> return "natural" -- TODO natural is a primitive type, but we don't ever want to generate it
+    Integer       -> integerTyError
+    Natural       -> naturalTyError
     Bit           -> return "std_logic"
     Vector n elTy -> do
       elTy' <- tyName' True elTy
@@ -1275,8 +1277,8 @@ normaliseType enums@(RenderEnums e) hwty = case hwty of
   Unsigned _    -> hwty
   BitVector _   -> hwty
   String        -> hwty
-  Integer       -> hwty
-  Natural       -> hwty
+  Integer       -> integerTyError
+  Natural       -> naturalTyError
   Bit           -> hwty
   FileType      -> hwty
 
@@ -1310,8 +1312,8 @@ filterTransparent hwty = case hwty of
   Unsigned _        -> hwty
   BitVector _       -> hwty
   String            -> hwty
-  Integer           -> hwty
-  Natural           -> hwty
+  Integer           -> integerTyError
+  Natural           -> naturalTyError
   Bit               -> hwty
   Clock _           -> hwty
   ClockN _          -> hwty

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
-                     2021-2024, QBayLogic B.V.
+                     2021-2026, QBayLogic B.V.
                      2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -1679,7 +1679,7 @@ expr_
   -> Expr
   -- ^ Expr to convert
   -> VHDLM Doc
-expr_ _ (Literal sizeM lit) = exprLit sizeM lit
+expr_ _ (Literal tyM lit) = exprLit tyM lit
 expr_ _ (Identifier id_ Nothing) = pretty id_
 
 expr_ _ (Identifier id_ (Just m)) = do
@@ -1714,7 +1714,7 @@ expr_ _ (DataCon ty@(MemBlob n m) _ [n0, m0, _, runs, _, ends])
   , Literal Nothing (StringLit runs0) <- runs
   , Literal Nothing (StringLit ends0) <- ends
   , es <- unpackNats n m (B8.pack runs0) (B8.pack ends0) =
-    let el val = exprLit (Just (BitVector m, m)) (BitVecLit 0 $ toInteger val)
+    let el val = exprLit (Just (BitVector m)) (BitVecLit 0 $ toInteger val)
     in qualTyName ty <> "'" <> (align $ tupled $ mapM el es)
 
 expr_ _ (DataCon ty@(RTree 0 elTy) _ [e]) = do
@@ -1768,41 +1768,37 @@ expr_ _ (DataCon (Enable _) _ [e]) =
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Signed.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  = exprLit (Just (Signed (fromInteger n),fromInteger n)) i
+  = exprLit (Just (Signed (fromInteger n))) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Unsigned.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  = exprLit (Just (Unsigned (fromInteger n),fromInteger n)) i
+  = exprLit (Just (Unsigned (fromInteger n))) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.BitVector.fromInteger#"
   , [Literal _ (NumLit n), Literal _ m, Literal _ i] <- extractLiterals bbCtx
   , NumLit m' <- m
   , NumLit i' <- i
-  = exprLit (Just (BitVector (fromInteger n),fromInteger n)) (BitVecLit m' i')
+  = exprLit (Just (BitVector (fromInteger n))) (BitVecLit m' i')
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.BitVector.fromInteger##"
   , [Literal _ m, Literal _ i] <- extractLiterals bbCtx
   , NumLit m' <- m
   , NumLit i' <- i
-  = exprLit (Just (Bit,1)) (BitLit $ toBit m' i')
+  = exprLit (Just Bit) (BitLit $ toBit m' i')
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Index.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  , Just k <- clogBase 2 n
-  , let k' = max 1 k
-  = exprLit (Just (Index n,k')) i
+  = exprLit (Just (Index n)) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Index.maxBound#"
   , [Literal _ (NumLit n)] <- extractLiterals bbCtx
   , n > 0
-  , Just k <- clogBase 2 n
-  , let k' = max 1 k
-  = exprLit (Just (Unsigned k',k')) (NumLit (n-1))
+  = exprLit (Just (Index n)) (NumLit (n-1))
 
 expr_ b (BlackBoxE _ libs imps inc bs bbCtx b') = do
   parenIf (b || b') (Ap (renderBlackBox libs imps inc bs bbCtx <*> pure 0))
@@ -1883,17 +1879,17 @@ rtreeChain (DataCon (RTree 1 _) _ [e])     = Just [e]
 rtreeChain (DataCon (RTree _ _) _ [e1,e2]) = liftA2 (++) (rtreeChain e1) (rtreeChain e2)
 rtreeChain _ = Nothing
 
-exprLit :: Maybe (HWType,Size) -> Literal -> VHDLM Doc
+exprLit :: Maybe HWType -> Literal -> VHDLM Doc
 exprLit Nothing (NumLit i) = integer i
 
-exprLit (Just (hty,sz)) (NumLit i) = case hty of
+exprLit (Just hty) (NumLit i) = case hty of
   Unsigned n
     | i <= (-2^(31 :: Integer))-> "unsigned" <> parens ("std_logic_vector" <> parens ("signed'" <> parens lit))
     | i < 0                    -> "unsigned" <> parens ("std_logic_vector" <> parens ("to_signed" <> parens(integer i <> "," <> int n)))
     | i < 2^(31 :: Integer) -> "to_unsigned" <> parens (integer i <> "," <> int n)
     | otherwise -> "unsigned'" <> parens lit
   Index n
-   | 0 <= i && i < n -> exprLit (Just (Unsigned sz, sz)) (NumLit i)  -- reuse Unsigned implementation above
+   | 0 <= i && i < n -> exprLit (Just (Unsigned sz)) (NumLit i)  -- reuse Unsigned implementation above
    | otherwise       -> hdlTypeErrValue hty
   Signed n
     | i < 2^(31 :: Integer) && i > (-2^(31 :: Integer)) -> "to_signed" <> parens (integer i <> "," <> int n)
@@ -1903,6 +1899,7 @@ exprLit (Just (hty,sz)) (NumLit i) = case hty of
   _           -> blit
 
   where
+    sz = typeSize hty
     validHexLit = sz `mod` 4 == 0 && sz /= 0
     lit = if validHexLit then hlit else blit
     blit = bits (toBits sz i)
@@ -1913,10 +1910,11 @@ exprLit (Just (hty,sz)) (NumLit i) = case hty of
              _ -> i `mod` 2^sz
     hlit = (if i' < 0 then "-" else emptyDoc) <> hex (toHex sz i')
 
-exprLit (Just (hty,sz)) (BitVecLit m i) = case m of
-  0 -> exprLit (Just (hty,sz)) (NumLit i)
+exprLit (Just hty) (BitVecLit m i) = case m of
+  0 -> exprLit (Just hty) (NumLit i)
   _ -> "std_logic_vector'" <> parens bvlit
   where
+    sz = typeSize hty
     bvlit = bits (toBits' sz m i)
 
 
@@ -2065,7 +2063,15 @@ toSLV (RTree _ _) e = do
 toSLV hty e = error $ $(curLoc) ++  "toSLV:\n\nType: " ++ show hty ++ "\n\nExpression: " ++ show e
 
 dcToExpr :: HWType -> Int -> Expr
-dcToExpr ty i = Literal (Just (ty,conSize ty)) (NumLit (toInteger i))
+dcToExpr ty i = Literal (Just (altTy ty)) (NumLit (toInteger i))
+
+-- | Calculate the type of an (case) alternative pattern in HDL
+--
+-- For 'SP' this equal to  @BitVector conSize@,
+-- otherwise it's just equal to the type itself.
+altTy :: HWType -> HWType
+altTy scrutTy | typeSize scrutTy /= conSize scrutTy = BitVector (conSize scrutTy)
+              | otherwise = scrutTy
 
 larrow :: VHDLM Doc
 larrow = "<="

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -200,6 +200,7 @@ instance Backend VHDLState where
     Signed {} -> pure PrimitiveType
     String -> pure PrimitiveType
     Integer -> pure PrimitiveType
+    Natural -> pure PrimitiveType  -- TODO natural is a primitive type, but we don't ever want to generate it
     FileType -> pure PrimitiveType
 
     -- Transparent types:
@@ -619,6 +620,7 @@ tyDec hwty = do
     Signed _    -> emptyDoc
     String      -> emptyDoc
     Integer     -> emptyDoc
+    Natural     -> emptyDoc
     FileType    -> emptyDoc
 
     -- Transparent types:
@@ -1211,6 +1213,7 @@ tyName' rec0 (filterTransparent -> t) = do
       return $ TextS.concat $ "std_logic_vector" : app
     String        -> return "string"
     Integer       -> return "integer"
+    -- Natural       -> return "natural" -- TODO natural is a primitive type, but we don't ever want to generate it
     Bit           -> return "std_logic"
     Vector n elTy -> do
       elTy' <- tyName' True elTy
@@ -1273,6 +1276,7 @@ normaliseType enums@(RenderEnums e) hwty = case hwty of
   BitVector _   -> hwty
   String        -> hwty
   Integer       -> hwty
+  Natural       -> hwty
   Bit           -> hwty
   FileType      -> hwty
 
@@ -1307,6 +1311,7 @@ filterTransparent hwty = case hwty of
   BitVector _       -> hwty
   String            -> hwty
   Integer           -> hwty
+  Natural           -> hwty
   Bit               -> hwty
   Clock _           -> hwty
   ClockN _          -> hwty
@@ -1896,6 +1901,7 @@ exprLit (Just hty) (NumLit i) = case hty of
     | otherwise -> "signed'" <> parens lit
   BitVector _ -> "std_logic_vector'" <> parens lit
   Bit         -> squotes (int (fromInteger i `mod` 2))
+  Natural     -> integer i  -- used for SNat when -fclash-no-tranlate-integer-natural
   _           -> blit
 
   where

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -1252,6 +1252,7 @@ exprLit k (Just hty) (NumLit i0) = case hty of
   Signed _
    | i < 0     -> string "-" <> int sz <> string "'sd" <> integer (abs i)
    | otherwise -> int sz <> string "'sd" <> integer i
+  Natural -> integer i0 -- used for SNat when -fclash-no-tranlate-integer-natural
   _ -> int sz <> string "'b" <> blit
   where
     sz = typeSize hty

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
-                     2021-2024, QBayLogic B.V.
+                     2021-2026, QBayLogic B.V.
                      2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -26,6 +26,7 @@ module Clash.Backend.Verilog
   , bits
   , bit_char
   , noEmptyInit
+  , altTy
   -- * split ranges
   , Range (..)
   , continueWithRange
@@ -85,7 +86,7 @@ import           Clash.Netlist.Types as N             hiding (intWidth, usages, 
 import           Clash.Netlist.Util
 import           Clash.Signal.Internal                (ActiveEdge (..))
 import           Clash.Util
-  (SrcSpan, clogBase, noSrcSpan, curLoc, indexNote, makeCached)
+  (SrcSpan, noSrcSpan, curLoc, indexNote, makeCached)
 
 -- | State for the 'Clash.Backend.Verilog.VerilogM' monad:
 data VerilogState =
@@ -591,7 +592,7 @@ inst_ (CondAssignment id_ _ scrut scrutTy es) = fmap Just $
     conds _ []                = return []
     conds i [(_,e)]           = ("default" <+> colon <+> stringS i <+> equals <+> expr_ False e) <:> return []
     conds i ((Nothing,e):_)   = ("default" <+> colon <+> stringS i <+> equals <+> expr_ False e) <:> return []
-    conds i ((Just c ,e):es') = (exprLitV (Just (scrutTy,conSize scrutTy)) c <+> colon <+> stringS i <+> equals <+> expr_ False e) <:> conds i es'
+    conds i ((Just c ,e):es') = (exprLitV (Just $ altTy scrutTy) c <+> colon <+> stringS i <+> equals <+> expr_ False e) <:> conds i es'
 
 inst_ (InstDecl _ _ attrs nm lbl ps pms0) = fmap Just $
     attrs' <> nest 2 (pretty nm <> params <> pretty lbl <> line <> pms2 <> semi)
@@ -624,6 +625,14 @@ inst_ (ConditionalDecl cond ds) = Just <$>
 
 inst_ d =
   error ("inst_: " ++ show d)
+
+-- | Calculate the type of an (case) alternative pattern in HDL
+--
+-- For 'SP' this equal to  @BitVector conSize@,
+-- otherwise it's just equal to the type itself.
+altTy :: HWType -> HWType
+altTy scrutTy | typeSize scrutTy /= conSize scrutTy = BitVector (conSize scrutTy)
+              | otherwise = scrutTy
 
 seq_ :: Seq -> VerilogM Doc
 seq_ (AlwaysClocked edge clk ds) =
@@ -660,7 +669,7 @@ seq_ (Branch scrut scrutTy es) =
         indent 2 (seqs sq) <> line <>
       "end") <:> return []
     conds ((Just c ,sq):es') =
-      (exprLitV (Just (scrutTy,conSize scrutTy)) c <+> colon <+> "begin" <> line <>
+      (exprLitV (Just (altTy scrutTy)) c <+> colon <+> "begin" <> line <>
         indent 2 (seqs sq) <> line <>
       "end") <:> conds es'
 
@@ -1099,7 +1108,7 @@ expr_ _ (DataCon (MemBlob n m) _ [n0, m0, _, runs, _, ends])
   , Literal Nothing (StringLit runs0) <- runs
   , Literal Nothing (StringLit ends0) <- ends
   , es <- unpackNats n m (B8.pack runs0) (B8.pack ends0) =
-    let el val = exprLitV (Just (BitVector m, m)) (BitVecLit 0 $ toInteger val)
+    let el val = exprLitV (Just (BitVector m)) (BitVecLit 0 $ toInteger val)
     in listBraces $ mapM el es
 
 expr_ _ (DataCon (RTree 0 _) _ [e]) = expr_ False e
@@ -1141,33 +1150,31 @@ expr_ _ (DataCon (Enable _) _ [e]) =
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Signed.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  = exprLitV (Just (Signed (fromInteger n),fromInteger n)) i
+  = exprLitV (Just (Signed (fromInteger n))) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Unsigned.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  = exprLitV (Just (Unsigned (fromInteger n),fromInteger n)) i
+  = exprLitV (Just (Unsigned (fromInteger n))) i
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.BitVector.fromInteger#"
   , [Literal _ (NumLit n), Literal _ m, Literal _ i] <- extractLiterals bbCtx
   , NumLit m' <- m
   , NumLit i' <- i
-  = exprLitV (Just (BitVector (fromInteger n),fromInteger n)) (BitVecLit m' i')
+  = exprLitV (Just (BitVector (fromInteger n))) (BitVecLit m' i')
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.BitVector.fromInteger##"
   , [Literal _ m, Literal _ i] <- extractLiterals bbCtx
   , NumLit m' <- m
   , NumLit i' <- i
-  = exprLitV (Just (Bit,1)) (BitLit $ toBit m' i')
+  = exprLitV (Just Bit) (BitLit $ toBit m' i')
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Index.fromInteger#"
   , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
-  , Just k <- clogBase 2 n
-  , let k' = max 1 k
-  = exprLitV (Just (Index (fromInteger n),k')) i
+  = exprLitV (Just (Index (fromInteger n))) i
 
 expr_ b (BlackBoxE _ libs imps inc bs bbCtx b') = do
   parenIf (b || b') (Ap (renderBlackBox libs imps inc bs bbCtx <*> pure 0))
@@ -1229,13 +1236,13 @@ rtreeChain (DataCon (RTree 0 _) _ [e])     = Just [e]
 rtreeChain (DataCon (RTree _ _) _ [e1,e2]) = Just e1 <:> rtreeChain e2
 rtreeChain _                               = Nothing
 
-exprLitV :: Maybe (HWType,Size) -> Literal -> VerilogM Doc
+exprLitV :: Maybe HWType -> Literal -> VerilogM Doc
 exprLitV = exprLit undefValue
 
-exprLit :: Backend s => Lens' s (Maybe (Maybe Int)) -> Maybe (HWType,Size) -> Literal -> Ap (State s) Doc
+exprLit :: Backend s => Lens' s (Maybe (Maybe Int)) -> Maybe HWType -> Literal -> Ap (State s) Doc
 exprLit _ Nothing (NumLit i) = integer i
 
-exprLit k (Just (hty,sz)) (NumLit i0) = case hty of
+exprLit k (Just hty) (NumLit i0) = case hty of
   Unsigned _
    | i < 0     -> string "-" <> int sz <> string "'d" <> integer (abs i)
    | otherwise -> int sz <> string "'d" <> integer i
@@ -1247,14 +1254,16 @@ exprLit k (Just (hty,sz)) (NumLit i0) = case hty of
    | otherwise -> int sz <> string "'sd" <> integer i
   _ -> int sz <> string "'b" <> blit
   where
+    sz = typeSize hty
     blit = bits k (toBits sz i)
     i = case hty of
              Signed _ -> let mask = 2^(sz-1) in case divMod i0 mask of
                 (s,i'') | even s    -> i''
                         | otherwise -> i'' - mask
              _ -> i0 `mod` 2^sz
-exprLit k (Just (_,sz)) (BitVecLit m i) = int sz <> string "'b" <> bvlit
+exprLit k (Just hty) (BitVecLit m i) = int sz <> string "'b" <> bvlit
   where
+    sz = typeSize hty
     bvlit = bits k (toBits' sz m i)
 
 exprLit _ _             (BoolLit t)   = string $ if t then "1'b1" else "1'b0"
@@ -1296,7 +1305,7 @@ bit_char k b = do
     _                 -> char (bit_char' b)
 
 dcToExpr :: HWType -> Int -> Expr
-dcToExpr ty i = Literal (Just (ty,conSize ty)) (NumLit (toInteger i))
+dcToExpr ty i = Literal (Just (altTy ty)) (NumLit (toInteger i))
 
 listBraces :: Monad m => m [Doc] -> m Doc
 listBraces = align . enclose lbrace rbrace . hsep . punctuate (comma <+> softline)

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -392,7 +392,13 @@ verilogType t = case t of
   FileType -> emptyDoc
   Annotated _ ty -> verilogType ty
   BiDirectional _ ty -> verilogType ty
+  Integer -> integerTyError
+  Natural -> naturalTyError
   _        -> brackets (int (typeSize t -1) <> colon <> int 0)
+
+integerTyError, naturalTyError :: HasCallStack => a
+integerTyError = error "Verilog backend processing a Integer, this shouldn't have happened :'("
+naturalTyError = error "Verilog backend processing a Natural, this shouldn't have happened :'("
 
 sigDecl :: VerilogM Doc -> HWType -> VerilogM Doc
 sigDecl d t = verilogType t <+> d

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -2,7 +2,7 @@
   Copyright   :  (C) 2012-2016, University of Twente,
                      2016-2017, Myrtle Software Ltd,
                      2017     , QBayLogic, Google Inc.
-                     2020-2024, QBayLogic,
+                     2020-2026, QBayLogic B.V.,
                      2022     , Google Inc.
 
   License     :  BSD2 (see the file LICENSE)
@@ -21,7 +21,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Driver where
-
 import           Control.Concurrent               (MVar, modifyMVar, modifyMVar_, newMVar, withMVar)
 import           Control.Concurrent.Async         (mapConcurrently_)
 import           Control.DeepSeq
@@ -42,6 +41,7 @@ import qualified Data.ByteString.Lazy             as ByteStringLazy
 import qualified Data.ByteString.Lazy.Char8       as ByteStringLazyChar8
 import           Data.Char                        (isAscii, isAlphaNum)
 import           Data.Default
+import           Data.Foldable                    (toList)
 import           Data.Hashable                    (hash)
 import           Data.HashMap.Strict              (HashMap)
 import qualified Data.HashMap.Strict              as HashMap
@@ -113,7 +113,7 @@ import           Clash.Driver.Manifest
   (Manifest(..), readFreshManifest, UnexpectedModification, pprintUnexpectedModifications,
    mkManifest, writeManifest, manifestFilename)
 import           Clash.Edalize.Edam
-import           Clash.Netlist                    (genNetlist, genTopNames)
+import           Clash.Netlist                    (checkComponent, genNetlist, genTopNames)
 import           Clash.Netlist.BlackBox.Parser    (runParse)
 import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate, BlackBoxFunction)
 import qualified Clash.Netlist.Id                 as Id
@@ -459,6 +459,14 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
 
       withMVar ioLockV . const $
         putStrLn ("Clash: Netlist generation took " ++ normNetDiff)
+
+      let netlistComps = snd <$> toList netlist
+          netlistErrors = concatMap checkComponent netlistComps
+          translBigNums = opt_translateBigNums opts
+      -- 3b. Check the netlist for bignums that shouldn't be there
+      Monad.when (not translBigNums && not (null netlistErrors)) $ do
+        IO.hPutStrLn IO.stderr $ unlines netlistErrors
+        error "got netlist errors"
 
       -- 4. Generate topEntity wrapper
       (hdlDocs, dfiles, mfiles) <- withMVar seenV $ \seen ->

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -467,9 +467,10 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
           iw = opt_intWidth opts
       let (netlist, _, netlistErrors) = runRWS (filterBigNums [] netlist0) iw ()
       -- 3b. Check the netlist for bignums that shouldn't be there
-      Monad.when (not translBigNums && not (null netlistErrors)) $ do
+      Monad.when (translBigNums /= BigNumSilent && not (null netlistErrors)) $ do
         IO.hPutStrLn IO.stderr $ unlines netlistErrors
-        error "got netlist errors"
+        Monad.when (translBigNums == BigNumError) $
+          error "got netlist errors"
 
       -- 4. Generate topEntity wrapper
       (hdlDocs, dfiles, mfiles) <- withMVar seenV $ \seen ->

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -33,6 +33,7 @@ import           Control.Monad.IO.Class           (MonadIO)
 import           Control.Monad.State              (evalState, get)
 import           Control.Monad.State.Strict       (State)
 import qualified Control.Monad.State.Strict       as State
+import           Control.Monad.Trans.RWS.CPS      (runRWS)
 import qualified Crypto.Hash.SHA256               as Sha256
 import           Data.Bifunctor                   (first, second)
 import           Data.ByteString                  (ByteString)
@@ -113,7 +114,7 @@ import           Clash.Driver.Manifest
   (Manifest(..), readFreshManifest, UnexpectedModification, pprintUnexpectedModifications,
    mkManifest, writeManifest, manifestFilename)
 import           Clash.Edalize.Edam
-import           Clash.Netlist                    (checkComponent, genNetlist, genTopNames)
+import           Clash.Netlist                    (checkComponent, filterBigNums, genNetlist, genTopNames)
 import           Clash.Netlist.BlackBox.Parser    (runParse)
 import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate, BlackBoxFunction)
 import qualified Clash.Netlist.Id                 as Id
@@ -446,7 +447,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
         putStrLn ("Clash: Normalization took " ++ prepNormDiff)
 
       -- 3. Generate netlist for topEntity
-      (topComponent, netlist) <- modifyMVar seenV $ \seen -> do
+      (topComponent, netlist0) <- modifyMVar seenV $ \seen -> do
         (topComponent, netlist, seen') <-
           -- TODO My word, this has far too many arguments.
           genNetlist env peEval isTb transformedBindings topEntityMap compNames
@@ -454,15 +455,17 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
 
         pure (seen', (topComponent, netlist))
 
-      netlistTime <- netlist `deepseq` Clock.getCurrentTime
+      netlistTime <- netlist0 `deepseq` Clock.getCurrentTime
       let normNetDiff = reportTimeDiff netlistTime normTime
 
       withMVar ioLockV . const $
         putStrLn ("Clash: Netlist generation took " ++ normNetDiff)
 
-      let netlistComps = snd <$> toList netlist
-          netlistErrors = concatMap checkComponent netlistComps
+      let -- netlistComps = snd <$> toList netlist0
+          -- netlistErrors = concatMap checkComponent netlistComps
           translBigNums = opt_translateBigNums opts
+          iw = opt_intWidth opts
+      let (netlist, _, netlistErrors) = runRWS (filterBigNums [] netlist0) iw ()
       -- 3b. Check the netlist for bignums that shouldn't be there
       Monad.when (not translBigNums && not (null netlistErrors)) $ do
         IO.hPutStrLn IO.stderr $ unlines netlistErrors

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -447,7 +447,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
         putStrLn ("Clash: Normalization took " ++ prepNormDiff)
 
       -- 3. Generate netlist for topEntity
-      (topComponent, netlist0) <- modifyMVar seenV $ \seen -> do
+      (topComponent0, netlist0) <- modifyMVar seenV $ \seen -> do
         (topComponent, netlist, seen') <-
           -- TODO My word, this has far too many arguments.
           genNetlist env peEval isTb transformedBindings topEntityMap compNames
@@ -465,7 +465,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
           -- netlistErrors = concatMap checkComponent netlistComps
           translBigNums = opt_translateBigNums opts
           iw = opt_intWidth opts
-      let (netlist, _, netlistErrors) = runRWS (filterBigNums [] netlist0) iw ()
+      let ((topComponent,netlist), _, netlistErrors) = runRWS (filterBigNums [] (topComponent0,netlist0)) iw ()
       -- 3b. Check the netlist for bignums that shouldn't be there
       Monad.when (translBigNums /= BigNumSilent && not (null netlistErrors)) $ do
         IO.hPutStrLn IO.stderr $ unlines netlistErrors
@@ -787,7 +787,10 @@ createHDL backend opts modName seen components domainConfs top topName = flip ev
       forM componentsL $ \(ComponentMeta{cmLoc, cmScope,cmUsage}, comp) ->
          genHDL opts modName cmLoc (Id.union seen cmScope) cmUsage comp
 
-  hwtys <- HashSet.toList <$> extractTypes <$> Ap get
+  hwtys0 <- HashSet.toList <$> extractTypes <$> Ap get
+  let (hwtys,_,_) = runRWS (filterBigNums [] hwtys0) iw ()
+      iw = opt_intWidth opts
+
   typesPkg0 <- mkTyPackage modName hwtys
   dataFiles <- Ap getDataFiles
   memFiles  <- Ap getMemoryDataFiles

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -412,6 +412,10 @@ data ClashOpts = ClashOpts
   -- /which/ input changed.
   --
   -- Command line flag: -fclash-debug-manifest-hash
+  , opt_translateBigNums :: Bool
+  -- ^ Translate bignums (Integer and Natural) to HDL
+  -- Defaults to on.
+  -- Command line flag: @-fclash-translate-bignums@ or @-fclash-no-translate-bignums@
   }
   deriving (Show, Eq, NFData, Generic, Hashable)
 
@@ -453,6 +457,7 @@ defClashOpts
   , opt_ignoreBrokenGhcs    = unsafeLookupEnvBool "CLASH_IGNORE_BROKEN_GHCS" False
   , opt_concurrentTopEntities = True
   , opt_debugManifestHash   = False
+  , opt_translateBigNums    = True
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -412,12 +412,14 @@ data ClashOpts = ClashOpts
   -- /which/ input changed.
   --
   -- Command line flag: -fclash-debug-manifest-hash
-  , opt_translateBigNums :: Bool
-  -- ^ Translate bignums (Integer and Natural) to HDL
-  -- Defaults to on.
-  -- Command line flag: @-fclash-translate-bignums@ or @-fclash-no-translate-bignums@
+  , opt_translateBigNums :: TranslateBigNums
+  -- ^ How bignums(Integer and Natural) are handled
+  -- Defaults to warn.
+  -- Command line flag: @-fclash-translate-bignums[=[silent,warn,error]]@
   }
   deriving (Show, Eq, NFData, Generic, Hashable)
+
+data TranslateBigNums = BigNumSilent | BigNumWarn | BigNumError deriving (Show,Eq,NFData,Generic,Hashable)
 
 defClashOpts :: ClashOpts
 defClashOpts
@@ -457,7 +459,7 @@ defClashOpts
   , opt_ignoreBrokenGhcs    = unsafeLookupEnvBool "CLASH_IGNORE_BROKEN_GHCS" False
   , opt_concurrentTopEntities = True
   , opt_debugManifestHash   = False
-  , opt_translateBigNums    = True
+  , opt_translateBigNums    = BigNumWarn
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -33,12 +33,13 @@ import           Data.Bifunctor                   (first, second)
 import           Data.Char                        (ord)
 import           Data.Either                      (partitionEithers, rights)
 import           Data.Foldable                    (foldlM)
+import qualified Data.IntMap.Strict               as IntMap
 import           Data.List                        (elemIndex, partition)
 import           Data.List.Extra                  (zipEqual)
 import           Data.List.NonEmpty               (NonEmpty (..))
 import qualified Data.List.NonEmpty.Extra         as NE
 import           Data.Maybe
-  (listToMaybe, fromMaybe)
+  (catMaybes, listToMaybe, fromMaybe, mapMaybe, maybeToList)
 import qualified Data.Map.Ordered                 as OMap
 import qualified Data.Set                         as Set
 import qualified Data.Text                        as StrictText
@@ -74,6 +75,7 @@ import           Clash.Core.VarEnv
    lookupVarEnv')
 import           Clash.Driver.Types               (BindingMap, Binding(..), ClashEnv(..), ClashOpts (..))
 import           Clash.Netlist.BlackBox
+import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate)
 import qualified Clash.Netlist.Id                 as Id
 import           Clash.Netlist.Types              as HW
 import           Clash.Netlist.Util
@@ -837,7 +839,8 @@ mkExpr :: HasCallStack
        -> NetlistMonad (Expr,[Declaration]) -- ^ Returned expression and a list of generate BlackBox declarations
 mkExpr _ _ _ (stripTicks -> Core.Literal l) = do
   iw <- Lens.view intWidth
-  return (mkLiteral iw l, [])
+  translBigNums <- Lens.view translateBigNums
+  return (mkLiteral iw translBigNums l, [])
 
 mkExpr bbEasD declType bndr app =
  let (appF,args,ticks) = collectArgsTicks app
@@ -1148,3 +1151,136 @@ mkDcApplication declType dstHTypes (MultiId argNms) _ args = do
     error "internal error"
 
 mkDcApplication _ _ _ _ _ = error "internal error"
+
+type ErrorMsg = String
+
+data NetlistContext =
+  CtxComponent Identifier | CtxPort PortDirection Identifier | CtxSignal Identifier | CtxBlackBox StrictText.Text | CtxBbInput Int | CtxBbResult Int | CtxType String
+
+showNetlistContexts :: [NetlistContext] -> String
+showNetlistContexts = concatMap go
+ where
+  go = \case
+    CtxComponent nm -> " in component " <> showIdentifier nm
+    CtxPort dir nm -> let dirStr = case dir of In -> "input"; Out -> "output"
+                      in " in " <> dirStr <> " port " <> showIdentifier nm
+    CtxSignal nm -> " in signal " <> showIdentifier nm
+    CtxBlackBox nm -> " blackbox " <> StrictText.unpack nm
+    CtxBbInput n -> " in input " <> show n <> " to"
+    CtxBbResult n -> " in result " <> show n <> " of"
+    CtxType str -> " in " <> str
+
+showIdentifier :: Identifier -> String
+showIdentifier = StrictText.unpack . Id.toText
+
+-- Checks the netlist for Integer/Natural usage
+checkComponent :: Component -> [ErrorMsg]
+checkComponent (Component compNm ins outs decls) = inErrs <> outErrs <> declErrs
+ where
+   compCtx = [CtxComponent compNm]
+   inErrs = mapMaybe (checkPort compCtx In) ins
+   outErrs = mapMaybe ((checkPort compCtx Out) . (\(_,x,_) -> x)) outs
+   declErrs = concatMap (checkDecl compCtx) decls
+   checkHWType :: [NetlistContext] -> HWType -> Maybe ErrorMsg
+   checkHWType ctx ty = case ty of
+     Natural -> Just $ "Found Natural" <> showNetlistContexts ctx
+     Integer -> Just $ "Found Integer" <> showNetlistContexts ctx
+     Vector _sz elemTy -> let ctx' = CtxType "Vector" : ctx in checkHWType ctx' elemTy
+     RTree _ elemTy -> let ctx' = CtxType "RTree" : ctx in checkHWType ctx' elemTy
+     Product _ _ tys -> let ctx' = CtxType "Product" : ctx in listToMaybe $ concatMap maybeToList $ map (checkHWType ctx') tys
+     SP _ xs -> let ctx' = CtxType "SP" : ctx in listToMaybe $ concatMap maybeToList $ map (checkHWType ctx') $ concatMap snd xs
+     BiDirectional _ ty' -> let ctx' = CtxType "BiDirectional" : ctx in checkHWType ctx' ty'
+     CustomSP _ _ _ xs -> let ctx' = CtxType "CustomSP" : ctx in listToMaybe $ concatMap maybeToList $ map (checkHWType ctx') $ concatMap (\(_,_,x) -> x) xs
+     CustomProduct _ _ _ _ xs -> let ctx' = CtxType "CustomProduct" : ctx in  listToMaybe $ concatMap maybeToList $ map (checkHWType ctx' . snd) xs
+     Annotated _ ty' -> let ctx' = CtxType "Annotated" : ctx in  checkHWType ctx' ty'
+
+     Void _ -> Nothing
+     String -> Nothing
+     Bool -> Nothing
+     Bit -> Nothing
+     BitVector _ -> Nothing
+     Index _ -> Nothing
+     Signed _ -> Nothing
+     Unsigned _ -> Nothing
+     MemBlob _ _ -> Nothing
+     Sum _ _ -> Nothing
+     Clock _ -> Nothing
+     ClockN _ -> Nothing
+     Reset _ -> Nothing
+     Enable _ -> Nothing
+     CustomSum {} -> Nothing
+     KnownDomain {} -> Nothing
+     FileType -> Nothing
+
+   checkTypedExpr1 :: [NetlistContext] -> HWType -> Expr -> Maybe ErrorMsg
+   checkTypedExpr1 ctx ty e = listToMaybe $ checkTypedExpr ctx ty e
+
+   -- Function arguments to HO blackboxes get the type "Void Nothing"
+   -- and a Expr containing an exception, so don't look inside
+   checkTypedExpr1IgnoreVoid :: [NetlistContext] -> HWType -> Expr -> Maybe ErrorMsg
+   checkTypedExpr1IgnoreVoid ctx ty e = case ty of
+     Void Nothing -> Nothing
+     _ -> checkTypedExpr1 ctx ty e
+
+
+   checkTypedExpr :: [NetlistContext] -> HWType -> Expr -> [ErrorMsg]
+   checkTypedExpr ctx ty e = case checkHWType ctx ty of
+     Just err -> [err]
+     Nothing -> checkExpr ctx e
+   checkPort :: [NetlistContext] -> PortDirection -> (Identifier,HWType) -> Maybe ErrorMsg
+   checkPort ctx portDirection (portNm,ty) = checkHWType (CtxPort portDirection portNm:ctx) ty
+   checkDecl :: [NetlistContext] -> Declaration -> [ErrorMsg]
+   checkDecl ctx x = case x of
+     Assignment nm _ expr -> checkExpr (CtxSignal nm : ctx) expr
+     CondAssignment nm ty scrut scrutTy alts ->
+       let ctx' = CtxSignal nm : ctx
+       in catMaybes [checkHWType ctx' ty, checkHWType ctx' scrutTy] <> checkExpr ctx' scrut <> concatMap (checkExpr ctx' . snd) alts
+     InstDecl {} -> [] -- will be checked when we check that components netlist
+     CompDecl{} -> [] -- will be checked when we check that components netlist
+     BlackBoxD nm _libs _use _qsys _bb bbCtx ->
+       let ctx' = CtxBlackBox nm : ctx
+       in checkBbCtx ctx' bbCtx
+     NetDecl' _ nm ty e -> let ctx' = CtxSignal nm : ctx in catMaybes [checkHWType ctx' ty, checkExpr1 ctx' =<< e]
+     TickDecl {} -> []
+     Seq xs -> concatMap (checkSeq ctx) xs
+     ConditionalDecl _ xs -> concatMap (checkDecl ctx) xs
+   checkExpr1 :: [NetlistContext] -> Expr -> Maybe ErrorMsg
+   checkExpr1 ctx e = listToMaybe $ checkExpr ctx e
+   checkExpr :: [NetlistContext] -> Expr -> [ErrorMsg]
+   checkExpr ctx = \case
+     HW.Literal mTy _ -> maybeToList $ checkHWType ctx =<< mTy
+     DataCon _ _ exprs -> concatMap (checkExpr ctx) exprs
+     Identifier{} -> mempty
+     DataTag ty _ -> maybeToList $ checkHWType ctx ty
+     BlackBoxE nm _libs _use _qsys _bb bbCtx _ ->
+       let ctx' = CtxBlackBox nm : ctx
+       in checkBbCtx ctx' bbCtx
+     ToBv _ ty e -> maybeToList (checkHWType ctx ty) <> checkExpr ctx e
+     FromBv _ ty e -> maybeToList (checkHWType ctx ty) <> checkExpr ctx e
+     IfThenElse eCond eThen eElse -> concatMap (checkExpr ctx) [eCond,eThen,eElse]
+     Noop -> mempty
+   checkSeq :: [NetlistContext] -> Seq -> [ErrorMsg]
+   checkSeq ctx = \case
+     AlwaysClocked _edge _clock seqs -> concatMap (checkSeq ctx) seqs
+     Initial seqs -> concatMap (checkSeq ctx) seqs
+     AlwaysComb seqs -> concatMap (checkSeq ctx) seqs
+     SeqDecl decl -> checkDecl ctx decl
+     Branch scrut scrutTy alts -> checkTypedExpr ctx scrutTy scrut <> concatMap (concatMap (checkSeq ctx) . snd) alts
+
+   checkBbCtx :: [NetlistContext] -> BlackBoxContext -> [ErrorMsg]
+   checkBbCtx ctx bbCtx =
+     let
+        bbInpErrs = mapMaybe (\(n,(e,ty,isConst)) -> if isConst then mempty else let ctx' = CtxBbInput n : ctx in checkTypedExpr1IgnoreVoid ctx' ty e) (zip [0..] $ bbInputs bbCtx)
+        bbResErrs = mapMaybe (\(n,(e,ty)) ->        let ctx' = CtxBbResult n : ctx in checkTypedExpr1 ctx' ty e) (zip [0..] $ bbResults bbCtx)
+        bbFunErrs = concatMap (\(n,xs) -> concatMap (checkBbFun (CtxBbInput n : ctx)) xs) $ IntMap.toList $ bbFunctions bbCtx
+     in bbInpErrs <> bbResErrs <> bbFunErrs
+
+   checkBbFun :: [NetlistContext]
+              -> (Either BlackBox (Identifier, [Declaration]), Usage,
+                  [BlackBoxTemplate],[BlackBoxTemplate],
+                  [((StrictText.Text, StrictText.Text), BlackBox)], BlackBoxContext
+                 )
+              -> [ErrorMsg]
+   checkBbFun ctx (eTempl, _usage, _lib, _imps, _incs, bbCtx) = case eTempl of
+     Left _bb -> checkBbCtx ctx bbCtx
+     Right (_nm,decls') -> concatMap (checkDecl ctx) decls' <> checkBbCtx ctx bbCtx

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -1339,8 +1339,16 @@ instance FilterBigNums Expr where
 
 instance FilterBigNums BlackBoxContext where
   filterBigNums ctx (Context {..}) =
-    Context bbName <$> filterBigNums ctx bbResults <*> filterBigNums ctx bbInputs <*> mapM (filterBigNums ctx) bbFunctions <*> pure bbQsysIncName <*> pure bbLevel <*> pure bbCompName <*> pure bbCtxName
-
+    Context bbName <$> filterBigNums ctx bbResults <*> filterInputs bbInputs <*> mapM (filterBigNums ctx) bbFunctions <*> pure bbQsysIncName <*> pure bbLevel <*> pure bbCompName <*> pure bbCtxName
+   where
+     -- filterInputs :: [(Expr, HWType, Bool)] -> _
+     filterInputs = zipWithM filterInput [0..]
+     filterInput n (e, ty, isConst) = (,,) <$> e' <*> filterBigNums ctx' ty <*> pure isConst
+      where
+        ctx' = CtxBbInput n : ctx
+        e' = case ty of
+          Void _ -> pure e
+          _ -> filterBigNums ctx' e
 
 -- Checks the netlist for Integer/Natural usage
 checkComponent :: Component -> [ErrorMsg]

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -1228,7 +1228,7 @@ instance FilterBigNums Declaration where
     InstDecl eOrC mLib attrs nm lbl params portmap -> InstDecl eOrC mLib attrs nm lbl <$> filterBigNums ctx params <*> filterBigNums ctx portmap
     CompDecl nm ports -> CompDecl nm <$> filterBigNums ctx ports
     BlackBoxD nm libs use qsys bb bbCtx -> let ctx' = CtxBlackBox nm : ctx in
-      BlackBoxD nm libs use qsys bb <$> filterBigNums ctx bbCtx
+      BlackBoxD nm libs use qsys bb <$> filterBigNums ctx' bbCtx
     NetDecl' comment nm ty e -> let ctx' = CtxSignal nm : ctx in
       NetDecl' comment nm <$> filterBigNums ctx' ty <*> filterBigNums ctx' e
     TickDecl {} -> pure d0

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -843,8 +843,7 @@ mkExpr :: HasCallStack
        -> NetlistMonad (Expr,[Declaration]) -- ^ Returned expression and a list of generate BlackBox declarations
 mkExpr _ _ _ (stripTicks -> Core.Literal l) = do
   iw <- Lens.view intWidth
-  translBigNums <- Lens.view translateBigNums
-  return (mkLiteral iw translBigNums l, [])
+  return (mkLiteral iw False l, [])
 
 mkExpr bbEasD declType bndr app =
  let (appF,args,ticks) = collectArgsTicks app

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -47,6 +47,7 @@ import           Data.Maybe
 import qualified Data.Map.Ordered                 as OMap
 import qualified Data.Set                         as Set
 import qualified Data.Text                        as StrictText
+import           Data.Text.Extra                  (showt)
 import           GHC.Stack                        (HasCallStack)
 
 import           GHC.Utils.Outputable             (ppr, showSDocUnsafe)
@@ -83,10 +84,12 @@ import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate,Element)
 import qualified Clash.Netlist.Id                 as Id
 import           Clash.Netlist.Types              as HW
 import           Clash.Netlist.Util
+import           Clash.Normalize.Primitives    (removedArg)
 import           Clash.Primitives.Types           as P
 import           Clash.Util
 import qualified Clash.Util.Interpolate           as I
 import Clash.Core.PartialEval (Evaluator)
+import Clash.Annotations.SynthesisAttributes (annotate)
 
 -- | Generate a hierarchical netlist out of a set of global binders with
 -- @topEntity@ at the top.
@@ -1329,8 +1332,10 @@ instance FilterBigNums Expr where
      DataCon ty modifier exprs -> DataCon <$> filterBigNums ctx ty <*> pure modifier <*> filterBigNums ctx exprs
      Identifier{} -> pure e0
      DataTag ty x -> DataTag <$> filterBigNums ctx ty <*> pure x
-     BlackBoxE nm libs use qsys bb bbCtx wrap -> let ctx' = CtxBlackBox nm : ctx in
-       BlackBoxE nm libs use qsys bb <$> filterBigNums ctx' bbCtx <*> pure wrap
+     BlackBoxE nm libs use qsys bb bbCtx wrap
+       | nm == showt 'removedArg -> pure e0 -- error ("got removedArg") --
+       | otherwise -> let ctx' = CtxBlackBox nm : ctx in
+         BlackBoxE nm libs use qsys bb <$> filterBigNums ctx' bbCtx <*> pure wrap
      ToBv   mNm ty e -> ToBv   mNm <$> filterBigNums ctx ty <*> filterBigNums ctx e
      FromBv mNm ty e -> FromBv mNm <$> filterBigNums ctx ty <*> filterBigNums ctx e
      IfThenElse eCond eThen eElse -> IfThenElse <$> filterBigNums ctx eCond <*> filterBigNums ctx eThen <*> filterBigNums ctx eElse
@@ -1341,13 +1346,26 @@ instance FilterBigNums BlackBoxContext where
     Context bbName <$> filterBigNums ctx bbResults <*> filterInputs bbInputs <*> mapM (filterBigNums ctx) bbFunctions <*> pure bbQsysIncName <*> pure bbLevel <*> pure bbCompName <*> pure bbCtxName
    where
      -- filterInputs :: [(Expr, HWType, Bool)] -> _
-     filterInputs = zipWithM filterInput [0..]
-     filterInput n (e, ty, isConst) = (,,) <$> e' <*> filterBigNums ctx' ty <*> pure isConst
+     filterInputs
+       | bbName == showt 'annotate = \(attrs : args) -> (attrs :) <$> zipWithM filterInput [1..] args
+       | otherwise = zipWithM filterInput [0..]
+     filterInput n inp@(e, ty, isConst) = case (ty,e) of
+          (Void {},_)       -> pure inp
+          _ | isConst && isLiteralExpr e -> pure inp -- allow all literals as inputs to blackboxes
+          _ | isRemovedArg e -> pure inp -- ignore removedArg
+
+          _ -> (,,) <$> filterBigNums ctx' e <*> filterBigNums ctx' ty <*> pure isConst
       where
         ctx' = CtxBbInput n : ctx
-        e' = case ty of
-          Void _ -> pure e
-          _ -> filterBigNums ctx' e
+
+isLiteralExpr e = case e of
+  HW.Literal{} -> True
+  DataCon _ (DC (Void Nothing,-1)) args -> all isLiteralExpr args -- look through newtype wrapper (mostly SNat)
+  _ -> False
+
+isRemovedArg e = case e of
+  BlackBoxE nm _ _ _ _ _ _ -> nm == showt 'removedArg
+  _ -> False
 
 -- Checks the netlist for Integer/Natural usage
 checkComponent :: Component -> [ErrorMsg]

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -1292,7 +1292,7 @@ instance FilterBigNums HWType where
      CustomProduct nm repr sz fieldNms xs -> let ctx' = CtxType ("CustomProduct " <> show nm) : ctx in
        CustomProduct nm repr sz fieldNms <$> mapM (\(fAnn,ty) -> (fAnn,) <$> filterBigNums ctx' ty) xs
 
-     SP nm xs -> let ctx' = CtxType ("SP" <> show nm) : ctx in
+     SP nm xs -> let ctx' = CtxType ("SP " <> show nm) : ctx in
        SP nm <$> mapM (\(nm',tys) -> (nm',) <$> filterBigNums ctx' tys) xs
 
      CustomSP nm repr sz xs -> let ctx' = CtxType ("CustomSP " <> show nm) : ctx in

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -11,6 +11,7 @@
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -19,6 +20,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 
 module Clash.Netlist where
 
@@ -29,7 +31,9 @@ import           Control.Monad                    (zipWithM)
 import           Control.Monad.Extra              (concatMapM, mapMaybeM)
 import           Control.Monad.Reader             (runReaderT)
 import           Control.Monad.State.Strict       (State, runStateT, runState)
+import           Control.Monad.Trans.RWS.CPS      (RWS, ask, tell)
 import           Data.Bifunctor                   (first, second)
+import           Data.Bitraversable               (bitraverse)
 import           Data.Char                        (ord)
 import           Data.Either                      (partitionEithers, rights)
 import           Data.Foldable                    (foldlM)
@@ -75,7 +79,7 @@ import           Clash.Core.VarEnv
    lookupVarEnv')
 import           Clash.Driver.Types               (BindingMap, Binding(..), ClashEnv(..), ClashOpts (..))
 import           Clash.Netlist.BlackBox
-import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate)
+import           Clash.Netlist.BlackBox.Types     (BlackBoxTemplate,Element)
 import qualified Clash.Netlist.Id                 as Id
 import           Clash.Netlist.Types              as HW
 import           Clash.Netlist.Util
@@ -1172,6 +1176,171 @@ showNetlistContexts = concatMap go
 
 showIdentifier :: Identifier -> String
 showIdentifier = StrictText.unpack . Id.toText
+
+type IntWidth = Int
+
+class FilterBigNums a where
+  filterBigNums :: [NetlistContext] -> a -> RWS IntWidth [ErrorMsg] () a
+
+instance FilterBigNums Component where
+  filterBigNums ctx0 (Component compNm0 ins0 outs0 decls0) = do
+    let ctx = CtxComponent compNm0 : ctx0
+    ins <- fmap (map snd) $ filterBigNums ctx $ map (\x -> (In,x)) ins0
+    outs <- fmap (map snd) $ filterBigNums ctx $ map (\x -> (Out,x)) outs0
+    decls <- filterBigNums ctx decls0
+    return $ Component compNm0 ins outs decls
+
+instance FilterBigNums a => FilterBigNums [a] where
+  filterBigNums ctx = mapM (filterBigNums ctx)
+
+instance FilterBigNums a => FilterBigNums (Maybe a) where
+  filterBigNums ctx = mapM (filterBigNums ctx)
+
+instance (FilterBigNums t1, FilterBigNums t2) => FilterBigNums (t1,t2) where
+  filterBigNums ctx (x1,x2) = (,) <$> filterBigNums ctx x1 <*> filterBigNums ctx x2
+instance (FilterBigNums t1, FilterBigNums t2, FilterBigNums t3) => FilterBigNums (t1,t2,t3) where
+  filterBigNums ctx (x1,x2,x3) = (,,) <$> filterBigNums ctx x1 <*> filterBigNums ctx x2 <*> filterBigNums ctx x3
+instance (FilterBigNums t1, FilterBigNums t2, FilterBigNums t3, FilterBigNums t4) => FilterBigNums (t1,t2,t3,t4) where
+  filterBigNums ctx (x1,x2,x3,x4) = (,,,) <$> filterBigNums ctx x1 <*> filterBigNums ctx x2 <*> filterBigNums ctx x3 <*> filterBigNums ctx x4
+instance (FilterBigNums t1, FilterBigNums t2, FilterBigNums t3, FilterBigNums t4, FilterBigNums t5) => FilterBigNums (t1,t2,t3,t4,t5) where
+  filterBigNums ctx (x1,x2,x3,x4,x5) = (,,,,) <$> filterBigNums ctx x1 <*> filterBigNums ctx x2 <*> filterBigNums ctx x3 <*> filterBigNums ctx x4 <*> filterBigNums ctx x5
+instance (FilterBigNums t1, FilterBigNums t2, FilterBigNums t3, FilterBigNums t4, FilterBigNums t5, FilterBigNums t6) => FilterBigNums (t1,t2,t3,t4,t5,t6) where
+  filterBigNums ctx (x1,x2,x3,x4,x5,x6) = (,,,,,) <$> filterBigNums ctx x1 <*> filterBigNums ctx x2 <*> filterBigNums ctx x3 <*> filterBigNums ctx x4 <*> filterBigNums ctx x5 <*> filterBigNums ctx x6
+
+instance (FilterBigNums a,FilterBigNums b) => FilterBigNums (Either a b) where
+  filterBigNums ctx = bitraverse (filterBigNums ctx) (filterBigNums ctx)
+
+instance (Ord k, FilterBigNums v) => FilterBigNums (OMap.OMap k v) where
+  filterBigNums ctx = traverse (filterBigNums ctx)
+
+
+instance FilterBigNums BlackBox where
+  filterBigNums ctx = pure
+instance FilterBigNums Element where
+  filterBigNums ctx = pure
+instance FilterBigNums ComponentMeta where
+  filterBigNums ctx = pure
+
+instance FilterBigNums Declaration where
+  filterBigNums ctx d0 = case d0 of
+    Assignment nm usage expr -> Assignment nm usage <$> filterBigNums (CtxSignal nm : ctx) expr
+    CondAssignment nm ty scrut scrutTy alts -> let ctx' = CtxSignal nm : ctx in
+        CondAssignment nm <$> filterBigNums ctx' ty <*> filterBigNums ctx' scrut <*> filterBigNums ctx' scrutTy <*> filterBigNums ctx' alts
+    InstDecl eOrC mLib attrs nm lbl params portmap -> InstDecl eOrC mLib attrs nm lbl <$> filterBigNums ctx params <*> filterBigNums ctx portmap
+    CompDecl nm ports -> CompDecl nm <$> filterBigNums ctx ports
+    BlackBoxD nm libs use qsys bb bbCtx -> let ctx' = CtxBlackBox nm : ctx in
+      BlackBoxD nm libs use qsys bb <$> filterBigNums ctx bbCtx
+    NetDecl' comment nm ty e -> let ctx' = CtxSignal nm : ctx in
+      NetDecl' comment nm <$> filterBigNums ctx' ty <*> filterBigNums ctx' e
+    TickDecl {} -> pure d0
+    Seq xs -> Seq <$> filterBigNums ctx xs
+    ConditionalDecl condText xs -> ConditionalDecl condText <$> filterBigNums ctx xs
+
+instance FilterBigNums PortMap where
+  filterBigNums ctx portmap = case portmap of
+    IndexedPortMap xs -> IndexedPortMap <$> filterBigNums ctx xs
+    NamedPortMap xs   -> NamedPortMap   <$> filterBigNums ctx xs
+
+instance FilterBigNums Seq where
+  filterBigNums ctx x = case x of
+    AlwaysClocked edge clkExpr xs -> AlwaysClocked edge <$> filterBigNums ctx clkExpr <*> filterBigNums ctx xs
+    Initial xs -> Initial <$> filterBigNums ctx xs
+    AlwaysComb xs -> AlwaysComb <$> filterBigNums ctx xs
+    SeqDecl s -> SeqDecl <$> filterBigNums ctx s
+    Branch scrut scrutTy alts -> Branch <$> filterBigNums ctx scrut <*> filterBigNums ctx scrutTy <*> filterBigNums ctx alts
+
+instance FilterBigNums PortDirection where
+  filterBigNums _ctx = pure
+
+instance FilterBigNums Identifier where
+  filterBigNums _ctx = pure
+
+instance FilterBigNums HW.Literal where
+  filterBigNums _ctx = pure
+
+instance FilterBigNums Usage where
+  filterBigNums _ctx = pure
+
+instance FilterBigNums Bool where
+  filterBigNums _ctx = pure
+
+instance FilterBigNums StrictText.Text where
+  filterBigNums _ctx = pure
+
+instance FilterBigNums HWType where
+  filterBigNums ctx ty0 = case ty0 of
+     Natural -> do
+       tell $ ["Found Natural" <> showNetlistContexts ctx]
+       iw <- ask
+       return (Unsigned iw)
+     Integer -> do
+       tell $ ["Found Integer" <> showNetlistContexts ctx]
+       iw <- ask
+       return (Signed iw)
+
+     Vector sz elemTy -> let ctx' = CtxType "Vector" : ctx in
+       Vector sz <$> filterBigNums ctx' elemTy
+
+     RTree sz elemTy -> let ctx' = CtxType "RTree" : ctx in
+       RTree sz <$> filterBigNums ctx' elemTy
+
+     BiDirectional dir ty' -> let ctx' = CtxType "BiDirectional" : ctx in
+       BiDirectional dir <$> filterBigNums ctx' ty'
+
+     Product nm fieldNms tys -> let ctx' = CtxType ("Product " <> show nm) : ctx in
+       Product nm fieldNms <$> filterBigNums ctx' tys
+
+     CustomProduct nm repr sz fieldNms xs -> let ctx' = CtxType ("CustomProduct " <> show nm) : ctx in
+       CustomProduct nm repr sz fieldNms <$> mapM (\(fAnn,ty) -> (fAnn,) <$> filterBigNums ctx' ty) xs
+
+     SP nm xs -> let ctx' = CtxType ("SP" <> show nm) : ctx in
+       SP nm <$> mapM (\(nm',tys) -> (nm',) <$> filterBigNums ctx' tys) xs
+
+     CustomSP nm repr sz xs -> let ctx' = CtxType ("CustomSP " <> show nm) : ctx in
+       CustomSP nm repr sz <$> mapM (\(cRepr,nm',tys) -> (cRepr,nm',) <$> filterBigNums ctx' tys) xs
+
+     Annotated attrs ty' -> let ctx' = CtxType "Annotated" : ctx in
+      Annotated attrs <$> filterBigNums ctx' ty'
+
+     Void mTy -> let ctx' = CtxType "Void" : ctx in Void <$> mapM (filterBigNums ctx') mTy
+
+     String -> return ty0
+     Bool -> return ty0
+     Bit -> return ty0
+     BitVector _ -> return ty0
+     Index _ -> return ty0
+     Signed _ -> return ty0
+     Unsigned _ -> return ty0
+     MemBlob _ _ -> return ty0
+     Sum _ _ -> return ty0
+     Clock _ -> return ty0
+     ClockN _ -> return ty0
+     Reset _ -> return ty0
+     Enable _ -> return ty0
+     CustomSum {} -> return ty0
+     KnownDomain {} -> return ty0
+     FileType -> return ty0
+
+instance FilterBigNums Expr where
+  filterBigNums ctx e0 = case e0 of
+     HW.Literal mTy0 lit -> do
+       mTy <- filterBigNums ctx mTy0
+       return $ HW.Literal mTy lit
+
+     DataCon ty modifier exprs -> DataCon <$> filterBigNums ctx ty <*> pure modifier <*> filterBigNums ctx exprs
+     Identifier{} -> pure e0
+     DataTag ty x -> DataTag <$> filterBigNums ctx ty <*> pure x
+     BlackBoxE nm libs use qsys bb bbCtx wrap -> let ctx' = CtxBlackBox nm : ctx in
+       BlackBoxE nm libs use qsys bb <$> filterBigNums ctx' bbCtx <*> pure wrap
+     ToBv   mNm ty e -> ToBv   mNm <$> filterBigNums ctx ty <*> filterBigNums ctx e
+     FromBv mNm ty e -> FromBv mNm <$> filterBigNums ctx ty <*> filterBigNums ctx e
+     IfThenElse eCond eThen eElse -> IfThenElse <$> filterBigNums ctx eCond <*> filterBigNums ctx eThen <*> filterBigNums ctx eElse
+     Noop -> pure e0
+
+instance FilterBigNums BlackBoxContext where
+  filterBigNums ctx (Context {..}) =
+    Context bbName <$> filterBigNums ctx bbResults <*> filterBigNums ctx bbInputs <*> mapM (filterBigNums ctx) bbFunctions <*> pure bbQsysIncName <*> pure bbLevel <*> pure bbCompName <*> pure bbCtxName
+
 
 -- Checks the netlist for Integer/Natural usage
 checkComponent :: Component -> [ErrorMsg]

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -149,7 +149,7 @@ mkBlackBoxContext bbName declType resIds args@(lefts -> termArgs) = do
       resNms = fmap Id.unsafeFromCoreId resIds
       resNm = fromMaybe (error "mkBlackBoxContext: head") (listToMaybe resNms)
     resTys <- mapM (unsafeCoreTypeToHWTypeM' $(curLoc) . coreTypeOf) resIds
-    (imps,impDecls) <- unzip <$> zipWithM (mkArgument bbName resNm declType) [0..] termArgs
+    (inps,inpDecls) <- unzip <$> zipWithM (mkArgument bbName resNm declType) [0..] termArgs
     (funs,funDecls) <-
       mapAccumLM
         (addFunction (map coreTypeOf resIds))
@@ -169,8 +169,8 @@ mkBlackBoxContext bbName declType resIds args@(lefts -> termArgs) = do
     -- `Clash.Magic.prefixName` and `Clash.Magic.suffixName`
     ctxName2 <- mapM affixName ctxName1
 
-    return ( Context bbName (zip ress resTys) imps funs [] lvl nm (listToMaybe ctxName2)
-           , concat impDecls ++ concat funDecls
+    return ( Context bbName (zip ress resTys) inps funs [] lvl nm (listToMaybe ctxName2)
+           , concat inpDecls ++ concat funDecls
            )
   where
     addFunction resTys im (arg,i) = do

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -283,6 +283,7 @@ mkArgument bbName bndr declType nArg e = do
     tcm   <- Lens.view tcCache
     let ty = inferCoreTypeOf tcm e
     iw    <- Lens.view intWidth
+    translBigNums <- Lens.view translateBigNums
     hwTyM <- fmap stripFiltered <$> N.termHWTypeM e
     let eTyMsg = "(" ++ showPpr e ++ " :: " ++ showPpr ty ++ ")"
     ((e',t,l),d) <- case hwTyM of
@@ -296,7 +297,7 @@ mkArgument bbName bndr declType nArg e = do
         (C.Var v,[],_) -> do
           return ((Identifier (Id.unsafeFromCoreId v) Nothing,hwTy,False),[])
         (C.Literal l,[],_) ->
-          return ((mkLiteral iw True l,hwTy,True),[])
+          return ((mkLiteral iw translBigNums l,hwTy,True),[])
 
         (Prim pinfo,args,ticks) -> withTicks ticks $ \tickDecls -> do
           (e',d) <- mkPrimitive True False declType (NetlistId bndr ty) pinfo args tickDecls

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -296,7 +296,7 @@ mkArgument bbName bndr declType nArg e = do
         (C.Var v,[],_) -> do
           return ((Identifier (Id.unsafeFromCoreId v) Nothing,hwTy,False),[])
         (C.Literal l,[],_) ->
-          return ((mkLiteral iw l,hwTy,True),[])
+          return ((mkLiteral iw True l,hwTy,True),[])
 
         (Prim pinfo,args,ticks) -> withTicks ticks $ \tickDecls -> do
           (e',d) <- mkPrimitive True False declType (NetlistId bndr ty) pinfo args tickDecls

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -283,7 +283,6 @@ mkArgument bbName bndr declType nArg e = do
     tcm   <- Lens.view tcCache
     let ty = inferCoreTypeOf tcm e
     iw    <- Lens.view intWidth
-    translBigNums <- Lens.view translateBigNums
     hwTyM <- fmap stripFiltered <$> N.termHWTypeM e
     let eTyMsg = "(" ++ showPpr e ++ " :: " ++ showPpr ty ++ ")"
     ((e',t,l),d) <- case hwTyM of
@@ -297,7 +296,7 @@ mkArgument bbName bndr declType nArg e = do
         (C.Var v,[],_) -> do
           return ((Identifier (Id.unsafeFromCoreId v) Nothing,hwTy,False),[])
         (C.Literal l,[],_) ->
-          return ((mkLiteral iw translBigNums l,hwTy,True),[])
+          return ((mkLiteral iw False l,hwTy,True),[])
 
         (Prim pinfo,args,ticks) -> withTicks ticks $ \tickDecls -> do
           (e',d) <- mkPrimitive True False declType (NetlistId bndr ty) pinfo args tickDecls

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -3,7 +3,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017     , Google Inc.,
-                    2021-2024, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
                     2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -552,7 +552,7 @@ mkPrimitive bbEParen bbEasD declType dst pInfo args tickDecls =
           | pNm == "GHC.Prim.dataToTag#" -> case args of
               [Right _,Left (Data dc)] -> do
                 iw <- Lens.view intWidth
-                return (N.Literal (Just (Signed iw,iw)) (NumLit $ toInteger $ dcTag dc - 1),[])
+                return (N.Literal (Just (Signed iw)) (NumLit $ toInteger $ dcTag dc - 1),[])
               [Right _,Left scrut] -> mkDataToTag declType assignTy scrut
               _ -> error $ $(curLoc) ++ "dataToTag: " ++ show (map (either showPpr showPpr) args)
 
@@ -560,7 +560,7 @@ mkPrimitive bbEParen bbEasD declType dst pInfo args tickDecls =
             ["GHC.Prim.dataToTagSmall#", "GHC.Prim.dataToTagLarge#"] -> case args of
               [Right _, Right _,Left (Data dc)] -> do
                 iw <- Lens.view intWidth
-                return (N.Literal (Just (Signed iw,iw)) (NumLit $ toInteger $ dcTag dc - 1),[])
+                return (N.Literal (Just (Signed iw)) (NumLit $ toInteger $ dcTag dc - 1),[])
               [Right _, Right _,Left scrut] -> mkDataToTag declType assignTy scrut
               _ -> error $ $(curLoc) ++ "dataToTag: " ++ show (map (either showPpr showPpr) args)
 
@@ -804,12 +804,12 @@ mkDataToTag declType assignTy scrut = do
       iw <- Lens.view intWidth
       let sIw = Signed iw
       if k <= 1
-        then pure ( N.Literal (Just (sIw, iw)) (NumLit 0)
+        then pure ( N.Literal (Just sIw) (NumLit 0)
                   , scrutDecls' )
         else do
           tag <- Id.make "c$dtt_tag"
           let alts = [ ( Just (NumLit (toInteger i))
-                       , N.Literal (Just (sIw, iw)) (NumLit (toInteger i)))
+                       , N.Literal (Just sIw) (NumLit (toInteger i)))
                      | i <- [0 .. k - 1] ]
               tagDecl = NetDecl' Nothing tag sIw Nothing
           assn <- N.condAssign tag sIw (Identifier scrutId Nothing) scrutHTy alts

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -849,11 +849,11 @@ renderTag b (Lit n) =
  where
   (e,_,_) = bbInputs b !! n
 
-  mkLit (Literal (Just (Signed _,_)) i)                                 = Literal Nothing i  -- Integer, Int#
-  mkLit (Literal (Just (Unsigned _,_)) i)                               = Literal Nothing i  -- KnownNat, Natural, Word#
+  mkLit (Literal (Just (Signed _)) i)                                 = Literal Nothing i  -- Integer, Int#
+  mkLit (Literal (Just (Unsigned _)) i)                               = Literal Nothing i  -- KnownNat, Natural, Word#
 
-  mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Signed _,_)) i])   = Literal Nothing i  -- Int
-  mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Unsigned _,_)) i]) = Literal Nothing i  -- SNat, Word
+  mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Signed _)) i])   = Literal Nothing i  -- Int
+  mkLit (DataCon _ (DC (Void {}, _)) [Literal (Just (Unsigned _)) i]) = Literal Nothing i  -- SNat, Word
 
   mkLit (BlackBoxE pNm _ _ _ _ bbCtx _) | pNm `elem` ["GHC.Int.I8#", "GHC.Int.I16#", "GHC.Int.I32#", "GHC.Int.I64#"
                                                      ,"GHC.Word.W8#","GHC.Word.W16#","GHC.Word.W32#","GHC.Word.W64#"

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -76,7 +76,7 @@ import Clash.Core.Var                       (Id)
 import Clash.Core.TyCon                     (TyConMap)
 import Clash.Core.VarEnv                    (VarEnv)
 import Clash.Driver.Types
-  (BindingMap, ClashEnv(..), ClashOpts(..))
+  (BindingMap, ClashEnv(..), ClashOpts(..),TranslateBigNums)
 import Clash.Netlist.BlackBox.Types         (BlackBoxTemplate)
 import Clash.Primitives.Types               (CompiledPrimMap)
 import Clash.Signal.Internal
@@ -993,7 +993,7 @@ Lens.makeLenses ''NetlistState
 intWidth :: Lens.Getter NetlistEnv Int
 intWidth = clashEnv . Lens.to (opt_intWidth . envOpts)
 
-translateBigNums :: Lens.Getter NetlistEnv Bool
+translateBigNums :: Lens.Getter NetlistEnv TranslateBigNums
 translateBigNums = clashEnv . Lens.to (opt_translateBigNums . envOpts)
 
 customReprs :: Lens.Getter NetlistEnv CustomReprs

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -432,7 +432,9 @@ data HWType
   | String
   -- ^ String type
   | Integer
-  -- ^ Integer type (for parameters only)
+  -- ^ Integer type (for parameters and for reporting untranslated Integers)
+  | Natural
+  -- ^ Natural type (for reporting untranslated Naturals only)
   | Bool
   -- ^ Boolean type
   | Bit
@@ -990,6 +992,9 @@ Lens.makeLenses ''NetlistState
 
 intWidth :: Lens.Getter NetlistEnv Int
 intWidth = clashEnv . Lens.to (opt_intWidth . envOpts)
+
+translateBigNums :: Lens.Getter NetlistEnv Bool
+translateBigNums = clashEnv . Lens.to (opt_translateBigNums . envOpts)
 
 customReprs :: Lens.Getter NetlistEnv CustomReprs
 customReprs = clashEnv . Lens.to envCustomReprs

--- a/clash-lib/src/Clash/Netlist/Types.hs
+++ b/clash-lib/src/Clash/Netlist/Types.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2017     , Myrtle Software Ltd,
                     2017-2018, Google Inc.
-                    2020-2023, QBayLogic B.V.
+                    2020-2026, QBayLogic B.V.
                     2022-2023, Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -761,7 +761,7 @@ data Modifier
 
 -- | Expression used in RHS of a declaration
 data Expr
-  = Literal    !(Maybe (HWType,Size)) !Literal -- ^ Literal expression
+  = Literal    !(Maybe HWType) !Literal -- ^ Literal expression
   | DataCon    !HWType       !Modifier  [Expr] -- ^ DataCon application
   | Identifier !Identifier   !(Maybe Modifier) -- ^ Signal reference
   | DataTag    !HWType       !(Either Identifier Identifier) -- ^ @Left e@: tagToEnum\#, @Right e@: dataToTag\#

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -2174,20 +2174,20 @@ expandTopEntity _ _ topEntityM =
 mkLiteral :: Int -- ^ int width
           -> C.Literal -> HW.Expr
 mkLiteral iw lit = case lit of
-  C.IntegerLiteral i -> HW.Literal (Just (Signed iw,iw)) $ NumLit i
-  C.IntLiteral i     -> HW.Literal (Just (Signed iw,iw)) $ NumLit i
-  C.WordLiteral w    -> HW.Literal (Just (Unsigned iw,iw)) $ NumLit w
-  C.Int64Literal i   -> HW.Literal (Just (Signed 64,64)) $ NumLit i
-  C.Word64Literal w  -> HW.Literal (Just (Unsigned 64,64)) $ NumLit w
-  C.Int8Literal i    -> HW.Literal (Just (Signed 8,8)) $ NumLit i
-  C.Int16Literal i   -> HW.Literal (Just (Signed 16,16)) $ NumLit i
-  C.Int32Literal i   -> HW.Literal (Just (Signed 32,32)) $ NumLit i
-  C.Word8Literal w   -> HW.Literal (Just (Unsigned 8,8)) $ NumLit w
-  C.Word16Literal w  -> HW.Literal (Just (Unsigned 16,16)) $ NumLit w
-  C.Word32Literal w  -> HW.Literal (Just (Unsigned 32,32)) $ NumLit w
-  C.CharLiteral c    -> HW.Literal (Just (Unsigned 21,21)) . NumLit . toInteger $ ord c
-  C.FloatLiteral w   -> HW.Literal (Just (BitVector 32,32)) (NumLit $ toInteger w)
-  C.DoubleLiteral w  -> HW.Literal (Just (BitVector 64,64)) (NumLit $ toInteger w)
-  C.NaturalLiteral n -> HW.Literal (Just (Unsigned iw,iw)) $ NumLit n
+  C.IntegerLiteral i -> HW.Literal (Just (Signed iw)) $ NumLit i
+  C.IntLiteral i     -> HW.Literal (Just (Signed iw)) $ NumLit i
+  C.WordLiteral w    -> HW.Literal (Just (Unsigned iw)) $ NumLit w
+  C.Int64Literal i   -> HW.Literal (Just (Signed 64)) $ NumLit i
+  C.Word64Literal w  -> HW.Literal (Just (Unsigned 64)) $ NumLit w
+  C.Int8Literal i    -> HW.Literal (Just (Signed 8)) $ NumLit i
+  C.Int16Literal i   -> HW.Literal (Just (Signed 16)) $ NumLit i
+  C.Int32Literal i   -> HW.Literal (Just (Signed 32)) $ NumLit i
+  C.Word8Literal w   -> HW.Literal (Just (Unsigned 8)) $ NumLit w
+  C.Word16Literal w  -> HW.Literal (Just (Unsigned 16)) $ NumLit w
+  C.Word32Literal w  -> HW.Literal (Just (Unsigned 32)) $ NumLit w
+  C.CharLiteral c    -> HW.Literal (Just (Unsigned 21)) . NumLit . toInteger $ ord c
+  C.FloatLiteral w   -> HW.Literal (Just (BitVector 32)) (NumLit $ toInteger w)
+  C.DoubleLiteral w  -> HW.Literal (Just (BitVector 64)) (NumLit $ toInteger w)
+  C.NaturalLiteral n -> HW.Literal (Just (Unsigned iw)) $ NumLit n
   C.ByteArrayLiteral (ByteArray ba) -> HW.Literal Nothing (NumLit (IP ba))
   C.StringLiteral s  -> HW.Literal Nothing $ StringLit s

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -675,6 +675,7 @@ typeSize (Void {}) = 0
 typeSize FileType = 32 -- (ref. page 287 of IEEE 1364-2005)
 typeSize String = 0
 typeSize Integer = 0
+typeSize Natural = 0
 typeSize (KnownDomain {}) = 0
 typeSize Bool = 1
 typeSize Bit = 1
@@ -2172,9 +2173,13 @@ expandTopEntity _ _ topEntityM =
 
 -- | Convert a Core 'C.Literal' to a Netlist v'HW.Literal'
 mkLiteral :: Int -- ^ int width
+          -> Bool -- ^ whether to translate Integer/Natural to Signed/Unsigned
           -> C.Literal -> HW.Expr
-mkLiteral iw lit = case lit of
-  C.IntegerLiteral i -> HW.Literal (Just (Signed iw)) $ NumLit i
+mkLiteral iw translBigNums lit = case lit of
+  C.IntegerLiteral i | translBigNums -> HW.Literal (Just (Signed iw)) $ NumLit i
+                     | otherwise     -> HW.Literal (Just Integer) $ NumLit i
+  C.NaturalLiteral n | translBigNums -> HW.Literal (Just (Unsigned iw)) $ NumLit n
+                     | otherwise     -> HW.Literal (Just Natural) $ NumLit n
   C.IntLiteral i     -> HW.Literal (Just (Signed iw)) $ NumLit i
   C.WordLiteral w    -> HW.Literal (Just (Unsigned iw)) $ NumLit w
   C.Int64Literal i   -> HW.Literal (Just (Signed 64)) $ NumLit i
@@ -2188,6 +2193,5 @@ mkLiteral iw lit = case lit of
   C.CharLiteral c    -> HW.Literal (Just (Unsigned 21)) . NumLit . toInteger $ ord c
   C.FloatLiteral w   -> HW.Literal (Just (BitVector 32)) (NumLit $ toInteger w)
   C.DoubleLiteral w  -> HW.Literal (Just (BitVector 64)) (NumLit $ toInteger w)
-  C.NaturalLiteral n -> HW.Literal (Just (Unsigned iw)) $ NumLit n
   C.ByteArrayLiteral (ByteArray ba) -> HW.Literal Nothing (NumLit (IP ba))
   C.StringLiteral s  -> HW.Literal Nothing $ StringLit s

--- a/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/DEC.hs
@@ -1,6 +1,6 @@
 {-|
   Copyright  :  (C) 2015-2016, University of Twente,
-                    2021-2024, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
                     2022,      LumiGuide Fietsdetectie B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -56,7 +56,6 @@ import Data.Monoid (All(..))
 import qualified Data.Text as Text
 import Data.Text.Extra (showt)
 import GHC.Stack (HasCallStack)
-import qualified Language.Haskell.TH as TH
 
 import GHC.Core.Make (chunkify, mkChunkified)
 
@@ -89,7 +88,7 @@ import Clash.Rewrite.Combinators (bottomupR)
 import Clash.Rewrite.Types
 import Clash.Rewrite.Util (changed, isFromInt, isUntranslatableType)
 import Clash.Rewrite.WorkFree (isConstant)
-import Clash.Util (MonadUnique, curLoc)
+import Clash.Util (MonadUnique, curLoc, fromTHName)
 import Clash.Util.Supply (splitSupply)
 
 -- primitives
@@ -784,6 +783,3 @@ interestingToLift inScope eval e@(Prim pInfo) args ticks
       (args',_) -> any isPolyFunTy (Either.rights args')
 
 interestingToLift _ _ _ _ _ = Nothing
-
-fromTHName :: TH.Name -> Text.Text
-fromTHName = Text.pack . show

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -429,22 +429,22 @@ untuple = deconstructProduct
 -- | The high literal bit.
 pattern High :: TExpr
 pattern High <- TExpr Bit (Literal _ (BitLit H))
-  where High = TExpr Bit (Literal (Just (Bit,1)) (BitLit H))
+  where High = TExpr Bit (Literal (Just Bit) (BitLit H))
 
 -- | The low literal bit.
 pattern Low :: TExpr
 pattern Low <- TExpr Bit (Literal _ (BitLit L))
-  where Low = TExpr Bit (Literal (Just (Bit,1)) (BitLit L))
+  where Low = TExpr Bit (Literal (Just Bit) (BitLit L))
 
 -- | The true literal bool.
 pattern T :: TExpr
 pattern T <- TExpr Bool (Literal _ (BoolLit True))
-  where T = TExpr Bool (Literal (Just (Bool,1)) (BoolLit True))
+  where T = TExpr Bool (Literal (Just Bool) (BoolLit True))
 
 -- | The false literal bool.
 pattern F :: TExpr
 pattern F <- TExpr Bool (Literal _ (BoolLit False))
-  where F = TExpr Bool (Literal (Just (Bool,1)) (BoolLit False))
+  where F = TExpr Bool (Literal (Just Bool) (BoolLit False))
 
 -- | Construct a fully defined BitVector literal
 bvLit
@@ -456,7 +456,7 @@ bvLit
 bvLit sz n =
   TExpr
     (BitVector sz)
-    (Literal (Just (BitVector sz, sz)) (BitVecLit 0 n))
+    (Literal (Just (BitVector sz)) (BitVecLit 0 n))
 
 -- | Convert a bool to a bit.
 boolToBit

--- a/clash-lib/src/Clash/Primitives/Sized/Vector.hs
+++ b/clash-lib/src/Clash/Primitives/Sized/Vector.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright   :  (C) 2020-2022 QBayLogic B.V.
+  Copyright   :  (C) 2020-2026 QBayLogic B.V.
                      2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -297,7 +297,7 @@ indexIntVerilogTemplate bbCtx
         ixI ix0 = case ix0 of
           Literal _ (NumLit j) ->
             fromInteger j
-          DataCon (Signed _) (DC (Void{},_)) [Literal (Just (Signed _,_)) (NumLit j)] ->
+          DataCon (Signed _) (DC (Void{},_)) [Literal (Just (Signed _)) (NumLit j)] ->
             fromInteger j
           BlackBoxE "GHC.Types.I#" _lib _use _incl _templ Context{bbInputs=[(Literal _ (NumLit j),_,_)]} _paren ->
             fromInteger j

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -43,6 +43,7 @@ import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.String
 #endif
 
+import qualified Data.Text            as Text
 import Data.Time.Clock                (UTCTime)
 import qualified Data.Time.Clock      as Clock
 import qualified Data.Time.Format     as Clock
@@ -81,6 +82,9 @@ instance Exception.Exception ClashException
 -- | Construct a string pattern match out of the given @TemplateHaskell@ name
 namePat :: TH.Name -> TH.Q TH.Pat
 namePat = return . TH.LitP . TH.StringL . show
+
+fromTHName :: TH.Name -> Text.Text
+fromTHName = Text.pack . show
 
 assertPanic
   :: String -> Int -> a

--- a/clash-lib/src/Clash/Util.hs
+++ b/clash-lib/src/Clash/Util.hs
@@ -1,5 +1,6 @@
 {-|
-  Copyright   :  (C) 2012-2016, University of Twente
+  Copyright   :  (C) 2012-2016, University of Twente,
+                     2026,      QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 

--- a/examples/ALU.hs
+++ b/examples/ALU.hs
@@ -4,7 +4,7 @@ import Clash.Prelude
 
 data OPC = ADD | MUL | SUB
 
-topEntity :: OPC -> Integer -> Integer -> Integer
+topEntity :: OPC -> Int -> Int -> Int
 topEntity SUB = (-)
 topEntity ADD = (+)
 topEntity MUL = (*)

--- a/examples/CochleaPlus.hs
+++ b/examples/CochleaPlus.hs
@@ -56,8 +56,8 @@ topEntity
   :: Clock  System
   -> Reset  System
   -> Enable System
-  -> Signal System (Vec 6 Integer)
-  -> Signal System (Vec 12 Integer)
+  -> Signal System (Vec 6 Int)
+  -> Signal System (Vec 12 Int)
 topEntity = exposeClockResetEnable (c_frm `mealy` (c_ws0,c_ts0,c_hist0))
 
 -- Haskell

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -147,7 +147,7 @@ workaroundMmapCrash = flakyTestWithRetryAction retryAction retryPolicy
   retryPolicy = limitRetries 5
 
 needBigNums :: TestOptions -> TestOptions
-needBigNums opts = opts { clashFlags = "-fclash-translate-bignums" : clashFlags opts}
+needBigNums opts = opts { clashFlags = clashFlags opts <> ["-fclash-translate-bignums"]}
 
 runClashTest :: IO ()
 runClashTest = defaultMain

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -147,7 +147,7 @@ workaroundMmapCrash = flakyTestWithRetryAction retryAction retryPolicy
   retryPolicy = limitRetries 5
 
 needBigNums :: TestOptions -> TestOptions
-needBigNums opts = opts { clashFlags = clashFlags opts <> ["-fclash-translate-bignums"]}
+needBigNums opts = opts { clashFlags = clashFlags opts <> ["-fclash-translate-bignums=silent"]}
 
 runClashTest :: IO ()
 runClashTest = defaultMain

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -146,6 +146,9 @@ workaroundMmapCrash = flakyTestWithRetryAction retryAction retryPolicy
   retryPolicy :: RetryPolicyM IO
   retryPolicy = limitRetries 5
 
+needBigNums :: TestOptions -> TestOptions
+needBigNums opts = opts { clashFlags = "-fclash-translate-bignums" : clashFlags opts}
+
 runClashTest :: IO ()
 runClashTest = defaultMain
   $ workaroundMmapCrash
@@ -349,11 +352,10 @@ runClashTest = defaultMain
           hdlTargets=[VHDL]
         , expectClashFail=Just (def, "This bndr has a non-representable return type and can't be normalized:")
         }
---        Disabled, due to it eating gigabytes of memory:
---      , runTest "RecursivePoly" def{
---          hdlTargets=[VHDL]
---        , expectClashFail=Just (def, "??")
---        }
+     , runTest "RecursivePoly" def{
+         hdlTargets=[VHDL]
+       , expectClashFail=Just (def, "Callgraph after normalization contains following recursive components")
+       }
       ]
     , clashTestGroup "shouldwork"
       [ clashTestGroup "AutoReg"
@@ -369,7 +371,7 @@ runClashTest = defaultMain
         , runTest "CaseOfErr" def{hdlTargets=[VHDL],hdlSim=[]}
         , runTest "Trace" def{hdlSim=[]}
         , runTest "DivMod" def{hdlSim=[]}
-        , runTest "DivZero" def
+        , runTest "DivZero" $ needBigNums def
         , runTest "LambdaDrop" def{hdlSim=[]}
         , runTest "IrrefError" def{hdlSim=[]}
         , outputTest "NameInlining" def
@@ -429,7 +431,7 @@ runClashTest = defaultMain
         , let _opts = def { hdlTargets = [VHDL], hdlSim = []}
            in runTest "T1354B" _opts
         , runTest "T1402" def{clashFlags=["-O"]}
-        , runTest "T1402b" def{hdlTargets=[VHDL], hdlSim=[]}
+        , runTest "T1402b" $ needBigNums def{hdlTargets=[VHDL], hdlSim=[]}
         , runTest "T1556" def
         , runTest "T1591" def{hdlTargets=[VHDL], hdlSim=[]}
         , runTest "TagToEnum" def{hdlSim=[]}
@@ -674,7 +676,7 @@ runClashTest = defaultMain
         , runTest "T2966" def{hdlSim=[],hdlTargets=[Verilog]}
         , runTest "T2988" def{hdlSim=[]}
         , outputTest "T3008" def{hdlSim=[]}
-        , outputTest "T3011" def{hdlSim=[]}
+        , outputTest "T3011" $ needBigNums def{hdlSim=[]}
         , let _opts = def { hdlTargets = [VHDL], hdlLoad = [], hdlSim = []}
            in runTest "T3021" _opts
         , runTest "T3041" def{hdlSim=[], hdlLoad=[]}
@@ -727,9 +729,9 @@ runClashTest = defaultMain
           , outputTest "HDLNotContainsLoc" def{hdlSim=[]}
           ]
       , clashTestGroup "Numbers"
-        [ runTest "BitInteger" def
+        [ runTest "BitInteger" $ needBigNums def
         , runTest "BitReverse" def
-        , runTest "BitsTB" def { buildTargets = BuildSpecific [ "bitsTB1"
+        , runTest "BitsTB" (needBigNums def) { buildTargets = BuildSpecific [ "bitsTB1"
                                                               , "bitsTB2"
                                                               , "bitsTB3"
                                                               ]}
@@ -737,52 +739,52 @@ runClashTest = defaultMain
           -- vivado segfaults
           runTest "Bounds" def { hdlSim=hdlSim def \\ [Vivado] }
 
-        , runTest "DivideByZero" def
-        , let _opts = def { clashFlags=["-fconstraint-solver-iterations=15"] }
+        , runTest "DivideByZero" (needBigNums def)
+        , let _opts = needBigNums def { clashFlags=["-fconstraint-solver-iterations=15"] }
            in runTest "ExpWithGhcCF" _opts
-        , let _opts = def { clashFlags=["-fconstraint-solver-iterations=15"] }
+        , let _opts = needBigNums def { clashFlags=["-fconstraint-solver-iterations=15"] }
            in runTest "ExpWithClashCF" _opts
-        , outputTest "ExpWithClashCF" def{ghcFlags=["-itests/shouldwork/Numbers"]}
+        , outputTest "ExpWithClashCF" $ needBigNums def{ghcFlags=["-itests/shouldwork/Numbers"]}
         , let _opts = def { hdlTargets = [VHDL], hdlSim = [] }
            in runTest "HalfAsBlackboxArg" _opts
         ,
           -- see https://github.com/clash-lang/clash-compiler/issues/2262,
           -- Vivado's mod misbehaves on negative dividend
-          runTest "IntegralTB" def{hdlSim=hdlSim def \\ [Vivado]}
+          runTest "IntegralTB" $ needBigNums def{hdlSim=hdlSim def \\ [Vivado]}
 
-        , runTest "NumConstantFoldingTB_1" def{clashFlags=["-itests/shouldwork/Numbers"]}
-        , outputTest "NumConstantFolding_1" def
+        , runTest "NumConstantFoldingTB_1" $ needBigNums def{clashFlags=["-itests/shouldwork/Numbers"]}
+        , outputTest "NumConstantFolding_1" $ needBigNums def
             { clashFlags=["-fconstraint-solver-iterations=15"]
             , ghcFlags=["-itests/shouldwork/Numbers"]
             }
-        , let _opts = def { clashFlags=["-itests/shouldwork/Numbers"]
+        , let _opts = needBigNums def { clashFlags=["-itests/shouldwork/Numbers"]
                           , hdlLoad = hdlLoad def \\ [Verilator]
                           , hdlSim = hdlSim def \\ [Verilator]
                           }
           in runTest "NumConstantFoldingTB_2" _opts
-        , outputTest "NumConstantFolding_2" def
+        , outputTest "NumConstantFolding_2" $ needBigNums def
             { clashFlags=["-fconstraint-solver-iterations=15"]
             , ghcFlags=["-itests/shouldwork/Numbers"]
             }
-        , runTest "Naturals" def
-        , runTest "NaturalToInteger" def{hdlSim=[]}
+        , runTest "Naturals" $ needBigNums def
+        , runTest "NaturalToInteger" $ needBigNums def{hdlSim=[]}
         , runTest "NegativeLits" def
         , runTest "Resize" def
         , runTest "Resize2" def
         , runTest "Resize3" def
         , runTest "SatMult" def{hdlSim=[]}
         , runTest "ShiftRotate" def
-        , runTest "ShiftRotateNegative" def{hdlTargets=[VHDL]}
+        , runTest "ShiftRotateNegative" $ needBigNums def{hdlTargets=[VHDL]}
         , runTest "SignedProjectionTB" def
         , runTest "SignedZero" def
-        , runTest "Signum" def
+        , runTest "Signum" $ needBigNums def
         ,
           -- vivado segfaults
           runTest "Strict" def{hdlSim=hdlSim def \\ [Vivado]}
 
-        , runTest "T1019" def{hdlSim=[]}
+        , runTest "T1019" $ needBigNums def{hdlSim=[]}
         , runTest "T1351" def
-        , runTest "T2149" def
+        , runTest "T2149" $ needBigNums def
         , outputTest "UndefinedConstantFolding" def{ghcFlags=["-itests/shouldwork/Numbers"]}
         , runTest "UnsignedZero" def
         ]
@@ -824,8 +826,8 @@ runClashTest = defaultMain
           -- see: https://github.com/clash-lang/clash-compiler/issues/2269
           runTest "BlockRamFile" def{hdlSim=hdlSim def \\ [Vivado]}
 
-        , runTest "BlockRam0" def
-        , runTest "BlockRam1" def
+        , runTest "BlockRam0" $ needBigNums def -- TODO shouldn't needBigNums, remove after we fixed blockRam1/U to not use Integer internally
+        , runTest "BlockRam1" $ needBigNums def -- TODO shouldn't needBigNums, remove after we fixed blockRam1/U to not use Integer internally
         , clashTestGroup "BlockRam"
           [ runTest "Blob" def
           ]
@@ -997,7 +999,7 @@ runClashTest = defaultMain
         , outputTest "PortNamesWithRTree" def{hdlTargets=[Verilog]}
         , clashLibTest "T1182A" def
         , clashLibTest "T1182B" def
-        , runTest "T3129" def{hdlSim=[], clashFlags=["-fclash-spec-limit=400"]}
+        , runTest "T3129" $ needBigNums (def{hdlSim=[], clashFlags=["-fclash-spec-limit=400"]})
         ]
       , clashTestGroup "Unit"
         [ runTest "Imap" def

--- a/tests/shouldfail/LiftRecursiveGroup.hs
+++ b/tests/shouldfail/LiftRecursiveGroup.hs
@@ -4,6 +4,6 @@ import Clash.Prelude
 
 topEntity x y z
   = let g p q k v = k (p + q) * v
-        h = ((3 :: Integer) *) . (g x y f)
-        f = ((4 :: Integer) *) . (g x y h)
+        h = ((3 :: Int) *) . (g x y f)
+        f = ((4 :: Int) *) . (g x y h)
     in  f (h z) + h (f z)

--- a/tests/shouldfail/RecursivePoly.hs
+++ b/tests/shouldfail/RecursivePoly.hs
@@ -3,7 +3,7 @@ module RecursivePoly where
 
 import Clash.Prelude
 
-topEntity :: Integer
+topEntity :: Int
 topEntity = f 0
 
 f :: (Integral b, Num b) => b -> b

--- a/tests/shouldfail/Signal/MAC.hs
+++ b/tests/shouldfail/Signal/MAC.hs
@@ -3,12 +3,12 @@ module MAC where
 import Clash.Prelude
 
 topEntity
-  :: Integer
+  :: Int
   -> Clock System
   -> Reset System
   -> Enable System
-  -> (Signal System Integer, Signal System Integer)
-  -> Signal System Integer
+  -> (Signal System Int, Signal System Int)
+  -> Signal System Int
 topEntity i = exposeClockResetEnable (macT <^> i)
 
 macT s (x,y) = (s',o)

--- a/tests/shouldwork/Basic/ClassOps.hs
+++ b/tests/shouldwork/Basic/ClassOps.hs
@@ -5,15 +5,15 @@ module ClassOps where
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
-topEntity :: (Integer,Integer) -> Integer
+topEntity :: (Int,Int) -> Int
 topEntity = uncurry mod
 {-# OPAQUE topEntity #-}
 
 testBench :: Signal System Bool
 testBench = done
   where
-    testInput      = stimuliGenerator clk rst $(listToVecTH [(19,4)::(Integer,Integer),(7,3),(55,-10),(9,-2),(0,-10),(11,10)])
-    expectedOutput = outputVerifier' clk rst $(listToVecTH ([3::Integer,1,-5,-1,0,1]))
+    testInput      = stimuliGenerator clk rst $(listToVecTH [(19,4)::(Int,Int),(7,3),(55,-10),(9,-2),(0,-10),(11,10)])
+    expectedOutput = outputVerifier' clk rst $(listToVecTH ([3::Int,1,-5,-1,0,1]))
     done           = expectedOutput (topEntity <$> testInput)
     clk            = tbSystemClockGen (not <$> done)
     rst            = systemResetGen

--- a/tests/shouldwork/Basic/DivMod.hs
+++ b/tests/shouldwork/Basic/DivMod.hs
@@ -4,7 +4,7 @@ module DivMod where
 
 import Clash.Prelude
 
-topEntity :: (Integer,Integer)
+topEntity :: (Int,Int)
 topEntity = topEntity1 height depthInput filterHeight stride cycles
   where
     height = SNat @5
@@ -15,12 +15,12 @@ topEntity = topEntity1 height depthInput filterHeight stride cycles
 
 topEntity1 height depthInput filterHeight stride cycles = snatToNum cycles `divMod` pools
   where
-    pools :: Integer
+    pools :: Int
     pools =
       rows *
       (((snatToNum height - snatToNum filterHeight) `div` snatToNum stride) + 1) *
       snatToNum depthInput
 
-    rows :: Integer
+    rows :: Int
     rows = ((snatToNum height - snatToNum filterHeight) `div` snatToNum stride) + 1
 {-# OPAQUE topEntity1 #-}

--- a/tests/shouldwork/Basic/SimpleConstructor.hs
+++ b/tests/shouldwork/Basic/SimpleConstructor.hs
@@ -2,6 +2,6 @@ module SimpleConstructor where
 
 import Prelude
 
-data Option = Empty | Value Integer
+data Option = Empty | Value Int
 
 topEntity = Value

--- a/tests/shouldwork/CSignal/MAC.hs
+++ b/tests/shouldwork/CSignal/MAC.hs
@@ -8,8 +8,8 @@ topEntity
   :: Clock DomA101
   -> Reset DomA101
   -> Enable DomA101
-  -> (Signal DomA101 Integer, Signal DomA101 Integer)
-  -> Signal DomA101 Integer
+  -> (Signal DomA101 Int, Signal DomA101 Int)
+  -> Signal DomA101 Int
 topEntity clk rst en = mealyB clk rst en macT 0
 
 macT s (x,y) = (s', o)

--- a/tests/shouldwork/Issues/T2220_toEnumOOB.hs
+++ b/tests/shouldwork/Issues/T2220_toEnumOOB.hs
@@ -7,7 +7,7 @@ import Clash.Explicit.Testbench
 
 topEntity :: BitVector 2 -> Maybe A_Index
 topEntity x | x == 3    = Nothing
-            | otherwise = Just $ toEnum $ fromIntegral x
+            | otherwise = Just $ toEnum $ numConvert x
 {-# OPAQUE topEntity #-}
 
 {-

--- a/tests/shouldwork/Issues/T2729.hs
+++ b/tests/shouldwork/Issues/T2729.hs
@@ -9,13 +9,13 @@ fromEnumTest :: Signed 8 -> Int
 fromEnumTest = fromEnum
 
 fromIntegralTest :: Signed 4 -> Signed 6
-fromIntegralTest = fromIntegral
+fromIntegralTest = numConvert
 
 toEnumTest :: Int -> Signed 6
 toEnumTest = toEnum
 
 topEntity :: Signed 4 -> (Int, Signed 6, Signed 6)
-topEntity x = (fromEnumTest (fromIntegral x), fromIntegralTest x, toEnumTest (fromEnum x))
+topEntity x = (fromEnumTest (numConvert x), fromIntegralTest x, toEnumTest (fromEnum x))
 {-# OPAQUE topEntity #-}
 
 testBench :: Signal System Bool

--- a/tests/shouldwork/Numbers/BitReverse.hs
+++ b/tests/shouldwork/Numbers/BitReverse.hs
@@ -5,10 +5,11 @@ import Data.Word
 
 -- ghc-8.10 adds new primitives: bitReverse8#, bitReverse16#, bitReverse32# and bitReverse64#
 
-topEntity x = ( bitReverse8  $ fromInteger x
-              , bitReverse16 $ fromInteger x
-              , bitReverse32 $ fromInteger x
-              , bitReverse64 $ fromInteger x
+topEntity :: Word8 -> (Word8, Word16, Word32, Word64)
+topEntity x = ( bitReverse8  $ numConvert x
+              , bitReverse16 $ numConvert x
+              , bitReverse32 $ numConvert x
+              , bitReverse64 $ numConvert x
               )
 
 testBench :: Signal System Bool
@@ -47,5 +48,5 @@ testBench = done
     clk  = tbSystemClockGen (not <$> done)
     rst  = systemResetGen
 
-expand :: Integer -> (Word8,Word16,Word32,Word64)
-expand x = (fromInteger x, fromInteger x `shiftL` 8, fromInteger x `shiftL` 24, fromInteger x `shiftL` 56)
+expand :: Word8 -> (Word8,Word16,Word32,Word64)
+expand x = (numConvert x, numConvert x `shiftL` 8, numConvert x `shiftL` 24, numConvert x `shiftL` 56)

--- a/tests/shouldwork/Numbers/Bounds.hs
+++ b/tests/shouldwork/Numbers/Bounds.hs
@@ -3,6 +3,7 @@
 module Bounds where
 import Clash.Prelude
 import Clash.Explicit.Testbench
+import Data.Int
 
 expected
     =     0 :>  42
@@ -11,22 +12,22 @@ expected
     :>    0 :> 511
     :>  -64 :>  63
     :>    0 :> 127
-    :> (Nil::Vec 0 Integer)
+    :> (Nil::Vec 0 Int64)
 
 actual
-    =  toInteger (minBound :: Index 43)             :> toInteger (maxBound :: Index 43)
-    :> toInteger (minBound :: Signed 9)             :> toInteger (maxBound :: Signed 9)
-    :> toInteger (minBound :: Unsigned 9)           :> toInteger (maxBound :: Unsigned 9)
-    :> toInteger (minBound :: BitVector 9)          :> toInteger (maxBound :: BitVector 9)
-    :> toInteger (unFixed (minBound :: SFixed 4 3)) :> toInteger (unFixed (maxBound :: SFixed 4 3))
-    :> toInteger (unFixed (minBound :: UFixed 3 4)) :> toInteger (unFixed (maxBound :: UFixed 3 4))
+    =  numConvert (minBound :: Index 43)             :> numConvert (maxBound :: Index 43)
+    :> numConvert (minBound :: Signed 9)             :> numConvert (maxBound :: Signed 9)
+    :> numConvert (minBound :: Unsigned 9)           :> numConvert (maxBound :: Unsigned 9)
+    :> numConvert (minBound :: BitVector 9)          :> numConvert (maxBound :: BitVector 9)
+    :> numConvert (unFixed (minBound :: SFixed 4 3)) :> numConvert (unFixed (maxBound :: SFixed 4 3))
+    :> numConvert (unFixed (minBound :: UFixed 3 4)) :> numConvert (unFixed (maxBound :: UFixed 3 4))
     :> Nil
 
 topEntity
   :: Clock System
   -> Reset System
   -> Enable System
-  -> Signal System () -> Signal System Integer
+  -> Signal System () -> Signal System Int64
 topEntity = exposeClockResetEnable (mealy loop actual)
 {-# OPAQUE topEntity #-}
 

--- a/tests/shouldwork/Numbers/ShiftRotateBase.hs
+++ b/tests/shouldwork/Numbers/ShiftRotateBase.hs
@@ -7,6 +7,7 @@ import Clash.Explicit.Testbench
 import Data.Word
 import Data.Int
 
+testpattern :: Int64
 testpattern = 0b1010011000
 
 -- test with shift/rotate amounts: 0..16,200, and a really large
@@ -25,8 +26,8 @@ testall v i
 {-# OPAQUE testall #-}
 
 testAs
-  :: (Num b, Bits b) => Integer -> Int -> Vec Ops b
-testAs v i = map (\f -> f (fromInteger v) i) shiftsAndRots
+  :: (BitPack b, Bits b) => Int64 -> Int -> Vec Ops b
+testAs v i = map (\f -> f (unpack . resize . pack $ v) i) shiftsAndRots
 
 type Ops = 4
 

--- a/tests/shouldwork/RTree/TFold.hs
+++ b/tests/shouldwork/RTree/TFold.hs
@@ -11,7 +11,7 @@ import Data.Singletons hiding (type (+))
 data IIndex (f :: TyFun Nat Type) :: Type
 type instance Apply IIndex l = Index ((2^l)+1)
 
-popCountT = tdfold (Proxy :: Proxy IIndex) fromIntegral (const add)
+popCountT = tdfold (Proxy :: Proxy IIndex) bitCoerce (const add)
 
 popCount = popCountT . v2t . bv2v
 

--- a/tests/shouldwork/Testbench/SyncTB.hs
+++ b/tests/shouldwork/Testbench/SyncTB.hs
@@ -27,8 +27,8 @@ topEntity
   :: Clock Dom2
   -> Clock Dom7
   -> Clock Dom9
-  -> Signal Dom7 Integer
-  -> Signal Dom9 Integer
+  -> Signal Dom7 Int
+  -> Signal Dom9 Int
 topEntity clk2 clk7 clk9 i =
   delay
     clk9
@@ -51,9 +51,9 @@ testBench
   :: Signal Dom9 Bool
 testBench = done
   where
-    testInput      = stimuliGenerator clk7 rst7 $(listToVecTH [(1::Integer)..20])
+    testInput      = stimuliGenerator clk7 rst7 $(listToVecTH [(1::Int)..20])
     expectedOutput = outputVerifier'   clk9 rst9
-                        (0 :> 1 :>  $(listToVecTH ([2,3,4,6,7,8,9,11,12,13,15,16]::[Integer])))
+                        (0 :> 1 :>  $(listToVecTH ([2,3,4,6,7,8,9,11,12,13,15,16]::[Int])))
     done           = expectedOutput (zeroAt0 clk9 rst9 (topEntity clk2 clk7 clk9 testInput))
     notDone        = not <$> done
     clk2           = tbClockGen @Dom2 (unsafeSynchronizer clk9 clk2 notDone)

--- a/tests/shouldwork/Vector/DTFold.hs
+++ b/tests/shouldwork/Vector/DTFold.hs
@@ -14,7 +14,7 @@ type instance Apply IIndex l = Index ((2^l)+1)
 populationCount :: (KnownNat k, KnownNat (2^k))
                 => BitVector (2^k) -> Index ((2^k)+1)
 populationCount bv = dtfold (Proxy :: Proxy IIndex)
-                            fromIntegral
+                            numConvert
                             (\_ x y -> add x y)
                             (bv2v bv)
 

--- a/tests/shouldwork/Vector/HOPrim.hs
+++ b/tests/shouldwork/Vector/HOPrim.hs
@@ -2,5 +2,5 @@ module HOPrim where
 
 import Clash.Prelude
 
-topEntity :: Vec 4 Integer -> Vec 4 (Unsigned 4)
-topEntity = map fromInteger
+topEntity :: Vec 4 Int -> Vec 4 Bool
+topEntity = map odd

--- a/tests/shouldwork/Vector/Scatter.hs
+++ b/tests/shouldwork/Vector/Scatter.hs
@@ -8,7 +8,9 @@ import Clash.Explicit.Testbench
 topEntity :: Vec 5 (Unsigned 10) -> Vec 5 (Unsigned 10)
 topEntity = scatter defvec to
   where
+    defvec :: Vec 5 (Unsigned 10)
     defvec = replicate d5 99
+    to :: Vec 5 Int
     to = 0 :> 4 :> 2 :> 3 :> 1 :> Nil
 {-# OPAQUE topEntity #-}
 

--- a/tests/shouldwork/Vector/VIndex.hs
+++ b/tests/shouldwork/Vector/VIndex.hs
@@ -2,5 +2,5 @@ module VIndex where
 
 import Clash.Prelude
 
-topEntity :: (Integer,Vec 8 (Vec 8 (Maybe Int))) -> Vec 8 (Maybe Int)
+topEntity :: (Int,Vec 8 (Vec 8 (Maybe Int))) -> Vec 8 (Maybe Int)
 topEntity (i,as) = zipWith (!!) as (iterateI (+1) i)

--- a/tests/shouldwork/Vector/VReplace.hs
+++ b/tests/shouldwork/Vector/VReplace.hs
@@ -5,7 +5,7 @@ module VReplace where
 import Clash.Prelude
 import Clash.Explicit.Testbench
 
-topEntity :: (Integer,Unsigned 4,Vec 8 (Unsigned 4)) -> Vec 8 (Vec 8 (Unsigned 4))
+topEntity :: (Int,Unsigned 4,Vec 8 (Unsigned 4)) -> Vec 8 (Vec 8 (Unsigned 4))
 topEntity (i,j,as) = zipWith (\i u -> replace i u as) (iterateI (+1) i) ((iterateI (subtract 1) j))
 {-# OPAQUE topEntity #-}
 
@@ -13,7 +13,7 @@ testBench :: Signal System Bool
 testBench = done
   where
     testInput      = stimuliGenerator clk rst
-                      $(listToVecTH ([(0,8,replicate d8 0)]::[(Integer,Unsigned 4,Vec 8 (Unsigned 4))]))
+                      $(listToVecTH ([(0,8,replicate d8 0)]::[(Int,Unsigned 4,Vec 8 (Unsigned 4))]))
     expectedOutput = outputVerifier' clk rst
                                     (((8:>0:>0:>0:>0:>0:>0:>0:>Nil):>
                                       (0:>7:>0:>0:>0:>0:>0:>0:>Nil):>

--- a/tests/shouldwork/Vector/VecOfSum.hs
+++ b/tests/shouldwork/Vector/VecOfSum.hs
@@ -3,8 +3,8 @@ module VecOfSum where
 import Clash.Prelude
 
 data Sum = Empty
-         | Half Integer Integer Integer Integer
-         | Full (Unsigned 4) (Signed 9) Bool Integer Bit (Maybe (Bool,Signed 3)) (Unsigned 3, Signed 4)
+         | Half Int Int Int Int
+         | Full (Unsigned 4) (Signed 9) Bool Int Bit (Maybe (Bool,Signed 3)) (Unsigned 3, Signed 4)
 
 topEntity :: Vec 3 Sum -> Vec 5 Sum
 topEntity xs = (Full 4 12 True 12 high (Just (False, 1)) (2,7)) :> Empty :> xs

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -142,7 +142,7 @@ instance Default TestOptions where
       , verificationTool=Nothing
       , hdlTargets=allTargets
       , ghcFlags=[]
-      , clashFlags=[]
+      , clashFlags=["-fclash-no-translate-bignums"]
       , buildTargets=BuildAuto
       , vvpStdoutNonEmptyFail=True
       }

--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -142,7 +142,7 @@ instance Default TestOptions where
       , verificationTool=Nothing
       , hdlTargets=allTargets
       , ghcFlags=[]
-      , clashFlags=["-fclash-no-translate-bignums"]
+      , clashFlags=["-fclash-translate-bignums=error"]
       , buildTargets=BuildAuto
       , vvpStdoutNonEmptyFail=True
       }

--- a/tests/src/Test/Tasty/Clash/NetlistTest.hs
+++ b/tests/src/Test/Tasty/Clash/NetlistTest.hs
@@ -83,7 +83,7 @@ runToNetlistStage target f src = do
 
   transformedBindings <-
     normalizeEntity env (designBindings design)
-      (ghcTypeToHWType (opt_intWidth opts))
+      (ghcTypeToHWType opts)
       ghcEvaluator
       evaluator
       teNames supplyN te
@@ -97,7 +97,7 @@ runToNetlistStage target f src = do
   hdl = buildTargetToHdl target
 
   netlistFrom (env, bm, tes, compNames, te, seen) =
-    genNetlist env ghcEvaluator False bm tes compNames (ghcTypeToHWType (opt_intWidth opts))
+    genNetlist env ghcEvaluator False bm tes compNames (ghcTypeToHWType opts)
       ite (SomeBackend hdlSt) seen hdlDir Nothing te
    where
     teS     = Text.unpack . nameOcc $ varName te


### PR DESCRIPTION


## Still TODO:

  - [ ] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
  - [x] Fix the detection of Integers/Naturals inside function arguments to HO prims like in the  Scatter test
  - [ ] Add some failing test with:
    - [ ] HO prims with Integers hidden in a HO argument
    - [ ] nested HO functions like: `map (map illegal)`
  - [ ] Think if it's possible and makes sense to disable the `elimCaseBigNumInternals` transformation (added in PR #3172) when `-fclash-no-translate-integer-natural` is set
  - [ ] `blockRamU` and `blockRam1` (and possibly others?) use Integers internally, convert them to some better type