### PR TITLE
`signalAutomaton` now allocates state in `IO`

### DIFF
--- a/changelog/2026-05-22T16_19_24+02_00_fix_2801_signalAutomaton
+++ b/changelog/2026-05-22T16_19_24+02_00_fix_2801_signalAutomaton
@@ -1,0 +1,1 @@
+FIXED: `signalAutomaton` now allocates fresh mutable simulation state in `IO`, preventing separate simulations from accidentally sharing continuations. See [#2801](https://github.com/clash-lang/clash-compiler/issues/2801).

--- a/clash-prelude/clash-prelude.cabal
+++ b/clash-prelude/clash-prelude.cabal
@@ -402,6 +402,7 @@ test-suite unittests
     build-depends:
       clash-prelude,
 
+      arrows,
       ghc-typelits-knownnat,
       ghc-typelits-natnormalise,
       ghc-typelits-extra,

--- a/clash-prelude/src/Clash/Signal.hs
+++ b/clash-prelude/src/Clash/Signal.hs
@@ -1739,14 +1739,12 @@ fromListWithReset = hideReset E.fromListWithReset
 
 -- | Build an 'Automaton' from a function over 'Signal's.
 --
--- __NB__: Consumption of continuation of the 'Automaton' must be affine; that
--- is, you can only apply the continuation associated with a particular element
--- at most once.
+-- __NB__: Each continuation function must be called at most once.
 signalAutomaton
   :: forall dom a b
    . KnownDomain dom
   => (HiddenClockResetEnable dom => Signal dom a -> Signal dom b)
-  -> Automaton (->) a b
+  -> IO (Automaton (->) a b)
 signalAutomaton f0 =
   let f1 = exposeClockResetEnable @dom f0 clockGen resetGen enableGen in
   E.signalAutomaton f1

--- a/clash-prelude/src/Clash/Signal/Internal.hs
+++ b/clash-prelude/src/Clash/Signal/Internal.hs
@@ -3,7 +3,7 @@ Copyright  :  (C) 2013-2016, University of Twente,
                   2017-2019, Myrtle Software Ltd,
                   2017-2022, Google Inc.,
                   2020     , Gergő Érdi,
-                  2021-2025, QBayLogic B.V.
+                  2021-2026, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -2098,32 +2098,34 @@ fsToHz (Femtoseconds period)
 
 -- | Build an 'Automaton' from a function over 'Signal's.
 --
--- __NB__: Consumption of continuation of the 'Automaton' must be affine; that
--- is, you can only apply the continuation associated with a particular element
--- at most once.
+-- __NB__: Each continuation function must be called at most once.
 signalAutomaton ::
   forall dom a b .
-  (Signal dom a -> Signal dom b) -> Automaton (->) a b
-signalAutomaton dut = Automaton $ \input0 -> unsafePerformIO $ do
+  (Signal dom a -> Signal dom b) -> IO (Automaton (->) a b)
+signalAutomaton dut = do
   inputRefs <- infiniteRefList Nothing
-  let inputs = input0 :- fmap readInput inputRefs
-      readInput ref = unsafePerformIO $ do
+  let readInput ref = unsafePerformIO $ do
         val <- readIORef ref
         case val of
-          Nothing -> fail "signalAutomaton: non-affine use of continuation"
+          Nothing -> fail "signalAutomaton: input not set: did you call the continuation more than once?"
           Just x  -> return x
 
-  let go (inRef :- inRefs) (out :- rest) = do
-        let next :: Automaton (->) a b
-            next = Automaton $ \i -> unsafePerformIO $ do
-              old <- atomicModifyIORef inRef (\old -> (Just i,old))
-              case old of
-                Nothing -> return ()
-                Just _  -> fail "signalAutomaton: non-affine use of continuation"
-              unsafeInterleaveIO (go inRefs rest)
-        return (out, next)
+      step input0 = unsafePerformIO $ do
+        let inputs = input0 :- fmap readInput inputRefs
 
-  go inputRefs (dut inputs)
+        let go (inRef :- inRefs) (out :- rest) = do
+              let next :: Automaton (->) a b
+                  next = Automaton $ \i -> unsafePerformIO $ do
+                    old <- atomicModifyIORef inRef (\old -> (Just i,old))
+                    case old of
+                      Nothing -> return ()
+                      Just _  -> fail "signalAutomaton: input not consumed: did you call the continuation more than once?"
+                    unsafeInterleaveIO (go inRefs rest)
+              return (out, next)
+
+        go inputRefs (dut inputs)
+
+  return (Automaton step)
 {-# OPAQUE signalAutomaton #-}
 
 infiniteRefList :: a -> IO (Signal dom (IORef a))

--- a/clash-prelude/tests/Clash/Tests/Signal.hs
+++ b/clash-prelude/tests/Clash/Tests/Signal.hs
@@ -1,7 +1,7 @@
 {-|
-Copyright  :  (C) 2019, Myrtle Software Ltd
-                  2022, Google Inc.
-                  2023, QBayLogic B.V.
+Copyright  :  (C) 2019     , Myrtle Software Ltd
+                  2022     , Google Inc.
+                  2023-2026, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -27,6 +27,8 @@ import           Clash.Prelude                  hiding (sample)
 import           Clash.Signal.Internal
   (Femtoseconds(..), dynamicClockGen, sample, head#)
 
+import           Control.Arrow.Transformer.Automaton
+  (Automaton(..))
 import           Control.Exception              (evaluate)
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -60,6 +62,9 @@ tests =
               a = fst (head# s)
             in
               evaluate a >> pure ()
+
+        , testCase "signalAutomaton is fresh in IO" $
+            case_signalAutomatonFreshState
         ]
     , testGroup "SaturatingNum"
       [ testCase "satSucc SatWrap" case_satSuccSatWrap
@@ -107,6 +112,34 @@ case_dynamicStaticEq = do
     "clk11+dclk77 == dclk11+clk77"
     (sampleMagicN (E.unsafeSynchronizer clk11 dclk77 counter))
     (sampleMagicN (E.unsafeSynchronizer dclk11 clk77 counter))
+
+-- | Regression test for sharing of the mutable input state used by
+-- 'signalAutomaton'.
+case_signalAutomatonFreshState :: Assertion
+case_signalAutomatonFreshState = do
+  let
+    circuit :: HiddenClockResetEnable dom => Signal dom Int -> Signal dom Int
+    circuit = register 0
+
+    runSim :: Int -> IO Int
+    runSim x = do
+      automaton <- signalAutomaton @System circuit
+      pure (start automaton x)
+
+    start (Automaton step) x = load sim x
+      where
+        (_, sim) = step 0
+
+    load (Automaton step) x = consume sim
+      where
+        (_, sim) = step x
+
+    consume (Automaton step) = output
+      where
+        (output, _) = step 0
+
+  actual <- traverse runSim [1, 3]
+  actual @?= [1, 3]
 
 -- | Asserts that "lying" about a clock's frequency has effect.
 case_dynamicHasEffect :: Assertion


### PR DESCRIPTION
preventing separate simulations from accidentally sharing continuations. Fixes [#2801](https://github.com/clash-lang/clash-compiler/issues/2801).


Unfortunately an API change. But the function is broken without it. 

