### PR TITLE
Add `__debug_hash` to Clash manifest files

### DIFF
--- a/changelog/2026-05-28T10_43_22+02_00_manifest_debug_subhashes
+++ b/changelog/2026-05-28T10_43_22+02_00_manifest_debug_subhashes
@@ -1,0 +1,1 @@
+ADDED: `-fclash-debug-manifest-hash`. When enabled, Clash emits a `__debug_hash` object in `clash-manifest.json` listing the SHA256 of each input that feeds into the top-level `hash` (`tops`, `prim_map`, `clash_mod_date`, `call_graph`, `opts`). As the name implies, this should only be used to debug and should not be relied upon by tooling.

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -87,6 +87,7 @@ flagsClash r = [
   , defFlag "fclash-timescale-precision"         $ SepArg (setTimescalePrecision r)
   , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
   , defFlag "fclash-no-concurrent-topentity-compilation" $ NoArg (liftEwM (setNoConcurrentTopEntities r))
+  , defFlag "fclash-debug-manifest-hash"         $ NoArg (liftEwM (setDebugManifestHash r))
   ]
 
 -- | Print deprecated flag warning
@@ -341,3 +342,6 @@ setNoRenderEnums r = modifyIORef r (\c -> c { opt_renderEnums = False })
 
 setNoConcurrentTopEntities :: IORef ClashOpts -> IO ()
 setNoConcurrentTopEntities r = modifyIORef r (\c -> c { opt_concurrentTopEntities = False })
+
+setDebugManifestHash :: IORef ClashOpts -> IO ()
+setDebugManifestHash r = modifyIORef r (\c -> c { opt_debugManifestHash = True })

--- a/clash-lib/src/Clash/Driver.hs
+++ b/clash-lib/src/Clash/Driver.hs
@@ -394,7 +394,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
   -- Get manifest file if cache is not stale and caching is enabled. This is used
   -- to prevent unnecessary recompilation.
   clashModDate <- getClashModificationDate
-  (userModifications, maybeManifest, topHash) <-
+  (userModifications, maybeManifest, topHashWithSubHashes) <-
     readFreshManifest topEntities0 (bindingsMap, topEntity) primMap opts clashModDate manPath
 
   let topEntityNames = map topId (eltsVarEnv topEntityMap)
@@ -492,7 +492,7 @@ generateHDL env design hdlState typeTrans peEval eval mainTopEntity startTime = 
         manifest =
           mkManifest
             hdlState' domainConfs opts topComponent components depIds
-            filesAndDigests1 topHash
+            filesAndDigests1 topHashWithSubHashes
       writeManifest manPath manifest
 
       topTime <- hdlDocs `seq` Clock.getCurrentTime

--- a/clash-lib/src/Clash/Driver/Manifest.hs
+++ b/clash-lib/src/Clash/Driver/Manifest.hs
@@ -125,11 +125,35 @@ newtype FilesManifest = FilesManifest [(FilePath, ByteString)]
 instance FromJSON FilesManifest where
   parseJSON = Aeson.withObject "FilesManifest" $ fmap FilesManifest . parseFiles
 
+-- | Per-input subhashes of the @manifestHash@. Exposed as @__debug_hash@ in
+-- the JSON manifest purely as a debugging aid: when two manifests disagree on
+-- @hash@, comparing these fields tells you *which* input changed. The leading
+-- double underscore and @debug@ in the name signal that downstream tools
+-- should not rely on these — their existence, names, and contents may change
+-- between Clash versions.
+data DebugSubHashes = DebugSubHashes
+  { dshTops :: ByteString
+    -- ^ Hash of the full @[TopEntityT]@ list discovered in the design.
+  , dshPrimMap :: ByteString
+    -- ^ Hash of the compiled primitive map.
+  , dshClashModDate :: ByteString
+    -- ^ Hash of the @clash@ executable's modification time.
+  , dshCallGraph :: ByteString
+    -- ^ Hash of the call-graph closure of the top entity (i.e., the bindings
+    -- that actually contribute to the generated HDL).
+  , dshOpts :: ByteString
+    -- ^ Hash of the (HDL-affecting subset of the) 'ClashOpts'.
+  } deriving (Show, Read, Eq)
+
 -- | Information about the generated HDL between (sub)runs of the compiler
 data Manifest
   = Manifest
   { manifestHash :: ByteString
     -- ^ Hash digest of the TopEntity and all its dependencies.
+  , manifestDebugSubHashes :: Maybe DebugSubHashes
+    -- ^ Per-input subhashes that feed into 'manifestHash'. Debug-only — see
+    -- 'DebugSubHashes'. 'Nothing' when reading an older manifest that
+    -- predates this field.
   , successFlags  :: (Int, Int)
     -- ^ Compiler flags used to achieve successful compilation:
     --
@@ -163,12 +187,36 @@ data Manifest
     -- on any component listed before it, but not after it.
   } deriving (Show,Read,Eq)
 
+-- | JSON shape for 'DebugSubHashes'. All values are hex-encoded SHA256 digests.
+instance ToJSON DebugSubHashes where
+  toJSON DebugSubHashes{..} = Aeson.object
+    [ "tops" .= toHexDigest dshTops
+    , "prim_map" .= toHexDigest dshPrimMap
+    , "clash_mod_date" .= toHexDigest dshClashModDate
+    , "call_graph" .= toHexDigest dshCallGraph
+    , "opts" .= toHexDigest dshOpts
+    ]
+
+instance FromJSON DebugSubHashes where
+  parseJSON = Aeson.withObject "DebugSubHashes" $ \v ->
+    DebugSubHashes
+      -- See Note [Failed hex digest decodes]
+      <$> (unsafeFromHexDigest <$> v .: "tops")
+      <*> (unsafeFromHexDigest <$> v .: "prim_map")
+      <*> (unsafeFromHexDigest <$> v .: "clash_mod_date")
+      <*> (unsafeFromHexDigest <$> v .: "call_graph")
+      <*> (unsafeFromHexDigest <$> v .: "opts")
+
 instance ToJSON Manifest where
   toJSON (Manifest{..}) =
-    Aeson.object
+    Aeson.object $
       [ "version" .= ("unstable" :: Text)
       , "hash" .= toHexDigest manifestHash
-      , "flags" .= successFlags
+      ] <>
+      (case manifestDebugSubHashes of
+        Just sh -> ["__debug_hash" .= sh]
+        Nothing -> []) <>
+      [ "flags" .= successFlags
         -- TODO: add nested ports (i.e., how Clash split/filtered arguments)
       , "components" .= componentNames
       , "top_component" .= Aeson.object
@@ -236,6 +284,7 @@ instance FromJSON Manifest where
       Manifest
             -- See Note [Failed hex digest decodes]
         <$> (unsafeFromHexDigest <$> v .: "hash")
+        <*> v .:? "__debug_hash"
         <*> v .: "flags"
         <*> (topComponent >>= (.: "ports_flat"))
         <*> v .: "components"
@@ -309,12 +358,13 @@ mkManifest ::
   [Id] ->
   -- | Files and  their hashes
   [(FilePath, ByteString)] ->
-  -- | Hash returned by 'readFreshManifest'
-  ByteString ->
+  -- | Hash and per-input subhashes returned by 'readFreshManifest'
+  (ByteString, DebugSubHashes) ->
   -- | New manifest
   Manifest
-mkManifest backend domains ClashOpts{..} Component{..} components deps files topHash = Manifest
+mkManifest backend domains ClashOpts{..} Component{..} components deps files (topHash, subHashes) = Manifest
   { manifestHash = topHash
+  , manifestDebugSubHashes = if opt_debugManifestHash then Just subHashes else Nothing
   , ports = inPorts <> inOutPorts <> outPorts
   , componentNames = map Id.toText compNames
   , topComponent = Id.toText componentName
@@ -378,8 +428,9 @@ readFreshManifest ::
   -- | Path to manifest file.
   FilePath ->
   -- | ( Nothing if no manifest file was found
-  --   , Nothing on stale cache, disabled cache, or not manifest file found )
-  IO (Maybe [UnexpectedModification], Maybe Manifest, ByteString)
+  --   , Nothing on stale cache, disabled cache, or not manifest file found
+  --   , Top-level hash plus per-input subhashes used to derive it )
+  IO (Maybe [UnexpectedModification], Maybe Manifest, (ByteString, DebugSubHashes))
 readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashModDate path = do
   modificationsM <- traverse (isUserModified path) =<< readManifest path
 
@@ -387,7 +438,7 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
   pure
     ( modificationsM
     , checkManifest =<< if opt_cachehdl then manifestM else Nothing
-    , topHash
+    , (topHash, subHashes)
     )
 
  where
@@ -433,12 +484,25 @@ readFreshManifest tops (bindingsMap, topId) primMap opts@(ClashOpts{..}) clashMo
 
   -- TODO: Binary encoding does not account for alpha equivalence (nor should
   --       it?), so the cache behaves more pessimisticly than it could.
+  --
+  -- Compute each input's digest independently so that they can be surfaced
+  -- via 'manifestDebugSubHashes'. The top-level hash is then a digest of the
+  -- subhashes — keeping it a deterministic function of the same inputs while
+  -- making it mechanically obvious which input changed between two runs.
+  subHashes = DebugSubHashes
+    { dshTops = Sha256.hashlazy (Binary.encode tops)
+    , dshPrimMap = Sha256.hashlazy (Binary.encode (hashCompiledPrimMap primMap))
+    , dshClashModDate = Sha256.hashlazy (Binary.encode (show clashModDate))
+    , dshCallGraph = Sha256.hashlazy (Binary.encode (callGraphBindings bindingsMap topId))
+    , dshOpts = Sha256.hashlazy (Binary.encode optsHash)
+    }
+
   topHash = Sha256.hashlazy $ Binary.encode
-    ( tops
-    , hashCompiledPrimMap primMap
-    , show clashModDate
-    , callGraphBindings bindingsMap topId
-    , optsHash
+    ( dshTops subHashes
+    , dshPrimMap subHashes
+    , dshClashModDate subHashes
+    , dshCallGraph subHashes
+    , dshOpts subHashes
     )
 
   checkManifest manifest@Manifest{manifestHash,successFlags}

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -404,6 +404,14 @@ data ClashOpts = ClashOpts
   -- investigating bugs, because it will make log output deterministic.
   --
   -- Command line flag: -fclash-no-concurrent-topentity-compilation
+  , opt_debugManifestHash :: Bool
+  -- ^ Emit a @__debug_hash@ field in @clash-manifest.json@ containing the
+  -- SHA256 of each input that feeds into the top-level @hash@. This is a
+  -- debugging aid for diagnosing cache misses across builds that produce
+  -- identical HDL: diffing two manifests' @__debug_hash@ fields reveals
+  -- /which/ input changed.
+  --
+  -- Command line flag: -fclash-debug-manifest-hash
   }
   deriving (Show, Eq, NFData, Generic, Hashable)
 
@@ -444,6 +452,7 @@ defClashOpts
   --      https://github.com/clash-lang/clash-compiler/issues/2762.
   , opt_ignoreBrokenGhcs    = unsafeLookupEnvBool "CLASH_IGNORE_BROKEN_GHCS" False
   , opt_concurrentTopEntities = True
+  , opt_debugManifestHash   = False
   }
 
 -- | Synopsys Design Constraint (SDC) information for a component.

--- a/clash-lib/tests/Clash/Tests/Driver/Manifest.hs
+++ b/clash-lib/tests/Clash/Tests/Driver/Manifest.hs
@@ -62,10 +62,20 @@ genPort =
     <*> Q.elements [False, True]
     <*> coerce @(Q.Gen (Maybe ArbitraryText)) Q.arbitrary
 
+genDebugSubHashes :: Q.Gen DebugSubHashes
+genDebugSubHashes =
+  DebugSubHashes
+    <$> genDigest
+    <*> genDigest
+    <*> genDigest
+    <*> genDigest
+    <*> genDigest
+
 genManifest :: Q.Gen Manifest
 genManifest =
   Manifest
     <$> genDigest -- hash
+    <*> Q.oneof [pure Nothing, Just <$> genDebugSubHashes] -- __debug_hash
     <*> Q.arbitrary -- flags
     <*> Q.listOf genPort -- ports
     <*> coerce @(Q.Gen [ArbitraryText]) @(Q.Gen [Text]) Q.arbitrary -- comp names


### PR DESCRIPTION
I'm trying to find out why we keep seeing cache invalidations over at `bittide-hardware` even though all the files Clash outputs (except for the manifest file) are byte identical. After writing the patch I figured it is probably useful to have it in there for future debug runs.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
