### PR TITLE
Remove obsolete nix flake patches

### DIFF
--- a/nix/overlay-ghc910.nix
+++ b/nix/overlay-ghc910.nix
@@ -31,15 +31,6 @@ in
   # Criterion test fails with tasty 1.5.4
   criterion = dontCheck prev.criterion;
 
-  # Upstream nixpkgs has this fix but they have not landed in a release yet
-  fourmolu = appendPatches prev.fourmolu [
-    (pkgs.fetchpatch {
-      name = "fourmolu-absolute-build-tool-paths.patch";
-      url = "https://github.com/fourmolu/fourmolu/commit/9217bc926ab80d20b815f0486be2184db07df4fc.patch";
-      hash = "sha256-ANzuKy5WfWCGZ7HFVBpTtuyUqzFfef/xR/v1KiyJEX4=";
-    })
-  ];
-
   # Randomly GHC panics with heap overflows during testing
   row-types = dontCheck prev.row-types;
 

--- a/nix/overlay-ghc912.nix
+++ b/nix/overlay-ghc912.nix
@@ -50,15 +50,6 @@ in
   hls-test-utils = disableLibProfiling prev.hls-test-utils;
   haskell-language-server = disableLibProfiling prev.haskell-language-server;
 
-  # Upstream nixpkgs has this fix but they have not landed in a release yet
-  fourmolu = appendPatches prev.fourmolu [
-    (pkgs.fetchpatch {
-      name = "fourmolu-absolute-build-tool-paths.patch";
-      url = "https://github.com/fourmolu/fourmolu/commit/9217bc926ab80d20b815f0486be2184db07df4fc.patch";
-      hash = "sha256-ANzuKy5WfWCGZ7HFVBpTtuyUqzFfef/xR/v1KiyJEX4=";
-    })
-  ];
-
   # Randomly GHC panics with heap overflows during testing
   row-types = dontCheck prev.row-types;
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -71,15 +71,6 @@ let
             sha256 = "sha256-c+3EpY6A/Z88MQsNpQv0bMDGvpWcaBHHVg6wxh5ZQuU=";
           } { })
           (drv: { preCheck = pluginPreCheck; });
-
-      # Upstream nixpkgs has this fix but they have not landed in a release yet
-      cabal-add = prev.haskell.lib.appendPatches hprev.cabal-add [
-        (prev.fetchpatch {
-          name = "cabal-add-absolute-build-tool-paths.patch";
-          url = "https://github.com/Bodigrim/cabal-add/commit/3b94b0175c294c2d0a30b6d8da3f56189216816c.patch";
-          hash = "sha256-4Nbro9Gl+RC78yprO8fYG/IWS7QvJPd0dKqSZb5jq9k=";
-        })
-      ];
     };
 
   # An overlay with the packages in this repository.


### PR DESCRIPTION
We're now using a nixpkgs version that includes these patches

## Still TODO:

  - [ ] ~Write a changelog entry (see changelog/README.md)~
  - [x] Check copyright notices are up to date in edited files