### PR TITLE
Run Nix CI for all pushes

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,9 +1,6 @@
 name: Nix Packaging
 
-on:
-  push:
-    branches:
-      - '*'
+on: push
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The workflow file specified `'*'` as the filter to select which branches to run for. However, `'*'` doesn't match slashes (for that, you should use `'**'`). So CI did not run for branches with a hierarchical name. But we don't need to filter at all, so just remove the filter.

Fixes: #3283 

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
