### PR TITLE
Update Github action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
             ghc: "9.12"
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: haskell-actions/setup@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553  # v2.11.0
         id: setup-haskell
         with:
           enable-stack: true
@@ -68,7 +68,7 @@ jobs:
 
       - name: Restore cache (Windows)
         if: ${{ startsWith(matrix.os, 'windows') }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         id: cache-win
         with:
           # On windows we have to use "\" as a path separator, otherwise caching fails
@@ -78,7 +78,7 @@ jobs:
           restore-keys: ${{ matrix.os }}-${{ matrix.ghc }}-
       - name: Restore cache (non-Windows)
         if: ${{ !startsWith(matrix.os, 'windows') }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         id: cache-other
         with:
           path: |
@@ -106,7 +106,7 @@ jobs:
         run: stack build --only-dependencies
 
       - name: Save cache (Windows)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         # Trying to save over an existing cache gives distracting
         # "Warning: Cache save failed." since they are immutable
         if: ${{ startsWith(matrix.os, 'windows') && steps.cache-win.outputs.cache-hit != 'true' }}
@@ -116,7 +116,7 @@ jobs:
             ${{ steps.setup-haskell.outputs.stack-root }}\snapshots
           key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('stack.yaml', '**/*.cabal', '.github/workflows/ci.yml') }}
       - name: Save cache (non-Windows)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         # Trying to save over an existing cache gives distracting
         # "Warning: Cache save failed." since they are immutable
         if: ${{ !startsWith(matrix.os, 'windows') && steps.cache-other.outputs.cache-hit != 'true' }}
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.ref }}
@@ -181,7 +181,7 @@ jobs:
           mv cabal.project.freeze frozen
 
       - name: Restore Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         id: cache
         with:
           path: |
@@ -200,7 +200,7 @@ jobs:
         # Trying to save over an existing cache gives distracting
         # "Warning: Cache save failed." since they are immutable
         if: ${{ !cancelled() && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             dist-newstyle
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Check dependencies for failures
         run: |

--- a/.github/workflows/kloonbot.yml
+++ b/.github/workflows/kloonbot.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - run: |
           ./.ci/kloonbot.sh

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
           ghc967
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Authenticate cache
         env:
@@ -88,7 +88,7 @@ jobs:
 
     needs: packages_common
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Authenticate cache
         env:
@@ -121,7 +121,7 @@ jobs:
         ]
     needs: packages_common
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Authenticate cache
         env:


### PR DESCRIPTION
We were still using old versions of actions that depend on Node.js 20
Which is deprecated and support will be dropped soon https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I've opted to use commit hashes instead of tags as precaution against supply chain attacks.
## Still TODO:

  - ~Write a changelog entry (see changelog/README.md)~
  - [x] Check copyright notices are up to date in edited files
