### PR TITLE
Migrate on-push PR jobs from Gitlab over to Github

### DIFF
--- a/.ci/build_docs.sh
+++ b/.ci/build_docs.sh
@@ -10,6 +10,7 @@ for pkg in ${haddock_pkgs}; do
   set -e
 
   # Cache dependencies
+  # This should be a no-op in the Github CI, but keeping it here just in case
   cabal v2-build ${pkg} -O0 --enable-documentation --only-dependencies
 
   # The preludes yield link destination warnings we cannot fix. Maybe fixed by:

--- a/.ci/cabal.project.local.in
+++ b/.ci/cabal.project.local.in
@@ -1,0 +1,43 @@
+-- use latest packages from hackage
+index-state: HEAD
+
+package *
+  ghc-options: -j__THREADS__
+
+  -- don't generate haddock for all our deps
+  documentation: False
+
+  -- Dynamic executables save oozles of space when archiving it on CI
+  executable-dynamic: True
+
+package clash-prelude
+  ghc-options: -Werror
+  tests: True
+  benchmarks: True
+
+package clash-lib
+  ghc-options: -Werror
+  tests: True
+
+package clash-ghc
+  ghc-options: -Werror
+
+package clash-prelude-hedgehog
+  ghc-options: -Werror
+  tests: True
+
+package clash-lib-hedgehog
+  ghc-options: -Werror
+  tests: True
+
+package clash-testsuite
+  ghc-options: -Werror
+
+package clash-benchmark
+  ghc-options: -Werror
+
+package clash-profiling
+  ghc-options: -Werror
+
+package clash-profiling-prepare
+  ghc-options: -Werror

--- a/.ci/gh-setup.sh
+++ b/.ci/gh-setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -xou pipefail
+
+# Make sure everything is up-to-date & installing missing dependencies
+sudo apt-get update
+sudo apt-get install libtinfo-dev -y
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+CI_DIR=$GIT_ROOT/.ci
+cd CI_DIR
+
+# Get the proper amount of cores we can use and configure ghc to use them
+THREADS=$($CI_DIR/effective_cpus.sh)
+sed "7s/-j4/-j$THREADS/g" cabal.project.local
+cp $CI_DIR/cabal.project.local $GIT_ROOT
+
+echo "--- cabal.project.local ---"
+cat $GIT_ROOT/cabal.project.local
+
+echo "--- thread count ---"
+echo "Using $THREADS threads"

--- a/.ci/gh-setup.sh
+++ b/.ci/gh-setup.sh
@@ -2,19 +2,21 @@
 set -xou pipefail
 
 # Make sure everything is up-to-date & installing missing dependencies
-sudo apt-get update
-sudo apt-get install libtinfo-dev -y
+sudo apt-get update || exit $?
+sudo apt-get install libtinfo-dev -y || exit $?
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
+[[ $? -ne 0 ]] && exit 1
 CI_DIR=$GIT_ROOT/.ci
 
 # Get the proper amount of cores we can use and configure ghc to use them
 THREADS=$($CI_DIR/effective_cpus.sh)
+[[ $? -ne 0 ]] && exit 1
 sed <$CI_DIR/cabal.project.local.in >$GIT_ROOT/cabal.project.local "
-    s/__THREADS__/$THREADS/"
+    s/__THREADS__/$THREADS/" || exit $?
 
 echo "--- cabal.project.local ---"
-cat $GIT_ROOT/cabal.project.local
+cat $GIT_ROOT/cabal.project.local || exit $?
 
 echo "--- thread count ---"
 echo "Using $THREADS threads"

--- a/.ci/gh-setup.sh
+++ b/.ci/gh-setup.sh
@@ -7,12 +7,11 @@ sudo apt-get install libtinfo-dev -y
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
 CI_DIR=$GIT_ROOT/.ci
-cd CI_DIR
 
 # Get the proper amount of cores we can use and configure ghc to use them
 THREADS=$($CI_DIR/effective_cpus.sh)
-sed "7s/-j4/-j$THREADS/g" cabal.project.local
-cp $CI_DIR/cabal.project.local $GIT_ROOT
+sed <$CI_DIR/cabal.project.local.in >$GIT_ROOT/cabal.project.local "
+    s/__THREADS__/$THREADS/"
 
 echo "--- cabal.project.local ---"
 cat $GIT_ROOT/cabal.project.local

--- a/.ci/small-tests.sh
+++ b/.ci/small-tests.sh
@@ -35,6 +35,6 @@ fi
 
 #Test if cabal can generate a build plan using the index state as specified in cabal.project
 # We should not have cabal.project.local in place for this
-rm $GIT_ROOT/cabal.project.local
-cabal v2-build -j$THREADS --dry-run all > /dev/null || (echo "Maybe state index should be updated?"; false)
-cp $CI_DIR/cabal.project.local $GIT_ROOT
+mv $GIT_ROOT/cabal.project.local $GIT_ROOT/cabal.project.local.disabled
+cabal v2-build -j$THREADS --dry-run all > /dev/null || { echo "Maybe state index should be updated?"; exit 1; }
+mv $GIT_ROOT/cabal.project.local.disabled $GIT_ROOT/cabal.project.local

--- a/.ci/small-tests.sh
+++ b/.ci/small-tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -xou pipefail
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+CI_DIR=$GIT_ROOT/.ci
+
+if [ ! -f $GIT_ROOT/cabal.project.local ]; then
+    echo "Requires gh-setup.sh to be invoked first, refusing to do that manually as to not create unintended effects"
+    exit 1;
+fi
+
+THREADS=$($CI_DIR/effective_cpus.sh)
+
+# Check for EOL whitespace
+grep -E ' $' -n -r . --include=*.{hs,hs-boot,sh} --exclude-dir=dist-newstyle
+if [[ $? == 0 ]]; then
+    echo "EOL whitespace detected. See ^"
+    exit 1;
+fi
+
+# Check whether version numbers in
+# clash-{prelude{,-hedgehog},lib{,-hedgehog},ghc} are the same
+cabal_files="$GIT_ROOT/clash-prelude/clash-prelude.cabal $GIT_ROOT/clash-prelude-hedgehog/clash-prelude-hedgehog.cabal $GIT_ROOT/clash-lib/clash-lib.cabal $GIT_ROOT/clash-lib-hedgehog/clash-lib-hedgehog.cabal $GIT_ROOT/clash-ghc/clash-ghc.cabal"
+versions=$(grep "^[vV]ersion" $cabal_files | grep -Eo '[0-9]+(\.[0-9]+)+')
+
+if [[ $(echo $versions | tr ' ' '\n' | wc -l) == 5 ]]; then
+    if [[ $(echo $versions | tr ' ' '\n' | uniq | wc -l) != 1 ]]; then
+        echo "Expected all distributions to have the same version number. Found: $versions"
+        exit 1;
+    fi
+else
+    echo "Expected to find version number in all distributions. Found: $versions";
+    exit 1;
+fi
+
+#Test if cabal can generate a build plan using the index state as specified in cabal.project
+# We should not have cabal.project.local in place for this
+rm $GIT_ROOT/cabal.project.local
+cabal v2-build -j$THREADS --dry-run all > /dev/null || (echo "Maybe state index should be updated?"; false)
+cp $CI_DIR/cabal.project.local $GIT_ROOT

--- a/.ci/small-tests.sh
+++ b/.ci/small-tests.sh
@@ -2,6 +2,7 @@
 set -xou pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
+[[ $? -ne 0 ]] && exit 1
 CI_DIR=$GIT_ROOT/.ci
 
 if [ ! -f $GIT_ROOT/cabal.project.local ]; then
@@ -10,6 +11,7 @@ if [ ! -f $GIT_ROOT/cabal.project.local ]; then
 fi
 
 THREADS=$($CI_DIR/effective_cpus.sh)
+[[ $? -ne 0 ]] && exit 1
 
 # Check for EOL whitespace
 grep -E ' $' -n -r . --include=*.{hs,hs-boot,sh} --exclude-dir=dist-newstyle
@@ -22,6 +24,7 @@ fi
 # clash-{prelude{,-hedgehog},lib{,-hedgehog},ghc} are the same
 cabal_files="$GIT_ROOT/clash-prelude/clash-prelude.cabal $GIT_ROOT/clash-prelude-hedgehog/clash-prelude-hedgehog.cabal $GIT_ROOT/clash-lib/clash-lib.cabal $GIT_ROOT/clash-lib-hedgehog/clash-lib-hedgehog.cabal $GIT_ROOT/clash-ghc/clash-ghc.cabal"
 versions=$(grep "^[vV]ersion" $cabal_files | grep -Eo '[0-9]+(\.[0-9]+)+')
+[[ $? -ne 0 ]] && exit 1
 
 if [[ $(echo $versions | tr ' ' '\n' | wc -l) == 5 ]]; then
     if [[ $(echo $versions | tr ' ' '\n' | uniq | wc -l) != 1 ]]; then
@@ -35,6 +38,6 @@ fi
 
 #Test if cabal can generate a build plan using the index state as specified in cabal.project
 # We should not have cabal.project.local in place for this
-mv $GIT_ROOT/cabal.project.local $GIT_ROOT/cabal.project.local.disabled
+mv $GIT_ROOT/cabal.project.local $GIT_ROOT/cabal.project.local.disabled || exit $?
 cabal v2-build -j$THREADS --dry-run all > /dev/null || { echo "Maybe state index should be updated?"; exit 1; }
-mv $GIT_ROOT/cabal.project.local.disabled $GIT_ROOT/cabal.project.local
+mv $GIT_ROOT/cabal.project.local.disabled $GIT_ROOT/cabal.project.local || exit $?

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,4 +1,4 @@
-name: Nix Packaging
+name: On push CI
 
 on: push
 
@@ -7,6 +7,99 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Nix by default runs tests, meaning that there's not much point in re-running tests in Cabal/Stack
+  # So for these we do a simple compilation test instead, checking that they still compile with
+  # whatever changes got made
+
+  cabal:
+    name: Cabal compilation test
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [
+          9.12.4,
+          9.10.3,
+          9.8.4,
+          9.6.7
+        ]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup cache
+        run: mkdir .cache
+      - uses: tespkg/actions-cache@v1
+        with:
+          endpoint: "192.168.102.136"
+          port: 9000
+          insecure: true
+          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
+          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-checkout-cabal
+          path: .cache
+
+      # Perhaps we should preinstall these on the container?
+      # This step always takes a minute...
+      # We'd lose the ability to select the version of cabal inside of the runner though
+      - name: Install GHC
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+
+      - name: Version information
+        run:
+          cabal --version
+
+  stack:
+    name: Stack compilation test
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [
+          9.12.4,
+          9.10.3,
+          9.8.4,
+          9.6.7
+        ]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup cache
+        run: mkdir .cache
+      - uses: tespkg/actions-cache@v1
+        with:
+          endpoint: "192.168.102.136"
+          port: 9000
+          insecure: true
+          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
+          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-checkout-stack
+          path: ~/.stack
+
+      # Perhaps we should preinstall these on the container?
+      # This step always takes a minute...
+      # We'd lose the ability to select the version of cabal inside of the runner though
+      - name: Install GHC
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          enable-stack: true
+          stack-version: latest
+
+      - name: Version information
+        run:
+          stack --version
+
   packages_common:
     name: Build Common (${{matrix.ghc}})
     runs-on: self-hosted
@@ -39,7 +132,6 @@ jobs:
       - run: |
           nix build -L .#clashPackages-${{matrix.ghc}}.clash-prelude
           attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-prelude)
-
       - run: |
           nix build -L .#clashPackages-${{matrix.ghc}}.clash-lib
           attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-lib)

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -24,11 +24,9 @@ jobs:
           9.6.7
         ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - name: Setup cache
-        run: mkdir .cache
-      - uses: tespkg/actions-cache@v1
+      - uses: tespkg/actions-cache/restore@v1
         with:
           endpoint: "192.168.102.136"
           port: 9000
@@ -39,8 +37,12 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-checkout-cabal
-          path: .cache
+          # The cabal.project file contains the index state & hashes
+          # Since we only cache the dependencies, and this is what determines what dependencies are grabbed
+          # hashing the cabal.project file should suffice in determining if the dependencies changed
+          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles("cabal.project") }
+          restore-keys: ${{ runner.os }}-${ matrix.ghc }-cabal-
+          path: ~/.cabal
 
       # Perhaps we should preinstall these on the container?
       # This step always takes a minute...
@@ -55,6 +57,36 @@ jobs:
         run:
           cabal --version
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install libtinfo-dev -y
+          sudo apt-get install tree -y
+          sudo apt-get install iverilog -y
+
+      - name: Build dependencies
+        run: |
+          cabal v2-build all --dependencies-only
+
+      - uses: tespkg/actions-cache/save@v1
+        with:
+          endpoint: "192.168.102.136"
+          port: 9000
+          insecure: true
+          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
+          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles("cabal.project") }
+          path: ~/.cabal
+
+      - name: Build
+        run: |
+          # clash-cosim really wants to be built first
+          cabal v2-build clash-cosim
+          cabal v2-build all
+
   stack:
     name: Stack compilation test
     runs-on: self-hosted
@@ -68,23 +100,7 @@ jobs:
           9.6.7
         ]
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup cache
-        run: mkdir .cache
-      - uses: tespkg/actions-cache@v1
-        with:
-          endpoint: "192.168.102.136"
-          port: 9000
-          insecure: true
-          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
-          secretKey: "${{ secrets.S3_SECRET_KEY }}"
-          bucket: runner
-          region: local
-          use-fallback: false
-          retry: false
-          key: ${{ runner.os }}-checkout-stack
-          path: ~/.stack
+      - uses: actions/checkout@v6
 
       # Perhaps we should preinstall these on the container?
       # This step always takes a minute...
@@ -96,9 +112,20 @@ jobs:
           enable-stack: true
           stack-version: latest
 
+
       - name: Version information
         run:
           stack --version
+
+      - name: Install system dependencies
+        run: sudo apt-get install libtinfo-dev -y
+
+      # From what I read online, stack is difficult to cache and also generates huge build artifacts
+      # So maybe it's better not to cache the stack builds? The current Gitlab runners don't either
+      - name: Build
+        run:
+          stack build -j$(nproc) --pedantic
+
 
   packages_common:
     name: Build Common (${{matrix.ghc}})

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -126,8 +126,6 @@ jobs:
         run: .ci/gh-setup.sh
 
       - name: Build & check documentation
-        env:
-          PKG: ${{ matrix.pkg }}
         run: .ci/build_docs.sh
 
   stack:
@@ -247,7 +245,7 @@ jobs:
           attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-ghc)
 
       - name: Cachix
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1.10.0'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1.10'
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: |
@@ -291,7 +289,7 @@ jobs:
         run: attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.${{matrix.package}})
 
       - name: Cachix
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1.10.0'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1.10'
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#clashPackages-${{matrix.ghc}}.${{matrix.package}} | cachix push clash-lang
@@ -324,7 +322,7 @@ jobs:
         run: attic push public $(nix path-info .#devShells.x86_64-linux.${{matrix.ghc}})
 
       - name: Cachix
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1.10.0'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1.10'
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#devShells.x86_64-linux.${{matrix.ghc}} | cachix push clash-lang
@@ -372,8 +370,38 @@ jobs:
             ${{ runner.os }}-master-cabal-${{ matrix.ghc }}
           path: ${{ steps.ghc-install.outputs.cabal-store }}
 
-      - name: Setup
-        run: .ci/gh-setup.sh
+      - name: Cachix
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1.10'
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
+        run: |
+          nix path-info .#clashPackages-${{matrix.ghc}}.clash-testsuite-debug | cachix push clash-lang
+
+  running_testsuite:
+    name: Running clash-testsuite (${{matrix.ghc}}, ${{matrix.hdl}})
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        hdl: [
+          'VHDL',
+          'Verilog',
+          'SystemVerilog'
+        ]
+        ghc: [
+          ghc9124,
+          ghc9103,
+          ghc984,
+          ghc967
+        ]
+    needs: packages_testsuite
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Authenticate cache
+        env:
+          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
+        run: .ci/attic-auth.sh
 
       - name: Run clash-testsuite
         run: cabal v2-run clash-testsuite -- -j$(.ci/effective_cpus.sh) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -40,7 +40,7 @@ jobs:
           # The cabal.project file contains the index state & hashes
           # Since we only cache the dependencies, and this is what determines what dependencies are grabbed
           # hashing the cabal.project file should suffice in determining if the dependencies changed
-          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles("cabal.project") }
+          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles("cabal.project", "*/*.cabal") }
           restore-keys: ${{ runner.os }}-${ matrix.ghc }-cabal-
           path: ~/.cabal
 
@@ -287,7 +287,6 @@ jobs:
     name: Running clash-testsuite (${{matrix.ghc}}, ${{matrix.hdl}})
     runs-on: self-hosted
     strategy:
-      # If caching fails for one package, then we are still interested in caching other packages
       fail-fast: false
       matrix:
         hdl: [

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -342,4 +342,23 @@ jobs:
 
       - name: Run clash-testsuite
         run: |
-          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(nproc) --hide-successes -p .${{matrix.hdl}} --no-vivado --no-modelsim
+          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(nproc) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
+
+  all:
+    name: All on-push jobs finished
+    if: ${{ !cancelled() }}
+    needs: [
+      cabal,
+      stack,
+      packages_common,
+      packages_other,
+      developer_shells,
+      packages_testsuite,
+      running_testsuite
+    ]
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - uses: clash-lang/all-jobs-ok@v2
+        with:
+          needs: ${{ toJSON(needs) }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -193,8 +193,7 @@ jobs:
             "clash-prelude-hedgehog",
             "clash-profiling",
             "clash-profiling-prepare",
-            "clash-term",
-            "clash-testsuite"
+            "clash-term"
         ]
     needs: packages_common
     steps:
@@ -249,3 +248,68 @@ jobs:
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#devShells.x86_64-linux.${{matrix.ghc}} | cachix push clash-lang
+
+  packages_testsuite:
+    name: Packaging clash-testsuite (${{matrix.ghc}})
+    runs-on: self-hosted
+    strategy:
+      # If caching fails for one package, then we are still interested in caching other packages
+      fail-fast: false
+      matrix:
+        ghc: [
+          ghc9124,
+          ghc9103,
+          ghc984,
+          ghc967
+        ]
+    needs: packages_common
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Authenticate cache
+        env:
+          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
+        run: .ci/attic-auth.sh
+
+      - name: Build clash-testsuite
+        run: |
+          nix build -L .#clashPackages-${{matrix.ghc}}.clash-testsuite
+          attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-prelude)
+
+      - name: Cachix
+        if: github.ref == 'refs/heads/master'
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
+        run: |
+          nix path-info .#clashPackages-${{matrix.ghc}}.clash-testsuite | cachix push clash-lang
+
+  running_testsuite:
+    name: Running clash-testsuite (${{matrix.ghc}}, ${{matrix.hdl}})
+    runs-on: self-hosted
+    strategy:
+      # If caching fails for one package, then we are still interested in caching other packages
+      fail-fast: false
+      matrix:
+        hdl: [
+          "VHDL",
+          "Verilog",
+          "SystemVerilog"
+        ]
+        ghc: [
+          ghc9124,
+          ghc9103,
+          ghc984,
+          ghc967
+        ]
+    needs: packages_testsuite
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Authenticate cache
+        env:
+          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
+        run: .ci/attic-auth.sh
+
+      - name: Run clash-testsuite
+        run: |
+          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(nproc) --hide-successes -p .${{matrix.hdl}} --no-vivado --no-modelsim

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -81,6 +81,22 @@ jobs:
         run: |
           cabal v2-build all -j$(.ci/effective_cpus.sh)
 
+      - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
+        with:
+          endpoint: '192.168.102.136'
+          port: 9000
+          insecure: true
+          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
+          secretKey: '${{ secrets.S3_SECRET_KEY }}'
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          # Notice the small change in the key here! Save the build artifacts so the clash-testsuite does not
+          # have to recompile itself (since we compile it here already)
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-testsuite-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local.in', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          path: ${{ steps.ghc-install.outputs.cabal-store }}
+
       - name: Run small tests
         run: .ci/small-tests.sh
 
@@ -313,69 +329,54 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#devShells.x86_64-linux.${{matrix.ghc}} | cachix push clash-lang
 
-  packages_testsuite:
-    name: Packaging clash-testsuite (${{matrix.ghc}})
+  cabal_testsuite:
+    name: Running clash-testsuite (${{matrix.ghc}})
     runs-on: self-hosted
     strategy:
       # If caching fails for one package, then we are still interested in caching other packages
       fail-fast: false
       matrix:
         ghc: [
-          ghc9124,
-          ghc9103,
-          ghc984,
-          ghc967
+          9.12.4,
+          9.10.3,
+          9.8.4,
+          9.6.7
         ]
     needs: packages_common
     steps:
       - uses: actions/checkout@v6
 
-      - name: Authenticate cache
-        env:
-          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
-        run: .ci/attic-auth.sh
+      - name: Install GHC
+        id: ghc-install
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
 
-      - name: Build clash-testsuite
-        run: |
-          nix build -L .#clashPackages-${{matrix.ghc}}.clash-testsuite
-          attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-prelude)
+      - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
+        with:
+          endpoint: '192.168.102.136'
+          port: 9000
+          insecure: true
+          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
+          secretKey: '${{ secrets.S3_SECRET_KEY }}'
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-testsuite-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local.in', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.ref_name }}-cabal-testsuite-${{ matrix.ghc }}
+            ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}
+            ${{ runner.os }}-master-cabal-testsuite-${{ matrix.ghc }}
+            ${{ runner.os }}-master-cabal-${{ matrix.ghc }}
+          path: ${{ steps.ghc-install.outputs.cabal-store }}
 
-      - name: Cachix
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1.10.0'
-        env:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
-        run: |
-          nix path-info .#clashPackages-${{matrix.ghc}}.clash-testsuite | cachix push clash-lang
-
-  running_testsuite:
-    name: Running clash-testsuite (${{matrix.ghc}}, ${{matrix.hdl}})
-    runs-on: self-hosted
-    strategy:
-      fail-fast: false
-      matrix:
-        hdl: [
-          'VHDL',
-          'Verilog',
-          'SystemVerilog'
-        ]
-        ghc: [
-          ghc9124,
-          ghc9103,
-          ghc984,
-          ghc967
-        ]
-    needs: packages_testsuite
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Authenticate cache
-        env:
-          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
-        run: .ci/attic-auth.sh
+      - name: Setup
+        run: .ci/gh-setup.sh
 
       - name: Run clash-testsuite
-        run: |
-          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(.ci/effective_cpus.sh) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
+        run: cabal v2-run clash-testsuite -- -j$(.ci/effective_cpus.sh) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
 
   all:
     name: All on-push jobs finished
@@ -387,8 +388,7 @@ jobs:
       packages_common,
       packages_other,
       developer_shells,
-      packages_testsuite,
-      running_testsuite
+      cabal_testsuite,
     ]
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -26,6 +26,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Perhaps we should preinstall these on the container?
+      # This step always takes a minute...
+      # We'd lose the ability to select the version of cabal inside of the runner though
+      - name: Install GHC
+        id: ghc-install
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+
       - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
           endpoint: "192.168.102.136"
@@ -37,21 +47,9 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          # The cabal.project file contains the index state & hashes
-          # Since we only cache the dependencies, and this is what determines what dependencies are grabbed
-          # hashing the cabal.project file should suffice in determining if the dependencies changed
-          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles("cabal.project", "*/*.cabal") }
+          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles( ${{ steps.ghc-install.outputs.cabal-store }}, "~/.cache/cabal" ) }
           restore-keys: ${{ runner.os }}-${ matrix.ghc }-cabal-
-          path: ~/.cabal
-
-      # Perhaps we should preinstall these on the container?
-      # This step always takes a minute...
-      # We'd lose the ability to select the version of cabal inside of the runner though
-      - name: Install GHC
-        uses: haskell-actions/setup@v2
-        with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: latest
+          path: ${{ steps.ghc-install.outputs.cabal-store }}
 
       - name: Version information
         run:
@@ -75,8 +73,8 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles("cabal.project") }
-          path: ~/.cabal
+          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles( ${{ steps.ghc-install.outputs.cabal-store }}, "~/.cache/cabal" ) }
+          path: ${{ steps.ghc-install.outputs.cabal-store }}
 
       - name: Build
         run: |
@@ -109,6 +107,20 @@ jobs:
           enable-stack: true
           stack-version: latest
 
+      - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
+        with:
+          endpoint: "192.168.102.136"
+          port: 9000
+          insecure: true
+          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
+          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-${ matrix.ghc }-stack-${ hashFiles( ${{ steps.ghc-install.outputs.stack-root }} ) }
+          restore-keys: ${{ runner.os }}-${ matrix.ghc }-stack-
+          path: ${{ steps.ghc-install.outputs.stack-root }}
 
       - name: Version information
         run:
@@ -117,8 +129,24 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get install libtinfo-dev -y
 
-      # From what I read online, stack is difficult to cache and also generates huge build artifacts
-      # So maybe it's better not to cache the stack builds? The current Gitlab runners don't either
+      - name: Build Dependencies
+        run:
+          stack build -j$(nproc) --pedantic --dependencies-only
+
+      - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
+        with:
+          endpoint: "192.168.102.136"
+          port: 9000
+          insecure: true
+          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
+          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-${ matrix.ghc }-stack-${ hashFiles( ${{ steps.ghc-install.outputs.stack-root }} ) }
+          path: ${{ steps.ghc-install.outputs.stack-root }}
+
       - name: Build
         run:
           stack build -j$(nproc) --pedantic

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -102,12 +102,46 @@ jobs:
           ghc-version: 9.6.7
           cabal-version: latest
 
+      - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
+        with:
+          endpoint: '192.168.102.136'
+          port: 9000
+          insecure: true
+          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
+          secretKey: '${{ secrets.S3_SECRET_KEY }}'
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-haddock-${{ hashFiles('.ci/cabal.project.local.in', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.ref_name }}-cabal-haddock-
+            ${{ runner.os }}-master-cabal-
+          path: ${{ steps.ghc-install.outputs.cabal-store }}
+
       - name: Version information
         run:
           cabal --version
 
       - name: Setup
         run: .ci/gh-setup.sh
+
+      - name: Build dependencies
+        run: cabal v2-build clash-prelude clash-prelude-hedgehog clash-lib clash-lib-hedgehog -O0 --enable-documentation --only-dependencies
+
+      - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
+        with:
+          endpoint: '192.168.102.136'
+          port: 9000
+          insecure: true
+          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
+          secretKey: '${{ secrets.S3_SECRET_KEY }}'
+          bucket: runner
+          region: local
+          use-fallback: false
+          retry: false
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-haddock-${{ hashFiles('.ci/cabal.project.local.in', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          path: ${{ steps.ghc-install.outputs.cabal-store }}
 
       - name: Build & check documentation
         run: .ci/build_docs.sh

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: tespkg/actions-cache/restore@v1
+      - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
           endpoint: "192.168.102.136"
           port: 9000
@@ -67,7 +67,7 @@ jobs:
         run: |
           cabal v2-build all --dependencies-only
 
-      - uses: tespkg/actions-cache/save@v1
+      - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
           endpoint: "192.168.102.136"
           port: 9000

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -92,10 +92,6 @@ jobs:
     runs-on: self-hosted
     strategy:
       fail-fast: false
-      matrix:
-        # Documentation is built at 9.6.7, testing on other versions therefore does not make a lot
-        # of sense
-        ghc: [ 9.6.7 ]
     steps:
       - uses: actions/checkout@v6
 
@@ -103,7 +99,7 @@ jobs:
         id: ghc-install
         uses: haskell-actions/setup@v2
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc-version: 9.6.7
           cabal-version: latest
 
       - name: Version information
@@ -123,8 +119,6 @@ jobs:
     runs-on: self-hosted
     strategy:
       fail-fast: false
-      matrix:
-        ghc: [ 9.12.4 ]
     steps:
       - uses: actions/checkout@v6
 
@@ -134,7 +128,6 @@ jobs:
       - name: Install GHC
         uses: haskell-actions/setup@v2
         with:
-          ghc-version: ${{ matrix.ghc }}
           enable-stack: true
           stack-no-global: true
           stack-version: latest

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -324,7 +324,6 @@ jobs:
           ghc984,
           ghc967
         ]
-    needs: packages_common
     steps:
       - uses: actions/checkout@v6
 
@@ -335,8 +334,8 @@ jobs:
 
       - name: Build clash-testsuite
         run: |
-          nix build -L .#clashPackages-${{matrix.ghc}}.clash-testsuite
-          attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-prelude)
+          nix build -L .#clashPackages-${{matrix.ghc}}.clash-testsuite-debug
+          attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-testsuite-debug)
 
       - name: Cachix
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1.10'
@@ -373,7 +372,7 @@ jobs:
 
       - name: Run clash-testsuite
         run: |
-          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(.ci/effective_cpus.sh) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
+          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite-debug -- -j$(.ci/effective_cpus.sh) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
 
   all:
     name: All on-push jobs finished

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -36,9 +36,6 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: latest
 
-      - name: Nproc
-        run: echo $(nproc)
-
       - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
           endpoint: '192.168.102.136'
@@ -60,21 +57,11 @@ jobs:
         run:
           cabal --version
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install libtinfo-dev tree -y
-
-        # Test if cabal can generate a build plan using the index state as specified in
-        # cabal.project
-        # This should be ran before cabal.project.local gets moved into the project root
-      - name: Test build plan
-        run: cabal v2-build --dry-run all > /dev/null || (echo "Maybe state index should be updated?"; false)
+      - name: Setup
+        run: .ci/gh-setup.sh
 
       - name: Build dependencies
-        run: |
-          cp .ci/cabal.project.local .
-          cabal v2-build all --dependencies-only
+        run: cabal v2-build all -j$(.ci/effective_cpus.sh) --dependencies-only
 
       - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
@@ -92,7 +79,10 @@ jobs:
 
       - name: Build
         run: |
-          cabal v2-build all
+          cabal v2-build all -j$(.ci/effective_cpus.sh)
+
+      - name: Run small tests
+        run: .ci/small-tests.sh
 
       - name: Clash-dev test
         run: .ci/build_clash_dev.sh
@@ -120,17 +110,13 @@ jobs:
         run:
           cabal --version
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install libtinfo-dev -y
+      - name: Setup
+        run: .ci/gh-setup.sh
 
       - name: Build & check documentation
         env:
           PKG: ${{ matrix.pkg }}
-        run: |
-          cp .ci/cabal.project.local .
-          .ci/build_docs.sh
+        run: .ci/build_docs.sh
 
   stack:
     name: Stack compilation test
@@ -173,18 +159,19 @@ jobs:
           # path: ${{ steps.ghc-install.outputs.stack-root }}
           path: ~/.stack
 
+      - name: Ensure stack is initialized
+        run: .ci/retry.sh stack build base -j1 +RTS -N1
+
       - name: Version information
         run:
           stack --version
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install libtinfo-dev -y
+      - name: Setup
+        run: .ci/gh-setup.sh
 
       - name: Build Dependencies
         run:
-          stack build -j$(nproc) --dependencies-only
+          stack build -j$(.ci/effective_cpus.sh) --dependencies-only
 
       - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
@@ -208,7 +195,7 @@ jobs:
           # Note: the --pedantic switch adds -Wall -Werror to the options passed to GHC. Options
           # specified in stack.yaml (like -Wcompat) are still passed; it is cumulative. Future
           # versions of Stack might add behavior to --pedantic.
-          stack build -j$(nproc) --pedantic
+          stack build -j$(.ci/effective_cpus.sh) --pedantic
 
 
   packages_common:
@@ -395,7 +382,7 @@ jobs:
 
       - name: Run clash-testsuite
         run: |
-          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(nproc) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
+          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(.ci/effective_cpus.sh) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
 
   all:
     name: All on-push jobs finished

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -81,22 +81,6 @@ jobs:
         run: |
           cabal v2-build all -j$(.ci/effective_cpus.sh)
 
-      - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
-        with:
-          endpoint: '192.168.102.136'
-          port: 9000
-          insecure: true
-          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
-          secretKey: '${{ secrets.S3_SECRET_KEY }}'
-          bucket: runner
-          region: local
-          use-fallback: false
-          retry: false
-          # Notice the small change in the key here! Save the build artifacts so the clash-testsuite does not
-          # have to recompile itself (since we compile it here already)
-          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-testsuite-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local.in', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
-          path: ${{ steps.ghc-install.outputs.cabal-store }}
-
       - name: Run small tests
         run: .ci/small-tests.sh
 
@@ -327,48 +311,32 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#devShells.x86_64-linux.${{matrix.ghc}} | cachix push clash-lang
 
-  cabal_testsuite:
-    name: Running clash-testsuite (${{matrix.ghc}})
+  packages_testsuite:
+    name: Packaging clash-testsuite (${{matrix.ghc}})
     runs-on: self-hosted
     strategy:
       # If caching fails for one package, then we are still interested in caching other packages
       fail-fast: false
       matrix:
         ghc: [
-          9.12.4,
-          9.10.3,
-          9.8.4,
-          9.6.7
+          ghc9124,
+          ghc9103,
+          ghc984,
+          ghc967
         ]
     needs: packages_common
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install GHC
-        id: ghc-install
-        uses: haskell-actions/setup@v2
-        with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: latest
+      - name: Authenticate cache
+        env:
+          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
+        run: .ci/attic-auth.sh
 
-      - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
-        with:
-          endpoint: '192.168.102.136'
-          port: 9000
-          insecure: true
-          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
-          secretKey: '${{ secrets.S3_SECRET_KEY }}'
-          bucket: runner
-          region: local
-          use-fallback: false
-          retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-testsuite-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local.in', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
-          restore-keys: |
-            ${{ runner.os }}-${{ github.ref_name }}-cabal-testsuite-${{ matrix.ghc }}
-            ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}
-            ${{ runner.os }}-master-cabal-testsuite-${{ matrix.ghc }}
-            ${{ runner.os }}-master-cabal-${{ matrix.ghc }}
-          path: ${{ steps.ghc-install.outputs.cabal-store }}
+      - name: Build clash-testsuite
+        run: |
+          nix build -L .#clashPackages-${{matrix.ghc}}.clash-testsuite
+          attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-prelude)
 
       - name: Cachix
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1.10'
@@ -404,7 +372,8 @@ jobs:
         run: .ci/attic-auth.sh
 
       - name: Run clash-testsuite
-        run: cabal v2-run clash-testsuite -- -j$(.ci/effective_cpus.sh) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
+        run: |
+          nix run .#clashPackages-${{matrix.ghc}}.clash-testsuite -- -j$(.ci/effective_cpus.sh) --hide-successes -p .${{matrix.hdl}}. --no-vivado --no-modelsim
 
   all:
     name: All on-push jobs finished
@@ -416,7 +385,8 @@ jobs:
       packages_common,
       packages_other,
       developer_shells,
-      cabal_testsuite,
+      packages_testsuite,
+      running_testsuite
     ]
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -36,6 +36,9 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: latest
 
+      - name: Nproc
+        run: echo $(nproc)
+
       - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
           endpoint: '192.168.102.136'
@@ -93,6 +96,41 @@ jobs:
 
       - name: Clash-dev test
         run: .ci/build_clash_dev.sh
+
+  cabal-haddock:
+    name: Haddock tests
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        # Documentation is built at 9.6.7, testing on other versions therefore does not make a lot
+        # of sense
+        ghc: [ 9.6.7 ]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install GHC
+        id: ghc-install
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+
+      - name: Version information
+        run:
+          cabal --version
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libtinfo-dev -y
+
+      - name: Build & check documentation
+        env:
+          PKG: ${{ matrix.pkg }}
+        run: |
+          cp .ci/cabal.project.local .
+          .ci/build_docs.sh
 
   stack:
     name: Stack compilation test

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -60,10 +60,17 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libtinfo-dev tree iverilog -y
+          sudo apt-get install libtinfo-dev -y
+
+        # Test if cabal can generate a build plan using the index state as specified in
+        # cabal.project
+        # This should be ran before cabal.project.local gets moved into the project root
+      - name: Test build plan
+        run: cabal v2-build --dry-run all > /dev/null || (echo "Maybe state index should be updated?"; false)
 
       - name: Build dependencies
         run: |
+          cp .ci/cabal.project.local .
           cabal v2-build all --dependencies-only
 
       - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
@@ -90,12 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [
-          9.12.4,
-          9.10.3,
-          9.8.4,
-          9.6.7
-        ]
+        ghc: [ 9.12.4 ]
     steps:
       - uses: actions/checkout@v6
 
@@ -107,6 +109,7 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           enable-stack: true
+          stack-no-global: true
           stack-version: latest
 
       - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
@@ -137,7 +140,7 @@ jobs:
 
       - name: Build Dependencies
         run:
-          stack build -j$(nproc) --pedantic --dependencies-only
+          stack build -j$(nproc) --dependencies-only
 
       - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
@@ -155,6 +158,9 @@ jobs:
 
       - name: Build
         run:
+          # Note: the --pedantic switch adds -Wall -Werror to the options passed to GHC. Options
+          # specified in stack.yaml (like -Wcompat) are still passed; it is cumulative. Future
+          # versions of Stack might add behavior to --pedantic.
           stack build -j$(nproc) --pedantic
 
 
@@ -198,7 +204,7 @@ jobs:
           attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-ghc)
 
       - name: Cachix
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1.10.0'
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: |
@@ -242,7 +248,7 @@ jobs:
         run: attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.${{matrix.package}})
 
       - name: Cachix
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1.10.0'
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#clashPackages-${{matrix.ghc}}.${{matrix.package}} | cachix push clash-lang
@@ -275,7 +281,7 @@ jobs:
         run: attic push public $(nix path-info .#devShells.x86_64-linux.${{matrix.ghc}})
 
       - name: Cachix
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1.10.0'
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: nix path-info .#devShells.x86_64-linux.${{matrix.ghc}} | cachix push clash-lang
@@ -308,7 +314,7 @@ jobs:
           attic push public $(nix path-info .#clashPackages-${{matrix.ghc}}.clash-prelude)
 
       - name: Cachix
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1.10.0'
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
         run: |
@@ -349,6 +355,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [
       cabal,
+      cabal-haddock,
       stack,
       packages_common,
       packages_other,

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -38,17 +38,19 @@ jobs:
 
       - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
-          endpoint: "192.168.102.136"
+          endpoint: '192.168.102.136'
           port: 9000
           insecure: true
-          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
-          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
+          secretKey: '${{ secrets.S3_SECRET_KEY }}'
           bucket: runner
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles( ${{ steps.ghc-install.outputs.cabal-store }}, "~/.cache/cabal" ) }
-          restore-keys: ${{ runner.os }}-${ matrix.ghc }-cabal-
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.ref_name }}-cabal-
+            ${{ runner.os }}-master-cabal-
           path: ${{ steps.ghc-install.outputs.cabal-store }}
 
       - name: Version information
@@ -66,16 +68,16 @@ jobs:
 
       - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
-          endpoint: "192.168.102.136"
+          endpoint: '192.168.102.136'
           port: 9000
           insecure: true
-          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
-          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
+          secretKey: '${{ secrets.S3_SECRET_KEY }}'
           bucket: runner
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${ matrix.ghc }-cabal-${ hashFiles( ${{ steps.ghc-install.outputs.cabal-store }}, "~/.cache/cabal" ) }
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
           path: ${{ steps.ghc-install.outputs.cabal-store }}
 
       - name: Build
@@ -109,17 +111,19 @@ jobs:
 
       - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
-          endpoint: "192.168.102.136"
+          endpoint: '192.168.102.136'
           port: 9000
           insecure: true
-          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
-          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
+          secretKey: '${{ secrets.S3_SECRET_KEY }}'
           bucket: runner
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${ matrix.ghc }-stack-${ hashFiles( ${{ steps.ghc-install.outputs.stack-root }} ) }
-          restore-keys: ${{ runner.os }}-${ matrix.ghc }-stack-
+          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'stack.yml', '**/*.cabal' ) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.ref_name }}-stack-
+            ${{ runner.os }}-master-stack-
           path: ${{ steps.ghc-install.outputs.stack-root }}
 
       - name: Version information
@@ -137,16 +141,16 @@ jobs:
 
       - uses: tespkg/actions-cache/save@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
-          endpoint: "192.168.102.136"
+          endpoint: '192.168.102.136'
           port: 9000
           insecure: true
-          accessKey: "${{ secrets.S3_ACCESS_KEY }}"
-          secretKey: "${{ secrets.S3_SECRET_KEY }}"
+          accessKey: '${{ secrets.S3_ACCESS_KEY }}'
+          secretKey: '${{ secrets.S3_SECRET_KEY }}'
           bucket: runner
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${ matrix.ghc }-stack-${ hashFiles( ${{ steps.ghc-install.outputs.stack-root }} ) }
+          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'stack.yml', '**/*.cabal' ) }}
           path: ${{ steps.ghc-install.outputs.stack-root }}
 
       - name: Build
@@ -215,12 +219,12 @@ jobs:
           ghc967
         ]
         package: [
-            "clash-benchmark",
-            "clash-lib-hedgehog",
-            "clash-prelude-hedgehog",
-            "clash-profiling",
-            "clash-profiling-prepare",
-            "clash-term"
+            'clash-benchmark',
+            'clash-lib-hedgehog',
+            'clash-prelude-hedgehog',
+            'clash-profiling',
+            'clash-profiling-prepare',
+            'clash-term'
         ]
     needs: packages_common
     steps:
@@ -317,9 +321,9 @@ jobs:
       fail-fast: false
       matrix:
         hdl: [
-          "VHDL",
-          "Verilog",
-          "SystemVerilog"
+          'VHDL',
+          'Verilog',
+          'SystemVerilog'
         ]
         ghc: [
           ghc9124,

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -47,7 +47,7 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local.in', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
           restore-keys: |
             ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}
             ${{ runner.os }}-master-cabal-${{ matrix.ghc }}
@@ -74,7 +74,7 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local.in', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
           path: ${{ steps.ghc-install.outputs.cabal-store }}
 
       - name: Build
@@ -150,10 +150,10 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ hashFiles('stack.yaml', '.github/workflow/on-push.yml', '**/*.cabal' ) }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.ref_name }}-stack-${{ matrix.ghc }}
-            ${{ runner.os }}-master-stack-${{ matrix.ghc }}
+            ${{ runner.os }}-${{ github.ref_name }}-stack-
+            ${{ runner.os }}-master-stack-
           # stack-root is set to null for some reason, which in turn breaks the entire stack cache
           # Hardcoding the stack path... for now
           # path: ${{ steps.ghc-install.outputs.stack-root }}
@@ -184,7 +184,7 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ hashFiles('stack.yaml', '.github/workflow/on-push.yml', '**/*.cabal' ) }}
           # stack-root is set to null for some reason, which in turn breaks the entire stack cache
           # Hardcoding the stack path... for now
           # path: ${{ steps.ghc-install.outputs.stack-root }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -58,10 +58,7 @@ jobs:
           cabal --version
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get install libtinfo-dev -y
-          sudo apt-get install tree -y
-          sudo apt-get install iverilog -y
+        run: sudo apt-get install libtinfo-dev tree iverilog -y
 
       - name: Build dependencies
         run: |

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -80,8 +80,6 @@ jobs:
 
       - name: Build
         run: |
-          # clash-cosim really wants to be built first
-          cabal v2-build clash-cosim
           cabal v2-build all
 
   stack:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -47,10 +47,10 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.ref_name }}-cabal-
-            ${{ runner.os }}-master-cabal-
+            ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}
+            ${{ runner.os }}-master-cabal-${{ matrix.ghc }}
           path: ${{ steps.ghc-install.outputs.cabal-store }}
 
       - name: Version information
@@ -60,7 +60,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libtinfo-dev -y
+          sudo apt-get install libtinfo-dev tree -y
 
         # Test if cabal can generate a build plan using the index state as specified in
         # cabal.project
@@ -84,12 +84,15 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-cabal-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
           path: ${{ steps.ghc-install.outputs.cabal-store }}
 
       - name: Build
         run: |
           cabal v2-build all
+
+      - name: Clash-dev test
+        run: .ci/build_clash_dev.sh
 
   stack:
     name: Stack compilation test
@@ -123,11 +126,14 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'stack.yml', '**/*.cabal' ) }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.ref_name }}-stack-
-            ${{ runner.os }}-master-stack-
-          path: ${{ steps.ghc-install.outputs.stack-root }}
+            ${{ runner.os }}-${{ github.ref_name }}-stack-${{ matrix.ghc }}
+            ${{ runner.os }}-master-stack-${{ matrix.ghc }}
+          # stack-root is set to null for some reason, which in turn breaks the entire stack cache
+          # Hardcoding the stack path... for now
+          # path: ${{ steps.ghc-install.outputs.stack-root }}
+          path: ~/.stack
 
       - name: Version information
         run:
@@ -153,8 +159,11 @@ jobs:
           region: local
           use-fallback: false
           retry: false
-          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'stack.yml', '**/*.cabal' ) }}
-          path: ${{ steps.ghc-install.outputs.stack-root }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-stack-${{ matrix.ghc }}-${{ hashFiles('.ci/cabal.project.local', '.github/workflow/on-push.yml', 'cabal.project', '**/*.cabal' ) }}
+          # stack-root is set to null for some reason, which in turn breaks the entire stack cache
+          # Hardcoding the stack path... for now
+          # path: ${{ steps.ghc-install.outputs.stack-root }}
+          path: ~/.stack
 
       - name: Build
         run:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -56,7 +56,9 @@ jobs:
           cabal --version
 
       - name: Install system dependencies
-        run: sudo apt-get install libtinfo-dev tree iverilog -y
+        run: |
+          sudo apt-get update
+          sudo apt-get install libtinfo-dev tree iverilog -y
 
       - name: Build dependencies
         run: |
@@ -127,7 +129,9 @@ jobs:
           stack --version
 
       - name: Install system dependencies
-        run: sudo apt-get install libtinfo-dev -y
+        run: |
+          sudo apt-get update
+          sudo apt-get install libtinfo-dev -y
 
       - name: Build Dependencies
         run:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,13 @@ include:
   - '/.ci/gitlab/publish.yml'
 #   - '/.ci/gitlab/benchmark.yml'
 
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH                  # Pushes
+      when: never
+    - if: $CI_COMMIT_TAG                     # When tags are set (releases)
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+
 variables:
   # Default GHC / Cabal version. Used for generating Haddock and releasing to
   # Hackage.

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,11 @@
             clash-profiling
             clash-profiling-prepare
             clash-term
-            clash-testsuite;
+            clash-testsuite
+            # Debug versions, mostly used for the CI
+            clash-lib-debug
+            clash-ghc-debug
+            clash-testsuite-debug;
 
           default =
             pkgs."clashPackages-${defaultGhcVersion}".clash-ghc;
@@ -121,7 +125,11 @@
                 clash-profiling
                 clash-profiling-prepare
                 clash-term
-                clash-testsuite;
+                clash-testsuite
+                # Debug versions, mostly used for the CI
+                clash-lib-debug
+                clash-ghc-debug
+                clash-testsuite-debug;
             };
           }) ghcVersions);
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -242,6 +242,74 @@ let
               ]}
           '';
         });
+
+      # A small set of packages with the debug flag enabled
+      # This is mostly useful for running the testsuite
+      clash-lib-debug = prev.haskell.lib.compose.enableCabalFlag "debug" hfinal.clash-lib;
+      clash-ghc-debug = hfinal.clash-ghc.override {
+        clash-lib = hfinal.clash-lib-debug;
+      };
+      # The reason we don't simply `override` this is because the postInstall contains a direct
+      # reference to clash-ghc
+      # So a copy-and-paste was easier
+      clash-testsuite-debug =
+        let
+          unmodified =
+            hprev.callCabal2nix
+              "clash-testsuite"
+              ../tests {
+                clash-lib = hfinal.clash-lib-debug;
+                clash-ghc = hfinal.clash-ghc-debug;
+              };
+        in
+        unmodified.overrideAttrs (old: {
+          buildInputs = (old.buildInputs or [ ]) ++ [
+            prev.makeWrapper
+          ];
+
+          postInstall = (old.postInstall or "") + ''
+            ghcBinDir=${dirOf "${old.passthru.env.NIX_GHC}"}
+            ghcLibDir="${old.passthru.env.NIX_GHC_LIBDIR}"
+            globalPackageDb="$ghcLibDir/package.conf.d"
+            testsuitePackageDb="$out/lib/''${ghcLibDir#*/lib/}/package.conf.d"
+            wrapperDir="$out/libexec/clash-testsuite-wrappers"
+
+            mkdir -p "$wrapperDir"
+
+            cat > "$wrapperDir/clash" <<EOF
+            #!${prev.runtimeShell}
+            exec ${hfinal.clash-ghc-debug}/bin/clash \
+              -package-db "$globalPackageDb" \
+              -package-db "$testsuitePackageDb" \
+              "\$@"
+            EOF
+            chmod +x "$wrapperDir/clash"
+
+            "$ghcBinDir/ghc-pkg" recache --package-db="$testsuitePackageDb"
+
+            wrapProgram $out/bin/clash-testsuite \
+              --prefix PATH : "$ghcBinDir" \
+              --prefix PATH : "$wrapperDir" \
+              --set GHC_PACKAGE_PATH "$testsuitePackageDb:$globalPackageDb:" \
+              --set USE_GLOBAL_CLASH 1 \
+              --prefix PATH : ${prev.lib.makeBinPath [
+                prev.gcc
+                # make and python3 are used in verilator invocations
+                prev.gnumake
+                prev.python3
+                final.ghdl-llvm
+                prev.sby
+                final.verilator
+                prev.iverilog
+                prev.yosys
+                prev.z3
+              ]} \
+              --set LIBRARY_PATH ${prev.lib.makeLibraryPath [
+                final.ghdl-llvm
+                prev.zlib.static
+              ]}
+          '';
+        });
     };
 
   haskellOverlays =


### PR DESCRIPTION
We have self-hosted Github runners, however we still mirror the repository to Gitlab to run jobs on PRs. This migrates over the jobs that the Gitlab runners do over to Github. In specific; only the jobs performed on push are copied over. This includes the following set of jobs:

 - Testing if all clash-* projects successfully compile against all supported GHC versions in Cabal
 - Testing if all clash-* projects succesfully compile with the `stack.yaml` in the root
 - Migrates the Haddock tests from Gitlab over to Github  
 - Package & cache all clash-* projects using Nix (this also runs tests for those packages) for all supported GHC versions
 - Run the clash testsuite for VHDL, Verilog and SystemVerilog in all supported GHC versions

Nix automatically caches whatever it builds to our local cache, pushes to the master and release branch also get cached in Cachix.

Original PR: #3275