### PR TITLE
Fix `reduceTraverse` crash on zero-length vectors

### DIFF
--- a/changelog/2026-06-08T14_29_48+02_00_fix_3290
+++ b/changelog/2026-06-08T14_29_48+02_00_fix_3290
@@ -1,0 +1,1 @@
+FIXED: Clash no longer crashes upon calling `sequenceA`/`traverse#` on a zero-sized `Vec`. See [#3290](https://github.com/clash-lang/clash-compiler/issues/3290).

--- a/clash-lib/src/Clash/Core/Util.hs
+++ b/clash-lib/src/Clash/Core/Util.hs
@@ -167,7 +167,7 @@ extractElems supply inScope consCon resTy s maxN vec =
   if maxN >= 1 then
     first fst (go maxN (supply,inScope) vec)
   else
-    error "extractElems must be called with positive number"
+    error "extractElems must be called with maxN >= 1"
  where
   go :: Integer -> (Supply,InScopeSet) -> Term
      -> ((Supply,InScopeSet),NonEmpty (Term, NonEmpty (Id, Term)))

--- a/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
+++ b/clash-lib/src/Clash/Normalize/PrimitiveReductions.hs
@@ -537,10 +537,14 @@ reduceTraverse n aTy fTy bTy dict fun arg (TransformContext is0 ctx) = do
               fmapTm = Case (Var functorDictId) fmapTy
                             [(fnPat, Var fmapId)]
 
-              (uniqs3,(vars,elems)) = second (second sconcat . NE.unzip)
-                                    $ uncurry extractElems uniqs2 consCon aTy 'T' n arg
+              (uniqs3,vars,elemBinds)
+                | n == 0    = (fst uniqs2,[],[])
+                | otherwise =
+                    let (us,(vs,es)) = second (second sconcat . NE.unzip)
+                                     $ uncurry extractElems uniqs2 consCon aTy 'T' n arg
+                    in  (us,NE.toList vs,NE.init es)
 
-              funApps = map (fun1 `App`) (NE.toList vars)
+              funApps = map (fun1 `App`) vars
 
               lbody   = mkTravVec vecTcNm nilCon consCon (Var (apDictIds!!1))
                                                         (Var (apDictIds!!2))
@@ -551,7 +555,7 @@ reduceTraverse n aTy fTy bTy dict fun arg (TransformContext is0 ctx) = do
                                 ,((apDictIds!!1), pureTm)
                                 ,((apDictIds!!2), apTm)
                                 ,((funcDicIds!!0), fmapTm)
-                                ] ++ NE.init elems) lbody
+                                ] ++ elemBinds) lbody
           uniqSupply Lens..= uniqs3
           lift (changed lb)
     go _ _ ty = error $ $(curLoc) ++ "reduceTraverse: argument does not have a vector type: " ++ showPpr ty

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -697,6 +697,7 @@ runClashTest = defaultMain
             , hdlLoad=[IVerilog]
             , hdlSim=[IVerilog]
             }
+        , runTest "T3290" def{hdlSim=[], hdlLoad=[]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T3290.hs
+++ b/tests/shouldwork/Issues/T3290.hs
@@ -1,0 +1,12 @@
+module T3290 where
+
+import Clash.Prelude
+
+-- | https://github.com/clash-lang/clash-compiler/issues/3290
+--
+-- @sequenceA@ (i.e. @traverse#@) over a zero-length vector used to crash
+-- normalization with "extractElems must be called with positive number",
+-- because 'reduceTraverse' called @extractElems@ with @n == 0@.
+topEntity :: Vec 0 (Maybe (Index 3)) -> Maybe (Vec 0 (Index 3))
+topEntity = sequenceA
+{-# OPAQUE topEntity #-}


### PR DESCRIPTION
`extractElems` errors when called with n == 0, so `sequenceA`/`traverse#` over a `Vec 0` crashed. Short- circuit `n == 0` to emit pure `Nil`.

Fixes #3290

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
