### PR TITLE
Clear stack in `reduceWHNF'`

### DIFF
--- a/changelog/2026-06-08T16_16_41+02_00_fix_3291
+++ b/changelog/2026-06-08T16_16_41+02_00_fix_3291
@@ -1,0 +1,1 @@
+FIXED: Clash no longer crashes with `mkVecNil: failed to instantiate Nil DC` when unfolding `traverse#` in very specific circumstances. See [#3291](https://github.com/clash-lang/clash-compiler/issues/3291).

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -4716,7 +4716,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
 
     reduceWHNF' mach1 e =
       let eval = Evaluator ghcStep ghcUnwind ghcPrimStep ghcPrimUnwind
-          mach2@Machine{mStack=[]} = whnf eval tcm isSubj (setTerm e mach1)
+          mach2@Machine{mStack=[]} = whnf eval tcm isSubj (setTerm e $ stackClear mach1)
        in Just $ mach2 { mStack = mStack mach }
 
     makeUndefinedIf :: Exception e => (e -> Bool) -> Term -> Term

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -698,6 +698,7 @@ runClashTest = defaultMain
             , hdlSim=[IVerilog]
             }
         , runTest "T3290" def{hdlSim=[], hdlLoad=[]}
+        , runTest "T3291" def{hdlTargets=[Verilog]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -86,6 +86,7 @@ library
     -- https://github.com/clash-lang/clash-compiler/issues/1796 for an example.
     shouldwork/LoadModules/precompiled
     shouldwork/Basic/precompiled
+    shouldwork/Issues/T3291-precompiled
 
   exposed-modules:
     Test.Tasty.Clash
@@ -107,6 +108,9 @@ library
     -- From tests/shouldwork/Basic/precompiled
     SimulationMagic2736a
 
+    -- From tests/shouldwork/Issues/T3291-precompiled
+    T3291.BitPackC
+
   other-modules:
     Paths_clash_testsuite
 
@@ -125,6 +129,9 @@ library
     singletons,
     template-haskell,
     unordered-containers,
+    ghc-typelits-extra,
+    ghc-typelits-knownnat,
+    ghc-typelits-natnormalise,
 
 
 executable clash-testsuite

--- a/tests/shouldwork/Issues/T3291-precompiled/T3291/BitPackC.hs
+++ b/tests/shouldwork/Issues/T3291-precompiled/T3291/BitPackC.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoStarIsType #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
+
+module T3291.BitPackC (packC, maybeUnpackC, BitPackC (..)) where
+
+import Clash.Prelude
+
+maybeUnpackVec ::
+  (KnownNat n) =>
+  BitVector (n * 8) -> Maybe (Vec n (BitVector 8))
+maybeUnpackVec = sequenceA . map Just . unconcatBitVector#
+
+packC :: (BitPackC a) => a -> Vec (ByteSizeC a) (BitVector 8)
+packC = fromJustX . maybeUnpackVec . packC#
+
+fromEndianBV ::
+  (KnownNat n) => BitVector (n * 8) -> BitVector (n * 8)
+fromEndianBV = pack . reverse . fromJustX . maybeUnpackVec
+
+class (KnownNat (ByteSizeC a)) => BitPackC (a :: Type) where
+  type ByteSizeC (a :: Type) :: Nat
+
+  packC# :: a -> BitVector (ByteSizeC a * 8)
+
+instance (KnownNat n) => BitPackC (Unsigned n) where
+  type ByteSizeC (Unsigned n) = 2 ^ CLog 2 (Max 1 (DivRU n 8))
+
+  packC# val = fromEndianBV (resize (pack val))
+
+-- Dead, but removing this triggers GHC opts (?) that make the reproduce fail to
+-- reproduce.
+maybeUnpackC ::
+  (KnownNat n) =>
+  Unsigned n -> BitVector (ByteSizeC (Unsigned n) * 8) -> Maybe (Unsigned n)
+maybeUnpackC _ bv = Just (unpack (resize (fromEndianBV bv)))

--- a/tests/shouldwork/Issues/T3291.hs
+++ b/tests/shouldwork/Issues/T3291.hs
@@ -1,0 +1,27 @@
+module T3291 where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+import T3291.BitPackC
+
+packUSym ::
+  forall n. (KnownNat n) =>
+  Unsigned n -> Vec (ByteSizeC (Unsigned n)) (BitVector 8)
+packUSym = packC
+{-# OPAQUE packUSym #-}
+
+topEntity :: () -> Vec (ByteSizeC (Unsigned 9)) (BitVector 8)
+topEntity () = packUSym @9 3
+{-# OPAQUE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+ where
+  testInput = stimuliGenerator clk rst (() :> Nil)
+  expectedOutput =
+    outputVerifier' clk rst
+      ((0b0000_0011 :> 0b0000_0000 :> Nil) :> Nil)
+  done = expectedOutput (topEntity <$> testInput)
+  clk = tbSystemClockGen (not <$> done)
+  rst = systemResetGen
+{-# OPAQUE testBench #-}


### PR DESCRIPTION
Like `reduceWHNF` its prime brother needs to clear the stack, lest the same stack risks getting unwound twice.

Fixes #3291

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~