### PR TITLE
Limit Clash invocations to 2G of RAM in testsuite

### DIFF
--- a/tests/src/Test/Tasty/Clash.hs
+++ b/tests/src/Test/Tasty/Clash.hs
@@ -212,6 +212,8 @@ commonArgs =
   [ "-fclash-debug", "DebugSilent"
   , "-fclash-ignore-broken-ghcs"
   , "-Werror=unrecognised-pragmas"
+  -- Limit memory use to 2G. Prevents OOM when debugging things like infinite loops.
+  , "+RTS", "-M2G", "-RTS"
   ]
 
 instance IsTest ClashGenTest where


### PR DESCRIPTION
I keep making this patch locally :-).

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~