### PR TITLE
Prune closure + parallelize closure loading

### DIFF
--- a/changelog/2026-06-12T12_52_51+02_00_prune_closure_before_loading
+++ b/changelog/2026-06-12T12_52_51+02_00_prune_closure_before_loading
@@ -1,0 +1,1 @@
+ADDED: Clash now prunes the binders it collects from top modules when loading from precompiled core. For larger projects, this can shave off 15% of package loading times. See [#3298](https://github.com/clash-lang/clash-compiler/issues/3298).

--- a/changelog/2026-06-12T13_01_29+02_00_parallelize_ghc2core
+++ b/changelog/2026-06-12T13_01_29+02_00_parallelize_ghc2core
@@ -1,0 +1,1 @@
+ADDED: Clash now converts GHC Core to its own Clash Core in parallel. For larger projects, this can shave off ~40% of load times. See [#3299](https://github.com/clash-lang/clash-compiler/issues/3299).

--- a/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GenerateBindings.hs
@@ -6,6 +6,7 @@
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -16,9 +17,9 @@ module Clash.GHC.GenerateBindings
 where
 
 import           Control.Arrow           ((***))
-import           Control.DeepSeq         (deepseq)
-import           Control.Lens            ((%~),(&),(.~))
-import           Control.Monad           (unless)
+import           Control.DeepSeq         (NFData, deepseq)
+import           Control.Lens            ((%~),(&),(.~),(^.))
+import           Control.Monad           (forM, unless)
 import qualified Control.Monad.State     as State
 import qualified Control.Monad.RWS.Strict as RWS
 import           Data.Coerce             (coerce)
@@ -26,10 +27,15 @@ import           Data.Either             (partitionEithers, lefts ,rights)
 import           Data.IntMap.Strict      (IntMap)
 import qualified Data.IntMap.Strict      as IMS
 import qualified Data.HashMap.Strict     as HashMap
+#if !MIN_VERSION_base(4,20,0)
+import           Data.List               (foldl')
+#endif
 import           Data.List               (isPrefixOf)
+import           Data.List.Split         (chunksOf)
 import           Data.Maybe              (listToMaybe)
 import qualified Data.Text               as Text
 import qualified Data.Time.Clock         as Clock
+import           GHC.Conc                (numCapabilities, par, pseq)
 
 import qualified GHC                     as GHC (Ghc)
 import qualified GHC.Types.SourceText    as GHC
@@ -206,45 +212,105 @@ mkBindings
          , VarEnv (Id,Int)
          )
 mkBindings primMap bindings clsOps unlocatable = do
-  bindingsList <- mapM (\case
-    GHC.NonRec v e -> do
-      let sp = GHC.getSrcSpan v
+  -- Converting each binder is independent: 'GHC2CoreState' only accumulates a
+  -- 'TyCon' map and a name cache, both of which are pure (deterministic per
+  -- key) memo tables. We therefore convert every binder from a fresh state in
+  -- parallel and merge the resulting 'TyCon' maps afterwards. See 'parRunC2C'.
+  env <- RWS.ask
+  let
+    bindingsList = parRunC2C env (map (processBind primMap unlocatable) bindings)
+    clsOpList    = parRunC2C env (map processClsOp clsOps)
+  -- Merge the 'TyCon' maps discovered while converting; the name caches are
+  -- not used after this point, so they are dropped. 'makeAllTyCons' later
+  -- recomputes over the merged map, so a plain union suffices.
+  RWS.modify (tyConMap %~ \tcm0 ->
+    foldl' (\acc st -> acc <> (st ^. tyConMap)) tcm0
+      (map snd bindingsList ++ map snd clsOpList))
+
+  return ( mkVarEnv (concatMap fst bindingsList)
+         , mkVarEnv (map fst clsOpList) )
+
+-- | Convert a single (possibly recursive) binder group to Clash Core bindings.
+-- See 'mkBindings' for how these conversions are run in parallel.
+processBind
+  :: CompiledPrimMap
+  -> [GHC.CoreBndr]
+  -> GHC.CoreBind
+  -> C2C [(Id, Binding Term)]
+processBind primMap unlocatable = \case
+  GHC.NonRec v e -> do
+    let sp = GHC.getSrcSpan v
+        inl = GHC.inlinePragmaSpec . GHC.inlinePragInfo $ GHC.idInfo v
+    tm <- RWS.local (srcSpan .~ sp) (coreToTerm primMap unlocatable e)
+    v' <- coreToId v
+    nm <- qualifiedNameString (GHC.varName v)
+    let pr = if HashMap.member nm primMap then IsPrim else IsFun
+    checkPrimitive primMap v
+    return [(v', (Binding v' sp inl pr tm False))]
+  GHC.Rec bs -> do
+    tms <- forM bs $ \(v,e) -> do
+      let sp  = GHC.getSrcSpan v
           inl = GHC.inlinePragmaSpec . GHC.inlinePragInfo $ GHC.idInfo v
       tm <- RWS.local (srcSpan .~ sp) (coreToTerm primMap unlocatable e)
       v' <- coreToId v
       nm <- qualifiedNameString (GHC.varName v)
       let pr = if HashMap.member nm primMap then IsPrim else IsFun
       checkPrimitive primMap v
-      return [(v', (Binding v' sp inl pr tm False))]
-    GHC.Rec bs -> do
-      tms <- mapM (\(v,e) -> do
-                    let sp  = GHC.getSrcSpan v
-                        inl = GHC.inlinePragmaSpec . GHC.inlinePragInfo $ GHC.idInfo v
-                    tm <- RWS.local (srcSpan .~ sp) (coreToTerm primMap unlocatable e)
-                    v' <- coreToId v
-                    nm <- qualifiedNameString (GHC.varName v)
-                    let pr = if HashMap.member nm primMap then IsPrim else IsFun
-                    checkPrimitive primMap v
-                    return (Binding v' sp inl pr tm True)
-                  ) bs
-      case tms of
-        [Binding v sp inl pr tm r] -> return [(v, Binding v sp inl pr tm r)]
+      return (Binding v' sp inl pr tm True)
+    case tms of
+      [Binding v sp inl pr tm r] -> return [(v, Binding v sp inl pr tm r)]
 
-        -- Rewrite the bindings to avoid triggering the recursion check.
-        -- See NOTE [bindings in recursive groups]
-        _ -> let vsL   = map (setIdScope LocalId . bindingId) tms
-                 vsV   = map Var vsL
-                 subst = extendGblSubstList (mkSubst emptyInScopeSet) (zip vsL vsV)
-                 lbs   = zipWith (\b vL -> (vL,substTm "mkBindings" subst (bindingTerm b))) tms vsL
-                 tms1  = zipWith (\b (i, _) -> (bindingId b, b { bindingTerm = Letrec lbs (Var i), bindingRecursive = False })) tms lbs
-             in  return tms1
-    ) bindings
-  clsOpList    <- mapM (\(v,i) -> do
-                          v' <- coreToId v
-                          return (v', (v',i))
-                       ) clsOps
+      -- Rewrite the bindings to avoid triggering the recursion check.
+      -- See NOTE [bindings in recursive groups]
+      _ -> let vsL   = map (setIdScope LocalId . bindingId) tms
+               vsV   = map Var vsL
+               subst = extendGblSubstList (mkSubst emptyInScopeSet) (zip vsL vsV)
+               lbs   = zipWith (\b vL -> (vL,substTm "mkBindings" subst (bindingTerm b))) tms vsL
+               tms1  = zipWith (\b (i, _) -> (bindingId b, b { bindingTerm = Letrec lbs (Var i), bindingRecursive = False })) tms lbs
+           in  return tms1
 
-  return (mkVarEnv (concat bindingsList), mkVarEnv clsOpList)
+-- | Convert a single class operation. See 'processBind'.
+processClsOp :: (GHC.CoreBndr, Int) -> C2C (Id, (Id, Int))
+processClsOp (v,i) = do
+  v' <- coreToId v
+  return (v', (v',i))
+
+-- | Run a list of independent 'C2C' computations, each starting from an empty
+-- 'GHC2CoreState', forcing their results to normal form in parallel across the
+-- available capabilities. Returns each computation's result paired with the
+-- state it produced (so the caller can merge the accumulated 'TyCon' maps).
+--
+-- This only runs in parallel when the RTS has more than one capability, i.e.,
+-- when the executable is run with @+RTS -N@ or built with @-with-rtsopts=-N@.
+-- With a single capability it degrades to sequential evaluation.
+parRunC2C :: NFData a => GHC2CoreEnv -> [C2C a] -> [(a, GHC2CoreState)]
+parRunC2C env ms = parListChunk chunkSize forceResult (map runC2C ms)
+ where
+  runC2C m = case RWS.runRWS m env emptyGHC2CoreState of
+    (a, s, _w) -> (a, s)
+  -- Force the converted result to normal form (this is the expensive
+  -- 'coreToTerm' work we want to parallelize). The state is left to be forced
+  -- lazily when its 'TyCon' map is merged; its entries are cheap GHC 'TyCon'
+  -- references (the heavy 'makeAllTyCons' conversion happens later).
+  forceResult p@(a, _s) = a `deepseq` p
+  -- Keep chunks small so the work stays balanced even when a few binders are
+  -- far larger than the rest; ~16 measured as a good size on large downstream
+  -- designs. For small designs we make chunks finer still, scaling with the
+  -- number of capabilities, but never below 1.
+  chunkSize = min 16 (max 1 (length ms `div` (numCapabilities * 4)))
+
+-- | Evaluate a list in parallel, in chunks, using only @base@ (@par@/@pseq@).
+-- Equivalent in spirit to @Control.Parallel.Strategies@' @parListChunk n@ with
+-- a caller-supplied forcing function, but avoids adding a dependency.
+parListChunk :: Int -> (a -> a) -> [a] -> [a]
+parListChunk n forceElem = concat . go . chunksOf n
+ where
+  forceChunk c = foldr (\x xs -> forceElem x `pseq` xs) () c `pseq` c
+  go []     = []
+  go (c:cs) =
+    let c'  = forceChunk c
+        cs' = go cs
+    in  c' `par` (cs' `pseq` (c' : cs'))
 
 {-
 NOTE [bindings in recursive groups]

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -184,6 +184,10 @@ loadExternalModule
   -> String
   -- ^ Module name. Can either be a filepath pointing to a .hs file, or a
   -- qualified module name (example: "Data.List").
+  -> Maybe String
+  -- ^ Name passed with @-main-is@, if any. When set, only the transitive
+  -- closure of this binder is loaded (instead of the closure of all exports of
+  -- the module). See 'loadSeed'.
   -> m (Either
           SomeException
           ( [CoreSyn.CoreBndr]                     -- Root binders
@@ -192,16 +196,67 @@ loadExternalModule
           , LoadedBinders
           , [CoreSyn.CoreBind]                     -- All bindings
           ) )
-loadExternalModule hdl modName0 = MC.try $ do
+loadExternalModule hdl modName0 mainIsM = MC.try $ do
   let modName1 = GHC.mkModuleName modName0
   foundMod <- GHC.findModule modName1 Nothing
   let errMsg = "Internal error: found  module, but could not load it"
   modInfo <- fromMaybe (error errMsg) <$> (GHC.getModuleInfo foundMod)
   tyThings <- catMaybes <$> mapM GHC.lookupGlobalName (GHC.modInfoExports modInfo)
   let rootIds = [id_ | GHC.AnId id_ <- tyThings]
-  loaded <- loadExternalBinders hdl rootIds
+  -- Only load (the transitive closure of) the binders we will actually compile.
+  -- With @-main-is@ that is the requested binder plus any other binder that
+  -- 'loadModules' can still select as a top entity (see 'loadSeed'); without it,
+  -- all exports.
+  seed <- loadSeed mainIsM rootIds
+  loaded <- loadExternalBinders hdl seed
   let allBinders = makeRecursiveGroups (Map.assocs (lbBinders loaded))
+  -- NB: we return the /full/ export list as the root binders, so resolution of
+  -- the @-main-is@ name and of (testbench/synthesize) annotations in
+  -- 'loadModules' is unaffected by the pruning above.
   return (rootIds, FamInstEnv.emptyFamInstEnv, modName1, loaded, allBinders)
+
+-- | Restrict the set of binders we load the transitive closure of. When a
+-- @-main-is@ name is given we do not need every export: any binder (and its
+-- closure) that is not selected as a top entity would be loaded, converted to
+-- Clash Core, and then discarded by 'Clash.GHCi.Common.getMainTopEntity'. When
+-- no name is given we keep all exports.
+--
+-- The seed must cover /every/ binder that 'loadModules' can select as a top
+-- entity, otherwise that binder is chosen but its binding is never loaded,
+-- leading to a spurious \"No top entity called ...\" error (see #3297). Besides
+-- the @-main-is@ binder itself, this is:
+--
+--   * magically named exports @topEntity@ and @testBench@;
+--   * @Synthesize@- and @TestBench@-annotated exports, and the designs under
+--     test the latter point at.
+--
+-- These match the implicit top entities computed in 'loadModules'. We do not
+-- prune them further based on @-main-is@ here, as 'getMainTopEntity' does that
+-- downstream; loading their (small) closures is cheap and keeps this in step
+-- with the selection logic.
+--
+-- If the @-main-is@ name cannot be found among the exports we fall back to all
+-- exports and let 'loadModules' produce the usual \"no top-level function
+-- called ...\" error.
+loadSeed
+  :: GHC.GhcMonad m
+  => Maybe String
+  -> [CoreSyn.CoreBndr]
+  -> m [CoreSyn.CoreBndr]
+loadSeed Nothing rootIds = pure rootIds
+loadSeed (Just nm) rootIds =
+  case filter ((== nm) . varNameString) rootIds of
+    [] -> pure rootIds
+    mainIs -> do
+      synAnns <- findSynthesizeAnnotations rootIds
+      benchAnns <- findTestBenches rootIds
+      let
+        implicit =
+             map fst synAnns
+          <> Map.keys benchAnns
+          <> concat (Map.elems benchAnns)
+          <> filter isMagicName rootIds
+      pure (nubSort (mainIs <> implicit))
 
 setupGhc
   :: GHC.GhcMonad m
@@ -398,6 +453,22 @@ nameString = OccName.occNameString . Name.nameOccName
 varNameString :: Var.Var -> String
 varNameString = nameString . Var.varName
 
+-- | Is the binder magically named @topEntity@? Such binders are implicitly
+-- treated as top entities (see 'isMagicName').
+isTopEntityName :: Var.Var -> Bool
+isTopEntityName = (== "topEntity") . varNameString
+
+-- | Is the binder magically named @testBench@? Such binders are implicitly
+-- treated as top entities (see 'isMagicName').
+isTestBenchName :: Var.Var -> Bool
+isTestBenchName = (== "testBench") . varNameString
+
+-- | Is the binder magically named, i.e. called @topEntity@ or @testBench@?
+-- These are picked up as top entities even without a @Synthesize@/@TestBench@
+-- annotation.
+isMagicName :: Var.Var -> Bool
+isMagicName v = isTopEntityName v || isTestBenchName v
+
 data LoadModulesException = LoadModulesException
   { moduleName :: String
   , externalError :: String
@@ -455,15 +526,11 @@ loadModules startAction useColor hdl modName dflagsM idirs = do
     let setupStartDiff = reportTimeDiff setupTime startTime
     MonadUtils.liftIO $ putStrLn $ "GHC: Setting up GHC took: " ++ setupStartDiff
 
-    -- TODO: We currently load the transitive closure of _all_ bindings found
-    -- TODO: in the top module. This is wasteful if one or more binders don't
-    -- TODO: contribute to any top entities. This effect is worsened when using
-    -- TODO: -main-is, which only synthesizes a single top entity (and all its
-    -- TODO: dependencies).
+    let mainIsM = GHC.mainFunIs =<< dflagsM
     (rootIds, modFamInstEnvs, _rootModule, LoadedBinders{..}, allBinders) <-
       -- We need to try and load external modules first, because we can't
       -- recover from errors in 'loadLocalModule'.
-      loadExternalModule hdl modName >>= \case
+      loadExternalModule hdl modName mainIsM >>= \case
         Left loadExternalErr -> do
           catch @_ @SomeException
             (loadLocalModule hdl modName)
@@ -503,12 +570,11 @@ loadModules startAction useColor hdl modName dflagsM idirs = do
       -- TestBench and the binders they're pointing to, plus magically named
       -- functions called "topEntity" or "testBench". Synthesized in case user
       -- didn't specify a particular target.
-      isMagicName = (`elem` ["topEntity", "testBench"])
       allImplicit = nubSort $
            Map.keys benchAnn
         <> Map.keys allSyn
         <> concat (Map.elems benchAnn)
-        <> filter (isMagicName . varNameString) rootIds
+        <> filter isMagicName rootIds
         <> topSyn
 
       -- Top entities we wish to synthesize. Users can filter these with -main-is.
@@ -797,8 +863,8 @@ findTestBenches bndrs0 = do
   -- Special case magic name 'testBench'. See function documentation.
   specialCaseMagicName m =
     let
-      topEntM = find ((=="topEntity") . varNameString) bndrs0
-      tbM = find ((=="testBench") . varNameString) bndrs0
+      topEntM = find isTopEntityName bndrs0
+      tbM = find isTestBenchName bndrs0
     in
       case (topEntM, tbM) of
         (Just dut, Just tb) -> insertTb m (dut, tb)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -967,6 +967,17 @@ runClashTest = defaultMain
             { hdlTargets = [VHDL]
             , clashFlags = ["-main-is", "topEntity3"]
             }
+        , -- Regression test for #3297: with -main-is, a magically named
+          -- 'testBench' living outside 'topEntity's closure must not be pruned
+          -- before it is loaded. 'T3297a' is compiled into the clash-testsuite
+          -- library, so (with no source on the search path) Clash loads it from
+          -- its external interface file, exercising the pruning in
+          -- 'loadExternalModule'. Gen-only: we only need loading to succeed.
+          runTest "T3297a" def
+            { hdlSim = []
+            , hdlLoad = []
+            , clashFlags = ["-package", "clash-testsuite", "-main-is", "topEntity"]
+            }
         , runTest "T1139" def{hdlSim=[]}
         , let _opts = def { hdlTargets=[Verilog]
                           , buildTargets=BuildSpecific ["PortNames_testBench"]

--- a/tests/clash-testsuite.cabal
+++ b/tests/clash-testsuite.cabal
@@ -87,6 +87,7 @@ library
     shouldwork/LoadModules/precompiled
     shouldwork/Basic/precompiled
     shouldwork/Issues/T3291-precompiled
+    shouldwork/TopEntity/precompiled
 
   exposed-modules:
     Test.Tasty.Clash
@@ -110,6 +111,9 @@ library
 
     -- From tests/shouldwork/Issues/T3291-precompiled
     T3291.BitPackC
+
+    -- From tests/shouldwork/TopEntity/precompiled
+    T3297a
 
   other-modules:
     Paths_clash_testsuite

--- a/tests/shouldwork/TopEntity/precompiled/T3297a.hs
+++ b/tests/shouldwork/TopEntity/precompiled/T3297a.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module T3297a where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+-- | The top entity we select with @-main-is topEntity@.
+topEntity :: Signal System (Unsigned 8) -> Signal System (Unsigned 8)
+topEntity = fmap (+1)
+{-# OPAQUE topEntity #-}
+
+-- | A design under test used only by 'testBench', deliberately kept out of
+-- 'topEntity's closure.
+dut :: Signal System (Unsigned 8) -> Signal System (Unsigned 8)
+dut = fmap (*2)
+{-# OPAQUE dut #-}
+
+-- | Magically named test bench that exercises 'dut' (not 'topEntity'), so it
+-- lies entirely outside 'topEntity's closure.
+--
+-- This module is compiled into the @clash-testsuite@ library, so Clash loads it
+-- from its external interface file (via 'loadExternalModule'). Before #3297 was
+-- fixed, compiling with @-main-is topEntity@ pruned everything outside
+-- 'topEntity's closure before loading, yet still selected the magically named
+-- 'testBench' as a top entity. Its binding was therefore never loaded, and
+-- Clash crashed with "No top entity called '...testBench...' found".
+testBench :: Signal System Bool
+testBench = done
+ where
+  testInput      = stimuliGenerator clk rst (1 :> 2 :> 3 :> Nil)
+  expectedOutput = outputVerifier' clk rst (2 :> 4 :> 6 :> Nil)
+  done           = expectedOutput (dut testInput)
+  clk            = tbSystemClockGen (not <$> done)
+  rst            = systemResetGen
+{-# OPAQUE testBench #-}


### PR DESCRIPTION
Time measurements on `bittide`:

| Patch                     | Cumulative loading time |
|---------------------------|-------------------------|
| Baseline                  | 22.135s                 |
| Prune                     | 19.357                  |
| Prune + parallel GHC2Core | 11.897s                 |

This does not offer any performance benefits for `clash-testsuite`.

For bittide: pruning the core results in slightly different HDL (names). The parallelization patch does not change the HDL at all.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
  - [x] Patch cleanup
  - [X] Cleanup commit messages
  - [x] Test on more GHCs

