### PR TITLE
Fix vhdl prims integerToNaturalThrow and integerToNaturalClamp

### DIFF
--- a/changelog/2026-07-06T14_40_32+02_00_fix_vhdl_prims_integerToNaturalxxx
+++ b/changelog/2026-07-06T14_40_32+02_00_fix_vhdl_prims_integerToNaturalxxx
@@ -1,0 +1,1 @@
+FIXED: The VHDL primitives for `integerToNaturalThrow` and `integerToNaturalClamp` no longer contain syntax errors. See [#3315](https://github.com/clash-lang/clash-compiler/pull/3315).

--- a/clash-lib/prims/vhdl/GHC_Num_Integer.primitives.yaml
+++ b/clash-lib/prims/vhdl/GHC_Num_Integer.primitives.yaml
@@ -14,7 +14,7 @@
       :: Integer -> Natural'
     template: |-
       -- integerToNaturalThrow begin
-      ~RESULT <= ~ERRORO when ~ARG[0] < ~SIZE[~TYP[0]]'d0 else
+      ~RESULT <= ~ERRORO when ~ARG[0] < to_signed(0,~SIZE[~TYP[0]]) else
                  resize(unsigned(std_logic_vector(~ARG[0])),~SIZE[~TYPO]);
       -- integerToNaturalThrow end
     warning: 'GHC.Num.Integer.integerToNaturalThrow: Naturals are dynamically sized
@@ -27,7 +27,7 @@
       :: Integer -> Natural'
     template: |-
       -- integerToNaturalClamp begin
-      ~RESULT <= to_unsigned(0,~SIZE[~TYPO]]) when ~ARG[0] < ~SIZE[~TYP[0]]'d0 else
+      ~RESULT <= to_unsigned(0,~SIZE[~TYPO]) when ~ARG[0] < to_signed(0,~SIZE[~TYP[0]]) else
                  resize(unsigned(std_logic_vector(~ARG[0])),~SIZE[~TYPO]);
       -- integerToNaturalClamp end
     warning: 'GHC.Num.Integer.integerToNaturalClamp: Naturals are dynamically sized

--- a/tests/shouldwork/Numbers/Naturals.hs
+++ b/tests/shouldwork/Numbers/Naturals.hs
@@ -6,6 +6,7 @@ import Clash.Prelude
 import Clash.Explicit.Testbench
 
 import GHC.Natural
+import GHC.Num.Integer (integerToNaturalClamp)
 
 -- Mark NOINLINE to prevent GHC constant folding
 plusNatural' :: Natural -> Natural -> Natural
@@ -29,10 +30,13 @@ naturalFromInteger' = naturalFromInteger
 {-# OPAQUE naturalFromInteger' #-}
 
 calc :: Integer -> Natural
-calc (naturalFromInteger -> n) = c + h
+calc i = c + h
   where
-    a = n + n
-    b = a * n
+    n = naturalFromInteger i
+    n2 = fromInteger i -- uses the integerToNaturalThrow prim,  see #3315
+    n3 = integerToNaturalClamp i -- yet a 3rd primitive we should test
+    a = n + n2
+    b = a * n3
     c = b - n
 
     -- TODO: Should get constant folded. Test using blackbox forcing an


### PR DESCRIPTION
Somehow some Verilog literal syntax slipped into these VHDL prims
Along with a stray `]`.
And these primitives were never tested.

All this is now fixed and these primitives are now included in the existing Naturals test.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [ ] ~Check copyright notices are up to date in edited files~
