### PR TITLE
Align `rom` interfaces

### DIFF
--- a/changelog/2026-07-10T16_32_36+02_00_fix_rom_interface
+++ b/changelog/2026-07-10T16_32_36+02_00_fix_rom_interface
@@ -1,0 +1,1 @@
+CHANGED: The interface of `Clash.Prelude.ROM.rom` has been aligned with the one of `Clash.Explicit.ROM.rom`. Arguments are no longer `Unsigned`, but `Enum` based.

--- a/clash-prelude/src/Clash/Explicit/ROM.hs
+++ b/clash-prelude/src/Clash/Explicit/ROM.hs
@@ -47,6 +47,9 @@ import Clash.XException       (deepErrorX, seqX, NFDataX)
 -- * __NB__: Initial output value is /undefined/, reading it will throw an
 -- 'Clash.XException.XException'
 --
+-- This primitive is particularly designed to enable mapping to a block RAM by
+-- downstream synthesis tools.
+--
 -- === See also:
 --
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Explicit.BlockRam#usingrams"
@@ -77,6 +80,9 @@ romPow2 = rom
 -- * __NB__: Read value is delayed by 1 cycle
 -- * __NB__: Initial output value is /undefined/, reading it will throw an
 -- 'Clash.XException.XException'
+--
+-- This primitive is particularly designed to enable mapping to a block RAM by
+-- downstream synthesis tools.
 --
 -- === See also:
 --

--- a/clash-prelude/src/Clash/Prelude/ROM.hs
+++ b/clash-prelude/src/Clash/Prelude/ROM.hs
@@ -2,7 +2,7 @@
 Copyright  :  (C) 2015-2016, University of Twente,
                   2017     , Google Inc.
                   2019     , Myrtle Software Ltd,
-                  2021-2022, QBayLogic B.V.
+                  2021-2026, QBayLogic B.V.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -131,6 +131,9 @@ asyncRom# content = safeAt
 -- * __NB__: Initial output value is /undefined/, reading it will throw an
 -- 'Clash.XException.XException'
 --
+-- This primitive is particularly designed to enable mapping to a block RAM by
+-- downstream synthesis tools.
+--
 -- === See also:
 --
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
@@ -139,17 +142,17 @@ asyncRom# content = safeAt
 -- is constructed. See 'Clash.Prelude.ROM.File.romFile' and
 -- 'Clash.Prelude.ROM.Blob.romBlob' for different approaches that scale well.
 rom
-  :: forall dom n m a
-   . ( NFDataX a
+  :: forall dom n addr a
+   . ( Enum addr
+     , NFDataX a
      , KnownNat n
-     , KnownNat m
      , HiddenClock dom
      , HiddenEnable dom  )
   => Vec n a
   -- ^ ROM content, also determines the size, @n@, of the ROM
   --
   -- __NB__: __MUST__ be a constant
-  -> Signal dom (Unsigned m)
+  -> Signal dom addr
   -- ^ Read address @r@
   -> Signal dom a
   -- ^ The value of the ROM at address @r@ from the previous clock cycle
@@ -161,6 +164,9 @@ rom = hideEnable (hideClock E.rom)
 -- * __NB__: Read value is delayed by 1 cycle
 -- * __NB__: Initial output value is /undefined/, reading it will throw an
 -- 'Clash.XException.XException'
+--
+-- This primitive is particularly designed to enable mapping to a block RAM by
+-- downstream synthesis tools.
 --
 -- === See also:
 --


### PR DESCRIPTION
Updates the interface of `Clash.Prelude.ROM.rom` to be in line with the one of `Clash.Explicit.ROM.rom`.

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files