### PR TITLE
Bunch of performance fixes

### DIFF
--- a/changelog/2026-07-12T22_45_00+02_00_evaluator_no_global_heap_copy
+++ b/changelog/2026-07-12T22_45_00+02_00_evaluator_no_global_heap_copy
@@ -1,0 +1,1 @@
+CHANGED: The compile-time evaluator no longer projects the entire global binding map into a fresh heap on (virtually) every invocation. We've observed a 25% Clash compile speedups for larger designs.

--- a/changelog/2026-07-13T00_30_00+02_00_unconcatbitvector_literal_fast_path
+++ b/changelog/2026-07-13T00_30_00+02_00_unconcatbitvector_literal_fast_path
@@ -1,0 +1,1 @@
+CHANGED: The compile-time evaluator peels elements off `unconcatBitVector#` of a literal BitVector as literals directly, instead of leaving residual `split#` calls that later rewrite passes evaluate separately. This speeds up normalization of designs that convert large BitVector constants to vectors.

--- a/changelog/2026-07-13T15_02_00+02_00_hwtype_translation_cache
+++ b/changelog/2026-07-13T15_02_00+02_00_hwtype_translation_cache
@@ -1,0 +1,1 @@
+CHANGED: The Core-type to HWType translation used by representability queries during normalization is memoized across the whole rewrite session, instead of being recomputed from scratch on every query. This speeds up normalization of designs with large or deeply nested types.

--- a/changelog/2026-07-13T15_57_00+02_00_ghc2core_conversion_speedup
+++ b/changelog/2026-07-13T15_57_00+02_00_ghc2core_conversion_speedup
@@ -1,0 +1,1 @@
+CHANGED: GHC Core to Clash Core conversion is significantly faster on large designs: type constructor annotations are pre-checked on the interned name, the accumulated TyCon map is no longer re-inserted into at every occurrence, and the types of global variables are converted once and cached.

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -4580,38 +4580,51 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
          n' | Right m <- runExcept (tyNatSize tcm mTy) ->
           let Just vecTc  = UniqMap.lookup vecTcNm tcm
               [_,consCon] = tyConDataCons vecTc
-              tupTcNm     = ghcTyconToTyConName (tupleTyCon Boxed 2)
-              Just tupTc  = UniqMap.lookup tupTcNm tcm
-              [tupDc]     = tyConDataCons tupTc
-              splitCall   =
-                mkApps (bvSplitPrim bvTcNm)
-                       [ Right (mkTyConApp typeNatMul [LitTy (NumTy (n'-1)),mTy])
-                       , Right mTy
-                       , Left (Literal (NaturalLiteral ((n'-1)*m)))
-                       , Left (valToTerm bv)
-                       ]
               mBVTy       = mkTyConApp bvTcNm [mTy]
-              n1BVTy      = mkTyConApp bvTcNm
-                              [mkTyConApp typeNatMul
-                                [LitTy (NumTy (n'-1))
-                                ,mTy]]
-              -- Guaranteed no capture, so okay to use unsafe name generation
-              xNm         = mkUnsafeSystemName "x" 0
-              bvNm        = mkUnsafeSystemName "bv'" 1
-              xId         = mkLocalId mBVTy xNm
-              bvId        = mkLocalId n1BVTy bvNm
-              tupPat      = DataPat tupDc [] [xId,bvId]
-              xAlt        = (tupPat, (Var xId))
-              bvAlt       = (tupPat, (Var bvId))
+              n1MTy       = mkTyConApp typeNatMul [LitTy (NumTy (n'-1)),mTy]
+              n1BVTy      = mkTyConApp bvTcNm [n1MTy]
 
-          in  reduce $ mkVecCons consCon (mkTyConApp bvTcNm [mTy]) n'
-                (Case splitCall mBVTy [xAlt])
+              (hd, tl) = case bitVectorLiteral bv of
+                -- Fast path for literals
+                Just (mski, i) ->
+                  let sh     = fromInteger ((n'-1) * m)
+                      loMask = bit sh - 1
+                  in  ( mkBitVectorLit mBVTy mTy m
+                          (mski `shiftR` sh) (i `shiftR` sh)
+                      , mkBitVectorLit n1BVTy n1MTy ((n'-1)*m)
+                          (mski .&. loMask) (i .&. loMask)
+                      )
+                Nothing ->
+                  let tupTcNm     = ghcTyconToTyConName (tupleTyCon Boxed 2)
+                      Just tupTc  = UniqMap.lookup tupTcNm tcm
+                      [tupDc]     = tyConDataCons tupTc
+                      splitCall   =
+                        mkApps (bvSplitPrim bvTcNm)
+                               [ Right n1MTy
+                               , Right mTy
+                               , Left (Literal (NaturalLiteral ((n'-1)*m)))
+                               , Left (valToTerm bv)
+                               ]
+                      -- Guaranteed no capture, so okay to use unsafe name
+                      -- generation
+                      xNm         = mkUnsafeSystemName "x" 0
+                      bvNm        = mkUnsafeSystemName "bv'" 1
+                      xId         = mkLocalId mBVTy xNm
+                      bvId        = mkLocalId n1BVTy bvNm
+                      tupPat      = DataPat tupDc [] [xId,bvId]
+                      xAlt        = (tupPat, (Var xId))
+                      bvAlt       = (tupPat, (Var bvId))
+                  in  ( Case splitCall mBVTy [xAlt]
+                      , Case splitCall n1BVTy [bvAlt]
+                      )
+
+          in  reduce $ mkVecCons consCon mBVTy n' hd
                 (mkApps (Prim pInfo)
                         [ Right (LitTy (NumTy (n'-1)))
                         , Right mTy
                         , Left (Literal (NaturalLiteral (n'-1)))
                         , Left (valToTerm km)
-                        , Left (Case splitCall n1BVTy [bvAlt])
+                        , Left tl
                         ])
          _ -> Nothing
   "Data.Text.Show.$wunpackCStringAscii#"

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -1,8 +1,8 @@
 {-|
   Copyright   :  (C) 2013-2016, University of Twente,
                      2016-2017, Myrtle Software Ltd,
-                     2017-2022, Google Inc.
-                     2021-2025, QBayLogic B.V.,
+                     2017-2022, Google Inc.,
+                     2021-2026, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
@@ -79,7 +79,7 @@ import GHC.Core.FamInstEnv
   ( FamInst (..), FamInstEnvs
   , familyInstances, normaliseType, emptyFamInstEnvs, topReduceTyFamApp_maybe
   )
-import GHC.Data.FastString (unpackFS, bytesFS)
+import GHC.Data.FastString (FastString, mkFastString, unpackFS, bytesFS)
 import GHC.Types.Id (isDataConId_maybe)
 import GHC.Types.Id.Info (IdDetails (..), unfoldingInfo)
 import GHC.Types.Literal (Literal (..), LitNumType (..), literalType)
@@ -87,7 +87,7 @@ import GHC.Unit.Module (moduleName, moduleNameString)
 import GHC.Types.Name
   (Name, nameModule_maybe, nameOccName, nameUnique, getSrcSpan)
 import GHC.Builtin.Names  (integerTyConKey, naturalTyConKey)
-import GHC.Types.Name.Occurrence (occNameString)
+import GHC.Types.Name.Occurrence (occNameFS, occNameString)
 import GHC.Data.Pair (Pair (..))
 import GHC.Types.SrcLoc (SrcSpan (..), isGoodSrcSpan)
 import GHC.Core.TyCon
@@ -131,6 +131,9 @@ data GHC2CoreState
   = GHC2CoreState
   { _tyConMap :: C.UniqMap TyCon
   , _nameMap  :: HashMap Name Text
+  , _varTypeMap :: HashMap Name C.Type
+  -- ^ Cache for converted types of global variables ('varType'). See
+  -- 'coreToVarType'.
   }
 
 makeLenses ''GHC2CoreState
@@ -144,7 +147,7 @@ data GHC2CoreEnv
 makeLenses ''GHC2CoreEnv
 
 emptyGHC2CoreState :: GHC2CoreState
-emptyGHC2CoreState = GHC2CoreState mempty HashMap.empty
+emptyGHC2CoreState = GHC2CoreState mempty HashMap.empty HashMap.empty
 
 newtype SrcSpanRB = SrcSpanRB {unSrcSpanRB :: SrcSpan}
 
@@ -505,7 +508,7 @@ coreToTerm primMap unlocs = term
     var x = do
         xPrim <- if isGlobalId x then coreToPrimVar x else coreToVar x
         let xNameS = C.nameOcc xPrim
-        xType  <- coreToType (varType x)
+        xType  <- coreToVarType x
         case isDataConId_maybe x of
           Just dc -> case lookupPrim xNameS of
             Just p  ->
@@ -867,14 +870,21 @@ coreToAttrs' [k, a, attrs] = do
 coreToAttrs' illegal =
   error $ "Unexpected type args to Annotate: " ++ show (map (showPprUnsafe) illegal)
 
+annotateOccFS :: FastString
+annotateOccFS = mkFastString "Annotate"
+{-# NOINLINE annotateOccFS #-}
+
 -- | If this type has an annotate type synonym, return list of attributes.
 coreToAttrs :: Type -> C2C [Attr Text]
-coreToAttrs (TyConApp tycon kindsOrTypes) = do
-  name' <- typeConstructorToString tycon
+coreToAttrs (TyConApp tycon kindsOrTypes)
+  -- Cheap pre-check on the interned occurrence name; only build the qualified
+  -- name when it can possibly be Clash.Annotations.SynthesisAttributes.Annotate.
+  | occNameFS (nameOccName (tyConName tycon)) == annotateOccFS = do
+      name' <- typeConstructorToString tycon
 
-  if name' == show ''Annotate
-  then coreToAttrs' kindsOrTypes
-  else return []
+      if name' == show ''Annotate
+      then coreToAttrs' kindsOrTypes
+      else return []
 
 coreToAttrs _ =
     return []
@@ -919,7 +929,7 @@ coreToType' (TyConApp tc args)
                         foldl C.AppTy <$> coreToType synTy' <*> mapM coreToType remArgs
                       _ -> do
                         tcName <- coreToName tyConName tyConUnique qualifiedNameString tc
-                        tyConMap %= (C.insert tcName tc)
+                        tyConMap %= C.insertIfAbsent tcName tc
                         C.mkTyConApp <$> (pure tcName) <*> mapM coreToType args
 coreToType' (ForAllTy (Bndr tv _) ty)   = C.ForAllTy <$> coreToTyVar tv <*> coreToType ty
 -- TODO: save the distinction between => and ->
@@ -944,13 +954,25 @@ coreToTyVar tv =
 coreToId :: Id
          -> C2C C.Id
 coreToId i = do
-  C.mkId <$> coreToType (varType i) <*> pure scope <*> coreToVar i
+  C.mkId <$> coreToVarType i <*> pure scope <*> coreToVar i
  where
   scope = if isGlobalId i then C.GlobalId else C.LocalId
 
 coreToVar :: Var
           -> C2C (C.Name a)
 coreToVar = coreToName varName varUnique qualifiedNameStringM
+
+-- | Convert the type of a variable, memoized on the variable's name.
+--
+-- Only global variables are memoized: their names come from GHC's name cache
+-- and are globally unique, so the same name always refers to the same
+-- variable, whose type is intrinsic. Names of local variables (e.g. binders
+-- instantiated when loading unfoldings from interface files) can collide
+-- between declarations and must not share cache entries.
+coreToVarType :: Var -> C2C C.Type
+coreToVarType v
+  | isGlobalId v = makeCached (varName v) varTypeMap (coreToType (varType v))
+  | otherwise = coreToType (varType v)
 
 coreToPrimVar :: Var
               -> C2C (C.Name C.Term)

--- a/clash-lib/src/Clash/Core/Evaluator/Types.hs
+++ b/clash-lib/src/Clash/Core/Evaluator/Types.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 {-|
-  Copyright     : (C) 2020-2024, QBayLogic B.V.
+  Copyright     : (C) 2020-2026, QBayLogic B.V.
   License       : BSD2 (see the file LICENSE)
   Maintainer    : QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -35,6 +35,7 @@ import Clash.Core.Var (Id, IdScope(..), TyVar)
 import Clash.Core.VarEnv
 import Clash.Driver.Types (BindingMap, bindingTerm)
 import Clash.Pretty (ClashPretty(..), fromPretty, showDoc)
+import Clash.Unique (getUnique)
 import Clash.Util.Supply (Supply)
 
 whnf'
@@ -53,8 +54,7 @@ whnf' eval bm lh tcm ph ids is isSubj e =
  where
   toResult x = (mHeapPrim x, mHeapLocal x, mTerm x)
 
-  m  = Machine ph gh lh [] ids is e
-  gh = mapVarEnv bindingTerm bm
+  m  = Machine ph bm emptyVarEnv emptyVarSet lh [] ids is e
 
 -- | Evaluate to WHNF given an existing Heap and Stack
 whnf
@@ -189,7 +189,16 @@ type PrimUnwind
 --
 data Machine = Machine
   { mHeapPrim   :: PrimHeap
-  , mHeapGlobal :: PureHeap
+  , mHeapGlobalBase :: BindingMap
+  -- ^ Immutable global bindings, projected to terms on demand in
+  -- 'heapLookup'. Kept as 'BindingMap' so 'whnf'' doesn't have to copy the
+  -- entire map on every invocation.
+  , mHeapGlobalOverlay :: PureHeap
+  -- ^ Global-heap entries added or updated during evaluation; shadows
+  -- 'mHeapGlobalBase'
+  , mHeapGlobalDeleted :: VarSet
+  -- ^ Global-heap entries deleted during evaluation (blackholing); shadows
+  -- both maps above
   , mHeapLocal  :: PureHeap
   , mStack      :: Stack
   , mSupply     :: Supply
@@ -198,7 +207,7 @@ data Machine = Machine
   }
 
 instance Show Machine where
-  show (Machine ph gh lh s _ _ x) =
+  show (Machine ph _ gh _ lh s _ _ x) =
     unlines
       [ "Machine:"
       , ""
@@ -349,8 +358,10 @@ primUpdate i x m =
    in m { mHeapPrim = (IntMap.insert i x gh, c) }
 
 heapLookup :: IdScope -> Id -> Machine -> Maybe Term
-heapLookup GlobalId i m =
-  lookupVarEnv i $ mHeapGlobal m
+heapLookup GlobalId i m
+  | elemVarSet i (mHeapGlobalDeleted m) = Nothing
+  | Just x <- lookupVarEnv i (mHeapGlobalOverlay m) = Just x
+  | otherwise = bindingTerm <$> lookupVarEnv i (mHeapGlobalBase m)
 heapLookup LocalId i m =
   lookupVarEnv i $ mHeapLocal m
 
@@ -359,13 +370,17 @@ heapContains scope i = isJust . heapLookup scope i
 
 heapInsert :: IdScope -> Id -> Term -> Machine -> Machine
 heapInsert GlobalId i x m =
-  m { mHeapGlobal = extendVarEnv i x (mHeapGlobal m) }
+  m { mHeapGlobalOverlay = extendVarEnv i x (mHeapGlobalOverlay m)
+    , mHeapGlobalDeleted = delVarSetByKey (getUnique i) (mHeapGlobalDeleted m)
+    }
 heapInsert LocalId i x m =
   m { mHeapLocal = extendVarEnv i x (mHeapLocal m) }
 
 heapDelete :: IdScope -> Id -> Machine -> Machine
 heapDelete GlobalId i m =
-  m { mHeapGlobal = delVarEnv (mHeapGlobal m) i }
+  m { mHeapGlobalOverlay = delVarEnv (mHeapGlobalOverlay m) i
+    , mHeapGlobalDeleted = extendVarSet (mHeapGlobalDeleted m) i
+    }
 heapDelete LocalId i m =
   m { mHeapLocal = delVarEnv (mHeapLocal m) i }
 

--- a/clash-lib/src/Clash/Core/VarEnv.hs
+++ b/clash-lib/src/Clash/Core/VarEnv.hs
@@ -45,6 +45,7 @@ module Clash.Core.VarEnv
   , emptyVarSet
   , unitVarSet
     -- ** Modification
+  , extendVarSet
   , delVarSetByKey
   , unionVarSet
   , differenceVarSet

--- a/clash-lib/src/Clash/Data/UniqMap.hs
+++ b/clash-lib/src/Clash/Data/UniqMap.hs
@@ -19,6 +19,7 @@ module Clash.Data.UniqMap
   , insertUnique
   , insertWith
   , insertMany
+  , insertIfAbsent
   , lookup
   , find
   , elem
@@ -144,6 +145,13 @@ insertWith f k v =
 insertMany :: Uniquable a => [(a, b)] -> UniqMap b -> UniqMap b
 insertMany kvs xs =
   List.foldl' (\acc (k, v) -> insert k v acc) xs kvs
+
+{-# SPECIALIZE insertIfAbsent :: Unique -> b -> UniqMap b -> UniqMap b #-}
+-- | Insert a key-value pair into the map if the key is not already present. Note
+-- that this will first do a lookup and only then use insert (when applicable).
+-- Use this when you can reasonably expect the key to already exist.
+insertIfAbsent :: Uniquable a => a -> b -> UniqMap b -> UniqMap b
+insertIfAbsent k v m = if elem k m then m else insert k v m
 
 {-# SPECIALIZE lookup :: Unique -> UniqMap b -> Maybe b #-}
 -- | Lookup an item in the map, using the unique of the given key.

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -653,8 +653,22 @@ representableType
   -> Type
   -> Bool
 representableType builtInTranslation reprs stringRepresentable m =
-    either (const False) isRepresentable .
     flip evalState mempty .
+    representableTypeState builtInTranslation reprs stringRepresentable m
+
+-- | Like 'representableType', but memoizes the Core-type to HWType
+-- translation in the given state.
+representableTypeState
+  :: (CustomReprs -> TyConMap -> Type ->
+      State HWMap (Maybe (Either String FilteredHWType)))
+  -> CustomReprs
+  -> Bool
+  -- ^ String considered representable
+  -> TyConMap
+  -> Type
+  -> State HWMap Bool
+representableTypeState builtInTranslation reprs stringRepresentable m =
+    fmap (either (const False) isRepresentable) .
     coreTypeToHWType' builtInTranslation reprs m
   where
     isRepresentable hty = case hty of

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -133,6 +133,7 @@ runNormalization env supply globals typeTrans peEval eval rcsMap topEnts =
                   0
                   (IntMap.empty, 0)
                   emptyVarEnv
+                  Map.empty    -- hwTypeCache
                   normState
 
     normState = NormalizeState

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2022, Google Inc.,
-                    2021-2024, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
   Transformations on case-expressions
@@ -30,7 +30,7 @@ module Clash.Normalize.Transformations.Case
 import Control.Exception.Base (patError)
 import GHC.Prim.Panic (absentError)
 import qualified Control.Lens as Lens
-import Control.Monad.State.Strict (evalState)
+
 import Data.Bifunctor (second)
 import Data.Coerce (coerce)
 import qualified Data.Either as Either
@@ -69,14 +69,15 @@ import Clash.Core.VarEnv
 import Clash.Debug (traceIf)
 import Clash.Driver.Types (DebugOpts(dbg_invariants))
 import Clash.Netlist.Types (FilteredHWType(..), HWType(..))
-import Clash.Netlist.Util (coreTypeToHWType, representableType)
+import Clash.Netlist.Util (coreTypeToHWType)
 import qualified Clash.Normalize.Primitives as NP (undefined, undefinedX)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Rewrite.Combinators ((>-!))
 import Clash.Rewrite.Types
   ( TransformContext(..), bindings, customReprs, debugOpts, tcCache
   , typeTranslator, workFreeBinders)
-import Clash.Rewrite.Util (changed, isFromInt, whnfRW)
+import Clash.Rewrite.Util
+  (changed, isFromInt, isUntranslatableType, runWithHWTypeCache, whnfRW)
 import Clash.Rewrite.WorkFree
 import Clash.Util (curLoc)
 
@@ -86,12 +87,7 @@ import Clash.XException (errorX)
 -- alternatives
 caseCase :: HasCallStack => NormRewrite
 caseCase (TransformContext is0 _) e@(Case (stripTicks -> Case scrut alts1Ty alts1) alts2Ty alts2) = do
-  ty1Rep <- representableType
-    <$> Lens.view typeTranslator
-    <*> Lens.view customReprs
-    <*> pure False
-    <*> Lens.view tcCache
-    <*> pure alts1Ty
+  ty1Rep <- not <$> isUntranslatableType False alts1Ty
 
   -- This is only worth doing if the inner case-expression has a
   -- non-representable alternative type.
@@ -308,7 +304,8 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
         let subjTy = inferCoreTypeOf tcm subj
         tran <- Lens.view typeTranslator
         reprs <- Lens.view customReprs
-        case (`evalState` mempty) (coreTypeToHWType tran reprs tcm subjTy) of
+        subjHwty <- runWithHWTypeCache (coreTypeToHWType tran reprs tcm subjTy)
+        case subjHwty of
           Right (FilteredHWType (Void (Just hty)) _areVoids)
             | hty `elem` [BitVector 0, Unsigned 0, Signed 0, Index 1]
             -- If we know that the type of the subject is zero-bits wide and

--- a/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Inline.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2022, Google Inc.,
-                    2021-2024, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -76,13 +76,12 @@ import Clash.Core.VarEnv
   , notElemVarSet, unionVarEnv, unionVarEnvWith, unitVarSet)
 import Clash.Debug (trace)
 import Clash.Driver.Types (Binding(..))
-import Clash.Netlist.Util (representableType)
 import Clash.Primitives.Types
   (CompiledPrimMap, Primitive(..), TemplateKind(..))
 import Clash.Rewrite.Combinators (allR)
 import Clash.Rewrite.Types
-  ( TransformContext(..), bindings, curFun, customReprs, tcCache, topEntities
-  , typeTranslator, inlineConstantLimit, inlineFunctionLimit, inlineLimit
+  ( TransformContext(..), bindings, curFun, tcCache, topEntities
+  , inlineConstantLimit, inlineFunctionLimit, inlineLimit
   , inlineWFCacheLimit, primitives)
 import Clash.Rewrite.Util
   ( changed, inlineBinders, inlineOrLiftBinders, isJoinPointIn
@@ -536,11 +535,7 @@ inlineNonRepWorker e@(Case scrut altsTy alts)
 
 
     bodyMaybe   <- lookupVarEnv f <$> Lens.use bindings
-    nonRepScrut <- not <$> (representableType <$> Lens.view typeTranslator
-                                              <*> Lens.view customReprs
-                                              <*> pure False
-                                              <*> Lens.view tcCache
-                                              <*> pure scrutTy)
+    nonRepScrut <- isUntranslatableType False scrutTy
     case (nonRepScrut, bodyMaybe) of
       (True, Just b) -> do
         if overLimit then
@@ -576,12 +571,7 @@ inlineOrLiftNonRep ctx eLet@(Letrec _ body) =
     bodyFreeOccs = countFreeOccurances body
 
     nonRepTest :: (Id, Term) -> NormalizeSession Bool
-    nonRepTest (Id {varType = ty}, _)
-      = not <$> (representableType <$> Lens.view typeTranslator
-                                   <*> Lens.view customReprs
-                                   <*> pure False
-                                   <*> Lens.view tcCache
-                                   <*> pure ty)
+    nonRepTest (Id {varType = ty}, _) = isUntranslatableType False ty
     nonRepTest _ = return False
 
     inlineTest :: Term -> (Id, Term) -> Bool

--- a/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2018, Google Inc.,
-                    2021-2022, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -50,7 +50,7 @@ import Clash.Core.HasType
 import Clash.Core.Name (mkUnsafeSystemName, nameOcc)
 import Clash.Core.Subst
 import Clash.Core.Term
-  ( LetBinding, Pat(..), PrimInfo(..), Term(..), collectArgs, collectArgsTicks
+  ( CoreContext(..), LetBinding, Pat(..), PrimInfo(..), Term(..), collectArgs, collectArgsTicks
   , collectTicks, isLambdaBodyCtx, isTickCtx, mkApps, mkLams, mkTicks, Bind(..)
   , partitionTicks, stripAllTicks)
 import Clash.Core.TermInfo (isCon, isLet, isLocalVar, isTick)
@@ -93,6 +93,40 @@ deadCode _ e = return e
 {-# SCC deadCode #-}
 
 removeUnusedExpr :: HasCallStack => NormRewrite
+-- The primitive and data-constructor equations below collect the whole
+-- application spine with 'collectArgsTicks'. Say we have an application:
+--
+--     f a b c
+--
+-- Then we're only interested in the root (@f a b c@), not in the inner nodes
+-- (@f a@, @f a b@). At the root, 'collectArgsTicks' collects the full argument
+-- list @[a, b, c]@; an inner node would only ever see a prefix of that (@[a]@,
+-- @[a, b]@) at the same argument indices. So any argument an inner node could
+-- remove, the root removes too, which makes the inner attempts wasted work.
+-- This holds through ticks and type applications as well, since
+-- 'collectArgsTicks' looks through both.
+--
+-- We therefore skip a node that is itself a spine node (@App@, @TyApp@, @Prim@,
+-- or @Tick@) sitting under a parent that continues the spine (@AppFun@,
+-- @TyAppC@, or @TickC@). The single-alternative-Case equation is unaffected:
+-- the spine only threads through applications, type applications, and ticks, so
+-- a Case is never an inner node of a spine.
+removeUnusedExpr (TransformContext _ (cc:_)) e
+  | isSpineCtx cc
+  , isSpineNode e
+  = return e
+ where
+  isSpineCtx AppFun = True
+  isSpineCtx TyAppC = True
+  isSpineCtx (TickC _) = True
+  isSpineCtx _ = False
+
+  isSpineNode App {} = True
+  isSpineNode TyApp {} = True
+  isSpineNode Prim {} = True
+  isSpineNode Tick {} = True
+  isSpineNode _ = False
+
 removeUnusedExpr _ e@(collectArgsTicks -> (p@(Prim pInfo),args,ticks)) = do
   bbM <- HashMap.lookup (primName pInfo) <$> Lens.view primitives
   let

--- a/clash-lib/src/Clash/Normalize/Transformations/Reduce.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Reduce.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016-2017, Myrtle Software Ltd,
                     2017-2018, Google Inc.,
-                    2021-2022, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -77,6 +77,12 @@ reduceBinders !subst processed ((i,substTm "reduceBinders" subst -> e):rest)
 {-# SCC reduceBinders #-}
 
 reduceConst :: HasCallStack => NormRewrite
+-- An 'App' in an 'AppFun' context is an inner node of an application spine,
+-- e.g. the @f a@ inside @f a b c@. Only evaluate at the root (@f a b c@):
+-- an under-applied primitive cannot fold, and if @f@ is itself an application
+-- (@(g x) a b c@) the evaluator reduces the whole thing to WHNF anyway, so it
+-- folds @g x@ as part of folding the root. Skip the evaluator call here.
+reduceConst (TransformContext _ (AppFun:_)) e = return e
 reduceConst ctx e@(App _ _)
   | (Prim p0, _) <- collectArgs e
   = whnfRW False ctx e $ \_ctx1 e1 -> case e1 of

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -80,14 +80,13 @@ import Clash.Core.VarEnv
 import qualified Clash.Data.UniqMap as UniqMap
 import Clash.Debug (traceIf, traceM)
 import Clash.Driver.Types (Binding(..), TransformationInfo(..), hasTransformationInfo)
-import Clash.Netlist.Util (representableType)
 import Clash.Rewrite.Combinators (topdownR)
 import Clash.Rewrite.Types
-  ( TransformContext(..), bindings, censor, curFun, customReprs, extra, tcCache
-  , typeTranslator, workFreeBinders, debugOpts, topEntities, specializationLimit)
+  ( TransformContext(..), bindings, censor, curFun, extra, tcCache
+  , workFreeBinders, debugOpts, topEntities, specializationLimit)
 import Clash.Rewrite.Util
   ( mkBinderFor, mkDerivedName, mkFunction, mkTmBinderFor, setChanged, changed
-  , normalizeTermTypes, normalizeId, whnfRW)
+  , isUntranslatableType, normalizeTermTypes, normalizeId, whnfRW)
 import Clash.Rewrite.WorkFree (isWorkFree)
 import Clash.Normalize.Types
   ( NormRewrite, NormalizeSession, specialisationCache, specialisationHistory)
@@ -608,11 +607,7 @@ nonRepSpec ctx e@(App e1 e2)
   = do tcm <- Lens.view tcCache
        let e2Ty = inferCoreTypeOf tcm e2
        let localVar = isLocalVar e2
-       nonRepE2 <- not <$> (representableType <$> Lens.view typeTranslator
-                                              <*> Lens.view customReprs
-                                              <*> pure False
-                                              <*> Lens.view tcCache
-                                              <*> pure e2Ty)
+       nonRepE2 <- isUntranslatableType False e2Ty
        if nonRepE2 && not localVar
          then do
            e2' <- inlineInternalSpecialisationArgument e2

--- a/clash-lib/src/Clash/Rewrite/Types.hs
+++ b/clash-lib/src/Clash/Rewrite/Types.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016     , Myrtle Software Ltd,
                     2017     , Google Inc.,
-                    2021-2022, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -92,6 +92,11 @@ data RewriteState extra
   -- ^ Used as a heap for compile-time evaluation of primitives that live in I/O
   , _workFreeBinders  :: VarEnv Bool
   -- ^ Map telling whether a binder's definition is work-free
+  , _hwTypeCache      :: HWMap
+  -- ^ Cache for the Core-type to HWType translation. The translation only
+  -- depends on environment that is constant for the whole rewrite session
+  -- (the type translator, custom representations, and the TyConMap), so the
+  -- cache never has to be invalidated.
   , _extra            :: !extra
   -- ^ Additional state
   }

--- a/clash-lib/src/Clash/Rewrite/Util.hs
+++ b/clash-lib/src/Clash/Rewrite/Util.hs
@@ -2,7 +2,7 @@
   Copyright  :  (C) 2012-2016, University of Twente,
                     2016     , Myrtle Software Ltd,
                     2017     , Google Inc.,
-                    2021-2023, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -78,7 +78,8 @@ import           Clash.Debug
 import           Clash.Driver.Types
   (TransformationInfo(..), DebugOpts(..), BindingMap, Binding(..), IsPrim(..),
   ClashEnv(..), ClashOpts(..), hasDebugInfo, isDebugging)
-import           Clash.Netlist.Util          (representableType)
+import           Clash.Netlist.Types         (HWMap)
+import           Clash.Netlist.Util          (representableTypeState)
 import           Clash.Pretty                (clashPretty, showDoc)
 import           Clash.Rewrite.Types
 import           Clash.Rewrite.WorkFree
@@ -685,6 +686,15 @@ cloneNameWithBindingMap binders nm = do
   return (uniqAway' (`UniqMap.elem` binders) i (setUnique nm i))
 
 {-# INLINE isUntranslatable #-}
+-- | Run a Core-type to HWType translation action against the session-wide
+-- translation cache ('hwTypeCache').
+runWithHWTypeCache :: State.State HWMap a -> RewriteMonad extra a
+runWithHWTypeCache m = do
+  cache0 <- Lens.use hwTypeCache
+  let (a, !cache1) = State.runState m cache0
+  hwTypeCache Lens..= cache1
+  pure a
+
 -- | Determine if a term cannot be represented in hardware
 isUntranslatable
   :: Bool
@@ -693,11 +703,7 @@ isUntranslatable
   -> RewriteMonad extra Bool
 isUntranslatable stringRepresentable tm = do
   tcm <- Lens.view tcCache
-  not <$> (representableType <$> Lens.view typeTranslator
-                             <*> Lens.view customReprs
-                             <*> pure stringRepresentable
-                             <*> pure tcm
-                             <*> pure (inferCoreTypeOf tcm tm))
+  isUntranslatableType stringRepresentable (inferCoreTypeOf tcm tm)
 
 {-# INLINE isUntranslatableType #-}
 -- | Determine if a type cannot be represented in hardware
@@ -706,12 +712,11 @@ isUntranslatableType
   -- ^ String representable
   -> Type
   -> RewriteMonad extra Bool
-isUntranslatableType stringRepresentable ty =
-  not <$> (representableType <$> Lens.view typeTranslator
-                             <*> Lens.view customReprs
-                             <*> pure stringRepresentable
-                             <*> Lens.view tcCache
-                             <*> pure ty)
+isUntranslatableType stringRepresentable ty = do
+  tt <- Lens.view typeTranslator
+  reprs <- Lens.view customReprs
+  tcm <- Lens.view tcCache
+  not <$> runWithHWTypeCache (representableTypeState tt reprs stringRepresentable tcm ty)
 
 normalizeTermTypes :: TyConMap -> Term -> Term
 normalizeTermTypes tcm e = case e of

--- a/clash-lib/tests/Test/Clash/Rewrite.hs
+++ b/clash-lib/tests/Test/Clash/Rewrite.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright  :  (C) 2020,2022 QBayLogic B.V.
+  Copyright  :  (C) 2020,2022-2026 QBayLogic B.V.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -83,6 +83,7 @@ instance Default extra => Default (RewriteState extra) where
     , _curFun=error "_curFun: NYI"
     , _nameCounter=2
     , _workFreeBinders=emptyVarEnv
+    , _hwTypeCache=mempty
     , _globalHeap=error "_globalHeap: NYI"
     , _extra=def
     }

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1077,6 +1077,9 @@ runClashTest = defaultMain
         , runTest "Split" def{hdlSim=[]}
         , runTest "ToList" def
         , runTest "Unconcat" def
+#if !defined(darwin_HOST_OS)
+        , clashLibTest "UnconcatBitVectorLiteral" def{hdlTargets=[Verilog]}
+#endif
         , runTest "VACC" def{hdlSim=[]}
         , runTest "VEmpty" def
         , runTest "VIndex" def{hdlSim=[]}

--- a/tests/shouldwork/Vector/UnconcatBitVectorLiteral.hs
+++ b/tests/shouldwork/Vector/UnconcatBitVectorLiteral.hs
@@ -1,0 +1,44 @@
+-- Test that `unconcatBitVector#` applied to a literal BitVector is fully
+-- reduced at compile time: neither `unconcatBitVector#` itself nor any
+-- residual `split#` call may survive into the netlist.
+--
+-- The result is consumed by `map`, whose pattern match makes each
+-- `unconcatBitVector#` application a case subject; the evaluator only
+-- reduces the primitive in subject position.
+{-# LANGUAGE MagicHash #-}
+
+module UnconcatBitVectorLiteral where
+
+import Clash.Prelude
+
+import Clash.Netlist.Types (Component(..), Declaration(..))
+import Test.Tasty.Clash
+import Test.Tasty.Clash.NetlistTest
+
+import qualified Clash.Sized.Internal.BitVector as BV
+import qualified Clash.Sized.Vector as V
+import qualified Data.Text as T
+
+topEntity :: Vec 4 (BitVector 8)
+topEntity = map complement (V.unconcatBitVector# 0xDEADBEEF)
+
+testPath :: FilePath
+testPath = "tests/shouldwork/Vector/UnconcatBitVectorLiteral.hs"
+
+assertFullyReduced :: Component -> IO ()
+assertFullyReduced = mapM_ checkDecl . declarations
+ where
+  checkDecl (BlackBoxD primName _ _ _ _ _)
+    | primName `elem` mustReduce =
+        error $ "Found unreduced primitive: " <> show primName
+  checkDecl _ = return ()
+
+  mustReduce = T.pack <$>
+    [ show 'V.unconcatBitVector#
+    , show 'BV.split#
+    ]
+
+mainVerilog :: IO ()
+mainVerilog = do
+  netlist <- runToNetlistStage SVerilog id testPath
+  mapM_ (assertFullyReduced . snd) netlist


### PR DESCRIPTION
I put Fable to work over the last 24 hours and it came up with these patches. I've confirmed that it passes the `clash-testsuite` on all supported GHCs and that it produces bit-for-bit equal HDL at every commit over at `bittide-hardware`. Benefits measured on a 4-core VM running on a AMD Ryzen 7 3700X (`wireDemoTest` @ `bittide-hardware`).

Per commit measurements:

| patch | runtime | net diff | net diff % |
|-------|--------:|---------:|-----------:|
| (base: master) | 8m23s | — | — |
| Evaluator: stop projecting the global binding map on every whnf' call | 6m07s | −136s | **−27.0%** |
| Evaluator: peel literal unconcatBitVector# without residual split# calls | 5m14s | −53s | **−14.4%** |
| ~~Dispatch rewrite bundles on the node constructor~~ | ~~4m18s~~ | ~~−56s~~ | ~~**−17.8%**~~ |
| Skip reduceConst on inner nodes of application spines | 4m08s | −10s | **−3.9%** |
| Cache Core-type to HWType translation across the rewrite session | 4m04s | −4s | **−1.6%** |
| Skip removeUnusedExpr on inner nodes of application spines | 3m56s | −8s | **−3.3%** |
| Speed up GHC Core to Clash Core conversion | 3m44s | −12s | **−5.1%** |

Every row produced bit-identical HDL to the previous branch tip. Total: 8m23s -> 3m44s (2.25x).

Edit: I've kicked one commit out due to maintainability issues, but I haven't updated the measurements. Overall picture still applies though.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] Check copyright notices are up to date in edited files
  - [X] Go over it manually (@martijnbastiaan)
  - [x] Split out performance benefits per commit
  - [X] Fix up the annoying AI habit of leaving code comments that talk about the past ("this piece of code is the same as it was before", OH THANKS)
  - [X] Trim the references to `bittide-hardware` as a concept that every Clash developer is just supposed to know
  - [X] Decide whether to leave timing instrumentation in
  - [x] Remove "Dispatch rewrite bundles on the node constructor" (PR will follow)
  - [x] Touch up commit messages and documentation to be more concise / less LLMy 
