### PR TITLE
Extend the blackbox template tag ~SYM to be able to accept a name

### DIFF
--- a/changelog/2026-07-20T16_21_02+02_00_named_SYMs
+++ b/changelog/2026-07-20T16_21_02+02_00_named_SYMs
@@ -1,0 +1,21 @@
+ADDED: In blackboxes `~SYM`s can now be referenced by name
+
+Instead of doing:
+```
+	signal ~GENSYM[foo][3] : ..;
+	signal ~GENSYM[bar][4] : ..;
+
+	.. <= ~SYM[3] - ~SYM[4];
+```
+
+You can now refer to SYMbols by name:
+```
+	signal ~SYM[foo] : ..;
+	signal ~SYM[bar] : ..;
+
+	.. <= ~SYM[foo] - ~SYM[bar];
+```
+
+The old behaviour with GENSYM and the numeric references is still fully supported.
+
+See [#3325](https://github.com/clash-lang/clash-compiler/issues/3325).

--- a/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Parser.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
                     2017     , Myrtle Software Ltd,
-                    2021-2022, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
                     2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -79,7 +79,6 @@ pTagE =  Result            <$  string "~RESULT"
      <|> Lit               <$> (string "~LIT" *> brackets' natural')
      <|> Name              <$> (string "~NAME" *> brackets' natural')
      <|> ToVar             <$> try (string "~VAR" *> brackets' pSigDorEmpty) <*> brackets' natural'
-     <|> (Sym Text.empty)  <$> (string "~SYM" *> brackets' natural')
      <|> Typ Nothing       <$  string "~TYPO"
      <|> (Typ . Just)      <$> try (string "~TYP" *> brackets' natural')
      <|> TypM Nothing      <$  string "~TYPMO"
@@ -117,6 +116,7 @@ pTagE =  Result            <$  string "~RESULT"
      <|> OutputUsage       <$> (string "~OUTPUTWIREREG" *> brackets' natural')
      <|> OutputUsage       <$> (string "~OUTPUTUSAGE" *> brackets' natural')
      <|> GenSym            <$> (string "~GENSYM" *> brackets' pSigD) <*> brackets' natural'
+     <|> (Sym Text.empty)  <$> (string "~SYM" *> brackets' (Left <$> natural'  <|>  Right <$> pSigD))
      <|> Template          <$> (string "~TEMPLATE" *> brackets' pSigD) <*> brackets' pSigD
      <|> Repeat            <$> (string "~REPEAT" *> brackets' pSigD) <*> brackets' pSigD
      <|> DevNull           <$> (string "~DEVNULL" *> brackets' pSigD)
@@ -154,6 +154,7 @@ pSigD = some (pTagE <|> (EscapedSymbol SquareBracketOpen <$ string "[\\")
                     <|> (EscapedSymbol SquareBracketClose <$ string "\\]")
                     <|> (Text <$> (pack <$> some (satisfyRange '\000' '\90')))
                     <|> (Text <$> (pack <$> some (satisfyRange '\94' '\125'))))
+                        -- excludes '[', '\\', ']', `~`
 
 pSigDorEmpty :: Parser [Element]
 pSigDorEmpty = pSigD <|> mempty

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -96,15 +96,15 @@ type BlackBoxTemplate = [Element]
 -- | Elements of a blackbox context. If you extend this list, make sure to
 -- update the following functions:
 --
---  - Clash.Netlist.BlackBox.Types.prettyElem
---  - Clash.Netlist.BlackBox.Types.renderElem
---  - Clash.Netlist.BlackBox.Types.renderTag
---  - Clash.Netlist.BlackBox.Types.setSym
+--  - Clash.Netlist.BlackBox.Util.prettyElem
+--  - Clash.Netlist.BlackBox.Util.renderElem
+--  - Clash.Netlist.BlackBox.Util.renderTag
+--  - Clash.Netlist.BlackBox.Util.setSym
 --  - Clash.Netlist.BlackBox.Util.inputHole
---  - Clash.Netlist.BlackBox.Types.getUsedArguments
---  - Clash.Netlist.BlackBox.Types.usedVariables
---  - Clash.Netlist.BlackBox.Types.verifyBlackBoxContext
---  - Clash.Netlist.BlackBox.Types.walkElement
+--  - Clash.Netlist.BlackBox.Util.getUsedArguments
+--  - Clash.Netlist.BlackBox.Util.usedVariables
+--  - Clash.Netlist.BlackBox.Util.verifyBlackBoxContext
+--  - Clash.Netlist.BlackBox.Util.walkElement
 data Element
   = Text !Text
   -- ^ Dumps given text without processing in HDL

--- a/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Types.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright  :  (C) 2012-2016, University of Twente,
                     2017     , Myrtle Software Ltd,
-                    2021-2022, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
                     2022     , LUMI GUIDE FIETSDETECTIE B.V.
                     2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
@@ -126,8 +126,6 @@ data Element
   | ToVar [Element] !Int
   -- ^ Like Arg but only insert variable reference (creating an assignment
   -- elsewhere if necessary).
-  | Sym !Text !Int
-  -- ^ Symbol hole
   | Typ !(Maybe Int)
   -- ^ Type declaration hole
   | TypM !(Maybe Int)
@@ -204,6 +202,9 @@ data Element
   | OutputUsage !Int
   | Vars !Int
   | GenSym [Element] !Int
+  -- ^ Define a name for a numbered symbol, and render that name too
+  | Sym !Text !(Either Int [Element])
+  -- ^ Symbol hole (indexed by either a number or a name)
   | Repeat [Element] [Element]
   -- ^ Repeat <hole> n times
   | DevNull [Element]

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -40,7 +40,7 @@ module Clash.Netlist.BlackBox.Util
 
 import           Control.Exception               (throw)
 import           Control.Lens
-  (use, (%=), _1, _2, element, (^?))
+  (use, (%=), _1, _2, _3, element, (^?))
 import           Control.Monad                   (forM, (<=<), filterM)
 import           Control.Monad.Extra             (ifM)
 import           Control.Monad.State             (State, StateT (..), lift, gets)
@@ -259,15 +259,16 @@ setSym
   -> BlackBoxTemplate
   -> m (BlackBoxTemplate,[N.Declaration])
 setSym bbCtx l = do
-    (a,(_,decls)) <- runStateT (mapM setSym' l) (IntMap.empty,IntMap.empty)
+    (a,(_,_,decls)) <- runStateT (mapM setSym' l) (IntMap.empty,HashMap.empty,IntMap.empty)
     return (a,concatMap snd (IntMap.elems decls))
   where
     bbnm = Data.Text.unpack (bbName bbCtx)
 
     setSym'
       :: Element
-      -> StateT ( IntMap.IntMap N.IdentifierText
-                , IntMap.IntMap (N.IdentifierText, [N.Declaration]))
+      -> StateT ( IntMap.IntMap N.IdentifierText  -- ~SYM[number] mapping
+                , HashMap.HashMap Text N.IdentifierText   -- ~SYM[string] mapping
+                , IntMap.IntMap (N.IdentifierText, [N.Declaration]))  -- ~VAR[nm][n] mapping
                 m
                 Element
     setSym' e = case e of
@@ -276,7 +277,7 @@ setSym bbCtx l = do
           return (ToVar [Text (Id.toLazyText nm0)] i)
 
         (e',hwTy,_) -> do
-          varM <- IntMap.lookup i <$> use _2
+          varM <- IntMap.lookup i <$> use _3
           case varM of
             Nothing -> do
               nm' <- lift (Id.make (Text.toStrict (concatT (Text "c$":nm))))
@@ -285,18 +286,26 @@ setSym bbCtx l = do
                     _ -> [N.NetDecl Nothing nm' hwTy
                          ,N.Assignment nm' N.Cont e' -- TODO De-hardcode Cont
                          ]
-              _2 %= (IntMap.insert i (Id.toText nm',decls))
+              _3 %= (IntMap.insert i (Id.toText nm',decls))
               return (ToVar [Text (Id.toLazyText nm')] i)
             Just (nm',_) ->
               return (ToVar [Text (Text.fromStrict nm')] i)
-      Sym _ i -> do
+      Sym _ x@(Left i) -> do
         symM <- IntMap.lookup i <$> use _1
         case symM of
           Nothing -> do
             t <- Id.toText <$> lift (Id.make "c$n")
             _1 %= (IntMap.insert i t)
-            return (Sym (Text.fromStrict t) i)
-          Just t -> return (Sym (Text.fromStrict t) i)
+            return (Sym (Text.fromStrict t) x)
+          Just t -> return (Sym (Text.fromStrict t) x)
+      Sym _ x@(Right (concatT -> nm)) -> do
+        symM <- HashMap.lookup nm <$> use _2
+        case symM of
+          Nothing -> do
+            t <- Id.toText <$> lift (Id.make $ Text.toStrict nm)
+            _2 %= (HashMap.insert nm t)
+            return (Sym (Text.fromStrict t) x)
+          Just t -> return (Sym (Text.fromStrict t) x)
       GenSym t i -> do
         symM <- IntMap.lookup i <$> use _1
         case symM of
@@ -341,8 +350,8 @@ setSym bbCtx l = do
             _ | [(Identifier t _, _)] <- bbResults bbCtx -> Id.toLazyText t
             _ -> error $ $(curLoc) ++ "Internal error when processing blackbox "
                       ++ "for " ++ bbnm
-        _ -> error $ $(curLoc) ++ "Unexpected element in GENSYM when processing "
-                  ++ "blackbox for " ++ bbnm
+        e -> error $ $(curLoc) ++ "Unexpected element in (GEN)SYM symbol name when processing "
+                  ++ "blackbox for " ++ bbnm ++ ": " ++ prettyBlackBoxStr [e]
         )
 
 type FileName = FilePath
@@ -1108,7 +1117,6 @@ prettyElem (Name i) = renderOneLine <$> (string "~NAME" <> brackets (int i))
 prettyElem (ToVar es i) = do
   es' <- prettyBlackBox es
   renderOneLine <$> (string "~VAR" <> brackets (string es') <> brackets (int i))
-prettyElem (Sym _ i) = renderOneLine <$> (string "~SYM" <> brackets (int i))
 prettyElem (Typ Nothing) = return "~TYPO"
 prettyElem (Typ (Just i)) = renderOneLine <$> (string "~TYP" <> brackets (int i))
 prettyElem (TypM Nothing) = return "~TYPMO"
@@ -1192,6 +1200,10 @@ prettyElem (StrCmp es i) = do
 prettyElem (GenSym es i) = do
   es' <- prettyBlackBox es
   renderOneLine <$> (string "~GENSYM" <> brackets (string es') <> brackets (int i))
+prettyElem (Sym _ (Left i)) = renderOneLine <$> (string "~SYM" <> brackets (int i))
+prettyElem (Sym _ (Right es)) = do
+    es' <- prettyBlackBox es
+    renderOneLine <$> (string "~SYM" <> brackets (string es'))
 prettyElem (Repeat [es] [i]) = do
   es' <- prettyElem es
   i'  <- prettyElem i
@@ -1255,6 +1267,8 @@ walkElement f el = maybeToList (f el) ++ walked
         SigD es _ -> concatMap go es
         BV _ es _ -> concatMap go es
         GenSym es _ -> concatMap go es
+        Sym _ (Left _) -> []
+        Sym _ (Right es) -> concatMap go es
         DevNull es -> concatMap go es
         Text _ -> []
         Result -> []
@@ -1264,7 +1278,6 @@ walkElement f el = maybeToList (f el) ++ walked
         Lit _ -> []
         Name _ -> []
         ToVar es _ -> concatMap go es
-        Sym _ _ -> []
         Typ _ -> []
         TypM _ -> []
         Err _ -> []

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -42,6 +42,7 @@ import           Control.Exception               (throw)
 import           Control.Lens
   (use, (%=), _1, _2, _3, element, (^?))
 import           Control.Monad                   (forM, (<=<), filterM)
+import           Control.Monad.Identity          (runIdentity)
 import           Control.Monad.Extra             (ifM)
 import           Control.Monad.State             (State, StateT (..), lift, gets)
 import           Data.Bitraversable              (bitraverse)
@@ -267,7 +268,7 @@ setSym bbCtx l = do
     setSym'
       :: Element
       -> StateT ( IntMap.IntMap N.IdentifierText  -- ~SYM[number] mapping
-                , HashMap.HashMap Text N.IdentifierText   -- ~SYM[string] mapping
+                , HashMap.HashMap Text (Maybe N.IdentifierText)   -- ~SYM[string] mapping, Nothing when a name is used by GENSYM
                 , IntMap.IntMap (N.IdentifierText, [N.Declaration]))  -- ~VAR[nm][n] mapping
                 m
                 Element
@@ -303,20 +304,32 @@ setSym bbCtx l = do
         case symM of
           Nothing -> do
             t <- Id.toText <$> lift (Id.make $ Text.toStrict nm)
-            _2 %= (HashMap.insert nm t)
+            _2 %= (HashMap.insert nm (Just t))
             return (Sym (Text.fromStrict t) x)
-          Just t -> return (Sym (Text.fromStrict t) x)
-      GenSym t i -> do
-        symM <- IntMap.lookup i <$> use _1
-        case symM of
-          Nothing -> do
-            t' <- Id.toText <$> lift (Id.makeBasic (Text.toStrict (concatT t)))
-            _1 %= (IntMap.insert i t')
-            return (GenSym [Text (Text.fromStrict t')] i)
-          Just _ ->
-            error ("Symbol #" ++ show (t,i)
-                ++ " is already defined in BlackBox for: "
-                ++ bbnm)
+          Just (Just t) -> return (Sym (Text.fromStrict t) x)
+          Just Nothing ->
+            error ("In BlackBox " ++ bbnm ++ ": "
+                ++ " ~SYM[" ++ Text.unpack nm ++ "] uses the same name as previously used in ~GENSYM.\n"
+                ++ "You can't mix numbered and named symbols.")
+      GenSym t@(concatT -> nm) i -> do
+        symNmM <- HashMap.lookup nm <$> use _2
+        case symNmM of
+          Just (Just _) ->
+            error ("In BlackBox " ++ bbnm ++ ": "
+                ++ "the name of ~GENSYM[" ++ prettyBlackBoxStr t ++ "][" ++ show i ++ "]"
+                ++ " would overwrite an earlier ~SYM[" ++ Text.unpack nm ++ "].\n"
+                ++ "You can't mix numbered and named symbols.")
+          _ -> do
+            symM <- IntMap.lookup i <$> use _1
+            case symM of
+              Nothing -> do
+                t' <- Id.toText <$> lift (Id.makeBasic (Text.toStrict nm))
+                _1 %= (IntMap.insert i t')
+                _2 %= (HashMap.insert nm Nothing) -- mark name as taken by GENSYM
+                return (GenSym [Text (Text.fromStrict t')] i)
+              Just _ ->
+                error ("In BlackBox " ++ bbnm ++ ": ~GENSYM[" ++ show t ++ "][" ++ show i ++ "]"
+                    ++ " is redefining symbol #" ++ show i ++ ".\n")
       Component (Decl n subN l') ->
         Component <$> (Decl n subN <$> mapM (bitraverse (mapM setSym') (mapM setSym')) l')
       IF c t f      -> IF <$> pure c <*> mapM setSym' t <*> mapM setSym' f
@@ -1091,6 +1104,9 @@ prettyBlackBox :: Monad m
                => BlackBoxTemplate
                -> Ap m Text
 prettyBlackBox bbT = Text.concat <$> mapM prettyElem bbT
+
+prettyBlackBoxStr :: BlackBoxTemplate -> String
+prettyBlackBoxStr = Text.unpack . runIdentity . getAp . prettyBlackBox
 
 prettyElem
   :: (HasCallStack, Monad m)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -215,6 +215,14 @@ runClashTest = defaultMain
               primitive for WrongReference.myMultiplyX. These names should be
               the same. |])
           }
+        , runTest "NamedSymbolsAndNumberedSymbols" def{
+            hdlTargets=[VHDL]
+          , expectClashFail=Just (def, "~SYM[mySymbol] uses the same name as previously used in ~GENSYM")
+          }
+        , runTest "NamedSymbolsAndNumberedSymbols2" def{
+            hdlTargets=[VHDL]
+          , expectClashFail=Just (def, "~GENSYM[mySymbol][1] would overwrite an earlier ~SYM[mySymbol]")
+          }
         , runTest "T1945" def{
             hdlTargets=[VHDL]
           , expectClashFail=Just (def, "Template function for returned False")

--- a/tests/shouldfail/BlackBox/NamedSymbolsAndNumberedSymbols.hs
+++ b/tests/shouldfail/BlackBox/NamedSymbolsAndNumberedSymbols.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+module NamedSymbolsAndNumberedSymbols where
+
+import           Clash.Annotations.Primitive  (Primitive(..), HDL(..), hasBlackBox)
+import           Clash.Netlist.Types          (TemplateFunction (..))
+import           Clash.Prelude
+
+import           Data.String.Interpolate      (__i)
+
+bbFirstGensym :: a -> a
+bbFirstGensym x = x
+{-# OPAQUE bbFirstGensym #-}
+{-# ANN bbFirstGensym hasBlackBox #-}
+{-# ANN bbFirstGensym (
+  let bbName = show 'bbFirstGensym
+  in InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [__i|
+    BlackBox:
+      name: "#{bbName}"
+      kind: Declaration
+      template: |-
+        ~GENSYM[mySymbol][1]
+        ~SYM[mySymbol]
+   |]) #-}
+
+topEntity :: Bool -> Bool
+topEntity = bbFirstGensym

--- a/tests/shouldfail/BlackBox/NamedSymbolsAndNumberedSymbols2.hs
+++ b/tests/shouldfail/BlackBox/NamedSymbolsAndNumberedSymbols2.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+module NamedSymbolsAndNumberedSymbols2 where
+
+import           Clash.Annotations.Primitive  (Primitive(..), HDL(..), hasBlackBox)
+import           Clash.Netlist.Types          (TemplateFunction (..))
+import           Clash.Prelude
+
+import           Data.String.Interpolate      (__i)
+
+bbFirstSym :: a -> a
+bbFirstSym x = x
+{-# OPAQUE bbFirstSym #-}
+{-# ANN bbFirstSym hasBlackBox #-}
+{-# ANN bbFirstSym (
+  let bbName = show 'bbFirstSym
+  in InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [__i|
+    BlackBox:
+      name: "#{bbName}"
+      kind: Declaration
+      template: |-
+        ~SYM[mySymbol]
+        ~GENSYM[mySymbol][1]
+   |]) #-}
+
+
+topEntity :: Bool -> Bool
+topEntity = bbFirstSym


### PR DESCRIPTION
Instead of doing:
```
	signal ~GENSYM[foo][3] : ..;
	signal ~GENSYM[bar][4] : ..;

	.. <= ~SYM[3] - ~SYM[4];
```
You can now refer to `SYM`bols by name:
```
	signal ~SYM[foo] : ..;
	signal ~SYM[bar] : ..;

	.. <= ~SYM[foo] - ~SYM[bar];
```
The old behaviour with GENSYM and the numeric references is still fully supported.

Implements #3325

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
