### PR TITLE
nix: avoid building local packages in dev shells

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -3,20 +3,22 @@ compilerVersion:
 let
   clashPkgs = pkgs."clashPackages-${compilerVersion}";
 in
-pkgs.mkShell {
-  inputsFrom = [
-    clashPkgs.clash-benchmark.env
-    clashPkgs.clash-cosim.env
-    clashPkgs.clash-ffi.env
-    clashPkgs.clash-ghc.env
-    clashPkgs.clash-lib.env
-    clashPkgs.clash-lib-hedgehog.env
-    clashPkgs.clash-prelude.env
-    clashPkgs.clash-prelude-hedgehog.env
-    clashPkgs.clash-profiling.env
-    clashPkgs.clash-profiling-prepare.env
-    clashPkgs.clash-term.env
-    clashPkgs.clash-testsuite.env
+clashPkgs.shellFor {
+  # shellFor combines the dependencies of these packages while filtering the
+  # packages themselves from the resulting environment. This lets Cabal build
+  # the packages from the working tree instead of requiring their Nix
+  # derivations to be built before entering the development shell.
+  packages = p: [
+    p.clash-benchmark
+    p.clash-ghc
+    p.clash-lib
+    p.clash-lib-hedgehog
+    p.clash-prelude
+    p.clash-prelude-hedgehog
+    p.clash-profiling
+    p.clash-profiling-prepare
+    p.clash-term
+    p.clash-testsuite
   ];
 
   buildInputs = [
@@ -32,6 +34,5 @@ pkgs.mkShell {
     pkgs.verilator
     pkgs.iverilog
     pkgs.yosys
-    clashPkgs.haskell-language-server
   ];
 }


### PR DESCRIPTION
This fixes a longstanding annoyance of mine. Entering a `nix develop` shell required a build of most local packages because the way it is setup is that we use the `*.env` environments of all packages. This puts all dependencies in the develop shell, which includes the local packages themselves.

using `shellFor` + `packages` automatically filters out the packages in the `packages` list, which means it now puts all haskell dependencies in the shell except the local packages.