### PR TITLE
Add `Hashable Term` and `Hashable Type`

### DIFF
--- a/changelog/2026-07-30T11_00_00+02_00_add_hashable_term
+++ b/changelog/2026-07-30T11_00_00+02_00_add_hashable_term
@@ -1,0 +1,1 @@
+ADDED: `Hashable Term` and `Hashable Type` instances. These were removed in Clash 1.4.7 due to a faulty implementation, but are now back. They hash modulo alpha equivalence, and so agree with `Eq Term` and `Eq Type`: alpha-equivalent terms hash alike.

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -412,6 +412,7 @@ test-suite unittests
       containers,
       data-default,
       deepseq,
+      hashable,
       haskell-src-exts,
       ghc,
       lens,

--- a/clash-lib/src/Clash/Core/DataCon.hs
+++ b/clash-lib/src/Clash/Core/DataCon.hs
@@ -24,7 +24,7 @@ where
 import Control.DeepSeq                        (NFData(..))
 import Data.Binary                            (Binary)
 import Data.Function                          (on)
-import Data.Hashable                          (Hashable)
+import Data.Hashable                          (Hashable (hashWithSalt))
 import qualified Data.Text                    as Text
 import GHC.Generics                           (Generic)
 
@@ -67,6 +67,9 @@ instance Eq DataCon where
 
 instance Ord DataCon where
   compare = compare `on` dcUniq
+
+instance Hashable DataCon where
+  hashWithSalt salt = hashWithSalt salt . dcUniq
 
 instance Uniquable DataCon where
   getUnique = dcUniq

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -14,7 +14,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -82,10 +81,9 @@ import qualified Data.List                 as List
 import qualified Data.List.Extra           as List
 import           Data.Ord                  (comparing)
 import           GHC.Stack                 (HasCallStack)
-import           GHC.SrcLoc.Extra          ()
-import           GHC.Types.SrcLoc          (leftmost_smallest)
-import           GHC.TypeLits
-  (TypeError, ErrorMessage (Text, (:<>:)))
+import           GHC.SrcLoc.Extra          () -- Hashable RealSrcSpan
+import           GHC.Types.SrcLoc
+  (SrcSpan (RealSrcSpan, UnhelpfulSpan), leftmost_smallest)
 
 import           Clash.Core.HasFreeVars
 import           Clash.Core.Pretty         (ppr, fromPpr)
@@ -969,13 +967,6 @@ instance Ord Type where
 instance Eq Term where
   (==) = aeqTerm
 
-instance TypeError (
-        'Text "A broken implementation of Hashable Term has been "
-  ':<>: 'Text "removed in Clash 1.4.7. If this is an issue for you, please submit "
-  ':<>: 'Text "an issue report at https://github.com/clash-lang/clash-compiler/issues."
-  ) => Hashable Term where
-    hashWithSalt = error "Term.hashWithSalt: unreachable"
-
 {- Note [Numbering binders by De Bruijn level]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Alpha comparison compares two variable occurrences by their De Bruijn level:
@@ -1231,3 +1222,167 @@ acmpTickInfoLevels !lvl tmL tmR tyL tyR = go
 
 instance Ord Term where
   compare = acmpTerm
+
+-- * Alpha hashing
+--
+-- Hashing is modulo alpha equivalence, so that it agrees with @Eq Term@ and
+-- @Eq Type@: alpha-equivalent terms hash alike. Only that direction holds,
+-- terms that are not alpha-equivalent may collide as with any hash. A bound
+-- variable is hashed by its De Bruijn level, see
+-- Note [Numbering binders by De Bruijn level].
+
+-- | Mix the tag of a constructor into a salt, so that terms differing only in
+-- which constructor they use do not hash alike.
+hashTag :: Int -> Int -> Int
+hashTag = hashWithSalt
+
+-- | Give a group of binders that come into scope together, such as a 'Rec' or a
+-- 'DataPat', consecutive levels, and return the level following the group.
+extendLevelsOf :: Int -> [Var a] -> VarEnv Int -> (Int, VarEnv Int)
+extendLevelsOf lvl vs env = List.foldl' one (lvl, env) vs
+ where
+  one (!l, e) v = (l + 1, extendVarEnv v l e)
+
+-- | Hash a 'SrcSpan' only as finely as @Eq Term@ tells one apart: all
+-- 'UnhelpfulSpan's alike, and a 'RealSrcSpan' by its file name and its start
+-- and end positions. The structural @Hashable SrcSpan@ orphan from
+-- "GHC.SrcLoc.Extra" is finer than that, as it takes in the buffer span and the
+-- reason of an unhelpful span as well, and would tell alpha-equivalent terms
+-- apart.
+hashSrcSpan :: Int -> SrcSpan -> Int
+hashSrcSpan salt = \case
+  RealSrcSpan realSrcSpan _bufSpan -> hashWithSalt salt (0 :: Int, realSrcSpan)
+  UnhelpfulSpan _reason -> hashWithSalt salt (1 :: Int)
+
+-- | Hash a 'Type' modulo alpha, under the binders enclosing it.
+-- See Note [Numbering binders by De Bruijn level].
+aTypeHashLevels ::
+  -- | Number of enclosing binders
+  Int ->
+  -- | Levels of the type binders enclosing the type
+  VarEnv Int ->
+  -- | Salt
+  Int ->
+  Type ->
+  Int
+aTypeHashLevels !lvl tyEnv = go
+ where
+  go :: Int -> Type -> Int
+  go salt = \case
+    VarTy tv ->
+      -- N.B.: Variables are hashed with a "tag" to differentiate between, e.g.,
+      --       a bound local variable bound at level "2" and a free local variable
+      --       with unique "2".
+      case lookupVarEnv tv tyEnv of
+        Just boundLvl -> hashWithSalt salt (0 :: Int, boundLvl)
+        Nothing -> hashWithSalt salt (1 :: Int, varUniq tv)
+    LitTy l -> hashWithSalt (hashTag salt 1) l
+    ConstTy c -> hashWithSalt (hashTag salt 2) c
+    AnnType attrs t -> go (hashWithSalt (hashTag salt 3) attrs) t
+    AppTy t1 t2 -> go (go (hashTag salt 4) t1) t2
+    ForAllTy tv t ->
+      aTypeHashLevels (lvl + 1) (extendVarEnv tv lvl tyEnv)
+        (go (hashTag salt 5) (varType tv)) t
+
+-- | Hash a 'Term' modulo alpha, under the binders enclosing it.
+-- See Note [Numbering binders by De Bruijn level].
+aTermHashLevels ::
+  -- | Number of enclosing binders
+  Int ->
+  -- | Levels of the term binders enclosing the term
+  VarEnv Int ->
+  -- | Levels of the type binders enclosing the term
+  VarEnv Int ->
+  -- | Salt
+  Int ->
+  Term ->
+  Int
+aTermHashLevels !lvl tmEnv tyEnv = go
+ where
+  goType = aTypeHashLevels lvl tyEnv
+
+  underTmBndr b = aTermHashLevels (lvl + 1) (extendVarEnv b lvl tmEnv) tyEnv
+  underTyBndr b = aTermHashLevels (lvl + 1) tmEnv (extendVarEnv b lvl tyEnv)
+
+  go :: Int -> Term -> Int
+  go salt = \case
+    Var i -> goVar (hashTag salt 0) i
+    Data dc -> hashWithSalt (hashTag salt 1) dc
+    Literal l -> hashWithSalt (hashTag salt 2) l
+    -- A primitive is identified by its name
+    Prim p -> hashWithSalt (hashTag salt 3) (primName p)
+    Cast e t1 t2 -> goType (goType (go (hashTag salt 4) e) t1) t2
+    App e1 e2 -> go (go (hashTag salt 5) e1) e2
+    TyApp e t -> goType (go (hashTag salt 6) e) t
+    Lam b e -> underTmBndr b (goType (hashTag salt 7) (varType b)) e
+    TyLam b e -> underTyBndr b (goType (hashTag salt 8) (varType b)) e
+    -- A 'NonRec' binder's type is pinned down by its right-hand side, so it is
+    -- left out. A 'Rec' binder may occur in its own right-hand side, and then
+    -- it is not: @let x = x in x@ is the same term whether @x@ is an Int or a
+    -- Bool.
+    Let (NonRec i x) e -> underTmBndr i (go (hashTag salt 9) x) e
+    Let (Rec bs) e ->
+      let (ids, rhss) = unzip bs
+          (lvl', tmEnv') = extendLevelsOf lvl ids tmEnv
+          under = aTermHashLevels lvl' tmEnv' tyEnv
+          types = goList goType (hashTag salt 10) (map varType ids)
+      in under (goList under types rhss) e
+    -- Note [Case result types and alpha-equivalence]
+    Case subj _ty alts -> goList goAlt (go (hashTag salt 11) subj) alts
+    Tick tick e -> go (goTick (hashTag salt 12) tick) e
+
+  -- Hash a list, mixing in its length, so that a list does not hash like one of
+  -- its prefixes
+  goList :: (Int -> a -> Int) -> Int -> [a] -> Int
+  goList hashElement salt xs =
+    hashWithSalt (List.foldl' hashElement salt xs) (length xs)
+
+  goAlt :: Int -> Alt -> Int
+  goAlt salt = \case
+    -- A 'DataCon' fixes how many variables its 'DataPat' binds, so the binder
+    -- counts need no hashing of their own
+    (DataPat dc tvs ids, e) ->
+      let (lvlTy, tyEnv') = extendLevelsOf lvl tvs tyEnv
+          (lvl', tmEnv') = extendLevelsOf lvlTy ids tmEnv
+      in aTermHashLevels lvl' tmEnv' tyEnv'
+           (hashWithSalt (hashTag salt 0) dc) e
+    (LitPat l, e) -> go (hashWithSalt (hashTag salt 1) l) e
+    (DefaultPat, e) -> go (hashTag salt 2) e
+
+  -- N.B.: Variables are hashed with a "tag" to differentiate between, e.g., a
+  --       local free variable with unique "2" and a bound free variable which
+  --       happens to be bound at level 2.
+  goVar :: Int -> Id -> Int
+  goVar salt i
+    -- Global, never bound with respect to 'tmEnv'
+    | isGlobalId i = hashWithSalt salt (0 :: Int, varUniq i)
+    -- Local, bound variable
+    | Just boundLvl <- lookupVarEnv i tmEnv = hashWithSalt salt (1 :: Int, boundLvl)
+    -- Free, local variable
+    | otherwise = hashWithSalt salt (2 :: Int, varUniq i)
+
+  -- A tick's payload lives in the scope enclosing the tick, so it is hashed
+  -- under the enclosing binders rather than in isolation
+  goTick :: Int -> TickInfo -> Int
+  goTick salt = \case
+    SrcSpan s -> hashSrcSpan (hashTag salt 0) s
+    NameMod m t -> goType (hashWithSalt (hashTag salt 1) m) t
+    DeDup -> hashTag salt 2
+    NoDeDup -> hashTag salt 3
+    Attributes t e -> go (goType (hashTag salt 4) t) e
+
+-- | Hash a 'Type' modulo alpha.
+-- See Note [Numbering binders by De Bruijn level].
+aTypeHashWithSalt :: Int -> Type -> Int
+aTypeHashWithSalt = aTypeHashLevels 0 emptyVarEnv
+
+-- | Hash a 'Term' modulo alpha.
+-- See Note [Numbering binders by De Bruijn level].
+aTermHashWithSalt :: Int -> Term -> Int
+aTermHashWithSalt = aTermHashLevels 0 emptyVarEnv emptyVarEnv
+
+instance Hashable Type where
+  hashWithSalt = aTypeHashWithSalt
+
+instance Hashable Term where
+  hashWithSalt = aTermHashWithSalt

--- a/clash-lib/src/Clash/Core/Type.hs
+++ b/clash-lib/src/Clash/Core/Type.hs
@@ -62,7 +62,7 @@ where
 import           Control.DeepSeq        as DS
 import           Data.Binary            (Binary)
 import           Data.Coerce            (coerce)
-import           Data.Hashable          (Hashable (hashWithSalt))
+import           Data.Hashable          (Hashable)
 #if !MIN_VERSION_base(4,20,0)
 import           Data.List              (foldl')
 #endif
@@ -73,7 +73,6 @@ import           GHC.Base               (isTrue#,(==#))
 import           GHC.Generics           (Generic(..))
 import           GHC.Integer            (smallInteger)
 import           GHC.Integer.Logarithms (integerLogBase#)
-import           GHC.TypeLits           (type TypeError, ErrorMessage(Text, (:<>:)))
 import           GHC.Base               (ord)
 import           Data.Char              (chr)
 import           Data.Maybe             (fromMaybe)
@@ -121,13 +120,6 @@ data Type
   | LitTy    !LitTy             -- ^ Type literal
   | AnnType  [Attr Text] !Type  -- ^ Annotated type, see Clash.Annotations.SynthesisAttributes
   deriving (Show, Generic, NFData, Binary)
-
-instance TypeError (
-        'Text "A broken implementation of Hashable Type has been "
-  ':<>: 'Text "removed in Clash 1.4.7. If this is an issue for you, please submit "
-  ':<>: 'Text "an issue report at https://github.com/clash-lang/clash-compiler/issues."
-  ) => Hashable Type where
-    hashWithSalt = error "Type.hashWithSalt: unreachable"
 
 -- | An easier view on types
 data TypeView

--- a/clash-lib/tests/Clash/Tests/Core/AlphaEquivalence.hs
+++ b/clash-lib/tests/Clash/Tests/Core/AlphaEquivalence.hs
@@ -3,7 +3,8 @@
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
-  Tests for alpha equivalence and alpha comparison of 'Term' and 'Type'
+  Tests for alpha equivalence, alpha comparison and alpha hashing of 'Term' and
+  'Type'
 -}
 
 {-# LANGUAGE LambdaCase #-}
@@ -12,6 +13,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Clash.Tests.Core.AlphaEquivalence (tests) where
+
+import Data.Hashable (Hashable, hash)
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -29,18 +32,20 @@ import Test.Clash.Rewrite (intTy, localId, parseToTermQQ, tyVar)
 
 
 -- | Assert that two terms (or types) are alpha-equivalent, and that 'Ord'
--- agrees, in both directions
-assertAlphaEqual :: (Ord a, Show a) => a -> a -> Assertion
+-- agrees, in both directions. Their hashes have to agree as well: hashing
+-- alpha-equivalent terms alike is the direction of the hash law that holds.
+assertAlphaEqual :: (Ord a, Show a, Hashable a) => a -> a -> Assertion
 assertAlphaEqual t1 t2 = do
   t1 @=? t2
   t2 @=? t1
   EQ @=? compare t1 t2
   EQ @=? compare t2 t1
+  hash t1 @=? hash t2
 
 -- | Assert that two terms (or types) are not alpha-equivalent, and that 'Ord'
 -- agrees. Also checks that comparison in the opposite direction yields the
 -- opposite result, i.e. that the order is antisymmetric on this pair.
-assertAlphaNotEqual :: (Ord a, Show a) => a -> a -> Assertion
+assertAlphaNotEqual :: (Ord a, Show a, Hashable a) => a -> a -> Assertion
 assertAlphaNotEqual t1 t2 = do
   assertBool "t1 /= t2" (t1 /= t2)
   assertBool "t2 /= t1" (t2 /= t1)
@@ -48,6 +53,18 @@ assertAlphaNotEqual t1 t2 = do
     EQ -> assertFailure "compare == EQ"
     LT -> GT @=? compare t2 t1
     GT -> LT @=? compare t2 t1
+
+  -- XXX: (a == b) `implies` (hash a == hash b), but not necessarily the other
+  --      way around. Still, chances of hitting a hash collision should be pretty
+  --      small. This test therefore serves as a sanity check to see whether the
+  --      generated hashes are chaotic enough.
+  --
+  --      IF you ever encounter a hash collision here, you can safely remove it.
+  --      Still, it would then be a good idea to think about how we want to test
+  --      the "chaoticness" of the function.
+  assertBool
+    "If you see this read the TODO comment ^: hash t1 /= hash t2"
+    (hash t1 /= hash t2)
 
 case_arxiv_2105_02856_eq1 :: Assertion
 case_arxiv_2105_02856_eq1 = assertAlphaEqual a b


### PR DESCRIPTION
This piggy-backs off the infrastructure made in https://github.com/clash-lang/clash-compiler/pull/3335 and follows the same idea for constructing hashes as the ideas for comparing terms.

This doesn't do anything on its own, but paves the way for using `HashMap`/`HashTable` for quick lookups.

I had originally intended to base this off of [Hashing Module Alpha-Equivalence](https://arxiv.org/abs/2105.02856), but that doesn't make a lot of sense. That paper focuses on hashing in a way that creates stable (position independent) hashes for all subterms. This is super useful for common subexpression elimination, but too computationally complex if you just want a hash for the root of an expression.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] Check copyright notices are up to date in edited files
  - [x] Merge https://github.com/clash-lang/clash-compiler/pull/3335
