### PR TITLE
Memoize GHC-to-Clash type conversion on the GHC type

### DIFF
--- a/changelog/2026-07-30T12_05_32+02_00_memoize_type_conversion
+++ b/changelog/2026-07-30T12_05_32+02_00_memoize_type_conversion
@@ -1,0 +1,1 @@
+CHANGED: The GHC-to-Clash type conversion is memoized on the GHC type, with unchanged output. Types repeat massively across binders, and converting one evaluates family-instance reductions and name conversions per node. On larger designs we've tested this halved the loading stage.

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -35,7 +35,7 @@ module Clash.GHC.GHC2Core
 where
 
 -- External Modules
-import           Control.Lens                ((^.), (%~), (&), (%=), (.~), view, makeLenses)
+import           Control.Lens                ((^.), (%~), (&), (%=), (.~), use, view, makeLenses)
 import           Control.Applicative         ((<|>))
 import           Control.Monad.Extra         (ifM, andM)
 import           Control.Monad.RWS.Strict    (RWS)
@@ -127,6 +127,60 @@ import           Clash.GHC.Util
 instance Hashable Name where
   hashWithSalt s = hashWithSalt s . getKey . nameUnique
 
+-- | A GHC 'Type' keyed for cache lookups: 'Eq' and 'Hashable' compare types
+-- structurally instead of up to alpha-equivalence or type synonym expansion.
+-- See 'eqType'.
+newtype StructuralType = StructuralType Type
+
+instance Eq StructuralType where
+  StructuralType l == StructuralType r = eqType l r
+
+instance Hashable StructuralType where
+  hashWithSalt salt (StructuralType ty) = hashType salt ty
+
+-- | Structural equality on GHC types: type synonyms stay unexpanded,
+-- alpha-equivalent types are distinct, and types containing casts or
+-- coercions never compare equal.
+eqType :: Type -> Type -> Bool
+eqType = go
+ where
+  go (TyVarTy v1) (TyVarTy v2) = v1 == v2
+  go (AppTy l1 r1) (AppTy l2 r2) = go l1 l2 && go r1 r2
+  go (TyConApp tc1 args1) (TyConApp tc2 args2) =
+    tc1 == tc2 && goList args1 args2
+  go (ForAllTy (Bndr v1 f1) t1) (ForAllTy (Bndr v2 f2) t2) =
+    v1 == v2 && f1 == f2 && go t1 t2
+  go (FunTy f1 m1 a1 r1) (FunTy f2 m2 a2 r2) =
+    f1 == f2 && go m1 m2 && go a1 a2 && go r1 r2
+  go (LitTy l1) (LitTy l2) = l1 == l2
+  -- XXX: Not sure how to handle casts/coercions, so for now just claim they're
+  --      not equal. That's fair in the only context this is used: caching.
+  go _ _ = False
+
+  goList (t1:ts1) (t2:ts2) = go t1 t2 && goList ts1 ts2
+  goList [] [] = True
+  goList _ _ = False
+
+-- | Hash a GHC type, matching 'eqType': types that compare equal hash equally.
+hashType :: Int -> Type -> Int
+hashType = go
+ where
+  go s ty = case ty of
+    TyVarTy v -> hashWithSalt (tag s 0) (getKey (varUnique v))
+    AppTy l r -> go (go (tag s 1) l) r
+    TyConApp tc args -> foldl go (hashWithSalt (tag s 2) (getKey (tyConUnique tc))) args
+    ForAllTy (Bndr v _) t -> go (hashWithSalt (tag s 3) (getKey (varUnique v))) t
+    FunTy _ m a r -> go (go (go (tag s 4) m) a) r
+    LitTy l -> case l of
+      NumTyLit i -> hashWithSalt (tag s 5) i
+      StrTyLit str -> hashWithSalt (tag s 6) (unpackFS str)
+      CharTyLit c -> hashWithSalt (tag s 7) c
+    CastTy t _ -> go (tag s 8) t
+    CoercionTy _ -> tag s 9
+
+  tag :: Int -> Int -> Int
+  tag = hashWithSalt
+
 data GHC2CoreState
   = GHC2CoreState
   { _tyConMap :: C.UniqMap TyCon
@@ -134,6 +188,8 @@ data GHC2CoreState
   , _varTypeMap :: HashMap Name C.Type
   -- ^ Cache for converted types of global variables ('varType'). See
   -- 'coreToVarType'.
+  , _convertedTypeCache :: HashMap StructuralType C.Type
+  -- ^ Cache for converted types, keyed on the GHC type. See 'coreToType'.
   }
 
 makeLenses ''GHC2CoreState
@@ -147,7 +203,8 @@ data GHC2CoreEnv
 makeLenses ''GHC2CoreEnv
 
 emptyGHC2CoreState :: GHC2CoreState
-emptyGHC2CoreState = GHC2CoreState mempty HashMap.empty HashMap.empty
+emptyGHC2CoreState =
+  GHC2CoreState mempty HashMap.empty HashMap.empty HashMap.empty
 
 newtype SrcSpanRB = SrcSpanRB {unSrcSpanRB :: SrcSpan}
 
@@ -494,12 +551,7 @@ coreToTerm primMap unlocs = term
 
 
     termSP sp = fmap (second unSrcSpanRB) . RWS.listen . addUsefullR sp . term
-    coreToIdSP sp = RWS.local (\r@(GHC2CoreEnv _ e) ->
-                                  if isGoodSrcSpan sp then
-                                    GHC2CoreEnv sp e
-                                  else
-                                    r)
-                  . coreToId
+    coreToIdSP sp = addUsefullR sp . coreToId
 
 
     lookupPrim :: Text -> Maybe (Maybe CompiledPrimitive)
@@ -635,6 +687,12 @@ addUsefullR x m =
   if isGoodSrcSpan x
   then RWS.local (srcSpan .~ x) m
   else m
+
+-- | Convert without an ambient source span: names GHC gives no location of
+-- their own get 'noSrcSpan' instead of the location of the binder under
+-- conversion.
+withoutSrcSpan :: C2C a -> C2C a
+withoutSrcSpan = RWS.local (srcSpan .~ noSrcSpan)
 
 isSizedCast :: Type -> Type -> C2C Bool
 isSizedCast (TyConApp tc1 _) (TyConApp tc2 _) = do
@@ -903,11 +961,25 @@ annotateType ty cty = do
 
 -- | Converts GHC Type to a Clash Type. Strips newtypes and signals, with the
 -- exception of newtypes used as annotations (see: SynthesisAttributes).
+--
+-- Conversions are memoized on the GHC type, which also shares the converted
+-- types. The conversion runs 'withoutSrcSpan' so that it depends on the GHC
+-- type alone; nothing ever reads back the source spans of names inside a
+-- type, so no information is lost.
 coreToType
   :: Type
   -> C2C C.Type
-coreToType ty = ty'' >>= annotateType ty
+coreToType ty = do
+  cache <- use convertedTypeCache
+  case HashMap.lookup (StructuralType ty) cache of
+    Just ty1 -> pure ty1
+    Nothing -> do
+      ty1 <- withoutSrcSpan convert
+      convertedTypeCache %= HashMap.insert (StructuralType ty) ty1
+      pure ty1
   where
+    convert = ty'' >>= annotateType ty
+
     ty'' | Just ty' <- coreView ty = coreToType ty'
          | TyConApp tc xs <- ty = do
              envs <- view famInstEnvs


### PR DESCRIPTION
Cuts the loading stage from 14.1s to 6.9s on `bittide-hardware`'s `wireDemoTest`.

It's slightly scrappy in that it ignores coercions, but it's better than getting it wrong I suppose.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~