### PR TITLE
Add and use `unsafeSubstTm` in `appProp` beta reduction

### DIFF
--- a/changelog/2026-07-30T14_23_19+02_00_unsafe_subst_tm_in_appprop
+++ b/changelog/2026-07-30T14_23_19+02_00_unsafe_subst_tm_in_appprop
@@ -1,0 +1,1 @@
+CHANGED: The beta-reduction step of the `appProp` transformation substitutes with a sharing-preserving substitution that leaves untouched subterms alone, instead of one that rebuilds every node it visits. Output is unchanged.

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -47,6 +47,7 @@ module Clash.Core.Subst
     -- ** Applying substitutions
   , substTm
   , maybeSubstTm
+  , unsafeSubstTm
   , substAlt
   , substId
     -- * Variable renaming
@@ -79,6 +80,7 @@ import           Data.Text.Prettyprint.Doc
 import           Data.Hashable             (Hashable (hashWithSalt))
 import qualified Data.List                 as List
 import qualified Data.List.Extra           as List
+import           Data.Maybe                (fromMaybe)
 import           Data.Ord                  (comparing)
 import           GHC.Stack                 (HasCallStack)
 import           GHC.SrcLoc.Extra          () -- Hashable RealSrcSpan
@@ -592,6 +594,92 @@ substTm doc subst = go where
   goTick t@DeDup        = t
   goTick t@NoDeDup      = t
   goTick (Attributes ty tm) = Attributes (substTy subst ty) (go tm)
+
+-- | Like 'substTm', but doesn't account for shadowing or free variable capture.
+--
+-- An example of shadowing: in @(x, \x -> x)@ with a substitution @x |-> 5@
+-- 'unsafeSubstTm' will yield @(5, \x -> 5)@, whereas a safe substitution would
+-- yield @(5, \x -> x)@.
+--
+-- An example of free variable capture: in @\x -> y@ and a substitution
+-- @y |-> f x@, 'unsafeSubstTm' will yield @\x -> f x@, whereas a safe substitution
+-- would yield @\x' -> f x@.
+--
+-- You should therefore only use this function if:
+--
+--   1. No binder in the term binds variables in the domain of the local
+--      substitution.
+--
+--   2. No binder in the term has the same unique as a local, free variable of any
+--      replacement term in the range of either substitution.
+--
+-- Both conditions hold if the term is deshadowed (see 'deShadowTerm') with
+-- respect to an in-scope set that contains the domains of the substitutions
+-- and the free variables of the replacement terms.
+--
+-- Note that global substituations are always safe. They never have local free
+-- variables and cannot be introduced through a binder. I.e., neither rule 1
+-- nor 2 applies.
+unsafeSubstTm
+  :: VarEnv Term
+  -- ^ Substitution: global variable to replacement term
+  -> VarEnv Term
+  -- ^ Substitution: local variable to replacement term
+  -> Term
+  -- ^ Term to substitute in
+  -> Term
+unsafeSubstTm globals locals = \term -> fromMaybe term (go term)
+ where
+  go :: Term -> Maybe Term
+  go = \case
+    Var v
+      | isGlobalId v -> lookupVarEnv v globals
+      | otherwise -> lookupVarEnv v locals
+    Lam v e -> Lam v <$> go e
+    TyLam tv e -> TyLam tv <$> go e
+    App l r -> case (go l, go r) of
+      (Nothing, Nothing) -> Nothing
+      (l1, r1) -> Just (App (fromMaybe l l1) (fromMaybe r r1))
+    TyApp e ty -> (`TyApp` ty) <$> go e
+    Let bs body -> case (goBind bs, go body) of
+      (Nothing, Nothing) -> Nothing
+      (bs1, body1) -> Just (Let (fromMaybe bs bs1) (fromMaybe body body1))
+    Case subject ty alternatives ->
+      case (go subject, goList goAlternative alternatives) of
+        (Nothing, Nothing) -> Nothing
+        (subject1, alternatives1) ->
+          Just (Case (fromMaybe subject subject1) ty
+                     (fromMaybe alternatives alternatives1))
+    Cast e t1 t2 -> (\e1 -> Cast e1 t1 t2) <$> go e
+    Tick tickInfo e -> case (goTickInfo tickInfo, go e) of
+      (Nothing, Nothing) -> Nothing
+      (tick1, e1) -> Just (Tick (fromMaybe tickInfo tick1) (fromMaybe e e1))
+    Data{} -> Nothing
+    Literal{} -> Nothing
+    Prim{} -> Nothing
+
+  goBind (NonRec v rhs) = NonRec v <$> go rhs
+  goBind (Rec bindings0) = Rec <$> goList goBinding bindings0
+
+  goBinding (v, rhs) = (,) v <$> go rhs
+
+  goAlternative (pat, alternative) = (,) pat <$> go alternative
+
+  -- Types contain no term variables, so of the tick constructors only
+  -- 'Attributes', which carries a term, needs a traversal.
+  goTickInfo (Attributes ty e) = Attributes ty <$> go e
+  goTickInfo SrcSpan{} = Nothing
+  goTickInfo NameMod{} = Nothing
+  goTickInfo DeDup = Nothing
+  goTickInfo NoDeDup = Nothing
+
+  goList :: (a -> Maybe a) -> [a] -> Maybe [a]
+  goList f = goElements
+   where
+    goElements [] = Nothing
+    goElements (x:xs) = case (f x, goElements xs) of
+      (Nothing, Nothing) -> Nothing
+      (x1, xs1) -> Just (fromMaybe x x1 : fromMaybe xs xs1)
 
 -- | Substitute within a case-alternative
 substAlt

--- a/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Specialize.hs
@@ -75,8 +75,8 @@ import Clash.Core.TysPrim
 import Clash.Core.Util (listToLets)
 import Clash.Core.Var (Var(..), Id, TyVar, mkTyVar)
 import Clash.Core.VarEnv
-  ( InScopeSet, extendInScopeSet, extendInScopeSetList, lookupVarEnv
-  , mkInScopeSet, mkVarSet, unionInScope, elemVarSet)
+  ( InScopeSet, emptyVarEnv, extendInScopeSet, extendInScopeSetList
+  , lookupVarEnv, mkInScopeSet, mkVarSet, unionInScope, unitVarEnv, elemVarSet)
 import qualified Clash.Data.UniqMap as UniqMap
 import Clash.Debug (traceIf, traceM)
 import Clash.Driver.Types (Binding(..), TransformationInfo(..), hasTransformationInfo)
@@ -203,8 +203,14 @@ appProp ctx@(TransformContext is _) = \case
     bndrs <- Lens.use bindings
     orM [pure (isVar arg), isWorkFree workFreeBinders bndrs arg] >>= \case
       True ->
-        let subst = extendIdSubst (mkSubst is0) v arg in
-        (`mkTicks` ticks) <$> go is0 (substTm "appProp.AppLam" subst e) args []
+        -- 'e' is deshadowed w.r.t. an in-scope set that contains the free
+        -- variables of 'arg': 'appProp' deshadows the function expression
+        -- w.r.t. 'is0' up front, and 'go' re-deshadows whenever it extends the
+        -- in-scope set. So no binder in 'e' shadows 'v' — the binder of the
+        -- enclosing lambda -- nor captures a free variable of 'arg', which is
+        -- exactly the precondition of 'unsafeSubstTm'.
+        (`mkTicks` ticks)
+          <$> go is0 (unsafeSubstTm emptyVarEnv (unitVarEnv v arg) e) args []
       False ->
         let is1 = extendInScopeSet is0 v in
         Let (NonRec v arg) <$> go is1 (deShadowTerm is1 e) args ticks

--- a/clash-lib/tests/Clash/Tests/Core/Subst.hs
+++ b/clash-lib/tests/Clash/Tests/Core/Subst.hs
@@ -12,12 +12,12 @@ import           SrcLoc                  (noSrcSpan)
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
-import           Clash.Core.Name         (Name(..), NameSort(..))
-import           Clash.Core.Term         (Term(Var))
+import           Clash.Core.Name         (Name(..), NameSort(..), OccName)
+import           Clash.Core.Term         (Bind(..), Pat(..), Term(..))
 import           Clash.Core.Type         (ConstTy(..), Type(ConstTy))
 import           Clash.Core.Subst
 import           Clash.Core.VarEnv
-import           Clash.Core.Var          (IdScope(..), Var(..))
+import           Clash.Core.Var          (Id, IdScope(..), Var(..))
 import           Clash.Unique            (Unique)
 
 fakeName :: Name a
@@ -32,16 +32,42 @@ fakeName =
 unique :: Unique
 unique = 20
 
-termVar :: Var Term
-termVar = Id {
-    varName = fakeName {nameUniq=unique, nameOcc="term"}
-  , varUniq = unique
+mkTestId :: IdScope -> OccName -> Unique -> Id
+mkTestId scope occ uniq = Id {
+    varName = fakeName {nameUniq=uniq, nameOcc=occ}
+  , varUniq = uniq
   , varType = ConstTy (TyCon fakeName)
-  , idScope = LocalId
+  , idScope = scope
   }
+
+termVar :: Var Term
+termVar = mkTestId LocalId "term" unique
 
 term1 :: Term
 term1 = Var termVar
+
+fakeType :: Type
+fakeType = ConstTy (TyCon fakeName)
+
+localX, localY, localZ, localW, globalG :: Id
+localX = mkTestId LocalId "x" 21
+localY = mkTestId LocalId "y" 22
+localZ = mkTestId LocalId "z" 23
+localW = mkTestId LocalId "w" 24
+globalG = mkTestId GlobalId "g" 25
+
+-- | The term substituted for 'localX' in the 'unsafeSubstTm' tests
+payload :: Term
+payload = Var localY
+
+-- | Deshadowed w.r.t. an in-scope set holding 'localX' and 'localY', so it
+-- satisfies 'unsafeSubstTm's precondition for substituting 'localX'
+deshadowedTerm :: Term
+deshadowedTerm =
+  Lam localZ
+    (Let (NonRec localW (Var localX))
+      (Case (Var localW) fakeType
+        [(DefaultPat, App (Var localX) (Var localZ))]))
 
 tests :: TestTree
 tests =
@@ -49,4 +75,32 @@ tests =
     "Clash.Tests.Core.Subst"
     [ testCase "deShadow type/term" $
         term1 @=? deShadowTerm (extendInScopeSet emptyInScopeSet termVar) term1
+
+    , testCase "unsafeSubstTm substitutes a local variable" $
+        App payload (Var localZ) @=?
+          unsafeSubstTm emptyVarEnv (unitVarEnv localX payload)
+            (App (Var localX) (Var localZ))
+
+    , testCase "unsafeSubstTm leaves unmatched variables alone" $
+        Var localZ @=?
+          unsafeSubstTm emptyVarEnv (unitVarEnv localX payload) (Var localZ)
+
+    , testCase "unsafeSubstTm looks globals up in the global substitution" $ do
+        payload @=? unsafeSubstTm (unitVarEnv globalG payload) emptyVarEnv
+                      (Var globalG)
+        -- A global is never looked up in the local substitution, nor the other
+        -- way around
+        Var globalG @=? unsafeSubstTm emptyVarEnv (unitVarEnv globalG payload)
+                          (Var globalG)
+        Var localX @=? unsafeSubstTm (unitVarEnv localX payload) emptyVarEnv
+                         (Var localX)
+
+    , testCase "unsafeSubstTm agrees with substTm on a deshadowed term" $
+        let
+          is = extendInScopeSetList emptyInScopeSet [localX, localY]
+          subst = extendIdSubst (mkSubst is) localX payload
+        in
+          substTm "unsafeSubstTm test" subst deshadowedTerm @=?
+            unsafeSubstTm emptyVarEnv (unitVarEnv localX payload)
+              deshadowedTerm
     ]


### PR DESCRIPTION
`appProp` used `substTm` on already deshadowed terms, leading to unneeded work. This patch introduces `unsafeSubstTm` for exactly those situations.

Also see discussion in #3333.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
