### PR TITLE
pack/unpack no longer instantiate any HDL logic. 

### DIFF
--- a/changelog/2026-07-31T14_00_00+02_00_generic_unpack_undefined
+++ b/changelog/2026-07-31T14_00_00+02_00_generic_unpack_undefined
@@ -1,0 +1,4 @@
+CHANGED: The `Generic` default implementation of `unpack` now returns an
+undefined value for bit patterns that do not encode a value of the target
+type, instead of silently decoding them to one of the constructors. See
+[#3146](https://github.com/clash-lang/clash-compiler/issues/3146).

--- a/changelog/2026-07-31T16_00_00+02_00_generic_bitpack_no_hdl_logic
+++ b/changelog/2026-07-31T16_00_00+02_00_generic_bitpack_no_hdl_logic
@@ -1,0 +1,4 @@
+CHANGED: The `Generic` default implementations of `pack`, `unpack`, and
+`maybeUnpack` no longer instantiate conversion logic in HDL: they are now
+rendered as the identity on the bit representation. Only the validity bit of
+`maybeUnpack` is still instantiated. See [#3146](https://github.com/clash-lang/clash-compiler/issues/3146).

--- a/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/Evaluator/Primitive.hs
@@ -123,7 +123,6 @@ import Clash.XException (isX)
 
 import {-# SOURCE #-} Clash.GHC.Evaluator
 
-import qualified Clash.Annotations.BitRepresentation.Deriving
 import qualified Clash.Class.BitPack.Internal
 import qualified Clash.Class.Exp
 import qualified Clash.Promoted.Nat
@@ -3508,7 +3507,7 @@ ghcPrimStep tcm isSubj pInfo tys args mach = case primName pInfo of
            [wordDc] = tyConDataCons wordTc
        in  reduce (mkApps (Data wordDc) [Left (Literal (WordLiteral (toInteger b)))])
 
-  $(namePat 'Clash.Annotations.BitRepresentation.Deriving.dontApplyInHDL)
+  $(namePat 'Clash.Class.BitPack.Internal.dontApplyInHDL)
     | isSubj
     , f : a : _ <- args
     -> reduceWHNF (mkApps (valToTerm f) [Left (valToTerm a)])

--- a/clash-lib/prims/common/Clash_Annotations_BitRepresentation_Deriving.primitives.yaml
+++ b/clash-lib/prims/common/Clash_Annotations_BitRepresentation_Deriving.primitives.yaml
@@ -1,7 +1,0 @@
-- BlackBox:
-    name: Clash.Annotations.BitRepresentation.Deriving.dontApplyInHDL
-    kind: Expression
-    type: 'dontApplyInHDL
-      :: (a -> b) -> a -> b'
-    template: ~ARG[1]
-    workInfo: Never

--- a/clash-lib/prims/common/Clash_Class_BitPack.primitives.yaml
+++ b/clash-lib/prims/common/Clash_Class_BitPack.primitives.yaml
@@ -32,3 +32,10 @@
     type: 'xToBV :: KnownNat n => BitVector n -> BitVector n'
     template: ~ARG[1]
     workInfo: Never
+- BlackBox:
+    name: Clash.Class.BitPack.Internal.dontApplyInHDL
+    kind: Expression
+    type: 'dontApplyInHDL
+      :: (a -> b) -> a -> b'
+    template: ~FROMBV[~TOBV[~VAR[v][1]][~TYP[1]]][~TYPO]
+    workInfo: Never

--- a/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Letrec.hs
@@ -39,7 +39,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Extra as Text
 import GHC.Stack (HasCallStack)
 
-import Clash.Annotations.BitRepresentation.Deriving (dontApplyInHDL)
+import Clash.Class.BitPack.Internal (dontApplyInHDL)
 import Clash.Sized.Vector as Vec (Vec(Cons), splitAt)
 
 import Clash.Annotations.Primitive (extractPrim)

--- a/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/clash-prelude/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -57,9 +57,9 @@ import Clash.Annotations.BitRepresentation.Util
 import qualified Clash.Annotations.BitRepresentation.Util
   as Util
 
-import           Clash.Annotations.Primitive  (hasBlackBox)
 import           Clash.Class.BitPack
   (BitPack, BitSize, pack, packXWith, unpack, maybeUnpack)
+import           Clash.Class.BitPack.Internal (dontApplyInHDL)
 import           Clash.Class.Resize           (resize)
 import           Language.Haskell.TH.Compat   (mkTySynInstD)
 import           Clash.Sized.BitVector        (BitVector, low, (++#))
@@ -906,15 +906,6 @@ buildPack dataRepr@(DataReprAnn _name _size constrs) = do
   let func        = FunD 'pack [Clause [VarP argNameIn] (NormalB packApplied) []]
   return [func]
 
-
--- | In Haskell apply the first argument to the second argument,
---   in HDL just return the second argument.
---
--- This is used in the generated pack/unpack to not do anything in HDL.
-dontApplyInHDL :: (a -> b) -> a -> b
-dontApplyInHDL f a = f a
-{-# OPAQUE dontApplyInHDL #-}
-{-# ANN dontApplyInHDL hasBlackBox #-}
 
 buildUnpackField
   :: Name

--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -54,6 +54,7 @@ import Clash.Promoted.Nat             (SNat(..), snatToNum)
 import Clash.Sized.Internal.BitVector
   (pack#, split#, checkUnpackUndef, undefined#, unpack#, unsafeToNatural, isLike#,
    BitVector, Bit, (++#), xToBV)
+import Clash.XException              (errorX)
 
 {- $setup
 >>> :m -Prelude
@@ -142,9 +143,11 @@ class KnownNat (BitSize a) => BitPack a where
 
   -- | Convert a 'BitVector' to an element of type @a@
   --
-  -- When the bit pattern is not the representation of any value of type @a@,
-  -- @unpack@ can return an invalid value, or some value @y@ where @'pack' y@
-  -- is not equal to the input. Use 'maybeUnpack' to detect such bit patterns.
+  -- If the bit pattern is not the representation of any value of type @a@,
+  -- i.e. there is no @x@ such that @bv == 'pack' x@, then @unpack bv@ is
+  -- undefined: an unused constructor encoding returns a fully undefined
+  -- value, while an invalid field encoding returns a value whose affected
+  -- fields are undefined. Use 'maybeUnpack' to detect such bit patterns.
   --
   -- >>> pack (-5 :: Signed 6)
   -- 0b11_1011
@@ -165,7 +168,7 @@ class KnownNat (BitSize a) => BitPack a where
        )
     => BitVector (BitSize a) -> a
   unpack b =
-    to (gUnpack sc 0 bFields)
+    to (snd (gUnpack True sc 0 bFields))
    where
     (checkUnpackUndef unpack . resize -> sc, bFields) = split# b
 
@@ -174,8 +177,8 @@ class KnownNat (BitSize a) => BitPack a where
   --
   -- Not every bit pattern is necessarily the representation of a value of type
   -- @a@. If there is no @x@ such that @bv == 'pack' x@, then @maybeUnpack bv@
-  -- returns @Nothing@. Conversely, 'unpack' @bv@ would return an invalid value,
-  -- or some value @y@ where @'pack' y@ is not equal to @bv@.
+  -- returns @Nothing@. Conversely, 'unpack' @bv@ would return an undefined
+  -- value.
   --
   -- >>> pack (maxBound :: Index 13)
   -- 0b1100
@@ -218,7 +221,9 @@ class KnownNat (BitSize a) => BitPack a where
        , (constrSize + fieldSize) ~ BitSize a
        )
     => BitVector (BitSize a) -> Maybe a
-  maybeUnpack b = to <$> gMaybeUnpack True sc 0 bFields
+  maybeUnpack b =
+    let (valid, x) = gUnpack True sc 0 bFields in
+    if valid then Just (to x) else Nothing
    where
     (checkUnpackUndef unpack . resize -> sc, bFields) = split# b
 
@@ -574,19 +579,12 @@ class GBitPack f where
     -> (Int, BitVector (GFieldSize f))
     -- ^ (Constructor number, Packed fields)
 
-  -- | Unpack whole type.
+  -- | Unpack whole type. Reports whether the bit pattern encodes a value of
+  -- the type, alongside the value itself. Wherever the bit pattern does not
+  -- encode a value, the returned value is undefined in the affected parts.
+  -- Both 'unpack' and 'maybeUnpack' are implemented in terms of this
+  -- function.
   gUnpack
-    :: Int
-    -- ^ Construct with constructor /n/
-    -> Int
-    -- ^ Current constructor
-    -> BitVector (GFieldSize f)
-    -- ^ BitVector containing fields
-    -> f a
-    -- ^ Unpacked result
-
-  -- | Attempt to unpack whole type.
-  gMaybeUnpack
     :: Bool
     -- ^ Check whether the constructor is in range. This should only be 'True'
     -- for the root of a generic representation.
@@ -596,17 +594,16 @@ class GBitPack f where
     -- ^ Current constructor
     -> BitVector (GFieldSize f)
     -- ^ BitVector containing fields
-    -> Maybe (f a)
-    -- ^ Possibly unpacked result
+    -> (Bool, f a)
+    -- ^ (Bit pattern encodes a value, unpacked result)
 
 instance GBitPack a => GBitPack (M1 m d a) where
   type GFieldSize (M1 m d a) = GFieldSize a
   type GConstructorCount (M1 m d a) = GConstructorCount a
 
   gPackFields cc (M1 m1) = gPackFields cc m1
-  gUnpack c cc b = M1 (gUnpack c cc b)
-  gMaybeUnpack checkBounds c cc b =
-    M1 <$> gMaybeUnpack checkBounds c cc b
+  gUnpack checkBounds c cc b =
+    let (valid, x) = gUnpack checkBounds c cc b in (valid, M1 x)
 
 instance ( KnownNat (GFieldSize g)
          , KnownNat (GFieldSize f)
@@ -628,28 +625,16 @@ instance ( KnownNat (GFieldSize g)
     let padding = undefined# :: BitVector (Max (GFieldSize f) (GFieldSize g) - GFieldSize g) in
     (sc, packed ++# padding)
 
-  gUnpack c cc b =
-    let cLeft = snatToNum (SNat @(GConstructorCount f)) in
-    if c < cc + cLeft then
-      L1 (gUnpack c cc f)
-    else
-      R1 (gUnpack c (cc + cLeft) g)
-
-   where
-    -- It's a thing of beauty, if I may say so myself!
-    (f, _ :: BitVector (Max (GFieldSize f) (GFieldSize g) - GFieldSize f)) = split# b
-    (g, _ :: BitVector (Max (GFieldSize f) (GFieldSize g) - GFieldSize g)) = split# b
-
-  gMaybeUnpack checkBounds c cc b =
+  gUnpack checkBounds c cc b =
     let
       cLeft = snatToNum (SNat @(GConstructorCount f))
       cTotal = snatToNum (SNat @(GConstructorCount (f :+: g)))
     in
     if not checkBounds || c < cc + cTotal
       then if c < cc + cLeft
-        then L1 <$> gMaybeUnpack False c cc f
-        else R1 <$> gMaybeUnpack False c (cc + cLeft) g
-      else Nothing
+        then let (valid, l) = gUnpack False c cc f in (valid, L1 l)
+        else let (valid, r) = gUnpack False c (cc + cLeft) g in (valid, R1 r)
+      else (False, errorX "unpack: bit pattern does not encode a value of the target type")
    where
     (f, _ :: BitVector (Max (GFieldSize f) (GFieldSize g) - GFieldSize f)) = split# b
     (g, _ :: BitVector (Max (GFieldSize f) (GFieldSize g) - GFieldSize g)) = split# b
@@ -666,33 +651,32 @@ instance (KnownNat (GFieldSize g), KnownNat (GFieldSize f), GBitPack f, GBitPack
       let (_, r1) = gPackFields cc r0 in
       l1 ++# r1
 
-  gUnpack c cc b =
-    gUnpack c cc front :*: gUnpack c cc back
+  gUnpack checkBounds c cc b =
+    let
+      (frontValid, front1) = gUnpack checkBounds c cc front0
+      (backValid, back1) = gUnpack checkBounds c cc back0
+    in
+    (frontValid && backValid, front1 :*: back1)
    where
-    (front, back) = split# b
-
-  gMaybeUnpack checkBounds c cc b =
-    (:*:)
-      <$> gMaybeUnpack checkBounds c cc front
-      <*> gMaybeUnpack checkBounds c cc back
-   where
-    (front, back) = split# b
+    (front0, back0) = split# b
 
 instance BitPack c => GBitPack (K1 i c) where
   type GFieldSize (K1 i c) = BitSize c
   type GConstructorCount (K1 i c)  = 1
 
   gPackFields cc (K1 i) = (cc, pack i)
-  gUnpack _c _cc b      = K1 (unpack b)
-  gMaybeUnpack _checkBounds _c _cc b = K1 <$> maybeUnpack b
+  gUnpack _checkBounds _c _cc b =
+    case maybeUnpack b of
+      Just x -> (True, K1 x)
+      Nothing ->
+        (False, K1 (errorX "unpack: bit pattern does not encode a value of the target type"))
 
 instance GBitPack U1 where
   type GFieldSize U1 = 0
   type GConstructorCount U1 = 1
 
   gPackFields cc U1 = (cc, 0)
-  gUnpack _c _cc _b = U1
-  gMaybeUnpack _checkBounds _c _cc _b = Just U1
+  gUnpack _checkBounds _c _cc _b = (True, U1)
 
 -- Instances derived using Generic
 instance BitPack Ordering

--- a/clash-prelude/src/Clash/Class/BitPack/Internal.hs
+++ b/clash-prelude/src/Clash/Class/BitPack/Internal.hs
@@ -50,7 +50,7 @@ import Numeric.Half                   (Half (..))
 import Clash.Annotations.Primitive    (hasBlackBox)
 import Clash.Class.BitPack.Internal.TH (deriveBitPackTuples)
 import Clash.Class.Resize             (zeroExtend, resize)
-import Clash.Promoted.Nat             (SNat(..), snatToNum)
+import Clash.Promoted.Nat             (SNat(..), SNatLE(..), compareSNat, snatToNum)
 import Clash.Sized.Internal.BitVector
   (pack#, split#, checkUnpackUndef, undefined#, unpack#, unsafeToNatural, isLike#,
    BitVector, Bit, (++#), xToBV)
@@ -135,7 +135,11 @@ class KnownNat (BitSize a) => BitPack a where
        , (constrSize + fieldSize) ~ BitSize a
        )
     => a -> BitVector (BitSize a)
-  pack = packXWith go
+  pack v = case compareSNat (SNat @(BitSize a)) (SNat @0) of
+    -- Zero-width primitives cannot be rendered; there is nothing to convert
+    -- anyway. The case is resolved at compile time.
+    SNatLE -> packXWith go v
+    SNatGT -> dontApplyInHDL (packXWith go) v
    where
     go a = resize (pack sc) ++# packedFields
      where
@@ -167,10 +171,13 @@ class KnownNat (BitSize a) => BitPack a where
        , (constrSize + fieldSize) ~ BitSize a
        )
     => BitVector (BitSize a) -> a
-  unpack b =
-    to (snd (gUnpack True sc 0 bFields))
+  unpack b = case compareSNat (SNat @(BitSize a)) (SNat @0) of
+    -- Zero-width primitives cannot be rendered; there is nothing to convert
+    -- anyway. The case is resolved at compile time.
+    SNatLE -> x
+    SNatGT -> dontApplyInHDL (const x) b
    where
-    (checkUnpackUndef unpack . resize -> sc, bFields) = split# b
+    (_, x) = unpackGeneric b :: (Bool, a)
 
   -- | Attempt to convert a 'BitVector' to an element of type @a@. If the unpacking
   -- is successful, outputs @Just a@, otherwise outputs @Nothing@.
@@ -222,10 +229,14 @@ class KnownNat (BitSize a) => BitPack a where
        )
     => BitVector (BitSize a) -> Maybe a
   maybeUnpack b =
-    let (valid, x) = gUnpack True sc 0 bFields in
-    if valid then Just (to x) else Nothing
+    if valid then Just payload else Nothing
    where
-    (checkUnpackUndef unpack . resize -> sc, bFields) = split# b
+    (valid, x) = unpackGeneric b :: (Bool, a)
+    -- Zero-width primitives cannot be rendered; there is nothing to convert
+    -- anyway. The case is resolved at compile time.
+    payload = case compareSNat (SNat @(BitSize a)) (SNat @0) of
+      SNatLE -> x
+      SNatGT -> dontApplyInHDL (const x) b
 
 packXWith
   :: KnownNat n
@@ -234,6 +245,42 @@ packXWith
   -> BitVector n
 packXWith f = xToBV . f
 {-# INLINE packXWith #-}
+
+-- | In Haskell, apply the first argument to the second argument. In HDL,
+-- convert the second argument to the result type directly instead -- a no-op
+-- in hardware. This is sound because a lawful 'BitPack' instance accurately
+-- reflects the bit representation of the data in HDL, and converting a bit
+-- pattern that does not encode a value is undefined, which the
+-- passed-through bits refine.
+--
+-- This is used by the generated pack/unpack of custom bit representations,
+-- and by the 'Generic' default implementations of 'pack', 'unpack', and
+-- 'maybeUnpack', to not instantiate any conversion logic in HDL.
+dontApplyInHDL :: (a -> b) -> a -> b
+dontApplyInHDL f a = f a
+{-# OPAQUE dontApplyInHDL #-}
+{-# ANN dontApplyInHDL hasBlackBox #-}
+
+-- | Generic implementation of 'unpack': reports whether the bit pattern
+-- encodes a value of the type, alongside the unpacked value. Wherever the
+-- bit pattern does not encode a value, the returned value is undefined in
+-- the affected parts.
+unpackGeneric
+  :: ( Generic a
+     , GBitPack (Rep a)
+     , KnownNat (BitSize a)
+     , KnownNat constrSize
+     , KnownNat fieldSize
+     , constrSize ~ CLog 2 (GConstructorCount (Rep a))
+     , fieldSize ~ GFieldSize (Rep a)
+     , (constrSize + fieldSize) ~ BitSize a
+     )
+  => BitVector (BitSize a)
+  -> (Bool, a)
+unpackGeneric b =
+  let (valid, x) = gUnpack True sc 0 bFields in (valid, to x)
+ where
+  (checkUnpackUndef unpack . resize -> sc, bFields) = split# b
 
 -- | Pack both arguments to a 'BitVector' and use
 -- 'Clash.Sized.Internal.BitVector.isLike#' to compare them. This is a more

--- a/clash-prelude/tests/Clash/Tests/BitPack.hs
+++ b/clash-prelude/tests/Clash/Tests/BitPack.hs
@@ -10,6 +10,7 @@ module Clash.Tests.BitPack where
 
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Tasty.HUnit.Extra (expectXException)
 
 import Clash.Class.BitPack
 import Clash.Sized.BitVector
@@ -194,6 +195,12 @@ maybeUnpackTuple4All =
     :> Nothing
     :> Nil )
 
+unpackBigSumInvalid :: Assertion
+unpackBigSumInvalid = expectXException (unpack @BigSum 0b101)
+
+unpackWrappedIndexInvalid :: Assertion
+unpackWrappedIndexInvalid = expectXException (unpack @WrappedIndex 0b11)
+
 packTuple4Layout :: Assertion
 packTuple4Layout =
   pack ((0, 1, 2, 0) :: (Index 3, Index 3, Index 3, Index 3))
@@ -241,6 +248,11 @@ tests =
         , testCase "Generic propagation only rejects wrapped invalid Index fields" maybeUnpackWrappedIndexAll
         , testCase "Tuples reject an invalid field at every position" maybeUnpackTuple4All
         , testCase "Balanced tuple packing preserves field order" packTuple4Layout
+        ]
+    , testGroup
+        "unpack"
+        [ testCase "Generic sums are undefined for unused constructor tags" unpackBigSumInvalid
+        , testCase "Generic types are undefined for invalid fields" unpackWrappedIndexInvalid
         ]
     , testCase "undefSpineVec" undefSpineVec
     , testCase "undefSpineRTree" undefSpineRTree


### PR DESCRIPTION
Based of https://github.com/clash-lang/clash-compiler/pull/3177

This PR essentially make `pack` and `unpack` id in HDL. From experiments synthesizer were not able to eliminate the logic for `pack` and `unpack` which is a footgun in scenarios where you really want it to be logic less. This is not a free change since now we need to enforce that user written `BitPack` instances are illegal, unless they match bit packing of the compiler one to one.

TODOs:

- [ ] Make documentation even more explicit that `BitPack` is not to be manually implemented.
- [ ] Investigate if it's possible to make user written instances impossible. Or at the very least very clear that it's highly unsafe to write custom instances.

This fixes https://github.com/clash-lang/clash-compiler/issues/3146

