### PR TITLE
Set default timeout for `clash-testsuite` to 5min

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -146,8 +146,15 @@ workaroundMmapCrash = flakyTestWithRetryAction retryAction retryPolicy
   retryPolicy :: RetryPolicyM IO
   retryPolicy = limitRetries 5
 
+-- | Default timeout applied to each test, unless the user explicitly set one
+-- with @--timeout@ or @TASTY_TIMEOUT@.
+defaultTimeout :: Timeout -> Timeout
+defaultTimeout NoTimeout = mkTimeout (5 * 60 * 1000000) -- 5 minutes
+defaultTimeout userSet = userSet
+
 runClashTest :: IO ()
 runClashTest = defaultMain
+  $ adjustOption defaultTimeout
   $ workaroundMmapCrash
   $ clashTestRoot
   [ clashTestGroup "examples"


### PR DESCRIPTION
Slowest test on my 6-year-old CPU takes 90 seconds, so a 5 minute timeout seems reasonable.

While hacking on the compiler I've had a few times where tests would get stuck and I would only realize after waaay to long..

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~
