### PR TITLE
Fix hardcoded variable names in blackboxes

### DIFF
--- a/changelog/2026-08-06T16_04_56+02_00_fix_3273_hardcoded_names_in_blackboxes
+++ b/changelog/2026-08-06T16_04_56+02_00_fix_3273_hardcoded_names_in_blackboxes
@@ -1,0 +1,1 @@
+FIXED: Built-in  blackboxes no longer generate name shadowing warnings. See [#3273](https://github.com/clash-lang/clash-compiler/issues/3273).

--- a/changelog/2026-08-06T16_04_56+02_00_fix_3273_hardcoded_names_in_blackboxes
+++ b/changelog/2026-08-06T16_04_56+02_00_fix_3273_hardcoded_names_in_blackboxes
@@ -1,0 +1,1 @@
+FIXED: The blackboxes no longer generate name shadowing warnings. See [#3273](https://github.com/clash-lang/clash-compiler/issues/3273).

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives.yaml
@@ -21,16 +21,16 @@
       ~GENSYM[~COMPNAME_blockRamFile][1] : block
         type ~GENSYM[RamType][7] is array(natural range <>) of bit_vector(~LIT[1]-1 downto 0);
 
-        impure function ~GENSYM[InitRamFromFile][2] (RamFileName : in string) return ~SYM[7] is
-          FILE RamFile : text open read_mode is RamFileName;
-          variable RamFileLine : line;
-          variable RAM : ~SYM[7](0 to ~LIT[5]-1);
+        impure function ~GENSYM[InitRamFromFile][2] (~SYM[RamFileName] : in string) return ~SYM[7] is
+          FILE ~SYM[RamFile] : text open read_mode is ~SYM[RamFileName];
+          variable ~SYM[RamFileLine] : line;
+          variable ~SYM[RAM_contents] : ~SYM[7](0 to ~LIT[5]-1);
         begin
-          for i in RAM'range loop
-            readline(RamFile,RamFileLine);
-            read(RamFileLine,RAM(i));
+          for ~SYM[i] in ~SYM[RAM_contents]'range loop
+            readline(~SYM[RamFile],~SYM[RamFileLine]);
+            read(~SYM[RamFileLine],~SYM[RAM_contents](~SYM[i]));
           end loop;
-          return RAM;
+          return ~SYM[RAM_contents];
         end function;
 
         signal ~GENSYM[RAM][3] : ~SYM[7](0 to ~LIT[5]-1) := ~SYM[2](~FILE[~LIT[6]]);

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives.yaml
@@ -16,22 +16,22 @@
       ~GENSYM[~COMPNAME_romFile][0] : block
         type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
 
-        impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is
-          FILE RomFile : text open read_mode is RomFileName;
-          variable RomFileLine : line;
-          variable ROM : ~SYM[4](0 to ~LIT[4]-1);
+        impure function ~GENSYM[InitRomFromFile][1] (~SYM[RomFileName] : in string) return ~SYM[4] is
+          FILE ~SYM[RomFile] : text open read_mode is ~SYM[RomFileName];
+          variable ~SYM[RomFileLine] : line;
+          variable ~SYM[ROM_contents] : ~SYM[4](0 to ~LIT[4]-1);
         begin
-          for i in ROM'range loop
-            readline(RomFile,RomFileLine);
-            read(RomFileLine,ROM(i));
+          for ~SYM[i] in ~SYM[ROM_contents]'range loop
+            readline(~SYM[RomFile],~SYM[RomFileLine]);
+            read(~SYM[RomFileLine],~SYM[ROM_contents](~SYM[i]));
           end loop;
-          return ROM;
+          return ~SYM[ROM_contents];
         end function;
 
         signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[4]-1) := ~SYM[1](~FILE[~LIT[5]]);
         signal ~GENSYM[rd][3] : integer range 0 to ~LIT[4]-1;
       begin
-        ~SYM[3] <=to_integer(~VAR[rdI][6](31 downto 0))
+        ~SYM[3] <= to_integer(~VAR[rdI][6](31 downto 0))
         -- pragma translate_off
                       mod ~LIT[4]
         -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives.yaml
@@ -16,22 +16,22 @@
       ~GENSYM[~COMPNAME_romFile][0] : block
         type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
 
-        impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is
-          FILE RomFile : text open read_mode is RomFileName;
-          variable RomFileLine : line;
-          variable ROM : ~SYM[4](0 to ~LIT[4]-1);
+        impure function ~GENSYM[InitRomFromFile][1] (~SYM[RomFileName] : in string) return ~SYM[4] is
+          FILE ~SYM[RomFile] : text open read_mode is ~SYM[RomFileName];
+          variable ~SYM[RomFileLine] : line;
+          variable ~SYM[ROM_contents] : ~SYM[4](0 to ~LIT[4]-1);
         begin
-          for i in ROM'range loop
-            readline(RomFile,RomFileLine);
-            read(RomFileLine,ROM(i));
+          for i in ~SYM[ROM_contents]'range loop
+            readline(~SYM[RomFile],~SYM[RomFileLine]);
+            read(~SYM[RomFileLine],~SYM[ROM_contents](i));
           end loop;
-          return ROM;
+          return ~SYM[ROM_contents];
         end function;
 
         signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[4]-1) := ~SYM[1](~FILE[~LIT[5]]);
         signal ~GENSYM[rd][3] : integer range 0 to ~LIT[4]-1;
       begin
-        ~SYM[3] <=to_integer(~VAR[rdI][6](31 downto 0))
+        ~SYM[3] <= to_integer(~VAR[rdI][6](31 downto 0))
         -- pragma translate_off
                       mod ~LIT[4]
         -- pragma translate_on

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.primitives.yaml
@@ -12,16 +12,16 @@
       ~GENSYM[asyncROMFile][0] : block
         type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
 
-        impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is
-          FILE RomFile : text open read_mode is RomFileName;
-          variable RomFileLine : line;
-          variable ROM : ~SYM[4](0 to ~LIT[1]-1);
+        impure function ~GENSYM[InitRomFromFile][1] (~SYM[RomFileName] : in string) return ~SYM[4] is
+          FILE ~SYM[RomFile] : text open read_mode is ~SYM[RomFileName];
+          variable ~SYM[RomFileLine] : line;
+          variable ~SYM[ROM_contents] : ~SYM[4](0 to ~LIT[1]-1);
         begin
-          for i in ROM'range loop
-            readline(RomFile,RomFileLine);
-            read(RomFileLine,ROM(i));
+          for i in ~SYM[ROM_contents]'range loop
+            readline(~SYM[RomFile],~SYM[RomFileLine]);
+            read(~SYM[RomFileLine],~SYM[ROM_contents](i));
           end loop;
-          return ROM;
+          return ~SYM[ROM_contents];
         end function;
 
         signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[1]-1) := ~SYM[1](~FILE[~LIT[2]]);

--- a/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Prelude_ROM_File.primitives.yaml
@@ -12,16 +12,16 @@
       ~GENSYM[asyncROMFile][0] : block
         type ~GENSYM[RomType][4] is array(natural range <>) of bit_vector(~LIT[0]-1 downto 0);
 
-        impure function ~GENSYM[InitRomFromFile][1] (RomFileName : in string) return ~SYM[4] is
-          FILE RomFile : text open read_mode is RomFileName;
-          variable RomFileLine : line;
-          variable ROM : ~SYM[4](0 to ~LIT[1]-1);
+        impure function ~GENSYM[InitRomFromFile][1] (~SYM[RomFileName] : in string) return ~SYM[4] is
+          FILE ~SYM[RomFile] : text open read_mode is ~SYM[RomFileName];
+          variable ~SYM[RomFileLine] : line;
+          variable ~SYM[ROM_contents] : ~SYM[4](0 to ~LIT[1]-1);
         begin
-          for i in ROM'range loop
-            readline(RomFile,RomFileLine);
-            read(RomFileLine,ROM(i));
+          for ~SYM[i] in ~SYM[ROM_contents]'range loop
+            readline(~SYM[RomFile],~SYM[RomFileLine]);
+            read(~SYM[RomFileLine],~SYM[ROM_contents](~SYM[i]));
           end loop;
-          return ROM;
+          return ~SYM[ROM_contents];
         end function;
 
         signal ~GENSYM[ROM][2] : ~SYM[4](0 to ~LIT[1]-1) := ~SYM[1](~FILE[~LIT[2]]);

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives.yaml
@@ -118,32 +118,32 @@
     type: 'reduceAnd# :: KnownNat
       n => BitVector n -> Bit'
     template: |-
-      -- reduceAnd begin,
+      -- reduceAnd begin
       ~IF~SIZE[~TYP[1]]~THEN
-      ~GENSYM[reduceAnd][0] : block
-        function and_reduce (arg : std_logic_vector) return std_logic is
-          variable upper, lower : std_logic;
-          variable half         : integer;
-          variable argi         : std_logic_vector (arg'length - 1 downto 0);
-          variable result       : std_logic;
+      ~SYM[reduceAnd] : block
+        function ~SYM[and_reduce] (~SYM[arg] : std_logic_vector) return std_logic is
+          variable ~SYM[upper], ~SYM[lower] : std_logic;
+          variable ~SYM[half]         : integer;
+          variable ~SYM[argi]         : std_logic_vector (~SYM[arg]'length - 1 downto 0);
+          variable ~SYM[result]       : std_logic;
         begin
-          if (arg'length < 1) then
-            result := '1';
+          if (~SYM[arg]'length < 1) then
+            ~SYM[result] := '1';
           else
-            argi := arg;
-            if (argi'length = 1) then
-              result := argi(argi'left);
+            ~SYM[argi] := ~SYM[arg];
+            if (~SYM[argi]'length = 1) then
+              ~SYM[result] := ~SYM[argi](~SYM[argi]'left);
             else
-              half   := (argi'length + 1) / 2; -- lsb-biased tree
-              upper  := and_reduce (argi (argi'left downto half));
-              lower  := and_reduce (argi (half - 1 downto argi'right));
-              result := upper and lower;
+              ~SYM[half]   := (~SYM[argi]'length + 1) / 2; -- lsb-biased tree
+              ~SYM[upper]  := ~SYM[and_reduce] (~SYM[argi] (~SYM[argi]'left downto ~SYM[half]));
+              ~SYM[lower]  := ~SYM[and_reduce] (~SYM[argi] (~SYM[half] - 1 downto ~SYM[argi]'right));
+              ~SYM[result] := ~SYM[upper] and ~SYM[lower];
             end if;
           end if;
-          return result;
+          return ~SYM[result];
         end;
       begin
-        ~RESULT <= and_reduce(~ARG[1]);
+        ~RESULT <= ~SYM[and_reduce](~ARG[1]);
       end block;~ELSE
       ~RESULT <= '1';~FI
       -- reduceAnd end
@@ -155,29 +155,29 @@
     template: |-
       -- reduceOr begin ~IF~SIZE[~TYP[1]]~THEN
       ~GENSYM[reduceOr][0] : block
-        function or_reduce (arg : std_logic_vector) return std_logic is
-          variable upper, lower : std_logic;
-          variable half         : integer;
-          variable argi         : std_logic_vector (arg'length - 1 downto 0);
-          variable result       : std_logic;
+        function ~SYM[or_reduce] (~SYM[arg] : std_logic_vector) return std_logic is
+          variable ~SYM[upper], ~SYM[lower] : std_logic;
+          variable ~SYM[half]         : integer;
+          variable ~SYM[argi]         : std_logic_vector (~SYM[arg]'length - 1 downto 0);
+          variable ~SYM[result]       : std_logic;
         begin
-          if (arg'length < 1) then
-            result := '0';
+          if (~SYM[arg]'length < 1) then
+            ~SYM[result] := '0';
           else
-            argi := arg;
-            if (argi'length = 1) then
-              result := argi(argi'left);
+            ~SYM[argi] := ~SYM[arg];
+            if (~SYM[argi]'length = 1) then
+              ~SYM[result] := ~SYM[argi](~SYM[argi]'left);
             else
-              half   := (argi'length + 1) / 2; -- lsb-biased tree
-              upper  := or_reduce (argi (argi'left downto half));
-              lower  := or_reduce (argi (half - 1 downto argi'right));
-              result := upper or lower;
+              ~SYM[half]   := (~SYM[argi]'length + 1) / 2; -- lsb-biased tree
+              ~SYM[upper]  := ~SYM[or_reduce] (~SYM[argi] (~SYM[argi]'left downto ~SYM[half]));
+              ~SYM[lower]  := ~SYM[or_reduce] (~SYM[argi] (~SYM[half] - 1 downto ~SYM[argi]'right));
+              ~SYM[result] := ~SYM[upper] or ~SYM[lower];
             end if;
           end if;
-          return result;
+          return ~SYM[result];
         end;
       begin
-        ~RESULT <= or_reduce(~ARG[1]);
+        ~RESULT <= ~SYM[or_reduce](~ARG[1]);
       end block;~ELSE
       ~RESULT <= '0'; ~FI
       -- reduceOr end
@@ -189,29 +189,29 @@
     template: |-
       -- reduceXor begin ~IF~SIZE[~TYP[1]]~THEN
       ~GENSYM[reduceXor][0] : block
-        function xor_reduce (arg : std_logic_vector) return std_logic is
-          variable upper, lower : std_logic;
-          variable half         : integer;
-          variable argi         : std_logic_vector (arg'length - 1 downto 0);
-          variable result       : std_logic;
+        function ~SYM[xor_reduce] (~SYM[arg] : std_logic_vector) return std_logic is
+          variable ~SYM[upper], ~SYM[lower] : std_logic;
+          variable ~SYM[half]         : integer;
+          variable ~SYM[argi]         : std_logic_vector (~SYM[arg]'length - 1 downto 0);
+          variable ~SYM[result]       : std_logic;
         begin
-          if (arg'length < 1) then
-            result := '0';
+          if (~SYM[arg]'length < 1) then
+            ~SYM[result] := '0';
           else
-            argi := arg;
-            if (argi'length = 1) then
-              result := argi(argi'left);
+            ~SYM[argi] := ~SYM[arg];
+            if (~SYM[argi]'length = 1) then
+              ~SYM[result] := ~SYM[argi](~SYM[argi]'left);
             else
-              half   := (argi'length + 1) / 2; -- lsb-biased tree
-              upper  := xor_reduce (argi (argi'left downto half));
-              lower  := xor_reduce (argi (half - 1 downto argi'right));
-              result := upper xor lower;
+              ~SYM[half]   := (~SYM[argi]'length + 1) / 2; -- lsb-biased tree
+              ~SYM[upper]  := ~SYM[xor_reduce] (~SYM[argi] (~SYM[argi]'left downto ~SYM[half]));
+              ~SYM[lower]  := ~SYM[xor_reduce] (~SYM[argi] (~SYM[half] - 1 downto ~SYM[argi]'right));
+              ~SYM[result] := ~SYM[upper] xor ~SYM[lower];
             end if;
           end if;
-          return result;
+          return ~SYM[result];
         end;
       begin
-        ~RESULT <= xor_reduce(~ARG[1]);
+        ~RESULT <= ~SYM[xor_reduce](~ARG[1]);
       end block;~ELSE
       ~RESULT <= '0';~FI
       -- reduceXor end

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives.yaml
@@ -116,10 +116,10 @@
     template: |-
       -- imap begin
       ~GENSYM[imap][0] : block
-        function ~GENSYM[max][6] (l,r : in natural) return natural is
+        function ~GENSYM[max][6] (~SYM[l],~SYM[r] : in natural) return natural is
         begin
-          if l > r then return l;
-          else return r;
+          if ~SYM[l] > ~SYM[r] then return ~SYM[l];
+          else return ~SYM[r];
           end if;
         end function;
       begin
@@ -217,7 +217,7 @@
       begin
         ~SYM[2](~LENGTH[~TYP[2]]) <= ~ARG[1];
 
-        foldr_loop : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[2]] - 1) generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN
+        ~SYM[foldr_loop] : for ~GENSYM[i][3] in 0 to (~LENGTH[~TYP[2]] - 1) generate~IF ~VIVADO ~THEN~IF~SIZE[~TYP[2]]~THEN
           signal ~GENSYM[foldr_in][4] : ~TYPEL[~TYP[2]];~ELSE ~FI
         begin~IF~SIZE[~TYP[2]]~THEN
           ~SYM[4] <= fromSLV(~VAR[vec][2](~SYM[3]));~ELSE ~FI

--- a/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Vector.primitives.yaml
@@ -116,10 +116,10 @@
     template: |-
       -- imap begin
       ~GENSYM[imap][0] : block
-        function ~GENSYM[max][6] (l,r : in natural) return natural is
+        function ~GENSYM[max][6] (~SYM[l],~SYM[r] : in natural) return natural is
         begin
-          if l > r then return l;
-          else return r;
+          if ~SYM[l] > ~SYM[r] then return ~SYM[l];
+          else return ~SYM[r];
           end if;
         end function;
       begin

--- a/clash-lib/prims/vhdl/GHC_Prim.primitives.yaml
+++ b/clash-lib/prims/vhdl/GHC_Prim.primitives.yaml
@@ -361,9 +361,9 @@
       ~GENSYM[popCnt8][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := 8;
@@ -401,9 +401,9 @@
       ~GENSYM[popCnt16][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := 16;
@@ -441,9 +441,9 @@
       ~GENSYM[popCnt32][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := 32;
@@ -481,9 +481,9 @@
       ~GENSYM[popCnt64][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[f][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := 64;
@@ -521,9 +521,9 @@
       ~GENSYM[popCnt][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := ~SIZE[~TYPO];

--- a/clash-lib/prims/vhdl/GHC_Prim.primitives.yaml
+++ b/clash-lib/prims/vhdl/GHC_Prim.primitives.yaml
@@ -553,533 +553,653 @@
       -- popCnt end
 - BlackBox:
     name: GHC.Prim.clz8#
-    kind: Declaration
-    type: 'clz8 :: Word# ->
-      Word#'
-    template: |-
-      -- clz8 begin
-      ~GENSYM[clz8][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
+    kind: Expression
+    type: 'clz8 :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz8
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz8#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+          function clz8 (constant v : unsigned(0 to 7)) return unsigned;
+        end;
 
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
 
-        function ~GENSYM[clz8][3] (constant v : unsigned(0 to 7)) return unsigned is
-          variable e : unsigned(0 to 7);     -- 8
-          variable a : unsigned(0 to 2*3-1); -- 6
-        begin
-          for i in 0 to 3 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-          for i in 0 to 1 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-          return ~SYM[2](3,a(0 to 5));
-        end function;
-      begin
-        ~RESULT <= resize(~SYM[3](~VAR[][0](7 downto 0)),~SIZE[~TYPO]);
-      end block;
-      -- clz8 end
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+
+          function clz8 (constant v : unsigned(0 to 7)) return unsigned is
+            variable e : unsigned(0 to 7);     -- 8
+            variable a : unsigned(0 to 2*3-1); -- 6
+          begin
+            for i in 0 to 3 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
+            for i in 0 to 1 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
+            return clzi(3,a(0 to 5));
+          end function;
+        end;
+    template: resize(~INCLUDENAME[0].clz8(~VAR[][0](7 downto 0)),~SIZE[~TYPO])
 - BlackBox:
     name: GHC.Prim.clz16#
-    kind: Declaration
-    type: 'clz16 :: Word#
-      -> Word#'
-    template: |-
-      -- clz16 begin
-      ~GENSYM[clz16][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
+    kind: Expression
+    type: 'clz16 :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz16
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz16#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+          function clz16 (constant v : unsigned(0 to 15)) return unsigned;
+        end;
 
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
 
-        function ~GENSYM[clz16][3] (constant v : unsigned(0 to 15)) return unsigned is
-          variable e : unsigned(0 to 15);    -- 16
-          variable a : unsigned(0 to 4*3-1); -- 12
-          variable b : unsigned(0 to 2*4-1); -- 8
-        begin
-          for i in 0 to 7 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-          for i in 0 to 3 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-          for i in 0 to 1 loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-          return ~SYM[2](4,b(0 to 7));
-        end function;
-      begin
-        ~RESULT <= resize(~SYM[3](~VAR[][0](15 downto 0)),~SIZE[~TYPO]);
-      end block;
-      -- clz16 end
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+
+          function clz16 (constant v : unsigned(0 to 15)) return unsigned is
+            variable e : unsigned(0 to 15);    -- 16
+            variable a : unsigned(0 to 4*3-1); -- 12
+            variable b : unsigned(0 to 2*4-1); -- 8
+          begin
+            for i in 0 to 7 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
+            for i in 0 to 3 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
+            for i in 0 to 1 loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
+            return clzi(4,b(0 to 7));
+          end function;
+        end;
+    template: resize(~INCLUDENAME[0].clz16(~VAR[][0](15 downto 0)),~SIZE[~TYPO])
 - BlackBox:
     name: GHC.Prim.clz32#
-    kind: Declaration
-    type: 'clz32 :: Word#
-      -> Word#'
-    template: |-
-      -- clz32 begin
-      ~GENSYM[clz32][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
+    kind: Expression
+    type: 'clz32 :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz32
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz32#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+          function clz32 (constant v : unsigned(0 to 31)) return unsigned;
+        end;
 
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
 
-        function ~GENSYM[clz32][3] (constant v : unsigned(0 to 31)) return unsigned is
-          variable e : unsigned(0 to 31);    -- 32
-          variable a : unsigned(0 to 8*3-1); -- 24
-          variable b : unsigned(0 to 4*4-1); -- 16
-          variable c : unsigned(0 to 2*5-1); -- 10
-        begin
-          for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-          for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-          for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-          for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
-          return ~SYM[2](5,c(0 to 9));
-        end function;
-      begin
-        ~RESULT <= resize(~SYM[3](~VAR[][0](31 downto 0)),~SIZE[~TYPO]);
-      end block;
-      -- clz32 end
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+
+          function clz32 (constant v : unsigned(0 to 31)) return unsigned is
+            variable e : unsigned(0 to 31);    -- 32
+            variable a : unsigned(0 to 8*3-1); -- 24
+            variable b : unsigned(0 to 4*4-1); -- 16
+            variable c : unsigned(0 to 2*5-1); -- 10
+          begin
+            for i in 0 to 15 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
+            for i in 0 to 7  loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
+            for i in 0 to 3  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
+            for i in 0 to 1  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7)); end loop;
+            return clzi(5,c(0 to 9));
+          end function;
+        end;
+    template: resize(~INCLUDENAME[0].clz32(~VAR[][0](31 downto 0)),~SIZE[~TYPO])
+
 - BlackBox:
     name: GHC.Prim.clz64#
-    kind: Declaration
-    type: 'clz64 :: Word#
-      -> Word#'
-    template: |-
-      -- clz64 begin
-      ~GENSYM[clz64][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
+    kind: Expression
+    type: 'clz64 :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz64
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz64#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+          function clz64 (constant v : unsigned(0 to 63)) return unsigned;
+        end;
 
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
 
-        function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
-          variable e : unsigned(0 to 63);     -- 64
-          variable a : unsigned(0 to 16*3-1); -- 48
-          variable b : unsigned(0 to 8*4-1);  -- 32
-          variable c : unsigned(0 to 4*5-1);  -- 20
-          variable d : unsigned(0 to 2*6-1);  -- 12
-        begin
-          for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
-          for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
-          for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
-          for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
-          for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
-          return ~SYM[2](6,d(0 to 11));
-        end function;
-      begin
-        ~RESULT <= resize(~SYM[3](~ARG[0]),~SIZE[~TYPO]);
-      end block;
-      -- clz64 end
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+
+          function clz64 (constant v : unsigned(0 to 63)) return unsigned is
+            variable e : unsigned(0 to 63);     -- 64
+            variable a : unsigned(0 to 16*3-1); -- 48
+            variable b : unsigned(0 to 8*4-1);  -- 32
+            variable c : unsigned(0 to 4*5-1);  -- 20
+            variable d : unsigned(0 to 2*6-1);  -- 12
+          begin
+            for i in 0 to 31 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));      end loop;
+            for i in 0 to 15 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3));   end loop;
+            for i in 0 to 7  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5));   end loop;
+            for i in 0 to 3  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7));   end loop;
+            for i in 0 to 1  loop d(i*6 to i*6+5):=clzi(5,c(i*10 to i*10+9)); end loop;
+            return clzi(6,d(0 to 11));
+          end function;
+        end;
+    template: resize(~INCLUDENAME[0].clz64(~ARG[0]),~SIZE[~TYPO])
 - BlackBox:
     name: GHC.Prim.clz#
-    kind: Declaration
-    type: 'clz :: Word# ->
-      Word#'
-    template: |-
-      -- clz begin
-      ~GENSYM[clz][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
+    kind: Expression
+    type: 'clz :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+        ~IF ~IW64 ~THEN
+          function clz (constant v : unsigned(0 to 63)) return unsigned;
+        ~ELSE
+          function clz (constant v : unsigned(0 to 31)) return unsigned;
+        ~FI
+        end;
 
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
-      ~IF ~IW64 ~THEN
-        function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
-          variable e : unsigned(0 to 63);     -- 64
-          variable a : unsigned(0 to 16*3-1); -- 48
-          variable b : unsigned(0 to 8*4-1);  -- 32
-          variable c : unsigned(0 to 4*5-1);  -- 20
-          variable d : unsigned(0 to 2*6-1);  -- 12
-        begin
-          for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
-          for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
-          for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
-          for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
-          for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
-          return ~SYM[2](6,d(0 to 11));
-        end function;
-      ~ELSE
-        function ~GENSYM[clz32][4] (constant v : unsigned(0 to 31)) return unsigned is
-          variable e : unsigned(0 to 31);    -- 32
-          variable a : unsigned(0 to 8*3-1); -- 24
-          variable b : unsigned(0 to 4*4-1); -- 16
-          variable c : unsigned(0 to 2*5-1); -- 10
-        begin
-          for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-          for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-          for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-          for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
-          return ~SYM[2](5,c(0 to 9));
-        end function;
-      ~FI
-      begin
-      ~IF ~IW64 ~THEN
-        ~RESULT <= resize(~SYM[3](~ARG[0]),~SIZE[~TYPO]);
-      ~ELSE
-        ~RESULT <= resize(~SYM[4](~ARG[0]),~SIZE[~TYPO]);
-      ~FI
-      end block;
-      -- clz end
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
+
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+        ~IF ~IW64 ~THEN
+          function clz (constant v : unsigned(0 to 63)) return unsigned is
+            variable e : unsigned(0 to 63);     -- 64
+            variable a : unsigned(0 to 16*3-1); -- 48
+            variable b : unsigned(0 to 8*4-1);  -- 32
+            variable c : unsigned(0 to 4*5-1);  -- 20
+            variable d : unsigned(0 to 2*6-1);  -- 12
+          begin
+            for i in 0 to 31 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));      end loop;
+            for i in 0 to 15 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3));   end loop;
+            for i in 0 to 7  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5));   end loop;
+            for i in 0 to 3  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7));   end loop;
+            for i in 0 to 1  loop d(i*6 to i*6+5):=clzi(5,c(i*10 to i*10+9)); end loop;
+            return clzi(6,d(0 to 11));
+          end function;
+        ~ELSE
+          function clz (constant v : unsigned(0 to 31)) return unsigned is
+            variable e : unsigned(0 to 31);    -- 32
+            variable a : unsigned(0 to 8*3-1); -- 24
+            variable b : unsigned(0 to 4*4-1); -- 16
+            variable c : unsigned(0 to 2*5-1); -- 10
+          begin
+            for i in 0 to 15 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
+            for i in 0 to 7  loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
+            for i in 0 to 3  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
+            for i in 0 to 1  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7)); end loop;
+            return clzi(5,c(0 to 9));
+          end function;
+        ~FI
+        end;
+    template: resize(~INCLUDENAME[0].clz(~ARG[0]),~SIZE[~TYPO])
 - BlackBox:
     name: GHC.Prim.ctz8#
     kind: Declaration
-    type: 'ctz8 :: Word# ->
-      Word#'
+    type: 'ctz8 :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz8
+      comment: This is a copy of clz8, it's used to implement ctz8
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz8#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+          function clz8 (constant v : unsigned(0 to 7)) return unsigned;
+        end;
+
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
+
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+
+          function clz8 (constant v : unsigned(0 to 7)) return unsigned is
+            variable e : unsigned(0 to 7);     -- 8
+            variable a : unsigned(0 to 2*3-1); -- 6
+          begin
+            for i in 0 to 3 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
+            for i in 0 to 1 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
+            return clzi(3,a(0 to 5));
+          end function;
+        end;
     template: |-
       -- ctz8 begin
       ~GENSYM[ctz8][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
-
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
-
-        function ~GENSYM[clz8][3] (constant v : unsigned(0 to 7)) return unsigned is
-          variable e : unsigned(0 to 7);     -- 8
-          variable a : unsigned(0 to 2*3-1); -- 6
-        begin
-          for i in 0 to 3 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-          for i in 0 to 1 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-          return ~SYM[2](3,a(0 to 5));
-        end function;
-
         signal ~GENSYM[w_reversed][5] : ~TYP[0];
       begin
         ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
           ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
         end generate;
       ~IF ~IW64 ~THEN
-        ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 56)),~SIZE[~TYPO]);
+        ~RESULT <= resize(~INCLUDENAME[0].clz8(~SYM[5](63 downto 56)),~SIZE[~TYPO]);
       ~ELSE
-        ~RESULT <= resize(~SYM[3](~SYM[5](31 downto 24)),~SIZE[~TYPO]);
+        ~RESULT <= resize(~INCLUDENAME[0].clz8(~SYM[5](31 downto 24)),~SIZE[~TYPO]);
       ~FI
       end block;
       -- ctz8 end
 - BlackBox:
     name: GHC.Prim.ctz16#
     kind: Declaration
-    type: 'ctz16 :: Word#
-      -> Word#'
+    type: 'ctz16 :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz16
+      comment: This is a copy of clz16, it's used to implement ctz16
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz16#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+          function clz16 (constant v : unsigned(0 to 15)) return unsigned;
+        end;
+
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
+
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+
+          function clz16 (constant v : unsigned(0 to 15)) return unsigned is
+            variable e : unsigned(0 to 15);    -- 16
+            variable a : unsigned(0 to 4*3-1); -- 12
+            variable b : unsigned(0 to 2*4-1); -- 8
+          begin
+            for i in 0 to 7 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
+            for i in 0 to 3 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
+            for i in 0 to 1 loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
+            return clzi(4,b(0 to 7));
+          end function;
+        end;
     template: |-
       -- ctz16 begin
       ~GENSYM[ctz16][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
-
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
-
-        function ~GENSYM[clz16][3] (constant v : unsigned(0 to 15)) return unsigned is
-          variable e : unsigned(0 to 15);    -- 16
-          variable a : unsigned(0 to 4*3-1); -- 12
-          variable b : unsigned(0 to 2*4-1); -- 8
-        begin
-          for i in 0 to 7 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-          for i in 0 to 3 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-          for i in 0 to 1 loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-          return ~SYM[2](4,b(0 to 7));
-        end function;
-
         signal ~GENSYM[w_reversed][5] : ~TYP[0];
       begin
         ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
           ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
         end generate;
       ~IF ~IW64 ~THEN
-        ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 48)),~SIZE[~TYPO]);
+        ~RESULT <= resize(~INCLUDENAME[0].clz16(~SYM[5](63 downto 48)),~SIZE[~TYPO]);
       ~ELSE
-        ~RESULT <= resize(~SYM[3](~SYM[5](31 downto 16)),~SIZE[~TYPO]);
+        ~RESULT <= resize(~INCLUDENAME[0].clz16(~SYM[5](31 downto 16)),~SIZE[~TYPO]);
       ~FI
       end block;
       -- ctz16 end
 - BlackBox:
     name: GHC.Prim.ctz32#
     kind: Declaration
-    type: 'ctz32 :: Word#
-      -> Word#'
+    type: 'ctz32 :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz32
+      comment: This is a copy of clz32, it's used to implement ctz32
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz32#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+          function clz32 (constant v : unsigned(0 to 31)) return unsigned;
+        end;
+
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
+
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+
+          function clz32 (constant v : unsigned(0 to 31)) return unsigned is
+            variable e : unsigned(0 to 31);    -- 32
+            variable a : unsigned(0 to 8*3-1); -- 24
+            variable b : unsigned(0 to 4*4-1); -- 16
+            variable c : unsigned(0 to 2*5-1); -- 10
+          begin
+            for i in 0 to 15 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
+            for i in 0 to 7  loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
+            for i in 0 to 3  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
+            for i in 0 to 1  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7)); end loop;
+            return clzi(5,c(0 to 9));
+          end function;
+        end;
     template: |-
       -- ctz32 begin
       ~GENSYM[ctz32][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
-
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
-
-        function ~GENSYM[clz32][3] (constant v : unsigned(0 to 31)) return unsigned is
-          variable e : unsigned(0 to 31);    -- 32
-          variable a : unsigned(0 to 8*3-1); -- 24
-          variable b : unsigned(0 to 4*4-1); -- 16
-          variable c : unsigned(0 to 2*5-1); -- 10
-        begin
-          for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-          for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-          for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-          for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
-          return ~SYM[2](5,c(0 to 9));
-        end function;
-
         signal ~GENSYM[w_reversed][5] : ~TYP[0];
       begin
         ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
           ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
         end generate;
       ~IF ~IW64 ~THEN
-        ~RESULT <= resize(~SYM[3](~SYM[5](63 downto 32)),~SIZE[~TYPO]);
+        ~RESULT <= resize(~INCLUDENAME[0].clz32(~SYM[5](63 downto 32)),~SIZE[~TYPO]);
       ~ELSE
-        ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);
+        ~RESULT <= resize(~INCLUDENAME[0].clz32(~SYM[5]),~SIZE[~TYPO]);
       ~FI
       end block;
       -- ctz32 end
 - BlackBox:
     name: GHC.Prim.ctz64#
     kind: Declaration
-    type: 'ctz64 :: Word#
-      -> Word#'
+    type: 'ctz64 :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz64
+      comment: This is a copy of clz64, it's used to implement ctz64
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz64#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+          function clz64 (constant v : unsigned(0 to 63)) return unsigned;
+        end;
+
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
+
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+
+          function clz64 (constant v : unsigned(0 to 63)) return unsigned is
+            variable e : unsigned(0 to 63);     -- 64
+            variable a : unsigned(0 to 16*3-1); -- 48
+            variable b : unsigned(0 to 8*4-1);  -- 32
+            variable c : unsigned(0 to 4*5-1);  -- 20
+            variable d : unsigned(0 to 2*6-1);  -- 12
+          begin
+            for i in 0 to 31 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));      end loop;
+            for i in 0 to 15 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3));   end loop;
+            for i in 0 to 7  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5));   end loop;
+            for i in 0 to 3  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7));   end loop;
+            for i in 0 to 1  loop d(i*6 to i*6+5):=clzi(5,c(i*10 to i*10+9)); end loop;
+            return clzi(6,d(0 to 11));
+          end function;
+        end;
     template: |-
       -- ctz64 begin
       ~GENSYM[ctz64][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
-
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
-
-        function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
-          variable e : unsigned(0 to 63);     -- 64
-          variable a : unsigned(0 to 16*3-1); -- 48
-          variable b : unsigned(0 to 8*4-1);  -- 32
-          variable c : unsigned(0 to 4*5-1);  -- 20
-          variable d : unsigned(0 to 2*6-1);  -- 12
-        begin
-          for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
-          for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
-          for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
-          for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
-          for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
-          return ~SYM[2](6,d(0 to 11));
-        end function;
-
         signal ~GENSYM[w_reversed][5] : ~TYP[0];
       begin
         ~GENSYM[reverse_loop][6] : for ~GENSYM[n][7] in ~VAR[w][0]'range generate
           ~SYM[5](~VAR[w][0]'high - ~SYM[7]) <= ~VAR[w][0](~SYM[7]);
         end generate;
 
-        ~RESULT <= resize(~SYM[3](~SYM[5]),~SIZE[~TYPO]);
+        ~RESULT <= resize(~INCLUDENAME[0].clz64(~SYM[5]),~SIZE[~TYPO]);
       end block;
       -- ctz64 end
 - BlackBox:
     name: GHC.Prim.ctz#
     kind: Declaration
-    type: 'ctz :: Word# ->
-      Word#'
+    type: 'ctz :: Word# -> Word#'
+    imports:
+    - ~INCLUDENAME[0].all
+    includes:
+    - name: clz
+      comment: This is a copy of clz, it's used to implement ctz
+      extension: vhdl
+      template: |-
+        -- helper function of GHC.Prim.clz#
+        library IEEE;
+        use IEEE.STD_LOGIC_1164.ALL;
+        use IEEE.NUMERIC_STD.ALL;
+        package ~INCLUDENAME[0] is
+        ~IF ~IW64 ~THEN
+          function clz (constant v : unsigned(0 to 63)) return unsigned;
+        ~ELSE
+          function clz (constant v : unsigned(0 to 31)) return unsigned;
+        ~FI
+        end;
+
+        package body ~INCLUDENAME[0] is
+          function enc (constant a : unsigned(1 downto 0)) return unsigned is
+          begin
+            case a is
+              when "00" => return "10";
+              when "01" => return "01";
+              when "10" => return "00";
+              when others => return "00";
+            end case;
+          end function;
+
+          function clzi (
+            constant n : in natural;
+            constant i : in unsigned) return unsigned is
+            variable v : unsigned(i'length-1 downto 0):=i;
+          begin
+            if v(n-1+n)='0' then
+              return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
+            else
+              return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
+            end if;
+          end function;
+        ~IF ~IW64 ~THEN
+          function clz (constant v : unsigned(0 to 63)) return unsigned is
+            variable e : unsigned(0 to 63);     -- 64
+            variable a : unsigned(0 to 16*3-1); -- 48
+            variable b : unsigned(0 to 8*4-1);  -- 32
+            variable c : unsigned(0 to 4*5-1);  -- 20
+            variable d : unsigned(0 to 2*6-1);  -- 12
+          begin
+            for i in 0 to 31 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));      end loop;
+            for i in 0 to 15 loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3));   end loop;
+            for i in 0 to 7  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5));   end loop;
+            for i in 0 to 3  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7));   end loop;
+            for i in 0 to 1  loop d(i*6 to i*6+5):=clzi(5,c(i*10 to i*10+9)); end loop;
+            return clzi(6,d(0 to 11));
+          end function;
+        ~ELSE
+          function clz (constant v : unsigned(0 to 31)) return unsigned is
+            variable e : unsigned(0 to 31);    -- 32
+            variable a : unsigned(0 to 8*3-1); -- 24
+            variable b : unsigned(0 to 4*4-1); -- 16
+            variable c : unsigned(0 to 2*5-1); -- 10
+          begin
+            for i in 0 to 15 loop e(i*2 to i*2+1):=enc(v(i*2 to i*2+1));    end loop;
+            for i in 0 to 7  loop a(i*3 to i*3+2):=clzi(2,e(i*4 to i*4+3)); end loop;
+            for i in 0 to 3  loop b(i*4 to i*4+3):=clzi(3,a(i*6 to i*6+5)); end loop;
+            for i in 0 to 1  loop c(i*5 to i*5+4):=clzi(4,b(i*8 to i*8+7)); end loop;
+            return clzi(5,c(0 to 9));
+          end function;
+        ~FI
+        end;
     template: |-
       -- ctz begin
       ~GENSYM[ctz][0] : block
-        function ~GENSYM[enc][1] (constant a : unsigned(1 downto 0)) return unsigned is
-        begin
-          case a is
-            when "00" => return "10";
-            when "01" => return "01";
-            when "10" => return "00";
-            when others => return "00";
-          end case;
-        end function;
-
-        function ~GENSYM[clzi][2] (
-          constant n : in natural;
-          constant i : in unsigned) return unsigned is
-          variable v : unsigned(i'length-1 downto 0):=i;
-        begin
-          if v(n-1+n)='0' then
-            return (v(n-1+n) and v(n-1)) & '0' & v(2*n-2 downto n);
-          else
-            return (v(n-1+n) and v(n-1)) & not v(n-1) & v(n-2 downto 0);
-          end if;
-        end function;
-
-      ~IF ~IW64 ~THEN
-        function ~GENSYM[clz64][3] (constant v : unsigned(0 to 63)) return unsigned is
-          variable e : unsigned(0 to 63);     -- 64
-          variable a : unsigned(0 to 16*3-1); -- 48
-          variable b : unsigned(0 to 8*4-1);  -- 32
-          variable c : unsigned(0 to 4*5-1);  -- 20
-          variable d : unsigned(0 to 2*6-1);  -- 12
-        begin
-          for i in 0 to 31 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));      end loop;
-          for i in 0 to 15 loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3));   end loop;
-          for i in 0 to 7  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5));   end loop;
-          for i in 0 to 3  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7));   end loop;
-          for i in 0 to 1  loop d(i*6 to i*6+5):=~SYM[2](5,c(i*10 to i*10+9)); end loop;
-          return ~SYM[2](6,d(0 to 11));
-        end function;
-      ~ELSE
-        function ~GENSYM[clz32][4] (constant v : unsigned(0 to 31)) return unsigned is
-          variable e : unsigned(0 to 31);    -- 32
-          variable a : unsigned(0 to 8*3-1); -- 24
-          variable b : unsigned(0 to 4*4-1); -- 16
-          variable c : unsigned(0 to 2*5-1); -- 10
-        begin
-          for i in 0 to 15 loop e(i*2 to i*2+1):=~SYM[1](v(i*2 to i*2+1));    end loop;
-          for i in 0 to 7  loop a(i*3 to i*3+2):=~SYM[2](2,e(i*4 to i*4+3)); end loop;
-          for i in 0 to 3  loop b(i*4 to i*4+3):=~SYM[2](3,a(i*6 to i*6+5)); end loop;
-          for i in 0 to 1  loop c(i*5 to i*5+4):=~SYM[2](4,b(i*8 to i*8+7)); end loop;
-          return ~SYM[2](5,c(0 to 9));
-        end function;
-      ~FI
-
         signal ~GENSYM[w_reversed][6] : ~TYP[0];
       begin
         ~GENSYM[reverse_loop][7] : for ~GENSYM[n][8] in ~VAR[w][0]'range generate
           ~SYM[6](~VAR[w][0]'high - ~SYM[8]) <= ~VAR[w][0](~SYM[8]);
         end generate;
-      ~IF ~IW64 ~THEN
-        ~RESULT <= resize(~SYM[3](~SYM[6]),~SIZE[~TYPO]);
-      ~ELSE
-        ~RESULT <= resize(~SYM[4](~SYM[6]),~SIZE[~TYPO]);
-      ~FI
+        ~RESULT <= resize(~INCLUDENAME[0].clz(~SYM[6]),~SIZE[~TYPO]);
       end block;
       -- ctz end
 - BlackBox:

--- a/clash-lib/prims/vhdl/GHC_Prim.primitives.yaml
+++ b/clash-lib/prims/vhdl/GHC_Prim.primitives.yaml
@@ -361,9 +361,9 @@
       ~GENSYM[popCnt8][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := 8;
@@ -401,9 +401,9 @@
       ~GENSYM[popCnt16][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := 16;
@@ -441,9 +441,9 @@
       ~GENSYM[popCnt32][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := 32;
@@ -481,9 +481,9 @@
       ~GENSYM[popCnt64][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := 64;
@@ -521,9 +521,9 @@
       ~GENSYM[popCnt][0] : block
         -- given a level and a depth, calculate the corresponding index into the
         -- intermediate array
-        function ~GENSYM[depth2Index][1] (levels,depth : in natural) return natural is
+        function ~GENSYM[depth2Index][1] (~SYM[levelsIn],~SYM[depthIn] : in natural) return natural is
         begin
-          return (2 ** levels - 2 ** depth);
+          return (2 ** ~SYM[levelsIn] - 2 ** ~SYM[depthIn]);
         end function;
 
         constant ~GENSYM[width][2] : natural := ~SIZE[~TYPO];


### PR DESCRIPTION
Fixes #3273

I've split this the PR in two commits, the first fixes a bunch of hardcoded names using the new named symbols.
The second moves some declared functions to external include files, which has the added benefit of being reusable, so clash doesn't emit the exact same function declaration multiple times anymore when the same primitive is used multiple times.

This PR only fixes the name shadowing warnings resulting from the blackboxes, there are still some name shadowing warnings generated by the tests: T1669_DEC,Imap,ZipWithUnitSP
Where some of the [arguments to functions generated in the `..._types.vhdl` files](https://github.com/clash-lang/clash-compiler/blob/a06d3452bd8317ab3d01b75b13c59090f9d59fc1/clash-lib/src/Clash/Backend/VHDL.hs#L641) collide with data constructors like `data AB = A | B`.

This PR built on top of PR #3326, ~which should be merged first.~
~(And when reviewing this PR you only have to look at the last two commits)~

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
