### PR TITLE
Remove enum generation in VHDL backend

### DIFF
--- a/changelog/2026-08-06T10_00_00+02_00_remove_vhdl_enums
+++ b/changelog/2026-08-06T10_00_00+02_00_remove_vhdl_enums
@@ -1,0 +1,10 @@
+CHANGED: Sum types and `Bool` are now rendered as `std_logic_vector` and `std_logic` in VHDL instead of enums.
+
+This includes deprecating the "-fclash-no-render-enums" flag. The flag still is accepted but generates a warning. The flag will be fully removed in a future release.
+
+VHDL Enums have a few problems:
+
+- Unstable bit representations which makes them incompatible with the Clash `BitPack` type class.
+- X-hiding as they cannot take on metavalues.
+
+Partially fixes [#2193](https://github.com/clash-lang/clash-compiler/issues/2193).

--- a/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/ClashFlags.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2016-2017, Myrtle Software Ltd,
-                     2021,      QBayLogic B.V.,
+                     2021-2026, QBayLogic B.V.,
                      2022,      Google Inc.,
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -83,7 +83,7 @@ flagsClash r = [
   , defFlag "fclash-aggressive-x-optimization-blackboxes" $ NoArg (liftEwM (setAggressiveXOptBB r))
   , defFlag "fclash-inline-workfree-limit"       $ IntSuffix (liftEwM . setInlineWFLimit r)
   , defFlag "fclash-edalize"                     $ NoArg (liftEwM (setEdalize r))
-  , defFlag "fclash-no-render-enums"             $ NoArg (liftEwM (setNoRenderEnums r))
+  , defFlag "fclash-no-render-enums"             $ NoArg (deprecatedNoOp "no-render-enums" "sum types are always rendered as bitvectors")
   , defFlag "fclash-timescale-precision"         $ SepArg (setTimescalePrecision r)
   , defFlag "fclash-ignore-broken-ghcs"          $ NoArg (liftEwM (setIgnoreBrokenGhcs r))
   , defFlag "fclash-no-concurrent-topentity-compilation" $ NoArg (liftEwM (setNoConcurrentTopEntities r))
@@ -105,6 +105,20 @@ deprecated wrong right f a = do
                              ++ right
                              ++ "' instead.")
   liftEwM (f a)
+
+-- | Print deprecation warning for a flag that no longer has any effect
+deprecatedNoOp
+  :: String
+  -- ^ Deprecated flag
+  -> String
+  -- ^ Why the flag is a no-op now
+  -> EwM IO ()
+deprecatedNoOp flag reason =
+  addWarn ("Using '-fclash-" ++ flag
+                             ++ "' is deprecated, it no longer has any effect: "
+                             ++ reason
+                             ++ ". It is accepted for backwards compatibility \
+                                \and will be removed in a future release.")
 
 setInlineLimit :: IORef ClashOpts
                -> Int
@@ -336,9 +350,6 @@ setRewriteHistoryFile r arg = do
  where
   setFile file opts =
     opts { opt_debug = (opt_debug opts) { dbg_historyFile = Just file } }
-
-setNoRenderEnums :: IORef ClashOpts -> IO ()
-setNoRenderEnums r = modifyIORef r (\c -> c { opt_renderEnums = False })
 
 setNoConcurrentTopEntities :: IORef ClashOpts -> IO ()
 setNoConcurrentTopEntities r = modifyIORef r (\c -> c { opt_concurrentTopEntities = False })

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam.primitives.yaml
@@ -37,7 +37,7 @@
         ~SYM[6] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+            if ~ARG[7] = '1' ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] = '1' ~ELSE ~FI then
               ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];
             end if;
             ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
@@ -46,7 +46,7 @@
         ~SYM[6] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+            if ~ARG[7] = '1' ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] = '1' ~ELSE ~FI then
               ~SYM[2](~SYM[5]) <= ~ARG[9];
             end if;
             ~RESULT <= ~SYM[2](~SYM[4]);
@@ -95,7 +95,7 @@
         ~SYM[6] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+            if ~ARG[7] = '1' ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] = '1' ~ELSE ~FI then
               ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[9]][~TYP[9]];
             end if;
             ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
@@ -104,7 +104,7 @@
         ~SYM[6] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[7] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+            if ~ARG[7] = '1' ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] = '1' ~ELSE ~FI then
               ~SYM[2](~SYM[5]) <= ~ARG[9];
             end if;
             ~RESULT <= ~SYM[2](~SYM[4]);
@@ -154,7 +154,7 @@
         ~SYM[6] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+            if ~ARG[8] = '1' ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] = '1' ~ELSE ~FI then
               ~SYM[2](~SYM[5]) <= ~TOBV[~ARG[10]][~TYP[10]];
             end if;
             ~RESULT <= fromSLV(~SYM[2](~SYM[4]));
@@ -163,7 +163,7 @@
         ~SYM[6] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[8] ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI then
+            if ~ARG[8] = '1' ~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] = '1' ~ELSE ~FI then
               ~SYM[2](~SYM[5]) <= ~ARG[10];
             end if;
             ~RESULT <= ~SYM[2](~SYM[4]);

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_Blob.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_Blob.primitives.yaml
@@ -34,7 +34,7 @@
         ~SYM[6] : process(~ARG[1])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[1]) then
-            if ~ARG[5]~IF~ISACTIVEENABLE[2]~THEN and ~ARG[2]~ELSE~FI then
+            if ~ARG[5] = '1'~IF~ISACTIVEENABLE[2]~THEN and ~ARG[2] = '1'~ELSE~FI then
               ~SYM[2](~SYM[5]) <= ~ARG[7];
             end if;
             ~RESULT <= ~SYM[2](~SYM[4]);

--- a/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_BlockRam_File.primitives.yaml
@@ -52,8 +52,8 @@
         ~GENSYM[blockRamFile_sync][10] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[4] then
-              if ~ARG[8] then
+            if ~ARG[4] = '1' then
+              if ~ARG[8] = '1' then
                 ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
               end if;
               ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
@@ -63,7 +63,7 @@
         ~SYM[10] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[8] then
+            if ~ARG[8] = '1' then
               ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
             end if;
             ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
@@ -72,10 +72,10 @@
         ~SYM[10] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[8] and ~ARG[4] then
+            if ~ARG[8] = '1' and ~ARG[4] = '1' then
               ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
             end if;
-            if ~ARG[4] then
+            if ~ARG[4] = '1' then
               ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));
             end if;
           end if;
@@ -83,7 +83,7 @@
         ~SYM[10] : process(~ARG[3])
         begin
           if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3]) then
-            if ~ARG[8] then
+            if ~ARG[8] = '1' then
               ~SYM[3](~SYM[6]) <= to_bitvector(~ARG[10]);
             end if;
             ~RESULT <= to_stdlogicvector(~SYM[3](~SYM[5]));

--- a/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_DDR.primitives.yaml
@@ -31,7 +31,7 @@
           if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
               ~SYM[1] <= ~ARG[9];
-            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] = '1' then~ELSEe~FI
               ~SYM[1] <= ~ARG[11];
             end if;
           end if;
@@ -42,7 +42,7 @@
           if ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[5]) then
             if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
               ~SYM[2] <= ~ARG[10];
-            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] = '1' then~ELSEe~FI
               ~SYM[2] <= ~ARG[11];
             end if;
           end if;
@@ -53,7 +53,7 @@
           if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
               ~SYM[3] <= ~ARG[8];
-            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] = '1' then~ELSEe~FI
               ~SYM[3] <= ~SYM[2];
             end if;
           end if;
@@ -65,7 +65,7 @@
         begin
           if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[1] <= ~ARG[9];
-          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] = '1' and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             ~SYM[1] <= ~ARG[11];
           end if;
         end process;
@@ -74,7 +74,7 @@
         begin
           if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[2] <= ~ARG[10];
-          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[5]) then
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] = '1' and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENfalling_edge~ELSErising_edge~FI(~ARG[5]) then
             ~SYM[2] <= ~ARG[11];
           end if;
         end process;
@@ -83,7 +83,7 @@
         begin
           if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[3] <= ~ARG[8];
-          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] = '1' and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             ~SYM[3] <= ~SYM[2];
           end if;
         end process;
@@ -122,7 +122,7 @@
           if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
               ~SYM[1] <= ~ARG[8];
-            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] = '1' then~ELSEe~FI
               ~SYM[1] <= ~ARG[9];
             end if;
           end if;
@@ -133,7 +133,7 @@
           if ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
               ~SYM[2] <= ~ARG[8];
-            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] then~ELSEe~FI
+            els~IF ~ISACTIVEENABLE[7] ~THENif ~ARG[7] = '1' then~ELSEe~FI
               ~SYM[2] <= ~ARG[10];
             end if;
           end if;
@@ -145,7 +145,7 @@
         begin
           if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[1] <= ~ARG[8];
-          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] = '1' and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             ~SYM[1] <= ~ARG[9];
           end if;
         end process;
@@ -154,7 +154,7 @@
         begin
           if ~ARG[6] = ~IF~ISACTIVEHIGH[2]~THEN'1'~ELSE'0'~FI then
             ~SYM[2] <= ~ARG[8];
-          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
+          elsif ~IF ~ISACTIVEENABLE[7] ~THEN ~ARG[7] = '1' and ~ELSE ~FI ~IF~ACTIVEEDGE[Rising][2]~THENrising_edge~ELSEfalling_edge~FI(~ARG[5]) then
             ~SYM[2] <= ~ARG[10];
           end if;
         end process;

--- a/clash-lib/prims/vhdl/Clash_Explicit_RAM.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_RAM.primitives.yaml
@@ -39,7 +39,7 @@
         ~GENSYM[asyncRam_sync][7] : process(~ARG[4])
         begin
           if ~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[4]) then
-            if (~ARG[9] ~IF ~ISACTIVEENABLE[6] ~THEN and ~ARG[6] ~ELSE ~FI) then~IF ~VIVADO ~THEN
+            if (~ARG[9] = '1' ~IF ~ISACTIVEENABLE[6] ~THEN and ~ARG[6] = '1' ~ELSE ~FI) then~IF ~VIVADO ~THEN
               ~SYM[1](~SYM[3]) <= ~TOBV[~ARG[11]][~TYP[11]];~ELSE
               ~SYM[1](~SYM[3]) <= ~ARG[11];~FI
             end if;

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM.primitives.yaml
@@ -26,7 +26,7 @@
                       ;
         ~GENSYM[romSync][6] : process (~ARG[3])
         begin
-          if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] ~ELSE ~FI) then~IF ~VIVADO ~THEN
+          if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[3])~IF ~ISACTIVEENABLE[4] ~THEN and ~ARG[4] = '1' ~ELSE ~FI) then~IF ~VIVADO ~THEN
             ~RESULT <= ~FROMBV[~SYM[2](~SYM[3])][~TYPO];~ELSE
             ~RESULT <= ~SYM[2](~SYM[3]);~FI
           end if;

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_Blob.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_Blob.primitives.yaml
@@ -25,7 +25,7 @@
                       ;
         ~GENSYM[romSync][6] : process (~ARG[1])
         begin
-          if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[1])~IF~ISACTIVEENABLE[2]~THEN and ~ARG[2]~ELSE~FI) then
+          if (~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[1])~IF~ISACTIVEENABLE[2]~THEN and ~ARG[2] = '1'~ELSE~FI) then
             ~RESULT <= ~SYM[2](~SYM[3]);
           end if;
         end process;

--- a/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_ROM_File.primitives.yaml
@@ -40,7 +40,7 @@
         ~GENSYM[romFileSync][7] : process (~ARG[2])
         begin
           if (~IF~ACTIVEEDGE[Rising][1]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2])) then
-            if ~ARG[3] then
+            if ~ARG[3] = '1' then
               ~RESULT <= to_stdlogicvector(~SYM[2](~SYM[3]));
             end if;
           end if;

--- a/clash-lib/prims/vhdl/Clash_Explicit_Testbench.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Explicit_Testbench.primitives.yaml
@@ -153,7 +153,7 @@
     kind: Declaration
     type: 'tbEnableGen ::
       Enable dom'
-    template: ~RESULT <= true;
+    template: ~RESULT <= '1';
     workInfo: Always
 - BlackBox:
     name: Clash.Explicit.Testbench.clockToDiffClock

--- a/clash-lib/prims/vhdl/Clash_Signal_BiSignal.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Signal_BiSignal.primitives.yaml
@@ -12,7 +12,7 @@
     renderVoid: RenderVoid
     template: |-
       -- writeToBiSignal# begin
-      ~ARG[1] <= ~ARG[4] when ~ARG[3] else (~SIZE[~TYP[1]]-1 downto 0 => 'Z');
+      ~ARG[1] <= ~ARG[4] when ~ARG[3] = '1' else (~SIZE[~TYP[1]]-1 downto 0 => 'Z');
       -- writeToBiSignal# end
 - BlackBox:
     name: Clash.Signal.BiSignal.readFromBiSignal#

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.primitives.yaml
@@ -20,7 +20,7 @@
       ~GENSYM[~RESULT_delay][4] : process(~ARG[2])
       begin
         if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-          if ~ARG[3] then
+          if ~ARG[3] = '1' then
             ~RESULT <= ~ARG[5];
           end if;
         end if;
@@ -59,7 +59,7 @@
           ~RESULT <= ~CONST[6];
         els~FIif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
           ~IF ~ISACTIVEENABLE[4] ~THEN
-          if ~ARG[4] then
+          if ~ARG[4] = '1' then
             ~RESULT <= ~ARG[7];
           end if;
           ~ELSE
@@ -94,7 +94,7 @@
         if ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
           ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
             ~RESULT <= ~CONST[6];
-          els~FIif ~ARG[4] then
+          els~FIif ~ARG[4] = '1' then
             ~RESULT <= ~ARG[7];
           end if;
         end if;
@@ -104,7 +104,7 @@
         ~IF ~ISUNDEFINED[6] ~THEN ~ELSEif ~ARG[3] = ~IF ~ISACTIVEHIGH[0] ~THEN '1' ~ELSE '0' ~FI then
           ~RESULT <= ~CONST[6];
         els~FIif ~IF~ACTIVEEDGE[Rising][0]~THENrising_edge~ELSEfalling_edge~FI(~ARG[2]) then
-          if ~ARG[4] then
+          if ~ARG[4] = '1' then
             ~RESULT <= ~ARG[7];
           end if;
         end if;
@@ -149,7 +149,7 @@
       begin
         ~RESULT <= ~IF~ACTIVEEDGE[Rising][0]~THEN'0'~ELSE'1'~FI;
         wait for ~LONGESTPERIOD ps;
-        ~IF~ISACTIVEENABLE[1]~THENwhile ~ARG[1] ~ELSE~FIloop
+        ~IF~ISACTIVEENABLE[1]~THENwhile ~ARG[1] = '1' ~ELSE~FIloop
           ~RESULT <= not ~RESULT;
           wait for ~SYM[1];
           ~RESULT <= not ~RESULT;
@@ -185,7 +185,7 @@
         ~RESULT <= ~IF~ACTIVEEDGE[Rising][0]~THEN'0'~ELSE'1'~FI;
         wait for ~LONGESTPERIOD ps;
 
-        ~IF~ISACTIVEENABLE[2]~THENwhile ~ARG[2] ~ELSE~FIloop
+        ~IF~ISACTIVEENABLE[2]~THENwhile ~ARG[2] = '1' ~ELSE~FIloop
           ~SYM[1] := to_integer(~VAR[periods][1]) * 1 fs;
           ~SYM[2] := ~SYM[1] / 2;
           ~SYM[3] := ~SYM[1] - ~SYM[2];
@@ -224,12 +224,12 @@
     kind: Declaration
     type: 'unsafeFromReset
       :: Reset dom -> Signal dom Bool'
-    template: ~RESULT <= true when ~ARG[0] = '1' else false;
+    template: ~RESULT <= ~ARG[0];
     workInfo: Never
 - BlackBox:
     name: Clash.Signal.Internal.unsafeToReset
     kind: Declaration
     type: 'unsafeToReset ::
       KnownDomain dom => Signal dom Bool -> Reset dom'
-    template: ~RESULT <= '1' when ~ARG[1] = true else '0';
+    template: ~RESULT <= ~ARG[1];
     workInfo: Never

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_BitVector.primitives.yaml
@@ -59,13 +59,13 @@
     kind: Expression
     type: 'eq## :: Bit ->
       Bit -> Bool'
-    template: ~ARG[0] = ~ARG[1]
+    template: to_std_logic(~ARG[0] = ~ARG[1])
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.neq##
     kind: Expression
     type: 'neq## :: Bit ->
       Bit -> Bool'
-    template: ~ARG[0] /= ~ARG[1]
+    template: to_std_logic(~ARG[0] /= ~ARG[1])
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.fromInteger##
     kind: Expression
@@ -344,37 +344,37 @@
     kind: Expression
     type: 'eq# :: KnownNat
       n => BitVector n -> BitVector n -> Bool'
-    template: ~IF~SIZE[~TYP[1]]~THEN~ARG[1] = ~ARG[2]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[1]]~THEN~ARG[1] = ~ARG[2]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.neq#
     kind: Expression
     type: 'neq# :: KnownNat
       n => BitVector n -> BitVector n -> Bool'
-    template: ~IF~SIZE[~TYP[1]]~THEN~ARG[1] /= ~ARG[2]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[1]]~THEN~ARG[1] /= ~ARG[2]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.lt#
     kind: Expression
     type: 'lt# :: KnownNat
       n => BitVector n -> BitVector n -> Bool'
-    template: ~IF~SIZE[~TYP[1]]~THEN~ARG[1] < ~ARG[2]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[1]]~THEN~ARG[1] < ~ARG[2]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.ge#
     kind: Expression
     type: 'ge# :: KnownNat
       n => BitVector n -> BitVector n -> Bool'
-    template: ~IF~SIZE[~TYP[1]]~THEN~ARG[1] >= ~ARG[2]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[1]]~THEN~ARG[1] >= ~ARG[2]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.gt#
     kind: Expression
     type: 'gt# :: KnownNat
       n => BitVector n -> BitVector n -> Bool'
-    template: ~IF~SIZE[~TYP[1]]~THEN~ARG[1] > ~ARG[2]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[1]]~THEN~ARG[1] > ~ARG[2]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.le#
     kind: Expression
     type: 'le# :: KnownNat
       n => BitVector n -> BitVector n -> Bool'
-    template: ~IF~SIZE[~TYP[1]]~THEN~ARG[1] <= ~ARG[2]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[1]]~THEN~ARG[1] <= ~ARG[2]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.BitVector.minBound#
     kind: Expression

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Index.primitives.yaml
@@ -17,37 +17,37 @@
     kind: Expression
     type: 'eq# :: Index n
       -> Index n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] = ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] = ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Index.neq#
     kind: Expression
     type: 'neq# :: Index n
       -> Index n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] /= ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] /= ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Index.lt#
     kind: Expression
     type: 'lt# :: Index n
       -> Index n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] < ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] < ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Index.ge#
     kind: Expression
     type: 'ge# :: Index n
       -> Index n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] >= ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] >= ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Index.gt#
     kind: Expression
     type: 'gt# :: Index n
       -> Index n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] > ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] > ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Index.le#
     kind: Expression
     type: 'le# :: Index n
       -> Index n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] <= ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] <= ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Index.maxBound#
     kind: Expression

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Signed.primitives.yaml
@@ -24,37 +24,37 @@
     kind: Expression
     type: 'eq# :: Signed n
       -> Signed n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] = ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] = ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Signed.neq#
     kind: Expression
     type: 'neq# :: Signed
       n -> Signed n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] /= ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] /= ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Signed.lt#
     kind: Expression
     type: 'lt# :: Signed n
       -> Signed n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] < ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] < ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Signed.ge#
     kind: Expression
     type: 'ge# :: Signed n
       -> Signed n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] >= ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] >= ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Signed.gt#
     kind: Expression
     type: 'gt# :: Signed n
       -> Signed n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] > ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] > ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Signed.le#
     kind: Expression
     type: 'le# :: Signed n
       -> Signed n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] <= ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] <= ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Signed.minBound#
     comment: the quantification with signed gives the array an ascending index

--- a/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Sized_Internal_Unsigned.primitives.yaml
@@ -24,37 +24,37 @@
     kind: Expression
     type: 'eq# :: Unsigned
       n -> Unsigned n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] = ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] = ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Unsigned.neq#
     kind: Expression
     type: 'neq# :: Unsigned
       n -> Unsigned n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] /= ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] /= ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Unsigned.lt#
     kind: Expression
     type: 'lt# :: Unsigned
       n -> Unsigned n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] < ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] < ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Unsigned.ge#
     kind: Expression
     type: 'ge# :: Unsigned
       n -> Unsigned n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] >= ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] >= ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Unsigned.gt#
     kind: Expression
     type: 'gt# :: Unsigned
       n -> Unsigned n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] > ~ARG[1]~ELSEfalse~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] > ~ARG[1]~ELSEfalse~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Unsigned.le#
     kind: Expression
     type: 'le# :: Unsigned
       n -> Unsigned n -> Bool'
-    template: ~IF~SIZE[~TYP[0]]~THEN~ARG[0] <= ~ARG[1]~ELSEtrue~FI
+    template: to_std_logic(~IF~SIZE[~TYP[0]]~THEN~ARG[0] <= ~ARG[1]~ELSEtrue~FI)
 - BlackBox:
     name: Clash.Sized.Internal.Unsigned.minBound#
     kind: Expression

--- a/clash-lib/prims/vhdl/GHC_Classes.primitives.yaml
+++ b/clash-lib/prims/vhdl/GHC_Classes.primitives.yaml
@@ -3,13 +3,13 @@
     kind: Expression
     type: 'eqInt :: Int ->
       Int -> Bool'
-    template: ~ARG[0] = ~ARG[1]
+    template: to_std_logic(~ARG[0] = ~ARG[1])
 - BlackBox:
     name: GHC.Classes.neInt
     kind: Expression
     type: 'neInt :: Int ->
       Int -> Bool'
-    template: ~ARG[0] /= ~ARG[1]
+    template: to_std_logic(~ARG[0] /= ~ARG[1])
 - BlackBox:
     name: GHC.Classes.&&
     kind: Expression

--- a/clash-lib/prims/vhdl/GHC_Integer_Type.primitives.yaml
+++ b/clash-lib/prims/vhdl/GHC_Integer_Type.primitives.yaml
@@ -149,7 +149,7 @@
     kind: Expression
     type: 'eqInteger :: Integer
       -> Integer -> Bool'
-    template: ~ARG[0] = ~ARG[1]
+    template: to_std_logic(~ARG[0] = ~ARG[1])
     warning: 'GHC.Integer.Type.eqInteger: Integers are dynamically sized in simulation,
       but fixed-length after synthesis. Use carefully.'
 - BlackBox:
@@ -157,7 +157,7 @@
     kind: Expression
     type: 'neqInteger :: Integer
       -> Integer -> Bool'
-    template: ~ARG[0] /= ~ARG[1]
+    template: to_std_logic(~ARG[0] /= ~ARG[1])
     warning: 'GHC.Integer.Type.neqInteger: Integers are dynamically sized in simulation,
       but fixed-length after synthesis. Use carefully.'
 - BlackBox:
@@ -257,7 +257,7 @@
     kind: Expression
     type: 'testBitInteger
       :: Integer -> Int# -> Bool'
-    template: ~VAR[input][0](to_integer(~ARG[1])) = '1'
+    template: to_std_logic(~VAR[input][0](to_integer(~ARG[1])) = '1')
     warning: 'GHC.Integer.Type.testBitInteger: Integers are dynamically sized in simulation,
       but fixed-length after synthesis. Use carefully.'
 - BlackBox:

--- a/clash-lib/prims/vhdl/GHC_Num_Integer.primitives.yaml
+++ b/clash-lib/prims/vhdl/GHC_Num_Integer.primitives.yaml
@@ -175,7 +175,7 @@
     kind: Expression
     type: 'integerEq :: Integer
       -> Integer -> Bool'
-    template: ~ARG[0] = ~ARG[1]
+    template: to_std_logic(~ARG[0] = ~ARG[1])
     warning: 'GHC.Num.Integer.integerEq: Integers are dynamically sized in simulation,
       but fixed-length after synthesis. Use carefully.'
 - BlackBox:
@@ -183,7 +183,7 @@
     kind: Expression
     type: 'integerNe :: Integer
       -> Integer -> Bool'
-    template: ~ARG[0] /= ~ARG[1]
+    template: to_std_logic(~ARG[0] /= ~ARG[1])
     warning: 'GHC.Num.Integer.integerNe: Integers are dynamically sized in simulation,
       but fixed-length after synthesis. Use carefully.'
 - BlackBox:

--- a/clash-lib/src/Clash/Backend.hs
+++ b/clash-lib/src/Clash/Backend.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright  :  (C) 2015-2016, University of Twente,
                     2017     , Myrtle Software Ltd, Google Inc.,
-                    2021-2022, QBayLogic B.V.
+                    2021-2026, QBayLogic B.V.
                     2022     , Google Inc.
   License    :  BSD2 (see the file LICENSE)
   Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -63,9 +63,6 @@ data Usage
 
 -- | Is '-fclash-aggresive-x-optimization-blackbox' set?
 newtype AggressiveXOptBB = AggressiveXOptBB Bool
-
--- | Is '-fclash-render-enums' set?
-newtype RenderEnums = RenderEnums Bool
 
 -- | Kind of a HDL type. Used to determine whether types need conversions in
 -- order to cross top entity boundaries.
@@ -162,8 +159,6 @@ class (HasUsageMap state, HasIdentifierSet state) => Backend state where
   ifThenElseExpr :: state -> Bool
   -- | Whether -fclash-aggressive-x-optimization-blackboxes was set
   aggressiveXOptBB :: State state AggressiveXOptBB
-  -- | Whether -fclash-no-render-enums was set
-  renderEnums :: State state RenderEnums
   -- | All the domain configurations of design
   domainConfigurations :: State state DomainMap
   -- | Set the domain configurations

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
-                     2021-2024, QBayLogic B.V.,
+                     2021-2026, QBayLogic B.V.,
                      2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -100,7 +100,6 @@ data SystemVerilogState =
     , _hdlsyn    :: HdlSyn
     , _undefValue :: Maybe (Maybe Int)
     , _aggressiveXOptBB_ :: AggressiveXOptBB
-    , _renderEnums_ :: RenderEnums
     , _domainConfigurations_ :: DomainMap
     , _usages :: UsageMap
     }
@@ -134,7 +133,6 @@ instance Backend SystemVerilogState where
     , _hdlsyn=opt_hdlSyn opts
     , _undefValue=opt_forceUndefined opts
     , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
-    , _renderEnums_=coerce (opt_renderEnums opts)
     , _domainConfigurations_=emptyDomainMap
     , _usages=mempty
     }
@@ -206,7 +204,6 @@ instance Backend SystemVerilogState where
   getMemoryDataFiles = use memoryDataFiles
   ifThenElseExpr _ = True
   aggressiveXOptBB = use aggressiveXOptBB_
-  renderEnums = use renderEnums_
   domainConfigurations = use domainConfigurations_
   setDomainConfigurations confs s = s {_domainConfigurations_ = confs}
 

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
-                     2021-2024, QBayLogic B.V.
+                     2021-2026, QBayLogic B.V.
                      2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -117,10 +117,7 @@ data VHDLState =
   , _undefValue :: Maybe (Maybe Int)
   , _productFieldNameCache :: HashMap (Maybe [TextS.Text], [HWType]) [TextS.Text]
   -- ^ Caches output of 'productFieldNames'.
-  , _enumNameCache :: HashMap HWType [TextS.Text]
-  -- ^ Cache for enum variant names.
   , _aggressiveXOptBB_ :: AggressiveXOptBB
-  , _renderEnums_ :: RenderEnums
   , _domainConfigurations_ :: DomainMap
   , _usages :: UsageMap
   }
@@ -152,9 +149,7 @@ instance Backend VHDLState where
     , _hdlsyn=opt_hdlSyn opts
     , _undefValue=opt_forceUndefined opts
     , _productFieldNameCache=mempty
-    , _enumNameCache=mempty
     , _aggressiveXOptBB_=coerce (opt_aggressiveXOptBB opts)
-    , _renderEnums_=coerce (opt_renderEnums opts)
     , _domainConfigurations_=emptyDomainMap
     , _usages=mempty
     }
@@ -175,11 +170,8 @@ instance Backend VHDLState where
     Product {} -> pure UserType
     MemBlob {} -> pure UserType
 
-    Sum {} -> do
-      -- If an enum is rendered, it is a user type. If not, an std_logic_vector
-      -- is rendered, and it is a synonym.
-      RenderEnums enums <- renderEnums
-      if enums then pure UserType else pure SynonymType
+    -- Rendered as an std_logic_vector subtype.
+    Sum {} -> pure SynonymType
 
     Clock {} -> pure SynonymType
     ClockN {} -> pure SynonymType
@@ -229,9 +221,8 @@ instance Backend VHDLState where
   expr            = expr_
   iwWidth         = use intWidth
 
-  toBV t id_ = do
-    enums <- Ap renderEnums
-    if isBV enums t then pretty id_ else do
+  toBV t id_ =
+    if isBV t then pretty id_ else do
       nm <- Ap $ use modNm
       -- TODO: restore hack
 --      seen <- use seenIdentifiers
@@ -242,9 +233,8 @@ instance Backend VHDLState where
 --            | otherwise =
       let e = hdlTypeMark t <> squote <> parens (pretty id_)
       pretty nm <> "_types.toSLV" <> parens e
-  fromBV t id_ = do
-    enums <- Ap renderEnums
-    if isBV enums t then pretty id_ else do
+  fromBV t id_ =
+    if isBV t then pretty id_ else do
       nm <- Ap $ use modNm
       qualTyName t <> "'" <> parens (pretty nm <> "_types.fromSLV" <> parens (pretty id_))
   hdlSyn          = use hdlsyn
@@ -285,16 +275,15 @@ instance Backend VHDLState where
   getMemoryDataFiles = use memoryDataFiles
   ifThenElseExpr _ = False
   aggressiveXOptBB = use aggressiveXOptBB_
-  renderEnums = use renderEnums_
   domainConfigurations = use domainConfigurations_
   setDomainConfigurations confs s = s {_domainConfigurations_ = confs}
 
 type VHDLM a = Ap (State VHDLState) a
 
 -- Check if the underlying type is a BitVector
-isBV :: RenderEnums -> HWType -> Bool
-isBV e (normaliseType e -> BitVector _) = True
-isBV _ _ = False
+isBV :: HWType -> Bool
+isBV (normaliseType -> BitVector _) = True
+isBV _ = False
 
 -- | Generate unique (partial) names for product fields. Example:
 --
@@ -374,21 +363,6 @@ selectProductField
 selectProductField fieldLabels fieldTypes fieldIndex =
   "_sel" <> int fieldIndex <> "_" <> productFieldName fieldLabels fieldTypes fieldIndex
 
-enumVariantName
-  :: HasCallStack
-  => HWType
-  -> Int
-  -> VHDLM Doc
-enumVariantName ty@(Sum _ vs) i = do
-  names <- makeCached ty enumNameCache (traverse variantName vs)
-  pure (PP.pretty (names !! i))
- where
-  -- Make a basic identifier from the last part of a qualified name
-  variantName = fmap Id.toText . Id.makeBasic . snd . TextS.breakOnEnd "."
-
-enumVariantName _ _ =
-  error $ $(curLoc) ++ "enumVariantName called on non-enum type"
-
 -- | Generate VHDL for a Netlist component
 genVHDL
   :: ClashOpts
@@ -430,12 +404,11 @@ mkTyPackage_ :: ModName -> [HWType] -> VHDLM [(String,Doc)]
 mkTyPackage_ modName (map filterTransparent -> hwtys) = do
     { Ap (tyPkgCtx .= True)
     ; syn <- Ap hdlSyn
-    ; enums <- Ap renderEnums
     ; let usedTys     = concatMap mkUsedTys hwtys
     ; let normTys0    = nub (map mkVecZ (hwtys ++ usedTys))
     ; let sortedTys0  = topSortHWTys normTys0
           packageDec  = vcat $ mapM tyDec (nubBy eqTypM sortedTys0)
-          (funDecs,funBodies) = unzip . mapMaybe (funDec enums syn) $ nubBy eqTypM (normaliseType enums <$> sortedTys0)
+          (funDecs,funBodies) = unzip . mapMaybe (funDec syn) $ nubBy eqTypM (normaliseType <$> sortedTys0)
 
     ; pkg <- (:[]) <$> (TextS.unpack (modName `TextS.append` "_types"),) <$>
       "library IEEE;" <> line <>
@@ -540,17 +513,15 @@ mkVecZ (RTree _ elTy)  = RTree 0 elTy
 mkVecZ t               = t
 
 typAliasDec :: HasCallStack => HWType -> VHDLM Doc
-typAliasDec hwty = do
-  enums <- Ap renderEnums
+typAliasDec hwty =
   "subtype" <+> tyName hwty
             <+> "is"
-            <+> sizedTyName (normaliseType enums hwty)
+            <+> sizedTyName (normaliseType hwty)
             <> semi
 
 tyDec :: HasCallStack => HWType -> VHDLM Doc
 tyDec hwty = do
   syn <- Ap hdlSyn
-  RenderEnums enums <- Ap renderEnums
 
   case hwty of
     -- "Proper" custom types:
@@ -589,13 +560,6 @@ tyDec hwty = do
       "type" <+> tyName hwty <+> "is record" <> line  <>
         indent 2 (vcat $ zipWithM (\x y -> x <+> colon <+> y <> semi) selNames selTys) <> line <>
       "end record" <> semi
-
-    Sum _ vs | enums ->
-        let variantNames = traverse (enumVariantName hwty) [0..length vs - 1] in
-          "type" <+> tyName hwty
-                 <+> "is"
-                 <+> parens (hsep (punctuate comma variantNames))
-                 <> semi
 
     MemBlob n m -> tyDec (Vector n (BitVector m))
 
@@ -636,8 +600,8 @@ tyDec hwty = do
 
 
 
-funDec :: RenderEnums -> HdlSyn -> HWType -> Maybe (VHDLM Doc,VHDLM Doc)
-funDec _ _ Bool = Just
+funDec :: HdlSyn -> HWType -> Maybe (VHDLM Doc,VHDLM Doc)
+funDec _ Bool = Just
   ( "function" <+> "toSLV" <+> parens ("b" <+> colon <+> "in" <+> "boolean") <+> "return" <+> "std_logic_vector" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("sl" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "boolean" <> semi <> line <>
     "function" <+> "tagToEnum" <+> parens ("s" <+> colon <+> "in" <+> "signed") <+> "return" <+> "boolean" <> semi <> line <>
@@ -680,7 +644,7 @@ funDec _ _ Bool = Just
     "end" <> semi
   )
 
-funDec _ _ bit@Bit = Just
+funDec _ bit@Bit = Just
   ( "function" <+> "toSLV" <+> parens ("sl" <+> colon <+> "in" <+> tyName bit) <+> "return" <+> "std_logic_vector" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> tyName bit <> semi
   , "function" <+> "toSLV" <+> parens ("sl" <+> colon <+> "in" <+> tyName bit) <+> "return" <+> "std_logic_vector" <+> "is" <> line <>
@@ -696,7 +660,7 @@ funDec _ _ bit@Bit = Just
     "end" <> semi
   )
 
-funDec _ _ (Signed _) = Just
+funDec _ (Signed _) = Just
   ( "function" <+> "toSLV" <+> parens ("s" <+> colon <+> "in" <+> "signed") <+> "return" <+> "std_logic_vector" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "signed" <> semi
   , "function" <+> "toSLV" <+> parens ("s" <+> colon <+> "in" <+> "signed") <+> "return" <+> "std_logic_vector" <+> "is" <> line <>
@@ -710,7 +674,7 @@ funDec _ _ (Signed _) = Just
     "end" <> semi
   )
 
-funDec _ _ (Unsigned _) = Just
+funDec _ (Unsigned _) = Just
   ( "function" <+> "toSLV" <+> parens ("u" <+> colon <+> "in" <+> "unsigned") <+> "return" <+> "std_logic_vector" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "unsigned" <> semi
   , "function" <+> "toSLV" <+> parens ("u" <+> colon <+> "in" <+> "unsigned") <+> "return" <+> "std_logic_vector" <+> "is"  <> line <>
@@ -725,7 +689,7 @@ funDec _ _ (Unsigned _) = Just
 
   )
 
-funDec _ _ t@(Product _ labels elTys) = Just
+funDec _ t@(Product _ labels elTys) = Just
   ( "function" <+> "toSLV" <+> parens ("p :" <+> sizedTyName t) <+> "return std_logic_vector" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> sizedTyName t <> semi
   , "function" <+> "toSLV" <+> parens ("p :" <+> sizedTyName t) <+> "return std_logic_vector" <+> "is" <> line <>
@@ -752,41 +716,7 @@ funDec _ _ t@(Product _ labels elTys) = Just
                        (\(s,e) -> "fromSLV" <>
                           parens ("islv" <> parens (int s <+> "to" <+> int e)))
 
-funDec (RenderEnums enums) _ t@(Sum _ _) | enums = Just
-  ( "function" <+> "toSLV" <+> parens("value" <+> colon <+> "in" <+> qualTyName t) <+> "return std_logic_vector" <> semi <> line <>
-    "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> qualTyName t <> semi
-  , "function" <+> "toSLV" <+> parens ("value" <+> colon <+> "in" <+> qualTyName t) <+> "return std_logic_vector" <+> "is" <> line <>
-    "begin" <> line <>
-    indent 2
-      ( "return" <+> "std_logic_vector" <>
-        parens ("to_unsigned" <>
-          parens (qualTyName t <> "'pos(value)" <> comma <+> int (typeSize t))
-        )) <> semi <> line <>
-    "end" <> semi <> line <>
-    "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> qualTyName t <+> "is" <> line <>
-    "begin" <> line <>
-    indent 2
-      (
-      translate_off (
-      "if unsigned(slv) <= " <> qualTyName t <> "'pos("<> qualTyName t <> "'high) then"
-      ) <> line <>
-        indent 2
-          ( "return" <+> qualTyName t <> "'val" <>
-            parens ("to_integer" <>
-              parens ("unsigned" <> parens "slv"))) <> semi <> line <>
-      translate_off (
-        "else" <> line <>
-        indent 2
-          ( "return" <+> qualTyName t <> "'val(0)") <> semi <> line <>
-        "end if" <> semi
-      )
-      ) <> line <>
-    "end" <> semi
-  )
-  where
-    translate_off body = "-- pragma translate_off" <> line <> body <> line <> "-- pragma translate_on"
-
-funDec _ syn t@(Vector _ elTy) = Just
+funDec syn t@(Vector _ elTy) = Just
   ( "function" <+> "toSLV" <+> parens ("value : " <+> qualTyName t) <+> "return std_logic_vector" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> qualTyName t <> semi
   , "function" <+> "toSLV" <+> parens ("value : " <+> qualTyName t) <+> "return std_logic_vector" <+> "is" <> line <>
@@ -832,7 +762,7 @@ funDec _ syn t@(Vector _ elTy) = Just
     eSz     = int (typeSize elTy)
     getElem = "islv" <> parens ("i * " <> eSz <+> "to (i+1) * " <> eSz <+> "- 1")
 
-funDec _ _ (BitVector _) = Just
+funDec _ (BitVector _) = Just
   ( "function" <+> "toSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "std_logic_vector" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "std_logic_vector" <> semi
   , "function" <+> "toSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "std_logic_vector" <+> "is" <> line <>
@@ -845,7 +775,7 @@ funDec _ _ (BitVector _) = Just
     "end" <> semi
   )
 
-funDec _ syn t@(RTree _ elTy) = Just
+funDec syn t@(RTree _ elTy) = Just
   ( "function" <+> "toSLV" <+> parens ("value : " <+> qualTyName t) <+> "return std_logic_vector" <> semi <> line <>
     "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> qualTyName t <> semi
   , "function" <+> "toSLV" <+> parens ("value : " <+> qualTyName t) <+> "return std_logic_vector" <+> "is" <> line <>
@@ -891,7 +821,7 @@ funDec _ syn t@(RTree _ elTy) = Just
     eSz     = int (typeSize elTy)
     getElem = "islv" <> parens ("i * " <> eSz <+> "to (i+1) * " <> eSz <+> "- 1")
 
-funDec _ _ _ = Nothing
+funDec _ _ = Nothing
 
 tyImports :: ModName -> VHDLM Doc
 tyImports nm = do
@@ -1261,8 +1191,8 @@ tyName' rec0 (filterTransparent -> t) = do
 
 -- | Returns underlying type of given HWType. That is, the type by which it
 -- eventually will be represented in VHDL.
-normaliseType :: RenderEnums -> HWType -> HWType
-normaliseType enums@(RenderEnums e) hwty = case hwty of
+normaliseType :: HWType -> HWType
+normaliseType hwty = case hwty of
   Void {} -> hwty
   KnownDomain {} -> hwty
 
@@ -1280,7 +1210,6 @@ normaliseType enums@(RenderEnums e) hwty = case hwty of
   Vector _ _    -> hwty
   RTree _ _     -> hwty
   Product _ _ _ -> hwty
-  Sum _ _       -> if e then hwty else BitVector (typeSize hwty)
   MemBlob n m   -> Vector n (BitVector m)
 
   -- Simple types, for which a subtype (without qualifiers) will be made in VHDL:
@@ -1289,14 +1218,15 @@ normaliseType enums@(RenderEnums e) hwty = case hwty of
   Reset _           -> Bit
   Enable _          -> Bool
   Index _           -> Unsigned (typeSize hwty)
+  Sum _ _           -> BitVector (typeSize hwty)
   CustomSP _ _ _ _  -> BitVector (typeSize hwty)
   SP _ _            -> BitVector (typeSize hwty)
   CustomSum _ _ _ _ -> BitVector (typeSize hwty)
   CustomProduct {}  -> BitVector (typeSize hwty)
 
   -- Transparent types:
-  Annotated _ elTy -> normaliseType enums elTy
-  BiDirectional _ elTy -> normaliseType enums elTy
+  Annotated _ elTy -> normaliseType elTy
+  BiDirectional _ elTy -> normaliseType elTy
 
 -- | Recursively remove transparent types from given type
 filterTransparent :: HWType -> HWType
@@ -1380,13 +1310,8 @@ sizedQualTyNameErrValue t@(RTree n elTy)    = do
     _ -> qualTyName t <> "'" <>  parens (int 0 <+> "to" <+> int (2^n - 1) <+> rarrow <+> sizedQualTyNameErrValue elTy)
 sizedQualTyNameErrValue t@(Product _ _ elTys) =
   qualTyName t <> "'" <> tupled (mapM sizedQualTyNameErrValue elTys)
-sizedQualTyNameErrValue t@(Sum _ _)  = do
-  -- No undefined / don't care for enums, so just set it to the first value
-  RenderEnums enums <- Ap renderEnums
-  if enums then
-    tyName t <> "'val" <> parens (int 0)
-  else
-    qualTyName t <> "'" <> parens (int 0 <+> "to" <+> int (typeSize t - 1) <+> rarrow <+> singularErrValue)
+sizedQualTyNameErrValue t@(Sum _ _)  =
+  qualTyName t <> "'" <> parens (int 0 <+> "to" <+> int (typeSize t - 1) <+> rarrow <+> singularErrValue)
 sizedQualTyNameErrValue (Clock _)  = singularErrValue
 sizedQualTyNameErrValue (ClockN _) = singularErrValue
 sizedQualTyNameErrValue (Reset _)  = singularErrValue
@@ -1743,12 +1668,7 @@ expr_ _ (DataCon ty@(SP _ args) (DC (_,i)) es) = assignExpr
                    n -> [bits (replicate n U)]
     assignExpr = "std_logic_vector'" <> parens (hcat $ punctuate " & " $ sequence (dcExpr:argExprs ++ extraArg))
 
-expr_ _ (DataCon ty@(Sum _ _) (DC (_,i)) []) = do
-  RenderEnums enums <- Ap renderEnums
-  if enums then
-    tyName ty <> "'" <> parens (enumVariantName ty i)
-  else
-    expr_ False (dcToExpr ty i)
+expr_ _ (DataCon ty@(Sum _ _) (DC (_,i)) []) = expr_ False (dcToExpr ty i)
 expr_ _ (DataCon ty@(CustomSum _ _ _ tys) (DC (_,i)) []) =
   let (ConstrRepr' _ _ _ value _) = fst $ tys !! i in
   "std_logic_vector" <> parens ("to_unsigned" <> parens (int (fromIntegral value) <> comma <> int (typeSize ty)))
@@ -1810,20 +1730,12 @@ expr_ b (BlackBoxE _ libs imps inc bs bbCtx b') = do
 expr_ _ (DataTag Bool (Left id_)) = "tagToEnum" <> parens (pretty id_)
 expr_ _ (DataTag Bool (Right id_)) = "dataToTag" <> parens (pretty id_)
 
-expr_ _ (DataTag hty@(Sum _ _) (Left id_)) = do
-  RenderEnums enums <- Ap renderEnums
-  nm <- Ap $ use modNm
-
-  let inner = "std_logic_vector" <> parens ("resize" <> parens ("unsigned" <> parens ("std_logic_vector" <> parens (pretty id_)) <> "," <> int (typeSize hty)))
-  if enums then pretty nm <> "_types.fromSLV" <> parens inner else inner
+expr_ _ (DataTag hty@(Sum _ _) (Left id_)) =
+  "std_logic_vector" <> parens ("resize" <> parens ("unsigned" <> parens ("std_logic_vector" <> parens (pretty id_)) <> "," <> int (typeSize hty)))
 
 expr_ _ (DataTag (Sum _ _) (Right id_)) = do
-  RenderEnums enums <- Ap renderEnums
   iw <- Ap $ use intWidth
-  nm <- Ap $ use modNm
-
-  let inner = if enums then pretty nm <> "_types.toSLV" <> parens (pretty id_) else pretty id_
-  "signed" <> parens ("std_logic_vector" <> parens ("resize" <> parens ("unsigned" <> parens inner <> "," <> int iw)))
+  "signed" <> parens ("std_logic_vector" <> parens ("resize" <> parens ("unsigned" <> parens (pretty id_) <> "," <> int iw)))
 
 expr_ _ (DataTag (Product {}) (Right _))  = do
   iw <- Ap $ use intWidth
@@ -1927,18 +1839,11 @@ exprLit _             l             = error $ $(curLoc) ++ "exprLit: " ++ show l
 
 patLit :: HWType -> Literal -> VHDLM Doc
 patLit Bit (NumLit i) = if i == 0 then "'0'" else "'1'"
-patLit hwty (NumLit i) = do
-  RenderEnums enums <- Ap renderEnums
-
-  case hwty of
-    Sum{} | enums ->
-      tyName hwty <> "'" <> parens (enumVariantName hwty (fromInteger i))
-
-    _ ->
-      let sz = conSize hwty
-       in case sz `mod` 4 of
-            0 -> hex  (toHex sz i)
-            _ -> bits (toBits sz i)
+patLit hwty (NumLit i) =
+  let sz = conSize hwty
+   in case sz `mod` 4 of
+        0 -> hex  (toHex sz i)
+        _ -> bits (toBits sz i)
 
 patLit _    l          = exprLit Nothing l
 
@@ -2006,13 +1911,7 @@ toSLV (BitVector _) e = expr_ True e
 toSLV (Signed _)   e = "std_logic_vector" <> parens (expr_ False e)
 toSLV (Unsigned _) e = "std_logic_vector" <> parens (expr_ False e)
 toSLV (Index _)    e = "std_logic_vector" <> parens (expr_ False e)
-toSLV (Sum _ _)    e = do
-  RenderEnums enums <- Ap renderEnums
-  if enums then do
-    nm <- Ap $ use modNm
-    pretty nm <> "_types.toSLV" <> parens (expr_ False e)
-  else
-    expr_ False e
+toSLV (Sum _ _)    e = expr_ False e
 toSLV (CustomSum _ _dataRepr size reprs) (DataCon _ (DC (_,i)) _) =
   let (ConstrRepr' _ _ _ value _) = fst $ reprs !! i in
   let unsigned = "to_unsigned" <> parens (int (fromIntegral value) <> comma <> int size) in
@@ -2436,11 +2335,10 @@ renderModifier (DontCare,_) _ = do
     sizedQualTyNameErrValue (Unsigned iw)
 renderModifier (Range r,t) doc = do
   nm <- Ap (use modNm)
-  enums <- Ap renderEnums
   let doc1 = case r of
         Contiguous start end -> slice start end
         Split rs -> parens (hcat (punctuate " & " (mapM (\(s,e,_) -> slice s e) rs)))
-  case normaliseType enums t of
+  case normaliseType t of
     BitVector _ -> doc1
     -- See [Note] Continuing from an SLV slice
     _ ->

--- a/clash-lib/src/Clash/Backend/VHDL.hs
+++ b/clash-lib/src/Clash/Backend/VHDL.hs
@@ -408,7 +408,8 @@ mkTyPackage_ modName (map filterTransparent -> hwtys) = do
     ; let normTys0    = nub (map mkVecZ (hwtys ++ usedTys))
     ; let sortedTys0  = topSortHWTys normTys0
           packageDec  = vcat $ mapM tyDec (nubBy eqTypM sortedTys0)
-          (funDecs,funBodies) = unzip . mapMaybe (funDec syn) $ nubBy eqTypM (normaliseType <$> sortedTys0)
+          (funDecs0,funBodies0) = unzip . mapMaybe (funDec syn) $ nubBy eqTypM (normaliseType <$> sortedTys0)
+          (funDecs,funBodies) = (toStdLogicDec:funDecs0, toStdLogicBody:funBodies0)
 
     ; pkg <- (:[]) <$> (TextS.unpack (modName `TextS.append` "_types"),) <$>
       "library IEEE;" <> line <>
@@ -438,6 +439,26 @@ mkTyPackage_ modName (map filterTransparent -> hwtys) = do
     eqTypM (Unsigned _) (Unsigned _)     = True
     eqTypM (BitVector _) (BitVector _)   = True
     eqTypM ty1 ty2                       = ty1 == ty2
+
+-- | Convert the @boolean@ a VHDL relational operator yields to a Clash 'Bool'.
+-- Always emitted, black boxes can't know whether a design declares it.
+toStdLogicDec :: VHDLM Doc
+toStdLogicDec =
+  "function" <+> "to_std_logic" <+> parens ("b" <+> colon <+> "in" <+> "boolean")
+             <+> "return" <+> "std_logic" <> semi
+
+toStdLogicBody :: VHDLM Doc
+toStdLogicBody =
+  "function" <+> "to_std_logic" <+> parens ("b" <+> colon <+> "in" <+> "boolean")
+             <+> "return" <+> "std_logic" <+> "is" <> line <>
+  "begin" <> line <>
+    indent 2 (vcat $ sequence [ "if" <+> "b" <+> "then"
+                              ,   indent 2 ("return" <+> squotes (int 1) <> semi)
+                              , "else"
+                              ,   indent 2 ("return" <+> squotes (int 0) <> semi)
+                              , "end" <+> "if" <> semi
+                              ]) <> line <>
+  "end" <> semi
 
 mkUsedTys :: HWType -> [HWType]
 mkUsedTys hwty = hwty : case hwty of
@@ -601,52 +622,14 @@ tyDec hwty = do
 
 
 funDec :: HdlSyn -> HWType -> Maybe (VHDLM Doc,VHDLM Doc)
-funDec _ Bool = Just
-  ( "function" <+> "toSLV" <+> parens ("b" <+> colon <+> "in" <+> "boolean") <+> "return" <+> "std_logic_vector" <> semi <> line <>
-    "function" <+> "fromSLV" <+> parens ("sl" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "boolean" <> semi <> line <>
-    "function" <+> "tagToEnum" <+> parens ("s" <+> colon <+> "in" <+> "signed") <+> "return" <+> "boolean" <> semi <> line <>
-    "function" <+> "dataToTag" <+> parens ("b" <+> colon <+> "in" <+> "boolean") <+> "return" <+> "signed" <> semi
-  , "function" <+> "toSLV" <+> parens ("b" <+> colon <+> "in" <+> "boolean") <+> "return" <+> "std_logic_vector" <+> "is" <> line <>
-    "begin" <> line <>
-      indent 2 (vcat $ sequence ["if" <+> "b" <+> "then"
-                                ,  indent 2 ("return" <+> dquotes (int 1) <> semi)
-                                ,"else"
-                                ,  indent 2 ("return" <+> dquotes (int 0) <> semi)
-                                ,"end" <+> "if" <> semi
-                                ]) <> line <>
-    "end" <> semi <> line <>
-    "function" <+> "fromSLV" <+> parens ("sl" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> "boolean" <+> "is" <> line <>
-    "begin" <> line <>
-      indent 2 (vcat $ sequence ["if" <+> "sl" <+> "=" <+> dquotes (int 1) <+> "then"
-                                ,   indent 2 ("return" <+> "true" <> semi)
-                                ,"else"
-                                ,   indent 2 ("return" <+> "false" <> semi)
-                                ,"end" <+> "if" <> semi
-                                ]) <> line <>
-    "end" <> semi <> line <>
-    "function" <+> "tagToEnum" <+> parens ("s" <+> colon <+> "in" <+> "signed") <+> "return" <+> "boolean" <+> "is" <> line <>
-    "begin" <> line <>
-      indent 2 (vcat $ sequence ["if" <+> "s" <+> "=" <+> "to_signed" <> parens (int 0 <> comma <> (Ap (use intWidth) >>= int)) <+> "then"
-                                ,   indent 2 ("return" <+> "false" <> semi)
-                                ,"else"
-                                ,   indent 2 ("return" <+> "true" <> semi)
-                                ,"end" <+> "if" <> semi
-                                ]) <> line <>
-    "end" <> semi <> line <>
-    "function" <+> "dataToTag" <+> parens ("b" <+> colon <+> "in" <+> "boolean") <+> "return" <+> "signed" <+> "is" <> line <>
-    "begin" <> line <>
-      indent 2 (vcat $ sequence ["if" <+> "b" <+> "then"
-                                ,  indent 2 ("return" <+> "to_signed" <> parens (int 1 <> comma <> (Ap (use intWidth) >>= int)) <> semi)
-                                ,"else"
-                                ,  indent 2 ("return" <+> "to_signed" <> parens (int 0 <> comma <> (Ap (use intWidth) >>= int)) <> semi)
-                                ,"end" <+> "if" <> semi
-                                ]) <> line <>
-    "end" <> semi
-  )
-
+-- 'Bool' is absent here: 'normaliseType' maps it onto 'Bit', so both share these
+-- @std_logic@ conversions. That is also why @tagToEnum@ and @dataToTag@ live
+-- here, they only ever apply to 'Bool'.
 funDec _ bit@Bit = Just
   ( "function" <+> "toSLV" <+> parens ("sl" <+> colon <+> "in" <+> tyName bit) <+> "return" <+> "std_logic_vector" <> semi <> line <>
-    "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> tyName bit <> semi
+    "function" <+> "fromSLV" <+> parens ("slv" <+> colon <+> "in" <+> "std_logic_vector") <+> "return" <+> tyName bit <> semi <> line <>
+    "function" <+> "tagToEnum" <+> parens ("s" <+> colon <+> "in" <+> "signed") <+> "return" <+> tyName bit <> semi <> line <>
+    "function" <+> "dataToTag" <+> parens ("sl" <+> colon <+> "in" <+> tyName bit) <+> "return" <+> "signed" <> semi
   , "function" <+> "toSLV" <+> parens ("sl" <+> colon <+> "in" <+> tyName bit) <+> "return" <+> "std_logic_vector" <+> "is" <> line <>
     "begin" <> line <>
       indent 2 ("return" <+> "std_logic_vector'" <> parens (int 0 <+> rarrow <+> "sl") <> semi) <> line <>
@@ -657,6 +640,24 @@ funDec _ bit@Bit = Just
         ) <> line <>
     "begin" <> line <>
       indent 2 ("return" <+> "islv" <> parens (int 0) <> semi) <> line <>
+    "end" <> semi <> line <>
+    "function" <+> "tagToEnum" <+> parens ("s" <+> colon <+> "in" <+> "signed") <+> "return" <+> tyName bit <+> "is" <> line <>
+    "begin" <> line <>
+      indent 2 (vcat $ sequence ["if" <+> "s" <+> "=" <+> "to_signed" <> parens (int 0 <> comma <> (Ap (use intWidth) >>= int)) <+> "then"
+                                ,   indent 2 ("return" <+> squotes (int 0) <> semi)
+                                ,"else"
+                                ,   indent 2 ("return" <+> squotes (int 1) <> semi)
+                                ,"end" <+> "if" <> semi
+                                ]) <> line <>
+    "end" <> semi <> line <>
+    "function" <+> "dataToTag" <+> parens ("sl" <+> colon <+> "in" <+> tyName bit) <+> "return" <+> "signed" <+> "is" <> line <>
+    "begin" <> line <>
+      indent 2 (vcat $ sequence ["if" <+> "sl" <+> "=" <+> squotes (int 1) <+> "then"
+                                ,  indent 2 ("return" <+> "to_signed" <> parens (int 1 <> comma <> (Ap (use intWidth) >>= int)) <> semi)
+                                ,"else"
+                                ,  indent 2 ("return" <+> "to_signed" <> parens (int 0 <> comma <> (Ap (use intWidth) >>= int)) <> semi)
+                                ,"end" <+> "if" <> semi
+                                ]) <> line <>
     "end" <> semi
   )
 
@@ -1129,7 +1130,7 @@ tyName' rec0 (filterTransparent -> t) = do
       return (error ($(curLoc) ++ "Forced to print KnownDomain tyName"))
     Void _ ->
       return (error ($(curLoc) ++ "Forced to print Void tyName: " ++ show t))
-    Bool          -> return "boolean"
+    Bool          -> return "std_logic"
     Signed n      ->
       let app = if rec0 then ["_", showt n] else [] in
       return $ TextS.concat $ "signed" : app
@@ -1197,7 +1198,6 @@ normaliseType hwty = case hwty of
   KnownDomain {} -> hwty
 
   -- Base types:
-  Bool          -> hwty
   Signed _      -> hwty
   Unsigned _    -> hwty
   BitVector _   -> hwty
@@ -1213,10 +1213,11 @@ normaliseType hwty = case hwty of
   MemBlob n m   -> Vector n (BitVector m)
 
   -- Simple types, for which a subtype (without qualifiers) will be made in VHDL:
+  Bool              -> Bit
   Clock _           -> Bit
   ClockN _          -> Bit
   Reset _           -> Bit
-  Enable _          -> Bool
+  Enable _          -> Bit
   Index _           -> Unsigned (typeSize hwty)
   Sum _ _           -> BitVector (typeSize hwty)
   CustomSP _ _ _ _  -> BitVector (typeSize hwty)
@@ -1288,11 +1289,8 @@ userTyName dflt nm0 hwTy = do
 
 -- | Convert a Netlist HWType to an error VHDL value for that type
 sizedQualTyNameErrValue :: HWType -> VHDLM Doc
-sizedQualTyNameErrValue Bool                = do
-  udf <- Ap (use undefValue)
-  case udf of
-    Just (Just 0) -> "false"
-    _             -> "true"
+-- Unlike a VHDL @boolean@, @std_logic@ can carry a don't-care.
+sizedQualTyNameErrValue Bool                = singularErrValue
 sizedQualTyNameErrValue Bit                 = singularErrValue
 sizedQualTyNameErrValue t@(Vector n elTy)   = do
   syn <-Ap hdlSyn
@@ -1482,7 +1480,9 @@ inst_ (Assignment id_ Cont e) = fmap Just $
 inst_ (CondAssignment id_ _ scrut _ [(Just (BoolLit b), l),(_,r)]) = fmap Just $
   pretty id_ <+> larrow
            <+> align (vsep (sequence [expr_ False t <+> "when" <+>
-                                      expr_ False scrut <+> "else"
+                                      -- A 'Bool' is a std_logic, so it needs a
+                                      -- test to become a condition
+                                      parens (expr_ False scrut <+> "=" <+> squotes (int 1)) <+> "else"
                                      ,expr_ False f <> semi
                                      ]))
   where
@@ -1604,6 +1604,10 @@ expr_
   -> Expr
   -- ^ Expr to convert
   -> VHDLM Doc
+-- A bare @'0'@ is an overloaded character literal, so @'0' = '1'@ is ambiguous.
+-- Qualify where the context may embed us in a larger expression.
+expr_ True (Literal _ (BoolLit v)) =
+  "std_logic'" <> parens (squotes (if v then char '1' else char '0'))
 expr_ _ (Literal sizeM lit) = exprLit sizeM lit
 expr_ _ (Identifier id_ Nothing) = pretty id_
 
@@ -1682,8 +1686,10 @@ expr_ _ (DataCon (CustomProduct _ dataRepr _size _labels tys) _ es) |
 expr_ _ (DataCon ty@(Product _ labels tys) _ es) =
     tupled $ zipWithM (\i e' -> tyName ty <> selectProductField labels tys i <+> rarrow <+> expr_ False e') [0..] es
 
-expr_ _ (DataCon (Enable _) _ [e]) =
-  expr_ False e
+-- 'Enable' is transparent, so pass @b@ on. Without this an 'andEnable' renders
+-- as a bare @a and b@, which reassociates if the consumer appends to it.
+expr_ b (DataCon (Enable _) _ [e]) =
+  expr_ b e
 
 expr_ _ (BlackBoxE pNm _ _ _ _ bbCtx _)
   | pNm == "Clash.Sized.Internal.Signed.fromInteger#"
@@ -1832,13 +1838,14 @@ exprLit (Just (hty,sz)) (BitVecLit m i) = case m of
     bvlit = bits (toBits' sz m i)
 
 
-exprLit _             (BoolLit t)   = if t then "true" else "false"
+exprLit _             (BoolLit t)   = squotes (if t then char '1' else char '0')
 exprLit _             (BitLit b)    = squotes $ bit_char b
 exprLit _             (StringLit s) = pretty . T.pack $ show s
 exprLit _             l             = error $ $(curLoc) ++ "exprLit: " ++ show l
 
 patLit :: HWType -> Literal -> VHDLM Doc
 patLit Bit (NumLit i) = if i == 0 then "'0'" else "'1'"
+patLit Bool (NumLit i) = if i == 0 then "'0'" else "'1'"
 patLit hwty (NumLit i) =
   let sz = conSize hwty
    in case sz `mod` 4 of

--- a/clash-lib/src/Clash/Backend/Verilog.hs
+++ b/clash-lib/src/Clash/Backend/Verilog.hs
@@ -1,7 +1,7 @@
 {-|
   Copyright   :  (C) 2015-2016, University of Twente,
                      2017-2018, Google Inc.,
-                     2021-2024, QBayLogic B.V.
+                     2021-2026, QBayLogic B.V.
                      2022     , Google Inc.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
@@ -208,7 +208,6 @@ instance Backend VerilogState where
   getMemoryDataFiles = use memoryDataFiles
   ifThenElseExpr _ = True
   aggressiveXOptBB = use aggressiveXOptBB_
-  renderEnums = pure (RenderEnums False)
   domainConfigurations = use domainConfigurations_
   setDomainConfigurations confs s = s {_domainConfigurations_ = confs}
 

--- a/clash-lib/src/Clash/Driver/Types.hs
+++ b/clash-lib/src/Clash/Driver/Types.hs
@@ -390,9 +390,6 @@ data ClashOpts = ClashOpts
   -- ^ At what size do we cache normalized work-free top-level binders.
   , opt_edalize :: Bool
   -- ^ Generate an EDAM file for use with Edalize.
-  , opt_renderEnums :: Bool
-  -- ^ Render sum types with all zero-width fields as enums where supported, as
-  -- opposed to rendering them as bitvectors.
   , opt_timescalePrecision :: Period
   -- ^ Timescale precision set in Verilog files. E.g., setting this would sets
   -- the second part of @`timescale 100fs/100fs@.
@@ -446,7 +443,6 @@ defClashOpts
   , opt_aggressiveXOptBB    = False
   , opt_inlineWFCacheLimit  = 10 -- TODO: find "optimal" value
   , opt_edalize             = False
-  , opt_renderEnums         = True
   , opt_timescalePrecision  = Period 100 Fs
   -- XXX: We probe environment variables until we've found a proper solution to
   --      https://github.com/clash-lang/clash-compiler/issues/2762.

--- a/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox/Util.hs
@@ -81,7 +81,7 @@ import           Text.Read                       (readEither)
 import           Text.Trifecta.Result            hiding (Err)
 
 import           Clash.Backend
-  (Backend (..), DomainMap, Usage (..), AggressiveXOptBB(..), RenderEnums(..))
+  (Backend (..), DomainMap, Usage (..), AggressiveXOptBB(..))
 import           Clash.Netlist.BlackBox.Parser
 import           Clash.Netlist.BlackBox.Types
 import           Clash.Netlist.Types
@@ -599,13 +599,12 @@ renderElem b (IF c t f) = do
   iw <- iwWidth
   hdl <- gets hdlKind
   syn <- hdlSyn
-  enums <- renderEnums
   xOpt <- aggressiveXOptBB
-  c' <- check (coerce xOpt) iw hdl syn enums c
+  c' <- check (coerce xOpt) iw hdl syn c
   if c' > 0 then renderTemplate b t else renderTemplate b f
   where
-    check :: Backend backend => Bool -> Int -> HDL -> HdlSyn -> RenderEnums -> Element -> State backend Int
-    check xOpt iw hdl syn enums c' = case c' of
+    check :: Backend backend => Bool -> Int -> HDL -> HdlSyn -> Element -> State backend Int
+    check xOpt iw hdl syn c' = case c' of
       (Size e)   -> pure $ typeSize (lineToType b [e])
       (Length e) -> pure $ case lineToType b [e] of
                        (Vector n _)              -> n
@@ -661,9 +660,6 @@ renderElem b (IF c t f) = do
                           isScalar _ Bit          = 1
                           isScalar _ Bool         = 1
                           isScalar VHDL Integer   = 1
-                          isScalar VHDL (Sum _ _) = case enums of
-                                                       RenderEnums True  -> 1
-                                                       RenderEnums False -> 0
                           isScalar _ _            = 0
                         in pure $ isScalar hdl ty
 
@@ -729,13 +725,13 @@ renderElem b (IF c t f) = do
                 | otherwise -> 0
               Nothing -> error $ $(curLoc) ++ "Expected a string literal: " ++ show e
       (And es)   -> do
-        es' <- mapM (check xOpt iw hdl syn enums) es
+        es' <- mapM (check xOpt iw hdl syn) es
         pure $ if all (/=0) es'
                        then 1
                        else 0
       CmpLE e1 e2 -> do
-        v1 <- check xOpt iw hdl syn enums e1
-        v2 <- check xOpt iw hdl syn enums e2
+        v1 <- check xOpt iw hdl syn e1
+        v2 <- check xOpt iw hdl syn e2
         if v1 <= v2
           then pure 1
           else pure 0

--- a/clash-lib/src/Clash/Primitives/DSL.hs
+++ b/clash-lib/src/Clash/Primitives/DSL.hs
@@ -543,7 +543,8 @@ boolFromBitVector
   -> TExpr
   -> State (BlockState VHDLState) TExpr
 boolFromBitVector n =
-  outputCoerce (BitVector n) Bool (\i -> "unsigned(" <> i <> ") > 0")
+  -- @>@ yields a boolean, but a 'Bool' is a std_logic
+  outputCoerce (BitVector n) Bool (\i -> "to_std_logic(unsigned(" <> i <> ") > 0)")
 
 -- | Used to create an output `Unsigned` from a `BitVector` of given
 -- size. Works in a similar way to `boolFromBit` above.
@@ -572,7 +573,10 @@ boolFromBits
   -> TExpr
   -> State (BlockState VHDLState) [TExpr]
 boolFromBits inNames = outputFn (map (const Bit) inNames) Bool
-  (foldl (<>) "" . intersperse " and " . map (\i -> "(" <> i <> " = '1')")) inNames
+  -- The conjunction yields a boolean, but a 'Bool' is a std_logic
+  (\is -> "to_std_logic("
+       <> foldl (<>) "" (intersperse " and " (map (\i -> "(" <> i <> " = '1')") is))
+       <> ")") inNames
 
 -- | Used to create an output value with an arbitrary VHDL coercion.
 -- The expression given should be the identifier of the output value

--- a/clash-prelude/src/Clash/Explicit/BlockRam.hs
+++ b/clash-prelude/src/Clash/Explicit/BlockRam.hs
@@ -1329,8 +1329,8 @@ trueDualPortBlockRamWrapper clkA enA weA addrA datA clkB enB weB addrB datB =
           process(~ARG[#{clockA}])
           begin
               if(rising_edge(~ARG[#{clockA}])) then
-                    if(~ARG[#{enaA}]) then
-                      if(~ARG[#{wenaA}]) then
+                    if(~ARG[#{enaA}] = '1') then
+                      if(~ARG[#{wenaA}] = '1') then
                           mem(~IF~SIZE[~TYP[#{addrA}]]~THENto_integer(~ARG[#{addrA}])~ELSE0~FI) := ~ARG[#{datA}];
                       end if;
                       ~SYM[#{symDoutA}] <= mem(~IF~SIZE[~TYP[#{addrA}]]~THENto_integer(~ARG[#{addrA}])~ELSE0~FI);
@@ -1342,8 +1342,8 @@ trueDualPortBlockRamWrapper clkA enA weA addrA datA clkB enB weB addrB datB =
           process(~ARG[#{clockB}])
           begin
               if(rising_edge(~ARG[#{clockB}])) then
-                  if(~ARG[#{enaB}]) then
-                      if(~ARG[#{wenaB}]) then
+                  if(~ARG[#{enaB}] = '1') then
+                      if(~ARG[#{wenaB}] = '1') then
                           mem(~IF~SIZE[~TYP[#{addrB}]]~THENto_integer(~ARG[#{addrB}])~ELSE0~FI) := ~ARG[#{datB}];
                       end if;
                       ~SYM[#{symDoutB}] <= mem(~IF~SIZE[~TYP[#{addrB}]]~THENto_integer(~ARG[#{addrB}])~ELSE0~FI);

--- a/tests/shouldwork/BlackBox/T1786.hs
+++ b/tests/shouldwork/BlackBox/T1786.hs
@@ -23,7 +23,7 @@ testAlwaysEnabled !_ = pure True
   [ { "BlackBox" :
       { "name"      : "T1786.testAlwaysEnabled"
       , "kind"      : "Expression"
-      , "template"  : "~IF ~ISACTIVEENABLE[0] ~THEN false ~ELSE true ~FI"
+      , "template"  : "~IF ~ISACTIVEENABLE[0] ~THEN '0' ~ELSE '1' ~FI"
       }
     }
   ]
@@ -52,7 +52,7 @@ testAlwaysEnabledBool !_ = pure True
   [ { "BlackBox" :
       { "name"      : "T1786.testAlwaysEnabledBool"
       , "kind"      : "Expression"
-      , "template"  : "~IF ~ISACTIVEENABLE[0] ~THEN false ~ELSE true ~FI"
+      , "template"  : "~IF ~ISACTIVEENABLE[0] ~THEN '0' ~ELSE '1' ~FI"
       }
     }
   ]

--- a/tests/shouldwork/BlackBox/T2117.hs
+++ b/tests/shouldwork/BlackBox/T2117.hs
@@ -58,7 +58,7 @@ testUndefined !_ = pure True
   [ { "BlackBox" :
       { "name"      : "T2117.testUndefined"
       , "kind"      : "Expression"
-      , "template"  : "~IF ~ISUNDEFINED[1] ~THEN true ~ELSE false ~FI"
+      , "template"  : "~IF ~ISUNDEFINED[1] ~THEN '1' ~ELSE '0' ~FI"
       }
     }
   ]
@@ -76,7 +76,7 @@ testDefined !_ = pure True
   [ { "BlackBox" :
       { "name"      : "T2117.testDefined"
       , "kind"      : "Expression"
-      , "template"  : "~IF ~ISUNDEFINED[1] ~THEN false ~ELSE true ~FI"
+      , "template"  : "~IF ~ISUNDEFINED[1] ~THEN '0' ~ELSE '1' ~FI"
       }
     }
   ]

--- a/tests/shouldwork/Issues/T2220_toEnumOOB.hs
+++ b/tests/shouldwork/Issues/T2220_toEnumOOB.hs
@@ -12,9 +12,8 @@ topEntity x | x == 3    = Nothing
 
 {-
 Because of the concurrent nature of the VHDL generate by clash,
-in VHDL the toEnum will be called with on 3 too.
-This toEnum is implemented in VHDL by fromSLV,
-which used to throw an exception on out-of-bound values.
+in VHDL the toEnum will be called with on 3 too. Back when sum types were
+rendered as enums this went through fromSLV, which threw on out-of-bound values.
 -}
 
 testBench :: Signal System Bool

--- a/tests/shouldwork/Issues/T431.hs
+++ b/tests/shouldwork/Issues/T431.hs
@@ -30,16 +30,21 @@ assertNotIn needle haystack
                                                     , "\n\nIn:\n\n", haystack ]
   | otherwise = pure ()
 
+-- Enums were requested in #431 but have since been removed again. Guard that
+-- sum types stay rendered as bit vectors.
 mainVHDL :: IO ()
 mainVHDL = do
   [topDir] <- getArgs
   content <- readFile (topDir </> show 'topEntity </> "topEntity.vhdl")
 
-  -- no bit vector literals appear, so no double quotes appear
-  assertNotIn "\"" content
+  -- no enum variants appear in the design
+  assertNotIn "TrafficLight'(Red)" content
+  assertNotIn "TrafficLight'(RedAmber)" content
+  assertNotIn "TrafficLight'(Amber)" content
+  assertNotIn "TrafficLight'(Green)" content
 
-  -- enum variants appear in the design
-  assertIn "TrafficLight'(Red)" content
-  assertIn "TrafficLight'(RedAmber)" content
-  assertIn "TrafficLight'(Amber)" content
-  assertIn "TrafficLight'(Green)" content
+  -- the constructors are encoded as bit vector literals instead
+  assertIn "\"01\" when \"00\"" content
+  assertIn "\"11\" when \"01\"" content
+  assertIn "\"00\" when \"10\"" content
+  assertIn "\"10\" when others" content


### PR DESCRIPTION
This PR is primarily a proposal, and I’d like to hear what the rest of the Clash developers think.

VHDL enums have a few user-facing problems, most notably X-hiding, see https://github.com/clash-lang/clash-compiler/issues/2193, and unstable bit representations. The latter also means they don’t behave lawfully with Clash’s `BitPack` type class. 

I don’t think there is a compelling reason for us to generate enums. They do make the generated code slightly nicer, and the original feature request was motivated by wanting VHDL simulations to display nicer values (https://github.com/clash-lang/clash-compiler/issues/431). However, I think we’ll have a much better story for this with clash-shockwaves once it supports native simulation.

Given the issues with enums, I propose removing VHDL enum generation.

In a follow up PR I aim to address the x-hiding through comparison expression as comparison or equality expression results in a VHDL boolean which with this PR is still x-hiding. 

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
