### PR TITLE
Fix performance regressions on `master`

### DIFF
--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -347,6 +347,37 @@ flattenNode b@(CBranch (nm,(Binding _ _ _ _ e _)) us) = do
            then return (Right ((nm,e),us))
            else return (Left b)
 
+{-
+Note [flatten pass structure]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Through experimentation we've learned the following:
+
+1. The evaluator-backed rewrites ('reduceConst', 'reduceNonRepPrim') must not
+   sit inside the top-down propagation bundle. 'topdownFixR' settles that bundle
+   at each node with 'repeatR', so a bundled 'reduceConst' is re-attempted -
+   evaluator call and all - for every 'appProp' or 'caseCon' that fires there.
+   On large designs we've measured that dominates; hoisting them out was worth
+   ~30%. See #3338.
+
+2. There should be exactly two traversals per round, and the bottom-up one has
+   to come first.
+
+   'allR' rebuilds every node it walks, so each extra traversal costs a full
+   term rebuild per round even when nothing fires. Running 'flattenLet' and the
+   evaluator-backed rewrites as one fused bottom-up pass instead of two
+   consecutive ones is therefore free of charge (it does not change which
+   rewrites fire, or in which order they fire relative to each other).
+
+   Running that bottom-up pass _before_ the top-down one lets the constants it
+   folds be consumed by 'caseCon' in the same round. With the passes the other
+   way round the folded constants sit unused until the next round, so
+   constant-heavy designs pay for an extra iteration of the whole loop:
+   @tests/shouldwork/Basic/AES.hs@ did ~36k extra node visits per transformation
+   that way.
+
+If you touch code related to this, please make sure to run benchmarks.
+-}
+
 -- | Flatten a 'CallTree', memoizing results by binder Id within one cleanup
 -- pass. Without the cache, every binder reachable from the root is flattened
 -- as many times as it appears in the (un-deduplicated) call tree.
@@ -407,17 +438,15 @@ flattenCallTree cache (CBranch (nm,(Binding nm' sp inl pr tm r)) used) = do
       else return (CBranch (nm,(Binding nm' sp inl pr newExpr r)) allUsed)
 
   flatten =
-    -- topdownFixR reaches a fixpoint for the top-down propagation bundle.
-    -- Keep flattenLet in the outer fixed-point loop: flattening can expose
-    -- fresh propagation redexes for the next top-down pass.
-    repeatR (topdownFixR (apply "appProp" appProp >->
-               apply "bindConstantVar" bindConstantVar >->
-               apply "caseCon" caseCon) >->
-             bottomupR (apply "flattenLet" flattenLet) >->
-             bottomupR ((apply "reduceConst" reduceConst !->
+    -- See Note [flatten pass structure].
+    repeatR (bottomupR (apply "flattenLet" flattenLet >->
+                        (apply "reduceConst" reduceConst !->
                            apply "deadcode" deadCode) >->
                         apply "reduceNonRepPrim" reduceNonRepPrim >->
-                        apply "removeUnusedExpr" removeUnusedExpr)) !->
+                        apply "removeUnusedExpr" removeUnusedExpr) >->
+             topdownFixR (apply "appProp" appProp >->
+               apply "bindConstantVar" bindConstantVar >->
+               apply "caseCon" caseCon)) !->
     topdownSucR (apply "topLet" topLet) >->
     -- See [Note] relation `collapseRHSNoops` and `inlineCleanup`
     -- Note that we do this as the very last step, after all constant propagation

--- a/clash-lib/src/Clash/Normalize/Strategy.hs
+++ b/clash-lib/src/Clash/Normalize/Strategy.hs
@@ -77,7 +77,10 @@ constantPropagation =
     -- The outer repeatR is still needed: inlineNR is a full traversal whose
     -- results can only be processed by re-running the top-down bundle from the
     -- new root.
-    inlineAndPropagate = repeatR (topdownFixR (applyMany transPropagateAndInline) >-> inlineNR)
+    --
+    -- NB: 'topdownFixR' is deliberately _not_ used here, see
+    -- Note [topdownFixR is not for inlining bundles].
+    inlineAndPropagate = repeatR (topdownR (applyMany transPropagateAndInline) >-> inlineNR)
     spec               = bottomupR (applyMany specTransformations)
     caseFlattening     = topdownFixR (apply "caseFlat" caseFlat)
     dec                = topdownFixR (apply "DEC" disjointExpressionConsolidation)

--- a/clash-lib/src/Clash/Rewrite/Combinators.hs
+++ b/clash-lib/src/Clash/Rewrite/Combinators.hs
@@ -159,6 +159,29 @@ the relevant parts of 'TransformContext' should not change when sibling
 subtrees are rewritten. Rewrites that inspect let-bound context whose binding
 terms may have changed, for example through 'whnfRW', still need an outer
 repeat or a normal repeated top-down traversal.
+
+Note [topdownFixR is not for inlining bundles]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'topdownFixR' trades traversals for re-descents, and that trade is only a win
+when rewrites are cheap and rarely fire at the same node twice.
+
+Whenever 'r' succeeds at a node, 'topdownFixR' re-descends into that node's
+_entire_ subtree, because the rewrite may have restructured it. So one
+'topdownFixR' costs
+
+> n + sum over nodes v of (times r fired at v) * size of subtree(v)
+
+node visits, where 'repeatR (topdownR r)' costs 'n' per round. 'topdownFixR'
+wins when it saves enough rounds to pay for those re-descents.
+
+For bundles that inline (@inlineWorkFree@, @inlineSmall@, @inlineOrLiftNonRep@)
+it loses: inlining replaces a small node by an arbitrarily large body, every
+enclosing node tends to become rewritable in turn, and each of those rewrites
+re-descends a subtree that just grew. Measured on
+@tests/shouldwork/Basic/T1354B.hs@ (a deeply nested chain of function
+compositions), using 'topdownFixR' for 'inlineAndPropagate' reaches exactly the
+same fixed point but needs 1.57x the node visits, costing ~40% wall-clock. It
+was ~3% slower on a larger industrial design we've measured too. See #3250.
 -}
 
 -- | Apply a transformation in a repeated top-down traversal.


### PR DESCRIPTION
Fixes performance regressions introduced by previous PRs. See https://clash-lang.github.io/clash-benchmarks/#machine=volthe&head=22505bfbe2aebb46875f8e86d3b04cbe41eeaed3.

## Still TODO:

  - [x] ~~Write a changelog entry (see changelog/README.md)~~ I don't think this warrants one, though we should probably write one big performance changelog with the accumulated end results.
  - [X] ~~Check copyright notices are up to date in edited files~~
  - [x] Remove Claudisms / review (@martijnbastiaan)

