### PR TITLE
Compare type variables structurally, not just by unique

### DIFF
--- a/changelog/2026-08-18T13_55_04+02_00_fix_3361
+++ b/changelog/2026-08-18T13_55_04+02_00_fix_3361
@@ -1,0 +1,1 @@
+FIXED: `eqType` (and friends) now take types of variables into account. See [#3361](https://github.com/clash-lang/clash-compiler/issues/3361).

--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -144,18 +144,32 @@ instance Hashable StructuralType where
 eqType :: Type -> Type -> Bool
 eqType = go
  where
-  go (TyVarTy v1) (TyVarTy v2) = v1 == v2
+  go (TyVarTy v1) (TyVarTy v2) = eqVar v1 v2
   go (AppTy l1 r1) (AppTy l2 r2) = go l1 l2 && go r1 r2
   go (TyConApp tc1 args1) (TyConApp tc2 args2) =
     tc1 == tc2 && goList args1 args2
   go (ForAllTy (Bndr v1 f1) t1) (ForAllTy (Bndr v2 f2) t2) =
-    v1 == v2 && f1 == f2 && go t1 t2
+    eqVar v1 v2 && f1 == f2 && go t1 t2
   go (FunTy f1 m1 a1 r1) (FunTy f2 m2 a2 r2) =
     f1 == f2 && go m1 m2 && go a1 a2 && go r1 r2
   go (LitTy l1) (LitTy l2) = l1 == l2
   -- XXX: Not sure how to handle casts/coercions, so for now just claim they're
   --      not equal. That's fair in the only context this is used: caching.
   go _ _ = False
+
+  -- GHC's 'Eq' on 'Var' and on 'Name' only compares uniques, and a unique only
+  -- identifies a variable within one scope. We want to use it for cache lookups,
+  -- so we should also take name and type differences into account!
+  eqVar v1 v2 =
+    v1 == v2 && eqVarName (varName v1) (varName v2)
+             && go (varType v1) (varType v2)
+
+  -- 'coreToName' reads a name's occurrence name and module (as a qualified
+  -- string, which also decides its 'C.NameSort') and its source span
+  eqVarName n1 n2 =
+    nameOccName n1 == nameOccName n2
+      && nameModule_maybe n1 == nameModule_maybe n2
+      && getSrcSpan n1 == getSrcSpan n2
 
   goList (t1:ts1) (t2:ts2) = go t1 t2 && goList ts1 ts2
   goList [] [] = True
@@ -166,10 +180,10 @@ hashType :: Int -> Type -> Int
 hashType = go
  where
   go s ty = case ty of
-    TyVarTy v -> hashWithSalt (tag s 0) (getKey (varUnique v))
+    TyVarTy v -> hashVar (tag s 0) v
     AppTy l r -> go (go (tag s 1) l) r
     TyConApp tc args -> foldl go (hashWithSalt (tag s 2) (getKey (tyConUnique tc))) args
-    ForAllTy (Bndr v _) t -> go (hashWithSalt (tag s 3) (getKey (varUnique v))) t
+    ForAllTy (Bndr v _) t -> go (hashVar (tag s 3) v) t
     FunTy _ m a r -> go (go (go (tag s 4) m) a) r
     LitTy l -> case l of
       NumTyLit i -> hashWithSalt (tag s 5) i
@@ -177,6 +191,11 @@ hashType = go
       CharTyLit c -> hashWithSalt (tag s 7) c
     CastTy t _ -> go (tag s 8) t
     CoercionTy _ -> tag s 9
+
+  -- Matching 'eqType', see comment there. Deliberately coarser than 'eqVar':
+  -- it skips the name, which only costs the odd collision. The hash law needs
+  -- equal values to hash equally, not the other way around.
+  hashVar s v = go (hashWithSalt s (getKey (varUnique v))) (varType v)
 
   tag :: Int -> Int -> Int
   tag = hashWithSalt

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -430,6 +430,7 @@ test-suite unittests
 
   Other-Modules: Clash.Tests.Core.AlphaEquivalence
                  Clash.Tests.Core.FreeVars
+                 Clash.Tests.Core.StructuralEquivalence
                  Clash.Tests.Core.Subst
                  Clash.Tests.Core.TermLiteral
                  Clash.Tests.Core.TermLiteral.Types

--- a/clash-lib/src/Clash/Core/Name.hs
+++ b/clash-lib/src/Clash/Core/Name.hs
@@ -26,7 +26,8 @@ import           Data.Text                              (Text, append)
 import           GHC.BasicTypes.Extra                   ()
 import           GHC.Generics                           (Generic)
 import           GHC.SrcLoc.Extra                       ()
-import           GHC.Types.SrcLoc                       (SrcSpan, noSrcSpan)
+import           GHC.Types.SrcLoc
+  (SrcSpan, leftmost_smallest, noSrcSpan)
 
 import           Clash.Unique
 
@@ -39,12 +40,32 @@ data Name a
   }
   deriving (Show,Generic,NFData,Binary)
 
+-- | N.B.: Equality checking only compares uniques, which only identify a name
+-- within one scope. If you want structural equality, use `eqName`.
 instance Eq (Name a) where
   (==) = (==) `on` nameUniq
   (/=) = (/=) `on` nameUniq
 
+-- | N.B.: Comparison only looks at uniques, which only identify a name within
+-- one scope. If you want structural comparison, use `ordName`.
 instance Ord (Name a) where
   compare = compare `on` nameUniq
+
+-- | Structural equality on 'Name's. See 'ordName'.
+eqName :: Name a -> Name a -> Bool
+eqName n1 n2 = ordName n1 n2 == EQ
+
+-- | Structural comparison on 'Name's: on top of the 'Ord' instance, which only
+-- compares uniques, this compares every other field too.
+--
+-- 'SrcSpan's are compared with 'leftmost_smallest', which treats all unhelpful
+-- spans alike, matching how they are hashed in "Clash.Core.Subst".
+ordName :: Name a -> Name a -> Ordering
+ordName n1 n2 =
+  compare (nameUniq n1) (nameUniq n2)
+    <> compare (nameSort n1) (nameSort n2)
+    <> compare (nameOcc n1) (nameOcc n2)
+    <> leftmost_smallest (nameLoc n1) (nameLoc n2)
 
 instance Hashable (Name a) where
   hashWithSalt salt nm = hashWithSalt salt (nameUniq nm)

--- a/clash-lib/src/Clash/Core/Subst.hs
+++ b/clash-lib/src/Clash/Core/Subst.hs
@@ -66,6 +66,9 @@ module Clash.Core.Subst
     -- * Structural equivalence
   , eqTerm
   , eqType
+  , ordType
+  , eqVar
+  , ordVar
   )
 where
 
@@ -88,6 +91,7 @@ import           GHC.Types.SrcLoc
   (SrcSpan (RealSrcSpan, UnhelpfulSpan), leftmost_smallest)
 
 import           Clash.Core.HasFreeVars
+import           Clash.Core.Name           (eqName, ordName)
 import           Clash.Core.Pretty         (ppr, fromPpr)
 import           Clash.Core.Term
   (Alt, Bind(..), Pat (..), Term (..), TickInfo (..), PrimInfo(primName))
@@ -923,6 +927,22 @@ acmpType
   -> Ordering
 acmpType = acmpTypeLevels 0 emptyVarEnv emptyVarEnv
 
+-- | Structural equality on 'Var's. See 'ordVar'.
+eqVar :: Var a -> Var a -> Bool
+eqVar v1 v2 =
+  v1 == v2 &&
+    eqName (varName v1) (varName v2) &&
+      eqType (varType v1) (varType v2)
+
+-- | Structural comparison on 'Var's: on top of the 'Ord' instance, which only
+-- compares uniques (and scope), this compares the variable's name and its
+-- type\/kind.
+ordVar :: Var a -> Var a -> Ordering
+ordVar v1 v2 =
+  compare (varKey v1) (varKey v2) `thenCompare`
+    ordName (varName v1) (varName v2) `thenCompare`
+      ordType (varType v1) (varType v2)
+
 -- | Structural equality on 'Type'
 eqType
   :: Type
@@ -930,14 +950,36 @@ eqType
   -> Bool
 eqType = go
  where
-  go (VarTy tv1) (VarTy tv2) = tv1 == tv2
+  go (VarTy tv1) (VarTy tv2) = eqVar tv1 tv2
   go (ConstTy c1) (ConstTy c2) = c1 == c2
-  go (ForAllTy tv1 t1) (ForAllTy tv2 t2) =
-    tv1 == tv2 && go (varType tv1) (varType tv2) && go t1 t2
+  go (ForAllTy tv1 t1) (ForAllTy tv2 t2) = eqVar tv1 tv2 && go t1 t2
   go (AppTy s1 t1) (AppTy s2 t2) = go s1 s2 && go t1 t2
   go (LitTy l1) (LitTy l2) = l1 == l2
   go (AnnType a1 t1) (AnnType a2 t2) = a1 == a2 && go t1 t2
   go _ _ = False
+
+-- | Structural comparison on 'Type'. See 'eqType'.
+ordType
+  :: Type
+  -> Type
+  -> Ordering
+ordType = go
+ where
+  go (VarTy tv1) (VarTy tv2) = ordVar tv1 tv2
+  go (ConstTy c1) (ConstTy c2) = compare c1 c2
+  go (ForAllTy tv1 t1) (ForAllTy tv2 t2) = ordVar tv1 tv2 `thenCompare` go t1 t2
+  go (AppTy s1 t1) (AppTy s2 t2) = go s1 s2 `thenCompare` go t1 t2
+  go (LitTy l1) (LitTy l2) = compare l1 l2
+  go (AnnType a1 t1) (AnnType a2 t2) = compare a1 a2 `thenCompare` go t1 t2
+  go t1 t2 = compare (getRank t1) (getRank t2)
+
+  getRank :: Type -> Word
+  getRank (VarTy {})    = 0
+  getRank (LitTy {})    = 1
+  getRank (ConstTy {})  = 2
+  getRank (AnnType {})  = 3
+  getRank (AppTy {})    = 4
+  getRank (ForAllTy {}) = 5
 
 -- | Alpha equality for terms
 aeqTerm
@@ -975,14 +1017,12 @@ acmpTickInfo =
 eqTerm :: Term -> Term -> Bool
 eqTerm = go
  where
-  go (Var id1) (Var id2) = id1 == id2
+  go (Var id1) (Var id2) = eqVar id1 id2
   go (Data dc1) (Data dc2) = dc1 == dc2
   go (Literal l1) (Literal l2) = l1 == l2
   go (Prim p1) (Prim p2) = primName p1 == primName p2
-  go (Lam b1 e1) (Lam b2 e2) =
-    b1 == b2 && eqType (varType b1) (varType b2) && go e1 e2
-  go (TyLam b1 e1) (TyLam b2 e2) =
-    b1 == b2 && eqType (varType b1) (varType b2) && go e1 e2
+  go (Lam b1 e1) (Lam b2 e2) = eqVar b1 b2 && go e1 e2
+  go (TyLam b1 e1) (TyLam b2 e2) = eqVar b1 b2 && go e1 e2
   go (App l1 r1) (App l2 r2) = go l1 l2 && go r1 r2
   go (TyApp l1 r1) (TyApp l2 r2) = go l1 l2 && eqType r1 r2
   go (Let bs1 e1) (Let bs2 e2) =
@@ -995,17 +1035,7 @@ eqTerm = go
       b1 == b2 && go r1 r2
     goBind (Rec brs1) (Rec brs2) =
       List.all2
-        (\(b1,r1) (b2,r2) ->
-          b1 == b2 &&
-          -- We need to check the types of Rec bindings, because:
-          --
-          -- letrec (x : Bool) = x in X
-          --
-          -- is not structurally equivalent to
-          --
-          -- letrec (x : Int) = x in x
-          eqType (varType b1) (varType b2) &&
-          go r1 r2)
+        (\(b1,r1) (b2,r2) -> eqVar b1 b2 && go r1 r2)
         brs1 brs2
     goBind _ _ = False
   -- Note [Case result types and alpha-equivalence]

--- a/clash-lib/src/Clash/Core/Var.hs
+++ b/clash-lib/src/Clash/Core/Var.hs
@@ -69,10 +69,16 @@ varKey Id{varUniq,idScope} = (varUniq, Just idScope)
 instance Hashable (Var a) where
   hashWithSalt salt a = hashWithSalt salt (varKey a)
 
+-- | N.B.: Equality checking assumes two variables are compared in the same
+-- scope, similar to `aeqType` and friends. If you want structural equality,
+-- use Subst's `eqVar`.
 instance Eq (Var a) where
   (==) = (==) `on` varKey
   (/=) = (/=) `on` varKey
 
+-- | N.B.: Equality checking assumes two variables are compared in the same
+-- scope, similar to `acmpType` and friends. If you want structural equality,
+-- use Subst's `ordVar`.
 instance Ord (Var a) where
   compare = compare `on` varKey
 

--- a/clash-lib/tests/Clash/Tests/Core/StructuralEquivalence.hs
+++ b/clash-lib/tests/Clash/Tests/Core/StructuralEquivalence.hs
@@ -1,0 +1,188 @@
+{-|
+  Copyright   :  (C) 2026, QBayLogic B.V.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  Tests for structural equality and comparison of 'Type'
+-}
+
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Clash.Tests.Core.StructuralEquivalence (tests) where
+
+import Data.Text (Text)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.TH (testGroupGenerator)
+
+import Clash.Core.Name (NameSort (..), mkUnsafeName)
+import Clash.Core.Subst (eqType, eqVar, ordType)
+import Clash.Core.Type (Kind, LitTy (..), Type (..))
+import Clash.Core.TysPrim (liftedTypeKind)
+import Clash.Core.Var (TyVar, Var (..))
+import Clash.Unique (Unique)
+
+import Test.Clash.Rewrite (intTy, parseTyConTy)
+
+-- | A 'TyVar' with the given human readable name, unique and kind. Unlike
+-- 'Test.Clash.Rewrite.tyVar', whose kind is always 'liftedTypeKind'.
+kindedTyVar :: Text -> Unique -> Kind -> TyVar
+kindedTyVar nm uniq kind = TyVar (mkUnsafeName User nm uniq) uniq kind
+
+-- | The kind variable @(~)@ and @Coercible@ bind, i.e. @mkAlphaTyVarUnique 0@
+kindVarK :: TyVar
+kindVarK = kindedTyVar "k" 0 liftedTypeKind
+
+-- | @(,)@'s second type variable, @b :: Type@
+bLifted :: TyVar
+bLifted = kindedTyVar "b" 2 liftedTypeKind
+
+-- | @(~)@'s second type variable, @b :: k@. GHC gives it the same unique as
+-- 'bLifted': both are @mkAlphaTyVarUnique 2@.
+bKinded :: TyVar
+bKinded = kindedTyVar "b" 2 (VarTy kindVarK)
+
+boolTy :: Type
+boolTy = parseTyConTy "Bool"
+
+-- | Assert that two types are structurally equal, and that 'ordType' agrees,
+-- in both directions.
+assertEqualTy :: Type -> Type -> Assertion
+assertEqualTy t1 t2 = do
+  assertBool "eqType t1 t2" (eqType t1 t2)
+  assertBool "eqType t2 t1" (eqType t2 t1)
+  EQ @=? ordType t1 t2
+  EQ @=? ordType t2 t1
+
+-- | Assert that two types are not structurally equal, and that 'ordType'
+-- agrees. Also checks that comparison in the opposite direction yields the
+-- opposite result, i.e. that the order is antisymmetric on this pair.
+assertNotEqualTy :: Type -> Type -> Assertion
+assertNotEqualTy t1 t2 = do
+  assertBool "not (eqType t1 t2)" (not (eqType t1 t2))
+  assertBool "not (eqType t2 t1)" (not (eqType t2 t1))
+  case ordType t1 t2 of
+    EQ -> assertFailure "ordType t1 t2 == EQ"
+    LT -> GT @=? ordType t2 t1
+    GT -> LT @=? ordType t2 t1
+
+-- | Regression test for #3361: type variables that share a unique but not a
+-- kind are not structurally equal.
+case_tyVarKindSignificant :: Assertion
+case_tyVarKindSignificant = do
+  assertNotEqualTy (VarTy bLifted) (VarTy bKinded)
+  assertBool "not (eqVar bLifted bKinded)" (not (eqVar bLifted bKinded))
+  -- The 'Eq' instance on 'Var' is exactly what is too coarse here: it only
+  -- compares uniques (and scope), which is why 'eqVar' exists.
+  assertBool "bLifted == bKinded" (bLifted == bKinded)
+
+-- | The kind of a 'ForAllTy' binder is significant. See
+-- 'case_tyVarKindSignificant'.
+case_forAllTyBinderKindSignificant :: Assertion
+case_forAllTyBinderKindSignificant =
+  assertNotEqualTy (ForAllTy bLifted intTy) (ForAllTy bKinded intTy)
+
+-- | A kind difference nested inside a type is found too. See
+-- 'case_tyVarKindSignificant'.
+case_nestedTyVarKindSignificant :: Assertion
+case_nestedTyVarKindSignificant =
+  assertNotEqualTy (AppTy intTy (VarTy bLifted)) (AppTy intTy (VarTy bKinded))
+
+-- | Type variables agreeing on unique /and/ kind are structurally equal.
+case_tyVarSameKindEqual :: Assertion
+case_tyVarSameKindEqual =
+  assertEqualTy (VarTy bLifted) (VarTy (kindedTyVar "b" 2 liftedTypeKind))
+
+-- | Type variables that differ only in their human readable name are not
+-- structurally equal either.
+--
+-- GHC really does produce such pairs. Its template variables are numbered from
+-- zero per wired-in construct, so the alpha uniques are reused wholesale:
+-- @(~)@'s @k@ and @(~~)@'s @k0@ are both @mkAlphaTyVarUnique 0@ kinded 'Type',
+-- and differ in nothing but their name.
+case_tyVarNameSignificant :: Assertion
+case_tyVarNameSignificant =
+  assertNotEqualTy (VarTy kindVarK) (VarTy (kindedTyVar "k0" 0 liftedTypeKind))
+
+-- | Structural equality is finer than alpha equivalence: alpha-equivalent
+-- types whose binders have different uniques are not structurally equal.
+case_structuralIsFinerThanAlpha :: Assertion
+case_structuralIsFinerThanAlpha = do
+  -- @Eq Type@ is alpha equivalence
+  t1 @=? t2
+  assertNotEqualTy t1 t2
+ where
+  t1 = ForAllTy a (VarTy a)
+  t2 = ForAllTy b (VarTy b)
+  a = kindedTyVar "a" 1 liftedTypeKind
+  b = kindedTyVar "b" 2 liftedTypeKind
+
+-- | At least one type per 'Type' constructor, plus the pairs that only differ
+-- in a nested detail, so that the 'ordType' laws below are exercised on
+-- types that compare equal as well as on types that don't.
+representativeTypes :: [Type]
+representativeTypes =
+  [ VarTy bLifted
+  , VarTy bKinded
+  , VarTy (kindedTyVar "b'" 2 liftedTypeKind)
+  , VarTy (kindedTyVar "c" 3 liftedTypeKind)
+  , intTy
+  , boolTy
+  , LitTy (NumTy 5)
+  , LitTy (NumTy 6)
+  , LitTy (SymTy "sym")
+  , LitTy (CharTy 'c')
+  , AppTy intTy boolTy
+  , AppTy boolTy intTy
+  , ForAllTy bLifted intTy
+  , ForAllTy bKinded intTy
+  , ForAllTy bLifted boolTy
+  , AnnType [] intTy
+  ]
+
+-- | 'ordType' yields 'EQ' exactly when 'eqType' holds.
+case_ordTypeAgreesWithEqType :: Assertion
+case_ordTypeAgreesWithEqType =
+  sequence_
+    [ assertEqual (show (t1, t2)) (eqType t1 t2) (ordType t1 t2 == EQ)
+    | t1 <- representativeTypes
+    , t2 <- representativeTypes
+    ]
+
+-- | Swapping 'ordType''s arguments flips the 'Ordering'.
+case_ordTypeAntisymmetric :: Assertion
+case_ordTypeAntisymmetric =
+  sequence_
+    [ assertEqual (show (t1, t2)) (flipOrdering (ordType t1 t2)) (ordType t2 t1)
+    | t1 <- representativeTypes
+    , t2 <- representativeTypes
+    ]
+ where
+  flipOrdering = \case
+    LT -> GT
+    EQ -> EQ
+    GT -> LT
+
+-- | 'ordType' is reflexive.
+case_ordTypeReflexive :: Assertion
+case_ordTypeReflexive =
+  sequence_
+    [ assertEqual (show t) EQ (ordType t t) | t <- representativeTypes ]
+
+-- | 'ordType' is transitive.
+case_ordTypeTransitive :: Assertion
+case_ordTypeTransitive =
+  sequence_
+    [ assertBool (show (t1, t2, t3)) (ordType t1 t3 /= GT)
+    | t1 <- representativeTypes
+    , t2 <- representativeTypes
+    , t3 <- representativeTypes
+    , ordType t1 t2 /= GT
+    , ordType t2 t3 /= GT
+    ]
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/clash-lib/tests/unittests.hs
+++ b/clash-lib/tests/unittests.hs
@@ -5,6 +5,7 @@ import Test.Tasty.QuickCheck
 
 import qualified Clash.Tests.Core.AlphaEquivalence
 import qualified Clash.Tests.Core.FreeVars
+import qualified Clash.Tests.Core.StructuralEquivalence
 import qualified Clash.Tests.Core.Subst
 import qualified Clash.Tests.Core.TermLiteral
 import qualified Clash.Tests.Driver.Manifest
@@ -23,6 +24,7 @@ tests :: TestTree
 tests = testGroup "Unittests"
   [ Clash.Tests.Core.AlphaEquivalence.tests
   , Clash.Tests.Core.FreeVars.tests
+  , Clash.Tests.Core.StructuralEquivalence.tests
   , Clash.Tests.Core.Subst.tests
   , Clash.Tests.Core.TermLiteral.tests
   , Clash.Tests.Driver.Manifest.tests


### PR DESCRIPTION
Add `eqName`/`ordName` for structural comparison of names, `eqVar`/`ordVar` for variables, and `ordType` to go with the existing structural `eqType`. Use `eqVar` in `eqType` and `eqTerm`, which had the same hole at occurrences: they already compared `varType` by hand at binders, so `eqVar` replaces those.

Note that `Name`s now also get compared. I'm not 100% sure that this is needed, but better safe than sorry..

Fixes #3361

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
    - Note that while the caching behavior isn't part of any release, the subtle error is still there. So I figured to include a changelog entry still.
  - [X] ~~Check copyright notices are up to date in edited files~~
  - [x] Wait for https://clash-lang.github.io/clash-benchmarks/#machine=oele&head=149ca37f4a25659fed68570d64508d414927dac5. Hopefully this doesn't undo the performance wins of https://github.com/clash-lang/clash-compiler/pull/3340
    - No performance regression, or very small.

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
