### PR TITLE
Properly support new string-interpolate

### DIFF
--- a/clash-lib/src/Clash/Util/Interpolate.hs
+++ b/clash-lib/src/Clash/Util/Interpolate.hs
@@ -40,13 +40,16 @@ OTHER DEALINGS IN THE SOFTWARE.
 -}
 
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- TODO: only export the @i@ quasiquoter when `ghcide` stops type-checking
 -- expanded quasiquote splices
 module Clash.Util.Interpolate (i, format, toString) where
 
-import           Language.Haskell.Meta.Parse (parseExp)
+-- This module also exists in @ghc-hs-meta@, see
+-- https://github.com/clash-lang/clash-compiler/pull/3366
+import "haskell-src-meta" Language.Haskell.Meta.Parse (parseExp)
 import           Language.Haskell.TH.Lib     (appE, varE)
 import           Language.Haskell.TH.Quote   (QuasiQuoter(..))
 import           Language.Haskell.TH.Syntax  (Q, Exp)

--- a/tests/shouldwork/BlackBox/LITrendering.hs
+++ b/tests/shouldwork/BlackBox/LITrendering.hs
@@ -46,7 +46,7 @@ foo !x1
   [ { "BlackBox" :
       { "name"      : "LITrendering.foo"
       , "kind"      : "Declaration"
-      , "template"  : "// #{L.intercalate "," ["~LIT[" <> show n <> "]" | n <- [0..18]]}"
+      , "template"  : "// #{L.intercalate "," (L.map (\n -> "~LIT[" <> show n <> "]") [0..18])}"
       }
     }
   ]


### PR DESCRIPTION
With `string-interpolate-1.0.0.0` and its dependencies, we can no longer use a list comprehension in interpolated expressions.

Furthermore, the new `string-interpolate` causes the package `ghc-hs-meta` to be put into the package environment, and it is incompatible with our own `haskell-src-meta` dependency. This is only a problem in invocations like we do in `/clash-dev`, where `ghci` will notice there are two modules named `Language.Haskell.Meta.Parse`. We can use `PackageImports` to avoid this situation, as for some reason passing `-hide-package` to `ghci` did not help.

PR #3364 only succeeded CI because it did not actually pick the new string-interpolate. Local testing for that PR only verified compilation, but it only shows when running the test suite.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
