### PR TITLE
Account for zero-length/under-applied primitives (backport #3349)

### DIFF
--- a/changelog/2026-08-06T08_29_09+02_00_fix_3348
+++ b/changelog/2026-08-06T08_29_09+02_00_fix_3348
@@ -1,0 +1,1 @@
+FIXED: `reduceNonRepPrim` now correctly accounts for non-work primitives returning a zero-length `Vec` and under-applied ones. See [#3348](https://github.com/clash-lang/clash-compiler/issues/3348).

--- a/clash-lib/src/Clash/Normalize/Transformations/Reduce.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Reduce.hs
@@ -38,8 +38,8 @@ import Clash.Core.Name (nameOcc)
 import Clash.Core.Pretty (showPpr)
 import Clash.Core.Subst (Subst, extendIdSubst, substTm)
 import Clash.Core.Term
-  ( CoreContext(..), LetBinding, PrimInfo(..), Term(..), TickInfo(..), collectArgs
-  , collectArgsTicks, mkApps, mkTicks, mkTmApps)
+  ( CoreContext(..), LetBinding, PrimInfo(..), Term(..), TickInfo(..)
+  , WorkInfo(..), collectArgs, collectArgsTicks, mkApps, mkTicks, mkTmApps)
 import Clash.Core.TyCon (TyCon(..), TyConMap, tyConDataCons)
 import Clash.Core.Type (Type, TypeView(..), mkTyConApp, splitFunForallTy, tyView, coreView)
 import Clash.Core.Util (mkVec, shouldSplit, tyNatSize, mkInternalVar)
@@ -158,11 +158,19 @@ reduceNonRepPrim c e@(App _ _)
     then return e
     else do
       let eTy = inferCoreTypeOf tcm e
-      let resTy = snd (splitFunForallTy eTy)
+      let (remainingArgTys, resTy) = splitFunForallTy eTy
       let tv = tyView (coreView tcm resTy)
       case zeroLengthVecTerm tcm tv of
-        Just nilE -> changed (mkTicks nilE ticks)
-        Nothing -> case handlerM of
+        -- Only replace the whole application by @Nil@ if the primitive is
+        -- fully applied (a partially applied primitive has a function type,
+        -- so replacing it by @Nil@ would change its arity) and if it does
+        -- not always perform work (e.g. blackboxes like an VIO must be
+        -- rendered even if their result is zero-width).
+        Just nilE
+          | null remainingArgTys
+          , primWorkInfo p /= WorkAlways
+          -> changed (mkTicks nilE ticks)
+        _ -> case handlerM of
           Nothing -> return e
           Just handler -> do
             ultraArg <- Lens.view normalizeUltra

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -711,6 +711,7 @@ runClashTest = defaultMain
         , runTest "T3311" def{hdlSim=[]}
         , runTest "T3308" def
         , runTest "T3308b" def
+        , runTest "T3348" def{hdlTargets=[Verilog], hdlSim=[]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T3348.hs
+++ b/tests/shouldwork/Issues/T3348.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-do-lambda-eta-expansion #-}
+
+module T3348 where
+
+import Clash.Explicit.Prelude
+
+import Clash.Annotations.Primitive (Primitive (InlineYamlPrimitive))
+import GHC.Magic (lazy)
+import Clash.Netlist.Types (BlackBox (BBTemplate))
+
+import qualified Clash.Netlist.BlackBox.Types as BB
+
+class Vio (dom :: Domain) a res | a -> res where
+  vioX :: a
+
+instance Vio dom (Signal dom o) o where
+  vioX = pure undefined
+
+instance Vio dom a o => Vio dom (Signal dom i -> a) o where
+  vioX !_i = vioX @dom @a @o
+
+vioProbe ::
+  forall dom a o n m.
+  (KnownDomain dom, Vio dom a o) =>
+  Vec n String ->
+  Vec m String ->
+  o ->
+  Clock dom ->
+  a
+vioProbe inputNames outputNames initialOutputProbeValues clk =
+  vioProbe# @dom @a @o inputNames outputNames initialOutputProbeValues clk
+{-# OPAQUE vioProbe #-}
+
+vioProbe# ::
+  forall dom a o n m.
+  (KnownDomain dom, Vio dom a o) =>
+  Vec n String ->
+  Vec m String ->
+  o ->
+  Clock dom ->
+  a
+vioProbe# !_inputNames !_outputNames !_initialOutputProbeValues clk =
+  lazy clk `seq` vioX @dom @a @o
+{-# OPAQUE vioProbe# #-}
+{-# ANN vioProbe# (InlineYamlPrimitive [minBound..] $ unlines
+  [ "BlackBoxHaskell:"
+  , "    name: T3348.vioProbe#"
+  , "    templateFunction: T3348.myTF"
+  , "    workInfo: Always"
+  ]) #-}
+
+myTF :: BB.BlackBoxFunction
+myTF _isD _primName _args _ty =
+  pure (Right (BB.emptyBlackBoxMeta, BBTemplate [BB.Text "0"]))
+
+topEntity ::
+  Clock XilinxSystem ->
+  Signal XilinxSystem Bit ->
+  Signal XilinxSystem Bool ->
+  Signal XilinxSystem (Vec 0 Bool)
+topEntity clk i1 i2 =
+  vioProbe @XilinxSystem ("a" :> "b" :> Nil) Nil Nil clk i1 i2
+


### PR DESCRIPTION
Backport of #3349