### PR TITLE
Do not add `-dynamic-too` when already dynamic (backport #3358)

### DIFF
--- a/changelog/2026-08-18T11_15_00+02_00_fix_3354
+++ b/changelog/2026-08-18T11_15_00+02_00_fix_3354
@@ -1,0 +1,1 @@
+FIXED: Clash no longer enables `-dynamic-too` when the build is already dynamic, which made GHC emit an `-Winconsistent-flags` warning. See [#3354](https://github.com/clash-lang/clash-compiler/issues/3354).

--- a/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/LoadModules.hs
@@ -325,8 +325,12 @@ setupGhc useColor dflagsM idirs = do
       ghcDynamic = case lookup "GHC Dynamic" (DynFlags.compilerInfo dflags) of
                     Just "YES" -> True
                     _          -> False
-      dflags3 = if ghcDynamic then DynFlags.gopt_set dflags2 DynFlags.Opt_BuildDynamicToo
-                              else dflags2
+      -- If the build is already dynamic, dynamic objects get built anyway and GHC
+      -- warns about '-dynamic-too' being ignored. See #3354.
+      targetIsDynamic = DynFlags.ways dflags2 `Ways.hasWay` Ways.WayDyn
+      dflags3 = if ghcDynamic && not targetIsDynamic
+                  then DynFlags.gopt_set dflags2 DynFlags.Opt_BuildDynamicToo
+                  else dflags2
 
   when (DynFlags.gopt DynFlags.Opt_WorkerWrapper dflags3) $
     trace

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -723,6 +723,12 @@ runClashTest = defaultMain
           []
       , clashTestGroup "LoadModules"
         [ runTest "T1796" def{hdlSim=[]}
+          -- Clash should not set '-dynamic-too' if '-dynamic' is already set
+        , runTest "T3354" def
+            { hdlTargets=[VHDL]
+            , clashFlags=["-dynamic"]
+            , expectClashFail=Just (TestSpecificExitCode 0, "NOT:-dynamic-too")
+            }
         ]
       , clashTestGroup "Naming"
         [ runTest "T967a" def{hdlSim=[]}

--- a/tests/shouldwork/LoadModules/T3354.hs
+++ b/tests/shouldwork/LoadModules/T3354.hs
@@ -1,0 +1,9 @@
+module T3354 where
+
+import Clash.Prelude
+
+-- | Compiled with @-dynamic@ by the testsuite: Clash used to additionally set
+-- @-dynamic-too@, which made GHC warn that it got ignored. See
+-- https://github.com/clash-lang/clash-compiler/issues/3354.
+topEntity :: Signal System Bit -> Signal System Bit
+topEntity = fmap complement


### PR DESCRIPTION
Backport of #3358