### PR TITLE
Correct `RTree` offset calculations in SV backend (backport #3360)

### DIFF
--- a/changelog/2026-08-18T11_53_09+02_00_fix_3359
+++ b/changelog/2026-08-18T11_53_09+02_00_fix_3359
@@ -1,0 +1,1 @@
+FIXED: The SystemVerilog backend no longer emits out-of-bounds array indices when a nested modifier selects a half of an `RTree`. The size of a tree half was computed as `(d-1)^2` instead of `2^(d-1)`, so for an `RTree 3` the right half was emitted as `[4:8]` on an array whose valid indices are `0..7`. See [#3359](https://github.com/clash-lang/clash-compiler/issues/3359).

--- a/clash-lib/src/Clash/Backend/SystemVerilog.hs
+++ b/clash-lib/src/Clash/Backend/SystemVerilog.hs
@@ -1456,7 +1456,7 @@ modifier offset mods (Indexed (ty@(RTree d argTy),1,0)) = case mods of
   where
     start   = typeSize ty - 1
     end     = typeSize ty `div` 2
-    lhsSz   = (d-1)^(2 :: Int)
+    lhsSz   = 2^(d-1)
 
 modifier offset mods (Indexed (ty@(RTree d argTy),1,1)) = case mods of
     Right {}:rest -> Just (Right (NRange (start+offset) offset):rest, RTree  (d-1) argTy)
@@ -1464,8 +1464,8 @@ modifier offset mods (Indexed (ty@(RTree d argTy),1,1)) = case mods of
     _ -> Just (Left (NRange rhsS rhsE):mods,RTree (d-1) argTy)
   where
     start   = (typeSize ty `div` 2) - 1
-    rhsS    = (d-1)^(2 :: Int)
-    rhsE    = d^(2 :: Int)-1
+    rhsS    = 2^(d-1)
+    rhsE    = 2^d - 1
 
 -- This is a HACK for Clash.Netlist.Util.mkTopOutput
 -- Vector's don't have a 10'th constructor, this is just so that we can

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -712,6 +712,7 @@ runClashTest = defaultMain
         , runTest "T3308" def
         , runTest "T3308b" def
         , runTest "T3348" def{hdlTargets=[Verilog], hdlSim=[]}
+        , outputTest "T3359" def{hdlTargets=[SystemVerilog], hdlSim=[]}
         ] <>
         if compiledWith == Cabal then
           -- This tests fails without environment files present, which are only

--- a/tests/shouldwork/Issues/T3359.hs
+++ b/tests/shouldwork/Issues/T3359.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-|
+The SystemVerilog backend used to compute the size of an 'RTree' half as
+@(d-1)^2@ instead of @2^(d-1)@ -- base and exponent flipped. An @RTree d@ has
+@2^d@ elements, so for @d=3@ the right half was emitted as @[4:8]@ on an array
+whose valid indices are @0..7@.
+
+@nestM@ merges every RTree-then-RTree nesting before the backend runs, so this
+path is not reachable from ordinary Haskell. It is reached here with a blackbox
+template function that renders an 'Identifier' carrying a 'Nested' modifier whose
+outer component is a 'Vec' projection -- a pairing @nestM@ leaves unmerged.
+
+See https://github.com/clash-lang/clash-compiler/issues/3359
+-}
+module T3359 where
+
+import qualified Prelude as P
+
+import Control.Monad.State (State)
+import Data.List (isInfixOf)
+import Data.Monoid (Ap(getAp))
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+
+import Clash.Prelude
+import Clash.Backend (Backend, expr)
+import qualified Clash.Netlist.Id as Id
+import Clash.Netlist.Types
+import Clash.Annotations.Primitive (Primitive(..), HDL(..))
+
+treeSelTF :: TemplateFunction
+treeSelTF = TemplateFunction [0] (const True) treeSelTemplate
+
+treeSelTemplate :: Backend s => BlackBoxContext -> State s Doc
+treeSelTemplate _ = do
+  nm <- Id.make "tree_sel"
+  let rt   = RTree 3 Bool
+      vec  = Vector 2 rt
+      -- Outer: element 0 of the vector. Inner: right half of the RTree.
+      modf = Nested (Indexed (vec, 10, 0)) (Indexed (rt, 1, 1))
+  getAp (expr False (Identifier nm (Just modf)))
+
+{-# ANN treeSel (InlinePrimitive [SystemVerilog] "[ { \"BlackBox\" : { \"name\" : \"T3359.treeSel\", \"kind\": \"Expression\", \"format\": \"Haskell\", \"templateFunction\": \"T3359.treeSelTF\"}} ]") #-}
+treeSel :: Signal System Bool -> Signal System Bool
+treeSel a = a
+{-# OPAQUE treeSel #-}
+
+topEntity :: Signal System Bool -> Signal System Bool
+topEntity = treeSel
+
+-- Output tests
+assertIn :: String -> String -> IO ()
+assertIn needle haystack
+  | needle `isInfixOf` haystack = return ()
+  | otherwise                   = P.error $ P.concat [ "Expected:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+
+assertNotIn :: String -> String -> IO ()
+assertNotIn needle haystack
+  | needle `isInfixOf` haystack = P.error $ P.concat [ "Did not expect:\n\n  ", needle
+                                                     , "\n\nIn:\n\n", haystack ]
+  | otherwise                   = return ()
+
+mainSystemVerilog :: IO ()
+mainSystemVerilog = do
+  [topDir] <- getArgs
+  content <- readFile (topDir </> show 'topEntity </> "topEntity.sv")
+  -- An RTree 3 has 8 elements, so the right half is [4:7]. Before the fix this
+  -- was emitted as [4:8], which is out of bounds.
+  assertIn    "tree_sel[0][4:7]" content
+  assertNotIn "tree_sel[0][4:8]" content


### PR DESCRIPTION
Backport of #3360