### PR TITLE
nix: Update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779877693,
-        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
+        "lastModified": 1787964612,
+        "narHash": "sha256-0N9nghg3nwzX6b6qc77EzjR9cu/Z+UR66FlfsCqiURs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
+        "rev": "e8be7818e19ada32105a8af937a6a473b38167ca",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,13 @@
     # Overlays are specified here, since they are not a per-system attribute of
       # a flake (unlike packages, apps, devShells etc.) which are system-specific.
     { inherit overlays; } //
-    flake-utils.lib.eachDefaultSystem (system:
+    # Nixpkgs 26.11 no longer supports x86_64-darwin. Keep generating outputs
+    # for the supported systems while avoiding evaluation of that platform.
+    flake-utils.lib.eachSystem [
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-linux"
+    ] (system:
       let
         # Our final nixpkgs has an overlay applied for each supported version of
         # GHC for the repository. We can extract all the flake outputs from this


### PR DESCRIPTION
This nixpkgs updates removes `x86_64-darwin`. 