### PR TITLE
qlog: configure PR links to display using #

### DIFF
--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -1,1 +1,2 @@
 project: "clash-lang/clash-compiler"
+md_pr_link: "[#{pr}]({pr_url})"


### PR DESCRIPTION
Update the qlog config so that PR links are displayed as #<number>.
