### PR TITLE
Retry `cabal update` on CI

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: latest
+          cabal-update: false
 
       - uses: tespkg/actions-cache/restore@e07e2d4953dc8c020d447363e5064e36d04f3cf9
         with:
@@ -56,6 +57,10 @@ jobs:
       - name: Version information
         run:
           cabal --version
+
+      - name: Cabal update
+        run:
+          .ci/retry.sh cabal update
 
       - name: Setup
         run: .ci/gh-setup.sh


### PR DESCRIPTION
Both Hackage and GitHub can be unreliable, making `cabal update` fail.

## Still TODO:

  - [X] ~~Write a changelog entry (see changelog/README.md)~~
  - [X] ~~Check copyright notices are up to date in edited files~~

[comment]: # (Depending on the change, some of these points may not be necessary. If so, leave the boxes unchecked so it is easier for a reviewer to see what has been omitted.)
