### PR TITLE
Try to fix GitLab nightlies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,10 +5,10 @@ include:
 
 workflow:
   rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_BRANCH                  # Pushes
       when: never
     - if: $CI_COMMIT_TAG                     # When tags are set (releases)
-    - if: $CI_PIPELINE_SOURCE == "schedule"
 
 variables:
   # Default GHC / Cabal version. Used for generating Haddock and releasing to


### PR DESCRIPTION
Nightlies stopped running when #3289 was merged. I suspect that `$CI_COMMIT_BRANCH` is set for scheduled pipelines (nightlies) as well, inhibiting them. If we list them first, it should trigger correctly.

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files
