### PR TITLE
Avoid `Integer` in `popCount` and `count{Leading,Trailing}Zeros`

### DIFF
--- a/changelog/entries/2026-09-04_T12:13:38_popcount_no_integer.md
+++ b/changelog/entries/2026-09-04_T12:13:38_popcount_no_integer.md
@@ -1,0 +1,7 @@
+---
+issues: []
+prs: [3409]
+---
+
+# FIXED
+`popCount`, `countLeadingZeros` and `countTrailingZeros` on `BitVector` (and hence on `Unsigned`, `Signed` and `Index`, which delegate to it) went through `Integer`, which made Clash emit a `Dubious primitive instantiation` warning for `GHC.Num.Integer.integerToInt#` and put an `Integer` in the generated HDL. They now use `Clash.Sized.Internal.Index.fromEnum#`, which has a black box of its own.

--- a/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
+++ b/clash-prelude/src/Clash/Sized/Internal/BitVector.hs
@@ -895,12 +895,15 @@ instance KnownNat n => Bits (BitVector n) where
   shiftR v i        = shiftR# v i
   rotateL v i       = rotateL# v i
   rotateR v i       = rotateR# v i
-  popCount bv       = fromInteger (I.toInteger# (popCountBV (bv ++# (0 :: BitVector 1))))
+  -- SAFETY: This fails if n > 2^(WORD_SIZE_IN_BITS-1), but such large vectors
+  -- don't make sense in hardware.
+  popCount bv       = I.fromEnum# (popCountBV (bv ++# (0 :: BitVector 1)))
 
 instance KnownNat n => FiniteBits (BitVector n) where
   finiteBitSize       = size#
-  countLeadingZeros   = fromInteger . I.toInteger# . countLeadingZerosBV
-  countTrailingZeros  = fromInteger . I.toInteger# . countTrailingZerosBV
+  -- SAFETY: see the note on 'popCount'
+  countLeadingZeros   = I.fromEnum# . countLeadingZerosBV
+  countTrailingZeros  = I.fromEnum# . countTrailingZerosBV
 
 type BitVectorPositiveLiteralError lit n =
   PotentiallyOutOfBounds

--- a/clash-prelude/src/Clash/Sized/Internal/Index.hs-boot
+++ b/clash-prelude/src/Clash/Sized/Internal/Index.hs-boot
@@ -18,3 +18,4 @@ data Index :: Nat -> Type
 
 instance KnownNat n => Num (Index n)
 toInteger# :: Index n -> Integer
+fromEnum# :: KnownNat n => Index n -> Int

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -474,6 +474,8 @@ runClashTest = defaultMain
         , runTest "ReduceOne" def
         , runTest "ExtendingNumZero" def
         , runTest "AppendZero" def
+        , runTest "PopCountNoInteger"
+            def{clashFlags=["-Werror=clash-dubious-primitive"]}
         , runTest "PackGHCNums" def
         , runTest "UnpackGHCNums" def
         , runTest "GenericBitPack" def{clashFlags=["-fconstraint-solver-iterations=15"]}

--- a/tests/shouldwork/BitVector/PopCountNoInteger.hs
+++ b/tests/shouldwork/BitVector/PopCountNoInteger.hs
@@ -1,0 +1,35 @@
+-- Regression test: 'popCount', 'countLeadingZeros' and 'countTrailingZeros' on
+-- the Clash number types must not drag 'Integer' into the netlist.
+module PopCountNoInteger where
+
+import Clash.Prelude
+import Clash.Explicit.Testbench
+
+topEntity ::
+  (BitVector 9, Unsigned 9, Signed 9, Index 300) ->
+  Vec 12 Int
+topEntity (bv, u, s, i) =
+     popCount bv :> countLeadingZeros bv :> countTrailingZeros bv
+  :> popCount u  :> countLeadingZeros u  :> countTrailingZeros u
+  :> popCount s  :> countLeadingZeros s  :> countTrailingZeros s
+  :> popCount i  :> countLeadingZeros i  :> countTrailingZeros i
+  :> Nil
+{-# OPAQUE topEntity #-}
+
+testBench :: Signal System Bool
+testBench = done
+ where
+  -- 0b0_0011_0000 in 9 bits: 2 bits set, 3 leading zeros, 4 trailing zeros.
+  -- 'Index 300' is 9 bits wide too (CLog 2 300 == 9), so 48 gives the same.
+  testInput = stimuliGenerator clk rst ((0x030, 0x030, 0x030, 48) :> Nil)
+  expectedOutput =
+    outputVerifier' clk rst
+      ((  2 :> 3 :> 4
+       :> 2 :> 3 :> 4
+       :> 2 :> 3 :> 4
+       :> 2 :> 3 :> 4
+       :> Nil) :> Nil)
+  done = expectedOutput (topEntity <$> testInput)
+  clk = tbSystemClockGen (not <$> done)
+  rst = systemResetGen
+{-# OPAQUE testBench #-}


### PR DESCRIPTION
`popCount`, `countLeadingZeros` and `countTrailingZeros` on `BitVector` (and hence on `Unsigned`, `Signed` and `Index`, which delegate to it) went through `Integer`, which made Clash emit a `Dubious primitive instantiation` warning for `GHC.Num.Integer.integerToInt#` and put an `Integer` in the generated HDL. They now use
`Clash.Sized.Internal.Index.fromEnum#`, which has a black box of its own.

Picked from #3351.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
