### PR TITLE
Warn about `resetGenN` on every backend

### DIFF
--- a/changelog/entries/2026-09-04_T12:13:44_reset_gen_n_not_synthesizable.md
+++ b/changelog/entries/2026-09-04_T12:13:44_reset_gen_n_not_synthesizable.md
@@ -1,0 +1,7 @@
+---
+issues: []
+prs: [3410]
+---
+
+# CHANGED
+`Clash.Signal.Internal.resetGenN` now reports `clash-non-synthesizable` on every backend, instead of only on SystemVerilog.

--- a/clash-lib/prims/systemverilog/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/systemverilog/Clash_Signal_Internal.primitives.yaml
@@ -174,5 +174,5 @@
       end
       // pragma translate_on
       // resetGen end
-    warning: Clash.Signal.Internal.resetGenN can not be synthesized to hardware!
+    warning: Clash.Signal.Internal.resetGenN cannot be synthesized to hardware!
     workInfo: Always

--- a/clash-lib/prims/verilog/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/verilog/Clash_Signal_Internal.primitives.yaml
@@ -180,4 +180,5 @@
       assign ~RESULT = ~SYM[0];
       // pragma translate_on
       // resetGen end
+    warning: Clash.Signal.Internal.resetGenN cannot be synthesized to hardware!
     workInfo: Always

--- a/clash-lib/prims/vhdl/Clash_Signal_Internal.primitives.yaml
+++ b/clash-lib/prims/vhdl/Clash_Signal_Internal.primitives.yaml
@@ -218,6 +218,7 @@
       -- pragma translate_on
       end block;
       -- resetGen end
+    warning: Clash.Signal.Internal.resetGenN cannot be synthesized to hardware!
     workInfo: Always
 - BlackBox:
     name: Clash.Signal.Internal.unsafeFromReset

--- a/clash-lib/src/Clash/Util/Interpolate.hs
+++ b/clash-lib/src/Clash/Util/Interpolate.hs
@@ -241,7 +241,7 @@ i = QuasiQuoter {
   }
   where
     err name =
-      error ("Clash.Util.Interpolate.i: This QuasiQuoter can not be used as a "
+      error ("Clash.Util.Interpolate.i: This QuasiQuoter cannot be used as a "
            ++ name ++ "!")
 
     toExp:: [Node] -> Q Exp


### PR DESCRIPTION
Its VHDL and Verilog black boxes render nothing outside `translate_off`, exactly like the SystemVerilog one, which was the only one marked non-synthesizable.

Picked from #3351

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
