### PR TITLE
Promote "unmatchable constant" warning to proper warning and improve warning traceability

### DIFF
--- a/changelog/entries/2026-09-04_T12:13:33_unmatchable_constant_is_a_warning.md
+++ b/changelog/entries/2026-09-04_T12:13:33_unmatchable_constant_is_a_warning.md
@@ -1,0 +1,7 @@
+---
+issues: []
+prs: [3411]
+---
+
+# CHANGED
+The `Unmatchable constant as case subject` report (emitted when invariants are checked, e.g. under `-fclash-debug DebugSilent`) is now a proper warning instead of a trace, so `-Werror` / `-Werror=clash-unmatchable-constant` turns it into an error. It also names the binder being normalized. The warning can be suppressed with `-Wno-clash-unmatchable-constant`.

--- a/changelog/entries/2026-09-04_T12:13:34_dubious_primitive_warning_context.md
+++ b/changelog/entries/2026-09-04_T12:13:34_dubious_primitive_warning_context.md
@@ -1,0 +1,7 @@
+---
+issues: []
+prs: [3411]
+---
+
+# CHANGED
+`Dubious primitive instantiation` warnings now name the component, the binder the primitive's result is assigned to, and the primitive's arguments (resolving variable references against sibling let-bindings). They are also deduplicated per *(component, primitive)* pair instead of per primitive, so a single run reveals every offending site rather than only the first. Designs with many offending components therefore emit more warnings than before.

--- a/clash-lib/src/Clash/Core/Pretty.hs
+++ b/clash-lib/src/Clash/Core/Pretty.hs
@@ -24,6 +24,7 @@ module Clash.Core.Pretty
   , SyntaxElement (..)
   , ppr, ppr'
   , showPpr, showPpr'
+  , showPprDiag
   , tracePprId
   , tracePpr
   , fromPpr
@@ -168,6 +169,17 @@ showPpr = showPpr' def
 
 showPpr' :: PrettyPrec p => PrettyOptions -> p -> String
 showPpr' opts = showDoc . ppr' opts
+
+-- | Print a 'PrettyPrec' thing for use in a one-line diagnostic: all runs of
+-- whitespace (including newlines) are collapsed into a single space, and the
+-- result is truncated to the given number of characters. Without this, a
+-- warning quoting a term containing a @case@ or @let@ spills over many lines
+-- and drowns out the rest of the message.
+showPprDiag :: PrettyPrec p => Int -> p -> String
+showPprDiag maxLen p =
+  case splitAt maxLen (unwords (words (showPpr p))) of
+    (shown, []) -> shown
+    (shown, _)  -> shown <> "..."
 
 tracePprId :: PrettyPrec p => p -> p
 tracePprId p = trace (showPpr p) p

--- a/clash-lib/src/Clash/Netlist.hs
+++ b/clash-lib/src/Clash/Netlist.hs
@@ -369,7 +369,9 @@ mkNetDecl (id_,tm) | (_,_,ticks) <- collectArgsTicks tm = preserveVarEnv $ withT
     -- Set the initialization value of a signal when a primitive wants to set it
     getResInits :: (Id, Term) -> NetlistMonad [Expr]
     getResInits (i,collectArgs -> (k,args0)) = case k of
-      Prim p -> extractPrimWarnOrFail (primName p) >>= go p
+      Prim p ->
+        let context = primWarnContext [] (showPpr (varName i)) args0
+         in extractPrimWarnOrFail context (primName p) >>= go p
       _ -> return []
      where
       go pInfo (BlackBox {resultInits=nmDs, multiResult=True}) = do

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs
@@ -74,7 +74,7 @@ import           Clash.Core.TyCon              as C (TyConMap, tyConDataCons)
 import           Clash.Core.Util
   (inverseTopSortLetBindings, splitShouldSplit)
 import           Clash.Core.Var                as V
-  (Id, mkLocalId, modifyVarName, varType)
+  (Id, mkLocalId, modifyVarName, varName, varType)
 import           Clash.Core.VarEnv
   (extendInScopeSet, mkInScopeSet, lookupVarEnv, uniqAway, unitVarSet)
 import {-# SOURCE #-} Clash.Netlist
@@ -294,10 +294,13 @@ mkArgument bbName bndr declType nArg e = do
 -- the guard wants to, or fail entirely.
 extractPrimWarnOrFail
   :: HasCallStack
-  => TextS.Text
+  => String
+  -- ^ Extra context to add to warnings, e.g. the id the primitive's result
+  -- is assigned to
+  -> TextS.Text
   -- ^ Name of primitive
   -> NetlistMonad CompiledPrimitive
-extractPrimWarnOrFail nm = do
+extractPrimWarnOrFail context nm = do
   prim <- HashMap.lookup nm <$> Lens.view primitives
   case prim of
     Just (HasBlackBox warnings compiledPrim) ->
@@ -326,6 +329,15 @@ extractPrimWarnOrFail nm = do
     -> CompiledPrimitive
     -> NetlistMonad CompiledPrimitive
 
+  -- The key a primitive is remembered under, see 'go [] cp' below. Note it
+  -- includes the current component: the warning mentions component specific
+  -- context, which would get lost if the primitive were only warned about once
+  -- per compilation. A single run therefore reveals all offending sites rather
+  -- than only the first.
+  seenKey = do
+    (curCompId,_) <- Lens.use curCompNm
+    pure (Id.toText curCompId <> ":" <> nm)
+
   go ((WarnAlways warning):ws) cp = do
     warnPrimitive W.WarnDubiousPrimitive warning
     go ws cp
@@ -335,18 +347,25 @@ extractPrimWarnOrFail nm = do
     unless isTB (warnPrimitive W.WarnNonSynthesizable warning)
     go ws cp
 
+  -- Only mark the primitive as seen once the whole list of warnings has been
+  -- emitted. A primitive can carry several 'WarnAlways' annotations, and all of
+  -- them should be reported, see 'tests/shouldwork/PrimitiveGuards/MultipleGuards'.
   go [] cp = do
-    seenPrimitives %= Set.insert nm
+    key <- seenKey
+    seenPrimitives %= Set.insert key
     return cp
 
   warnPrimitive :: W.ClashWarning -> String -> NetlistMonad ()
   warnPrimitive w warning = do
-    seen <- Set.member nm <$> Lens.use seenPrimitives
-    (_,sp) <- Lens.use curCompNm
+    seen <- Set.member <$> seenKey <*> Lens.use seenPrimitives
+    (curCompId,sp) <- Lens.use curCompNm
 
     unless seen
       $ warnAboutM w sp
-      $ "Dubious primitive instantiation for "
+      $ "Dubious primitive instantiation in "
+     ++ unpack (Id.toText curCompId)
+     ++ (if null context then "" else " (" ++ context ++ ")")
+     ++ " for "
      ++ unpack nm
      ++ ": "
      ++ warning
@@ -368,8 +387,14 @@ mkPrimitive
   -- ^ Tick declarations
   -> NetlistMonad (Expr,[Declaration])
 mkPrimitive bbEParen bbEasD declType dst pInfo args tickDecls =
-  go =<< extractPrimWarnOrFail (primName pInfo)
+  go =<< extractPrimWarnOrFail context (primName pInfo)
   where
+    context = N.primWarnContext [] dstName args
+    dstName =
+      case dst of
+        NetlistId i _ -> unpack (Id.toText i)
+        CoreId i -> showPpr (V.varName i)
+        MultiId is -> unwords (map (showPpr . V.varName) is)
     tys = netlistTypes dst
     ty = fromMaybe (error "mkPrimitive") (listToMaybe tys)
     assignTy = declTypeUsage declType
@@ -1061,7 +1086,10 @@ mkFunInput parentName declType resId e =
   -- TODO: generates strings that are later parsed/interpreted again. Silly!
   templ <- case appE of
             Prim p -> do
-              bb  <- extractPrimWarnOrFail (primName p)
+              bb  <- extractPrimWarnOrFail
+                       (N.primWarnContext [] (showPpr (V.varName resId)) args
+                          <> ", as an argument of: " <> unpack parentName)
+                       (primName p)
               case bb of
                 P.BlackBox {..} ->
                   pure (Left (kind,outputUsage,libraries,imports,includes,primName p,template))

--- a/clash-lib/src/Clash/Netlist/BlackBox.hs-boot
+++ b/clash-lib/src/Clash/Netlist/BlackBox.hs-boot
@@ -16,7 +16,8 @@ import Clash.Primitives.Types (CompiledPrimitive)
 
 extractPrimWarnOrFail
   :: HasCallStack
-  => Text
+  => String
+  -> Text
   -> NetlistMonad CompiledPrimitive
 
 mkBlackBoxContext

--- a/clash-lib/src/Clash/Netlist/Util.hs
+++ b/clash-lib/src/Clash/Netlist/Util.hs
@@ -88,7 +88,7 @@ import qualified Clash.Core.Literal      as C
 import           Clash.Core.Name
   (Name (..), appendToName, mkUnsafeSystemName, nameOcc)
 import           Clash.Core.PartialEval
-import           Clash.Core.Pretty       (showPpr)
+import           Clash.Core.Pretty       (PrettyPrec, showPpr, showPprDiag)
 import           Clash.Core.Subst
   (Subst (..), extendIdSubst, extendIdSubstList, extendInScopeId,
    extendInScopeIdList, mkSubst, substTm)
@@ -810,7 +810,7 @@ mkUniqueNormalized is0 topMM (args, binds, res) = do
     Just (oports, owrappers, res1, subst0) -> do
       -- Collect new names, see 'renameBinder' for more information
       (listToMaybe -> resRenameM0, HashMap.fromList -> renames0) <-
-        partition ((== res) . fst) <$> concatMapM renameBinder binds
+        partition ((== res) . fst) <$> concatMapM (renameBinder binds) binds
 
       let
         -- Is the result variable read by any of the other binders? In that case
@@ -867,19 +867,62 @@ orNothing :: Bool -> a -> Maybe a
 orNothing True a = Just a
 orNothing False _ = Nothing
 
+-- | Build the extra context 'extractPrimWarnOrFail' adds to a \"Dubious
+-- primitive instantiation\" warning: which binder the primitive's result is
+-- assigned to, and what the primitive is applied to. Without it a warning only
+-- names the primitive, which for a primitive as common as
+-- @GHC.Num.Integer.integerToInt#@ is not enough to find the offending code.
+--
+-- Arguments that reference one of the given sibling bindings are resolved (up
+-- to a fixed depth), because on its own a generated name like @c$app_arg@ says
+-- very little.
+primWarnContext
+  :: [(Id, Term)]
+  -- ^ Sibling bindings, used to resolve variable references. Pass @[]@ if they
+  -- are not available.
+  -> String
+  -- ^ Name of the binder the primitive's result is assigned to
+  -> [Either Term Type]
+  -- ^ Arguments the primitive is applied to
+  -> String
+primWarnContext binds dst args =
+  "result assigned to: " <> dst <> ", applied to: "
+    <> unwords (map (either (showArg maxResolveDepth) showDiag) args)
+ where
+  showArg :: Int -> Term -> String
+  showArg depth (stripTicks -> Var v)
+    | depth > 0
+    , Just rhs <- lookup v binds
+    , (h, rhsArgs, _) <- collectArgsTicks rhs
+    = "(" <> showPpr (varName v) <> " = "
+        <> unwords (showDiag h : map (either (showArg (depth - 1)) showDiag) rhsArgs)
+        <> ")"
+  showArg _ tm = showDiag tm
+
+  showDiag :: PrettyPrec p => p -> String
+  showDiag = showPprDiag maxArgLen
+
+  -- How deep to resolve variable references into sibling bindings
+  maxResolveDepth = 5
+
+  -- Longest rendering of a single argument
+  maxArgLen = 160
+
 -- | Set the name of the binder if the given term is a blackbox requesting
 -- a specific name for the result binder. It might return multiple names in
 -- case of a multi result primitive.
 --
-renameBinder :: (Id, Term) -> NetlistMonad [(Id, Id)]
-renameBinder (i, collectArgsTicks -> (k, args, ticks)) = withTicks ticks $ \_ -> do
+renameBinder :: [(Id, Term)] -> (Id, Term) -> NetlistMonad [(Id, Id)]
+renameBinder binds (i, collectArgsTicks -> (k, args, ticks)) = withTicks ticks $ \_ -> do
   case k of
     Prim p ->
       case primMultiResult p of
-        SingleResult -> extractPrimWarnOrFail (primName p) >>= goSingle p
-        MultiResult -> extractPrimWarnOrFail (primName p) >>= goMulti p
+        SingleResult -> extractPrimWarnOrFail context (primName p) >>= goSingle p
+        MultiResult -> extractPrimWarnOrFail context (primName p) >>= goMulti p
     _ -> pure []
  where
+  context = primWarnContext binds (showPpr (varName i)) args
+
   -- Routine for multi result primitives. For more info:
   -- 'Clash.Normalize.Transformations.setupMultiResultPrim'.
   goMulti :: PrimInfo -> CompiledPrimitive -> NetlistMonad [(Id, Id)]

--- a/clash-lib/src/Clash/Normalize.hs
+++ b/clash-lib/src/Clash/Normalize.hs
@@ -28,7 +28,7 @@ import qualified Data.IORef                       as IORef
 import           Clash.Data.UniqMap               (UniqMap)
 import qualified Clash.Data.UniqMap               as UniqMap
 import           Data.List
-  (intersect, mapAccumL)
+  (intercalate, intersect, mapAccumL)
 import qualified Data.Map                         as Map
 import qualified Data.Maybe                       as Maybe
 import qualified Data.Set                         as Set
@@ -227,11 +227,27 @@ normalize' nm = do
             -- (GHC-8.4 does this with tests/shouldwork/Numbers/Exp.hs)
             -- It will later be inlined by flattenCallTree.
             opts <- Lens.view debugOpts
+            -- Which already-normalized binders reference this one? Without that,
+            -- the trace below says nothing about where the offending binder came
+            -- from.
+            referers <-
+              if dbg_invariants opts
+                 then do
+                   prevNorm <- Lens.use (extra.normalized)
+                   pure [ showPpr (varName (bindingId b))
+                        | b <- eltsVarEnv prevNorm
+                        , nm `elem` Lens.toListOf globalIds (bindingTerm b)
+                        ]
+                 else pure []
             traceIf (dbg_invariants opts)
                     (concat [$(curLoc), "Expr belonging to bndr: ", nmS, " (:: "
                             , showPpr (coreTypeOf nm')
                             , ") has a non-representable return type."
-                            , " Not normalising:\n", showPpr tm] )
+                            , " Referenced by: "
+                            , if null referers
+                                 then "nothing normalized so far"
+                                 else intercalate ", " referers
+                            , ". Not normalizing:\n", showPpr tm] )
                     (return ([],(nm,(Binding nm' sp inl pr tm r))))
 
 

--- a/clash-lib/src/Clash/Normalize/Transformations/Case.hs
+++ b/clash-lib/src/Clash/Normalize/Transformations/Case.hs
@@ -28,6 +28,7 @@ module Clash.Normalize.Transformations.Case
   ) where
 
 import Control.Exception.Base (patError)
+import Control.Monad (when)
 import GHC.Prim.Panic (absentError)
 import qualified Control.Lens as Lens
 
@@ -63,23 +64,25 @@ import Clash.Core.TyCon (TyConMap)
 import Clash.Core.Type (LitTy(..), Type(..), TypeView(..), coreView1, tyView)
 import Clash.Core.TysPrim (integerIsDc, naturalNsDc)
 import Clash.Core.Util (listToLets, mkInternalVar)
+import Clash.Core.Var (varName)
 import Clash.Core.VarEnv
   ( InScopeSet, elemVarSet, extendInScopeSet, extendInScopeSetList, mkVarSet
   , unitVarSet, uniqAway)
-import Clash.Debug (traceIf)
 import Clash.Driver.Types (DebugOpts(dbg_invariants))
+import Clash.Driver.Warning (warnAboutM)
 import Clash.Netlist.Types (FilteredHWType(..), HWType(..))
 import Clash.Netlist.Util (coreTypeToHWType)
 import qualified Clash.Normalize.Primitives as NP (undefined, undefinedX)
 import Clash.Normalize.Types (NormRewrite, NormalizeSession)
 import Clash.Rewrite.Combinators ((>-!))
 import Clash.Rewrite.Types
-  ( TransformContext(..), bindings, customReprs, debugOpts, tcCache
+  ( TransformContext(..), bindings, curFun, customReprs, debugOpts, tcCache
   , typeTranslator, workFreeBinders)
 import Clash.Rewrite.Util
   (changed, isFromInt, isUntranslatableType, runWithHWTypeCache, whnfRW)
 import Clash.Rewrite.WorkFree
 import Clash.Util (curLoc)
+import Clash.Warning (ClashWarning(WarnUnmatchableConstant))
 
 import Clash.XException (errorX)
 
@@ -315,14 +318,17 @@ caseCon' ctx@(TransformContext is0 _) e@(Case subj ty alts) = do
             -> caseCon ctx1 (Case (Literal (IntegerLiteral 0)) ty alts)
           _ -> do
             opts <- Lens.view debugOpts
+            (curFunId,sp) <- Lens.use curFun
             -- When invariants are being checked, report missing evaluation
             -- rules for the primitive evaluator.
-            traceIf (dbg_invariants opts && isConstant subj)
-              ("Unmatchable constant as case subject: " ++ showPpr subj ++
-                 "\nWHNF is: " ++ showPpr subj1)
-              -- Otherwise check whether the entire case-expression has a
-              -- single alternative, and pick that one.
-              (caseOneAlt e)
+            when (dbg_invariants opts && isConstant subj)
+              $ warnAboutM WarnUnmatchableConstant sp
+              $ "Unmatchable constant as case subject in " ++
+                  showPpr (varName curFunId) ++ ": " ++ showPpr subj ++
+                  "\nWHNF is: " ++ showPpr subj1
+            -- Otherwise check whether the entire case-expression has a
+            -- single alternative, and pick that one.
+            caseOneAlt e
 
   -- The subject is a variable
   (Var v, [], _) | isNum0 (coreTypeOf v) ->

--- a/clash-lib/src/Clash/Warning.hs
+++ b/clash-lib/src/Clash/Warning.hs
@@ -77,6 +77,12 @@ data ClashWarning
   -- possibly dropping most significant bits.
   --
   -- Flag: @-Wclash-integer-narrowing@
+  | WarnUnmatchableConstant
+  -- ^ A case subject evaluated to a constant that matches none of the
+  -- alternatives, usually a missing reduction rule in the primitive evaluator.
+  -- Only reported when invariants are being checked (@-fclash-debug@).
+  --
+  -- Flag: @-Wclash-unmatchable-constant@
   deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData, Hashable)
 
 -- | The name of a warning as used in command line flags, e.g.
@@ -88,6 +94,7 @@ warningName = \case
   WarnPrimitiveDefinition -> "clash-primitive-definition"
   WarnCastSpecialization -> "clash-cast-specialization"
   WarnIntegerNarrowing -> "clash-integer-narrowing"
+  WarnUnmatchableConstant -> "clash-unmatchable-constant"
 
 -- | Inverse of 'warningName'
 parseWarningName :: String -> Maybe ClashWarning


### PR DESCRIPTION
More or less ad-hoc additions to warnings in order to track down the provenance of warnings seen in (a downstream project) `bittide-hardware`.

Picked from #3351.

## Still TODO:

  - [X] Write a changelog entry (see changelog/README.md)
  - [X] ~~Check copyright notices are up to date in edited files~~
  - [ ] Think about whether we want more/less (unless a reviewer says OK :-))