### PR TITLE
Fix GHC 9.14 unary-class to include superclass dictionaries

### DIFF
--- a/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/Clash/GHC/GHC2Core.hs
@@ -86,9 +86,6 @@ import GHC.Core
 import GHC.Types.Tickish (GenTickish (..))
 import GHC.Core.DataCon
   (DataCon, dataConExTyCoVars, dataConName,
-#if MIN_VERSION_ghc(9,14,0)
-   dataConOrigArgTys,
-#endif
    dataConRepArgTys,
    dataConTag, dataConTyCon, dataConUnivTyVars, dataConWorkId,
    dataConFieldLabels, flLabel, HsImplBang(..), dataConImplBangs)
@@ -410,9 +407,14 @@ makeAlgTyConRhs _tc algTcRhs = case algTcRhs of
     let tvs = tyConTyVars _tc
         -- The DataCon for a unary class has exactly one field; that's the
         -- newtype's RHS (e.g. 'SNat n' for 'KnownNat n').
-        rhsEtad = case dataConOrigArgTys dc of
+        rhsEtad = case dataConRepArgTys dc of
           [scaled] -> scaledThing scaled
-          _ -> error "makeAlgTyConRhs: UnaryClassTyCon DataCon does not have one field"
+          args -> error [__i|
+            makeAlgTyConRhs: UnaryClassTyCon DataCon does not have one field
+              Type constructor: #{showPprUnsafe _tc}
+              Data constructor: #{showPprUnsafe dc}
+              Representation argument types (#{length args}): #{showPprUnsafe args}
+            |]
     Just <$> (C.NewTyCon <$> coreToDataCon dc
                          <*> ((,) <$> mapM coreToTyVar tvs
                                   <*> coreToType rhsEtad))

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -834,6 +834,7 @@ runClashTest = defaultMain
         , runTest "FunctionInstances" def
         , runTest "GADTExistential" def{hdlSim=[]}
         , runTest "LocalPoly" def{hdlSim=[]}
+        , runTest "UnaryClass" def{hdlSim=[]}
         ]
       , clashTestGroup "PrimitiveGuards"
         [ runTest "WarnAlways" def{

--- a/tests/shouldwork/Polymorphism/UnaryClass.hs
+++ b/tests/shouldwork/Polymorphism/UnaryClass.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module UnaryClass where
+
+import Clash.Prelude
+
+class KnownNat n => Alias n
+instance KnownNat n => Alias n
+
+increment :: Alias n => Unsigned n -> Unsigned n
+increment x = x + 1
+{-# OPAQUE increment #-}
+
+topEntity :: Unsigned 8 -> Unsigned 8
+topEntity = increment


### PR DESCRIPTION
Reported by @kleinreact as he hit this in the clash-crypto project

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
 