### PR TITLE
Use error class for CI failure message

### DIFF
--- a/.ci/small-tests.sh
+++ b/.ci/small-tests.sh
@@ -45,7 +45,7 @@ mv $GIT_ROOT/cabal.project.local.disabled $GIT_ROOT/cabal.project.local || exit 
 # Test for old changelog entries
 old_entries=$(find changelog/ -maxdepth 1 -type f -name '20*')
 
-if [ -n "$old_entries" ]; then
-    echo "::warning title=Old-style changelog entries found::$old_entries"
+if [[ -n $old_entries ]]; then
+    echo "::error title=Old-style changelog entries found::$old_entries"
     exit 1
 fi


### PR DESCRIPTION
Just a small improvement upon #3421

## Still TODO:

  - ~~Write a changelog entry (see changelog/README.md)~~
  - [x] Check copyright notices are up to date in edited files